### PR TITLE
refactor: import agno.agent in 147 ms instead of 233 ms

### DIFF
--- a/libs/agno/agno/agent/_init.py
+++ b/libs/agno/agno/agent/_init.py
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
 
 from agno.compression.manager import CompressionManager
 from agno.db.base import AsyncBaseDb
-from agno.learn.machine import LearningMachine
 from agno.memory import MemoryManager
 from agno.models.utils import get_model
 from agno.session import SessionSummaryManager
@@ -125,6 +124,8 @@ def set_learning_machine(agent: Agent) -> None:
     - learning=False/None: Disabled
     - learning=LearningMachine(...): Use provided, inject db/model/knowledge
     """
+    from agno.learn.machine import LearningMachine
+
     agent._learning_init_attempted = True
 
     # Handle learning=False or learning=None

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -22,7 +22,6 @@ from typing import (
 from pydantic import BaseModel
 
 from agno.agent import (
-    _cli,
     _default_tools,
     _init,
     _managers,
@@ -39,7 +38,10 @@ from agno.eval.base import BaseEval
 from agno.filters import FilterExpr
 from agno.guardrails import BaseGuardrail
 from agno.knowledge.protocol import KnowledgeProtocol
-from agno.learn.machine import LearningMachine
+
+if TYPE_CHECKING:
+    from agno.learn.machine import LearningMachine
+
 from agno.media import Audio, File, Image, Video
 from agno.media.storage.base import AsyncMediaStorage, MediaStorage
 from agno.memory import MemoryManager
@@ -1187,6 +1189,8 @@ class Agent:
         tags_to_include_in_markdown: Optional[Set[str]] = None,
         **kwargs: Any,
     ) -> None:
+        from agno.agent import _cli
+
         return _cli.agent_print_response(
             self,
             input=input,
@@ -1243,6 +1247,8 @@ class Agent:
         tags_to_include_in_markdown: Optional[Set[str]] = None,
         **kwargs: Any,
     ) -> None:
+        from agno.agent import _cli
+
         return await _cli.agent_aprint_response(
             self,
             input=input,
@@ -1283,6 +1289,8 @@ class Agent:
         exit_on: Optional[List[str]] = None,
         **kwargs: Any,
     ) -> None:
+        from agno.agent import _cli
+
         return _cli.cli_app(
             self,
             input=input,
@@ -1308,6 +1316,8 @@ class Agent:
         exit_on: Optional[List[str]] = None,
         **kwargs: Any,
     ) -> None:
+        from agno.agent import _cli
+
         return await _cli.acli_app(
             self,
             input=input,

--- a/libs/agno/agno/knowledge/__init__.py
+++ b/libs/agno/agno/knowledge/__init__.py
@@ -1,9 +1,40 @@
-from agno.knowledge.filesystem import FileSystemKnowledge
-from agno.knowledge.knowledge import Knowledge
-from agno.knowledge.protocol import KnowledgeProtocol
+"""Knowledge package.
+
+The public classes resolve on first access (PEP 562) so importing a leaf
+module such as ``agno.knowledge.types`` does not load the readers, the
+remote-content backends and their cloud clients.
+"""
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from agno.knowledge.filesystem import FileSystemKnowledge
+    from agno.knowledge.knowledge import Knowledge
+    from agno.knowledge.protocol import KnowledgeProtocol
 
 __all__ = [
     "FileSystemKnowledge",
     "Knowledge",
     "KnowledgeProtocol",
 ]
+
+_LAZY_ATTRS = {
+    "FileSystemKnowledge": "agno.knowledge.filesystem",
+    "Knowledge": "agno.knowledge.knowledge",
+    "KnowledgeProtocol": "agno.knowledge.protocol",
+}
+
+
+def __getattr__(name: str) -> Any:
+    module_name = _LAZY_ATTRS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    from importlib import import_module
+
+    value = getattr(import_module(module_name), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list:
+    return sorted(set(globals()) | set(__all__))

--- a/libs/agno/agno/run/cancellation_management/__init__.py
+++ b/libs/agno/agno/run/cancellation_management/__init__.py
@@ -1,9 +1,23 @@
+from typing import TYPE_CHECKING, Any
+
 from agno.run.cancellation_management.base import BaseRunCancellationManager
 from agno.run.cancellation_management.in_memory_cancellation_manager import InMemoryRunCancellationManager
-from agno.run.cancellation_management.redis_cancellation_manager import RedisRunCancellationManager
+
+if TYPE_CHECKING:
+    from agno.run.cancellation_management.redis_cancellation_manager import RedisRunCancellationManager
 
 __all__ = [
     "BaseRunCancellationManager",
     "InMemoryRunCancellationManager",
     "RedisRunCancellationManager",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    # The Redis manager imports the redis client, and with it opentelemetry and
+    # psutil. Nothing that does not ask for it should pay that at import time.
+    if name == "RedisRunCancellationManager":
+        from agno.run.cancellation_management.redis_cancellation_manager import RedisRunCancellationManager
+
+        return RedisRunCancellationManager
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/libs/agno/agno/team/_init.py
+++ b/libs/agno/agno/team/_init.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from agno.learn.machine import LearningMachine
     from agno.team.mode import TeamMode
     from agno.team.team import Team
     from agno.offload.store import ResultStore
@@ -33,7 +34,6 @@ from agno.eval.base import BaseEval
 from agno.filters import FilterExpr
 from agno.guardrails import BaseGuardrail
 from agno.knowledge.protocol import KnowledgeProtocol
-from agno.learn.machine import LearningMachine
 from agno.media.storage.base import AsyncMediaStorage, MediaStorage
 from agno.memory import MemoryManager
 from agno.models.base import Model
@@ -717,6 +717,8 @@ def _set_learning_machine(team: "Team") -> None:
     - learning=False/None: Disabled
     - learning=LearningMachine(...): Use provided, inject db/model
     """
+    from agno.learn.machine import LearningMachine
+
     team._learning_init_attempted = True
 
     if team.learning is None or team.learning is False:

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -29,7 +29,10 @@ from agno.eval.base import BaseEval
 from agno.filters import FilterExpr
 from agno.guardrails import BaseGuardrail
 from agno.knowledge.protocol import KnowledgeProtocol
-from agno.learn.machine import LearningMachine
+
+if TYPE_CHECKING:
+    from agno.learn.machine import LearningMachine
+
 from agno.media import Audio, File, Image, Video
 from agno.media.storage.base import AsyncMediaStorage, MediaStorage
 from agno.memory import MemoryManager
@@ -53,7 +56,6 @@ from agno.session import SessionSummaryManager, TeamSession
 from agno.session.summary import SessionSummary
 from agno.skills import Skills
 from agno.team import (
-    _cli,
     _default_tools,
     _init,
     _managers,
@@ -1252,6 +1254,8 @@ class Team:
         tags_to_include_in_markdown: Optional[Set[str]] = None,
         **kwargs: Any,
     ) -> None:
+        from agno.team import _cli
+
         return _cli.team_print_response(
             self,
             input=input,
@@ -1310,6 +1314,8 @@ class Team:
         tags_to_include_in_markdown: Optional[Set[str]] = None,
         **kwargs: Any,
     ) -> None:
+        from agno.team import _cli
+
         return await _cli.team_aprint_response(
             self,
             input=input,
@@ -1340,6 +1346,8 @@ class Team:
         )
 
     def _get_member_name(self, entity_id: str) -> str:
+        from agno.team import _cli
+
         return _cli._get_member_name(self, entity_id=entity_id)
 
     def scrub_run_output_for_storage(self, run_response: TeamRunOutput) -> bool:
@@ -1358,6 +1366,8 @@ class Team:
         exit_on: Optional[List[str]] = None,
         **kwargs: Any,
     ) -> None:
+        from agno.team import _cli
+
         return _cli.cli_app(
             self, input=input, user=user, emoji=emoji, stream=stream, markdown=markdown, exit_on=exit_on, **kwargs
         )
@@ -1374,6 +1384,8 @@ class Team:
         exit_on: Optional[List[str]] = None,
         **kwargs: Any,
     ) -> None:
+        from agno.team import _cli
+
         return await _cli.acli_app(
             self,
             input=input,

--- a/libs/agno/agno/utils/media.py
+++ b/libs/agno/agno/utils/media.py
@@ -3,9 +3,7 @@ import mimetypes
 import time
 from enum import Enum
 from pathlib import Path
-from typing import List, Optional, Union
-
-import httpx
+from typing import Any, List, Optional, Union
 
 from agno.media import Audio, File, Image, Video
 from agno.utils.log import log_info, log_warning
@@ -80,6 +78,8 @@ def download_image(url: str, output_path: str) -> bool:
     - url (str): URL of the image to download.
     - output_path (str): Local filesystem path to save the image
     """
+    import httpx
+
     try:
         # Send HTTP GET request to the image URL
         response = httpx.get(url)
@@ -113,6 +113,8 @@ def download_image(url: str, output_path: str) -> bool:
 
 def download_audio(url: str, output_path: str) -> str:
     """Download audio from URL"""
+    import httpx
+
     response = httpx.get(url)
     response.raise_for_status()
 
@@ -124,6 +126,8 @@ def download_audio(url: str, output_path: str) -> str:
 
 def download_video(url: str, output_path: str) -> str:
     """Download video from URL"""
+    import httpx
+
     response = httpx.get(url)
     response.raise_for_status()
 
@@ -144,6 +148,8 @@ def download_file(url: str, output_path: str) -> None:
     Raises:
         httpx.HTTPError: If the download fails
     """
+    import httpx
+
     try:
         response = httpx.get(url)
         response.raise_for_status()
@@ -197,6 +203,8 @@ def wait_for_media_ready(url: str, timeout: int = 120, interval: int = 5, verbos
     Returns:
         bool: True if media is ready, False if timeout reached
     """
+    import httpx
+
     max_attempts = timeout // interval
 
     if verbose:
@@ -514,3 +522,13 @@ def reconstruct_response_audio(audio: Optional[dict]) -> Optional[Audio]:
     if not audio:
         return None
     return reconstruct_audio_from_dict(audio)
+
+
+def __getattr__(name: str) -> Any:
+    # ``agno.utils.media.httpx`` stays resolvable for callers that patch it,
+    # without the module paying for the httpx import when nothing downloads.
+    if name == "httpx":
+        import httpx
+
+        return httpx
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/libs/agno/agno/utils/print_response/agent.py
+++ b/libs/agno/agno/utils/print_response/agent.py
@@ -6,7 +6,6 @@ from pydantic import BaseModel
 from rich.console import Group
 from rich.json import JSON
 from rich.live import Live
-from rich.markdown import Markdown
 from rich.status import Status
 from rich.text import Text
 
@@ -21,6 +20,8 @@ from agno.utils.response import create_panel, create_paused_run_output_panel, es
 from agno.utils.timer import Timer
 
 if TYPE_CHECKING:
+    from rich.markdown import Markdown
+
     from agno.agent.agent import Agent
 
 
@@ -50,6 +51,8 @@ def print_response_stream(
     metadata: Optional[Dict[str, Any]] = None,
     **kwargs: Any,
 ):
+    from rich.markdown import Markdown
+
     _response_content: str = ""
     _response_reasoning_content: str = ""
     response_content_batch: Union[str, JSON, Markdown] = ""
@@ -255,6 +258,8 @@ async def aprint_response_stream(
     metadata: Optional[Dict[str, Any]] = None,
     **kwargs: Any,
 ):
+    from rich.markdown import Markdown
+
     _response_content: str = ""
     _response_reasoning_content: str = ""
     reasoning_steps: List[ReasoningStep] = []
@@ -435,7 +440,7 @@ async def aprint_response_stream(
 
 
 def build_panels_stream(
-    response_content: Union[str, JSON, Markdown],
+    response_content: "Union[str, JSON, Markdown]",
     response_event: RunOutputEvent,
     response_timer: Timer,
     response_reasoning_content_buffer: str,
@@ -445,6 +450,8 @@ def build_panels_stream(
     accumulated_tool_calls: Optional[List] = None,
     compression_manager: Optional[Any] = None,
 ):
+    from rich.markdown import Markdown
+
     panels = []
 
     if len(reasoning_steps) > 0 and show_reasoning:
@@ -794,6 +801,8 @@ def build_panels(
     markdown: bool = False,
     compression_manager: Optional[Any] = None,
 ):
+    from rich.markdown import Markdown
+
     panels = []
 
     reasoning_steps = []

--- a/libs/agno/agno/utils/print_response/workflow.py
+++ b/libs/agno/agno/utils/print_response/workflow.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 from pydantic import BaseModel
 from rich.console import Group
 from rich.live import Live
-from rich.markdown import Markdown
 from rich.status import Status
 from rich.text import Text
 
@@ -210,6 +209,8 @@ def print_response_stream(
     **kwargs: Any,
 ) -> None:
     """Print workflow execution with clean streaming"""
+    from rich.markdown import Markdown
+
     if console is None:
         from rich.console import Console
 
@@ -1052,6 +1053,8 @@ async def aprint_response_stream(
     **kwargs: Any,
 ) -> None:
     """Print workflow execution with clean streaming - orange step blocks displayed once"""
+    from rich.markdown import Markdown
+
     if console is None:
         from rich.console import Console
 


### PR DESCRIPTION
## Summary

`import agno.agent` took **233 ms**; it now takes **147 ms** (-37%). `import agno.team` is the same. A real agent — `Agent(model=OpenAIResponses(...))` plus `initialize_agent()`, which pulls the OpenAI SDK and with it httpx — goes from **418 ms to 345 ms** (-17%).

Nineteen third-party top-level packages leave the default import path: `redis`, `opentelemetry`, `psutil`, `httpx`, `click`, `brotli`, `markdown_it`, `mdurl`, `pygments`, `cryptography`, `idna`, and the stdlib modules they dragged in (`ctypes`, `mmap`, `queue`, `http`, `html`, `glob`, `gettext`, `pwd`). Total module count for `import agno.agent`: 122 -> 103.

Nothing here changes behaviour. Every public name resolves exactly as before; the work is moving imports to the point of use.

## What was slow, and why

Measured with `python -X importtime -c "import agno.agent"`, warm cache, on the same machine, median of 7 runs interleaved between trees:

| Cause | Cost | How it was reached |
|---|---|---|
| `redis` (+ `opentelemetry.sdk.metrics`, `psutil`) | 34 ms | `agno/run/cancellation_management/__init__.py` re-exported `RedisRunCancellationManager` eagerly, and `agno.run.cancel` imports that package |
| `agno.agent._cli` and the print-response stack | ~19 ms after the rest | `agent.py` imported `_cli` at module level for four delegating methods |
| `agno.knowledge` full stack (readers, remote content, `agno.cloud.aws.s3`) | 12 ms | `agent/_default_tools.py` imports `agno.knowledge.types`, which ran the package `__init__` |
| `httpx` (+ `click`, `brotli`) | 18 ms | `agno/utils/media.py` had a module-level `import httpx` for five download helpers |
| `rich.markdown` (+ `markdown_it`, `mdurl`, `pygments`) | 14 ms | module-level import in `utils/print_response/agent.py` and `workflow.py` |
| `agno.learn.machine` | 7 ms | `agent/_init.py` and `team/_init.py` imported `LearningMachine` for one `isinstance` each |

## Changes

- **`run/cancellation_management/__init__.py`**: `RedisRunCancellationManager` resolves through a module `__getattr__` (PEP 562). `from agno.run.cancellation_management import RedisRunCancellationManager` still returns the same class object.
- **`agent/agent.py`, `team/team.py`**: the `_cli` import moves into the four/five methods that delegate to it (`print_response`, `aprint_response`, `cli_app`, `acli_app`, and `Team._get_member_name`).
- **`knowledge/__init__.py`**: `Knowledge`, `FileSystemKnowledge` and `KnowledgeProtocol` resolve through a module `__getattr__`, so importing a leaf module such as `agno.knowledge.types` no longer loads the readers and cloud clients. `__dir__` is provided so tab-completion and `dir()` still list them.
- **`utils/media.py`**: `import httpx` moves into the five download helpers; a module `__getattr__` keeps `agno.utils.media.httpx` resolvable so existing monkeypatches keep working.
- **`utils/print_response/agent.py`, `workflow.py`**: `Markdown` is imported inside the functions that build renderables; the one signature annotation that referenced it is quoted.
- **`agent/_init.py`, `team/_init.py`, `agent/agent.py`, `team/team.py`**: `LearningMachine` is a `TYPE_CHECKING` import for the annotations and a local import in `set_learning_machine` / `_set_learning_machine`. All four modules already use `from __future__ import annotations`.

## Rejected

Making `agno.run.team` and `agno.run.workflow` `TYPE_CHECKING`-only in `agno/db/base.py` and `agno/utils/response.py` was measured and rejected: they are hard runtime dependencies of the agent path through `models/base.py` (`isinstance` over `TeamRunOutputEvent`), `agent/_response.py`, `session/{agent,team,workflow}.py` (`from_dict` rehydration) and `utils/events.py`, so deferring the two annotation-only sites removes nothing from the import graph.

The remaining fixed cost is pydantic model construction: `agno.media` (~30 ms), `agno.run.agent` (12 ms), `agno.run.team` (13 ms), `agno.run.workflow` (9 ms). Those are genuine runtime dependencies and would need model restructuring, not import moves.

## Type of change

- [x] Improvement (performance)

## Testing

| Lane | Result |
|---|---|
| `libs/agno/tests/unit` (full suite, same ignores as CI) | 16,527 passed, 84 skipped, 8 failed - the same 8 fail on the untouched base (gmail x2, google_base, chromadb, team_skills, xai credential, openai service tier, workflow stream persist) |
| ruff format + ruff check | clean |
| mypy over the touched packages | clean |
| Behaviour probes | lazy attributes are identical objects to direct imports; `dir()` lists them; unknown attributes still raise `AttributeError`; `agno.utils.media.httpx` still patchable; the print-response methods stay bound and callable |

Import measurements are medians of 7 runs per tree, interleaved, warm cache, on one machine, and were reproduced independently on a second tree built from the same six changes (agent 233 -> 149 ms there).

A leave-one-out pass over the combined tree gives each change's marginal contribution once the others are in:

| Change | Standalone | Marginal in combination |
|---|---|---|
| redis lazy | 32 ms | **37 ms** |
| httpx lazy | 12 ms | 17 ms |
| knowledge + LearningMachine lazy | 18 ms | 16 ms |
| `_cli` lazy | 19 ms | 5 ms |
| `rich.markdown` lazy | 12 ms | ~0 ms (subsumed by `_cli`) |

`rich.markdown` is kept even though `_cli` already hides it: it is the only thing that keeps the cost off anyone importing `agno.utils.print_response` directly.

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts
- [x] Self-review completed
- [x] Documentation updated (comments)
- [x] Tests added/updated (existing suite covers the moved imports)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)