### PR TITLE
fix: standardize AgentOS media validation

### DIFF
--- a/libs/agno/agno/media.py
+++ b/libs/agno/agno/media.py
@@ -8,6 +8,13 @@ from pydantic import BaseModel, field_validator, model_validator
 from agno.utils.log import log_error
 
 
+def normalize_mime_type(mime_type: Optional[str]) -> Optional[str]:
+    """Return a canonical MIME type for case-insensitive comparisons."""
+    if mime_type is None:
+        return None
+    return mime_type.strip().lower()
+
+
 class Image(BaseModel):
     """Unified Image class for all use cases (input, output, artifacts)"""
 
@@ -415,6 +422,7 @@ class File(BaseModel):
     @classmethod
     def validate_mime_type(cls, v):
         """Validate that the mime_type is one of the allowed types."""
+        v = normalize_mime_type(v)
         if v is not None and v not in cls.valid_mime_types():
             raise ValueError(f"Invalid MIME type: {v}. Must be one of: {cls.valid_mime_types()}")
         return v

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -706,7 +706,7 @@ def process_audio(file: UploadFile) -> Audio:
     content = file.file.read()
     if not content:
         raise HTTPException(status_code=400, detail="Empty file")
-    return Audio(content=content, format=extract_format(file), mime_type=file.content_type)
+    return Audio(content=content, format=extract_format(file), mime_type=normalize_mime_type(file.content_type))
 
 
 def process_video(file: UploadFile) -> Video:

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -20,7 +20,7 @@ from agno.factory import (
     RequestContext,
 )
 from agno.knowledge.knowledge import Knowledge
-from agno.media import Audio, Image, Video
+from agno.media import Audio, Image, Video, normalize_mime_type
 from agno.media import File as FileMedia
 from agno.models.message import Message
 from agno.os.config import AgentOSConfig
@@ -677,7 +677,7 @@ def classify_upload_file(file: UploadFile) -> Optional[str]:
     to be useful (common for `.md` and `.pptx` uploaded from browsers), falls back to the
     filename extension. Returns None if the file type is not supported.
     """
-    content_type = file.content_type
+    content_type = normalize_mime_type(file.content_type)
     if content_type in IMAGE_MIME_TYPES:
         return "image"
     if content_type in AUDIO_MIME_TYPES:
@@ -699,7 +699,7 @@ def process_image(file: UploadFile) -> Image:
     content = file.file.read()
     if not content:
         raise HTTPException(status_code=400, detail="Empty file")
-    return Image(content=content, format=extract_format(file), mime_type=file.content_type)
+    return Image(content=content, format=extract_format(file), mime_type=normalize_mime_type(file.content_type))
 
 
 def process_audio(file: UploadFile) -> Audio:
@@ -713,7 +713,7 @@ def process_video(file: UploadFile) -> Video:
     content = file.file.read()
     if not content:
         raise HTTPException(status_code=400, detail="Empty file")
-    return Video(content=content, format=extract_format(file), mime_type=file.content_type)
+    return Video(content=content, format=extract_format(file), mime_type=normalize_mime_type(file.content_type))
 
 
 # Map document file extensions to their canonical MIME type, used to recover a valid
@@ -749,12 +749,13 @@ def _resolve_document_mime_type(file: UploadFile) -> Optional[str]:
     documents with ambiguous content types (e.g. `.md` sent as octet-stream) still get a
     mime_type accepted by `FileMedia`.
     """
-    if file.content_type and file.content_type in DOCUMENT_MIME_TYPES:
-        return file.content_type
+    content_type = normalize_mime_type(file.content_type)
+    if content_type and content_type in DOCUMENT_MIME_TYPES:
+        return content_type
     if file.filename and "." in file.filename:
         extension = file.filename.rsplit(".", 1)[-1].lower()
         return _DOCUMENT_EXTENSION_MIME.get(extension)
-    return file.content_type
+    return content_type
 
 
 def process_document(file: UploadFile) -> Optional[FileMedia]:

--- a/libs/agno/tests/unit/os/test_utils.py
+++ b/libs/agno/tests/unit/os/test_utils.py
@@ -171,6 +171,18 @@ class TestClassifyUploadFile:
         # An image content type with a misleading .txt name is still an image.
         assert classify_upload_file(_make_upload_file("photo.txt", "image/png")) == "image"
 
+    @pytest.mark.parametrize(
+        "content_type, filename, expected",
+        [
+            (" IMAGE/PNG ", "中文 图像 (v1).png", "image"),
+            ("Application/PDF", "报告 (final).v2.pdf", "document"),
+            ("VIDEO/MP4", "clip (1).mp4", "video"),
+            ("application/octet-stream", "无扩展名", None),
+        ],
+    )
+    def test_normalizes_mime_types_without_trusting_filenames(self, content_type, filename, expected):
+        assert classify_upload_file(_make_upload_file(filename, content_type)) == expected
+
 
 class TestProcessDocument:
     """process_document must build a FileMedia with a mime_type accepted by File.valid_mime_types()."""
@@ -195,6 +207,11 @@ class TestProcessDocument:
         with pytest.raises(HTTPException) as exc_info:
             process_document(_make_upload_file("notes.md", "text/markdown", b""))
         assert exc_info.value.status_code == 400
+
+    def test_mixed_case_mime_type_is_normalized(self):
+        result = process_document(_make_upload_file("报告 (final).pdf", " Application/PDF ", b"data"))
+        assert result is not None
+        assert result.mime_type == "application/pdf"
 
 
 class TestDocumentMimeTypesConsistency:

--- a/libs/agno/tests/unit/os/test_utils.py
+++ b/libs/agno/tests/unit/os/test_utils.py
@@ -11,6 +11,7 @@ from agno.media import File
 from agno.os.utils import (
     DOCUMENT_MIME_TYPES,
     classify_upload_file,
+    process_audio,
     process_document,
     to_utc_datetime,
 )
@@ -212,6 +213,19 @@ class TestProcessDocument:
         result = process_document(_make_upload_file("报告 (final).pdf", " Application/PDF ", b"data"))
         assert result is not None
         assert result.mime_type == "application/pdf"
+
+
+class TestProcessAudio:
+    """Audio uploads must retain the same normalized MIME used for routing."""
+
+    @pytest.mark.parametrize("content_type", ["AUDIO/WAV", " AUDIO/WAV "])
+    def test_mixed_case_mime_type_is_normalized(self, content_type):
+        upload = _make_upload_file("clip.wav", content_type, b"audio-data")
+
+        assert classify_upload_file(upload) == "audio"
+
+        result = process_audio(upload)
+        assert result.mime_type == "audio/wav"
 
 
 class TestDocumentMimeTypesConsistency:


### PR DESCRIPTION
## Summary

Fixes #7311.

Standardizes MIME handling in the shared AgentOS upload path by trimming and lowercasing MIME values before classification, media construction, and `File` validation. This keeps Agent and Team upload behavior aligned because both routers already use the shared helpers on current `main`.

The change preserves current filename behavior, including Unicode and special characters, and does not infer safety from a non-ambiguous filename extension.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (not applicable; internal upload validation)
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that other PRs reference #7311
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (AI-assisted; all changes and test results were reviewed)

---

## Why this is intentionally narrower than #9423 and #7310

Current `main` already has shared Agent/Team upload classification and processing in `agno.os.utils`, plus Excel/MSG support and consistency tests. This PR fixes the remaining concrete bug in that current architecture rather than replacing it:

- #9423 also implements #7306, introduces a `BaseMedia` hierarchy, filename normalization, and session-state persistence.
- #7310 introduces a global MIME registry and changes a broader set of validation and router tests.
- This PR adds one shared `normalize_mime_type()` helper and reuses the existing current-main upload entry points. It does not change public APIs, filenames, router structure, or supported formats.

## MIME normalization and filenames

- MIME values are stripped and lowercased for case-insensitive comparison.
- Image, audio, video, and document upload objects retain the normalized MIME.
- `File` validation accepts padded/mixed-case forms while preserving the existing allowlist.
- Known MIME remains authoritative when the extension disagrees.
- Extension fallback remains limited to missing/ambiguous MIME; an extensionless octet-stream upload remains unsupported.

## Tests

Added deterministic coverage for:

- `image/png`, `IMAGE/PNG`, and padded image MIME
- `Application/PDF` and padded document MIME
- `VIDEO/MP4`
- `AUDIO/WAV` and ` AUDIO/WAV `, including the constructed `Audio.mime_type`
- Unicode filenames; spaces, parentheses, and multiple dots
- no-extension uploads
- MIME/extension mismatch
- existing Excel and MSG MIME consistency remains covered by the existing suite

Commands run:

- `./scripts/dev_setup.sh` — passed after adapting Git Bash path conversion for Windows-native uv outside the repository
- `pytest libs/agno/tests/unit/os/test_utils.py -v` — 150 passed, 1 unrelated existing Windows failure (`datetime.fromtimestamp(-86400)` raises `OSError: [Errno 22]`)
- `pytest libs/agno/tests/unit/os/test_utils.py::TestProcessAudio -v` — 2 passed
- `python -m py_compile libs/agno/agno/media.py libs/agno/agno/os/utils.py libs/agno/tests/unit/os/test_utils.py` — passed
- `./scripts/format.sh` — passed; no repository diff remained
- `./scripts/validate.sh` — passed (ruff, mypy, cookbook pattern check)
- `git diff --check` — passed

## Additional Notes

No binary content, paths, or generated files are added. Public serialization remains compatible; explicitly supplied MIME values are now stored canonically in lowercase without surrounding whitespace.