### PR TITLE
fix: keep a workflow session's runs to its own runs

### DIFF
--- a/libs/agno/agno/db/clickhouse/clickhouse.py
+++ b/libs/agno/agno/db/clickhouse/clickhouse.py
@@ -741,7 +741,7 @@ class ClickhouseDb(BaseDb):
     def create_eval_run(self, eval_run: EvalRunRecord) -> Optional[EvalRunRecord]:
         raise NotImplementedError(_TRACES_ONLY_ERROR)
 
-    def delete_eval_runs(self, eval_run_ids: List[str]) -> None:
+    def delete_eval_runs(self, eval_run_ids: List[str], user_id: Optional[str] = None) -> None:
         raise NotImplementedError(_TRACES_ONLY_ERROR)
 
     def get_eval_run(self, *args, **kwargs):  # type: ignore[override]

--- a/libs/agno/agno/db/dynamo/dynamo.py
+++ b/libs/agno/agno/db/dynamo/dynamo.py
@@ -2454,9 +2454,12 @@ class DynamoDb(BaseDb):
                 },
                 ReturnValues="ALL_NEW",
             )
-            # Only rename if owned by this user (also fails when the run is absent).
+            # Avoid upserting a phantom item when the run doesn't exist. Such an item carries
+            # no eval_type, and every later read of the table fails on it.
+            update_kwargs["ConditionExpression"] = "attribute_exists(run_id)"
+            # Only rename if owned by this user.
             if user_id is not None:
-                update_kwargs["ConditionExpression"] = "user_id = :user_id"
+                update_kwargs["ConditionExpression"] += " AND user_id = :user_id"
                 update_kwargs["ExpressionAttributeValues"][":user_id"] = {"S": user_id}
 
             try:

--- a/libs/agno/agno/db/utils.py
+++ b/libs/agno/agno/db/utils.py
@@ -172,9 +172,10 @@ def get_run_type(run: Any) -> str:
     if isinstance(run, WorkflowRunOutput):
         return "workflow"
     if isinstance(run, dict):
-        if run.get("agent_id"):
+        # A member run persisted without its id still identifies itself by name.
+        if run.get("agent_id") or run.get("agent_name"):
             return "agent"
-        if run.get("team_id"):
+        if run.get("team_id") or run.get("team_name"):
             return "team"
         return "workflow"
     raise ValueError(f"Cannot determine run type for: {type(run)}")

--- a/libs/agno/agno/session/workflow.py
+++ b/libs/agno/agno/session/workflow.py
@@ -92,6 +92,11 @@ class WorkflowSession:
                     # Already a WorkflowRunOutput object (from deserialize_session_json_fields)
                     runs.append(run_item)
                 elif isinstance(run_item, dict):
+                    # A step's agent/team run shares this session id; the workflow run carries it.
+                    from agno.db.utils import get_run_type  # circular at module level
+
+                    if get_run_type(run_item) != "workflow":
+                        continue
                     # Still a dictionary, needs to be converted
                     runs.append(WorkflowRunOutput.from_dict(run_item))
                 else:

--- a/libs/agno/tests/unit/session/test_workflow_session_runs.py
+++ b/libs/agno/tests/unit/session/test_workflow_session_runs.py
@@ -1,0 +1,78 @@
+"""A workflow session's runs are its own top-level runs.
+
+The runs table keys every run by session_id, and a step's agent/team run shares the
+workflow's session id, so the read hands those back too. Deserializing one as a
+WorkflowRunOutput raises on its metrics (no "steps") or, when it has none, mints a
+phantom workflow run carrying the member's content.
+"""
+
+from agno.session.workflow import WorkflowSession
+
+WORKFLOW_RUN = {
+    "run_id": "wf-1",
+    "workflow_id": "wf",
+    "workflow_name": "WfHitl",
+    "session_id": "s1",
+    "status": "PAUSED",
+    "metrics": {"steps": {}, "duration": 1.0},
+}
+MEMBER_AGENT_RUN = {
+    "run_id": "ag-1",
+    "agent_id": "deployer",
+    "agent_name": "Deployer",
+    "session_id": "s1",
+    "status": "PAUSED",
+    "content": "deployed",
+    "metrics": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+}
+MEMBER_TEAM_RUN = {
+    "run_id": "tm-1",
+    "team_id": "squad",
+    "team_name": "Squad",
+    "session_id": "s1",
+    "status": "COMPLETED",
+}
+
+
+def _session(runs):
+    return WorkflowSession.from_dict({"session_id": "s1", "workflow_id": "wf", "runs": runs})
+
+
+class TestWorkflowSessionRuns:
+    def test_member_agent_run_is_not_a_session_run(self):
+        session = _session([WORKFLOW_RUN, MEMBER_AGENT_RUN])
+        assert [r.run_id for r in session.runs] == ["wf-1"]
+
+    def test_member_team_run_is_not_a_session_run(self):
+        session = _session([WORKFLOW_RUN, MEMBER_TEAM_RUN])
+        assert [r.run_id for r in session.runs] == ["wf-1"]
+
+    def test_a_member_run_without_metrics_does_not_become_a_phantom_workflow_run(self):
+        # This one never raised -- it minted a workflow run carrying the member's content.
+        no_metrics = {k: v for k, v in MEMBER_AGENT_RUN.items() if k != "metrics"}
+        session = _session([WORKFLOW_RUN, no_metrics])
+        assert [r.run_id for r in session.runs] == ["wf-1"]
+        assert all(r.workflow_id == "wf" for r in session.runs)
+
+    def test_the_workflows_own_runs_are_all_kept(self):
+        second = {**WORKFLOW_RUN, "run_id": "wf-2", "status": "COMPLETED"}
+        session = _session([WORKFLOW_RUN, second])
+        assert [r.run_id for r in session.runs] == ["wf-1", "wf-2"]
+
+    def test_a_paused_run_is_still_a_session_run(self):
+        session = _session([WORKFLOW_RUN])
+        assert [r.status for r in session.runs] == ["PAUSED"]
+
+
+class TestMemberRunIdentifiedByNameAlone:
+    """A member run persisted without its id still identifies itself by name."""
+
+    def test_agent_run_with_only_a_name_is_not_a_session_run(self):
+        by_name = {"run_id": "ag-2", "agent_name": "Deployer", "session_id": "s1", "content": "x"}
+        session = _session([WORKFLOW_RUN, by_name])
+        assert [r.run_id for r in session.runs] == ["wf-1"]
+
+    def test_team_run_with_only_a_name_is_not_a_session_run(self):
+        by_name = {"run_id": "tm-2", "team_name": "Squad", "session_id": "s1"}
+        session = _session([WORKFLOW_RUN, by_name])
+        assert [r.run_id for r in session.runs] == ["wf-1"]


### PR DESCRIPTION
## Summary

A workflow session was returning a step's member run as one of its own top-level runs.

The runs table keys every run by `session_id`, and a step's agent or team run shares the workflow's session id. So `get_session()` hands those rows back as the session's runs, and `WorkflowSession.from_dict` deserializes each one as a `WorkflowRunOutput`:

- with metrics → `KeyError: 'steps'`, because an agent's metrics have no `steps` key
- without metrics → **no error at all**; a `WorkflowRunOutput` with no `workflow_id` is minted carrying the member's content

The read is wrapped in a `try/except` that reports it as *"Exception reading from session table"*, so a paused workflow simply stops and can never be resumed. On `AsyncPostgresDb` it is swallowed entirely and `get_session` returns `None`.

This is a v3.0 regression. Before runs were denormalized into `agno_runs`, the session's run list was written from `session.runs`, which only ever held the workflow's own runs.

### The fix

Skip runs that identify as an agent or a team. Nothing is lost — the workflow run already carries them in `step_executor_runs`, and the rows stay retrievable via `db.get_runs(session_id=...)`.

```python
if get_run_type(run_item) != "workflow":
    continue
```

`get_run_type` now matches on `agent_name`/`team_name` as well as the ids, mirroring the dispatch already in `WorkflowRunOutput.from_dict`, so a member run persisted without its id is still recognised. `WorkflowRunOutput` carries neither name field, so this cannot drop a genuine workflow run.

### Also included

Two eval adapter defects found alongside it:

- **`DynamoDb.rename_eval_run`** — `update_item` is an upsert, so renaming an absent run created a phantom item with no `eval_type`, and every later read of the table then failed. The condition guarding this only applied when a `user_id` was passed.
- **`ClickhouseDb.delete_eval_runs`** — missing the `user_id` parameter its base class declares.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes
