### PR TITLE
fix: file-generation import warnings fire only when PDF/DOCX is requested

### DIFF
--- a/libs/agno/agno/tools/file_generation.py
+++ b/libs/agno/agno/tools/file_generation.py
@@ -21,7 +21,9 @@ try:
     PDF_AVAILABLE = True
 except ImportError as e:
     PDF_AVAILABLE = False
-    log_warning(
+    # Missing optional deps only matter if PDF generation is requested — the
+    # constructor warns then. At import time this is expected, so debug only.
+    log_debug(
         f"reportlab not installed. PDF generation will not be available. Install with: pip install reportlab: {str(e)}"
     )
 
@@ -31,7 +33,7 @@ try:
     DOCX_AVAILABLE = True
 except ImportError as e:
     DOCX_AVAILABLE = False
-    log_warning(
+    log_debug(
         f"python-docx not installed. DOCX generation will not be available. Install with: pip install python-docx: {str(e)}"
     )
 


### PR DESCRIPTION
## Problem

`FileGenerationTools` logs two warnings at **module import time** when the optional PDF/DOCX deps are missing:

```
WARNING reportlab not installed. PDF generation will not be available. ...
WARNING python-docx not installed. DOCX generation will not be available. ...
```

Every platform that mounts the toolkit sees these on boot — including deployments that explicitly opted out with `enable_pdf_generation=False, enable_docx_generation=False`. The missing dep only matters when the feature is requested, and the constructor already warns for that case ("PDF generation requested but reportlab is not installed. Disabling PDF generation.").

## Fix

Drop the import-guard messages to `log_debug`. The constructor warnings are untouched and remain the signal for the real misconfiguration.

Behavior with the deps blocked, after this change:

| Moment | Warning? |
|---|---|
| `import agno.tools.file_generation` | no (debug only) |
| `FileGenerationTools(enable_pdf_generation=False, enable_docx_generation=False)` | no |
| `FileGenerationTools()` (PDF/DOCX requested by default) | yes — both constructor warnings |

## Tests

`tests/unit/tools/test_file_generation.py`: 53 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)