### PR TITLE
chore: update gemini defaults to use 3.7 flash

### DIFF
--- a/cookbook/10_reasoning/models/gemini/async_reasoning_stream.py
+++ b/cookbook/10_reasoning/models/gemini/async_reasoning_stream.py
@@ -22,7 +22,7 @@ def run_example() -> None:
         # Note: For Gemini, you MUST set thinking_budget to enable thinking mode
         agent = Agent(
             reasoning_model=Gemini(
-                id="gemini-2.5-flash",
+                id="gemini-3.7-flash",
                 thinking_budget=1024,  # Required to enable thinking mode
                 include_thoughts=True,  # Include thought summaries in response
             ),

--- a/cookbook/10_reasoning/models/gemini/basic_reasoning.py
+++ b/cookbook/10_reasoning/models/gemini/basic_reasoning.py
@@ -21,14 +21,14 @@ def run_example() -> None:
 
     # Create a regular agent (no reasoning)
     regular_agent = Agent(
-        model=Gemini(id="gemini-2.5-flash"),
+        model=Gemini(id="gemini-3.7-flash"),
         markdown=True,
     )
 
     # Create an agent with thinking budget
     reasoning_agent = Agent(
-        model=Gemini(id="gemini-2.5-flash"),
-        reasoning_model=Gemini(id="gemini-2.5-flash", thinking_budget=1024),
+        model=Gemini(id="gemini-3.7-flash"),
+        reasoning_model=Gemini(id="gemini-3.7-flash", thinking_budget=1024),
         markdown=True,
     )
 

--- a/cookbook/10_reasoning/models/gemini/basic_reasoning_stream.py
+++ b/cookbook/10_reasoning/models/gemini/basic_reasoning_stream.py
@@ -18,7 +18,7 @@ def run_example() -> None:
     # Note: For Gemini, you MUST set thinking_budget to enable thinking mode
     agent = Agent(
         reasoning_model=Gemini(
-            id="gemini-2.5-flash",
+            id="gemini-3.7-flash",
             thinking_budget=1024,  # Required to enable thinking mode
             include_thoughts=True,  # Include thought summaries in response
         ),

--- a/cookbook/90_models/google/gemini/audio_input_bytes_content.py
+++ b/cookbook/90_models/google/gemini/audio_input_bytes_content.py
@@ -15,7 +15,7 @@ from agno.models.google import Gemini
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model=Gemini(id="gemini-3.7-flash"),
     markdown=True,
 )
 

--- a/cookbook/90_models/google/gemini/audio_input_file_upload.py
+++ b/cookbook/90_models/google/gemini/audio_input_file_upload.py
@@ -16,7 +16,7 @@ from google.genai.types import UploadFileConfig
 # Create Agent
 # ---------------------------------------------------------------------------
 
-model = Gemini(id="gemini-3.5-flash")
+model = Gemini(id="gemini-3.7-flash")
 agent = Agent(
     model=model,
     markdown=True,

--- a/cookbook/90_models/google/gemini/audio_input_local_file_upload.py
+++ b/cookbook/90_models/google/gemini/audio_input_local_file_upload.py
@@ -16,7 +16,7 @@ from agno.models.google import Gemini
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model=Gemini(id="gemini-3.7-flash"),
     markdown=True,
 )
 

--- a/cookbook/90_models/google/gemini/basic.py
+++ b/cookbook/90_models/google/gemini/basic.py
@@ -13,7 +13,7 @@ import asyncio
 # Create Agent
 # ---------------------------------------------------------------------------
 
-agent = Agent(model=Gemini(id="gemini-3.5-flash"), markdown=True)
+agent = Agent(model=Gemini(id="gemini-3.7-flash"), markdown=True)
 
 # Get the response in a variable
 # run: RunOutput = agent.run("Share a 2 sentence horror story")

--- a/cookbook/90_models/google/gemini/csv_input.py
+++ b/cookbook/90_models/google/gemini/csv_input.py
@@ -23,7 +23,7 @@ download_file(
 )
 
 agent = Agent(
-    model=Gemini(id="gemini-2.5-flash"),
+    model=Gemini(id="gemini-3.7-flash"),
     markdown=True,
 )
 

--- a/cookbook/90_models/google/gemini/db.py
+++ b/cookbook/90_models/google/gemini/db.py
@@ -14,7 +14,7 @@ db_url = "postgresql+psycopg://ai:ai@localhost:5532/ai"
 db = PostgresDb(db_url=db_url)
 
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model=Gemini(id="gemini-3.7-flash"),
     db=db,
     tools=[WebSearchTools()],
     add_history_to_context=True,

--- a/cookbook/90_models/google/gemini/external_url_input.py
+++ b/cookbook/90_models/google/gemini/external_url_input.py
@@ -25,7 +25,7 @@ from agno.models.google import Gemini
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model=Gemini(id="gemini-3.7-flash"),
     markdown=True,
 )
 

--- a/cookbook/90_models/google/gemini/file_search_advanced.py
+++ b/cookbook/90_models/google/gemini/file_search_advanced.py
@@ -15,7 +15,7 @@ from agno.models.google import Gemini
 # ---------------------------------------------------------------------------
 
 # Create Gemini model
-model = Gemini(id="gemini-2.5-flash")
+model = Gemini(id="gemini-3.7-flash")
 
 # Create agent
 agent = Agent(model=model, markdown=True)

--- a/cookbook/90_models/google/gemini/file_search_basic.py
+++ b/cookbook/90_models/google/gemini/file_search_basic.py
@@ -15,7 +15,7 @@ from agno.models.google import Gemini
 # ---------------------------------------------------------------------------
 
 # Create Gemini model
-model = Gemini(id="gemini-2.5-flash")
+model = Gemini(id="gemini-3.7-flash")
 
 # Create agent with the model
 agent = Agent(model=model, markdown=True)

--- a/cookbook/90_models/google/gemini/file_search_image_upload.py
+++ b/cookbook/90_models/google/gemini/file_search_image_upload.py
@@ -48,7 +48,7 @@ if not mime_type:
 # Create model and store
 # ---------------------------------------------------------------------------
 
-model = Gemini(id="gemini-3.5-flash")
+model = Gemini(id="gemini-3.7-flash")
 agent = Agent(model=model, markdown=True)
 
 # Create a multimodal store with gemini-embedding-2 for image support

--- a/cookbook/90_models/google/gemini/file_search_rag_pipeline.py
+++ b/cookbook/90_models/google/gemini/file_search_rag_pipeline.py
@@ -165,7 +165,7 @@ async def main():
         return
 
     # Initialize model
-    model = Gemini(id="gemini-2.5-flash")
+    model = Gemini(id="gemini-3.7-flash")
 
     # Step 1: Create and populate store
     print("\n" + "=" * 80)

--- a/cookbook/90_models/google/gemini/file_upload_with_cache.py
+++ b/cookbook/90_models/google/gemini/file_upload_with_cache.py
@@ -56,7 +56,7 @@ if not txt_file:
 
 # Create a cache with 5min TTL
 cache = client.caches.create(
-    model="gemini-3.5-flash",
+    model="gemini-3.7-flash",
     config={
         "system_instruction": "You are an expert at analyzing transcripts.",
         "contents": [txt_file],
@@ -70,7 +70,7 @@ cache = client.caches.create(
 
 if __name__ == "__main__":
     agent = Agent(
-        model=Gemini(id="gemini-3.5-flash", cached_content=cache.name),
+        model=Gemini(id="gemini-3.7-flash", cached_content=cache.name),
     )
     run_output = agent.run(
         "Find a lighthearted moment from this transcript",  # No need to pass the txt file

--- a/cookbook/90_models/google/gemini/gcs_file_input.py
+++ b/cookbook/90_models/google/gemini/gcs_file_input.py
@@ -25,7 +25,7 @@ from agno.models.google import Gemini
 # Set GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION env vars
 agent = Agent(
     model=Gemini(
-        id="gemini-3.5-flash",
+        id="gemini-3.7-flash",
         vertexai=True,
     ),
     markdown=True,

--- a/cookbook/90_models/google/gemini/gemini_2_to_3.py
+++ b/cookbook/90_models/google/gemini/gemini_2_to_3.py
@@ -17,7 +17,7 @@ from agno.tools.websearch import WebSearchTools
 session_id = str(uuid4())
 
 agent = Agent(
-    model=Gemini(id="gemini-2.5-flash"),
+    model=Gemini(id="gemini-3.7-flash"),
     db=SqliteDb(db_file="tmp/data.db"),
     tools=[WebSearchTools()],
     markdown=True,
@@ -32,7 +32,7 @@ asyncio.run(
 
 # Create a new agent with Gemini 3 Pro and re-use the history from the previous session
 agent = Agent(
-    model=Gemini(id="gemini-3-pro-preview"),
+    model=Gemini(id="gemini-3.1-pro-preview"),
     db=SqliteDb(db_file="tmp/data.db"),
     markdown=True,
     add_history_to_context=True,

--- a/cookbook/90_models/google/gemini/gemini_3_pro.py
+++ b/cookbook/90_models/google/gemini/gemini_3_pro.py
@@ -14,7 +14,7 @@ from agno.tools.websearch import WebSearchTools
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Gemini(id="gemini-3-pro-preview"),
+    model=Gemini(id="gemini-3.1-pro-preview"),
     db=SqliteDb(db_file="tmp/data.db"),
     tools=[WebSearchTools()],
     markdown=True,

--- a/cookbook/90_models/google/gemini/gemini_3_pro_thinking_level.py
+++ b/cookbook/90_models/google/gemini/gemini_3_pro_thinking_level.py
@@ -12,7 +12,7 @@ from agno.models.google import Gemini
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Gemini(id="gemini-3-pro-preview", thinking_level="low"),
+    model=Gemini(id="gemini-3.1-pro-preview", thinking_level="low"),
     markdown=True,
 )
 

--- a/cookbook/90_models/google/gemini/grounding.py
+++ b/cookbook/90_models/google/gemini/grounding.py
@@ -16,7 +16,7 @@ from agno.models.google import Gemini
 
 agent = Agent(
     model=Gemini(
-        id="gemini-3.5-flash",
+        id="gemini-3.7-flash",
         grounding=True,
         grounding_dynamic_threshold=0.7,  # Optional: set threshold for grounding
     ),

--- a/cookbook/90_models/google/gemini/image_editing.py
+++ b/cookbook/90_models/google/gemini/image_editing.py
@@ -19,7 +19,7 @@ from PIL import Image as PILImage
 # No system message should be provided (Gemini requires only the image)
 agent = Agent(
     model=Gemini(
-        id="gemini-3.5-flash",
+        id="gemini-3.7-flash",
         response_modalities=["Text", "Image"],
     )
 )

--- a/cookbook/90_models/google/gemini/image_generation.py
+++ b/cookbook/90_models/google/gemini/image_generation.py
@@ -18,7 +18,7 @@ from PIL import Image
 # No system message should be provided
 agent = Agent(
     model=Gemini(
-        id="gemini-3.5-flash",
+        id="gemini-3.7-flash",
         response_modalities=["Text", "Image"],
     )
 )

--- a/cookbook/90_models/google/gemini/image_input.py
+++ b/cookbook/90_models/google/gemini/image_input.py
@@ -15,7 +15,7 @@ from agno.tools.websearch import WebSearchTools
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Gemini(id="gemini-2.0-flash-exp"),
+    model=Gemini(id="gemini-3.7-flash"),
     tools=[WebSearchTools()],
     markdown=True,
 )

--- a/cookbook/90_models/google/gemini/image_input_file_upload.py
+++ b/cookbook/90_models/google/gemini/image_input_file_upload.py
@@ -19,7 +19,7 @@ from google.generativeai.types import file_types
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Gemini(id="gemini-2.0-flash-exp"),
+    model=Gemini(id="gemini-3.7-flash"),
     tools=[WebSearchTools()],
     markdown=True,
 )

--- a/cookbook/90_models/google/gemini/knowledge.py
+++ b/cookbook/90_models/google/gemini/knowledge.py
@@ -22,7 +22,7 @@ knowledge = Knowledge(
 # Add content to the knowledge
 knowledge.insert(url="https://agno-public.s3.amazonaws.com/recipes/ThaiRecipes.pdf")
 
-agent = Agent(model=Gemini(id="gemini-3.5-flash"), knowledge=knowledge)
+agent = Agent(model=Gemini(id="gemini-3.7-flash"), knowledge=knowledge)
 agent.print_response("How to make Thai curry?", markdown=True)
 
 # ---------------------------------------------------------------------------

--- a/cookbook/90_models/google/gemini/parallel_grounding.py
+++ b/cookbook/90_models/google/gemini/parallel_grounding.py
@@ -29,7 +29,7 @@ from agno.models.google import Gemini
 # Create an agent with Parallel web search grounding
 agent = Agent(
     model=Gemini(
-        id="gemini-2.0-flash",
+        id="gemini-3.7-flash",
         vertexai=True,  # Required for Parallel grounding
         parallel_search=True,
         # Optional: provide API key directly instead of env var.

--- a/cookbook/90_models/google/gemini/pdf_input_file_upload.py
+++ b/cookbook/90_models/google/gemini/pdf_input_file_upload.py
@@ -42,7 +42,7 @@ while retrieved_file is None and retries < 3:
 
 if retrieved_file is not None:
     agent = Agent(
-        model=Gemini(id="gemini-3.5-flash"),
+        model=Gemini(id="gemini-3.7-flash"),
         markdown=True,
         add_history_to_context=True,
     )

--- a/cookbook/90_models/google/gemini/pdf_input_local.py
+++ b/cookbook/90_models/google/gemini/pdf_input_local.py
@@ -24,7 +24,7 @@ download_file(
 )
 
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model=Gemini(id="gemini-3.7-flash"),
     markdown=True,
     add_history_to_context=True,
 )

--- a/cookbook/90_models/google/gemini/pdf_input_url.py
+++ b/cookbook/90_models/google/gemini/pdf_input_url.py
@@ -15,7 +15,7 @@ from agno.models.google import Gemini
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model=Gemini(id="gemini-3.7-flash"),
     markdown=True,
     db=InMemoryDb(),
     add_history_to_context=True,

--- a/cookbook/90_models/google/gemini/s3_url_file_input.py
+++ b/cookbook/90_models/google/gemini/s3_url_file_input.py
@@ -36,7 +36,7 @@ presigned_url = s3_client.generate_presigned_url(
 )
 
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model=Gemini(id="gemini-3.7-flash"),
     markdown=True,
 )
 

--- a/cookbook/90_models/google/gemini/search.py
+++ b/cookbook/90_models/google/gemini/search.py
@@ -14,7 +14,7 @@ from agno.models.google import Gemini
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash", search=True),
+    model=Gemini(id="gemini-3.7-flash", search=True),
     markdown=True,
 )
 

--- a/cookbook/90_models/google/gemini/storage_and_memory.py
+++ b/cookbook/90_models/google/gemini/storage_and_memory.py
@@ -20,7 +20,7 @@ knowledge_base = PDFUrlKnowledgeBase(
 knowledge_base.load(recreate=True)  # Comment out after first run
 
 agent = Agent(
-    model=Gemini(id="gemini-2.0-flash-001"),
+    model=Gemini(id="gemini-3.7-flash"),
     tools=[WebSearchTools()],
     knowledge=knowledge_base,
     # Store the memories and summary in a database

--- a/cookbook/90_models/google/gemini/timeout.py
+++ b/cookbook/90_models/google/gemini/timeout.py
@@ -17,7 +17,7 @@ from agno.models.google import Gemini
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Gemini(id="gemini-2.5-flash", timeout=30.0),
+    model=Gemini(id="gemini-3.7-flash", timeout=30.0),
     markdown=True,
 )
 

--- a/cookbook/90_models/google/gemini/tool_use.py
+++ b/cookbook/90_models/google/gemini/tool_use.py
@@ -11,7 +11,7 @@ from agno.tools.websearch import WebSearchTools
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Gemini(id="gemini-2.0-flash-001"),
+    model=Gemini(id="gemini-3.7-flash"),
     tools=[WebSearchTools()],
     markdown=True,
 )

--- a/cookbook/90_models/google/gemini/url_context.py
+++ b/cookbook/90_models/google/gemini/url_context.py
@@ -8,7 +8,7 @@ from agno.models.google import Gemini
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Gemini(id="gemini-2.5-flash", url_context=True),
+    model=Gemini(id="gemini-3.7-flash", url_context=True),
     markdown=True,
 )
 

--- a/cookbook/90_models/google/gemini/url_context_with_search.py
+++ b/cookbook/90_models/google/gemini/url_context_with_search.py
@@ -12,7 +12,7 @@ from agno.models.google import Gemini
 
 # Create agent with both Google Search and URL context enabled
 agent = Agent(
-    model=Gemini(id="gemini-2.5-flash", search=True, url_context=True),
+    model=Gemini(id="gemini-3.7-flash", search=True, url_context=True),
     markdown=True,
 )
 

--- a/cookbook/90_models/google/gemini/vertex_ai_search.py
+++ b/cookbook/90_models/google/gemini/vertex_ai_search.py
@@ -26,7 +26,7 @@ datastore_id = "projects/your-project-id/locations/global/collections/default_co
 
 agent = Agent(
     model=Gemini(
-        id="gemini-2.5-flash",
+        id="gemini-3.7-flash",
         vertexai_search=True,
         vertexai_search_datastore=datastore_id,
         vertexai=True,  # Use Vertex AI endpoint

--- a/cookbook/90_models/google/gemini/vertexai.py
+++ b/cookbook/90_models/google/gemini/vertexai.py
@@ -21,7 +21,7 @@ from agno.models.google import Gemini
 # Create Agent
 # ---------------------------------------------------------------------------
 
-agent = Agent(model=Gemini(id="gemini-3.5-flash"), markdown=True)
+agent = Agent(model=Gemini(id="gemini-3.7-flash"), markdown=True)
 
 # Get the response in a variable
 # run: RunOutput = agent.run("Share a 2 sentence horror story")

--- a/cookbook/90_models/google/gemini/vertexai_with_credentials.py
+++ b/cookbook/90_models/google/gemini/vertexai_with_credentials.py
@@ -24,7 +24,7 @@ credentials = None  # Replace with your actual credentials object
 
 # 2. Initialize the Gemini model with the credentials parameter
 model = Gemini(
-    id="gemini-3.5-flash",
+    id="gemini-3.7-flash",
     vertexai=True,
     project_id="your-google-cloud-project-id",
     location="us-central1",

--- a/cookbook/90_models/google/gemini/video_input_bytes_content.py
+++ b/cookbook/90_models/google/gemini/video_input_bytes_content.py
@@ -15,7 +15,7 @@ from agno.models.google import Gemini
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model=Gemini(id="gemini-3.7-flash"),
     markdown=True,
 )
 

--- a/cookbook/90_models/google/gemini/video_input_file_upload.py
+++ b/cookbook/90_models/google/gemini/video_input_file_upload.py
@@ -18,7 +18,7 @@ from google.genai.types import UploadFileConfig
 # Create Agent
 # ---------------------------------------------------------------------------
 
-model = Gemini(id="gemini-3.5-flash")
+model = Gemini(id="gemini-3.7-flash")
 agent = Agent(
     model=model,
     markdown=True,

--- a/cookbook/90_models/google/gemini/video_input_local_file_upload.py
+++ b/cookbook/90_models/google/gemini/video_input_local_file_upload.py
@@ -16,7 +16,7 @@ from agno.models.google import Gemini
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model=Gemini(id="gemini-3.7-flash"),
     markdown=True,
 )
 

--- a/cookbook/90_models/google/gemini/video_input_youtube.py
+++ b/cookbook/90_models/google/gemini/video_input_youtube.py
@@ -14,7 +14,7 @@ from agno.models.google import Gemini
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model=Gemini(id="gemini-3.7-flash"),
     markdown=True,
 )
 
@@ -26,7 +26,7 @@ agent.print_response(
 # Video upload via URL is also supported with Vertex AI
 
 # agent = Agent(
-#     model=Gemini(id="gemini-3.5-flash", vertexai=True),
+#     model=Gemini(id="gemini-3.7-flash", vertexai=True),
 #     markdown=True,
 # )
 

--- a/cookbook/90_models/google/gemini_interactions/audio_understanding.py
+++ b/cookbook/90_models/google/gemini_interactions/audio_understanding.py
@@ -15,7 +15,7 @@ from agno.models.google import GeminiInteractions
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=GeminiInteractions(id="gemini-3.5-flash"),
+    model=GeminiInteractions(id="gemini-3.7-flash"),
     markdown=True,
 )
 

--- a/cookbook/90_models/google/gemini_interactions/basic.py
+++ b/cookbook/90_models/google/gemini_interactions/basic.py
@@ -18,7 +18,7 @@ from agno.models.google import GeminiInteractions
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=GeminiInteractions(id="gemini-3-flash-preview"),
+    model=GeminiInteractions(id="gemini-3.7-flash"),
     markdown=True,
 )
 

--- a/cookbook/90_models/google/gemini_interactions/document_processing.py
+++ b/cookbook/90_models/google/gemini_interactions/document_processing.py
@@ -15,7 +15,7 @@ from agno.models.google import GeminiInteractions
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=GeminiInteractions(id="gemini-3.5-flash"),
+    model=GeminiInteractions(id="gemini-3.7-flash"),
     markdown=True,
 )
 

--- a/cookbook/90_models/google/gemini_interactions/image_understanding.py
+++ b/cookbook/90_models/google/gemini_interactions/image_understanding.py
@@ -15,7 +15,7 @@ from agno.models.google import GeminiInteractions
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=GeminiInteractions(id="gemini-3.5-flash"),
+    model=GeminiInteractions(id="gemini-3.7-flash"),
     markdown=True,
 )
 

--- a/cookbook/90_models/google/gemini_interactions/multi_turn.py
+++ b/cookbook/90_models/google/gemini_interactions/multi_turn.py
@@ -21,7 +21,7 @@ from agno.models.google import GeminiInteractions
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=GeminiInteractions(id="gemini-3.5-flash"),
+    model=GeminiInteractions(id="gemini-3.7-flash"),
     add_history_to_context=True,
     db=SqliteDb(db_file="tmp/data.db"),
     markdown=True,

--- a/cookbook/90_models/google/gemini_interactions/search.py
+++ b/cookbook/90_models/google/gemini_interactions/search.py
@@ -16,7 +16,7 @@ from agno.models.google import GeminiInteractions
 
 agent = Agent(
     model=GeminiInteractions(
-        id="gemini-3.5-flash",
+        id="gemini-3.7-flash",
         search=True,
     ),
     markdown=True,

--- a/cookbook/90_models/google/gemini_interactions/structured_output.py
+++ b/cookbook/90_models/google/gemini_interactions/structured_output.py
@@ -28,7 +28,7 @@ class MovieReview(BaseModel):
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=GeminiInteractions(id="gemini-3.5-flash"),
+    model=GeminiInteractions(id="gemini-3.7-flash"),
     output_schema=MovieReview,
     markdown=True,
 )

--- a/cookbook/90_models/google/gemini_interactions/thinking.py
+++ b/cookbook/90_models/google/gemini_interactions/thinking.py
@@ -16,7 +16,7 @@ from agno.models.google import GeminiInteractions
 
 agent = Agent(
     model=GeminiInteractions(
-        id="gemini-3.5-flash",
+        id="gemini-3.7-flash",
         thinking_level="high",
     ),
     markdown=True,

--- a/cookbook/90_models/google/gemini_interactions/tool_use.py
+++ b/cookbook/90_models/google/gemini_interactions/tool_use.py
@@ -16,7 +16,7 @@ from agno.tools.websearch import WebSearchTools
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=GeminiInteractions(id="gemini-3.5-flash"),
+    model=GeminiInteractions(id="gemini-3.7-flash"),
     tools=[WebSearchTools()],
     markdown=True,
 )

--- a/cookbook/90_models/google/gemini_interactions/video_understanding.py
+++ b/cookbook/90_models/google/gemini_interactions/video_understanding.py
@@ -17,7 +17,7 @@ from agno.models.google import GeminiInteractions
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=GeminiInteractions(id="gemini-3.5-flash"),
+    model=GeminiInteractions(id="gemini-3.7-flash"),
     markdown=True,
 )
 

--- a/cookbook/gemini_3/10_audio_input.py
+++ b/cookbook/gemini_3/10_audio_input.py
@@ -38,7 +38,7 @@ You are an audio analysis expert. Transcribe and summarize audio content clearly
 # ---------------------------------------------------------------------------
 audio_agent = Agent(
     name="Audio Analyst",
-    model=Gemini(id="gemini-3.5-flash"),
+    model=Gemini(id="gemini-3.7-flash"),
     instructions=instructions,
     markdown=True,
 )

--- a/cookbook/gemini_3/12_video_input.py
+++ b/cookbook/gemini_3/12_video_input.py
@@ -41,7 +41,7 @@ a clear summary.
 # ---------------------------------------------------------------------------
 video_agent = Agent(
     name="Video Analyst",
-    model=Gemini(id="gemini-3.5-flash"),
+    model=Gemini(id="gemini-3.7-flash"),
     instructions=instructions,
     markdown=True,
 )

--- a/cookbook/gemini_3/13_pdf_input.py
+++ b/cookbook/gemini_3/13_pdf_input.py
@@ -38,7 +38,7 @@ and provide clear summaries.
 # ---------------------------------------------------------------------------
 doc_reader = Agent(
     name="Document Reader",
-    model=Gemini(id="gemini-3.5-flash"),
+    model=Gemini(id="gemini-3.7-flash"),
     instructions=instructions,
     markdown=True,
 )

--- a/cookbook/gemini_3/14_csv_input.py
+++ b/cookbook/gemini_3/14_csv_input.py
@@ -45,7 +45,7 @@ with tables and summaries.
 # ---------------------------------------------------------------------------
 csv_agent = Agent(
     name="Data Analyst",
-    model=Gemini(id="gemini-3.5-flash"),
+    model=Gemini(id="gemini-3.7-flash"),
     instructions=instructions,
     markdown=True,
 )

--- a/cookbook/gemini_3/16_prompt_caching.py
+++ b/cookbook/gemini_3/16_prompt_caching.py
@@ -69,7 +69,7 @@ if not txt_file:
 # ---------------------------------------------------------------------------
 print("\nCreating cache (5 min TTL)...")
 cache = client.caches.create(
-    model="gemini-3.5-flash",
+    model="gemini-3.7-flash",
     config={
         "system_instruction": "You are an expert at analyzing transcripts.",
         "contents": [txt_file],
@@ -85,7 +85,7 @@ print(f"Cache created: {cache.name}")
 cache_agent = Agent(
     name="Transcript Analyst",
     # cached_content links the agent to the pre-loaded cache
-    model=Gemini(id="gemini-3.5-flash", cached_content=cache.name),
+    model=Gemini(id="gemini-3.7-flash", cached_content=cache.name),
 )
 
 # ---------------------------------------------------------------------------

--- a/cookbook/gemini_3/17_knowledge.py
+++ b/cookbook/gemini_3/17_knowledge.py
@@ -67,7 +67,7 @@ You are a recipe assistant with access to a Thai cookbook.
 # ---------------------------------------------------------------------------
 recipe_agent = Agent(
     name="Recipe Assistant",
-    model=Gemini(id="gemini-3.5-flash"),
+    model=Gemini(id="gemini-3.7-flash"),
     instructions=instructions,
     knowledge=knowledge,
     # Agent automatically searches knowledge when relevant

--- a/cookbook/gemini_3/18_memory.py
+++ b/cookbook/gemini_3/18_memory.py
@@ -83,7 +83,7 @@ You are a personal language tutor that adapts to each student.
 # ---------------------------------------------------------------------------
 tutor_agent = Agent(
     name="Personal Tutor",
-    model=Gemini(id="gemini-3.5-flash"),
+    model=Gemini(id="gemini-3.7-flash"),
     instructions=instructions,
     # ReasoningTools gives the agent a "think" tool for structured reasoning
     tools=[ReasoningTools()],

--- a/cookbook/gemini_3/19_team.py
+++ b/cookbook/gemini_3/19_team.py
@@ -46,7 +46,7 @@ writer = Agent(
     name="Writer",
     # role helps the team leader understand what this agent does
     role="Write engaging blog post drafts",
-    model=Gemini(id="gemini-3.5-flash"),
+    model=Gemini(id="gemini-3.7-flash"),
     instructions=writer_instructions,
     tools=[WebSearchTools()],
     db=gemini_agents_db,
@@ -78,7 +78,7 @@ You are a senior editor. Review content for quality and suggest improvements.
 editor = Agent(
     name="Editor",
     role="Review and improve content for clarity and quality",
-    model=Gemini(id="gemini-3.5-flash"),
+    model=Gemini(id="gemini-3.7-flash"),
     instructions=editor_instructions,
     db=gemini_agents_db,
     add_datetime_to_context=True,
@@ -109,7 +109,7 @@ fact_checker_member = Agent(
     name="Fact Checker",
     role="Verify factual claims using web search",
     # Uses Gemini's native search for fact-checking
-    model=Gemini(id="gemini-3.5-flash", search=True),
+    model=Gemini(id="gemini-3.7-flash", search=True),
     instructions=fact_checker_instructions,
     db=gemini_agents_db,
     add_datetime_to_context=True,

--- a/cookbook/gemini_3/1_basic.py
+++ b/cookbook/gemini_3/1_basic.py
@@ -25,7 +25,7 @@ from agno.models.google import Gemini
 # ---------------------------------------------------------------------------
 chat_agent = Agent(
     name="Chat Assistant",
-    model=Gemini(id="gemini-3.5-flash"),
+    model=Gemini(id="gemini-3.7-flash"),
     # markdown=True renders rich formatting in the terminal
     markdown=True,
 )

--- a/cookbook/gemini_3/20_workflow.py
+++ b/cookbook/gemini_3/20_workflow.py
@@ -36,7 +36,7 @@ from db import gemini_agents_db
 # ---------------------------------------------------------------------------
 web_researcher = Agent(
     name="Web Researcher",
-    model=Gemini(id="gemini-3.5-flash", search=True),
+    model=Gemini(id="gemini-3.7-flash", search=True),
     instructions="""\
 You are a web researcher. Search for the latest information on the given topic.
 
@@ -52,7 +52,7 @@ You are a web researcher. Search for the latest information on the given topic.
 
 deep_researcher = Agent(
     name="Deep Researcher",
-    model=Gemini(id="gemini-3.5-flash"),
+    model=Gemini(id="gemini-3.7-flash"),
     tools=[WebSearchTools()],
     instructions="""\
 You are a deep researcher. Search extensively for background context,
@@ -104,7 +104,7 @@ publication-ready report.
 
 fact_checker = Agent(
     name="Fact Checker",
-    model=Gemini(id="gemini-3.5-flash", search=True),
+    model=Gemini(id="gemini-3.7-flash", search=True),
     instructions="""\
 You are a fact-checker. Verify the factual claims in the report.
 

--- a/cookbook/gemini_3/2_tools.py
+++ b/cookbook/gemini_3/2_tools.py
@@ -44,7 +44,7 @@ You are a finance research agent. You find and analyze current financial news.
 # ---------------------------------------------------------------------------
 finance_agent = Agent(
     name="Finance Agent",
-    model=Gemini(id="gemini-3.5-flash"),
+    model=Gemini(id="gemini-3.7-flash"),
     instructions=instructions,
     tools=[WebSearchTools()],
     # Adds current date/time to the system message so the agent knows "today"

--- a/cookbook/gemini_3/4_search.py
+++ b/cookbook/gemini_3/4_search.py
@@ -37,7 +37,7 @@ You are a news analyst. Summarize the latest developments clearly and concisely.
 news_agent = Agent(
     name="News Agent",
     # search=True enables Gemini's native Google Search, no extra tools needed
-    model=Gemini(id="gemini-3.5-flash", search=True),
+    model=Gemini(id="gemini-3.7-flash", search=True),
     instructions=instructions,
     add_datetime_to_context=True,
     markdown=True,
@@ -59,7 +59,7 @@ if __name__ == "__main__":
 Native search vs tool-based search:
 
 1. Native search (this example)
-   model=Gemini(id="gemini-3.5-flash", search=True)
+   model=Gemini(id="gemini-3.7-flash", search=True)
    - Seamless: model decides when to search
    - Less controllable: you can't see individual search calls
    - No extra packages needed

--- a/cookbook/gemini_3/8_image_input.py
+++ b/cookbook/gemini_3/8_image_input.py
@@ -40,7 +40,7 @@ and provide relevant context.
 image_agent = Agent(
     name="Image Analyst",
     # search=True lets the agent look up context about what it sees
-    model=Gemini(id="gemini-3.5-flash", search=True),
+    model=Gemini(id="gemini-3.7-flash", search=True),
     instructions=instructions,
     markdown=True,
 )

--- a/libs/agno/agno/models/google/gemini.py
+++ b/libs/agno/agno/models/google/gemini.py
@@ -83,7 +83,7 @@ class Gemini(Model):
     Based on https://googleapis.github.io/python-genai/
     """
 
-    id: str = "gemini-3.5-flash"
+    id: str = "gemini-3.7-flash"
     name: str = "Gemini"
     provider: str = "Google"
 
@@ -2014,7 +2014,7 @@ class Gemini(Model):
 
         Example:
             ```python
-            model = Gemini(id="gemini-2.5-flash")
+            model = Gemini(id="gemini-3.7-flash")
             model.delete_document("fileSearchStores/store-123/documents/doc-456")
             ```
         """

--- a/libs/agno/agno/models/google/gemini_interactions.py
+++ b/libs/agno/agno/models/google/gemini_interactions.py
@@ -155,7 +155,7 @@ class GeminiInteractions(Model):
         ```
     """
 
-    id: str = "gemini-3-flash-preview"
+    id: str = "gemini-3.7-flash"
     name: str = "GeminiInteractions"
     provider: str = "Google"
 

--- a/libs/agno/tests/unit/models/google/test_gemini_interactions.py
+++ b/libs/agno/tests/unit/models/google/test_gemini_interactions.py
@@ -233,7 +233,7 @@ class TestGetRequestKwargs:
         model = self._make_model()
         messages = [Message(role="user", content="Hello")]
         kwargs = model._get_request_kwargs(messages)
-        assert kwargs["model"] == "gemini-3-flash-preview"
+        assert kwargs["model"] == "gemini-3.7-flash"
         assert "input" in kwargs
         assert "system_instruction" not in kwargs
 
@@ -1309,7 +1309,7 @@ class TestInvoke:
 
         mock_client.interactions.create.assert_called_once()
         call_kwargs = mock_client.interactions.create.call_args[1]
-        assert call_kwargs["model"] == "gemini-3-flash-preview"
+        assert call_kwargs["model"] == "gemini-3.7-flash"
         assert "input" in call_kwargs
 
     def test_invoke_passes_tools(self):
@@ -2293,7 +2293,7 @@ class TestToDict:
     def test_basic_serialization(self):
         model = GeminiInteractions(api_key="test-key")
         d = model.to_dict()
-        assert d["id"] == "gemini-3-flash-preview"
+        assert d["id"] == "gemini-3.7-flash"
         assert d["name"] == "GeminiInteractions"
         assert d["provider"] == "Google"
 


### PR DESCRIPTION
## Summary

Updating docs & cookbook to use the newest gemino-3.7-flash model as the default. Some examples were using 2.0, which is unavailable & will error..

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [x] Other: docs 

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Re: testing, I ran all of the cookbook files that were changed.