### PR TITLE
[fix] include team member messages in AgentOS session chat_history

### DIFF
--- a/libs/agno/agno/os/schema.py
+++ b/libs/agno/agno/os/schema.py
@@ -499,7 +499,11 @@ class TeamSessionDetailSchema(BaseModel):
             else None,
             metrics=session.session_data.get("session_metrics", {}) if session.session_data else None,
             metadata=session.metadata,
-            # Include member-agent messages so the REST payload matches the runs endpoint
+            # Include member-agent messages so the REST payload matches the runs endpoint.
+            # Messages follow stored run order: on the default checkpoint path member runs
+            # are upserted before the parent team run, so member messages may appear before
+            # the leader's preceding turn. Conversational reordering is intentionally not
+            # done here — this endpoint mirrors GET /sessions/{id}/runs storage order.
             chat_history=[
                 message.to_dict()
                 for message in session.get_messages(

--- a/libs/agno/agno/os/schema.py
+++ b/libs/agno/agno/os/schema.py
@@ -473,7 +473,9 @@ class TeamSessionDetailSchema(BaseModel):
     metrics: Optional[dict] = Field(None, description="Session metrics")
     team_data: Optional[dict] = Field(None, description="Team-specific data")
     metadata: Optional[dict] = Field(None, description="Additional metadata")
-    chat_history: Optional[List[dict]] = Field(None, description="Complete chat history")
+    chat_history: Optional[List[dict]] = Field(
+        None, description="Complete chat history, including member-agent messages"
+    )
     created_at: Optional[datetime] = Field(None, description="Session creation timestamp")
     updated_at: Optional[datetime] = Field(None, description="Last update timestamp")
     total_tokens: Optional[int] = Field(None, description="Total tokens used in this session")
@@ -497,7 +499,15 @@ class TeamSessionDetailSchema(BaseModel):
             else None,
             metrics=session.session_data.get("session_metrics", {}) if session.session_data else None,
             metadata=session.metadata,
-            chat_history=[message.to_dict() for message in session.get_chat_history()],
+            # Include member-agent messages so the REST payload matches the runs endpoint
+            chat_history=[
+                message.to_dict()
+                for message in session.get_messages(
+                    skip_roles=["system", "tool"],
+                    skip_member_messages=False,
+                    skip_statuses=[],
+                )
+            ],
             created_at=to_utc_datetime(created_at),
             updated_at=to_utc_datetime(updated_at),
         )

--- a/libs/agno/tests/unit/os/test_schemas.py
+++ b/libs/agno/tests/unit/os/test_schemas.py
@@ -190,3 +190,55 @@ def test_team_run_schema_lineage_defaults_to_none_when_absent():
     assert schema.forked_from_session_id is None
     assert schema.regenerated_from is None
     assert schema.last_checkpoint_at_message_index is None
+
+
+def test_team_session_detail_chat_history_includes_member_messages():
+    """GET /sessions/{session_id} must return the complete chat history for team
+    sessions, including member-agent messages — matching what GET /sessions/{id}/runs
+    already exposes. The SDK helper get_chat_history() keeps skipping member
+    messages, since it builds model context rather than the REST payload."""
+    from agno.models.message import Message
+    from agno.os.schema import TeamSessionDetailSchema
+    from agno.run.agent import RunOutput, RunStatus
+    from agno.run.team import TeamRunOutput
+    from agno.session.team import TeamSession
+
+    team_run = TeamRunOutput(
+        run_id="team-run-1",
+        team_id="t1",
+        parent_run_id=None,
+        status=RunStatus.completed,
+        messages=[
+            Message(role="user", content="What is the weather in Tokyo?"),
+            Message(role="assistant", content="Delegating to the weather agent."),
+        ],
+    )
+    member_run = RunOutput(
+        run_id="member-run-1",
+        agent_id="weather-agent",
+        parent_run_id="team-run-1",
+        status=RunStatus.completed,
+        messages=[
+            Message(role="user", content="Get the weather in Tokyo."),
+            Message(role="assistant", content="It is sunny in Tokyo."),
+        ],
+    )
+    session = TeamSession(
+        session_id="team-session-1",
+        team_id="t1",
+        session_data={"session_name": "Weather session"},
+        runs=[team_run, member_run],
+        created_at=1719859200,
+        updated_at=1719859200,
+    )
+
+    schema = TeamSessionDetailSchema.from_session(session)
+
+    contents = [message["content"] for message in schema.chat_history or []]
+    assert "Delegating to the weather agent." in contents
+    assert "It is sunny in Tokyo." in contents
+
+    # The SDK helper is for model context and must keep excluding member messages
+    sdk_contents = [message.content for message in session.get_chat_history()]
+    assert "Delegating to the weather agent." in sdk_contents
+    assert "It is sunny in Tokyo." not in sdk_contents

--- a/libs/agno/tests/unit/os/test_schemas.py
+++ b/libs/agno/tests/unit/os/test_schemas.py
@@ -242,3 +242,58 @@ def test_team_session_detail_chat_history_includes_member_messages():
     sdk_contents = [message.content for message in session.get_chat_history()]
     assert "Delegating to the weather agent." in sdk_contents
     assert "It is sunny in Tokyo." not in sdk_contents
+
+
+def test_team_session_detail_chat_history_uses_member_first_persistence_order():
+    """On the default team path, delegate_task_to_member upserts the member run
+    before _cleanup_and_store upserts the parent team run, so session.runs is
+    stored member-first. get_messages() walks stored run order, so the REST
+    chat_history lists the member messages before the leader's turn. This test
+    pins that storage-order behavior; conversational reordering is a separate
+    change."""
+    from agno.models.message import Message
+    from agno.os.schema import TeamSessionDetailSchema
+    from agno.run.agent import RunOutput, RunStatus
+    from agno.run.team import TeamRunOutput
+    from agno.session.team import TeamSession
+
+    member_run = RunOutput(
+        run_id="member-run-1",
+        agent_id="weather-agent",
+        parent_run_id="team-run-1",
+        status=RunStatus.completed,
+        messages=[
+            Message(role="user", content="Get the weather in Tokyo."),
+            Message(role="assistant", content="It is sunny in Tokyo."),
+        ],
+    )
+    team_run = TeamRunOutput(
+        run_id="team-run-1",
+        team_id="t1",
+        parent_run_id=None,
+        status=RunStatus.completed,
+        messages=[
+            Message(role="user", content="What is the weather in Tokyo?"),
+            Message(role="assistant", content="Delegating to the weather agent."),
+        ],
+    )
+    session = TeamSession(
+        session_id="team-session-1",
+        team_id="t1",
+        session_data={"session_name": "Weather session"},
+        runs=[member_run, team_run],
+        created_at=1719859200,
+        updated_at=1719859200,
+    )
+
+    schema = TeamSessionDetailSchema.from_session(session)
+
+    contents = [message["content"] for message in schema.chat_history or []]
+    assert "It is sunny in Tokyo." in contents
+    assert "Delegating to the weather agent." in contents
+    # Storage order is preserved: the member's messages come before the leader's
+    assert contents.index("It is sunny in Tokyo.") < contents.index("Delegating to the weather agent.")
+
+    # The SDK helper is for model context and must keep excluding member messages
+    sdk_contents = [message.content for message in session.get_chat_history()]
+    assert "It is sunny in Tokyo." not in sdk_contents


### PR DESCRIPTION
## Summary

AgentOS `GET /sessions/{session_id}` advertised `chat_history` as complete, but team sessions dropped member-agent messages.

`TeamSessionDetailSchema.from_session` built the REST payload from `session.get_chat_history()`, which always uses `skip_member_messages=True` (correct for model context). `GET /sessions/{session_id}/runs` already returns those member runs via `classify_session_run`. A team UI that loads session history after a handoff therefore saw only the leader.

This PR builds REST `chat_history` with `skip_member_messages=False`. The SDK helper default is unchanged.

Related to #8204 (member history lost in `/sessions/{session_id}`). This PR does not change `<team_history_context>` stuffing.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

Implementation was drafted with Claude Code (fable) and reviewed locally. Unit tests `test_team_session_detail_chat_history_includes_member_messages` and `test_team_session_detail_chat_history_uses_member_first_persistence_order` pass (`12 passed`).

---

## Additional Notes

Hit while wiring an AgentOS UI that streams team handoffs, then reloads `GET /sessions/{session_id}` for the thread. No architecture rewrite. No change to team orchestration or MCP tool connection.

On the default checkpoint path, member runs are upserted before the parent team run, so `chat_history` may list member messages before the leader's preceding turn. Reordering to conversational order is tracked separately. Follow-up commit `eceab80d` adds a unit test that uses member-first persistence (matching live storage) and a schema comment documenting that this endpoint mirrors `GET /sessions/{id}/runs` storage order.
