### PR TITLE
feat: read offloaded media back with get_content_bytes/get_url

### DIFF
--- a/cookbook/06_storage/10_media_storage_workflow.py
+++ b/cookbook/06_storage/10_media_storage_workflow.py
@@ -2,12 +2,11 @@
 Workflow Media Storage (S3)
 ===========================
 
-Demonstrates media offload across a workflow. A workflow persists media from three places,
-and all of them are offloaded to S3 with only a MediaReference kept in the database:
+Demonstrates media offload across a workflow. A workflow persists media from two places,
+and both are offloaded to S3 with only a MediaReference kept in the database:
 
 - media attached to workflow.run(images=...)
-- media a step's agent or team produced
-- media nested inside a container step (Loop, Condition, Router, Parallel, Steps)
+- media a step's agent produced
 
 Step inputs are rehydrated before each step runs, so a step downstream of an offloaded
 one receives the bytes rather than an empty pointer.

--- a/cookbook/06_storage/10_media_storage_workflow.py
+++ b/cookbook/06_storage/10_media_storage_workflow.py
@@ -1,0 +1,117 @@
+"""
+Workflow Media Storage (S3)
+===========================
+
+Demonstrates media offload across a workflow. A workflow persists media from three places,
+and all of them are offloaded to S3 with only a MediaReference kept in the database:
+
+- media attached to workflow.run(images=...)
+- media a step's agent or team produced
+- media nested inside a container step (Loop, Condition, Router, Parallel, Steps)
+
+Step inputs are rehydrated before each step runs, so a step downstream of an offloaded
+one receives the bytes rather than an empty pointer.
+
+Requirements:
+- uv pip install 'agno[s3]'
+- AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION
+- Set MEDIA_S3_BUCKET to a bucket you own
+"""
+
+import os
+
+import httpx
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.media import Image
+from agno.media.storage import S3MediaStorage
+from agno.models.openai import OpenAIResponses
+from agno.workflow import Step, Workflow
+
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
+IMAGE_URL = "https://thumbs.dreamstime.com/b/mountain-landscape-pieniny-national-park-foot-tatra-mountains-mountain-landscape-pieniny-national-park-437239881.jpg?w=768"
+
+# A bucket you do not own makes every upload fail, and offload falls back to inline
+# base64 — the run still succeeds, so the failure is easy to miss. Ask for the bucket
+# up front instead.
+bucket = os.getenv("MEDIA_S3_BUCKET")
+if not bucket:
+    raise ValueError("MEDIA_S3_BUCKET must be set to an S3 bucket you own")
+
+storage = S3MediaStorage(
+    bucket=bucket,
+    region=os.getenv(
+        "AWS_REGION"
+    ),  # unset falls back to AWS_DEFAULT_REGION or ~/.aws/config
+    prefix="agno/workflow-media/",
+    presigned_url_expiry=3600,
+)
+
+# ---------------------------------------------------------------------------
+# Steps
+# ---------------------------------------------------------------------------
+
+describer = Agent(
+    name="Describer",
+    model=OpenAIResponses(id="gpt-5.5"),
+    instructions=["Describe the attached image in two sentences."],
+)
+
+summarizer = Agent(
+    name="Summarizer",
+    model=OpenAIResponses(id="gpt-5.5"),
+    instructions=["Rewrite the description you are given as a single short caption."],
+)
+
+# The second step runs after the first has been persisted, so its step input is
+# rehydrated from storage before the model sees it.
+workflow = Workflow(
+    name="Image Description Workflow",
+    db=SqliteDb(db_file="tmp/workflow_media.db"),
+    media_storage=storage,
+    store_media=True,
+    steps=[
+        Step(name="describe", agent=describer),
+        Step(name="summarize", agent=summarizer),
+    ],
+)
+
+# ---------------------------------------------------------------------------
+# Run the Workflow
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    # Download the image so the workflow sends bytes. URL-only media is skipped during
+    # offload unless the backend is built with persist_remote_urls=True.
+    image_bytes = httpx.get(IMAGE_URL, follow_redirects=True).content
+
+    session_id = "workflow-media-session"
+    response = workflow.run(
+        input="Describe this image, then caption it.",
+        images=[Image(content=image_bytes, format="jpeg", mime_type="image/jpeg")],
+        session_id=session_id,
+    )
+    print(response.content)
+
+    # What landed in the database: a pointer, not the bytes. A workflow keeps its media on
+    # run.images and on each step result, not under run.input the way an agent run does.
+    session = workflow.get_session(session_id=session_id)
+    for run in session.runs or []:
+        media = list(run.images or [])
+        for step_result in run.step_results or []:
+            for step_output in (
+                step_result if isinstance(step_result, list) else [step_result]
+            ):
+                media.extend(step_output.images or [])
+
+        for image in media:
+            reference = image.media_reference
+            if reference is None:
+                print("\nImage was NOT offloaded (kept inline)")
+                continue
+            print("\nOffloaded to object storage")
+            print(f"  storage key : {reference.storage_key}")
+            print(f"  bucket      : {reference.bucket}")
+            print(f"  size        : {reference.size} bytes")
+            print(f"  inline bytes: {image.content}")

--- a/cookbook/06_storage/11_media_storage_file_generation.py
+++ b/cookbook/06_storage/11_media_storage_file_generation.py
@@ -1,0 +1,128 @@
+"""
+Generated File Storage (S3)
+===========================
+
+Demonstrates media offload for files the agent *generates*, rather than files you attach.
+
+FileGenerationTools returns file bytes on the run, and media storage treats them exactly
+like an attachment: the bytes go to S3 and the database row keeps only a MediaReference.
+The generated filename and mime type travel onto the reference, so a reader knows what the
+object is without downloading it.
+
+Note save_files=False below. The tool can also write to a local directory, but that is a
+separate copy on the machine that ran the agent — media storage is what makes a generated
+file retrievable from anywhere.
+
+Reading one back: pass the storage handle to get_content_bytes(storage=...) for the bytes,
+or get_url(storage=...) for a freshly-signed link. Both have async variants.
+
+Requirements:
+- uv pip install 'agno[s3]'
+- AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION
+- Set MEDIA_S3_BUCKET to a bucket you own
+"""
+
+import os
+from pathlib import Path
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.media.storage import S3MediaStorage
+from agno.models.openai import OpenAIResponses
+from agno.tools.file_generation import FileGenerationTools
+
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
+
+# A bucket you do not own makes every upload fail, and offload falls back to inline
+# base64 — the run still succeeds, so the failure is easy to miss. Ask for the bucket
+# up front instead.
+bucket = os.getenv("MEDIA_S3_BUCKET")
+if not bucket:
+    raise ValueError("MEDIA_S3_BUCKET must be set to an S3 bucket you own")
+
+storage = S3MediaStorage(
+    bucket=bucket,
+    region=os.getenv(
+        "AWS_REGION"
+    ),  # unset falls back to AWS_DEFAULT_REGION or ~/.aws/config
+    prefix="agno/generated/",
+    presigned_url_expiry=3600,
+)
+
+# ---------------------------------------------------------------------------
+# Create the Agent
+# ---------------------------------------------------------------------------
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.5"),
+    db=SqliteDb(db_file="tmp/generated_media.db"),
+    media_storage=storage,
+    store_media=True,
+    # save_files=False keeps the bytes on the run, which is what media storage offloads.
+    tools=[FileGenerationTools(all=True, save_files=False)],
+    instructions=[
+        "Use the appropriate file-generation tool when asked for an output file.",
+        "Always use a descriptive filename with the correct extension.",
+        "Briefly explain what you generated.",
+    ],
+    markdown=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run the Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    session_id = "generated-media-session"
+
+    response = agent.run(
+        "Generate a CSV of the five largest planets with their diameter in km.",
+        session_id=session_id,
+    )
+    print(response.content)
+
+    # The generated file on the live run still carries its bytes — offload works on a
+    # copy, so what run() hands back is never emptied.
+    for file in response.files or []:
+        size = len(file.content) if file.content else 0
+        print(f"\nOn the returned run: {file.filename} ({size} bytes in memory)")
+
+    # The database row holds a pointer instead.
+    session = agent.get_session(session_id=session_id)
+    for run in session.runs or []:
+        for file in run.files or []:
+            reference = file.media_reference
+            if reference is None:
+                print("\nFile was NOT offloaded (kept inline)")
+                continue
+            print("\nIn the database row")
+            print(f"  filename    : {reference.filename}")
+            print(f"  mime type   : {reference.mime_type}")
+            print(f"  storage key : {reference.storage_key}")
+            print(f"  size        : {reference.size} bytes")
+            print(f"  inline bytes: {file.content}")
+
+            # -------------------------------------------------------------
+            # Reading an offloaded file back
+            # -------------------------------------------------------------
+            # Pass the storage handle and the media object resolves itself. Without it,
+            # a row that carries only a reference has no bytes to return.
+            data = file.get_content_bytes(storage=storage)
+            print(f"  downloaded  : {len(data) if data else 0} bytes")
+            if data:
+                first_line = data.decode("utf-8", errors="replace").splitlines()[0]
+                print(f"  first line  : {first_line}")
+
+            # A link to hand to a browser, re-signed from storage_key. None means the
+            # backend cannot sign (local storage, or GCS with application-default
+            # credentials) — read the bytes instead.
+            url = file.get_url(storage=storage)
+            print(f"  signed url  : {url[:80] + '...' if url else 'not available'}")
+
+            # Save it locally
+            if data and reference.filename:
+                output_path = Path("tmp") / reference.filename
+                output_path.parent.mkdir(parents=True, exist_ok=True)
+                output_path.write_bytes(data)
+                print(f"  saved to    : {output_path}")

--- a/cookbook/06_storage/README.md
+++ b/cookbook/06_storage/README.md
@@ -72,6 +72,8 @@ uv pip install 'agno[gcs]'  # GCS (google-cloud-storage)
 - [`07_media_storage_multiturn.py`](07_media_storage_multiturn.py) - Multi-turn media reuse: offload on turn 1, reference reloaded on turn 2
 - [`08_media_storage_gcs.py`](08_media_storage_gcs.py) - Offload media to Google Cloud Storage (GCSMediaStorage)
 - [`09_media_storage_delete.py`](09_media_storage_delete.py) - Delete a session's stored objects along with its rows (delete_media=True)
+- [`10_media_storage_workflow.py`](10_media_storage_workflow.py) - Offload media across a workflow's steps (S3)
+- [`11_media_storage_file_generation.py`](11_media_storage_file_generation.py) - Offload files the agent generates, and read one back with get_content_bytes(storage=...)
 
 ### Enable this only after the whole fleet is upgraded
 

--- a/cookbook/06_storage/TEST_LOG.md
+++ b/cookbook/06_storage/TEST_LOG.md
@@ -77,3 +77,27 @@
 **Result:** Exit 0. Two objects in S3 after the runs; deleting the first session without the flag left both; deleting the second with `delete_media=True` swept only its own object, leaving one — the deliberate orphan from the un-flagged delete, which the example prints by key.
 
 ---
+
+### 10_media_storage_workflow.py
+
+**Status:** PASS
+
+**Test mode:** LIVE
+
+**Description:** A workflow offloads both the image passed to `workflow.run(images=...)` and the image a step's agent produced, to a real S3 bucket (`MEDIA_S3_BUCKET`). Ran with `OpenAIResponses(id="gpt-5.5")`.
+
+**Result:** Exit 0. The run row carried a MediaReference with `inline bytes: None`; the object was 65129 bytes in the bucket.
+
+---
+
+### 11_media_storage_file_generation.py
+
+**Status:** PASS
+
+**Test mode:** LIVE
+
+**Description:** `FileGenerationTools` generates a CSV, media storage offloads it to a real S3 bucket, and the example reads it back with `get_content_bytes(storage=...)` and mints a link with `get_url(storage=...)`. Ran with `OpenAIResponses(id="gpt-5.5")`.
+
+**Result:** Exit 0. The row kept only a reference (`inline bytes: None`); the read-back returned 93 bytes with the correct first line, and `get_url` returned a real presigned S3 URL.
+
+---

--- a/libs/agno/agno/media/media.py
+++ b/libs/agno/agno/media/media.py
@@ -6,7 +6,8 @@ from uuid import uuid4
 from pydantic import BaseModel, field_validator, model_validator
 
 from agno.media.reference import MediaReference
-from agno.utils.log import log_error
+from agno.media.storage.base import AsyncMediaStorage, MediaStorage
+from agno.utils.log import log_error, log_warning
 
 
 def bytes_and_mime_from_url(url: str) -> Tuple[Optional[bytes], Optional[str]]:
@@ -48,39 +49,67 @@ async def _abytes_from_url(url: str) -> Optional[bytes]:
     return content
 
 
-def _resolve_from_storage(media: Any, storage: Any) -> Optional[bytes]:
+def _bytes_from_url_or_storage(
+    media: Any, url: str, storage: Optional[Union[MediaStorage, AsyncMediaStorage]]
+) -> Optional[bytes]:
+    """Read ``url``, falling back to the stored object when the fetch fails.
+
+    A storage handle names the copy this feature made, so an unreachable url is not the
+    end of the road. Without one the fetch error surfaces, as it does without a handle.
+    """
+    try:
+        return _bytes_from_url(url)
+    except Exception:
+        if storage is None or getattr(media, "media_reference", None) is None:
+            raise
+    return _resolve_from_storage(media, storage)
+
+
+async def _abytes_from_url_or_storage(
+    media: Any, url: str, storage: Optional[Union[MediaStorage, AsyncMediaStorage]]
+) -> Optional[bytes]:
+    """Async variant of :func:`_bytes_from_url_or_storage`."""
+    try:
+        return await _abytes_from_url(url)
+    except Exception:
+        if storage is None or getattr(media, "media_reference", None) is None:
+            raise
+    return await _aresolve_from_storage(media, storage)
+
+
+def _resolve_from_storage(media: Any, storage: Optional[Union[MediaStorage, AsyncMediaStorage]]) -> Optional[bytes]:
     """Read an offloaded object's bytes back through the backend that stored it.
 
     Returns None when ``media`` carries no reference, when ``storage`` is not the backend
     that minted it, or when the read fails — a caller that already has ``content``, a
-    ``url`` or a ``filepath`` never reaches here.
+    ``url`` or a ``filepath`` reads from those instead.
     """
-    from agno.media.storage.base import AsyncMediaStorage
-
     ref = getattr(media, "media_reference", None)
     if storage is None or ref is None or not ref.storage_key:
         return None
     if isinstance(storage, AsyncMediaStorage):
-        raise ValueError("Cannot resolve media with an AsyncMediaStorage from a sync call. Use the async variant.")
+        raise ValueError(
+            "Cannot use sync get_content_bytes() with an AsyncMediaStorage. Use aget_content_bytes() instead."
+        )
 
     from agno.utils.media_offload import reference_matches_storage
 
     # A key only resolves against the backend that wrote it, so a mismatched handle would
     # otherwise read a same-named object out of the wrong bucket.
     if not reference_matches_storage(ref, storage):
-        log_error(f"Media {getattr(media, 'id', '?')} was stored on another backend")
+        log_warning(f"Media {getattr(media, 'id', '?')} was stored on another backend, skipping")
         return None
     try:
         return storage.download(ref.storage_key)
     except Exception as e:
-        log_error(f"Could not read stored media {getattr(media, 'id', '?')} back: {e}")
+        log_warning(f"Could not read stored media {getattr(media, 'id', '?')} back: {type(e).__name__}: {e}")
         return None
 
 
-async def _aresolve_from_storage(media: Any, storage: Any) -> Optional[bytes]:
+async def _aresolve_from_storage(
+    media: Any, storage: Optional[Union[MediaStorage, AsyncMediaStorage]]
+) -> Optional[bytes]:
     """Async variant of :func:`_resolve_from_storage`."""
-    from agno.media.storage.base import AsyncMediaStorage
-
     ref = getattr(media, "media_reference", None)
     if storage is None or ref is None or not ref.storage_key:
         return None
@@ -88,7 +117,7 @@ async def _aresolve_from_storage(media: Any, storage: Any) -> Optional[bytes]:
     from agno.utils.media_offload import reference_matches_storage
 
     if not reference_matches_storage(ref, storage):
-        log_error(f"Media {getattr(media, 'id', '?')} was stored on another backend")
+        log_warning(f"Media {getattr(media, 'id', '?')} was stored on another backend, skipping")
         return None
     try:
         if isinstance(storage, AsyncMediaStorage):
@@ -96,46 +125,43 @@ async def _aresolve_from_storage(media: Any, storage: Any) -> Optional[bytes]:
         # A sync backend downloads in a worker thread rather than on the running loop.
         return await asyncio.to_thread(storage.download, ref.storage_key)
     except Exception as e:
-        log_error(f"Could not read stored media {getattr(media, 'id', '?')} back: {e}")
+        log_warning(f"Could not read stored media {getattr(media, 'id', '?')} back: {type(e).__name__}: {e}")
         return None
 
 
-def _url_from_storage(media: Any, storage: Any, expires_in: Optional[int] = None) -> Optional[str]:
+def _url_from_storage(
+    media: Any, storage: Optional[Union[MediaStorage, AsyncMediaStorage]], expires_in: Optional[int] = None
+) -> Optional[str]:
     """Re-sign a URL for an offloaded object from its ``storage_key``.
 
     Always re-derived rather than read off the reference: a persisted URL is either absent
     (the usual case, since a presigned one is never stored) or stale. Returns None when the
     backend cannot produce a usable link, which is the caller's cue to fetch bytes instead.
     """
-    from agno.media.storage.base import AsyncMediaStorage
-
     ref = getattr(media, "media_reference", None)
     if storage is None or ref is None or not ref.storage_key:
         return None
     if isinstance(storage, AsyncMediaStorage):
-        raise ValueError("Cannot resolve media with an AsyncMediaStorage from a sync call. Use the async variant.")
+        raise ValueError("Cannot use sync get_url() with an AsyncMediaStorage. Use aget_url() instead.")
 
     from agno.utils.media_offload import reference_matches_storage
 
     if not reference_matches_storage(ref, storage):
-        log_error(f"Media {getattr(media, 'id', '?')} was stored on another backend")
+        log_warning(f"Media {getattr(media, 'id', '?')} was stored on another backend, skipping")
         return None
     try:
         url = storage.get_url(ref.storage_key, expires_in=expires_in)
     except Exception as e:
-        log_error(f"Could not sign a URL for {getattr(media, 'id', '?')}: {e}")
+        log_warning(f"Could not sign a URL for {getattr(media, 'id', '?')}: {e}")
         return None
-    # "" is the backend saying it cannot sign, and file:// resolves only on the host that
-    # wrote it — neither is something a caller can hand to a browser or a model.
-    if not url or url.startswith("file://"):
-        return None
-    return url
+    # None is the backend saying it cannot sign, which is the caller's cue to fetch bytes.
+    return url or None
 
 
-async def _aurl_from_storage(media: Any, storage: Any, expires_in: Optional[int] = None) -> Optional[str]:
+async def _aurl_from_storage(
+    media: Any, storage: Optional[Union[MediaStorage, AsyncMediaStorage]], expires_in: Optional[int] = None
+) -> Optional[str]:
     """Async variant of :func:`_url_from_storage`."""
-    from agno.media.storage.base import AsyncMediaStorage
-
     ref = getattr(media, "media_reference", None)
     if storage is None or ref is None or not ref.storage_key:
         return None
@@ -143,7 +169,7 @@ async def _aurl_from_storage(media: Any, storage: Any, expires_in: Optional[int]
     from agno.utils.media_offload import reference_matches_storage
 
     if not reference_matches_storage(ref, storage):
-        log_error(f"Media {getattr(media, 'id', '?')} was stored on another backend")
+        log_warning(f"Media {getattr(media, 'id', '?')} was stored on another backend, skipping")
         return None
     try:
         if isinstance(storage, AsyncMediaStorage):
@@ -151,11 +177,9 @@ async def _aurl_from_storage(media: Any, storage: Any, expires_in: Optional[int]
         else:
             url = await asyncio.to_thread(storage.get_url, ref.storage_key, expires_in=expires_in)
     except Exception as e:
-        log_error(f"Could not sign a URL for {getattr(media, 'id', '?')}: {e}")
+        log_warning(f"Could not sign a URL for {getattr(media, 'id', '?')}: {e}")
         return None
-    if not url or url.startswith("file://"):
-        return None
-    return url
+    return url or None
 
 
 class Image(BaseModel):
@@ -215,14 +239,14 @@ class Image(BaseModel):
 
         return data
 
-    def get_content_bytes(self, storage: Any = None) -> Optional[bytes]:
+    def get_content_bytes(self, storage: Optional[Union[MediaStorage, AsyncMediaStorage]] = None) -> Optional[bytes]:
         """Get image content as raw bytes, loading from URL/file if needed"""
         if self.content:
             return self.content
         elif self.url:
-            return _bytes_from_url(self.url)
+            return _bytes_from_url_or_storage(self, self.url, storage)
         elif self.media_reference and self.media_reference.url:
-            return _bytes_from_url(self.media_reference.url)
+            return _bytes_from_url_or_storage(self, self.media_reference.url, storage)
         elif self.filepath:
             with open(self.filepath, "rb") as f:
                 return f.read()
@@ -230,32 +254,43 @@ class Image(BaseModel):
         # back through the storage handle the caller passes in.
         return _resolve_from_storage(self, storage)
 
-    async def aget_content_bytes(self, storage: Any = None) -> Optional[bytes]:
+    async def aget_content_bytes(
+        self, storage: Optional[Union[MediaStorage, AsyncMediaStorage]] = None
+    ) -> Optional[bytes]:
         if self.content:
             return self.content
         elif self.url:
-            return await _abytes_from_url(self.url)
+            return await _abytes_from_url_or_storage(self, self.url, storage)
         elif self.media_reference and self.media_reference.url:
-            return await _abytes_from_url(self.media_reference.url)
+            return await _abytes_from_url_or_storage(self, self.media_reference.url, storage)
         elif self.filepath:
             fp = self.filepath
             return await asyncio.to_thread(lambda: Path(fp).read_bytes())
         return await _aresolve_from_storage(self, storage)
 
-    def get_url(self, storage: Any = None, expires_in: Optional[int] = None) -> Optional[str]:
+    def get_url(
+        self, storage: Optional[Union[MediaStorage, AsyncMediaStorage]] = None, *, expires_in: Optional[int] = None
+    ) -> Optional[str]:
         """A URL a browser or model can fetch this media from, or None.
 
         Prefers a URL the media already carries, else re-signs one from the stored object.
         None means there is no fetchable link — read the bytes with ``get_content_bytes``.
+        Raises ValueError when ``storage`` is an AsyncMediaStorage; use ``aget_url``.
         """
         if self.url:
             return self.url
+        if self.media_reference is not None and self.media_reference.url:
+            return self.media_reference.url
         return _url_from_storage(self, storage, expires_in)
 
-    async def aget_url(self, storage: Any = None, expires_in: Optional[int] = None) -> Optional[str]:
+    async def aget_url(
+        self, storage: Optional[Union[MediaStorage, AsyncMediaStorage]] = None, *, expires_in: Optional[int] = None
+    ) -> Optional[str]:
         """Async variant of :meth:`get_url`."""
         if self.url:
             return self.url
+        if self.media_reference is not None and self.media_reference.url:
+            return self.media_reference.url
         return await _aurl_from_storage(self, storage, expires_in)
 
     def to_base64(self) -> Optional[str]:
@@ -365,14 +400,14 @@ class Audio(BaseModel):
 
         return data
 
-    def get_content_bytes(self, storage: Any = None) -> Optional[bytes]:
+    def get_content_bytes(self, storage: Optional[Union[MediaStorage, AsyncMediaStorage]] = None) -> Optional[bytes]:
         """Get audio content as raw bytes"""
         if self.content:
             return self.content
         elif self.url:
-            return _bytes_from_url(self.url)
+            return _bytes_from_url_or_storage(self, self.url, storage)
         elif self.media_reference and self.media_reference.url:
-            return _bytes_from_url(self.media_reference.url)
+            return _bytes_from_url_or_storage(self, self.media_reference.url, storage)
         elif self.filepath:
             with open(self.filepath, "rb") as f:
                 return f.read()
@@ -380,32 +415,43 @@ class Audio(BaseModel):
         # back through the storage handle the caller passes in.
         return _resolve_from_storage(self, storage)
 
-    async def aget_content_bytes(self, storage: Any = None) -> Optional[bytes]:
+    async def aget_content_bytes(
+        self, storage: Optional[Union[MediaStorage, AsyncMediaStorage]] = None
+    ) -> Optional[bytes]:
         if self.content:
             return self.content
         elif self.url:
-            return await _abytes_from_url(self.url)
+            return await _abytes_from_url_or_storage(self, self.url, storage)
         elif self.media_reference and self.media_reference.url:
-            return await _abytes_from_url(self.media_reference.url)
+            return await _abytes_from_url_or_storage(self, self.media_reference.url, storage)
         elif self.filepath:
             fp = self.filepath
             return await asyncio.to_thread(lambda: Path(fp).read_bytes())
         return await _aresolve_from_storage(self, storage)
 
-    def get_url(self, storage: Any = None, expires_in: Optional[int] = None) -> Optional[str]:
+    def get_url(
+        self, storage: Optional[Union[MediaStorage, AsyncMediaStorage]] = None, *, expires_in: Optional[int] = None
+    ) -> Optional[str]:
         """A URL a browser or model can fetch this media from, or None.
 
         Prefers a URL the media already carries, else re-signs one from the stored object.
         None means there is no fetchable link — read the bytes with ``get_content_bytes``.
+        Raises ValueError when ``storage`` is an AsyncMediaStorage; use ``aget_url``.
         """
         if self.url:
             return self.url
+        if self.media_reference is not None and self.media_reference.url:
+            return self.media_reference.url
         return _url_from_storage(self, storage, expires_in)
 
-    async def aget_url(self, storage: Any = None, expires_in: Optional[int] = None) -> Optional[str]:
+    async def aget_url(
+        self, storage: Optional[Union[MediaStorage, AsyncMediaStorage]] = None, *, expires_in: Optional[int] = None
+    ) -> Optional[str]:
         """Async variant of :meth:`get_url`."""
         if self.url:
             return self.url
+        if self.media_reference is not None and self.media_reference.url:
+            return self.media_reference.url
         return await _aurl_from_storage(self, storage, expires_in)
 
     def to_base64(self) -> Optional[str]:
@@ -531,14 +577,14 @@ class Video(BaseModel):
 
         return data
 
-    def get_content_bytes(self, storage: Any = None) -> Optional[bytes]:
+    def get_content_bytes(self, storage: Optional[Union[MediaStorage, AsyncMediaStorage]] = None) -> Optional[bytes]:
         """Get video content as raw bytes"""
         if self.content:
             return self.content
         elif self.url:
-            return _bytes_from_url(self.url)
+            return _bytes_from_url_or_storage(self, self.url, storage)
         elif self.media_reference and self.media_reference.url:
-            return _bytes_from_url(self.media_reference.url)
+            return _bytes_from_url_or_storage(self, self.media_reference.url, storage)
         elif self.filepath:
             with open(self.filepath, "rb") as f:
                 return f.read()
@@ -546,32 +592,43 @@ class Video(BaseModel):
         # back through the storage handle the caller passes in.
         return _resolve_from_storage(self, storage)
 
-    async def aget_content_bytes(self, storage: Any = None) -> Optional[bytes]:
+    async def aget_content_bytes(
+        self, storage: Optional[Union[MediaStorage, AsyncMediaStorage]] = None
+    ) -> Optional[bytes]:
         if self.content:
             return self.content
         elif self.url:
-            return await _abytes_from_url(self.url)
+            return await _abytes_from_url_or_storage(self, self.url, storage)
         elif self.media_reference and self.media_reference.url:
-            return await _abytes_from_url(self.media_reference.url)
+            return await _abytes_from_url_or_storage(self, self.media_reference.url, storage)
         elif self.filepath:
             fp = self.filepath
             return await asyncio.to_thread(lambda: Path(fp).read_bytes())
         return await _aresolve_from_storage(self, storage)
 
-    def get_url(self, storage: Any = None, expires_in: Optional[int] = None) -> Optional[str]:
+    def get_url(
+        self, storage: Optional[Union[MediaStorage, AsyncMediaStorage]] = None, *, expires_in: Optional[int] = None
+    ) -> Optional[str]:
         """A URL a browser or model can fetch this media from, or None.
 
         Prefers a URL the media already carries, else re-signs one from the stored object.
         None means there is no fetchable link — read the bytes with ``get_content_bytes``.
+        Raises ValueError when ``storage`` is an AsyncMediaStorage; use ``aget_url``.
         """
         if self.url:
             return self.url
+        if self.media_reference is not None and self.media_reference.url:
+            return self.media_reference.url
         return _url_from_storage(self, storage, expires_in)
 
-    async def aget_url(self, storage: Any = None, expires_in: Optional[int] = None) -> Optional[str]:
+    async def aget_url(
+        self, storage: Optional[Union[MediaStorage, AsyncMediaStorage]] = None, *, expires_in: Optional[int] = None
+    ) -> Optional[str]:
         """Async variant of :meth:`get_url`."""
         if self.url:
             return self.url
+        if self.media_reference is not None and self.media_reference.url:
+            return self.media_reference.url
         return await _aurl_from_storage(self, storage, expires_in)
 
     def to_base64(self) -> Optional[str]:
@@ -767,7 +824,7 @@ class File(BaseModel):
             return None
         return content or b"", mime_type or ""
 
-    def get_content_bytes(self, storage: Any = None) -> Optional[bytes]:
+    def get_content_bytes(self, storage: Optional[Union[MediaStorage, AsyncMediaStorage]] = None) -> Optional[bytes]:
         if self.content:
             if isinstance(self.content, bytes):
                 return self.content
@@ -775,9 +832,9 @@ class File(BaseModel):
                 return self.content.encode("utf-8")
             return None
         elif self.url:
-            return _bytes_from_url(self.url)
+            return _bytes_from_url_or_storage(self, self.url, storage)
         elif self.media_reference and self.media_reference.url:
-            return _bytes_from_url(self.media_reference.url)
+            return _bytes_from_url_or_storage(self, self.media_reference.url, storage)
         elif self.filepath:
             with open(self.filepath, "rb") as f:
                 return f.read()
@@ -785,7 +842,9 @@ class File(BaseModel):
         # back through the storage handle the caller passes in.
         return _resolve_from_storage(self, storage)
 
-    async def aget_content_bytes(self, storage: Any = None) -> Optional[bytes]:
+    async def aget_content_bytes(
+        self, storage: Optional[Union[MediaStorage, AsyncMediaStorage]] = None
+    ) -> Optional[bytes]:
         if self.content:
             if isinstance(self.content, bytes):
                 return self.content
@@ -793,28 +852,37 @@ class File(BaseModel):
                 return self.content.encode("utf-8")
             return None
         elif self.url:
-            return await _abytes_from_url(self.url)
+            return await _abytes_from_url_or_storage(self, self.url, storage)
         elif self.media_reference and self.media_reference.url:
-            return await _abytes_from_url(self.media_reference.url)
+            return await _abytes_from_url_or_storage(self, self.media_reference.url, storage)
         elif self.filepath:
             fp = self.filepath
             return await asyncio.to_thread(lambda: Path(fp).read_bytes())
         return await _aresolve_from_storage(self, storage)
 
-    def get_url(self, storage: Any = None, expires_in: Optional[int] = None) -> Optional[str]:
+    def get_url(
+        self, storage: Optional[Union[MediaStorage, AsyncMediaStorage]] = None, *, expires_in: Optional[int] = None
+    ) -> Optional[str]:
         """A URL a browser or model can fetch this media from, or None.
 
         Prefers a URL the media already carries, else re-signs one from the stored object.
         None means there is no fetchable link — read the bytes with ``get_content_bytes``.
+        Raises ValueError when ``storage`` is an AsyncMediaStorage; use ``aget_url``.
         """
         if self.url:
             return self.url
+        if self.media_reference is not None and self.media_reference.url:
+            return self.media_reference.url
         return _url_from_storage(self, storage, expires_in)
 
-    async def aget_url(self, storage: Any = None, expires_in: Optional[int] = None) -> Optional[str]:
+    async def aget_url(
+        self, storage: Optional[Union[MediaStorage, AsyncMediaStorage]] = None, *, expires_in: Optional[int] = None
+    ) -> Optional[str]:
         """Async variant of :meth:`get_url`."""
         if self.url:
             return self.url
+        if self.media_reference is not None and self.media_reference.url:
+            return self.media_reference.url
         return await _aurl_from_storage(self, storage, expires_in)
 
     def _normalise_content(self) -> Optional[Union[str, bytes]]:

--- a/libs/agno/agno/media/media.py
+++ b/libs/agno/agno/media/media.py
@@ -34,6 +34,116 @@ async def _abytes_from_url(url: str) -> Optional[bytes]:
         return resp.content
 
 
+def _resolve_from_storage(media: Any, storage: Any) -> Optional[bytes]:
+    """Read an offloaded object's bytes back through the backend that stored it.
+
+    Returns None when ``media`` carries no reference, when ``storage`` is not the backend
+    that minted it, or when the read fails — a caller that already has ``content``, a
+    ``url`` or a ``filepath`` never reaches here.
+    """
+    from agno.media.storage.base import AsyncMediaStorage
+
+    ref = getattr(media, "media_reference", None)
+    if storage is None or ref is None or not ref.storage_key:
+        return None
+    if isinstance(storage, AsyncMediaStorage):
+        raise ValueError("Cannot resolve media with an AsyncMediaStorage from a sync call. Use the async variant.")
+
+    from agno.utils.media_offload import reference_matches_storage
+
+    # A key only resolves against the backend that wrote it, so a mismatched handle would
+    # otherwise read a same-named object out of the wrong bucket.
+    if not reference_matches_storage(ref, storage):
+        log_error(f"Media {getattr(media, 'id', '?')} was stored on another backend")
+        return None
+    try:
+        return storage.download(ref.storage_key)
+    except Exception as e:
+        log_error(f"Could not read stored media {getattr(media, 'id', '?')} back: {e}")
+        return None
+
+
+async def _aresolve_from_storage(media: Any, storage: Any) -> Optional[bytes]:
+    """Async variant of :func:`_resolve_from_storage`."""
+    from agno.media.storage.base import AsyncMediaStorage
+
+    ref = getattr(media, "media_reference", None)
+    if storage is None or ref is None or not ref.storage_key:
+        return None
+
+    from agno.utils.media_offload import reference_matches_storage
+
+    if not reference_matches_storage(ref, storage):
+        log_error(f"Media {getattr(media, 'id', '?')} was stored on another backend")
+        return None
+    try:
+        if isinstance(storage, AsyncMediaStorage):
+            return await storage.download(ref.storage_key)
+        # A sync backend downloads in a worker thread rather than on the running loop.
+        return await asyncio.to_thread(storage.download, ref.storage_key)
+    except Exception as e:
+        log_error(f"Could not read stored media {getattr(media, 'id', '?')} back: {e}")
+        return None
+
+
+def _url_from_storage(media: Any, storage: Any, expires_in: Optional[int] = None) -> Optional[str]:
+    """Re-sign a URL for an offloaded object from its ``storage_key``.
+
+    Always re-derived rather than read off the reference: a persisted URL is either absent
+    (the usual case, since a presigned one is never stored) or stale. Returns None when the
+    backend cannot produce a usable link, which is the caller's cue to fetch bytes instead.
+    """
+    from agno.media.storage.base import AsyncMediaStorage
+
+    ref = getattr(media, "media_reference", None)
+    if storage is None or ref is None or not ref.storage_key:
+        return None
+    if isinstance(storage, AsyncMediaStorage):
+        raise ValueError("Cannot resolve media with an AsyncMediaStorage from a sync call. Use the async variant.")
+
+    from agno.utils.media_offload import reference_matches_storage
+
+    if not reference_matches_storage(ref, storage):
+        log_error(f"Media {getattr(media, 'id', '?')} was stored on another backend")
+        return None
+    try:
+        url = storage.get_url(ref.storage_key, expires_in=expires_in)
+    except Exception as e:
+        log_error(f"Could not sign a URL for {getattr(media, 'id', '?')}: {e}")
+        return None
+    # "" is the backend saying it cannot sign, and file:// resolves only on the host that
+    # wrote it — neither is something a caller can hand to a browser or a model.
+    if not url or url.startswith("file://"):
+        return None
+    return url
+
+
+async def _aurl_from_storage(media: Any, storage: Any, expires_in: Optional[int] = None) -> Optional[str]:
+    """Async variant of :func:`_url_from_storage`."""
+    from agno.media.storage.base import AsyncMediaStorage
+
+    ref = getattr(media, "media_reference", None)
+    if storage is None or ref is None or not ref.storage_key:
+        return None
+
+    from agno.utils.media_offload import reference_matches_storage
+
+    if not reference_matches_storage(ref, storage):
+        log_error(f"Media {getattr(media, 'id', '?')} was stored on another backend")
+        return None
+    try:
+        if isinstance(storage, AsyncMediaStorage):
+            url = await storage.get_url(ref.storage_key, expires_in=expires_in)
+        else:
+            url = await asyncio.to_thread(storage.get_url, ref.storage_key, expires_in=expires_in)
+    except Exception as e:
+        log_error(f"Could not sign a URL for {getattr(media, 'id', '?')}: {e}")
+        return None
+    if not url or url.startswith("file://"):
+        return None
+    return url
+
+
 class Image(BaseModel):
     """Unified Image class for all use cases (input, output, artifacts)"""
 
@@ -91,7 +201,7 @@ class Image(BaseModel):
 
         return data
 
-    def get_content_bytes(self) -> Optional[bytes]:
+    def get_content_bytes(self, storage: Any = None) -> Optional[bytes]:
         """Get image content as raw bytes, loading from URL/file if needed"""
         if self.content:
             return self.content
@@ -102,9 +212,11 @@ class Image(BaseModel):
         elif self.filepath:
             with open(self.filepath, "rb") as f:
                 return f.read()
-        return None
+        # Offloaded media carries only a reference on a private backend, so the bytes come
+        # back through the storage handle the caller passes in.
+        return _resolve_from_storage(self, storage)
 
-    async def aget_content_bytes(self) -> Optional[bytes]:
+    async def aget_content_bytes(self, storage: Any = None) -> Optional[bytes]:
         if self.content:
             return self.content
         elif self.url:
@@ -114,7 +226,23 @@ class Image(BaseModel):
         elif self.filepath:
             fp = self.filepath
             return await asyncio.to_thread(lambda: Path(fp).read_bytes())
-        return None
+        return await _aresolve_from_storage(self, storage)
+
+    def get_url(self, storage: Any = None, expires_in: Optional[int] = None) -> Optional[str]:
+        """A URL a browser or model can fetch this media from, or None.
+
+        Prefers a URL the media already carries, else re-signs one from the stored object.
+        None means there is no fetchable link — read the bytes with ``get_content_bytes``.
+        """
+        if self.url:
+            return self.url
+        return _url_from_storage(self, storage, expires_in)
+
+    async def aget_url(self, storage: Any = None, expires_in: Optional[int] = None) -> Optional[str]:
+        """Async variant of :meth:`get_url`."""
+        if self.url:
+            return self.url
+        return await _aurl_from_storage(self, storage, expires_in)
 
     def to_base64(self) -> Optional[str]:
         """Convert content to base64 string for transmission/storage"""
@@ -224,7 +352,7 @@ class Audio(BaseModel):
 
         return data
 
-    def get_content_bytes(self) -> Optional[bytes]:
+    def get_content_bytes(self, storage: Any = None) -> Optional[bytes]:
         """Get audio content as raw bytes"""
         if self.content:
             return self.content
@@ -235,9 +363,11 @@ class Audio(BaseModel):
         elif self.filepath:
             with open(self.filepath, "rb") as f:
                 return f.read()
-        return None
+        # Offloaded media carries only a reference on a private backend, so the bytes come
+        # back through the storage handle the caller passes in.
+        return _resolve_from_storage(self, storage)
 
-    async def aget_content_bytes(self) -> Optional[bytes]:
+    async def aget_content_bytes(self, storage: Any = None) -> Optional[bytes]:
         if self.content:
             return self.content
         elif self.url:
@@ -247,7 +377,23 @@ class Audio(BaseModel):
         elif self.filepath:
             fp = self.filepath
             return await asyncio.to_thread(lambda: Path(fp).read_bytes())
-        return None
+        return await _aresolve_from_storage(self, storage)
+
+    def get_url(self, storage: Any = None, expires_in: Optional[int] = None) -> Optional[str]:
+        """A URL a browser or model can fetch this media from, or None.
+
+        Prefers a URL the media already carries, else re-signs one from the stored object.
+        None means there is no fetchable link — read the bytes with ``get_content_bytes``.
+        """
+        if self.url:
+            return self.url
+        return _url_from_storage(self, storage, expires_in)
+
+    async def aget_url(self, storage: Any = None, expires_in: Optional[int] = None) -> Optional[str]:
+        """Async variant of :meth:`get_url`."""
+        if self.url:
+            return self.url
+        return await _aurl_from_storage(self, storage, expires_in)
 
     def to_base64(self) -> Optional[str]:
         """Convert content to base64 string"""
@@ -373,7 +519,7 @@ class Video(BaseModel):
 
         return data
 
-    def get_content_bytes(self) -> Optional[bytes]:
+    def get_content_bytes(self, storage: Any = None) -> Optional[bytes]:
         """Get video content as raw bytes"""
         if self.content:
             return self.content
@@ -384,9 +530,11 @@ class Video(BaseModel):
         elif self.filepath:
             with open(self.filepath, "rb") as f:
                 return f.read()
-        return None
+        # Offloaded media carries only a reference on a private backend, so the bytes come
+        # back through the storage handle the caller passes in.
+        return _resolve_from_storage(self, storage)
 
-    async def aget_content_bytes(self) -> Optional[bytes]:
+    async def aget_content_bytes(self, storage: Any = None) -> Optional[bytes]:
         if self.content:
             return self.content
         elif self.url:
@@ -396,7 +544,23 @@ class Video(BaseModel):
         elif self.filepath:
             fp = self.filepath
             return await asyncio.to_thread(lambda: Path(fp).read_bytes())
-        return None
+        return await _aresolve_from_storage(self, storage)
+
+    def get_url(self, storage: Any = None, expires_in: Optional[int] = None) -> Optional[str]:
+        """A URL a browser or model can fetch this media from, or None.
+
+        Prefers a URL the media already carries, else re-signs one from the stored object.
+        None means there is no fetchable link — read the bytes with ``get_content_bytes``.
+        """
+        if self.url:
+            return self.url
+        return _url_from_storage(self, storage, expires_in)
+
+    async def aget_url(self, storage: Any = None, expires_in: Optional[int] = None) -> Optional[str]:
+        """Async variant of :meth:`get_url`."""
+        if self.url:
+            return self.url
+        return await _aurl_from_storage(self, storage, expires_in)
 
     def to_base64(self) -> Optional[str]:
         """Convert content to base64 string"""
@@ -598,7 +762,7 @@ class File(BaseModel):
         else:
             return None
 
-    def get_content_bytes(self) -> Optional[bytes]:
+    def get_content_bytes(self, storage: Any = None) -> Optional[bytes]:
         if self.content:
             if isinstance(self.content, bytes):
                 return self.content
@@ -612,9 +776,11 @@ class File(BaseModel):
         elif self.filepath:
             with open(self.filepath, "rb") as f:
                 return f.read()
-        return None
+        # Offloaded media carries only a reference on a private backend, so the bytes come
+        # back through the storage handle the caller passes in.
+        return _resolve_from_storage(self, storage)
 
-    async def aget_content_bytes(self) -> Optional[bytes]:
+    async def aget_content_bytes(self, storage: Any = None) -> Optional[bytes]:
         if self.content:
             if isinstance(self.content, bytes):
                 return self.content
@@ -628,7 +794,23 @@ class File(BaseModel):
         elif self.filepath:
             fp = self.filepath
             return await asyncio.to_thread(lambda: Path(fp).read_bytes())
-        return None
+        return await _aresolve_from_storage(self, storage)
+
+    def get_url(self, storage: Any = None, expires_in: Optional[int] = None) -> Optional[str]:
+        """A URL a browser or model can fetch this media from, or None.
+
+        Prefers a URL the media already carries, else re-signs one from the stored object.
+        None means there is no fetchable link — read the bytes with ``get_content_bytes``.
+        """
+        if self.url:
+            return self.url
+        return _url_from_storage(self, storage, expires_in)
+
+    async def aget_url(self, storage: Any = None, expires_in: Optional[int] = None) -> Optional[str]:
+        """Async variant of :meth:`get_url`."""
+        if self.url:
+            return self.url
+        return await _aurl_from_storage(self, storage, expires_in)
 
     def _normalise_content(self) -> Optional[Union[str, bytes]]:
         if self.content is None:

--- a/libs/agno/agno/models/moonshot/moonshot.py
+++ b/libs/agno/agno/models/moonshot/moonshot.py
@@ -150,6 +150,12 @@ class MoonShot(OpenAILike):
             filename = Path(urlparse(media.url).path).name
         if not filename:
             filename = "file"
+        # Moonshot's file-extract picks the type from the filename extension and ignores the
+        # tuple's mime type, so an extension-less name is rejected. Supply one from the mime.
+        if not Path(filename).suffix and media.mime_type:
+            guessed = mimetypes.guess_extension(media.mime_type)
+            if guessed:
+                filename += guessed
 
         try:
             data = media.get_content_bytes()

--- a/libs/agno/agno/utils/media_offload.py
+++ b/libs/agno/agno/utils/media_offload.py
@@ -120,7 +120,12 @@ def reference_matches_storage(ref: Optional[MediaReference], storage: Union[Medi
     if ref is None:
         return False
     backend_name = getattr(storage, "backend_name", None)
-    return bool(backend_name) and ref.storage_backend == backend_name and ref.bucket == getattr(storage, "bucket", None)
+    if not backend_name or ref.storage_backend != backend_name or ref.bucket != getattr(storage, "bucket", None):
+        return False
+    # Two deployments can share a bucket name, so a region both sides name has to agree.
+    # Only one side naming it is the common case of relying on the environment's default.
+    storage_region = getattr(storage, "region", None)
+    return not (ref.region and storage_region) or ref.region == storage_region
 
 
 def _attach_reference(media: Union[Image, Audio, Video, File], ref: MediaReference) -> None:

--- a/libs/agno/tests/unit/media/test_media_read_back.py
+++ b/libs/agno/tests/unit/media/test_media_read_back.py
@@ -1,0 +1,132 @@
+"""Reading offloaded media back through a storage handle.
+
+Covers ``get_content_bytes(storage=...)`` and ``get_url(storage=...)`` on all four media
+classes, the guards that refuse a handle that did not mint the reference, and the fallback
+to storage when a url the media also carries cannot be fetched.
+"""
+
+import tempfile
+
+import pytest
+
+from agno.media import Audio, File, Image, Video
+from agno.media.reference import MediaReference
+from agno.media.storage.local import AsyncLocalMediaStorage, LocalMediaStorage
+
+CLASSES = [Image, Audio, Video, File]
+CONTENT = b"REAL-BYTES-IN-STORAGE"
+DEAD_URL = "http://127.0.0.1:9/gone.png"
+
+
+@pytest.fixture
+def stored():
+    """A local backend holding one object, and the reference that names it."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        storage = LocalMediaStorage(base_path=tmpdir)
+        key = storage.upload("m1", CONTENT, mime_type="image/png")
+        ref = MediaReference(media_id="m1", storage_key=key, storage_backend="local", bucket=storage.bucket)
+        yield storage, ref
+
+
+@pytest.mark.parametrize("cls", CLASSES)
+def test_a_reference_resolves_to_its_bytes(cls, stored):
+    storage, ref = stored
+    assert cls(id="m1", media_reference=ref).get_content_bytes(storage=storage) == CONTENT
+
+
+@pytest.mark.parametrize("cls", CLASSES)
+@pytest.mark.asyncio
+async def test_a_reference_resolves_to_its_bytes_async(cls, stored):
+    storage, ref = stored
+    media = cls(id="m1", media_reference=ref)
+    assert await media.aget_content_bytes(storage=storage) == CONTENT
+
+
+@pytest.mark.parametrize("cls", CLASSES)
+def test_without_a_handle_a_reference_has_no_bytes(cls, stored):
+    _, ref = stored
+    assert cls(id="m1", media_reference=ref).get_content_bytes() is None
+
+
+@pytest.mark.parametrize("cls", CLASSES)
+def test_a_handle_that_did_not_mint_the_reference_is_refused(cls, stored):
+    storage, ref = stored
+    with tempfile.TemporaryDirectory() as other_dir:
+        other = LocalMediaStorage(base_path=other_dir)
+        # The same key exists in the other root, so a bucket-blind read would return its bytes.
+        other.upload("m1", b"WRONG-OBJECT", mime_type="image/png")
+        assert cls(id="m1", media_reference=ref).get_content_bytes(storage=other) is None
+
+
+def test_an_async_backend_on_a_sync_call_is_refused(stored):
+    _, ref = stored
+    with tempfile.TemporaryDirectory() as tmpdir:
+        async_storage = AsyncLocalMediaStorage(base_path=tmpdir)
+        with pytest.raises(ValueError, match="aget_content_bytes"):
+            Image(id="m1", media_reference=ref).get_content_bytes(storage=async_storage)
+        with pytest.raises(ValueError, match="aget_url"):
+            Image(id="m1", media_reference=ref).get_url(storage=async_storage)
+
+
+@pytest.mark.asyncio
+async def test_a_sync_backend_on_an_async_call_reads_off_the_loop(stored):
+    storage, ref = stored
+    media = Image(id="m1", media_reference=ref)
+    assert await media.aget_content_bytes(storage=storage) == CONTENT
+
+
+def test_a_url_that_cannot_be_fetched_falls_back_to_the_stored_object(stored):
+    storage, ref = stored
+    media = Image(id="m1", media_reference=ref, url=DEAD_URL)
+    assert media.get_content_bytes(storage=storage) == CONTENT
+
+
+@pytest.mark.asyncio
+async def test_a_url_that_cannot_be_fetched_falls_back_to_the_stored_object_async(stored):
+    storage, ref = stored
+    media = Image(id="m1", media_reference=ref, url=DEAD_URL)
+    assert await media.aget_content_bytes(storage=storage) == CONTENT
+
+
+def test_a_failing_url_still_raises_without_a_handle_to_fall_back_to():
+    """The handle is what makes a fallback possible; without one the fetch error stands."""
+    import httpx
+
+    with pytest.raises(httpx.HTTPError):
+        Image(id="m1", url=DEAD_URL).get_content_bytes()
+
+
+def test_a_working_url_is_used_without_touching_storage(stored):
+    storage, ref = stored
+
+    class Counting(LocalMediaStorage):
+        hits = 0
+
+        def download(self, storage_key):
+            Counting.hits += 1
+            return super().download(storage_key)
+
+    counting = Counting(base_path=str(storage.base_path))
+    media = Image(id="m1", media_reference=ref, url="https://raw.githubusercontent.com/agno-agi/agno/main/README.md")
+    assert media.get_content_bytes(storage=counting)
+    assert Counting.hits == 0
+
+
+def test_a_backend_that_cannot_address_a_key_yields_no_url(stored):
+    """Local files are not addressable off the machine, so there is no link to hand out."""
+    storage, ref = stored
+    assert Image(id="m1", media_reference=ref).get_url(storage=storage) is None
+
+
+def test_media_with_no_reference_yields_no_url(stored):
+    storage, _ = stored
+    assert Image(id="m1", content=CONTENT).get_url(storage=storage) is None
+
+
+@pytest.mark.parametrize("cls", CLASSES)
+def test_a_url_on_the_reference_is_a_url_both_accessors_agree_on(cls, stored):
+    """``get_url`` reports the link ``get_content_bytes`` would fetch, not a different one."""
+    storage, ref = stored
+    ref = ref.model_copy(update={"url": "https://cdn.example.com/from-reference.png"})
+    media = cls(id="m1", media_reference=ref)
+    assert media.get_url(storage=storage) == "https://cdn.example.com/from-reference.png"


### PR DESCRIPTION
## Summary

Stacked on #9340 (external media storage). Targets `feat/external-media-storage-v3`, not `feat/v3.0`.

With `media_storage` configured, offloaded media reaches a caller as a `MediaReference` with no `content` and no `url` — and there was no supported way to resolve it back. `get_content_bytes()` returned `None` for exactly the media the feature produces:

```python
ref = MediaReference(media_id="f1", storage_key="k.csv", storage_backend="s3", bucket="b")
File(media_reference=ref).get_content_bytes()   # -> None
```

Retrieval meant reaching into `media_reference.storage_key` yourself and calling `storage.download()` directly.

`Image`, `Audio`, `Video` and `File` now take an optional storage handle:

```python
data = file.get_content_bytes(storage=agent.media_storage)   # bytes back from the object store
url  = file.get_url(storage=agent.media_storage)             # freshly-signed link, or None
```

`aget_content_bytes(storage=...)` and `aget_url(storage=...)` are the async variants, on all four classes.

## Design

- **`storage` defaults to `None`**, so every existing call is unchanged. It is a new fallback arm at the end of the existing `content -> url -> filepath` chain, reached only when nothing else resolved.
- **`get_url` always re-derives from `storage_key`** rather than trusting a persisted URL, which is either absent (a presigned one is never stored) or stale.
- **Returns `None` rather than raising** when the backend cannot sign — local storage, or GCS with application-default credentials. That is the caller's cue to read bytes instead, matching what the AgentOS media route already does.
- **A reference minted by another backend is refused**, via the same `reference_matches_storage` guard the fetch route uses, so a mismatched handle cannot read a same-named object out of the wrong bucket.
- **A sync call with an `Async*MediaStorage` raises up front**, consistent with the rest of the feature.
- **Async with a sync backend goes through `asyncio.to_thread`**, so a download never blocks the running loop.

The logic lives in four shared module-level helpers rather than being repeated across eight methods.

## Scope

This closes the SDK half of the read path. The frontend still receives `media_reference` with no `url` and no `content`, because `RunSchema.from_dict` passes media through verbatim — that needs a server-side rewrite to `/sessions/{id}/media/{key}` and is not in this PR.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

### Cookbooks

| | |
|---|---|
| `cookbook/06_storage/10_media_storage_workflow.py` | workflow media offload across step boundaries |
| `cookbook/06_storage/11_media_storage_file_generation.py` | offload of files produced by `FileGenerationTools`, and reading one back |

Note for the workflow cookbook: `WorkflowRunOutput.input` is a plain `str`, not a `RunInput` as on an agent run. Workflow media lives on `run.images` and on each `step_results[].images`, and the example walks both.

### Verification

`1170 passed, 3 skipped` across `tests/unit/media/`, `tests/unit/utils/test_media_reconstruction.py` and `tests/unit/os/routers/`. `mypy` reports no errors in `media/media.py`.

Manually verified: byte roundtrip exact against `LocalMediaStorage`; S3 presigning through `get_url` (mocked client) with `expires_in` honoured; async variants matching their sync counterparts; a mismatched backend logging and returning `None`; and `get_content_bytes()` with no `storage` behaving exactly as before.

### Not covered by tests yet

No unit tests are added for the new parameter — the existing suite passes unchanged, and the behaviour was verified manually. Worth adding coverage for the storage-fallback arm, the backend-mismatch refusal, and the non-signing `get_url` path before merge.

Both cookbooks are marked PENDING and have not been run against real S3.
