### PR TITLE
fix: expire cancel-before-start intents in the in-memory cancellation manager

### DIFF
--- a/libs/agno/agno/run/cancellation_management/in_memory_cancellation_manager.py
+++ b/libs/agno/agno/run/cancellation_management/in_memory_cancellation_manager.py
@@ -2,7 +2,8 @@
 
 import asyncio
 import threading
-from typing import Dict, Set
+import time
+from typing import Dict, Optional, Set, Tuple
 
 from agno.exceptions import RunCancelledException
 from agno.run.cancellation_management.base import BaseRunCancellationManager
@@ -10,43 +11,91 @@ from agno.utils.log import logger
 
 
 class InMemoryRunCancellationManager(BaseRunCancellationManager):
-    def __init__(self):
-        self._cancelled_runs: Dict[str, bool] = {}
-        self._member_runs: Dict[str, Set[str]] = {}
+    """In-memory cancellation manager for single-process run cancellation.
+
+    Args:
+        ttl_seconds: TTL for entries in seconds. Defaults to 86400 (1 day).
+            Entries auto-expire to prevent unbounded growth: cancel_run stores
+            intent even for run ids that never start (cancel-before-start for
+            background runs), and only a completing run triggers cleanup_run,
+            so without a TTL each such id would occupy memory forever.
+            Set to None to disable expiration. Fixed at construction: the
+            expiry sweep relies on entries expiring in insertion order.
+    """
+
+    DEFAULT_TTL_SECONDS = 60 * 60 * 24  # 1 day, matching RedisRunCancellationManager
+
+    def __init__(self, ttl_seconds: Optional[float] = DEFAULT_TTL_SECONDS):
+        self.ttl_seconds = ttl_seconds
+        # Both dicts keep iteration order == expiry order: every write that
+        # grants a fresh TTL removes the key and re-appends it, and the TTL is
+        # a per-manager constant, so stored expiry times are non-decreasing in
+        # iteration order and _purge_expired only ever pops from the front.
+        self._cancelled_runs: Dict[str, Tuple[bool, float]] = {}
+        self._member_runs: Dict[str, Tuple[Set[str], float]] = {}
         self._lock = threading.Lock()
         self._async_lock = asyncio.Lock()
+        self._clock = time.monotonic
+
+    def _expires_at(self) -> float:
+        return float("inf") if self.ttl_seconds is None else self._clock() + self.ttl_seconds
+
+    def _purge_expired(self) -> None:
+        """Drop expired entries. Must be called with the relevant lock held."""
+        if self.ttl_seconds is None:
+            return
+        now = self._clock()
+        while self._cancelled_runs:
+            run_id = next(iter(self._cancelled_runs))
+            if self._cancelled_runs[run_id][1] > now:
+                break
+            del self._cancelled_runs[run_id]
+        while self._member_runs:
+            team_run_id = next(iter(self._member_runs))
+            if self._member_runs[team_run_id][1] > now:
+                break
+            del self._member_runs[team_run_id]
 
     def register_run(self, run_id: str) -> None:
         """Register a new run as not cancelled.
 
-        Uses setdefault to preserve any existing cancellation intent
-        (cancel-before-start support for background runs).
+        Only creates the entry if absent, preserving any existing cancellation
+        intent (cancel-before-start support for background runs). An existing
+        entry keeps its original TTL.
         """
         with self._lock:
-            self._cancelled_runs.setdefault(run_id, False)
+            self._purge_expired()
+            if run_id not in self._cancelled_runs:
+                self._cancelled_runs[run_id] = (False, self._expires_at())
 
     async def aregister_run(self, run_id: str) -> None:
         """Register a new run as not cancelled (async version).
 
-        Uses setdefault to preserve any existing cancellation intent
-        (cancel-before-start support for background runs).
+        Only creates the entry if absent, preserving any existing cancellation
+        intent (cancel-before-start support for background runs). An existing
+        entry keeps its original TTL.
         """
         async with self._async_lock:
-            self._cancelled_runs.setdefault(run_id, False)
+            self._purge_expired()
+            if run_id not in self._cancelled_runs:
+                self._cancelled_runs[run_id] = (False, self._expires_at())
 
     def cancel_run(self, run_id: str) -> bool:
         """Cancel a run by marking it as cancelled.
 
         Always stores cancellation intent, even for runs not yet registered
-        (cancel-before-start support for background runs).
+        (cancel-before-start support for background runs). The intent expires
+        after ttl_seconds, so ids that never start cannot accumulate forever.
 
         Returns:
             bool: True if run was previously registered, False if storing
             cancellation intent for an unregistered run.
         """
         with self._lock:
+            self._purge_expired()
             was_registered = run_id in self._cancelled_runs
-            self._cancelled_runs[run_id] = True
+            self._cancelled_runs.pop(run_id, None)
+            self._cancelled_runs[run_id] = (True, self._expires_at())
             if was_registered:
                 logger.info(f"Run {run_id} marked for cancellation")
             else:
@@ -57,15 +106,18 @@ class InMemoryRunCancellationManager(BaseRunCancellationManager):
         """Cancel a run by marking it as cancelled (async version).
 
         Always stores cancellation intent, even for runs not yet registered
-        (cancel-before-start support for background runs).
+        (cancel-before-start support for background runs). The intent expires
+        after ttl_seconds, so ids that never start cannot accumulate forever.
 
         Returns:
             bool: True if run was previously registered, False if storing
             cancellation intent for an unregistered run.
         """
         async with self._async_lock:
+            self._purge_expired()
             was_registered = run_id in self._cancelled_runs
-            self._cancelled_runs[run_id] = True
+            self._cancelled_runs.pop(run_id, None)
+            self._cancelled_runs[run_id] = (True, self._expires_at())
             if was_registered:
                 logger.info(f"Run {run_id} marked for cancellation")
             else:
@@ -75,24 +127,28 @@ class InMemoryRunCancellationManager(BaseRunCancellationManager):
     def is_cancelled(self, run_id: str) -> bool:
         """Check if a run is cancelled."""
         with self._lock:
-            return self._cancelled_runs.get(run_id, False)
+            self._purge_expired()
+            entry = self._cancelled_runs.get(run_id)
+            return entry[0] if entry is not None else False
 
     async def ais_cancelled(self, run_id: str) -> bool:
         """Check if a run is cancelled (async version)."""
         async with self._async_lock:
-            return self._cancelled_runs.get(run_id, False)
+            self._purge_expired()
+            entry = self._cancelled_runs.get(run_id)
+            return entry[0] if entry is not None else False
 
     def cleanup_run(self, run_id: str) -> None:
         """Remove a run from tracking (called when run completes)."""
         with self._lock:
-            if run_id in self._cancelled_runs:
-                del self._cancelled_runs[run_id]
+            self._purge_expired()
+            self._cancelled_runs.pop(run_id, None)
 
     async def acleanup_run(self, run_id: str) -> None:
         """Remove a run from tracking (called when run completes) (async version)."""
         async with self._async_lock:
-            if run_id in self._cancelled_runs:
-                del self._cancelled_runs[run_id]
+            self._purge_expired()
+            self._cancelled_runs.pop(run_id, None)
 
     def raise_if_cancelled(self, run_id: str) -> None:
         """Check if a run should be cancelled and raise exception if so."""
@@ -109,39 +165,59 @@ class InMemoryRunCancellationManager(BaseRunCancellationManager):
     def get_active_runs(self) -> Dict[str, bool]:
         """Get all currently tracked runs and their cancellation status."""
         with self._lock:
-            return self._cancelled_runs.copy()
+            self._purge_expired()
+            return {run_id: cancelled for run_id, (cancelled, _) in self._cancelled_runs.items()}
 
     async def aget_active_runs(self) -> Dict[str, bool]:
         """Get all currently tracked runs and their cancellation status (async version)."""
         async with self._async_lock:
-            return self._cancelled_runs.copy()
+            self._purge_expired()
+            return {run_id: cancelled for run_id, (cancelled, _) in self._cancelled_runs.items()}
 
     def register_member_run(self, team_run_id: str, member_run_id: str) -> None:
-        """Record that a member run belongs to a team run for cancel-cascade."""
+        """Record that a member run belongs to a team run for cancel-cascade.
+
+        Each registration refreshes the member set's TTL.
+        """
         with self._lock:
-            self._member_runs.setdefault(team_run_id, set()).add(member_run_id)
+            self._purge_expired()
+            members, _ = self._member_runs.pop(team_run_id, (set(), 0.0))
+            members.add(member_run_id)
+            self._member_runs[team_run_id] = (members, self._expires_at())
 
     async def aregister_member_run(self, team_run_id: str, member_run_id: str) -> None:
-        """Record that a member run belongs to a team run for cancel-cascade (async version)."""
+        """Record that a member run belongs to a team run for cancel-cascade (async version).
+
+        Each registration refreshes the member set's TTL.
+        """
         async with self._async_lock:
-            self._member_runs.setdefault(team_run_id, set()).add(member_run_id)
+            self._purge_expired()
+            members, _ = self._member_runs.pop(team_run_id, (set(), 0.0))
+            members.add(member_run_id)
+            self._member_runs[team_run_id] = (members, self._expires_at())
 
     def get_member_run_ids(self, team_run_id: str) -> Set[str]:
         """Return the in-flight member run_ids of a team run."""
         with self._lock:
-            return set(self._member_runs.get(team_run_id, set()))
+            self._purge_expired()
+            entry = self._member_runs.get(team_run_id)
+            return set(entry[0]) if entry is not None else set()
 
     async def aget_member_run_ids(self, team_run_id: str) -> Set[str]:
         """Return the in-flight member run_ids of a team run (async version)."""
         async with self._async_lock:
-            return set(self._member_runs.get(team_run_id, set()))
+            self._purge_expired()
+            entry = self._member_runs.get(team_run_id)
+            return set(entry[0]) if entry is not None else set()
 
     def cleanup_member_runs(self, team_run_id: str) -> None:
         """Drop a team run's member mapping when the team run finishes."""
         with self._lock:
+            self._purge_expired()
             self._member_runs.pop(team_run_id, None)
 
     async def acleanup_member_runs(self, team_run_id: str) -> None:
         """Drop a team run's member mapping when the team run finishes (async version)."""
         async with self._async_lock:
+            self._purge_expired()
             self._member_runs.pop(team_run_id, None)

--- a/libs/agno/tests/unit/run/test_cancellation_ttl.py
+++ b/libs/agno/tests/unit/run/test_cancellation_ttl.py
@@ -1,0 +1,196 @@
+"""TTL bounds on the in-memory cancellation manager.
+
+cancel_run stores intent even for run ids that never start
+(cancel-before-start), and only a completing run calls cleanup_run, so on a
+long-lived process the intent dict is only bounded by the TTL. These tests pin
+that bound and its parity with the Redis manager's TTL contract, so swapping
+managers does not change semantics.
+"""
+
+from agno.run.cancellation_management.in_memory_cancellation_manager import InMemoryRunCancellationManager
+from agno.run.cancellation_management.redis_cancellation_manager import RedisRunCancellationManager
+
+DAY = 60 * 60 * 24
+
+
+class FakeClock:
+    def __init__(self, now: float = 1000.0):
+        self.now = now
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def make_manager(ttl_seconds: float = DAY) -> tuple[InMemoryRunCancellationManager, FakeClock]:
+    manager = InMemoryRunCancellationManager(ttl_seconds=ttl_seconds)
+    clock = FakeClock()
+    manager._clock = clock
+    return manager, clock
+
+
+class TestTtlDefaults:
+    def test_default_ttl_matches_redis_manager(self):
+        assert InMemoryRunCancellationManager.DEFAULT_TTL_SECONDS == DAY
+        assert InMemoryRunCancellationManager.DEFAULT_TTL_SECONDS == RedisRunCancellationManager.DEFAULT_TTL_SECONDS
+        assert InMemoryRunCancellationManager().ttl_seconds == DAY
+
+    def test_ttl_none_disables_expiry(self):
+        manager = InMemoryRunCancellationManager(ttl_seconds=None)
+        clock = FakeClock()
+        manager._clock = clock
+        manager.cancel_run("run-1")
+        clock.advance(1000 * DAY)
+        assert manager.is_cancelled("run-1") is True
+
+
+class TestCancelBeforeStartWithTtl:
+    def test_intent_survives_within_ttl(self):
+        manager, clock = make_manager()
+        assert manager.cancel_run("future-run") is False
+        clock.advance(DAY - 1)
+        manager.register_run("future-run")
+        assert manager.is_cancelled("future-run") is True
+
+    def test_intent_expires_after_ttl(self):
+        manager, clock = make_manager()
+        manager.cancel_run("never-started")
+        clock.advance(DAY + 1)
+        assert manager.is_cancelled("never-started") is False
+        assert manager._cancelled_runs == {}
+
+    def test_reused_id_is_not_insta_cancelled_after_expiry(self):
+        """A legitimate run that reuses an id after the intent expired runs normally."""
+        manager, clock = make_manager()
+        manager.cancel_run("reused-id")
+        clock.advance(DAY + 1)
+        manager.register_run("reused-id")
+        assert manager.is_cancelled("reused-id") is False
+
+    def test_expired_intents_are_purged_on_unrelated_access(self):
+        """The dict stays bounded even when the stale ids are never queried again."""
+        manager, clock = make_manager()
+        for i in range(50):
+            manager.cancel_run(f"junk-{i}")
+        clock.advance(DAY + 1)
+        manager.cancel_run("fresh")
+        assert set(manager._cancelled_runs) == {"fresh"}
+
+
+class TestTtlRefreshParity:
+    def test_cancel_refreshes_ttl(self):
+        manager, clock = make_manager()
+        manager.cancel_run("run-1")
+        clock.advance(0.9 * DAY)
+        assert manager.cancel_run("run-1") is True
+        clock.advance(0.9 * DAY)
+        assert manager.is_cancelled("run-1") is True
+
+    def test_register_does_not_refresh_ttl(self):
+        manager, clock = make_manager()
+        manager.register_run("run-1")
+        clock.advance(0.5 * DAY)
+        manager.register_run("run-1")
+        clock.advance(0.6 * DAY)
+        assert "run-1" not in manager.get_active_runs()
+
+    def test_register_does_not_extend_cancel_intent(self):
+        manager, clock = make_manager()
+        manager.cancel_run("run-1")
+        clock.advance(0.9 * DAY)
+        manager.register_run("run-1")
+        clock.advance(0.2 * DAY)
+        assert manager.is_cancelled("run-1") is False
+
+    def test_registered_run_expiry_fails_open(self):
+        """A run older than the TTL is not spuriously cancelled, and a cancel
+        after expiry reports unregistered but still stores intent."""
+        manager, clock = make_manager()
+        manager.register_run("long-run")
+        clock.advance(DAY + 1)
+        assert manager.is_cancelled("long-run") is False
+        assert manager.cancel_run("long-run") is False
+        assert manager.is_cancelled("long-run") is True
+
+    def test_refresh_does_not_shield_older_siblings_from_purge(self):
+        """A refreshed entry must move behind its unexpired peers, or the
+        front-of-dict purge would stop at it and never reach expired ones."""
+        manager, clock = make_manager()
+        manager.cancel_run("refreshed")
+        clock.advance(0.1 * DAY)
+        manager.cancel_run("stale")
+        clock.advance(0.4 * DAY)
+        manager.cancel_run("refreshed")
+        clock.advance(0.7 * DAY)
+        assert manager.get_active_runs() == {"refreshed": True}
+        assert "stale" not in manager._cancelled_runs
+
+    def test_member_refresh_does_not_shield_older_teams_from_purge(self):
+        manager, clock = make_manager()
+        manager.register_member_run("team-refreshed", "member-1")
+        clock.advance(0.1 * DAY)
+        manager.register_member_run("team-stale", "member-2")
+        clock.advance(0.4 * DAY)
+        manager.register_member_run("team-refreshed", "member-3")
+        clock.advance(0.7 * DAY)
+        assert manager.get_member_run_ids("team-refreshed") == {"member-1", "member-3"}
+        assert "team-stale" not in manager._member_runs
+
+    def test_purge_preserves_unexpired_entries(self):
+        manager, clock = make_manager()
+        manager.cancel_run("old")
+        clock.advance(0.5 * DAY)
+        manager.register_run("mid")
+        clock.advance(0.3 * DAY)
+        manager.cancel_run("new")
+        clock.advance(0.3 * DAY)
+        assert manager.get_active_runs() == {"mid": False, "new": True}
+
+
+class TestMemberRunTtl:
+    def test_member_runs_expire(self):
+        manager, clock = make_manager()
+        manager.register_member_run("team-run", "member-1")
+        clock.advance(DAY + 1)
+        assert manager.get_member_run_ids("team-run") == set()
+        assert manager._member_runs == {}
+
+    def test_member_registration_refreshes_ttl(self):
+        manager, clock = make_manager()
+        manager.register_member_run("team-run", "member-1")
+        clock.advance(0.9 * DAY)
+        manager.register_member_run("team-run", "member-2")
+        clock.advance(0.6 * DAY)
+        assert manager.get_member_run_ids("team-run") == {"member-1", "member-2"}
+        clock.advance(0.5 * DAY)
+        assert manager.get_member_run_ids("team-run") == set()
+
+
+class TestAsyncVariants:
+    async def test_async_cancel_before_start_expires(self):
+        manager, clock = make_manager()
+        assert await manager.acancel_run("future-run") is False
+        await manager.aregister_run("future-run")
+        assert await manager.ais_cancelled("future-run") is True
+        clock.advance(DAY + 1)
+        assert await manager.ais_cancelled("future-run") is False
+        assert manager._cancelled_runs == {}
+
+    async def test_async_cancel_refreshes_and_register_does_not(self):
+        manager, clock = make_manager()
+        await manager.acancel_run("cancelled")
+        await manager.aregister_run("registered")
+        clock.advance(0.9 * DAY)
+        assert await manager.acancel_run("cancelled") is True
+        await manager.aregister_run("registered")
+        clock.advance(0.9 * DAY)
+        assert await manager.aget_active_runs() == {"cancelled": True}
+
+    async def test_async_member_runs_expire(self):
+        manager, clock = make_manager()
+        await manager.aregister_member_run("team-run", "member-1")
+        clock.advance(DAY + 1)
+        assert await manager.aget_member_run_ids("team-run") == set()
+        assert manager._member_runs == {}


### PR DESCRIPTION
## Summary

`InMemoryRunCancellationManager` stored cancel-before-start intent forever. `cancel_run()`/`acancel_run()` insert into `_cancelled_runs` even for run ids that were never registered (deliberate: background runs may be cancelled before they start), and only `cleanup_run()` — called when a run actually completes — removes an entry. A run that never starts therefore left a permanent entry. Since the REST cancel routes answer 200 for arbitrary run ids, any authenticated caller could grow the dict without bound on a long-lived AgentOS process, and a later legitimate run that happened to reuse the id started insta-cancelled.

`RedisRunCancellationManager` already solves this with `DEFAULT_TTL_SECONDS` = 1 day on every key ("Keys auto-expire to prevent orphaned keys if runs aren't cleaned up"). This PR gives the in-memory manager the same TTL contract:

- `ttl_seconds` constructor arg, default 86400 (shared 1-day default is pinned equal to the Redis manager's by a test); `None` disables expiry.
- Refresh semantics mirror Redis exactly: `register_run` creates with a TTL only when absent and never refreshes an existing entry (`SET NX EX`), `cancel_run` always refreshes (`SET EX`), `register_member_run` refreshes the member set (`SADD` + `EXPIRE`), reads never refresh, and an expired entry reads as absent — so a run older than the TTL fails open (not spuriously cancelled) and a fresh cancel still stores intent.
- Expiry is lazy with amortized O(1) cost: every TTL-granting write removes and re-appends its key, and the TTL is a per-manager constant, so dict iteration order equals expiry order and each access only pops expired entries from the front. No per-access full sweep, so the purge itself cannot be turned into a CPU sink.
- Cancel-before-start semantics are intact: intent stored for unregistered ids, `register_run` preserves it, `was_registered` return values unchanged. Both sync and async variants behave identically.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Testing.** New `tests/unit/run/test_cancellation_ttl.py` (18 tests, sync + async) drives a fake clock through the TTL contract: intent survives within the TTL and expires after it, a reused id is not insta-cancelled once the intent expires, expired intents are purged on unrelated accesses (the boundedness pin), cancel refreshes while register does not, a refreshed entry cannot shield older expired siblings from the front-of-dict purge, member sets expire and refresh, and `ttl_seconds=None` disables expiry. All pre-existing pins pass unchanged: `tests/unit/run/`, `tests/unit/agent/test_background_execution.py`, `tests/unit/team/test_background_execution.py`, `tests/unit/agent/test_run_regressions.py`, `tests/unit/os/test_rehydration_http_status.py`, `tests/unit/os/test_queue_wiring.py`.

**Mutation check.** Six hand-written mutations (skip purge in cancel, register refreshes TTL, cancel without move-to-end, member refresh without move-to-end, purge pops only one entry, doubled expiry) were each executed against the suite; all six are killed.

**Not changed.** `get_active_runs()` still returns `Dict[str, bool]`; `BaseRunCancellationManager` is untouched; the Redis manager is untouched. A team run living longer than the TTL loses its member mapping for cancel-cascade — identical to the Redis manager's existing behavior, and each member registration refreshes the set's TTL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
