### PR TITLE
fix: make the Claude models work with anthropic 1.0.0

### DIFF
--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -689,10 +689,18 @@ class Claude(Model):
 
         self._apply_cache_tools(request_kwargs)
 
-        # Build output_format if response_format is provided
+        # Structured output travels inside output_config. anthropic 1.0.0 dropped the
+        # older output_format parameter from create() on both the stable and the beta
+        # endpoint, where passing it raises TypeError before the request is ever sent.
+        # Merge rather than assign, so a caller who set output_config for effort keeps
+        # it -- and build a new dict, because get_request_params() returns a shallow
+        # copy whose output_config value is still the model's own object.
         output_format = self._build_output_format(response_format)
         if output_format:
-            request_kwargs["output_format"] = output_format
+            request_kwargs["output_config"] = {
+                **(request_kwargs.get("output_config") or {}),
+                "format": output_format,
+            }
 
         if request_kwargs:
             log_debug(f"Calling {self.provider} with request parameters: {request_kwargs}", log_level=2)

--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -21,6 +21,8 @@ from agno.utils.models.claude import (
     build_system_blocks,
     format_messages,
     format_tools_for_model,
+    resolve_http_client,
+    route_sampling_params_to_extra_body,
     supports_prefill,
 )
 from agno.utils.tokens import count_schema_tokens
@@ -414,11 +416,9 @@ class Claude(Model):
             return self.client
 
         _client_params = self._get_client_params()
-        if self.http_client:
-            if isinstance(self.http_client, httpx.Client):
-                _client_params["http_client"] = self.http_client
-            else:
-                log_warning("http_client is not an instance of httpx.Client. Ignoring and using Anthropic SDK default.")
+        http_client = resolve_http_client(self.http_client)
+        if http_client is not None:
+            _client_params["http_client"] = http_client
         # When no custom http_client is provided, let the Anthropic SDK use its own default client.
         # Each model instance gets its own connection, preventing HTTP/2 stream saturation
         # when multiple models (main agent, MemoryManager, etc.) run concurrently.
@@ -434,13 +434,9 @@ class Claude(Model):
             return self.async_client
 
         _client_params = self._get_client_params()
-        if self.http_client:
-            if isinstance(self.http_client, httpx.AsyncClient):
-                _client_params["http_client"] = self.http_client
-            else:
-                log_warning(
-                    "http_client is not an instance of httpx.AsyncClient. Ignoring and using Anthropic SDK default."
-                )
+        http_client = resolve_http_client(self.http_client, is_async=True)
+        if http_client is not None:
+            _client_params["http_client"] = http_client
         # When no custom http_client is provided, let the Anthropic SDK use its own default client.
         # Each model instance gets its own connection, preventing HTTP/2 stream saturation
         # when multiple models (main agent, MemoryManager, etc.) run concurrently.
@@ -582,7 +578,7 @@ class Claude(Model):
         if self.request_params:
             _request_params.update(self.request_params)
 
-        return _request_params
+        return route_sampling_params_to_extra_body(_request_params)
 
     @staticmethod
     def _extract_container_id_from_messages(messages: List["Message"]) -> Optional[str]:

--- a/libs/agno/agno/models/aws/claude.py
+++ b/libs/agno/agno/models/aws/claude.py
@@ -2,12 +2,11 @@ from dataclasses import dataclass
 from os import getenv
 from typing import Any, Dict, List, Optional, Type, Union
 
-import httpx
 from pydantic import BaseModel
 
 from agno.models.anthropic import Claude as AnthropicClaude
 from agno.utils.log import log_debug, log_warning
-from agno.utils.models.claude import format_tools_for_model
+from agno.utils.models.claude import format_tools_for_model, resolve_http_client, route_sampling_params_to_extra_body
 
 try:
     from anthropic import AnthropicBedrock, AsyncAnthropicBedrock
@@ -116,11 +115,9 @@ class Claude(AnthropicClaude):
 
         client_params = self._get_client_params()
 
-        if self.http_client:
-            if isinstance(self.http_client, httpx.Client):
-                client_params["http_client"] = self.http_client
-            else:
-                log_warning("http_client is not an instance of httpx.Client. Ignoring and using SDK default.")
+        http_client = resolve_http_client(self.http_client)
+        if http_client is not None:
+            client_params["http_client"] = http_client
         # When no custom http_client is provided, let the SDK use its own default client.
         # Each model instance gets its own connection, preventing HTTP/2 stream saturation
         # when multiple models (main agent, MemoryManager, etc.) run concurrently.
@@ -153,11 +150,9 @@ class Claude(AnthropicClaude):
 
         client_params = self._get_client_params()
 
-        if self.http_client:
-            if isinstance(self.http_client, httpx.AsyncClient):
-                client_params["http_client"] = self.http_client
-            else:
-                log_warning("http_client is not an instance of httpx.AsyncClient. Ignoring and using SDK default.")
+        http_client = resolve_http_client(self.http_client, is_async=True)
+        if http_client is not None:
+            client_params["http_client"] = http_client
         # When no custom http_client is provided, let the SDK use its own default client.
         # Each model instance gets its own connection, preventing HTTP/2 stream saturation
         # when multiple models (main agent, MemoryManager, etc.) run concurrently.
@@ -218,6 +213,8 @@ class Claude(AnthropicClaude):
 
         if self.request_params:
             _request_params.update(self.request_params)
+
+        route_sampling_params_to_extra_body(_request_params)
 
         if _request_params:
             log_debug(f"Calling {self.provider} with request parameters: {_request_params}", log_level=2)

--- a/libs/agno/agno/models/azure/claude.py
+++ b/libs/agno/agno/models/azure/claude.py
@@ -6,14 +6,13 @@ from dataclasses import dataclass
 from os import getenv
 from typing import Any, Callable, Dict, Type, Union
 
-import httpx
 from pydantic import BaseModel
 
 from agno.models.anthropic import Claude as AnthropicClaude
 from agno.models.message import Message
 from agno.utils.http import get_default_async_client, get_default_sync_client
 from agno.utils.log import log_debug, log_warning
-from agno.utils.models.claude import format_tools_for_model
+from agno.utils.models.claude import format_tools_for_model, resolve_http_client, route_sampling_params_to_extra_body
 
 try:
     from anthropic import AnthropicFoundry, AsyncAnthropicFoundry
@@ -89,14 +88,11 @@ class Claude(AnthropicClaude):
             return self.client
 
         _client_params = self._get_client_params()
-        if self.http_client:
-            if isinstance(self.http_client, httpx.Client):
-                _client_params["http_client"] = self.http_client
-            else:
-                log_warning("http_client is not an instance of httpx.Client. Using default global httpx.Client.")
-                _client_params["http_client"] = get_default_sync_client()
-        else:
-            _client_params["http_client"] = get_default_sync_client()
+        # The shared agno client is httpx's; an httpx2-based SDK (anthropic >= 1.0.0)
+        # will not take it, so fall through to the SDK's own default rather than raise.
+        http_client = resolve_http_client(self.http_client, fallback=get_default_sync_client())
+        if http_client is not None:
+            _client_params["http_client"] = http_client
         self.client = AnthropicFoundry(**_client_params)
         return self.client
 
@@ -106,16 +102,9 @@ class Claude(AnthropicClaude):
             return self.async_client
 
         _client_params = self._get_client_params()
-        if self.http_client:
-            if isinstance(self.http_client, httpx.AsyncClient):
-                _client_params["http_client"] = self.http_client
-            else:
-                log_warning(
-                    "http_client is not an instance of httpx.AsyncClient. Using default global httpx.AsyncClient."
-                )
-                _client_params["http_client"] = get_default_async_client()
-        else:
-            _client_params["http_client"] = get_default_async_client()
+        http_client = resolve_http_client(self.http_client, is_async=True, fallback=get_default_async_client())
+        if http_client is not None:
+            _client_params["http_client"] = http_client
         self.async_client = AsyncAnthropicFoundry(**_client_params)
         return self.async_client
 
@@ -152,6 +141,8 @@ class Claude(AnthropicClaude):
 
         if self.request_params:
             _request_params.update(self.request_params)
+
+        route_sampling_params_to_extra_body(_request_params)
 
         if _request_params:
             log_debug(f"Calling {self.provider} with request parameters: {_request_params}", log_level=2)

--- a/libs/agno/agno/models/vertexai/claude.py
+++ b/libs/agno/agno/models/vertexai/claude.py
@@ -2,12 +2,11 @@ from dataclasses import dataclass
 from os import getenv
 from typing import Any, Dict, List, Optional, Type, Union
 
-import httpx
 from pydantic import BaseModel
 
 from agno.models.anthropic import Claude as AnthropicClaude
-from agno.utils.log import log_debug, log_warning
-from agno.utils.models.claude import format_tools_for_model
+from agno.utils.log import log_debug
+from agno.utils.models.claude import format_tools_for_model, resolve_http_client, route_sampling_params_to_extra_body
 
 try:
     from anthropic import AnthropicVertex, AsyncAnthropicVertex
@@ -67,11 +66,9 @@ class Claude(AnthropicClaude):
             return self.client
 
         _client_params = self._get_client_params()
-        if self.http_client:
-            if isinstance(self.http_client, httpx.Client):
-                _client_params["http_client"] = self.http_client
-            else:
-                log_warning("http_client is not an instance of httpx.Client. Ignoring and using SDK default.")
+        http_client = resolve_http_client(self.http_client)
+        if http_client is not None:
+            _client_params["http_client"] = http_client
         # When no custom http_client is provided, let the SDK use its own default client.
         # Each model instance gets its own connection, preventing HTTP/2 stream saturation
         # when multiple models (main agent, MemoryManager, etc.) run concurrently.
@@ -87,11 +84,9 @@ class Claude(AnthropicClaude):
             return self.async_client
 
         _client_params = self._get_client_params()
-        if self.http_client:
-            if isinstance(self.http_client, httpx.AsyncClient):
-                _client_params["http_client"] = self.http_client
-            else:
-                log_warning("http_client is not an instance of httpx.AsyncClient. Ignoring and using SDK default.")
+        http_client = resolve_http_client(self.http_client, is_async=True)
+        if http_client is not None:
+            _client_params["http_client"] = http_client
         # When no custom http_client is provided, let the SDK use its own default client.
         # Each model instance gets its own connection, preventing HTTP/2 stream saturation
         # when multiple models (main agent, MemoryManager, etc.) run concurrently.
@@ -141,6 +136,8 @@ class Claude(AnthropicClaude):
 
         if self.request_params:
             _request_params.update(self.request_params)
+
+        route_sampling_params_to_extra_body(_request_params)
 
         if _request_params:
             log_debug(f"Calling {self.provider} with request parameters: {_request_params}", log_level=2)

--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -722,3 +722,70 @@ def format_tools_for_model(tools: Optional[List[Dict[str, Any]]] = None) -> Opti
 
         parsed_tools.append(tool)
     return parsed_tools
+
+
+# Sampling parameters the Anthropic SDK stopped declaring on its request methods in
+# 1.0.0: passing one raises TypeError before the request leaves the process. The API
+# still honours them, so they travel in extra_body, which every SDK version merges
+# into the request JSON as-is.
+SAMPLING_PARAMS = ("temperature", "top_p", "top_k")
+
+
+def route_sampling_params_to_extra_body(request_params: Dict[str, Any]) -> Dict[str, Any]:
+    """Move the sampling parameters out of the request kwargs and into extra_body.
+
+    Mutates and returns the dict it is given, so it also catches a sampling parameter
+    that arrived through ``request_params`` rather than through a model field.
+    """
+    moved = {name: request_params.pop(name) for name in SAMPLING_PARAMS if name in request_params}
+    if moved:
+        # A caller who wrote extra_body themselves outranks the model's own fields.
+        request_params["extra_body"] = {**moved, **(request_params.get("extra_body") or {})}
+    return request_params
+
+
+def sdk_http_client_type(is_async: bool = False) -> type:
+    """The HTTP client class the installed Anthropic SDK accepts.
+
+    anthropic 1.0.0 moved its HTTP layer from httpx to httpx2 and raises TypeError at
+    construction when handed an ``httpx.Client``, so the accepted class is read off the
+    SDK's own re-export rather than assumed to be httpx's.
+    """
+    import httpx
+
+    fallback = httpx.AsyncClient if is_async else httpx.Client
+    try:
+        from anthropic import DefaultAsyncHttpxClient, DefaultHttpxClient
+    except ImportError:
+        return fallback
+
+    default = DefaultAsyncHttpxClient if is_async else DefaultHttpxClient
+    wanted = "AsyncClient" if is_async else "Client"
+    for base in default.__mro__[1:]:
+        if base.__name__ == wanted:
+            return base
+    return fallback
+
+
+def resolve_http_client(
+    http_client: Optional[Any], is_async: bool = False, fallback: Optional[Any] = None
+) -> Optional[Any]:
+    """Return the HTTP client to hand the Anthropic SDK, or None to let it build its own.
+
+    A client of the wrong flavour is dropped with a warning instead of being passed on,
+    where it would raise TypeError at client construction and take every request with it.
+    """
+    expected = sdk_http_client_type(is_async)
+
+    if http_client is not None:
+        if isinstance(http_client, expected):
+            return http_client
+        log_warning(
+            f"http_client is not an instance of {expected.__module__}.{expected.__qualname__} "
+            f"(the Anthropic SDK's HTTP client). Ignoring and using the SDK default."
+        )
+
+    # The shared agno client is httpx's, which an httpx2-based SDK will not take.
+    if fallback is not None and isinstance(fallback, expected):
+        return fallback
+    return None

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -86,7 +86,10 @@ arize = ["arize-phoenix", "agno[opentelemetry]", "opentelemetry-exporter-otlp-pr
 langfuse = ["langfuse"]
 
 # Dependencies for Models
-anthropic = ["anthropic"]
+# >=0.77.0: the first release accepting output_config on the stable messages endpoint
+# as well as the beta one. Structured output rides inside it, and anthropic 1.0.0
+# dropped the output_format parameter that carried it before.
+anthropic = ["anthropic>=0.77.0"]
 aws-bedrock = ["boto3", "aioboto3"]
 azure = ["azure-ai-inference", "aiohttp"]
 cerebras = ["cerebras-cloud-sdk"]

--- a/libs/agno/tests/unit/models/anthropic/test_http_client_flavour.py
+++ b/libs/agno/tests/unit/models/anthropic/test_http_client_flavour.py
@@ -1,0 +1,72 @@
+"""A custom HTTP client has to be the flavour the installed Anthropic SDK accepts.
+
+anthropic 1.0.0 moved its HTTP layer from ``httpx`` to ``httpx2`` and now raises
+``TypeError`` at client construction when handed an ``httpx.Client``. Agno hands the SDK
+both the caller's client and, for Azure, its own shared one -- so the check that used to
+read ``isinstance(x, httpx.Client)`` has to follow whatever the SDK is built on, and a
+client of the wrong flavour has to be dropped rather than passed through.
+"""
+
+import httpx
+import pytest
+from anthropic import DefaultAsyncHttpxClient, DefaultHttpxClient
+
+from agno.models.anthropic.claude import Claude
+from agno.models.azure.claude import Claude as AzureClaude
+from agno.utils.models.claude import resolve_http_client, sdk_http_client_type
+
+
+def test_the_expected_type_is_the_one_the_sdk_is_built_on():
+    assert issubclass(DefaultHttpxClient, sdk_http_client_type())
+    assert issubclass(DefaultAsyncHttpxClient, sdk_http_client_type(is_async=True))
+
+
+@pytest.mark.parametrize("is_async", [False, True], ids=["sync", "async"])
+def test_a_client_of_the_wrong_flavour_is_dropped(is_async):
+    class NotAnHttpClient:
+        pass
+
+    assert resolve_http_client(NotAnHttpClient(), is_async=is_async) is None
+
+
+@pytest.mark.parametrize("is_async", [False, True], ids=["sync", "async"])
+def test_a_client_of_the_right_flavour_is_passed_through(is_async):
+    client = sdk_http_client_type(is_async)()
+    try:
+        assert resolve_http_client(client, is_async=is_async) is client
+    finally:
+        if not is_async:
+            client.close()
+
+
+def test_a_fallback_is_only_used_when_the_sdk_would_take_it():
+    expected = sdk_http_client_type()
+    usable = expected()
+    try:
+        assert resolve_http_client(None, fallback=usable) is usable
+        assert resolve_http_client(None, fallback=object()) is None
+    finally:
+        usable.close()
+
+
+MODELS = {
+    "anthropic": lambda **kwargs: Claude(api_key="test", **kwargs),
+    "azure": lambda **kwargs: AzureClaude(api_key="test", base_url="https://example.invalid", **kwargs),
+}
+
+
+@pytest.mark.parametrize("provider", list(MODELS))
+def test_the_client_builds_whatever_flavour_the_caller_brings(provider):
+    """An httpx client from the wrong package must not reach the SDK constructor."""
+    http_client = httpx.Client()
+    try:
+        assert MODELS[provider](http_client=http_client).get_client() is not None
+    finally:
+        http_client.close()
+
+
+def test_azure_builds_a_client_with_no_custom_http_client():
+    """Azure defaults to agno's shared httpx client, which an httpx2 SDK will not take."""
+    model = AzureClaude(api_key="test", base_url="https://example.invalid")
+
+    assert model.get_client() is not None

--- a/libs/agno/tests/unit/models/anthropic/test_http_client_flavour.py
+++ b/libs/agno/tests/unit/models/anthropic/test_http_client_flavour.py
@@ -12,7 +12,6 @@ import pytest
 from anthropic import DefaultAsyncHttpxClient, DefaultHttpxClient
 
 from agno.models.anthropic.claude import Claude
-from agno.models.azure.claude import Claude as AzureClaude
 from agno.utils.models.claude import resolve_http_client, sdk_http_client_type
 
 
@@ -49,9 +48,18 @@ def test_a_fallback_is_only_used_when_the_sdk_would_take_it():
         usable.close()
 
 
+def _azure_claude(**kwargs):
+    """Imported here, not at module scope: importing agno.models.azure registers the
+    installed `azure` namespace package, and tests/unit/models/azure/ is itself
+    collected as `azure.<module>`, which that import would then shadow."""
+    from agno.models.azure.claude import Claude as AzureClaude
+
+    return AzureClaude(api_key="test", base_url="https://example.invalid", **kwargs)
+
+
 MODELS = {
     "anthropic": lambda **kwargs: Claude(api_key="test", **kwargs),
-    "azure": lambda **kwargs: AzureClaude(api_key="test", base_url="https://example.invalid", **kwargs),
+    "azure": _azure_claude,
 }
 
 
@@ -67,6 +75,4 @@ def test_the_client_builds_whatever_flavour_the_caller_brings(provider):
 
 def test_azure_builds_a_client_with_no_custom_http_client():
     """Azure defaults to agno's shared httpx client, which an httpx2 SDK will not take."""
-    model = AzureClaude(api_key="test", base_url="https://example.invalid")
-
-    assert model.get_client() is not None
+    assert _azure_claude().get_client() is not None

--- a/libs/agno/tests/unit/models/anthropic/test_request_kwargs_match_sdk.py
+++ b/libs/agno/tests/unit/models/anthropic/test_request_kwargs_match_sdk.py
@@ -1,0 +1,115 @@
+"""The request kwargs Claude builds must be accepted by the installed Anthropic SDK.
+
+``_prepare_request_kwargs`` output is splatted into the SDK call, so a parameter the
+SDK does not declare raises ``TypeError`` before the request leaves the process: the
+run fails with no HTTP call made and no provider error to read. anthropic 1.0.0
+dropped ``output_format`` from ``create()`` exactly that way.
+
+One set of kwargs reaches four surfaces -- stable and beta, streaming and not -- and
+they do not take the same parameters, so every case is bound against all the surfaces
+its request can actually reach.
+"""
+
+import inspect
+from typing import Any, Callable, Dict, List, Optional
+
+import pytest
+from anthropic import Anthropic
+from pydantic import BaseModel
+
+from agno.models.anthropic.claude import Claude
+
+
+class _Schema(BaseModel):
+    answer: str
+
+
+@pytest.fixture(scope="module")
+def client():
+    return Anthropic(api_key="test")
+
+
+def _surfaces(client: Anthropic, model: Claude, response_format: Optional[Any] = None) -> List[Callable]:
+    """Both the streaming and non-streaming call the model will really make."""
+    if model._has_beta_features(response_format=response_format):
+        return [client.beta.messages.create, client.beta.messages.stream]
+    return [client.messages.create, client.messages.stream]
+
+
+def _bind(create: Callable, request_kwargs: Dict[str, Any]) -> None:
+    """Fail exactly where a real call would, without sending one."""
+    inspect.signature(create).bind_partial(model="claude-sonnet-4-5", messages=[], **request_kwargs)
+
+
+def test_the_bind_check_can_actually_fail(client):
+    """A **kwargs-accepting signature would swallow anything and make the rest vacuous."""
+    every_surface = [
+        client.messages.create,
+        client.messages.stream,
+        client.beta.messages.create,
+        client.beta.messages.stream,
+    ]
+    for surface in every_surface:
+        assert not any(p.kind is inspect.Parameter.VAR_KEYWORD for p in inspect.signature(surface).parameters.values())
+        with pytest.raises(TypeError):
+            _bind(surface, {"not_a_real_anthropic_parameter": 1})
+
+
+def test_structured_output_kwargs_are_accepted(client):
+    model = Claude(id="claude-sonnet-4-5")
+
+    kwargs = model._prepare_request_kwargs("sys", response_format=_Schema)
+
+    assert "output_format" not in kwargs, "output_format was removed from create() in anthropic 1.0.0"
+    for surface in _surfaces(client, model, _Schema):
+        _bind(surface, kwargs)
+
+
+def test_a_plain_request_is_accepted(client):
+    model = Claude(id="claude-sonnet-4-5")
+
+    kwargs = model._prepare_request_kwargs("sys")
+
+    assert "output_config" not in kwargs
+    for surface in _surfaces(client, model):
+        _bind(surface, kwargs)
+
+
+def test_structured_output_routes_to_the_surfaces_that_take_its_kwargs(client):
+    """The beta header rides along with the schema, and only the beta surfaces take it."""
+    model = Claude(id="claude-sonnet-4-5")
+
+    kwargs = model._prepare_request_kwargs("sys", response_format=_Schema)
+
+    assert "structured-outputs-2025-11-13" in kwargs["betas"]
+    assert _surfaces(client, model, _Schema) == [client.beta.messages.create, client.beta.messages.stream]
+
+
+def test_the_schema_is_nested_under_output_config_format():
+    kwargs = Claude(id="claude-sonnet-4-5")._prepare_request_kwargs("sys", response_format=_Schema)
+
+    fmt = kwargs["output_config"]["format"]
+    assert fmt["type"] == "json_schema"
+    assert fmt["schema"]["properties"]["answer"]["type"] == "string"
+
+
+def test_a_caller_supplied_output_config_survives_and_is_not_mutated():
+    supplied = {"effort": "high"}
+    model = Claude(id="claude-sonnet-4-5", output_config=supplied)
+
+    kwargs = model._prepare_request_kwargs("sys", response_format=_Schema)
+
+    assert kwargs["output_config"]["effort"] == "high", "the caller's effort was dropped"
+    assert kwargs["output_config"]["format"]["type"] == "json_schema"
+    assert supplied == {"effort": "high"}, "the model's own output_config was mutated"
+    assert model.output_config == {"effort": "high"}
+
+
+def test_a_second_run_does_not_accumulate_state():
+    """The shallow copy means an in-place merge would leak into every later request."""
+    model = Claude(id="claude-sonnet-4-5", output_config={"effort": "high"})
+
+    model._prepare_request_kwargs("sys", response_format=_Schema)
+    plain = model._prepare_request_kwargs("sys")
+
+    assert plain["output_config"] == {"effort": "high"}

--- a/libs/agno/tests/unit/models/anthropic/test_request_kwargs_match_sdk.py
+++ b/libs/agno/tests/unit/models/anthropic/test_request_kwargs_match_sdk.py
@@ -17,6 +17,7 @@ Two things follow, and both are what these tests pin:
 """
 
 import inspect
+from importlib import import_module
 from typing import Any, Callable, Dict, List, Optional
 
 import pytest
@@ -24,9 +25,6 @@ from anthropic import Anthropic, AnthropicBedrock, AnthropicFoundry, AnthropicVe
 from pydantic import BaseModel
 
 from agno.models.anthropic.claude import Claude
-from agno.models.aws.claude import Claude as AwsClaude
-from agno.models.azure.claude import Claude as AzureClaude
-from agno.models.vertexai.claude import Claude as VertexClaude
 from agno.utils.models.claude import SAMPLING_PARAMS
 
 
@@ -34,14 +32,27 @@ class _Schema(BaseModel):
     answer: str
 
 
-# Each provider's model class next to the client its requests are actually made on: the
+# Each provider's model module next to the client its requests are actually made on: the
 # four clients are separate generated classes and drift apart from one another.
+#
+# The model classes are imported inside the tests rather than here, because importing
+# agno.models.azure pulls in azure-ai-inference and so registers the installed `azure`
+# namespace package. tests/unit/models/azure/ is itself collected as `azure.<module>`,
+# which that import makes unresolvable for every test module collected after this one.
 PROVIDERS = {
-    "anthropic": (Claude, lambda: Anthropic(api_key="test")),
-    "aws": (AwsClaude, lambda: AnthropicBedrock(aws_region="us-east-1", aws_access_key="k", aws_secret_key="s")),
-    "azure": (AzureClaude, lambda: AnthropicFoundry(api_key="test", base_url="https://example.invalid")),
-    "vertexai": (VertexClaude, lambda: AnthropicVertex(region="us-east5", project_id="test")),
+    "anthropic": ("agno.models.anthropic.claude", lambda: Anthropic(api_key="test")),
+    "aws": (
+        "agno.models.aws.claude",
+        lambda: AnthropicBedrock(aws_region="us-east-1", aws_access_key="k", aws_secret_key="s"),
+    ),
+    "azure": ("agno.models.azure.claude", lambda: AnthropicFoundry(api_key="test", base_url="https://example.invalid")),
+    "vertexai": ("agno.models.vertexai.claude", lambda: AnthropicVertex(region="us-east5", project_id="test")),
 }
+
+
+def _model_class(provider: str) -> type:
+    return import_module(PROVIDERS[provider][0]).Claude
+
 
 # Fields a caller can set that add or change a request parameter. `temperature` and
 # `top_p` are kept apart because the API rejects the pair for a single request.
@@ -105,8 +116,7 @@ def test_the_bind_check_can_actually_fail(clients, provider):
 @pytest.mark.parametrize("configuration", list(CONFIGURATIONS))
 @pytest.mark.parametrize("response_format", [None, _Schema], ids=["plain", "structured_output"])
 def test_every_configuration_is_accepted(clients, provider, configuration, response_format):
-    model_class, _ = PROVIDERS[provider]
-    model = model_class(**CONFIGURATIONS[configuration])
+    model = _model_class(provider)(**CONFIGURATIONS[configuration])
 
     kwargs = model._prepare_request_kwargs("sys", response_format=response_format)
 
@@ -117,8 +127,7 @@ def test_every_configuration_is_accepted(clients, provider, configuration, respo
 @pytest.mark.parametrize("provider", list(PROVIDERS))
 def test_sampling_params_travel_in_extra_body(provider):
     """The SDK stopped declaring them in 1.0.0; the API still reads them from the body."""
-    model_class, _ = PROVIDERS[provider]
-    model = model_class(temperature=0.2, top_k=5)
+    model = _model_class(provider)(temperature=0.2, top_k=5)
 
     kwargs = model._prepare_request_kwargs("sys")
 

--- a/libs/agno/tests/unit/models/anthropic/test_request_kwargs_match_sdk.py
+++ b/libs/agno/tests/unit/models/anthropic/test_request_kwargs_match_sdk.py
@@ -1,39 +1,84 @@
-"""The request kwargs Claude builds must be accepted by the installed Anthropic SDK.
+"""The request kwargs a Claude model builds must be accepted by the installed Anthropic SDK.
 
-``_prepare_request_kwargs`` output is splatted into the SDK call, so a parameter the
-SDK does not declare raises ``TypeError`` before the request leaves the process: the
-run fails with no HTTP call made and no provider error to read. anthropic 1.0.0
-dropped ``output_format`` from ``create()`` exactly that way.
+``_prepare_request_kwargs`` output is splatted into the SDK call, so a parameter the SDK
+does not declare raises ``TypeError`` before the request leaves the process: the run fails
+with no HTTP call made and no provider error to read. anthropic 1.0.0 dropped
+``output_format``, ``temperature``, ``top_p`` and ``top_k`` from its request methods
+exactly that way.
 
-One set of kwargs reaches four surfaces -- stable and beta, streaming and not -- and
-they do not take the same parameters, so every case is bound against all the surfaces
-its request can actually reach.
+Two things follow, and both are what these tests pin:
+
+* Every configuration has to be bound, not just a default model. A parameter that only
+  appears once a caller sets a field is invisible to a test that builds ``Claude(id=...)``
+  and nothing else -- which is how the sampling parameters went unnoticed.
+* One set of kwargs reaches four surfaces -- stable and beta, streaming and not -- and they
+  do not take the same parameters, so every case is bound against all the surfaces its
+  request can actually reach, on the client of its own provider.
 """
 
 import inspect
 from typing import Any, Callable, Dict, List, Optional
 
 import pytest
-from anthropic import Anthropic
+from anthropic import Anthropic, AnthropicBedrock, AnthropicFoundry, AnthropicVertex
 from pydantic import BaseModel
 
 from agno.models.anthropic.claude import Claude
+from agno.models.aws.claude import Claude as AwsClaude
+from agno.models.azure.claude import Claude as AzureClaude
+from agno.models.vertexai.claude import Claude as VertexClaude
+from agno.utils.models.claude import SAMPLING_PARAMS
 
 
 class _Schema(BaseModel):
     answer: str
 
 
+# Each provider's model class next to the client its requests are actually made on: the
+# four clients are separate generated classes and drift apart from one another.
+PROVIDERS = {
+    "anthropic": (Claude, lambda: Anthropic(api_key="test")),
+    "aws": (AwsClaude, lambda: AnthropicBedrock(aws_region="us-east-1", aws_access_key="k", aws_secret_key="s")),
+    "azure": (AzureClaude, lambda: AnthropicFoundry(api_key="test", base_url="https://example.invalid")),
+    "vertexai": (VertexClaude, lambda: AnthropicVertex(region="us-east5", project_id="test")),
+}
+
+# Fields a caller can set that add or change a request parameter. `temperature` and
+# `top_p` are kept apart because the API rejects the pair for a single request.
+CONFIGURATIONS = {
+    "default": {},
+    "temperature": {"temperature": 0.2},
+    "top_p": {"top_p": 0.9},
+    "top_k": {"top_k": 5},
+    "stop_sequences": {"stop_sequences": ["STOP"]},
+    "max_tokens": {"max_tokens": 128},
+    "output_config": {"output_config": {"effort": "high"}},
+    "betas": {"betas": ["context-1m-2025-08-07"]},
+    "request_params": {"request_params": {"metadata": {"user_id": "u1"}}},
+    "everything": {
+        "temperature": 0.2,
+        "top_k": 5,
+        "stop_sequences": ["STOP"],
+        "max_tokens": 128,
+        "output_config": {"effort": "high"},
+        "betas": ["context-1m-2025-08-07"],
+    },
+}
+
+
 @pytest.fixture(scope="module")
-def client():
-    return Anthropic(api_key="test")
+def clients():
+    return {name: build() for name, (_, build) in PROVIDERS.items()}
 
 
-def _surfaces(client: Anthropic, model: Claude, response_format: Optional[Any] = None) -> List[Callable]:
-    """Both the streaming and non-streaming call the model will really make."""
-    if model._has_beta_features(response_format=response_format):
-        return [client.beta.messages.create, client.beta.messages.stream]
-    return [client.messages.create, client.messages.stream]
+def _surfaces(client: Any, model: Claude, response_format: Optional[Any] = None) -> List[Callable]:
+    """Both the streaming and non-streaming call this model will really make.
+
+    Older SDKs do not expose every surface on every client -- Bedrock grew
+    ``beta.messages.stream`` only in 0.122.0 -- so only what is there is bound.
+    """
+    messages = client.beta.messages if model._has_beta_features(response_format=response_format) else client.messages
+    return [surface for surface in (getattr(messages, "create", None), getattr(messages, "stream", None)) if surface]
 
 
 def _bind(create: Callable, request_kwargs: Dict[str, Any]) -> None:
@@ -41,42 +86,79 @@ def _bind(create: Callable, request_kwargs: Dict[str, Any]) -> None:
     inspect.signature(create).bind_partial(model="claude-sonnet-4-5", messages=[], **request_kwargs)
 
 
-def test_the_bind_check_can_actually_fail(client):
+@pytest.mark.parametrize("provider", list(PROVIDERS))
+def test_the_bind_check_can_actually_fail(clients, provider):
     """A **kwargs-accepting signature would swallow anything and make the rest vacuous."""
+    client = clients[provider]
     every_surface = [
-        client.messages.create,
-        client.messages.stream,
-        client.beta.messages.create,
-        client.beta.messages.stream,
+        getattr(messages, name, None)
+        for messages in (client.messages, client.beta.messages)
+        for name in ("create", "stream")
     ]
-    for surface in every_surface:
+    for surface in [surface for surface in every_surface if surface]:
         assert not any(p.kind is inspect.Parameter.VAR_KEYWORD for p in inspect.signature(surface).parameters.values())
         with pytest.raises(TypeError):
             _bind(surface, {"not_a_real_anthropic_parameter": 1})
 
 
-def test_structured_output_kwargs_are_accepted(client):
-    model = Claude(id="claude-sonnet-4-5")
+@pytest.mark.parametrize("provider", list(PROVIDERS))
+@pytest.mark.parametrize("configuration", list(CONFIGURATIONS))
+@pytest.mark.parametrize("response_format", [None, _Schema], ids=["plain", "structured_output"])
+def test_every_configuration_is_accepted(clients, provider, configuration, response_format):
+    model_class, _ = PROVIDERS[provider]
+    model = model_class(**CONFIGURATIONS[configuration])
 
-    kwargs = model._prepare_request_kwargs("sys", response_format=_Schema)
+    kwargs = model._prepare_request_kwargs("sys", response_format=response_format)
 
-    assert "output_format" not in kwargs, "output_format was removed from create() in anthropic 1.0.0"
-    for surface in _surfaces(client, model, _Schema):
+    for surface in _surfaces(clients[provider], model, response_format):
         _bind(surface, kwargs)
 
 
-def test_a_plain_request_is_accepted(client):
-    model = Claude(id="claude-sonnet-4-5")
+@pytest.mark.parametrize("provider", list(PROVIDERS))
+def test_sampling_params_travel_in_extra_body(provider):
+    """The SDK stopped declaring them in 1.0.0; the API still reads them from the body."""
+    model_class, _ = PROVIDERS[provider]
+    model = model_class(temperature=0.2, top_k=5)
 
     kwargs = model._prepare_request_kwargs("sys")
 
-    assert "output_config" not in kwargs
-    for surface in _surfaces(client, model):
-        _bind(surface, kwargs)
+    assert not any(name in kwargs for name in SAMPLING_PARAMS)
+    assert kwargs["extra_body"] == {"temperature": 0.2, "top_k": 5}
 
 
-def test_structured_output_routes_to_the_surfaces_that_take_its_kwargs(client):
+def test_a_sampling_param_set_through_request_params_is_routed_too():
+    """request_params is a raw passthrough, so the same parameter can arrive that way."""
+    model = Claude(id="claude-sonnet-4-5", request_params={"top_p": 0.9})
+
+    kwargs = model._prepare_request_kwargs("sys")
+
+    assert "top_p" not in kwargs
+    assert kwargs["extra_body"] == {"top_p": 0.9}
+
+
+def test_an_explicit_extra_body_outranks_the_model_fields():
+    supplied = {"extra_body": {"temperature": 0.9}}
+    model = Claude(id="claude-sonnet-4-5", temperature=0.2, request_params=supplied)
+
+    kwargs = model._prepare_request_kwargs("sys")
+
+    assert kwargs["extra_body"] == {"temperature": 0.9}
+    assert supplied == {"extra_body": {"temperature": 0.9}}, "the caller's request_params was mutated"
+
+
+def test_a_second_run_does_not_accumulate_sampling_state():
+    model = Claude(id="claude-sonnet-4-5", temperature=0.2)
+
+    first = model._prepare_request_kwargs("sys")
+    second = model._prepare_request_kwargs("sys")
+
+    assert first["extra_body"] == second["extra_body"] == {"temperature": 0.2}
+    assert model.temperature == 0.2, "the model's own field was consumed"
+
+
+def test_structured_output_routes_to_the_surfaces_that_take_its_kwargs(clients):
     """The beta header rides along with the schema, and only the beta surfaces take it."""
+    client = clients["anthropic"]
     model = Claude(id="claude-sonnet-4-5")
 
     kwargs = model._prepare_request_kwargs("sys", response_format=_Schema)
@@ -88,6 +170,7 @@ def test_structured_output_routes_to_the_surfaces_that_take_its_kwargs(client):
 def test_the_schema_is_nested_under_output_config_format():
     kwargs = Claude(id="claude-sonnet-4-5")._prepare_request_kwargs("sys", response_format=_Schema)
 
+    assert "output_format" not in kwargs, "output_format was removed from create() in anthropic 1.0.0"
     fmt = kwargs["output_config"]["format"]
     assert fmt["type"] == "json_schema"
     assert fmt["schema"]["properties"]["answer"]["type"] == "string"
@@ -105,8 +188,8 @@ def test_a_caller_supplied_output_config_survives_and_is_not_mutated():
     assert model.output_config == {"effort": "high"}
 
 
-def test_a_second_run_does_not_accumulate_state():
-    """The shallow copy means an in-place merge would leak into every later request."""
+def test_a_second_run_does_not_accumulate_output_config():
+    """get_request_params returns a shallow copy, so an in-place merge would leak."""
     model = Claude(id="claude-sonnet-4-5", output_config={"effort": "high"})
 
     model._prepare_request_kwargs("sys", response_format=_Schema)

--- a/libs/agno/tests/unit/models/test_claude_request_params.py
+++ b/libs/agno/tests/unit/models/test_claude_request_params.py
@@ -227,32 +227,34 @@ def test_vertexai_prepare_request_kwargs_signature_matches_parent():
 
 
 # =============================================================================
-# temperature / top_p / top_k: zero values must not be silently dropped
+# temperature / top_p / top_k: zero values must not be silently dropped.
+# They ride in extra_body because anthropic 1.0.0 stopped declaring them on the
+# request methods, so a zero being dropped now means a zero missing from there.
 # =============================================================================
 
 
 def test_anthropic_temperature_zero_included():
-    """temperature=0.0 must appear in request params (falsy-check regression)."""
+    """temperature=0.0 must survive into the request, in extra_body (falsy-check regression)."""
     model = AnthropicClaude(id="claude-haiku-4-5-20251001", temperature=0.0)
     params = model.get_request_params()
-    assert "temperature" in params
-    assert params["temperature"] == 0.0
+    assert "temperature" not in params, "sampling params travel in extra_body"
+    assert params["extra_body"]["temperature"] == 0.0
 
 
 def test_anthropic_top_p_zero_included():
-    """top_p=0.0 must appear in request params (falsy-check regression)."""
+    """top_p=0.0 must survive into the request, in extra_body (falsy-check regression)."""
     model = AnthropicClaude(id="claude-haiku-4-5-20251001", top_p=0.0)
     params = model.get_request_params()
-    assert "top_p" in params
-    assert params["top_p"] == 0.0
+    assert "top_p" not in params, "sampling params travel in extra_body"
+    assert params["extra_body"]["top_p"] == 0.0
 
 
 def test_anthropic_top_k_zero_included():
-    """top_k=0 must appear in request params (falsy-check regression)."""
+    """top_k=0 must survive into the request, in extra_body (falsy-check regression)."""
     model = AnthropicClaude(id="claude-haiku-4-5-20251001", top_k=0)
     params = model.get_request_params()
-    assert "top_k" in params
-    assert params["top_k"] == 0
+    assert "top_k" not in params, "sampling params travel in extra_body"
+    assert params["extra_body"]["top_k"] == 0
 
 
 def test_anthropic_temperature_none_excluded():
@@ -260,6 +262,7 @@ def test_anthropic_temperature_none_excluded():
     model = AnthropicClaude(id="claude-haiku-4-5-20251001")
     params = model.get_request_params()
     assert "temperature" not in params
+    assert "extra_body" not in params
 
 
 def test_anthropic_top_p_none_excluded():
@@ -267,6 +270,7 @@ def test_anthropic_top_p_none_excluded():
     model = AnthropicClaude(id="claude-haiku-4-5-20251001")
     params = model.get_request_params()
     assert "top_p" not in params
+    assert "extra_body" not in params
 
 
 def test_anthropic_top_k_none_excluded():
@@ -274,55 +278,56 @@ def test_anthropic_top_k_none_excluded():
     model = AnthropicClaude(id="claude-haiku-4-5-20251001")
     params = model.get_request_params()
     assert "top_k" not in params
+    assert "extra_body" not in params
 
 
 def test_anthropic_positive_temperature_included():
-    """Positive temperature is still forwarded correctly."""
+    """Positive temperature is still forwarded correctly, in extra_body."""
     model = AnthropicClaude(id="claude-haiku-4-5-20251001", temperature=0.7)
     params = model.get_request_params()
-    assert params["temperature"] == 0.7
+    assert params["extra_body"]["temperature"] == 0.7
 
 
 def test_anthropic_all_sampling_params_zero():
-    """All three sampling params at zero must all appear in request params."""
+    """All three sampling params at zero must all survive into extra_body."""
     model = AnthropicClaude(id="claude-haiku-4-5-20251001", temperature=0.0, top_p=0.0, top_k=0)
     params = model.get_request_params()
-    assert params["temperature"] == 0.0
-    assert params["top_p"] == 0.0
-    assert params["top_k"] == 0
+    assert params["extra_body"]["temperature"] == 0.0
+    assert params["extra_body"]["top_p"] == 0.0
+    assert params["extra_body"]["top_k"] == 0
 
 
 def test_aws_temperature_zero_included():
-    """AWS Claude: temperature=0.0 must appear in request params."""
+    """AWS Claude: temperature=0.0 must survive into the request, in extra_body."""
     pytest.importorskip("boto3")
     from agno.models.aws.claude import Claude as AwsClaude
 
     model = AwsClaude(temperature=0.0)
     params = model.get_request_params()
-    assert "temperature" in params
-    assert params["temperature"] == 0.0
+    assert "temperature" not in params, "sampling params travel in extra_body"
+    assert params["extra_body"]["temperature"] == 0.0
 
 
 def test_aws_top_p_zero_included():
-    """AWS Claude: top_p=0.0 must appear in request params."""
+    """AWS Claude: top_p=0.0 must survive into the request, in extra_body."""
     pytest.importorskip("boto3")
     from agno.models.aws.claude import Claude as AwsClaude
 
     model = AwsClaude(top_p=0.0)
     params = model.get_request_params()
-    assert "top_p" in params
-    assert params["top_p"] == 0.0
+    assert "top_p" not in params, "sampling params travel in extra_body"
+    assert params["extra_body"]["top_p"] == 0.0
 
 
 def test_aws_top_k_zero_included():
-    """AWS Claude: top_k=0 must appear in request params."""
+    """AWS Claude: top_k=0 must survive into the request, in extra_body."""
     pytest.importorskip("boto3")
     from agno.models.aws.claude import Claude as AwsClaude
 
     model = AwsClaude(top_k=0)
     params = model.get_request_params()
-    assert "top_k" in params
-    assert params["top_k"] == 0
+    assert "top_k" not in params, "sampling params travel in extra_body"
+    assert params["extra_body"]["top_k"] == 0
 
 
 def test_aws_temperature_none_excluded():
@@ -333,30 +338,31 @@ def test_aws_temperature_none_excluded():
     model = AwsClaude()
     params = model.get_request_params()
     assert "temperature" not in params
+    assert "extra_body" not in params
 
 
 def test_vertexai_temperature_zero_included():
-    """VertexAI Claude: temperature=0.0 must appear in request params."""
+    """VertexAI Claude: temperature=0.0 must survive into the request, in extra_body."""
     model = VertexAIClaude(temperature=0.0)
     params = model.get_request_params()
-    assert "temperature" in params
-    assert params["temperature"] == 0.0
+    assert "temperature" not in params, "sampling params travel in extra_body"
+    assert params["extra_body"]["temperature"] == 0.0
 
 
 def test_vertexai_top_p_zero_included():
-    """VertexAI Claude: top_p=0.0 must appear in request params."""
+    """VertexAI Claude: top_p=0.0 must survive into the request, in extra_body."""
     model = VertexAIClaude(top_p=0.0)
     params = model.get_request_params()
-    assert "top_p" in params
-    assert params["top_p"] == 0.0
+    assert "top_p" not in params, "sampling params travel in extra_body"
+    assert params["extra_body"]["top_p"] == 0.0
 
 
 def test_vertexai_top_k_zero_included():
-    """VertexAI Claude: top_k=0 must appear in request params."""
+    """VertexAI Claude: top_k=0 must survive into the request, in extra_body."""
     model = VertexAIClaude(top_k=0)
     params = model.get_request_params()
-    assert "top_k" in params
-    assert params["top_k"] == 0
+    assert "top_k" not in params, "sampling params travel in extra_body"
+    assert params["extra_body"]["top_k"] == 0
 
 
 def test_vertexai_temperature_none_excluded():
@@ -364,3 +370,4 @@ def test_vertexai_temperature_none_excluded():
     model = VertexAIClaude()
     params = model.get_request_params()
     assert "temperature" not in params
+    assert "extra_body" not in params


### PR DESCRIPTION
## Summary

`anthropic` **1.0.0**, released 2026-08-20 19:58 UTC, is a major release, and `agno[anthropic]` was unpinned (`anthropic = ["anthropic"]`) — so a fresh install picks it up and `Claude` breaks. Three separate ways:

| What the release changed | What it does to agno |
| --- | --- |
| `output_format` removed from `create()` | `Agent(model=Claude(...), output_schema=...)` raises `TypeError` |
| `temperature`, `top_p`, `top_k` removed from **every** messages surface | `Claude(temperature=...)` raises `TypeError` — all four Claude classes |
| HTTP layer moved from `httpx` to `httpx2` | a custom `http_client` raises `TypeError` at construction; **Azure fails with no user configuration at all** |

The kwargs are splatted into the SDK call, so each one raises before the request leaves the process — no HTTP call, no provider error, the run just ends in `RunStatus.error`:

```
Messages.create() got an unexpected keyword argument 'temperature'
```

Measured on this branch's parent, against the live API:

```
PRE-FIX  Claude(temperature=0.0) -> RunStatus.error
         Messages.create() got an unexpected keyword argument 'temperature'
```

## Changes

**1. Structured output moves into `output_config.format`.** Merged into whatever `output_config` the caller already set rather than assigned over it, so a `Claude(output_config={"effort": "high"})` keeps its effort. Built as a new dict, because `get_request_params()` returns a *shallow* copy — an in-place merge would weld a `format` key onto `self.output_config` and leak it into every later request.

**2. Sampling parameters travel in `extra_body`.** `temperature`, `top_p` and `top_k` are gone from `messages.create/stream/count_tokens` and their `beta` counterparts, on the first-party client and on the Bedrock, Vertex and Foundry ones alike. `extra_body` is merged into the request JSON as-is by every SDK version, so the wire request is byte-for-byte what it was and the API still honours the values — verified live: each parameter is accepted on `claude-sonnet-4-5` through `extra_body`, and the one 400 you can still provoke (`temperature` and `top_p` together) is the same API rule as before.

The routing runs at the end of `get_request_params()`, so a sampling parameter that arrived through `request_params` is caught as well as one set on a field, and an `extra_body` the caller wrote themselves outranks both.

**3. The HTTP client check follows the SDK.** anthropic 1.0.0 builds on `httpx2` and raises `TypeError: Expected an instance of httpx2.Client` when handed an `httpx.Client`. Both branches of the old `isinstance(x, httpx.Client)` guard were wrong on 1.0.0: an `httpx` client passed the check and blew up in the SDK constructor, an `httpx2` client failed it and was silently dropped. The accepted class is now read off the SDK's own `DefaultHttpxClient`, and a client of the wrong flavour is dropped with a warning naming the class the SDK actually wants.

Azure is the sharp edge here: it passed agno's shared `get_default_sync_client()` — an `httpx.Client` — **unconditionally**, so on 1.0.0 every Azure Foundry Claude request failed without the user configuring anything. It now uses the shared client when the SDK will take it and falls through to the SDK's own default when it will not.

**4. `agno[anthropic]` floored at `>=0.77.0`**, the first release accepting `output_config` on the stable endpoint as well as the beta one. Bisected across the 2026 releases and re-verified: `0.76.0` has it on beta only, `0.77.0` on both.

**5. The SDK-drift test, rebuilt.** The original version bound the kwargs of a *default-constructed* `Claude` — and `get_request_params()` omits every unset field, so it only ever exercised `max_tokens`, `system`, `betas` and `output_config`. That is exactly why the sampling parameters slipped past it. It now binds a matrix of configurations (each sampling parameter, `stop_sequences`, `betas`, `output_config`, a `request_params` passthrough, and all of them together) × plain and structured output × all four provider clients, against every surface each request can actually reach. A first test asserts no surface takes `**kwargs`, so none of it can pass vacuously.

`test_claude_request_params.py`'s sampling tests now assert on the `extra_body` those values ride in. The regression they were written for — a zero value being silently dropped by a falsy check — is unchanged and still enforced, and the unset cases now also assert that no `extra_body` is conjured.

## This was reported five months ago

Issue #7111 (2026-03-22) named the `output_format` line, its cause and its fix. It was closed the same day pointing at #7067 — which merged three days *earlier* and only added the `output_config` **passthrough field**, never touching `_prepare_request_kwargs`. `git blame` shows the line untouched since #5463 on 2025-11-21. `output_format` was deprecated-but-accepted until 1.0.0, so nothing surfaced until now. Worth reopening #7111 or closing it against this PR.

## Verification

Everything below was run against a clean `anthropic==1.0.0` install.

**Live, through `Agent.run()`:**

```
temperature=0.0                    status=RunStatus.completed content='ok'
top_k=5                            status=RunStatus.completed content='ok'
output_schema                      status=RunStatus.completed content="city='Paris' country='France'"
temperature + output_schema        status=RunStatus.completed content="city='Tokyo' country='Japan'"
streaming with temperature         events=2
```

**The three integration tests the 2026-08-21 `Main Validation` run broke**, against the live API:

```
libs/agno/tests/integration/models/anthropic/test_basic.py::test_structured_output
libs/agno/tests/integration/agent/test_parser_model.py::test_openai_with_claude_parser_model
libs/agno/tests/integration/agent/test_parser_model.py::test_parser_model_stream
3 passed
```

**Unit:** 244 passed, 7 skipped (the skips are `litellm not installed`, in an unrelated file) — and the same 244 pass against `anthropic==0.77.0`, so the floor is honest and old SDKs keep working.

**Mutation check**, five reversions, each caught:

| Reverted | Tests red |
| --- | --- |
| sampling routing in the first-party model | 11 |
| sampling routing in aws/azure/vertexai | 27 |
| `extra_body` precedence reversed | 1 |
| HTTP client check back to plain `httpx` | 6 |
| Azure's shared client passed unconditionally | 2 |

`ruff format` / `ruff check` / `mypy` clean.

## Scope notes

- `aws/claude.py`, `azure/claude.py` and `vertexai/claude.py` set `supports_native_structured_outputs = False`, so change (1) does not reach them — which independently confirms open issue #8119 ("AWS Bedrock Claude never uses structured outputs"). Not fixed here. Changes (2) and (3) do reach them and are applied to all four.
- One more 1.0.0 change is left alone deliberately: `AnthropicBedrock` used to warn and fall back to `us-east-1` when no region could be found and now raises `ValueError` at construction. agno passes `aws_region=None` on that path, so an unresolvable region is a hard error instead of a silent `us-east-1`. That is the SDK's intended new behaviour and a clearer failure than the fallback, so it stands.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Independent of #9685, which fixes the missing Postgres service on the `test-remaining` job in the same red run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJDL7mN7xM7UsuZHQUCXf6