### PR TITLE
fix: workflow event serialization survives cyclic object graphs

### DIFF
--- a/libs/agno/agno/run/workflow.py
+++ b/libs/agno/agno/run/workflow.py
@@ -100,17 +100,34 @@ class BaseWorkflowRunOutputEvent(BaseRunOutputEvent):
     nested_depth: int = 0
 
     def to_dict(self) -> Dict[str, Any]:
-        # Temporarily clear run_output before asdict() to avoid infinite recursion:
-        # WorkflowCompletedEvent.run_output -> WorkflowRunOutput.events -> WorkflowCompletedEvent.run_output -> ...
-        # asdict() recursively traverses all fields before we can filter, so we must clear it first.
-        saved_run_output = getattr(self, "run_output", None)
-        if saved_run_output is not None:
-            object.__setattr__(self, "run_output", None)
+        # Temporarily clear the DEEP fields before asdict(): it traverses
+        # every dataclass field BEFORE the post-hoc filter can drop a key,
+        # and these object graphs can reach back to this very event -
+        # run_output.events contains it, and
+        # step_requirements[].step_input.workflow_session.runs[].events
+        # contains it too (the WS HITL continue leg produces exactly that
+        # shape once the event lands on the live run). asdict() has no cycle
+        # detection, so traversal is fatal; each cleared field is
+        # re-serialized below through its own cycle-safe to_dict.
+        _deep_fields = (
+            "run_output",
+            "step_requirements",
+            "step_results",
+            "step_executor_runs",
+            "step_response",
+            "iteration_results",
+        )
+        _saved: Dict[str, Any] = {}
+        for _name in _deep_fields:
+            _value = getattr(self, _name, None)
+            if _value is not None:
+                _saved[_name] = _value
+                object.__setattr__(self, _name, None)
         try:
             _dict = {k: v for k, v in asdict(self).items() if v is not None and k not in ("run_output", "metrics")}
         finally:
-            if saved_run_output is not None:
-                object.__setattr__(self, "run_output", saved_run_output)
+            for _name, _value in _saved.items():
+                object.__setattr__(self, _name, _value)
 
         if hasattr(self, "content") and self.content and isinstance(self.content, BaseModel):
             _dict["content"] = self.content.model_dump(exclude_none=True)

--- a/libs/agno/tests/unit/run/test_workflow_event_cycle_serialization.py
+++ b/libs/agno/tests/unit/run/test_workflow_event_cycle_serialization.py
@@ -1,0 +1,80 @@
+"""Workflow event serialization survives cyclic object graphs.
+
+dataclasses.asdict() traverses every field with NO cycle detection, and a
+workflow event's deep fields can reach back to the event itself:
+run_output.events contains the event, and
+step_requirements[].step_input.workflow_session.runs[].events contains it
+too - the WS HITL continue leg produces exactly that shape once the event
+lands on the live run's event list. The blowup was racy in the wild
+(depends on whether the append beat the serialization) and silently
+dropped the event from every sink: to_json failed, the event-stream
+publish failed, and the WebSocket delivery failed.
+"""
+
+import json
+
+from agno.run.base import RunStatus
+from agno.run.workflow import WorkflowPausedEvent, WorkflowRunOutput
+from agno.session.workflow import WorkflowSession
+from agno.utils.serialize import json_serializer
+from agno.workflow.types import StepInput, StepRequirement
+
+
+def _build_cyclic_paused_event() -> WorkflowPausedEvent:
+    """The exact field path from the field repro:
+    event.step_requirements[].step_input.workflow_session.runs[].events[]
+    -> the same event object."""
+    event = WorkflowPausedEvent(run_id="r-cycle", workflow_id="wf-1", workflow_name="WF", session_id="s-cycle")
+    run_output = WorkflowRunOutput(
+        run_id="r-cycle", workflow_id="wf-1", workflow_name="WF", session_id="s-cycle", status=RunStatus.paused
+    )
+    run_output.events = [event]  # the live run carries the event...
+    session = WorkflowSession(session_id="s-cycle", workflow_id="wf-1", runs=[run_output])
+    step_input = StepInput(input="v1.2.3", workflow_session=session)
+    requirement = StepRequirement(
+        step_id="step-1",
+        step_name="Inspect Release",
+        step_index=0,
+        requires_confirmation=True,
+        step_input=step_input,  # ...and the requirement's input reaches the live session
+    )
+    event.step_requirements = [requirement]
+    return event
+
+
+class TestCyclicEventSerialization:
+    def test_paused_event_reaching_itself_serializes(self):
+        event = _build_cyclic_paused_event()
+
+        data = event.to_dict()  # RecursionError on unfixed source
+
+        assert data["run_id"] == "r-cycle"
+        reqs = data["step_requirements"]
+        assert reqs and reqs[0]["step_id"] == "step-1"
+        # The whole payload must survive the wire encoding too
+        json.dumps(data, default=json_serializer)
+        assert event.to_json()
+
+    def test_deep_fields_are_restored_after_serialization(self):
+        """The asdict cycle-guard temporarily clears the deep fields; a
+        failure to restore would corrupt the LIVE event other sinks and the
+        session store still read."""
+        event = _build_cyclic_paused_event()
+        requirement = event.step_requirements[0]
+
+        event.to_dict()
+
+        assert event.step_requirements == [requirement], "deep fields must be restored after to_dict"
+        assert requirement.step_input is not None and requirement.step_input.workflow_session is not None
+
+    def test_run_output_cycle_still_covered(self):
+        """The previously-guarded cycle (run_output.events -> event) keeps
+        working with the widened guard."""
+        event = WorkflowPausedEvent(run_id="r-cycle2", workflow_id="wf-1", session_id="s")
+        run_output = WorkflowRunOutput(run_id="r-cycle2", workflow_id="wf-1", session_id="s")
+        run_output.events = [event]
+        event.run_output = run_output
+
+        data = event.to_dict()
+        assert "run_output" not in data  # excluded by long-standing contract
+        json.dumps(data, default=json_serializer)


### PR DESCRIPTION
## Summary

Fixes the `maximum recursion depth exceeded` errors seen when running `cookbook/05_agent_os/05_human_in_the_loop/workflow_hitl.py` through the workflow WebSocket door:

```
ERROR   Failed to convert response event to json: maximum recursion depth exceeded
WARNING Failed to publish event to event stream for workflow run <id>
WARNING Failed to handle WebSocket event: maximum recursion depth exceeded
```

The affected event was **silently dropped from every sink** — it never reached the event stream (so `/resume` replays are missing it) nor the socket. The UI appeared to work because the surviving events carried the flow.

### Root cause

`BaseWorkflowRunOutputEvent.to_dict` feeds the whole event to `dataclasses.asdict`, which traverses every dataclass field with **no cycle detection** — and the post-hoc key filter runs only after traversal, too late to help. The existing guard temp-clears `run_output` (the known `run_output.events → event` cycle) but there is a second route back to the event:

```
event.step_requirements[]              (StepRequirement)
    .step_input                        (StepInput — snapshot for the continuation)
        .workflow_session              (the LIVE WorkflowSession)
            .runs[].events[]           → the same event object
```

The requirement's `StepInput` carries the live session, whose run accumulates the very events being serialized. The WS HITL continue leg produces exactly this shape — and only **racily**, because the blowup depends on whether the event lands on `run.events` before or after serialization (which is why the repro was intermittent).

### Fix

The temp-clear guard now covers every deep field the method already re-serializes manually through its own cycle-safe `to_dict` (`step_requirements`, `step_results`, `step_executor_runs`, `step_response`, `iteration_results`) alongside `run_output`, with restore in a `finally`. Same pattern the code already used, applied to the whole class of deep fields instead of one.

### Verification

- New tests build the exact cyclic shape **deterministically** (the field repro was timing-dependent): the event serializes and JSON-encodes; the deep fields are restored afterwards (a lost restore would corrupt the live event for the session store and other sinks); the long-guarded `run_output` cycle stays covered. Both new-cycle tests `RecursionError` on unfixed source.
- Six consecutive end-to-end WS HITL flows (start → three pauses → completion over the real `/workflows/ws` door via TestClient) run clean with the fix; the same harness reproduced the errors on unfixed source.
- Full `unit/workflow` + `unit/run` suites green (738 tests); ruff and mypy clean on the changed file.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

- Pre-existing bug, unrelated to the reliability-wave PRs — reproducible on the feat/v3.0 tip.
- The clear/restore mutation window during `asdict` is the pre-existing pattern (`run_output` used it already); the restore-verification test pins that widening the field set did not introduce a lost-restore path.
