### PR TITLE
fix(models): count Anthropic cache tokens in input_tokens and total_tokens

### DIFF
--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -1290,11 +1290,18 @@ class Claude(Model):
         """
         metrics = MessageMetrics()
 
-        metrics.input_tokens = response_usage.input_tokens or 0
-        metrics.output_tokens = response_usage.output_tokens or 0
-        metrics.total_tokens = metrics.input_tokens + metrics.output_tokens
         metrics.cache_read_tokens = response_usage.cache_read_input_tokens or 0
         metrics.cache_write_tokens = response_usage.cache_creation_input_tokens or 0
+        # Anthropic reports input_tokens NET of the cache and bills the two cache counters
+        # separately on top, so the cache has to be added back for input_tokens to mean what
+        # it means everywhere else here. The OpenAI parser sets input_tokens from
+        # prompt_tokens, which already includes the cached tokens, and records
+        # cache_read_tokens as a breakdown of it rather than an addition to it.
+        metrics.input_tokens = (
+            (response_usage.input_tokens or 0) + metrics.cache_read_tokens + metrics.cache_write_tokens
+        )
+        metrics.output_tokens = response_usage.output_tokens or 0
+        metrics.total_tokens = metrics.input_tokens + metrics.output_tokens
 
         # Anthropic-specific additional fields
         if response_usage.server_tool_use:

--- a/libs/agno/agno/models/aws/bedrock.py
+++ b/libs/agno/agno/models/aws/bedrock.py
@@ -840,11 +840,16 @@ class AwsBedrock(Model):
         """
         metrics = MessageMetrics()
 
-        metrics.input_tokens = response_usage.get("inputTokens", 0) or 0
-        metrics.output_tokens = response_usage.get("outputTokens", 0) or 0
-        metrics.total_tokens = metrics.input_tokens + metrics.output_tokens
-
         metrics.cache_read_tokens = response_usage.get("cacheReadInputTokens", 0) or 0
         metrics.cache_write_tokens = response_usage.get("cacheWriteInputTokens", 0) or 0
+
+        # Bedrock passes Anthropic's accounting through: inputTokens is net of the cache and
+        # the two cache counters are billed on top, so they are added back here to match the
+        # gross input_tokens the OpenAI parser produces.
+        metrics.input_tokens = (
+            (response_usage.get("inputTokens", 0) or 0) + metrics.cache_read_tokens + metrics.cache_write_tokens
+        )
+        metrics.output_tokens = response_usage.get("outputTokens", 0) or 0
+        metrics.total_tokens = metrics.input_tokens + metrics.output_tokens
 
         return metrics

--- a/libs/agno/tests/unit/models/anthropic/test_cache_token_metrics.py
+++ b/libs/agno/tests/unit/models/anthropic/test_cache_token_metrics.py
@@ -1,0 +1,85 @@
+"""
+Tests that Anthropic and Bedrock report the same gross input_tokens as every other provider.
+
+Anthropic reports `input_tokens` NET of the prompt cache and bills
+`cache_read_input_tokens` and `cache_creation_input_tokens` separately on top of it.
+OpenAI reports `prompt_tokens` INCLUSIVE of the cache and exposes `cached_tokens` as a
+breakdown of it.
+
+So the same MessageMetrics field carried two different meanings depending on the provider,
+and `total_tokens`, which every parser except OpenAI's derives as input + output, silently
+excluded the cache on Anthropic and Bedrock. BaseMetrics.accumulate sums total_tokens across
+models, so a session using both providers added two different definitions together.
+
+Verifies that:
+- input_tokens is gross, so the cache read and cache write are inside it.
+- total_tokens equals input_tokens + output_tokens and covers everything billed.
+- cache_read_tokens and cache_write_tokens still report the breakdown.
+- Calls with no cache are completely unchanged.
+"""
+
+import importlib
+import types
+
+import pytest
+
+from agno.models.anthropic.claude import Claude
+
+_has_boto3 = importlib.util.find_spec("boto3") is not None
+_skip_boto3 = pytest.mark.skipif(not _has_boto3, reason="boto3 not installed")
+
+
+def _usage(input_tokens, output_tokens, cache_read=0, cache_write=0):
+    """A minimal stand-in for an Anthropic Usage object."""
+    return types.SimpleNamespace(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_read_input_tokens=cache_read,
+        cache_creation_input_tokens=cache_write,
+        server_tool_use=None,
+    )
+
+
+def test_cached_call_reports_every_billed_token():
+    metrics = Claude(id="claude-sonnet-4-6")._get_metrics(
+        _usage(input_tokens=10, output_tokens=5, cache_read=1000, cache_write=200)
+    )
+
+    # 10 uncached + 1000 read from cache + 200 written to cache
+    assert metrics.input_tokens == 1210
+    assert metrics.output_tokens == 5
+    assert metrics.total_tokens == 1215
+    assert metrics.total_tokens == metrics.input_tokens + metrics.output_tokens
+
+    # The breakdown is still reported, now as a subset of input_tokens rather than
+    # an addition to it, which is how the OpenAI parser already treats it.
+    assert metrics.cache_read_tokens == 1000
+    assert metrics.cache_write_tokens == 200
+
+
+def test_uncached_call_is_unchanged():
+    metrics = Claude(id="claude-sonnet-4-6")._get_metrics(_usage(input_tokens=10, output_tokens=5))
+
+    assert metrics.input_tokens == 10
+    assert metrics.total_tokens == 15
+    assert metrics.cache_read_tokens == 0
+    assert metrics.cache_write_tokens == 0
+
+
+@_skip_boto3
+def test_bedrock_matches_anthropic():
+    """Bedrock passes Anthropic's accounting through and carried the same defect."""
+    from agno.models.aws.bedrock import AwsBedrock
+
+    metrics = AwsBedrock(id="anthropic.claude-sonnet-4-6-v1:0")._get_metrics(
+        {
+            "inputTokens": 10,
+            "outputTokens": 5,
+            "cacheReadInputTokens": 1000,
+            "cacheWriteInputTokens": 200,
+        }
+    )
+
+    assert metrics.input_tokens == 1210
+    assert metrics.total_tokens == 1215
+    assert metrics.total_tokens == metrics.input_tokens + metrics.output_tokens


### PR DESCRIPTION
Fixes #9538

### The defect

`MessageMetrics.input_tokens` means two different things depending on which parser filled it.

**`models/openai/chat.py`**: `prompt_tokens` already includes the cached tokens, and `cache_read_tokens` is recorded as a breakdown of it:

```python
metrics.input_tokens = response_usage.prompt_tokens or 0
metrics.total_tokens = response_usage.total_tokens or 0
metrics.cache_read_tokens = prompt_token_details.cached_tokens or 0
```

**`models/anthropic/claude.py`**, Anthropic reports `input_tokens` NET of the cache and bills the two cache counters on top of it:

```python
metrics.input_tokens = response_usage.input_tokens or 0
metrics.output_tokens = response_usage.output_tokens or 0
metrics.total_tokens = metrics.input_tokens + metrics.output_tokens
metrics.cache_read_tokens = response_usage.cache_read_input_tokens or 0
metrics.cache_write_tokens = response_usage.cache_creation_input_tokens or 0
```

The counters are read two lines below the total, so the numbers are already there. Only the aggregate is wrong.

Against `main`, on a call with 10 uncached input, 1000 cache-read, 200 cache-write and 5 output tokens:

```
input=10 output=5 total=15
cache_read=1000 cache_write=200
billed tokens 1215, reported total 15 -> 1.2%
```

`models/aws/bedrock.py` passes Anthropic's accounting through and has the same shape.

### Why it spreads

`BaseMetrics.accumulate` sums `total_tokens` across models:

```python
self.total_tokens += other.total_tokens or 0
```

So a session that uses both OpenAI and Anthropic adds two different definitions of the same field together. In an agent loop the system prompt and accumulated history are re-read from cache on every step, so the cache read quickly becomes most of the input and the Anthropic share of that sum drifts further from the truth the longer the run goes.

### The change

Add the cache read and cache write back into `input_tokens` in both parsers. That makes it gross, matching OpenAI, and leaves `cache_read_tokens` and `cache_write_tokens` as the breakdown rather than an addition. `total_tokens = input + output` is then correct without changing the formula the other parsers use.

**Calls with no cache are unchanged**, so this only moves numbers that were already wrong.

### Tests

`libs/agno/tests/unit/models/anthropic/test_cache_token_metrics.py`:

- the cached call on Claude, asserting gross `input_tokens` of 1210 and `total_tokens` of 1215
- the same on Bedrock, skipped when boto3 is absent
- an uncached call pinned at 10 and 15, so the no-cache path is demonstrably untouched

The first two fail on `main`; the uncached one passes on both.

### Note

I have deliberately not touched `models/google/gemini.py`, which uses the same `input + output` formula. Google reports `prompt_token_count` inclusive of cached content, so that file is already correct and adding the cache there would double count.


