### PR TITLE
fix: docs clarify human-readable ID collision guarantees

### DIFF
--- a/libs/agno/agno/utils/names.py
+++ b/libs/agno/agno/utils/names.py
@@ -2,7 +2,8 @@
 
 Generates IDs in the format ``adjective-name-hexsuffix``, where the
 adjective and name are chosen deterministically from a UUID4, and the
-hex suffix is derived from the same UUID to guarantee uniqueness.
+hex suffix is derived from the same UUID as a compact collision-resistant
+identifier.
 """
 
 from uuid import uuid4
@@ -153,10 +154,13 @@ def generate_human_readable_id() -> str:
 
     The adjective and name are selected deterministically from the UUID's
     integer value, and an 8-character hex suffix derived from the same UUID
-    ensures collision resistance equivalent to UUID4.
+    gives the returned ID roughly 44 bits of distinguishing entropy. This is
+    substantially smaller than UUID4's random space, so the ID is not
+    collision-resistant to the same degree as a full UUID4.
 
     Returns:
-        str: A human-readable, unique identifier.
+        str: A compact human-readable identifier; it is not guaranteed
+            globally unique.
     """
     uid = uuid4()
     uid_int = uid.int

--- a/libs/agno/tests/unit/utils/test_names.py
+++ b/libs/agno/tests/unit/utils/test_names.py
@@ -34,3 +34,10 @@ def test_generate_human_readable_id_uniqueness():
     """1000 generated IDs should all be unique"""
     ids = {generate_human_readable_id() for _ in range(1000)}
     assert len(ids) == 1000
+
+
+def test_generate_human_readable_id_documents_compact_entropy():
+    """The public contract must not promise UUID4-equivalent uniqueness."""
+    doc = " ".join((generate_human_readable_id.__doc__ or "").split())
+    assert "roughly 44 bits of distinguishing entropy" in doc
+    assert "not collision-resistant to the same degree as a full UUID4" in doc


### PR DESCRIPTION
## Problem
The `generate_human_readable_id` documentation says its compact ID has collision resistance equivalent to UUID4. The implementation uses two 64-entry word lists plus an 8-character UUID prefix, so that guarantee is materially overstated.

## Root Cause
The module and function docstrings describe the UUID4 source rather than the entropy retained in the returned string. The returned format carries roughly 44 distinguishing bits, not the full UUID4 random space.

## Solution
Correct the documentation to describe the compact identifier as collision-resistant but not equivalent to a full UUID4, and state that it is not guaranteed globally unique.

## Changes
- Clarify the module-level ID format description.
- Replace the UUID4-equivalence claim with the approximate 44-bit entropy limitation.
- Clarify the return-value guarantee without changing the generated format or runtime behavior.

## Testing
- Baseline and final import smoke: `PYTHONPATH=libs/agno py -3.10 -c "from agno.utils.names import generate_human_readable_id; ..."` — passed; format remains `adjective-name-hexsuffix`.
- `py -3.10 -m ruff check libs/agno/agno/utils/names.py` — passed.
- `py -3.10 -m ruff format --check libs/agno/agno/utils/names.py` — passed.
- `py -3.10 -m pytest libs/agno/tests/unit/utils/test_names.py -q` — 6 passed.
- `py -3.10 -m compileall -q libs/agno/agno/utils/names.py` — passed.
- `git diff --check` — passed.
- Full Agno test suite and dedicated typecheck were not run; the repository's optional-extra resolution is currently unsatisfiable on this checkout because `brave-search` conflicts with the `a2a` httpx requirement.

## Compatibility/Risk
This is documentation-only. Runtime ID generation, length, format, and storage behavior are unchanged.

## Notes for Reviewer
The issue offers either widening the suffix or correcting the claim. This PR chooses the non-breaking documentation correction and leaves the public identifier format unchanged.

## Linked Issue
Fixes #9651