### PR TITLE
fix: don't mark defaulted dataclass fields as required in tool schemas (#9650)

### DIFF
--- a/libs/agno/agno/utils/json_schema.py
+++ b/libs/agno/agno/utils/json_schema.py
@@ -1,3 +1,4 @@
+from dataclasses import MISSING
 from enum import Enum
 from typing import Any, Dict, Literal, Optional, Union, get_args, get_origin
 
@@ -190,7 +191,8 @@ def get_json_schema_for_arg(type_hint: Any) -> Optional[Dict[str, Any]]:
                 if non_null_type is not None:
                     field_schema["type"] = non_null_type
                     field_schema.pop("anyOf")
-            else:
+            elif field.default is MISSING and field.default_factory is MISSING:
+                # A field is only required when the dataclass itself has no fallback for it.
                 required.append(field_name)
 
             if field_schema:

--- a/libs/agno/tests/unit/utils/test_json_schema.py
+++ b/libs/agno/tests/unit/utils/test_json_schema.py
@@ -452,3 +452,56 @@ def test_get_json_schema_with_mixed_nested_structures():
     assert "contact_info" in dataclass_schema["properties"]
     assert "address" in pydantic_schema["properties"]["contact_info"]["properties"]
     assert "address" in dataclass_schema["properties"]["contact_info"]["properties"]
+
+
+def test_dataclass_fields_with_defaults_are_not_required():
+    """Dataclass fields carrying a default must not be listed as required."""
+
+    @dataclass
+    class SearchParams:
+        query: str
+        max_results: int = 10
+        include_archived: bool = False
+        tags: List[str] = field(default_factory=list)
+        tag: Optional[str] = None
+
+    schema = get_json_schema_for_arg(SearchParams)
+
+    # Every field is still advertised to the model...
+    assert set(schema["properties"]) == {"query", "max_results", "include_archived", "tags", "tag"}
+    # ...but only the one the caller genuinely has to supply is required.
+    assert schema["required"] == ["query"]
+
+
+def test_dataclass_required_matches_pydantic_for_the_same_fields():
+    """The dataclass branch and the pydantic branch must agree on required-ness."""
+
+    @dataclass
+    class AsDataclass:
+        query: str
+        max_results: int = 10
+        tag: Optional[str] = None
+
+    class AsModel(BaseModel):
+        query: str
+        max_results: int = 10
+        tag: Optional[str] = None
+
+    dataclass_schema = get_json_schema_for_arg(AsDataclass)
+    model_schema = get_json_schema_for_arg(AsModel)
+
+    assert dataclass_schema["required"] == model_schema["required"] == ["query"]
+
+
+def test_dataclass_with_only_defaulted_fields_omits_required():
+    """A dataclass whose fields all have defaults must not emit a required key at all."""
+
+    @dataclass
+    class AllOptional:
+        limit: int = 5
+        verbose: bool = False
+
+    schema = get_json_schema_for_arg(AllOptional)
+
+    assert set(schema["properties"]) == {"limit", "verbose"}
+    assert "required" not in schema


### PR DESCRIPTION
## Description

Fixes #9650.

The dataclass branch of `get_json_schema_for_arg` (`libs/agno/agno/utils/json_schema.py`) decides required-ness from the field's **type** shape alone:

```python
if field_schema and "anyOf" in field_schema and any(... == "null" ...):
    ...unwrap Optional...
else:
    required.append(field_name)
```

The `else` runs for every field whose schema is not `Optional[...]`-shaped, and appends it unconditionally. `field.default` and `field.default_factory` are never read, so a field with a plain type **and a default** is reported as required.

This is not confined to an internal representation: `get_json_schema_for_arg` is what `agno/tools/function.py` uses to build the schema sent to the provider for every tool call. The model is told it must supply arguments the tool would happily default, and a provider that validates strict schemas can reject an otherwise valid partial argument set.

### Before

```python
@dataclass
class SearchParams:
    query: str                      # genuinely required
    max_results: int = 10
    include_archived: bool = False
    tags: List[str] = field(default_factory=list)
    tag: Optional[str] = None       # already excluded, by type shape

get_json_schema_for_arg(SearchParams)["required"]
# ['query', 'max_results', 'include_archived', 'tags']
```

### After

```python
# ['query']
```

## The fix

Gate the append on the field actually having no fallback:

```python
elif field.default is MISSING and field.default_factory is MISSING:
    # A field is only required when the dataclass itself has no fallback for it.
    required.append(field_name)
```

Three lines, one import. Every field is still emitted into `properties` exactly as before — only the `required` list changes.

**This makes the dataclass branch agree with the pydantic branch directly above it**, whose `model_json_schema()` already excludes defaulted fields. The same five fields declared as a `BaseModel` produce `required == ['query']` today; the dataclass form now matches.

The `Optional[...]` handling is deliberately left untouched — this PR only stops defaulted fields from being marked required, and does not change which types get unwrapped.

## Testing

Three tests added to `libs/agno/tests/unit/utils/test_json_schema.py`:

- `test_dataclass_fields_with_defaults_are_not_required` — the reproduction above; asserts all five fields stay in `properties` and only `query` is required.
- `test_dataclass_required_matches_pydantic_for_the_same_fields` — pins the dataclass/pydantic agreement so the two branches can't drift apart again.
- `test_dataclass_with_only_defaulted_fields_omits_required` — a dataclass where everything has a default emits no `required` key at all.

```
# on main:    3 failed, 20 passed
# with fix:  23 passed
```

All 20 pre-existing tests in that file pass unchanged, including `test_get_json_schema_with_nested_dataclasses`, which asserts an exact `required == ["email", "address"]` on a dataclass whose other fields are genuinely default-free. `ruff format --diff` and `ruff check` are clean at the repo's `line-length = 120` / `target-version = py39`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
