### PR TITLE
fix(team): don't emit a blank content event for empty stop chunks (#9491)

### DIFF
--- a/libs/agno/agno/team/_response.py
+++ b/libs/agno/agno/team/_response.py
@@ -1396,8 +1396,10 @@ def _handle_model_response_chunk(
             content_type = "str"
 
             should_yield = False
-            # Process content
-            if model_response_event.content is not None:
+            # Process content. An empty string is a provider stop/metadata chunk
+            # that carries no visible text; skip it so it does not surface a
+            # blank content event (see issue #9491).
+            if model_response_event.content is not None and model_response_event.content != "":
                 if parse_structured_output:
                     full_model_response.content = model_response_event.content
                     _convert_response_to_structured_format(team, full_model_response, run_context=run_context)

--- a/libs/agno/tests/unit/team/test_team_empty_content_events.py
+++ b/libs/agno/tests/unit/team/test_team_empty_content_events.py
@@ -1,0 +1,79 @@
+import pytest
+
+from agno.agent import Agent
+from agno.models.message import Citations
+from agno.models.response import ModelResponse, ModelResponseEvent
+from agno.run.team import TeamRunEvent, TeamRunOutput
+from agno.session import TeamSession
+from agno.team import Team
+
+
+def _new_state():
+    team = Team(members=[Agent(name="Agent1")])
+    session = TeamSession(session_id="session_1")
+    run_response = TeamRunOutput(run_id="run_1", team_id="team_1", team_name="Team")
+    return team, session, run_response, ModelResponse()
+
+
+def _feed(team, session, run_response, full_model_response, content, **kwargs):
+    return list(
+        team._handle_model_response_chunk(
+            session=session,
+            run_response=run_response,
+            full_model_response=full_model_response,
+            model_response_event=ModelResponse(
+                event=ModelResponseEvent.assistant_response.value,
+                content=content,
+                **kwargs,
+            ),
+            stream_events=True,
+        )
+    )
+
+
+def test_empty_string_content_yields_no_event_but_keeps_accumulated_text():
+    team, session, run_response, fmr = _new_state()
+
+    first = _feed(team, session, run_response, fmr, "Hello")
+    empty = _feed(team, session, run_response, fmr, "")
+    followup = _feed(team, session, run_response, fmr, " world")
+
+    assert len(first) == 1
+    assert first[0].event == TeamRunEvent.run_content.value
+    assert first[0].content == "Hello"
+    assert empty == []
+    assert len(followup) == 1
+    assert followup[0].content == " world"
+    assert fmr.content == "Hello world"
+    assert run_response.content == "Hello world"
+
+
+def test_metadata_on_empty_content_chunk_is_preserved_without_emitting():
+    team, session, run_response, fmr = _new_state()
+    citations = Citations(raw={"source": "provider"})
+    provider_data = {"response_id": "response-1"}
+
+    events = _feed(
+        team,
+        session,
+        run_response,
+        fmr,
+        "",
+        citations=citations,
+        provider_data=provider_data,
+    )
+
+    assert events == []
+    assert run_response.citations == citations
+    assert run_response.model_provider_data == provider_data
+
+
+@pytest.mark.parametrize("falsy_content", [False, 0, [], {}])
+def test_non_string_falsy_content_still_emits(falsy_content):
+    team, session, run_response, fmr = _new_state()
+
+    events = _feed(team, session, run_response, fmr, falsy_content)
+
+    assert len(events) == 1
+    assert events[0].event == TeamRunEvent.run_content.value
+    assert events[0].content == falsy_content


### PR DESCRIPTION
## Summary

Fixes #9491.

When a `Team` streams with an Anthropic model, the provider sends a stop/metadata
chunk whose `content` is an empty string (`""`) — intentionally empty so that
citations and provider metadata can flow through without duplicating text that was
already streamed. In `agno/team/_response.py`, `_handle_model_response_chunk`
guarded the content branch with `content is not None`, so an empty string still
entered the branch and set `should_yield = True`, surfacing a spurious
`TeamRunContent` event with `content == ""`.

## Fix

Skip the content branch when the chunk carries an empty string:

```python
if model_response_event.content is not None and model_response_event.content != "":
```

Nothing else changes: already-accumulated content, reasoning, audio, citations and
provider data are still processed by their own branches, so metadata on an empty
chunk is preserved — it just no longer emits a blank content event. Non-string
falsy values (`False`, `0`, `[]`, `{}`) are deliberately left untouched.

## Testing

Adds `libs/agno/tests/unit/team/test_team_empty_content_events.py`:

- an empty-string chunk yields no event while accumulated text is preserved and later chunks still stream;
- citations / provider data on an empty chunk are recorded without emitting an event;
- non-string falsy content still emits.

Verified locally against `agno==2.9.0`: the two empty-content assertions fail before
the change and pass after; the full new test module is green (`6 passed`).

> Note: the earlier PR #9495 for this issue was withdrawn (closed by its author); this
> is an independent fix + test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
