### PR TITLE
[fix] fail closed when agent tool deepcopy raises

### DIFF
--- a/libs/agno/agno/agent/_utils.py
+++ b/libs/agno/agno/agent/_utils.py
@@ -155,6 +155,12 @@ def deep_copy(agent: Agent, *, update: Optional[Dict[str, Any]] = None) -> Agent
 
         field_value = getattr(agent, f.name)
         if field_value is not None:
+            if f.name == "tools":
+                # A failed tool copy must remain a failure. Falling back to the
+                # original list would defeat per-request isolation.
+                fields_for_new_agent[f.name] = deep_copy_field(agent, f.name, field_value)
+                continue
+
             try:
                 fields_for_new_agent[f.name] = deep_copy_field(agent, f.name, field_value)
             except Exception as e:
@@ -176,7 +182,11 @@ def deep_copy(agent: Agent, *, update: Optional[Dict[str, Any]] = None) -> Agent
 
 
 def deep_copy_field(agent: Agent, field_name: str, field_value: Any) -> Any:
-    """Helper function to deep copy a field based on its type."""
+    """Helper function to deep copy a field based on its type.
+
+    Tool copy failures intentionally propagate so callers cannot silently
+    replace a supposedly isolated tool with the original shared instance.
+    """
     from copy import copy, deepcopy
 
     from pydantic import BaseModel
@@ -195,30 +205,20 @@ def deep_copy_field(agent: Agent, field_name: str, field_value: Any) -> Any:
         if is_callable_factory(field_value, excluded_types=(Toolkit, Function)):
             return field_value
 
-        try:
-            copied_tools = []
-            for tool in field_value:  # type: ignore
-                try:
-                    # Share MCP tools (they maintain server connections)
-                    is_mcp_tool = hasattr(type(tool), "__mro__") and any(
-                        c.__name__ in ["MCPTools", "MultiMCPTools"] for c in type(tool).__mro__
-                    )
-                    if is_mcp_tool:
-                        copied_tools.append(tool)
-                    else:
-                        try:
-                            copied_tools.append(deepcopy(tool))
-                        except Exception:
-                            # Tool can't be deep copied, share by reference
-                            copied_tools.append(tool)
-                except Exception:
-                    # MCP detection failed, share tool by reference to be safe
-                    copied_tools.append(tool)
-            return copied_tools
-        except Exception as e:
-            # If entire tools processing fails, log and return original list
-            log_warning(f"Failed to process tools for deep copy: {str(e)}")
-            return field_value
+        copied_tools = []
+        for tool in field_value:  # type: ignore
+            # Share MCP tools (they maintain server connections)
+            is_mcp_tool = hasattr(type(tool), "__mro__") and any(
+                c.__name__ in ["MCPTools", "MultiMCPTools"] for c in type(tool).__mro__
+            )
+            if is_mcp_tool:
+                copied_tools.append(tool)
+            else:
+                # A failed deepcopy is not consent to share a per-request tool.
+                # An explicit __deepcopy__ implementation that returns self still
+                # works and remains an intentional sharing decision.
+                copied_tools.append(deepcopy(tool))
+        return copied_tools
 
     # Share heavy resources - these maintain connections/pools that shouldn't be duplicated
     if field_name in SHARED_BY_REFERENCE_FIELDS:

--- a/libs/agno/tests/unit/os/test_per_request_isolation.py
+++ b/libs/agno/tests/unit/os/test_per_request_isolation.py
@@ -1477,8 +1477,8 @@ class TestToolsDeepCopyUnit:
         # MultiMCPTools should be shared
         assert copy.tools[0] is multi
 
-    def test_non_copyable_tool_shared(self):
-        """Tool that can't be copied should be shared."""
+    def test_non_copyable_tool_fails_copy(self):
+        """A failed tool copy must not silently fall back to the original tool."""
 
         class UnpicklableTool:
             def __init__(self):
@@ -1490,11 +1490,22 @@ class TestToolsDeepCopyUnit:
         tool = UnpicklableTool()
         agent = Agent(name="test", id="test-id", tools=[tool])
 
-        # Should not raise
-        copy = agent.deep_copy()
+        with pytest.raises(TypeError, match="Cannot copy"):
+            agent.deep_copy()
 
-        # Should fall back to sharing
-        assert copy.tools[0] is tool
+    def test_tool_explicitly_returning_self_is_shared(self):
+        """An explicit __deepcopy__ -> self remains an intentional share."""
+
+        class SharedTool:
+            def __deepcopy__(self, memo):
+                return self
+
+        tool = SharedTool()
+        agent = Agent(name="test", id="test-id", tools=[tool])
+
+        copied = agent.deep_copy()
+
+        assert copied.tools[0] is tool
 
     def test_empty_tools_list(self):
         """Empty tools list should be copied as empty list."""

--- a/libs/agno/tests/unit/tools/test_studio_runner.py
+++ b/libs/agno/tests/unit/tools/test_studio_runner.py
@@ -726,6 +726,20 @@ class TestDispatchIsolation:
         assert "lost its identity" in out["error"]
         assert downcast.seen is None
 
+    def test_tool_copy_failure_refuses_dispatch(self, db):
+        """A tool deepcopy exception must not make Studio dispatch the original tool."""
+        from agno.agent import Agent
+
+        class _RaisingTool:
+            def __deepcopy__(self, memo):
+                raise RuntimeError("tool cannot be copied")
+
+        agent = Agent(id="tool-copy-failure", name="Tool Copy Failure", tools=[_RaisingTool()])
+        runner = StudioRunnerTools(db=db, agents_list=[agent])
+
+        with pytest.raises(Exception, match="deep_copy failed.*tool cannot be copied"):
+            runner._agent_for_run("tool-copy-failure")
+
     def test_copy_dropping_model_instructions_or_member_isolation_refuses_dispatch(self, db):
         # The fidelity loop checks model, instructions and member isolation, not
         # only id and name: a rebuild that keeps the identity fields but drops


### PR DESCRIPTION
## Summary

Fixes #9445.

`Agent.deep_copy()` treated an exception from a tool's `__deepcopy__` as permission to reuse the original tool. A per-request copy could therefore silently share mutable tool state with other requests.

This change:

- propagates tool-copy failures instead of installing the original tool/list;
- preserves callable-factory and MCP sharing rules;
- preserves an explicit `__deepcopy__` implementation that returns `self`;
- makes StudioRunner refuse dispatch when the copy is unsafe.

The Team member/tool copy paths are intentionally out of scope; Team member fallback is tracked separately in #9414.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`) — targeted Ruff and mypy checks passed; the full mypy run is blocked by existing missing/third-party errors in unrelated files
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (not applicable)
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach (no overlapping open PR found)
- [x] Check if this PR was entirely AI-generated (by Codex); the changes were reviewed and tested locally

## Additional Notes

Tests:

- `PYTHONPATH=libs/agno uv run --with pytest==9.1.1 --with pytest-asyncio==1.4.0 python -m pytest libs/agno/tests/unit/os/test_per_request_isolation.py libs/agno/tests/unit/tools/test_studio_runner.py libs/agno/tests/unit/agent/test_callable_resources.py libs/agno/tests/unit/team/test_callable_resources.py -q`
- Result: 361 passed.
- Targeted Ruff and mypy checks pass for the changed source and tests.
