### PR TITLE
refactor: cut avoidable per-run and per-chunk overhead on the hot paths

### DIFF
--- a/libs/agno/agno/agent/_messages.py
+++ b/libs/agno/agno/agent/_messages.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import re
+import string
+from collections import ChainMap
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -60,12 +63,13 @@ def format_message_with_state_variables(
     run_context: Optional[RunContext] = None,
 ) -> Any:
     """Format a message with the session state variables from run_context."""
-    import re
-    import string
-    from collections import ChainMap
-    from copy import deepcopy
-
     if not isinstance(message, str):
+        return message
+
+    # A message without "{" cannot contain a {var} placeholder, and without "$"
+    # Template.safe_substitute is an identity transform - skip the regex and
+    # template machinery entirely for the common plain-text case.
+    if "{" not in message and "$" not in message:
         return message
 
     # Extract values from run_context
@@ -82,7 +86,7 @@ def format_message_with_state_variables(
         {"user_id": user_id} if user_id is not None else {},
     )
 
-    converted_msg = deepcopy(message)
+    converted_msg = message
     for var_name in format_variables.keys():
         # Only convert standalone {var_name} patterns, not nested ones
         pattern = r"\{" + re.escape(var_name) + r"\}"

--- a/libs/agno/agno/agent/_response.py
+++ b/libs/agno/agno/agent/_response.py
@@ -14,7 +14,6 @@ from typing import (
     Type,
     Union,
     cast,
-    get_args,
 )
 from uuid import uuid4
 
@@ -31,10 +30,10 @@ from agno.models.message import Message
 from agno.models.response import ModelResponse, ModelResponseEvent
 from agno.reasoning.step import NextAction, ReasoningStep, ReasoningSteps
 from agno.run import RunContext
-from agno.run.agent import Followups, RunEvent, RunOutput, RunOutputEvent
+from agno.run.agent import RUN_OUTPUT_EVENT_TYPES, Followups, RunEvent, RunOutput, RunOutputEvent
 from agno.run.messages import RunMessages
 from agno.run.requirement import RunRequirement
-from agno.run.team import TeamRunOutputEvent
+from agno.run.team import TEAM_RUN_OUTPUT_EVENT_TYPES, TeamRunOutputEvent
 from agno.session import AgentSession
 from agno.tools.function import Function
 from agno.utils.events import (
@@ -1359,12 +1358,12 @@ def handle_model_response_chunk(
     session_state: Optional[Dict[str, Any]] = None,
     run_context: Optional[RunContext] = None,
 ) -> Iterator[RunOutputEvent]:
-    from agno.run.workflow import WorkflowRunOutputEvent
+    from agno.run.workflow import WORKFLOW_RUN_OUTPUT_EVENT_TYPES
 
     if (
-        isinstance(model_response_event, tuple(get_args(RunOutputEvent)))
-        or isinstance(model_response_event, tuple(get_args(TeamRunOutputEvent)))
-        or isinstance(model_response_event, tuple(get_args(WorkflowRunOutputEvent)))
+        isinstance(model_response_event, RUN_OUTPUT_EVENT_TYPES)
+        or isinstance(model_response_event, TEAM_RUN_OUTPUT_EVENT_TYPES)
+        or isinstance(model_response_event, WORKFLOW_RUN_OUTPUT_EVENT_TYPES)
     ):
         if model_response_event.event == RunEvent.custom_event:  # type: ignore
             model_response_event.agent_id = agent.id  # type: ignore

--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -22,7 +22,6 @@ from typing import (
     Tuple,
     Type,
     Union,
-    get_args,
 )
 
 if TYPE_CHECKING:
@@ -42,11 +41,11 @@ from agno.media import Audio, File, Image, Video
 from agno.metrics import MessageMetrics, ModelType, ToolCallMetrics
 from agno.models.message import Citations, Message
 from agno.models.response import ModelResponse, ModelResponseEvent, ToolExecution
-from agno.run.agent import CustomEvent, RunContentEvent, RunOutput, RunOutputEvent
+from agno.run.agent import RUN_OUTPUT_EVENT_TYPES, CustomEvent, RunContentEvent, RunOutput, RunOutputEvent
 from agno.run.requirement import RunRequirement
+from agno.run.team import TEAM_RUN_OUTPUT_EVENT_TYPES, TeamRunOutput, TeamRunOutputEvent
 from agno.run.team import RunContentEvent as TeamRunContentEvent
-from agno.run.team import TeamRunOutput, TeamRunOutputEvent
-from agno.run.workflow import WorkflowRunOutputEvent
+from agno.run.workflow import WORKFLOW_RUN_OUTPUT_EVENT_TYPES
 from agno.tools.function import (
     Function,
     FunctionCall,
@@ -58,6 +57,10 @@ from agno.tools.function import (
 from agno.utils.log import log_debug, log_error, log_info, log_warning
 from agno.utils.timer import Timer
 from agno.utils.tools import get_function_call_for_tool_call, get_function_call_for_tool_execution
+
+# Every run-event type a tool-result generator can bubble up, cached once:
+# these isinstance checks run per streamed item on the hot path.
+_ALL_RUN_OUTPUT_EVENT_TYPES = RUN_OUTPUT_EVENT_TYPES + TEAM_RUN_OUTPUT_EVENT_TYPES + WORKFLOW_RUN_OUTPUT_EVENT_TYPES
 
 
 @dataclass
@@ -2174,11 +2177,7 @@ class Model(ABC):
             try:
                 for item in function_execution_result.result:
                     # This function yields agent/team/workflow run events
-                    if (
-                        isinstance(item, tuple(get_args(RunOutputEvent)))
-                        or isinstance(item, tuple(get_args(TeamRunOutputEvent)))
-                        or isinstance(item, tuple(get_args(WorkflowRunOutputEvent)))
-                    ):
+                    if isinstance(item, _ALL_RUN_OUTPUT_EVENT_TYPES):
                         # We only capture content events for output accumulation
                         if isinstance(item, RunContentEvent) or isinstance(item, TeamRunContentEvent):
                             if item.content is not None and isinstance(item.content, BaseModel):
@@ -2206,7 +2205,7 @@ class Model(ABC):
 
                         # Yield the event itself to bubble it up. The isinstance guards
                         # above narrow item at runtime, but mypy cannot see through
-                        # tuple(get_args(...)).
+                        # the cached union-member tuple.
                         yield item  # type: ignore[misc]
 
                     else:
@@ -2685,6 +2684,11 @@ class Model(ABC):
                 )
             ]
 
+        # gather even for a single call: its cancel bookkeeping re-raises
+        # caller cancellation even when a tool swallows the CancelledError
+        # thrown into it, and its task wrapper isolates the tool's contextvars.
+        # A bare await loses both; replicating them needs Task.cancelling(),
+        # which requires Python 3.11.
         results = await asyncio.gather(
             *(self.arun_function_call(fc) for fc in function_calls_to_run), return_exceptions=True
         )
@@ -2719,12 +2723,7 @@ class Model(ABC):
             try:
                 async for item in function_call.result:
                     # This function yields agent/team/workflow run events
-                    if isinstance(
-                        item,
-                        tuple(get_args(RunOutputEvent))
-                        + tuple(get_args(TeamRunOutputEvent))
-                        + tuple(get_args(WorkflowRunOutputEvent)),
-                    ):
+                    if isinstance(item, _ALL_RUN_OUTPUT_EVENT_TYPES):
                         # We only capture content events
                         if isinstance(item, RunContentEvent) or isinstance(item, TeamRunContentEvent):
                             if item.content is not None and isinstance(item.content, BaseModel):
@@ -2857,12 +2856,7 @@ class Model(ABC):
                 try:
                     for item in function_call.result:
                         # This function yields agent/team/workflow run events
-                        if isinstance(
-                            item,
-                            tuple(get_args(RunOutputEvent))
-                            + tuple(get_args(TeamRunOutputEvent))
-                            + tuple(get_args(WorkflowRunOutputEvent)),
-                        ):
+                        if isinstance(item, _ALL_RUN_OUTPUT_EVENT_TYPES):
                             # We only capture content events
                             if isinstance(item, RunContentEvent) or isinstance(item, TeamRunContentEvent):
                                 if item.content is not None and isinstance(item.content, BaseModel):

--- a/libs/agno/agno/models/message.py
+++ b/libs/agno/agno/models/message.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict, Field
 
+import agno.utils.log
 from agno.media import Audio, File, Image, Video
 from agno.metrics import MessageMetrics
 from agno.utils.log import log_debug, log_error, log_info, log_warning
@@ -356,6 +357,13 @@ class Message(BaseModel):
                 Defaults to debug.
             use_compressed_content (bool): Whether to use compressed content.
         """
+        # Everything below builds strings for the sink to discard when debug is
+        # off (the default level logs via log_debug, which checks the same
+        # flag), including a terminal-size syscall. Read the flag off the
+        # module so runtime toggles are honored.
+        if level is None and not agno.utils.log.debug_on:
+            return
+
         _logger = log_debug
         if level == "info":
             _logger = log_info

--- a/libs/agno/agno/run/agent.py
+++ b/libs/agno/agno/run/agent.py
@@ -1,7 +1,8 @@
+from copy import copy
 from dataclasses import asdict, dataclass, field
 from enum import Enum
 from time import time
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union, get_args
 
 from pydantic import BaseModel, Field
 
@@ -559,6 +560,11 @@ RunOutputEvent = Union[
     CustomEvent,
 ]
 
+# Cached union members for isinstance checks: rebuilding
+# tuple(get_args(RunOutputEvent)) per streamed chunk is measurable on the hot
+# event-dispatch path.
+RUN_OUTPUT_EVENT_TYPES = get_args(RunOutputEvent)
+
 
 # Map event string to dataclass
 RUN_EVENT_TYPE_REGISTRY = {
@@ -716,33 +722,41 @@ class RunOutput:
     def tools_awaiting_external_execution(self):
         return [t for t in self.tools if t.external_execution_required] if self.tools else []
 
+    # Fields hand-serialized in to_dict below; nulled on a shallow copy before
+    # asdict so their (deep, expensive) recursive serialization never runs.
+    _HAND_SERIALIZED_FIELDS = (
+        "messages",
+        "metrics",
+        "tools",
+        "metadata",
+        "images",
+        "videos",
+        "audio",
+        "files",
+        "response_audio",
+        "input",
+        "citations",
+        "events",
+        "additional_input",
+        "reasoning_steps",
+        "reasoning_messages",
+        "references",
+        "requirements",
+        "followups",
+    )
+
     def to_dict(self) -> Dict[str, Any]:
-        _dict = {
-            k: v
-            for k, v in asdict(self).items()
-            if v is not None
-            and k
-            not in [
-                "messages",
-                "metrics",
-                "tools",
-                "metadata",
-                "images",
-                "videos",
-                "audio",
-                "files",
-                "response_audio",
-                "input",
-                "citations",
-                "events",
-                "additional_input",
-                "reasoning_steps",
-                "reasoning_messages",
-                "references",
-                "requirements",
-                "followups",
-            ]
-        }
+        # Serialize a shallow copy with the hand-serialized fields nulled:
+        # asdict would otherwise deep-serialize them (messages, events, media)
+        # only for the dict comprehension to throw that work away.
+        light_copy = copy(self)
+        for field_name in self._HAND_SERIALIZED_FIELDS:
+            setattr(light_copy, field_name, None)
+        if light_copy.content and isinstance(light_copy.content, BaseModel):
+            # Re-serialized below via model_dump under the same truthiness
+            # condition; asdict would deep-copy it here for nothing
+            light_copy.content = None
+        _dict = {k: v for k, v in asdict(light_copy).items() if v is not None}
 
         if self.metrics is not None:
             _dict["metrics"] = self.metrics.to_dict() if isinstance(self.metrics, RunMetrics) else self.metrics

--- a/libs/agno/agno/run/base.py
+++ b/libs/agno/agno/run/base.py
@@ -1,3 +1,4 @@
+from copy import copy
 from dataclasses import asdict, dataclass
 from enum import Enum
 from typing import Any, Dict, List, Optional, Type, Union
@@ -72,36 +73,44 @@ class _EventIndexCarrier:
 
 @dataclass
 class BaseRunOutputEvent(_EventIndexCarrier):
+    # Fields hand-serialized in to_dict below (when the subclass has them);
+    # nulled on a shallow copy before asdict so their deep recursive
+    # serialization never runs only to be discarded.
+    _HAND_SERIALIZED_FIELDS = (
+        "tools",
+        "tool",
+        "metadata",
+        "image",
+        "images",
+        "videos",
+        "audio",
+        "response_audio",
+        "citations",
+        "member_responses",
+        "reasoning_messages",
+        "reasoning_steps",
+        "references",
+        "additional_input",
+        "session_summary",
+        "metrics",
+        "run_input",
+        "requirements",
+        "tasks",
+        "memories",
+        "followups",
+    )
+
     def to_dict(self) -> Dict[str, Any]:
-        _dict = {
-            k: v
-            for k, v in asdict(self).items()
-            if v is not None
-            and k
-            not in [
-                "tools",
-                "tool",
-                "metadata",
-                "image",
-                "images",
-                "videos",
-                "audio",
-                "response_audio",
-                "citations",
-                "member_responses",
-                "reasoning_messages",
-                "reasoning_steps",
-                "references",
-                "additional_input",
-                "session_summary",
-                "metrics",
-                "run_input",
-                "requirements",
-                "tasks",
-                "memories",
-                "followups",
-            ]
-        }
+        light_copy = copy(self)
+        for field_name in self._HAND_SERIALIZED_FIELDS:
+            if hasattr(light_copy, field_name):
+                setattr(light_copy, field_name, None)
+        light_content = getattr(light_copy, "content", None)
+        if light_content and isinstance(light_content, BaseModel):
+            # Re-serialized below via model_dump under the same truthiness
+            # condition; asdict would deep-copy it here for nothing
+            setattr(light_copy, "content", None)
+        _dict = {k: v for k, v in asdict(light_copy).items() if v is not None}
 
         # Not a dataclass field (3.9-compatible class attribute - see its
         # declaration), so asdict() misses it: carry it explicitly

--- a/libs/agno/agno/run/team.py
+++ b/libs/agno/agno/run/team.py
@@ -1,7 +1,8 @@
+from copy import copy
 from dataclasses import asdict, dataclass, field
 from enum import Enum
 from time import time
-from typing import Any, Dict, List, Optional, Sequence, Union
+from typing import Any, Dict, List, Optional, Sequence, Union, get_args
 
 from pydantic import BaseModel
 
@@ -680,6 +681,11 @@ TeamRunOutputEvent = Union[
     CustomEvent,
 ]
 
+# Cached union members for isinstance checks: rebuilding
+# tuple(get_args(TeamRunOutputEvent)) per streamed chunk is measurable on the
+# hot event-dispatch path.
+TEAM_RUN_OUTPUT_EVENT_TYPES = get_args(TeamRunOutputEvent)
+
 # Map event string to dataclass for team events
 TEAM_RUN_EVENT_TYPE_REGISTRY = {
     TeamRunEvent.run_started.value: RunStartedEvent,
@@ -831,33 +837,42 @@ class TeamRunOutput:
     def is_cancelled(self):
         return self.status == RunStatus.cancelled
 
+    # Fields hand-serialized in to_dict below; nulled on a shallow copy before
+    # asdict so their (deep, expensive) recursive serialization never runs.
+    # member_responses and input are the heaviest: they nest full member run
+    # outputs that asdict used to serialize once only to be overwritten.
+    _HAND_SERIALIZED_FIELDS = (
+        "messages",
+        "metrics",
+        "status",
+        "tools",
+        "metadata",
+        "images",
+        "videos",
+        "audio",
+        "files",
+        "response_audio",
+        "citations",
+        "events",
+        "additional_input",
+        "reasoning_steps",
+        "reasoning_messages",
+        "references",
+        "requirements",
+        "followups",
+        "member_responses",
+        "input",
+    )
+
     def to_dict(self) -> Dict[str, Any]:
-        _dict = {
-            k: v
-            for k, v in asdict(self).items()
-            if v is not None
-            and k
-            not in [
-                "messages",
-                "metrics",
-                "status",
-                "tools",
-                "metadata",
-                "images",
-                "videos",
-                "audio",
-                "files",
-                "response_audio",
-                "citations",
-                "events",
-                "additional_input",
-                "reasoning_steps",
-                "reasoning_messages",
-                "references",
-                "requirements",
-                "followups",
-            ]
-        }
+        light_copy = copy(self)
+        for field_name in self._HAND_SERIALIZED_FIELDS:
+            setattr(light_copy, field_name, None)
+        if light_copy.content and isinstance(light_copy.content, BaseModel):
+            # Re-serialized below via model_dump under the same truthiness
+            # condition; asdict would deep-copy it here for nothing
+            light_copy.content = None
+        _dict = {k: v for k, v in asdict(light_copy).items() if v is not None}
         if self.events is not None:
             _dict["events"] = [e.to_dict() for e in self.events]
 
@@ -906,7 +921,9 @@ class TeamRunOutput:
             else:
                 _dict["response_audio"] = self.response_audio
 
-        if self.member_responses:
+        # An empty list still serializes as [] (the field defaults to [], and
+        # consumers of the serialized form have always seen the key present)
+        if self.member_responses is not None:
             _dict["member_responses"] = [
                 response.to_dict() if hasattr(response, "to_dict") else response for response in self.member_responses
             ]

--- a/libs/agno/agno/run/workflow.py
+++ b/libs/agno/agno/run/workflow.py
@@ -1,7 +1,7 @@
 from dataclasses import asdict, dataclass, field, fields
 from enum import Enum
 from time import time
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, get_args
 
 from pydantic import BaseModel
 
@@ -660,6 +660,11 @@ WorkflowRunOutputEvent = Union[
     StepOutputEvent,
     CustomEvent,
 ]
+
+# Cached union members for isinstance checks: rebuilding
+# tuple(get_args(WorkflowRunOutputEvent)) per streamed chunk is measurable on
+# the hot event-dispatch path.
+WORKFLOW_RUN_OUTPUT_EVENT_TYPES = get_args(WorkflowRunOutputEvent)
 
 # Map event string to dataclass for workflow events
 WORKFLOW_RUN_EVENT_TYPE_REGISTRY = {

--- a/libs/agno/agno/team/_messages.py
+++ b/libs/agno/agno/team/_messages.py
@@ -8,6 +8,8 @@ if TYPE_CHECKING:
     from agno.team.team import Team
 
 import json
+import re
+import string
 from collections import ChainMap
 from typing import (
     Any,
@@ -1530,10 +1532,13 @@ def _format_message_with_state_variables(
     run_context: Optional[RunContext] = None,
 ) -> Any:
     """Format a message with the session state variables from run_context."""
-    import re
-    import string
-
     if not isinstance(message, str):
+        return message
+
+    # A message without "{" cannot contain a {var} placeholder, and without "$"
+    # Template.safe_substitute is an identity transform - skip the regex and
+    # template machinery entirely for the common plain-text case.
+    if "{" not in message and "$" not in message:
         return message
 
     # Extract values from run_context

--- a/libs/agno/agno/team/_response.py
+++ b/libs/agno/agno/team/_response.py
@@ -14,7 +14,6 @@ from typing import (
     Type,
     Union,
     cast,
-    get_args,
 )
 from uuid import uuid4
 
@@ -28,10 +27,11 @@ from agno.models.message import Message
 from agno.models.response import ModelResponse, ModelResponseEvent
 from agno.reasoning.step import NextAction, ReasoningStep, ReasoningSteps
 from agno.run import RunContext
-from agno.run.agent import RunOutput, RunOutputEvent
+from agno.run.agent import RUN_OUTPUT_EVENT_TYPES, RunOutput, RunOutputEvent
 from agno.run.messages import RunMessages
 from agno.run.requirement import RunRequirement
 from agno.run.team import (
+    TEAM_RUN_OUTPUT_EVENT_TYPES,
     TeamRunEvent,
     TeamRunOutput,
     TeamRunOutputEvent,
@@ -1317,8 +1317,8 @@ def _handle_model_response_chunk(
     session_state: Optional[Dict[str, Any]] = None,
     run_context: Optional[RunContext] = None,
 ) -> Iterator[Union[TeamRunOutputEvent, RunOutputEvent]]:
-    if isinstance(model_response_event, tuple(get_args(RunOutputEvent))) or isinstance(
-        model_response_event, tuple(get_args(TeamRunOutputEvent))
+    if isinstance(model_response_event, RUN_OUTPUT_EVENT_TYPES) or isinstance(
+        model_response_event, TEAM_RUN_OUTPUT_EVENT_TYPES
     ):
         if team.stream_member_events:
             if model_response_event.event == TeamRunEvent.custom_event:  # type: ignore

--- a/libs/agno/agno/utils/log.py
+++ b/libs/agno/agno/utils/log.py
@@ -117,12 +117,16 @@ debug_level: Literal[1, 2] = 1
 log_tracebacks: bool = getenv("AGNO_LOG_TRACEBACKS", "false").lower() in ("true", "1", "yes")
 
 
+# These setters run on every agent/team/workflow run. Logger.setLevel clears
+# the level cache of EVERY logger in the process (cost grows with the host
+# app's logger count), so skip it when the level is already correct.
 def set_log_level_to_debug(source_type: Optional[str] = None, level: Literal[1, 2] = 1):
     if source_type is None:
         use_agent_logger()
 
     _logger = logging.getLogger(LOGGER_NAME if source_type is None else f"{LOGGER_NAME}-{source_type}")
-    _logger.setLevel(logging.DEBUG)
+    if _logger.level != logging.DEBUG:
+        _logger.setLevel(logging.DEBUG)
 
     global debug_on
     debug_on = True
@@ -133,7 +137,8 @@ def set_log_level_to_debug(source_type: Optional[str] = None, level: Literal[1, 
 
 def set_log_level_to_info(source_type: Optional[str] = None):
     _logger = logging.getLogger(LOGGER_NAME if source_type is None else f"{LOGGER_NAME}-{source_type}")
-    _logger.setLevel(logging.INFO)
+    if _logger.level != logging.INFO:
+        _logger.setLevel(logging.INFO)
 
     global debug_on
     debug_on = False
@@ -141,7 +146,8 @@ def set_log_level_to_info(source_type: Optional[str] = None):
 
 def set_log_level_to_warning(source_type: Optional[str] = None):
     _logger = logging.getLogger(LOGGER_NAME if source_type is None else f"{LOGGER_NAME}-{source_type}")
-    _logger.setLevel(logging.WARNING)
+    if _logger.level != logging.WARNING:
+        _logger.setLevel(logging.WARNING)
 
     global debug_on
     debug_on = False
@@ -149,7 +155,8 @@ def set_log_level_to_warning(source_type: Optional[str] = None):
 
 def set_log_level_to_error(source_type: Optional[str] = None):
     _logger = logging.getLogger(LOGGER_NAME if source_type is None else f"{LOGGER_NAME}-{source_type}")
-    _logger.setLevel(logging.ERROR)
+    if _logger.level != logging.ERROR:
+        _logger.setLevel(logging.ERROR)
 
     global debug_on
     debug_on = False

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -5335,9 +5335,7 @@ class Workflow:
         Yields:
             WorkflowRunOutputEvent: Events from workflow execution (agent events are filtered)
         """
-        from typing import get_args
-
-        from agno.run.workflow import WorkflowCompletedEvent, WorkflowRunOutputEvent
+        from agno.run.workflow import WORKFLOW_RUN_OUTPUT_EVENT_TYPES, WorkflowCompletedEvent
 
         # Initialize agent with stream_events=True so tool yields events
         self._initialize_workflow_agent(session, execution_input, run_context=run_context, stream=stream)
@@ -5392,7 +5390,7 @@ class Workflow:
             dependencies=run_context.dependencies,  # Pass context dynamically per-run
             session_state=run_context.session_state,  # Pass session state dynamically per-run
         ):  # type: ignore
-            if isinstance(event, tuple(get_args(WorkflowRunOutputEvent))):
+            if isinstance(event, WORKFLOW_RUN_OUTPUT_EVENT_TYPES):
                 yield event  # type: ignore[misc]
 
                 # Track if workflow was executed by checking for WorkflowCompletedEvent
@@ -5735,9 +5733,7 @@ class Workflow:
         Yields:
             WorkflowRunOutputEvent: Events from workflow execution (agent events are filtered)
         """
-        from typing import get_args
-
-        from agno.run.workflow import WorkflowCompletedEvent, WorkflowRunOutputEvent
+        from agno.run.workflow import WORKFLOW_RUN_OUTPUT_EVENT_TYPES, WorkflowCompletedEvent
 
         logger.info("Workflow agent enabled - async streaming mode")
         log_debug(f"User input: {agent_input}")
@@ -5799,7 +5795,7 @@ class Workflow:
             dependencies=run_context.dependencies,  # Pass context dynamically per-run
             session_state=run_context.session_state,  # Pass session state dynamically per-run
         ):  # type: ignore
-            if isinstance(event, tuple(get_args(WorkflowRunOutputEvent))):
+            if isinstance(event, WORKFLOW_RUN_OUTPUT_EVENT_TYPES):
                 yield event  # type: ignore[misc]
 
                 if isinstance(event, WorkflowCompletedEvent):


### PR DESCRIPTION
## Summary

Five measured, surgical fixes to the per-run hot paths. No behavior change; every fix was found by profiling the no-network benchmark suite (`cookbook/performance`), independently re-measured before being applied, and verified for output parity after.

Interleaved A/B against the unpatched tree (Apple M4 Max, medians of 3 rounds x 300 iterations, mock model — pure framework overhead):

| Scenario | Base | Patched | |
|---|---|---|---|
| `Agent.run()` | 84.4 us | 62.5 us | -26% |
| `Agent.arun()` | 88.3 us | 67.8 us | -23% |
| Streaming run (sync / async) | 98.8 / 109.8 us | 75.9 / 83.8 us | -23% |
| Run with storage, InMemoryDb + history (sync / async) | 309.1 / 317.2 us | 197.0 / 202.3 us | **-36%** |
| Tool-call run (sync / async) | 352.1 / 459.5 us | 321.5 / 420.8 us | -9% |

## The fixes

1. **`Message.log` early-returns when debug logging is off** (`models/message.py`). It used to format the complete message dump — including a `shutil.get_terminal_size()` syscall — on every message of every run, for `log_debug` to discard against the same flag. Explicit `level="info"/"warning"/"error"` calls are unaffected, and debug mode still prints everything (the flag is read live, so per-run `debug_mode=True` keeps working).

2. **State-variable template formatting skips plain messages** (`agent/_messages.py`, `team/_messages.py`). A message containing no `{` cannot hold a `{var}` placeholder and without `$` `Template.safe_substitute` is an identity transform, yet every system and user message paid 4 regex passes plus `string.Template` per run (session state always carries `current_session_id`/`current_run_id`). Also hoists the per-call imports and drops a `deepcopy` of an immutable `str`.

3. **`set_log_level_to_*` skip `Logger.setLevel` when already at the target level** (`utils/log.py`). `setLevel` clears the level cache of every logger in the process; agents call this on every run, so the cost scales with the host application's logger count (measured 1.6 us at 67 loggers, 44 us at 2,671).

4. **`to_dict` stops serializing fields it immediately discards** (`run/agent.py`, `run/team.py`, `run/base.py`). `RunOutput.to_dict` ran recursive `asdict(self)` over messages, events and media, then dropped those 18 keys and re-serialized them by hand. It now runs `asdict` on a shallow copy with the hand-serialized fields nulled — the same pattern `AgentSession.to_dict` already uses. `TeamRunOutput` additionally stops double-serializing `member_responses` and `input` (the heaviest team fields). This is on the write path of every db adapter, not just InMemoryDb. One documented cosmetic delta: for `BaseModel` content and the two team fields, the keys now appear at the tail of the dict instead of mid-dict — values identical, `from_dict` unaffected.

5. **Event-dispatch type tuples cached at import** (`run/agent.py`, `run/team.py`, `run/workflow.py` + consumers in `agent/_response.py`, `team/_response.py`, `models/base.py`, and the workflow agent-streaming loops in `workflow/workflow.py`). The streaming hot path rebuilt `tuple(get_args(RunOutputEvent))` (and the team/workflow unions) up to three times per streamed chunk. The union members are now cached once as `RUN_OUTPUT_EVENT_TYPES` etc. — measured -1.6 us per chunk (~40% of per-chunk dispatch overhead).

## What was tried and deliberately rejected

A fast path replacing `asyncio.gather` for single tool calls (~46 us/turn) was implemented, then reverted after adversarial review found two semantic drifts, both confirmed by executed repro: gather's cancel bookkeeping re-raises caller cancellation even when a tool swallows the `CancelledError` thrown into it (reachable from job-queue timeout enforcement), and gather's task wrapper isolates tool `ContextVar` writes. Replicating both needs `Task.cancelling()` (Python 3.11+); with a 3.9 floor this is not a quick win. A comment now pins the reasoning at the gather call site.

## Verification

- **Output parity**: differential harness serializes 8 run-output shapes (minimal, messages+metrics, tools+media+structured `BaseModel` content, *falsy* `BaseModel` content, attached events, bare event, team with empty `member_responses`, team with nested member response) under old and new code — identical after normalizing timestamps/generated ids.
- **Semantics**: functional smoke drives run/arun/stream, two-turn tool loops sync+async, a failing tool (surfaces as `tool_call_error` exactly as before), debug-mode message dumps, template substitution, and literal-brace passthrough. A cancellation probe confirms a `CancelledError`-swallowing tool cannot defeat run cancellation.
- **Tests**: full unit suite (12,400+ tests) failure sets are **identical** patched vs unpatched on the same base commit (remaining local failures are missing optional provider SDKs in the dev venv; CI runs them with extras).
- **Adversarial review**: a 14-agent review pass with executed repros confirmed 5 findings on the first cut of this diff — a falsy-`BaseModel` parity break, a key-order scope gap in the parity claim, the two gather semantic drifts, and two missed workflow-side dispatch sites. All five are addressed in this final version (three fixed, gather fast path reverted, claims re-scoped).

Related: the cold-import side of this work is #9678 (separate lane). The remaining larger wins (tool `Function` prototype caching ~-150 us/tool run, InMemoryDb `include_runs=False`, history copy-on-write, metrics round-trip removal) are tracked in the performance roadmap and deliberately not here: each needs an invalidation design or a sibling-surface audit.

## Type of change

- [x] Performance improvement (non-breaking)

## Checklist

- [x] Code formatted (`./scripts/format.sh`)
- [x] Validation passes (`./scripts/validate.sh` — ruff + mypy green)
- [x] Unit tests pass (failure sets identical to base; CI authoritative for provider-SDK tests)
- [x] Output parity verified differentially; benchmarks re-run before/after

🤖 Generated with [Claude Code](https://claude.com/claude-code)
