### PR TITLE
fix: constrain delegate_task_to_member's member_id to an enum

### DIFF
--- a/libs/agno/agno/team/_default_tools.py
+++ b/libs/agno/agno/team/_default_tools.py
@@ -463,6 +463,7 @@ def _get_delegate_task_function(
     from agno.team._tools import (
         _determine_team_member_interactions,
         _find_member_by_id,
+        _get_delegatable_member_ids,
         _get_history_for_member_agent,
         _propagate_member_pause,
     )
@@ -1425,6 +1426,12 @@ def _get_delegate_task_function(
             delegate_function = delegate_task_to_member  # type: ignore
 
         delegate_func = Function.from_callable(delegate_function, name="delegate_task_to_member")
+
+        # Constrain member_id to an enum of the actually delegatable member IDs,
+        # so models can't hallucinate an ID that isn't in the team or subteams.
+        member_ids = _get_delegatable_member_ids(team, run_context=run_context)
+        if member_ids:
+            delegate_func.parameters["properties"]["member_id"]["enum"] = member_ids
 
     if team.respond_directly:
         delegate_func.stop_after_tool_call = True

--- a/libs/agno/agno/team/_tools.py
+++ b/libs/agno/agno/team/_tools.py
@@ -603,6 +603,31 @@ def _find_member_by_id(
     return None
 
 
+def _get_delegatable_member_ids(team: "Team", run_context: Optional["RunContext"] = None) -> List[str]:
+    """Collect every member ID `_find_member_by_id` would accept, including subteam members.
+
+    Used to constrain the `member_id` argument of the delegation tools to a fixed
+    enum, so models can't hallucinate an ID that isn't actually delegatable.
+    """
+    from agno.team.team import Team
+    from agno.utils.callables import get_resolved_members
+
+    resolved_members = get_resolved_members(team, run_context)
+    if resolved_members is None:
+        return []
+
+    member_ids: List[str] = []
+    for member in resolved_members:
+        member_id = get_member_id(member)
+        if member_id is not None:
+            member_ids.append(member_id)
+
+        if isinstance(member, Team):
+            member_ids.extend(_get_delegatable_member_ids(member, run_context=run_context))
+
+    return member_ids
+
+
 def _find_member_route_by_id(
     team: "Team", member_id: str, run_context: Optional[RunContext] = None
 ) -> Optional[Tuple[int, Union[Agent, "Team"]]]:

--- a/libs/agno/tests/unit/team/test_delegate_member_id_enum.py
+++ b/libs/agno/tests/unit/team/test_delegate_member_id_enum.py
@@ -1,0 +1,132 @@
+"""
+Unit tests for constraining `delegate_task_to_member`'s `member_id` argument to
+an enum of the team's actually-delegatable member IDs.
+
+Without this, `member_id` is a free-text string and a model can hallucinate an
+ID that was never in the team (e.g. confusing a routing/classification label
+with a member name), which fails at call time with "Member with ID ... not
+found" instead of being constrained up front by the tool schema.
+"""
+
+from agno.agent.agent import Agent
+from agno.run import RunContext
+from agno.run.team import TeamRunOutput
+from agno.session.team import TeamSession
+from agno.team._tools import _get_delegatable_member_ids
+from agno.team.team import Team
+
+
+def _run_context() -> RunContext:
+    return RunContext(session_state={}, run_id="test-run", session_id="test-session")
+
+
+def test_get_delegatable_member_ids_flat_team():
+    team = Team(
+        name="Flat Team",
+        members=[
+            Agent(name="Billing Agent", id="billing-agent"),
+            Agent(name="Fulfilment Agent", id="fulfilment-agent"),
+            Agent(name="Assurance Agent", id="assurance-agent"),
+        ],
+    )
+
+    assert _get_delegatable_member_ids(team, run_context=_run_context()) == [
+        "billing-agent",
+        "fulfilment-agent",
+        "assurance-agent",
+    ]
+
+
+def test_get_delegatable_member_ids_includes_nested_subteam_members():
+    sub_team = Team(
+        name="Sub Team",
+        id="sub-team",
+        members=[
+            Agent(name="Nested Agent A", id="nested-agent-a"),
+            Agent(name="Nested Agent B", id="nested-agent-b"),
+        ],
+    )
+    team = Team(
+        name="Parent Team",
+        members=[
+            Agent(name="Top Agent", id="top-agent"),
+            sub_team,
+        ],
+    )
+
+    member_ids = _get_delegatable_member_ids(team, run_context=_run_context())
+
+    # The subteam itself is delegatable (as a single unit) ...
+    assert "top-agent" in member_ids
+    assert "sub-team" in member_ids
+    # ... and so are its own members, since _find_member_by_id recurses into subteams.
+    assert "nested-agent-a" in member_ids
+    assert "nested-agent-b" in member_ids
+
+
+def test_get_delegatable_member_ids_empty_team_returns_empty_list():
+    team = Team(name="Empty Team", members=[])
+
+    assert _get_delegatable_member_ids(team, run_context=_run_context()) == []
+
+
+def test_delegate_task_to_member_schema_has_member_id_enum():
+    team = Team(
+        name="Router Team",
+        members=[
+            Agent(name="Billing Agent", id="billing-agent"),
+            Agent(name="Fulfilment Agent", id="fulfilment-agent"),
+        ],
+    )
+
+    function = team._get_delegate_task_function(
+        session=TeamSession(session_id="test-session"),
+        run_response=TeamRunOutput(content="Hello, world!"),
+        run_context=_run_context(),
+        team_run_context={},
+    )
+
+    assert function.parameters["properties"]["member_id"]["enum"] == [
+        "billing-agent",
+        "fulfilment-agent",
+    ]
+
+
+def test_delegate_task_to_member_still_rejects_ids_outside_the_enum():
+    """The enum steers the model, but the runtime check remains the source of truth."""
+    team = Team(
+        name="Router Team",
+        members=[Agent(name="Billing Agent", id="billing-agent")],
+    )
+
+    function = team._get_delegate_task_function(
+        session=TeamSession(session_id="test-session"),
+        run_response=TeamRunOutput(content="Hello, world!"),
+        run_context=_run_context(),
+        team_run_context={},
+    )
+
+    response = list(function.entrypoint(member_id="non-billing-agent", task="Do the thing"))
+    assert "Member with ID non-billing-agent not found in the team or any subteams" in response[0]
+
+
+def test_delegate_task_to_members_plural_mode_has_no_member_id_param():
+    """delegate_to_all_members=True fans out to every member — there's no member_id
+    argument to constrain, so the enum injection must not run (and must not crash)."""
+    team = Team(
+        name="Fan-out Team",
+        members=[
+            Agent(name="Billing Agent", id="billing-agent"),
+            Agent(name="Fulfilment Agent", id="fulfilment-agent"),
+        ],
+        delegate_to_all_members=True,
+    )
+
+    function = team._get_delegate_task_function(
+        session=TeamSession(session_id="test-session"),
+        run_response=TeamRunOutput(content="Hello, world!"),
+        run_context=_run_context(),
+        team_run_context={},
+    )
+
+    assert "member_id" not in function.parameters["properties"]


### PR DESCRIPTION
## Summary

Fixes #9557

`delegate_task_to_member(member_id: str, task: str)` takes `member_id` as a plain free-text string. The tool schema has no constraint on valid values, even though the team already knows its full member list at construction time (`Team(members=[...])`). Validity is only enforced after the fact, in `_find_member_by_id`, which returns `"Member with ID {member_id} not found..."` on a miss.

In production, a weaker model fused a routing label from its instructions ("NON-BILLING") with a real member id (`fulfilment-agent`) and called the tool with `non-billing-agent`, which isn't a member. That's avoidable: the team already had the closed set of valid ids, it just wasn't passed into the schema.

This PR adds `_get_delegatable_member_ids(team, run_context)`, which walks the team the same way `_find_member_by_id` does (including subteam members), and uses it to set an `enum` on `member_id` in the built tool schema. `delegate_task_to_members` (the `delegate_to_all_members=True` fan-out variant) has no `member_id` param, so it's untouched. The runtime check stays in place as the source of truth, the enum just steers the model away from picking a bad id in the first place.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`ruff format`, `ruff check`, `mypy`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Written by Claude Code from a production Langfuse trace showing the exact hallucination described above.

New tests in `libs/agno/tests/unit/team/test_delegate_member_id_enum.py`:

- Flat team returns exactly its members' ids
- Subteam id and its nested members' ids are all included
- Empty team returns an empty list, no crash
- Built tool schema carries the enum
- Runtime still rejects an out-of-enum id like `non-billing-agent`
- `delegate_to_all_members=True` mode has no `member_id` param, enum injection correctly skipped

Full `libs/agno/tests/unit/team` suite (461 tests, 3 modules excluded for an unrelated missing `sqlalchemy` install in this sandbox) passes with no regressions. `ruff format`, `ruff check`, and `mypy` all clean.