### PR TITLE
[fix] strict tool schema: exclude framework-owned params from required and complete nested required (#9454, #9413)

### DIFF
--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -1387,16 +1387,26 @@ class Function(BaseModel):
         """Process the schema to make it strict mode compliant."""
 
         def make_nested_strict(schema):
-            """Recursively ensure all object schemas have additionalProperties: false"""
+            """Recursively make a schema strict-mode compliant.
+
+            Every object level gets additionalProperties: false and a fully
+            populated `required`; anyOf/oneOf list branches are visited too.
+            """
             if not isinstance(schema, dict):
                 return schema
 
             # Make a copy to avoid modifying the original
             result = schema.copy()
 
-            # If this is an object schema, ensure additionalProperties: false
+            # If this is an object schema, ensure additionalProperties: false.
+            # Also complete pydantic's `required`, which omits defaulted or
+            # Optional fields -- OpenAI strict mode requires it to name every
+            # property (issue #9413).
             if result.get("type") == "object" or "properties" in result:
                 result["additionalProperties"] = False
+                properties = result.get("properties")
+                if isinstance(properties, dict):
+                    result["required"] = list(properties.keys())
 
             # If schema has no type but has other schema properties, give it a type
             if "type" not in result:
@@ -1412,9 +1422,12 @@ class Function(BaseModel):
             for key, value in result.items():
                 if key == "properties" and isinstance(value, dict):
                     result[key] = {k: make_nested_strict(v) for k, v in value.items()}
-                elif key == "items" and isinstance(value, dict):
-                    # This handles array items like List[KnowledgeFilter]
-                    result[key] = make_nested_strict(value)
+                elif isinstance(value, list):
+                    # anyOf/oneOf/allOf branches, and tuple-form items
+                    result[key] = [
+                        make_nested_strict(item) if isinstance(item, dict) else item
+                        for item in value
+                    ]
                 elif isinstance(value, dict):
                     result[key] = make_nested_strict(value)
 

--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -1418,18 +1418,33 @@ class Function(BaseModel):
                 ):
                     result["type"] = "string"
 
-            # Recursively process nested schemas
+            # Recursively process nested schemas. Only schema-bearing keys are
+            # walked: properties, items (single or tuple-form), the composition
+            # lists, and $defs. Literal-value keys -- enum, examples, default,
+            # const -- hold instance data, not schemas, and must stay untouched
+            # even when a literal happens to look like a schema.
             for key, value in result.items():
                 if key == "properties" and isinstance(value, dict):
                     result[key] = {k: make_nested_strict(v) for k, v in value.items()}
-                elif isinstance(value, list):
-                    # anyOf/oneOf/allOf branches, and tuple-form items
+                elif key == "items":
+                    if isinstance(value, dict):
+                        result[key] = make_nested_strict(value)
+                    elif isinstance(value, list):
+                        # tuple-form items: each element is a schema
+                        result[key] = [
+                            make_nested_strict(item) if isinstance(item, dict) else item
+                            for item in value
+                        ]
+                elif key in ("anyOf", "oneOf", "allOf", "prefixItems") and isinstance(value, list):
                     result[key] = [
                         make_nested_strict(item) if isinstance(item, dict) else item
                         for item in value
                     ]
-                elif isinstance(value, dict):
-                    result[key] = make_nested_strict(value)
+                elif key in ("$defs", "definitions", "additionalProperties") and isinstance(value, dict):
+                    if key == "additionalProperties":
+                        result[key] = make_nested_strict(value)
+                    else:
+                        result[key] = {k: make_nested_strict(v) for k, v in value.items()}
 
             return result
 

--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -1423,12 +1423,17 @@ class Function(BaseModel):
         # Apply strict mode to the entire schema
         self.parameters = make_nested_strict(self.parameters)
 
+        # Root-level `required` must also exclude the parameters the framework
+        # owns: the static reserved names (FRAMEWORK/AGNO injected) and any
+        # parameter the entrypoint claims by a framework-typed annotation
+        # (self._framework_params, e.g. a renamed `ctx: RunContext`). Issue #9454.
         self.parameters["required"] = [
             name
             for name in self.parameters["properties"]
             if name not in ("return", "self")
             and name not in FRAMEWORK_INJECTED_PARAMS
             and name not in AGNO_INJECTED_PARAMS
+            and name not in (self._framework_params or set())
         ]
 
     @staticmethod

--- a/libs/agno/tests/unit/tools/test_functions.py
+++ b/libs/agno/tests/unit/tools/test_functions.py
@@ -1744,6 +1744,27 @@ def test_strict_processing_does_not_require_an_injected_parameter():
     assert func.parameters["required"] == ["query"]
 
 
+def test_strict_processing_excludes_framework_typed_renamed_parameter():
+    """A param the framework claims by annotation (renamed from the reserved names)
+    must not be forced into strict-mode `required`. Issue #9454."""
+
+    def probe(query: str, ctx: RunContext = None) -> str:
+        return query
+
+    func = Function(
+        name="probe",
+        entrypoint=probe,
+        parameters={
+            "type": "object",
+            "properties": {"query": {"type": "string"}, "ctx": {"type": "object"}},
+            "required": ["query"],
+        },
+    )
+    func.process_entrypoint(strict=True)
+    assert func._framework_params == {"ctx"}
+    assert func.parameters["required"] == ["query"]
+
+
 # ----------------------------------------------------------------------
 # Regression: the guard must also engage on the from_callable path
 # (Agent(tools=[fn]) registers plain callables without process_entrypoint)

--- a/libs/agno/tests/unit/tools/test_functions.py
+++ b/libs/agno/tests/unit/tools/test_functions.py
@@ -1765,6 +1765,63 @@ def test_strict_processing_excludes_framework_typed_renamed_parameter():
     assert func.parameters["required"] == ["query"]
 
 
+def test_strict_processing_completes_required_at_every_level():
+    """make_nested_strict must finish pydantic's `required` list at every object
+    level, so defaulted or Optional fields are not omitted from strict `required`.
+    `format` keys are not a violation and must be preserved. Issue #9413."""
+    from datetime import datetime
+
+    class Inner(BaseModel):
+        label: str
+        weight: float = 1.0
+
+    class Payload(BaseModel):
+        name: str
+        created_at: datetime
+        inner: Inner
+        note: Optional[str] = None
+
+    func = Function(name="payload", parameters=Payload.model_json_schema())
+    func.process_schema_for_strict()
+
+    params = func.parameters
+    assert sorted(params["required"]) == ["created_at", "inner", "name", "note"]
+    assert params["additionalProperties"] is False
+    inner_def = params["$defs"]["Inner"]
+    assert sorted(inner_def["required"]) == ["label", "weight"]
+    assert inner_def["additionalProperties"] is False
+    # format keys survive strict processing (OpenAI preserves them verbatim)
+    assert params["properties"]["created_at"].get("format") == "date-time"
+
+
+def test_strict_processing_visits_anyof_branches():
+    """Object schemas reached through an anyOf list get additionalProperties: false
+    and a completed required, like every other object level. Issue #9413."""
+
+    schema = {
+        "type": "object",
+        "properties": {
+            "mode": {
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "properties": {"level": {"type": "integer"}, "flag": {"type": "boolean"}},
+                        "required": ["level"],
+                    },
+                    {"type": "string"},
+                ]
+            }
+        },
+        "required": ["mode"],
+    }
+    func = Function(name="f", parameters=schema)
+    func.process_schema_for_strict()
+
+    inline = func.parameters["properties"]["mode"]["anyOf"][0]
+    assert sorted(inline["required"]) == ["flag", "level"]
+    assert inline["additionalProperties"] is False
+
+
 # ----------------------------------------------------------------------
 # Regression: the guard must also engage on the from_callable path
 # (Agent(tools=[fn]) registers plain callables without process_entrypoint)

--- a/libs/agno/tests/unit/tools/test_functions.py
+++ b/libs/agno/tests/unit/tools/test_functions.py
@@ -1822,6 +1822,35 @@ def test_strict_processing_visits_anyof_branches():
     assert inline["additionalProperties"] is False
 
 
+def test_strict_processing_leaves_literal_values_untouched():
+    """enum/examples/default hold instance values, not schemas: strict processing
+    must not rewrite them even when a literal happens to look like a schema."""
+
+    schema = {
+        "type": "object",
+        "properties": {
+            "preset": {
+                "type": "object",
+                "enum": [
+                    {"type": "object", "properties": {"a": {"type": "string"}}},
+                    {"type": "object", "properties": {"b": {"type": "string"}}},
+                ],
+                "default": {"type": "object", "properties": {"c": {"type": "string"}}},
+            }
+        },
+        "required": ["preset"],
+    }
+    func = Function(name="f", parameters=schema)
+    func.process_schema_for_strict()
+
+    preset = func.parameters["properties"]["preset"]
+    assert preset["enum"] == [
+        {"type": "object", "properties": {"a": {"type": "string"}}},
+        {"type": "object", "properties": {"b": {"type": "string"}}},
+    ]
+    assert preset["default"] == {"type": "object", "properties": {"c": {"type": "string"}}}
+
+
 # ----------------------------------------------------------------------
 # Regression: the guard must also engage on the from_callable path
 # (Agent(tools=[fn]) registers plain callables without process_entrypoint)


### PR DESCRIPTION
## Summary

Two strict-mode tool schema fixes in `Function.process_schema_for_strict` (`libs/agno/agno/tools/function.py`):

- **#9454** — the root `required` rebuild only filtered the static reserved names (`agent`, `team`, `run_context`, `_agno_*`). A parameter the entrypoint claims by a framework-typed annotation (e.g. a renamed `ctx: RunContext`) lives in `self._framework_params` but not those tuples, so it stayed required and the model was forced to fabricate a value the runtime discards. The rebuild now also excludes `self._framework_params`. The static names stay filtered too: a hand-written schema can declare an `agent` property with no matching signature parameter, which the dynamic set would not cover.
- **#9413** — `make_nested_strict` only added `additionalProperties: false`; it never completed `required` below the root and never recursed into list elements. A tool with a defaulted or `Optional` pydantic field at any nesting level (or a model reached through an `anyOf` list) shipped an under-populated `required` and was rejected by OpenAI strict mode. `required` is now completed at every object level, `anyOf`/`oneOf`/`allOf` branches are visited, and `format` keys are preserved (OpenAI's strict transformer keeps them verbatim).

## Tests

- `test_strict_processing_excludes_framework_typed_renamed_parameter` (#9454)
- `test_strict_processing_completes_required_at_every_level` (#9413)
- `test_strict_processing_visits_anyof_branches` (#9413)

Each test failed against the pre-fix code and passes after. Full `tests/unit/tools/test_functions.py` is green (only pre-existing Windows-only cache-permission failures remain, unrelated to this change). Verified with ruff (pinned `0.15.20`) and mypy on both changed files.

## Disclosure

This PR was generated with AI assistance (Claude Code), per the project's AI-generated content policy. The author reviewed the full diff and ran the verification suite before opening.