### PR TITLE
feat: add Siliconflow embedding and reranking support

### DIFF
--- a/cookbook/07_knowledge/02_building_blocks/03_reranking.py
+++ b/cookbook/07_knowledge/02_building_blocks/03_reranking.py
@@ -12,6 +12,7 @@ Supported rerankers:
 - SentenceTransformerReranker: Local reranking with BAAI/bge models
 - InfinityReranker: Self-hosted reranking
 - BedrockReranker: AWS Bedrock reranking
+- SiliconflowReranker: Siliconflow cloud reranking
 
 See also: 02_hybrid_search.py for search type options.
 """

--- a/cookbook/07_knowledge/05_integrations/rag/README.md
+++ b/cookbook/07_knowledge/05_integrations/rag/README.md
@@ -7,10 +7,12 @@ Examples for third-party RAG and retrieval-stack integrations.
 - [`agentic_rag_infinity_reranker.py`](./agentic_rag_infinity_reranker.py): Agentic RAG with Infinity reranker.
 - [`agentic_rag_with_lightrag.py`](./agentic_rag_with_lightrag.py): Agentic RAG with LightRAG.
 - [`local_rag_langchain_qdrant.py`](./local_rag_langchain_qdrant.py): Local RAG with LangChain + Qdrant.
+- [`siliconflow.py`](./siliconflow.py): Self-contained Siliconflow text embedding and reranking.
 
 ## Prerequisites
 
 - Load environment variables with `direnv allow` (including `OPENAI_API_KEY` and provider-specific keys where needed).
+- Set `SILICONFLOW_API_KEY` before running `siliconflow.py`.
 - Create the demo environment with `./scripts/demo_setup.sh`, then run cookbooks with `.venvs/demo/bin/python`.
 - Some examples require optional local services and dependencies (for example Infinity, Ollama, or extra pip packages).
 

--- a/cookbook/07_knowledge/05_integrations/rag/TEST_LOG.md
+++ b/cookbook/07_knowledge/05_integrations/rag/TEST_LOG.md
@@ -37,3 +37,13 @@
 **Result:** Requires optional dependencies/services (for example `ollama`, Qdrant, and LangChain extras).
 
 ---
+
+### siliconflow.py
+
+**Status:** PASS
+
+**Description:** Exercises Siliconflow text embedding and reranking through the live API without a vector database.
+
+**Result:** Returned four 1024-dimensional embeddings in one batch and reranked three documents to the requested top two. The Eiffel Tower document ranked first with the highest relevance score.
+
+---

--- a/cookbook/07_knowledge/05_integrations/rag/siliconflow.py
+++ b/cookbook/07_knowledge/05_integrations/rag/siliconflow.py
@@ -1,0 +1,50 @@
+"""
+Siliconflow Embedding and Reranking
+===================================
+
+Demonstrates Siliconflow text embeddings and reranking without a vector database.
+
+Set SILICONFLOW_API_KEY before running this example.
+"""
+
+from agno.knowledge.document import Document
+from agno.knowledge.embedder.siliconflow import SiliconflowEmbedder
+from agno.knowledge.reranker.siliconflow import SiliconflowReranker
+
+# ---------------------------------------------------------------------------
+# Create Siliconflow Clients
+# ---------------------------------------------------------------------------
+embedder = SiliconflowEmbedder()
+reranker = SiliconflowReranker(top_n=2, raise_on_error=True)
+
+query = "Where is the Eiffel Tower?"
+documents = [
+    Document(content="The Eiffel Tower is in Paris."),
+    Document(content="Python is a programming language."),
+    Document(content="Paris is the capital of France."),
+]
+
+
+# ---------------------------------------------------------------------------
+# Run Embedding and Reranking
+# ---------------------------------------------------------------------------
+def main() -> None:
+    texts = [query, *[document.content for document in documents]]
+    embeddings, usages = embedder.get_embeddings_batch_and_usage(texts)
+
+    query_embedding = embeddings[0]
+    for document, embedding in zip(documents, embeddings[1:]):
+        document.embedding = embedding
+
+    print(f"Query embedding dimensions: {len(query_embedding)}")
+    if usages[0] is not None:
+        print("Usage is reported for the entire embedding batch.")
+
+    reranked_documents = reranker.rerank(query, documents)
+    print("Reranked documents:")
+    for document in reranked_documents:
+        print(f"- {document.reranking_score:.4f}: {document.content}")
+
+
+if __name__ == "__main__":
+    main()

--- a/cookbook/07_knowledge/README.md
+++ b/cookbook/07_knowledge/README.md
@@ -10,9 +10,9 @@ Knowledge is Agno's RAG framework. It handles the full pipeline: reading documen
 |-----------|-------------|---------|
 | **Readers** | Extract text from files | PDF, DOCX, CSV, JSON, Web, YouTube, ArXiv |
 | **Chunking** | Split text into searchable pieces | Fixed, Recursive, Semantic, Code, Markdown, Agentic |
-| **Embedders** | Convert text to vectors | OpenAI, Cohere, Bedrock, Ollama, 14+ more |
+| **Embedders** | Convert text to vectors | OpenAI, Cohere, Bedrock, Ollama, Siliconflow, 14+ more |
 | **Vector DBs** | Store and search vectors | Qdrant, LanceDB, ChromaDB, Pinecone, 14+ more |
-| **Rerankers** | Re-score results for quality | Cohere, SentenceTransformer, Bedrock, Infinity |
+| **Rerankers** | Re-score results for quality | Cohere, SentenceTransformer, Bedrock, Infinity, Siliconflow |
 
 ## Quick Start
 

--- a/libs/agno/agno/knowledge/embedder/siliconflow.py
+++ b/libs/agno/agno/knowledge/embedder/siliconflow.py
@@ -1,0 +1,250 @@
+import math
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import httpx
+
+from agno.exceptions import AgnoError
+from agno.knowledge.embedder.base import Embedder
+from agno.knowledge.siliconflow import (
+    DEFAULT_SILICONFLOW_BASE_URL,
+    get_malformed_siliconflow_response_error,
+    get_siliconflow_headers,
+    get_siliconflow_request_error,
+    get_siliconflow_trace_id,
+    get_siliconflow_url,
+    raise_for_siliconflow_status,
+)
+from agno.utils.http import get_default_async_client, get_default_sync_client
+
+DEFAULT_SILICONFLOW_EMBEDDING_MODEL = "BAAI/bge-m3"
+DEFAULT_SILICONFLOW_EMBEDDING_DIMENSIONS = 1024
+MAX_SILICONFLOW_BATCH_SIZE = 32
+
+
+@dataclass
+class SiliconflowEmbedder(Embedder):
+    """Embed text with Siliconflow's embeddings API.
+
+    The default ``BAAI/bge-m3`` model produces 1024-dimensional vectors. A
+    custom model requires an explicit ``dimensions`` value because Agno vector
+    databases need the dimension before the first API request.
+    """
+
+    id: str = DEFAULT_SILICONFLOW_EMBEDDING_MODEL
+    dimensions: Optional[int] = None
+    enable_batch: bool = True
+    batch_size: int = MAX_SILICONFLOW_BATCH_SIZE
+    api_key: Optional[str] = field(default=None, repr=False)
+    base_url: str = DEFAULT_SILICONFLOW_BASE_URL
+    timeout: float = 30.0
+    send_dimensions: Optional[bool] = None
+    request_params: Optional[Dict[str, Any]] = None
+    extra_headers: Optional[Dict[str, str]] = None
+    http_client: Optional[httpx.Client] = field(default=None, repr=False)
+    async_http_client: Optional[httpx.AsyncClient] = field(default=None, repr=False)
+
+    def __post_init__(self) -> None:
+        if not self.id:
+            raise ValueError("id must not be empty")
+        if self.dimensions is None:
+            if self.id != DEFAULT_SILICONFLOW_EMBEDDING_MODEL:
+                raise ValueError("dimensions must be provided when using a custom Siliconflow embedding model")
+            self.dimensions = DEFAULT_SILICONFLOW_EMBEDDING_DIMENSIONS
+        if isinstance(self.dimensions, bool) or not isinstance(self.dimensions, int) or self.dimensions <= 0:
+            raise ValueError("dimensions must be a positive integer")
+        if isinstance(self.batch_size, bool) or not isinstance(self.batch_size, int):
+            raise ValueError("batch_size must be an integer")
+        if not 1 <= self.batch_size <= MAX_SILICONFLOW_BATCH_SIZE:
+            raise ValueError(f"batch_size must be between 1 and {MAX_SILICONFLOW_BATCH_SIZE}")
+        if isinstance(self.timeout, bool) or not isinstance(self.timeout, (int, float)) or self.timeout <= 0:
+            raise ValueError("timeout must be a positive number")
+
+    @property
+    def client(self) -> httpx.Client:
+        return self.http_client or get_default_sync_client()
+
+    @property
+    def aclient(self) -> httpx.AsyncClient:
+        return self.async_http_client or get_default_async_client()
+
+    @property
+    def endpoint(self) -> str:
+        return get_siliconflow_url(self.base_url, "/embeddings")
+
+    def _should_send_dimensions(self) -> bool:
+        if self.send_dimensions is not None:
+            return self.send_dimensions
+        return self.id.startswith("Qwen/Qwen3-Embedding-")
+
+    def _build_payload(self, inputs: Union[str, List[str]]) -> Dict[str, Any]:
+        payload = dict(self.request_params or {})
+        payload.update(
+            {
+                "model": self.id,
+                "input": inputs,
+                "encoding_format": "float",
+            }
+        )
+        if self._should_send_dimensions():
+            payload["dimensions"] = self.dimensions
+        else:
+            payload.pop("dimensions", None)
+        return payload
+
+    @staticmethod
+    def _validate_text(text: str) -> None:
+        if not isinstance(text, str) or not text:
+            raise ValueError("text must be a non-empty string")
+
+    @classmethod
+    def _validate_texts(cls, texts: List[str]) -> None:
+        if not isinstance(texts, list):
+            raise ValueError("texts must be a list")
+        for text in texts:
+            cls._validate_text(text)
+
+    def _parse_response(
+        self, response_body: Any, expected_count: int, trace_id: Optional[str]
+    ) -> Tuple[List[List[float]], Optional[Dict[str, Any]]]:
+        if not isinstance(response_body, dict) or not isinstance(response_body.get("data"), list):
+            raise get_malformed_siliconflow_response_error("data must be a list", self.id, trace_id)
+
+        data = response_body["data"]
+        if len(data) != expected_count:
+            raise get_malformed_siliconflow_response_error(
+                f"expected {expected_count} embeddings, received {len(data)}", self.id, trace_id
+            )
+
+        embeddings_by_index: Dict[int, List[float]] = {}
+        for item in data:
+            if not isinstance(item, dict):
+                raise get_malformed_siliconflow_response_error("each data item must be an object", self.id, trace_id)
+
+            index = item.get("index")
+            embedding = item.get("embedding")
+            if isinstance(index, bool) or not isinstance(index, int) or not 0 <= index < expected_count:
+                raise get_malformed_siliconflow_response_error("embedding index is invalid", self.id, trace_id)
+            if index in embeddings_by_index:
+                raise get_malformed_siliconflow_response_error("embedding indices must be unique", self.id, trace_id)
+            if not isinstance(embedding, list) or len(embedding) != self.dimensions:
+                raise get_malformed_siliconflow_response_error(
+                    f"embedding at index {index} must contain {self.dimensions} values", self.id, trace_id
+                )
+
+            parsed_embedding: List[float] = []
+            for value in embedding:
+                if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(float(value)):
+                    raise get_malformed_siliconflow_response_error(
+                        f"embedding at index {index} must contain only finite numbers", self.id, trace_id
+                    )
+                parsed_embedding.append(float(value))
+            embeddings_by_index[index] = parsed_embedding
+
+        expected_indices = set(range(expected_count))
+        if set(embeddings_by_index) != expected_indices:
+            raise get_malformed_siliconflow_response_error("embedding indices must be complete", self.id, trace_id)
+
+        usage = response_body.get("usage")
+        if usage is not None and not isinstance(usage, dict):
+            raise get_malformed_siliconflow_response_error("usage must be an object", self.id, trace_id)
+
+        return [embeddings_by_index[index] for index in range(expected_count)], usage
+
+    def _request(
+        self, inputs: Union[str, List[str]], expected_count: int
+    ) -> Tuple[List[List[float]], Optional[Dict[str, Any]]]:
+        try:
+            response = self.client.post(
+                self.endpoint,
+                headers=get_siliconflow_headers(self.api_key, self.extra_headers),
+                json=self._build_payload(inputs),
+                timeout=self.timeout,
+            )
+            raise_for_siliconflow_status(response, self.id)
+            trace_id = get_siliconflow_trace_id(response)
+            try:
+                response_body = response.json()
+            except ValueError as error:
+                raise get_malformed_siliconflow_response_error(
+                    "response is not valid JSON", self.id, trace_id
+                ) from error
+            return self._parse_response(response_body, expected_count, trace_id)
+        except AgnoError:
+            raise
+        except httpx.RequestError as error:
+            raise get_siliconflow_request_error(error, self.id) from error
+        except Exception as error:
+            raise get_siliconflow_request_error(error, self.id) from error
+
+    async def _async_request(
+        self, inputs: Union[str, List[str]], expected_count: int
+    ) -> Tuple[List[List[float]], Optional[Dict[str, Any]]]:
+        try:
+            response = await self.aclient.post(
+                self.endpoint,
+                headers=get_siliconflow_headers(self.api_key, self.extra_headers),
+                json=self._build_payload(inputs),
+                timeout=self.timeout,
+            )
+            raise_for_siliconflow_status(response, self.id)
+            trace_id = get_siliconflow_trace_id(response)
+            try:
+                response_body = response.json()
+            except ValueError as error:
+                raise get_malformed_siliconflow_response_error(
+                    "response is not valid JSON", self.id, trace_id
+                ) from error
+            return self._parse_response(response_body, expected_count, trace_id)
+        except AgnoError:
+            raise
+        except httpx.RequestError as error:
+            raise get_siliconflow_request_error(error, self.id) from error
+        except Exception as error:
+            raise get_siliconflow_request_error(error, self.id) from error
+
+    def get_embedding(self, text: str) -> List[float]:
+        self._validate_text(text)
+        embeddings, _ = self._request(text, expected_count=1)
+        return embeddings[0]
+
+    def get_embedding_and_usage(self, text: str) -> Tuple[List[float], Optional[Dict]]:
+        self._validate_text(text)
+        embeddings, usage = self._request(text, expected_count=1)
+        return embeddings[0], usage
+
+    async def async_get_embedding(self, text: str) -> List[float]:
+        self._validate_text(text)
+        embeddings, _ = await self._async_request(text, expected_count=1)
+        return embeddings[0]
+
+    async def async_get_embedding_and_usage(self, text: str) -> Tuple[List[float], Optional[Dict]]:
+        self._validate_text(text)
+        embeddings, usage = await self._async_request(text, expected_count=1)
+        return embeddings[0], usage
+
+    def get_embeddings_batch_and_usage(self, texts: List[str]) -> Tuple[List[List[float]], List[Optional[Dict]]]:
+        """Embed texts in batches and repeat each batch-level usage record per result."""
+        self._validate_texts(texts)
+        all_embeddings: List[List[float]] = []
+        all_usage: List[Optional[Dict]] = []
+        for index in range(0, len(texts), self.batch_size):
+            batch = texts[index : index + self.batch_size]
+            embeddings, usage = self._request(batch, expected_count=len(batch))
+            all_embeddings.extend(embeddings)
+            all_usage.extend([dict(usage) if usage is not None else None for _ in embeddings])
+        return all_embeddings, all_usage
+
+    async def async_get_embeddings_batch_and_usage(
+        self, texts: List[str]
+    ) -> Tuple[List[List[float]], List[Optional[Dict]]]:
+        """Asynchronously embed texts and repeat each batch-level usage record per result."""
+        self._validate_texts(texts)
+        all_embeddings: List[List[float]] = []
+        all_usage: List[Optional[Dict]] = []
+        for index in range(0, len(texts), self.batch_size):
+            batch = texts[index : index + self.batch_size]
+            embeddings, usage = await self._async_request(batch, expected_count=len(batch))
+            all_embeddings.extend(embeddings)
+            all_usage.extend([dict(usage) if usage is not None else None for _ in embeddings])
+        return all_embeddings, all_usage

--- a/libs/agno/agno/knowledge/reranker/siliconflow.py
+++ b/libs/agno/agno/knowledge/reranker/siliconflow.py
@@ -1,0 +1,195 @@
+import math
+from typing import Any, Dict, List, Optional, Tuple
+
+import httpx
+from pydantic import Field
+
+from agno.exceptions import AgnoError
+from agno.knowledge.document import Document
+from agno.knowledge.reranker.base import Reranker
+from agno.knowledge.siliconflow import (
+    DEFAULT_SILICONFLOW_BASE_URL,
+    get_malformed_siliconflow_response_error,
+    get_siliconflow_headers,
+    get_siliconflow_request_error,
+    get_siliconflow_trace_id,
+    get_siliconflow_url,
+    raise_for_siliconflow_status,
+)
+from agno.utils.http import get_default_async_client, get_default_sync_client
+from agno.utils.log import logger
+
+
+class SiliconflowReranker(Reranker):
+    """Rerank text documents with Siliconflow's rerank API.
+
+    The reranker reads ``SILICONFLOW_API_KEY`` lazily when ``api_key`` is not
+    provided. Provider failures return the original documents by default; set
+    ``raise_on_error=True`` to receive typed Agno provider exceptions instead.
+    """
+
+    model: str = Field(default="BAAI/bge-reranker-v2-m3", min_length=1)
+    api_key: Optional[str] = Field(default=None, exclude=True, repr=False)
+    base_url: str = Field(default=DEFAULT_SILICONFLOW_BASE_URL, min_length=1)
+    top_n: Optional[int] = Field(default=None, gt=0)
+    instruction: Optional[str] = Field(default=None, min_length=1)
+    max_chunks_per_doc: Optional[int] = Field(default=None, ge=1)
+    overlap_tokens: Optional[int] = Field(default=None, ge=0, le=80)
+    timeout: float = Field(default=30.0, gt=0)
+    raise_on_error: bool = False
+    request_params: Optional[Dict[str, Any]] = None
+    extra_headers: Optional[Dict[str, str]] = None
+    http_client: Optional[httpx.Client] = Field(default=None, exclude=True, repr=False)
+    async_http_client: Optional[httpx.AsyncClient] = Field(default=None, exclude=True, repr=False)
+
+    @property
+    def client(self) -> httpx.Client:
+        return self.http_client or get_default_sync_client()
+
+    @property
+    def aclient(self) -> httpx.AsyncClient:
+        return self.async_http_client or get_default_async_client()
+
+    @property
+    def endpoint(self) -> str:
+        return get_siliconflow_url(self.base_url, "/rerank")
+
+    def _build_payload(self, query: str, documents: List[Document]) -> Tuple[Dict[str, Any], int]:
+        if not query:
+            raise ValueError("query must not be empty")
+
+        top_n = min(self.top_n or len(documents), len(documents))
+        payload = dict(self.request_params or {})
+        payload.update(
+            {
+                "model": self.model,
+                "query": query,
+                "documents": [document.content for document in documents],
+                "top_n": top_n,
+                "return_documents": False,
+            }
+        )
+        if self.instruction is not None:
+            payload["instruction"] = self.instruction
+        else:
+            payload.pop("instruction", None)
+        if self.max_chunks_per_doc is not None:
+            payload["max_chunks_per_doc"] = self.max_chunks_per_doc
+        else:
+            payload.pop("max_chunks_per_doc", None)
+        if self.overlap_tokens is not None:
+            payload["overlap_tokens"] = self.overlap_tokens
+        else:
+            payload.pop("overlap_tokens", None)
+        return payload, top_n
+
+    def _parse_response(
+        self, response_body: Any, documents: List[Document], expected_count: int, trace_id: Optional[str]
+    ) -> List[Document]:
+        if not isinstance(response_body, dict) or not isinstance(response_body.get("results"), list):
+            raise get_malformed_siliconflow_response_error("results must be a list", self.model, trace_id)
+
+        results = response_body["results"]
+        if len(results) != expected_count:
+            raise get_malformed_siliconflow_response_error(
+                f"expected {expected_count} results, received {len(results)}", self.model, trace_id
+            )
+
+        parsed_results: List[Tuple[int, float]] = []
+        seen_indices = set()
+        for result in results:
+            if not isinstance(result, dict):
+                raise get_malformed_siliconflow_response_error("each result must be an object", self.model, trace_id)
+
+            index = result.get("index")
+            score = result.get("relevance_score")
+            if isinstance(index, bool) or not isinstance(index, int) or not 0 <= index < len(documents):
+                raise get_malformed_siliconflow_response_error("result index is invalid", self.model, trace_id)
+            if index in seen_indices:
+                raise get_malformed_siliconflow_response_error("result indices must be unique", self.model, trace_id)
+            if isinstance(score, bool) or not isinstance(score, (int, float)) or not math.isfinite(float(score)):
+                raise get_malformed_siliconflow_response_error(
+                    "relevance_score must be a finite number", self.model, trace_id
+                )
+
+            seen_indices.add(index)
+            parsed_results.append((index, float(score)))
+
+        reranked_documents: List[Document] = []
+        for index, score in parsed_results:
+            document = documents[index]
+            document.reranking_score = score
+            reranked_documents.append(document)
+        return reranked_documents
+
+    def _rerank(self, query: str, documents: List[Document]) -> List[Document]:
+        payload, expected_count = self._build_payload(query, documents)
+        try:
+            response = self.client.post(
+                self.endpoint,
+                headers=get_siliconflow_headers(self.api_key, self.extra_headers),
+                json=payload,
+                timeout=self.timeout,
+            )
+            raise_for_siliconflow_status(response, self.model)
+            trace_id = get_siliconflow_trace_id(response)
+            try:
+                response_body = response.json()
+            except ValueError as error:
+                raise get_malformed_siliconflow_response_error(
+                    "response is not valid JSON", self.model, trace_id
+                ) from error
+            return self._parse_response(response_body, documents, expected_count, trace_id)
+        except AgnoError:
+            raise
+        except httpx.RequestError as error:
+            raise get_siliconflow_request_error(error, self.model) from error
+        except Exception as error:
+            raise get_siliconflow_request_error(error, self.model) from error
+
+    async def _arerank(self, query: str, documents: List[Document]) -> List[Document]:
+        payload, expected_count = self._build_payload(query, documents)
+        try:
+            response = await self.aclient.post(
+                self.endpoint,
+                headers=get_siliconflow_headers(self.api_key, self.extra_headers),
+                json=payload,
+                timeout=self.timeout,
+            )
+            raise_for_siliconflow_status(response, self.model)
+            trace_id = get_siliconflow_trace_id(response)
+            try:
+                response_body = response.json()
+            except ValueError as error:
+                raise get_malformed_siliconflow_response_error(
+                    "response is not valid JSON", self.model, trace_id
+                ) from error
+            return self._parse_response(response_body, documents, expected_count, trace_id)
+        except AgnoError:
+            raise
+        except httpx.RequestError as error:
+            raise get_siliconflow_request_error(error, self.model) from error
+        except Exception as error:
+            raise get_siliconflow_request_error(error, self.model) from error
+
+    def rerank(self, query: str, documents: List[Document]) -> List[Document]:
+        if not documents:
+            return []
+        try:
+            return self._rerank(query, documents)
+        except Exception:
+            if self.raise_on_error:
+                raise
+            logger.exception("Siliconflow reranking failed. Returning original documents")
+            return documents
+
+    async def arerank(self, query: str, documents: List[Document]) -> List[Document]:
+        if not documents:
+            return []
+        try:
+            return await self._arerank(query, documents)
+        except Exception:
+            if self.raise_on_error:
+                raise
+            logger.exception("Siliconflow reranking failed. Returning original documents")
+            return documents

--- a/libs/agno/agno/knowledge/siliconflow.py
+++ b/libs/agno/agno/knowledge/siliconflow.py
@@ -1,0 +1,126 @@
+from os import getenv
+from typing import Dict, Mapping, Optional
+
+import httpx
+
+from agno.exceptions import AgnoError, ModelAuthenticationError, ModelProviderError, ModelRateLimitError
+
+DEFAULT_SILICONFLOW_BASE_URL = "https://api.siliconflow.cn/v1"
+SILICONFLOW_API_KEY_ENV_VAR = "SILICONFLOW_API_KEY"
+SILICONFLOW_PROVIDER_NAME = "Siliconflow"
+
+
+def get_siliconflow_api_key(api_key: Optional[str]) -> str:
+    resolved_api_key = api_key or getenv(SILICONFLOW_API_KEY_ENV_VAR)
+    if not resolved_api_key:
+        raise ModelAuthenticationError(
+            message=(
+                "SILICONFLOW_API_KEY not set. Please set the SILICONFLOW_API_KEY environment variable or pass api_key."
+            ),
+            model_name=SILICONFLOW_PROVIDER_NAME,
+        )
+    return resolved_api_key
+
+
+def get_siliconflow_headers(
+    api_key: Optional[str], extra_headers: Optional[Mapping[str, str]] = None
+) -> Dict[str, str]:
+    headers = dict(extra_headers or {})
+    headers.update(
+        {
+            "Authorization": f"Bearer {get_siliconflow_api_key(api_key)}",
+            "Content-Type": "application/json",
+        }
+    )
+    return headers
+
+
+def get_siliconflow_url(base_url: str, endpoint: str) -> str:
+    return f"{base_url.rstrip('/')}/{endpoint.lstrip('/')}"
+
+
+def get_siliconflow_trace_id(response: httpx.Response) -> Optional[str]:
+    return response.headers.get("x-siliconcloud-trace-id")
+
+
+def _get_error_message(response: httpx.Response) -> str:
+    message: Optional[str] = None
+    try:
+        response_body = response.json()
+        if isinstance(response_body, dict):
+            error = response_body.get("error")
+            if isinstance(error, dict) and isinstance(error.get("message"), str):
+                message = error["message"]
+            elif isinstance(error, str):
+                message = error
+            elif isinstance(response_body.get("message"), str):
+                message = response_body["message"]
+    except ValueError:
+        pass
+
+    if not message:
+        message = response.reason_phrase or "Unknown provider error"
+
+    trace_id = get_siliconflow_trace_id(response)
+    trace_suffix = f" (trace ID: {trace_id})" if trace_id else ""
+    return f"Siliconflow API request failed with status {response.status_code}: {message}{trace_suffix}"
+
+
+def raise_for_siliconflow_status(response: httpx.Response, model_id: str) -> None:
+    if response.is_success:
+        return
+
+    message = _get_error_message(response)
+    if response.status_code in {401, 403}:
+        raise ModelAuthenticationError(
+            message=message,
+            status_code=response.status_code,
+            model_name=SILICONFLOW_PROVIDER_NAME,
+        )
+    if response.status_code in {429, 529}:
+        raise ModelRateLimitError(
+            message=message,
+            status_code=response.status_code,
+            model_name=SILICONFLOW_PROVIDER_NAME,
+            model_id=model_id,
+        )
+    raise ModelProviderError(
+        message=message,
+        status_code=response.status_code,
+        model_name=SILICONFLOW_PROVIDER_NAME,
+        model_id=model_id,
+    )
+
+
+def get_siliconflow_request_error(error: Exception, model_id: str) -> AgnoError:
+    if isinstance(error, AgnoError):
+        return error
+
+    if isinstance(error, httpx.TimeoutException):
+        message = "Siliconflow API request timed out"
+        status_code = 504
+    elif isinstance(error, httpx.RequestError):
+        message = "Siliconflow API request failed due to a network error"
+        status_code = 503
+    else:
+        message = "Siliconflow API returned a malformed response"
+        status_code = 502
+
+    return ModelProviderError(
+        message=message,
+        status_code=status_code,
+        model_name=SILICONFLOW_PROVIDER_NAME,
+        model_id=model_id,
+    )
+
+
+def get_malformed_siliconflow_response_error(
+    message: str, model_id: str, trace_id: Optional[str] = None
+) -> ModelProviderError:
+    trace_suffix = f" (trace ID: {trace_id})" if trace_id else ""
+    return ModelProviderError(
+        message=f"Siliconflow API returned a malformed response: {message}{trace_suffix}",
+        status_code=502,
+        model_name=SILICONFLOW_PROVIDER_NAME,
+        model_id=model_id,
+    )

--- a/libs/agno/tests/integration/embedder/test_siliconflow_embedder.py
+++ b/libs/agno/tests/integration/embedder/test_siliconflow_embedder.py
@@ -1,0 +1,19 @@
+import os
+
+import pytest
+
+from agno.knowledge.embedder.siliconflow import SiliconflowEmbedder
+
+pytestmark = pytest.mark.skipif(not os.getenv("SILICONFLOW_API_KEY"), reason="SILICONFLOW_API_KEY not set")
+
+
+def test_siliconflow_embedder_live_batch():
+    embedder = SiliconflowEmbedder()
+
+    embeddings, usages = embedder.get_embeddings_batch_and_usage(
+        ["The Eiffel Tower is in Paris.", "Python is a programming language."]
+    )
+
+    assert len(embeddings) == len(usages) == 2
+    assert all(len(embedding) == 1024 for embedding in embeddings)
+    assert all(isinstance(value, float) for embedding in embeddings for value in embedding)

--- a/libs/agno/tests/integration/reranker/test_siliconflow_reranker.py
+++ b/libs/agno/tests/integration/reranker/test_siliconflow_reranker.py
@@ -1,0 +1,24 @@
+import os
+
+import pytest
+
+from agno.knowledge.document import Document
+from agno.knowledge.reranker.siliconflow import SiliconflowReranker
+
+pytestmark = pytest.mark.skipif(not os.getenv("SILICONFLOW_API_KEY"), reason="SILICONFLOW_API_KEY not set")
+
+
+def test_siliconflow_reranker_live():
+    documents = [
+        Document(content="The Eiffel Tower is in Paris."),
+        Document(content="Python is a programming language."),
+        Document(content="Paris is the capital of France."),
+    ]
+    reranker = SiliconflowReranker(top_n=2, raise_on_error=True)
+
+    result = reranker.rerank("Where is the Eiffel Tower?", documents)
+
+    assert len(result) == 2
+    assert all(document in documents for document in result)
+    assert all(document.reranking_score is not None for document in result)
+    assert result[0].reranking_score >= result[1].reranking_score

--- a/libs/agno/tests/unit/knowledge/test_siliconflow_embedder.py
+++ b/libs/agno/tests/unit/knowledge/test_siliconflow_embedder.py
@@ -1,0 +1,234 @@
+import json
+
+import httpx
+import pytest
+
+from agno.exceptions import ModelAuthenticationError, ModelProviderError, ModelRateLimitError
+from agno.knowledge.embedder.siliconflow import SiliconflowEmbedder
+
+
+def _embedding_response(vectors, usage=None):
+    return {
+        "object": "list",
+        "model": "test-model",
+        "data": [{"object": "embedding", "embedding": vector, "index": index} for index, vector in enumerate(vectors)],
+        "usage": usage,
+    }
+
+
+def test_default_model_and_dimensions():
+    embedder = SiliconflowEmbedder()
+
+    assert embedder.id == "BAAI/bge-m3"
+    assert embedder.dimensions == 1024
+    assert embedder.enable_batch is True
+    assert embedder.batch_size == 32
+
+
+def test_custom_model_requires_explicit_dimensions():
+    with pytest.raises(ValueError, match="dimensions must be provided"):
+        SiliconflowEmbedder(id="custom/model")
+
+
+@pytest.mark.parametrize("batch_size", [0, 33, True])
+def test_batch_size_is_validated(batch_size):
+    with pytest.raises(ValueError, match="batch_size"):
+        SiliconflowEmbedder(batch_size=batch_size)
+
+
+def test_get_embedding_uses_float_payload_and_omits_dimensions_for_bge():
+    vector = [0.25] * 1024
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        assert request.url == "https://example.test/v1/embeddings"
+        assert request.headers["Authorization"] == "Bearer test-key"
+        assert request.headers["X-Test"] == "value"
+        assert payload == {
+            "custom_option": True,
+            "model": "BAAI/bge-m3",
+            "input": "hello",
+            "encoding_format": "float",
+        }
+        return httpx.Response(200, json=_embedding_response([vector]))
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        embedder = SiliconflowEmbedder(
+            api_key="test-key",
+            base_url="https://example.test/v1/",
+            request_params={
+                "custom_option": True,
+                "model": "overridden-model",
+                "input": "overridden-input",
+                "encoding_format": "base64",
+                "dimensions": 5,
+            },
+            extra_headers={"Authorization": "Bearer wrong-key", "X-Test": "value"},
+            http_client=client,
+        )
+        result = embedder.get_embedding("hello")
+
+    assert result == vector
+
+
+def test_qwen_model_sends_configured_dimensions():
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        assert payload["dimensions"] == 2
+        return httpx.Response(200, json=_embedding_response([[0.1, 0.2]]))
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        embedder = SiliconflowEmbedder(
+            id="Qwen/Qwen3-Embedding-0.6B",
+            dimensions=2,
+            api_key="test-key",
+            http_client=client,
+        )
+        assert embedder.get_embedding("hello") == [0.1, 0.2]
+
+
+def test_send_dimensions_can_be_overridden():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert json.loads(request.content)["dimensions"] == 2
+        return httpx.Response(200, json=_embedding_response([[0.1, 0.2]]))
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        embedder = SiliconflowEmbedder(
+            id="custom/model",
+            dimensions=2,
+            send_dimensions=True,
+            api_key="test-key",
+            http_client=client,
+        )
+        assert embedder.get_embedding("hello") == [0.1, 0.2]
+
+
+def test_get_embedding_and_usage_returns_usage():
+    usage = {"prompt_tokens": 3, "total_tokens": 3}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=_embedding_response([[0.1, 0.2]], usage))
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        embedder = SiliconflowEmbedder(id="custom/model", dimensions=2, api_key="test-key", http_client=client)
+        embedding, result_usage = embedder.get_embedding_and_usage("hello")
+
+    assert embedding == [0.1, 0.2]
+    assert result_usage == usage
+
+
+def test_sync_batch_chunks_requests_restores_index_order_and_copies_usage():
+    request_sizes = []
+    usage = {"prompt_tokens": 10, "total_tokens": 10}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        inputs = payload["input"]
+        request_sizes.append(len(inputs))
+        data = [
+            {"object": "embedding", "embedding": [float(index), 1.0], "index": index}
+            for index in reversed(range(len(inputs)))
+        ]
+        return httpx.Response(200, json={"data": data, "usage": usage})
+
+    texts = [f"text-{index}" for index in range(35)]
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        embedder = SiliconflowEmbedder(id="custom/model", dimensions=2, api_key="test-key", http_client=client)
+        embeddings, usages = embedder.get_embeddings_batch_and_usage(texts)
+
+    assert request_sizes == [32, 3]
+    assert embeddings[0] == [0.0, 1.0]
+    assert embeddings[31] == [31.0, 1.0]
+    assert embeddings[32] == [0.0, 1.0]
+    assert len(embeddings) == len(usages) == len(texts)
+    assert all(item == usage for item in usages)
+    assert usages[0] is not usages[1]
+
+
+@pytest.mark.asyncio
+async def test_async_single_and_batch_embedding():
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        inputs = payload["input"]
+        values = inputs if isinstance(inputs, list) else [inputs]
+        return httpx.Response(
+            200,
+            json=_embedding_response([[float(index), 0.5] for index, _ in enumerate(values)], {"total_tokens": 4}),
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        embedder = SiliconflowEmbedder(id="custom/model", dimensions=2, api_key="test-key", async_http_client=client)
+        embedding, usage = await embedder.async_get_embedding_and_usage("hello")
+        embeddings, usages = await embedder.async_get_embeddings_batch_and_usage(["one", "two"])
+
+    assert embedding == [0.0, 0.5]
+    assert usage == {"total_tokens": 4}
+    assert embeddings == [[0.0, 0.5], [1.0, 0.5]]
+    assert usages == [{"total_tokens": 4}, {"total_tokens": 4}]
+
+
+def test_empty_batch_returns_empty_without_api_call():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError("API should not be called")
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        embedder = SiliconflowEmbedder(api_key="test-key", http_client=client)
+        assert embedder.get_embeddings_batch_and_usage([]) == ([], [])
+
+
+def test_invalid_text_is_rejected_before_api_call():
+    embedder = SiliconflowEmbedder(api_key="test-key")
+
+    with pytest.raises(ValueError, match="non-empty"):
+        embedder.get_embedding("")
+
+
+@pytest.mark.parametrize(
+    ("status_code", "error_type"),
+    [
+        (401, ModelAuthenticationError),
+        (403, ModelAuthenticationError),
+        (429, ModelRateLimitError),
+        (503, ModelProviderError),
+    ],
+)
+def test_http_errors_are_mapped_to_agno_exceptions(status_code, error_type):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status_code, json={"message": "provider error"})
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        embedder = SiliconflowEmbedder(api_key="test-key", http_client=client)
+        with pytest.raises(error_type) as error:
+            embedder.get_embedding("hello")
+
+    assert error.value.status_code == status_code
+
+
+def test_malformed_embedding_dimension_raises_provider_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=_embedding_response([[0.1]]))
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        embedder = SiliconflowEmbedder(id="custom/model", dimensions=2, api_key="test-key", http_client=client)
+        with pytest.raises(ModelProviderError, match="2 values"):
+            embedder.get_embedding("hello")
+
+
+def test_timeout_is_mapped_to_provider_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("timed out", request=request)
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        embedder = SiliconflowEmbedder(api_key="test-key", http_client=client)
+        with pytest.raises(ModelProviderError) as error:
+            embedder.get_embedding("hello")
+
+    assert error.value.status_code == 504
+
+
+def test_api_key_is_resolved_lazily(monkeypatch):
+    monkeypatch.delenv("SILICONFLOW_API_KEY", raising=False)
+    embedder = SiliconflowEmbedder()
+
+    with pytest.raises(ModelAuthenticationError):
+        embedder.get_embedding("hello")

--- a/libs/agno/tests/unit/knowledge/test_siliconflow_reranker.py
+++ b/libs/agno/tests/unit/knowledge/test_siliconflow_reranker.py
@@ -1,0 +1,202 @@
+import json
+
+import httpx
+import pytest
+from pydantic import ValidationError
+
+from agno.exceptions import ModelAuthenticationError, ModelProviderError, ModelRateLimitError
+from agno.knowledge.document import Document
+from agno.knowledge.reranker.siliconflow import SiliconflowReranker
+
+
+@pytest.fixture
+def documents():
+    return [
+        Document(content="Alpha"),
+        Document(content="Beta"),
+        Document(content="Gamma"),
+    ]
+
+
+def test_rerank_builds_protected_payload_and_preserves_response_order(documents):
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        assert request.url == "https://example.test/v1/rerank"
+        assert request.headers["Authorization"] == "Bearer test-key"
+        assert request.headers["X-Test"] == "value"
+        assert payload == {
+            "custom_option": True,
+            "model": "BAAI/bge-reranker-v2-m3",
+            "query": "gamma",
+            "documents": ["Alpha", "Beta", "Gamma"],
+            "top_n": 2,
+            "return_documents": False,
+            "instruction": "Rank by relevance",
+            "max_chunks_per_doc": 8,
+            "overlap_tokens": 20,
+        }
+        return httpx.Response(
+            200,
+            json={
+                "results": [
+                    {"index": 2, "relevance_score": 0.95},
+                    {"index": 0, "relevance_score": 0.4},
+                ]
+            },
+        )
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        reranker = SiliconflowReranker(
+            api_key="test-key",
+            base_url="https://example.test/v1/",
+            top_n=2,
+            instruction="Rank by relevance",
+            max_chunks_per_doc=8,
+            overlap_tokens=20,
+            request_params={
+                "custom_option": True,
+                "model": "overridden-model",
+                "query": "overridden-query",
+                "top_n": 99,
+                "return_documents": True,
+            },
+            extra_headers={"Authorization": "Bearer wrong-key", "X-Test": "value"},
+            http_client=client,
+            raise_on_error=True,
+        )
+        result = reranker.rerank("gamma", documents)
+
+    assert result == [documents[2], documents[0]]
+    assert [document.reranking_score for document in result] == [0.95, 0.4]
+    assert documents[1].reranking_score is None
+
+
+def test_rerank_clamps_top_n_to_document_count(documents):
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert json.loads(request.content)["top_n"] == 3
+        return httpx.Response(
+            200,
+            json={
+                "results": [
+                    {"index": 0, "relevance_score": 0.9},
+                    {"index": 1, "relevance_score": 0.8},
+                    {"index": 2, "relevance_score": 0.7},
+                ]
+            },
+        )
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        reranker = SiliconflowReranker(api_key="test-key", top_n=100, http_client=client, raise_on_error=True)
+        result = reranker.rerank("query", documents)
+
+    assert result == documents
+
+
+def test_rerank_empty_documents_does_not_call_api():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError("API should not be called")
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        reranker = SiliconflowReranker(api_key="test-key", http_client=client)
+        assert reranker.rerank("query", []) == []
+
+
+@pytest.mark.asyncio
+async def test_async_rerank_matches_sync_behavior(documents):
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert json.loads(request.content)["top_n"] == 1
+        return httpx.Response(200, json={"results": [{"index": 1, "relevance_score": 0.88}]})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        reranker = SiliconflowReranker(api_key="test-key", top_n=1, async_http_client=client, raise_on_error=True)
+        result = await reranker.arerank("beta", documents)
+
+    assert result == [documents[1]]
+    assert result[0].reranking_score == 0.88
+
+
+def test_rerank_fails_open_by_default(documents):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, json={"message": "Model overloaded"})
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        reranker = SiliconflowReranker(api_key="test-key", http_client=client)
+        assert reranker.rerank("query", documents) == documents
+
+
+def test_rerank_raises_typed_authentication_error_with_trace_id(documents):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            401,
+            headers={"x-siliconcloud-trace-id": "trace-123"},
+            json={"error": {"message": "Invalid API key"}},
+        )
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        reranker = SiliconflowReranker(api_key="test-key", http_client=client, raise_on_error=True)
+        with pytest.raises(ModelAuthenticationError, match="trace-123") as error:
+            reranker.rerank("query", documents)
+
+    assert error.value.status_code == 401
+
+
+def test_rerank_raises_rate_limit_error(documents):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(429, json={"message": "Rate limited"})
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        reranker = SiliconflowReranker(api_key="test-key", http_client=client, raise_on_error=True)
+        with pytest.raises(ModelRateLimitError) as error:
+            reranker.rerank("query", documents)
+
+    assert error.value.status_code == 429
+
+
+def test_rerank_rejects_malformed_results_without_mutating_documents(documents):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "results": [
+                    {"index": 0, "relevance_score": 0.9},
+                    {"index": 0, "relevance_score": 0.8},
+                    {"index": 2, "relevance_score": 0.7},
+                ]
+            },
+        )
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        reranker = SiliconflowReranker(api_key="test-key", http_client=client, raise_on_error=True)
+        with pytest.raises(ModelProviderError, match="unique"):
+            reranker.rerank("query", documents)
+
+    assert all(document.reranking_score is None for document in documents)
+
+
+def test_rerank_maps_timeout_to_provider_error(documents):
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("timed out", request=request)
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        reranker = SiliconflowReranker(api_key="test-key", http_client=client, raise_on_error=True)
+        with pytest.raises(ModelProviderError) as error:
+            reranker.rerank("query", documents)
+
+    assert error.value.status_code == 504
+
+
+def test_rerank_resolves_api_key_lazily(monkeypatch, documents):
+    monkeypatch.delenv("SILICONFLOW_API_KEY", raising=False)
+    reranker = SiliconflowReranker(raise_on_error=True)
+
+    with pytest.raises(ModelAuthenticationError):
+        reranker.rerank("query", documents)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("top_n", 0), ("max_chunks_per_doc", 0), ("overlap_tokens", 81), ("timeout", 0)],
+)
+def test_reranker_validates_configuration(field, value):
+    with pytest.raises(ValidationError):
+        SiliconflowReranker(**{field: value})


### PR DESCRIPTION
## Summary

Add first-class SiliconFlow embedding and reranking support to Agno.

Key changes:

- Add `SiliconflowEmbedder` with:
  - `BAAI/bge-m3` as the default 1024-dimensional model
  - Synchronous and asynchronous embedding APIs
  - Batch embedding support with a maximum batch size of 32
  - Configurable dimensions for custom models
  - Strict response, index, and vector-dimension validation
- Add `SiliconflowReranker` with:
  - `BAAI/bge-reranker-v2-m3` as the default model
  - Synchronous and asynchronous reranking
  - Support for `top_n`, instructions, chunking, and overlap parameters
  - Fail-open behavior by default, with optional strict error handling
- Add shared SiliconFlow authentication, URL handling, HTTP client reuse, and typed provider-error mapping.
- Add mocked unit tests and optional live integration tests.
- Add a self-contained cookbook demonstrating embedding and reranking without requiring a vector database.
- Update related knowledge and cookbook documentation.

This enables users to configure both components through `SILICONFLOW_API_KEY` without introducing an additional SDK dependency.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Validation completed successfully:

- `./scripts/format.sh`
- `./scripts/validate.sh`
- 34 new mocked unit tests
- 43 related unit and regression tests
- 2 live SiliconFlow integration tests
- Live cookbook execution using the configured `SILICONFLOW_API_KEY`

The API key is resolved lazily from the environment and is excluded from logs and object representations. Core authorization headers and request fields cannot be overridden through extension parameters.

The implementation uses Agno's shared `httpx` clients and does not automatically retry POST requests, avoiding unexpected latency or duplicate billing.
