### PR TITLE
feat: move dynamic context (datetime/location) from system message to trailing message

### DIFF
--- a/libs/agno/agno/agent/_messages.py
+++ b/libs/agno/agno/agent/_messages.py
@@ -217,49 +217,8 @@ def get_system_message(
     # 3.2.1 Add instructions for using markdown
     if agent.markdown and output_schema is None:
         additional_information.append("Use markdown to format your answers.")
-    # 3.2.2 Add the current datetime
-    if agent.add_datetime_to_context:
-        from datetime import datetime
 
-        tz = None
-
-        if agent.timezone_identifier:
-            try:
-                from zoneinfo import ZoneInfo
-
-                tz = ZoneInfo(agent.timezone_identifier)
-            except Exception as e:
-                log_warning(f"Invalid timezone identifier: {str(e)}")
-
-        time = datetime.now(tz) if tz else datetime.now()
-
-        if agent.datetime_format:
-            formatted_time = time.strftime(agent.datetime_format)
-        else:
-            formatted_time = str(time)
-
-        additional_information.append(f"The current time is {formatted_time}.")
-
-    # 3.2.3 Add the current location
-    if agent.add_location_to_context:
-        from agno.utils.location import get_location
-
-        location = get_location()
-        if location:
-            location_str = ", ".join(
-                filter(
-                    None,
-                    [
-                        location.get("city"),
-                        location.get("region"),
-                        location.get("country"),
-                    ],
-                )
-            )
-            if location_str:
-                additional_information.append(f"Your approximate location is: {location_str}.")
-
-    # 3.2.4 Add agent name if provided
+    # 3.2.2 Add agent name if provided
     if agent.name is not None and agent.add_name_to_context:
         additional_information.append(f"Your name is: {agent.name}.")
     # Tell the model what a result envelope is and how to read the rest
@@ -514,49 +473,8 @@ async def aget_system_message(
     # 3.2.1 Add instructions for using markdown
     if agent.markdown and output_schema is None:
         additional_information.append("Use markdown to format your answers.")
-    # 3.2.2 Add the current datetime
-    if agent.add_datetime_to_context:
-        from datetime import datetime
 
-        tz = None
-
-        if agent.timezone_identifier:
-            try:
-                from zoneinfo import ZoneInfo
-
-                tz = ZoneInfo(agent.timezone_identifier)
-            except Exception as e:
-                log_warning(f"Invalid timezone identifier: {str(e)}")
-
-        time = datetime.now(tz) if tz else datetime.now()
-
-        if agent.datetime_format:
-            formatted_time = time.strftime(agent.datetime_format)
-        else:
-            formatted_time = str(time)
-
-        additional_information.append(f"The current time is {formatted_time}.")
-
-    # 3.2.3 Add the current location
-    if agent.add_location_to_context:
-        from agno.utils.location import get_location
-
-        location = get_location()
-        if location:
-            location_str = ", ".join(
-                filter(
-                    None,
-                    [
-                        location.get("city"),
-                        location.get("region"),
-                        location.get("country"),
-                    ],
-                )
-            )
-            if location_str:
-                additional_information.append(f"Your approximate location is: {location_str}.")
-
-    # 3.2.4 Add agent name if provided
+    # 3.2.2 Add agent name if provided
     if agent.name is not None and agent.add_name_to_context:
         additional_information.append(f"Your name is: {agent.name}.")
     # Tell the model what a result envelope is and how to read the rest
@@ -1088,6 +1006,62 @@ def _resolve_media_storage(agent: Agent) -> Optional[Any]:
     return agent.media_storage or getattr(getattr(agent, "_team", None), "media_storage", None)
 
 
+def _get_dynamic_context_message(agent: "Agent") -> Optional[Message]:
+    """Build a message containing per-turn dynamic context (datetime, location).
+
+    Appended near the end of the messages list (after history, before the user
+    message) rather than embedded in the system message, so that:
+    - It works regardless of whether a custom system_message is set.
+    - The system message stays byte-identical across requests, preserving
+      prompt cache hits.
+    """
+    parts: List[str] = []
+
+    if agent.add_datetime_to_context:
+        from datetime import datetime
+
+        tz = None
+        if agent.timezone_identifier:
+            try:
+                from zoneinfo import ZoneInfo
+
+                tz = ZoneInfo(agent.timezone_identifier)
+            except Exception as e:
+                log_warning(f"Invalid timezone identifier: {str(e)}")
+
+        time = datetime.now(tz) if tz else datetime.now()
+
+        if agent.datetime_format:
+            formatted_time = time.strftime(agent.datetime_format)
+        else:
+            formatted_time = str(time)
+
+        parts.append(f"The current time is {formatted_time}.")
+
+    if agent.add_location_to_context:
+        from agno.utils.location import get_location
+
+        location = get_location()
+        if location:
+            location_str = ", ".join(
+                filter(
+                    None,
+                    [
+                        location.get("city"),
+                        location.get("region"),
+                        location.get("country"),
+                    ],
+                )
+            )
+            if location_str:
+                parts.append(f"Your approximate location is: {location_str}.")
+
+    if not parts:
+        return None
+
+    return Message(role="system", content="\n".join(parts))
+
+
 def get_run_messages(
     agent: Agent,
     *,
@@ -1199,6 +1173,13 @@ def get_run_messages(
             log_debug(f"Adding {len(history_copy)} messages from history")
 
             run_messages.messages += history_copy
+
+    # 3.5 Add per-turn dynamic context (datetime, location) as a trailing message.
+    # Placed after history and before the user message so the system message and
+    # history stay byte-identical across requests, preserving prompt cache hits.
+    dynamic_context_message = _get_dynamic_context_message(agent)
+    if dynamic_context_message is not None:
+        run_messages.messages.append(dynamic_context_message)
 
     # 4. Add user message to run_messages
     user_message: Optional[Message] = None
@@ -1405,6 +1386,13 @@ async def aget_run_messages(
             log_debug(f"Adding {len(history_copy)} messages from history")
 
             run_messages.messages += history_copy
+
+    # 3.5 Add per-turn dynamic context (datetime, location) as a trailing message.
+    # Placed after history and before the user message so the system message and
+    # history stay byte-identical across requests, preserving prompt cache hits.
+    dynamic_context_message = _get_dynamic_context_message(agent)
+    if dynamic_context_message is not None:
+        run_messages.messages.append(dynamic_context_message)
 
     # 4. Add user message to run_messages
     user_message: Optional[Message] = None

--- a/libs/agno/agno/agent/_messages.py
+++ b/libs/agno/agno/agent/_messages.py
@@ -1059,7 +1059,10 @@ def _get_dynamic_context_message(agent: "Agent") -> Optional[Message]:
     if not parts:
         return None
 
-    return Message(role="system", content="\n".join(parts))
+    # Use role="user" so adapters that extract system messages (Gemini, Bedrock)
+    # don't overwrite the primary system prompt. Skip persistence so stale
+    # per-turn values don't leak into subsequent runs via history.
+    return Message(role="user", content="\n".join(parts), add_to_agent_memory=False)
 
 
 def get_run_messages(

--- a/libs/agno/agno/team/_messages.py
+++ b/libs/agno/agno/team/_messages.py
@@ -510,42 +510,8 @@ def get_system_message(
     # 1.3.1 Add instructions for using markdown
     if team.markdown and output_schema is None:
         additional_information.append("Use markdown to format your answers.")
-    # 1.3.2 Add the current datetime
-    if team.add_datetime_to_context:
-        from datetime import datetime
 
-        tz = None
-
-        if team.timezone_identifier:
-            try:
-                from zoneinfo import ZoneInfo
-
-                tz = ZoneInfo(team.timezone_identifier)
-            except Exception as e:
-                log_warning(f"Invalid timezone identifier: {str(e)}")
-
-        time = datetime.now(tz) if tz else datetime.now()
-
-        if team.datetime_format:
-            formatted_time = time.strftime(team.datetime_format)
-        else:
-            formatted_time = str(time)
-
-        additional_information.append(f"The current time is {formatted_time}.")
-
-    # 1.3.3 Add the current location
-    if team.add_location_to_context:
-        from agno.utils.location import get_location
-
-        location = get_location()
-        if location:
-            location_str = ", ".join(
-                filter(None, [location.get("city"), location.get("region"), location.get("country")])
-            )
-            if location_str:
-                additional_information.append(f"Your approximate location is: {location_str}.")
-
-    # 1.3.4 Add team name if provided
+    # 1.3.2 Add team name if provided
     if team.name is not None and team.add_name_to_context:
         additional_information.append(f"Your name is: {team.name}.")
 
@@ -764,42 +730,8 @@ async def aget_system_message(
     # 1.3.1 Add instructions for using markdown
     if team.markdown and output_schema is None:
         additional_information.append("Use markdown to format your answers.")
-    # 1.3.2 Add the current datetime
-    if team.add_datetime_to_context:
-        from datetime import datetime
 
-        tz = None
-
-        if team.timezone_identifier:
-            try:
-                from zoneinfo import ZoneInfo
-
-                tz = ZoneInfo(team.timezone_identifier)
-            except Exception as e:
-                log_warning(f"Invalid timezone identifier: {str(e)}")
-
-        time = datetime.now(tz) if tz else datetime.now()
-
-        if team.datetime_format:
-            formatted_time = time.strftime(team.datetime_format)
-        else:
-            formatted_time = str(time)
-
-        additional_information.append(f"The current time is {formatted_time}.")
-
-    # 1.3.3 Add the current location
-    if team.add_location_to_context:
-        from agno.utils.location import get_location
-
-        location = get_location()
-        if location:
-            location_str = ", ".join(
-                filter(None, [location.get("city"), location.get("region"), location.get("country")])
-            )
-            if location_str:
-                additional_information.append(f"Your approximate location is: {location_str}.")
-
-    # 1.3.4 Add team name if provided
+    # 1.3.2 Add team name if provided
     if team.name is not None and team.add_name_to_context:
         additional_information.append(f"Your name is: {team.name}.")
 
@@ -941,6 +873,55 @@ def _get_formatted_session_state_for_system_message(team: "Team", session_state:
     return f"\n<session_state>\n{session_state}\n</session_state>\n\n"
 
 
+def _get_dynamic_context_message(team: "Team") -> Optional[Message]:
+    """Build a message containing per-turn dynamic context (datetime, location).
+
+    Appended near the end of the messages list (after history, before the user
+    message) rather than embedded in the system message, so that:
+    - It works regardless of whether a custom system_message is set.
+    - The system message stays byte-identical across requests, preserving
+      prompt cache hits.
+    """
+    parts: List[str] = []
+
+    if team.add_datetime_to_context:
+        from datetime import datetime
+
+        tz = None
+        if team.timezone_identifier:
+            try:
+                from zoneinfo import ZoneInfo
+
+                tz = ZoneInfo(team.timezone_identifier)
+            except Exception as e:
+                log_warning(f"Invalid timezone identifier: {str(e)}")
+
+        time = datetime.now(tz) if tz else datetime.now()
+
+        if team.datetime_format:
+            formatted_time = time.strftime(team.datetime_format)
+        else:
+            formatted_time = str(time)
+
+        parts.append(f"The current time is {formatted_time}.")
+
+    if team.add_location_to_context:
+        from agno.utils.location import get_location
+
+        location = get_location()
+        if location:
+            location_str = ", ".join(
+                filter(None, [location.get("city"), location.get("region"), location.get("country")])
+            )
+            if location_str:
+                parts.append(f"Your approximate location is: {location_str}.")
+
+    if not parts:
+        return None
+
+    return Message(role="system", content="\n".join(parts))
+
+
 def _get_run_messages(
     team: "Team",
     *,
@@ -1049,6 +1030,13 @@ def _get_run_messages(
 
             # Extend the messages with the history
             run_messages.messages += history_copy
+
+    # 3.5 Add per-turn dynamic context (datetime, location) as a trailing message.
+    # Placed after history and before the user message so the system message and
+    # history stay byte-identical across requests, preserving prompt cache hits.
+    dynamic_context_message = _get_dynamic_context_message(team)
+    if dynamic_context_message is not None:
+        run_messages.messages.append(dynamic_context_message)
 
     # 5. Add user message to run_messages (message second as per Dirk's requirement)
     # 5.1 Build user message if message is None, str or list
@@ -1183,6 +1171,13 @@ async def _aget_run_messages(
 
             # Extend the messages with the history
             run_messages.messages += history_copy
+
+    # 3.5 Add per-turn dynamic context (datetime, location) as a trailing message.
+    # Placed after history and before the user message so the system message and
+    # history stay byte-identical across requests, preserving prompt cache hits.
+    dynamic_context_message = _get_dynamic_context_message(team)
+    if dynamic_context_message is not None:
+        run_messages.messages.append(dynamic_context_message)
 
     # 5. Add user message to run_messages (message second as per Dirk's requirement)
     # 5.1 Build user message if message is None, str or list

--- a/libs/agno/agno/team/_messages.py
+++ b/libs/agno/agno/team/_messages.py
@@ -919,7 +919,10 @@ def _get_dynamic_context_message(team: "Team") -> Optional[Message]:
     if not parts:
         return None
 
-    return Message(role="system", content="\n".join(parts))
+    # Use role="user" so adapters that extract system messages (Gemini, Bedrock)
+    # don't overwrite the primary system prompt. Skip persistence so stale
+    # per-turn values don't leak into subsequent runs via history.
+    return Message(role="user", content="\n".join(parts), add_to_agent_memory=False)
 
 
 def _get_run_messages(

--- a/libs/agno/tests/unit/agent/test_datetime_format.py
+++ b/libs/agno/tests/unit/agent/test_datetime_format.py
@@ -3,7 +3,7 @@
 import re
 from unittest.mock import MagicMock
 
-from agno.agent._messages import get_system_message
+from agno.agent._messages import _get_dynamic_context_message, get_system_message
 from agno.agent.agent import Agent
 from agno.session import AgentSession
 
@@ -59,7 +59,7 @@ def test_datetime_format_from_dict_missing():
 
 
 # =============================================================================
-# System message tests
+# Dynamic context message tests
 # =============================================================================
 
 
@@ -76,11 +76,11 @@ def _make_agent_with_model(**kwargs) -> Agent:
 def test_default_format_includes_full_datetime():
     """When no datetime_format is set, the full default datetime str is used."""
     agent = _make_agent_with_model(add_datetime_to_context=True)
-    session = AgentSession(session_id="test-session")
 
-    msg = get_system_message(agent, session)
+    msg = _get_dynamic_context_message(agent)
 
     assert msg is not None
+    assert msg.role == "system"
     # Default Python datetime str format: YYYY-MM-DD HH:MM:SS.ffffff
     assert re.search(r"The current time is \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}", msg.content)
 
@@ -91,9 +91,8 @@ def test_custom_date_only_format():
         add_datetime_to_context=True,
         datetime_format="%Y-%m-%d",
     )
-    session = AgentSession(session_id="test-session")
 
-    msg = get_system_message(agent, session)
+    msg = _get_dynamic_context_message(agent)
 
     assert msg is not None
     # Should match YYYY-MM-DD followed by period (no time component)
@@ -106,22 +105,44 @@ def test_custom_format_slash_style():
         add_datetime_to_context=True,
         datetime_format="%d/%m/%Y %H:%M",
     )
-    session = AgentSession(session_id="test-session")
 
-    msg = get_system_message(agent, session)
+    msg = _get_dynamic_context_message(agent)
 
     assert msg is not None
     assert re.search(r"The current time is \d{2}/\d{2}/\d{4} \d{2}:\d{2}\.", msg.content)
 
 
 def test_no_datetime_when_disabled():
-    """When add_datetime_to_context is False, no datetime info is added."""
+    """When add_datetime_to_context is False, no dynamic context message is generated."""
     agent = _make_agent_with_model(
         add_datetime_to_context=False,
         datetime_format="%Y-%m-%d",
     )
+
+    msg = _get_dynamic_context_message(agent)
+
+    assert msg is None
+
+
+def test_datetime_not_in_system_message():
+    """Datetime context should NOT appear in the system message."""
+    agent = _make_agent_with_model(add_datetime_to_context=True)
     session = AgentSession(session_id="test-session")
+
     msg = get_system_message(agent, session)
 
     if msg is not None:
         assert "current time" not in msg.content.lower()
+
+
+def test_timezone_identifier():
+    """Timezone identifier should be respected in the output."""
+    agent = _make_agent_with_model(
+        add_datetime_to_context=True,
+        timezone_identifier="Asia/Shanghai",
+    )
+
+    msg = _get_dynamic_context_message(agent)
+
+    assert msg is not None
+    assert "+08:00" in msg.content

--- a/libs/agno/tests/unit/agent/test_datetime_format.py
+++ b/libs/agno/tests/unit/agent/test_datetime_format.py
@@ -80,7 +80,8 @@ def test_default_format_includes_full_datetime():
     msg = _get_dynamic_context_message(agent)
 
     assert msg is not None
-    assert msg.role == "system"
+    assert msg.role == "user"
+    assert msg.add_to_agent_memory is False
     # Default Python datetime str format: YYYY-MM-DD HH:MM:SS.ffffff
     assert re.search(r"The current time is \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}", msg.content)
 

--- a/libs/agno/tests/unit/team/test_datetime_format.py
+++ b/libs/agno/tests/unit/team/test_datetime_format.py
@@ -84,7 +84,8 @@ def test_default_format_includes_full_datetime():
     msg = _get_dynamic_context_message(team)
 
     assert msg is not None
-    assert msg.role == "system"
+    assert msg.role == "user"
+    assert msg.add_to_agent_memory is False
     assert re.search(r"The current time is \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}", msg.content)
 
 

--- a/libs/agno/tests/unit/team/test_datetime_format.py
+++ b/libs/agno/tests/unit/team/test_datetime_format.py
@@ -4,7 +4,7 @@ import re
 from unittest.mock import MagicMock
 
 from agno.session import TeamSession
-from agno.team._messages import get_system_message
+from agno.team._messages import _get_dynamic_context_message, get_system_message
 from agno.team.team import Team
 
 # =============================================================================
@@ -63,7 +63,7 @@ def test_datetime_format_from_dict_missing():
 
 
 # =============================================================================
-# System message tests
+# Dynamic context message tests
 # =============================================================================
 
 
@@ -80,11 +80,11 @@ def _make_team_with_model(**kwargs) -> Team:
 def test_default_format_includes_full_datetime():
     """When no datetime_format is set, the full default datetime str is used."""
     team = _make_team_with_model(add_datetime_to_context=True)
-    session = TeamSession(session_id="test-session")
 
-    msg = get_system_message(team, session)
+    msg = _get_dynamic_context_message(team)
 
     assert msg is not None
+    assert msg.role == "system"
     assert re.search(r"The current time is \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}", msg.content)
 
 
@@ -94,9 +94,8 @@ def test_custom_date_only_format():
         add_datetime_to_context=True,
         datetime_format="%Y-%m-%d",
     )
-    session = TeamSession(session_id="test-session")
 
-    msg = get_system_message(team, session)
+    msg = _get_dynamic_context_message(team)
 
     assert msg is not None
     assert re.search(r"The current time is \d{4}-\d{2}-\d{2}\.", msg.content)
@@ -108,21 +107,30 @@ def test_custom_format_slash_style():
         add_datetime_to_context=True,
         datetime_format="%d/%m/%Y %H:%M",
     )
-    session = TeamSession(session_id="test-session")
 
-    msg = get_system_message(team, session)
+    msg = _get_dynamic_context_message(team)
 
     assert msg is not None
     assert re.search(r"The current time is \d{2}/\d{2}/\d{4} \d{2}:\d{2}\.", msg.content)
 
 
 def test_no_datetime_when_disabled():
-    """When add_datetime_to_context is False, no datetime info is added."""
+    """When add_datetime_to_context is False, no dynamic context message is generated."""
     team = _make_team_with_model(
         add_datetime_to_context=False,
         datetime_format="%Y-%m-%d",
     )
+
+    msg = _get_dynamic_context_message(team)
+
+    assert msg is None
+
+
+def test_datetime_not_in_system_message():
+    """Datetime context should NOT appear in the system message."""
+    team = _make_team_with_model(add_datetime_to_context=True)
     session = TeamSession(session_id="test-session")
+
     msg = get_system_message(team, session)
 
     if msg is not None:


### PR DESCRIPTION
## Summary

Move `add_datetime_to_context` and `add_location_to_context` output from the system message to a separate trailing message appended after history and before the user message. This fixes two issues:

1. **Dynamic context was silently dropped when a custom `system_message` was set.** `get_system_message()` returns early on the custom `system_message` branch, skipping the entire `<additional_information>` block. Users who set both `system_message` and `add_datetime_to_context=True` got no time info and no warning.

2. **Dynamic values in the system message broke prompt caching.** Prompt caching (Anthropic, OpenAI) matches tokens from the first position forward. Embedding `The current time is 2026-08-13 14:22:47.774825+08:00` (microsecond precision by default) in the system message guaranteed a full cache miss on every request, causing the entire system prompt to be re-processed at full cost.

By appending the dynamic context as a separate message near the end of the messages list, the system message and history stay byte-identical across requests, preserving prompt cache hits. The dynamic context also works identically whether or not a custom `system_message` is set.

Applied to both Agent and Team, sync and async paths.

Closes #9543

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach

---

## Additional Notes

**What changed:**

- `agno/agent/_messages.py`: Removed datetime/location from `get_system_message()`'s `additional_information`. Added `_get_dynamic_context_message()` that builds a standalone `Message(role="system", ...)`. Injected it in `get_run_messages()` between history and user message (both sync and async paths).
- `agno/team/_messages.py`: Same changes for Team.
- `tests/unit/agent/test_datetime_format.py` + `tests/unit/team/test_datetime_format.py`: Updated tests to target `_get_dynamic_context_message()` instead of `get_system_message()`. Added `test_datetime_not_in_system_message` and `test_timezone_identifier`.

**What did NOT change:**

- The flags themselves (`add_datetime_to_context`, `add_location_to_context`, `timezone_identifier`, `datetime_format`) — same API, same defaults.
- The content format (`The current time is ...`, `Your approximate location is ...`) — unchanged.
- `add_name_to_context` — remains in the system message, as the agent name is persona-level info that doesn't change per turn.
