### PR TITLE
[fix] Skip rejected user-input tools so a requirements payload cannot execute a deny

### DIFF
--- a/libs/agno/agno/agent/_tools.py
+++ b/libs/agno/agno/agent/_tools.py
@@ -940,14 +940,24 @@ def handle_tool_call_updates(
             _t.requires_user_input = False
             _t.answered = True
 
-        # Case 4: Handle user input required tools
+        # Case 4: Handle user input required tools.
+        # confirmed is False means an admin explicitly rejected the call (e.g.
+        # @approval + requires_user_input). Do not execute even if the payload
+        # filled in the input fields. confirmed is None keeps the plain
+        # user-input path (no approval record) executing after answers land.
         elif _t.requires_user_input is not None and _t.requires_user_input is True:
-            handle_user_input_update(agent, tool=_t)
+            if _t.confirmed is False:
+                reject_tool_call(agent, run_messages, _t, functions=_functions)
+                _t.confirmation_note = _t.confirmation_note or "Tool call was rejected"
+                _t.tool_call_error = True
+                _maybe_create_audit_approval(agent, _t, run_response, "rejected")
+            else:
+                handle_user_input_update(agent, tool=_t)
+                # Consume the generator without yielding
+                deque(run_tool(agent, run_response, run_messages, _t, functions=_functions), maxlen=0)
+                _maybe_create_audit_approval(agent, _t, run_response, "approved")
             _t.requires_user_input = False
             _t.answered = True
-            # Consume the generator without yielding
-            deque(run_tool(agent, run_response, run_messages, _t, functions=_functions), maxlen=0)
-            _maybe_create_audit_approval(agent, _t, run_response, "approved")
 
 
 def handle_tool_call_updates_stream(
@@ -995,13 +1005,19 @@ def handle_tool_call_updates_stream(
 
         # Case 4: Handle user input required tools
         elif _t.requires_user_input is not None and _t.requires_user_input is True:
-            handle_user_input_update(agent, tool=_t)
-            yield from run_tool(
-                agent, run_response, run_messages, _t, functions=_functions, stream_events=stream_events
-            )
+            if _t.confirmed is False:
+                reject_tool_call(agent, run_messages, _t, functions=_functions)
+                _t.confirmation_note = _t.confirmation_note or "Tool call was rejected"
+                _t.tool_call_error = True
+                _maybe_create_audit_approval(agent, _t, run_response, "rejected")
+            else:
+                handle_user_input_update(agent, tool=_t)
+                yield from run_tool(
+                    agent, run_response, run_messages, _t, functions=_functions, stream_events=stream_events
+                )
+                _maybe_create_audit_approval(agent, _t, run_response, "approved")
             _t.requires_user_input = False
             _t.answered = True
-            _maybe_create_audit_approval(agent, _t, run_response, "approved")
 
 
 async def ahandle_tool_call_updates(
@@ -1043,12 +1059,18 @@ async def ahandle_tool_call_updates(
             _t.answered = True
         # Case 4: Handle user input required tools
         elif _t.requires_user_input is not None and _t.requires_user_input is True:
-            handle_user_input_update(agent, tool=_t)
-            async for _ in arun_tool(agent, run_response, run_messages, _t, functions=_functions):
-                pass
+            if _t.confirmed is False:
+                reject_tool_call(agent, run_messages, _t, functions=_functions)
+                _t.confirmation_note = _t.confirmation_note or "Tool call was rejected"
+                _t.tool_call_error = True
+                await _amaybe_create_audit_approval(agent, _t, run_response, "rejected")
+            else:
+                handle_user_input_update(agent, tool=_t)
+                async for _ in arun_tool(agent, run_response, run_messages, _t, functions=_functions):
+                    pass
+                await _amaybe_create_audit_approval(agent, _t, run_response, "approved")
             _t.requires_user_input = False
             _t.answered = True
-            await _amaybe_create_audit_approval(agent, _t, run_response, "approved")
 
 
 async def ahandle_tool_call_updates_stream(
@@ -1096,11 +1118,17 @@ async def ahandle_tool_call_updates_stream(
             _t.answered = True
         # Case 4: Handle user input required tools
         elif _t.requires_user_input is not None and _t.requires_user_input is True:
-            handle_user_input_update(agent, tool=_t)
-            async for event in arun_tool(
-                agent, run_response, run_messages, _t, functions=_functions, stream_events=stream_events
-            ):
-                yield event
+            if _t.confirmed is False:
+                reject_tool_call(agent, run_messages, _t, functions=_functions)
+                _t.confirmation_note = _t.confirmation_note or "Tool call was rejected"
+                _t.tool_call_error = True
+                await _amaybe_create_audit_approval(agent, _t, run_response, "rejected")
+            else:
+                handle_user_input_update(agent, tool=_t)
+                async for event in arun_tool(
+                    agent, run_response, run_messages, _t, functions=_functions, stream_events=stream_events
+                ):
+                    yield event
+                await _amaybe_create_audit_approval(agent, _t, run_response, "approved")
             _t.requires_user_input = False
             _t.answered = True
-            await _amaybe_create_audit_approval(agent, _t, run_response, "approved")

--- a/libs/agno/tests/unit/tools/test_user_input_tool_rejection.py
+++ b/libs/agno/tests/unit/tools/test_user_input_tool_rejection.py
@@ -1,0 +1,197 @@
+"""Rejected user-input tools must not execute when a requirements payload answers them.
+
+Fixes #9451. Case 4 of handle_tool_call_updates previously ran any
+requires_user_input tool after filling answered fields, without consulting
+_t.confirmed. An @approval(type="required") user-input tool that an admin
+rejected still executed with the client's values.
+"""
+
+from typing import Any, AsyncIterator, Iterator, List
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agno.agent._tools import (
+    ahandle_tool_call_updates,
+    ahandle_tool_call_updates_stream,
+    handle_tool_call_updates,
+    handle_tool_call_updates_stream,
+)
+from agno.models.response import ToolExecution
+from agno.run.agent import RunOutput
+from agno.run.messages import RunMessages
+from agno.tools.function import Function, UserInputField
+
+
+def _agent() -> MagicMock:
+    agent = MagicMock()
+    agent.model = MagicMock()
+    agent.db = None
+    agent.id = "agent-1"
+    agent.name = "test-agent"
+    agent.events_to_skip = None
+    agent.store_events = False
+    return agent
+
+
+def _tool(*, confirmed: Any = None) -> ToolExecution:
+    return ToolExecution(
+        tool_call_id="tc-wire-1",
+        tool_name="submit_wire",
+        tool_args={"amount": 1},
+        requires_user_input=True,
+        confirmed=confirmed,
+        user_input_schema=[UserInputField(name="amount", field_type=int, value=999)],
+    )
+
+
+def _run(tool: ToolExecution) -> RunOutput:
+    return RunOutput(run_id="run-1", session_id="sess-1", tools=[tool])
+
+
+def _functions() -> List[Function]:
+    return [Function(name="submit_wire", description="Submit a wire", entrypoint=lambda amount: f"sent {amount}")]
+
+
+def _fake_run_tool(*_args, **_kwargs) -> Iterator[Any]:
+    return iter(())
+
+
+async def _fake_arun_tool(*_args, **_kwargs) -> AsyncIterator[Any]:
+    if False:
+        yield None
+
+
+def test_rejected_user_input_tool_does_not_execute_sync():
+    tool = _tool(confirmed=False)
+    run_messages = RunMessages()
+    with (
+        patch("agno.agent._tools.run_tool", side_effect=_fake_run_tool) as run_tool,
+        patch("agno.agent._tools.reject_tool_call") as reject,
+        patch("agno.agent._tools._maybe_create_audit_approval") as audit,
+    ):
+        handle_tool_call_updates(_agent(), _run(tool), run_messages, _functions())
+
+    run_tool.assert_not_called()
+    reject.assert_called_once()
+    audit.assert_called_once()
+    assert audit.call_args.args[-1] == "rejected"
+    assert tool.tool_call_error is True
+    assert tool.confirmed is False
+    assert tool.requires_user_input is False
+    assert tool.answered is True
+    assert tool.confirmation_note == "Tool call was rejected"
+    # Reject must not bind the payload's answered fields onto the tool.
+    assert tool.tool_args == {"amount": 1}
+
+
+def test_confirmed_user_input_tool_still_executes_sync():
+    tool = _tool(confirmed=True)
+    run_messages = RunMessages()
+    with (
+        patch("agno.agent._tools.run_tool", side_effect=_fake_run_tool) as run_tool,
+        patch("agno.agent._tools.reject_tool_call") as reject,
+        patch("agno.agent._tools._maybe_create_audit_approval") as audit,
+    ):
+        handle_tool_call_updates(_agent(), _run(tool), run_messages, _functions())
+
+    run_tool.assert_called_once()
+    reject.assert_not_called()
+    audit.assert_called_once()
+    assert audit.call_args.args[-1] == "approved"
+    assert tool.requires_user_input is False
+    assert tool.answered is True
+    assert tool.tool_args == {"amount": 999}
+
+
+def test_unconfirmed_user_input_tool_still_executes_sync():
+    """Plain user-input (no approval record, confirmed=None) is unchanged."""
+    tool = _tool(confirmed=None)
+    run_messages = RunMessages()
+    with (
+        patch("agno.agent._tools.run_tool", side_effect=_fake_run_tool) as run_tool,
+        patch("agno.agent._tools.reject_tool_call") as reject,
+        patch("agno.agent._tools._maybe_create_audit_approval") as audit,
+    ):
+        handle_tool_call_updates(_agent(), _run(tool), run_messages, _functions())
+
+    run_tool.assert_called_once()
+    reject.assert_not_called()
+    audit.assert_called_once()
+    assert audit.call_args.args[-1] == "approved"
+    assert tool.tool_args == {"amount": 999}
+
+
+def test_rejected_user_input_tool_does_not_execute_stream():
+    tool = _tool(confirmed=False)
+    run_messages = RunMessages()
+    with (
+        patch("agno.agent._tools.run_tool", side_effect=_fake_run_tool) as run_tool,
+        patch("agno.agent._tools.reject_tool_call") as reject,
+        patch("agno.agent._tools._maybe_create_audit_approval") as audit,
+    ):
+        list(handle_tool_call_updates_stream(_agent(), _run(tool), run_messages, _functions()))
+
+    run_tool.assert_not_called()
+    reject.assert_called_once()
+    assert audit.call_args.args[-1] == "rejected"
+    assert tool.tool_call_error is True
+    assert tool.tool_args == {"amount": 1}
+
+
+@pytest.mark.asyncio
+async def test_rejected_user_input_tool_does_not_execute_async():
+    tool = _tool(confirmed=False)
+    run_messages = RunMessages()
+    with (
+        patch("agno.agent._tools.arun_tool", side_effect=_fake_arun_tool) as arun_tool,
+        patch("agno.agent._tools.reject_tool_call") as reject,
+        patch("agno.agent._tools._amaybe_create_audit_approval", new_callable=AsyncMock) as audit,
+    ):
+        await ahandle_tool_call_updates(_agent(), _run(tool), run_messages, _functions())
+
+    arun_tool.assert_not_called()
+    reject.assert_called_once()
+    audit.assert_awaited_once()
+    assert audit.await_args.args[-1] == "rejected"
+    assert tool.tool_call_error is True
+    assert tool.tool_args == {"amount": 1}
+
+
+@pytest.mark.asyncio
+async def test_rejected_user_input_tool_does_not_execute_async_stream():
+    tool = _tool(confirmed=False)
+    run_messages = RunMessages()
+    with (
+        patch("agno.agent._tools.arun_tool", side_effect=_fake_arun_tool) as arun_tool,
+        patch("agno.agent._tools.reject_tool_call") as reject,
+        patch("agno.agent._tools._amaybe_create_audit_approval", new_callable=AsyncMock) as audit,
+    ):
+        events = []
+        async for event in ahandle_tool_call_updates_stream(_agent(), _run(tool), run_messages, _functions()):
+            events.append(event)
+
+    assert events == []
+    arun_tool.assert_not_called()
+    reject.assert_called_once()
+    audit.assert_awaited_once()
+    assert audit.await_args.args[-1] == "rejected"
+    assert tool.tool_call_error is True
+    assert tool.tool_args == {"amount": 1}
+
+
+@pytest.mark.asyncio
+async def test_confirmed_user_input_tool_still_executes_async():
+    tool = _tool(confirmed=True)
+    run_messages = RunMessages()
+    with (
+        patch("agno.agent._tools.arun_tool", side_effect=_fake_arun_tool) as arun_tool,
+        patch("agno.agent._tools.reject_tool_call") as reject,
+        patch("agno.agent._tools._amaybe_create_audit_approval", new_callable=AsyncMock) as audit,
+    ):
+        await ahandle_tool_call_updates(_agent(), _run(tool), run_messages, _functions())
+
+    arun_tool.assert_called_once()
+    reject.assert_not_called()
+    assert audit.await_args.args[-1] == "approved"
+    assert tool.tool_args == {"amount": 999}


### PR DESCRIPTION
## Summary

Fixes #9451.

`handle_tool_call_updates` Case 4 ran every `requires_user_input` tool after filling answered fields, without consulting `_t.confirmed`. Confirmation tools (Case 1) already refuse when `confirmed is not True`. User-input tools under `@approval(type="required")` did not, so an admin reject followed by a requirements payload still executed the tool with the client's values and the audit recorded `"approved"`.

All four Case-4 branches (sync/async × stream/non-stream) now:

- Route `confirmed is False` through `reject_tool_call` (confirmation note, `tool_call_error`, audit `"rejected"`)
- Leave `confirmed is None` executing after answers land, so plain user-input without an approval record is unchanged
- Still execute `confirmed is True`

The reject path does not bind payload field values onto the tool.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

This PR was drafted with Cursor. I reviewed the four Case-4 branches against Case 1, confirmed #9396 does not cover the payload-resend path, and ran the new unit tests before opening it.

## Tests

`pytest libs/agno/tests/unit/tools/test_user_input_tool_rejection.py` — 7 passed.

`ruff format` and `ruff check` on the two changed files.

Coverage:

- Rejected sync / stream / async / async-stream: `run_tool` / `arun_tool` is not called; `reject_tool_call` is; audit is `"rejected"`; answered payload fields are not bound
- Confirmed sync and async still execute and bind answered fields
- `confirmed is None` still executes (plain user-input)

## Additional Notes

Related prior work: #9396 persisted paused member runs so resume survived a session reload. A rejected user-input/external tool is skipped on that approval-lane path. This patch is the payload-resend path in `agent/_tools.py`, which was out of that PR's scope.

---

I work on production HITL / Gate-Prove failures for teams deploying agent products. If a similar reject-still-ran path is showing up in a live AgentOS deploy, A2Z SOC offers an Instant Audit ([$499](https://a2zsoc.com/productized-services#instant-audit-tripwire)) and a [consultation](https://a2zsoc.com/consultation).