### PR TITLE
[fix] surface usage cost and prompt-cache tokens in model metrics

### DIFF
--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -1291,10 +1291,14 @@ class Claude(Model):
         metrics = MessageMetrics()
 
         metrics.input_tokens = response_usage.input_tokens or 0
-        metrics.output_tokens = response_usage.output_tokens or 0
-        metrics.total_tokens = metrics.input_tokens + metrics.output_tokens
         metrics.cache_read_tokens = response_usage.cache_read_input_tokens or 0
         metrics.cache_write_tokens = response_usage.cache_creation_input_tokens or 0
+        # Anthropic reports `input_tokens` net of the cache and bills cache reads/writes
+        # separately. Gross input_tokens so it matches the OpenAI parser's meaning and
+        # `total_tokens` covers everything billed. No-op when there is no cache usage.
+        metrics.input_tokens += metrics.cache_read_tokens + metrics.cache_write_tokens
+        metrics.output_tokens = response_usage.output_tokens or 0
+        metrics.total_tokens = metrics.input_tokens + metrics.output_tokens
 
         # Anthropic-specific additional fields
         if response_usage.server_tool_use:

--- a/libs/agno/agno/models/aws/bedrock.py
+++ b/libs/agno/agno/models/aws/bedrock.py
@@ -841,10 +841,13 @@ class AwsBedrock(Model):
         metrics = MessageMetrics()
 
         metrics.input_tokens = response_usage.get("inputTokens", 0) or 0
-        metrics.output_tokens = response_usage.get("outputTokens", 0) or 0
-        metrics.total_tokens = metrics.input_tokens + metrics.output_tokens
-
         metrics.cache_read_tokens = response_usage.get("cacheReadInputTokens", 0) or 0
         metrics.cache_write_tokens = response_usage.get("cacheWriteInputTokens", 0) or 0
+        # Bedrock passes through Anthropic's accounting: `inputTokens` is net of the
+        # cache and cache reads/writes are billed on top. Gross input_tokens so
+        # `total_tokens` covers everything billed. No-op when there is no cache usage.
+        metrics.input_tokens += metrics.cache_read_tokens + metrics.cache_write_tokens
+        metrics.output_tokens = response_usage.get("outputTokens", 0) or 0
+        metrics.total_tokens = metrics.input_tokens + metrics.output_tokens
 
         return metrics

--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -1384,4 +1384,8 @@ class OpenAIResponses(Model):
         if output_tokens_details := response_usage.output_tokens_details:
             metrics.reasoning_tokens = output_tokens_details.reasoning_tokens
 
+        # OpenRouter (and other Responses-compatible providers) include a per-request
+        # `cost` in usage; OpenAI itself does not, so this is a no-op for OpenAI.
+        metrics.cost = getattr(response_usage, "cost", None)
+
         return metrics

--- a/libs/agno/tests/unit/models/anthropic/test_cache_metrics.py
+++ b/libs/agno/tests/unit/models/anthropic/test_cache_metrics.py
@@ -1,0 +1,36 @@
+"""Unit tests for Anthropic prompt-cache token accounting (#9538).
+
+Anthropic reports `input_tokens` net of the cache and bills cache reads/writes
+separately. `Claude._get_metrics` must gross up `input_tokens` so `total_tokens`
+covers everything billed.
+"""
+
+from anthropic.types import Usage
+
+from agno.models.anthropic.claude import Claude
+
+
+def _usage(input_tokens: int, output_tokens: int, cache_read: int = 0, cache_write: int = 0) -> Usage:
+    return Usage(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_creation_input_tokens=cache_write,
+        cache_read_input_tokens=cache_read,
+        server_tool_use=None,
+    )
+
+
+def test_claude_metrics_gross_input_tokens_with_prompt_cache():
+    claude = Claude(id="claude-sonnet-4-6")
+    metrics = claude._get_metrics(_usage(input_tokens=10, output_tokens=5, cache_read=1000, cache_write=200))
+    assert metrics.input_tokens == 1210
+    assert metrics.cache_read_tokens == 1000
+    assert metrics.cache_write_tokens == 200
+    assert metrics.total_tokens == 1215
+
+
+def test_claude_metrics_uncached_unchanged():
+    claude = Claude(id="claude-sonnet-4-6")
+    metrics = claude._get_metrics(_usage(input_tokens=50, output_tokens=10))
+    assert metrics.input_tokens == 50
+    assert metrics.total_tokens == 60

--- a/libs/agno/tests/unit/models/aws/test_bedrock_metrics.py
+++ b/libs/agno/tests/unit/models/aws/test_bedrock_metrics.py
@@ -1,0 +1,33 @@
+"""Unit tests for AWS Bedrock usage parsing (#9538).
+
+Bedrock passes through Anthropic's accounting: `inputTokens` is net of the cache
+and cache reads/writes are billed on top. `AwsBedrock._get_metrics` must gross up
+`input_tokens` so `total_tokens` covers everything billed.
+"""
+
+from agno.models.aws.bedrock import AwsBedrock
+
+
+def _usage(input_tokens: int, output_tokens: int, cache_read: int = 0, cache_write: int = 0) -> dict:
+    return {
+        "inputTokens": input_tokens,
+        "outputTokens": output_tokens,
+        "cacheReadInputTokens": cache_read,
+        "cacheWriteInputTokens": cache_write,
+    }
+
+
+def test_bedrock_metrics_gross_input_tokens_with_prompt_cache():
+    model = AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0")
+    metrics = model._get_metrics(_usage(input_tokens=10, output_tokens=5, cache_read=1000, cache_write=200))
+    assert metrics.input_tokens == 1210
+    assert metrics.cache_read_tokens == 1000
+    assert metrics.cache_write_tokens == 200
+    assert metrics.total_tokens == 1215
+
+
+def test_bedrock_metrics_uncached_unchanged():
+    model = AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0")
+    metrics = model._get_metrics(_usage(input_tokens=50, output_tokens=10))
+    assert metrics.input_tokens == 50
+    assert metrics.total_tokens == 60

--- a/libs/agno/tests/unit/models/openai/test_responses_metrics.py
+++ b/libs/agno/tests/unit/models/openai/test_responses_metrics.py
@@ -1,0 +1,34 @@
+"""Unit tests for OpenAIResponses/OpenRouterResponses usage parsing.
+
+OpenRouter's Responses API includes a per-request `cost` in usage; the shared
+`OpenAIResponses._get_metrics` (inherited by `OpenRouterResponses`) must surface it.
+"""
+
+from openai.types.responses import ResponseUsage
+
+from agno.models.openai.open_responses import OpenResponses
+
+
+def _usage(**overrides) -> ResponseUsage:
+    fields = {
+        "input_tokens": 10,
+        "output_tokens": 5,
+        "total_tokens": 15,
+        "input_tokens_details": None,
+        "output_tokens_details": None,
+    }
+    fields.update(overrides)
+    return ResponseUsage.model_construct(**fields)
+
+
+def test_responses_metrics_populates_cost_when_present():
+    model = OpenResponses(id="openai/gpt-oss-20b")
+    metrics = model._get_metrics(_usage(cost=0.00123))
+    assert metrics.cost == 0.00123
+
+
+def test_responses_metrics_cost_none_without_cost_field():
+    """OpenAI itself does not return `cost`; metrics.cost must stay None (no-op)."""
+    model = OpenResponses(id="openai/gpt-oss-20b")
+    metrics = model._get_metrics(_usage())
+    assert metrics.cost is None


### PR DESCRIPTION
## Summary

Two related metrics bugs in model providers:

- `OpenAIResponses._get_metrics` never read `cost` from usage, so
  `OpenRouterResponses` (which inherits it) always reported `MessageMetrics.cost = None`
  even though OpenRouter's Responses API includes a per-request `cost`. fix: read
  `cost` off the usage object when present (no-op for OpenAI, which sends none).
- Anthropic reports `input_tokens` net of the prompt cache and bills
  `cache_read_input_tokens` / `cache_creation_input_tokens` on top. `Claude._get_metrics`
  and `AwsBedrock._get_metrics` (Bedrock passes Anthropic's accounting through) excluded
  those from `input_tokens` and `total_tokens`, so a session using prompt caching
  reported a small fraction of the tokens actually billed. fix: gross up
  `input_tokens` with cache reads/writes before computing `total_tokens`; uncached
  calls are unchanged.

## Changes

- `libs/agno/agno/models/openai/responses.py` — parse `cost` in `_get_metrics`
- `libs/agno/agno/models/anthropic/claude.py` — include prompt-cache tokens in `input_tokens`/`total_tokens`
- `libs/agno/agno/models/aws/bedrock.py` — same for Bedrock's Anthropic-style usage

## How it was verified

- Reproduced both bugs offline: OpenRouter usage cost was present on the usage object but
  dropped by `_get_metrics`; a 10-token Anthropic response with 1000 cache-read +
  200 cache-write tokens reported `input_tokens=10, total_tokens=15` instead of `1210 / 1215`.
- Added regression tests: `test_responses_metrics.py`, `test_cache_metrics.py`,
  `test_bedrock_metrics.py`.
- `pytest` on touched provider test files: 21 passed (6 new + 15 existing).
- `ruff format` / `ruff check` (pinned `ruff==0.15.20`) clean; `mypy` introduces no new errors.

fixes #9566
fixes #9538

## AI-generated PR disclosure

This PR was written with the assistance of an AI coding tool. The changes were
reviewed by the author, run against the project's tests and linters, and understood
end-to-end before opening.