### PR TITLE
[fix] Respect dataclass defaults in tool schemas

### DIFF
--- a/libs/agno/agno/utils/json_schema.py
+++ b/libs/agno/agno/utils/json_schema.py
@@ -1,3 +1,4 @@
+from dataclasses import MISSING
 from enum import Enum
 from typing import Any, Dict, Literal, Optional, Union, get_args, get_origin
 
@@ -177,6 +178,7 @@ def get_json_schema_for_arg(type_hint: Any) -> Optional[Dict[str, Any]]:
         for field_name, field in type_hint.__dataclass_fields__.items():
             field_type = field.type
             field_schema = get_json_schema_for_arg(field_type)
+            has_default = field.default is not MISSING or field.default_factory is not MISSING
 
             if (
                 field_schema
@@ -190,7 +192,8 @@ def get_json_schema_for_arg(type_hint: Any) -> Optional[Dict[str, Any]]:
                 if non_null_type is not None:
                     field_schema["type"] = non_null_type
                     field_schema.pop("anyOf")
-            else:
+
+            if not has_default:
                 required.append(field_name)
 
             if field_schema:

--- a/libs/agno/tests/unit/utils/test_json_schema.py
+++ b/libs/agno/tests/unit/utils/test_json_schema.py
@@ -260,6 +260,21 @@ def test_get_json_schema_with_dataclass():
     assert user_schema["properties"]["age"]["type"] == "integer"
     assert user_schema["properties"]["is_active"]["type"] == "boolean"
     assert user_schema["properties"]["tags"]["type"] == "array"
+    assert user_schema["required"] == ["name", "age"]
+
+
+def test_get_json_schema_dataclass_required_fields_follow_defaults():
+    @dataclass
+    class Config:
+        required_value: str
+        optional_required_value: Optional[str]
+        default_value: int = 10
+        generated_value: List[str] = field(default_factory=list)
+        optional_default_value: Optional[str] = None
+
+    schema = get_json_schema_for_arg(Config)
+
+    assert schema["required"] == ["required_value", "optional_required_value"]
 
 
 def test_get_json_schema_dataclass_optional_field_without_type():


### PR DESCRIPTION
<!-- codex-oss-sweep -->

## Summary

Fixes #9650 by deriving dataclass JSON Schema `required` fields from whether each field has a default or `default_factory`. Non-default fields remain required, while defaulted fields are optional on the wire.

## Root cause

`get_json_schema_for_arg()` marked every non-`Optional` dataclass field as required based only on its type shape. It never inspected `dataclasses.Field.default` or `default_factory`, so tool schemas required values that Python dataclass construction can supply automatically.

## Changes

- Use `dataclasses.MISSING` to detect absent defaults and default factories.
- Preserve the existing Optional unwrapping behavior.
- Add regression coverage for required fields, plain defaults, `default_factory`, and Optional fields with and without defaults.

## Verification

- `PYTHONPATH=libs/agno .venv/bin/python -m pytest -q libs/agno/tests/unit/utils/test_json_schema.py` — 21 passed
- `.venv/bin/ruff format --check libs/agno/agno/utils/json_schema.py libs/agno/tests/unit/utils/test_json_schema.py` — passed
- `.venv/bin/ruff check libs/agno/agno/utils/json_schema.py libs/agno/tests/unit/utils/test_json_schema.py` — passed
- `.venv/bin/mypy libs/agno/agno/utils/json_schema.py --config-file libs/agno/pyproject.toml` — passed
- `python3 -m py_compile` for changed Python files — passed

The full repository scripts were not run because this isolated environment does not include all optional development dependencies; the focused checks above cover the changed module and test.

## AI assistance disclosure

This pull request was prepared with AI assistance. I reviewed the complete diff and verification results, and I am responsible for the change.
