### PR TITLE
fix: invalidate the cached session when db is reassigned

### DIFF
--- a/libs/agno/agno/agent/_session.py
+++ b/libs/agno/agno/agent/_session.py
@@ -99,16 +99,10 @@ def get_session(
     session_id_to_load: str = session_id or agent.session_id  # type: ignore[assignment]
 
     # If there is a cached session, return it (never for a bounded/partial read).
-    if (
-        runs_limit is None
-        and agent.cache_session
-        and hasattr(agent, "_cached_session")
-        and agent._cached_session is not None
-    ):
-        if agent._cached_session.session_id == session_id_to_load and (
-            user_id is None or agent._cached_session.user_id == user_id
-        ):
-            return agent._cached_session
+    if runs_limit is None and agent.cache_session:
+        cached_session = agent._get_cached_session(session_id_to_load, user_id=user_id)
+        if cached_session is not None:
+            return cached_session
 
     if _init.has_async_db(agent):
         raise ValueError("Cannot use sync get_session() with an async database. Use aget_session() instead.")
@@ -150,7 +144,7 @@ def get_session(
 
         # Cache the session if relevant (never cache a bounded/partial read).
         if loaded_session is not None and agent.cache_session and runs_limit is None:
-            agent._cached_session = loaded_session  # type: ignore
+            agent._set_cached_session(loaded_session)  # type: ignore[arg-type]
 
         return loaded_session
 
@@ -184,16 +178,10 @@ async def aget_session(
     session_id_to_load: str = session_id or agent.session_id  # type: ignore[assignment]
 
     # If there is a cached session, return it (never for a bounded/partial read).
-    if (
-        runs_limit is None
-        and agent.cache_session
-        and hasattr(agent, "_cached_session")
-        and agent._cached_session is not None
-    ):
-        if agent._cached_session.session_id == session_id_to_load and (
-            user_id is None or agent._cached_session.user_id == user_id
-        ):
-            return agent._cached_session
+    if runs_limit is None and agent.cache_session:
+        cached_session = agent._get_cached_session(session_id_to_load, user_id=user_id)
+        if cached_session is not None:
+            return cached_session
 
     # Load and return the session from the database
     if agent.db is not None:
@@ -232,7 +220,7 @@ async def aget_session(
 
         # Cache the session if relevant (never cache a bounded/partial read).
         if loaded_session is not None and agent.cache_session and runs_limit is None:
-            agent._cached_session = loaded_session  # type: ignore
+            agent._set_cached_session(loaded_session)  # type: ignore[arg-type]
 
         return loaded_session
 

--- a/libs/agno/agno/agent/_storage.py
+++ b/libs/agno/agno/agent/_storage.py
@@ -551,12 +551,9 @@ def read_or_create_session(
     from uuid import uuid4
 
     # Returning cached session if we have one
-    if (
-        agent._cached_session is not None
-        and agent._cached_session.session_id == session_id
-        and (user_id is None or agent._cached_session.user_id == user_id)
-    ):
-        return agent._cached_session
+    cached_session = agent._get_cached_session(session_id, user_id=user_id)
+    if cached_session is not None:
+        return cached_session
 
     # Try to load from database
     agent_session = None
@@ -607,7 +604,7 @@ def read_or_create_session(
                 upsert_run(agent, run=introduction_run, session_id=session_id, user_id=user_id, run_index=0)
 
     if agent.cache_session:
-        agent._cached_session = agent_session
+        agent._set_cached_session(agent_session)
 
     return agent_session
 
@@ -623,12 +620,9 @@ async def aread_or_create_session(
     from agno.agent import _init
 
     # Returning cached session if we have one
-    if (
-        agent._cached_session is not None
-        and agent._cached_session.session_id == session_id
-        and (user_id is None or agent._cached_session.user_id == user_id)
-    ):
-        return agent._cached_session
+    cached_session = agent._get_cached_session(session_id, user_id=user_id)
+    if cached_session is not None:
+        return cached_session
 
     # Try to load from database
     agent_session = None
@@ -685,7 +679,7 @@ async def aread_or_create_session(
                     upsert_run(agent, run=introduction_run, session_id=session_id, user_id=user_id, run_index=0)
 
     if agent.cache_session:
-        agent._cached_session = agent_session
+        agent._set_cached_session(agent_session)
 
     return agent_session
 

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -647,6 +647,8 @@ class Agent:
 
         # If we are caching the agent session
         self._cached_session: Optional[AgentSession] = None
+        # The db the cached session was loaded from; the cache is only valid for that db
+        self._cached_session_db: Optional[Union[BaseDb, AsyncBaseDb]] = None
 
         self._tool_instructions: Optional[List[str]] = None
         self._team: Optional[Any] = None
@@ -685,6 +687,27 @@ class Agent:
     @property
     def cached_session(self) -> Optional[AgentSession]:
         return self._cached_session
+
+    def _get_cached_session(self, session_id: str, user_id: Optional[str] = None) -> Optional[AgentSession]:
+        """Return the cached session if it matches session_id/user_id and the current db."""
+        cached = getattr(self, "_cached_session", None)
+        if cached is None:
+            return None
+        if getattr(self, "_cached_session_db", None) is not self.db:
+            # The cached session was loaded from a previously assigned db; serving it
+            # would leak that db's runs into the current one, so drop it.
+            self._cached_session = None
+            self._cached_session_db = None
+            return None
+        if cached.session_id != session_id:
+            return None
+        if user_id is not None and cached.user_id != user_id:
+            return None
+        return cached
+
+    def _set_cached_session(self, session: AgentSession) -> None:
+        self._cached_session = session
+        self._cached_session_db = self.db
 
     @property
     def learning_machine(self) -> Optional[LearningMachine]:

--- a/libs/agno/agno/team/_init.py
+++ b/libs/agno/agno/team/_init.py
@@ -382,6 +382,7 @@ def __init__(
 
     # Team session
     team._cached_session = None
+    team._cached_session_db = None
 
     team._tool_instructions = None
 

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -8668,7 +8668,7 @@ async def _acontinue_run_background_stream(
                                 await apersist_run_transition(team, "team", session_id, fresh_run, user_id=user_id)
                                 persist_run.status = cast(RunStatus, restore_status)
                                 if team.cache_session:
-                                    team._cached_session = fresh_session
+                                    team._set_cached_session(fresh_session)
                 except Exception:
                     log_error(
                         f"Failed to restore the pre-continue state for background continue-run stream {_run_id}",
@@ -8703,7 +8703,7 @@ async def _acontinue_run_background_stream(
                                 await apersist_run_transition(team, "team", session_id, fresh_run, user_id=user_id)
                                 persist_run.status = RunStatus.error
                                 if team.cache_session:
-                                    team._cached_session = fresh_session
+                                    team._set_cached_session(fresh_session)
                 except Exception:
                     log_error(
                         f"Failed to persist error state for background continue-run stream {_run_id}",

--- a/libs/agno/agno/team/_session.py
+++ b/libs/agno/agno/team/_session.py
@@ -67,11 +67,10 @@ def get_session(
     session_id_to_load: str = session_id or team.session_id  # type: ignore[assignment]
 
     # If there is a cached session, return it
-    if team.cache_session and hasattr(team, "_cached_session") and team._cached_session is not None:
-        if team._cached_session.session_id == session_id_to_load and (
-            user_id is None or team._cached_session.user_id == user_id
-        ):
-            return team._cached_session
+    if team.cache_session:
+        cached_session = team._get_cached_session(session_id_to_load, user_id=user_id)
+        if cached_session is not None:
+            return cached_session
 
     if _has_async_db(team):
         raise ValueError("Cannot use sync get_session() with an async database. Use aget_session() instead.")
@@ -96,7 +95,7 @@ def get_session(
 
         # Cache the session if relevant
         if loaded_session is not None and team.cache_session:
-            team._cached_session = loaded_session
+            team._set_cached_session(loaded_session)
 
         return loaded_session  # type: ignore[return-value]
 
@@ -127,11 +126,10 @@ async def aget_session(
     session_id_to_load: str = session_id or team.session_id  # type: ignore[assignment]
 
     # If there is a cached session, return it
-    if team.cache_session and hasattr(team, "_cached_session") and team._cached_session is not None:
-        if team._cached_session.session_id == session_id_to_load and (
-            user_id is None or team._cached_session.user_id == user_id
-        ):
-            return team._cached_session
+    if team.cache_session:
+        cached_session = team._get_cached_session(session_id_to_load, user_id=user_id)
+        if cached_session is not None:
+            return cached_session
 
     # Load and return the session from the database
     if team.db is not None:
@@ -169,7 +167,7 @@ async def aget_session(
 
         # Cache the session if relevant
         if loaded_session is not None and team.cache_session:
-            team._cached_session = loaded_session
+            team._set_cached_session(loaded_session)
 
         return loaded_session  # type: ignore[return-value]
 

--- a/libs/agno/agno/team/_storage.py
+++ b/libs/agno/agno/team/_storage.py
@@ -296,12 +296,9 @@ def _read_or_create_session(team: "Team", session_id: str, user_id: Optional[str
     from agno.team._telemetry import get_team_data
 
     # Return existing session if we have one
-    if (
-        team._cached_session is not None
-        and team._cached_session.session_id == session_id
-        and (user_id is None or team._cached_session.user_id == user_id)
-    ):
-        return team._cached_session
+    cached_session = team._get_cached_session(session_id, user_id=user_id)
+    if cached_session is not None:
+        return cached_session
 
     # Try to load from database
     team_session = None
@@ -351,7 +348,7 @@ def _read_or_create_session(team: "Team", session_id: str, user_id: Optional[str
 
     # Cache the session if relevant
     if team_session is not None and team.cache_session:
-        team._cached_session = team_session
+        team._set_cached_session(team_session)
 
     return team_session
 
@@ -369,12 +366,9 @@ async def _aread_or_create_session(team: "Team", session_id: str, user_id: Optio
     from agno.team._telemetry import get_team_data
 
     # Return existing session if we have one
-    if (
-        team._cached_session is not None
-        and team._cached_session.session_id == session_id
-        and (user_id is None or team._cached_session.user_id == user_id)
-    ):
-        return team._cached_session
+    cached_session = team._get_cached_session(session_id, user_id=user_id)
+    if cached_session is not None:
+        return cached_session
 
     # Try to load from database
     team_session = None
@@ -432,7 +426,7 @@ async def _aread_or_create_session(team: "Team", session_id: str, user_id: Optio
 
     # Cache the session if relevant
     if team_session is not None and team.cache_session:
-        team._cached_session = team_session
+        team._set_cached_session(team_session)
 
     return team_session
 

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -409,6 +409,8 @@ class Team:
     videos: Optional[List[Video]] = None
     # Cached session
     _cached_session: Optional[TeamSession] = None
+    # The db the cached session was loaded from; the cache is only valid for that db
+    _cached_session_db: Optional[Union[BaseDb, AsyncBaseDb]] = None
     # Tool instructions
     _tool_instructions: Optional[List[str]] = None
     # Member response model
@@ -679,6 +681,27 @@ class Team:
     @property
     def cached_session(self) -> Optional[TeamSession]:
         return _init.cached_session(self)
+
+    def _get_cached_session(self, session_id: str, user_id: Optional[str] = None) -> Optional[TeamSession]:
+        """Return the cached session if it matches session_id/user_id and the current db."""
+        cached = getattr(self, "_cached_session", None)
+        if cached is None:
+            return None
+        if getattr(self, "_cached_session_db", None) is not self.db:
+            # The cached session was loaded from a previously assigned db; serving it
+            # would leak that db's runs into the current one, so drop it.
+            self._cached_session = None
+            self._cached_session_db = None
+            return None
+        if cached.session_id != session_id:
+            return None
+        if user_id is not None and cached.user_id != user_id:
+            return None
+        return cached
+
+    def _set_cached_session(self, session: TeamSession) -> None:
+        self._cached_session = session
+        self._cached_session_db = self.db
 
     def set_id(self) -> None:
         return _init.set_id(self)

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -684,6 +684,8 @@ class Workflow:
         self.add_workflow_history_to_steps = add_workflow_history_to_steps
         self.num_history_runs = num_history_runs
         self._workflow_session: Optional[WorkflowSession] = None
+        # The db the cached session was loaded from; the cache is only valid for that db
+        self._cached_session_db: Optional[Union[BaseDb, AsyncBaseDb]] = None
         self.stream_events = stream_events
 
         # Warn if workflow history is enabled without a database
@@ -1481,6 +1483,27 @@ class Workflow:
                 log_warning(f"No run responses found in WorkflowSession {session_id}")
                 return None
 
+    def _get_cached_session(self, session_id: str, user_id: Optional[str] = None) -> Optional[WorkflowSession]:
+        """Return the cached session if it matches session_id/user_id and the current db."""
+        cached = getattr(self, "_workflow_session", None)
+        if cached is None:
+            return None
+        if getattr(self, "_cached_session_db", None) is not self.db:
+            # The cached session was loaded from a previously assigned db; serving it
+            # would leak that db's runs into the current one, so drop it.
+            self._workflow_session = None
+            self._cached_session_db = None
+            return None
+        if cached.session_id != session_id:
+            return None
+        if user_id is not None and cached.user_id != user_id:
+            return None
+        return cached
+
+    def _set_cached_session(self, session: WorkflowSession) -> None:
+        self._workflow_session = session
+        self._cached_session_db = self.db
+
     def read_or_create_session(
         self,
         session_id: str,
@@ -1489,12 +1512,9 @@ class Workflow:
         from time import time
 
         # Returning cached session if we have one
-        if (
-            self._workflow_session is not None
-            and self._workflow_session.session_id == session_id
-            and (user_id is None or self._workflow_session.user_id == user_id)
-        ):
-            return self._workflow_session
+        cached_session = self._get_cached_session(session_id, user_id=user_id)
+        if cached_session is not None:
+            return cached_session
 
         if self._has_async_db():
             raise ValueError(
@@ -1528,7 +1548,7 @@ class Workflow:
 
         # Cache the session if relevant
         if workflow_session is not None and self.cache_session:
-            self._workflow_session = workflow_session
+            self._set_cached_session(workflow_session)
 
         return workflow_session
 
@@ -1540,12 +1560,9 @@ class Workflow:
         from time import time
 
         # Returning cached session if we have one
-        if (
-            self._workflow_session is not None
-            and self._workflow_session.session_id == session_id
-            and (user_id is None or self._workflow_session.user_id == user_id)
-        ):
-            return self._workflow_session
+        cached_session = self._get_cached_session(session_id, user_id=user_id)
+        if cached_session is not None:
+            return cached_session
 
         # Try to load from database
         workflow_session = None
@@ -1574,7 +1591,7 @@ class Workflow:
 
         # Cache the session if relevant
         if workflow_session is not None and self.cache_session:
-            self._workflow_session = workflow_session
+            self._set_cached_session(workflow_session)
 
         return workflow_session
 

--- a/libs/agno/tests/unit/agent/test_cache_session_db_swap.py
+++ b/libs/agno/tests/unit/agent/test_cache_session_db_swap.py
@@ -1,0 +1,210 @@
+"""Regression tests: with ``cache_session=True`` the cached session must not survive
+a reassignment of ``agent.db``.
+
+Bug: an agent with ``cache_session=True`` and a fixed ``session_id`` kept serving the
+same cached session object after ``agent.db`` was pointed at a fresh database. The
+cached session accumulated every prior conversation's runs, so history leaked across
+databases and each turn re-serialized an ever-growing session into whichever db was
+current (measured as ~31ms -> ~272ms per conversation over 11 conversations).
+
+The cache is tagged with the db it was loaded from and is dropped when the tag no
+longer matches ``agent.db``. Switching ``session_id`` was already handled by the
+read-time session_id comparison; those semantics are pinned here too.
+"""
+
+from typing import Any, AsyncIterator, Iterator
+
+import pytest
+
+from agno.agent.agent import Agent
+from agno.db.in_memory import InMemoryDb
+from agno.models.base import Model
+from agno.models.message import MessageMetrics
+from agno.models.response import ModelResponse
+
+
+class MockModel(Model):
+    """Minimal offline model: returns a canned text response without any network call."""
+
+    def __init__(self):
+        super().__init__(id="test-model", name="test-model", provider="test")
+        self.instructions = None
+        self._mock_response = ModelResponse(
+            content="ok",
+            role="assistant",
+            response_usage=MessageMetrics(),
+        )
+
+    def get_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    def get_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    def parse_args(self, *args, **kwargs):
+        return {}
+
+    def invoke(self, *args, **kwargs) -> ModelResponse:
+        return self._mock_response
+
+    async def ainvoke(self, *args, **kwargs) -> ModelResponse:
+        return self._mock_response
+
+    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+        yield self._mock_response
+
+    async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+        yield self._mock_response
+        return
+
+    def _parse_provider_response(self, response: Any, **kwargs) -> ModelResponse:
+        return self._mock_response
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return self._mock_response
+
+
+def _make_agent(**kwargs) -> Agent:
+    return Agent(model=MockModel(), cache_session=True, add_history_to_context=True, **kwargs)
+
+
+def _user_message_count(response) -> int:
+    return len([m for m in response.messages if m.role == "user"])
+
+
+class TestCacheHitWithinOneDb:
+    def test_second_run_reuses_cached_session_object(self):
+        agent = _make_agent(db=InMemoryDb())
+
+        agent.run("first", session_id="conv")
+        first_cached = agent.cached_session
+        assert first_cached is not None
+        assert len(first_cached.runs) == 1
+
+        agent.run("second", session_id="conv")
+        assert agent.cached_session is first_cached
+        assert len(first_cached.runs) == 2
+
+    def test_get_session_serves_cached_object(self):
+        agent = _make_agent(db=InMemoryDb())
+
+        agent.run("first", session_id="conv")
+        cached = agent.cached_session
+        assert agent.get_session(session_id="conv") is cached
+
+
+class TestDbSwapInvalidation:
+    def test_db_swap_drops_cached_session(self):
+        agent = _make_agent(db=InMemoryDb())
+        agent.run("first", session_id="conv")
+        old_cached = agent.cached_session
+        assert old_cached is not None
+
+        agent.db = InMemoryDb()
+        agent.run("second", session_id="conv")
+
+        new_cached = agent.cached_session
+        assert new_cached is not None
+        assert new_cached is not old_cached
+        assert len(new_cached.runs) == 1
+        # The old cached session keeps only its own conversation
+        assert len(old_cached.runs) == 1
+
+    def test_history_does_not_leak_across_dbs(self):
+        agent = _make_agent(db=InMemoryDb())
+        for _ in range(3):
+            agent.run("hi", session_id="conv")
+
+        agent.db = InMemoryDb()
+        response = agent.run("hi", session_id="conv")
+
+        # First turn against the fresh db: no history from the old db's conversation
+        assert _user_message_count(response) == 1
+
+    def test_no_cross_db_leakage_of_runs(self):
+        db1 = InMemoryDb()
+        agent = _make_agent(db=db1)
+        agent.run("first", session_id="conv")
+
+        db2 = InMemoryDb()
+        agent.db = db2
+        agent.run("second", session_id="conv")
+
+        # Each db holds exactly the runs produced while it was assigned
+        assert len(db1.get_runs(session_id="conv")) == 1
+        assert len(db2.get_runs(session_id="conv")) == 1
+
+        # A fresh read from each db yields that db's conversation only
+        agent.db = db1
+        session_from_db1 = agent.get_session(session_id="conv")
+        assert session_from_db1 is not None
+        assert len(session_from_db1.runs) == 1
+        assert session_from_db1.runs[0].messages is not None
+
+    def test_swap_back_to_original_db_reloads_from_that_db(self):
+        db1 = InMemoryDb()
+        agent = _make_agent(db=db1)
+        agent.run("first", session_id="conv")
+
+        agent.db = InMemoryDb()
+        agent.run("second", session_id="conv")
+
+        agent.db = db1
+        agent.run("third", session_id="conv")
+        cached = agent.cached_session
+        assert cached is not None
+        # db1's conversation had 1 run; the new turn makes 2. The interleaved
+        # db2 conversation must not appear.
+        assert len(cached.runs) == 2
+
+    @pytest.mark.asyncio
+    async def test_db_swap_drops_cached_session_async(self):
+        agent = _make_agent(db=InMemoryDb())
+        await agent.arun("first", session_id="conv")
+        old_cached = agent.cached_session
+        assert old_cached is not None
+
+        agent.db = InMemoryDb()
+        response = await agent.arun("second", session_id="conv")
+
+        new_cached = agent.cached_session
+        assert new_cached is not None
+        assert new_cached is not old_cached
+        assert len(new_cached.runs) == 1
+        assert _user_message_count(response) == 1
+
+
+class TestSessionIdSwitch:
+    def test_session_id_switch_does_not_serve_stale_cache(self):
+        agent = _make_agent(db=InMemoryDb())
+
+        agent.run("first", session_id="conv-a")
+        cached_a = agent.cached_session
+        assert cached_a is not None
+
+        agent.run("second", session_id="conv-b")
+        cached_b = agent.cached_session
+        assert cached_b is not None
+        assert cached_b is not cached_a
+        assert cached_b.session_id == "conv-b"
+        assert len(cached_b.runs) == 1
+
+    def test_runs_do_not_leak_across_session_ids(self):
+        agent = _make_agent(db=InMemoryDb())
+
+        agent.run("first", session_id="conv-a")
+        agent.run("second", session_id="conv-b")
+        response = agent.run("third", session_id="conv-a")
+
+        # conv-a's second turn sees only conv-a's history
+        assert _user_message_count(response) == 2
+        cached = agent.cached_session
+        assert cached is not None
+        assert cached.session_id == "conv-a"
+        assert len(cached.runs) == 2

--- a/libs/agno/tests/unit/team/test_cache_session_db_swap.py
+++ b/libs/agno/tests/unit/team/test_cache_session_db_swap.py
@@ -1,0 +1,157 @@
+"""Regression tests: with ``cache_session=True`` the cached session must not survive
+a reassignment of ``team.db``.
+
+Sibling of ``tests/unit/agent/test_cache_session_db_swap.py`` — the same hazard exists
+on Team: a cached TeamSession kept being served (and growing) after ``team.db`` was
+pointed at a fresh database, leaking runs across databases.
+"""
+
+from typing import Any, AsyncIterator, Iterator
+
+import pytest
+
+from agno.db.in_memory import InMemoryDb
+from agno.models.base import Model
+from agno.models.message import MessageMetrics
+from agno.models.response import ModelResponse
+from agno.team.team import Team
+
+
+class MockModel(Model):
+    """Minimal offline model: returns a canned text response without any network call."""
+
+    def __init__(self):
+        super().__init__(id="test-model", name="test-model", provider="test")
+        self.instructions = None
+        self._mock_response = ModelResponse(
+            content="ok",
+            role="assistant",
+            response_usage=MessageMetrics(),
+        )
+
+    def get_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    def get_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    def parse_args(self, *args, **kwargs):
+        return {}
+
+    def invoke(self, *args, **kwargs) -> ModelResponse:
+        return self._mock_response
+
+    async def ainvoke(self, *args, **kwargs) -> ModelResponse:
+        return self._mock_response
+
+    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+        yield self._mock_response
+
+    async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+        yield self._mock_response
+        return
+
+    def _parse_provider_response(self, response: Any, **kwargs) -> ModelResponse:
+        return self._mock_response
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return self._mock_response
+
+
+def _make_team(**kwargs) -> Team:
+    return Team(
+        name="test-team",
+        members=[],
+        model=MockModel(),
+        cache_session=True,
+        add_history_to_context=True,
+        **kwargs,
+    )
+
+
+class TestTeamCacheHitWithinOneDb:
+    def test_second_run_reuses_cached_session_object(self):
+        team = _make_team(db=InMemoryDb())
+
+        team.run("first", session_id="conv")
+        first_cached = team.cached_session
+        assert first_cached is not None
+        assert len(first_cached.runs) == 1
+
+        team.run("second", session_id="conv")
+        assert team.cached_session is first_cached
+        assert len(first_cached.runs) == 2
+
+
+class TestTeamDbSwapInvalidation:
+    def test_db_swap_drops_cached_session(self):
+        team = _make_team(db=InMemoryDb())
+        team.run("first", session_id="conv")
+        old_cached = team.cached_session
+        assert old_cached is not None
+
+        team.db = InMemoryDb()
+        team.run("second", session_id="conv")
+
+        new_cached = team.cached_session
+        assert new_cached is not None
+        assert new_cached is not old_cached
+        assert len(new_cached.runs) == 1
+        # The old cached session keeps only its own conversation
+        assert len(old_cached.runs) == 1
+
+    def test_no_cross_db_leakage_of_runs(self):
+        db1 = InMemoryDb()
+        team = _make_team(db=db1)
+        team.run("first", session_id="conv")
+
+        db2 = InMemoryDb()
+        team.db = db2
+        team.run("second", session_id="conv")
+
+        # Each db holds exactly the runs produced while it was assigned
+        assert len(db1.get_runs(session_id="conv")) == 1
+        assert len(db2.get_runs(session_id="conv")) == 1
+
+        # A fresh read from each db yields that db's conversation only
+        team.db = db1
+        session_from_db1 = team.get_session(session_id="conv")
+        assert session_from_db1 is not None
+        assert len(session_from_db1.runs) == 1
+
+    @pytest.mark.asyncio
+    async def test_db_swap_drops_cached_session_async(self):
+        team = _make_team(db=InMemoryDb())
+        await team.arun("first", session_id="conv")
+        old_cached = team.cached_session
+        assert old_cached is not None
+
+        team.db = InMemoryDb()
+        await team.arun("second", session_id="conv")
+
+        new_cached = team.cached_session
+        assert new_cached is not None
+        assert new_cached is not old_cached
+        assert len(new_cached.runs) == 1
+
+
+class TestTeamSessionIdSwitch:
+    def test_session_id_switch_does_not_serve_stale_cache(self):
+        team = _make_team(db=InMemoryDb())
+
+        team.run("first", session_id="conv-a")
+        cached_a = team.cached_session
+        assert cached_a is not None
+
+        team.run("second", session_id="conv-b")
+        cached_b = team.cached_session
+        assert cached_b is not None
+        assert cached_b is not cached_a
+        assert cached_b.session_id == "conv-b"
+        assert len(cached_b.runs) == 1

--- a/libs/agno/tests/unit/workflow/test_cache_session_db_swap.py
+++ b/libs/agno/tests/unit/workflow/test_cache_session_db_swap.py
@@ -1,0 +1,64 @@
+"""Regression tests: with ``cache_session=True`` the cached session must not survive
+a reassignment of ``workflow.db``.
+
+Sibling of ``tests/unit/agent/test_cache_session_db_swap.py`` — Workflow caches its
+session in ``_workflow_session`` and had the same hazard: after ``workflow.db`` was
+pointed at a fresh database, ``read_or_create_session`` kept serving the session
+loaded from the old database.
+"""
+
+import pytest
+
+from agno.db.in_memory import InMemoryDb
+from agno.workflow.workflow import Workflow
+
+
+def _make_workflow(**kwargs) -> Workflow:
+    return Workflow(name="test-workflow", steps=[], cache_session=True, **kwargs)
+
+
+class TestWorkflowCacheHitWithinOneDb:
+    def test_second_read_reuses_cached_session_object(self):
+        workflow = _make_workflow(db=InMemoryDb())
+
+        first = workflow.read_or_create_session(session_id="conv")
+        assert workflow.read_or_create_session(session_id="conv") is first
+
+    @pytest.mark.asyncio
+    async def test_second_read_reuses_cached_session_object_async(self):
+        workflow = _make_workflow(db=InMemoryDb())
+
+        first = await workflow.aread_or_create_session(session_id="conv")
+        assert await workflow.aread_or_create_session(session_id="conv") is first
+
+
+class TestWorkflowDbSwapInvalidation:
+    def test_db_swap_drops_cached_session(self):
+        workflow = _make_workflow(db=InMemoryDb())
+        old_session = workflow.read_or_create_session(session_id="conv")
+
+        workflow.db = InMemoryDb()
+        new_session = workflow.read_or_create_session(session_id="conv")
+
+        assert new_session is not old_session
+
+    @pytest.mark.asyncio
+    async def test_db_swap_drops_cached_session_async(self):
+        workflow = _make_workflow(db=InMemoryDb())
+        old_session = await workflow.aread_or_create_session(session_id="conv")
+
+        workflow.db = InMemoryDb()
+        new_session = await workflow.aread_or_create_session(session_id="conv")
+
+        assert new_session is not old_session
+
+
+class TestWorkflowSessionIdSwitch:
+    def test_session_id_switch_does_not_serve_stale_cache(self):
+        workflow = _make_workflow(db=InMemoryDb())
+
+        session_a = workflow.read_or_create_session(session_id="conv-a")
+        session_b = workflow.read_or_create_session(session_id="conv-b")
+
+        assert session_b is not session_a
+        assert session_b.session_id == "conv-b"


### PR DESCRIPTION
## Summary

With `cache_session=True`, the cached session survives reassignment of `.db` on `Agent`, `Team`, and `Workflow`. An agent with a fixed `session_id` that gets a fresh db assigned (`agent.db = InMemoryDb()`) keeps serving and growing the SAME cached session across databases: history leaks from the old db's conversations into the new one, and the ever-growing session is re-serialized each turn into whichever db is current. Reproduced during benchmark work: 25-turn conversations degraded from ~31ms to ~272ms over ~11 conversations because the cached session accumulated every prior conversation's runs.

This is not just a benchmark artifact: `AgentOS` mounting (`os/app.py`), the Studio runner, and the environments rollout runner all assign `.db` on existing components, so any of them could inherit a stale cached session.

**Fix**: the session cache is tagged with the db object it was loaded from. Every cache read goes through a new `_get_cached_session(session_id, user_id)` helper that drops the cached entry when the tag no longer matches the current `.db` (identity comparison), and every cache write goes through `_set_cached_session(session)` which records the tag. Implemented identically on `Agent`, `Team` (sibling surface), and `Workflow`:

- `agent/_session.py` (`get_session`/`aget_session`), `agent/_storage.py` (`read_or_create_session`/`aread_or_create_session`)
- `team/_session.py`, `team/_storage.py`, and the two cache-refresh sites in `team/_run.py`
- `workflow/workflow.py` (`read_or_create_session`/`aread_or_create_session`)

**session_id audit**: switching `session_id` (or `user_id`) was already safe — the read-time comparison misses and the subsequent db load overwrites the single-entry cache. That behavior is unchanged and now pinned by tests. The in-memory run accessors (`utils/agent.py` `get_run_output`/`get_last_run_output` fallbacks and workflow `get_run` helpers) intentionally keep serving the in-memory session; they are explicit run-id/last-run lookups, not the leak surface.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Why read-time tagging instead of a `db` property setter**: a setter requires renaming the dataclass field, and `deep_copy` iterates `dataclasses.fields()` skipping `_`-prefixed names — the copy would silently lose its db. A `__setattr__` hook would put a Python-level call on every attribute write (Agent init does ~100). The read-time identity check adds only an `is` comparison on the cache-hit path and centralizes all validity logic in one helper per class.

**Tests** (`test_cache_session_db_swap.py` under `tests/unit/agent`, `tests/unit/team`, `tests/unit/workflow`, 19 total): cache hit within one db (object identity across runs), invalidation on db swap (sync + async), no cross-db leakage of runs (per-db run counts and fresh reads), history not leaking into the first turn after a swap, swap-back reloads from the original db, and session_id-switch semantics. Mutation-checked: with the library fix reverted, all 10 db-swap tests fail and the 9 pinning tests still pass.

**Verification**: unit suites for agent (677), team (737), workflow (531), os (2471), environments/eval/session (343) all pass; skips and the 41 telegram collection errors are pre-existing missing-extras in the dev venv (`telebot`, `cel-python`, `duckduckgo_search`, `anthropic`), identical on the unfixed baseline. The original repro (fresh `InMemoryDb` per 5-turn conversation) holds flat at 5 runs per conversation with the fix; without it the cached session grows 5 → 10 → 15…

🤖 Generated with [Claude Code](https://claude.com/claude-code)
