### PR TITLE
cookbook: add emem entry to MCP cookbook README index

### DIFF
--- a/cookbook/91_tools/mcp/README.md
+++ b/cookbook/91_tools/mcp/README.md
@@ -42,7 +42,7 @@ This example connects to the hosted DeepWiki MCP server (public, no API key) to 
 
 10. emem Agent (`emem.py`)
 
-This example connects to the hosted emem MCP server (public, no API key) for shared, signed memory of the physical world. It shows how to ground a place, recall a signed fact, and hand another agent a token it can verify offline.
+This example connects to the hosted emem MCP server (public, no API key) for shared, signed memory of the physical world. It shows an agent answering a plain-language question about a place by calling emem's MCP tools directly.
 
 
 ## Getting Started

--- a/cookbook/91_tools/mcp/README.md
+++ b/cookbook/91_tools/mcp/README.md
@@ -40,6 +40,10 @@ This example shows how to create an agent that uses MCP and Gemini 2.5 Pro to se
 
 This example connects to the hosted DeepWiki MCP server (public, no API key) to answer questions about GitHub repositories. It shows how a tool's `structuredContent` is preserved on `ToolResult.metadata["structured_content"]` and read back through a tool hook.
 
+10. emem Agent (`emem.py`)
+
+This example connects to the hosted emem MCP server (public, no API key) for shared, signed memory of the physical world. It shows how to ground a place, recall a signed fact, and hand another agent a token it can verify offline.
+
 
 ## Getting Started
 
@@ -66,6 +70,7 @@ python filesystem.py
 python github.py
 python bgpt.py
 python structured_content.py
+python emem.py
 ```
 
 ## How It Works


### PR DESCRIPTION
Follow-up to #9624, which added the emem.py cookbook example but did not add it to this directory's README index.