### PR TITLE
fix: apply updated_at sort fallback in in-memory queue store

### DIFF
--- a/libs/agno/agno/job_queue/store.py
+++ b/libs/agno/agno/job_queue/store.py
@@ -238,14 +238,22 @@ class InMemoryQueueStore:
 
         status accepts one value or a list (match any). An unknown sort_by is
         silently ignored (the list-API convention); None-valued sort fields
-        group together rather than erroring."""
+        group together rather than erroring. Sorting by updated_at falls back
+        to created_at when updated_at is None, matching the DB adapters."""
         statuses = [status] if isinstance(status, str) else status
         async with self._lock:
             jobs = [dict(j) for j in self._jobs.values() if statuses is None or j["status"] in statuses]
         total_count = len(jobs)
         if sort_by and jobs and sort_by in jobs[0]:
+
+            def sort_value(job: Dict[str, Any]) -> Any:
+                value = job.get(sort_by)
+                if value is None and sort_by == "updated_at":
+                    value = job.get("created_at")
+                return value
+
             jobs.sort(
-                key=lambda j: (j.get(sort_by) is None, j.get(sort_by)),
+                key=lambda j: (sort_value(j) is None, sort_value(j)),
                 reverse=(sort_order != "asc"),
             )
         start = max(page - 1, 0) * limit

--- a/libs/agno/tests/unit/run/test_queue_store.py
+++ b/libs/agno/tests/unit/run/test_queue_store.py
@@ -260,6 +260,20 @@ class TestOpsSurface:
         assert len(jobs) == 5
 
     @pytest.mark.asyncio
+    async def test_sort_updated_at_falls_back_to_created_at(self, store):
+        # Jobs with a NULL updated_at must sort by created_at instead of
+        # grouping together, matching the DB adapters' COALESCE behaviour.
+        store._jobs["a"] = make_job("a", created_at=100)  # updated_at None -> effective 100
+        store._jobs["b"] = make_job("b", created_at=200, updated_at=150)
+        store._jobs["c"] = make_job("c", created_at=50, updated_at=300)
+
+        desc, _ = await store.list_jobs(limit=5, page=1, sort_by="updated_at", sort_order="desc")
+        assert [j["id"] for j in desc] == ["c", "b", "a"]
+
+        asc, _ = await store.list_jobs(limit=5, page=1, sort_by="updated_at", sort_order="asc")
+        assert [j["id"] for j in asc] == ["a", "b", "c"]
+
+    @pytest.mark.asyncio
     async def test_requeue_grants_one_more_attempt(self, store):
         await store.enqueue_job(make_job("r1"))
         claimed = await store.claim_job("w1")


### PR DESCRIPTION
## Description

Follow-up to #9504. Fixes one remaining sort inconsistency across the queue `list_jobs` store implementations.

`InMemoryQueueStore.list_jobs` sorted on the raw field value, so sorting by `updated_at` grouped every job with a `NULL` `updated_at` together (all treated as the same key) instead of falling back to `created_at`. Both production adapters already apply that fallback:

- **Postgres** (`apply_sorting`): `COALESCE(updated_at, created_at)`
- **Redis** (`apply_sorting` -> `get_sort_value`): falls back to `created_at` when `updated_at` is `None`

So the dev/in-memory store ordered `updated_at`-sorted results differently from production. This change mirrors the fallback in the in-memory sort key so all three backends agree.

Scope note: the other items raised in review of #9504 need no code change here — the Postgres pagination-stability tiebreak (`ORDER BY ... , id`) was already added in that PR's second commit, and the Redis "load the whole index" approach is the deliberate, documented tradeoff shared with the other Redis list APIs.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing

- New `test_sort_updated_at_falls_back_to_created_at` in `tests/unit/run/test_queue_store.py`: seeds jobs with and without `updated_at` and asserts asc/desc ordering falls back to `created_at`.
- Full queue suite green: `test_queue_store.py`, `test_queue_list_pagination.py`, `test_redis_db_queue.py` — 89 passed.
- `./scripts/format.sh` and `./scripts/validate.sh` clean (ruff + mypy, no issues).

## Checklist

- [x] In-memory store variant updated (Postgres/Redis already correct)
- [x] Test added for new behavior
- [x] `./scripts/format.sh` and `./scripts/validate.sh` run