### PR TITLE
test: assert the archive race by what landed, not by which call raised

### DIFF
--- a/libs/agno/tests/unit/db/test_component_catalog_hardening_postgres.py
+++ b/libs/agno/tests/unit/db/test_component_catalog_hardening_postgres.py
@@ -12,10 +12,11 @@ Each test runs in its own schema, dropped on teardown. The whole module
 skips when psycopg is missing or the server is unreachable.
 """
 
+import threading
 import uuid
 
 import pytest
-from sqlalchemy import create_engine, text
+from sqlalchemy import create_engine, event, text
 
 from agno.db.base import (
     DELETED_CONFIG_STAGE,
@@ -551,15 +552,49 @@ class TestCycles:
         assert _has_cycle_stub(graph)
 
 
+class _HoldFirstStatementOfThread:
+    """Pause one named thread at its first statement until released.
+
+    The pause lands before that thread has issued any SQL, so it holds no
+    row lock and starts no transaction while it waits: the other thread's
+    write commits in full, and the paused caller resumes against the
+    committed state. Arms once, for one thread, on an engine both threads
+    share.
+    """
+
+    def __init__(self, engine, thread_name: str):
+        self.engine = engine
+        self.thread_name = thread_name
+        self.reached = threading.Event()
+        self.release = threading.Event()
+        self._armed = True
+
+    def _hook(self, conn, cursor, statement, parameters, context, executemany):
+        if self._armed and threading.current_thread().name == self.thread_name:
+            self._armed = False
+            self.reached.set()
+            assert self.release.wait(timeout=15), "held thread was never released"
+
+    def __enter__(self):
+        event.listen(self.engine, "before_cursor_execute", self._hook)
+        return self
+
+    def __exit__(self, *exc):
+        # The held thread has joined and the hook disarmed itself; removal is
+        # deferred to here so no dispatch iterates a mutating listener deque.
+        event.remove(self.engine, "before_cursor_execute", self._hook)
+        return False
+
+
 class TestConcurrentCASWrites:
     """The compare-and-set guards must ride the write itself: with a
     check-then-write shape, two writers expecting the same state both pass
-    the check and both win. Each race here asserts exactly one winner and
-    exactly one ComponentVersionConflictError."""
+    the check and both win. Each race here asserts exactly one mutation
+    lands. Two symmetric writers can only settle as one win and one
+    ComponentVersionConflictError; an archive racing a pointer move settles
+    either way, so that race reads the committed row for its verdict."""
 
     def _race(self, fn_a, fn_b):
-        import threading
-
         barrier = threading.Barrier(2)
         results: list = [None, None]
 
@@ -605,6 +640,17 @@ class TestConcurrentCASWrites:
         errs = [r[1] for r in results if r[0] == "err"]
         assert isinstance(errs[0], ComponentVersionConflictError)
 
+    def test_the_unraced_guarded_pair_both_land(self, db):
+        """False-refusal baseline for the archive race below: run the same two
+        guarded calls with nothing competing and both must land. A conflict
+        verdict in the raced tests is then the race, not a guard that refuses
+        a healthy write."""
+        cid = self._component_with_versions(db, cid="race-unraced")
+        assert db.set_current_version(cid, 1, expected_current_version=2) is True
+        assert db.get_component(cid)["current_version"] == 1
+        assert db.delete_component(cid, hard_delete=False, expected_current_version=1) is True
+        assert db.get_component(cid, include_deleted=True)["deleted_at"] is not None
+
     def test_archive_race_has_one_winner(self, db):
         from agno.db.base import ComponentVersionConflictError
 
@@ -613,10 +659,70 @@ class TestConcurrentCASWrites:
             lambda: db.set_current_version(cid, 1, expected_current_version=2),
             lambda: db.delete_component(cid, hard_delete=False, expected_current_version=2),
         )
-        outcomes = sorted(r[0] for r in results)
-        assert outcomes == ["err", "ok"], results
-        errs = [r[1] for r in results if r[0] == "err"]
-        assert isinstance(errs[0], ComponentVersionConflictError)
+
+        # Either order is legitimate, and which one runs is a scheduling
+        # detail, so the invariant is that exactly one MUTATION lands - not
+        # that a particular call raised.
+        #
+        # Pointer move first: the archive's CAS sees current_version moved and
+        # raises. Archive first: the pointer move finds an archived row and
+        # reports False, the same verdict its pre-check gives for a row that
+        # was already archived (pinned in test_component_archive_race.py).
+        landed = [r for r in results if r[0] == "ok" and r[1] is not False]
+        assert len(landed) == 1, results
+
+        archived = db.get_component(cid, include_deleted=True)["deleted_at"] is not None
+        if archived:
+            # The archive won, so the pointer must not have moved onto it.
+            assert db.get_component(cid, include_deleted=True)["current_version"] == 2
+            assert any(r[0] == "ok" and r[1] is False for r in results), results
+        else:
+            # The pointer move won, so the archive must have reported the conflict.
+            errs = [r[1] for r in results if r[0] == "err"]
+            assert errs and isinstance(errs[0], ComponentVersionConflictError), results
+            assert db.get_component(cid)["current_version"] == 1
+
+    def test_archive_conflicts_when_the_pointer_moves_mid_flight(self, db):
+        """The archive loses: forced, not left to the scheduler.
+
+        delete_component opens its transaction on a locked read of the
+        components row, so the natural race on Postgres always resolves with
+        the archive committed before the pointer move even reads. Holding the
+        archive thread before it issues any SQL puts the pointer move first:
+        the archive's guard then sees current_version 1, raises, and the row
+        stays live carrying the moved pointer.
+        """
+        from agno.db.base import ComponentVersionConflictError
+
+        cid = self._component_with_versions(db, cid="race-ptr-first")
+        outcome: dict = {}
+
+        def archive():
+            try:
+                outcome["result"] = db.delete_component(cid, hard_delete=False, expected_current_version=2)
+            except Exception as e:
+                outcome["error"] = e
+            finally:
+                db.Session.remove()
+
+        with _HoldFirstStatementOfThread(db.db_engine, "cas-archiver") as hold:
+            t = threading.Thread(target=archive, name="cas-archiver")
+            t.start()
+            try:
+                assert hold.reached.wait(timeout=15), "archiver never issued a statement"
+                assert db.set_current_version(cid, 1, expected_current_version=2) is True
+            finally:
+                # The held thread must be released and joined on every exit:
+                # the listener is removed on the way out of this block and
+                # must not be torn down under a live dispatch.
+                hold.release.set()
+                t.join(timeout=30)
+            assert not t.is_alive()
+
+        assert isinstance(outcome.get("error"), ComponentVersionConflictError), outcome
+        row = db.get_component(cid, include_deleted=True)
+        assert row["deleted_at"] is None
+        assert row["current_version"] == 1
 
     def test_guarded_publish_race_has_one_winner(self, db):
         from agno.db.base import ComponentVersionConflictError


### PR DESCRIPTION
## Summary

`test_archive_race_has_one_winner` races `set_current_version` against `delete_component` and asserted `outcomes == ["err", "ok"]`. The race has two legitimate resolutions and that assertion admitted only one of them, so the test failed on every run, on every branch, and blocked unrelated pull requests from going green.

- **The pointer move commits first**: `delete_component`'s guard sees `current_version` moved off 2 and raises `ComponentVersionConflictError`.
- **The archive commits first**: `set_current_version` finds an archived row and returns `False`. That verdict is the documented contract, and `test_component_archive_race.py` already pins it on both backends.

`delete_component` opens its transaction with a locked read of the components row as its first statement, while `set_current_version` runs two unlocked pre-reads. On Postgres the archive therefore commits before the pointer move issues its first read, so the archive-first branch is the only branch natural scheduling reaches. The test asserted the branch that never runs.

The SQLite mirror of this test was already corrected this way. The Postgres copy was missed.

**The old assertion also caught nothing.** Dropping `deleted_at IS NULL` from the pointer `UPDATE` — the check-then-write bug this class of test exists for — passes it untouched. It was failing 100% of the time while catching 0% of what it was for.

### What changed

Only the test file. The adapter is correct and is not modified.

- The assertion is now the real invariant: exactly one mutation lands, and the committed row decides which call had to give way.
- `test_archive_conflicts_when_the_pointer_moves_mid_flight` holds the archiving thread before it issues any SQL, so the pointer move goes first and the archive raises. This forces the branch scheduling never reaches, and it kills the `deleted_at IS NULL` mutation.
- `test_the_unraced_guarded_pair_both_land` runs the same two guarded calls with nothing competing, so a conflict verdict in the raced tests is the race and not a guard refusing a healthy write.

### Verification

Against a real Postgres (pgvector container, PostgreSQL 18.1; the module's existing skip on an unreachable server is untouched):

| | before | after |
|---|---|---|
| `test_archive_race_has_one_winner`, 10 consecutive runs | 0 passed | 10 passed |
| whole file | 52 collected, 1 failed | 54 collected, all passed |

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)