### PR TITLE
fix: match a learnings record owner against the caller by value, not by type

### DIFF
--- a/libs/agno/agno/learn/utils.py
+++ b/libs/agno/agno/learn/utils.py
@@ -57,6 +57,20 @@ def build_learning_id(
     return None
 
 
+def same_user(left: Any, right: Any) -> bool:
+    """Whether two user ids identify the same user.
+
+    The owner column is a string column, so a non-string user id reads back as its
+    ``str()``. The entity key applies the same coercion (see :func:`build_learning_id`),
+    so ``123`` and ``"123"`` address the same record and must compare equal here too.
+
+    ``None`` means "no owner" and matches nothing, not even another ``None``.
+    """
+    if left is None or right is None:
+        return False
+    return str(left) == str(right)
+
+
 def content_values_text(content: Any) -> str:
     """Flatten a content payload to a lowercased text of its VALUES only.
 

--- a/libs/agno/agno/os/routers/learnings/router.py
+++ b/libs/agno/agno/os/routers/learnings/router.py
@@ -8,7 +8,7 @@ from fastapi import Depends, HTTPException, Path, Query, Request
 from fastapi.routing import APIRouter
 
 from agno.db.base import AsyncBaseDb, BaseDb
-from agno.learn.utils import IDENTITY_KEYED_LEARNING_TYPES, build_learning_id
+from agno.learn.utils import IDENTITY_KEYED_LEARNING_TYPES, build_learning_id, same_user
 from agno.os.auth import get_authentication_dependency
 from agno.os.middleware.user_scope import get_scoped_user_id
 from agno.os.routers.learnings.schema import LearningCreate, LearningResponse, LearningUpdate, LearningUserStats
@@ -533,6 +533,10 @@ def _enforce_user_scope(request: Request, record: dict, *, mutating: bool = Fals
       to any authenticated caller, but mutating them (``mutating=True``, i.e. PATCH/DELETE) is
       admin-only -- a regular user must not overwrite or delete shared rows it doesn't own.
     - A record owned by a different user returns 404 (not 403) to avoid leaking which IDs exist.
+
+    Ownership compares as strings (``same_user``): only the SQL adapters type the ``user_id``
+    column and coerce on write, so a store that keeps whatever the writer passed holds the
+    owner in the writer's type, while the request carries it as the JWT subject string.
     """
     scoped_user_id = get_scoped_user_id(request)
     if scoped_user_id is None:
@@ -544,5 +548,5 @@ def _enforce_user_scope(request: Request, record: dict, *, mutating: bool = Fals
                 status_code=403, detail="Only admins can modify learnings that have no owner (user_id is null)"
             )
         return
-    if record_user_id != scoped_user_id:
+    if not same_user(record_user_id, scoped_user_id):
         raise HTTPException(status_code=404, detail="Learning not found")

--- a/libs/agno/agno/os/routers/learnings/schema.py
+++ b/libs/agno/agno/os/routers/learnings/schema.py
@@ -1,6 +1,16 @@
 from typing import Any, Dict, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+def _owner_as_string(value: Any) -> Any:
+    """Render a stored owner id as the string the owner column holds.
+
+    Only the SQL adapters type ``user_id`` as a string column and coerce on write; a store
+    that keeps whatever the writer passed returns the owner in the writer's type, which a
+    string field rejects.
+    """
+    return value if value is None or isinstance(value, str) else str(value)
 
 
 class LearningResponse(BaseModel):
@@ -21,6 +31,11 @@ class LearningResponse(BaseModel):
     metadata: Optional[Dict[str, Any]] = Field(None, description="Optional metadata")
     created_at: Optional[int] = Field(None, description="Creation timestamp (Unix epoch seconds)")
     updated_at: Optional[int] = Field(None, description="Last update timestamp (Unix epoch seconds)")
+
+    @field_validator("user_id", mode="before")
+    @classmethod
+    def _coerce_user_id(cls, value: Any) -> Any:
+        return _owner_as_string(value)
 
 
 class LearningCreate(BaseModel):
@@ -65,3 +80,8 @@ class LearningUserStats(BaseModel):
     last_learning_updated_at: Optional[int] = Field(
         None, description="Most recent learning update for this user (Unix epoch seconds)"
     )
+
+    @field_validator("user_id", mode="before")
+    @classmethod
+    def _coerce_user_id(cls, value: Any) -> Any:
+        return _owner_as_string(value)

--- a/libs/agno/tests/unit/learn/test_same_user.py
+++ b/libs/agno/tests/unit/learn/test_same_user.py
@@ -1,0 +1,51 @@
+"""Tests for same_user, the owner-id comparison used by the learnings scope guard."""
+
+from uuid import UUID
+
+from agno.learn.utils import build_learning_id, same_user
+
+
+class TestSameUser:
+    def test_matching_strings(self):
+        assert same_user("user-A", "user-A") is True
+
+    def test_different_strings(self):
+        assert same_user("user-A", "user-B") is False
+
+    def test_non_string_matches_its_str(self):
+        # A writer that passed an int user_id leaves an int in stores that do not type the
+        # column; the same identity arrives from the request as the JWT subject string.
+        assert same_user(123, "123") is True
+        assert same_user("123", 123) is True
+
+    def test_non_string_does_not_match_a_different_id(self):
+        assert same_user(123, "456") is False
+        assert same_user(456, "123") is False
+
+    def test_uuid_matches_its_canonical_string(self):
+        uid = UUID("2f8a1b7c-0d3e-4f5a-9b6c-7d8e9f0a1b2c")
+        assert same_user(uid, str(uid)) is True
+        assert same_user(uid, "2f8a1b7c-0d3e-4f5a-9b6c-7d8e9f0a1b2c") is True
+
+    def test_none_never_matches(self):
+        assert same_user(None, "user-A") is False
+        assert same_user("user-A", None) is False
+        assert same_user(None, None) is False
+
+    def test_empty_string_is_not_none(self):
+        assert same_user("", "") is True
+        assert same_user("", "user-A") is False
+
+    def test_zero_is_not_none(self):
+        assert same_user(0, "0") is True
+        assert same_user(0, None) is False
+
+    def test_bool_and_int_are_distinct_ids(self):
+        assert same_user(True, "1") is False
+        assert same_user(1, "True") is False
+
+    def test_agrees_with_the_entity_key(self):
+        # The record id derived for a non-string user_id is the same one derived for its
+        # str(), so a record written by either reconciles with the other.
+        assert build_learning_id("user_profile", user_id=123) == build_learning_id("user_profile", user_id="123")  # type: ignore[arg-type]
+        assert same_user(123, "123") is True

--- a/libs/agno/tests/unit/os/routers/test_learnings_router.py
+++ b/libs/agno/tests/unit/os/routers/test_learnings_router.py
@@ -2,6 +2,7 @@
 
 import time
 from unittest.mock import MagicMock
+from uuid import UUID
 
 import pytest
 from fastapi import FastAPI
@@ -522,6 +523,151 @@ class TestIDORScoping:
         resp = jwt_client.delete("/learnings/users/user-B")
         assert resp.status_code == 403
         mock_db.delete_user_learnings.assert_not_called()
+
+
+class TestNonStringOwnerScoping:
+    """Owner ids are compared as strings, because only the SQL adapters type the user_id
+    column and coerce on write -- MongoDb, AsyncMongoDb and ValkeyDb store whatever the
+    writer passed, so an agent that ran with a non-string user_id leaves a non-string in
+    that column while the request always carries the JWT subject string.
+
+    An id that is genuinely someone else's is still 404, and None still owns nothing.
+    """
+
+    @pytest.fixture
+    def jwt_client(self, mock_db, settings):
+        # Regular (non-admin) user with user isolation enabled; JWT subject "123".
+        return _scoped_client(mock_db, settings, user_isolation_enabled=True, user_id="123", scopes=[])
+
+    def test_get_own_string_owned_record(self, jwt_client, mock_db):
+        # False-refusal guard: the ordinary string-owned record must stay reachable.
+        mock_db.get_learning_by_id = MagicMock(return_value=_make_learning(user_id="123"))
+        assert jwt_client.get("/learnings/lrn-1").status_code == 200
+
+    def test_get_own_int_owned_record(self, jwt_client, mock_db):
+        mock_db.get_learning_by_id = MagicMock(return_value=_make_learning(user_id=123))
+        resp = jwt_client.get("/learnings/lrn-1")
+        assert resp.status_code == 200
+        assert resp.json()["learning_id"] == "lrn-1"
+
+    def test_patch_own_int_owned_record(self, jwt_client, mock_db):
+        existing = _make_learning(user_id=123)
+        updated = _make_learning(user_id=123, content={"new": True})
+        mock_db.get_learning_by_id = MagicMock(side_effect=[existing, updated])
+        resp = jwt_client.patch("/learnings/lrn-1", json={"content": {"new": True}})
+        assert resp.status_code == 200
+        assert mock_db.update_learning.call_args[1]["content"] == {"new": True}
+
+    def test_delete_own_int_owned_record(self, jwt_client, mock_db):
+        mock_db.get_learning_by_id = MagicMock(return_value=_make_learning(user_id=123))
+        assert jwt_client.delete("/learnings/lrn-1").status_code == 204
+        mock_db.delete_learning.assert_called_once_with("lrn-1")
+
+    def test_get_own_uuid_owned_record(self, mock_db, settings):
+        owner = UUID("2f8a1b7c-0d3e-4f5a-9b6c-7d8e9f0a1b2c")
+        client = _scoped_client(mock_db, settings, user_isolation_enabled=True, user_id=str(owner), scopes=[])
+        mock_db.get_learning_by_id = MagicMock(return_value=_make_learning(user_id=owner))
+        assert client.get("/learnings/lrn-1").status_code == 200
+
+    def test_other_users_int_owned_record_still_404(self, jwt_client, mock_db):
+        mock_db.get_learning_by_id = MagicMock(return_value=_make_learning(user_id=456))
+        assert jwt_client.get("/learnings/lrn-1").status_code == 404
+
+    def test_other_users_int_owned_record_not_mutable(self, jwt_client, mock_db):
+        mock_db.get_learning_by_id = MagicMock(return_value=_make_learning(user_id=456))
+        assert jwt_client.patch("/learnings/lrn-1", json={"content": {"x": 1}}).status_code == 404
+        mock_db.update_learning.assert_not_called()
+
+        mock_db.get_learning_by_id = MagicMock(return_value=_make_learning(user_id=456))
+        assert jwt_client.delete("/learnings/lrn-1").status_code == 404
+        mock_db.delete_learning.assert_not_called()
+
+    def test_prefix_of_the_subject_is_not_the_owner(self, jwt_client, mock_db):
+        # Coercion is str(), not a substring or numeric comparison.
+        mock_db.get_learning_by_id = MagicMock(return_value=_make_learning(user_id=12))
+        assert jwt_client.get("/learnings/lrn-1").status_code == 404
+
+    def test_non_string_subject_reaches_a_string_owned_record(self, mock_db, settings):
+        # The same coercion in the other direction: the subject claim carries the non-string.
+        client = _scoped_client(mock_db, settings, user_isolation_enabled=True, user_id=123, scopes=[])
+        mock_db.get_learning_by_id = MagicMock(return_value=_make_learning(user_id="123"))
+        assert client.get("/learnings/lrn-1").status_code == 200
+
+    def test_non_string_subject_still_404s_on_another_owner(self, mock_db, settings):
+        client = _scoped_client(mock_db, settings, user_isolation_enabled=True, user_id=123, scopes=[])
+        mock_db.get_learning_by_id = MagicMock(return_value=_make_learning(user_id="456"))
+        assert client.get("/learnings/lrn-1").status_code == 404
+
+    def test_null_owner_record_unchanged(self, jwt_client, mock_db):
+        # None is "no owner": readable by any caller, mutable only by an admin.
+        mock_db.get_learning_by_id = MagicMock(return_value=_make_learning(user_id=None))
+        assert jwt_client.get("/learnings/lrn-1").status_code == 200
+
+        mock_db.get_learning_by_id = MagicMock(return_value=_make_learning(user_id=None))
+        assert jwt_client.patch("/learnings/lrn-1", json={"content": {"x": 1}}).status_code == 403
+
+        mock_db.get_learning_by_id = MagicMock(return_value=_make_learning(user_id=None))
+        assert jwt_client.delete("/learnings/lrn-1").status_code == 403
+
+    def test_caller_without_identity_never_matches_a_record(self, mock_db, settings):
+        # Isolation on with no subject fails closed at get_scoped_user_id (403), so a
+        # null-identity caller never reaches a record, matching or not.
+        client = _scoped_client(mock_db, settings, user_isolation_enabled=True, user_id=None, scopes=[])
+        mock_db.get_learning_by_id = MagicMock(return_value=_make_learning(user_id=None))
+        assert client.get("/learnings/lrn-1").status_code == 403
+
+    def test_admin_unchanged_for_int_owned_record(self, mock_db, settings):
+        client = _scoped_client(
+            mock_db, settings, user_isolation_enabled=True, user_id="admin-1", scopes=["agent_os:admin"]
+        )
+        mock_db.get_learning_by_id = MagicMock(return_value=_make_learning(user_id=456))
+        assert client.get("/learnings/lrn-1").status_code == 200
+
+    def test_isolation_off_unchanged_for_int_owned_record(self, mock_db, settings):
+        client = _scoped_client(mock_db, settings, user_isolation_enabled=False, user_id="123", scopes=[])
+        mock_db.get_learning_by_id = MagicMock(return_value=_make_learning(user_id=456))
+        assert client.get("/learnings/lrn-1").status_code == 200
+
+    def test_explicit_user_id_guards_still_reject_a_different_user(self, jwt_client, mock_db):
+        # The collection guards compare two request-supplied values and are untouched.
+        assert jwt_client.get("/learnings?user_id=456").status_code == 403
+        assert jwt_client.get("/learnings/users?user_id=456").status_code == 403
+        assert jwt_client.delete("/learnings/users/456").status_code == 403
+        assert (
+            jwt_client.post(
+                "/learnings", json={"learning_type": "user_profile", "content": {}, "user_id": "456"}
+            ).status_code
+            == 403
+        )
+        mock_db.delete_user_learnings.assert_not_called()
+        mock_db.upsert_learning.assert_not_called()
+
+    def test_create_body_user_id_must_still_be_a_string(self, jwt_client, mock_db):
+        # Request-side strictness is unchanged: the body is validated before the guard runs.
+        resp = jwt_client.post("/learnings", json={"learning_type": "user_profile", "content": {}, "user_id": 123})
+        assert resp.status_code == 422
+        mock_db.upsert_learning.assert_not_called()
+
+    def test_list_renders_an_int_owner(self, mock_db, settings):
+        # A non-string owner in the page must not fail the whole response.
+        client = _scoped_client(
+            mock_db, settings, user_isolation_enabled=True, user_id="admin-1", scopes=["agent_os:admin"]
+        )
+        mock_db.list_learnings = MagicMock(return_value=([_make_learning(user_id=123)], 1))
+        resp = client.get("/learnings")
+        assert resp.status_code == 200
+        assert resp.json()["data"][0]["user_id"] == "123"
+
+    def test_list_users_renders_an_int_owner(self, mock_db, settings):
+        client = _scoped_client(
+            mock_db, settings, user_isolation_enabled=True, user_id="admin-1", scopes=["agent_os:admin"]
+        )
+        mock_db.get_learnings_user_stats = MagicMock(
+            return_value=([{"user_id": 123, "last_learning_updated_at": 5}], 1)
+        )
+        resp = client.get("/learnings/users")
+        assert resp.status_code == 200
+        assert resp.json()["data"][0]["user_id"] == "123"
 
 
 def _scoped_client(mock_db, settings, **state):


### PR DESCRIPTION
## Summary

`_enforce_user_scope` in the learnings router compared a stored value with a request value using `!=`. The left operand is the row's `user_id` column; the right is the JWT subject, which is always a string.

Only the SQL adapters type `user_id` as a string column and coerce on write. `MongoDb`, `AsyncMongoDb` and `ValkeyDb` keep whatever the writer passed. So an agent that ran with `user_id=123` leaves an integer in that column, and the owner's own `GET`, `PATCH` and `DELETE` of that record answered **404 Learning not found**.

The comparison now goes through `same_user`, which compares the two ids as strings and treats `None` as matching nothing.

**Fixing the comparison alone was not enough.** `LearningResponse.user_id` and `LearningUserStats.user_id` are string fields, so the same rows raised out of `model_validate`: a 500 on the single-record endpoints, and a 500 for the whole page on `GET /learnings` and `GET /learnings/users`, admins included. A `mode="before"` validator on those two response fields renders a stored owner id as its `str()`. `LearningCreate.user_id` is untouched, so a request body carrying a non-string `user_id` is still rejected with 422.

### Scope of the change

This widens access, so it is deliberately narrow. It grants a caller their own record when the stored owner and the subject are the same id written in different types. Nothing else changes.

There are five owner comparisons on this router's request path. Four of them compare a query, body or path value against the JWT subject. Neither operand has been through the storage layer, so the column's coercion cannot come between them, and loosening those 403s would widen authorization with no defect behind it. They are unchanged, and a test pins that they still reject a different user.

### Verification

- 349 tests pass across `test_learnings_router.py` and `tests/unit/learn`. Every pre-existing `TestIDORScoping` and `TestAdminAndUnscopedAccess` test is unchanged and still passes.
- Four mutations, each reverted after the run:

| mutation | result |
|---|---|
| guard back to `!=` | 5 failed, including all three int-owned own-record tests |
| response coercion dropped | 7 failed, pydantic `ValidationError` on the read paths |
| `same_user` forced to `True` | 12 failed, including the pre-existing `TestIDORScoping` cross-user 404 tests |
| `None` guard removed | `same_user(None, None)` wrongly matches |

The third one matters most: forcing the comparison open breaks the existing IDOR tests, which shows the guard is still load-bearing and this change has not opened it.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)