### PR TITLE
fix: cut per-turn history and session-save cost in long conversations

### DIFF
--- a/libs/agno/agno/agent/_messages.py
+++ b/libs/agno/agno/agent/_messages.py
@@ -1193,7 +1193,6 @@ def get_run_messages(
 
     # 3. Add history to run_messages
     if add_history_to_context:
-
         # Only skip messages from history when system_message_role is NOT a standard conversation role.
         # Standard conversation roles ("user", "assistant", "tool") should never be filtered
         # to preserve conversation continuity.
@@ -1400,7 +1399,6 @@ async def aget_run_messages(
 
     # 3. Add history to run_messages
     if add_history_to_context:
-
         # Only skip messages from history when system_message_role is NOT a standard conversation role.
         # Standard conversation roles ("user", "assistant", "tool") should never be filtered
         # to preserve conversation continuity.
@@ -1573,7 +1571,6 @@ def _build_continue_run_messages(
 
     # 2. Add history messages if not already present in input
     if add_history_to_context and session is not None and not input_has_history:
-
         # Only skip messages from history when system_message_role is NOT a standard conversation role.
         # Standard conversation roles ("user", "assistant", "tool") should never be filtered
         # to preserve conversation continuity.

--- a/libs/agno/agno/agent/_messages.py
+++ b/libs/agno/agno/agent/_messages.py
@@ -40,7 +40,7 @@ from agno.utils.agent import (
 from agno.utils.common import is_typed_dict
 from agno.utils.knowledge import get_user_id_kwarg
 from agno.utils.log import log_debug, log_warning
-from agno.utils.message import filter_tool_calls, get_text_from_message
+from agno.utils.message import copy_history_message, filter_tool_calls, get_text_from_message
 from agno.utils.prompts import get_json_output_prompt, get_response_model_format_prompt
 from agno.utils.timer import Timer
 
@@ -1193,7 +1193,6 @@ def get_run_messages(
 
     # 3. Add history to run_messages
     if add_history_to_context:
-        from copy import deepcopy
 
         # Only skip messages from history when system_message_role is NOT a standard conversation role.
         # Standard conversation roles ("user", "assistant", "tool") should never be filtered
@@ -1210,12 +1209,7 @@ def get_run_messages(
         )
 
         if len(history) > 0:
-            # Create a deep copy of the history messages to avoid modifying the original messages
-            history_copy = [deepcopy(msg) for msg in history]
-
-            # Tag each message as coming from history
-            for _msg in history_copy:
-                _msg.from_history = True
+            history_copy = [copy_history_message(msg) for msg in history]
 
             # Filter tool calls from history if limit is set (before adding to run_messages)
             if agent.max_tool_calls_from_history is not None:
@@ -1406,7 +1400,6 @@ async def aget_run_messages(
 
     # 3. Add history to run_messages
     if add_history_to_context:
-        from copy import deepcopy
 
         # Only skip messages from history when system_message_role is NOT a standard conversation role.
         # Standard conversation roles ("user", "assistant", "tool") should never be filtered
@@ -1423,12 +1416,7 @@ async def aget_run_messages(
         )
 
         if len(history) > 0:
-            # Create a deep copy of the history messages to avoid modifying the original messages
-            history_copy = [deepcopy(msg) for msg in history]
-
-            # Tag each message as coming from history
-            for _msg in history_copy:
-                _msg.from_history = True
+            history_copy = [copy_history_message(msg) for msg in history]
 
             # Filter tool calls from history if limit is set (before adding to run_messages)
             if agent.max_tool_calls_from_history is not None:
@@ -1585,7 +1573,6 @@ def _build_continue_run_messages(
 
     # 2. Add history messages if not already present in input
     if add_history_to_context and session is not None and not input_has_history:
-        from copy import deepcopy
 
         # Only skip messages from history when system_message_role is NOT a standard conversation role.
         # Standard conversation roles ("user", "assistant", "tool") should never be filtered
@@ -1602,12 +1589,7 @@ def _build_continue_run_messages(
         )
 
         if len(history) > 0:
-            # Create a deep copy of the history messages to avoid modifying the original messages
-            history_copy = [deepcopy(msg) for msg in history]
-
-            # Tag each message as coming from history
-            for _msg in history_copy:
-                _msg.from_history = True
+            history_copy = [copy_history_message(msg) for msg in history]
 
             # Filter tool calls from history if limit is set (before adding to run_messages)
             if agent.max_tool_calls_from_history is not None:

--- a/libs/agno/agno/db/in_memory/in_memory_db.py
+++ b/libs/agno/agno/db/in_memory/in_memory_db.py
@@ -295,7 +295,11 @@ class InMemoryDb(BaseDb):
         self, session: Session, deserialize: Optional[bool] = True
     ) -> Optional[Union[Session, Dict[str, Any]]]:
         try:
-            session_dict = session.to_dict()
+            # Serialize without runs: the runs list on the stored row is
+            # maintained incrementally by upsert_run, and re-serializing every
+            # run here would make each save cost grow with session length
+            # (the SQL adapters already serialize with include_runs=False).
+            session_dict = session.to_dict(include_runs=False)
 
             # Add session_type based on session instance type
             if isinstance(session, AgentSession):
@@ -315,13 +319,29 @@ class InMemoryDb(BaseDb):
                 if existing_uid is not None and existing_uid != session_dict.get("user_id"):
                     return None
                 session_dict["updated_at"] = int(time.time())
+                # A session-row update must never drop runs written by
+                # upsert_run: carry the stored list forward. The list is
+                # already owned by the store, so it needs no copy.
+                runs_for_store = existing_session.get("runs")
             else:
                 session_dict["created_at"] = session_dict.get("created_at", int(time.time()))
                 session_dict["updated_at"] = session_dict.get("created_at")
+                # First insert: serialize whatever runs the incoming session
+                # carries, once (bulk import and restore callers never call
+                # upsert_run). to_dict output is freshly built, so it needs
+                # no defensive copy.
+                incoming_runs = session.runs
+                runs_for_store = (
+                    [run.to_dict() if hasattr(run, "to_dict") else deepcopy(run) for run in incoming_runs]
+                    if incoming_runs
+                    else None
+                )
 
-            self._sessions[session_id] = deepcopy(session_dict)
+            stored_session = deepcopy(session_dict)
+            stored_session["runs"] = runs_for_store
+            self._sessions[session_id] = stored_session
 
-            session_dict_copy = deepcopy(session_dict)
+            session_dict_copy = deepcopy(stored_session)
             if not deserialize:
                 return session_dict_copy
 
@@ -477,7 +497,9 @@ class InMemoryDb(BaseDb):
                 log_debug(f"upsert_run: session {session_id} not found; skipping")
                 return
 
-            runs = session.setdefault("runs", [])
+            # The stored row holds "runs": None until the first run lands
+            runs = session.get("runs") or []
+            session["runs"] = runs
             for i, existing in enumerate(runs):
                 existing_id = (
                     existing.get("run_id") if isinstance(existing, dict) else getattr(existing, "run_id", None)

--- a/libs/agno/agno/team/_messages.py
+++ b/libs/agno/agno/team/_messages.py
@@ -952,7 +952,6 @@ def _get_run_messages(
 
     # 3. Add history to run_messages
     if add_history_to_context:
-
         # Only skip messages from history when system_message_role is NOT a standard conversation role.
         # Standard conversation roles ("user", "assistant", "tool") should never be filtered
         # to preserve conversation continuity.
@@ -1088,7 +1087,6 @@ async def _aget_run_messages(
 
     # 3. Add history to run_messages
     if add_history_to_context:
-
         # Only skip messages from history when system_message_role is NOT a standard conversation role.
         # Standard conversation roles ("user", "assistant", "tool") should never be filtered
         # to preserve conversation continuity.

--- a/libs/agno/agno/team/_messages.py
+++ b/libs/agno/agno/team/_messages.py
@@ -48,7 +48,7 @@ from agno.utils.log import (
     log_debug,
     log_warning,
 )
-from agno.utils.message import filter_tool_calls, get_text_from_message
+from agno.utils.message import copy_history_message, filter_tool_calls, get_text_from_message
 from agno.utils.team import (
     get_member_id,
 )
@@ -952,7 +952,6 @@ def _get_run_messages(
 
     # 3. Add history to run_messages
     if add_history_to_context:
-        from copy import deepcopy
 
         # Only skip messages from history when system_message_role is NOT a standard conversation role.
         # Standard conversation roles ("user", "assistant", "tool") should never be filtered
@@ -967,12 +966,7 @@ def _get_run_messages(
         )
 
         if len(history) > 0:
-            # Create a deep copy of the history messages to avoid modifying the original messages
-            history_copy = [deepcopy(msg) for msg in history]
-
-            # Tag each message as coming from history
-            for _msg in history_copy:
-                _msg.from_history = True
+            history_copy = [copy_history_message(msg) for msg in history]
 
             # Refresh pre-signed URLs for media loaded from history
             if team.media_storage is not None:
@@ -1094,7 +1088,6 @@ async def _aget_run_messages(
 
     # 3. Add history to run_messages
     if add_history_to_context:
-        from copy import deepcopy
 
         # Only skip messages from history when system_message_role is NOT a standard conversation role.
         # Standard conversation roles ("user", "assistant", "tool") should never be filtered
@@ -1108,12 +1101,7 @@ async def _aget_run_messages(
         )
 
         if len(history) > 0:
-            # Create a deep copy of the history messages to avoid modifying the original messages
-            history_copy = [deepcopy(msg) for msg in history]
-
-            # Tag each message as coming from history
-            for _msg in history_copy:
-                _msg.from_history = True
+            history_copy = [copy_history_message(msg) for msg in history]
 
             # Refresh pre-signed URLs for media loaded from history
             if team.media_storage is not None:

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -5374,9 +5374,7 @@ def _build_continue_run_messages(
         run_messages.messages.append(system_message)
 
     if add_history_to_context and session is not None and not input_has_history:
-        from copy import deepcopy
-
-        from agno.utils.message import filter_tool_calls
+        from agno.utils.message import copy_history_message, filter_tool_calls
 
         skip_role = team.system_message_role if team.system_message_role not in ["user", "assistant", "tool"] else None
 
@@ -5388,9 +5386,7 @@ def _build_continue_run_messages(
         )
 
         if len(history) > 0:
-            history_copy = [deepcopy(msg) for msg in history]
-            for _msg in history_copy:
-                _msg.from_history = True
+            history_copy = [copy_history_message(msg) for msg in history]
             if team.max_tool_calls_from_history is not None:
                 filter_tool_calls(history_copy, team.max_tool_calls_from_history)
             log_debug(f"Adding {len(history_copy)} messages from history")

--- a/libs/agno/agno/team/_tools.py
+++ b/libs/agno/agno/team/_tools.py
@@ -50,6 +50,7 @@ from agno.utils.log import (
     log_debug,
     log_warning,
 )
+from agno.utils.message import copy_history_message
 from agno.utils.team import (
     get_member_id,
     get_team_member_interactions_str,
@@ -539,14 +540,7 @@ def _get_history_for_member_agent(
     )
 
     if len(history) > 0:
-        # Create a deep copy of the history messages to avoid modifying the original messages
-        history_copy = [deepcopy(msg) for msg in history]
-
-        # Tag each message as coming from history
-        for _msg in history_copy:
-            _msg.from_history = True
-
-        return history_copy
+        return [copy_history_message(msg) for msg in history]
     return []
 
 

--- a/libs/agno/agno/utils/message.py
+++ b/libs/agno/agno/utils/message.py
@@ -7,6 +7,28 @@ from agno.models.message import Message
 from agno.utils.log import log_debug
 
 
+def copy_history_message(msg: Message) -> Message:
+    """Copy a history message and tag the copy with from_history=True.
+
+    Messages take a shallow copy: downstream consumers (tool-call filtering,
+    compression, scrubbing, provider formatting) rebind attributes on the
+    copy rather than mutating nested state, so the session's cached messages
+    stay untouched. Deep-copying every message costs ~11us per message per
+    turn, which compounds quadratically over a conversation.
+
+    Two shapes keep the deep copy because their nested state can be written
+    in place downstream: media-carrying messages (the media-offload refresh
+    writes fresh URLs and downloaded bytes into the media objects), and
+    messages whose content is a list of provider blocks (provider request
+    builders may alias the same list).
+    """
+    if msg.images or msg.videos or msg.audio or msg.files or msg.audio_output or isinstance(msg.content, list):
+        copied = deepcopy(msg)
+        copied.from_history = True
+        return copied
+    return msg.model_copy(update={"from_history": True})
+
+
 def safe_truncation_index(messages: Sequence[Message], requested_index: int) -> int:
     """Snap a requested truncation boundary DOWN to the nearest pair-safe index.
 

--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -518,6 +518,11 @@ def format_messages(
         elif message.role == "user":
             if isinstance(content, str):
                 content = [{"type": "text", "text": content}]
+            elif isinstance(content, list):
+                # Work on a copy: appending media blocks into the live
+                # Message.content would duplicate them on every model round
+                # of the run and persist provider blocks into the message
+                content = list(content)
 
             if message.images is not None:
                 for image in message.images:
@@ -638,6 +643,10 @@ def format_messages(
     # Merge consecutive messages with the same role (Claude requires alternating user/assistant roles).
     # This happens when multiple tool results (mapped to "user") appear in sequence, or when a tool
     # result is followed by a user message.
+    # Merging must always build a NEW content list: a list here can be the
+    # same object as a live Message.content (session history included), and
+    # extending or inserting into it in place would corrupt that message on
+    # every subsequent request.
     merged_messages: List[Dict[str, Union[str, list]]] = []
     for msg in chat_messages:
         if merged_messages and merged_messages[-1]["role"] == msg["role"]:
@@ -645,20 +654,13 @@ def format_messages(
             prev_content = merged_messages[-1]["content"]
             curr_content = msg["content"]
 
-            # Handle different content type combinations
-            if isinstance(prev_content, list) and isinstance(curr_content, list):
-                prev_content.extend(curr_content)
-            elif isinstance(prev_content, list):
-                prev_content.append({"type": "text", "text": str(curr_content)})
-            elif isinstance(curr_content, list):
-                curr_content.insert(0, {"type": "text", "text": str(prev_content)})
-                merged_messages[-1]["content"] = curr_content
-            else:
-                # Both strings, convert to list
-                merged_messages[-1]["content"] = [
-                    {"type": "text", "text": str(prev_content)},
-                    {"type": "text", "text": str(curr_content)},
-                ]
+            prev_blocks = (
+                prev_content if isinstance(prev_content, list) else [{"type": "text", "text": str(prev_content)}]
+            )
+            curr_blocks = (
+                curr_content if isinstance(curr_content, list) else [{"type": "text", "text": str(curr_content)}]
+            )
+            merged_messages[-1]["content"] = [*prev_blocks, *curr_blocks]
         else:
             merged_messages.append(msg)
 

--- a/libs/agno/tests/unit/agent/test_history_copy_on_write.py
+++ b/libs/agno/tests/unit/agent/test_history_copy_on_write.py
@@ -1,0 +1,156 @@
+"""History messages are copied before being tagged with from_history.
+
+Messages without media take a shallow (model_copy) copy for speed, so the
+session's cached Message objects must never be mutated by a later run's
+history tagging. Media-carrying messages keep a deep copy because the
+media-offload refresh writes into the media objects in place.
+"""
+
+from typing import Any, AsyncIterator, Iterator
+
+import pytest
+
+from agno.agent import Agent
+from agno.db.in_memory import InMemoryDb
+from agno.media import Image
+from agno.models.base import Model
+from agno.models.message import MessageMetrics
+from agno.models.response import ModelResponse
+
+
+class MockModel(Model):
+    """Minimal offline model: returns a canned text response without any network call."""
+
+    def __init__(self):
+        super().__init__(id="test-model", name="test-model", provider="test")
+        self.instructions = None
+        self._mock_response = ModelResponse(
+            content="ok",
+            role="assistant",
+            response_usage=MessageMetrics(),
+        )
+
+    def get_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    def get_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    def parse_args(self, *args, **kwargs):
+        return {}
+
+    def invoke(self, *args, **kwargs) -> ModelResponse:
+        return self._mock_response
+
+    async def ainvoke(self, *args, **kwargs) -> ModelResponse:
+        return self._mock_response
+
+    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+        yield self._mock_response
+
+    async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+        yield self._mock_response
+        return
+
+    def _parse_provider_response(self, response: Any, **kwargs) -> ModelResponse:
+        return self._mock_response
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return self._mock_response
+
+
+def _make_agent() -> Agent:
+    # cache_session=True keeps the session's Message objects live on the
+    # agent, so any in-place mutation of history by a later run would be
+    # visible on the earlier run's messages.
+    return Agent(
+        model=MockModel(),
+        db=InMemoryDb(),
+        add_history_to_context=True,
+        cache_session=True,
+        telemetry=False,
+    )
+
+
+def test_history_tagging_does_not_mutate_cached_messages():
+    agent = _make_agent()
+    first = agent.run("first turn", session_id="s1")
+    assert all(m.from_history is False for m in first.messages)
+
+    second = agent.run("second turn", session_id="s1")
+
+    # The originals from run 1 (aliased into the cached session) are untouched
+    assert all(m.from_history is False for m in first.messages)
+
+    # Run 2's context contains tagged copies of run 1's messages, not the originals
+    history = [m for m in second.messages if m.from_history]
+    assert len(history) >= 2
+    first_ids = {id(m) for m in first.messages}
+    assert all(id(m) not in first_ids for m in history)
+    assert any("first turn" in str(m.content) for m in history)
+
+
+def test_media_history_messages_are_deep_copied():
+    agent = _make_agent()
+    first = agent.run(
+        "describe this",
+        images=[Image(url="https://example.com/one.png")],
+        session_id="s1",
+    )
+    original_user = next(m for m in first.messages if m.images)
+
+    second = agent.run("second turn", session_id="s1")
+    history_user = next(m for m in second.messages if m.from_history and m.images)
+
+    # The media-carrying copy must not share media objects with the original:
+    # the media-offload refresh mutates image.url in place on the copy.
+    assert history_user is not original_user
+    assert history_user.images[0] is not original_user.images[0]
+    assert history_user.images[0].url == original_user.images[0].url
+
+
+def test_copy_history_message_deep_copies_list_content():
+    # Provider request builders can alias a list-shaped content into the
+    # payload they build, so those messages must not share the list
+    from agno.models.message import Message
+    from agno.utils.message import copy_history_message
+
+    msg = Message(role="user", content=[{"type": "text", "text": "FIRST"}])
+    copied = copy_history_message(msg)
+
+    assert copied.from_history is True
+    assert msg.from_history is False
+    assert copied.content == msg.content
+    assert copied.content is not msg.content
+
+
+def test_copy_history_message_tags_only_the_copy():
+    from agno.models.message import Message
+    from agno.utils.message import copy_history_message
+
+    msg = Message(role="user", content="hello")
+    copied = copy_history_message(msg)
+
+    assert copied is not msg
+    assert copied.from_history is True
+    assert msg.from_history is False
+
+
+@pytest.mark.asyncio
+async def test_history_tagging_does_not_mutate_cached_messages_async():
+    agent = _make_agent()
+    first = await agent.arun("first turn", session_id="s1")
+
+    second = await agent.arun("second turn", session_id="s1")
+
+    assert all(m.from_history is False for m in first.messages)
+    history = [m for m in second.messages if m.from_history]
+    assert len(history) >= 2
+    first_ids = {id(m) for m in first.messages}
+    assert all(id(m) not in first_ids for m in history)

--- a/libs/agno/tests/unit/db/test_in_memory_sessions.py
+++ b/libs/agno/tests/unit/db/test_in_memory_sessions.py
@@ -230,3 +230,68 @@ class TestMetricsHelpersOverSessions:
         db.upsert_session(_agent_session("s2", created_at=1000))
         starting_date = db._get_metrics_calculation_starting_date([])
         assert starting_date == datetime.fromtimestamp(1000, tz=timezone.utc).date()
+
+
+class TestSessionRowAndRuns:
+    """The session row is serialized without runs; the stored runs list is
+    maintained incrementally by upsert_run. Saving the session row must
+    neither drop those runs nor re-serialize them on every save."""
+
+    def test_update_preserves_runs_written_by_upsert_run(self):
+        db = InMemoryDb()
+        db.upsert_session(_agent_session("s1"))
+        db.upsert_run({"run_id": "r1", "content": "one"}, session_id="s1")
+        db.upsert_run({"run_id": "r2", "content": "two"}, session_id="s1")
+
+        # A later session-row update must carry the stored runs forward
+        db.upsert_session(_agent_session("s1"))
+
+        raw = db.get_session("s1", deserialize=False)
+        assert [r["run_id"] for r in raw["runs"]] == ["r1", "r2"]
+
+    def test_update_ignores_stale_runs_on_the_incoming_session(self):
+        from agno.run.agent import RunOutput
+
+        db = InMemoryDb()
+        db.upsert_session(_agent_session("s1"))
+        db.upsert_run({"run_id": "r1", "content": "stored"}, session_id="s1")
+
+        stale = _agent_session("s1")
+        stale.runs = [RunOutput(run_id="stale-run", content="should not land")]
+        db.upsert_session(stale)
+
+        raw = db.get_session("s1", deserialize=False)
+        assert [r["run_id"] for r in raw["runs"]] == ["r1"]
+
+    def test_insert_serializes_incoming_runs(self):
+        from agno.run.agent import RunOutput
+
+        db = InMemoryDb()
+        session = _agent_session("s1")
+        session.runs = [RunOutput(run_id="r1", agent_id="a1", content="imported")]
+        db.upsert_session(session)
+
+        raw = db.get_session("s1", deserialize=False)
+        assert raw["runs"][0]["run_id"] == "r1"
+
+        roundtrip = db.get_session("s1", session_type=SessionType.AGENT)
+        assert roundtrip.runs and roundtrip.runs[0].run_id == "r1"
+
+    def test_upsert_return_carries_stored_runs(self):
+        db = InMemoryDb()
+        db.upsert_session(_agent_session("s1"))
+        db.upsert_run({"run_id": "r1", "content": "one"}, session_id="s1")
+
+        result = db.upsert_session(_agent_session("s1"), deserialize=False)
+        assert [r["run_id"] for r in result["runs"]] == ["r1"]
+
+    def test_stored_runs_are_isolated_from_the_returned_copy(self):
+        db = InMemoryDb()
+        db.upsert_session(_agent_session("s1"))
+        db.upsert_run({"run_id": "r1", "content": "one"}, session_id="s1")
+
+        result = db.upsert_session(_agent_session("s1"), deserialize=False)
+        result["runs"][0]["content"] = "mutated by caller"
+
+        raw = db.get_session("s1", deserialize=False)
+        assert raw["runs"][0]["content"] == "one"

--- a/libs/agno/tests/unit/models/anthropic/test_format_messages_merge.py
+++ b/libs/agno/tests/unit/models/anthropic/test_format_messages_merge.py
@@ -1,0 +1,69 @@
+"""The same-role merge in format_messages must never mutate message content.
+
+A list-shaped Message.content can be aliased into the chat payload, and the
+message itself can be live session history. Merging consecutive same-role
+messages must build a new content list; extending the existing one in place
+corrupts the session message and compounds on every subsequent request.
+"""
+
+import pytest
+
+pytest.importorskip("anthropic")
+
+from agno.models.message import Message
+from agno.utils.models.claude import format_messages
+
+
+def test_merge_list_then_str_does_not_mutate_original():
+    first = Message(role="user", content=[{"type": "text", "text": "FIRST"}])
+    second = Message(role="user", content="SECOND")
+    original_list = first.content
+
+    chat_messages, _ = format_messages([first, second])
+
+    assert chat_messages == [
+        {"role": "user", "content": [{"type": "text", "text": "FIRST"}, {"type": "text", "text": "SECOND"}]}
+    ]
+    assert first.content is original_list
+    assert original_list == [{"type": "text", "text": "FIRST"}]
+
+
+def test_merge_str_then_list_does_not_mutate_original():
+    first = Message(role="user", content="FIRST")
+    second = Message(role="user", content=[{"type": "text", "text": "SECOND"}])
+    original_list = second.content
+
+    chat_messages, _ = format_messages([first, second])
+
+    assert chat_messages == [
+        {"role": "user", "content": [{"type": "text", "text": "FIRST"}, {"type": "text", "text": "SECOND"}]}
+    ]
+    assert second.content is original_list
+    assert original_list == [{"type": "text", "text": "SECOND"}]
+
+
+def test_merge_list_then_list_does_not_mutate_either():
+    first = Message(role="user", content=[{"type": "text", "text": "FIRST"}])
+    second = Message(role="user", content=[{"type": "text", "text": "SECOND"}])
+
+    chat_messages, _ = format_messages([first, second])
+
+    assert chat_messages == [
+        {"role": "user", "content": [{"type": "text", "text": "FIRST"}, {"type": "text", "text": "SECOND"}]}
+    ]
+    assert first.content == [{"type": "text", "text": "FIRST"}]
+    assert second.content == [{"type": "text", "text": "SECOND"}]
+
+
+def test_repeated_formatting_is_stable():
+    # The old in-place merge grew the first message's list on every call,
+    # duplicating blocks on each subsequent request.
+    first = Message(role="user", content=[{"type": "text", "text": "FIRST"}])
+    second = Message(role="user", content=[{"type": "text", "text": "SECOND"}])
+
+    for _ in range(3):
+        chat_messages, _ = format_messages([first, second])
+        assert chat_messages[0]["content"] == [
+            {"type": "text", "text": "FIRST"},
+            {"type": "text", "text": "SECOND"},
+        ]

--- a/libs/agno/tests/unit/workflow/test_workflow_agent_background.py
+++ b/libs/agno/tests/unit/workflow/test_workflow_agent_background.py
@@ -27,22 +27,22 @@ class TestWorkflowAgentBackgroundSingleRun:
 
         async def fake_execute(user_input=None, execution_input=None, run_context=None, stream=False, **kw):
             observed["run_id"] = run_context.run_id
-            # The real path persists the run under the caller's id (9258)
+            # The real path persists the run under the caller's id (9258),
+            # pairing the session-row save with a per-run write
             from agno.run.workflow import WorkflowRunOutput
 
             session, _ = await wf._aload_or_create_session(
                 session_id=run_context.session_id, user_id=None, session_state=None
             )
-            session.upsert_run(
-                run=WorkflowRunOutput(
-                    run_id=run_context.run_id,
-                    session_id=run_context.session_id,
-                    workflow_id=wf.id,
-                    status=RunStatus.completed,
-                    content="done",
-                )
+            run = WorkflowRunOutput(
+                run_id=run_context.run_id,
+                session_id=run_context.session_id,
+                workflow_id=wf.id,
+                status=RunStatus.completed,
+                content="done",
             )
-            wf.save_session(session=session)
+            session.upsert_run(run=run)
+            await wf._apersist_session_and_run(session=session, run=run)
             from types import SimpleNamespace
 
             return SimpleNamespace(run_id=run_context.run_id, status=RunStatus.completed)


### PR DESCRIPTION
## Summary

Two performance fixes for long conversations, plus one real bug the adversarial review of this change surfaced in the Anthropic request builder. Both perf fixes target per-turn costs that grow with conversation length, which compound quadratically over a session.

**1. History messages: copy-on-write instead of deepcopy**

Every turn, each history message loaded into context was `deepcopy`ed before being tagged `from_history=True` (~11us per message per turn). A new shared helper, `copy_history_message` (`utils/message.py`), now takes a pydantic `model_copy(update={"from_history": True})` — downstream consumers (tool-call filtering, compression, scrubbing, provider formatting) rebind attributes on the copy rather than mutating nested state, so the session's cached messages stay untouched. Two shapes keep the deep copy because their nested state can be written in place downstream: media-carrying messages (the media-offload refresh writes URLs and bytes into the media objects) and messages with list-shaped content (provider request builders can alias the list). All seven history-tagging sites now go through the one helper: agent `get_run_messages`/`aget_run_messages`/continue-run, team sync/async run messages, team continue-run, and team member-history delegation.

**2. InMemoryDb: stop re-serializing every run on every session save**

`upsert_session` serialized the session with `include_runs=True`, so each save re-serialized the entire runs list — O(session length) per turn. The runs list on the stored row is already maintained incrementally by `upsert_run`, so the session row is now serialized with `include_runs=False` (verified: every other adapter already does this) and the stored runs list is carried forward on update. On first insert, incoming `session.runs` are serialized once (covers bulk import/restore callers that never call `upsert_run`).

Also hardens `upsert_run` against a pre-existing crash: a session stored with no runs holds `"runs": None`, and a direct `upsert_run` then died on `'NoneType' object is not iterable` (reproducible on the base branch via the public API).

**3. Anthropic same-role merge corrupted aliased content lists (found by this PR's review, fix included)**

`format_messages`' consecutive-same-role merge extended the previous message's list-shaped `content` **in place**. That list can be the same object as a live `Message.content` — with the shallow history copies it was session history itself, and the executed repro showed run 2's text spliced into run 1's stored message, compounding every turn and reaching both persistence and every subsequent request. The pre-existing exposure (current-run messages with list content) was already reachable before this PR. The merge now always builds a new list; semantics were verified equivalent across 151 executed input combinations and are pinned by tests.

The verification pass on that fix found the same aliasing defect in the user branch: image/file blocks were appended into the live `Message.content` list, duplicating base64 media blocks on every model round of a run and persisting provider blocks into the message (executed repro). The append now goes to a copy.

## Measured effect

25-turn conversation with `add_history_to_context=True`, `num_history_runs=30`, mock model (framework overhead only), median of 10:

| Scenario | Before | After | LangGraph reference |
|---|---|---|---|
| InMemoryDb (default) | 38.6 ms | **~22 ms** | 23.7 ms (InMemorySaver) |
| InMemoryDb + `cache_session=True` | 31.1 ms | **~13 ms** | 23.7 ms (InMemorySaver) |
| SqliteDb (durable) | 60.3 ms | ~51 ms | 38.8 ms (SqliteSaver) |

The two in-memory rows flip from losses to wins in the cross-framework 25-turn benchmark (`cookbook/performance`, PR #9694). The durable row improves but still trails; the SQL adapter write path is a separate follow-up.

## Behavioral notes

- Direct `InMemoryDb` API users: during a session-row **update**, `upsert_session` no longer overwrites the stored runs list with whatever the incoming session object carries — `upsert_run`/`delete_run` are the write path for runs (matching the SQL adapters). First insert still serializes the incoming session's runs.
- Tool-hook authors: `run_context.messages` history entries are now shallow copies. Rebinding attributes on them is safe (as all in-tree consumers do); mutating nested state in place (`msg.tool_calls[i][...] = x`) would now reach the cached session where the old deepcopy isolated it.

## Verification

- Three independent adversarial review agents (shallow-copy mutation hunt across every downstream consumer, InMemoryDb caller sweep, sibling-surface sweep over all 7 tagging sites and all 17 db adapters), plus a fourth verifying the fix-delta. The mutation hunt is what found the Anthropic merge bug — confirmed by executed repro on sync Agent, async Agent, and Team, with a clean differential against the old deepcopy code; all repros re-run clean after the fix.
- New tests: `tests/unit/db/test_in_memory_sessions.py` (runs preserved across session-row updates, stale incoming runs ignored, insert serializes runs, returned copy isolated), `tests/unit/agent/test_history_copy_on_write.py` (cached messages not mutated by later runs' history tagging, media and list-content messages deep-copied, async variant), `tests/unit/models/anthropic/test_format_messages_merge.py` (merge builds new lists, all four type combinations, repeat-format stability). The anthropic tests were executed in an env with the SDK installed, not just skipped.
- Full db/agent/team/session unit suites: failure set identical to base (2,577 passed; 5 pre-existing environmental DynamoDB failures on both trees). `./scripts/format.sh` and mypy clean.
- Re-confirmed against the current `feat/v3.0` tip (this branch forked before #9695 and #9699 landed): the merge is clean, and the db/agent/team/workflow/session unit failure set on the merged tree is identical to the tip alone (3,142 vs 3,132 passed, same 7 failures and 9 collection errors, all pre-existing or missing optional drivers).
- Each new test file was also executed against the pre-fix code to confirm it pins the fix rather than describing it: 3 of the 4 anthropic merge tests, 5 of the InMemoryDb tests and 2 of the copy-on-write tests fail there.
- Stored-session differential probes, before vs after, are byte-identical: team delegation with member runs (member runs still get their own `upsert_run` write), a multi-turn agent, and a 5-turn `cache_session=True` conversation with tool calls and `max_tool_calls_from_history` set. No `from_history` tag leaks into the stored session.
- The measured effect was reproduced independently on a second run: 25 turns, InMemoryDb, 36.1 ms -> 19.2 ms.

Two coverage notes, neither introduced here:

- `tests/unit/models/anthropic/*` — including this PR's merge-corruption regression test — never runs in CI: the `dev` extra does not include `agno[anthropic]`, so every module in that directory `importorskip`s away. The four new tests were executed locally with the SDK installed and pass; adding `agno[anthropic]` to the dev extras is a separate change.
- The style-check job runs `ruff check` and mypy but not `ruff format --check`, so format drift cannot fail CI. The last commit here clears the five blank lines the removed `deepcopy` imports left behind.

## Type of change

- [x] Bug fix / performance improvement (non-breaking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

