### PR TITLE
fix: cache table resolutions in SQL adapters to cut per-query round-trips

### DIFF
--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -100,6 +100,49 @@ class BaseDb(ABC):
         self.mcp_oauth_codes_table_name = mcp_oauth_codes_table or "agno_mcp_oauth_codes"
         self.mcp_oauth_refresh_tokens_table_name = mcp_oauth_refresh_tokens_table or "agno_mcp_oauth_refresh_tokens"
         self.mcp_oauth_keys_table_name = mcp_oauth_keys_table or "agno_mcp_oauth_keys"
+        # Table objects resolved by the adapter, keyed by table name. Concurrent
+        # resolutions may both store; both hold the same metadata-registered object.
+        self._resolved_tables: Dict[str, Any] = {}
+
+    def _invalidate_resolved_table(self, table_name: str) -> None:
+        """Forget a resolved table so the next access re-resolves it from the database.
+
+        Reflected tables stay pinned on the adapter's SQLAlchemy metadata even
+        after the underlying table changes, so this also unregisters the table
+        from the metadata when the adapter has one.
+        """
+        resolved_tables = getattr(self, "_resolved_tables", None)
+        if resolved_tables is not None:
+            resolved_tables.pop(table_name, None)
+        metadata = getattr(self, "metadata", None)
+        if metadata is not None:
+            for table in list(metadata.tables.values()):
+                if table.name == table_name:
+                    metadata.remove(table)
+
+    def _fk_dependencies(self, table_type: str) -> List[Tuple[str, str]]:
+        """Tables that the given table type's schema declares foreign keys to.
+
+        Returns (table_type, configured_table_name) pairs. Each referenced
+        Table must be registered on the adapter's SQLAlchemy metadata before
+        the dependent table can be constructed.
+        """
+        edges = {
+            "runs": [("sessions", "session_table_name")],
+            "spans": [("traces", "trace_table_name")],
+            "schedule_runs": [("schedules", "schedules_table_name")],
+            "component_configs": [("components", "components_table_name")],
+            "component_links": [
+                ("components", "components_table_name"),
+                ("component_configs", "component_configs_table_name"),
+            ],
+        }
+        dependencies = []
+        for ref_type, attr in edges.get(table_type, []):
+            ref_name = getattr(self, attr, None)
+            if ref_name:
+                dependencies.append((ref_type, ref_name))
+        return dependencies
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -1655,6 +1698,49 @@ class AsyncBaseDb(ABC):
         self.approvals_table_name = approvals_table or "agno_approvals"
         self.auth_tokens_table_name = auth_tokens_table or "agno_auth_tokens"
         self.service_accounts_table_name = service_accounts_table or "agno_service_accounts"
+        # Table objects resolved by the adapter, keyed by table name. Concurrent
+        # resolutions may both store; both hold the same metadata-registered object.
+        self._resolved_tables: Dict[str, Any] = {}
+
+    def _invalidate_resolved_table(self, table_name: str) -> None:
+        """Forget a resolved table so the next access re-resolves it from the database.
+
+        Reflected tables stay pinned on the adapter's SQLAlchemy metadata even
+        after the underlying table changes, so this also unregisters the table
+        from the metadata when the adapter has one.
+        """
+        resolved_tables = getattr(self, "_resolved_tables", None)
+        if resolved_tables is not None:
+            resolved_tables.pop(table_name, None)
+        metadata = getattr(self, "metadata", None)
+        if metadata is not None:
+            for table in list(metadata.tables.values()):
+                if table.name == table_name:
+                    metadata.remove(table)
+
+    def _fk_dependencies(self, table_type: str) -> List[Tuple[str, str]]:
+        """Tables that the given table type's schema declares foreign keys to.
+
+        Returns (table_type, configured_table_name) pairs. Each referenced
+        Table must be registered on the adapter's SQLAlchemy metadata before
+        the dependent table can be constructed.
+        """
+        edges = {
+            "runs": [("sessions", "session_table_name")],
+            "spans": [("traces", "trace_table_name")],
+            "schedule_runs": [("schedules", "schedules_table_name")],
+            "component_configs": [("components", "components_table_name")],
+            "component_links": [
+                ("components", "components_table_name"),
+                ("component_configs", "component_configs_table_name"),
+            ],
+        }
+        dependencies = []
+        for ref_type, attr in edges.get(table_type, []):
+            ref_name = getattr(self, attr, None)
+            if ref_name:
+                dependencies.append((ref_type, ref_name))
+        return dependencies
 
     async def _create_all_tables(self) -> None:
         """Create all tables for this database. Override in subclasses."""

--- a/libs/agno/agno/db/migrations/V3_MIGRATION_GUIDE.md
+++ b/libs/agno/agno/db/migrations/V3_MIGRATION_GUIDE.md
@@ -306,6 +306,14 @@ upsert names a conflict target that does not exist — while MySQL's
 numbers on the first owner's row without erroring. What an operator notices either way
 is that metrics stop moving, not that something failed.
 
+One caveat on the `is_valid_table` guard: a running process validates each table on
+its first access and then caches the resolved table. Migrations that run through
+`MigrationManager` on the live instance (including `POST /databases/{id}/migrate`)
+invalidate that cache themselves. A schema change made behind the process's back —
+another process migrating the shared database, or an ALTER by hand — is not seen
+until the process restarts or something calls `_invalidate_resolved_table` on the
+adapter.
+
 It runs with the rest of the version — `MigrationManager(db).up()` — or on its own:
 
 ```python

--- a/libs/agno/agno/db/migrations/manager.py
+++ b/libs/agno/agno/db/migrations/manager.py
@@ -100,7 +100,12 @@ class MigrationManager:
                         break
 
                     log_info(f"Applying migration {normalised_version} on {table_name}")
-                    migration_executed = await self._up_migration(version, table_type, table_name)
+                    try:
+                        migration_executed = await self._up_migration(version, table_type, table_name)
+                    finally:
+                        # The migration may have changed the table shape; the
+                        # next access must re-resolve the table.
+                        self.db._invalidate_resolved_table(table_name)
                     # False means "nothing to migrate" — failures raise and abort
                     # before stamping, so no-ops still advance the stamp.
                     latest_version = normalised_version.public
@@ -189,7 +194,12 @@ class MigrationManager:
             for version, normalised_version in reversed(self.available_versions):
                 if normalised_version > _target_version:
                     log_info(f"Reverting migration {normalised_version} on table {table_name}")
-                    migration_executed = await self._down_migration(version, table_type, table_name)
+                    try:
+                        migration_executed = await self._down_migration(version, table_type, table_name)
+                    finally:
+                        # The migration may have changed the table shape; the
+                        # next access must re-resolve the table.
+                        self.db._invalidate_resolved_table(table_name)
                     if migration_executed:
                         any_migration_executed = True
                         log_info(f"Successfully reverted migration {normalised_version} on table {table_name}")

--- a/libs/agno/agno/db/migrations/versions/v3_0_0.py
+++ b/libs/agno/agno/db/migrations/versions/v3_0_0.py
@@ -401,9 +401,12 @@ def _forget_table(db, table_name: Optional[str], attribute: str) -> None:
     """Drop a table from the adapter's SQLAlchemy state after it goes away.
 
     ``DROP TABLE`` and ``RENAME TO`` leave the Table object registered on
-    ``db.metadata``, so a later up() in the same process fails with
-    "Table is already defined".
+    ``db.metadata`` and in the adapter's resolved-table cache, so a later
+    up() in the same process fails with "Table is already defined".
     """
+    resolved_tables = getattr(db, "_resolved_tables", None)
+    if resolved_tables is not None and table_name is not None:
+        resolved_tables.pop(table_name, None)
     metadata = getattr(db, "metadata", None)
     if metadata is not None and table_name is not None:
         for table in list(metadata.tables.values()):

--- a/libs/agno/agno/db/mysql/async_mysql.py
+++ b/libs/agno/agno/db/mysql/async_mysql.py
@@ -173,12 +173,15 @@ class AsyncMySQLDb(AsyncBaseDb):
             Table: SQLAlchemy Table object
         """
         # Ensure sessions Table is registered on metadata so the runs FK can resolve.
-        if table_type == "runs":
-            fq_sessions = f"{self.db_schema}.{self.session_table_name}" if self.db_schema else self.session_table_name
-            if fq_sessions not in self.metadata.tables:
+        # A table whose schema declares foreign keys needs each referenced
+        # Table registered in ``self.metadata`` before ``Table(...)`` can
+        # resolve the references.
+        for ref_table_type, ref_table_name in self._fk_dependencies(table_type):
+            fq_ref = f"{self.db_schema}.{ref_table_name}" if self.db_schema else ref_table_name
+            if fq_ref not in self.metadata.tables:
                 await self._get_or_create_table(
-                    table_name=self.session_table_name,
-                    table_type="sessions",
+                    table_name=ref_table_name,
+                    table_type=ref_table_type,
                     create_table_if_not_found=True,
                 )
         try:
@@ -312,6 +315,9 @@ class AsyncMySQLDb(AsyncBaseDb):
         ]
 
         for table_name, table_type in tables_to_create:
+            # Re-resolve even if cached: callers use this to guarantee the
+            # tables exist, including after an external drop.
+            self._invalidate_resolved_table(table_name)
             await self._get_or_create_table(
                 table_name=table_name, table_type=table_type, create_table_if_not_found=True
             )
@@ -400,6 +406,10 @@ class AsyncMySQLDb(AsyncBaseDb):
         """
         Check if the table exists and is valid, else create it.
 
+        Successful resolutions are cached on the instance, so only the first
+        access to a table pays the existence and validation queries. Call
+        _invalidate_resolved_table after changing a table outside this adapter.
+
         Args:
             table_name (str): Name of the table to get or create
             table_type (str): Type of table (used to get schema definition)
@@ -407,6 +417,9 @@ class AsyncMySQLDb(AsyncBaseDb):
         Returns:
             Table: SQLAlchemy Table object representing the schema.
         """
+        cached_table = self._resolved_tables.get(table_name)
+        if cached_table is not None:
+            return cached_table
 
         async with self.async_session_factory() as sess, sess.begin():
             table_is_available = await ais_table_available(
@@ -414,7 +427,10 @@ class AsyncMySQLDb(AsyncBaseDb):
             )
 
         if (not table_is_available) and create_table_if_not_found:
-            return await self._create_table(table_name=table_name, table_type=table_type)
+            table = await self._create_table(table_name=table_name, table_type=table_type)
+            if table is not None:
+                self._resolved_tables[table_name] = table
+            return table
 
         if not await ais_valid_table(
             db_engine=self.db_engine,
@@ -431,6 +447,10 @@ class AsyncMySQLDb(AsyncBaseDb):
                     return Table(table_name, self.metadata, schema=self.db_schema, autoload_with=connection)
 
                 table = await conn.run_sync(create_table)
+                # A concurrent first resolution can observe another thread's
+                # half-built Table; cache only a fully built, still-registered one.
+                if table.columns and self.metadata.tables.get(table.key) is table:
+                    self._resolved_tables[table_name] = table
                 return table
 
         except Exception as e:
@@ -504,7 +524,10 @@ class AsyncMySQLDb(AsyncBaseDb):
 
             log_info(f"Dropping legacy runs column from {self.session_table_name}")
             await sess.execute(text(f"ALTER TABLE `{self.db_schema}`.`{self.session_table_name}` DROP COLUMN `runs`"))
-            return True
+        # Invalidate only after the transaction commits, so a concurrent
+        # resolution cannot re-cache the pre-drop shape.
+        self._invalidate_resolved_table(self.session_table_name)
+        return True
 
     # -- Run methods --
     async def _get_session_runs_data(

--- a/libs/agno/agno/db/mysql/mysql.py
+++ b/libs/agno/agno/db/mysql/mysql.py
@@ -170,12 +170,15 @@ class MySQLDb(BaseDb):
             Table: SQLAlchemy Table object
         """
         # Ensure sessions Table is registered on metadata so the runs FK can resolve.
-        if table_type == "runs":
-            fq_sessions = f"{self.db_schema}.{self.session_table_name}" if self.db_schema else self.session_table_name
-            if fq_sessions not in self.metadata.tables:
+        # A table whose schema declares foreign keys needs each referenced
+        # Table registered in ``self.metadata`` before ``Table(...)`` can
+        # resolve the references.
+        for ref_table_type, ref_table_name in self._fk_dependencies(table_type):
+            fq_ref = f"{self.db_schema}.{ref_table_name}" if self.db_schema else ref_table_name
+            if fq_ref not in self.metadata.tables:
                 self._get_or_create_table(
-                    table_name=self.session_table_name,
-                    table_type="sessions",
+                    table_name=ref_table_name,
+                    table_type=ref_table_type,
                     create_table_if_not_found=True,
                 )
         try:
@@ -305,6 +308,9 @@ class MySQLDb(BaseDb):
         ]
 
         for table_name, table_type in tables_to_create:
+            # Re-resolve even if cached: callers use this to guarantee the
+            # tables exist, including after an external drop.
+            self._invalidate_resolved_table(table_name)
             self._get_or_create_table(table_name=table_name, table_type=table_type, create_table_if_not_found=True)
 
     def _get_table(self, table_type: str, create_table_if_not_found: Optional[bool] = False) -> Optional[Table]:
@@ -392,6 +398,10 @@ class MySQLDb(BaseDb):
         """
         Check if the table exists and is valid, else create it.
 
+        Successful resolutions are cached on the instance, so only the first
+        access to a table pays the existence and validation queries. Call
+        _invalidate_resolved_table after changing a table outside this adapter.
+
         Args:
             table_name (str): Name of the table to get or create
             table_type (str): Type of table (used to get schema definition)
@@ -399,6 +409,9 @@ class MySQLDb(BaseDb):
         Returns:
             Table: SQLAlchemy Table object representing the schema.
         """
+        cached_table = self._resolved_tables.get(table_name)
+        if cached_table is not None:
+            return cached_table
 
         with self.Session() as sess, sess.begin():
             table_is_available = is_table_available(session=sess, table_name=table_name, db_schema=self.db_schema)
@@ -408,7 +421,8 @@ class MySQLDb(BaseDb):
                 return None
 
             created_table = self._create_table(table_name=table_name, table_type=table_type)
-
+            if created_table is not None:
+                self._resolved_tables[table_name] = created_table
             return created_table
 
         if not is_valid_table(
@@ -421,6 +435,10 @@ class MySQLDb(BaseDb):
 
         try:
             table = Table(table_name, self.metadata, schema=self.db_schema, autoload_with=self.db_engine)
+            # A concurrent first resolution can observe another thread's
+            # half-built Table; cache only a fully built, still-registered one.
+            if table.columns and self.metadata.tables.get(table.key) is table:
+                self._resolved_tables[table_name] = table
             return table
 
         except Exception as e:
@@ -507,7 +525,10 @@ class MySQLDb(BaseDb):
 
             log_info(f"Dropping legacy runs column from {self.session_table_name}")
             sess.execute(text(f"ALTER TABLE `{self.db_schema}`.`{self.session_table_name}` DROP COLUMN `runs`"))
-            return True
+        # Invalidate only after the transaction commits, so a concurrent
+        # resolution cannot re-cache the pre-drop shape.
+        self._invalidate_resolved_table(self.session_table_name)
+        return True
 
     # -- Run methods --
     def _get_session_runs_data(

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -246,6 +246,9 @@ class AsyncPostgresDb(AsyncBaseDb):
         ]
 
         for table_name, table_type in tables_to_create:
+            # Re-resolve even if cached: callers use this to guarantee the
+            # tables exist, including after an external drop.
+            self._invalidate_resolved_table(table_name)
             await self._get_or_create_table(
                 table_name=table_name, table_type=table_type, create_table_if_not_found=True
             )
@@ -262,12 +265,15 @@ class AsyncPostgresDb(AsyncBaseDb):
             Table: SQLAlchemy Table object
         """
         # Ensure sessions Table is registered on metadata so the runs FK can resolve.
-        if table_type == "runs":
-            fq_sessions = f"{self.db_schema}.{self.session_table_name}" if self.db_schema else self.session_table_name
-            if fq_sessions not in self.metadata.tables:
+        # A table whose schema declares foreign keys needs each referenced
+        # Table registered in ``self.metadata`` before ``Table(...)`` can
+        # resolve the references.
+        for ref_table_type, ref_table_name in self._fk_dependencies(table_type):
+            fq_ref = f"{self.db_schema}.{ref_table_name}" if self.db_schema else ref_table_name
+            if fq_ref not in self.metadata.tables:
                 await self._get_or_create_table(
-                    table_name=self.session_table_name,
-                    table_type="sessions",
+                    table_name=ref_table_name,
+                    table_type=ref_table_type,
                     create_table_if_not_found=True,
                 )
         try:
@@ -536,6 +542,10 @@ class AsyncPostgresDb(AsyncBaseDb):
         """
         Check if the table exists and is valid, else create it.
 
+        Successful resolutions are cached on the instance, so only the first
+        access to a table pays the existence and validation queries. Call
+        _invalidate_resolved_table after changing a table outside this adapter.
+
         Args:
             table_name (str): Name of the table to get or create
             table_type (str): Type of table (used to get schema definition)
@@ -543,6 +553,9 @@ class AsyncPostgresDb(AsyncBaseDb):
         Returns:
             Table: SQLAlchemy Table object representing the schema.
         """
+        cached_table = self._resolved_tables.get(table_name)
+        if cached_table is not None:
+            return cached_table
 
         async with self.async_session_factory() as sess, sess.begin():
             table_is_available = await ais_table_available(
@@ -552,7 +565,10 @@ class AsyncPostgresDb(AsyncBaseDb):
         if not table_is_available:
             if not create_table_if_not_found:
                 return None
-            return await self._create_table(table_name=table_name, table_type=table_type)
+            table = await self._create_table(table_name=table_name, table_type=table_type)
+            if table is not None:
+                self._resolved_tables[table_name] = table
+            return table
 
         if not await ais_valid_table(
             db_engine=self.db_engine,
@@ -569,7 +585,10 @@ class AsyncPostgresDb(AsyncBaseDb):
                     return Table(table_name, self.metadata, schema=self.db_schema, autoload_with=connection)
 
                 table = await conn.run_sync(create_table)
-
+                # A concurrent first resolution can observe another thread's
+                # half-built Table; cache only a fully built, still-registered one.
+                if table.columns and self.metadata.tables.get(table.key) is table:
+                    self._resolved_tables[table_name] = table
                 return table
 
         except Exception as e:
@@ -660,7 +679,10 @@ class AsyncPostgresDb(AsyncBaseDb):
 
             log_info(f"Dropping legacy runs column from {self.session_table_name}")
             await sess.execute(text(f'ALTER TABLE {self.db_schema}."{self.session_table_name}" DROP COLUMN runs'))
-            return True
+        # Invalidate only after the transaction commits, so a concurrent
+        # resolution cannot re-cache the pre-drop shape.
+        self._invalidate_resolved_table(self.session_table_name)
+        return True
 
     # -- Run methods --
     async def _get_session_runs_data(

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -314,6 +314,9 @@ class PostgresDb(BaseDb):
         ]
 
         for table_name, table_type in tables_to_create:
+            # Re-resolve even if cached: callers use this to guarantee the
+            # tables exist, including after an external drop.
+            self._invalidate_resolved_table(table_name)
             self._get_or_create_table(table_name=table_name, table_type=table_type, create_table_if_not_found=True)
 
     def _create_table(self, table_name: str, table_type: str) -> Table:
@@ -329,12 +332,15 @@ class PostgresDb(BaseDb):
         # The runs table declares a FK to sessions — ensure the sessions
         # Table is registered in ``self.metadata`` first so SQLAlchemy can
         # resolve the FK reference at ``Table(...)`` construction.
-        if table_type == "runs":
-            fq_sessions = f"{self.db_schema}.{self.session_table_name}" if self.db_schema else self.session_table_name
-            if fq_sessions not in self.metadata.tables:
+        # A table whose schema declares foreign keys needs each referenced
+        # Table registered in ``self.metadata`` before ``Table(...)`` can
+        # resolve the references.
+        for ref_table_type, ref_table_name in self._fk_dependencies(table_type):
+            fq_ref = f"{self.db_schema}.{ref_table_name}" if self.db_schema else ref_table_name
+            if fq_ref not in self.metadata.tables:
                 self._get_or_create_table(
-                    table_name=self.session_table_name,
-                    table_type="sessions",
+                    table_name=ref_table_name,
+                    table_type=ref_table_type,
                     create_table_if_not_found=True,
                 )
         try:
@@ -722,6 +728,10 @@ class PostgresDb(BaseDb):
         """
         Check if the table exists and is valid, else create it.
 
+        Successful resolutions are cached on the instance, so only the first
+        access to a table pays the existence and validation queries. Call
+        _invalidate_resolved_table after changing a table outside this adapter.
+
         Args:
             table_name (str): Name of the table to get or create
             table_type (str): Type of table (used to get schema definition)
@@ -729,6 +739,9 @@ class PostgresDb(BaseDb):
         Returns:
             Optional[Table]: SQLAlchemy Table object representing the schema.
         """
+        cached_table = self._resolved_tables.get(table_name)
+        if cached_table is not None:
+            return cached_table
 
         with self.Session() as sess, sess.begin():
             table_is_available = is_table_available(session=sess, table_name=table_name, db_schema=self.db_schema)
@@ -736,7 +749,10 @@ class PostgresDb(BaseDb):
         if not table_is_available:
             if not create_table_if_not_found:
                 return None
-            return self._create_table(table_name=table_name, table_type=table_type)
+            table = self._create_table(table_name=table_name, table_type=table_type)
+            if table is not None:
+                self._resolved_tables[table_name] = table
+            return table
 
         if not is_valid_table(
             db_engine=self.db_engine,
@@ -748,6 +764,10 @@ class PostgresDb(BaseDb):
 
         try:
             table = Table(table_name, self.metadata, schema=self.db_schema, autoload_with=self.db_engine)
+            # A concurrent first resolution can observe another thread's
+            # half-built Table; cache only a fully built, still-registered one.
+            if table.columns and self.metadata.tables.get(table.key) is table:
+                self._resolved_tables[table_name] = table
             return table
 
         except Exception as e:
@@ -837,7 +857,10 @@ class PostgresDb(BaseDb):
 
             log_info(f"Dropping legacy runs column from {self.session_table_name}")
             sess.execute(text(f'ALTER TABLE {self.db_schema}."{self.session_table_name}" DROP COLUMN runs'))
-            return True
+        # Invalidate only after the transaction commits, so a concurrent
+        # resolution cannot re-cache the pre-drop shape.
+        self._invalidate_resolved_table(self.session_table_name)
+        return True
 
     # -- Run methods --
     def _get_session_runs_data(

--- a/libs/agno/agno/db/singlestore/singlestore.py
+++ b/libs/agno/agno/db/singlestore/singlestore.py
@@ -215,6 +215,9 @@ class SingleStoreDb(BaseDb):
         ]
 
         for table_name, table_type in tables_to_create:
+            # Re-resolve even if cached: callers use this to guarantee the
+            # tables exist, including after an external drop.
+            self._invalidate_resolved_table(table_name)
             self._get_or_create_table(table_name=table_name, table_type=table_type, create_table_if_not_found=True)
 
     def _create_table(self, table_name: str, table_type: str) -> Table:
@@ -230,12 +233,15 @@ class SingleStoreDb(BaseDb):
         """
         # Ensure sessions Table is registered on metadata so the runs FK can resolve.
         # (SingleStore parses but does not enforce FKs.)
-        if table_type == "runs":
-            fq_sessions = f"{self.db_schema}.{self.session_table_name}" if self.db_schema else self.session_table_name
-            if fq_sessions not in self.metadata.tables:
+        # A table whose schema declares foreign keys needs each referenced
+        # Table registered in ``self.metadata`` before ``Table(...)`` can
+        # resolve the references.
+        for ref_table_type, ref_table_name in self._fk_dependencies(table_type):
+            fq_ref = f"{self.db_schema}.{ref_table_name}" if self.db_schema else ref_table_name
+            if fq_ref not in self.metadata.tables:
                 self._get_or_create_table(
-                    table_name=self.session_table_name,
-                    table_type="sessions",
+                    table_name=ref_table_name,
+                    table_type=ref_table_type,
                     create_table_if_not_found=True,
                 )
         table_ref = f"{self.db_schema}.{table_name}" if self.db_schema else table_name
@@ -469,6 +475,10 @@ class SingleStoreDb(BaseDb):
         """
         Check if the table exists and is valid, else create it.
 
+        Successful resolutions are cached on the instance, so only the first
+        access to a table pays the existence and validation queries. Call
+        _invalidate_resolved_table after changing a table outside this adapter.
+
         Args:
             table_name (str): Name of the table to get or create
             table_type (str): Type of table (used to get schema definition)
@@ -476,6 +486,9 @@ class SingleStoreDb(BaseDb):
         Returns:
             Table: SQLAlchemy Table object representing the schema.
         """
+        cached_table = self._resolved_tables.get(table_name)
+        if cached_table is not None:
+            return cached_table
 
         with self.Session() as sess, sess.begin():
             table_is_available = is_table_available(session=sess, table_name=table_name, db_schema=self.db_schema)
@@ -489,7 +502,10 @@ class SingleStoreDb(BaseDb):
                 latest_schema_version = MigrationManager(self).latest_schema_version
                 self.upsert_schema_version(table_name=table_name, version=latest_schema_version.public)
 
-            return self._create_table(table_name=table_name, table_type=table_type)
+            table = self._create_table(table_name=table_name, table_type=table_type)
+            if table is not None:
+                self._resolved_tables[table_name] = table
+            return table
 
         if not is_valid_table(
             db_engine=self.db_engine,
@@ -501,7 +517,10 @@ class SingleStoreDb(BaseDb):
             raise ValueError(f"Table {table_ref} has an invalid schema")
 
         try:
-            return self._create_table_structure_only(table_name=table_name, table_type=table_type)
+            table = self._create_table_structure_only(table_name=table_name, table_type=table_type)
+            if table is not None:
+                self._resolved_tables[table_name] = table
+            return table
 
         except Exception as e:
             table_ref = f"{self.db_schema}.{table_name}" if self.db_schema else table_name
@@ -580,7 +599,10 @@ class SingleStoreDb(BaseDb):
 
             log_info(f"Dropping legacy runs column from {self.session_table_name}")
             sess.execute(text(f"ALTER TABLE `{schema}`.`{self.session_table_name}` DROP COLUMN `runs`"))
-            return True
+        # Invalidate only after the transaction commits, so a concurrent
+        # resolution cannot re-cache the pre-drop shape.
+        self._invalidate_resolved_table(self.session_table_name)
+        return True
 
     # -- Run methods --
     def _get_session_runs_data(

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -219,6 +219,9 @@ class AsyncSqliteDb(AsyncBaseDb):
         ]
 
         for table_name, table_type in tables_to_create:
+            # Re-resolve even if cached: callers use this to guarantee the
+            # tables exist, including after an external drop.
+            self._invalidate_resolved_table(table_name)
             await self._get_or_create_table(
                 table_name=table_name, table_type=table_type, create_table_if_not_found=True
             )
@@ -235,12 +238,16 @@ class AsyncSqliteDb(AsyncBaseDb):
             Table: SQLAlchemy Table object
         """
         # Ensure sessions Table is registered on metadata so the runs FK can resolve.
-        if table_type == "runs" and self.session_table_name not in self.metadata.tables:
-            await self._get_or_create_table(
-                table_name=self.session_table_name,
-                table_type="sessions",
-                create_table_if_not_found=True,
-            )
+        # A table whose schema declares foreign keys needs each referenced
+        # Table registered in ``self.metadata`` before ``Table(...)`` can
+        # resolve the references.
+        for ref_table_type, ref_table_name in self._fk_dependencies(table_type):
+            if ref_table_name not in self.metadata.tables:
+                await self._get_or_create_table(
+                    table_name=ref_table_name,
+                    table_type=ref_table_type,
+                    create_table_if_not_found=True,
+                )
         try:
             # Pass table names for foreign key resolution
             table_schema = get_table_schema_definition(
@@ -494,6 +501,10 @@ class AsyncSqliteDb(AsyncBaseDb):
         """
         Check if the table exists and is valid, else create it.
 
+        Successful resolutions are cached on the instance, so only the first
+        access to a table pays the existence and validation queries. Call
+        _invalidate_resolved_table after changing a table outside this adapter.
+
         Args:
             table_name (str): Name of the table to get or create
             table_type (str): Type of table (used to get schema definition)
@@ -501,13 +512,20 @@ class AsyncSqliteDb(AsyncBaseDb):
         Returns:
             Table: SQLAlchemy Table object
         """
+        cached_table = self._resolved_tables.get(table_name)
+        if cached_table is not None:
+            return cached_table
+
         async with self.async_session_factory() as sess, sess.begin():
             table_is_available = await ais_table_available(session=sess, table_name=table_name)
 
         if not table_is_available:
             if not create_table_if_not_found:
                 return None
-            return await self._create_table(table_name=table_name, table_type=table_type)
+            table = await self._create_table(table_name=table_name, table_type=table_type)
+            if table is not None:
+                self._resolved_tables[table_name] = table
+            return table
 
         # SQLite version of table validation (no schema)
         if not await ais_valid_table(db_engine=self.db_engine, table_name=table_name, table_type=table_type):
@@ -520,6 +538,10 @@ class AsyncSqliteDb(AsyncBaseDb):
                     return Table(table_name, self.metadata, autoload_with=connection)
 
                 table = await conn.run_sync(load_table)
+                # A concurrent first resolution can observe another thread's
+                # half-built Table; cache only a fully built, still-registered one.
+                if table.columns and self.metadata.tables.get(table.key) is table:
+                    self._resolved_tables[table_name] = table
                 return table
 
         except Exception as e:
@@ -597,9 +619,11 @@ class AsyncSqliteDb(AsyncBaseDb):
                         "non-null `runs` content. Run MigrationManager(db).up() first, or pass force=True."
                     )
 
+            dropped = False
             try:
                 await sess.execute(text(f"ALTER TABLE {self.session_table_name} DROP COLUMN runs"))
                 log_info(f"Dropped legacy runs column from {self.session_table_name}")
+                dropped = True
             except Exception:
                 # SQLite < 3.35 does not support DROP COLUMN; clear the column instead.
                 await sess.execute(text(f"UPDATE {self.session_table_name} SET runs = NULL"))
@@ -607,7 +631,11 @@ class AsyncSqliteDb(AsyncBaseDb):
                     f"Could not drop runs column from {self.session_table_name} "
                     "(SQLite < 3.35); cleared its content instead."
                 )
-            return True
+        # Invalidate only after the transaction commits, so a concurrent
+        # resolution cannot re-cache the pre-drop shape.
+        if dropped:
+            self._invalidate_resolved_table(self.session_table_name)
+        return True
 
     # -- Run methods --
     async def _get_session_runs_data(

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -210,6 +210,13 @@ class SqliteDb(BaseDb):
         # Zero means never refreshed; get_metrics uses this to refresh lazily, at most once per minute
         self._metrics_refreshed_at: float = 0.0
 
+        # In-memory SQLite gets a SingletonThreadPool: one private database per
+        # thread, so "this table exists" is not a process-wide fact and resolved
+        # tables must not be cached across threads.
+        from sqlalchemy.pool import SingletonThreadPool
+
+        self._cache_resolved_tables: bool = not isinstance(self.db_engine.pool, SingletonThreadPool)
+
     # -- Serialization methods --
     def to_dict(self) -> Dict[str, Any]:
         base = super().to_dict()
@@ -290,6 +297,9 @@ class SqliteDb(BaseDb):
         ]
 
         for table_name, table_type in tables_to_create:
+            # Re-resolve even if cached: callers use this to guarantee the
+            # tables exist, including after an external drop.
+            self._invalidate_resolved_table(table_name)
             self._get_or_create_table(table_name=table_name, table_type=table_type, create_table_if_not_found=True)
 
     def _create_table(self, table_name: str, table_type: str) -> Table:
@@ -312,12 +322,16 @@ class SqliteDb(BaseDb):
         # The runs table declares a FK to sessions — ensure the real sessions
         # Table object is registered in ``self.metadata`` first so SQLAlchemy
         # can resolve the FK reference at ``Table(...)`` construction.
-        if table_type == "runs" and self.session_table_name not in self.metadata.tables:
-            self._get_or_create_table(
-                table_name=self.session_table_name,
-                table_type="sessions",
-                create_table_if_not_found=True,
-            )
+        # A table whose schema declares foreign keys needs each referenced
+        # Table registered in ``self.metadata`` before ``Table(...)`` can
+        # resolve the references.
+        for ref_table_type, ref_table_name in self._fk_dependencies(table_type):
+            if ref_table_name not in self.metadata.tables:
+                self._get_or_create_table(
+                    table_name=ref_table_name,
+                    table_type=ref_table_type,
+                    create_table_if_not_found=True,
+                )
         try:
             from sqlalchemy.schema import ForeignKeyConstraint, PrimaryKeyConstraint
 
@@ -695,6 +709,10 @@ class SqliteDb(BaseDb):
         """
         Check if the table exists and is valid, else create it.
 
+        Successful resolutions are cached on the instance, so only the first
+        access to a table pays the existence and validation queries. Call
+        _invalidate_resolved_table after changing a table outside this adapter.
+
         Args:
             table_name (str): Name of the table to get or create
             table_type (str): Type of table (used to get schema definition)
@@ -702,13 +720,21 @@ class SqliteDb(BaseDb):
         Returns:
             Table: SQLAlchemy Table object
         """
+        if self._cache_resolved_tables:
+            cached_table = self._resolved_tables.get(table_name)
+            if cached_table is not None:
+                return cached_table
+
         with self.Session() as sess, sess.begin():
             table_is_available = is_table_available(session=sess, table_name=table_name)
 
         if not table_is_available:
             if not create_table_if_not_found:
                 return None
-            return self._create_table(table_name=table_name, table_type=table_type)
+            table = self._create_table(table_name=table_name, table_type=table_type)
+            if table is not None and self._cache_resolved_tables:
+                self._resolved_tables[table_name] = table
+            return table
 
         # SQLite version of table validation (no schema)
         if not is_valid_table(db_engine=self.db_engine, table_name=table_name, table_type=table_type):
@@ -716,6 +742,10 @@ class SqliteDb(BaseDb):
 
         try:
             table = Table(table_name, self.metadata, autoload_with=self.db_engine)
+            # A concurrent first resolution can observe another thread's
+            # half-built Table; cache only a fully built, still-registered one.
+            if self._cache_resolved_tables and table.columns and self.metadata.tables.get(table.key) is table:
+                self._resolved_tables[table_name] = table
             return table
 
         except Exception as e:
@@ -795,9 +825,11 @@ class SqliteDb(BaseDb):
                         "non-null `runs` content. Run MigrationManager(db).up() first, or pass force=True."
                     )
 
+            dropped = False
             try:
                 sess.execute(text(f"ALTER TABLE {self.session_table_name} DROP COLUMN runs"))
                 log_info(f"Dropped legacy runs column from {self.session_table_name}")
+                dropped = True
             except Exception:
                 # SQLite < 3.35 does not support DROP COLUMN; clear the column instead.
                 sess.execute(text(f"UPDATE {self.session_table_name} SET runs = NULL"))
@@ -805,7 +837,11 @@ class SqliteDb(BaseDb):
                     f"Could not drop runs column from {self.session_table_name} "
                     "(SQLite < 3.35); cleared its content instead."
                 )
-            return True
+        # Invalidate only after the transaction commits, so a concurrent
+        # resolution cannot re-cache the pre-drop shape.
+        if dropped:
+            self._invalidate_resolved_table(self.session_table_name)
+        return True
 
     # -- Run methods --
     def _get_session_runs_data(

--- a/libs/agno/tests/integration/db/sqlite/test_service_accounts.py
+++ b/libs/agno/tests/integration/db/sqlite/test_service_accounts.py
@@ -71,8 +71,10 @@ class TestServiceAccountsTable:
         sqlite_db_real.db_engine.dispose()
         sqlite_db_real.db_url = "sqlite:////nonexistent/path/definitely_missing.db"
         from sqlalchemy import create_engine
+        from sqlalchemy.orm import scoped_session, sessionmaker
 
         sqlite_db_real.db_engine = create_engine(sqlite_db_real.db_url)
+        sqlite_db_real.Session = scoped_session(sessionmaker(bind=sqlite_db_real.db_engine))
         with pytest.raises(Exception):
             sqlite_db_real.get_service_account_by_token_hash("hash-1")
 

--- a/libs/agno/tests/unit/db/test_delete_run_scrubs_legacy_blob.py
+++ b/libs/agno/tests/unit/db/test_delete_run_scrubs_legacy_blob.py
@@ -216,8 +216,7 @@ class TestSqliteDbDeleteRunScrubsLegacyBlob:
         # Refresh SQLAlchemy metadata so the read path sees the legacy column.
         db.metadata = MetaData()
         db.metadata.reflect(bind=db.db_engine)
-        if hasattr(db, "_tables"):
-            db._tables = {}
+        db._resolved_tables = {}
 
         return db
 

--- a/libs/agno/tests/unit/db/test_table_resolution_cache.py
+++ b/libs/agno/tests/unit/db/test_table_resolution_cache.py
@@ -1,0 +1,351 @@
+"""Tests for the per-instance table resolution cache in the SQL adapters.
+
+A resolved table is cached on the adapter, so steady-state operations skip the
+per-call existence check and schema inspection. A missing table is never
+cached: a read before the table exists returns None and a later write can
+still create the table.
+"""
+
+import os
+import tempfile
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import event, text
+
+from agno.db.migrations.manager import MigrationManager
+from agno.session import AgentSession
+
+# ============================================================================
+# FIXTURES
+# ============================================================================
+
+
+@pytest.fixture
+def sqlite_db():
+    from agno.db.sqlite.sqlite import SqliteDb
+
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    db = SqliteDb(db_file=path)
+    yield db
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+
+
+@pytest.fixture
+def async_sqlite_db():
+    from agno.db.sqlite.async_sqlite import AsyncSqliteDb
+
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    db = AsyncSqliteDb(db_file=path)
+    yield db
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+
+
+RESOLUTION_MARKERS = ("sqlite_master", "table_info", "table_xinfo")
+
+
+def _collect_statements(sync_engine):
+    statements = []
+
+    def on_execute(conn, cursor, statement, parameters, context, executemany):
+        statements.append(statement)
+
+    event.listen(sync_engine, "before_cursor_execute", on_execute)
+    return statements, on_execute
+
+
+def _resolution_statements(statements):
+    return [s for s in statements if any(marker in s for marker in RESOLUTION_MARKERS)]
+
+
+# ============================================================================
+# STEADY-STATE QUERY COUNT
+# ============================================================================
+
+
+def test_steady_state_read_emits_no_resolution_queries(sqlite_db):
+    sqlite_db._create_all_tables()
+    session = AgentSession(session_id="s1", agent_id="a1", user_id="u1")
+    sqlite_db.upsert_session(session)
+    assert sqlite_db.get_session(session_id="s1") is not None
+
+    statements, listener = _collect_statements(sqlite_db.db_engine)
+    try:
+        assert sqlite_db.get_session(session_id="s1") is not None
+    finally:
+        event.remove(sqlite_db.db_engine, "before_cursor_execute", listener)
+
+    assert _resolution_statements(statements) == []
+    # The data queries themselves still run.
+    assert len(statements) > 0
+
+
+async def test_steady_state_read_emits_no_resolution_queries_async(async_sqlite_db):
+    await async_sqlite_db._create_all_tables()
+    session = AgentSession(session_id="s1", agent_id="a1", user_id="u1")
+    await async_sqlite_db.upsert_session(session)
+    assert await async_sqlite_db.get_session(session_id="s1") is not None
+
+    statements, listener = _collect_statements(async_sqlite_db.db_engine.sync_engine)
+    try:
+        assert await async_sqlite_db.get_session(session_id="s1") is not None
+    finally:
+        event.remove(async_sqlite_db.db_engine.sync_engine, "before_cursor_execute", listener)
+
+    assert _resolution_statements(statements) == []
+    assert len(statements) > 0
+
+
+def test_steady_state_read_on_existing_tables_emits_no_resolution_queries(sqlite_db):
+    from agno.db.sqlite.sqlite import SqliteDb
+
+    sqlite_db._create_all_tables()
+    session = AgentSession(session_id="s1", agent_id="a1", user_id="u1")
+    sqlite_db.upsert_session(session)
+
+    # A fresh instance over existing tables resolves through reflection.
+    db2 = SqliteDb(db_file=sqlite_db.db_file)
+    assert db2.get_session(session_id="s1") is not None
+
+    statements, listener = _collect_statements(db2.db_engine)
+    try:
+        assert db2.get_session(session_id="s1") is not None
+    finally:
+        event.remove(db2.db_engine, "before_cursor_execute", listener)
+
+    assert _resolution_statements(statements) == []
+    assert len(statements) > 0
+
+
+def test_repeated_resolution_returns_same_table_object(sqlite_db):
+    t1 = sqlite_db._get_table(table_type="sessions", create_table_if_not_found=True)
+    t2 = sqlite_db._get_table(table_type="sessions", create_table_if_not_found=False)
+    assert t1 is not None
+    assert t1 is t2
+    assert sqlite_db.session_table_name in sqlite_db._resolved_tables
+
+
+# ============================================================================
+# A MISSING TABLE IS NEVER CACHED
+# ============================================================================
+
+
+def test_missing_table_is_not_cached(sqlite_db):
+    # Reads before the table exists return None.
+    assert sqlite_db._get_table(table_type="sessions", create_table_if_not_found=False) is None
+    assert sqlite_db._get_table(table_type="sessions", create_table_if_not_found=False) is None
+    assert sqlite_db.session_table_name not in sqlite_db._resolved_tables
+
+    # A later write can still create the table.
+    session = AgentSession(session_id="s1", agent_id="a1", user_id="u1")
+    sqlite_db.upsert_session(session)
+    assert sqlite_db.get_session(session_id="s1") is not None
+
+
+async def test_missing_table_is_not_cached_async(async_sqlite_db):
+    assert await async_sqlite_db._get_table(table_type="sessions", create_table_if_not_found=False) is None
+    assert await async_sqlite_db._get_table(table_type="sessions", create_table_if_not_found=False) is None
+    assert async_sqlite_db.session_table_name not in async_sqlite_db._resolved_tables
+
+    session = AgentSession(session_id="s1", agent_id="a1", user_id="u1")
+    await async_sqlite_db.upsert_session(session)
+    assert await async_sqlite_db.get_session(session_id="s1") is not None
+
+
+# ============================================================================
+# INVALIDATION
+# ============================================================================
+
+
+def test_invalidation_allows_recreate_after_external_drop(sqlite_db):
+    table = sqlite_db._get_table(table_type="sessions", create_table_if_not_found=True)
+    assert table is not None
+
+    with sqlite_db.Session() as sess, sess.begin():
+        sess.execute(text(f"DROP TABLE {sqlite_db.session_table_name}"))
+
+    sqlite_db._invalidate_resolved_table(sqlite_db.session_table_name)
+    assert sqlite_db.session_table_name not in sqlite_db._resolved_tables
+
+    # Recreation only works when the invalidation also unregistered the
+    # table from the adapter's metadata.
+    recreated = sqlite_db._get_table(table_type="sessions", create_table_if_not_found=True)
+    assert recreated is not None
+
+    session = AgentSession(session_id="s1", agent_id="a1", user_id="u1")
+    sqlite_db.upsert_session(session)
+    assert sqlite_db.get_session(session_id="s1") is not None
+
+
+async def test_invalidation_allows_recreate_after_external_drop_async(async_sqlite_db):
+    table = await async_sqlite_db._get_table(table_type="sessions", create_table_if_not_found=True)
+    assert table is not None
+
+    async with async_sqlite_db.async_session_factory() as sess, sess.begin():
+        await sess.execute(text(f"DROP TABLE {async_sqlite_db.session_table_name}"))
+
+    async_sqlite_db._invalidate_resolved_table(async_sqlite_db.session_table_name)
+
+    recreated = await async_sqlite_db._get_table(table_type="sessions", create_table_if_not_found=True)
+    assert recreated is not None
+
+
+# ============================================================================
+# MIGRATIONS INVALIDATE THE CACHE
+# ============================================================================
+
+
+async def test_up_migration_invalidates_resolved_tables(sqlite_db):
+    session = AgentSession(session_id="s1", agent_id="a1", user_id="u1")
+    sqlite_db.upsert_session(session)
+    assert sqlite_db.session_table_name in sqlite_db._resolved_tables
+
+    manager = MigrationManager(sqlite_db)
+    with (
+        patch.object(manager, "_up_migration", new=AsyncMock(return_value=True)),
+        patch.object(sqlite_db, "get_latest_schema_version", return_value="2.0.0"),
+        patch.object(sqlite_db, "upsert_schema_version"),
+    ):
+        await manager.up(table_type="sessions")
+
+    assert sqlite_db.session_table_name not in sqlite_db._resolved_tables
+
+
+async def test_failed_migration_still_invalidates_resolved_tables(sqlite_db):
+    session = AgentSession(session_id="s1", agent_id="a1", user_id="u1")
+    sqlite_db.upsert_session(session)
+    assert sqlite_db.session_table_name in sqlite_db._resolved_tables
+
+    manager = MigrationManager(sqlite_db)
+    with (
+        patch.object(manager, "_up_migration", new=AsyncMock(side_effect=RuntimeError("boom"))),
+        patch.object(sqlite_db, "get_latest_schema_version", return_value="2.0.0"),
+        patch.object(sqlite_db, "upsert_schema_version"),
+    ):
+        with pytest.raises(RuntimeError, match="boom"):
+            await manager.up(table_type="sessions")
+
+    assert sqlite_db.session_table_name not in sqlite_db._resolved_tables
+
+
+async def test_down_migration_invalidates_resolved_tables(sqlite_db):
+    session = AgentSession(session_id="s1", agent_id="a1", user_id="u1")
+    sqlite_db.upsert_session(session)
+    assert sqlite_db.session_table_name in sqlite_db._resolved_tables
+
+    manager = MigrationManager(sqlite_db)
+    with (
+        patch.object(manager, "_down_migration", new=AsyncMock(return_value=True)),
+        patch.object(sqlite_db, "get_latest_schema_version", return_value="3.0.0"),
+        patch.object(sqlite_db, "upsert_schema_version"),
+    ):
+        await manager.down(target_version="2.5.6", table_type="sessions")
+
+    assert sqlite_db.session_table_name not in sqlite_db._resolved_tables
+
+
+async def test_dependent_table_creation_works_after_migration_invalidated_parent(sqlite_db):
+    """Invalidation removes the parent from metadata; creating a dependent
+    table afterwards must re-register the parent, not raise
+    NoReferencedTableError."""
+    schedules = sqlite_db._get_table(table_type="schedules", create_table_if_not_found=True)
+    assert schedules is not None
+
+    manager = MigrationManager(sqlite_db)
+    with (
+        patch.object(manager, "_up_migration", new=AsyncMock(return_value=True)),
+        patch.object(sqlite_db, "get_latest_schema_version", return_value="2.0.0"),
+        patch.object(sqlite_db, "upsert_schema_version"),
+    ):
+        await manager.up(table_type="schedules")
+    assert sqlite_db.schedules_table_name not in sqlite_db._resolved_tables
+
+    schedule_runs = sqlite_db._get_table(table_type="schedule_runs", create_table_if_not_found=True)
+    assert schedule_runs is not None
+
+
+def test_create_all_tables_recreates_externally_dropped_table(sqlite_db):
+    sqlite_db._create_all_tables()
+    session = AgentSession(session_id="s1", agent_id="a1", user_id="u1")
+    sqlite_db.upsert_session(session)
+
+    with sqlite_db.Session() as sess, sess.begin():
+        sess.execute(text(f"DROP TABLE {sqlite_db.session_table_name}"))
+
+    sqlite_db._create_all_tables()
+    assert sqlite_db.get_session(session_id="s1") is None
+    sqlite_db.upsert_session(session)
+    assert sqlite_db.get_session(session_id="s1") is not None
+
+
+def test_in_memory_sqlite_does_not_cache_across_threads():
+    """In-memory SQLite keeps one private database per thread, so resolved
+    tables must not be cached: a worker thread would query a table that only
+    exists in the creating thread's database."""
+    import threading
+
+    from agno.db.sqlite.sqlite import SqliteDb
+
+    db = SqliteDb(db_url="sqlite:///:memory:")
+    assert db._cache_resolved_tables is False
+
+    session = AgentSession(session_id="s1", agent_id="a1", user_id="u1")
+    db.upsert_session(session)
+    assert db._resolved_tables == {}
+
+    errors = []
+
+    def read_from_other_thread():
+        try:
+            # This thread's private database has no tables; the read must
+            # degrade to None, not fail on a cached Table.
+            assert db.get_session(session_id="s1") is None
+        except Exception as e:
+            errors.append(e)
+
+    t = threading.Thread(target=read_from_other_thread)
+    t.start()
+    t.join()
+    assert errors == []
+
+
+def test_file_backed_sqlite_keeps_caching_enabled(sqlite_db):
+    assert sqlite_db._cache_resolved_tables is True
+
+
+# ============================================================================
+# RUNTIME DDL INVALIDATES THE CACHE
+# ============================================================================
+
+
+def test_cleanup_legacy_runs_column_invalidates_sessions_table(sqlite_db):
+    session = AgentSession(session_id="s1", agent_id="a1", user_id="u1")
+    sqlite_db.upsert_session(session)
+
+    # Simulate a legacy database: the sessions table has a runs column and the
+    # adapter resolved the table while the column existed.
+    with sqlite_db.Session() as sess, sess.begin():
+        sess.execute(text(f"ALTER TABLE {sqlite_db.session_table_name} ADD COLUMN runs TEXT"))
+    sqlite_db._invalidate_resolved_table(sqlite_db.session_table_name)
+    table = sqlite_db._get_table(table_type="sessions", create_table_if_not_found=False)
+    assert table is not None
+    assert "runs" in table.c
+
+    assert sqlite_db.cleanup_legacy_runs_column(force=True) is True
+    assert sqlite_db.session_table_name not in sqlite_db._resolved_tables
+
+    # Reads keep working after the drop: the re-resolved table no longer
+    # carries the dropped column.
+    fetched = sqlite_db.get_session(session_id="s1")
+    assert fetched is not None
+    refreshed = sqlite_db._get_table(table_type="sessions", create_table_if_not_found=False)
+    assert refreshed is not None
+    assert "runs" not in refreshed.c


### PR DESCRIPTION
## Summary

The SQL adapters re-checked table existence and re-inspected the table schema before every query. Each operation paid one existence query, one column inspection, and two extra connection checkouts per table it touched. None of that work could detect anything after the first access: SQLAlchemy pins the first reflection in `MetaData`, so a re-resolution always returned the same pinned `Table` object.

This PR caches successful table resolutions on the adapter instance and invalidates the cache at every place that changes a table at runtime.

Measured on SQLite (each statement is one wire round-trip on Postgres, and each checkout adds a `pool_pre_ping` ping):

| Operation | Before | After |
|---|---|---|
| `get_session` (2-table read) | 6 statements, 7 checkouts | 2 statements, 1 checkout |
| `upsert_session` | 3 statements, 4 checkouts | 1 statement, 1 checkout |

This came out of Sam's report that a few small authz reads cost ~14 round-trips per request. His measurement was correct and slightly conservative.

## What changed

- `db/base.py`: `BaseDb` and `AsyncBaseDb` gain `self._resolved_tables` (dict keyed by table name) and `_invalidate_resolved_table(table_name)`. Invalidation pops the dict and removes the table from `self.metadata`. The metadata removal matters: without it a re-resolution returns the stale pinned object.
- All 7 SQL adapters (`postgres`, `async_postgres`, `sqlite`, `async_sqlite`, `mysql`, `async_mysql`, `singlestore`): `_get_or_create_table` returns the cached table when present, and stores the table after a successful create or reflection. A `None` result (missing table on a read path) is never cached, so a later write can still create the table. A previous cache attempt was reverted in #6128 for caching exactly that `None`.
- `migrations/manager.py`: `up()` and `down()` invalidate the migrated table in a `finally` block around each migration step. A live process now re-reflects a table after the `/databases/{id}/migrate` endpoints alter it. Before this PR the process kept the stale pinned reflection forever.
- `migrations/versions/v3_0_0.py`: `_forget_table` also pops the new cache.
- `cleanup_legacy_runs_column` (all 7 adapters): invalidates the sessions table after dropping the legacy `runs` column. Before this PR the same process kept serving the stale reflection that still contained the dropped column. The invalidation runs after the transaction commits, so a concurrent resolution cannot re-cache the pre-drop shape.
- `_create_table` (all 7 adapters): the hardcoded "runs needs sessions first" guard is now a schema-driven loop (`BaseDb._fk_dependencies`) covering every foreign-key edge: runs→sessions, spans→traces, schedule_runs→schedules, component_configs→components, component_links→components+component_configs. Without this, invalidating a parent table (which unregisters it from metadata) made a later first-time creation of a dependent table fail with `NoReferencedTableError`. This was found by adversarial review with an end-to-end repro against a live migration; the repro now passes.
- Reflect branches only cache a fully built, still-registered `Table`, so a concurrent first resolution can never pin another thread's half-built object.
- `_create_all_tables` invalidates each table before resolving it, so it still recreates tables that were dropped externally.
- In-memory SQLite (`SingletonThreadPool`, one private database per thread) disables the cache: "this table exists" is not a process-wide fact there. File-backed SQLite and all server databases cache normally.
- `V3_MIGRATION_GUIDE.md`: documents that a schema change made behind a running process's back (another process migrating a shared database) is not seen until restart or explicit invalidation.

## Behavior notes

- The first access to each table still runs the existence check and schema validation, so an un-migrated table still fails loudly on first access, as the migration guide promises.
- If an external process drops a table mid-run, reads on an instance that already resolved it now raise at query time instead of returning empty. Recreating through the adapter after `_invalidate_resolved_table` now works; before this PR it crashed with "Table is already defined".
- `async_mysql` keeps its pre-existing divergence (missing table on a read path raises `ValueError` instead of returning `None` like the other six adapters). Aligning it needs `Optional` plumbing through ~60 call sites; left for a follow-up.
- Sam's authz-scoped cache in #9092 becomes redundant once this lands; this PR generalizes the same design (cache on success only, never cache `None`).

## Tests

- New: `tests/unit/db/test_table_resolution_cache.py` — 16 tests: steady-state statement counts (create path and reflect path), `None` never cached (the #6128 regression), invalidation and recreate after an external drop, migration up/down/failed-migration invalidation, dependent-table creation after a migration invalidated its FK parent, `_create_all_tables` after an external drop, the in-memory SQLite bypass, `cleanup_legacy_runs_column` invalidation. Sync and async. Each guard was mutation-tested: 9 mutations, each caught by a named test.
- Updated: `test_delete_run_scrubs_legacy_blob.py` (fixture simulates out-of-band DDL and already reset adapter state; it now also clears the new cache) and `test_service_accounts.py` (the dead-connection test now rebinds the Session factory to the broken engine, so it exercises the data path that actually raises in production).
- Full unit tree (10,641 passed) and the sqlite + postgres/async_postgres integration suites show zero new failures against the feat/v3.0 baseline.

## Type of change

- [x] Performance improvement (with two correctness fixes on the invalidation paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
