### PR TITLE
feat(spark): add iFLYTEK Spark model provider

### DIFF
--- a/cookbook/90_models/spark/README.md
+++ b/cookbook/90_models/spark/README.md
@@ -4,7 +4,7 @@
 models through an
 [OpenAI-compatible HTTP API](https://www.xfyun.cn/doc/spark/HTTP%E8%B0%83%E7%94%A8%E6%96%87%E6%A1%A3.html),
 so you can drive them through Agno the same way you'd drive any OpenAI-compatible
-provider. The Agno `Spark` class defaults to `generalv3.5` (Spark Max) and points
+provider. The Agno `Spark` class defaults to `4.0Ultra` (Spark 4.0 Ultra) and points
 at `https://spark-api-open.xf-yun.com/v1`.
 
 ## Models

--- a/cookbook/90_models/spark/README.md
+++ b/cookbook/90_models/spark/README.md
@@ -1,0 +1,59 @@
+# iFLYTEK Spark
+
+[iFLYTEK Spark](https://www.xfyun.cn/solutions/xinghuoAPI) (讯飞星火) exposes its
+models through an
+[OpenAI-compatible HTTP API](https://www.xfyun.cn/doc/spark/HTTP%E8%B0%83%E7%94%A8%E6%96%87%E6%A1%A3.html),
+so you can drive them through Agno the same way you'd drive any OpenAI-compatible
+provider. The Agno `Spark` class defaults to `generalv3.5` (Spark Max) and points
+at `https://spark-api-open.xf-yun.com/v1`.
+
+## Models
+
+| id | Model | Tool calling |
+| --- | --- | --- |
+| `4.0Ultra` | Spark 4.0 Ultra | ✅ |
+| `generalv3.5` | Spark Max | ✅ |
+| `max-32k` | Spark Max-32K | ✅ |
+| `generalv3` | Spark Pro | — |
+| `pro-128k` | Spark Pro-128K | — |
+| `lite` | Spark Lite | — |
+
+## Get an API Password
+
+Sign in to the [iFLYTEK console](https://console.xfyun.cn), create a Spark
+application, then copy the HTTP-service **API Password**
+(`http服务接口认证信息` → `APIPassword`). This single Bearer credential is what the
+`spark-api-open.xf-yun.com` OpenAI-compatible endpoint expects — it is different
+from the APPID/APIKey/APISecret triple used by the legacy WebSocket API.
+
+### 1. Create and activate a virtual environment
+
+See the repository [Development setup](https://github.com/agno-agi/agno/blob/main/CONTRIBUTING.md#development-setup).
+
+### 2. Export your API Password
+
+```shell
+export SPARK_API_KEY=***
+```
+
+### 3. Install libraries
+
+```shell
+uv pip install -U openai ddgs agno
+```
+
+## Examples
+
+```shell
+# Basic agent (sync, async, streaming)
+.venvs/demo/bin/python cookbook/90_models/spark/basic.py
+
+# Create an agent from the "spark:<model-id>" string shorthand
+.venvs/demo/bin/python cookbook/90_models/spark/string_model.py
+
+# Structured output: return a typed Pydantic object via JSON mode
+.venvs/demo/bin/python cookbook/90_models/spark/structured_output.py
+
+# Tool use: web search with a function-calling model
+.venvs/demo/bin/python cookbook/90_models/spark/tool_use.py
+```

--- a/cookbook/90_models/spark/basic.py
+++ b/cookbook/90_models/spark/basic.py
@@ -22,7 +22,7 @@ from agno.models.spark import Spark
 # Create Agent
 # ---------------------------------------------------------------------------
 
-agent = Agent(model=Spark(id="generalv3.5"), markdown=True)
+agent = Agent(model=Spark(id="4.0Ultra"), markdown=True)
 
 # ---------------------------------------------------------------------------
 # Run Agent

--- a/cookbook/90_models/spark/basic.py
+++ b/cookbook/90_models/spark/basic.py
@@ -1,0 +1,41 @@
+"""
+iFLYTEK Spark Basic
+===================
+
+The minimal Spark agent, run four ways: sync, sync + streaming, async, and
+async + streaming. Start here to confirm your `SPARK_API_KEY` works.
+
+Get an API Password:
+    Sign in to the iFLYTEK console (https://console.xfyun.cn), create a Spark
+    application, then copy the HTTP-service API Password
+    (`http服务接口认证信息` -> `APIPassword`) and export it:
+
+        export SPARK_API_KEY=***
+"""
+
+import asyncio
+
+from agno.agent import Agent
+from agno.models.spark import Spark
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+agent = Agent(model=Spark(id="generalv3.5"), markdown=True)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    # --- Sync ---
+    agent.print_response("Share a 2 sentence horror story.")
+
+    # --- Sync + Streaming ---
+    agent.print_response("Share a 2 sentence horror story.", stream=True)
+
+    # --- Async ---
+    asyncio.run(agent.aprint_response("Share a 2 sentence horror story."))
+
+    # --- Async + Streaming ---
+    asyncio.run(agent.aprint_response("Share a 2 sentence horror story.", stream=True))

--- a/cookbook/90_models/spark/string_model.py
+++ b/cookbook/90_models/spark/string_model.py
@@ -1,0 +1,24 @@
+"""
+iFLYTEK Spark String Model
+==========================
+
+Create a Spark agent without importing the model class, using the
+`model="spark:<model-id>"` string shorthand.
+"""
+
+from agno.agent import Agent
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+agent = Agent(model="spark:4.0Ultra", markdown=True)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    agent.print_response(
+        "Explain why tool-calling agents need conversation history.",
+        stream=True,
+    )

--- a/cookbook/90_models/spark/structured_output.py
+++ b/cookbook/90_models/spark/structured_output.py
@@ -1,0 +1,56 @@
+"""
+iFLYTEK Spark Structured Output
+===============================
+
+Get a typed Pydantic object back instead of free text. Spark supports JSON mode
+(`response_format={"type": "json_object"}`) but not native json_schema structured
+outputs, so pass `use_json_mode=True` alongside `output_schema`.
+"""
+
+from typing import List
+
+from agno.agent import Agent
+from agno.models.spark import Spark
+from pydantic import BaseModel, Field
+
+# ---------------------------------------------------------------------------
+# Define the output schema
+# ---------------------------------------------------------------------------
+
+
+class MovieScript(BaseModel):
+    setting: str = Field(
+        ..., description="Provide a nice setting for a blockbuster movie."
+    )
+    ending: str = Field(
+        ...,
+        description="Ending of the movie. If not available, provide a happy ending.",
+    )
+    genre: str = Field(
+        ...,
+        description="Genre of the movie. If not available, select action, thriller or romantic comedy.",
+    )
+    name: str = Field(..., description="Give a name to this movie")
+    characters: List[str] = Field(..., description="Name of characters for this movie.")
+    storyline: str = Field(
+        ..., description="3 sentence storyline for the movie. Make it exciting!"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+# Spark does not support native json_schema structured outputs, so use JSON mode.
+agent = Agent(
+    model=Spark(id="generalv3.5"),
+    description="You help people write movie scripts.",
+    output_schema=MovieScript,
+    use_json_mode=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    agent.print_response("New York")

--- a/cookbook/90_models/spark/structured_output.py
+++ b/cookbook/90_models/spark/structured_output.py
@@ -43,7 +43,7 @@ class MovieScript(BaseModel):
 
 # Spark does not support native json_schema structured outputs, so use JSON mode.
 agent = Agent(
-    model=Spark(id="generalv3.5"),
+    model=Spark(id="4.0Ultra"),
     description="You help people write movie scripts.",
     output_schema=MovieScript,
     use_json_mode=True,

--- a/cookbook/90_models/spark/tool_use.py
+++ b/cookbook/90_models/spark/tool_use.py
@@ -1,0 +1,33 @@
+"""
+iFLYTEK Spark Tool Use
+======================
+
+Give the agent a web search tool and let it call tools. Spark Max
+(`generalv3.5`), Spark Max-32K (`max-32k`) and Spark 4.0 Ultra (`4.0Ultra`)
+support function calling.
+
+Run `uv pip install ddgs` to install dependencies.
+"""
+
+from agno.agent import Agent
+from agno.models.spark import Spark
+from agno.tools.websearch import WebSearchTools
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+agent = Agent(
+    model=Spark(id="4.0Ultra"),
+    tools=[WebSearchTools()],
+    markdown=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    agent.print_response(
+        "What is happening in France?",
+        stream=True,
+    )

--- a/libs/agno/agno/models/spark/__init__.py
+++ b/libs/agno/agno/models/spark/__init__.py
@@ -1,0 +1,5 @@
+from agno.models.spark.spark import Spark
+
+__all__ = [
+    "Spark",
+]

--- a/libs/agno/agno/models/spark/spark.py
+++ b/libs/agno/agno/models/spark/spark.py
@@ -14,18 +14,18 @@ class Spark(OpenAILike):
     Spark exposes an OpenAI-compatible HTTP endpoint at
     https://spark-api-open.xf-yun.com/v1 that authenticates with a single Bearer
     API Password, so it is a thin wrapper over OpenAILike. The default id is
-    ``generalv3.5`` (Spark Max); other public model ids include ``4.0Ultra``,
-    ``max-32k``, ``generalv3`` (Spark Pro), ``pro-128k`` and ``lite``.
+    ``4.0Ultra`` (Spark 4.0 Ultra); other public model ids include ``generalv3.5``
+    (Spark Max), ``max-32k``, ``generalv3`` (Spark Pro), ``pro-128k`` and ``lite``.
 
     Attributes:
-        id (str): The model id. Defaults to "generalv3.5".
+        id (str): The model id. Defaults to "4.0Ultra".
         name (str): The model name. Defaults to "Spark".
         provider (str): The provider name. Defaults to "iFLYTEK Spark".
         api_key (Optional[str]): The API Password for the Spark HTTP service.
         base_url (str): The base URL. Defaults to "https://spark-api-open.xf-yun.com/v1".
     """
 
-    id: str = "generalv3.5"
+    id: str = "4.0Ultra"
     name: str = "Spark"
     provider: str = "iFLYTEK Spark"
 

--- a/libs/agno/agno/models/spark/spark.py
+++ b/libs/agno/agno/models/spark/spark.py
@@ -1,0 +1,65 @@
+from dataclasses import dataclass, field
+from os import getenv
+from typing import Any, Dict, Optional
+
+from agno.exceptions import ModelAuthenticationError
+from agno.models.openai.like import OpenAILike
+
+
+@dataclass
+class Spark(OpenAILike):
+    """
+    A class for interacting with iFLYTEK Spark (讯飞星火) models.
+
+    Spark exposes an OpenAI-compatible HTTP endpoint at
+    https://spark-api-open.xf-yun.com/v1 that authenticates with a single Bearer
+    API Password, so it is a thin wrapper over OpenAILike. The default id is
+    ``generalv3.5`` (Spark Max); other public model ids include ``4.0Ultra``,
+    ``max-32k``, ``generalv3`` (Spark Pro), ``pro-128k`` and ``lite``.
+
+    Attributes:
+        id (str): The model id. Defaults to "generalv3.5".
+        name (str): The model name. Defaults to "Spark".
+        provider (str): The provider name. Defaults to "iFLYTEK Spark".
+        api_key (Optional[str]): The API Password for the Spark HTTP service.
+        base_url (str): The base URL. Defaults to "https://spark-api-open.xf-yun.com/v1".
+    """
+
+    id: str = "generalv3.5"
+    name: str = "Spark"
+    provider: str = "iFLYTEK Spark"
+
+    api_key: Optional[str] = field(default_factory=lambda: getenv("SPARK_API_KEY"))
+    base_url: str = "https://spark-api-open.xf-yun.com/v1"
+
+    # Spark supports JSON mode (response_format={"type": "json_object"}) but not
+    # native/json_schema structured outputs, so output_schema needs use_json_mode=True.
+    supports_native_structured_outputs: bool = False
+
+    def _get_client_params(self) -> Dict[str, Any]:
+        if not self.api_key:
+            self.api_key = getenv("SPARK_API_KEY")
+            if not self.api_key:
+                raise ModelAuthenticationError(
+                    message="SPARK_API_KEY not set. Please set the SPARK_API_KEY environment variable.",
+                    model_name=self.name,
+                )
+
+        # Define base client params
+        base_params = {
+            "api_key": self.api_key,
+            "organization": self.organization,
+            "base_url": self.base_url,
+            "timeout": self.timeout,
+            "max_retries": self.max_retries,
+            "default_headers": self.default_headers,
+            "default_query": self.default_query,
+        }
+
+        # Create client_params dict with non-None values
+        client_params = {k: v for k, v in base_params.items() if v is not None}
+
+        # Add additional client params if provided
+        if self.client_params:
+            client_params.update(self.client_params)
+        return client_params

--- a/libs/agno/agno/models/spark/spark.py
+++ b/libs/agno/agno/models/spark/spark.py
@@ -45,21 +45,4 @@ class Spark(OpenAILike):
                     model_name=self.name,
                 )
 
-        # Define base client params
-        base_params = {
-            "api_key": self.api_key,
-            "organization": self.organization,
-            "base_url": self.base_url,
-            "timeout": self.timeout,
-            "max_retries": self.max_retries,
-            "default_headers": self.default_headers,
-            "default_query": self.default_query,
-        }
-
-        # Create client_params dict with non-None values
-        client_params = {k: v for k, v in base_params.items() if v is not None}
-
-        # Add additional client params if provided
-        if self.client_params:
-            client_params.update(self.client_params)
-        return client_params
+        return super()._get_client_params()

--- a/libs/agno/agno/models/utils.py
+++ b/libs/agno/agno/models/utils.py
@@ -64,6 +64,7 @@ _PROVIDERS: Dict[str, Tuple[str, str, str, str]] = {
     "requesty": ("agno.models.requesty", "Requesty", "Requesty", "requesty"),
     "sambanova": ("agno.models.sambanova", "Sambanova", "Sambanova", "sambanova"),
     "siliconflow": ("agno.models.siliconflow", "Siliconflow", "Siliconflow", "siliconflow"),
+    "spark": ("agno.models.spark", "Spark", "Spark", "iflytek spark"),
     "together": ("agno.models.together", "Together", "Together", "together"),
     "tokenlab": ("agno.models.tokenlab", "TokenLab", "TokenLab", "tokenlab"),
     "trustedrouter": ("agno.models.trustedrouter", "TrustedRouter", "TrustedRouter", "trustedrouter"),

--- a/libs/agno/tests/unit/models/spark/test_spark.py
+++ b/libs/agno/tests/unit/models/spark/test_spark.py
@@ -39,7 +39,7 @@ def test_spark_client_params():
 
 def test_spark_default_values():
     model = Spark(api_key="test-api-key")
-    assert model.id == "generalv3.5"
+    assert model.id == "4.0Ultra"
     assert model.name == "Spark"
     assert model.provider == "iFLYTEK Spark"
 

--- a/libs/agno/tests/unit/models/spark/test_spark.py
+++ b/libs/agno/tests/unit/models/spark/test_spark.py
@@ -1,0 +1,50 @@
+import os
+from unittest.mock import patch
+
+import pytest
+
+from agno.exceptions import ModelAuthenticationError
+from agno.models.spark import Spark
+from agno.models.utils import get_model
+
+
+def test_spark_initialization_with_api_key():
+    model = Spark(id="generalv3.5", api_key="test-api-key")
+    assert model.id == "generalv3.5"
+    assert model.api_key == "test-api-key"
+    assert model.base_url == "https://spark-api-open.xf-yun.com/v1"
+
+
+def test_spark_initialization_without_api_key():
+    with patch.dict(os.environ, {}, clear=True):
+        model = Spark(id="generalv3.5")
+        client_params = None
+        with pytest.raises(ModelAuthenticationError):
+            client_params = model._get_client_params()
+        assert client_params is None
+
+
+def test_spark_initialization_with_env_api_key():
+    with patch.dict(os.environ, {"SPARK_API_KEY": "env-api-key"}):
+        model = Spark(id="generalv3.5")
+        assert model.api_key == "env-api-key"
+
+
+def test_spark_client_params():
+    model = Spark(id="generalv3.5", api_key="test-api-key")
+    client_params = model._get_client_params()
+    assert client_params["api_key"] == "test-api-key"
+    assert client_params["base_url"] == "https://spark-api-open.xf-yun.com/v1"
+
+
+def test_spark_default_values():
+    model = Spark(api_key="test-api-key")
+    assert model.id == "generalv3.5"
+    assert model.name == "Spark"
+    assert model.provider == "iFLYTEK Spark"
+
+
+def test_get_model_parses_spark_string():
+    model = get_model("spark:4.0Ultra")
+    assert isinstance(model, Spark)
+    assert model.id == "4.0Ultra"

--- a/libs/agno/tests/unit/models/spark/test_spark.py
+++ b/libs/agno/tests/unit/models/spark/test_spark.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import pytest
 
 from agno.exceptions import ModelAuthenticationError
+from agno.models.openai.like import OpenAILike
 from agno.models.spark import Spark
 from agno.models.utils import get_model
 
@@ -35,6 +36,14 @@ def test_spark_client_params():
     client_params = model._get_client_params()
     assert client_params["api_key"] == "test-api-key"
     assert client_params["base_url"] == "https://spark-api-open.xf-yun.com/v1"
+
+
+def test_spark_client_params_delegate_to_openai_like():
+    with patch.object(OpenAILike, "_get_client_params", return_value={"delegated": True}) as get_client_params:
+        model = Spark(api_key="test-api-key")
+
+        assert model._get_client_params() == {"delegated": True}
+        get_client_params.assert_called_once_with()
 
 
 def test_spark_default_values():


### PR DESCRIPTION
Fixes #9664

## Summary

Adds an **iFLYTEK Spark (讯飞星火)** model provider. Spark is one of the few major
Chinese foundation models not yet available in Agno (DeepSeek, Qwen/DashScope,
MiniMax, Moonshot, InternLM, Xiaomi MiMo and others already are), so this fills a
gap for users in that ecosystem.

Spark exposes an OpenAI-compatible HTTP endpoint at
`https://spark-api-open.xf-yun.com/v1` that authenticates with a single Bearer
**API Password**, so `Spark` is a thin `OpenAILike` wrapper — the same shape as
the existing Nebius / MiMo providers.

- `Spark` defaults to `generalv3.5` (Spark Max); other public ids: `4.0Ultra`,
  `max-32k`, `generalv3` (Spark Pro), `pro-128k`, `lite`.
- Reads the key from `SPARK_API_KEY`.
- Registered under the `spark` provider key, so `model="spark:4.0Ultra"` string
  shorthand and `to_dict()`/`from_dict()` round-tripping work.
- Unit tests + cookbook examples (basic, string-model, tool-use, structured
  output) mirror the recent Xiaomi MiMo provider addition.

## Type of change

- [x] New feature
- [x] Model update

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

- The registry entry matches the drift guard in
  `tests/unit/models/test_provider_resolution.py`: `_canonical_provider_display("spark")`
  is `"iflytek spark"`, exactly `Spark().provider.lower()`.
- I couldn't run `./scripts/format.sh` / `./scripts/validate.sh` or a full clean-env
  test locally; happy to push follow-ups if CI flags anything (e.g. formatting).
- The Bearer API Password is the credential for the `spark-api-open.xf-yun.com`
  OpenAI-compatible endpoint — distinct from the APPID/APIKey/APISecret triple used
  by Spark's legacy WebSocket API.
### AI assistance disclosure

OpenAI Codex assisted with the review-follow-up refactor in commit `89989d0` (delegating Spark client parameter construction to `OpenAILike`) and its focused regression test. I reviewed the exact diff and validation results before pushing.