### PR TITLE
feat: add MigrationRequiredError for stale database schemas

### DIFF
--- a/libs/agno/agno/db/mysql/utils.py
+++ b/libs/agno/agno/db/mysql/utils.py
@@ -105,7 +105,10 @@ def is_valid_table(db_engine: Engine, table_name: str, table_type: str, db_schem
         db_schema (str): Database schema name
 
     Returns:
-        bool: True if table has all expected columns, False otherwise
+        bool: True if table has all expected columns, False if expected columns are missing
+
+    Raises:
+        Any error from inspecting the table, so a failed inspection is not read as a stale schema.
     """
     try:
         expected_table_schema = get_table_schema_definition(table_type)
@@ -125,7 +128,7 @@ def is_valid_table(db_engine: Engine, table_name: str, table_type: str, db_schem
         return True
     except Exception as e:
         log_error(f"Error validating table schema for {db_schema}.{table_name}: {str(e)}")
-        return False
+        raise
 
 
 # -- Metrics util methods --
@@ -431,7 +434,10 @@ async def ais_valid_table(db_engine: AsyncEngine, table_name: str, table_type: s
         db_schema (str): Database schema name
 
     Returns:
-        bool: True if table has all expected columns, False otherwise
+        bool: True if table has all expected columns, False if expected columns are missing
+
+    Raises:
+        Any error from inspecting the table, so a failed inspection is not read as a stale schema.
     """
     try:
         expected_table_schema = get_table_schema_definition(table_type)
@@ -450,7 +456,7 @@ async def ais_valid_table(db_engine: AsyncEngine, table_name: str, table_type: s
         return True
     except Exception as e:
         log_error(f"Error validating table schema for {db_schema}.{table_name}: {str(e)}")
-        return False
+        raise
 
 
 def _get_table_columns(connection, table_name: str, db_schema: str) -> set[str]:

--- a/libs/agno/agno/db/postgres/utils.py
+++ b/libs/agno/agno/db/postgres/utils.py
@@ -134,7 +134,10 @@ def is_valid_table(db_engine: Engine, table_name: str, table_type: str, db_schem
         schema (str): Database schema name
 
     Returns:
-        bool: True if table has all expected columns, False otherwise
+        bool: True if table has all expected columns, False if expected columns are missing
+
+    Raises:
+        Any error from inspecting the table, so a failed inspection is not read as a stale schema.
     """
     try:
         expected_table_schema = get_table_schema_definition(table_type)
@@ -154,7 +157,7 @@ def is_valid_table(db_engine: Engine, table_name: str, table_type: str, db_schem
         return True
     except Exception as e:
         log_error(f"Error validating table schema for {db_schema}.{table_name}: {str(e)}")
-        return False
+        raise
 
 
 async def ais_valid_table(db_engine: AsyncEngine, table_name: str, table_type: str, db_schema: str) -> bool:
@@ -166,7 +169,10 @@ async def ais_valid_table(db_engine: AsyncEngine, table_name: str, table_type: s
         schema (str): Database schema name
 
     Returns:
-        bool: True if table has all expected columns, False otherwise
+        bool: True if table has all expected columns, False if expected columns are missing
+
+    Raises:
+        Any error from inspecting the table, so a failed inspection is not read as a stale schema.
     """
     try:
         expected_table_schema = get_table_schema_definition(table_type)
@@ -188,7 +194,7 @@ async def ais_valid_table(db_engine: AsyncEngine, table_name: str, table_type: s
         return False
     except Exception as e:
         log_error(f"Error validating table schema for {db_schema}.{table_name}: {str(e)}")
-        return False
+        raise
 
 
 def _get_table_columns(conn, table_name: str, db_schema: str) -> set[str]:

--- a/libs/agno/agno/db/singlestore/utils.py
+++ b/libs/agno/agno/db/singlestore/utils.py
@@ -116,7 +116,10 @@ def is_valid_table(db_engine: Engine, table_name: str, table_type: str, db_schem
         schema (str): Database schema name
 
     Returns:
-        bool: True if table has all expected columns, False otherwise
+        bool: True if table has all expected columns, False if expected columns are missing
+
+    Raises:
+        Any error from inspecting the table, so a failed inspection is not read as a stale schema.
     """
     try:
         expected_table_schema = get_table_schema_definition(table_type)
@@ -149,7 +152,7 @@ def is_valid_table(db_engine: Engine, table_name: str, table_type: str, db_schem
     except Exception as e:
         table_ref = f"{db_schema}.{table_name}" if db_schema else table_name
         log_error(f"Error validating table schema for {table_ref}: {str(e)}")
-        return False
+        raise
 
 
 # -- Metrics util methods --

--- a/libs/agno/agno/db/sqlite/utils.py
+++ b/libs/agno/agno/db/sqlite/utils.py
@@ -108,7 +108,10 @@ def is_valid_table(db_engine: Engine, table_name: str, table_type: str) -> bool:
         table_type (str): Type of table to get expected schema
 
     Returns:
-        bool: True if table has all expected columns, False otherwise
+        bool: True if table has all expected columns, False if expected columns are missing
+
+    Raises:
+        Any error from inspecting the table, so a failed inspection is not read as a stale schema.
     """
     try:
         expected_table_schema = get_table_schema_definition(table_type)
@@ -128,7 +131,7 @@ def is_valid_table(db_engine: Engine, table_name: str, table_type: str) -> bool:
         return True
     except Exception as e:
         log_error(f"Error validating table schema for {table_name}: {str(e)}")
-        return False
+        raise
 
 
 async def ais_valid_table(db_engine: AsyncEngine, table_name: str, table_type: str) -> bool:
@@ -141,7 +144,10 @@ async def ais_valid_table(db_engine: AsyncEngine, table_name: str, table_type: s
         table_type (str): Type of table to get expected schema
 
     Returns:
-        bool: True if table has all expected columns, False otherwise
+        bool: True if table has all expected columns, False if expected columns are missing
+
+    Raises:
+        Any error from inspecting the table, so a failed inspection is not read as a stale schema.
     """
     try:
         expected_table_schema = get_table_schema_definition(table_type)
@@ -160,7 +166,7 @@ async def ais_valid_table(db_engine: AsyncEngine, table_name: str, table_type: s
 
     except Exception as e:
         log_error(f"Error validating table schema for {table_name}: {str(e)}")
-        return False
+        raise
 
 
 def _get_table_columns(conn, table_name: str) -> set[str]:

--- a/libs/agno/agno/db/utils.py
+++ b/libs/agno/agno/db/utils.py
@@ -496,9 +496,12 @@ def validate_pagination(limit: Optional[int], page: Optional[int]) -> None:
         raise ValueError(f"`page` must be >= 1 (pages are 1-indexed); got {page}.")
 
 
-# Table types MigrationManager.up() can migrate. Must stay in sync with
-# ``_table_type_to_attr`` in agno/db/migrations/manager.py, which cannot be
-# imported here: manager -> db.base -> this module would be a cycle.
+# Table types MigrationManager.up() knows how to migrate at all, across every
+# version it ships, not just the ones with a pending step in the current
+# release: a sessions table still at its 2.0 shape needs the 2.3/2.5 steps even
+# though 3.0 adds none. Must stay in sync with ``_table_type_to_attr`` in
+# agno/db/migrations/manager.py, which cannot be imported here: manager ->
+# db.base -> this module would be a cycle.
 MIGRATABLE_TABLE_TYPES = frozenset(
     {
         "memories",

--- a/libs/agno/agno/db/utils.py
+++ b/libs/agno/agno/db/utils.py
@@ -6,6 +6,7 @@ from datetime import date, datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, Union
 from uuid import UUID
 
+from agno.exceptions import MigrationRequiredError, SchemaMismatchError
 from agno.metrics import ModelMetrics, RunMetrics, SessionMetrics
 from agno.models.message import Message
 from agno.run.base import HISTORY_SKIP_STATUSES as _RUN_HISTORY_SKIP_STATUSES
@@ -514,15 +515,16 @@ MIGRATABLE_TABLE_TYPES = frozenset(
 )
 
 
-def table_schema_mismatch_error(table_ref: str, table_type: Optional[str] = None) -> ValueError:
+def table_schema_mismatch_error(table_ref: str, table_type: Optional[str] = None) -> SchemaMismatchError:
     """Build the error raised when an existing table fails schema validation.
 
     For table types MigrationManager can handle, the most common cause is an
     upgrade across Agno versions whose migrations have not been applied yet
-    (e.g. v2.x data with a v3.x install), so the message points the user at
-    the migration path instead of dead-ending. Other table types have no
-    pending migrations, so migration advice would send the user in a circle;
-    they get repair guidance instead.
+    (e.g. v2.x data with a v3.x install), so the result is a
+    ``MigrationRequiredError`` whose message points the user at the migration
+    path instead of dead-ending. Other table types have no pending migrations,
+    so migration advice would send the user in a circle; they get a plain
+    ``SchemaMismatchError`` with repair guidance instead.
     """
     message = (
         f"Table {table_ref} has an invalid schema: it does not match what this version of Agno "
@@ -535,13 +537,13 @@ def table_schema_mismatch_error(table_ref: str, table_type: Optional[str] = None
             "`agno.db.migrations.manager`; await the call directly in async code), or via the "
             "AgentOS endpoint `POST /databases/all/migrate`."
         )
-    else:
-        message += (
-            "No Agno migration covers this table, so it was likely created or modified outside "
-            "Agno. Compare it against the expected schema and repair it, or move Agno to a new "
-            "table name so the table is recreated."
-        )
-    return ValueError(message)
+        return MigrationRequiredError(table_name=table_ref, message=message)
+    message += (
+        "No Agno migration covers this table, so it was likely created or modified outside "
+        "Agno. Compare it against the expected schema and repair it, or move Agno to a new "
+        "table name so the table is recreated."
+    )
+    return SchemaMismatchError(table_name=table_ref, message=message)
 
 
 def metric_record_day(record: Dict[str, Any]) -> Optional[date]:

--- a/libs/agno/agno/exceptions.py
+++ b/libs/agno/agno/exceptions.py
@@ -299,6 +299,52 @@ class ComponentPinError(ComponentRehydrationError):
     """
 
 
+class SchemaMismatchError(AgnoError):
+    """Raised when an existing database table does not match the schema this version of Agno expects.
+
+    Base class for schema validation failures. ``MigrationRequiredError`` is raised for
+    table types that ``MigrationManager`` can migrate; this class is raised for the rest,
+    where the table was likely created or modified outside Agno and needs repair rather
+    than a migration. Build instances with ``agno.db.utils.table_schema_mismatch_error``
+    so the message names the right remedy.
+
+    Surfaces over HTTP as a 500 whose body carries ``error_id``, so clients can tell it
+    apart from other server errors without parsing the message.
+    """
+
+    def __init__(self, table_name: str, message: Optional[str] = None):
+        if message is None:
+            message = f"Table {table_name} has an invalid schema: it does not match what this version of Agno expects."
+        super().__init__(message, status_code=500)
+        self.table_name = table_name
+        self.type = "schema_mismatch_error"
+        self.error_id = "schema_mismatch_error"
+
+
+class MigrationRequiredError(SchemaMismatchError):
+    """Raised when a table's schema is stale and a pending Agno migration can fix it.
+
+    The usual cause is a database created by an older version of Agno whose migrations
+    have not been applied yet. Run them from code with
+    ``asyncio.run(MigrationManager(db).up())`` (``agno.db.migrations.manager``) or over
+    HTTP with ``POST /databases/all/migrate`` on AgentOS.
+
+    Carries ``error_id="migration_required_error"`` so a client can offer the migration.
+    """
+
+    def __init__(self, table_name: str, message: Optional[str] = None):
+        if message is None:
+            message = (
+                f"Table {table_name} has an invalid schema: it does not match what this version of Agno "
+                "expects. If this database was created by an older version of Agno, apply the pending "
+                "migrations with `asyncio.run(MigrationManager(db).up())` (import it from "
+                "`agno.db.migrations.manager`) or via the AgentOS endpoint `POST /databases/all/migrate`."
+            )
+        super().__init__(table_name, message)
+        self.type = "migration_required_error"
+        self.error_id = "migration_required_error"
+
+
 class RunNotFoundError(RuntimeError):
     """Raised when a run_id cannot be found in the session.
 

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -146,6 +146,20 @@ async def _drain_cancel_persist_tasks(timeout: float = 30.0) -> None:
         await asyncio.wait(pending, timeout=remaining)
 
 
+def _error_body(detail: str, exc: BaseException) -> Dict[str, Any]:
+    """Build the JSON error body, carrying the error's identity when the exception has one.
+
+    ``AgnoError`` subclasses (and ``AgnoHTTPException``, which wraps them) expose ``error_id``
+    and a type so clients can branch on the kind of failure rather than on ``detail`` text.
+    """
+    body: Dict[str, Any] = {"detail": detail}
+    error_id = getattr(exc, "error_id", None)
+    if error_id:
+        body["error_id"] = error_id
+        body["error_type"] = getattr(exc, "error_type", None) or getattr(exc, "type", None)
+    return body
+
+
 @asynccontextmanager
 async def db_lifespan(app: FastAPI, agent_os: "AgentOS"):
     """Initializes databases in the event loop and closes them on shutdown."""
@@ -1202,7 +1216,7 @@ class AgentOS:
                 log_error(f"HTTP exception: {exc.status_code} {exc.detail}")
                 return JSONResponse(
                     status_code=exc.status_code,
-                    content={"detail": str(exc.detail)},
+                    content=_error_body(str(exc.detail), exc),
                 )
 
             @fastapi_app.exception_handler(HTTPStatusError)
@@ -1231,7 +1245,7 @@ class AgentOS:
                 detail = str(exc) if status_code < 500 else f"Internal server error ({type(exc).__name__})"
                 return JSONResponse(
                     status_code=status_code,
-                    content={"detail": detail},
+                    content=_error_body(detail, exc),
                 )
 
         # Update CORS middleware

--- a/libs/agno/agno/os/routers/components/components.py
+++ b/libs/agno/agno/os/routers/components/components.py
@@ -17,6 +17,7 @@ from agno.db.base import (
 )
 from agno.db.base import ComponentType as DbComponentType
 from agno.db.utils import DB_TABLE_NAME_KEYS
+from agno.exceptions import AgnoError
 from agno.os.auth import get_authentication_dependency
 from agno.os.middleware.user_scope import get_scoped_user_id
 from agno.os.schema import (
@@ -38,7 +39,7 @@ from agno.os.schema import (
     ValidationErrorResponse,
 )
 from agno.os.settings import AgnoAPISettings
-from agno.os.utils import draft_preview_identity, may_read_draft_configs
+from agno.os.utils import AgnoHTTPException, draft_preview_identity, may_read_draft_configs
 from agno.registry import Registry
 from agno.utils.log import log_error, log_warning
 from agno.utils.string import generate_component_id_from_name, hash_string_sha256, validate_component_id
@@ -742,6 +743,8 @@ def attach_routes(
             )
         except HTTPException:
             raise
+        except AgnoError as e:
+            raise AgnoHTTPException(e)
         except Exception as e:
             log_error(f"Error listing components: {str(e)}")
             raise HTTPException(status_code=500, detail="Internal server error")
@@ -844,6 +847,8 @@ def attach_routes(
             raise HTTPException(status_code=400, detail=str(e))
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
+        except AgnoError as e:
+            raise AgnoHTTPException(e)
         except Exception as e:
             log_error(f"Error creating component: {str(e)}")
             raise HTTPException(status_code=500, detail="Internal server error")
@@ -873,6 +878,8 @@ def attach_routes(
             return ComponentResponse(**component)
         except HTTPException:
             raise
+        except AgnoError as e:
+            raise AgnoHTTPException(e)
         except Exception as e:
             log_error(f"Error getting component: {str(e)}")
             raise HTTPException(status_code=500, detail="Internal server error")
@@ -962,6 +969,8 @@ def attach_routes(
             raise HTTPException(status_code=400, detail=str(e))
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
+        except AgnoError as e:
+            raise AgnoHTTPException(e)
         except Exception as e:
             log_error(f"Error updating component: {str(e)}")
             raise HTTPException(status_code=500, detail="Internal server error")
@@ -1020,6 +1029,8 @@ def attach_routes(
             raise HTTPException(status_code=409, detail=_conflict_detail(db, component_id, scoped_user_id, e))
         except ComponentDraftRequiredError as e:
             raise HTTPException(status_code=400, detail=str(e))
+        except AgnoError as e:
+            raise AgnoHTTPException(e)
         except Exception as e:
             log_error(f"Error deleting component: {str(e)}")
             raise HTTPException(status_code=500, detail="Internal server error")
@@ -1062,6 +1073,8 @@ def attach_routes(
             raise HTTPException(status_code=400, detail=str(e))
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
+        except AgnoError as e:
+            raise AgnoHTTPException(e)
         except Exception as e:
             log_error(f"Error restoring component: {str(e)}")
             raise HTTPException(status_code=500, detail="Internal server error")
@@ -1092,6 +1105,8 @@ def attach_routes(
             return [_config_response(c, component_row, scoped_user_id) for c in configs]
         except HTTPException:
             raise
+        except AgnoError as e:
+            raise AgnoHTTPException(e)
         except Exception as e:
             log_error(f"Error listing configs: {str(e)}")
             raise HTTPException(status_code=500, detail="Internal server error")
@@ -1155,6 +1170,8 @@ def attach_routes(
             raise HTTPException(status_code=400, detail=str(e))
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
+        except AgnoError as e:
+            raise AgnoHTTPException(e)
         except Exception as e:
             log_error(f"Error creating config: {str(e)}")
             raise HTTPException(status_code=500, detail="Internal server error")
@@ -1222,6 +1239,8 @@ def attach_routes(
             raise HTTPException(status_code=400, detail=str(e))
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
+        except AgnoError as e:
+            raise AgnoHTTPException(e)
         except Exception as e:
             log_error(f"Error updating config: {str(e)}")
             raise HTTPException(status_code=500, detail="Internal server error")
@@ -1250,6 +1269,8 @@ def attach_routes(
             return _config_response(config, component_row, scoped_user_id)
         except HTTPException:
             raise
+        except AgnoError as e:
+            raise AgnoHTTPException(e)
         except Exception as e:
             log_error(f"Error getting config: {str(e)}")
             raise HTTPException(status_code=500, detail="Internal server error")
@@ -1289,6 +1310,8 @@ def attach_routes(
             return _config_response(config, component_row, scoped_user_id)
         except HTTPException:
             raise
+        except AgnoError as e:
+            raise AgnoHTTPException(e)
         except Exception as e:
             log_error(f"Error getting config: {str(e)}")
             raise HTTPException(status_code=500, detail="Internal server error")
@@ -1326,6 +1349,8 @@ def attach_routes(
             raise HTTPException(status_code=400, detail=str(e))
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
+        except AgnoError as e:
+            raise AgnoHTTPException(e)
         except Exception as e:
             log_error(f"Error deleting config: {str(e)}")
             raise HTTPException(status_code=500, detail="Internal server error")
@@ -1390,6 +1415,8 @@ def attach_routes(
             raise HTTPException(status_code=400, detail=str(e))
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
+        except AgnoError as e:
+            raise AgnoHTTPException(e)
         except Exception as e:
             log_error(f"Error setting current config: {str(e)}")
             raise HTTPException(status_code=500, detail="Internal server error")

--- a/libs/agno/agno/os/routers/database.py
+++ b/libs/agno/agno/os/routers/database.py
@@ -10,6 +10,7 @@ from packaging import version
 
 from agno.db.base import AsyncBaseDb
 from agno.db.migrations.manager import MigrationManager
+from agno.exceptions import AgnoError
 from agno.os.auth import get_authentication_dependency
 from agno.os.schema import (
     BadRequestResponse,
@@ -20,6 +21,7 @@ from agno.os.schema import (
 )
 from agno.os.settings import AgnoAPISettings
 from agno.os.utils import (
+    AgnoHTTPException,
     get_db,
 )
 from agno.remote.base import RemoteDb
@@ -46,9 +48,13 @@ def get_database_router(
     )
 
     async def _migrate_single_db(db, target_version: Optional[str] = None) -> None:
-        """Migrate a single database."""
+        """Migrate a single local database.
+
+        Remote databases are rejected: they belong to another AgentOS, which owns
+        their schema and exposes its own migrate endpoints.
+        """
         if isinstance(db, RemoteDb):
-            log_info("Skipping logs for remote DB")
+            raise ValueError(f"Database '{db.id}' is remote; run the migration on the AgentOS that owns it instead.")
 
         if target_version:
             # Use the session table as proxy for the database schema version
@@ -87,31 +93,36 @@ def get_database_router(
         },
     )
     async def migrate_all_databases(target_version: Optional[str] = None):
-        """Migrate all databases."""
+        """Migrate all local databases. Remote databases are skipped and listed in the response."""
         all_dbs = {db.id: db for db_id, dbs in os.dbs.items() for db in dbs}
+        local_dbs = {db_id: db for db_id, db in all_dbs.items() if not isinstance(db, RemoteDb)}
+        skipped_dbs = [db_id for db_id in all_dbs if db_id not in local_dbs]
+        if skipped_dbs:
+            log_info(f"Skipping migration for remote databases: {', '.join(skipped_dbs)}")
         failed_dbs: dict[str, str] = {}
 
-        for db_id, db in all_dbs.items():
+        for db_id, db in local_dbs.items():
             try:
                 await _migrate_single_db(db, target_version)
             except Exception as e:
                 failed_dbs[db_id] = str(e)
 
         version_msg = f"version {target_version}" if target_version else "latest version"
-        migrated_count = len(all_dbs) - len(failed_dbs)
+        migrated_count = len(local_dbs) - len(failed_dbs)
 
         if failed_dbs:
-            return JSONResponse(
-                content={
-                    "message": f"Migrated {migrated_count}/{len(all_dbs)} databases to {version_msg}",
-                    "failed": failed_dbs,
-                },
-                status_code=207,  # Multi-Status
-            )
+            content = {
+                "message": f"Migrated {migrated_count}/{len(local_dbs)} databases to {version_msg}",
+                "failed": failed_dbs,
+            }
+            if skipped_dbs:
+                content["skipped"] = skipped_dbs
+            return JSONResponse(content=content, status_code=207)  # Multi-Status
 
-        return JSONResponse(
-            content={"message": f"All databases migrated successfully to {version_msg}"}, status_code=200
-        )
+        content = {"message": f"All databases migrated successfully to {version_msg}"}
+        if skipped_dbs:
+            content["skipped"] = skipped_dbs
+        return JSONResponse(content=content, status_code=200)
 
     @router.post(
         "/databases/{db_id}/migrate",
@@ -140,6 +151,12 @@ def get_database_router(
         if not db:
             raise HTTPException(status_code=404, detail="Database not found")
 
+        if isinstance(db, RemoteDb):
+            raise HTTPException(
+                status_code=400,
+                detail=f"Database '{db_id}' is remote; run the migration on the AgentOS that owns it instead.",
+            )
+
         try:
             await _migrate_single_db(db, target_version)
 
@@ -149,6 +166,8 @@ def get_database_router(
             )
         except HTTPException:
             raise
+        except AgnoError as e:
+            raise AgnoHTTPException(e, detail=f"Failed to migrate database: {str(e)}")
         except Exception as e:
             raise HTTPException(status_code=500, detail=f"Failed to migrate database: {str(e)}")
 

--- a/libs/agno/agno/os/routers/evals/evals.py
+++ b/libs/agno/agno/os/routers/evals/evals.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from agno.agent import Agent, RemoteAgent
 from agno.db.base import AsyncBaseDb, BaseDb
 from agno.db.schemas.evals import EvalFilterType, EvalType
+from agno.exceptions import AgnoError
 from agno.models.utils import get_model
 from agno.os.auth import get_auth_token_from_request, get_authentication_dependency
 from agno.os.middleware.user_scope import apply_scope_to_kwargs, get_scoped_user_id
@@ -33,7 +34,7 @@ from agno.os.schema import (
     ValidationErrorResponse,
 )
 from agno.os.settings import AgnoAPISettings
-from agno.os.utils import get_agent_by_id, get_db, get_team_by_id
+from agno.os.utils import AgnoHTTPException, get_agent_by_id, get_db, get_team_by_id
 from agno.remote.base import RemoteDb
 from agno.team import RemoteTeam, Team
 from agno.utils.log import log_warning
@@ -283,6 +284,8 @@ def attach_routes(
                 db.delete_eval_runs(eval_run_ids=request.eval_run_ids, **scope)
         except HTTPException:
             raise
+        except AgnoError as e:
+            raise AgnoHTTPException(e)
         except Exception as e:
             raise HTTPException(status_code=500, detail=f"Failed to delete eval runs: {e}")
 
@@ -350,6 +353,8 @@ def attach_routes(
                 eval_run = db.rename_eval_run(eval_run_id=eval_run_id, name=request.name, deserialize=False, **scope)
         except HTTPException:
             raise
+        except AgnoError as e:
+            raise AgnoHTTPException(e)
         except Exception as e:
             raise HTTPException(status_code=500, detail=f"Failed to rename eval run: {e}")
 

--- a/libs/agno/agno/os/routers/knowledge/knowledge.py
+++ b/libs/agno/agno/os/routers/knowledge/knowledge.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional, Union
 from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, HTTPException, Path, Query, Request, UploadFile
 
 from agno.db.base import AsyncBaseDb
+from agno.exceptions import AgnoError
 from agno.knowledge.content import Content, FileData
 from agno.knowledge.knowledge import Knowledge
 from agno.knowledge.reader import ReaderFactory
@@ -41,7 +42,7 @@ from agno.os.schema import (
     ValidationErrorResponse,
 )
 from agno.os.settings import AgnoAPISettings
-from agno.os.utils import get_knowledge_instance
+from agno.os.utils import AgnoHTTPException, get_knowledge_instance
 from agno.remote.base import RemoteKnowledge
 from agno.utils.log import log_debug, log_error, log_info
 from agno.utils.string import generate_id
@@ -491,6 +492,8 @@ def attach_routes(router: APIRouter, knowledge_instances: List[Union[Knowledge, 
                 updated_content_dict = await knowledge.apatch_content(content, user_id=scoped_user_id)
             else:
                 updated_content_dict = knowledge.patch_content(content, user_id=scoped_user_id)
+        except AgnoError as e:
+            raise AgnoHTTPException(e)
         except Exception as e:
             log_error(f"Error updating content: {str(e)}")
             raise HTTPException(status_code=500, detail=f"Error updating content: {str(e)}")

--- a/libs/agno/agno/os/routers/learnings/router.py
+++ b/libs/agno/agno/os/routers/learnings/router.py
@@ -9,6 +9,7 @@ from fastapi import Depends, HTTPException, Path, Query, Request
 from fastapi.routing import APIRouter
 
 from agno.db.base import AsyncBaseDb, BaseDb
+from agno.exceptions import AgnoError
 from agno.learn.utils import (
     DEFAULT_LEARNING_NAMESPACE,
     IDENTITY_KEYED_LEARNING_TYPES,
@@ -29,7 +30,7 @@ from agno.os.schema import (
     ValidationErrorResponse,
 )
 from agno.os.settings import AgnoAPISettings
-from agno.os.utils import get_db
+from agno.os.utils import AgnoHTTPException, get_db
 from agno.remote.base import RemoteDb
 
 logger = logging.getLogger(__name__)
@@ -162,6 +163,8 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
                 )
         except NotImplementedError:
             raise HTTPException(status_code=501, detail="Learnings not supported by the configured database")
+        except AgnoError as e:
+            raise AgnoHTTPException(e)
         except Exception as e:
             raise HTTPException(status_code=500, detail=f"Failed to list learnings: {e}")
 
@@ -311,6 +314,8 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
             raise HTTPException(status_code=501, detail="Learnings not supported by the configured database")
         except HTTPException:
             raise  # e.g. the 409 conflict above
+        except AgnoError as e:
+            raise AgnoHTTPException(e)
         except Exception as e:
             raise HTTPException(status_code=500, detail=f"Failed to create learning: {e}")
 
@@ -380,6 +385,8 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
                 )
         except NotImplementedError:
             raise HTTPException(status_code=501, detail="Learnings not supported by the configured database")
+        except AgnoError as e:
+            raise AgnoHTTPException(e)
         except Exception as e:
             raise HTTPException(status_code=500, detail=f"Failed to get learning users: {e}")
 
@@ -434,6 +441,8 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
                 cast(BaseDb, db).delete_user_learnings(user_id, learning_type=learning_type)
         except NotImplementedError:
             raise HTTPException(status_code=501, detail="Learnings not supported by the configured database")
+        except AgnoError as e:
+            raise AgnoHTTPException(e)
         except Exception as e:
             # Don't report a destructive bulk delete as a success (204) when it failed.
             raise HTTPException(status_code=500, detail=f"Failed to delete user learnings: {e}")
@@ -506,6 +515,8 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
                 matched = cast(BaseDb, db).update_learning(learning_id, content=new_content, metadata=new_metadata)
         except NotImplementedError:
             raise HTTPException(status_code=501, detail="Learnings not supported by the configured database")
+        except AgnoError as e:
+            raise AgnoHTTPException(e)
         except Exception as e:
             raise HTTPException(status_code=500, detail=f"Failed to update learning: {e}")
 
@@ -560,6 +571,8 @@ async def _fetch_learning(db: Union[BaseDb, AsyncBaseDb, RemoteDb], learning_id:
             record = cast(BaseDb, db).get_learning_by_id(learning_id)
     except NotImplementedError:
         raise HTTPException(status_code=501, detail="Learnings not supported by the configured database")
+    except AgnoError as e:
+        raise AgnoHTTPException(e)
     except Exception as e:
         # A DB error is not "not found" -- surface it rather than emit a misleading 404.
         raise HTTPException(status_code=500, detail=f"Failed to fetch learning: {e}")

--- a/libs/agno/agno/os/routers/memory/memory.py
+++ b/libs/agno/agno/os/routers/memory/memory.py
@@ -8,6 +8,7 @@ from fastapi.routing import APIRouter
 
 from agno.db.base import AsyncBaseDb, BaseDb
 from agno.db.schemas import UserMemory
+from agno.exceptions import AgnoError
 from agno.models.utils import get_model
 from agno.os.auth import get_auth_token_from_request, get_authentication_dependency
 from agno.os.middleware.user_scope import get_scoped_user_id, resolve_db_and_scope
@@ -30,6 +31,7 @@ from agno.os.schema import (
     ValidationErrorResponse,
 )
 from agno.os.settings import AgnoAPISettings
+from agno.os.utils import AgnoHTTPException
 from agno.remote.base import RemoteDb
 
 logger = logging.getLogger(__name__)
@@ -614,6 +616,8 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
                 ),
             )
 
+        except AgnoError as e:
+            raise AgnoHTTPException(e)
         except Exception as e:
             raise HTTPException(status_code=500, detail=f"Failed to get user statistics: {str(e)}")
 
@@ -771,6 +775,8 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
 
         except HTTPException:
             raise
+        except AgnoError as e:
+            raise AgnoHTTPException(e)
         except Exception as e:
             logger.exception(f"Failed to optimize memories for user {request.user_id}")
             raise HTTPException(status_code=500, detail=f"Failed to optimize memories: {str(e)}")

--- a/libs/agno/agno/os/routers/metrics/metrics.py
+++ b/libs/agno/agno/os/routers/metrics/metrics.py
@@ -8,6 +8,7 @@ from starlette.concurrency import run_in_threadpool
 
 from agno.db.base import AsyncBaseDb, BaseDb
 from agno.db.utils import aggregate_metrics_by_date, identify_metrics_by_owner, is_legacy_metric
+from agno.exceptions import AgnoError
 from agno.os.auth import get_auth_token_from_request, get_authentication_dependency
 from agno.os.middleware.user_scope import resolve_db_and_scope
 from agno.os.routers.metrics.schemas import (
@@ -24,7 +25,7 @@ from agno.os.schema import (
     ValidationErrorResponse,
 )
 from agno.os.settings import AgnoAPISettings
-from agno.os.utils import get_db, to_utc_datetime
+from agno.os.utils import AgnoHTTPException, get_db, to_utc_datetime
 from agno.remote.base import RemoteDb
 
 logger = logging.getLogger(__name__)
@@ -154,6 +155,8 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
 
         except HTTPException:
             raise
+        except AgnoError as e:
+            raise AgnoHTTPException(e)
         except Exception as e:
             logger.exception("GET /metrics failed")
             raise HTTPException(status_code=500, detail=f"Error getting metrics: {str(e)}")
@@ -331,6 +334,8 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
 
         except HTTPException:
             raise
+        except AgnoError as e:
+            raise AgnoHTTPException(e)
         except Exception as e:
             raise HTTPException(status_code=500, detail=f"Error refreshing metrics: {str(e)}")
 

--- a/libs/agno/agno/os/routers/session/session.py
+++ b/libs/agno/agno/os/routers/session/session.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, Reques
 
 from agno.db.base import AsyncBaseDb, BaseDb, SessionType
 from agno.db.utils import deserialize_session_by_type, resolve_session_type
+from agno.exceptions import AgnoError
 from agno.os.auth import get_auth_token_from_request, get_authentication_dependency
 from agno.os.middleware.user_scope import (
     enforce_owner_on_entity,
@@ -36,6 +37,7 @@ from agno.os.schema import (
 from agno.os.services.sessions import SessionNotFoundError, get_sessions_page
 from agno.os.services.sessions import get_session_runs as get_session_runs_from_service
 from agno.os.settings import AgnoAPISettings
+from agno.os.utils import AgnoHTTPException
 from agno.remote.base import RemoteDb
 from agno.session import AgentSession, Session, TeamSession, WorkflowSession
 
@@ -277,7 +279,10 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
                     )
                 return db.get_session(session_id=session_id, session_type=session_type, user_id=uid, deserialize=False)
 
-            owned_session = await _get(scoped_user_id)
+            try:
+                owned_session = await _get(scoped_user_id)
+            except AgnoError as e:
+                raise AgnoHTTPException(e)
             if owned_session is not None:
                 # The caller owns (or, as admin/unscoped, can see) the colliding session:
                 # safe to point them at PATCH, since this reveals nothing they can't read.
@@ -286,7 +291,11 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
                     detail=f"Session with id '{session_id}' already exists. "
                     f"Use PATCH /sessions/{session_id} to update it.",
                 )
-            if scoped_user_id is not None and await _get(None) is not None:
+            try:
+                id_taken = scoped_user_id is not None and await _get(None) is not None
+            except AgnoError as e:
+                raise AgnoHTTPException(e)
+            if id_taken:
                 # The id is taken by another owner. session_id is a global primary key, so
                 # the collision itself is unavoidable (as with any client-chosen unique id),
                 # but the response must not confirm that the session belongs to someone else
@@ -363,6 +372,8 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
                 return TeamSessionDetailSchema.from_session(created_session)  # type: ignore
             else:
                 return WorkflowSessionDetailSchema.from_session(created_session)  # type: ignore
+        except AgnoError as e:
+            raise AgnoHTTPException(e)
         except Exception as e:
             logger.exception("Error creating session")
             raise HTTPException(status_code=500, detail=f"Failed to create session: {str(e)}")

--- a/libs/agno/agno/os/routers/traces/traces.py
+++ b/libs/agno/agno/os/routers/traces/traces.py
@@ -5,6 +5,7 @@ from fastapi import Depends, HTTPException, Query, Request
 from fastapi.routing import APIRouter
 
 from agno.db.base import AsyncBaseDb, BaseDb
+from agno.exceptions import AgnoError
 from agno.os.auth import get_auth_token_from_request, get_authentication_dependency
 from agno.os.middleware.user_scope import resolve_db_and_scope
 from agno.os.routers.traces.schemas import (
@@ -27,7 +28,7 @@ from agno.os.schema import (
     ValidationErrorResponse,
 )
 from agno.os.settings import AgnoAPISettings
-from agno.os.utils import timestamp_to_datetime
+from agno.os.utils import AgnoHTTPException, timestamp_to_datetime
 from agno.remote.base import RemoteDb
 from agno.utils.log import log_error
 
@@ -266,6 +267,8 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
                 ),
             )
 
+        except AgnoError as e:
+            raise AgnoHTTPException(e)
         except Exception as e:
             log_error(f"Error retrieving traces: {str(e)}")
             raise HTTPException(status_code=500, detail=f"Error retrieving traces: {str(e)}")
@@ -470,6 +473,8 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
 
         except HTTPException:
             raise
+        except AgnoError as e:
+            raise AgnoHTTPException(e)
         except Exception as e:
             log_error(f"Error retrieving trace {trace_id}: {str(e)}")
             raise HTTPException(status_code=500, detail=f"Error retrieving trace: {str(e)}")
@@ -626,6 +631,8 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
                 ),
             )
 
+        except AgnoError as e:
+            raise AgnoHTTPException(e)
         except Exception as e:
             log_error(f"Error retrieving trace statistics: {str(e)}")
             raise HTTPException(status_code=500, detail=f"Error retrieving statistics: {str(e)}")
@@ -806,6 +813,8 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
 
         except ValueError as e:
             raise HTTPException(status_code=400, detail=f"Invalid filter expression: {str(e)}")
+        except AgnoError as e:
+            raise AgnoHTTPException(e)
         except Exception as e:
             log_error(f"Error searching traces: {str(e)}")
             raise HTTPException(status_code=500, detail=f"Error searching traces: {str(e)}")

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -11,7 +11,7 @@ from starlette.middleware.cors import CORSMiddleware
 from agno.agent import Agent, AgentFactory, RemoteAgent
 from agno.agent.protocol import AgentProtocol
 from agno.db.base import AsyncBaseDb, BaseDb
-from agno.exceptions import ComponentRehydrationError
+from agno.exceptions import AgnoError, ComponentRehydrationError
 from agno.factory import (
     FactoryContextRequired,
     FactoryError,
@@ -33,6 +33,23 @@ from agno.team import RemoteTeam, Team, TeamFactory
 from agno.tools import Function, Toolkit
 from agno.utils.log import log_debug, log_warning, logger
 from agno.workflow import RemoteWorkflow, Workflow, WorkflowFactory
+
+
+class AgnoHTTPException(HTTPException):
+    """HTTPException raised from an ``AgnoError`` that keeps the error's identity.
+
+    Routers that wrap database and model calls in a blanket ``except Exception`` use this
+    to re-raise an ``AgnoError`` with its own status code. The owned-app exception handler
+    copies ``error_id`` and ``error_type`` into the JSON body so clients can branch on them
+    (``migration_required_error``, ``model_provider_error``, ...) instead of parsing
+    ``detail``. On a caller-supplied app FastAPI's default handler still answers with the
+    right status code and ``detail``.
+    """
+
+    def __init__(self, error: AgnoError, detail: Optional[str] = None):
+        super().__init__(status_code=error.status_code, detail=detail if detail is not None else str(error))
+        self.error_id: Optional[str] = getattr(error, "error_id", None)
+        self.error_type: Optional[str] = getattr(error, "type", None)
 
 
 def to_utc_datetime(value: Optional[Union[str, int, float, date, datetime]]) -> Optional[datetime]:

--- a/libs/agno/tests/unit/db/test_postgres.py
+++ b/libs/agno/tests/unit/db/test_postgres.py
@@ -15,6 +15,7 @@ from agno.db.postgres.schemas import (
     get_table_schema_definition,
 )
 from agno.db.utils import json_serializer
+from agno.exceptions import MigrationRequiredError
 
 
 @pytest.fixture
@@ -397,8 +398,11 @@ def test_get_or_create_table_invalid_schema(mock_is_valid, mock_is_available, po
 
     postgres_db.Session = Mock(return_value=mock_session)
 
-    with pytest.raises(ValueError, match="has an invalid schema"):
+    with pytest.raises(MigrationRequiredError, match="has an invalid schema") as exc_info:
         postgres_db._get_or_create_table("test_table", "sessions", "test_schema")
+
+    assert exc_info.value.table_name == "test_schema.test_table"
+    assert exc_info.value.error_id == "migration_required_error"
 
 
 @patch("agno.db.postgres.postgres.is_table_available")

--- a/libs/agno/tests/unit/db/test_table_resolution_cache.py
+++ b/libs/agno/tests/unit/db/test_table_resolution_cache.py
@@ -17,6 +17,7 @@ import pytest
 from sqlalchemy import event, text
 
 from agno.db.sqlite import SqliteDb
+from agno.exceptions import SchemaMismatchError
 
 
 @pytest.fixture
@@ -232,7 +233,7 @@ def test_same_physical_name_for_two_types_fails_loudly():
     tmp = tempfile.mkdtemp()
     shared = SqliteDb(db_file=f"{tmp}/t.db", session_table="agno_shared", memory_table="agno_shared")
     shared._get_table(table_type="sessions", create_table_if_not_found=True)
-    with pytest.raises(ValueError, match="invalid schema"):
+    with pytest.raises(SchemaMismatchError, match="invalid schema"):
         shared._get_table(table_type="memories", create_table_if_not_found=True)
 
 

--- a/libs/agno/tests/unit/os/routers/test_database_router.py
+++ b/libs/agno/tests/unit/os/routers/test_database_router.py
@@ -1,0 +1,183 @@
+"""The migrate endpoints run the pending migrations and report failures faithfully.
+
+``POST /databases/all/migrate`` answers 200 when every local database migrated,
+207 with a ``failed`` map otherwise, and skips remote databases instead of failing
+them. ``POST /databases/{db_id}/migrate`` answers 200, 404 for an unknown id, 400
+for a remote database, and keeps an ``AgnoError``'s identity on failure.
+"""
+
+import sqlite3
+from unittest.mock import Mock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agno.db.migrations.manager import MigrationManager
+from agno.db.sqlite import AsyncSqliteDb, SqliteDb
+from agno.exceptions import MigrationRequiredError
+from agno.os import AgentOS
+from agno.remote.base import RemoteDb
+
+
+def _client(agent_os):
+    return TestClient(agent_os.get_app(), raise_server_exceptions=False)
+
+
+@pytest.fixture
+def sqlite_db(tmp_path):
+    return SqliteDb(db_file=str(tmp_path / "migrate.db"))
+
+
+@pytest.fixture
+def async_sqlite_db(tmp_path):
+    return AsyncSqliteDb(db_file=str(tmp_path / "migrate_async.db"))
+
+
+@pytest.fixture
+def stale_approvals_db(tmp_path):
+    """A SqliteDb whose approvals table is at its 2.5.0 shape: ``run_status`` was added in 2.5.6."""
+    db_file = tmp_path / "stale_approvals.db"
+    seed = SqliteDb(db_file=str(db_file))
+    seed._create_all_tables()
+    seed.upsert_schema_version(seed.approvals_table_name, "2.5.0")
+    with sqlite3.connect(db_file) as conn:
+        conn.execute("DROP INDEX IF EXISTS idx_agno_approvals_run_status")
+        conn.execute("ALTER TABLE agno_approvals DROP COLUMN run_status")
+    # A fresh instance so no Table objects reflected before the column drop are cached.
+    return SqliteDb(db_file=str(db_file))
+
+
+class TestMigrateAllDatabases:
+    def test_fresh_sync_database_migrates_to_latest(self, sqlite_db):
+        client = _client(AgentOS(id="os", db=sqlite_db))
+
+        response = client.post("/databases/all/migrate")
+
+        assert response.status_code == 200
+        assert response.json() == {"message": "All databases migrated successfully to latest version"}
+
+    def test_fresh_async_database_migrates_to_latest(self, async_sqlite_db):
+        client = _client(AgentOS(id="os", db=async_sqlite_db))
+
+        response = client.post("/databases/all/migrate")
+
+        assert response.status_code == 200
+        assert response.json() == {"message": "All databases migrated successfully to latest version"}
+
+    def test_target_version_is_echoed(self, sqlite_db):
+        client = _client(AgentOS(id="os", db=sqlite_db))
+
+        response = client.post("/databases/all/migrate?target_version=2.5.6")
+
+        assert response.status_code == 200
+        assert response.json()["message"] == "All databases migrated successfully to version 2.5.6"
+
+    def test_stale_table_is_brought_up_to_date(self, stale_approvals_db):
+        client = _client(AgentOS(id="os", db=stale_approvals_db))
+
+        response = client.post("/databases/all/migrate")
+
+        assert response.status_code == 200
+        with sqlite3.connect(stale_approvals_db.db_file) as conn:
+            columns = {row[1] for row in conn.execute("PRAGMA table_info(agno_approvals)")}
+            versions = dict(conn.execute("SELECT table_name, version FROM agno_schema_versions").fetchall())
+        assert "run_status" in columns
+        assert versions["agno_approvals"] == str(MigrationManager(stale_approvals_db).latest_schema_version)
+
+    def test_failure_is_reported_per_database_as_207(self, sqlite_db):
+        client = _client(AgentOS(id="os", db=sqlite_db))
+
+        async def boom(self, *args, **kwargs):
+            raise RuntimeError("boom")
+
+        with patch.object(MigrationManager, "up", boom):
+            response = client.post("/databases/all/migrate")
+
+        assert response.status_code == 207
+        body = response.json()
+        assert body["message"] == "Migrated 0/1 databases to latest version"
+        assert body["failed"] == {sqlite_db.id: "boom"}
+
+    def test_remote_database_is_skipped_not_failed(self, sqlite_db):
+        agent_os = AgentOS(id="os", db=sqlite_db)
+        client = _client(agent_os)
+        agent_os.dbs["remote-1"] = [RemoteDb(id="remote-1", client=Mock())]
+
+        response = client.post("/databases/all/migrate")
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "message": "All databases migrated successfully to latest version",
+            "skipped": ["remote-1"],
+        }
+
+    def test_remote_database_is_skipped_with_a_target_version(self, sqlite_db):
+        """The target-version branch reads the schema version off the db, which a RemoteDb lacks."""
+        agent_os = AgentOS(id="os", db=sqlite_db)
+        client = _client(agent_os)
+        agent_os.dbs["remote-1"] = [RemoteDb(id="remote-1", client=Mock())]
+
+        response = client.post("/databases/all/migrate?target_version=2.5.6")
+
+        assert response.status_code == 200
+        assert response.json()["skipped"] == ["remote-1"]
+
+
+class TestMigrateDatabase:
+    def test_fresh_database_migrates(self, sqlite_db):
+        client = _client(AgentOS(id="os", db=sqlite_db))
+
+        response = client.post(f"/databases/{sqlite_db.id}/migrate")
+
+        assert response.status_code == 200
+        assert response.json() == {"message": "Database migrated successfully to latest version"}
+
+    def test_async_database_migrates(self, async_sqlite_db):
+        client = _client(AgentOS(id="os", db=async_sqlite_db))
+
+        response = client.post(f"/databases/{async_sqlite_db.id}/migrate")
+
+        assert response.status_code == 200
+
+    def test_unknown_database_is_404(self, sqlite_db):
+        client = _client(AgentOS(id="os", db=sqlite_db))
+
+        response = client.post("/databases/does-not-exist/migrate")
+
+        assert response.status_code == 404
+
+    def test_remote_database_is_400(self, sqlite_db):
+        agent_os = AgentOS(id="os", db=sqlite_db)
+        client = _client(agent_os)
+        agent_os.dbs["remote-1"] = [RemoteDb(id="remote-1", client=Mock())]
+
+        response = client.post("/databases/remote-1/migrate")
+
+        assert response.status_code == 400
+        assert "remote" in response.json()["detail"]
+
+    def test_generic_failure_is_500_with_detail(self, sqlite_db):
+        client = _client(AgentOS(id="os", db=sqlite_db))
+
+        async def boom(self, *args, **kwargs):
+            raise RuntimeError("boom")
+
+        with patch.object(MigrationManager, "up", boom):
+            response = client.post(f"/databases/{sqlite_db.id}/migrate")
+
+        assert response.status_code == 500
+        assert response.json() == {"detail": "Failed to migrate database: boom"}
+
+    def test_agno_error_keeps_its_identity(self, sqlite_db):
+        client = _client(AgentOS(id="os", db=sqlite_db))
+
+        async def boom(self, *args, **kwargs):
+            raise MigrationRequiredError(table_name="agno_sessions")
+
+        with patch.object(MigrationManager, "up", boom):
+            response = client.post(f"/databases/{sqlite_db.id}/migrate")
+
+        assert response.status_code == 500
+        body = response.json()
+        assert body["error_id"] == "migration_required_error"
+        assert body["detail"].startswith("Failed to migrate database: Table agno_sessions has an invalid schema")

--- a/libs/agno/tests/unit/os/test_migration_required_http.py
+++ b/libs/agno/tests/unit/os/test_migration_required_http.py
@@ -1,0 +1,131 @@
+"""A table left behind by an older schema answers with a distinguishable error.
+
+The database adapters raise ``MigrationRequiredError`` when an existing table is
+missing columns this version expects. Over HTTP the owned-app handlers put its
+``error_id`` in the body so a client can branch on it instead of parsing the
+message; on a caller-supplied app the status code and detail still survive.
+"""
+
+import sqlite3
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from agno.db.sqlite import SqliteDb
+from agno.db.utils import table_schema_mismatch_error
+from agno.exceptions import AgnoError, MigrationRequiredError, SchemaMismatchError
+from agno.os import AgentOS
+from agno.os.utils import AgnoHTTPException
+
+
+@pytest.fixture
+def stale_db(tmp_path):
+    """A SqliteDb whose metrics table predates the current schema (missing most columns)."""
+    db_file = tmp_path / "stale.db"
+    with sqlite3.connect(db_file) as conn:
+        conn.execute("CREATE TABLE agno_metrics (id TEXT PRIMARY KEY, date TEXT)")
+    return SqliteDb(db_file=str(db_file), metrics_table="agno_metrics")
+
+
+def _client(app):
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class TestMigrationRequiredError:
+    def test_is_an_agno_error_with_a_stable_id(self):
+        error = MigrationRequiredError(table_name="public.agno_metrics")
+
+        assert isinstance(error, AgnoError)
+        assert error.status_code == 500
+        assert error.error_id == "migration_required_error"
+        assert error.type == "migration_required_error"
+        assert error.table_name == "public.agno_metrics"
+        assert "public.agno_metrics has an invalid schema" in str(error)
+        assert "POST /databases/all/migrate" in str(error)
+
+    def test_is_a_schema_mismatch_error(self):
+        assert issubclass(MigrationRequiredError, SchemaMismatchError)
+        assert SchemaMismatchError(table_name="t").error_id == "schema_mismatch_error"
+
+    def test_helper_picks_migration_required_for_migratable_tables(self):
+        error = table_schema_mismatch_error("public.agno_metrics", table_type="metrics")
+
+        assert type(error) is MigrationRequiredError
+        assert "POST /databases/all/migrate" in str(error)
+
+    def test_helper_picks_plain_mismatch_for_tables_no_migration_covers(self):
+        """Migration advice for a table no migration touches would send the user in a circle."""
+        error = table_schema_mismatch_error("agno_traces", table_type="traces")
+
+        assert type(error) is SchemaMismatchError
+        assert error.error_id == "schema_mismatch_error"
+        assert "No Agno migration covers this table" in str(error)
+        assert "MigrationManager" not in str(error)
+
+    def test_custom_message_is_kept(self):
+        error = MigrationRequiredError(table_name="t", message="custom")
+
+        assert str(error) == "custom"
+        assert error.error_id == "migration_required_error"
+
+    def test_adapter_raises_it_for_a_stale_table(self, stale_db):
+        with pytest.raises(MigrationRequiredError) as exc_info:
+            stale_db.get_metrics()
+
+        assert exc_info.value.table_name == "agno_metrics"
+
+    def test_inspection_failure_is_not_read_as_a_stale_schema(self, stale_db):
+        """A table that cannot be inspected is an operational error, not a pending migration."""
+        with patch("agno.db.sqlite.utils.inspect", side_effect=RuntimeError("no metadata access")):
+            with pytest.raises(RuntimeError, match="no metadata access"):
+                stale_db.get_metrics()
+
+
+class TestAgnoHTTPException:
+    def test_carries_status_and_identity_of_the_wrapped_error(self):
+        http_error = AgnoHTTPException(MigrationRequiredError(table_name="agno_metrics"))
+
+        assert http_error.status_code == 500
+        assert http_error.error_id == "migration_required_error"
+        assert http_error.error_type == "migration_required_error"
+        assert "agno_metrics has an invalid schema" in http_error.detail
+
+    def test_detail_override(self):
+        http_error = AgnoHTTPException(MigrationRequiredError(table_name="t"), detail="short")
+
+        assert http_error.detail == "short"
+        assert http_error.error_id == "migration_required_error"
+
+
+class TestMigrationRequiredOverHttp:
+    def test_owned_app_answers_with_error_id(self, stale_db):
+        client = _client(AgentOS(id="stale-os", db=stale_db).get_app())
+
+        response = client.get("/metrics")
+
+        assert response.status_code == 500
+        body = response.json()
+        assert body["error_id"] == "migration_required_error"
+        assert body["error_type"] == "migration_required_error"
+        assert "agno_metrics has an invalid schema" in body["detail"]
+
+    def test_caller_supplied_app_keeps_status_and_detail(self, stale_db):
+        """AgentOS registers no handlers on a caller-supplied app, so the status
+        has to come from the router; the body is FastAPI's default shape."""
+        client = _client(AgentOS(id="mounted-os", db=stale_db, base_app=FastAPI()).get_app())
+
+        response = client.get("/metrics")
+
+        assert response.status_code == 500
+        assert "agno_metrics has an invalid schema" in response.json()["detail"]
+
+    def test_plain_errors_do_not_grow_an_error_id(self, stale_db):
+        """Only errors that carry an identity get one in the body; a 404 stays as it was."""
+        client = _client(AgentOS(id="stale-os", db=stale_db).get_app())
+
+        response = client.get("/sessions/does-not-exist")
+
+        assert response.status_code == 404
+        assert "error_id" not in response.json()


### PR DESCRIPTION
## Summary

Port of https://github.com/agno-agi/agno/pull/9669 onto `feat/v3.0`, built on top of the `table_schema_mismatch_error` helper this branch already had (the helper now returns the typed error instead of a `ValueError`; its message text is unchanged).

When an existing table does not match the schema this version of Agno expects (typically a database created by an older version whose migrations have not been applied), the SQL adapters raised a bare `ValueError("Table X has an invalid schema")` and AgentOS flattened it into a generic 500 `{"detail": "Error getting metrics: ..."}`. Clients could only detect "this database needs a migration" by parsing the message text.

This PR gives that condition its own error type and carries its identity through to the HTTP response so a frontend can branch on it.

- New `SchemaMismatchError(AgnoError)` and `MigrationRequiredError(SchemaMismatchError)` in `agno.exceptions`
  - Both: `status_code=500`, `.table_name`; `error_id` is `schema_mismatch_error` or `migration_required_error`
  - `MigrationRequiredError` is raised for table types `MigrationManager` can migrate and its message names both remedies: `asyncio.run(MigrationManager(db).up())` and `POST /databases/all/migrate`; the plain `SchemaMismatchError` is raised for tables no Agno migration covers, with repair guidance instead (migration advice there would send the user in a circle)
  - `agno.db.utils.table_schema_mismatch_error(table_ref, table_type)` builds the right one, so the adapters share one decision and one message
  - Deliberately not `ValueError` subclasses: several routers map `ValueError` to 400, which would report a stale database as a client error
- Postgres, MySQL, SQLite (sync and async) and SingleStore adapters raise it from `_get_or_create_table` via the helper instead of a bare `ValueError`
- `is_valid_table` / `ais_valid_table` let inspection errors propagate instead of returning `False`, so a transient or permissions failure is not reported as a pending migration; only genuinely missing columns are
- New `AgnoHTTPException` in `agno.os.utils`: an `HTTPException` built from an `AgnoError` that keeps its status code, `error_id` and `error_type`
- Owned-app exception handlers (`http_exception_handler`, `general_exception_handler`) add `error_id` and `error_type` to the JSON body when the exception carries them; errors without an id keep the existing `{"detail": ...}` shape. The v3.0 policy of not echoing `str(exc)` for unhandled 5xx is kept: an unhandled `MigrationRequiredError` answers `Internal server error (MigrationRequiredError)` plus `error_id`, while the router-wrapped paths keep the full remedy text in `detail`
- Routers with a blanket `except Exception -> 500` around database calls (metrics, sessions, memory, traces, evals, learnings, knowledge, components) now re-raise `AgnoError` via `AgnoHTTPException` first, so any `AgnoError` in those paths surfaces with its own status and id instead of a generic 500

Response body on an AgentOS-owned app:

```json
{
  "detail": "Table agno_metrics has an invalid schema: it does not match what this version of Agno expects ... or via the AgentOS endpoint `POST /databases/all/migrate`.",
  "error_id": "migration_required_error",
  "error_type": "migration_required_error"
}
```

On a caller-supplied `base_app` (where AgentOS registers no handlers) the response keeps the 500 and `detail`, as before, without the id.

Migrate endpoints, verified end to end while here:

- `POST /databases/all/migrate` and `POST /databases/{db_id}/migrate` migrate fresh sync and async SQLite databases and bring a real 2.5.0 approvals table (missing `run_status`) up to 2.5.6
- A `RemoteDb` in `os.dbs` used to reach `MigrationManager` and fail with `'RemoteDb' object has no attribute ...` in the `failed` map (the "Skipping logs for remote DB" branch never returned). `/all/migrate` now skips remote databases and lists them under `skipped`; `/{db_id}/migrate` answers 400 for a remote id
- An `AgnoError` raised during a single-database migration keeps its `error_id` in the 500 body; generic failures stay `{"detail": "Failed to migrate database: ..."}` and per-database failures in `/all/migrate` stay a 207 with a `failed` map

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

- The schema-mismatch exception was previously a `ValueError`; code catching `ValueError` for this specific case should catch `SchemaMismatchError` (or `MigrationRequiredError`) instead. No in-tree callers did.
- Also updates `test_table_resolution_cache.py::test_same_physical_name_for_two_types_fails_loudly` and `test_postgres.py::test_get_or_create_table_invalid_schema` for the new types.
- Tests: `libs/agno/tests/unit/os/routers/test_database_router.py` covers both migrate endpoints (fresh sync/async, stale 2.5.0 approvals table, per-db failure, remote skip/400, 404, AgnoError identity); `libs/agno/tests/unit/os/test_migration_required_http.py` builds a real stale SQLite `agno_metrics` table and asserts the HTTP round trip on both an owned and a caller-supplied app; `test_postgres.py::test_get_or_create_table_invalid_schema` updated for the new type. `unit/os` and the adapter `unit/db` suites pass.
- `validate.sh` mypy reports pre-existing errors in `models/anthropic`, `models/google` and `utils/models/_genai_compat.py` that are unrelated to this diff; mypy is clean on every changed file.
- Follow-up candidate: the `*ErrorResponse` OpenAPI models still document an unused `error_code` field rather than `error_id`/`error_type`.