### PR TITLE
fix: replace the deprecated Groq `llama-3.3-70b-versatile` with `openai/gpt-oss-120b`

### DIFF
--- a/.github/workflows/test_on_release.yml
+++ b/.github/workflows/test_on_release.yml
@@ -8,7 +8,6 @@ on:
       - "*release*" # Run on release-* format
       - "release/*" # Run on release/1.2.3 branch format
       - "feat/environments"
-      - "groq-model-deprecation" # TEMPORARY
   workflow_dispatch: # Allows manual triggering
     inputs:
       branch:

--- a/.github/workflows/test_on_release.yml
+++ b/.github/workflows/test_on_release.yml
@@ -8,6 +8,7 @@ on:
       - "*release*" # Run on release-* format
       - "release/*" # Run on release/1.2.3 branch format
       - "feat/environments"
+      - "groq-model-deprecation" # TEMPORARY
   workflow_dispatch: # Allows manual triggering
     inputs:
       branch:

--- a/cookbook/10_reasoning/models/groq/fast_reasoning.py
+++ b/cookbook/10_reasoning/models/groq/fast_reasoning.py
@@ -30,7 +30,7 @@ def run_example() -> None:
     try:
         start = time.time()
         agent_deepseek = Agent(
-            model=Groq(id="llama-3.3-70b-versatile"),
+            model=Groq(id="openai/gpt-oss-120b"),
             markdown=True,
         )
         response = agent_deepseek.run(task, stream=False)
@@ -50,7 +50,7 @@ def run_example() -> None:
     try:
         start = time.time()
         agent_llama = Agent(
-            model=Groq(id="llama-3.3-70b-versatile"),
+            model=Groq(id="openai/gpt-oss-120b"),
             markdown=True,
         )
         response = agent_llama.run(task, stream=False)

--- a/cookbook/90_models/groq/agent_team.py
+++ b/cookbook/90_models/groq/agent_team.py
@@ -18,7 +18,7 @@ from agno.tools.yfinance import YFinanceTools
 web_agent = Agent(
     name="Web Agent",
     role="Search the web for information",
-    model=Groq(id="llama-3.3-70b-versatile"),
+    model=Groq(id="openai/gpt-oss-120b"),
     tools=[WebSearchTools()],
     instructions="Always include sources",
     markdown=True,
@@ -27,7 +27,7 @@ web_agent = Agent(
 finance_agent = Agent(
     name="Finance Agent",
     role="Get financial data",
-    model=Groq(id="llama-3.3-70b-versatile"),
+    model=Groq(id="openai/gpt-oss-120b"),
     tools=[YFinanceTools()],
     instructions="Use tables to display data",
     markdown=True,
@@ -36,7 +36,7 @@ finance_agent = Agent(
 agent_team = Team(
     members=[web_agent, finance_agent],
     model=Groq(
-        id="llama-3.3-70b-versatile"
+        id="openai/gpt-oss-120b"
     ),  # You can use a different model for the team leader agent
     instructions=["Always include sources", "Use tables to display data"],
     markdown=True,

--- a/cookbook/90_models/groq/basic.py
+++ b/cookbook/90_models/groq/basic.py
@@ -13,7 +13,7 @@ import asyncio
 # Create Agent
 # ---------------------------------------------------------------------------
 
-agent = Agent(model=Groq(id="llama-3.3-70b-versatile"), markdown=True)
+agent = Agent(model=Groq(id="openai/gpt-oss-120b"), markdown=True)
 
 # Get the response in a variable
 # run: RunOutput = agent.run("Share a 2 sentence horror story")

--- a/cookbook/90_models/groq/db.py
+++ b/cookbook/90_models/groq/db.py
@@ -14,7 +14,7 @@ db_url = "postgresql+psycopg://ai:ai@localhost:5532/ai"
 db = PostgresDb(db_url=db_url)
 
 agent = Agent(
-    model=Groq(id="llama-3.3-70b-versatile"),
+    model=Groq(id="openai/gpt-oss-120b"),
     db=db,
     tools=[WebSearchTools()],
     add_history_to_context=True,

--- a/cookbook/90_models/groq/deep_knowledge.py
+++ b/cookbook/90_models/groq/deep_knowledge.py
@@ -58,7 +58,7 @@ def create_agent(session_id: Optional[str] = None) -> Agent:
     return Agent(
         name="DeepKnowledge",
         session_id=session_id,
-        model=Groq(id="llama-3.3-70b-versatile"),
+        model=Groq(id="openai/gpt-oss-120b"),
         description=dedent("""\
         You are DeepKnowledge, an advanced reasoning agent designed to provide thorough,
         well-researched answers to any query by searching your knowledge base.

--- a/cookbook/90_models/groq/knowledge.py
+++ b/cookbook/90_models/groq/knowledge.py
@@ -18,7 +18,7 @@ knowledge = Knowledge(
 knowledge.insert(url="https://agno-public.s3.amazonaws.com/recipes/ThaiRecipes.pdf")
 
 agent = Agent(
-    model=Groq(id="llama-3.3-70b-versatile"),
+    model=Groq(id="openai/gpt-oss-120b"),
     knowledge=knowledge,
 )
 agent.print_response("How to make Thai curry?", markdown=True)

--- a/cookbook/90_models/groq/metrics.py
+++ b/cookbook/90_models/groq/metrics.py
@@ -16,7 +16,7 @@ from rich.pretty import pprint
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Groq(id="llama-3.3-70b-versatile"),
+    model=Groq(id="openai/gpt-oss-120b"),
     tools=[YFinanceTools()],
     markdown=True,
 )

--- a/cookbook/90_models/groq/reasoning_agent.py
+++ b/cookbook/90_models/groq/reasoning_agent.py
@@ -14,9 +14,9 @@ from agno.models.groq import Groq
 
 # Create a reasoning agent that uses:
 # - `deepseek-r1-distill-llama-70b` as the reasoning model
-# - `llama-3.3-70b-versatile` to generate the final response
+# - `openai/gpt-oss-120b` to generate the final response
 reasoning_agent = Agent(
-    model=Groq(id="llama-3.3-70b-versatile"),
+    model=Groq(id="openai/gpt-oss-120b"),
     reasoning_model=Groq(
         id="deepseek-r1-distill-llama-70b", temperature=0.6, max_tokens=1024, top_p=0.95
     ),

--- a/cookbook/90_models/groq/research_agent_exa.py
+++ b/cookbook/90_models/groq/research_agent_exa.py
@@ -20,7 +20,7 @@ if not tmp.exists():
 today = datetime.now().strftime("%Y-%m-%d")
 
 agent = Agent(
-    model=Groq(id="llama-3.3-70b-versatile"),
+    model=Groq(id="openai/gpt-oss-120b"),
     tools=[ExaTools(start_published_date=today, type="keyword")],
     description="You are an advanced AI researcher writing a report on a topic.",
     instructions=[

--- a/cookbook/90_models/groq/research_agent_seltz.py
+++ b/cookbook/90_models/groq/research_agent_seltz.py
@@ -17,7 +17,7 @@ if not tmp.exists():
     tmp.mkdir(exist_ok=True, parents=True)
 
 agent = Agent(
-    model=Groq(id="llama-3.3-70b-versatile"),
+    model=Groq(id="openai/gpt-oss-120b"),
     tools=[SeltzTools(max_results=10, show_results=True)],
     description="You are an advanced AI researcher writing a report on a topic.",
     instructions=[

--- a/cookbook/90_models/groq/structured_output.py
+++ b/cookbook/90_models/groq/structured_output.py
@@ -37,7 +37,7 @@ class MovieScript(BaseModel):
 
 
 json_mode_agent = Agent(
-    model=Groq(id="llama-3.3-70b-versatile"),
+    model=Groq(id="openai/gpt-oss-120b"),
     description="You help people write movie scripts.",
     output_schema=MovieScript,
     use_json_mode=True,

--- a/cookbook/90_models/groq/tool_use.py
+++ b/cookbook/90_models/groq/tool_use.py
@@ -14,7 +14,7 @@ from agno.tools.websearch import WebSearchTools
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Groq(id="llama-3.3-70b-versatile"),
+    model=Groq(id="openai/gpt-oss-120b"),
     tools=[WebSearchTools(), Newspaper4kTools()],
     description="You are a senior NYT researcher writing an article on a topic.",
     instructions=[

--- a/cookbook/91_tools/mcp/groq_mcp.py
+++ b/cookbook/91_tools/mcp/groq_mcp.py
@@ -37,7 +37,7 @@ async def create_filesystem_agent(session):
 
     # Create an agent with the MCP toolkit and Groq's fast LLM
     return Agent(
-        model=Groq(id="llama-3.3-70b-versatile"),
+        model=Groq(id="openai/gpt-oss-120b"),
         tools=[mcp_tools],
         instructions=dedent("""\
             You are a high-performance filesystem assistant powered by Groq and MCP.

--- a/cookbook/91_tools/mcp/include_tools.py
+++ b/cookbook/91_tools/mcp/include_tools.py
@@ -33,7 +33,7 @@ async def run_agent(message: str) -> None:
         ) as fs_tools,
     ):
         agent = Agent(
-            model=Groq(id="llama-3.3-70b-versatile"),
+            model=Groq(id="openai/gpt-oss-120b"),
             tools=[fs_tools],
             instructions=dedent("""\
                 - First, ALWAYS use the list_allowed_directories tool to find directories that you can access

--- a/cookbook/91_tools/mcp/local_server/client.py
+++ b/cookbook/91_tools/mcp/local_server/client.py
@@ -24,7 +24,7 @@ async def run_agent(message: str) -> None:
         ) as mcp_tools,
     ):
         agent = Agent(
-            model=Groq(id="llama-3.3-70b-versatile"),
+            model=Groq(id="openai/gpt-oss-120b"),
             tools=[mcp_tools],
             markdown=True,
         )

--- a/libs/agno/agno/models/groq/groq.py
+++ b/libs/agno/agno/models/groq/groq.py
@@ -34,7 +34,7 @@ class Groq(Model):
     For more information, see: https://console.groq.com/docs/libraries
     """
 
-    id: str = "llama-3.3-70b-versatile"
+    id: str = "openai/gpt-oss-120b"
     name: str = "Groq"
     provider: str = "Groq"
 

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -113,7 +113,10 @@ arxiv = ["arxiv"]
 brave = ["brave-search"]
 browserbase = ["browserbase", "playwright"]
 cartesia = ["cartesia"]
-confluence = ["atlassian-python-api"]
+# Pinned below 5.0: that release split Confluence into Cloud and Server classes and left the
+# base ``Confluence`` with no space or page methods, so ConfluenceTools raises AttributeError.
+# Lift once the tools are ported to the split classes.
+confluence = ["atlassian-python-api<5"]
 crawl4ai = ["crawl4ai>=0.6.3"]
 daytona = ["daytona"]
 ddg = ["ddgs"]

--- a/libs/agno/tests/integration/agent/test_agent_reasoning_new_models.py
+++ b/libs/agno/tests/integration/agent/test_agent_reasoning_new_models.py
@@ -403,7 +403,7 @@ def test_agent_groq_reasoning_non_streaming():
     """Test that Agent reasoning works with Groq reasoning models (deepseek variants) in non-streaming mode."""
     # Create an Agent with Groq reasoning model
     agent = Agent(
-        model=Groq(id="llama-3.3-70b-versatile"),
+        model=Groq(id="openai/gpt-oss-120b"),
         reasoning_model=Groq(id="deepseek-r1-distill-llama-70b"),
         instructions=dedent("""\
             You are an expert problem-solving assistant with strong analytical skills! 🧠
@@ -433,7 +433,7 @@ def test_agent_groq_reasoning_streaming(shared_db):
     """Test that Agent reasoning works with Groq reasoning models (deepseek variants) in streaming mode."""
     # Create an Agent with Groq reasoning model
     agent = Agent(
-        model=Groq(id="llama-3.3-70b-versatile"),
+        model=Groq(id="openai/gpt-oss-120b"),
         reasoning_model=Groq(id="deepseek-r1-distill-llama-70b"),
         db=shared_db,
         instructions=dedent("""\
@@ -677,7 +677,7 @@ def test_agent_accepts_groq_reasoning_model():
     """Test that Agent can be instantiated with Groq reasoning model."""
     try:
         agent = Agent(
-            model=Groq(id="llama-3.3-70b-versatile"),
+            model=Groq(id="openai/gpt-oss-120b"),
             reasoning_model=Groq(id="deepseek-r1-distill-llama-70b"),
         )
         assert agent.reasoning_model is not None

--- a/libs/agno/tests/integration/models/groq/test_basic.py
+++ b/libs/agno/tests/integration/models/groq/test_basic.py
@@ -1,4 +1,3 @@
-import re
 
 import pytest
 from pydantic import BaseModel, Field
@@ -89,9 +88,10 @@ def test_with_memory(groq_model):
     # Second interaction should remember the name
     response2 = agent.run("What's my name?")
     assert response2.content is not None
-    # Models format names with typographic spaces (U+202F narrow no-break space, U+00A0), so
-    # compare on the normalised text rather than failing a correct answer on whitespace.
-    normalised = re.sub(r"\s+", " ", response2.content.replace(" ", " ").replace("\xa0", " "))
+    # Models render names with typographic spaces (U+202F narrow no-break, U+00A0 no-break),
+    # so fold just those two back to a plain space. Anything wider - collapsing \s+ - would
+    # also accept "John\nSmith" and stop the assertion catching format regressions.
+    normalised = response2.content.replace("\u202f", " ").replace("\xa0", " ")
     assert "John Smith" in normalised
 
     # Verify memories were created

--- a/libs/agno/tests/integration/models/groq/test_basic.py
+++ b/libs/agno/tests/integration/models/groq/test_basic.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 from pydantic import BaseModel, Field
 
@@ -9,7 +11,7 @@ from agno.models.groq import Groq
 @pytest.fixture(scope="module")
 def groq_model():
     """Fixture that provides a Groq model and reuses it across all tests in the module."""
-    return Groq(id="llama-3.3-70b-versatile")
+    return Groq(id="openai/gpt-oss-120b")
 
 
 def _assert_metrics(response: RunOutput):
@@ -87,7 +89,10 @@ def test_with_memory(groq_model):
     # Second interaction should remember the name
     response2 = agent.run("What's my name?")
     assert response2.content is not None
-    assert "John Smith" in response2.content
+    # Models format names with typographic spaces (U+202F narrow no-break space, U+00A0), so
+    # compare on the normalised text rather than failing a correct answer on whitespace.
+    normalised = re.sub(r"\s+", " ", response2.content.replace(" ", " ").replace("\xa0", " "))
+    assert "John Smith" in normalised
 
     # Verify memories were created
     messages = agent.get_session_messages()

--- a/libs/agno/tests/integration/models/groq/test_reasoning_streaming.py
+++ b/libs/agno/tests/integration/models/groq/test_reasoning_streaming.py
@@ -17,7 +17,7 @@ from agno.run.agent import RunEvent
 @pytest.fixture(scope="module")
 def groq_model():
     """Fixture that provides a Groq model and reuses it across all tests in the module."""
-    return Groq(id="llama-3.3-70b-versatile")
+    return Groq(id="openai/gpt-oss-120b")
 
 
 @pytest.fixture(scope="module")

--- a/libs/agno/tests/integration/models/groq/test_tool_use.py
+++ b/libs/agno/tests/integration/models/groq/test_tool_use.py
@@ -12,7 +12,7 @@ from agno.tools.yfinance import YFinanceTools
 @pytest.mark.skip(reason="This test fails often on CI for Groq")
 def test_tool_use():
     agent = Agent(
-        model=Groq(id="llama-3.3-70b-versatile"),
+        model=Groq(id="openai/gpt-oss-120b"),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -29,7 +29,7 @@ def test_tool_use():
 @pytest.mark.skip(reason="Groq streaming is not working with tools at the moment.")
 def test_tool_use_stream():
     agent = Agent(
-        model=Groq(id="llama-3.3-70b-versatile"),
+        model=Groq(id="openai/gpt-oss-120b"),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -56,7 +56,7 @@ def test_tool_use_stream():
 @pytest.mark.skip(reason="This test fails often on CI for Groq")
 async def test_async_tool_use():
     agent = Agent(
-        model=Groq(id="llama-3.3-70b-versatile"),
+        model=Groq(id="openai/gpt-oss-120b"),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -74,7 +74,7 @@ async def test_async_tool_use():
 @pytest.mark.skip(reason="Groq streaming is not working with tools at the moment.")
 async def test_async_tool_use_stream():
     agent = Agent(
-        model=Groq(id="llama-3.3-70b-versatile"),
+        model=Groq(id="openai/gpt-oss-120b"),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -100,7 +100,7 @@ async def test_async_tool_use_stream():
 @pytest.mark.flaky(reruns=2)
 def test_parallel_tool_calls():
     agent = Agent(
-        model=Groq(id="llama-3.3-70b-versatile"),
+        model=Groq(id="openai/gpt-oss-120b"),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -128,7 +128,7 @@ def test_tool_use_with_native_structured_outputs():
         currency: str = Field(..., description="The currency of the stock")
 
     agent = Agent(
-        model=Groq(id="llama-3.3-70b-versatile"),
+        model=Groq(id="openai/gpt-oss-120b"),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         output_schema=StockPrice,
@@ -150,7 +150,7 @@ def test_tool_call_custom_tool_no_parameters():
         return "It is currently 70 degrees and cloudy in Tokyo"
 
     agent = Agent(
-        model=Groq(id="llama-3.3-70b-versatile"),
+        model=Groq(id="openai/gpt-oss-120b"),
         tools=[get_the_weather_in_tokyo],
         markdown=True,
         telemetry=False,
@@ -179,7 +179,7 @@ def test_tool_call_custom_tool_optional_parameters():
             return f"It is currently 70 degrees and cloudy in {city}"
 
     agent = Agent(
-        model=Groq(id="llama-3.3-70b-versatile"),
+        model=Groq(id="openai/gpt-oss-120b"),
         tools=[get_the_weather],
         markdown=True,
         telemetry=False,
@@ -196,7 +196,7 @@ def test_tool_call_custom_tool_optional_parameters():
 @pytest.mark.skip(reason="This test fails often on CI for Groq")
 def test_tool_call_list_parameters():
     agent = Agent(
-        model=Groq(id="llama-3.3-70b-versatile"),
+        model=Groq(id="openai/gpt-oss-120b"),
         tools=[ExaTools()],
         instructions="Use a single tool call if possible",
         markdown=True,

--- a/libs/agno/tests/integration/teams/test_team_reasoning_new_models.py
+++ b/libs/agno/tests/integration/teams/test_team_reasoning_new_models.py
@@ -438,7 +438,7 @@ def test_team_groq_reasoning_non_streaming():
     """Test that Team reasoning works with Groq reasoning models (deepseek variants) in non-streaming mode."""
     # Create a Team with Groq reasoning model
     team = Team(
-        model=Groq(id="llama-3.3-70b-versatile"),
+        model=Groq(id="openai/gpt-oss-120b"),
         reasoning_model=Groq(id="deepseek-r1-distill-llama-70b"),
         members=[],
         instructions=dedent("""\
@@ -469,7 +469,7 @@ def test_team_groq_reasoning_streaming(shared_db):
     """Test that Team reasoning works with Groq reasoning models (deepseek variants) in streaming mode."""
     # Create a Team with Groq reasoning model
     team = Team(
-        model=Groq(id="llama-3.3-70b-versatile"),
+        model=Groq(id="openai/gpt-oss-120b"),
         reasoning_model=Groq(id="deepseek-r1-distill-llama-70b"),
         db=shared_db,
         members=[],
@@ -738,7 +738,7 @@ def test_team_accepts_groq_reasoning_model():
     """Test that Team can be instantiated with Groq reasoning model."""
     try:
         team = Team(
-            model=Groq(id="llama-3.3-70b-versatile"),
+            model=Groq(id="openai/gpt-oss-120b"),
             reasoning_model=Groq(id="deepseek-r1-distill-llama-70b"),
             members=[],
         )

--- a/libs/agno/tests/unit/a2a/test_client.py
+++ b/libs/agno/tests/unit/a2a/test_client.py
@@ -446,9 +446,7 @@ class TestStreamMessage:
                 async for event in client.stream_message(message="Hello"):
                     yield event
 
-            run_events = [
-                event async for event in map_stream_events_to_run_events(raw_stream(), agent_id="agent-1")
-            ]
+            run_events = [event async for event in map_stream_events_to_run_events(raw_stream(), agent_id="agent-1")]
 
             assert [type(e) for e in run_events] == [
                 RunStartedEvent,

--- a/libs/agno/tests/unit/reasoning/test_reasoning_checkers.py
+++ b/libs/agno/tests/unit/reasoning/test_reasoning_checkers.py
@@ -578,7 +578,7 @@ def test_groq_without_deepseek():
     """Test Groq model without deepseek in ID returns False."""
     model = MockModel(
         class_name="Groq",
-        model_id="llama-3.3-70b-versatile",
+        model_id="meta-llama/llama-4-scout-17b-16e-instruct",
     )
     assert is_groq_reasoning_model(model) is False
 


### PR DESCRIPTION
## Summary

Groq shut down `llama-3.3-70b-versatile` on 16 August 2026. Every Groq call now returns 404, which broke the `test-groq` CI job: https://github.com/agno-agi/agno/actions/runs/32016477449/job/95359706351?pr=8245

`"The model llama-3.3-70b-versatile does not exist or you do not have access to it.`

<img width="892" height="412" alt="Screenshot 2026-08-17 at 4 12 24 PM" src="https://github.com/user-attachments/assets/992ae39a-b393-4072-a933-d52a172d5add" />


 Verified against a live Groq account before choosing a replacement:                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                      
  | model | status |                                                                                                                                                                                                                                                                                  
  | --- | --- |                                                                                                                                                                                                                                                                                       
  | `llama-3.3-70b-versatile` | HTTP 404 |                                                                                                                                                                                                                                       
  | `openai/gpt-oss-120b` | HTTP 200 |


The documented migration path is `openai/gpt-oss-120b` or `qwen/qwen3.6-27b`. This PR takes the first: it is Groq's primary recommendation. 

Passed CI run https://github.com/agno-agi/agno/actions/runs/32023860942/job/95369002334?pr=9588

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes


Pinned the atlassian version for now, will migrate to latest it in a follow-up PR.
