### PR TITLE
feat: Release 2.9.0

### DIFF
--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agno"
-version = "2.8.7"
+version = "2.8.8"
 description = "The programming language for agentic software."
 requires-python = ">=3.9,<4"
 readme = "README.md"

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agno"
-version = "2.8.8"
+version = "2.9.0"
 description = "The programming language for agentic software."
 requires-python = ">=3.9,<4"
 readme = "README.md"


### PR DESCRIPTION
# Changelog

## **New Features**

- **StudioRunnerTools**: New identity-aware dispatch toolkit (`agno.tools.studio_runner.StudioRunnerTools`) that splits execution out of `StudioTools`. Any component (team lead, router) can mount it to discover and run Studio-built agents/teams/workflows without getting the Studio's create/edit/delete surface. `run_*` tools thread the caller's `user_id` into the sub-run so per-user state lands on the right person.
- **`list_components` name filter**: Added a `name` filter to `list_components`.

## **Bug Fixes**

- **A2A**: Fixed the A2A stream client dropping Task-level metadata by breaking on status-update.
- **Workflow (WebSocket)**: Honor the selected workflow version over WebSocket.
- **Team HITL**: Persist paused member runs so team HITL resume survives a session reload.
- **Rehydration**: Preserve toolkit instructions on rehydration.
- **Framework annotations**: Guard framework return annotations.

## **Behaviour & Breaking Changes**

- **MCP tool `tool_name` override blocked (Security)**: MCP tool entrypoints no longer allow a call-time `tool_name` override. Previously a model could pass `tool_name="delete_repo"` to any MCP tool and the server would execute that tool while allow-lists, `requires_confirmation`, HITL approval, and logging all resolved from the declared name — bypassing any HITL/approval gate. The executed tool name is now closed over from `tool.name`. Model-supplied `tool_name` args are forwarded as ordinary arguments (not used to pick the tool), so tools that legitimately declare a `tool_name` parameter keep working.
- **Tool result caching now uses per-user keys (Security / behaviour change)**: With `cache_results=True`, the cache key now includes stable run-context identity (`user_id`, `session_id`), fixing a cross-user cache leak where a cached tool taking `run_context` (e.g. MemoryTools) served one user's result to another. `run_id` stays out of the key so caching remains useful across a user's runs. **Existing cache behaviour changes** — keys are composed differently, so prior cache hits won't line up the same way.
- **Rehydration now fails loudly (behaviour change)**: Deserializing a persisted component with unresolvable references used to silently degrade (an agent's tools became `[]`, a team lost members, schemas/knowledge dropped) and then run. Unresolvable references now raise `ComponentRehydrationError` (an `AgnoError`, `status_code=422`) on strict paths. **Strictness is a caller property:** public `from_dict`/`load` default `strict=False` (round-trips keep working), but **AgentOS lookups and every dispatch path** (REST `POST /runs`, continue, MCP run tools, StudioRunner) default `strict=True` and now return a 422 naming the unresolvable piece instead of running a degraded component. Pinned member versions are also honored.