### PR TITLE
fix: add cost metric support to OpenRouterResponses

### DIFF
--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -1384,4 +1384,6 @@ class OpenAIResponses(Model):
         if output_tokens_details := response_usage.output_tokens_details:
             metrics.reasoning_tokens = output_tokens_details.reasoning_tokens
 
+        metrics.cost = getattr(response_usage, "cost", None)
+
         return metrics

--- a/libs/agno/tests/unit/models/openai/test_openai_responses_metrics.py
+++ b/libs/agno/tests/unit/models/openai/test_openai_responses_metrics.py
@@ -1,0 +1,128 @@
+"""
+Unit tests for OpenAI Responses metrics collection.
+
+Verifies that _get_metrics parses cost (and other usage fields) from the
+ResponseUsage object into MessageMetrics.
+"""
+
+from typing import Optional
+
+from agno.models.openai.responses import OpenAIResponses
+
+
+class MockResponseUsage:
+    """Mock ResponseUsage object for testing."""
+
+    def __init__(
+        self,
+        input_tokens: Optional[int] = 0,
+        output_tokens: Optional[int] = 0,
+        total_tokens: Optional[int] = 0,
+        input_tokens_details=None,
+        output_tokens_details=None,
+        cost: Optional[float] = None,
+    ):
+        self.input_tokens = input_tokens
+        self.output_tokens = output_tokens
+        self.total_tokens = total_tokens
+        self.input_tokens_details = input_tokens_details
+        self.output_tokens_details = output_tokens_details
+        self.cost = cost
+
+
+class MockResponseUsageWithoutCost:
+    """Mock ResponseUsage object that has no cost attribute."""
+
+    def __init__(self):
+        self.input_tokens = 12
+        self.output_tokens = 3
+        self.total_tokens = 15
+        self.input_tokens_details = None
+        self.output_tokens_details = None
+
+
+class MockInputTokensDetails:
+    def __init__(self, cached_tokens: Optional[int] = None):
+        self.cached_tokens = cached_tokens
+
+
+class MockOutputTokensDetails:
+    def __init__(self, reasoning_tokens: Optional[int] = None):
+        self.reasoning_tokens = reasoning_tokens
+
+
+def test_openai_responses_get_metrics_basic():
+    """Test that OpenAIResponses._get_metrics converts ResponseUsage to MessageMetrics."""
+    model = OpenAIResponses(id="gpt-4o-mini")
+    usage = MockResponseUsage(input_tokens=12, output_tokens=3, total_tokens=15)
+
+    metrics = model._get_metrics(usage)  # type: ignore[arg-type]
+
+    assert metrics.input_tokens == 12
+    assert metrics.output_tokens == 3
+    assert metrics.total_tokens == 15
+
+
+def test_openai_responses_get_metrics_parses_cost():
+    """Test that OpenAIResponses._get_metrics parses cost from ResponseUsage."""
+    model = OpenAIResponses(id="gpt-4o-mini")
+    usage = MockResponseUsage(
+        input_tokens=12,
+        output_tokens=3,
+        total_tokens=15,
+        cost=3.6e-06,
+    )
+
+    metrics = model._get_metrics(usage)  # type: ignore[arg-type]
+
+    assert metrics.cost == 3.6e-06
+
+
+def test_openai_responses_get_metrics_cost_defaults_to_none_when_unavailable():
+    """Test that OpenAIResponses._get_metrics leaves cost as None when usage has no cost attribute."""
+    model = OpenAIResponses(id="gpt-4o-mini")
+    usage = MockResponseUsageWithoutCost()
+
+    metrics = model._get_metrics(usage)  # type: ignore[arg-type]
+
+    assert metrics.cost is None
+    assert metrics.input_tokens == 12
+    assert metrics.output_tokens == 3
+    assert metrics.total_tokens == 15
+
+
+def test_openai_responses_get_metrics_zero_cost():
+    """Test that OpenAIResponses preserves a zero cost from ResponseUsage."""
+    model = OpenAIResponses(id="gpt-4o-mini")
+    usage = MockResponseUsage(
+        input_tokens=12,
+        output_tokens=3,
+        total_tokens=15,
+        cost=0.0,
+    )
+
+    metrics = model._get_metrics(usage)  # type: ignore[arg-type]
+
+    assert metrics.cost == 0.0
+
+
+def test_openai_responses_get_metrics_with_details_and_cost():
+    """Test that OpenAIResponses._get_metrics parses cost along with token details."""
+    model = OpenAIResponses(id="gpt-4o-mini")
+    usage = MockResponseUsage(
+        input_tokens=100,
+        output_tokens=50,
+        total_tokens=150,
+        input_tokens_details=MockInputTokensDetails(cached_tokens=20),
+        output_tokens_details=MockOutputTokensDetails(reasoning_tokens=5),
+        cost=0.0002,
+    )
+
+    metrics = model._get_metrics(usage)  # type: ignore[arg-type]
+
+    assert metrics.input_tokens == 100
+    assert metrics.output_tokens == 50
+    assert metrics.total_tokens == 150
+    assert metrics.cache_read_tokens == 20
+    assert metrics.reasoning_tokens == 5
+    assert metrics.cost == 0.0002

--- a/libs/agno/tests/unit/models/openrouter_model/test_openrouter_responses.py
+++ b/libs/agno/tests/unit/models/openrouter_model/test_openrouter_responses.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 import pytest
+from openai.types.responses import ResponseUsage
 
 from agno.exceptions import ModelAuthenticationError
 from agno.models.openrouter import OpenRouterResponses
@@ -121,6 +122,34 @@ def test_openrouter_responses_get_metrics_parses_cost():
     model = OpenRouterResponses(id="openai/gpt-4o-mini", api_key="test-key")
 
     metrics = model._get_metrics(MockResponseUsage(cost=3.6e-06))  # type: ignore[arg-type]
+
+    assert metrics.cost == 3.6e-06
+    assert metrics.input_tokens == 12
+    assert metrics.output_tokens == 3
+    assert metrics.total_tokens == 15
+
+
+def test_openrouter_responses_get_metrics_parses_cost_from_real_sdk_usage():
+    """Test cost is preserved through OpenAI SDK ResponseUsage into MessageMetrics."""
+    model = OpenRouterResponses(id="openai/gpt-4o-mini", api_key="test-key")
+
+    usage = ResponseUsage.model_validate(
+        {
+            "input_tokens": 12,
+            "input_tokens_details": {
+                "cached_tokens": 0,
+                "cache_write_tokens": 0,
+            },
+            "output_tokens": 3,
+            "output_tokens_details": {"reasoning_tokens": 0},
+            "total_tokens": 15,
+            "cost": 3.6e-06,
+        }
+    )
+
+    assert getattr(usage, "cost", None) == 3.6e-06
+
+    metrics = model._get_metrics(usage)
 
     assert metrics.cost == 3.6e-06
     assert metrics.input_tokens == 12

--- a/libs/agno/tests/unit/models/openrouter_model/test_openrouter_responses.py
+++ b/libs/agno/tests/unit/models/openrouter_model/test_openrouter_responses.py
@@ -91,3 +91,59 @@ def test_openrouter_responses_client_params():
     assert params["base_url"] == "https://openrouter.ai/api/v1"
     assert params["timeout"] == 30.0
     assert params["max_retries"] == 3
+
+
+class MockResponseUsage:
+    """Mock ResponseUsage object for testing cost parsing."""
+
+    def __init__(self, cost=None):
+        self.input_tokens = 12
+        self.output_tokens = 3
+        self.total_tokens = 15
+        self.input_tokens_details = None
+        self.output_tokens_details = None
+        self.cost = cost
+
+
+class MockResponseUsageWithoutCost:
+    """Mock ResponseUsage object that has no cost attribute."""
+
+    def __init__(self):
+        self.input_tokens = 12
+        self.output_tokens = 3
+        self.total_tokens = 15
+        self.input_tokens_details = None
+        self.output_tokens_details = None
+
+
+def test_openrouter_responses_get_metrics_parses_cost():
+    """Test OpenRouterResponses parses cost from ResponseUsage into MessageMetrics."""
+    model = OpenRouterResponses(id="openai/gpt-4o-mini", api_key="test-key")
+
+    metrics = model._get_metrics(MockResponseUsage(cost=3.6e-06))  # type: ignore[arg-type]
+
+    assert metrics.cost == 3.6e-06
+    assert metrics.input_tokens == 12
+    assert metrics.output_tokens == 3
+    assert metrics.total_tokens == 15
+
+
+def test_openrouter_responses_get_metrics_cost_defaults_to_none_when_unavailable():
+    """Test OpenRouterResponses leaves cost as None when usage has no cost attribute."""
+    model = OpenRouterResponses(id="openai/gpt-4o-mini", api_key="test-key")
+
+    metrics = model._get_metrics(MockResponseUsageWithoutCost())  # type: ignore[arg-type]
+
+    assert metrics.cost is None
+    assert metrics.input_tokens == 12
+    assert metrics.output_tokens == 3
+    assert metrics.total_tokens == 15
+
+
+def test_openrouter_responses_get_metrics_zero_cost():
+    """Test OpenRouterResponses preserves a zero cost from ResponseUsage."""
+    model = OpenRouterResponses(id="openai/gpt-4o-mini", api_key="test-key")
+
+    metrics = model._get_metrics(MockResponseUsage(cost=0.0))  # type: ignore[arg-type]
+
+    assert metrics.cost == 0.0


### PR DESCRIPTION
## Summary

Fixes an issue where OpenRouterResponses did not populate MessageMetrics.cost even when the OpenRouter Responses API returned cost information in the usage data.

The fix propagates the optional cost value from response_usage into MessageMetrics.cost while remaining compatible with usage objects that do not expose a cost attribute.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Added regression coverage for cost values, missing cost attributes, and zero-cost responses.
No API or breaking changes.
No documentation or cookbook changes are required for this internal metrics fix.
Related issue: #9566
