### PR TITLE
fix: accept the base's run_response in RampRouter.get_request_params

### DIFF
--- a/libs/agno/agno/models/ramp/router.py
+++ b/libs/agno/agno/models/ramp/router.py
@@ -9,6 +9,7 @@ from agno.metrics import MessageMetrics
 from agno.models.message import Message
 from agno.models.openai.open_responses import OpenResponses
 from agno.models.response import ModelResponse
+from agno.run.agent import RunOutput
 from agno.tools.function import Function
 from agno.utils.log import log_warning
 
@@ -178,6 +179,7 @@ class RampRouter(OpenResponses):
         response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
         tools: Optional[List[Dict[str, Any]]] = None,
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
+        run_response: Optional[RunOutput] = None,
     ) -> Dict[str, Any]:
         """
         Returns keyword arguments for API requests, including the Router-only request fields.
@@ -190,6 +192,7 @@ class RampRouter(OpenResponses):
             response_format=response_format,
             tools=tools,
             tool_choice=tool_choice,
+            run_response=run_response,
         )
 
         # The OpenAI SDK's create() has a closed signature, so Router-only body fields ride in


### PR DESCRIPTION
## What broke

The xAI OAuth PR (#9616) adds a `run_response` parameter to `OpenAIResponses.get_request_params()`, and all four invoke legs (`invoke`, `ainvoke`, `invoke_stream`, `ainvoke_stream`) pass it down as a keyword.

`RampRouter` overrides `get_request_params()`. An override does not pick up the new parameter, so once that base change lands, every RampRouter request dies before it reaches the wire:

```
TypeError: RampRouter.get_request_params() got an unexpected keyword argument 'run_response'
```

## The fix

Accept `run_response` and forward it to `super()`. This is the same shape `OpenRouterResponses` already uses, which carries the parameter for exactly this reason. One file, three lines.

## Merge order: this goes AFTER #9616

Please do not merge this on its own. The forward to `super()` is only valid once the base accepts the parameter. On current `feat/v3.0` without #9616, this change makes ramp worse rather than better: the suite goes from 38 of 38 passing to 15 failures, plus one new mypy `call-arg` error. Both clear the moment #9616 lands.

## Evidence

Measured against `feat/v3.0` merged with the xAI branch, which is the state that reproduces the bug.

- `feat/v3.0` alone, before anything: ramp suite 38 of 38 green.
- Merged with the xAI branch, no fix: 6 failing, 32 passing.
- Merged with the xAI branch, with this fix: 43 passing (38 ramp, plus the 5 in the lineage guard).
- Across the whole `unit/models/` tree the fix removes 7 failures and adds none.
- mypy stays at baseline on the merged tree (26 errors in 5 files, unchanged).

All four invoke legs were verified by execution against a stub transport, including both async legs, and each one fails with the `TypeError` above when the fix is reverted.

No new test is added here. #9616 already ships a lineage guard, `test_no_responses_subclass_narrows_the_signature`, which walks the model package and catches any Responses subclass that narrows this signature. It fails without this change and passes with it, so it already proves the fix in both directions and already covers `RampRouter`. A second guard would duplicate it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Code complies with style guidelines
- [x] Ran `./scripts/format.sh` and `./scripts/validate.sh`
- [x] Self-review completed
- [x] Verified against the merged base that reproduces the failure
