### PR TITLE
fix: accept every reasoning effort and service tier the OpenAI API takes

### DIFF
--- a/cookbook/90_models/openai/responses/TEST_LOG.md
+++ b/cookbook/90_models/openai/responses/TEST_LOG.md
@@ -1,3 +1,11 @@
 # TEST_LOG
 
-No cookbook tests have been recorded for this directory yet.
+### reasoning_effort.py
+
+**Status:** PASS
+
+**Description:** Runs `OpenAIResponses(id="gpt-5.5", reasoning_effort="xhigh", reasoning_summary="auto")` against the live API and asks the three-switches riddle.
+
+**Result:** The API accepted `xhigh`, the run streamed a thinking summary for 4.0s and answered the riddle correctly.
+
+---

--- a/cookbook/90_models/openai/responses/reasoning_effort.py
+++ b/cookbook/90_models/openai/responses/reasoning_effort.py
@@ -1,0 +1,35 @@
+"""
+Openai Reasoning Effort
+=======================
+
+Cookbook example for `openai/responses/reasoning_effort.py`.
+"""
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+# reasoning_effort sets how much the model thinks before it answers. OpenAI names
+# "none", "minimal", "low", "medium", "high", "xhigh" and "max", and each model page
+# lists the ones that model takes. reasoning_summary asks for a summary of the thinking.
+agent = Agent(
+    model=OpenAIResponses(
+        id="gpt-5.5", reasoning_effort="xhigh", reasoning_summary="auto"
+    ),
+    markdown=True,
+)
+
+agent.print_response(
+    "Three switches downstairs, one bulb upstairs. One trip up. Which switch?",
+    stream=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    pass

--- a/libs/agno/agno/models/openai/__init__.py
+++ b/libs/agno/agno/models/openai/__init__.py
@@ -2,10 +2,15 @@ from agno.models.openai.chat import OpenAIChat
 from agno.models.openai.like import OpenAILike
 from agno.models.openai.open_responses import OpenResponses
 from agno.models.openai.responses import OpenAIResponses
+from agno.models.openai.types import ReasoningEffort, ReasoningSummary, ServiceTier, Verbosity
 
 __all__ = [
     "OpenAIChat",
     "OpenAILike",
     "OpenAIResponses",
     "OpenResponses",
+    "ReasoningEffort",
+    "ReasoningSummary",
+    "ServiceTier",
+    "Verbosity",
 ]

--- a/libs/agno/agno/models/openai/chat.py
+++ b/libs/agno/agno/models/openai/chat.py
@@ -1,7 +1,7 @@
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from os import getenv
-from typing import Any, Dict, Iterator, List, Literal, Optional, Type, Union
+from typing import Any, Dict, Iterator, List, Optional, Type, Union
 from uuid import uuid4
 
 import httpx
@@ -12,6 +12,7 @@ from agno.media import Audio
 from agno.metrics import MessageMetrics
 from agno.models.base import Model
 from agno.models.message import Citations, Message, UrlCitation
+from agno.models.openai.types import ReasoningEffort, ServiceTier, Verbosity
 from agno.models.response import ModelResponse
 from agno.run.agent import RunOutput
 from agno.run.team import TeamRunOutput
@@ -47,8 +48,8 @@ class OpenAIChat(Model):
 
     # Request parameters
     store: Optional[bool] = None
-    reasoning_effort: Optional[str] = None
-    verbosity: Optional[Literal["low", "medium", "high"]] = None
+    reasoning_effort: Optional[ReasoningEffort] = None
+    verbosity: Optional[Verbosity] = None
     metadata: Optional[Dict[str, Any]] = None
     frequency_penalty: Optional[float] = None
     logit_bias: Optional[Any] = None
@@ -66,7 +67,7 @@ class OpenAIChat(Model):
     temperature: Optional[float] = None
     user: Optional[str] = None
     top_p: Optional[float] = None
-    service_tier: Optional[str] = None  # "auto" | "default" | "flex" | "priority", defaults to "auto" when not set
+    service_tier: Optional[ServiceTier] = None  # Defaults to "auto" when not set
     strict_output: bool = True  # When True, guarantees schema adherence for structured outputs. When False, attempts to follow schema as a guide but may occasionally deviate
     extra_headers: Optional[Any] = None
     extra_query: Optional[Any] = None

--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -12,6 +12,7 @@ from agno.media import File
 from agno.metrics import MessageMetrics
 from agno.models.base import Model
 from agno.models.message import Citations, Message, UrlCitation
+from agno.models.openai.types import ReasoningEffort, ReasoningSummary, ServiceTier, Verbosity
 from agno.models.response import ModelResponse
 from agno.run.agent import RunOutput
 from agno.tools.function import Function
@@ -47,15 +48,15 @@ class OpenAIResponses(Model):
     metadata: Optional[Dict[str, Any]] = None
     parallel_tool_calls: Optional[bool] = None
     reasoning: Optional[Dict[str, Any]] = None
-    verbosity: Optional[Literal["low", "medium", "high"]] = None
-    reasoning_effort: Optional[Literal["minimal", "low", "medium", "high"]] = None
-    reasoning_summary: Optional[Literal["auto", "concise", "detailed"]] = None
+    verbosity: Optional[Verbosity] = None
+    reasoning_effort: Optional[ReasoningEffort] = None
+    reasoning_summary: Optional[ReasoningSummary] = None
     store: Optional[bool] = None
     temperature: Optional[float] = None
     top_p: Optional[float] = None
     truncation: Optional[Literal["auto", "disabled"]] = None
     user: Optional[str] = None
-    service_tier: Optional[Literal["auto", "default", "flex", "priority"]] = None
+    service_tier: Optional[ServiceTier] = None
     strict_output: bool = True  # When True, guarantees schema adherence for structured outputs. When False, attempts to follow schema as a guide but may occasionally deviate
     background: Optional[bool] = (
         None  # When True, enables background mode for long-running tasks. The API returns immediately and the response is polled until completion. Not supported for streaming.

--- a/libs/agno/agno/models/openai/types.py
+++ b/libs/agno/agno/models/openai/types.py
@@ -1,0 +1,31 @@
+"""Types for OpenAI request parameters whose value set grows with each model release.
+
+Every alias names the values OpenAI documents today and also accepts any other string, so a value
+introduced by a later model works without an agno release. Editors keep offering the named values
+as completions. Which of them a request may use depends on the model and the endpoint, and the API
+rejects a value the target model does not support.
+"""
+
+from typing import Literal, Union
+
+__all__ = [
+    "ReasoningEffort",
+    "ReasoningSummary",
+    "ServiceTier",
+    "Verbosity",
+]
+
+# How much the model thinks before it answers. The values a model takes are listed on its model
+# page. See https://platform.openai.com/docs/guides/reasoning
+ReasoningEffort = Union[Literal["none", "minimal", "low", "medium", "high", "xhigh", "max"], str]
+
+# Level of detail of the reasoning summary returned with the response. "auto" gives the most
+# detailed summary a model offers.
+ReasoningSummary = Union[Literal["auto", "concise", "detailed"], str]
+
+# Processing tier that serves the request. The tiers an account may use vary, and "ultrafast" is
+# Responses only.
+ServiceTier = Union[Literal["auto", "default", "flex", "scale", "priority", "fast", "ultrafast"], str]
+
+# Length of the answer, from terse to expansive.
+Verbosity = Union[Literal["low", "medium", "high"], str]

--- a/libs/agno/agno/models/ramp/router.py
+++ b/libs/agno/agno/models/ramp/router.py
@@ -54,8 +54,8 @@ class RampRouter(OpenResponses):
     Router rejects unknown request parameters rather than ignoring them, and the accepted set
     varies by the model that serves the request: `temperature`/`top_p` are rejected by reasoning
     models, and `reasoning.effort` is rejected by non-reasoning ones. Effort vocabularies are
-    per-model and wider than OpenAI's, so values outside "minimal"/"low"/"medium"/"high" go
-    through `reasoning` rather than `reasoning_effort`: `RampRouter(reasoning={"effort": "xhigh"})`.
+    per-model and wider than OpenAI's, and `reasoning_effort` takes any of them:
+    `RampRouter(reasoning_effort="xhigh")`.
 
     `background=True` is not supported. Router accepts the request and queues the generation, but
     serves no endpoint to read it back, so it can never be collected.

--- a/libs/agno/tests/unit/models/openai/test_request_param_types.py
+++ b/libs/agno/tests/unit/models/openai/test_request_param_types.py
@@ -1,0 +1,82 @@
+"""Tests for the OpenAI request parameter types.
+
+The installed OpenAI SDK is the reference for which values exist. A test here fails when the SDK
+names a value `agno.models.openai.types` does not, which means the completions and the comments in
+that module are behind the API. The aliases accept any string, so a value missing from them never
+blocks a caller.
+"""
+
+from typing import Any, Literal, Set, get_args, get_origin
+
+from agno.models.openai.chat import OpenAIChat
+from agno.models.openai.responses import OpenAIResponses
+from agno.models.openai.types import ReasoningEffort, ReasoningSummary, ServiceTier, Verbosity
+
+
+def named_values(alias: Any) -> Set[str]:
+    """Return the values named by the Literal inside a type alias."""
+    for arg in get_args(alias):
+        if get_origin(arg) is Literal:
+            return set(get_args(arg))
+    raise AssertionError(f"{alias} names no Literal values")
+
+
+def test_named_values_reads_the_literal_out_of_an_alias():
+    assert named_values(ReasoningSummary) == {"auto", "concise", "detailed"}
+
+
+def test_aliases_accept_values_they_do_not_name():
+    for alias in (ReasoningEffort, ReasoningSummary, ServiceTier, Verbosity):
+        assert str in get_args(alias), f"{alias} rejects values it does not name"
+
+
+def test_reasoning_effort_names_every_sdk_value():
+    from openai.types.shared.reasoning_effort import ReasoningEffort as SDKReasoningEffort
+
+    assert named_values(SDKReasoningEffort) <= named_values(ReasoningEffort)
+
+
+def test_reasoning_summary_names_every_sdk_value():
+    from openai.types.shared.reasoning import Reasoning
+
+    assert named_values(Reasoning.model_fields["summary"].annotation) <= named_values(ReasoningSummary)
+
+
+def test_verbosity_names_every_sdk_value():
+    from openai.types.responses.response_text_config import ResponseTextConfig
+
+    assert named_values(ResponseTextConfig.model_fields["verbosity"].annotation) <= named_values(Verbosity)
+
+
+def test_service_tier_names_every_sdk_value():
+    from openai.types.chat.chat_completion import ChatCompletion
+    from openai.types.responses.service_tier import ServiceTier as SDKServiceTier
+
+    assert named_values(SDKServiceTier) <= named_values(ServiceTier)
+    assert named_values(ChatCompletion.model_fields["service_tier"].annotation) <= named_values(ServiceTier)
+
+
+def test_responses_sends_an_effort_the_aliases_do_not_name():
+    model = OpenAIResponses(id="gpt-5.6", api_key="test-key", reasoning_effort="ultra", reasoning_summary="brief")
+
+    params = model.get_request_params()
+
+    assert params["reasoning"] == {"effort": "ultra", "summary": "brief"}
+
+
+def test_responses_sends_a_service_tier_and_verbosity_the_aliases_do_not_name():
+    model = OpenAIResponses(id="gpt-5.6", api_key="test-key", service_tier="hyperfast", verbosity="terse")
+
+    params = model.get_request_params()
+
+    assert params["service_tier"] == "hyperfast"
+    assert params["text"]["verbosity"] == "terse"
+
+
+def test_chat_sends_values_the_aliases_do_not_name():
+    model = OpenAIChat(id="gpt-5.6", api_key="test-key", reasoning_effort="ultra", service_tier="hyperfast")
+
+    params = model.get_request_params()
+
+    assert params["reasoning_effort"] == "ultra"
+    assert params["service_tier"] == "hyperfast"


### PR DESCRIPTION
## Summary

`OpenAIResponses.reasoning_effort` was typed as `"minimal" | "low" | "medium" | "high"`. OpenAI has since added `"none"`, `"xhigh"` and `"max"`, and `service_tier` has added `"scale"`, `"fast"` and `"ultrafast"`. Every new value failed type checking, so `./scripts/validate.sh` and any user running mypy or Pylance rejected calls the API accepts:

```
error: Argument "reasoning_effort" to "OpenAIResponses" has incompatible type "Literal['xhigh']";
       expected "Literal['minimal', 'low', 'medium', 'high'] | None"
```

The workaround was the raw `reasoning={"effort": "xhigh"}` dict or a type-ignore comment. `RampRouter` documented that workaround in its docstring.

### What changed

New module `agno/models/openai/types.py` holds the four request parameter types whose value set grows with each model release:

```python
ReasoningEffort = Union[Literal["none", "minimal", "low", "medium", "high", "xhigh", "max"], str]
ReasoningSummary = Union[Literal["auto", "concise", "detailed"], str]
ServiceTier = Union[Literal["auto", "default", "flex", "scale", "priority", "fast", "ultrafast"], str]
Verbosity = Union[Literal["low", "medium", "high"], str]
```

`OpenAIResponses` and `OpenAIChat` use them, and every model that builds on those two inherits the change: `OpenResponses`, `OpenAILike`, `OpenRouterResponses`, `RampRouter`, `AzureOpenAI`, `DeepSeek` and `MoonShot`.

### How this covers future values

Each alias names the values OpenAI documents today **and also accepts any other string**. This is the same shape the OpenAI SDK uses for its own moving fields, for example `mode: Union[str, Literal["standard", "pro"]]` and `model: Union[str, ChatModel]`.

- The next value OpenAI ships works on the day it ships. No agno release needed, no type-ignore.
- Completions survive. Pyright still offers exactly the seven named efforts inside `reasoning_effort=""` (verified against `pyright-langserver` 1.1.413).
- The API stays the authority on what a given model accepts. agno does not second-guess it, which matters because support is per-model: `gpt-5.5` takes `xhigh`, `gpt-5.6` takes `max` but rejects `minimal`, `gpt-5.4-mini` rejects `max`.

To stop the named sets from quietly falling behind, `test_request_param_types.py` reads the installed OpenAI SDK and fails when the SDK names a value an alias does not. The assertion runs one way only (SDK values must be a subset of ours), so an older pinned SDK never fails the suite.

### Verification

- Live probe against the API through agno's own request path: `gpt-5.6` accepted `none`, `low`, `xhigh` and `max` and rejected `minimal`; `gpt-5.4-mini` accepted `xhigh` and rejected `max`. Sending an unknown effort returns the API's own list: `'none', 'minimal', 'low', 'medium', 'high', 'xhigh', and 'max'`, which matches the alias exactly.
- The mypy repro above now reports `Success: no issues found`.
- 10 mutations of the new types and the two request paths, all killed by the new tests.
- `mypy` clean over 976 files, `ruff check` clean, 137 model unit tests pass.
- New cookbook example runs against the live API. See `cookbook/90_models/openai/responses/TEST_LOG.md`.

### Not in this PR

`GeminiInteractions.thinking_level` and its `service_tier` are closed literals with the same failure mode. Their values are current today, so they are left for a follow-up.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [x] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

No behaviour change. The values were already passed through to the API untouched; only the types were behind.

`OpenAIChat.reasoning_effort` was a bare `str` and `OpenAIChat.service_tier` carried a stale comment listing four tiers. Both now use the shared aliases, which gains them completions and drops the comment.

The four aliases are exported from `agno.models.openai` for users who annotate their own config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
