### PR TITLE
[fix] Repair stale cookbook links

### DIFF
--- a/cookbook/08_learning/10_demo/README.md
+++ b/cookbook/08_learning/10_demo/README.md
@@ -66,7 +66,7 @@ curl "http://localhost:7777/learnings?learning_type=user_profile"
 curl "http://localhost:7777/learnings/users"
 ```
 
-Interactive docs are at `http://localhost:7777/docs`. For a client-side walkthrough of the CRUD endpoints, see [cookbook/05_agent_os/learnings](../../05_agent_os/learnings/).
+Interactive docs are at `http://localhost:7777/docs`. For a client-side walkthrough of the CRUD endpoints, see [cookbook/05_agent_os/11_learnings](../../05_agent_os/11_learnings/).
 
 ## Start fresh
 

--- a/cookbook/08_learning/README.md
+++ b/cookbook/08_learning/README.md
@@ -494,7 +494,7 @@ Try it with the demo in this cookbook:
 .venvs/demo/bin/python cookbook/08_learning/10_demo/run.py
 ```
 
-See [10_demo](10_demo/) for the walkthrough, and [cookbook/05_agent_os/learnings](../05_agent_os/learnings/) for a client-side tour of the REST endpoints.
+See [10_demo](10_demo/) for the walkthrough, and [cookbook/05_agent_os/11_learnings](../05_agent_os/11_learnings/) for a client-side tour of the REST endpoints.
 
 ## Learn More
 

--- a/cookbook/integrations/README.md
+++ b/cookbook/integrations/README.md
@@ -19,8 +19,8 @@ Some integrations now live closer to their topic:
 | Observability (Langfuse, Arize Phoenix, AgentOps, LangSmith, …) | [`cookbook/observability`](../observability/) |
 | Memory providers (Mem0, Memori, Zep) | [`cookbook/11_memory/integrations`](../11_memory/integrations/) |
 | RAG stacks (Infinity, LightRAG, LangChain + Qdrant) | [`cookbook/07_knowledge/05_integrations/rag`](../07_knowledge/05_integrations/rag/) |
-| Discord bot | [`cookbook/05_agent_os/interfaces/discord`](../05_agent_os/interfaces/discord/) |
-| A2A basic server/client | [`cookbook/05_agent_os/interfaces/a2a/basic_agent`](../05_agent_os/interfaces/a2a/basic_agent/) |
+| Discord bot | [`cookbook/integrations/discord`](./discord/) |
+| A2A basic server/client | [`cookbook/05_agent_os/15_a2a`](../05_agent_os/15_a2a/) |
 
 ## Running Examples
 


### PR DESCRIPTION
Closes #9591.

## Summary

Repair four cookbook links that still point to directories moved during the AgentOS cookbook reorganization:

- Route both learning walkthrough links to `cookbook/05_agent_os/11_learnings`.
- Route the Discord integration link to `cookbook/integrations/discord`.
- Route the A2A integration link to `cookbook/05_agent_os/15_a2a`.

Each target directory was verified in the current checkout.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`) (documentation-only change)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment (verified all relative link targets)
- [ ] Tests added/updated (not applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Prepared with AI assistance. The diff was reviewed and each replacement target was checked against the current repository tree.