### PR TITLE
fix: standardize AgentOS media validation

### DIFF
--- a/libs/agno/agno/media.py
+++ b/libs/agno/agno/media.py
@@ -8,6 +8,13 @@ from pydantic import BaseModel, field_validator, model_validator
 from agno.utils.log import log_error
 
 
+def normalize_mime_type(mime_type: Optional[str]) -> Optional[str]:
+    """Return a canonical MIME type for case-insensitive comparisons."""
+    if mime_type is None:
+        return None
+    return mime_type.strip().lower()
+
+
 class Image(BaseModel):
     """Unified Image class for all use cases (input, output, artifacts)"""
 
@@ -415,6 +422,7 @@ class File(BaseModel):
     @classmethod
     def validate_mime_type(cls, v):
         """Validate that the mime_type is one of the allowed types."""
+        v = normalize_mime_type(v)
         if v is not None and v not in cls.valid_mime_types():
             raise ValueError(f"Invalid MIME type: {v}. Must be one of: {cls.valid_mime_types()}")
         return v

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -20,7 +20,7 @@ from agno.factory import (
     RequestContext,
 )
 from agno.knowledge.knowledge import Knowledge
-from agno.media import Audio, Image, Video
+from agno.media import Audio, Image, Video, normalize_mime_type
 from agno.media import File as FileMedia
 from agno.models.message import Message
 from agno.os.config import AgentOSConfig
@@ -677,7 +677,7 @@ def classify_upload_file(file: UploadFile) -> Optional[str]:
     to be useful (common for `.md` and `.pptx` uploaded from browsers), falls back to the
     filename extension. Returns None if the file type is not supported.
     """
-    content_type = file.content_type
+    content_type = normalize_mime_type(file.content_type)
     if content_type in IMAGE_MIME_TYPES:
         return "image"
     if content_type in AUDIO_MIME_TYPES:
@@ -699,7 +699,7 @@ def process_image(file: UploadFile) -> Image:
     content = file.file.read()
     if not content:
         raise HTTPException(status_code=400, detail="Empty file")
-    return Image(content=content, format=extract_format(file), mime_type=file.content_type)
+    return Image(content=content, format=extract_format(file), mime_type=normalize_mime_type(file.content_type))
 
 
 def process_audio(file: UploadFile) -> Audio:
@@ -713,7 +713,7 @@ def process_video(file: UploadFile) -> Video:
     content = file.file.read()
     if not content:
         raise HTTPException(status_code=400, detail="Empty file")
-    return Video(content=content, format=extract_format(file), mime_type=file.content_type)
+    return Video(content=content, format=extract_format(file), mime_type=normalize_mime_type(file.content_type))
 
 
 # Map document file extensions to their canonical MIME type, used to recover a valid
@@ -749,12 +749,13 @@ def _resolve_document_mime_type(file: UploadFile) -> Optional[str]:
     documents with ambiguous content types (e.g. `.md` sent as octet-stream) still get a
     mime_type accepted by `FileMedia`.
     """
-    if file.content_type and file.content_type in DOCUMENT_MIME_TYPES:
-        return file.content_type
+    content_type = normalize_mime_type(file.content_type)
+    if content_type and content_type in DOCUMENT_MIME_TYPES:
+        return content_type
     if file.filename and "." in file.filename:
         extension = file.filename.rsplit(".", 1)[-1].lower()
         return _DOCUMENT_EXTENSION_MIME.get(extension)
-    return file.content_type
+    return content_type
 
 
 def process_document(file: UploadFile) -> Optional[FileMedia]:

--- a/libs/agno/tests/unit/os/test_utils.py
+++ b/libs/agno/tests/unit/os/test_utils.py
@@ -171,6 +171,18 @@ class TestClassifyUploadFile:
         # An image content type with a misleading .txt name is still an image.
         assert classify_upload_file(_make_upload_file("photo.txt", "image/png")) == "image"
 
+    @pytest.mark.parametrize(
+        "content_type, filename, expected",
+        [
+            (" IMAGE/PNG ", "中文 图像 (v1).png", "image"),
+            ("Application/PDF", "报告 (final).v2.pdf", "document"),
+            ("VIDEO/MP4", "clip (1).mp4", "video"),
+            ("application/octet-stream", "无扩展名", None),
+        ],
+    )
+    def test_normalizes_mime_types_without_trusting_filenames(self, content_type, filename, expected):
+        assert classify_upload_file(_make_upload_file(filename, content_type)) == expected
+
 
 class TestProcessDocument:
     """process_document must build a FileMedia with a mime_type accepted by File.valid_mime_types()."""
@@ -195,6 +207,11 @@ class TestProcessDocument:
         with pytest.raises(HTTPException) as exc_info:
             process_document(_make_upload_file("notes.md", "text/markdown", b""))
         assert exc_info.value.status_code == 400
+
+    def test_mixed_case_mime_type_is_normalized(self):
+        result = process_document(_make_upload_file("报告 (final).pdf", " Application/PDF ", b"data"))
+        assert result is not None
+        assert result.mime_type == "application/pdf"
 
 
 class TestDocumentMimeTypesConsistency:


### PR DESCRIPTION
## Summary

Fixes #7311.

Standardizes AgentOS upload MIME handling in the shared media and router utility layers. Agent and Team routers already use the same `classify_upload_file` / processing entry points; this change removes the remaining case-sensitive MIME behavior there and in `File` validation.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`) — local `.venv` is not configured
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Tested in clean environment — not available locally
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated — AI-assisted; reviewed before submission

---

## Additional Notes

### Root cause and consistency

The latest main already centralizes Agent and Team Router upload classification in `agno.os.utils`, including Excel and MSG MIME support. The remaining inconsistency was strict MIME comparison in the shared upload functions and `File` validator: mixed-case or padded values such as `IMAGE/PNG` and ` Application/PDF ` were rejected.

### Shared validation

`normalize_mime_type()` is shared from the media module and trims/lowercases MIME values. The shared upload classifier, Image/Video construction, document resolution, and `File` validator reuse it. Existing known MIME continues to take precedence over filenames; ambiguous MIME may use the extension fallback as before, and an extensionless octet-stream upload remains unsupported.

### Tests

Added boundary coverage for image, video, and document uploads with mixed-case MIME, Chinese/space/parenthesis/multi-dot filenames, no extension, and MIME/extension mismatch. Because both routers call the same utilities, this validates their shared behavior.

### Commands run

- `python -m py_compile libs/agno/agno/media.py libs/agno/agno/os/utils.py libs/agno/tests/unit/os/test_utils.py` — passed
- `git diff --check` — passed
- `pytest`, `./scripts/format.sh`, and `./scripts/validate.sh` — not run because local `.venv` is not configured.