### PR TITLE
chore: fix import sorting

### DIFF
--- a/libs/agno/agno/agent/_response.py
+++ b/libs/agno/agno/agent/_response.py
@@ -22,9 +22,9 @@ from pydantic import BaseModel
 if TYPE_CHECKING:
     from agno.agent.agent import Agent
 
+from agno.agent._tools import result_store_kwargs
 from agno.exceptions import RunCancelledException
 from agno.media import Audio
-from agno.agent._tools import result_store_kwargs
 from agno.models.base import Model
 from agno.models.fallback import acall_model_stream_with_fallback, call_model_stream_with_fallback
 from agno.models.message import Message

--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
 from agno.agent._init import _initialize_session_state
 from agno.agent._run_options import resolve_run_options
 from agno.agent._session import initialize_session, update_session_metrics
+from agno.agent._tools import result_store_kwargs
 from agno.exceptions import (
     InputCheckError,
     OutputCheckError,
@@ -42,7 +43,6 @@ from agno.exceptions import (
 from agno.filters import FilterExpr
 from agno.media import Audio, File, Image, Video
 from agno.metrics import RunMetrics, merge_background_metrics
-from agno.agent._tools import result_store_kwargs
 from agno.models.base import Model
 from agno.models.fallback import acall_model_with_fallback, call_model_with_fallback
 from agno.models.message import Message

--- a/libs/agno/agno/team/_init.py
+++ b/libs/agno/agno/team/_init.py
@@ -6,9 +6,9 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from agno.learn.machine import LearningMachine
+    from agno.offload.store import ResultStore
     from agno.team.mode import TeamMode
     from agno.team.team import Team
-    from agno.offload.store import ResultStore
 
 from os import getenv
 from typing import (

--- a/libs/agno/agno/team/_response.py
+++ b/libs/agno/agno/team/_response.py
@@ -19,9 +19,9 @@ from uuid import uuid4
 
 from pydantic import BaseModel
 
+from agno.agent._tools import result_store_kwargs
 from agno.exceptions import RunCancelledException
 from agno.media import Audio
-from agno.agent._tools import result_store_kwargs
 from agno.models.base import Model
 from agno.models.fallback import acall_model_stream_with_fallback, call_model_stream_with_fallback
 from agno.models.message import Message

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -27,6 +27,7 @@ from uuid import uuid4
 
 from pydantic import BaseModel
 
+from agno.agent._tools import result_store_kwargs
 from agno.exceptions import (
     InputCheckError,
     OutputCheckError,
@@ -37,7 +38,6 @@ from agno.exceptions import (
 from agno.filters import FilterExpr
 from agno.media import Audio, File, Image, Video
 from agno.metrics import RunMetrics, merge_background_metrics
-from agno.agent._tools import result_store_kwargs
 from agno.models.base import Model
 from agno.models.fallback import acall_model_with_fallback, call_model_with_fallback
 from agno.models.message import Message

--- a/libs/agno/agno/team/_storage.py
+++ b/libs/agno/agno/team/_storage.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from agno.offload.store import ResultStore
     from agno.team.mode import TeamMode
     from agno.team.team import Team
-    from agno.offload.store import ResultStore
 
 from typing import (
     Any,

--- a/libs/agno/tests/unit/offload/test_result_store.py
+++ b/libs/agno/tests/unit/offload/test_result_store.py
@@ -14,9 +14,9 @@ from agno.offload import ResultStore, result_id_for
 from agno.offload.store import (
     NEVER_OFFLOADED_TOOLS,
     READ_MAX_CHARS,
+    SWEEP_INTERVAL_SECONDS,
     render_refused_envelope,
     render_stored_envelope,
-    SWEEP_INTERVAL_SECONDS,
 )
 
 
@@ -321,9 +321,9 @@ def test_live_ids_are_newest_first_and_capped(store, monkeypatch):
     # created_at has one-second resolution, so distinct timestamps are forced:
     # on equal values a reverse-sorted assertion could not catch an
     # oldest-first regression.
-    from agno.offload import store as store_module
-
     import itertools
+
+    from agno.offload import store as store_module
 
     base = 1_700_000_000
     tick = itertools.count()


### PR DESCRIPTION
## Summary

Running `./scripts/format.sh` on `feat/v3.0` currently produces changes, because a few recent merges (the #9689 / #9693 era) skipped the format script. This PR is the script's output for `libs/`, committed so that `format.sh` is a no-op again for everyone else.

Eight import-sort fixes across seven files, all pure re-ordering (ruff `--select I`), no semantic changes:

- `libs/agno/agno/agent/_response.py`, `agent/_run.py`, `team/_response.py`, `team/_run.py` — `from agno.agent._tools import result_store_kwargs` sorted into its alphabetical position
- `libs/agno/agno/team/_init.py`, `team/_storage.py` — `agno.offload.store` TYPE_CHECKING import sorted before `agno.team.*`
- `libs/agno/tests/unit/offload/test_result_store.py` — `SWEEP_INTERVAL_SECONDS` sorted among the uppercase names; stdlib `itertools` sorted before the local `agno.offload` import

Deliberately excluded: `format.sh` also re-orders imports in 2 cookbook files (`cookbook/02_agents/22_result_offloading/03_where_results_live.py`, `06_postgres_layout.py`), where ruff classifies `agno` as third-party and merges it into the same import block as `sqlalchemy`. Whether cookbook should treat `agno` as first-party or third-party is a separate open question, so those are left untouched here.

## Type of change

- [x] Other: chore — formatting only

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings) — N/A
- [ ] Examples and guides — N/A
- [x] Tested in clean environment
- [ ] Tests added/updated — N/A

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

`./scripts/validate.sh` passes end to end after the change (ruff check + mypy clean on `libs/agno` and `libs/agnoctl`, cookbook checks green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)