### PR TITLE
fix: repair garbled scheduler log messages

### DIFF
--- a/libs/agno/agno/scheduler/executor.py
+++ b/libs/agno/agno/scheduler/executor.py
@@ -224,7 +224,7 @@ class ScheduleExecutor:
                     )
                 except Exception as e:
                     log_warning(
-                        f"Failed to compute next_run_at for schedule {schedule_id}; : {e}"
+                        f"Failed to compute next_run_at for schedule {schedule_id}; "
                         f"disabling schedule to prevent it from becoming stuck: {e}",
                     )
 
@@ -423,7 +423,7 @@ class ScheduleExecutor:
                     params={"session_id": session_id},
                 )
             except Exception as exc:
-                log_warning(f"Poll request failed for run {run_id}: {exc}: {exc}")
+                log_warning(f"Poll request failed for run {run_id}: {exc}")
                 continue
 
             if resp.status_code == 404:


### PR DESCRIPTION
## Summary

Repairs two garbled log messages in the schedule executor (`libs/agno/agno/scheduler/executor.py`), introduced by eaef22f31:

- The `next_run_at` failure warning was built from two implicitly concatenated f-strings and rendered as `Failed to compute next_run_at for schedule {id}; : {e}disabling schedule to prevent it from becoming stuck: {e}` — the exception printed twice, with a stray `; :` and no separator between the fragments. It now reads `Failed to compute next_run_at for schedule {schedule_id}; disabling schedule to prevent it from becoming stuck: {e}`.
- The poll failure warning printed the exception twice: `Poll request failed for run {run_id}: {exc}: {exc}`. The duplicate is dropped.

No behavior change — log output only. A grep of the whole `scheduler/` package for repeated exception placeholders confirmed these were the only two instances.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

- `./scripts/format.sh` passed with no files changed; `ruff check libs/agno` passed clean. `mypy libs/agno` reports one pre-existing error in `knowledge/reader/llms_txt_reader.py` (beautifulsoup4 stub mismatch) that exists on the branch tip independent of this change.
- The bad statements also exist on `main` via the same commit — this fix will need a cherry-pick there if `feat/v3.0` doesn't merge soon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
