### PR TITLE
feat: make Team and Workflow constructors keyword-only

### DIFF
--- a/libs/agno/agno/team/_init.py
+++ b/libs/agno/agno/team/_init.py
@@ -63,6 +63,7 @@ from agno.utils.string import generate_id_from_name
 def __init__(
     team: "Team",
     members: Union[List[Union[Agent, "Team"]], Callable[..., List]],
+    *,
     id: Optional[str] = None,
     model: Optional[Union[Model, str]] = None,
     fallback_config: Optional[FallbackConfig] = None,

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -438,6 +438,7 @@ class Team:
     def __init__(
         self,
         members: Union[List[Union[Agent, "Team"]], Callable[..., List]],
+        *,
         id: Optional[str] = None,
         model: Optional[Union[Model, str]] = None,
         fallback_config: Optional[FallbackConfig] = None,

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -481,6 +481,7 @@ class Workflow:
 
     def __init__(
         self,
+        *,
         id: Optional[str] = None,
         name: Optional[str] = None,
         description: Optional[str] = None,

--- a/libs/agno/tests/unit/team/test_keyword_only_constructor.py
+++ b/libs/agno/tests/unit/team/test_keyword_only_constructor.py
@@ -1,0 +1,26 @@
+"""Team.__init__ is keyword-only after members.
+
+Positional arguments past members would otherwise silently rebind whenever a
+parameter is added mid-signature.
+"""
+
+import pytest
+
+from agno.agent import Agent
+from agno.team import Team
+
+
+def test_members_stays_positional():
+    team = Team([Agent(name="member")])
+    assert team.members is not None
+
+
+def test_params_after_members_are_keyword_only():
+    with pytest.raises(TypeError):
+        Team([Agent(name="member")], "some-id")  # type: ignore[misc]
+
+
+def test_keyword_construction_unchanged():
+    team = Team(members=[Agent(name="member")], id="some-id", name="team")
+    assert team.id == "some-id"
+    assert team.name == "team"

--- a/libs/agno/tests/unit/workflow/test_keyword_only_constructor.py
+++ b/libs/agno/tests/unit/workflow/test_keyword_only_constructor.py
@@ -1,0 +1,20 @@
+"""Workflow.__init__ is keyword-only.
+
+Positional arguments would otherwise silently rebind whenever a parameter is
+added mid-signature.
+"""
+
+import pytest
+
+from agno.workflow import Workflow
+
+
+def test_constructor_is_keyword_only():
+    with pytest.raises(TypeError):
+        Workflow("some-id")  # type: ignore[misc]
+
+
+def test_keyword_construction_unchanged():
+    workflow = Workflow(id="some-id", name="workflow")
+    assert workflow.id == "some-id"
+    assert workflow.name == "workflow"


### PR DESCRIPTION
## Summary

Makes `Team.__init__` and `Workflow.__init__` keyword-only, matching `Agent.__init__` which already is.

- `Team`: keyword-only after `members`, so `Team([agent_a, agent_b])` keeps working.
- `Workflow`: fully keyword-only.
- The internal `team/_init.py` initializer gets the same marker so the two signatures cannot drift.

**Why:** these constructors have 100+ parameters. With positional binding allowed, any parameter added mid-signature silently rebinds existing positional calls - e.g. a positional `True, 5` intended for `add_workflow_history_to_steps, num_history_runs` would bind to whatever new parameter lands in front of them, changing behavior with no error. Keyword-only turns that silent mis-binding into an immediate `TypeError`. This also unblocks inserting future parameters next to their related ones instead of appending them at the end forever.

**Impact:** technically breaking, intended for 3.0. Verified there are no positional call sites past `members` anywhere in the framework, cookbooks, or tests (mypy across the lib passes, plus a repo-wide grep). External code calling e.g. `Team(members, "some-id")` positionally will now fail loudly with an obvious fix.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

- New tests pin the contract: `Team([m], "id")` and `Workflow("id")` raise `TypeError`; `Team([m])` and keyword construction are unchanged.
- Full `tests/unit/team` and `tests/unit/workflow` suites pass (1211 passed, 9 skipped).
- Extracted from #9507 so it can land independently of the grouped-config discussion; #9507 carries the same change and will merge cleanly on top.
