### PR TITLE
fix: install a usable Postgres driver with the postgres and dev extras

### DIFF
--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -63,6 +63,9 @@ dev = [
   "sqlalchemy",
   "aiosqlite",
   "greenlet",
+  # Driver for the Postgres adapter suites under tests/unit/db; without it
+  # they importorskip away and only the SQLite half of each guard is run.
+  "agno[postgres]",
   # First-party interfaces exercised by the unit suite
   "agno[slack]",
   "agno[agui]",
@@ -144,7 +147,7 @@ opencv = ["opencv-python"]
 oxylabs = ["oxylabs"]
 parallel = ["parallel-web>=1.0"]
 plivo = ["plivo"]
-psycopg = ["psycopg-binary", "psycopg"]
+psycopg = ["psycopg[binary]"]
 redmine = ["python-redmine"]
 redshift = ["redshift-connector"]
 reportlab = ["reportlab"]
@@ -172,7 +175,7 @@ async-postgres = ["asyncpg"]
 firestore = ["google-cloud-firestore"]
 gcs = ["google-cloud-storage"]
 mysql = ["pymysql", "asyncmy"]
-postgres = ["psycopg-binary"]
+postgres = ["sqlalchemy", "psycopg[binary]"]
 redis = ["redis>=4.5.4", "redisvl>=0.12.1"]  # >=4.5.4: safe cancellation of blocking commands (XREAD in event stream tail)
 sql = ["sqlalchemy"]
 sqlite = ["sqlalchemy", "aiosqlite"]


### PR DESCRIPTION
## Summary

`pip install "agno[postgres]"` did not install a working Postgres driver, and the dev environment could not run the Postgres adapter tests.

**The `postgres` extra was `["psycopg-binary"]`.** `psycopg-binary` is not the driver. It is the companion package that ships the compiled C accelerator, and it does not depend on `psycopg`. So the extra installed no importable `psycopg` module. It also installed no engine layer, unlike the neighbouring `sqlite = ["sqlalchemy", "aiosqlite"]`. On a clean environment:

```
$ pip install -e "libs/agno[postgres]"
$ python -c "from agno.db.postgres import PostgresDb; PostgresDb(db_url='postgresql+psycopg://...')"
ModuleNotFoundError: No module named 'sqlalchemy'
```

**The `dev` extra declared no Postgres driver at all.** The venv built by `./scripts/dev_setup.sh` therefore had no `psycopg`, and the five suites under `libs/agno/tests/unit/db/` that call `pytest.importorskip("psycopg")` skipped in full:

```
$ pytest libs/agno/tests/unit/db/test_component_catalog_hardening_postgres.py
SKIPPED [1] .../test_component_catalog_hardening_postgres.py:32: could not import 'psycopg'
no tests collected in 0.28s
```

This reads as "nothing to run" rather than as a failure, so it went unnoticed. CI hides it too: `.github/workflows/test.yml` installs `psycopg[binary]` inline, so the Postgres jobs are green while every local dev run is dark.

### Changes

All in `libs/agno/pyproject.toml`:

| Extra | Before | After |
|---|---|---|
| `postgres` | `["psycopg-binary"]` | `["sqlalchemy", "psycopg[binary]"]` |
| `psycopg` | `["psycopg-binary", "psycopg"]` | `["psycopg[binary]"]` |
| `dev` | no Postgres driver | adds `"agno[postgres]"` |

`postgres` now pairs the engine with its driver the same way `sqlite` does. `psycopg` keeps the identical set of packages but uses the one spelling that locks the accelerator to the driver version instead of letting the two float apart. `dev` pulls the driver so the adapter suites run locally.

### Effect

Across the eight `*postgres*.py` suites in `libs/agno/tests/unit/db/`, in a venv built only from `agno[dev]`:

| | Before | After |
|---|---|---|
| Modules collected | 3 of 8 | 8 of 8 |
| Tests run | 31 passed, 5 modules skipped | **110 passed** |

79 tests that never ran for any developer now run. `agno[storage]` gains a real driver as a side effect, since it composes `agno[postgres]`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**How this was verified.** Every check below used a throwaway venv built from this branch, not the working `.venv`.

- `agno[postgres]` alone now opens a real connection: `PostgresDb(...).db_engine.connect()` returns `PostgreSQL 18.1`. On the base branch the same script raises `ModuleNotFoundError`.
- A fresh venv from `agno[dev]` (the exact `dev_setup.sh` install line) resolves `psycopg 3.3.4`, and the originally reported file goes from `no tests collected` to `52 passed`.
- Removing only the driver from that venv reproduces the old result, which confirms the driver is what the change added.
- `agno[psycopg]` resolves to the same two packages as before, so the tools path is unchanged.
- `agno[tests]` is unaffected; it already reached `psycopg` through `agno[tools]`.
- Resolved for `x86_64-unknown-linux-gnu` as well as macOS arm64, so the CI runners get the same result.
- `./scripts/format.sh` reports no changes. `./scripts/validate.sh` passes, with mypy clean across 975 source files. That last point matters because `psycopg` ships `py.typed`: now that `style-check-agno` installs it via `.[dev]`, mypy reads its real types rather than the missing-import override, and it still passes.

**Not changed.** `.github/workflows/test.yml` still installs `psycopg[binary]` inline. That line is now redundant, but it is the thing that keeps a resolution regression from silently turning the Postgres jobs green-and-empty again, so it is worth keeping.

**Follow-up, not in this PR.** `mysql = ["pymysql", "asyncmy"]` has the same shape as the old `postgres`: drivers with no `sqlalchemy`, so `agno[mysql]` is not usable on its own either.
