### PR TITLE
fix: give the remaining-integration CI job a Postgres server

### DIFF
--- a/.github/workflows/test_on_release.yml
+++ b/.github/workflows/test_on_release.yml
@@ -1207,6 +1207,28 @@ jobs:
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+    # The offload and CodeMode-snapshot suites parametrize over sqlite and
+    # postgresql, and open the Postgres engine in a session fixture with no
+    # skip marker: without a server every postgresql case errors on connection
+    # refused instead of skipping, and the sqlite lane alone is not a gate on
+    # the adapter production runs. Same image, port and credentials the suites
+    # target (postgresql+psycopg://ai:ai@localhost:5532/ai).
+    services:
+      postgres:
+        image: agnohq/pgvector:18
+        env:
+          POSTGRES_DB: ai
+          POSTGRES_USER: ai
+          POSTGRES_PASSWORD: ai
+        ports:
+          - "5532:5432"
+        options: >-
+          --health-cmd "pg_isready -U ai -d ai"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -1231,11 +1253,10 @@ jobs:
 
   # Run the DbFileSystem suite against a real Postgres (both dialects).
   #
-  # This suite is ignored by test-remaining because its conftest eager-connects
-  # to Postgres with no skip marker; without a DB, every postgresql-parametrized
-  # case errors on connection-refused. Give it its own job with a pgvector
-  # service on localhost:5532 — the exact host/port/creds the conftest targets —
-  # so both the sqlite and postgresql lanes run in CI.
+  # test-remaining ignores this suite and runs it here instead, in parallel,
+  # so the largest Postgres-backed suite does not stretch that job's wall clock.
+  # The pgvector service is on localhost:5532 — the exact host/port/creds the
+  # conftest targets — so both the sqlite and postgresql lanes run in CI.
   test-fs:
     runs-on: ubuntu-latest
     timeout-minutes: 20


### PR DESCRIPTION
## Summary

`test-remaining` in `test_on_release.yml` has been red since #9436 landed: **117 errors, 0 failures**, every one a `sqlalchemy.exc.OperationalError` — `connection to server at "127.0.0.1", port 5532 failed: Connection refused`.

Three suites that PR added parametrize over `["sqlite", "postgresql"]` and open the Postgres engine in a **session-scoped fixture with no skip marker**, so on a runner with no server every `postgresql` case errors at setup instead of skipping:

| suite | postgresql cases erroring |
|---|---|
| `integration/offload/test_agent_offloading.py` | 49 |
| `integration/offload/test_team_offloading.py` | 43 |
| `integration/tools/test_code_snapshot.py` | 25 |
| | **117** |

All three land in `test-remaining`, which is the one Postgres-touching job in this workflow that never got a service — `test-fs` has one, and so does the `tests` job in `test.yml`. `PYTEST_ADDOPTS: "--reruns 1"` then retries each error, which is the matching `117 rerun` in the summary line.

**The fix:** give `test-remaining` the same `agnohq/pgvector:18` service the other two jobs already use, on the host/port/credentials the suites target (`postgresql+psycopg://ai:ai@localhost:5532/ai`).

Not fixed by making the fixtures skip when no server is reachable — that is the failure mode `test.yml` already calls out, where only the SQLite half of each guard is ever executed and the adapter production actually runs has no gate at all.

Also rewords the comment above `test-fs`, which claimed the suite was carved out of `test-remaining` *because* that job had no DB. That reason no longer holds; it stays its own job so the largest Postgres-backed suite runs in parallel rather than stretching `test-remaining`'s wall clock.

## Verification

Ran all three suites at `origin/feat/v3.0` against that exact image on port 5532, both dialect lanes:

```
239 passed, 1 skipped in 123.62s
```

(the one skip is `test_two_postgres_schemas_do_not_share_or_delete_each_others_payloads`, which skips itself on the sqlite lane by design.)

Blast radius checked: nothing else `test-remaining` collects references port 5532. The root `integration/conftest.py` `postgres_engine` fixture is consumed only by `integration/db`, which the job ignores, and the 28 tests it already skips are Bedrock reranker, Couchbase migration and LanceDB — none Postgres-gated. So the service adds the 117 cases and changes nothing else.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`) — CI YAML only, no Python touched; workflow parses clean and both jobs resolve
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

`Main Validation` only triggers on push to `feat/v3.0` (and the release branches), so this PR's own checks run `test.yml`, not the workflow being changed. To see `test-remaining` go green before merge, add this branch to `on.push.branches` temporarily — the same thing 1bded5dd7 later reverted — and strip that line before merging.

While in here: `on.push.branches` still lists `fix/sql-table-cache`, a stale entry from #9623 that can be dropped.

Unrelated to this change, the same run had three other red jobs — `test-deepinfra` (provider returned 429 `engine_overloaded`, then a string instead of the schema), `test-agents-2` (2 x `test_parser_model.py`) and `test-anthropic` (1). They are being looked at separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EEWVA61oSr3rUJz3koK4JS
