### PR TITLE
fix: length-prefix the parts of the Valkey scoped document id (#9412)

### DIFF
--- a/libs/agno/agno/vectordb/valkey/valkeydb.py
+++ b/libs/agno/agno/vectordb/valkey/valkeydb.py
@@ -293,10 +293,20 @@ class ValkeyDB(VectorDb):
     def _scoped_doc_id(self, base_id: str, user_id: Optional[str]) -> str:
         """Fold the owner into the deterministic id so two users uploading the
         same content get distinct keys. The shared bucket keeps the legacy id.
+
+        The parts are length-prefixed before they are joined. A bare delimiter
+        is not injective once a part can contain it, and both parts can: base_id
+        is a document id or a content digest, and user_id is only screened for
+        brace and wildcard characters. Joined bare, ("doc_a", "u") and
+        ("doc", "a_u") fold onto one key, and each owner then reads or
+        overwrites the other's document -- defeating the scoping this exists to
+        provide.
         """
         if user_id is None:
             return base_id
-        return hash_string_sha256(f"{base_id}_{user_id}")
+        # Length-prefixed so no part can impersonate a boundary.
+        key = "|".join(f"{len(part)}:{part}" for part in (base_id, user_id))
+        return hash_string_sha256(key)
 
     def _parse_hash(self, doc: Document, user_id: Optional[str] = None) -> Dict[str, Any]:
         """Create a dict serializable into a Valkey HASH structure.

--- a/libs/agno/tests/unit/vectordb/test_valkeydb.py
+++ b/libs/agno/tests/unit/vectordb/test_valkeydb.py
@@ -324,3 +324,37 @@ def test_username_without_password_raises(import_valkeydb, mock_embedder):
 
     with pytest.raises(ValueError, match="password"):
         ValkeyDB(index_name="test_index", username="user", embedder=mock_embedder)
+
+
+def test_scoped_doc_id_separates_pairs_that_a_bare_join_collides(valkey_db):
+    db = valkey_db[0]
+
+    # Both parts can contain the delimiter: base_id is a document id or a
+    # content digest, and user_id is only screened for braces and wildcards.
+    # Joined bare, "doc_a" + "_" + "u" and "doc" + "_" + "a_u" are one string.
+    assert db._scoped_doc_id("doc_a", "u") != db._scoped_doc_id("doc", "a_u")
+
+
+def test_scoped_doc_id_is_deterministic_and_owner_specific(valkey_db):
+    db = valkey_db[0]
+
+    assert db._scoped_doc_id("doc", "alice") == db._scoped_doc_id("doc", "alice")
+    assert db._scoped_doc_id("doc", "alice") != db._scoped_doc_id("doc", "bob")
+    assert db._scoped_doc_id("doc-1", "alice") != db._scoped_doc_id("doc-2", "alice")
+
+
+def test_scoped_doc_id_leaves_the_shared_bucket_on_the_legacy_id(valkey_db):
+    db = valkey_db[0]
+
+    # The unscoped bucket is keyed by the bare id, so it survives this change.
+    assert db._scoped_doc_id("doc-1", None) == "doc-1"
+
+
+def test_parse_hash_scopes_the_stored_id_per_owner(valkey_db):
+    db = valkey_db[0]
+    doc = Document(content="Doc A", name="doc_a", id="doc_a")
+
+    alice = db._parse_hash(doc, user_id="u")["id"]
+    bob = db._parse_hash(Document(content="Doc A", name="doc", id="doc"), user_id="a_u")["id"]
+
+    assert alice != bob


### PR DESCRIPTION
## Summary

Fixes #9412.

`ValkeyDb._scoped_doc_id` (`libs/agno/agno/vectordb/valkey/valkeydb.py`) folded the owner into the per-user document key with a bare `_` join before hashing:

```python
return hash_string_sha256(f"{base_id}_{user_id}")
```

That join is **not injective** once either part can contain the delimiter — and both can. `base_id` is the document id or a content digest, and `user_id` is only screened for the reserved tags, braces and wildcards, never for `_`. So:

```python
hash_string_sha256("doc_a" + "_" + "u") == hash_string_sha256("doc" + "_" + "a_u")  # True
```

The pairs (`doc_id="doc_a"`, `user="u"`) and (`doc_id="doc"`, `user="a_u"`) name **one** key, which defeats exactly the per-user isolation the function exists to provide: one owner's document can overwrite, or be read as, another's.

### Fix

Length-prefix each part before joining — the same netstring shape `StudioRunnerTools._sub_session_id` already uses in this repo, and for the same reason (its docstring spells out the non-injective-join hazard):

```python
key = "|".join(f"{len(part)}:{part}" for part in (base_id, user_id))
return hash_string_sha256(key)
```

The unscoped path (`user_id is None`) still returns the bare `base_id`, so the shared bucket keeps its existing keys and is untouched. `redisdb.py` calls the hash helper on a single content string and is not affected.

### Migration note

This changes every **user-scoped** derived doc id, so rows written under the old derivation are orphaned and user-scoped content needs to be re-indexed. The shared bucket is unaffected. Happy to version the derivation explicitly (e.g. a `v2|` prefix) if you would rather the two identities be distinguishable during a migration — that was raised on the issue and is a one-line change on top of this.

### Verification

`libs/agno/tests/unit/vectordb/test_valkeydb.py`, run against the tree at `b889441`:

| | result |
|---|---|
| unpatched source + new tests | **2 failed, 18 passed** — the collision test and the `_parse_hash` end-to-end test both fail |
| patched source | **20 passed** |

The 16 pre-existing tests pass unchanged in both runs. The three added cases that pass either way (determinism, per-owner distinctness, and the untouched `user_id=None` bucket) are there to pin that the new derivation does not regress those properties.

`ruff format`, `ruff check`, and `ruff check --select I` (v0.15.20, the pin in `libs/agno/pyproject.toml`) are clean on both files; `mypy` reports no error in the changed file.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

#9483 previously proposed the same repair and was closed by the automatic duplicate check, which matched it to #9371 via the issue reference. As noted on #9412, #9371 shipped without touching `libs/agno/agno/vectordb/valkey/`, so the Valkey collision was never actually fixed — it is still reproducible on `main` today. This PR re-lands that narrow fix with regression coverage.

## Additional Notes

Security-relevant: the collision is a cross-tenant read/write in the user-scoped knowledge store, reachable by any caller that controls a document id or a user id containing `_`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
