### PR TITLE
fix: make the remote client stack work without fastapi installed

### DIFF
--- a/libs/agno/agno/client/os.py
+++ b/libs/agno/agno/client/os.py
@@ -1,9 +1,15 @@
 import json
 from datetime import date
-from typing import Any, AsyncIterator, Callable, Dict, List, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any, AsyncIterator, Callable, Dict, List, Optional, Sequence, Union
 
-from fastapi import UploadFile
 from httpx import ConnectError, ConnectTimeout, TimeoutException
+
+if TYPE_CHECKING:
+    from fastapi import UploadFile
+else:
+    # fastapi only ships with the "os" extra; a loose binding keeps the
+    # upload annotations resolvable by get_type_hints() without it.
+    UploadFile = Any
 
 from agno.db.base import SessionType
 from agno.db.schemas.evals import EvalFilterType, EvalType
@@ -2426,14 +2432,16 @@ class AgentOSClient:
             form_data["chunk_overlap"] = str(chunk_overlap)
 
         if file:
-            # Handle both agno.media.File and FastAPI UploadFile
-            if isinstance(file, UploadFile):
+            # Handle both agno.media.File and FastAPI UploadFile; the check runs
+            # against agno's type because fastapi may not be installed.
+            if isinstance(file, MediaFile):
+                if file.content:
+                    files = {
+                        "file": (file.filename or "upload", file.content, file.mime_type or "application/octet-stream")
+                    }
+            else:
                 files = {
                     "file": (file.filename or "upload", file.file, file.content_type or "application/octet-stream")
-                }
-            elif file.content:
-                files = {
-                    "file": (file.filename or "upload", file.content, file.mime_type or "application/octet-stream")
                 }
 
         data = await self._apost_multipart("/knowledge/content", form_data, files=files, params=params, headers=headers)

--- a/libs/agno/agno/os/__init__.py
+++ b/libs/agno/agno/os/__init__.py
@@ -1,15 +1,22 @@
 from typing import TYPE_CHECKING, Any
 
-from agno.os.app import AgentOS
 from agno.os.config import MCP_BUILTIN_TAGS, MCPBuiltinTag, MCPServerConfig
 
 if TYPE_CHECKING:
+    from agno.os.app import AgentOS
     from agno.os.mcp_auth_builtin import AgentOSBuiltinAuth
 
 __all__ = ["AgentOS", "MCPServerConfig", "MCPBuiltinTag", "MCP_BUILTIN_TAGS"]
 
 
 def __getattr__(name: str) -> Any:
+    # Lazy so the pure-pydantic schema modules under agno.os stay importable
+    # without the `os` extra (fastapi); the app is only pulled in when used.
+    if name == "AgentOS":
+        from agno.os.app import AgentOS
+
+        globals()[name] = AgentOS
+        return AgentOS
     # Lazy so importing agno.os does not require the `mcp` extra (fastmcp); the built-in
     # MCP OAuth server is only pulled in when a deployment actually uses it.
     if name == "AgentOSBuiltinAuth":

--- a/libs/agno/agno/os/routers/__init__.py
+++ b/libs/agno/agno/os/routers/__init__.py
@@ -1,3 +1,17 @@
-from agno.os.routers.session.session import get_session_router
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from agno.os.routers.session.session import get_session_router
 
 __all__ = ["get_session_router"]
+
+
+def __getattr__(name: str) -> Any:
+    # Lazy so the pure-pydantic schema modules in this package stay importable
+    # without the `os` extra (fastapi); the router is only pulled in when used.
+    if name == "get_session_router":
+        from agno.os.routers.session.session import get_session_router
+
+        globals()[name] = get_session_router
+        return get_session_router
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/libs/agno/agno/os/routers/agents/__init__.py
+++ b/libs/agno/agno/os/routers/agents/__init__.py
@@ -1,3 +1,17 @@
-from agno.os.routers.agents.router import get_agent_router
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from agno.os.routers.agents.router import get_agent_router
 
 __all__ = ["get_agent_router"]
+
+
+def __getattr__(name: str) -> Any:
+    # Lazy so the pure-pydantic schema modules in this package stay importable
+    # without the `os` extra (fastapi); the router is only pulled in when used.
+    if name == "get_agent_router":
+        from agno.os.routers.agents.router import get_agent_router
+
+        globals()[name] = get_agent_router
+        return get_agent_router
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/libs/agno/agno/os/routers/agents/schema.py
+++ b/libs/agno/agno/os/routers/agents/schema.py
@@ -11,9 +11,7 @@ if TYPE_CHECKING:
 from agno.agent import Agent
 from agno.models.message import Message
 from agno.os.schema import ModelResponse
-from agno.os.utils import (
-    format_tools,
-)
+from agno.os.schema_utils import format_tools
 from agno.run import RunContext
 from agno.run.agent import RunOutput
 from agno.session import AgentSession

--- a/libs/agno/agno/os/routers/evals/__init__.py
+++ b/libs/agno/agno/os/routers/evals/__init__.py
@@ -1,3 +1,17 @@
-from agno.os.routers.evals.evals import get_eval_router
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from agno.os.routers.evals.evals import get_eval_router
 
 __all__ = ["get_eval_router"]
+
+
+def __getattr__(name: str) -> Any:
+    # Lazy so the pure-pydantic schema modules in this package stay importable
+    # without the `os` extra (fastapi); the router is only pulled in when used.
+    if name == "get_eval_router":
+        from agno.os.routers.evals.evals import get_eval_router
+
+        globals()[name] = get_eval_router
+        return get_eval_router
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/libs/agno/agno/os/routers/evals/schemas.py
+++ b/libs/agno/agno/os/routers/evals/schemas.py
@@ -10,7 +10,7 @@ from agno.eval.accuracy import AccuracyEval
 from agno.eval.agent_as_judge import AgentAsJudgeEval
 from agno.eval.performance import PerformanceEval
 from agno.eval.reliability import ReliabilityEval
-from agno.os.utils import to_utc_datetime
+from agno.os.schema_utils import to_utc_datetime
 
 
 class EvalRunInput(BaseModel):

--- a/libs/agno/agno/os/routers/knowledge/__init__.py
+++ b/libs/agno/agno/os/routers/knowledge/__init__.py
@@ -1,3 +1,17 @@
-from agno.os.routers.knowledge.knowledge import get_knowledge_router
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from agno.os.routers.knowledge.knowledge import get_knowledge_router
 
 __all__ = ["get_knowledge_router"]
+
+
+def __getattr__(name: str) -> Any:
+    # Lazy so the pure-pydantic schema modules in this package stay importable
+    # without the `os` extra (fastapi); the router is only pulled in when used.
+    if name == "get_knowledge_router":
+        from agno.os.routers.knowledge.knowledge import get_knowledge_router
+
+        globals()[name] = get_knowledge_router
+        return get_knowledge_router
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/libs/agno/agno/os/routers/memory/__init__.py
+++ b/libs/agno/agno/os/routers/memory/__init__.py
@@ -1,3 +1,17 @@
-from agno.os.routers.memory.memory import get_memory_router
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from agno.os.routers.memory.memory import get_memory_router
 
 __all__ = ["get_memory_router"]
+
+
+def __getattr__(name: str) -> Any:
+    # Lazy so the pure-pydantic schema modules in this package stay importable
+    # without the `os` extra (fastapi); the router is only pulled in when used.
+    if name == "get_memory_router":
+        from agno.os.routers.memory.memory import get_memory_router
+
+        globals()[name] = get_memory_router
+        return get_memory_router
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/libs/agno/agno/os/routers/memory/schemas.py
+++ b/libs/agno/agno/os/routers/memory/schemas.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
-from agno.os.utils import to_utc_datetime
+from agno.os.schema_utils import to_utc_datetime
 
 
 class DeleteMemoriesRequest(BaseModel):

--- a/libs/agno/agno/os/routers/metrics/__init__.py
+++ b/libs/agno/agno/os/routers/metrics/__init__.py
@@ -1,3 +1,17 @@
-from agno.os.routers.metrics.metrics import get_metrics_router
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from agno.os.routers.metrics.metrics import get_metrics_router
 
 __all__ = ["get_metrics_router"]
+
+
+def __getattr__(name: str) -> Any:
+    # Lazy so the pure-pydantic schema modules in this package stay importable
+    # without the `os` extra (fastapi); the router is only pulled in when used.
+    if name == "get_metrics_router":
+        from agno.os.routers.metrics.metrics import get_metrics_router
+
+        globals()[name] = get_metrics_router
+        return get_metrics_router
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/libs/agno/agno/os/routers/metrics/schemas.py
+++ b/libs/agno/agno/os/routers/metrics/schemas.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
-from agno.os.utils import to_utc_datetime
+from agno.os.schema_utils import to_utc_datetime
 
 
 class DayAggregatedMetrics(BaseModel):

--- a/libs/agno/agno/os/routers/session/__init__.py
+++ b/libs/agno/agno/os/routers/session/__init__.py
@@ -1,3 +1,17 @@
-from agno.os.routers.session.session import get_session_router
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from agno.os.routers.session.session import get_session_router
 
 __all__ = ["get_session_router"]
+
+
+def __getattr__(name: str) -> Any:
+    # Lazy so the pure-pydantic schema modules in this package stay importable
+    # without the `os` extra (fastapi); the router is only pulled in when used.
+    if name == "get_session_router":
+        from agno.os.routers.session.session import get_session_router
+
+        globals()[name] = get_session_router
+        return get_session_router
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/libs/agno/agno/os/routers/teams/__init__.py
+++ b/libs/agno/agno/os/routers/teams/__init__.py
@@ -1,3 +1,17 @@
-from agno.os.routers.teams.router import get_team_router
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from agno.os.routers.teams.router import get_team_router
 
 __all__ = ["get_team_router"]
+
+
+def __getattr__(name: str) -> Any:
+    # Lazy so the pure-pydantic schema modules in this package stay importable
+    # without the `os` extra (fastapi); the router is only pulled in when used.
+    if name == "get_team_router":
+        from agno.os.routers.teams.router import get_team_router
+
+        globals()[name] = get_team_router
+        return get_team_router
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/libs/agno/agno/os/routers/teams/schema.py
+++ b/libs/agno/agno/os/routers/teams/schema.py
@@ -11,9 +11,7 @@ if TYPE_CHECKING:
 from agno.agent import Agent
 from agno.os.routers.agents.schema import AgentResponse
 from agno.os.schema import ModelResponse
-from agno.os.utils import (
-    format_team_tools,
-)
+from agno.os.schema_utils import format_team_tools
 from agno.run import RunContext
 from agno.run.team import TeamRunOutput
 from agno.session import TeamSession

--- a/libs/agno/agno/os/routers/traces/__init__.py
+++ b/libs/agno/agno/os/routers/traces/__init__.py
@@ -1,3 +1,17 @@
-from agno.os.routers.traces.traces import get_traces_router
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from agno.os.routers.traces.traces import get_traces_router
 
 __all__ = ["get_traces_router"]
+
+
+def __getattr__(name: str) -> Any:
+    # Lazy so the pure-pydantic schema modules in this package stay importable
+    # without the `os` extra (fastapi); the router is only pulled in when used.
+    if name == "get_traces_router":
+        from agno.os.routers.traces.traces import get_traces_router
+
+        globals()[name] = get_traces_router
+        return get_traces_router
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/libs/agno/agno/os/routers/traces/schemas.py
+++ b/libs/agno/agno/os/routers/traces/schemas.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
-from agno.os.utils import format_duration_ms
+from agno.os.schema_utils import format_duration_ms
 
 
 class TraceSearchGroupBy(str, Enum):

--- a/libs/agno/agno/os/routers/workflows/__init__.py
+++ b/libs/agno/agno/os/routers/workflows/__init__.py
@@ -1,3 +1,17 @@
-from agno.os.routers.workflows.router import get_workflow_router
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from agno.os.routers.workflows.router import get_workflow_router
 
 __all__ = ["get_workflow_router"]
+
+
+def __getattr__(name: str) -> Any:
+    # Lazy so the pure-pydantic schema modules in this package stay importable
+    # without the `os` extra (fastapi); the router is only pulled in when used.
+    if name == "get_workflow_router":
+        from agno.os.routers.workflows.router import get_workflow_router
+
+        globals()[name] = get_workflow_router
+        return get_workflow_router
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/libs/agno/agno/os/schema.py
+++ b/libs/agno/agno/os/schema.py
@@ -21,8 +21,8 @@ from agno.os.config import (
     SessionConfig,
     TracesConfig,
 )
+from agno.os.schema_utils import extract_input_media, get_run_input, get_session_name, to_utc_datetime
 from agno.os.scopes import split_scope
-from agno.os.utils import extract_input_media, get_run_input, get_session_name, to_utc_datetime
 from agno.session import AgentSession, TeamSession, WorkflowSession
 from agno.team.factory import TeamFactory
 from agno.team.remote import RemoteTeam

--- a/libs/agno/agno/os/schema_utils.py
+++ b/libs/agno/agno/os/schema_utils.py
@@ -1,0 +1,212 @@
+"""Helpers for building AgentOS response schemas from session and run dicts.
+
+These run on the client side as well (AgentOSClient parses server responses
+with the schema modules), so this module must stay importable without the
+`os` extra: no fastapi imports, directly or transitively.
+"""
+
+import json
+from datetime import date, datetime, time, timezone
+from typing import Any, Callable, Dict, List, Optional, Union
+
+from pydantic import BaseModel
+
+from agno.models.message import Message
+from agno.tools import Function, Toolkit
+from agno.utils.log import logger
+
+
+def to_utc_datetime(value: Optional[Union[str, int, float, date, datetime]]) -> Optional[datetime]:
+    """Convert a timestamp, ISO 8601 string, date, or datetime to a UTC datetime."""
+    if value is None:
+        return None
+
+    if isinstance(value, datetime):
+        # If already a datetime, make sure the timezone is UTC
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value
+
+    # datetime is a subclass of date, so this must come after the datetime check
+    if isinstance(value, date):
+        return datetime.combine(value, time.min, tzinfo=timezone.utc)
+
+    if isinstance(value, str):
+        try:
+            if value.endswith("Z"):
+                value = value[:-1] + "+00:00"
+            return datetime.fromisoformat(value)
+        except (ValueError, TypeError):
+            return None
+
+    return datetime.fromtimestamp(value, tz=timezone.utc)
+
+
+def get_run_input(run_dict: Dict[str, Any], is_workflow_run: bool = False) -> str:
+    """Get the run input from the given run dictionary
+
+    Uses the RunInput/TeamRunInput object which stores the original user input.
+    """
+
+    # For agent or team runs, use the stored input_content
+    if not is_workflow_run and run_dict.get("input") is not None:
+        input_data = run_dict.get("input")
+        if isinstance(input_data, dict) and input_data.get("input_content") is not None:
+            return stringify_input_content(input_data["input_content"])
+
+    if is_workflow_run:
+        # Check the input field directly
+        input_value = run_dict.get("input")
+        if input_value is not None:
+            return stringify_input_content(input_value)
+
+        # Check the step executor runs for fallback
+        step_executor_runs = run_dict.get("step_executor_runs", [])
+        if step_executor_runs:
+            for message in reversed(step_executor_runs[0].get("messages", [])):
+                if message.get("role") == "user":
+                    return message.get("content", "")
+
+    # Final fallback: scan messages
+    if run_dict.get("messages") is not None:
+        for message in reversed(run_dict["messages"]):
+            if message.get("role") == "user":
+                return message.get("content", "")
+
+    return ""
+
+
+def get_session_name(session: Dict[str, Any]) -> str:
+    """Get the session name from the given session dictionary"""
+
+    # If session_data.session_name is set, return that
+    session_data = session.get("session_data")
+    if session_data is not None and session_data.get("session_name") is not None:
+        return session_data["session_name"]
+
+    runs = session.get("runs", []) or []
+    session_type = session.get("session_type")
+
+    # Handle workflows separately
+    if session_type == "workflow":
+        if not runs:
+            return ""
+        workflow_run = runs[0]
+        workflow_input = workflow_run.get("input")
+        if isinstance(workflow_input, str):
+            return workflow_input
+        elif isinstance(workflow_input, dict):
+            try:
+                return json.dumps(workflow_input)
+            except (TypeError, ValueError):
+                pass
+        workflow_name = session.get("workflow_data", {}).get("name")
+        return f"New {workflow_name} Session" if workflow_name else ""
+
+    # For team, filter to team runs (runs without agent_id); for agents, use all runs
+    if session_type == "team":
+        runs_to_check = [r for r in runs if not r.get("agent_id")]
+    else:
+        runs_to_check = runs
+
+    # Find the first user message across runs
+    for r in runs_to_check:
+        if r is None:
+            continue
+        run_dict = r if isinstance(r, dict) else r.to_dict()
+
+        for message in run_dict.get("messages") or []:
+            if message.get("role") == "user" and message.get("content"):
+                return message["content"]
+
+        run_input = r.get("input")
+        if run_input is not None:
+            return stringify_input_content(run_input)
+
+    return ""
+
+
+def extract_input_media(run_dict: Dict[str, Any]) -> Dict[str, Any]:
+    input_media: Dict[str, List[Any]] = {
+        "images": [],
+        "videos": [],
+        "audios": [],
+        "files": [],
+    }
+
+    input_data = run_dict.get("input", {})
+    if isinstance(input_data, dict):
+        input_media["images"].extend(input_data.get("images", []))
+        input_media["videos"].extend(input_data.get("videos", []))
+        input_media["audios"].extend(input_data.get("audios", []))
+        input_media["files"].extend(input_data.get("files", []))
+
+    return input_media
+
+
+def stringify_input_content(input_content: Union[str, Dict[str, Any], List[Any], BaseModel]) -> str:
+    """Convert any given input_content into its string representation.
+
+    This handles both serialized (dict) and live (object) input_content formats.
+    """
+    if isinstance(input_content, str):
+        return input_content
+    elif isinstance(input_content, Message):
+        return json.dumps(input_content.to_dict())
+    elif isinstance(input_content, dict):
+        return json.dumps(input_content, indent=2, default=str)
+    elif isinstance(input_content, list):
+        if input_content:
+            # Handle live Message objects
+            if isinstance(input_content[0], Message):
+                return json.dumps([m.to_dict() for m in input_content])
+            # Handle serialized Message dicts
+            elif isinstance(input_content[0], dict) and input_content[0].get("role") == "user":
+                return input_content[0].get("content", str(input_content))
+        return str(input_content)
+    else:
+        return str(input_content)
+
+
+def format_duration_ms(duration_ms: Optional[int]) -> str:
+    """Format a duration in milliseconds to a human-readable string.
+
+    Args:
+        duration_ms: Duration in milliseconds
+
+    Returns:
+        Formatted string like "150ms" or "1.50s"
+    """
+    if duration_ms is None or duration_ms < 1000:
+        return f"{duration_ms or 0}ms"
+    return f"{duration_ms / 1000:.2f}s"
+
+
+def format_team_tools(team_tools: List[Union[Function, dict]]):
+    formatted_tools: List[Dict] = []
+    if team_tools is not None:
+        for tool in team_tools:
+            if isinstance(tool, dict):
+                formatted_tools.append(tool)
+            elif isinstance(tool, Function):
+                formatted_tools.append(tool.to_dict())
+    return formatted_tools
+
+
+def format_tools(agent_tools: List[Union[Dict[str, Any], Toolkit, Function, Callable]]):
+    formatted_tools: List[Dict] = []
+    if agent_tools is not None:
+        for tool in agent_tools:
+            if isinstance(tool, dict):
+                formatted_tools.append(tool)
+            elif isinstance(tool, Toolkit):
+                for _, f in tool.functions.items():
+                    formatted_tools.append(f.to_dict())
+            elif isinstance(tool, Function):
+                formatted_tools.append(tool.to_dict())
+            elif callable(tool):
+                func = Function.from_callable(tool)
+                formatted_tools.append(func.to_dict())
+            else:
+                logger.warning(f"Unknown tool type: {type(tool)}")
+    return formatted_tools

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -1,5 +1,5 @@
 import json
-from datetime import date, datetime, time, timezone
+from datetime import datetime
 from os import getenv
 from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, Type, Union
 
@@ -22,15 +22,23 @@ from agno.factory import (
 from agno.knowledge.knowledge import Knowledge
 from agno.media import Audio, Image, Video
 from agno.media import File as FileMedia
-from agno.models.message import Message
 from agno.os.config import AgentOSConfig
+from agno.os.schema_utils import (  # noqa: F401  (re-exported)
+    extract_input_media,
+    format_duration_ms,
+    format_team_tools,
+    format_tools,
+    get_run_input,
+    get_session_name,
+    stringify_input_content,
+    to_utc_datetime,
+)
 from agno.registry import Registry, ToolSource
 from agno.remote.base import RemoteDb, RemoteKnowledge
 from agno.run.agent import RunOutputEvent
 from agno.run.team import TeamRunOutputEvent
 from agno.run.workflow import WorkflowRunOutputEvent
 from agno.team import RemoteTeam, Team, TeamFactory
-from agno.tools import Function, Toolkit
 from agno.utils.log import log_debug, log_warning, logger
 from agno.workflow import RemoteWorkflow, Workflow, WorkflowFactory
 
@@ -50,32 +58,6 @@ class AgnoHTTPException(HTTPException):
         super().__init__(status_code=error.status_code, detail=detail if detail is not None else str(error))
         self.error_id: Optional[str] = getattr(error, "error_id", None)
         self.error_type: Optional[str] = getattr(error, "type", None)
-
-
-def to_utc_datetime(value: Optional[Union[str, int, float, date, datetime]]) -> Optional[datetime]:
-    """Convert a timestamp, ISO 8601 string, date, or datetime to a UTC datetime."""
-    if value is None:
-        return None
-
-    if isinstance(value, datetime):
-        # If already a datetime, make sure the timezone is UTC
-        if value.tzinfo is None:
-            return value.replace(tzinfo=timezone.utc)
-        return value
-
-    # datetime is a subclass of date, so this must come after the datetime check
-    if isinstance(value, date):
-        return datetime.combine(value, time.min, tzinfo=timezone.utc)
-
-    if isinstance(value, str):
-        try:
-            if value.endswith("Z"):
-                value = value[:-1] + "+00:00"
-            return datetime.fromisoformat(value)
-        except (ValueError, TypeError):
-            return None
-
-    return datetime.fromtimestamp(value, tz=timezone.utc)
 
 
 # Matched to the most generous object-store metadata budget.
@@ -878,108 +860,6 @@ def get_knowledge_instance(
         detail=f"db_id or knowledge_id query parameter is required when using multiple knowledge bases. "
         f"Available IDs: {knowledge_ids}",
     )
-
-
-def get_run_input(run_dict: Dict[str, Any], is_workflow_run: bool = False) -> str:
-    """Get the run input from the given run dictionary
-
-    Uses the RunInput/TeamRunInput object which stores the original user input.
-    """
-
-    # For agent or team runs, use the stored input_content
-    if not is_workflow_run and run_dict.get("input") is not None:
-        input_data = run_dict.get("input")
-        if isinstance(input_data, dict) and input_data.get("input_content") is not None:
-            return stringify_input_content(input_data["input_content"])
-
-    if is_workflow_run:
-        # Check the input field directly
-        input_value = run_dict.get("input")
-        if input_value is not None:
-            return stringify_input_content(input_value)
-
-        # Check the step executor runs for fallback
-        step_executor_runs = run_dict.get("step_executor_runs", [])
-        if step_executor_runs:
-            for message in reversed(step_executor_runs[0].get("messages", [])):
-                if message.get("role") == "user":
-                    return message.get("content", "")
-
-    # Final fallback: scan messages
-    if run_dict.get("messages") is not None:
-        for message in reversed(run_dict["messages"]):
-            if message.get("role") == "user":
-                return message.get("content", "")
-
-    return ""
-
-
-def get_session_name(session: Dict[str, Any]) -> str:
-    """Get the session name from the given session dictionary"""
-
-    # If session_data.session_name is set, return that
-    session_data = session.get("session_data")
-    if session_data is not None and session_data.get("session_name") is not None:
-        return session_data["session_name"]
-
-    runs = session.get("runs", []) or []
-    session_type = session.get("session_type")
-
-    # Handle workflows separately
-    if session_type == "workflow":
-        if not runs:
-            return ""
-        workflow_run = runs[0]
-        workflow_input = workflow_run.get("input")
-        if isinstance(workflow_input, str):
-            return workflow_input
-        elif isinstance(workflow_input, dict):
-            try:
-                return json.dumps(workflow_input)
-            except (TypeError, ValueError):
-                pass
-        workflow_name = session.get("workflow_data", {}).get("name")
-        return f"New {workflow_name} Session" if workflow_name else ""
-
-    # For team, filter to team runs (runs without agent_id); for agents, use all runs
-    if session_type == "team":
-        runs_to_check = [r for r in runs if not r.get("agent_id")]
-    else:
-        runs_to_check = runs
-
-    # Find the first user message across runs
-    for r in runs_to_check:
-        if r is None:
-            continue
-        run_dict = r if isinstance(r, dict) else r.to_dict()
-
-        for message in run_dict.get("messages") or []:
-            if message.get("role") == "user" and message.get("content"):
-                return message["content"]
-
-        run_input = r.get("input")
-        if run_input is not None:
-            return stringify_input_content(run_input)
-
-    return ""
-
-
-def extract_input_media(run_dict: Dict[str, Any]) -> Dict[str, Any]:
-    input_media: Dict[str, List[Any]] = {
-        "images": [],
-        "videos": [],
-        "audios": [],
-        "files": [],
-    }
-
-    input_data = run_dict.get("input", {})
-    if isinstance(input_data, dict):
-        input_media["images"].extend(input_data.get("images", []))
-        input_media["videos"].extend(input_data.get("videos", []))
-        input_media["audios"].extend(input_data.get("audios", []))
-        input_media["files"].extend(input_data.get("files", []))
-
-    return input_media
 
 
 # Supported MIME types per media category, used to route uploaded files to the
@@ -2567,20 +2447,6 @@ def setup_tracing_for_os(db: Union[BaseDb, AsyncBaseDb, RemoteDb]) -> None:
         log_warning(f"Failed to enable tracing: {str(e)}")
 
 
-def format_duration_ms(duration_ms: Optional[int]) -> str:
-    """Format a duration in milliseconds to a human-readable string.
-
-    Args:
-        duration_ms: Duration in milliseconds
-
-    Returns:
-        Formatted string like "150ms" or "1.50s"
-    """
-    if duration_ms is None or duration_ms < 1000:
-        return f"{duration_ms or 0}ms"
-    return f"{duration_ms / 1000:.2f}s"
-
-
 def timestamp_to_datetime(datetime_str: str, param_name: str = "datetime") -> "datetime":
     """Parse an ISO 8601 datetime string and convert to UTC.
 
@@ -2603,62 +2469,6 @@ def timestamp_to_datetime(datetime_str: str, param_name: str = "datetime") -> "d
             status_code=400,
             detail=f"Invalid {param_name} format. Use ISO 8601 format (e.g., '2025-11-19T10:00:00Z' or '2025-11-19T10:00:00+05:30'): {e}",
         )
-
-
-def format_team_tools(team_tools: List[Union[Function, dict]]):
-    formatted_tools: List[Dict] = []
-    if team_tools is not None:
-        for tool in team_tools:
-            if isinstance(tool, dict):
-                formatted_tools.append(tool)
-            elif isinstance(tool, Function):
-                formatted_tools.append(tool.to_dict())
-    return formatted_tools
-
-
-def format_tools(agent_tools: List[Union[Dict[str, Any], Toolkit, Function, Callable]]):
-    formatted_tools: List[Dict] = []
-    if agent_tools is not None:
-        for tool in agent_tools:
-            if isinstance(tool, dict):
-                formatted_tools.append(tool)
-            elif isinstance(tool, Toolkit):
-                for _, f in tool.functions.items():
-                    formatted_tools.append(f.to_dict())
-            elif isinstance(tool, Function):
-                formatted_tools.append(tool.to_dict())
-            elif callable(tool):
-                func = Function.from_callable(tool)
-                formatted_tools.append(func.to_dict())
-            else:
-                logger.warning(f"Unknown tool type: {type(tool)}")
-    return formatted_tools
-
-
-def stringify_input_content(input_content: Union[str, Dict[str, Any], List[Any], BaseModel]) -> str:
-    """Convert any given input_content into its string representation.
-
-    This handles both serialized (dict) and live (object) input_content formats.
-    """
-    import json
-
-    if isinstance(input_content, str):
-        return input_content
-    elif isinstance(input_content, Message):
-        return json.dumps(input_content.to_dict())
-    elif isinstance(input_content, dict):
-        return json.dumps(input_content, indent=2, default=str)
-    elif isinstance(input_content, list):
-        if input_content:
-            # Handle live Message objects
-            if isinstance(input_content[0], Message):
-                return json.dumps([m.to_dict() for m in input_content])
-            # Handle serialized Message dicts
-            elif isinstance(input_content[0], dict) and input_content[0].get("role") == "user":
-                return input_content[0].get("content", str(input_content))
-        return str(input_content)
-    else:
-        return str(input_content)
 
 
 # ---------------------------------------------------------------------------

--- a/libs/agno/agno/remote/base.py
+++ b/libs/agno/agno/remote/base.py
@@ -46,6 +46,10 @@ if TYPE_CHECKING:
         WorkflowRunSchema,
         WorkflowSessionDetailSchema,
     )
+else:
+    # fastapi only ships with the "os" extra; a loose binding keeps the
+    # upload annotations resolvable by get_type_hints() without it.
+    UploadFile = Any
 
 
 @dataclass

--- a/libs/agno/agno/workflow/__init__.py
+++ b/libs/agno/agno/workflow/__init__.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING, Any
+
 from agno.workflow.agent import WorkflowAgent
 from agno.workflow.cel import CEL_AVAILABLE, validate_cel_expression
 from agno.workflow.condition import Condition
@@ -5,12 +7,14 @@ from agno.workflow.decorators import pause
 from agno.workflow.factory import WorkflowFactory
 from agno.workflow.loop import Loop
 from agno.workflow.parallel import Parallel
-from agno.workflow.remote import RemoteWorkflow
 from agno.workflow.router import Router
 from agno.workflow.step import Step
 from agno.workflow.steps import Steps
 from agno.workflow.types import HumanReview, OnError, OnReject, OnTimeout, StepInput, StepOutput, WorkflowExecutionInput
 from agno.workflow.workflow import Workflow, get_workflow_by_id, get_workflows
+
+if TYPE_CHECKING:
+    from agno.workflow.remote import RemoteWorkflow
 
 __all__ = [
     "Workflow",
@@ -38,3 +42,17 @@ __all__ = [
     # Decorators
     "pause",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    # Resolving RemoteWorkflow on first access keeps the remote-client stack
+    # off the import path of everything that does not use it.
+    if name == "RemoteWorkflow":
+        from agno.workflow.remote import RemoteWorkflow
+
+        return RemoteWorkflow
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list:
+    return sorted(set(globals()) | set(__all__))

--- a/libs/agno/agno/workflow/__init__.py
+++ b/libs/agno/agno/workflow/__init__.py
@@ -50,6 +50,7 @@ def __getattr__(name: str) -> Any:
     if name == "RemoteWorkflow":
         from agno.workflow.remote import RemoteWorkflow
 
+        globals()[name] = RemoteWorkflow
         return RemoteWorkflow
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 

--- a/libs/agno/agno/workflow/remote.py
+++ b/libs/agno/agno/workflow/remote.py
@@ -1,7 +1,6 @@
 import time
 from typing import TYPE_CHECKING, Any, AsyncIterator, Dict, List, Literal, Optional, Tuple, Union, overload
 
-from fastapi import WebSocket
 from pydantic import BaseModel
 
 from agno.media import Audio, File, Image, Video
@@ -12,6 +11,8 @@ from agno.utils.agent import validate_input
 from agno.utils.remote import serialize_input
 
 if TYPE_CHECKING:
+    from fastapi import WebSocket
+
     from agno.os.routers.workflows.schema import WorkflowResponse
 
 
@@ -150,7 +151,7 @@ class RemoteWorkflow(BaseRemote):
         stream_events: Optional[bool] = None,
         stream_intermediate_steps: Optional[bool] = None,
         background: Optional[bool] = False,
-        websocket: Optional[WebSocket] = None,
+        websocket: Optional["WebSocket"] = None,
         background_tasks: Optional[Any] = None,
         auth_token: Optional[str] = None,
     ) -> WorkflowRunOutput: ...
@@ -172,7 +173,7 @@ class RemoteWorkflow(BaseRemote):
         stream_events: Optional[bool] = None,
         stream_intermediate_steps: Optional[bool] = None,
         background: Optional[bool] = False,
-        websocket: Optional[WebSocket] = None,
+        websocket: Optional["WebSocket"] = None,
         background_tasks: Optional[Any] = None,
         auth_token: Optional[str] = None,
     ) -> AsyncIterator[WorkflowRunOutputEvent]: ...
@@ -192,7 +193,7 @@ class RemoteWorkflow(BaseRemote):
         stream: bool = False,
         stream_events: Optional[bool] = None,
         background: Optional[bool] = False,
-        websocket: Optional[WebSocket] = None,
+        websocket: Optional["WebSocket"] = None,
         background_tasks: Optional[Any] = None,
         auth_token: Optional[str] = None,
         **kwargs: Any,

--- a/libs/agno/agno/workflow/remote.py
+++ b/libs/agno/agno/workflow/remote.py
@@ -14,6 +14,10 @@ if TYPE_CHECKING:
     from fastapi import WebSocket
 
     from agno.os.routers.workflows.schema import WorkflowResponse
+else:
+    # fastapi only ships with the "os" extra; a loose binding keeps the
+    # websocket annotations resolvable by get_type_hints() without it.
+    WebSocket = Any
 
 
 class RemoteWorkflow(BaseRemote):
@@ -151,7 +155,7 @@ class RemoteWorkflow(BaseRemote):
         stream_events: Optional[bool] = None,
         stream_intermediate_steps: Optional[bool] = None,
         background: Optional[bool] = False,
-        websocket: Optional["WebSocket"] = None,
+        websocket: Optional[WebSocket] = None,
         background_tasks: Optional[Any] = None,
         auth_token: Optional[str] = None,
     ) -> WorkflowRunOutput: ...
@@ -173,7 +177,7 @@ class RemoteWorkflow(BaseRemote):
         stream_events: Optional[bool] = None,
         stream_intermediate_steps: Optional[bool] = None,
         background: Optional[bool] = False,
-        websocket: Optional["WebSocket"] = None,
+        websocket: Optional[WebSocket] = None,
         background_tasks: Optional[Any] = None,
         auth_token: Optional[str] = None,
     ) -> AsyncIterator[WorkflowRunOutputEvent]: ...
@@ -193,7 +197,7 @@ class RemoteWorkflow(BaseRemote):
         stream: bool = False,
         stream_events: Optional[bool] = None,
         background: Optional[bool] = False,
-        websocket: Optional["WebSocket"] = None,
+        websocket: Optional[WebSocket] = None,
         background_tasks: Optional[Any] = None,
         auth_token: Optional[str] = None,
         **kwargs: Any,

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -23,10 +23,11 @@ from typing import (
 )
 from uuid import uuid4
 
-from fastapi import WebSocket
 from pydantic import BaseModel
 
 if TYPE_CHECKING:
+    from fastapi import WebSocket
+
     from agno.os.managers import WebSocketHandler
 
 from agno.agent.agent import Agent
@@ -8451,7 +8452,7 @@ class Workflow:
         stream: Literal[False] = False,
         stream_events: Optional[bool] = None,
         background: Optional[bool] = False,
-        websocket: Optional[WebSocket] = None,
+        websocket: Optional["WebSocket"] = None,
         enable_websocket: bool = False,
     ) -> WorkflowRunOutput: ...
 
@@ -8466,7 +8467,7 @@ class Workflow:
         stream: Literal[True] = True,
         stream_events: Optional[bool] = None,
         background: Optional[bool] = False,
-        websocket: Optional[WebSocket] = None,
+        websocket: Optional["WebSocket"] = None,
         enable_websocket: bool = False,
     ) -> AsyncIterator[WorkflowRunOutputEvent]: ...
 
@@ -8480,7 +8481,7 @@ class Workflow:
         stream: Optional[bool] = None,
         stream_events: Optional[bool] = None,
         background: Optional[bool] = False,
-        websocket: Optional[WebSocket] = None,
+        websocket: Optional["WebSocket"] = None,
         enable_websocket: bool = False,
         **kwargs: Any,
     ) -> Union[WorkflowRunOutput, AsyncIterator[WorkflowRunOutputEvent]]:
@@ -10574,7 +10575,7 @@ class Workflow:
         stream: Literal[False] = False,
         stream_events: Optional[bool] = None,
         background: Optional[bool] = False,
-        websocket: Optional[WebSocket] = None,
+        websocket: Optional["WebSocket"] = None,
         enable_websocket: bool = False,
         background_tasks: Optional[Any] = None,
         dependencies: Optional[Dict[str, Any]] = None,
@@ -10599,7 +10600,7 @@ class Workflow:
         stream: Literal[True] = True,
         stream_events: Optional[bool] = None,
         background: Optional[bool] = False,
-        websocket: Optional[WebSocket] = None,
+        websocket: Optional["WebSocket"] = None,
         enable_websocket: bool = False,
         background_tasks: Optional[Any] = None,
         dependencies: Optional[Dict[str, Any]] = None,
@@ -10623,7 +10624,7 @@ class Workflow:
         stream: Optional[bool] = None,
         stream_events: Optional[bool] = None,
         background: Optional[bool] = False,
-        websocket: Optional[WebSocket] = None,
+        websocket: Optional["WebSocket"] = None,
         enable_websocket: bool = False,
         background_tasks: Optional[Any] = None,
         dependencies: Optional[Dict[str, Any]] = None,

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -29,6 +29,11 @@ if TYPE_CHECKING:
     from fastapi import WebSocket
 
     from agno.os.managers import WebSocketHandler
+else:
+    # fastapi only ships with the "os" extra. Binding WebSocket loosely keeps
+    # the websocket annotations resolvable by get_type_hints() -- and with
+    # them Function.from_callable() on run methods -- without importing it.
+    WebSocket = Any
 
 from agno.agent.agent import Agent
 from agno.db.base import AsyncBaseDb, BaseDb, ComponentType, SessionType
@@ -8452,7 +8457,7 @@ class Workflow:
         stream: Literal[False] = False,
         stream_events: Optional[bool] = None,
         background: Optional[bool] = False,
-        websocket: Optional["WebSocket"] = None,
+        websocket: Optional[WebSocket] = None,
         enable_websocket: bool = False,
     ) -> WorkflowRunOutput: ...
 
@@ -8467,7 +8472,7 @@ class Workflow:
         stream: Literal[True] = True,
         stream_events: Optional[bool] = None,
         background: Optional[bool] = False,
-        websocket: Optional["WebSocket"] = None,
+        websocket: Optional[WebSocket] = None,
         enable_websocket: bool = False,
     ) -> AsyncIterator[WorkflowRunOutputEvent]: ...
 
@@ -8481,7 +8486,7 @@ class Workflow:
         stream: Optional[bool] = None,
         stream_events: Optional[bool] = None,
         background: Optional[bool] = False,
-        websocket: Optional["WebSocket"] = None,
+        websocket: Optional[WebSocket] = None,
         enable_websocket: bool = False,
         **kwargs: Any,
     ) -> Union[WorkflowRunOutput, AsyncIterator[WorkflowRunOutputEvent]]:
@@ -10575,7 +10580,7 @@ class Workflow:
         stream: Literal[False] = False,
         stream_events: Optional[bool] = None,
         background: Optional[bool] = False,
-        websocket: Optional["WebSocket"] = None,
+        websocket: Optional[WebSocket] = None,
         enable_websocket: bool = False,
         background_tasks: Optional[Any] = None,
         dependencies: Optional[Dict[str, Any]] = None,
@@ -10600,7 +10605,7 @@ class Workflow:
         stream: Literal[True] = True,
         stream_events: Optional[bool] = None,
         background: Optional[bool] = False,
-        websocket: Optional["WebSocket"] = None,
+        websocket: Optional[WebSocket] = None,
         enable_websocket: bool = False,
         background_tasks: Optional[Any] = None,
         dependencies: Optional[Dict[str, Any]] = None,
@@ -10624,7 +10629,7 @@ class Workflow:
         stream: Optional[bool] = None,
         stream_events: Optional[bool] = None,
         background: Optional[bool] = False,
-        websocket: Optional["WebSocket"] = None,
+        websocket: Optional[WebSocket] = None,
         enable_websocket: bool = False,
         background_tasks: Optional[Any] = None,
         dependencies: Optional[Dict[str, Any]] = None,

--- a/libs/agno/tests/unit/os/test_fastapi_optional.py
+++ b/libs/agno/tests/unit/os/test_fastapi_optional.py
@@ -1,0 +1,149 @@
+"""Regression tests: the remote client stack must work without ``fastapi`` installed.
+
+fastapi only ships with the ``os`` extra, so a bare ``pip install agno`` must be
+able to instantiate RemoteAgent, RemoteTeam, and RemoteWorkflow -- each of which
+builds an AgentOSClient, importing ``agno.client.os`` and with it the response
+schema modules under ``agno.os``. Those modules bind fastapi's ``UploadFile``
+loosely at runtime so ``get_type_hints()`` -- and with it
+``Function.from_callable()`` -- keeps working whether or not fastapi is
+installed, and the ``agno.os`` package inits resolve the app and routers
+lazily so the schema modules never pull fastapi in transitively.
+
+The no-fastapi cases run in a subprocess with ``fastapi`` masked in
+``sys.modules``, which is deterministic across environments (the CI test env
+has fastapi installed transitively via the dev extra).
+"""
+
+import subprocess
+import sys
+import textwrap
+from io import BytesIO
+from typing import get_type_hints
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+def _run_masked(code: str) -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"subprocess failed. stdout={result.stdout!r} stderr={result.stderr!r}"
+    assert result.stdout.strip() == "OK"
+
+
+def test_remote_classes_usable_without_fastapi():
+    """Instantiate all three remote classes and introspect the client with fastapi masked."""
+    code = textwrap.dedent(
+        """
+        import sys
+        # Mask fastapi so any attempt to import it raises ModuleNotFoundError.
+        sys.modules["fastapi"] = None  # type: ignore[assignment]
+
+        from typing import get_type_hints
+
+        from agno.agent import RemoteAgent
+        from agno.team import RemoteTeam
+        from agno.workflow import RemoteWorkflow
+
+        # Instantiation builds an AgentOSClient, which imports agno.client.os
+        # and the response schema modules under agno.os.
+        RemoteAgent(base_url="http://localhost:7777", agent_id="agent-1")
+        RemoteTeam(base_url="http://localhost:7777", team_id="team-1")
+        RemoteWorkflow(base_url="http://localhost:7777", workflow_id="workflow-1")
+
+        # The upload annotations must resolve without fastapi.
+        from agno.client import AgentOSClient
+
+        assert "file" in get_type_hints(AgentOSClient.upload_knowledge_content)
+
+        # Tool-schema generation walks those same annotations.
+        from agno.tools.function import Function
+
+        schema = Function.from_callable(AgentOSClient.upload_knowledge_content)
+        assert schema.parameters["properties"]
+
+        print("OK")
+        """
+    )
+    _run_masked(code)
+
+
+def test_schema_modules_import_without_fastapi():
+    """The response schema modules the client depends on must not pull in fastapi."""
+    code = textwrap.dedent(
+        """
+        import sys
+        sys.modules["fastapi"] = None  # type: ignore[assignment]
+
+        import agno.os.routers.agents.schema
+        import agno.os.routers.evals.schemas
+        import agno.os.routers.knowledge.schemas
+        import agno.os.routers.memory.schemas
+        import agno.os.routers.metrics.schemas
+        import agno.os.routers.teams.schema
+        import agno.os.routers.traces.schemas
+        import agno.os.routers.workflows.schema
+        import agno.os.schema
+        import agno.os.schema_utils
+
+        print("OK")
+        """
+    )
+    _run_masked(code)
+
+
+def test_import_agno_client_does_not_load_fastapi():
+    """Even with fastapi available, importing agno.client must not load it."""
+    code = textwrap.dedent(
+        """
+        import sys
+
+        import agno.client
+
+        assert "fastapi" not in sys.modules, "import agno.client pulled in fastapi"
+        assert "agno.os.app" not in sys.modules, "import agno.client pulled in the AgentOS app"
+        print("OK")
+        """
+    )
+    _run_masked(code)
+
+
+def test_upload_annotations_resolve_with_fastapi_installed():
+    pytest.importorskip("fastapi", reason="dev/CI envs always have fastapi; bare envs are covered above")
+
+    from agno.client import AgentOSClient
+    from agno.tools.function import Function
+
+    assert "file" in get_type_hints(AgentOSClient.upload_knowledge_content)
+    schema = Function.from_callable(AgentOSClient.upload_knowledge_content)
+    assert schema.parameters["properties"]
+
+
+async def test_upload_content_builds_multipart_for_both_file_types():
+    """The upload path must route agno File and fastapi UploadFile to the right multipart tuple."""
+    fastapi = pytest.importorskip("fastapi", reason="dev/CI envs always have fastapi; bare envs are covered above")
+
+    from agno.client import AgentOSClient
+    from agno.media import File
+
+    client = AgentOSClient(base_url="http://localhost:7777")
+    client._apost_multipart = AsyncMock(return_value={"id": "content-1"})  # type: ignore[method-assign]
+
+    # agno.media.File with content is sent as (filename, content, mime_type)
+    await client.upload_knowledge_content(file=File(content=b"agno bytes", filename="a.txt", mime_type="text/plain"))
+    files = client._apost_multipart.call_args.kwargs["files"]
+    assert files == {"file": ("a.txt", b"agno bytes", "text/plain")}
+
+    # fastapi UploadFile is sent as (filename, file object, content_type)
+    upload = fastapi.UploadFile(file=BytesIO(b"fastapi bytes"), filename="b.txt")
+    await client.upload_knowledge_content(file=upload)
+    files = client._apost_multipart.call_args.kwargs["files"]
+    assert files == {"file": ("b.txt", upload.file, "application/octet-stream")}
+
+    # agno.media.File without content yields no files payload
+    await client.upload_knowledge_content(file=File(url="http://example.com/c.txt"), name="c")
+    assert client._apost_multipart.call_args.kwargs["files"] is None

--- a/libs/agno/tests/unit/workflow/test_fastapi_optional.py
+++ b/libs/agno/tests/unit/workflow/test_fastapi_optional.py
@@ -1,0 +1,113 @@
+"""Regression tests: ``agno.workflow`` must work without ``fastapi`` installed.
+
+fastapi only ships with the ``os`` extra, so a bare ``pip install agno`` must
+still be able to import the package, build and run a workflow, and resolve
+``RemoteWorkflow``. The websocket parameters on the async run methods are
+annotated with fastapi's ``WebSocket``; the modules bind that name loosely at
+runtime so ``get_type_hints()`` -- and with it ``Function.from_callable()`` --
+keeps working whether or not fastapi is installed.
+
+The no-fastapi cases run in a subprocess with ``fastapi`` masked in
+``sys.modules``, which is deterministic across environments (the CI test env
+has fastapi installed transitively via the dev extra).
+"""
+
+import subprocess
+import sys
+import textwrap
+from typing import get_type_hints
+
+import pytest
+
+
+def _run_masked(code: str) -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"subprocess failed. stdout={result.stdout!r} stderr={result.stderr!r}"
+    assert result.stdout.strip() == "OK"
+
+
+def test_workflow_usable_without_fastapi():
+    """Import, construct, run, and introspect a workflow with fastapi masked."""
+    code = textwrap.dedent(
+        """
+        import sys
+        # Mask fastapi so any attempt to import it raises ModuleNotFoundError.
+        sys.modules["fastapi"] = None  # type: ignore[assignment]
+
+        from typing import get_type_hints
+
+        from agno.workflow import RemoteWorkflow, Step, StepOutput, Workflow
+
+        def hello(step_input):
+            return StepOutput(content="hello")
+
+        wf = Workflow(name="no-fastapi", steps=[Step(name="hello", executor=hello)])
+        result = wf.run(input="hi")
+        assert result.content == "hello"
+
+        # The websocket annotations must resolve without fastapi.
+        assert "websocket" in get_type_hints(Workflow.arun)
+        assert "websocket" in get_type_hints(Workflow.acontinue_run)
+        assert "websocket" in get_type_hints(RemoteWorkflow.arun)
+
+        # Tool-schema generation walks those same annotations.
+        from agno.tools.function import Function
+
+        schema = Function.from_callable(wf.arun)
+        assert schema.parameters["properties"]
+
+        print("OK")
+        """
+    )
+    _run_masked(code)
+
+
+def test_import_does_not_load_fastapi():
+    """Even with fastapi available, importing agno.workflow must not load it."""
+    code = textwrap.dedent(
+        """
+        import sys
+
+        import agno.workflow
+
+        assert "fastapi" not in sys.modules, "import agno.workflow pulled in fastapi"
+        assert "agno.workflow.remote" not in sys.modules, "RemoteWorkflow was imported eagerly"
+        print("OK")
+        """
+    )
+    _run_masked(code)
+
+
+def test_websocket_annotations_resolve_with_fastapi_installed():
+    pytest.importorskip("fastapi", reason="dev/CI envs always have fastapi; bare envs are covered above")
+
+    from agno.tools.function import Function
+    from agno.workflow import Step, StepOutput, Workflow
+    from agno.workflow.remote import RemoteWorkflow
+
+    assert "websocket" in get_type_hints(Workflow.arun)
+    assert "websocket" in get_type_hints(Workflow.acontinue_run)
+    assert "websocket" in get_type_hints(RemoteWorkflow.arun)
+
+    wf = Workflow(name="t", steps=[Step(name="s", executor=lambda si: StepOutput(content="x"))])
+    schema = Function.from_callable(wf.arun)
+    assert schema.parameters["properties"]
+
+
+def test_remote_workflow_resolves_lazily_and_is_cached():
+    import agno.workflow
+
+    cls = agno.workflow.RemoteWorkflow
+    assert cls.__name__ == "RemoteWorkflow"
+    # First access stores the class in the module namespace, so vars()-based
+    # introspection works from then on.
+    assert vars(agno.workflow)["RemoteWorkflow"] is cls
+    assert "RemoteWorkflow" in dir(agno.workflow)
+
+    with pytest.raises(AttributeError):
+        agno.workflow.DoesNotExist


### PR DESCRIPTION
## Summary

A bare `pip install agno` (no extras) could not instantiate `RemoteAgent`, `RemoteTeam`, or `RemoteWorkflow`: each builds an `AgentOSClient` in `__init__`, and importing `agno.client.os` raised `ModuleNotFoundError: fastapi`. The module-level `from fastapi import UploadFile` at `agno/client/os.py:5` was only the first failure — behind it, the client's imports of the response schema modules under `agno.os` pulled fastapi in transitively, because the `agno.os` / `agno.os.routers.*` package inits eagerly import the FastAPI app and routers, and the schema modules imported helpers from the fastapi-coupled `agno/os/utils.py`.

**Stacked on #9696** (`agno.workflow` importable without fastapi): this branch includes that PR's commits because the `RemoteWorkflow` regression test needs them. Merge #9696 first and this diff reduces to the client/os changes. Both merge orders are clean.

### Changes

- **`agno/client/os.py`** — `UploadFile` moves under `TYPE_CHECKING` with a runtime `UploadFile = Any` binding (the P2 pattern from #9696's review: a bare `TYPE_CHECKING` move breaks `get_type_hints()` and with it `Function.from_callable()`). The multipart branch in `upload_knowledge_content` now discriminates on `isinstance(file, MediaFile)` instead of `isinstance(file, UploadFile)`, since `isinstance` against `Any` raises `TypeError` and fastapi may not be installed.
- **`agno/remote/base.py`** — the same runtime binding for its existing `TYPE_CHECKING` `UploadFile` import. Before this, `get_type_hints(RemoteKnowledge.upload_content)` raised `NameError: UploadFile` *even with fastapi installed*.
- **`agno/os/__init__.py`** — `AgentOS` resolves lazily through the module `__getattr__` (extending the existing lazy `AgentOSBuiltinAuth` precedent), so importing schema submodules no longer executes `agno/os/app.py`.
- **Ten router package inits** (`agno/os/routers/{__init__,agents,evals,knowledge,memory,metrics,session,teams,traces,workflows}`) — router factories resolve lazily via `__getattr__`, so importing `agno.os.routers.<x>.schema(s)` no longer imports the fastapi router modules. `from agno.os.routers.<x> import get_<x>_router` continues to work with fastapi installed.
- **`agno/os/schema_utils.py` (new)** — fastapi-free home for the eight dict→schema helpers the schema modules call at client parse time: `to_utc_datetime`, `get_run_input`, `get_session_name`, `extract_input_media`, `stringify_input_content`, `format_duration_ms`, `format_tools`, `format_team_tools`. Moved verbatim from `agno/os/utils.py` (which cannot be made fastapi-optional — it subclasses `HTTPException` at class-definition time). `agno/os/utils.py` re-exports all eight, so every existing `from agno.os.utils import ...` site keeps working.
- **Schema modules** (`agno/os/schema.py`, `routers/{agents,teams}/schema.py`, `routers/{evals,memory,metrics,traces}/schemas.py`) — import the helpers from `agno.os.schema_utils` instead of `agno.os.utils`.

### Verification

- New `libs/agno/tests/unit/os/test_fastapi_optional.py` (modeled on #9696's test): masked-subprocess instantiation of all three remote classes via their public imports (`from agno.agent import RemoteAgent`, etc.), masked import of every schema module, `import agno.client` loads neither fastapi nor `agno.os.app` even with fastapi installed, annotation/`Function.from_callable` resolution both masked and installed, and the multipart payload pinned for agno `File` (with and without content) and fastapi `UploadFile`.
- Mutation check: the three masked/lazy tests fail on unmodified `feat/v3.0`; the two fastapi-installed behavior tests pass there, showing no behavior change with fastapi present.
- `Function.from_callable(AgentOSClient.upload_knowledge_content).parameters` is byte-identical across base-with-fastapi, this-branch-with-fastapi, and this-branch-masked (the `file` hint resolves to `Union[File, Any, None]` instead of `Union[File, UploadFile, None]` — the same trade-off #9696 made for `WebSocket`).
- `tests/unit/{os,utils,remote,workflow}`: 3615 passed. The one failure (`test_stream_error_persist.py::test_sync_multistep_stream_error_persists_error_run`) is order-dependent and reproduces identically on unmodified `feat/v3.0`; it passes in isolation on both. Telegram/gemini collection errors are missing-extras in the dev venv, pre-existing.
- `./scripts/format.sh` and `./scripts/validate.sh` (ruff + mypy, 1014 files) pass.

Known remaining gap (pre-existing, out of scope): `get_type_hints(RemoteKnowledge.upload_content)` now gets past `UploadFile` but still fails on the return annotation `ContentResponseSchema`, which `agno/remote/base.py` imports only under `TYPE_CHECKING` — that was equally broken before this PR.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue (#9696 covers the workflow import path only; this PR stacks on it for the client/instantiation path)
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

The no-fastapi test cases run in subprocesses with `fastapi` masked in `sys.modules`, so they are deterministic in CI where fastapi is installed via the dev extra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
