### PR TITLE
test: isolate global run-cancellation state between unit tests

### DIFF
--- a/libs/agno/tests/unit/conftest.py
+++ b/libs/agno/tests/unit/conftest.py
@@ -1,0 +1,31 @@
+"""Shared isolation for the unit suite."""
+
+import pytest
+
+import agno.run.cancel as cancel_module
+from agno.run.cancellation_management.in_memory_cancellation_manager import InMemoryRunCancellationManager
+
+
+@pytest.fixture(autouse=True)
+def isolate_run_cancellation_state():
+    """Reset the process-global run-cancellation registry after every test.
+
+    cancel_run() records cancel-before-start intent for run_ids it has never
+    seen, and only a completed run's cleanup purges an entry. A test that
+    cancels a run_id which never executes (e.g. POST .../runs/r1/cancel) would
+    otherwise poison every later test that reuses that run_id: the later run is
+    insta-cancelled instead of executing.
+
+    Restores the manager and its explicitly-set flag directly rather than via
+    set_cancellation_manager(), which would force the flag to True.
+    """
+    original_manager = cancel_module._cancellation_manager
+    original_explicitly_set = cancel_module._cancellation_manager_explicitly_set
+    yield
+    cancel_module._cancellation_manager = original_manager
+    cancel_module._cancellation_manager_explicitly_set = original_explicitly_set
+    cancel_module._member_drain_tasks.clear()
+    if isinstance(original_manager, InMemoryRunCancellationManager):
+        with original_manager._lock:
+            original_manager._cancelled_runs.clear()
+            original_manager._member_runs.clear()


### PR DESCRIPTION
## Summary

Fixes an order-dependent unit-test failure: `tests/unit/workflow/test_stream_error_persist.py::TestStreamingWorkflowErrorPersist::test_sync_multistep_stream_error_persists_error_run` passes in isolation but fails (`DID NOT RAISE RuntimeError`) when the `tests/unit/os` suite runs first.

**Root cause.** The run-cancellation registry is process-global (`agno.run.cancel`), and `cancel_run()` deliberately records cancel-before-start intent for run_ids it has never seen; only a completed run's cleanup purges an entry. Two tests in `tests/unit/os/test_rehydration_http_status.py` (`test_cancel_of_a_broken_component_is_not_blocked` and `test_broken_workflow_stays_listed_cancellable_and_distinguishable`) POST `.../runs/r1/cancel` against components where run `r1` never executes, so the intent for `"r1"` survives for the rest of the process. Any later test that reuses run_id `"r1"` is then cancelled the moment it starts — the workflow error-persist test takes the cancelled branch ("Workflow run r1 was cancelled during streaming") instead of raising the orchestration error it asserts on. Either culprit reproduces the failure on its own in a two-test run.

**Fix.** A new `tests/unit/conftest.py` with one autouse fixture that resets the global cancellation state after every unit test: it restores `_cancellation_manager` and `_cancellation_manager_explicitly_set` directly (calling `set_cancellation_manager()` for the restore would force the explicitly-set flag to True — the per-file reset fixtures in the agent/team/run background-execution tests have exactly that side effect, which this conftest also neutralizes), clears `_member_drain_tasks`, and empties the in-memory manager's `_cancelled_runs` / `_member_runs`. The save/restore pattern is lifted from the fixture `tests/unit/os/test_queue_wiring.py` already used locally.

Related: #9701 bounds the production-side twin of this leak (unbounded in-memory intent retention) with a TTL; this PR is the test-isolation side and is still needed independently of it.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Verification on `feat/v3.0` (794e8a546):

- Repro command (`pytest tests/unit/os tests/unit/utils tests/unit/remote tests/unit/workflow`, missing-extras files excluded): **1 failed / 3606 passed before → 0 failed / 3607 passed after**.
- Bisected the leak to the two rehydration tests; each reproduces the failure independently when run directly before the workflow test.
- The remaining 27 `tests/unit` directories were run with and without the new conftest: the failed-test sets are byte-identical (all pre-existing missing-extras/service failures in the dev environment), so the fixture changes no other test's outcome. The agent/team/run suites, whose files carry their own manager-swapping fixtures, pass unchanged (1596 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
