### PR TITLE
fix: preserve OpenRouter Responses usage cost

### DIFF
--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -1377,6 +1377,7 @@ class OpenAIResponses(Model):
         metrics.input_tokens = response_usage.input_tokens or 0
         metrics.output_tokens = response_usage.output_tokens or 0
         metrics.total_tokens = response_usage.total_tokens or 0
+        metrics.cost = getattr(response_usage, "cost", None)
 
         if input_tokens_details := response_usage.input_tokens_details:
             metrics.cache_read_tokens = input_tokens_details.cached_tokens

--- a/libs/agno/tests/unit/models/openrouter_model/test_openrouter_responses.py
+++ b/libs/agno/tests/unit/models/openrouter_model/test_openrouter_responses.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -70,6 +71,26 @@ def test_openrouter_responses_reasoning_model_detection():
     # OpenAI o3 model via OpenRouter
     model = OpenRouterResponses(id="openai/o3-mini", api_key="test-key")
     assert model._using_reasoning_model() is True
+
+
+def test_openrouter_responses_metrics_include_cost():
+    """Test that provider usage cost is preserved in response metrics."""
+    model = OpenRouterResponses(api_key="test-key")
+    response_usage = SimpleNamespace(
+        input_tokens=10,
+        output_tokens=5,
+        total_tokens=15,
+        cost=0.000170412,
+        input_tokens_details=None,
+        output_tokens_details=None,
+    )
+
+    metrics = model._get_metrics(response_usage)
+
+    assert metrics.input_tokens == 10
+    assert metrics.output_tokens == 5
+    assert metrics.total_tokens == 15
+    assert metrics.cost == 0.000170412
 
     # OpenAI o4 model via OpenRouter
     model = OpenRouterResponses(id="openai/o4-mini", api_key="test-key")


### PR DESCRIPTION
## Summary

Fixes #9566.

- Preserve the provider's optional `cost` value when converting OpenAI Responses usage into `MessageMetrics`.
- Add a regression test covering OpenRouter Responses usage metrics without making an API call.

## Type of change

- [x] Bug fix
- [x] Tests added

## Validation

- `uv run --frozen pytest libs/agno/tests/unit/models/openrouter_model/test_openrouter_responses.py`
- `./scripts/format.sh`
- `./scripts/validate.sh`
- `git diff --check`