### PR TITLE
fix: propagate workflow ID to nested executors

### DIFF
--- a/cookbook/05_agent_os/09_serving_workflows/nested_workflow_run_persistence.py
+++ b/cookbook/05_agent_os/09_serving_workflows/nested_workflow_run_persistence.py
@@ -1,0 +1,130 @@
+"""
+Reproduce Nested Workflow Run Persistence
+=========================================
+
+Serve a database-backed Workflow whose final Agent and Team executors are
+inside a Steps container. This reproduces the regression where nested
+executors do not receive the Workflow ID and persist as standalone runs.
+
+Before the fix, repeated Studio runs may show nested Agent/Team outputs as
+separate top-level messages, or persisted history may contain only the nested
+executor runs instead of the Workflow run. After the fix, each submission
+should persist and render as one Workflow run with embedded executor runs.
+
+Prerequisites: OPENAI_API_KEY
+Run: .venvs/demo/bin/python cookbook/05_agent_os/09_serving_workflows/nested_workflow_run_persistence.py
+
+Then connect Studio to http://localhost:7777, select
+``nested-workflow-run-persistence``, send the same prompt several times, and
+reload the session after each run.
+"""
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIResponses
+from agno.os import AgentOS
+from agno.team import Team
+from agno.workflow import Step, Steps, Workflow
+
+# ---------------------------------------------------------------------------
+# Create Served Workflow
+# ---------------------------------------------------------------------------
+
+WORKFLOW_ID = "nested-workflow-run-persistence"
+
+db = SqliteDb(
+    id="nested-workflow-run-persistence-db",
+    db_file="tmp/nested_workflow_run_persistence.db",
+)
+
+research_agent = Agent(
+    id="nested-workflow-researcher",
+    name="Nested Workflow Researcher",
+    role="Collect the key facts for a topic",
+    model=OpenAIResponses(id="gpt-5.5"),
+    db=db,
+    instructions="Collect the key facts for the topic in a concise brief.",
+)
+
+draft_agent = Agent(
+    id="nested-workflow-drafter",
+    name="Nested Workflow Drafter",
+    role="Turn research notes into a short draft",
+    model=OpenAIResponses(id="gpt-5.5"),
+    db=db,
+    instructions="Turn the preceding research into a concise draft.",
+)
+
+fact_checker = Agent(
+    id="nested-workflow-fact-checker",
+    name="Nested Workflow Fact Checker",
+    role="Check the draft for factual consistency",
+    model=OpenAIResponses(id="gpt-5.5"),
+    db=db,
+    instructions="Check the preceding draft and identify factual issues.",
+)
+
+editor = Agent(
+    id="nested-workflow-editor",
+    name="Nested Workflow Editor",
+    role="Produce the final reviewed response",
+    model=OpenAIResponses(id="gpt-5.5"),
+    db=db,
+    instructions="Return a concise final response incorporating the review.",
+)
+
+review_team = Team(
+    id="nested-workflow-review-team",
+    name="Nested Workflow Review Team",
+    members=[fact_checker, editor],
+    model=OpenAIResponses(id="gpt-5.5"),
+    db=db,
+    instructions="Review the draft and return one polished final response.",
+)
+
+nested_workflow = Workflow(
+    id=WORKFLOW_ID,
+    name="Nested Workflow Run Persistence",
+    description="Reproduce persistence behavior for nested Agent and Team steps",
+    db=db,
+    steps=[
+        Step(
+            name="Initial Research",
+            agent=research_agent,
+            description="Collect the initial facts for the topic",
+        ),
+        Steps(
+            name="Nested Draft and Review",
+            steps=[
+                Step(
+                    name="Draft Response",
+                    agent=draft_agent,
+                    description="Draft a response from the initial research",
+                ),
+                Step(
+                    name="Review Response",
+                    team=review_team,
+                    description="Review and improve the drafted response",
+                ),
+            ],
+        ),
+    ],
+)
+
+agent_os = AgentOS(
+    id="nested-workflow-run-persistence-os",
+    description="AgentOS reproduction for nested Workflow run persistence.",
+    agents=[research_agent, draft_agent],
+    teams=[review_team],
+    workflows=[nested_workflow],
+    db=db,
+)
+app = agent_os.get_app()
+
+# ---------------------------------------------------------------------------
+# Run Workflow Server
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    print("Nested workflow persistence AgentOS on http://localhost:7777")
+    agent_os.serve(app=app, port=7777)

--- a/libs/agno/agno/team/_init.py
+++ b/libs/agno/agno/team/_init.py
@@ -487,6 +487,9 @@ def _set_telemetry(team: "Team") -> None:
 def _initialize_member(team: "Team", member: Union["Team", Agent], debug_mode: Optional[bool] = None) -> None:
     from agno.team.team import Team
 
+    if team.workflow_id is not None:
+        member.workflow_id = team.workflow_id
+
     # Set debug mode for all members
     if debug_mode:
         member.debug_mode = True

--- a/libs/agno/agno/workflow/step.py
+++ b/libs/agno/agno/workflow/step.py
@@ -106,6 +106,17 @@ def _is_team_instance(candidate: Any) -> bool:
     return isinstance(candidate, Team)
 
 
+def _set_workflow_id_on_executor(executor: Any, workflow_id: Optional[str]) -> None:
+    """Mark an Agent or Team tree as belonging to a workflow."""
+    if workflow_id is None or not isinstance(executor, (Agent, Team)):
+        return
+
+    executor.workflow_id = workflow_id
+    if isinstance(executor, Team) and isinstance(executor.members, list):
+        for member in executor.members:
+            _set_workflow_id_on_executor(member, workflow_id)
+
+
 class UnresolvableCallableError(RuntimeError):
     """Raised when a lenient-load placeholder for an unresolved callable executes.
 
@@ -959,6 +970,16 @@ class Step:
         else:
             raise ValueError("No executor configured")
 
+    def _set_active_executor_workflow_id(
+        self,
+        workflow_run_response: Optional["WorkflowRunOutput"],
+        run_context: Optional[RunContext],
+    ) -> None:
+        workflow_id = getattr(workflow_run_response, "workflow_id", None) or getattr(
+            run_context, "workflow_id", None
+        )
+        _set_workflow_id_on_executor(self.active_executor, workflow_id)
+
     def _extract_metrics_from_response(self, response: Union[RunOutput, TeamRunOutput]) -> Optional[RunMetrics]:
         """Extract metrics from agent or team response"""
         if hasattr(response, "metrics") and response.metrics:
@@ -1022,6 +1043,7 @@ class Step:
     ) -> StepOutput:
         """Execute the step with StepInput, returning final StepOutput (non-streaming)"""
         log_debug(f"Executing step: {self.name}")
+        self._set_active_executor_workflow_id(workflow_run_response, run_context)
 
         if step_input.previous_step_outputs:
             step_input.previous_step_content = step_input.get_last_step_content()
@@ -1349,6 +1371,7 @@ class Step:
         add_session_state_to_context: Optional[bool] = None,
     ) -> Iterator[Union[WorkflowRunOutputEvent, StepOutput]]:
         """Execute the step with event-driven streaming support"""
+        self._set_active_executor_workflow_id(workflow_run_response, run_context)
 
         if step_input.previous_step_outputs:
             step_input.previous_step_content = step_input.get_last_step_content()
@@ -1674,6 +1697,7 @@ class Step:
         """Execute the step with StepInput, returning final StepOutput (non-streaming)"""
         logger.info(f"Executing async step (non-streaming): {self.name}")
         log_debug(f"Executor type: {self._executor_type}")
+        self._set_active_executor_workflow_id(workflow_run_response, run_context)
 
         if step_input.previous_step_outputs:
             step_input.previous_step_content = step_input.get_last_step_content()
@@ -1961,6 +1985,7 @@ class Step:
         add_session_state_to_context: Optional[bool] = None,
     ) -> AsyncIterator[Union[WorkflowRunOutputEvent, StepOutput]]:
         """Execute the step with event-driven streaming support"""
+        self._set_active_executor_workflow_id(workflow_run_response, run_context)
 
         if step_input.previous_step_outputs:
             step_input.previous_step_content = step_input.get_last_step_content()

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -119,7 +119,7 @@ from agno.workflow.condition import Condition
 from agno.workflow.loop import Loop
 from agno.workflow.parallel import Parallel
 from agno.workflow.router import Router
-from agno.workflow.step import Step, UnresolvableCallableError
+from agno.workflow.step import Step, UnresolvableCallableError, _set_workflow_id_on_executor
 from agno.workflow.steps import Steps
 from agno.workflow.types import (
     StepInput,
@@ -10360,25 +10360,37 @@ class Workflow:
 
         return self._get_session_metrics(session=session)
 
-    def update_agents_and_teams_session_info(self):
-        """Update agents and teams with workflow session information"""
+    def update_agents_and_teams_session_info(self) -> None:
+        """Update agents and teams with workflow session information."""
         log_debug("Updating agents and teams with session information")
-        # Initialize steps - only if steps is iterable (not callable)
+
+        def update_executor(executor: Any) -> None:
+            _set_workflow_id_on_executor(executor, self.id)
+
+        def update_step(step: Any) -> None:
+            if isinstance(step, (Agent, Team)):
+                update_executor(step)
+                return
+
+            if isinstance(step, Step):
+                update_executor(step.active_executor)
+                return
+
+            if isinstance(step, (list, tuple)):
+                for nested_step in step:
+                    update_step(nested_step)
+                return
+
+            if isinstance(step, (Steps, Loop, Parallel, Condition, Router)):
+                for attr_name in ("steps", "else_steps", "choices"):
+                    for nested_step in getattr(step, attr_name, None) or []:
+                        update_step(nested_step)
+
+        # Initialize steps only when they are configured statically.
         if self.steps and not callable(self.steps):
             steps_list = self.steps.steps if isinstance(self.steps, Steps) else self.steps
             for step in steps_list:
-                # TODO: Handle properly steps inside other primitives
-                if isinstance(step, Step):
-                    active_executor = step.active_executor
-
-                    if hasattr(active_executor, "workflow_id"):
-                        active_executor.workflow_id = self.id
-
-                    # If it's a team, update all members
-                    if hasattr(active_executor, "members"):
-                        for member in active_executor.members:  # type: ignore
-                            if hasattr(member, "workflow_id"):
-                                member.workflow_id = self.id
+                update_step(step)
 
     def propagate_run_hooks_in_background(self, run_in_background: bool = True) -> None:
         """

--- a/libs/agno/tests/unit/workflow/test_workflow_executor_propagation.py
+++ b/libs/agno/tests/unit/workflow/test_workflow_executor_propagation.py
@@ -1,0 +1,205 @@
+from unittest.mock import patch
+
+import pytest
+
+from agno.agent.agent import Agent
+from agno.run.agent import RunOutput
+from agno.run.base import RunStatus
+from agno.run.workflow import WorkflowRunOutput
+from agno.team.team import Team
+from agno.workflow.condition import Condition
+from agno.workflow.loop import Loop
+from agno.workflow.parallel import Parallel
+from agno.workflow.router import Router
+from agno.workflow.step import Step
+from agno.workflow.steps import Steps
+from agno.workflow.types import StepInput, StepOutput
+from agno.workflow.workflow import Workflow
+
+
+def test_top_level_agent_receives_workflow_id():
+    agent = Agent(id="top-level-agent")
+    workflow = Workflow(
+        id="top-level-workflow",
+        steps=[Step(name="agent-step", agent=agent)],
+    )
+
+    workflow.update_agents_and_teams_session_info()
+
+    assert agent.workflow_id == workflow.id
+
+
+@pytest.mark.parametrize(
+    "container_factory",
+    [
+        pytest.param(lambda step: Steps(name="steps", steps=[step]), id="steps"),
+        pytest.param(lambda step: Loop(name="loop", steps=[step]), id="loop"),
+        pytest.param(lambda step: Parallel(step, name="parallel"), id="parallel"),
+        pytest.param(lambda step: Condition(name="condition", steps=[step]), id="condition"),
+        pytest.param(
+            lambda step: Condition(name="condition", steps=[], else_steps=[step]),
+            id="condition-else",
+        ),
+        pytest.param(lambda step: Router(name="router", choices=[step]), id="router"),
+    ],
+)
+def test_nested_agent_receives_workflow_id(container_factory):
+    agent = Agent(id="nested-agent")
+    workflow = Workflow(
+        id="studio-workflow",
+        steps=[container_factory(Step(name="inner-step", agent=agent))],
+    )
+
+    workflow.update_agents_and_teams_session_info()
+
+    assert agent.workflow_id == workflow.id
+
+
+def test_bare_agent_in_nested_steps_receives_workflow_id():
+    agent = Agent(id="bare-nested-agent")
+    workflow = Workflow(
+        id="bare-agent-workflow",
+        steps=[Steps(name="steps", steps=[agent])],
+    )
+
+    workflow.update_agents_and_teams_session_info()
+
+    assert agent.workflow_id == workflow.id
+
+
+def test_agent_in_grouped_router_choice_receives_workflow_id():
+    agent = Agent(id="grouped-choice-agent")
+    workflow = Workflow(
+        id="grouped-choice-workflow",
+        steps=[
+            Router(
+                name="router",
+                choices=[[Step(name="grouped-choice-step", agent=agent)]],
+            )
+        ],
+    )
+
+    workflow.update_agents_and_teams_session_info()
+
+    assert agent.workflow_id == workflow.id
+
+
+def test_dynamic_router_step_sets_workflow_id_before_agent_execution():
+    agent = Agent(id="dynamic-agent")
+    dynamic_step = Step(name="dynamic-step", agent=agent)
+    configured_step = Step(name="configured-step", executor=lambda _: StepOutput(content="configured"))
+    router = Router(
+        name="dynamic-router",
+        choices=[configured_step],
+        selector=lambda _: dynamic_step,
+    )
+    workflow_run_response = WorkflowRunOutput(
+        run_id="workflow-run",
+        workflow_id="dynamic-workflow",
+        session_id="workflow-session",
+    )
+
+    def run_agent(**kwargs):
+        assert agent.workflow_id == workflow_run_response.workflow_id
+        return RunOutput(
+            run_id=kwargs["run_id"],
+            agent_id=agent.id,
+            session_id=kwargs.get("session_id"),
+            content="dynamic",
+            status=RunStatus.completed,
+        )
+
+    with patch.object(agent, "run", side_effect=run_agent) as run_agent_mock:
+        result = router.execute(
+            StepInput(input="route dynamically"),
+            session_id=workflow_run_response.session_id,
+            workflow_run_response=workflow_run_response,
+        )
+
+    assert agent.workflow_id == workflow_run_response.workflow_id
+    run_agent_mock.assert_called_once()
+    assert result.steps is not None
+    assert result.steps[0].content == "dynamic"
+    assert workflow_run_response.step_executor_runs is not None
+    assert workflow_run_response.step_executor_runs[0].parent_run_id == workflow_run_response.run_id
+    assert workflow_run_response.step_executor_runs[0].agent_id == agent.id
+
+
+def test_deeply_nested_agent_receives_workflow_id():
+    agent = Agent(id="deeply-nested-agent")
+    nested_steps = Steps(
+        name="steps",
+        steps=[
+            Condition(
+                name="condition",
+                steps=[
+                    Router(
+                        name="router",
+                        choices=[
+                            Loop(
+                                name="loop",
+                                steps=[
+                                    Parallel(
+                                        Step(name="inner-step", agent=agent),
+                                        name="parallel",
+                                    )
+                                ],
+                            )
+                        ],
+                    )
+                ],
+            )
+        ],
+    )
+    workflow = Workflow(id="deep-workflow", steps=[nested_steps])
+
+    workflow.update_agents_and_teams_session_info()
+
+    assert agent.workflow_id == workflow.id
+
+
+def test_nested_team_and_members_receive_workflow_id():
+    member = Agent(id="team-member")
+    nested_member = Agent(id="nested-team-member")
+    nested_team = Team(id="nested-team", members=[nested_member])
+    team = Team(id="team", members=[member, nested_team])
+    workflow = Workflow(
+        id="team-workflow",
+        steps=[Steps(name="steps", steps=[Step(name="team-step", team=team)])],
+    )
+
+    workflow.update_agents_and_teams_session_info()
+
+    assert team.workflow_id == workflow.id
+    assert member.workflow_id == workflow.id
+    assert nested_team.workflow_id == workflow.id
+    assert nested_member.workflow_id == workflow.id
+
+
+def test_bare_team_in_nested_steps_receives_workflow_id():
+    member = Agent(id="bare-team-member")
+    team = Team(id="bare-nested-team", members=[member])
+    workflow = Workflow(
+        id="bare-team-workflow",
+        steps=[Steps(name="steps", steps=[team])],
+    )
+
+    workflow.update_agents_and_teams_session_info()
+
+    assert team.workflow_id == workflow.id
+    assert member.workflow_id == workflow.id
+
+
+def test_callable_team_member_inherits_workflow_id_when_initialized():
+    member = Agent(id="callable-team-member")
+    team = Team(id="callable-team", members=lambda: [member])
+    workflow = Workflow(
+        id="callable-team-workflow",
+        steps=[Steps(name="steps", steps=[Step(name="team-step", team=team)])],
+    )
+
+    workflow.update_agents_and_teams_session_info()
+    team._initialize_member(member)
+
+    assert team.workflow_id == workflow.id
+    assert member.workflow_id == workflow.id


### PR DESCRIPTION
- Propagate `workflow_id` to Agent and Team executors nested inside `Steps`, `Loop`, `Parallel`, `Condition`, and `Router`.
- Propagate workflow ownership through nested and dynamically initialized Team members.
- Set the workflow ID immediately before Step execution to cover dynamically resolved executors.
- Add regression tests for nested, grouped, dynamic, and callable executor configurations.
- Add an AgentOS cookbook reproducing the nested executor persistence issue.

## Why

Nested Agent/Team executors could run without a `workflow_id`, causing them to persist as standalone runs in the workflow session. Depending on save timing, this could replace the persisted Workflow run and cause missing or duplicate outputs in the UI.

## Summary

Describe key changes, mention related issues or motivation for the changes.

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
