### PR TITLE
fix: external agents crash the background streaming route with raw ev…

### DIFF
--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -194,6 +194,7 @@ async def agent_resumable_response_streamer(
         kwargs["auth_token"] = auth_token
 
     try:
+        warned_not_resumable = False
         async for sse_data in agent.arun(
             input=message,
             session_id=session_id,
@@ -207,7 +208,19 @@ async def agent_resumable_response_streamer(
             background=True,
             **kwargs,
         ):
-            yield sse_data
+            if isinstance(sse_data, str):
+                yield sse_data
+            else:
+                # Agents without background support (e.g. external adapters)
+                # ignore background=True and yield raw events: format them so
+                # the stream works, though the run is not resumable.
+                if not warned_not_resumable:
+                    warned_not_resumable = True
+                    log_warning(
+                        f"Agent '{getattr(agent, 'id', None)}' does not support background execution; "
+                        "streaming inline (run is not resumable)."
+                    )
+                yield format_sse_event(sse_data)
     except (InputCheckError, OutputCheckError) as e:
         error_response = RunErrorEvent(
             content=str(e),

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -216,7 +216,7 @@ async def agent_resumable_response_streamer(
                 # the stream works, though the run is not resumable.
                 if not warned_not_resumable:
                     warned_not_resumable = True
-                    log_warning(
+                    log_debug(
                         f"Agent '{getattr(agent, 'id', None)}' does not support background execution; "
                         "streaming inline (run is not resumable)."
                     )

--- a/libs/agno/tests/unit/os/test_external_agent_background_stream.py
+++ b/libs/agno/tests/unit/os/test_external_agent_background_stream.py
@@ -1,0 +1,55 @@
+"""External agents don't support background=True; the resumable streaming route
+must degrade to inline SSE instead of forwarding raw event objects to Starlette
+(which crashes with "'RunStartedEvent' object has no attribute 'encode'")."""
+
+import tempfile
+from dataclasses import dataclass
+from typing import Any, AsyncIterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agno.agents.base import BaseExternalAgent
+from agno.db.sqlite import SqliteDb
+from agno.os import AgentOS
+from agno.run.agent import RunContentEvent, RunOutputEvent
+
+
+@dataclass
+class EchoAgent(BaseExternalAgent):
+    framework: str = "test-framework"
+
+    async def _arun_adapter(self, input: Any, **kwargs: Any) -> str:
+        return f"echo: {input}"
+
+    async def _arun_adapter_stream(self, input: Any, **kwargs: Any) -> AsyncIterator[RunOutputEvent]:
+        yield RunContentEvent(run_id=kwargs.get("run_id", ""), content=f"echo: {input}")
+
+
+@pytest.fixture
+def client():
+    tmp = tempfile.mkdtemp()
+    db = SqliteDb(db_file=f"{tmp}/os.db")
+    agent = EchoAgent(name="Echo", id="echo-agent", db=db)
+    app = AgentOS(id="test-os", db=db, agents=[agent]).get_app()
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_background_stream_degrades_to_inline_sse(client):
+    response = client.post(
+        "/agents/echo-agent/runs",
+        data={"message": "hi", "stream": "true", "background": "true"},
+    )
+    assert response.status_code == 200
+    events = [line for line in response.text.splitlines() if line.startswith("event:")]
+    assert any("RunStarted" in line for line in events)
+    assert any("RunCompleted" in line for line in events)
+
+
+def test_plain_stream_still_works(client):
+    response = client.post(
+        "/agents/echo-agent/runs",
+        data={"message": "hi", "stream": "true"},
+    )
+    assert response.status_code == 200
+    assert "RunCompleted" in response.text


### PR DESCRIPTION
## Summary

`POST /agents/{id}/runs` with `stream=true&background=true` returns a 500 for
external framework agents (LangGraph, Claude, DSPy, etc.):

```
AttributeError: 'RunStartedEvent' object has no attribute 'encode'
```

The resumable streaming route trusts `agent.arun(background=True, stream=True)`
to yield pre-formatted SSE strings and forwards them to the client untouched.
External adapters (`BaseExternalAgent`) do not implement background execution —
the `background` kwarg falls into `**kwargs` and is silently ignored — so they
yield raw event objects instead, and Starlette crashes trying to `.encode()` the
first one.

This was latent on `main` too (same streamer, same guard, same `arun`
signature): the background branch only guards `RemoteAgent`, never external
agents. It surfaces now because the OS UI's default run flow
(`stream=true, background=true`) reaches external agents on v3. A plain `curl`
with `background=true` reproduces it on either branch — frontend behavior was
never a real guard.

### Fix

The resumable streamer now type-checks each chunk: strings pass through
untouched (internal agents keep full resumability), raw events are formatted
with `format_sse_event` and a one-time warning is logged:

```
Agent 'X' does not support background execution; streaming inline (run is not resumable).
```

The stream completes normally (`RunStarted -> RunContent -> RunCompleted`,
HTTP 200). Extending real background semantics (detached task, event
buffering, `/resume`) to external adapters is intentionally out of scope.