### PR TITLE
fix: opensearch refuses a scope filter the index mapping cannot honour

### DIFF
--- a/libs/agno/agno/vectordb/opensearch/opensearch.py
+++ b/libs/agno/agno/vectordb/opensearch/opensearch.py
@@ -979,7 +979,7 @@ class OpenSearch(VectorDb):
             Uses batch embedding for improved performance.
         """
         self._validate_user_id(user_id)
-        self._require_owner_field(user_id)
+        await asyncio.to_thread(self._require_owner_field, user_id)
         self._apply_content_hash_and_filters(documents, content_hash, filters)
         await self._async_execute_bulk_operation(
             "insert", documents, self._prepare_bulk_insert_data, use_batch_embed=True, user_id=user_id
@@ -1050,9 +1050,9 @@ class OpenSearch(VectorDb):
             chunks for this hash first.
         """
         self._validate_user_id(user_id)
-        self._require_owner_field(user_id)
-        if self.content_hash_exists(content_hash, user_id=user_id):
-            self._delete_by_content_hash(content_hash, user_id=user_id)
+        await asyncio.to_thread(self._require_owner_field, user_id)
+        if await asyncio.to_thread(self.content_hash_exists, content_hash, user_id):
+            await asyncio.to_thread(self._delete_by_content_hash, content_hash, user_id)
         self._apply_content_hash_and_filters(documents, content_hash, filters)
         await self._async_execute_bulk_operation(
             "upsert", documents, self._prepare_bulk_upsert_data, use_batch_embed=True, user_id=user_id

--- a/libs/agno/agno/vectordb/opensearch/opensearch.py
+++ b/libs/agno/agno/vectordb/opensearch/opensearch.py
@@ -979,7 +979,7 @@ class OpenSearch(VectorDb):
             Uses batch embedding for improved performance.
         """
         self._validate_user_id(user_id)
-        await asyncio.to_thread(self._require_owner_field, user_id)
+        self._require_owner_field(user_id)
         self._apply_content_hash_and_filters(documents, content_hash, filters)
         await self._async_execute_bulk_operation(
             "insert", documents, self._prepare_bulk_insert_data, use_batch_embed=True, user_id=user_id
@@ -1050,9 +1050,9 @@ class OpenSearch(VectorDb):
             chunks for this hash first.
         """
         self._validate_user_id(user_id)
-        await asyncio.to_thread(self._require_owner_field, user_id)
-        if await asyncio.to_thread(self.content_hash_exists, content_hash, user_id):
-            await asyncio.to_thread(self._delete_by_content_hash, content_hash, user_id)
+        self._require_owner_field(user_id)
+        if self.content_hash_exists(content_hash, user_id=user_id):
+            self._delete_by_content_hash(content_hash, user_id=user_id)
         self._apply_content_hash_and_filters(documents, content_hash, filters)
         await self._async_execute_bulk_operation(
             "upsert", documents, self._prepare_bulk_upsert_data, use_batch_embed=True, user_id=user_id

--- a/libs/agno/agno/vectordb/opensearch/opensearch.py
+++ b/libs/agno/agno/vectordb/opensearch/opensearch.py
@@ -132,6 +132,8 @@ class OpenSearch(VectorDb):
         self.engine = engine
         self.distance = distance
         self.search_type = search_type
+        # Whether the live index can honour a user_id scope filter; resolved lazily on first use.
+        self._owner_field_exact: Optional[bool] = None
 
         # Connection configuration
         self.http_auth = http_auth
@@ -432,6 +434,7 @@ class OpenSearch(VectorDb):
             log_debug(f"Creating index: {self.index_name}")
             self.client.indices.create(index=self.index_name, body=self.mapping)
             log_info(f"Successfully created index: {self.index_name}")
+            self._owner_field_exact = True
         else:
             log_debug(f"Index {self.index_name} already exists")
 
@@ -445,6 +448,7 @@ class OpenSearch(VectorDb):
             log_debug(f"Creating index (async): {self.index_name}")
             await self.async_client.indices.create(index=self.index_name, body=self.mapping)
             log_info(f"Successfully created index (async): {self.index_name}")
+            self._owner_field_exact = True
         else:
             log_info(f"Index {self.index_name} already exists")
 
@@ -514,6 +518,8 @@ class OpenSearch(VectorDb):
             log_debug(f"Deleting index: {self.index_name}")
             self.client.indices.delete(index=self.index_name)
             log_info(f"Successfully deleted index: {self.index_name}")
+            # The next index under this name is created with the mapping — re-resolve lazily
+            self._owner_field_exact = None
         else:
             log_info(f"Index {self.index_name} does not exist, nothing to delete")
 
@@ -527,6 +533,7 @@ class OpenSearch(VectorDb):
             log_debug(f"Deleting index (async): {self.index_name}")
             await self.async_client.indices.delete(index=self.index_name)
             log_info(f"Successfully deleted index (async): {self.index_name}")
+            self._owner_field_exact = None
         else:
             log_info(f"Index {self.index_name} does not exist, nothing to delete")
 
@@ -947,6 +954,7 @@ class OpenSearch(VectorDb):
             Creates index if it doesn't exist. Skips documents that fail preparation.
         """
         self._validate_user_id(user_id)
+        self._require_owner_field(user_id)
         self._apply_content_hash_and_filters(documents, content_hash, filters)
         self._execute_bulk_operation("insert", documents, self._prepare_bulk_insert_data, user_id=user_id)
 
@@ -971,6 +979,7 @@ class OpenSearch(VectorDb):
             Uses batch embedding for improved performance.
         """
         self._validate_user_id(user_id)
+        self._require_owner_field(user_id)
         self._apply_content_hash_and_filters(documents, content_hash, filters)
         await self._async_execute_bulk_operation(
             "insert", documents, self._prepare_bulk_insert_data, use_batch_embed=True, user_id=user_id
@@ -1012,6 +1021,7 @@ class OpenSearch(VectorDb):
             splits into fewer chunks leaves no surplus behind.
         """
         self._validate_user_id(user_id)
+        self._require_owner_field(user_id)
         if self.content_hash_exists(content_hash, user_id=user_id):
             self._delete_by_content_hash(content_hash, user_id=user_id)
         self._apply_content_hash_and_filters(documents, content_hash, filters)
@@ -1040,6 +1050,7 @@ class OpenSearch(VectorDb):
             chunks for this hash first.
         """
         self._validate_user_id(user_id)
+        self._require_owner_field(user_id)
         if self.content_hash_exists(content_hash, user_id=user_id):
             self._delete_by_content_hash(content_hash, user_id=user_id)
         self._apply_content_hash_and_filters(documents, content_hash, filters)
@@ -1497,6 +1508,7 @@ class OpenSearch(VectorDb):
             Uses the search type configured during initialization (vector, keyword, or hybrid).
         """
         self._validate_user_id(user_id)
+        self._require_owner_field(user_id)
         search_methods = {
             SearchType.vector: self.vector_search,
             SearchType.keyword: self.keyword_search,
@@ -1560,6 +1572,7 @@ class OpenSearch(VectorDb):
             Generates query embedding and performs KNN search.
         """
         self._validate_user_id(user_id)
+        self._require_owner_field(user_id)
         return self._execute_search_with_timing("vector", query, limit, self._build_vector_query, filters, user_id)
 
     def keyword_search(
@@ -1585,6 +1598,7 @@ class OpenSearch(VectorDb):
             Uses multi-match query on content and name fields.
         """
         self._validate_user_id(user_id)
+        self._require_owner_field(user_id)
         return self._execute_search_with_timing("keyword", query, limit, self._build_keyword_query, filters, user_id)
 
     def hybrid_search(
@@ -1610,6 +1624,7 @@ class OpenSearch(VectorDb):
             Combines vector similarity (70% weight) and keyword relevance (30% weight).
         """
         self._validate_user_id(user_id)
+        self._require_owner_field(user_id)
         return self._execute_search_with_timing("hybrid", query, limit, self._build_hybrid_query, filters, user_id)
 
     def _execute_search_with_timing(
@@ -1808,6 +1823,41 @@ class OpenSearch(VectorDb):
         """
         return self.engine != Engine.nmslib
 
+    def _owner_field_is_exact(self) -> bool:
+        """Whether the live index maps ``user_id`` in a way the scope filter can honour.
+
+        An absent field is fine: the docs carry no owner and read as the shared bucket, which
+        is what an index predating isolation is documented to do. A field mapped as anything
+        but keyword is not: it is analyzed, so the filter matches tokens rather than the id
+        and user_id="dave" also matches "Dave" and "dave smith".
+        """
+        if self._owner_field_exact is None:
+            try:
+                mappings = self.client.indices.get_mapping(index=self.index_name)
+                # Keyed by concrete index, never by the name asked for, so an alias or a
+                # wildcard resolves to several real indexes and each one has to be exact.
+                types = [
+                    index_mapping.get("mappings", {}).get("properties", {}).get(USER_ID_FIELD, {}).get("type")
+                    for index_mapping in mappings.values()
+                ]
+                answer = all(t in (None, "keyword") for t in types)
+                if set(mappings) != {self.index_name}:
+                    # An alias or a wildcard: it can be repointed while this process lives,
+                    # so the answer is about whatever it resolved to just now, not the name.
+                    return answer
+                self._owner_field_exact = answer
+            except opensearch_exceptions.NotFoundError:
+                # No live index yet, and the one that appears under this name may not be ours
+                return True
+            except Exception:
+                # Assume mapped, uncached: caching a failed inspection would mask a bad mapping
+                logger.warning(
+                    f"Could not inspect index '{self.index_name}' for the user_id mapping; "
+                    "proceeding as mapped for this operation."
+                )
+                return True
+        return self._owner_field_exact
+
     def _validate_user_id(self, user_id: Optional[str]) -> None:
         """
         Reject a user_id the field-absence contract cannot express.
@@ -1824,6 +1874,29 @@ class OpenSearch(VectorDb):
         """
         if user_id is not None and user_id.strip() == "":
             raise ValueError("user_id must not be empty or whitespace-only")
+
+    def _require_owner_field(self, user_id: Optional[str]) -> bool:
+        """Gate every owner-field reference on the live index mapping.
+
+        True when the mapping can honour a scope filter, False when it cannot and the
+        operation is unscoped. A scoped operation on an index that maps the field as
+        analyzed text raises rather than matching another owner's tokens.
+        """
+        if self._owner_field_is_exact():
+            return True
+        if user_id is None:
+            return False
+        # The cached answer may predate a reindex — re-inspect once before refusing
+        self._owner_field_exact = None
+        if self._owner_field_is_exact():
+            return True
+        raise ValueError(
+            f"user_id={user_id!r} was passed but index '{self.index_name}' does not support "
+            f"per-user isolation: it maps '{USER_ID_FIELD}' as analyzed text, so the scope "
+            "filter matches its tokens rather than the owner. A field type can only be set "
+            "when the index is created, so recreate the index and re-ingest — reindexing "
+            "into the same mapping is not sufficient."
+        )
 
     def _owner_filter(self, user_id: str) -> Dict[str, Any]:
         """
@@ -2128,6 +2201,7 @@ class OpenSearch(VectorDb):
             match exactly the chunks _delete_by_content_hash clears for the same user_id.
         """
         self._validate_user_id(user_id)
+        self._require_owner_field(user_id)
         return self._check_field_exists("content_hash", content_hash, self._exact_owner_scope(user_id))
 
     def delete_by_id(self, id: str) -> bool:
@@ -2223,6 +2297,7 @@ class OpenSearch(VectorDb):
             it, so removing shared chunks takes an unscoped call.
         """
         self._validate_user_id(user_id)
+        self._require_owner_field(user_id)
         content_id_term = {"term": {"content_id.keyword": content_id}}
 
         if user_id is None:

--- a/libs/agno/tests/unit/vectordb/test_opensearch_user_isolation.py
+++ b/libs/agno/tests/unit/vectordb/test_opensearch_user_isolation.py
@@ -559,3 +559,158 @@ class TestLegacyIndexCompatibility:
         opensearch_db.insert("h_bob", [doc("bob", BOB)], user_id="bob")
 
         assert opensearch_db.client.mapping_updates == []
+
+
+def gated_db(mapping_response):
+    """An adapter whose live mapping is whatever the test says it is."""
+    db = OpenSearch(index_name=TEST_INDEX_NAME, dimension=TEST_DIMENSION, embedder=DeterministicEmbedder())
+    db._client = Mock()
+    db._client.indices.get_mapping.return_value = mapping_response
+    return db
+
+
+def mapping_for(index_name, user_id_type):
+    """A get_mapping response; ``user_id_type=None`` leaves the field out entirely."""
+    properties = {} if user_id_type is None else {"user_id": {"type": user_id_type}}
+    return {index_name: {"mappings": {"properties": properties}}}
+
+
+class TestOwnerFieldMappingGate:
+    """A scope filter is only honoured when the live mapping stores the owner as an exact term.
+
+    OpenSearch dynamic-maps a string as analyzed ``text``, so the first scoped write to an index
+    created before the field existed types it wrongly, and ``{"term": {"user_id": x}}`` then matches
+    that value's tokens: user_id="dave" also matches "Dave" and "dave smith".
+    """
+
+    def test_keyword_mapping_is_honoured(self):
+        db = gated_db(mapping_for(TEST_INDEX_NAME, "keyword"))
+
+        assert db._require_owner_field("alice") is True
+
+    def test_analyzed_mapping_refuses_a_scoped_operation(self):
+        db = gated_db(mapping_for(TEST_INDEX_NAME, "text"))
+
+        with pytest.raises(ValueError, match="recreate the index"):
+            db._require_owner_field("alice")
+
+    def test_a_keyword_subfield_does_not_rescue_an_analyzed_parent(self):
+        """The dynamic default is text with a .keyword subfield, but the filter names the parent."""
+        db = gated_db(
+            {
+                TEST_INDEX_NAME: {
+                    "mappings": {
+                        "properties": {"user_id": {"type": "text", "fields": {"keyword": {"type": "keyword"}}}}
+                    }
+                }
+            }
+        )
+
+        with pytest.raises(ValueError, match="recreate the index"):
+            db._require_owner_field("alice")
+
+    def test_analyzed_mapping_still_serves_an_unscoped_operation(self):
+        """Unscoped callers never name the field, so a wrong mapping cannot mismatch for them."""
+        db = gated_db(mapping_for(TEST_INDEX_NAME, "text"))
+
+        assert db._require_owner_field(None) is False
+
+    def test_an_absent_field_is_the_shared_bucket_not_a_refusal(self):
+        """The documented pre-v3 contract: no owners stored, so every document reads as shared."""
+        db = gated_db(mapping_for(TEST_INDEX_NAME, None))
+
+        assert db._require_owner_field("alice") is True
+
+    def test_an_alias_is_judged_by_every_index_it_resolves_to(self):
+        """get_mapping keys by concrete index, so the alias name is absent from its own response."""
+        db = gated_db(
+            {
+                "concrete-good": {"mappings": {"properties": {"user_id": {"type": "keyword"}}}},
+                "concrete-bad": {"mappings": {"properties": {"user_id": {"type": "text"}}}},
+            }
+        )
+
+        with pytest.raises(ValueError, match="recreate the index"):
+            db._require_owner_field("alice")
+
+    def test_an_alias_resolving_only_to_exact_indexes_is_honoured(self):
+        db = gated_db(
+            {
+                "concrete-a": {"mappings": {"properties": {"user_id": {"type": "keyword"}}}},
+                "concrete-b": {"mappings": {"properties": {"user_id": {"type": "keyword"}}}},
+            }
+        )
+
+        assert db._require_owner_field("alice") is True
+        # An alias can be repointed while the process lives, so its verdict is never cached.
+        assert db._owner_field_exact is None
+
+    def test_an_unreadable_mapping_does_not_refuse_and_is_not_cached(self):
+        """A blip must not permanently mask a real legacy index, so it is re-inspected next time."""
+        db = gated_db(None)
+        db._client.indices.get_mapping.side_effect = RuntimeError("cluster unreachable")
+
+        assert db._require_owner_field("alice") is True
+        assert db._owner_field_exact is None
+
+    def test_an_exact_mapping_is_inspected_once(self):
+        db = gated_db(mapping_for(TEST_INDEX_NAME, "keyword"))
+
+        for _ in range(3):
+            db._require_owner_field("alice")
+
+        assert db._client.indices.get_mapping.call_count == 1
+
+    def test_create_records_the_mapping_it_just_wrote(self):
+        db = OpenSearch(index_name=TEST_INDEX_NAME, dimension=TEST_DIMENSION, embedder=DeterministicEmbedder())
+        db._client = Mock()
+        db._client.indices.exists.return_value = False
+
+        db.create()
+
+        assert db._require_owner_field("alice") is True
+        assert db._client.indices.get_mapping.call_count == 0
+
+    def test_drop_forgets_the_mapping_of_the_index_it_removed(self):
+        db = OpenSearch(index_name=TEST_INDEX_NAME, dimension=TEST_DIMENSION, embedder=DeterministicEmbedder())
+        db._client = Mock()
+        db._client.indices.exists.return_value = True
+        db._owner_field_exact = True
+
+        db.drop()
+
+        assert db._owner_field_exact is None
+
+    @pytest.mark.parametrize(
+        "operation",
+        [
+            lambda db: db.search("q", user_id="alice"),
+            lambda db: db.vector_search("q", user_id="alice"),
+            lambda db: db.keyword_search("q", user_id="alice"),
+            lambda db: db.hybrid_search("q", user_id="alice"),
+            lambda db: db.insert("h", [doc("alice", ALICE)], user_id="alice"),
+            lambda db: db.upsert("h", [doc("alice", ALICE)], user_id="alice"),
+            lambda db: db.content_hash_exists("h", user_id="alice"),
+            lambda db: db.delete_by_content_id("cid", user_id="alice"),
+        ],
+    )
+    def test_every_scoped_entry_point_is_gated(self, operation):
+        db = gated_db(mapping_for(TEST_INDEX_NAME, "text"))
+
+        with pytest.raises(ValueError, match="recreate the index"):
+            operation(db)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "operation",
+        [
+            lambda db: db.async_search("q", user_id="alice"),
+            lambda db: db.async_insert("h", [doc("alice", ALICE)], user_id="alice"),
+            lambda db: db.async_upsert("h", [doc("alice", ALICE)], user_id="alice"),
+        ],
+    )
+    async def test_every_scoped_async_entry_point_is_gated(self, operation):
+        db = gated_db(mapping_for(TEST_INDEX_NAME, "text"))
+
+        with pytest.raises(ValueError, match="recreate the index"):
+            await operation(db)

--- a/libs/agno/tests/unit/vectordb/test_vdb_legacy_schema_fallback.py
+++ b/libs/agno/tests/unit/vectordb/test_vdb_legacy_schema_fallback.py
@@ -87,6 +87,16 @@ def _make_weaviate():
     return db, "_user_id_property_exists", db._require_owner_property
 
 
+def _make_opensearch():
+    pytest.importorskip("opensearchpy")
+    from agno.vectordb.opensearch import OpenSearch
+
+    db = OpenSearch(index_name="t", dimension=DIM, embedder=StubEmbedder())
+    # The gate inspects the live mapping, so the client must never reach a real cluster.
+    db._client = MagicMock()
+    return db, "_owner_field_is_exact", db._require_owner_field
+
+
 BACKENDS = {
     "pgvector": _make_pgvector,
     "clickhouse": _make_clickhouse,
@@ -94,6 +104,7 @@ BACKENDS = {
     "lancedb": _make_lancedb,
     "redis": _make_redis,
     "weaviate": _make_weaviate,
+    "opensearch": _make_opensearch,
 }
 
 


### PR DESCRIPTION
## Summary

OpenSearch was the only vector-db backend with no pre-v3 gate. On an index created before the owner field existed, a scoped search silently matched other tenants.

The adapter declares the owner field as `keyword` so `{"term": {"user_id": X}}` matches the id exactly — its own comment says *"keyword rather than text so the scope filter matches the id exactly instead of its analyzed tokens"*. An index created before that field existed never received the mapping, so OpenSearch dynamic-maps the first scoped write as analyzed `text`, and the term filter then matches tokens rather than the id. Reproduced on a real cluster:

```
mapping OpenSearch inferred for user_id: {'type': 'text', ...}
term query for user_id='dave' matched: ['Dave', 'dave', 'dave smith']
```

Three tenants, one query. Field types are immutable in OpenSearch, so such an index has to be recreated — which is exactly what the error says.

`_validate_user_id` is already called by all 10 scoped entry points (`search`, `vector_search`, `keyword_search`, `hybrid_search`, `insert`, `upsert`, `content_hash_exists`, `delete_by_content_id`, and the async variants that delegate through them), so the check goes there and covers every path at once.

### It refuses only on positive evidence

| live index state | scoped operations | why |
|---|---|---|
| `user_id` mapped as `keyword` | work | correct mapping |
| `user_id` mapped as anything else | **refuse** | the filter would match other owners |
| `user_id` absent from the mapping | work | no owners stored; documents read as the shared bucket |
| mapping unreadable / index missing | work, uncached | a blip must not permanently mask a real legacy index |

The third row is the documented contract in `TestLegacyIndexCompatibility` — *"An index created before this field existed has to keep working"* — where a document with no owner **is** the shared bucket. An earlier version of this change refused any legacy index and failed 48 tests; those tests were right.

Only an answer about a field that is actually present is cached. Both create impls set the cache, both drop impls clear it.

### Sibling parity

Every other backend already gates this way; OpenSearch was the gap.

| adapter | gate references |
|---|---|
| weaviate | 27 |
| pgvector | 26 |
| singlestore | 24 |
| clickhouse | 22 |
| lancedb | 20 |
| redis | 18 |
| **opensearch (before)** | **0** |

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Depends on the `Knowledge.search` re-raise from #9526**, which is already merged into this base. Without it, `Knowledge.search`/`asearch` catch `Exception` and return `[]`, so the gate raises a precise error that never reaches the caller and the agent sees an empty knowledge base instead. Verified on a branch built before that merge: the tool result was the literal string `"No documents found"` in all 12 dispatch modes. After rebasing onto the merged base, both `Knowledge.search` and `asearch` propagate the error, and `user_id=None` (the admin view) is unaffected.

**Verification.** A real `agent_os.serve()` on 13 HTTP probes with a real embedder (`text-embedding-3-small`) and a real model, across agent and team, sync and async, streaming and non-streaming: zero cross-owner leaks in all 12 cells (`alice -> ['alice-doc','shared-doc']`, `bob -> ['bob-doc','shared-doc']`, team member delegation correctly scoped). At the parent commit the same scoped search as `dave` returned `Dave`'s and `dave smith`'s documents. Streaming behaves identically to non-streaming — normal SSE, no error event, stream never dies. No mapping is ever written by the adapter: `indices.get_mapping` is byte-identical before and after a full agent run against both a clean legacy and a poisoned index. `1145 passed, 4 skipped` on `unit/vectordb`.

**Not addressed here.**

- A *clean* legacy index still accepts a scoped write, and that write is what creates the wrong mapping. The gate then refuses every read afterwards, which is correct but late. Closing it means refusing scoped writes on legacy indexes, which contradicts `test_the_index_mapping_is_never_written_to` and the neighbouring compatibility tests — a product decision rather than a bug fix.
- `create()` caching a positive answer can go stale if another process drops and recreates the index as legacy. This matches what the sibling adapters do after their own `create()`.
- Pre-existing and not caused by this change: scoped **vector** and **hybrid** search against a clean legacy index fail on a real cluster with `RequestError(400, 'search_phase_execution_exception', 'failed to create query: Rewrite first')` — on the Lucene knn engine (the adapter default) any filter on a field absent from the mapping triggers it, and the result is swallowed to `[]`. Identical at the parent commit. Worth knowing that `test_documents_without_the_field_read_as_shared` passes only because its fixture is an in-memory fake client, so the legacy contract it encodes does not hold on a real cluster for the default search type.
- Only OpenSearch 2.11.0 with the lucene engine was exercised; the `nmslib` path (`supports_knn_filter=False`, different query shape) and `faiss` are untested.
