### PR TITLE
[feat] Add TaskMarket agent toolkit

### DIFF
--- a/cookbook/91_tools/TEST_LOG.md
+++ b/cookbook/91_tools/TEST_LOG.md
@@ -109,3 +109,12 @@
 **Result:** Both examples completed without errors. Domain-restricted search returned arxiv-sourced MoE papers, and the news agent returned items from the last few days. Note: answer text is model-composed; the domain restriction applies to the search results feeding it.
 
 ---
+### taskmarket_tools.py
+
+**Status:** PASS
+
+**Description:** Added `TaskMarketTools`, an Agno toolkit for public TaskMarket task discovery, live task and submission inspection, exact Base/USDC budget previews, and one explicitly authorized create path through the first-party CLI. The toolkit has sync and async read variants, requires confirmation plus a maximum spend before creation, verifies Base chain ID 8453, and never blindly retries an ambiguous create result.
+
+**Result:** The focused unit suite passes (`7 passed`). Read-only live smoke checks against `https://api.taskmarket.dev` returned the current public task list and a valid task detail response. The cookbook module imports with the local Agno package; running the agent requires a model provider credential.
+
+---

--- a/cookbook/91_tools/TEST_LOG.md
+++ b/cookbook/91_tools/TEST_LOG.md
@@ -115,6 +115,6 @@
 
 **Description:** Added `TaskMarketTools`, an Agno toolkit for public TaskMarket task discovery, live task and submission inspection, exact Base/USDC budget previews, and one explicitly authorized create path through the first-party CLI. The toolkit has sync and async read variants, requires confirmation plus a maximum spend before creation, verifies Base chain ID 8453, and never blindly retries an ambiguous create result.
 
-**Result:** The focused unit suite passes (`7 passed`). Read-only live smoke checks against `https://api.taskmarket.dev` returned the current public task list and a valid task detail response. The cookbook module imports with the local Agno package; running the agent requires a model provider credential.
+**Result:** The focused unit suite passes (`9 passed`). Read-only live smoke checks against `https://api.taskmarket.dev` returned the current public task list and a valid task detail response. The cookbook module imports with the local Agno package; running the agent requires a model provider credential.
 
 ---

--- a/cookbook/91_tools/TEST_LOG.md
+++ b/cookbook/91_tools/TEST_LOG.md
@@ -113,7 +113,7 @@
 
 **Status:** PASS
 
-**Description:** Added `TaskMarketTools`, an Agno toolkit for public TaskMarket task discovery, live task and submission inspection, exact Base/USDC budget previews, and one explicitly authorized create path through the first-party CLI. The toolkit has sync and async read variants, requires confirmation plus a maximum spend before creation, verifies Base chain ID 8453, and never blindly retries an ambiguous create result.
+**Description:** Added `TaskMarketTools`, an Agno toolkit for public TaskMarket task discovery, live task and submission inspection, exact Base/USDC budget previews, and one explicitly authorized create path through the first-party CLI. The toolkit has sync and async read variants, binds creation to the exact preview confirmation token plus a maximum spend, verifies Base chain ID 8453, and never blindly retries an ambiguous create result.
 
 **Result:** The focused unit suite passes (`9 passed`). Read-only live smoke checks against `https://api.taskmarket.dev` returned the current public task list and a valid task detail response. The cookbook module imports with the local Agno package; running the agent requires a model provider credential.
 

--- a/cookbook/91_tools/taskmarket_tools.py
+++ b/cookbook/91_tools/taskmarket_tools.py
@@ -17,7 +17,7 @@ agent = Agent(
     instructions=[
         "Use TaskMarket when external workers can deliver research, coding, or verification.",
         "Before creating a task, show the exact description, reward, deadline, Base network, and maximum spend.",
-        "Never create or fund a task without fresh explicit user confirmation.",
+        "Never create or fund a task without fresh explicit user confirmation and the preview confirmationToken.",
         "Present submissions for human review and never accept or reject work automatically.",
     ],
     markdown=True,

--- a/cookbook/91_tools/taskmarket_tools.py
+++ b/cookbook/91_tools/taskmarket_tools.py
@@ -1,0 +1,28 @@
+"""TaskMarket Tools
+==================
+
+Give an Agno agent a safe TaskMarket delegation surface.
+
+The toolkit can discover public tasks, inspect submissions, preview a proposed
+budget, and create a task only after the user explicitly approves the exact
+preview. Install the first-party TaskMarket CLI separately to enable creation;
+the toolkit never handles its wallet key.
+"""
+
+from agno.agent import Agent
+from agno.tools.taskmarket import TaskMarketTools
+
+agent = Agent(
+    tools=[TaskMarketTools()],
+    instructions=[
+        "Use TaskMarket when external workers can deliver research, coding, or verification.",
+        "Before creating a task, show the exact description, reward, deadline, Base network, and maximum spend.",
+        "Never create or fund a task without fresh explicit user confirmation.",
+        "Present submissions for human review and never accept or reject work automatically.",
+    ],
+    markdown=True,
+)
+
+
+if __name__ == "__main__":
+    agent.print_response("List the five highest-reward open TaskMarket tasks.")

--- a/libs/agno/agno/tools/taskmarket.py
+++ b/libs/agno/agno/tools/taskmarket.py
@@ -162,18 +162,17 @@ class TaskMarketTools(Toolkit):
         the payment rail, this method returns ``retry: false`` and an unknown
         settlement state instead of retrying automatically.
         """
-        preview, error = self._build_preview(
-            description=description,
-            reward_usdc=reward_usdc,
-            duration_hours=duration_hours,
-            tags=tags,
-            max_spend_usdc=max_spend_usdc,
-            mode=mode,
-        )
-        if error:
-            return self._json_error(error, notSubmitted=True, retry=False)
-
         if not confirm:
+            preview, error = self._build_preview(
+                description=description,
+                reward_usdc=reward_usdc,
+                duration_hours=duration_hours,
+                tags=tags,
+                max_spend_usdc=max_spend_usdc,
+                mode=mode,
+            )
+            if error:
+                return self._json_error(error, notSubmitted=True, retry=False)
             preview_with_token = self._remember_preview(preview)
             return self._json(
                 {
@@ -191,19 +190,35 @@ class TaskMarketTools(Toolkit):
                 retry=False,
             )
 
-        approved_preview = self._pending_previews.pop(confirmation_token, None)
+        approved_preview = self._pending_previews.get(confirmation_token)
         if approved_preview is None:
             return self._json_error(
                 "confirmation_token is unknown or already used; preview the exact task again",
                 notSubmitted=True,
                 retry=False,
             )
-        if not self._same_preview_request(preview, approved_preview):
+
+        # Validate the confirmed request without rebuilding the deadline. A
+        # fresh ``datetime.now()`` here would make an otherwise exact preview
+        # appear to have changed while the user was approving it.
+        request_preview, error = self._build_preview(
+            description=description,
+            reward_usdc=reward_usdc,
+            duration_hours=duration_hours,
+            tags=tags,
+            max_spend_usdc=max_spend_usdc,
+            mode=mode,
+            include_deadline=False,
+        )
+        if error:
+            return self._json_error(error, notSubmitted=True, retry=False)
+        if not self._same_preview_request(request_preview, approved_preview):
             return self._json_error(
                 "create arguments do not match the approved preview; preview the exact task again",
                 notSubmitted=True,
                 retry=False,
             )
+        self._pending_previews.pop(confirmation_token, None)
         preview = approved_preview
 
         max_spend = Decimal(preview["maxSpendUsdc"])
@@ -381,6 +396,7 @@ class TaskMarketTools(Toolkit):
         tags: Union[str, Sequence[str]],
         max_spend_usdc: str,
         mode: str,
+        include_deadline: bool = True,
     ) -> Tuple[Dict[str, Any], Optional[str]]:
         if not isinstance(description, str) or not description.strip() or len(description) > 10000:
             return {}, "description must be a non-empty string of at most 10000 characters"
@@ -412,14 +428,14 @@ class TaskMarketTools(Toolkit):
             duration_float = float(duration)
             if not math.isfinite(duration_float):
                 return {}, "duration_hours must be a positive finite number within the supported date range"
-            deadline = datetime.now(timezone.utc) + timedelta(hours=duration_float)
+            duration_delta = timedelta(hours=duration_float)
+            deadline = datetime.now(timezone.utc) + duration_delta if include_deadline else None
         except (OverflowError, ValueError):
             return {}, "duration_hours must be a positive finite number within the supported date range"
         preview = {
             "description": description,
             "rewardUsdc": self._format_usdc(reward),
             "durationHours": self._format_duration(duration),
-            "deadlineUtc": deadline.replace(microsecond=0).isoformat().replace("+00:00", "Z"),
             "tags": normalized_tags,
             "mode": mode,
             "maxSpendUsdc": self._format_usdc(max_spend),
@@ -429,6 +445,8 @@ class TaskMarketTools(Toolkit):
             "relayBufferUsdc": self._format_usdc(RELAY_BUFFER_USDC),
             "network": {"name": "Base", "chainId": BASE_CHAIN_ID, "asset": "USDC"},
         }
+        if deadline is not None:
+            preview["deadlineUtc"] = deadline.replace(microsecond=0).isoformat().replace("+00:00", "Z")
         return preview, None
 
     def _remember_preview(self, preview: Dict[str, Any]) -> Dict[str, Any]:

--- a/libs/agno/agno/tools/taskmarket.py
+++ b/libs/agno/agno/tools/taskmarket.py
@@ -429,7 +429,9 @@ class TaskMarketTools(Toolkit):
             if not math.isfinite(duration_float):
                 return {}, "duration_hours must be a positive finite number within the supported date range"
             duration_delta = timedelta(hours=duration_float)
-            deadline = datetime.now(timezone.utc) + duration_delta if include_deadline else None
+            deadline = None
+            if include_deadline:
+                deadline = datetime.now(timezone.utc) + duration_delta
         except (OverflowError, ValueError):
             return {}, "duration_hours must be a positive finite number within the supported date range"
         preview = {

--- a/libs/agno/agno/tools/taskmarket.py
+++ b/libs/agno/agno/tools/taskmarket.py
@@ -1,7 +1,9 @@
 """TaskMarket tools for discovering and safely delegating agent work."""
 
 import asyncio
+import hashlib
 import json
+import math
 import subprocess
 from datetime import datetime, timedelta, timezone
 from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
@@ -55,6 +57,7 @@ class TaskMarketTools(Toolkit):
         self.api_base_url = api_base_url.rstrip("/")
         self.cli_command = cli_command
         self.timeout = timeout
+        self._pending_previews: Dict[str, Dict[str, Any]] = {}
 
         tools: List[Any] = []
         async_tools: List[Tuple[Any, str]] = []
@@ -137,7 +140,8 @@ class TaskMarketTools(Toolkit):
         )
         if error:
             return self._json_error(error, notSubmitted=True)
-        return self._json({"preview": preview, "notSubmitted": True, "success": True})
+        preview_with_token = self._remember_preview(preview)
+        return self._json({"preview": preview_with_token, "notSubmitted": True, "success": True})
 
     def create_task(
         self,
@@ -148,6 +152,7 @@ class TaskMarketTools(Toolkit):
         max_spend_usdc: str,
         confirm: bool = False,
         mode: str = "bounty",
+        confirmation_token: Optional[str] = None,
     ) -> str:
         """Create a TaskMarket task once after explicit user authorization.
 
@@ -168,14 +173,37 @@ class TaskMarketTools(Toolkit):
             return self._json_error(error, notSubmitted=True, retry=False)
 
         if not confirm:
+            preview_with_token = self._remember_preview(preview)
             return self._json(
                 {
                     "confirmationRequired": True,
                     "notSubmitted": True,
-                    "preview": preview,
-                    "message": "Call again with confirm=true only after the user approves this exact preview.",
+                    "preview": preview_with_token,
+                    "message": "Call again with confirm=true and the preview confirmationToken only after the user approves this exact preview.",
                 }
             )
+
+        if not isinstance(confirmation_token, str) or not confirmation_token:
+            return self._json_error(
+                "confirmation_token is required and must come from the exact preview being approved",
+                notSubmitted=True,
+                retry=False,
+            )
+
+        approved_preview = self._pending_previews.pop(confirmation_token, None)
+        if approved_preview is None:
+            return self._json_error(
+                "confirmation_token is unknown or already used; preview the exact task again",
+                notSubmitted=True,
+                retry=False,
+            )
+        if not self._same_preview_request(preview, approved_preview):
+            return self._json_error(
+                "create arguments do not match the approved preview; preview the exact task again",
+                notSubmitted=True,
+                retry=False,
+            )
+        preview = approved_preview
 
         max_spend = Decimal(preview["maxSpendUsdc"])
         estimated = Decimal(preview["estimatedMaxSpendUsdc"])
@@ -379,11 +407,17 @@ class TaskMarketTools(Toolkit):
             return {}, "tags must contain between 1 and 10 non-empty values"
 
         estimated = self._estimate_max_spend(reward)
-        deadline = datetime.now(timezone.utc) + timedelta(seconds=float(duration) * 3600)
+        try:
+            duration_float = float(duration)
+            if not math.isfinite(duration_float):
+                return {}, "duration_hours must be a positive finite number within the supported date range"
+            deadline = datetime.now(timezone.utc) + timedelta(hours=duration_float)
+        except (OverflowError, ValueError):
+            return {}, "duration_hours must be a positive finite number within the supported date range"
         preview = {
             "description": description,
             "rewardUsdc": self._format_usdc(reward),
-            "durationHours": str(duration_hours),
+            "durationHours": self._format_duration(duration),
             "deadlineUtc": deadline.replace(microsecond=0).isoformat().replace("+00:00", "Z"),
             "tags": normalized_tags,
             "mode": mode,
@@ -395,6 +429,20 @@ class TaskMarketTools(Toolkit):
             "network": {"name": "Base", "chainId": BASE_CHAIN_ID, "asset": "USDC"},
         }
         return preview, None
+
+    def _remember_preview(self, preview: Dict[str, Any]) -> Dict[str, Any]:
+        token_payload = json.dumps(preview, sort_keys=True, separators=(",", ":"))
+        token = hashlib.sha256(token_payload.encode("utf-8")).hexdigest()
+        self._pending_previews[token] = preview
+        if len(self._pending_previews) > 32:
+            oldest_token = next(iter(self._pending_previews))
+            del self._pending_previews[oldest_token]
+        return {**preview, "confirmationToken": token}
+
+    @staticmethod
+    def _same_preview_request(first: Dict[str, Any], second: Dict[str, Any]) -> bool:
+        fields = ("description", "rewardUsdc", "durationHours", "tags", "mode", "maxSpendUsdc")
+        return all(first.get(field) == second.get(field) for field in fields)
 
     @staticmethod
     def _parse_usdc(value: Any, field_name: str) -> Tuple[Decimal, Optional[str]]:
@@ -423,6 +471,11 @@ class TaskMarketTools(Toolkit):
     @staticmethod
     def _format_usdc(value: Decimal) -> str:
         return format(value.quantize(USDC_QUANTUM, rounding=ROUND_HALF_UP), "f")
+
+    @staticmethod
+    def _format_duration(value: Decimal) -> str:
+        formatted = format(value, "f").rstrip("0").rstrip(".")
+        return formatted or "0"
 
     @staticmethod
     def _validate_task_id(task_id: str) -> Optional[str]:

--- a/libs/agno/agno/tools/taskmarket.py
+++ b/libs/agno/agno/tools/taskmarket.py
@@ -1,0 +1,443 @@
+"""TaskMarket tools for discovering and safely delegating agent work."""
+
+import asyncio
+import json
+import subprocess
+from datetime import datetime, timedelta, timezone
+from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+
+import httpx
+
+from agno.tools import Toolkit
+
+DEFAULT_API_BASE_URL = "https://api.taskmarket.dev"
+BASE_CHAIN_ID = 8453
+PLATFORM_FEE_BPS = 750
+RELAY_BUFFER_USDC = Decimal("0.001")
+USDC_QUANTUM = Decimal("0.000001")
+SUPPORTED_MODES = {"bounty", "claim", "pitch", "benchmark"}
+
+
+class TaskMarketTools(Toolkit):
+    """Expose TaskMarket discovery and an explicitly authorized create flow.
+
+    The read tools use TaskMarket's public API. Creating a task is deliberately
+    delegated to the first-party CLI so this toolkit never reads or handles a
+    wallet key. The create method requires both ``confirm=True`` and a maximum
+    spend that covers the reward, platform fee estimate, and relay buffer.
+
+    Args:
+        api_base_url: Public TaskMarket API base URL.
+        cli_command: First-party TaskMarket CLI executable or command name.
+        timeout: Timeout in seconds for HTTP and CLI operations.
+        enable_list_tasks: Register the public task listing tool.
+        enable_get_task: Register the task status tool.
+        enable_list_submissions: Register the submission review tool.
+        enable_preview_task: Register the non-paying cost preview tool.
+        enable_create_task: Register the guarded create tool.
+        all: Register every tool, overriding individual enable flags.
+    """
+
+    def __init__(
+        self,
+        api_base_url: str = DEFAULT_API_BASE_URL,
+        cli_command: str = "taskmarket",
+        timeout: int = 30,
+        enable_list_tasks: bool = True,
+        enable_get_task: bool = True,
+        enable_list_submissions: bool = True,
+        enable_preview_task: bool = True,
+        enable_create_task: bool = True,
+        all: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        self.api_base_url = api_base_url.rstrip("/")
+        self.cli_command = cli_command
+        self.timeout = timeout
+
+        tools: List[Any] = []
+        async_tools: List[Tuple[Any, str]] = []
+        confirmation_tools = list(kwargs.pop("requires_confirmation_tools", []) or [])
+
+        if all or enable_list_tasks:
+            tools.append(self.list_tasks)
+            async_tools.append((self.alist_tasks, "list_tasks"))
+        if all or enable_get_task:
+            tools.append(self.get_task)
+            async_tools.append((self.aget_task, "get_task"))
+        if all or enable_list_submissions:
+            tools.append(self.list_submissions)
+            async_tools.append((self.alist_submissions, "list_submissions"))
+        if all or enable_preview_task:
+            tools.append(self.preview_task)
+            async_tools.append((self.apreview_task, "preview_task"))
+        if all or enable_create_task:
+            tools.append(self.create_task)
+            async_tools.append((self.acreate_task, "create_task"))
+            if "create_task" not in confirmation_tools:
+                confirmation_tools.append("create_task")
+
+        super().__init__(
+            name="taskmarket_tools",
+            tools=tools,
+            async_tools=async_tools,
+            requires_confirmation_tools=confirmation_tools,
+            timeout=timeout,
+            **kwargs,
+        )
+
+    def list_tasks(self, status: str = "open", limit: int = 20) -> str:
+        """List public TaskMarket tasks without spending funds.
+
+        Args:
+            status: Task status such as ``open`` or ``completed``.
+            limit: Maximum number of tasks to return, from 1 to 100.
+
+        Returns:
+            JSON containing the public API response or an error.
+        """
+        if not isinstance(limit, int) or isinstance(limit, bool) or not 1 <= limit <= 100:
+            return self._json_error("limit must be an integer between 1 and 100")
+        if not status or len(status) > 40:
+            return self._json_error("status must be a non-empty string")
+        return self._get_json("/api/tasks", {"status": status, "limit": limit})
+
+    def get_task(self, task_id: str) -> str:
+        """Retrieve one public TaskMarket task by its hexadecimal ID."""
+        error = self._validate_task_id(task_id)
+        if error:
+            return self._json_error(error)
+        return self._get_json(f"/api/tasks/{task_id}")
+
+    def list_submissions(self, task_id: str) -> str:
+        """List submissions for a public task for human review."""
+        error = self._validate_task_id(task_id)
+        if error:
+            return self._json_error(error)
+        return self._get_json(f"/api/tasks/{task_id}/submissions")
+
+    def preview_task(
+        self,
+        description: str,
+        reward_usdc: str,
+        duration_hours: float,
+        tags: Union[str, Sequence[str]],
+        max_spend_usdc: str,
+        mode: str = "bounty",
+    ) -> str:
+        """Preview a task's budget and deadline without submitting it."""
+        preview, error = self._build_preview(
+            description=description,
+            reward_usdc=reward_usdc,
+            duration_hours=duration_hours,
+            tags=tags,
+            max_spend_usdc=max_spend_usdc,
+            mode=mode,
+        )
+        if error:
+            return self._json_error(error, notSubmitted=True)
+        return self._json({"preview": preview, "notSubmitted": True, "success": True})
+
+    def create_task(
+        self,
+        description: str,
+        reward_usdc: str,
+        duration_hours: float,
+        tags: Union[str, Sequence[str]],
+        max_spend_usdc: str,
+        confirm: bool = False,
+        mode: str = "bounty",
+    ) -> str:
+        """Create a TaskMarket task once after explicit user authorization.
+
+        The first-party CLI is called at most once. If the CLI reports a
+        failure after it may have contacted the payment rail, this method
+        returns ``retry: false`` and an unknown settlement state instead of
+        retrying automatically.
+        """
+        preview, error = self._build_preview(
+            description=description,
+            reward_usdc=reward_usdc,
+            duration_hours=duration_hours,
+            tags=tags,
+            max_spend_usdc=max_spend_usdc,
+            mode=mode,
+        )
+        if error:
+            return self._json_error(error, notSubmitted=True, retry=False)
+
+        if not confirm:
+            return self._json(
+                {
+                    "confirmationRequired": True,
+                    "notSubmitted": True,
+                    "preview": preview,
+                    "message": "Call again with confirm=true only after the user approves this exact preview.",
+                }
+            )
+
+        max_spend = Decimal(preview["maxSpendUsdc"])
+        estimated = Decimal(preview["estimatedMaxSpendUsdc"])
+        if max_spend < estimated:
+            return self._json_error(
+                f"max_spend_usdc must be at least {preview['estimatedMaxSpendUsdc']} USDC",
+                notSubmitted=True,
+                retry=False,
+            )
+
+        deposit = self._run_cli(["deposit"])
+        if deposit["returncode"] != 0 or not deposit["json"]:
+            return self._json(
+                {
+                    "error": "Unable to verify the first-party TaskMarket wallet/network; task was not submitted.",
+                    "notSubmitted": True,
+                    "paymentState": "not_started",
+                    "retry": False,
+                }
+            )
+
+        wallet = deposit["json"].get("data", deposit["json"])
+        if (
+            wallet.get("chainId") != BASE_CHAIN_ID
+            or str(wallet.get("network", "")).lower() != "base"
+            or str(wallet.get("currency", "")).upper() != "USDC"
+        ):
+            return self._json(
+                {
+                    "error": "TaskMarket wallet must report Base chain ID 8453 and USDC; task was not submitted.",
+                    "notSubmitted": True,
+                    "paymentState": "not_started",
+                    "retry": False,
+                }
+            )
+
+        cli_args = [
+            "task",
+            "create",
+            "--description",
+            description,
+            "--reward",
+            reward_usdc,
+            "--duration",
+            str(duration_hours),
+            "--mode",
+            mode,
+            "--tags",
+            ",".join(preview["tags"]),
+        ]
+        created = self._run_cli(cli_args)
+        if created["returncode"] != 0:
+            return self._json(
+                {
+                    "error": "TaskMarket create command failed; inspect live task state before any manual decision.",
+                    "notSubmitted": False,
+                    "paymentState": "unknown_or_not_settled",
+                    "retry": False,
+                }
+            )
+
+        task_payload = created["json"] or {}
+        task_data = task_payload.get("data", task_payload)
+        task_id = task_data.get("id") or task_data.get("taskId") or task_payload.get("taskId")
+        if not task_id:
+            return self._json(
+                {
+                    "error": "TaskMarket create returned no task ID; settlement is unknown.",
+                    "notSubmitted": False,
+                    "paymentState": "unknown_or_not_settled",
+                    "retry": False,
+                }
+            )
+
+        return self._json(
+            {
+                "success": True,
+                "taskId": task_id,
+                "taskUrl": f"{self.api_base_url}/api/tasks/{task_id}",
+                "preview": preview,
+                "paymentState": "submitted_once",
+                "retry": False,
+            }
+        )
+
+    async def alist_tasks(self, status: str = "open", limit: int = 20) -> str:
+        """Async variant of :meth:`list_tasks`."""
+        if not isinstance(limit, int) or isinstance(limit, bool) or not 1 <= limit <= 100:
+            return self._json_error("limit must be an integer between 1 and 100")
+        if not status or len(status) > 40:
+            return self._json_error("status must be a non-empty string")
+        return await self._async_get_json("/api/tasks", {"status": status, "limit": limit})
+
+    async def aget_task(self, task_id: str) -> str:
+        """Async variant of :meth:`get_task`."""
+        error = self._validate_task_id(task_id)
+        if error:
+            return self._json_error(error)
+        return await self._async_get_json(f"/api/tasks/{task_id}")
+
+    async def alist_submissions(self, task_id: str) -> str:
+        """Async variant of :meth:`list_submissions`."""
+        error = self._validate_task_id(task_id)
+        if error:
+            return self._json_error(error)
+        return await self._async_get_json(f"/api/tasks/{task_id}/submissions")
+
+    async def apreview_task(self, *args: Any, **kwargs: Any) -> str:
+        """Async variant of :meth:`preview_task`."""
+        return await asyncio.to_thread(self.preview_task, *args, **kwargs)
+
+    async def acreate_task(self, *args: Any, **kwargs: Any) -> str:
+        """Async variant of :meth:`create_task`."""
+        return await asyncio.to_thread(self.create_task, *args, **kwargs)
+
+    def _get_json(self, path: str, params: Optional[Dict[str, Any]] = None) -> str:
+        try:
+            with httpx.Client(base_url=self.api_base_url, timeout=self.timeout) as client:
+                response = client.get(path, params=params)
+                response.raise_for_status()
+                return self._json(response.json())
+        except httpx.HTTPStatusError as exc:
+            status_code = exc.response.status_code if exc.response is not None else "unknown"
+            return self._json_error(f"TaskMarket API returned HTTP {status_code}", retry=False)
+        except httpx.RequestError:
+            return self._json_error("TaskMarket API request failed", retry=False)
+        except (TypeError, ValueError):
+            return self._json_error("TaskMarket API returned invalid JSON", retry=False)
+
+    async def _async_get_json(self, path: str, params: Optional[Dict[str, Any]] = None) -> str:
+        try:
+            async with httpx.AsyncClient(base_url=self.api_base_url, timeout=self.timeout) as client:
+                response = await client.get(path, params=params)
+                response.raise_for_status()
+                return self._json(response.json())
+        except httpx.HTTPStatusError as exc:
+            status_code = exc.response.status_code if exc.response is not None else "unknown"
+            return self._json_error(f"TaskMarket API returned HTTP {status_code}", retry=False)
+        except httpx.RequestError:
+            return self._json_error("TaskMarket API request failed", retry=False)
+        except (TypeError, ValueError):
+            return self._json_error("TaskMarket API returned invalid JSON", retry=False)
+
+    def _run_cli(self, args: List[str]) -> Dict[str, Any]:
+        try:
+            completed = subprocess.run(
+                [self.cli_command, *args],
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+                check=False,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            return {"returncode": 1, "json": None}
+
+        return {"returncode": completed.returncode, "json": self._parse_cli_json(completed.stdout)}
+
+    @staticmethod
+    def _parse_cli_json(output: str) -> Optional[Dict[str, Any]]:
+        for line in reversed(output.splitlines()):
+            try:
+                parsed = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(parsed, dict):
+                return parsed
+        return None
+
+    def _build_preview(
+        self,
+        description: str,
+        reward_usdc: str,
+        duration_hours: float,
+        tags: Union[str, Sequence[str]],
+        max_spend_usdc: str,
+        mode: str,
+    ) -> Tuple[Dict[str, Any], Optional[str]]:
+        if not isinstance(description, str) or not description.strip() or len(description) > 10000:
+            return {}, "description must be a non-empty string of at most 10000 characters"
+        if mode not in SUPPORTED_MODES:
+            return {}, f"mode must be one of: {', '.join(sorted(SUPPORTED_MODES))}"
+
+        reward, reward_error = self._parse_usdc(reward_usdc, "reward_usdc")
+        if reward_error:
+            return {}, reward_error
+        max_spend, max_spend_error = self._parse_usdc(max_spend_usdc, "max_spend_usdc")
+        if max_spend_error:
+            return {}, max_spend_error
+
+        try:
+            duration = Decimal(str(duration_hours))
+        except (InvalidOperation, ValueError):
+            return {}, "duration_hours must be a positive finite number"
+        if not duration.is_finite() or duration <= 0:
+            return {}, "duration_hours must be a positive finite number"
+
+        normalized_tags = self._normalize_tags(tags)
+        if not normalized_tags:
+            return {}, "tags must contain between 1 and 10 non-empty values"
+        if len(normalized_tags) > 10:
+            return {}, "tags must contain between 1 and 10 non-empty values"
+
+        estimated = self._estimate_max_spend(reward)
+        deadline = datetime.now(timezone.utc) + timedelta(seconds=float(duration) * 3600)
+        preview = {
+            "description": description,
+            "rewardUsdc": self._format_usdc(reward),
+            "durationHours": str(duration_hours),
+            "deadlineUtc": deadline.replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+            "tags": normalized_tags,
+            "mode": mode,
+            "maxSpendUsdc": self._format_usdc(max_spend),
+            "estimatedMaxSpendUsdc": self._format_usdc(estimated),
+            "maxSpendSufficient": max_spend >= estimated,
+            "platformFeeEstimateBps": PLATFORM_FEE_BPS,
+            "relayBufferUsdc": self._format_usdc(RELAY_BUFFER_USDC),
+            "network": {"name": "Base", "chainId": BASE_CHAIN_ID, "asset": "USDC"},
+        }
+        return preview, None
+
+    @staticmethod
+    def _parse_usdc(value: Any, field_name: str) -> Tuple[Decimal, Optional[str]]:
+        try:
+            parsed = Decimal(str(value))
+        except (InvalidOperation, ValueError):
+            return Decimal(0), f"{field_name} must be a positive USDC amount with at most 6 decimals"
+        exponent = parsed.as_tuple().exponent
+        if not parsed.is_finite() or parsed <= 0 or not isinstance(exponent, int) or exponent < -6:
+            return Decimal(0), f"{field_name} must be a positive USDC amount with at most 6 decimals"
+        return parsed, None
+
+    @staticmethod
+    def _normalize_tags(tags: Union[str, Sequence[str]]) -> List[str]:
+        if isinstance(tags, str):
+            values = tags.split(",")
+        else:
+            values = list(tags)
+        return [tag.strip() for tag in values if isinstance(tag, str) and tag.strip()]
+
+    @staticmethod
+    def _estimate_max_spend(reward: Decimal) -> Decimal:
+        total = reward * (Decimal(10000 + PLATFORM_FEE_BPS) / Decimal(10000)) + RELAY_BUFFER_USDC
+        return total.quantize(USDC_QUANTUM, rounding=ROUND_HALF_UP)
+
+    @staticmethod
+    def _format_usdc(value: Decimal) -> str:
+        return format(value.quantize(USDC_QUANTUM, rounding=ROUND_HALF_UP), "f")
+
+    @staticmethod
+    def _validate_task_id(task_id: str) -> Optional[str]:
+        if not isinstance(task_id, str) or not task_id.startswith("0x") or len(task_id) < 4:
+            return "task_id must be a 0x-prefixed hexadecimal ID"
+        try:
+            int(task_id[2:], 16)
+        except ValueError:
+            return "task_id must be a 0x-prefixed hexadecimal ID"
+        return None
+
+    @staticmethod
+    def _json(payload: Dict[str, Any]) -> str:
+        return json.dumps(payload, indent=2, sort_keys=True)
+
+    @classmethod
+    def _json_error(cls, message: str, **extra: Any) -> str:
+        return cls._json({"error": message, **extra})

--- a/libs/agno/agno/tools/taskmarket.py
+++ b/libs/agno/agno/tools/taskmarket.py
@@ -26,8 +26,9 @@ class TaskMarketTools(Toolkit):
 
     The read tools use TaskMarket's public API. Creating a task is deliberately
     delegated to the first-party CLI so this toolkit never reads or handles a
-    wallet key. The create method requires both ``confirm=True`` and a maximum
-    spend that covers the reward, platform fee estimate, and relay buffer.
+    wallet key. The create method requires ``confirm=True``, the exact
+    ``confirmation_token`` returned by a preview, and a maximum spend that
+    covers the reward, platform fee estimate, and relay buffer.
 
     Args:
         api_base_url: Public TaskMarket API base URL.
@@ -156,10 +157,10 @@ class TaskMarketTools(Toolkit):
     ) -> str:
         """Create a TaskMarket task once after explicit user authorization.
 
-        The first-party CLI is called at most once. If the CLI reports a
-        failure after it may have contacted the payment rail, this method
-        returns ``retry: false`` and an unknown settlement state instead of
-        retrying automatically.
+        The first-party CLI is called at most once after the exact preview token
+        is verified. If the CLI reports a failure after it may have contacted
+        the payment rail, this method returns ``retry: false`` and an unknown
+        settlement state instead of retrying automatically.
         """
         preview, error = self._build_preview(
             description=description,

--- a/libs/agno/tests/unit/tools/test_taskmarket.py
+++ b/libs/agno/tests/unit/tools/test_taskmarket.py
@@ -1,0 +1,186 @@
+"""Unit tests for TaskMarketTools."""
+
+import json
+from subprocess import CompletedProcess
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from agno.tools.taskmarket import TaskMarketTools
+
+
+def _response(payload):
+    response = Mock()
+    response.json.return_value = payload
+    response.raise_for_status.return_value = None
+    return response
+
+
+def test_list_tasks_returns_public_task_data():
+    """The toolkit exposes public TaskMarket tasks through the agent tool API."""
+    tools = TaskMarketTools()
+    payload = {
+        "tasks": [
+            {
+                "id": "0xabc",
+                "reward": "5000000",
+                "status": "open",
+                "submissionCount": 2,
+            }
+        ],
+        "hasMore": False,
+    }
+
+    with patch("agno.tools.taskmarket.httpx.Client") as mock_client:
+        client = mock_client.return_value.__enter__.return_value
+        client.get.return_value = _response(payload)
+
+        result = tools.list_tasks(status="open", limit=5)
+
+    result_data = json.loads(result)
+    assert result_data["tasks"][0]["id"] == "0xabc"
+    assert result_data["tasks"][0]["status"] == "open"
+    client.get.assert_called_once_with("/api/tasks", params={"status": "open", "limit": 5})
+
+
+def test_preview_task_calculates_budget_and_keeps_request_unsubmitted():
+    """The preview exposes Base/USDC cost information without a write call."""
+    tools = TaskMarketTools()
+
+    result = tools.preview_task(
+        description="Collect and verify a short report",
+        reward_usdc="0.50",
+        duration_hours=24,
+        tags="research, verification",
+        max_spend_usdc="0.55",
+    )
+
+    result_data = json.loads(result)
+    assert result_data["notSubmitted"] is True
+    assert result_data["preview"]["estimatedMaxSpendUsdc"] == "0.538500"
+    assert result_data["preview"]["maxSpendSufficient"] is True
+    assert result_data["preview"]["network"] == {"name": "Base", "chainId": 8453, "asset": "USDC"}
+    assert result_data["preview"]["tags"] == ["research", "verification"]
+
+
+def test_preview_task_rejects_modes_without_supported_create_arguments():
+    """The toolkit must not advertise a mode its create command cannot express."""
+    tools = TaskMarketTools()
+
+    result = tools.preview_task(
+        description="Collect and verify a short report",
+        reward_usdc="0.50",
+        duration_hours=24,
+        tags="research,verification",
+        max_spend_usdc="0.55",
+        mode="auction",
+    )
+
+    result_data = json.loads(result)
+    assert "auction" not in result_data["error"]
+    assert result_data["notSubmitted"] is True
+
+
+def test_create_task_requires_explicit_confirmation_before_calling_cli():
+    """A preview-like create call must not invoke the payment-capable CLI."""
+    tools = TaskMarketTools()
+
+    with patch("agno.tools.taskmarket.subprocess.run") as run_cli:
+        result = tools.create_task(
+            description="Collect and verify a short report",
+            reward_usdc="0.50",
+            duration_hours=24,
+            tags="research,verification",
+            max_spend_usdc="0.55",
+        )
+
+    result_data = json.loads(result)
+    assert result_data["confirmationRequired"] is True
+    assert result_data["notSubmitted"] is True
+    run_cli.assert_not_called()
+
+
+def test_create_task_checks_base_wallet_then_calls_cli_once():
+    """An authorized create verifies Base/USDC and returns the created ID."""
+    tools = TaskMarketTools(cli_command="taskmarket")
+    deposit = CompletedProcess(
+        args=["taskmarket", "deposit"],
+        returncode=0,
+        stdout='{"ok":true,"data":{"network":"Base","chainId":8453,"currency":"USDC"}}',
+        stderr="",
+    )
+    created = CompletedProcess(
+        args=["taskmarket", "task", "create"],
+        returncode=0,
+        stdout='{"ok":true,"data":{"id":"0xcreated"}}',
+        stderr="",
+    )
+
+    with patch("agno.tools.taskmarket.subprocess.run", side_effect=[deposit, created]) as run_cli:
+        result = tools.create_task(
+            description="Collect and verify a short report",
+            reward_usdc="0.50",
+            duration_hours=24,
+            tags="research,verification",
+            max_spend_usdc="0.55",
+            confirm=True,
+        )
+
+    result_data = json.loads(result)
+    assert result_data["success"] is True
+    assert result_data["taskId"] == "0xcreated"
+    assert result_data["paymentState"] == "submitted_once"
+    assert run_cli.call_count == 2
+    assert run_cli.call_args_list[0].args[0] == ["taskmarket", "deposit"]
+    create_args = run_cli.call_args_list[1].args[0]
+    assert create_args[:3] == ["taskmarket", "task", "create"]
+    assert "--confirm" not in create_args
+    assert "--reward" in create_args
+
+
+def test_create_task_does_not_retry_unknown_cli_failure():
+    """A failed create never invites an automatic second payment attempt."""
+    tools = TaskMarketTools()
+    deposit = CompletedProcess(
+        args=["taskmarket", "deposit"],
+        returncode=0,
+        stdout='{"ok":true,"data":{"network":"Base","chainId":8453,"currency":"USDC"}}',
+        stderr="",
+    )
+    failed_create = CompletedProcess(
+        args=["taskmarket", "task", "create"],
+        returncode=1,
+        stdout="",
+        stderr="network timeout",
+    )
+
+    with patch("agno.tools.taskmarket.subprocess.run", side_effect=[deposit, failed_create]) as run_cli:
+        result = tools.create_task(
+            description="Collect and verify a short report",
+            reward_usdc="0.50",
+            duration_hours=24,
+            tags="research,verification",
+            max_spend_usdc="0.55",
+            confirm=True,
+        )
+
+    result_data = json.loads(result)
+    assert result_data["paymentState"] == "unknown_or_not_settled"
+    assert result_data["retry"] is False
+    assert run_cli.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_async_list_tasks_uses_the_same_public_contract():
+    """Async agents can discover tasks through the same JSON interface."""
+    tools = TaskMarketTools()
+    response = _response({"tasks": [{"id": "0xasync", "status": "open"}]})
+
+    with patch("agno.tools.taskmarket.httpx.AsyncClient") as mock_client:
+        client = mock_client.return_value.__aenter__.return_value
+        client.get = AsyncMock(return_value=response)
+
+        result = await tools.alist_tasks(status="open", limit=1)
+
+    assert json.loads(result)["tasks"][0]["id"] == "0xasync"
+    client.get.assert_awaited_once_with("/api/tasks", params={"status": "open", "limit": 1})

--- a/libs/agno/tests/unit/tools/test_taskmarket.py
+++ b/libs/agno/tests/unit/tools/test_taskmarket.py
@@ -59,6 +59,7 @@ def test_preview_task_calculates_budget_and_keeps_request_unsubmitted():
     assert result_data["notSubmitted"] is True
     assert result_data["preview"]["estimatedMaxSpendUsdc"] == "0.538500"
     assert result_data["preview"]["maxSpendSufficient"] is True
+    assert result_data["preview"]["confirmationToken"]
     assert result_data["preview"]["network"] == {"name": "Base", "chainId": 8453, "asset": "USDC"}
     assert result_data["preview"]["tags"] == ["research", "verification"]
 
@@ -78,6 +79,23 @@ def test_preview_task_rejects_modes_without_supported_create_arguments():
 
     result_data = json.loads(result)
     assert "auction" not in result_data["error"]
+    assert result_data["notSubmitted"] is True
+
+
+def test_preview_task_returns_structured_error_for_duration_overflow():
+    """Extreme duration input must not escape as a timedelta overflow."""
+    tools = TaskMarketTools()
+
+    result = tools.preview_task(
+        description="Collect and verify a short report",
+        reward_usdc="0.50",
+        duration_hours=1e300,
+        tags="research,verification",
+        max_spend_usdc="0.55",
+    )
+
+    result_data = json.loads(result)
+    assert "duration_hours" in result_data["error"]
     assert result_data["notSubmitted"] is True
 
 
@@ -103,6 +121,15 @@ def test_create_task_requires_explicit_confirmation_before_calling_cli():
 def test_create_task_checks_base_wallet_then_calls_cli_once():
     """An authorized create verifies Base/USDC and returns the created ID."""
     tools = TaskMarketTools(cli_command="taskmarket")
+    preview = json.loads(
+        tools.preview_task(
+            description="Collect and verify a short report",
+            reward_usdc="0.50",
+            duration_hours=24,
+            tags="research,verification",
+            max_spend_usdc="0.55",
+        )
+    )
     deposit = CompletedProcess(
         args=["taskmarket", "deposit"],
         returncode=0,
@@ -124,12 +151,14 @@ def test_create_task_checks_base_wallet_then_calls_cli_once():
             tags="research,verification",
             max_spend_usdc="0.55",
             confirm=True,
+            confirmation_token=preview["preview"]["confirmationToken"],
         )
 
     result_data = json.loads(result)
     assert result_data["success"] is True
     assert result_data["taskId"] == "0xcreated"
     assert result_data["paymentState"] == "submitted_once"
+    assert result_data["preview"]["deadlineUtc"] == preview["preview"]["deadlineUtc"]
     assert run_cli.call_count == 2
     assert run_cli.call_args_list[0].args[0] == ["taskmarket", "deposit"]
     create_args = run_cli.call_args_list[1].args[0]
@@ -141,6 +170,15 @@ def test_create_task_checks_base_wallet_then_calls_cli_once():
 def test_create_task_does_not_retry_unknown_cli_failure():
     """A failed create never invites an automatic second payment attempt."""
     tools = TaskMarketTools()
+    preview = json.loads(
+        tools.preview_task(
+            description="Collect and verify a short report",
+            reward_usdc="0.50",
+            duration_hours=24,
+            tags="research,verification",
+            max_spend_usdc="0.55",
+        )
+    )
     deposit = CompletedProcess(
         args=["taskmarket", "deposit"],
         returncode=0,
@@ -162,12 +200,33 @@ def test_create_task_does_not_retry_unknown_cli_failure():
             tags="research,verification",
             max_spend_usdc="0.55",
             confirm=True,
+            confirmation_token=preview["preview"]["confirmationToken"],
         )
 
     result_data = json.loads(result)
     assert result_data["paymentState"] == "unknown_or_not_settled"
     assert result_data["retry"] is False
     assert run_cli.call_count == 2
+
+
+def test_create_task_requires_preview_token_after_confirmation():
+    """Confirmation alone cannot authorize a create without an exact preview."""
+    tools = TaskMarketTools()
+
+    with patch("agno.tools.taskmarket.subprocess.run") as run_cli:
+        result = tools.create_task(
+            description="Collect and verify a short report",
+            reward_usdc="0.50",
+            duration_hours=24,
+            tags="research,verification",
+            max_spend_usdc="0.55",
+            confirm=True,
+        )
+
+    result_data = json.loads(result)
+    assert "confirmation_token" in result_data["error"]
+    assert result_data["notSubmitted"] is True
+    run_cli.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/libs/agno/tests/unit/tools/test_taskmarket.py
+++ b/libs/agno/tests/unit/tools/test_taskmarket.py
@@ -1,5 +1,6 @@
 """Unit tests for TaskMarketTools."""
 
+from datetime import datetime, timezone
 import json
 from subprocess import CompletedProcess
 from unittest.mock import AsyncMock, Mock, patch
@@ -165,6 +166,54 @@ def test_create_task_checks_base_wallet_then_calls_cli_once():
     assert create_args[:3] == ["taskmarket", "task", "create"]
     assert "--confirm" not in create_args
     assert "--reward" in create_args
+
+
+def test_create_task_does_not_recompute_approved_deadline():
+    """Confirmation must use the deadline that the user actually approved."""
+    tools = TaskMarketTools()
+    fixed_now = datetime(2030, 1, 1, tzinfo=timezone.utc)
+
+    with patch("agno.tools.taskmarket.datetime") as datetime_type:
+        datetime_type.now.return_value = fixed_now
+        preview = json.loads(
+            tools.preview_task(
+                description="Collect and verify a short report",
+                reward_usdc="0.50",
+                duration_hours=24,
+                tags="research,verification",
+                max_spend_usdc="0.55",
+            )
+        )
+
+        def unexpected_now_call(*args, **kwargs):
+            raise AssertionError("confirmation recomputed the approved deadline")
+
+        datetime_type.now.side_effect = unexpected_now_call
+        deposit = CompletedProcess(
+            args=["taskmarket", "deposit"],
+            returncode=0,
+            stdout='{"ok":true,"data":{"network":"Base","chainId":8453,"currency":"USDC"}}',
+            stderr="",
+        )
+        created = CompletedProcess(
+            args=["taskmarket", "task", "create"],
+            returncode=0,
+            stdout='{"ok":true,"data":{"id":"0xcreated"}}',
+            stderr="",
+        )
+        with patch("agno.tools.taskmarket.subprocess.run", side_effect=[deposit, created]):
+            result = tools.create_task(
+                description="Collect and verify a short report",
+                reward_usdc="0.50",
+                duration_hours=24,
+                tags="research,verification",
+                max_spend_usdc="0.55",
+                confirm=True,
+                confirmation_token=preview["preview"]["confirmationToken"],
+            )
+
+    result_data = json.loads(result)
+    assert result_data["preview"]["deadlineUtc"] == preview["preview"]["deadlineUtc"]
 
 
 def test_create_task_does_not_retry_unknown_cli_failure():


### PR DESCRIPTION
## Summary

Fixes #9553

- Add `TaskMarketTools` for public TaskMarket task discovery, task detail, and submission inspection.
- Add a non-paying Base/USDC budget preview with explicit deadline and maximum-spend calculation.
- Add a guarded task-creation path that requires confirmation bound to an exact preview token, verifies the first-party CLI reports Base chain ID 8453 and USDC, and never retries an ambiguous create result.
- Add sync and async tool entry points plus a runnable cookbook example.

## Design notes

The toolkit does not read or store wallet keys. Payment-capable creation is delegated to the first-party `taskmarket` CLI, and the toolkit requires `confirm=True` plus the `confirmationToken` returned by the exact preview after the caller has reviewed it. The approved deadline is reused rather than recalculated. Extreme duration inputs return structured validation errors. The supported mode list intentionally excludes modes that require create arguments not represented by this toolkit.

## Validation

- `PYTHONPATH=libs/agno libs/agno/.venv/bin/python -m pytest -q libs/agno/tests/unit/tools/test_taskmarket.py` — 10 passed
- `PATH="$PWD/libs/agno/.venv/bin:$PATH" ./scripts/format.sh` — passed
- `PATH="$PWD/libs/agno/.venv/bin:$PATH" ./scripts/validate.sh` — passed (Agno mypy: 960 files; cookbook checks: 0 violations)
- `uvx ruff==0.15.20 check libs/agno/agno/tools/taskmarket.py libs/agno/tests/unit/tools/test_taskmarket.py` — passed
- `uvx ruff==0.15.20 format --check libs/agno/agno/tools/taskmarket.py libs/agno/tests/unit/tools/test_taskmarket.py` — passed
- `uvx pyright libs/agno/agno/tools/taskmarket.py libs/agno/tests/unit/tools/test_taskmarket.py` — 0 errors, 0 warnings, 0 informations
- Read-only live smoke against `https://api.taskmarket.dev` — current public task listing and task detail returned successfully; local preview returned Base chain ID 8453 and USDC without submitting anything

The repository-wide `./scripts/test.sh` was also attempted. Collection was blocked in this environment by optional dependencies that are not installed (for example FastAPI, OpenAI, SQLAlchemy, and provider-specific integrations); the focused TaskMarket suite passes independently.

## AI disclosure

This change was generated with AI assistance. I reviewed the diff, ran the focused tests and repository validation, and verified the read-only live smoke behavior described above.

Issue link (explicit): Fixes #9553.