### PR TITLE
fix: case-sensitive knowledge test assertions fail on lowercase model output

### DIFF
--- a/libs/agno/tests/integration/knowledge/test_docling_knowledge.py
+++ b/libs/agno/tests/integration/knowledge/test_docling_knowledge.py
@@ -153,7 +153,7 @@ def test_docling_knowledge_base_docx(setup_vector_db):
     agent = Agent(knowledge=kb, search_knowledge=True)
     response = agent.run("What is the story of little prince about?", markdown=True)
 
-    assert any(term in response.content for term in ["little prince", "prince", "planet", "rose"])
+    assert any(term in response.content.lower() for term in ["little prince", "prince", "planet", "rose"])
 
 
 def test_docling_knowledge_base_with_metadata(setup_vector_db):

--- a/libs/agno/tests/integration/knowledge/test_text_knowledge.py
+++ b/libs/agno/tests/integration/knowledge/test_text_knowledge.py
@@ -142,7 +142,7 @@ def test_text_knowledge_base_with_metadata_path(setup_vector_db):
     assert (
         "entry" in response.content.lower()
         or "junior" in response.content.lower()
-        or "Jordan" in response.content.lower()
+        or "jordan" in response.content.lower()
     )
     assert "senior developer" not in response.content.lower()
 


### PR DESCRIPTION
## Summary

Fixes the `test-knowledge-1` CI failure on PR #9604: `test_text_knowledge_base_with_metadata_path` failed because the model answered entirely in lowercase ("jordan mitchell's experience includes...") while the assertion was effectively case-sensitive.

The assertion already lowercases the response, but its third clause still compared the capitalized literal `"Jordan"` against the lowercased content — a clause that can never match. This PR lowercases the literal to `"jordan"`.

A scan of `libs/agno/tests/integration/knowledge/` for the same failure class found one more instance: `test_docling_knowledge_base_docx` checks lowercase terms (`"little prince"`, `"planet"`, ...) against the raw response, which fails whenever the model capitalizes ("The Little Prince", "Planet B-612"). Added `.lower()` there. All other response-content assertions in the directory already compare lowercase literals against lowercased content.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

`./scripts/format.sh` passes with no changes and `./scripts/validate.sh` passes for the edited files; validate reports one pre-existing mypy error in `agno/knowledge/reader/llms_txt_reader.py:94` that exists on the `feat/v3.0` base and is untouched by this PR. The change is a pure string-literal case fix with no logic change, so the live integration tests (which need an LLM API key and a LanceDB load) were verified by inspection rather than run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
