### PR TITLE
[fix] Claim paused team continues so overlapping resumes cannot double-execute gated tools

### DIFF
--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 import time
 from collections import deque
+from collections.abc import Iterator as AbcIterator
 from time import time as unix_time
 from typing import (
     TYPE_CHECKING,
@@ -123,6 +125,68 @@ from agno.utils.log import (
 # Strong references to background tasks so they aren't garbage-collected mid-execution.
 # See: https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task
 _background_tasks: set[asyncio.Task[None]] = set()
+
+# In-process exclusive claim for an in-place continue of one (session_id, run_id).
+# threading.Lock cannot be held across awaits: two asyncio tasks share a thread
+# and a blocking acquire deadlocks the event loop. The map is mutated only while
+# this lock is held for the lookup. Nested acquires with the same token succeed
+# so the AgentOS background SSE wrapper can hold the claim until its producer
+# finishes while _acontinue_run_stream participates without releasing early.
+_paused_continue_claims: Dict[Tuple[str, str], str] = {}
+_paused_continue_claims_lock = threading.Lock()
+
+
+class _PausedContinueClaim:
+    """Exactly one in-process continue may own an in-place resume.
+
+    A second overlapping continue raises RunNotContinuableError without applying
+    the payload. Crash recovery of a leftover RUNNING run in a fresh process
+    still succeeds because the map is empty after process restart.
+    """
+
+    def __init__(self, session_id: str, run_id: str) -> None:
+        self.session_id = session_id
+        self.run_id = run_id
+        self.token = uuid4().hex
+        self._held = False
+
+    @property
+    def _key(self) -> Tuple[str, str]:
+        return (self.session_id, self.run_id)
+
+    def acquire_or_refuse(self) -> None:
+        with _paused_continue_claims_lock:
+            owner = _paused_continue_claims.get(self._key)
+            if owner is None:
+                _paused_continue_claims[self._key] = self.token
+                self._held = True
+                return
+            if owner == self.token:
+                self._held = True
+                return
+        raise RunNotContinuableError(
+            f"Cannot continue run {self.run_id}: another continue already claimed this paused run. "
+            "The stored run is unchanged."
+        )
+
+    def release(self) -> None:
+        if not self._held:
+            return
+        with _paused_continue_claims_lock:
+            if _paused_continue_claims.get(self._key) == self.token:
+                del _paused_continue_claims[self._key]
+        self._held = False
+
+
+def _release_paused_continue_after_iter(claim: _PausedContinueClaim, result: AbcIterator) -> Iterator[Any]:
+    def _gen() -> Iterator[Any]:
+        try:
+            yield from result
+        finally:
+            claim.release()
+
+    return _gen()
+
 
 # Cancel raises immediately on every event. Only terminal events bypass so the
 # member's own cancel handler can yield them to the stream. RunError is excluded —
@@ -6965,416 +7029,466 @@ def continue_run_dispatch(
     if not fork and run_response.status == RunStatus.completed:
         fork = True
 
-    # Apply modifiers BEFORE the requirements machinery. If we forked, the
-    # rest of the dispatch operates on the new run with cloned members.
-    _did_snapshot_dispatch = fork or _will_truncate_team_run(run_response, continue_index)
-    run_response = _apply_continue_modifiers_team(run_response, fork, continue_index)
-    if regenerate and original_run_id_for_lineage:
-        run_response.regenerated_from = original_run_id_for_lineage
-        if replace_original is not False and run_response.forked_from_run_id:
-            # Mark the original run REGENERATED so history builders skip it.
-            for r in team_session.runs or []:
-                if r.run_id == original_run_id_for_lineage:
-                    r.status = RunStatus.regenerated
-                    break
+    # Exactly one in-place continue may claim (session_id, run_id). Fork and
+    # regenerate mint a new run_id and must not contend with a paused resume.
+    # Hold the claim for the whole continue, including returned stream iterators.
+    paused_claim: Optional[_PausedContinueClaim] = None
+    paused_claim_handed_off = False
+    if not fork and not regenerate:
+        paused_claim = _PausedContinueClaim(session_id, run_response.run_id)
+        paused_claim.acquire_or_refuse()
 
-    # Append the new user-message (from input / additional_instructions) so
-    # the model loop picks it up.
-    if input:
-        _maybe_append_input_message_team(run_response, input, team)
+    def _finish_continue(
+        result: Union[TeamRunOutput, Iterator[Union[TeamRunOutputEvent, RunOutputEvent, TeamRunOutput]]],
+    ) -> Union[TeamRunOutput, Iterator[Union[TeamRunOutputEvent, RunOutputEvent, TeamRunOutput]]]:
+        nonlocal paused_claim_handed_off
+        if paused_claim is None:
+            return result
+        if isinstance(result, AbcIterator) and not isinstance(result, (str, bytes)):
+            paused_claim_handed_off = True
+            return _release_paused_continue_after_iter(paused_claim, result)
+        return result
 
-    # A freshly-forked run has no PAUSED requirements contract — skip the
-    # HITL machinery and route straight to the model loop. Member-level
-    # tool resolution for HITL is a property of the SOURCE run; the fork
-    # is a new attempt and its tools/messages are seeded from the
-    # snapshot.
-    if _did_snapshot_dispatch:
-        # Reset run state for a fresh model loop on the forked run.
-        run_response.status = RunStatus.running
-        run_response.content = None
+    try:
+        # Apply modifiers BEFORE the requirements machinery. If we forked, the
+        # rest of the dispatch operates on the new run with cloned members.
+        _did_snapshot_dispatch = fork or _will_truncate_team_run(run_response, continue_index)
+        run_response = _apply_continue_modifiers_team(run_response, fork, continue_index)
+        if regenerate and original_run_id_for_lineage:
+            run_response.regenerated_from = original_run_id_for_lineage
+            if replace_original is not False and run_response.forked_from_run_id:
+                # Mark the original run REGENERATED so history builders skip it.
+                for r in team_session.runs or []:
+                    if r.run_id == original_run_id_for_lineage:
+                        r.status = RunStatus.regenerated
+                        break
 
-        response_format = get_response_format(team, run_context=run_context) if team.parser_model is None else None
-        team.model = cast(Model, team.model)
+        # Append the new user-message (from input / additional_instructions) so
+        # the model loop picks it up.
+        if input:
+            _maybe_append_input_message_team(run_response, input, team)
 
-        team_run_context_local: Dict[str, Any] = {}
-        _tools_fork = _determine_tools_for_model(
-            team,
-            model=team.model,
-            run_response=run_response,
-            run_context=run_context,
-            team_run_context=team_run_context_local,
-            session=team_session,
-            user_id=user_id,
-            async_mode=False,
-            stream=opts.stream or False,
-            stream_events=opts.stream_events or False,
-        )
+        # A freshly-forked run has no PAUSED requirements contract — skip the
+        # HITL machinery and route straight to the model loop. Member-level
+        # tool resolution for HITL is a property of the SOURCE run; the fork
+        # is a new attempt and its tools/messages are seeded from the
+        # snapshot.
+        if _did_snapshot_dispatch:
+            # Reset run state for a fresh model loop on the forked run.
+            run_response.status = RunStatus.running
+            run_response.content = None
 
-        input_messages = run_response.messages or []
-        run_messages = _get_continue_run_messages(
-            team,
-            input=input_messages,
-            session=team_session,
-            add_history_to_context=team.add_history_to_context,
-            run_context=run_context,
-        )
+            response_format = get_response_format(team, run_context=run_context) if team.parser_model is None else None
+            team.model = cast(Model, team.model)
 
-        log_debug(f"Team Continue Run (forked): {run_response.run_id}", center=True)
-
-        if opts.stream:
-            return _continue_run_stream(
+            team_run_context_local: Dict[str, Any] = {}
+            _tools_fork = _determine_tools_for_model(
                 team,
+                model=team.model,
                 run_response=run_response,
-                run_messages=run_messages,
                 run_context=run_context,
-                tools=_tools_fork,
+                team_run_context=team_run_context_local,
                 session=team_session,
                 user_id=user_id,
-                response_format=response_format,
-                stream_events=opts.stream_events,
-                yield_run_output=opts.yield_run_output,
-                debug_mode=debug_mode,
-                background_tasks=background_tasks,
-                **kwargs,
+                async_mode=False,
+                stream=opts.stream or False,
+                stream_events=opts.stream_events or False,
             )
-        else:
-            return _continue_run(
+
+            input_messages = run_response.messages or []
+            run_messages = _get_continue_run_messages(
                 team,
-                run_response=run_response,
-                run_messages=run_messages,
-                run_context=run_context,
-                tools=_tools_fork,
+                input=input_messages,
                 session=team_session,
-                user_id=user_id,
-                response_format=response_format,
-                debug_mode=debug_mode,
-                background_tasks=background_tasks,
-                **kwargs,
+                add_history_to_context=team.add_history_to_context,
+                run_context=run_context,
             )
-    # --- End snapshot dispatch ----------------------------------------------
 
-    # Normalize and apply requirements
-    if requirements:
-        old_requirements, old_tools, decisions = _apply_requirements_payload(run_response, requirements)
+            log_debug(f"Team Continue Run (forked): {run_response.run_id}", center=True)
 
-        # Also apply any resolved approval
-        if run_response.tools:
+            if opts.stream:
+                return _finish_continue(
+                    _continue_run_stream(
+                        team,
+                        run_response=run_response,
+                        run_messages=run_messages,
+                        run_context=run_context,
+                        tools=_tools_fork,
+                        session=team_session,
+                        user_id=user_id,
+                        response_format=response_format,
+                        stream_events=opts.stream_events,
+                        yield_run_output=opts.yield_run_output,
+                        debug_mode=debug_mode,
+                        background_tasks=background_tasks,
+                        **kwargs,
+                    )
+                )
+            else:
+                return _finish_continue(
+                    _continue_run(
+                        team,
+                        run_response=run_response,
+                        run_messages=run_messages,
+                        run_context=run_context,
+                        tools=_tools_fork,
+                        session=team_session,
+                        user_id=user_id,
+                        response_format=response_format,
+                        debug_mode=debug_mode,
+                        background_tasks=background_tasks,
+                        **kwargs,
+                    )
+                )
+        # --- End snapshot dispatch ----------------------------------------------
+
+        # Normalize and apply requirements
+        if requirements:
+            old_requirements, old_tools, decisions = _apply_requirements_payload(run_response, requirements)
+
+            # Also apply any resolved approval
+            if run_response.tools:
+                from agno.run.approval import check_and_apply_approval_resolution
+
+                try:
+                    check_and_apply_approval_resolution(team.db, run_id_resolved, run_response)
+                except RuntimeError as e:
+                    run_response.requirements = old_requirements
+                    run_response.tools = old_tools
+                    _restore_requirement_decisions(decisions)
+                    # The payload was supplied; the approval gate is what refused.
+                    # Surface its reason instead of asking for a payload again.
+                    raise ValueError(str(e))
+        elif run_response.tools:
             from agno.run.approval import check_and_apply_approval_resolution
 
             try:
                 check_and_apply_approval_resolution(team.db, run_id_resolved, run_response)
-            except RuntimeError as e:
-                run_response.requirements = old_requirements
-                run_response.tools = old_tools
-                _restore_requirement_decisions(decisions)
-                # The payload was supplied; the approval gate is what refused.
-                # Surface its reason instead of asking for a payload again.
-                raise ValueError(str(e))
-    elif run_response.tools:
-        from agno.run.approval import check_and_apply_approval_resolution
-
-        try:
-            check_and_apply_approval_resolution(team.db, run_id_resolved, run_response)
-        except RuntimeError:
-            # No resolved approval found — fall through to bare-resume.
-            pass
-        # A RUNNING/ERROR run with already-executed tools (e.g. crash recovery
-        # after a delegation, or an ERROR retry) is NOT a HITL pause: resume via
-        # the team-leader model regardless of whether an approval was applied.
-        # Without this, such a run falls through to terminal cleanup with no
-        # final turn (content=None). Unresolved requirements are re-paused
-        # downstream, so this does not bypass HITL.
-        #
-        # Guard: a PAUSED run with requirements is a real HITL pause (the user
-        # called continue_run(response) after mutating req.confirm() in place).
-        # Don't bypass — fall through to member-routing / team-level resolution
-        # below. The team-leader bypass is only for non-HITL crash recovery.
-        if run_response.status != RunStatus.paused or not run_response.requirements:
-            _did_snapshot_dispatch = True  # route to team-leader model call
-    else:
-        # No requirements AND no tools — this is a bare resume of a mid-flight
-        # run (RUNNING / ERROR / CANCELLED that crashed before any tool batch).
-        # Don't raise; let the team-leader model loop run with whatever
-        # messages survived in run_response.
-        _did_snapshot_dispatch = True
-
-    # Determine what kind of pause we're continuing from
-    run_response.requirements = _reclaim_own_requirements(team, run_response.requirements, run_response.run_id)
-    has_member = _has_member_requirements(run_response.requirements or [])
-    has_team_level = _has_team_level_requirements(run_response.requirements or [])
-
-    # Guard: a member requirement the client left unresolved has to re-pause,
-    # not dispatch. Routing hands it to the member's continue_run, which reads
-    # the pause as settled and runs the gated tool with whatever the schema
-    # holds -- for a requested field left untouched, with None. The team-level
-    # lane already re-pauses on its own unresolved requirements; a requirement
-    # addressed to a member is no less unresolved for being addressed to one.
-    unresolved_member = [
-        r
-        for r in (run_response.requirements or [])
-        if getattr(r, "member_agent_id", None) is not None and not r.is_resolved()
-    ]
-    if unresolved_member:
-        from agno.team import _hooks
-
-        if opts.stream:
-
-            def _member_paused_stream_with_final() -> Iterator[
-                Union[TeamRunOutputEvent, RunOutputEvent, TeamRunOutput]
-            ]:
-                yield from _hooks.handle_team_run_paused_stream(
-                    team, run_response=run_response, session=team_session, run_context=run_context
-                )
-                if opts.yield_run_output:
-                    yield run_response
-
-            return _member_paused_stream_with_final()
+            except RuntimeError:
+                # No resolved approval found — fall through to bare-resume.
+                pass
+            # A RUNNING/ERROR run with already-executed tools (e.g. crash recovery
+            # after a delegation, or an ERROR retry) is NOT a HITL pause: resume via
+            # the team-leader model regardless of whether an approval was applied.
+            # Without this, such a run falls through to terminal cleanup with no
+            # final turn (content=None). Unresolved requirements are re-paused
+            # downstream, so this does not bypass HITL.
+            #
+            # Guard: a PAUSED run with requirements is a real HITL pause (the user
+            # called continue_run(response) after mutating req.confirm() in place).
+            # Don't bypass — fall through to member-routing / team-level resolution
+            # below. The team-leader bypass is only for non-HITL crash recovery.
+            if run_response.status != RunStatus.paused or not run_response.requirements:
+                _did_snapshot_dispatch = True  # route to team-leader model call
         else:
-            return _hooks.handle_team_run_paused(
-                team, run_response=run_response, session=team_session, run_context=run_context
-            )
+            # No requirements AND no tools — this is a bare resume of a mid-flight
+            # run (RUNNING / ERROR / CANCELLED that crashed before any tool batch).
+            # Don't raise; let the team-leader model loop run with whatever
+            # messages survived in run_response.
+            _did_snapshot_dispatch = True
 
-    # Route member requirements to member agents
-    member_results: List[str] = []
-    if has_member:
-        member_reqs = [r for r in (run_response.requirements or []) if getattr(r, "member_agent_id", None) is not None]
-        team_level_reqs = [r for r in (run_response.requirements or []) if getattr(r, "member_agent_id", None) is None]
-        # Set only member reqs for routing; _route_requirements_to_members
-        # may append newly propagated reqs via _propagate_member_pause (chained HITL).
-        original_member_req_ids = {id(r) for r in member_reqs}
-        run_response.requirements = member_reqs
+        # Determine what kind of pause we're continuing from
+        run_response.requirements = _reclaim_own_requirements(team, run_response.requirements, run_response.run_id)
+        has_member = _has_member_requirements(run_response.requirements or [])
+        has_team_level = _has_team_level_requirements(run_response.requirements or [])
 
-        if opts.stream:
-            # Streaming: use the generator variant that yields member events.
-            # We collect member_results via a mutable list and chain with the
-            # team continuation stream below.
-            member_event_stream = _route_requirements_to_members_stream(
-                team,
-                run_response=run_response,
-                session=team_session,
-                member_results=member_results,
-                run_context=run_context,
-                stream_events=opts.stream_events or False,
-            )
-        else:
-            member_event_stream = None
-            try:
-                member_results = _route_requirements_to_members(
-                    team,
-                    run_response=run_response,
-                    session=team_session,
-                    run_context=run_context,
-                )
-            except Exception:
-                # Routing failed mid-flight; put the team-level requirements
-                # back so the caller's run object stays complete for a retry.
-                run_response.requirements = team_level_reqs + (run_response.requirements or [])
-                raise
-
-        # For non-streaming, member routing is done eagerly above.
-        # For streaming, we must consume member events lazily inside a returned generator.
-        # But first we need to check for chained pauses AFTER member routing completes.
-        # So for streaming, we defer everything to a wrapper generator.
-        if opts.stream and member_event_stream is not None:
-            return _continue_run_dispatch_stream_with_member_events(
-                team=team,
-                run_response=run_response,
-                member_event_stream=member_event_stream,
-                member_results=member_results,
-                original_member_req_ids=original_member_req_ids,
-                team_level_reqs=team_level_reqs,
-                has_team_level=has_team_level,
-                team_session=team_session,
-                run_context=run_context,
-                opts=opts,
-                user_id=user_id,
-                debug_mode=debug_mode,
-                background_tasks=background_tasks,
-                **kwargs,
-            )
-
-        # Non-streaming: merge and check for chained pauses
-        newly_propagated = [r for r in (run_response.requirements or []) if id(r) not in original_member_req_ids]
-        run_response.requirements = team_level_reqs + newly_propagated
-
-        # Check if any members are still paused
-        if run_response.requirements and any(not req.is_resolved() for req in run_response.requirements):
-            from agno.team import _hooks
-
-            return _hooks.handle_team_run_paused(
-                team, run_response=run_response, session=team_session, run_context=run_context
-            )
-
-    # Handle team-level tool resolution
-    if has_team_level or _did_snapshot_dispatch:
-        # Includes _did_snapshot_dispatch: bare-resume of a crashed run (no
-        # requirements, no tools) still needs the team-leader model call to
-        # produce a response. Without this, those runs would fall through
-        # with no model invocation.
-        # Guard: if team-level requirements are unresolved, re-pause instead of auto-rejecting
-        unresolved_team = [
+        # Guard: a member requirement the client left unresolved has to re-pause,
+        # not dispatch. Routing hands it to the member's continue_run, which reads
+        # the pause as settled and runs the gated tool with whatever the schema
+        # holds -- for a requested field left untouched, with None. The team-level
+        # lane already re-pauses on its own unresolved requirements; a requirement
+        # addressed to a member is no less unresolved for being addressed to one.
+        unresolved_member = [
             r
             for r in (run_response.requirements or [])
-            if getattr(r, "member_agent_id", None) is None and not r.is_resolved()
+            if getattr(r, "member_agent_id", None) is not None and not r.is_resolved()
         ]
-        if unresolved_team:
+        if unresolved_member:
             from agno.team import _hooks
 
             if opts.stream:
 
-                def _paused_stream_with_final() -> Iterator[Union[TeamRunOutputEvent, RunOutputEvent, TeamRunOutput]]:
+                def _member_paused_stream_with_final() -> Iterator[
+                    Union[TeamRunOutputEvent, RunOutputEvent, TeamRunOutput]
+                ]:
                     yield from _hooks.handle_team_run_paused_stream(
                         team, run_response=run_response, session=team_session, run_context=run_context
                     )
                     if opts.yield_run_output:
                         yield run_response
 
-                return _paused_stream_with_final()
+                return _finish_continue(_member_paused_stream_with_final())
             else:
-                return _hooks.handle_team_run_paused(
-                    team, run_response=run_response, session=team_session, run_context=run_context
+                return _finish_continue(
+                    _hooks.handle_team_run_paused(
+                        team, run_response=run_response, session=team_session, run_context=run_context
+                    )
                 )
 
-        response_format = get_response_format(team, run_context=run_context) if team.parser_model is None else None
-        team.model = cast(Model, team.model)
+        # Route member requirements to member agents
+        member_results: List[str] = []
+        if has_member:
+            member_reqs = [
+                r for r in (run_response.requirements or []) if getattr(r, "member_agent_id", None) is not None
+            ]
+            team_level_reqs = [
+                r for r in (run_response.requirements or []) if getattr(r, "member_agent_id", None) is None
+            ]
+            # Set only member reqs for routing; _route_requirements_to_members
+            # may append newly propagated reqs via _propagate_member_pause (chained HITL).
+            original_member_req_ids = {id(r) for r in member_reqs}
+            run_response.requirements = member_reqs
 
-        # Prepare tools
-        team_run_context: Dict[str, Any] = {}
-        _tools = _determine_tools_for_model(
-            team,
-            model=team.model,
-            run_response=run_response,
-            run_context=run_context,
-            team_run_context=team_run_context,
-            session=team_session,
-            user_id=user_id,
-            async_mode=False,
-            stream=opts.stream or False,
-            stream_events=opts.stream_events or False,
-        )
+            if opts.stream:
+                # Streaming: use the generator variant that yields member events.
+                # We collect member_results via a mutable list and chain with the
+                # team continuation stream below.
+                member_event_stream = _route_requirements_to_members_stream(
+                    team,
+                    run_response=run_response,
+                    session=team_session,
+                    member_results=member_results,
+                    run_context=run_context,
+                    stream_events=opts.stream_events or False,
+                )
+            else:
+                member_event_stream = None
+                try:
+                    member_results = _route_requirements_to_members(
+                        team,
+                        run_response=run_response,
+                        session=team_session,
+                        run_context=run_context,
+                    )
+                except Exception:
+                    # Routing failed mid-flight; put the team-level requirements
+                    # back so the caller's run object stays complete for a retry.
+                    run_response.requirements = team_level_reqs + (run_response.requirements or [])
+                    raise
 
-        # Get continue run messages from existing conversation
-        input_messages = run_response.messages or []
-        run_messages = _get_continue_run_messages(
-            team,
-            input=input_messages,
-            session=team_session,
-            add_history_to_context=team.add_history_to_context,
-            run_context=run_context,
-        )
+            # For non-streaming, member routing is done eagerly above.
+            # For streaming, we must consume member events lazily inside a returned generator.
+            # But first we need to check for chained pauses AFTER member routing completes.
+            # So for streaming, we defer everything to a wrapper generator.
+            if opts.stream and member_event_stream is not None:
+                return _finish_continue(
+                    _continue_run_dispatch_stream_with_member_events(
+                        team=team,
+                        run_response=run_response,
+                        member_event_stream=member_event_stream,
+                        member_results=member_results,
+                        original_member_req_ids=original_member_req_ids,
+                        team_level_reqs=team_level_reqs,
+                        has_team_level=has_team_level,
+                        team_session=team_session,
+                        run_context=run_context,
+                        opts=opts,
+                        user_id=user_id,
+                        debug_mode=debug_mode,
+                        background_tasks=background_tasks,
+                        **kwargs,
+                    )
+                )
 
-        # Handle tool call updates (execute confirmed tools, etc.)
-        _handle_team_tool_call_updates(team, run_response=run_response, run_messages=run_messages, tools=_tools)
+            # Non-streaming: merge and check for chained pauses
+            newly_propagated = [r for r in (run_response.requirements or []) if id(r) not in original_member_req_ids]
+            run_response.requirements = team_level_reqs + newly_propagated
 
-        # Reset run state for continuation
-        run_response.status = RunStatus.running
-        # Reset content before re-running the model; _update_run_response appends
-        # to existing content, so stale content from the paused run must be cleared.
-        run_response.content = None
+            # Check if any members are still paused
+            if run_response.requirements and any(not req.is_resolved() for req in run_response.requirements):
+                from agno.team import _hooks
 
-        log_debug(f"Team Continue Run Start: {run_response.run_id}", center=True)
+                return _finish_continue(
+                    _hooks.handle_team_run_paused(
+                        team, run_response=run_response, session=team_session, run_context=run_context
+                    )
+                )
 
-        if opts.stream:
-            return _continue_run_stream(
+        # Handle team-level tool resolution
+        if has_team_level or _did_snapshot_dispatch:
+            # Includes _did_snapshot_dispatch: bare-resume of a crashed run (no
+            # requirements, no tools) still needs the team-leader model call to
+            # produce a response. Without this, those runs would fall through
+            # with no model invocation.
+            # Guard: if team-level requirements are unresolved, re-pause instead of auto-rejecting
+            unresolved_team = [
+                r
+                for r in (run_response.requirements or [])
+                if getattr(r, "member_agent_id", None) is None and not r.is_resolved()
+            ]
+            if unresolved_team:
+                from agno.team import _hooks
+
+                if opts.stream:
+
+                    def _paused_stream_with_final() -> Iterator[
+                        Union[TeamRunOutputEvent, RunOutputEvent, TeamRunOutput]
+                    ]:
+                        yield from _hooks.handle_team_run_paused_stream(
+                            team, run_response=run_response, session=team_session, run_context=run_context
+                        )
+                        if opts.yield_run_output:
+                            yield run_response
+
+                    return _finish_continue(_paused_stream_with_final())
+                else:
+                    return _finish_continue(
+                        _hooks.handle_team_run_paused(
+                            team, run_response=run_response, session=team_session, run_context=run_context
+                        )
+                    )
+
+            response_format = get_response_format(team, run_context=run_context) if team.parser_model is None else None
+            team.model = cast(Model, team.model)
+
+            # Prepare tools
+            team_run_context: Dict[str, Any] = {}
+            _tools = _determine_tools_for_model(
                 team,
+                model=team.model,
                 run_response=run_response,
-                run_messages=run_messages,
                 run_context=run_context,
-                tools=_tools,
+                team_run_context=team_run_context,
                 session=team_session,
                 user_id=user_id,
-                response_format=response_format,
-                stream_events=opts.stream_events,
-                yield_run_output=opts.yield_run_output,
-                debug_mode=debug_mode,
-                background_tasks=background_tasks,
-                **kwargs,
+                async_mode=False,
+                stream=opts.stream or False,
+                stream_events=opts.stream_events or False,
             )
-        else:
-            return _continue_run(
+
+            # Get continue run messages from existing conversation
+            input_messages = run_response.messages or []
+            run_messages = _get_continue_run_messages(
                 team,
-                run_response=run_response,
-                run_messages=run_messages,
+                input=input_messages,
+                session=team_session,
+                add_history_to_context=team.add_history_to_context,
                 run_context=run_context,
-                tools=_tools,
+            )
+
+            # Handle tool call updates (execute confirmed tools, etc.)
+            _handle_team_tool_call_updates(team, run_response=run_response, run_messages=run_messages, tools=_tools)
+
+            # Reset run state for continuation
+            run_response.status = RunStatus.running
+            # Reset content before re-running the model; _update_run_response appends
+            # to existing content, so stale content from the paused run must be cleared.
+            run_response.content = None
+
+            log_debug(f"Team Continue Run Start: {run_response.run_id}", center=True)
+
+            if opts.stream:
+                return _finish_continue(
+                    _continue_run_stream(
+                        team,
+                        run_response=run_response,
+                        run_messages=run_messages,
+                        run_context=run_context,
+                        tools=_tools,
+                        session=team_session,
+                        user_id=user_id,
+                        response_format=response_format,
+                        stream_events=opts.stream_events,
+                        yield_run_output=opts.yield_run_output,
+                        debug_mode=debug_mode,
+                        background_tasks=background_tasks,
+                        **kwargs,
+                    )
+                )
+            else:
+                return _finish_continue(
+                    _continue_run(
+                        team,
+                        run_response=run_response,
+                        run_messages=run_messages,
+                        run_context=run_context,
+                        tools=_tools,
+                        session=team_session,
+                        user_id=user_id,
+                        response_format=response_format,
+                        debug_mode=debug_mode,
+                        background_tasks=background_tasks,
+                        **kwargs,
+                    )
+                )
+
+        # Member-only case: continue the same run with member results
+        if member_results and not has_team_level:
+            response_format = get_response_format(team, run_context=run_context) if team.parser_model is None else None
+            team.model = cast(Model, team.model)
+
+            # Prepare tools for the continuation
+            team_run_context: Dict[str, Any] = {}  # type: ignore[no-redef]
+            _tools = _determine_tools_for_model(
+                team,
+                model=team.model,
+                run_response=run_response,
+                run_context=run_context,
+                team_run_context=team_run_context,
                 session=team_session,
                 user_id=user_id,
-                response_format=response_format,
-                debug_mode=debug_mode,
-                background_tasks=background_tasks,
-                **kwargs,
+                async_mode=False,
+                stream=opts.stream or False,
+                stream_events=opts.stream_events or False,
             )
 
-    # Member-only case: continue the same run with member results
-    if member_results and not has_team_level:
-        response_format = get_response_format(team, run_context=run_context) if team.parser_model is None else None
-        team.model = cast(Model, team.model)
-
-        # Prepare tools for the continuation
-        team_run_context: Dict[str, Any] = {}  # type: ignore[no-redef]
-        _tools = _determine_tools_for_model(
-            team,
-            model=team.model,
-            run_response=run_response,
-            run_context=run_context,
-            team_run_context=team_run_context,
-            session=team_session,
-            user_id=user_id,
-            async_mode=False,
-            stream=opts.stream or False,
-            stream_events=opts.stream_events or False,
-        )
-
-        # Get existing messages
-        input_messages = run_response.messages or []
-        run_messages = _get_continue_run_messages(
-            team,
-            input=input_messages,
-            session=team_session,
-            add_history_to_context=team.add_history_to_context,
-            run_context=run_context,
-        )
-
-        # Prepare for member HITL continuation
-        _prepare_member_hitl_continuation(run_response, run_messages, member_results)
-
-        log_debug(f"Team Continue Run (Member HITL): {run_response.run_id}", center=True)
-
-        if opts.stream:
-            return _continue_run_stream(
+            # Get existing messages
+            input_messages = run_response.messages or []
+            run_messages = _get_continue_run_messages(
                 team,
-                run_response=run_response,
-                run_messages=run_messages,
-                run_context=run_context,
-                tools=_tools,
+                input=input_messages,
                 session=team_session,
-                user_id=user_id,
-                response_format=response_format,
-                stream_events=opts.stream_events,
-                yield_run_output=opts.yield_run_output,
-                debug_mode=debug_mode,
-                background_tasks=background_tasks,
-                **kwargs,
-            )
-        else:
-            return _continue_run(
-                team,
-                run_response=run_response,
-                run_messages=run_messages,
+                add_history_to_context=team.add_history_to_context,
                 run_context=run_context,
-                tools=_tools,
-                session=team_session,
-                user_id=user_id,
-                response_format=response_format,
-                debug_mode=debug_mode,
-                background_tasks=background_tasks,
-                **kwargs,
             )
 
-    # Fallback: nothing to do
-    run_response.status = RunStatus.completed
-    _cleanup_and_store(team, run_response=run_response, session=team_session)
-    return run_response
+            # Prepare for member HITL continuation
+            _prepare_member_hitl_continuation(run_response, run_messages, member_results)
+
+            log_debug(f"Team Continue Run (Member HITL): {run_response.run_id}", center=True)
+
+            if opts.stream:
+                return _finish_continue(
+                    _continue_run_stream(
+                        team,
+                        run_response=run_response,
+                        run_messages=run_messages,
+                        run_context=run_context,
+                        tools=_tools,
+                        session=team_session,
+                        user_id=user_id,
+                        response_format=response_format,
+                        stream_events=opts.stream_events,
+                        yield_run_output=opts.yield_run_output,
+                        debug_mode=debug_mode,
+                        background_tasks=background_tasks,
+                        **kwargs,
+                    )
+                )
+            else:
+                return _finish_continue(
+                    _continue_run(
+                        team,
+                        run_response=run_response,
+                        run_messages=run_messages,
+                        run_context=run_context,
+                        tools=_tools,
+                        session=team_session,
+                        user_id=user_id,
+                        response_format=response_format,
+                        debug_mode=debug_mode,
+                        background_tasks=background_tasks,
+                        **kwargs,
+                    )
+                )
+
+        # Fallback: nothing to do
+        run_response.status = RunStatus.completed
+        _cleanup_and_store(team, run_response=run_response, session=team_session)
+        return _finish_continue(run_response)
+    finally:
+        if paused_claim is not None and not paused_claim_handed_off:
+            paused_claim.release()
 
 
 def _continue_run_dispatch_stream_with_member_events(
@@ -8140,12 +8254,28 @@ async def _acontinue_run_background_stream(
                 "and cannot be continued in place. Use acontinue_run(run_id=..., fork=True) to branch off a "
                 "finished run. The stored run is unchanged."
             )
+
+    # Claim before the RUNNING write is visible to a sibling continue. The
+    # producer releases after the in-place resume finishes — not when this
+    # SSE generator returns — so a foreground continue cannot overlap it.
+    paused_continue_claim: Optional[_PausedContinueClaim] = None
+    if not (fork or regenerate) and _as_run_status(status_before_takeover) not in (
+        RunStatus.completed,
+        RunStatus.cancelled,
+    ):
+        paused_continue_claim = _PausedContinueClaim(session_id, _run_id)
+        paused_continue_claim.acquire_or_refuse()
+    try:
         # A fork or regenerate executes under a NEW run id; writing RUNNING
         # under the original id would strand the original run at RUNNING.
-        if not (fork or regenerate):
+        if run_response is not None and not (fork or regenerate):
             run_response.status = RunStatus.running
             team_session.upsert_run(run_response=run_response)
-    await asave_session(team, session=team_session)
+        await asave_session(team, session=team_session)
+    except BaseException:
+        if paused_continue_claim is not None:
+            paused_continue_claim.release()
+        raise
 
     log_info(f"Background continue-run stream {_run_id} persisted with RUNNING status")
 
@@ -8205,6 +8335,7 @@ async def _acontinue_run_background_stream(
                 yield_run_output=True,
                 debug_mode=debug_mode,
                 background_tasks=background_tasks,
+                paused_continue_claim=paused_continue_claim,
                 **kwargs,
             ):
                 if isinstance(event, TeamRunOutput):
@@ -8379,6 +8510,9 @@ async def _acontinue_run_background_stream(
                 await asyncio.shield(sse_subscriber_manager.complete(_run_id))
             except (Exception, asyncio.CancelledError):
                 log_warning(f"Failed to signal SSE subscribers for continue-run {_run_id} completion")
+
+            if paused_continue_claim is not None:
+                paused_continue_claim.release()
 
     task = asyncio.create_task(_background_producer())
     _background_tasks.add(task)
@@ -8603,6 +8737,8 @@ async def _acontinue_run(
     # skipped and the run would complete without the leader ever being called.
     routed_member_results: List[str] = []
 
+    paused_claim: Optional[_PausedContinueClaim] = None
+
     try:
         num_attempts = team.retries + 1
         for attempt in range(num_attempts):
@@ -8652,6 +8788,12 @@ async def _acontinue_run(
                 # Auto-fork on COMPLETED — preserves 1-run-1-loop invariant.
                 if not fork and run_response.status == RunStatus.completed:
                     fork = True
+
+                if paused_claim is None and not fork and not regenerate:
+                    paused_claim = _PausedContinueClaim(session_id, run_response.run_id)
+                    paused_claim.acquire_or_refuse()
+                elif paused_claim is not None and not fork and not regenerate:
+                    paused_claim.acquire_or_refuse()
 
                 _did_snapshot_dispatch = fork or _will_truncate_team_run(run_response, continue_index)
                 run_response = _apply_continue_modifiers_team(run_response, fork, continue_index)
@@ -9021,6 +9163,8 @@ async def _acontinue_run(
                 return run_response
 
     finally:
+        if paused_claim is not None:
+            paused_claim.release()
         _disconnect_connectable_tools(team)
         await _disconnect_mcp_tools(team)  # type: ignore
         if run_response and run_response.run_id:
@@ -9048,6 +9192,7 @@ async def _acontinue_run_stream(
     yield_run_output: bool = False,
     debug_mode: Optional[bool] = None,
     background_tasks: Optional[Any] = None,
+    paused_continue_claim: Optional[_PausedContinueClaim] = None,
     **kwargs: Any,
 ) -> AsyncIterator[Union[TeamRunOutputEvent, RunOutputEvent, TeamRunOutput]]:
     """Continue a paused team run (async, streaming)."""
@@ -9071,6 +9216,8 @@ async def _acontinue_run_stream(
     # run that skipped it.
     requirements_applied = False
     routed_member_results: List[str] = []
+    inherited_claim = paused_continue_claim
+    paused_claim: Optional[_PausedContinueClaim] = inherited_claim
 
     try:
         num_attempts = team.retries + 1
@@ -9121,6 +9268,12 @@ async def _acontinue_run_stream(
                 # Auto-fork on COMPLETED — preserves 1-run-1-loop invariant.
                 if not fork and run_response.status == RunStatus.completed:
                     fork = True
+
+                if paused_claim is None and not fork and not regenerate:
+                    paused_claim = _PausedContinueClaim(session_id, run_response.run_id)
+                    paused_claim.acquire_or_refuse()
+                elif paused_claim is not None and not fork and not regenerate:
+                    paused_claim.acquire_or_refuse()
 
                 _did_snapshot_dispatch = fork or _will_truncate_team_run(run_response, continue_index)
                 run_response = _apply_continue_modifiers_team(run_response, fork, continue_index)
@@ -9722,6 +9875,8 @@ async def _acontinue_run_stream(
                     yield run_response
 
     finally:
+        if paused_claim is not None and paused_claim is not inherited_claim:
+            paused_claim.release()
         _disconnect_connectable_tools(team)
         await _disconnect_mcp_tools(team)  # type: ignore
         if run_response and run_response.run_id:

--- a/libs/agno/tests/unit/team/test_paused_member_persistence.py
+++ b/libs/agno/tests/unit/team/test_paused_member_persistence.py
@@ -6076,3 +6076,231 @@ def test_a_routing_failure_restores_the_callers_team_level_requirements(tmp_path
 
     names = [r.tool_execution.tool_name for r in (run1.requirements or [])]
     assert names.count("publish") == 1, f"the caller's run object carries: {names}"
+
+
+# ---------------------------------------------------------------------------
+# Overlapping continues of one paused run
+#
+# Regression for: https://github.com/agno-agi/agno/issues/9448
+#
+# Two concurrent continues of the same paused team run both used to bind the
+# payload and execute the approval-gated tool. Exactly one continue may claim
+# the in-place resume; the other raises RunNotContinuableError and must not
+# execute the tool. Sequential continues of a completed run still auto-fork
+# instead of refusing.
+# ---------------------------------------------------------------------------
+
+
+def _agate_first_n_calls(orig, n: int = 2):
+    calls = 0
+    lock = asyncio.Lock()
+    barrier = asyncio.Barrier(n)
+
+    async def gated(*args: Any, **kwargs: Any):
+        nonlocal calls
+        result = await orig(*args, **kwargs)
+        wait = False
+        async with lock:
+            if calls < n:
+                calls += 1
+                wait = True
+        if wait:
+            await barrier.wait()
+        return result
+
+    return gated
+
+
+def _split_continue_outcomes(results: List[Any]) -> Tuple[List[Any], List[BaseException]]:
+    oks = [r for r in results if not isinstance(r, BaseException)]
+    errors = [r for r in results if isinstance(r, BaseException)]
+    return oks, errors
+
+
+@pytest.mark.asyncio
+async def test_overlapping_async_continues_execute_gated_tool_once(tmp_path):
+    """Two concurrent acontinue_run calls on one paused run: one executes, one refuses."""
+    from agno.team._run import _asetup_session
+
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "overlap_acontinue.db")
+    session_id = "s-overlap-acontinue"
+
+    run1 = await _build_flat_team(SqliteDb(db_file=db_file), resuming=False).arun(
+        "Email a@example.com", session_id=session_id
+    )
+    assert run1.is_paused
+    payload = _wire_requirements(run1.requirements)
+    team = _build_flat_team(SqliteDb(db_file=db_file), resuming=True)
+
+    with patch("agno.team._run._asetup_session", new=_agate_first_n_calls(_asetup_session)):
+        results = await asyncio.gather(
+            team.acontinue_run(run_id=run1.run_id, session_id=session_id, requirements=payload),
+            team.acontinue_run(run_id=run1.run_id, session_id=session_id, requirements=payload),
+            return_exceptions=True,
+        )
+
+    oks, errors = _split_continue_outcomes(list(results))
+    assert len(oks) == 1, f"expected one winner, got {results!r}"
+    assert len(errors) == 1
+    assert isinstance(errors[0], RunNotContinuableError)
+    assert _EXECUTED == ["a@example.com"]
+    stored = [r for r in _reload_runs(db_file, session_id) if r.run_id == run1.run_id][0]
+    assert stored.status == RunStatus.completed
+    assert oks[0].status == RunStatus.completed
+    assert oks[0].run_id == run1.run_id
+
+
+@pytest.mark.asyncio
+async def test_overlapping_async_stream_continues_execute_gated_tool_once(tmp_path):
+    from agno.team._run import _asetup_session
+
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "overlap_stream.db")
+    session_id = "s-overlap-stream"
+
+    run1 = await _build_flat_team(SqliteDb(db_file=db_file), resuming=False).arun(
+        "Email a@example.com", session_id=session_id
+    )
+    assert run1.is_paused
+    payload = _wire_requirements(run1.requirements)
+    team = _build_flat_team(SqliteDb(db_file=db_file), resuming=True)
+
+    async def _consume() -> Any:
+        last = None
+        async for event in team.acontinue_run(
+            run_id=run1.run_id,
+            session_id=session_id,
+            requirements=payload,
+            stream=True,
+            stream_events=True,
+        ):
+            last = event
+        return last
+
+    with patch("agno.team._run._asetup_session", new=_agate_first_n_calls(_asetup_session)):
+        results = await asyncio.gather(_consume(), _consume(), return_exceptions=True)
+
+    oks, errors = _split_continue_outcomes(list(results))
+    assert len(oks) == 1, f"expected one winner, got {results!r}"
+    assert len(errors) == 1
+    assert isinstance(errors[0], RunNotContinuableError)
+    assert _EXECUTED == ["a@example.com"]
+    stored = [r for r in _reload_runs(db_file, session_id) if r.run_id == run1.run_id][0]
+    assert stored.status == RunStatus.completed
+
+
+def test_paused_continue_claim_refuses_a_second_holder():
+    """The in-process claim is what continue_run_dispatch uses; sqlite is not
+    thread-safe enough to race two continue_run calls on one connection."""
+    from agno.team._run import _PausedContinueClaim
+
+    first = _PausedContinueClaim("s-claim", "run-claim")
+    second = _PausedContinueClaim("s-claim", "run-claim")
+    first.acquire_or_refuse()
+    with pytest.raises(RunNotContinuableError, match="already claimed"):
+        second.acquire_or_refuse()
+    first.release()
+    second.acquire_or_refuse()
+    second.release()
+
+
+def test_paused_continue_claim_nested_same_token_survives_background_wrapper():
+    from agno.team._run import _PausedContinueClaim
+
+    claim = _PausedContinueClaim("s-nested", "run-nested")
+    claim.acquire_or_refuse()
+    claim.acquire_or_refuse()
+    claim.release()
+    other = _PausedContinueClaim("s-nested", "run-nested")
+    other.acquire_or_refuse()
+    other.release()
+
+
+def test_sync_continue_refuses_when_another_continue_holds_the_claim(tmp_path):
+    from agno.team._run import _PausedContinueClaim
+
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "held_claim_sync.db")
+    session_id = "s-held-claim-sync"
+
+    run1 = _build_flat_team(SqliteDb(db_file=db_file), resuming=False).run("Email a@example.com", session_id=session_id)
+    assert run1.is_paused
+    holder = _PausedContinueClaim(session_id, run1.run_id)
+    holder.acquire_or_refuse()
+    try:
+        team = _build_flat_team(SqliteDb(db_file=db_file), resuming=True)
+        with pytest.raises(RunNotContinuableError, match="already claimed"):
+            team.continue_run(
+                run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+            )
+        assert _EXECUTED == []
+        stored = [r for r in _reload_runs(db_file, session_id) if r.run_id == run1.run_id][0]
+        assert stored.status == RunStatus.paused
+    finally:
+        holder.release()
+
+
+@pytest.mark.asyncio
+async def test_overlapping_background_continues_execute_gated_tool_once(tmp_path):
+    from agno.team._storage import _aread_or_create_session
+
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "overlap_bg.db")
+    session_id = "s-overlap-bg"
+
+    run1 = await _build_flat_team(SqliteDb(db_file=db_file), resuming=False).arun(
+        "Email a@example.com", session_id=session_id
+    )
+    assert run1.is_paused
+    payload = _wire_requirements(run1.requirements)
+    team = _build_flat_team(SqliteDb(db_file=db_file), resuming=True)
+
+    async def _consume_bg() -> None:
+        async for _ in team.acontinue_run(
+            run_id=run1.run_id,
+            session_id=session_id,
+            requirements=payload,
+            stream=True,
+            stream_events=True,
+            background=True,
+        ):
+            pass
+
+    with patch(
+        "agno.team._storage._aread_or_create_session",
+        new=_agate_first_n_calls(_aread_or_create_session),
+    ):
+        results = await asyncio.gather(_consume_bg(), _consume_bg(), return_exceptions=True)
+    await _drain_background_tasks()
+
+    oks, errors = _split_continue_outcomes(list(results))
+    assert len(oks) == 1, f"expected one winner, got {results!r}"
+    assert len(errors) == 1
+    assert isinstance(errors[0], RunNotContinuableError)
+    assert _EXECUTED == ["a@example.com"]
+    stored = [r for r in _reload_runs(db_file, session_id) if r.run_id == run1.run_id][0]
+    assert stored.status == RunStatus.completed
+
+
+@pytest.mark.asyncio
+async def test_sequential_continues_after_completion_do_not_reexecute_the_gated_tool(tmp_path):
+    """Sequential continues of a completed run auto-fork; the gated tool stays once."""
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "sequential_continue.db")
+    session_id = "s-sequential-continue"
+
+    run1 = await _build_flat_team(SqliteDb(db_file=db_file), resuming=False).arun(
+        "Email a@example.com", session_id=session_id
+    )
+    assert run1.is_paused
+    payload = _wire_requirements(run1.requirements)
+    team = _build_flat_team(SqliteDb(db_file=db_file), resuming=True)
+
+    run2 = await team.acontinue_run(run_id=run1.run_id, session_id=session_id, requirements=payload)
+    assert run2.status == RunStatus.completed
+    assert _EXECUTED == ["a@example.com"]
+
+    run3 = await team.acontinue_run(run_id=run1.run_id, session_id=session_id, requirements=payload)
+    assert _EXECUTED == ["a@example.com"], "a sequential continue of a completed run must not re-fire the gated tool"
+    assert run3.run_id != run1.run_id


### PR DESCRIPTION
## Summary

Fixes #9448.

Two overlapping `continue_run` / `acontinue_run` calls on the same paused team run both loaded `PAUSED`, both bound the approval payload, and both executed the gated tool. Exactly one in-place continue may now claim `(session_id, run_id)`. The loser raises `RunNotContinuableError` (HTTP 409) **before** the payload is applied, so the stored run is unchanged by that request.

The claim lives in the shared continue entry points (`continue_run_dispatch`, `_acontinue_run`, `_acontinue_run_stream`) rather than only the AgentOS background SSE wrapper. Background continues take the claim **before** writing `RUNNING` and hold it until the producer task finishes. Nested acquires with the same token let the wrapper and the stream share one claim without releasing early.

Fork and regenerate still mint a new `run_id` and never contend with a paused resume. Sequential continues of a completed run still auto-fork and do not re-fire the gated tool. A leftover `RUNNING` row in a new process still resumes (crash recovery) because the claim map is process-local.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

This PR was drafted with Cursor. I reviewed the continue-run entry points, the background SSE takeover, and the overlapping-continue tests before opening it.

## Tests

`pytest libs/agno/tests/unit/team/test_paused_member_persistence.py` — 149 passed.

Coverage added:

- Two overlapping `acontinue_run` calls (plain and stream): one executes the gated tool, the other raises `RunNotContinuableError`
- Two overlapping AgentOS background continues
- Sync `continue_run` refuses when another continue already holds the claim; stored run stays `PAUSED`
- Sequential continue of a completed run auto-forks and does not re-execute the tool

## Additional Notes

`RunNotContinuableError` is already a `ValueError`; AgentOS maps it to HTTP 409.

Related prior work: #9396 persisted paused member runs so resume survived a session reload. That path is sequential. This patch serializes overlapping in-place continues of one run.

---

I work on production HITL / Gate-Prove failures for teams deploying agent products. If a similar pause/resume race is showing up in a live AgentOS deploy, A2Z SOC offers an Instant Audit ([\$499](https://a2zsoc.com/productized-services#instant-audit-tripwire)) and a [consultation](https://a2zsoc.com/consultation).

Made with [Cursor](https://cursor.com)