### PR TITLE
[cookbook] Align Team HITL examples with cookbook standards

### DIFF
--- a/cookbook/03_teams/20_human_in_the_loop/CLAUDE.md
+++ b/cookbook/03_teams/20_human_in_the_loop/CLAUDE.md
@@ -71,6 +71,9 @@ caller resolves that requirement and resumes the Team directly with
 - Most persisted examples use SQLite under `tmp/`
 - `team_tool_confirmation_stream.py` uses PostgreSQL at
   `postgresql+psycopg://ai:ai@localhost:5532/ai`
+- `confirmation_required_async.py`, `confirmation_rejected.py`,
+  `confirmation_required_with_dependencies.py`, and `team_tool_confirmation.py`
+  configure no `db`, so they need no database setup and write no session rows
 - The `tmp/` directory must be writable (created automatically)
 
 ---

--- a/cookbook/03_teams/20_human_in_the_loop/CLAUDE.md
+++ b/cookbook/03_teams/20_human_in_the_loop/CLAUDE.md
@@ -14,11 +14,17 @@ Instructions for Claude Code when testing the Team HITL cookbooks.
 
 **Run a cookbook:**
 ```bash
-.venvs/demo/bin/python cookbook/03_teams/20_human_in_the_loop/confirmation_required.py
-.venvs/demo/bin/python cookbook/03_teams/20_human_in_the_loop/external_tool_execution.py
-.venvs/demo/bin/python cookbook/03_teams/20_human_in_the_loop/user_input_required.py
-.venvs/demo/bin/python cookbook/03_teams/20_human_in_the_loop/multi_round_user_input.py
+.venvs/demo/bin/python cookbook/03_teams/20_human_in_the_loop/<example>.py
 ```
+
+| Pattern | Examples |
+|---------|----------|
+| Member confirmation | `confirmation_required.py`, `confirmation_required_async.py`, `confirmation_required_stream.py`, `confirmation_required_async_stream.py` |
+| Dependency forwarding | `confirmation_required_with_dependencies.py` |
+| Member rejection | `confirmation_rejected.py`, `confirmation_rejected_stream.py` |
+| User input | `user_input_required.py`, `user_input_required_stream.py`, `multi_round_user_input.py` |
+| External execution | `external_tool_execution.py`, `external_tool_execution_stream.py` |
+| Team-level tool confirmation | `team_tool_confirmation.py`, `team_tool_confirmation_stream.py` |
 
 **Test results file:**
 ```
@@ -33,27 +39,38 @@ cookbook/03_teams/20_human_in_the_loop/TEST_LOG.md
 
 - Ensure the virtual environment exists (run `./scripts/demo_setup.sh` if needed)
 - Set `OPENAI_API_KEY` environment variable
+- Start PostgreSQL with `./cookbook/scripts/run_pgvector.sh` before running
+  `team_tool_confirmation_stream.py`
 
 ### 2. Running Tests
 
-Each script is interactive and requires terminal input:
+These scripts require terminal input:
 - **confirmation_required.py** -- Prompts y/n to approve/deny a weather lookup
 - **external_tool_execution.py** -- Prompts for the result of an external email send
 - **user_input_required.py** -- Prompts for destination and budget values
 - **multi_round_user_input.py** -- Prompts for name, then cuisine/budget (2 HITL rounds)
 
+The other examples resolve their requirements programmatically after the model
+pauses, so they require no terminal input.
+
 ### 3. Expected Behavior
 
-All three examples follow the same pattern:
+Member-tool examples follow this pattern:
 1. Team delegates task to a member agent
 2. Member encounters a HITL tool and pauses
 3. Pause propagates to the team level with member context
 4. User resolves the requirement (confirm/reject, provide input, or provide result)
-5. `team.continue_run()` routes the resolution back to the member and completes
+5. `team.continue_run()` or `team.acontinue_run()` routes the resolution back to the member and completes
 
-### 4. Known Issues
+Team-level tool examples pause when the Team calls its own guarded tool. The
+caller resolves that requirement and resumes the Team directly with
+`team.continue_run()`.
 
-- These examples use SQLite (`tmp/team_hitl.db`) for session persistence
+### 4. Persistence Prerequisites
+
+- Most persisted examples use SQLite under `tmp/`
+- `team_tool_confirmation_stream.py` uses PostgreSQL at
+  `postgresql+psycopg://ai:ai@localhost:5532/ai`
 - The `tmp/` directory must be writable (created automatically)
 
 ---

--- a/cookbook/03_teams/20_human_in_the_loop/README.md
+++ b/cookbook/03_teams/20_human_in_the_loop/README.md
@@ -4,13 +4,25 @@ Examples for team workflows in human_in_the_loop.
 
 ## Prerequisites
 
-- Load environment variables (for example, OPENAI_API_KEY) via direnv allow.
-- Use .venvs/demo/bin/python to run cookbook examples.
-- Some examples require additional services (for example PostgreSQL, LanceDB, or Infinity server) as noted in file docstrings.
+- Load `OPENAI_API_KEY` (for example, with `direnv allow`).
+- Use `.venvs/demo/bin/python` to run cookbook examples.
+- Examples that persist paused runs use SQLite files under `tmp/`, except
+  `team_tool_confirmation_stream.py`, which uses PostgreSQL. Start the local
+  database with `./cookbook/scripts/run_pgvector.sh` before running it.
 
 ## Files
 
-- confirmation_required.py - Demonstrates confirmation required.
-- external_tool_execution.py - Demonstrates external tool execution.
-- user_input_required.py - Demonstrates user input required.
-- multi_round_user_input.py - Demonstrates multi-round HITL (member pauses multiple times).
+- `confirmation_required.py` - Confirm or reject a member tool call.
+- `confirmation_required_async.py` - Confirm a member tool call asynchronously.
+- `confirmation_required_stream.py` - Confirm a member tool call while streaming.
+- `confirmation_required_async_stream.py` - Confirm a member tool call with async streaming.
+- `confirmation_required_with_dependencies.py` - Preserve caller dependencies when an async member run resumes.
+- `confirmation_rejected.py` - Reject a member tool call and continue the team run.
+- `confirmation_rejected_stream.py` - Reject a member tool call while streaming.
+- `user_input_required.py` - Collect required user input for a member tool.
+- `user_input_required_stream.py` - Provide required user input while streaming.
+- `multi_round_user_input.py` - Handle multiple member pause and resume cycles.
+- `external_tool_execution.py` - Return an externally produced result to a member tool.
+- `external_tool_execution_stream.py` - Execute a member tool externally while streaming.
+- `team_tool_confirmation.py` - Confirm a tool attached directly to the Team.
+- `team_tool_confirmation_stream.py` - Confirm a Team-level tool while streaming with PostgreSQL persistence.

--- a/cookbook/03_teams/20_human_in_the_loop/README.md
+++ b/cookbook/03_teams/20_human_in_the_loop/README.md
@@ -6,9 +6,13 @@ Examples for team workflows in human_in_the_loop.
 
 - Load `OPENAI_API_KEY` (for example, with `direnv allow`).
 - Use `.venvs/demo/bin/python` to run cookbook examples.
-- Examples that persist paused runs use SQLite files under `tmp/`, except
-  `team_tool_confirmation_stream.py`, which uses PostgreSQL. Start the local
+- Most examples persist paused runs to SQLite files under `tmp/`.
+  `team_tool_confirmation_stream.py` uses PostgreSQL instead. Start the local
   database with `./cookbook/scripts/run_pgvector.sh` before running it.
+- `confirmation_required_async.py`, `confirmation_rejected.py`,
+  `confirmation_required_with_dependencies.py`, and `team_tool_confirmation.py`
+  configure no database. They pause and resume within a single process, so the
+  paused run is not recoverable after the script exits.
 
 ## Files
 

--- a/cookbook/03_teams/20_human_in_the_loop/confirmation_required_with_dependencies.py
+++ b/cookbook/03_teams/20_human_in_the_loop/confirmation_required_with_dependencies.py
@@ -22,6 +22,9 @@ from agno.team.team import Team
 from agno.tools import tool
 
 
+# ---------------------------------------------------------------------------
+# Tools
+# ---------------------------------------------------------------------------
 @tool(requires_confirmation=True)
 def group_del_stock(
     group_id: str, stock_list: list, run_context: RunContext
@@ -43,6 +46,9 @@ def group_del_stock(
     }
 
 
+# ---------------------------------------------------------------------------
+# Create Members
+# ---------------------------------------------------------------------------
 stock_agent = Agent(
     name="Stock Agent",
     role="Manages user stock watch groups. Uses group_del_stock to remove stocks.",
@@ -50,6 +56,10 @@ stock_agent = Agent(
     tools=[group_del_stock],
 )
 
+
+# ---------------------------------------------------------------------------
+# Create Team
+# ---------------------------------------------------------------------------
 stock_team = Team(
     name="Stock Team",
     members=[stock_agent],
@@ -60,6 +70,9 @@ stock_team = Team(
 )
 
 
+# ---------------------------------------------------------------------------
+# Run Team
+# ---------------------------------------------------------------------------
 async def main() -> None:
     # The caller threads their auth token through `dependencies`.
     dependencies = {"user_token": "Bearer demo-token-123"}


### PR DESCRIPTION
## Summary

- document all 14 Team HITL cookbook examples instead of the previous 4-file subset;
- distinguish interactive examples from examples that resolve requirements programmatically;
- document the PostgreSQL prerequisite for the streaming Team-level tool example;
- add the section banners required by the cookbook pattern checker to `confirmation_required_with_dependencies.py`.

The change is cookbook-only and does not alter Team/HITL behavior.

Closes #9670.

## Verification

- `./scripts/format.sh`
- `./scripts/validate.sh`
- `.venvs/demo/bin/python cookbook/scripts/check_cookbook_pattern.py --base-dir cookbook/03_teams/20_human_in_the_loop` -- 14 files, 0 violations
- `.venv/bin/pytest -q cookbook/scripts/tests/test_check_cookbook_pattern.py` -- 3 passed
- focused Team/HITL unit suites -- 230 passed
- construction smoke in the freshly created `.venvs/demo` environment -- all 14 modules constructed successfully

The historical live-provider results in `TEST_LOG.md` were deliberately left unchanged because no fresh run with `OPENAI_API_KEY` was performed.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable; no new behavior was introduced)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach (not applicable; no similar PR found)
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

AI disclosure: this contribution was generated with OpenAI Codex at the GitHub account owner's direction. The diff was independently reviewed and validated with the repository's required scripts before publication.

---

## Additional Notes

Out of scope by design:

- no changes under `libs/agno/agno/team/**`;
- no Team/HITL behavior changes;
- no PostgreSQL-to-SQLite substitution;
- no relabeling of historical live-provider results without a fresh live run.
