### PR TITLE
feat: add emem cookbook example

### DIFF
--- a/cookbook/91_tools/mcp/emem.py
+++ b/cookbook/91_tools/mcp/emem.py
@@ -21,7 +21,6 @@ Run: `uv pip install agno mcp openai` to install the dependencies
 import asyncio
 
 from agno.agent import Agent
-from agno.models.openai import OpenAIChat
 from agno.tools.mcp import MCPTools
 
 # ---------------------------------------------------------------------------

--- a/cookbook/91_tools/mcp/emem.py
+++ b/cookbook/91_tools/mcp/emem.py
@@ -1,0 +1,51 @@
+"""MCP emem Agent - Shared Memory for AI Agents Working in the Real World
+
+emem is shared memory for AI agents working together in the real world. One
+agent writes down what it observed. Another agent reads the same bytes, not a
+summary of them. Every fact has one address, so two agents mean the same
+thing when they name it. Every fact is signed, so you can check it without
+trusting whoever handed it to you.
+
+No API key or account is required for reads.
+
+Example prompts to try:
+- "Has this place flooded historically?"
+- "What's the air quality at this place right now?"
+- "Is this neighbourhood hot for an urban area?"
+- "How similar are two places?"
+- "Has this place lost forest?"
+
+Run: `uv pip install agno mcp openai` to install the dependencies
+"""
+
+import asyncio
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+from agno.tools.mcp import MCPTools
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+server_url = "https://emem.dev/mcp"
+
+
+async def run_agent(message: str) -> None:
+    mcp_tools = MCPTools(transport="streamable-http", url=server_url)
+    await mcp_tools.connect()
+    agent = Agent(
+        model=OpenAIChat(id="gpt-4o"),
+        tools=[mcp_tools],
+        markdown=True,
+    )
+    await agent.aprint_response(input=message, stream=True, markdown=True)
+    await mcp_tools.close()
+
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    asyncio.run(run_agent("Has this place flooded historically? Mumbai, India."))

--- a/cookbook/91_tools/mcp/emem.py
+++ b/cookbook/91_tools/mcp/emem.py
@@ -32,15 +32,13 @@ server_url = "https://emem.dev/mcp"
 
 
 async def run_agent(message: str) -> None:
-    mcp_tools = MCPTools(transport="streamable-http", url=server_url)
-    await mcp_tools.connect()
-    agent = Agent(
-        model=OpenAIChat(id="gpt-4o"),
-        tools=[mcp_tools],
-        markdown=True,
-    )
-    await agent.aprint_response(input=message, stream=True, markdown=True)
-    await mcp_tools.close()
+    async with MCPTools(transport="streamable-http", url=server_url) as mcp_tools:
+        agent = Agent(
+            model=OpenAIChat(id="gpt-4o"),
+            tools=[mcp_tools],
+            markdown=True,
+        )
+        await agent.aprint_response(input=message, stream=True, markdown=True)
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/91_tools/mcp/emem.py
+++ b/cookbook/91_tools/mcp/emem.py
@@ -34,7 +34,6 @@ server_url = "https://emem.dev/mcp"
 async def run_agent(message: str) -> None:
     async with MCPTools(transport="streamable-http", url=server_url) as mcp_tools:
         agent = Agent(
-            model=OpenAIChat(id="gpt-4o"),
             tools=[mcp_tools],
             markdown=True,
         )


### PR DESCRIPTION
## Summary
Adds a cookbook example showing how to connect an Agno agent to emem, shared memory for AI agents working together in the real world: every fact has one address, is signed, and says how it was produced, so an agent can check it without trusting whoever handed it to you. No API key required.

closes #9625

## Type of change
- [x] New feature

## Checklist
- [x] Examples and guides: Relevant cookbook example included

### Duplicate and AI-Generated PR Check
- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)