### PR TITLE
fix: make agno.workflow importable without fastapi installed

### DIFF
--- a/libs/agno/agno/workflow/__init__.py
+++ b/libs/agno/agno/workflow/__init__.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING, Any
+
 from agno.workflow.agent import WorkflowAgent
 from agno.workflow.cel import CEL_AVAILABLE, validate_cel_expression
 from agno.workflow.condition import Condition
@@ -5,12 +7,14 @@ from agno.workflow.decorators import pause
 from agno.workflow.factory import WorkflowFactory
 from agno.workflow.loop import Loop
 from agno.workflow.parallel import Parallel
-from agno.workflow.remote import RemoteWorkflow
 from agno.workflow.router import Router
 from agno.workflow.step import Step
 from agno.workflow.steps import Steps
 from agno.workflow.types import HumanReview, OnError, OnReject, OnTimeout, StepInput, StepOutput, WorkflowExecutionInput
 from agno.workflow.workflow import Workflow, get_workflow_by_id, get_workflows
+
+if TYPE_CHECKING:
+    from agno.workflow.remote import RemoteWorkflow
 
 __all__ = [
     "Workflow",
@@ -38,3 +42,17 @@ __all__ = [
     # Decorators
     "pause",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    # Resolving RemoteWorkflow on first access keeps the remote-client stack
+    # off the import path of everything that does not use it.
+    if name == "RemoteWorkflow":
+        from agno.workflow.remote import RemoteWorkflow
+
+        return RemoteWorkflow
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list:
+    return sorted(set(globals()) | set(__all__))

--- a/libs/agno/agno/workflow/__init__.py
+++ b/libs/agno/agno/workflow/__init__.py
@@ -50,6 +50,7 @@ def __getattr__(name: str) -> Any:
     if name == "RemoteWorkflow":
         from agno.workflow.remote import RemoteWorkflow
 
+        globals()[name] = RemoteWorkflow
         return RemoteWorkflow
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 

--- a/libs/agno/agno/workflow/__init__.py
+++ b/libs/agno/agno/workflow/__init__.py
@@ -1,5 +1,3 @@
-from typing import TYPE_CHECKING, Any
-
 from agno.workflow.agent import WorkflowAgent
 from agno.workflow.cel import CEL_AVAILABLE, validate_cel_expression
 from agno.workflow.condition import Condition
@@ -7,14 +5,12 @@ from agno.workflow.decorators import pause
 from agno.workflow.factory import WorkflowFactory
 from agno.workflow.loop import Loop
 from agno.workflow.parallel import Parallel
+from agno.workflow.remote import RemoteWorkflow
 from agno.workflow.router import Router
 from agno.workflow.step import Step
 from agno.workflow.steps import Steps
 from agno.workflow.types import HumanReview, OnError, OnReject, OnTimeout, StepInput, StepOutput, WorkflowExecutionInput
 from agno.workflow.workflow import Workflow, get_workflow_by_id, get_workflows
-
-if TYPE_CHECKING:
-    from agno.workflow.remote import RemoteWorkflow
 
 __all__ = [
     "Workflow",
@@ -42,18 +38,3 @@ __all__ = [
     # Decorators
     "pause",
 ]
-
-
-def __getattr__(name: str) -> Any:
-    # Resolving RemoteWorkflow on first access keeps the remote-client stack
-    # off the import path of everything that does not use it.
-    if name == "RemoteWorkflow":
-        from agno.workflow.remote import RemoteWorkflow
-
-        globals()[name] = RemoteWorkflow
-        return RemoteWorkflow
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-def __dir__() -> list:
-    return sorted(set(globals()) | set(__all__))

--- a/libs/agno/agno/workflow/remote.py
+++ b/libs/agno/agno/workflow/remote.py
@@ -1,7 +1,6 @@
 import time
 from typing import TYPE_CHECKING, Any, AsyncIterator, Dict, List, Literal, Optional, Tuple, Union, overload
 
-from fastapi import WebSocket
 from pydantic import BaseModel
 
 from agno.media import Audio, File, Image, Video
@@ -12,6 +11,8 @@ from agno.utils.agent import validate_input
 from agno.utils.remote import serialize_input
 
 if TYPE_CHECKING:
+    from fastapi import WebSocket
+
     from agno.os.routers.workflows.schema import WorkflowResponse
 
 
@@ -150,7 +151,7 @@ class RemoteWorkflow(BaseRemote):
         stream_events: Optional[bool] = None,
         stream_intermediate_steps: Optional[bool] = None,
         background: Optional[bool] = False,
-        websocket: Optional[WebSocket] = None,
+        websocket: Optional["WebSocket"] = None,
         background_tasks: Optional[Any] = None,
         auth_token: Optional[str] = None,
     ) -> WorkflowRunOutput: ...
@@ -172,7 +173,7 @@ class RemoteWorkflow(BaseRemote):
         stream_events: Optional[bool] = None,
         stream_intermediate_steps: Optional[bool] = None,
         background: Optional[bool] = False,
-        websocket: Optional[WebSocket] = None,
+        websocket: Optional["WebSocket"] = None,
         background_tasks: Optional[Any] = None,
         auth_token: Optional[str] = None,
     ) -> AsyncIterator[WorkflowRunOutputEvent]: ...
@@ -192,7 +193,7 @@ class RemoteWorkflow(BaseRemote):
         stream: bool = False,
         stream_events: Optional[bool] = None,
         background: Optional[bool] = False,
-        websocket: Optional[WebSocket] = None,
+        websocket: Optional["WebSocket"] = None,
         background_tasks: Optional[Any] = None,
         auth_token: Optional[str] = None,
         **kwargs: Any,

--- a/libs/agno/agno/workflow/remote.py
+++ b/libs/agno/agno/workflow/remote.py
@@ -14,6 +14,10 @@ if TYPE_CHECKING:
     from fastapi import WebSocket
 
     from agno.os.routers.workflows.schema import WorkflowResponse
+else:
+    # fastapi only ships with the "os" extra; a loose binding keeps the
+    # websocket annotations resolvable by get_type_hints() without it.
+    WebSocket = Any
 
 
 class RemoteWorkflow(BaseRemote):
@@ -151,7 +155,7 @@ class RemoteWorkflow(BaseRemote):
         stream_events: Optional[bool] = None,
         stream_intermediate_steps: Optional[bool] = None,
         background: Optional[bool] = False,
-        websocket: Optional["WebSocket"] = None,
+        websocket: Optional[WebSocket] = None,
         background_tasks: Optional[Any] = None,
         auth_token: Optional[str] = None,
     ) -> WorkflowRunOutput: ...
@@ -173,7 +177,7 @@ class RemoteWorkflow(BaseRemote):
         stream_events: Optional[bool] = None,
         stream_intermediate_steps: Optional[bool] = None,
         background: Optional[bool] = False,
-        websocket: Optional["WebSocket"] = None,
+        websocket: Optional[WebSocket] = None,
         background_tasks: Optional[Any] = None,
         auth_token: Optional[str] = None,
     ) -> AsyncIterator[WorkflowRunOutputEvent]: ...
@@ -193,7 +197,7 @@ class RemoteWorkflow(BaseRemote):
         stream: bool = False,
         stream_events: Optional[bool] = None,
         background: Optional[bool] = False,
-        websocket: Optional["WebSocket"] = None,
+        websocket: Optional[WebSocket] = None,
         background_tasks: Optional[Any] = None,
         auth_token: Optional[str] = None,
         **kwargs: Any,

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -23,10 +23,11 @@ from typing import (
 )
 from uuid import uuid4
 
-from fastapi import WebSocket
 from pydantic import BaseModel
 
 if TYPE_CHECKING:
+    from fastapi import WebSocket
+
     from agno.os.managers import WebSocketHandler
 
 from agno.agent.agent import Agent
@@ -8451,7 +8452,7 @@ class Workflow:
         stream: Literal[False] = False,
         stream_events: Optional[bool] = None,
         background: Optional[bool] = False,
-        websocket: Optional[WebSocket] = None,
+        websocket: Optional["WebSocket"] = None,
         enable_websocket: bool = False,
     ) -> WorkflowRunOutput: ...
 
@@ -8466,7 +8467,7 @@ class Workflow:
         stream: Literal[True] = True,
         stream_events: Optional[bool] = None,
         background: Optional[bool] = False,
-        websocket: Optional[WebSocket] = None,
+        websocket: Optional["WebSocket"] = None,
         enable_websocket: bool = False,
     ) -> AsyncIterator[WorkflowRunOutputEvent]: ...
 
@@ -8480,7 +8481,7 @@ class Workflow:
         stream: Optional[bool] = None,
         stream_events: Optional[bool] = None,
         background: Optional[bool] = False,
-        websocket: Optional[WebSocket] = None,
+        websocket: Optional["WebSocket"] = None,
         enable_websocket: bool = False,
         **kwargs: Any,
     ) -> Union[WorkflowRunOutput, AsyncIterator[WorkflowRunOutputEvent]]:
@@ -10574,7 +10575,7 @@ class Workflow:
         stream: Literal[False] = False,
         stream_events: Optional[bool] = None,
         background: Optional[bool] = False,
-        websocket: Optional[WebSocket] = None,
+        websocket: Optional["WebSocket"] = None,
         enable_websocket: bool = False,
         background_tasks: Optional[Any] = None,
         dependencies: Optional[Dict[str, Any]] = None,
@@ -10599,7 +10600,7 @@ class Workflow:
         stream: Literal[True] = True,
         stream_events: Optional[bool] = None,
         background: Optional[bool] = False,
-        websocket: Optional[WebSocket] = None,
+        websocket: Optional["WebSocket"] = None,
         enable_websocket: bool = False,
         background_tasks: Optional[Any] = None,
         dependencies: Optional[Dict[str, Any]] = None,
@@ -10623,7 +10624,7 @@ class Workflow:
         stream: Optional[bool] = None,
         stream_events: Optional[bool] = None,
         background: Optional[bool] = False,
-        websocket: Optional[WebSocket] = None,
+        websocket: Optional["WebSocket"] = None,
         enable_websocket: bool = False,
         background_tasks: Optional[Any] = None,
         dependencies: Optional[Dict[str, Any]] = None,

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -29,6 +29,11 @@ if TYPE_CHECKING:
     from fastapi import WebSocket
 
     from agno.os.managers import WebSocketHandler
+else:
+    # fastapi only ships with the "os" extra. Binding WebSocket loosely keeps
+    # the websocket annotations resolvable by get_type_hints() -- and with
+    # them Function.from_callable() on run methods -- without importing it.
+    WebSocket = Any
 
 from agno.agent.agent import Agent
 from agno.db.base import AsyncBaseDb, BaseDb, ComponentType, SessionType
@@ -8452,7 +8457,7 @@ class Workflow:
         stream: Literal[False] = False,
         stream_events: Optional[bool] = None,
         background: Optional[bool] = False,
-        websocket: Optional["WebSocket"] = None,
+        websocket: Optional[WebSocket] = None,
         enable_websocket: bool = False,
     ) -> WorkflowRunOutput: ...
 
@@ -8467,7 +8472,7 @@ class Workflow:
         stream: Literal[True] = True,
         stream_events: Optional[bool] = None,
         background: Optional[bool] = False,
-        websocket: Optional["WebSocket"] = None,
+        websocket: Optional[WebSocket] = None,
         enable_websocket: bool = False,
     ) -> AsyncIterator[WorkflowRunOutputEvent]: ...
 
@@ -8481,7 +8486,7 @@ class Workflow:
         stream: Optional[bool] = None,
         stream_events: Optional[bool] = None,
         background: Optional[bool] = False,
-        websocket: Optional["WebSocket"] = None,
+        websocket: Optional[WebSocket] = None,
         enable_websocket: bool = False,
         **kwargs: Any,
     ) -> Union[WorkflowRunOutput, AsyncIterator[WorkflowRunOutputEvent]]:
@@ -10575,7 +10580,7 @@ class Workflow:
         stream: Literal[False] = False,
         stream_events: Optional[bool] = None,
         background: Optional[bool] = False,
-        websocket: Optional["WebSocket"] = None,
+        websocket: Optional[WebSocket] = None,
         enable_websocket: bool = False,
         background_tasks: Optional[Any] = None,
         dependencies: Optional[Dict[str, Any]] = None,
@@ -10600,7 +10605,7 @@ class Workflow:
         stream: Literal[True] = True,
         stream_events: Optional[bool] = None,
         background: Optional[bool] = False,
-        websocket: Optional["WebSocket"] = None,
+        websocket: Optional[WebSocket] = None,
         enable_websocket: bool = False,
         background_tasks: Optional[Any] = None,
         dependencies: Optional[Dict[str, Any]] = None,
@@ -10624,7 +10629,7 @@ class Workflow:
         stream: Optional[bool] = None,
         stream_events: Optional[bool] = None,
         background: Optional[bool] = False,
-        websocket: Optional["WebSocket"] = None,
+        websocket: Optional[WebSocket] = None,
         enable_websocket: bool = False,
         background_tasks: Optional[Any] = None,
         dependencies: Optional[Dict[str, Any]] = None,

--- a/libs/agno/tests/unit/workflow/test_fastapi_optional.py
+++ b/libs/agno/tests/unit/workflow/test_fastapi_optional.py
@@ -1,7 +1,7 @@
 """Regression tests: ``agno.workflow`` must work without ``fastapi`` installed.
 
 fastapi only ships with the ``os`` extra, so a bare ``pip install agno`` must
-still be able to import the package, build and run a workflow, and resolve
+still be able to import the package, build and run a workflow, and import
 ``RemoteWorkflow``. The websocket parameters on the async run methods are
 annotated with fastapi's ``WebSocket``; the modules bind that name loosely at
 runtime so ``get_type_hints()`` -- and with it ``Function.from_callable()`` --
@@ -76,7 +76,6 @@ def test_import_does_not_load_fastapi():
         import agno.workflow
 
         assert "fastapi" not in sys.modules, "import agno.workflow pulled in fastapi"
-        assert "agno.workflow.remote" not in sys.modules, "RemoteWorkflow was imported eagerly"
         print("OK")
         """
     )
@@ -97,17 +96,3 @@ def test_websocket_annotations_resolve_with_fastapi_installed():
     wf = Workflow(name="t", steps=[Step(name="s", executor=lambda si: StepOutput(content="x"))])
     schema = Function.from_callable(wf.arun)
     assert schema.parameters["properties"]
-
-
-def test_remote_workflow_resolves_lazily_and_is_cached():
-    import agno.workflow
-
-    cls = agno.workflow.RemoteWorkflow
-    assert cls.__name__ == "RemoteWorkflow"
-    # First access stores the class in the module namespace, so vars()-based
-    # introspection works from then on.
-    assert vars(agno.workflow)["RemoteWorkflow"] is cls
-    assert "RemoteWorkflow" in dir(agno.workflow)
-
-    with pytest.raises(AttributeError):
-        agno.workflow.DoesNotExist

--- a/libs/agno/tests/unit/workflow/test_fastapi_optional.py
+++ b/libs/agno/tests/unit/workflow/test_fastapi_optional.py
@@ -1,0 +1,113 @@
+"""Regression tests: ``agno.workflow`` must work without ``fastapi`` installed.
+
+fastapi only ships with the ``os`` extra, so a bare ``pip install agno`` must
+still be able to import the package, build and run a workflow, and resolve
+``RemoteWorkflow``. The websocket parameters on the async run methods are
+annotated with fastapi's ``WebSocket``; the modules bind that name loosely at
+runtime so ``get_type_hints()`` -- and with it ``Function.from_callable()`` --
+keeps working whether or not fastapi is installed.
+
+The no-fastapi cases run in a subprocess with ``fastapi`` masked in
+``sys.modules``, which is deterministic across environments (the CI test env
+has fastapi installed transitively via the dev extra).
+"""
+
+import subprocess
+import sys
+import textwrap
+from typing import get_type_hints
+
+import pytest
+
+
+def _run_masked(code: str) -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"subprocess failed. stdout={result.stdout!r} stderr={result.stderr!r}"
+    assert result.stdout.strip() == "OK"
+
+
+def test_workflow_usable_without_fastapi():
+    """Import, construct, run, and introspect a workflow with fastapi masked."""
+    code = textwrap.dedent(
+        """
+        import sys
+        # Mask fastapi so any attempt to import it raises ModuleNotFoundError.
+        sys.modules["fastapi"] = None  # type: ignore[assignment]
+
+        from typing import get_type_hints
+
+        from agno.workflow import RemoteWorkflow, Step, StepOutput, Workflow
+
+        def hello(step_input):
+            return StepOutput(content="hello")
+
+        wf = Workflow(name="no-fastapi", steps=[Step(name="hello", executor=hello)])
+        result = wf.run(input="hi")
+        assert result.content == "hello"
+
+        # The websocket annotations must resolve without fastapi.
+        assert "websocket" in get_type_hints(Workflow.arun)
+        assert "websocket" in get_type_hints(Workflow.acontinue_run)
+        assert "websocket" in get_type_hints(RemoteWorkflow.arun)
+
+        # Tool-schema generation walks those same annotations.
+        from agno.tools.function import Function
+
+        schema = Function.from_callable(wf.arun)
+        assert schema.parameters["properties"]
+
+        print("OK")
+        """
+    )
+    _run_masked(code)
+
+
+def test_import_does_not_load_fastapi():
+    """Even with fastapi available, importing agno.workflow must not load it."""
+    code = textwrap.dedent(
+        """
+        import sys
+
+        import agno.workflow
+
+        assert "fastapi" not in sys.modules, "import agno.workflow pulled in fastapi"
+        assert "agno.workflow.remote" not in sys.modules, "RemoteWorkflow was imported eagerly"
+        print("OK")
+        """
+    )
+    _run_masked(code)
+
+
+def test_websocket_annotations_resolve_with_fastapi_installed():
+    pytest.importorskip("fastapi", reason="dev/CI envs always have fastapi; bare envs are covered above")
+
+    from agno.tools.function import Function
+    from agno.workflow import Step, StepOutput, Workflow
+    from agno.workflow.remote import RemoteWorkflow
+
+    assert "websocket" in get_type_hints(Workflow.arun)
+    assert "websocket" in get_type_hints(Workflow.acontinue_run)
+    assert "websocket" in get_type_hints(RemoteWorkflow.arun)
+
+    wf = Workflow(name="t", steps=[Step(name="s", executor=lambda si: StepOutput(content="x"))])
+    schema = Function.from_callable(wf.arun)
+    assert schema.parameters["properties"]
+
+
+def test_remote_workflow_resolves_lazily_and_is_cached():
+    import agno.workflow
+
+    cls = agno.workflow.RemoteWorkflow
+    assert cls.__name__ == "RemoteWorkflow"
+    # First access stores the class in the module namespace, so vars()-based
+    # introspection works from then on.
+    assert vars(agno.workflow)["RemoteWorkflow"] is cls
+    assert "RemoteWorkflow" in dir(agno.workflow)
+
+    with pytest.raises(AttributeError):
+        agno.workflow.DoesNotExist


### PR DESCRIPTION
## Summary

`from agno.workflow import Workflow` failed with `ModuleNotFoundError: No module named 'fastapi'` in any environment without the `os` extra, because `agno/workflow/workflow.py` and `agno/workflow/remote.py` both do `from fastapi import WebSocket` at module level — and `WebSocket` is only ever used in type annotations.

The fix is confined to those two files:

- The `WebSocket` import moves under `TYPE_CHECKING`, with a runtime `WebSocket = Any` binding in the `else` branch. The annotations resolve to `Optional[Any]` whether or not fastapi is installed, so `get_type_hints()` on `Workflow.arun` / `Workflow.acontinue_run` / `RemoteWorkflow.arun` — and `Function.from_callable()` on those methods (18/14-property tool schemas) — behave as on the base without ever loading fastapi.
- `workflow/__init__.py` is unchanged from base: with fastapi guarded, the eager `RemoteWorkflow` import costs 0.16 ms, so no lazy-export machinery is needed. (Earlier revisions of this PR tried a PEP 562 lazy export and, before that, quoted annotations with no runtime binding — the latter broke `get_type_hints()` even with fastapi installed; caught in review, both superseded by the current shape.)
- **`tests/unit/workflow/test_fastapi_optional.py`** (new): a subprocess test with fastapi masked in `sys.modules` (import, construct, run, `get_type_hints` on all three run methods, `Function.from_callable`), a guard that `import agno.workflow` does not load fastapi even when it is available, and an in-process annotation-resolution regression. CI installs fastapi via the dev extra, so without the masked subprocess the defining no-fastapi behavior would never be exercised in CI.

`agno.agent` and `agno.team` were checked for the same pattern: both eagerly export `RemoteAgent`/`RemoteTeam`, but `agent/remote.py` and `team/remote.py` never import fastapi (`remote/base.py` guards its `UploadFile` under `TYPE_CHECKING`), so no change is needed there.

**Cold-import saving**: in environments that do have fastapi, `python -X importtime -c "import agno.workflow"` drops from ~222 ms to ~150 ms (median of 5 runs, ~32%) since the fastapi/starlette tree no longer loads.

**Known limitation (pre-existing, out of scope)**: `RemoteWorkflow` now imports in a core-only environment but still cannot be instantiated there, because `BaseRemote` reaches `agno/client/os.py`, which imports `fastapi.UploadFile` at module level (also annotation-only). Fixing that would change behavior for `RemoteAgent`/`RemoteTeam` too and belongs in its own PR.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Verification performed at head:

- Fresh venv with bare `pip install -e libs/agno` (no extras, fastapi confirmed absent): `from agno.workflow import Workflow, Step, RemoteWorkflow` works, a workflow constructs and `wf.run()` completes with `RunStatus.completed`; `get_type_hints(Workflow.arun)` resolves and `Function.from_callable(wf.arun)` builds an 18-property schema. `import agno.os` still fails with the expected fastapi error.
- With fastapi installed: `get_type_hints` resolves on all three run methods, `Function.from_callable` yields the base's 18/14 properties, and `agno.os` imports cleanly.
- Mutation check: removing the runtime `WebSocket = Any` binding fails all new tests.
- `tests/unit/workflow`: 533 passed, 7 skipped (all pre-existing `cel-python not installed` skips).
- `tests/unit/remote` + `tests/unit/os`: 2665 passed; the 41 errors are one telegram test file requiring `pyTelegramBotAPI`, confirmed identical on the unmodified tree.
- `./scripts/validate.sh` fully green (ruff check + mypy on 1013 source files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)