### PR TITLE
fix(models): don't yield empty stream chunks on default tool_calls list

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -1969,7 +1969,10 @@ class Model(ABC):
                     stream_data.response_provider_data[key] = value
 
         # Update stream_data tool calls
-        if model_response_delta.tool_calls is not None:
+        # `tool_calls` defaults to an empty list (field(default_factory=list)), so an
+        # `is not None` check is always true and would flip `should_yield` on every
+        # empty metadata chunk. Guard on non-empty content instead.
+        if model_response_delta.tool_calls:
             if stream_data.response_tool_calls is None:
                 stream_data.response_tool_calls = []
             stream_data.response_tool_calls.extend(model_response_delta.tool_calls)

--- a/libs/agno/tests/unit/models/base/test_populate_stream_data.py
+++ b/libs/agno/tests/unit/models/base/test_populate_stream_data.py
@@ -1,0 +1,45 @@
+"""
+Regression test for #9490.
+
+`ModelResponse.tool_calls` defaults to an empty list (field(default_factory=list)),
+never None. `_populate_stream_data` guarded it with `is not None`, which is always
+true, so `should_yield` was flipped to True on empty metadata chunks (e.g.
+content_block_start), yielding zero-payload events up the stack.
+"""
+
+from agno.models.base import MessageData, Model
+from agno.models.response import ModelResponse
+
+
+def _drain(delta: ModelResponse):
+    """Call the unbound method (it only uses self as a bound handle) and return yielded deltas."""
+    stream_data = MessageData()
+    return list(Model._populate_stream_data(object(), stream_data, delta)), stream_data
+
+
+def test_empty_delta_does_not_yield():
+    # An empty metadata chunk: no content, no tool calls (tool_calls defaults to []).
+    yielded, _ = _drain(ModelResponse())
+    assert yielded == [], "empty delta must not yield a zero-payload event"
+
+
+def test_delta_with_empty_tool_calls_list_does_not_yield():
+    delta = ModelResponse(tool_calls=[])
+    yielded, stream_data = _drain(delta)
+    assert yielded == [], "an empty tool_calls list must not trigger a yield"
+    # Nothing was accumulated (stays at the default empty list).
+    assert stream_data.response_tool_calls == []
+
+
+def test_delta_with_real_tool_call_yields():
+    delta = ModelResponse(tool_calls=[{"id": "1", "function": {"name": "f", "arguments": "{}"}}])
+    yielded, stream_data = _drain(delta)
+    assert len(yielded) == 1, "a non-empty tool_calls delta must yield"
+    assert stream_data.response_tool_calls == delta.tool_calls
+
+
+def test_delta_with_content_yields():
+    delta = ModelResponse(content="hello")
+    yielded, stream_data = _drain(delta)
+    assert len(yielded) == 1
+    assert stream_data.response_content == "hello"


### PR DESCRIPTION
## Summary

Fixes #9490.

`ModelResponse.tool_calls` is declared `tool_calls: List[Dict[str, Any]] = field(default_factory=list)` — it defaults to an empty list and is never `None`. In `Model._populate_stream_data` (`libs/agno/agno/models/base.py`), the stream-delta accumulator guarded it with:

```python
if model_response_delta.tool_calls is not None:
    ...
    should_yield = True
```

Because `[] is not None` is `True`, `should_yield` was flipped to `True` on **every** delta — including empty metadata chunks such as `content_block_start` that carry no content and no tool calls. That emits zero-payload events up the stack.

The fix guards on non-empty content (`if model_response_delta.tool_calls:`), matching the truthiness intent of the surrounding checks. `Message.tool_calls` (the other `is not None` sites in this file) genuinely defaults to `None`, so those are left unchanged.

## Type of change

- [x] Bug fix

## Verification

Added `tests/unit/models/base/test_populate_stream_data.py`:

- empty delta → no yield
- delta with an empty `tool_calls` list → no yield, nothing accumulated
- delta with a real tool call → yields, accumulates
- delta with content → yields

The two empty-delta tests fail on `main` and pass with this change; the existing `tests/unit/models/anthropic/test_streaming_metrics.py` still passes.

## Additional Notes

Authored and tested locally by @jaideeppyne. Drafted with AI assistance and reviewed by a human before submission.
