### PR TITLE
fix: stale-schema errors keep their remedy, and the Studio catalog binding survives a per-request copy

### DIFF
--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -1051,6 +1051,13 @@ class AgentOS:
             # serving OS never reads, reporting success either way.
             if not isinstance(tools, list):
                 if tools is not None:
+                    # Keyed by id on the shared registry, not stored on the
+                    # component: a per-request copy is rebuilt through
+                    # __init__ and drops private attributes, so a note left on
+                    # the component would be gone by the time the factory that
+                    # needs it actually runs.
+                    if self.registry is not None:
+                        self.registry.declare_studio_serving_os(getattr(component, "id", None), self)
                     # First stamp wins, exactly as the first binding does for a
                     # materialized list: two OS instances serving one component
                     # must not have the answer decided by which constructed

--- a/libs/agno/agno/registry/registry.py
+++ b/libs/agno/agno/registry/registry.py
@@ -120,6 +120,11 @@ class Registry:
     # that OS move its own declaration later - a resync, or its db swapped in
     # place - while a different OS is still refused an existing declaration.
     component_db_declared_by: Optional["ReferenceType[Any]"] = field(default=None, init=False, repr=False)
+    # Which AgentOS serves a component whose tools arrive from a callable
+    # factory, keyed by component id and held weakly (see
+    # declare_studio_serving_os). Keyed by id rather than kept on the
+    # component because a per-request copy drops private attributes.
+    _studio_serving_os: Dict[str, "ReferenceType[Any]"] = field(default_factory=dict, init=False, repr=False)
 
     @cached_property
     def _entrypoint_lookup(self) -> Dict[EntrypointKey, EntrypointSource]:
@@ -545,6 +550,35 @@ class Registry:
         self.component_db = db if isinstance(db, BaseDb) else None
         self.component_db_declared = True
         self.component_db_declared_by = ref(declared_by) if declared_by is not None else None
+
+    def declare_studio_serving_os(self, component_id: Optional[str], serving_os: Any) -> None:
+        """Record which AgentOS serves a component whose tools are a factory.
+
+        A callable tools factory cannot be inspected while the OS is being
+        constructed, so the Studio toolkit inside one is bound the first time
+        the factory runs. The component itself cannot carry that pointer: a
+        per-request copy is rebuilt through ``__init__`` and drops every
+        private attribute, so the copy that actually runs would arrive
+        unbound. The registry is the object both the template and its copies
+        already share, so the note lives here, keyed by an id that survives
+        the copy.
+
+        First writer wins, matching the binding it stands in for, and the OS
+        that made an entry may replace its own.
+        """
+        if component_id is None:
+            return
+        existing = self._studio_serving_os.get(component_id)
+        stamped_by = existing() if existing is not None else None
+        if existing is None or stamped_by is serving_os:
+            self._studio_serving_os[component_id] = ref(serving_os)
+
+    def studio_serving_os(self, component_id: Optional[str]) -> Optional[Any]:
+        """The AgentOS serving this component, or None once it is gone."""
+        if component_id is None:
+            return None
+        existing = self._studio_serving_os.get(component_id)
+        return existing() if existing is not None else None
 
     def resolve_component_db(self) -> Optional[BaseDb]:
         """The database a component-catalog toolkit should use when given none.

--- a/libs/agno/agno/tools/studio.py
+++ b/libs/agno/agno/tools/studio.py
@@ -76,6 +76,7 @@ import inspect
 import json
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, Set, Union
 
+from agno.exceptions import SchemaMismatchError
 from agno.run import RunContext
 from agno.tools.function import Function
 from agno.tools.studio_runner import AmbiguousComponentNameError, StudioRunnerError, StudioRunnerTools, _slugify
@@ -993,6 +994,16 @@ class StudioTools(Toolkit):
             # An adapter without the component catalog (e.g. Mongo): an honest
             # capability answer, not an internal error.
             return error_result("db_not_configured", "This database does not support the component catalog.")
+        if isinstance(exc, SchemaMismatchError):
+            # The catalog table exists but is on an older shape, and the
+            # message names the migration that fixes it. Distinct from
+            # db_not_configured, where no catalog exists at all: the remedy
+            # differs, so the code has to. Matched by type rather than by
+            # class name so MigrationRequiredError and any other subclass are
+            # covered, and kept ahead of the ValueError branch because these
+            # are deliberately not ValueErrors - several routers map those to
+            # 400, which would report a stale database as a client error.
+            return error_result("db_schema_stale", str(exc))
         if isinstance(exc, ValueError) and str(exc):
             return error_result("invalid_request", str(exc))
         logger.exception(fallback_message)
@@ -1009,7 +1020,7 @@ class StudioTools(Toolkit):
         metadata, the field most likely to hold something a caller would not
         publish -- and, on a connection error, the server it was reaching for.
         """
-        if type(exc).__name__ in self._TYPED_ERROR_CODES or isinstance(exc, ValueError):
+        if type(exc).__name__ in self._TYPED_ERROR_CODES or isinstance(exc, (SchemaMismatchError, ValueError)):
             return f"{message}: {exc}"
         logger.exception(message)
         return f"{message}: {type(exc).__name__}. The server log has the details."

--- a/libs/agno/agno/tools/studio_schema.py
+++ b/libs/agno/agno/tools/studio_schema.py
@@ -43,6 +43,10 @@ StudioErrorCode = Literal[
     "schedule_conflict",
     "target_not_published",
     "db_not_configured",
+    # The catalog table exists but is on an older shape. Distinct from
+    # db_not_configured, where there is no catalog at all: the remedy is a
+    # migration, not configuration, and the message carries the command.
+    "db_schema_stale",
     "validation_failed",
     "internal_error",
 ]

--- a/libs/agno/agno/utils/callables.py
+++ b/libs/agno/agno/utils/callables.py
@@ -221,20 +221,30 @@ def bind_studio_catalog_db(entity: Any, tools: Any) -> None:
     declared first; its writes then land in a catalog the serving OS never
     reads, and report success.
     """
-    binding = getattr(entity, "_studio_catalog_os", None)
-    if binding is None:
+    component_id = getattr(entity, "id", None)
+    if component_id is None:
         return
-    serving_os = binding()
-    if serving_os is None:
-        # The OS that stamped this carrier is gone; the registry declaration is
-        # the only answer left, which is what an unstamped carrier gets too.
+    # The registry is the object a component and its per-request copies share,
+    # so it holds which OS serves this id. Reached through the toolkits the
+    # factory just produced, because the component itself carries no registry.
+    for tool in tools:
+        registry = getattr(tool, "registry", None)
+        lookup = getattr(registry, "studio_serving_os", None)
+        if lookup is None:
+            continue
+        serving_os = lookup(component_id)
+        if serving_os is None:
+            # No OS serves this id, or the one that did is gone; the registry
+            # declaration is the answer, which is what an unrecorded component
+            # gets too.
+            continue
+        try:
+            serving_os._bind_studio_tools(entity, tools)
+        except Exception as e:
+            # Binding is an improvement on the registry declaration, never a
+            # precondition for running the tools the factory just produced.
+            log_debug(f"Could not bind a Studio toolkit produced by a tools factory: {e}")
         return
-    try:
-        serving_os._bind_studio_tools(entity, tools)
-    except Exception as e:
-        # Binding is an optimisation over the registry declaration, never a
-        # precondition for running the tools the factory just produced.
-        log_debug(f"Could not bind a Studio toolkit produced by a tools factory: {e}")
 
 
 def resolve_callable_tools(entity: Any, run_context: "RunContext") -> None:

--- a/libs/agno/tests/unit/os/test_studio_zero_config.py
+++ b/libs/agno/tests/unit/os/test_studio_zero_config.py
@@ -705,9 +705,14 @@ class TestACallableToolsFactoryBindsWhenItRuns:
         studio, builder, db_a, db_b, _os_a, _os_b = self._wiring(tmp_path, tools_are_a_factory=True)
         run_context = RunContext(run_id="r1", session_id="s1", user_id="u1")
 
-        # The factory runs on the first dispatch, which is where the binding
-        # it could not get at construction time has to happen.
-        resolve_callable_tools(builder, run_context)
+        # The production path, not the template: a run rebuilds the component
+        # through __init__, which drops every private attribute, so anything
+        # left ON the component at construction time is gone by the time the
+        # factory that needs it runs. Exercising the template instead hides
+        # exactly this.
+        fresh = builder.deep_copy()
+        assert not hasattr(fresh, "_studio_catalog_os"), "a private stamp would make this test prove nothing"
+        resolve_callable_tools(fresh, run_context)
         created = _loads(studio.create_agent(name="Probe", instructions="i", _agno_run_context=run_context))
 
         assert created["ok"] is True, created
@@ -733,4 +738,4 @@ class TestACallableToolsFactoryBindsWhenItRuns:
         first = AgentOS(agents=[builder], registry=registry, db=db_a)
         AgentOS(agents=[builder], registry=registry, db=db_b)
 
-        assert builder._studio_catalog_os() is first
+        assert registry.studio_serving_os("builder") is first

--- a/libs/agno/tests/unit/tools/test_studio_error_contract.py
+++ b/libs/agno/tests/unit/tools/test_studio_error_contract.py
@@ -180,3 +180,52 @@ class TestTheClassDocstringMatchesTheConstructor:
         doc = StudioTools.__doc__ or ""
         documented = {name for name in inspect.signature(StudioTools.__init__).parameters if f"{name}:" in doc}
         assert {"allowed_tools", "denied_tools"} <= documented
+
+
+class TestAStaleCatalogSchemaKeepsItsRemedy:
+    """A stale catalog table is an operational condition with a fix the caller
+    can apply, and the exception's message carries the command that applies it.
+
+    These are deliberately not ValueErrors -- several routers map ValueError to
+    400, which would report a stale database as a client error -- so the error
+    mapper has to recognise them by type. Without that they fall through to
+    `internal_error`, whose message is a fixed fallback string, and both the
+    identity of the failure and its remedy are lost before the caller sees it.
+    """
+
+    @staticmethod
+    def _studio():
+        return StudioTools(registry=Registry(name="R", models=[OpenAIResponses(id="gpt-5.5")]))
+
+    def test_the_envelope_names_the_condition_and_keeps_the_message(self):
+        from agno.exceptions import MigrationRequiredError
+
+        exc = MigrationRequiredError("agno_components is on an older schema; run: agno db migrate")
+
+        out = json.loads(self._studio()._error_from_exception(exc, "Failed to create agent"))
+
+        assert out["error"]["code"] == "db_schema_stale", out
+        assert "agno db migrate" in out["error"]["message"], out
+
+    def test_a_subclass_is_recognised_by_type_not_by_class_name(self):
+        # MigrationRequiredError subclasses SchemaMismatchError; the mapper's
+        # by-name table would miss any subclass, so this must match on type.
+        from agno.exceptions import SchemaMismatchError
+
+        class NarrowerSchemaProblem(SchemaMismatchError):
+            pass
+
+        out = json.loads(self._studio()._error_from_exception(NarrowerSchemaProblem("stale"), "Failed"))
+
+        assert out["error"]["code"] == "db_schema_stale", out
+
+    def test_the_warning_channel_keeps_it_too(self):
+        # A best-effort warning rides in a SUCCESS envelope. A schema error is
+        # ours and safe to name there, unlike a raw driver exception.
+        from agno.exceptions import MigrationRequiredError
+
+        warning = self._studio()._warning_from_exception(
+            MigrationRequiredError("run: agno db migrate"), "row lags the live version"
+        )
+
+        assert "agno db migrate" in warning, warning


### PR DESCRIPTION
## Summary

Two follow-ups to #9639, both found by review after it merged. Neither is a regression from that PR's own baseline — they are gaps in capability it added, plus one interaction that only exists once #9639 and #9669 are on the same branch.

**1. A stale catalog schema keeps its identity and its remedy.**

#9669 deliberately moved schema-mismatch failures off `ValueError` onto `SchemaMismatchError` / `MigrationRequiredError` — several routers map `ValueError` to 400, which would report a stale database as a client error. `StudioTools`' error mapper still recognised only `ValueError`, so once both changes were on `feat/v3.0` a stale `agno_components` table reached the builder agent as:

```json
{"code": "internal_error", "message": "Failed to create agent"}
```

losing both what went wrong and the migration command that fixes it. Neither PR's CI could see this: it only exists in the combination.

Matched by type rather than class name so every subclass is covered, and placed ahead of the `ValueError` branch. It gets its own code — `db_not_configured` means there is no catalog at all, and the remedy differs. The warning channel, which reports a best-effort failure inside a *success* envelope, keeps the message for the same reason.

**2. The Studio catalog binding survives a component's per-request copy.**

A callable tools factory cannot be inspected while `AgentOS` is being constructed, so a Studio toolkit inside one is bound the first time the factory runs. The note recording *which* OS serves the component was left on the component — which does not survive: a run rebuilds the component through `__init__` (`agent/_utils.py` `deep_copy` skips every field starting with `_`), so the copy that actually dispatches arrived unbound and fell back to the registry-wide declaration. That declaration belongs to whichever `AgentOS` declared *first*, which on a shared registry need not be the one serving the run — so a write reported success into a catalog the serving OS never reads.

Executed, serving OS = A, first-declaring OS = B:

```
before:  fresh copy -> studio.db = db-B   A=0  B=1   WRONG DB
after:   fresh copy -> studio.db = db-A   A=1  B=0   CORRECT
```

The note now lives on the `Registry`, keyed by component id: the registry is the object a component and its copies already share, and the id survives the rebuild. First writer wins and an OS may replace its own entry, matching the binding this stands in for.

The earlier test for this went through the stamped template and so never exercised the copy. It now deep-copies first and asserts the copy carries no private attribute, so it cannot pass for the wrong reason again.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Verification.** Every fix has a test that was run against the unfixed code and failed: removing the registry record, making it last-writer-wins, and disabling the type match each turn one red. The binding fix was additionally verified against the merged head, where the fresh-copy path writes to the first-declaring database and here writes to the serving one.

Paired unit-suite diff against the base over `os`, `tools`, `agent`, `team`, `workflow`: 7,114 passed vs 7,112, with one apparent new failure — `test_event_streams_redis.py::test_true_ttl_expiry_reseeds` — investigated and **not** attributable to this change. That file imports nothing this PR touches, it passes isolated and whole-file on both trees, and `tests/unit/os` alone is byte-identical on both (2,637 passed, 0 failed). It is a TTL-timing flake that appears only in very large combined runs, the same class as the pre-existing `test_stream_error_persist`.

**Known and deliberately not addressed here:** a nested workflow's stored `step_workflow` version pin is recorded but cannot be honoured, because nested workflows resolve from the registry only. #9639 made that divergence loud rather than silent; honouring the pin needs a db-load tier with its own cycle guard, which is its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
