### PR TITLE
fix: enforce non-SQL schema version checks

### DIFF
--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -1,10 +1,14 @@
 import asyncio
 import threading
 from abc import ABC, abstractmethod
+from contextlib import contextmanager
+from contextvars import ContextVar
 from datetime import date, datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Literal, Optional, Set, Tuple, Union
 from uuid import uuid4
+
+from packaging import version as packaging_version
 
 if TYPE_CHECKING:
     from agno.tracing.schemas import Span, Trace
@@ -12,12 +16,25 @@ if TYPE_CHECKING:
 from agno.db.schemas import UserMemory
 from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
+from agno.db.utils import MIGRATABLE_TABLE_TYPES, table_schema_mismatch_error
 from agno.run.agent import RunOutput
 from agno.run.base import RunStatus
 from agno.run.team import TeamRunOutput
 from agno.run.workflow import WorkflowRunOutput
 from agno.session import Session
 from agno.utils.log import log_debug
+
+_schema_version_checks_suspended: ContextVar[bool] = ContextVar("schema_version_checks_suspended", default=False)
+
+
+@contextmanager
+def suspend_schema_version_checks() -> Iterator[None]:
+    """Let migrations use stale tables while they bring them up to date."""
+    token = _schema_version_checks_suspended.set(True)
+    try:
+        yield
+    finally:
+        _schema_version_checks_suspended.reset(token)
 
 
 class SessionType(str, Enum):
@@ -335,6 +352,7 @@ class BaseDb(ABC):
         # Avoids re-running the existence check and schema validation on
         # every query; see TableResolutionCache.
         self._table_cache = TableResolutionCache()
+        self._schema_versions_checked: Set[Tuple[str, str]] = set()
         # Serializes table resolution: concurrent reflection into the shared
         # metadata can expose a half-built Table to other threads. Reentrant
         # because resolving a table may resolve its FK parents.
@@ -377,7 +395,52 @@ class BaseDb(ABC):
     def _store_resolved_table(self, table_type: str, table_name: str, table: Any) -> None:
         self._table_cache.store(table_type, table_name, table, getattr(self, "metadata", None))
 
+    def _validate_schema_version(self, table_name: str, table_type: str) -> None:
+        """Fail closed when a migratable table is behind this Agno release.
+
+        Successful checks are cached per logical/physical table pair. Stale and
+        failed checks are deliberately not cached so a migration performed by
+        this or another process can make a later access succeed.
+        """
+        if _schema_version_checks_suspended.get() or table_type not in MIGRATABLE_TABLE_TYPES:
+            return
+
+        cache_key = (table_type, table_name)
+        if cache_key in self._schema_versions_checked:
+            return
+
+        with self._resolve_lock:
+            if cache_key in self._schema_versions_checked:
+                return
+
+            from agno.db.migrations.manager import MigrationManager
+
+            current_version = packaging_version.parse(
+                self.get_latest_schema_version(table_name) or self.default_schema_version
+            )
+            latest_version = MigrationManager(self).latest_schema_version
+            if current_version < latest_version:
+                raise table_schema_mismatch_error(table_name, table_type)
+            self._schema_versions_checked.add(cache_key)
+
+    def _stamp_schema_version(self, table_name: str, table_type: str) -> None:
+        """Stamp a newly created migratable table and cache only on success."""
+        if table_type not in MIGRATABLE_TABLE_TYPES:
+            return
+
+        from agno.db.migrations.manager import MigrationManager
+
+        cache_key = (table_type, table_name)
+        with self._resolve_lock:
+            self.upsert_schema_version(table_name, MigrationManager(self).latest_schema_version.public)
+            self._schema_versions_checked.add(cache_key)
+
+    def _invalidate_schema_version_check(self, table_name: str) -> None:
+        stale_keys = {cache_key for cache_key in self._schema_versions_checked if cache_key[1] == table_name}
+        self._schema_versions_checked.difference_update(stale_keys)
+
     def _invalidate_table_cache(self, table_name: str) -> None:
+        self._invalidate_schema_version_check(table_name)
         self._table_cache.invalidate(table_name, getattr(self, "metadata", None))
 
     def _fk_dependencies(self, table_type: str) -> List[Tuple[str, str]]:
@@ -2113,6 +2176,7 @@ class AsyncBaseDb(ABC):
 
         # See BaseDb._table_cache: same contract for async adapters.
         self._table_cache = TableResolutionCache()
+        self._schema_versions_checked: Set[Tuple[str, str]] = set()
         # See BaseDb._resolve_lock: task-reentrant, because resolving a table
         # may resolve FK parents and stamp the versions table.
         self._resolve_lock_async = _ReentrantAsyncLock()
@@ -2151,7 +2215,47 @@ class AsyncBaseDb(ABC):
     def _store_resolved_table(self, table_type: str, table_name: str, table: Any) -> None:
         self._table_cache.store(table_type, table_name, table, getattr(self, "metadata", None))
 
+    async def _validate_schema_version(self, table_name: str, table_type: str) -> None:
+        """Async twin of ``BaseDb._validate_schema_version``."""
+        if _schema_version_checks_suspended.get() or table_type not in MIGRATABLE_TABLE_TYPES:
+            return
+
+        cache_key = (table_type, table_name)
+        if cache_key in self._schema_versions_checked:
+            return
+
+        async with self._resolve_lock_async:
+            if cache_key in self._schema_versions_checked:
+                return
+
+            from agno.db.migrations.manager import MigrationManager
+
+            current_version = packaging_version.parse(
+                await self.get_latest_schema_version(table_name) or BaseDb.default_schema_version
+            )
+            latest_version = MigrationManager(self).latest_schema_version
+            if current_version < latest_version:
+                raise table_schema_mismatch_error(table_name, table_type)
+            self._schema_versions_checked.add(cache_key)
+
+    async def _stamp_schema_version(self, table_name: str, table_type: str) -> None:
+        """Async twin of ``BaseDb._stamp_schema_version``."""
+        if table_type not in MIGRATABLE_TABLE_TYPES:
+            return
+
+        from agno.db.migrations.manager import MigrationManager
+
+        cache_key = (table_type, table_name)
+        async with self._resolve_lock_async:
+            await self.upsert_schema_version(table_name, MigrationManager(self).latest_schema_version.public)
+            self._schema_versions_checked.add(cache_key)
+
+    def _invalidate_schema_version_check(self, table_name: str) -> None:
+        stale_keys = {cache_key for cache_key in self._schema_versions_checked if cache_key[1] == table_name}
+        self._schema_versions_checked.difference_update(stale_keys)
+
     def _invalidate_table_cache(self, table_name: str) -> None:
+        self._invalidate_schema_version_check(table_name)
         self._table_cache.invalidate(table_name, getattr(self, "metadata", None))
 
     def _fk_dependencies(self, table_type: str) -> List[Tuple[str, str]]:

--- a/libs/agno/agno/db/dynamo/dynamo.py
+++ b/libs/agno/agno/db/dynamo/dynamo.py
@@ -157,11 +157,8 @@ class DynamoDb(BaseDb):
             ("knowledge", self.knowledge_table_name),
         ]
 
-        for table_type, table_name in tables_to_create:
-            if not self.table_exists(table_name):
-                schema = get_table_schema_definition(table_type)
-                schema["TableName"] = table_name
-                create_table_if_not_exists(self.client, table_name, schema)
+        for table_type, _ in tables_to_create:
+            self._get_table(table_type, create_table_if_not_found=True)
 
     def _get_table(self, table_type: str, create_table_if_not_found: Optional[bool] = True) -> Optional[str]:
         """
@@ -199,11 +196,18 @@ class DynamoDb(BaseDb):
         else:
             raise ValueError(f"Unknown table type: {table_type}")
 
-        # Check if table exists, create if it doesn't
-        if not self.table_exists(table_name) and create_table_if_not_found:
-            schema = get_table_schema_definition(table_type)
-            schema["TableName"] = table_name
-            create_table_if_not_exists(self.client, table_name, schema)
+        with self._resolve_lock:
+            if self.table_exists(table_name):
+                self._validate_schema_version(table_name, table_type)
+            elif create_table_if_not_found:
+                schema = get_table_schema_definition(table_type)
+                schema["TableName"] = table_name
+                created = create_table_if_not_exists(self.client, table_name, schema)
+                if created:
+                    self._stamp_schema_version(table_name, table_type)
+                else:
+                    # A peer won the create race; only that peer may stamp.
+                    self._validate_schema_version(table_name, table_type)
 
         return table_name
 
@@ -221,11 +225,15 @@ class DynamoDb(BaseDb):
         Defaults to "2.0.0" when nothing is stamped so the MigrationManager
         runs migrations instead of skipping the table.
         """
-        self._ensure_schema_versions_table()
-        response = self.client.get_item(
-            TableName=self.versions_table_name,
-            Key={"table_name": {"S": table_name}},
-        )
+        if not self.table_exists(self.versions_table_name):
+            return "2.0.0"
+        try:
+            response = self.client.get_item(
+                TableName=self.versions_table_name,
+                Key={"table_name": {"S": table_name}},
+            )
+        except self.client.exceptions.ResourceNotFoundException:
+            return "2.0.0"
         item = response.get("Item")
         if not item:
             return "2.0.0"
@@ -242,6 +250,7 @@ class DynamoDb(BaseDb):
                 "updated_at": {"N": str(int(time.time()))},
             },
         )
+        self._invalidate_schema_version_check(table_name)
 
     # --- Runs ---
 

--- a/libs/agno/agno/db/dynamo/utils.py
+++ b/libs/agno/agno/db/dynamo/utils.py
@@ -183,26 +183,33 @@ def deserialize_eval_record(item: Dict[str, Any]) -> EvalRunRecord:
 
 
 def create_table_if_not_exists(dynamodb_client, table_name: str, schema: Dict[str, Any]) -> bool:
-    """Create DynamoDB table if it doesn't exist."""
+    """Create a table and report whether this caller created it.
+
+    A concurrent creator is treated as an existing table. Other creation
+    failures propagate; callers must never continue with a half-created table.
+    """
     try:
         dynamodb_client.describe_table(TableName=table_name)
-        return True
+        return False
 
     except dynamodb_client.exceptions.ResourceNotFoundException:
         log_info(f"Creating table {table_name}")
         try:
             dynamodb_client.create_table(**schema)
-            # Wait for table to be created
-            waiter = dynamodb_client.get_waiter("table_exists")
-            waiter.wait(TableName=table_name)
-
-            log_debug(f"Table {table_name} created successfully")
-
-            return True
-
         except Exception as e:
-            log_error(f"Failed to create table {table_name}: {str(e)}")
-            return False
+            error_code = getattr(e, "response", {}).get("Error", {}).get("Code")
+            if error_code != "ResourceInUseException":
+                log_error(f"Failed to create table {table_name}: {str(e)}")
+                raise
+            created = False
+        else:
+            created = True
+
+        waiter = dynamodb_client.get_waiter("table_exists")
+        waiter.wait(TableName=table_name)
+        if created:
+            log_debug(f"Table {table_name} created successfully")
+        return created
 
 
 def apply_pagination(

--- a/libs/agno/agno/db/firestore/firestore.py
+++ b/libs/agno/agno/db/firestore/firestore.py
@@ -21,6 +21,7 @@ from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.schemas.memory import UserMemory
 from agno.db.utils import (
+    MIGRATABLE_TABLE_TYPES,
     build_single_run_row,
     deserialize_run,
     deserialize_session,
@@ -45,6 +46,13 @@ except ImportError:
     raise ImportError(
         "`google-cloud-firestore` not installed. Please install it using `pip install google-cloud-firestore`"
     )
+
+try:
+    from google.api_core.exceptions import AlreadyExists  # type: ignore[import-untyped]
+except ImportError:
+
+    class AlreadyExists(Exception):  # type: ignore[no-redef]
+        pass
 
 
 # Firestore batched writes have a hard 500-operation limit per commit.
@@ -121,7 +129,13 @@ class FirestoreDb(BaseDb):
         Returns:
             bool: True if the collection exists in the database, False otherwise
         """
-        return table_name in self.db_client.list_collections()
+        # google-cloud-firestore exposes ``collections()``. Keep the
+        # ``list_collections()`` fallback for older mocks and compatible
+        # third-party clients.
+        list_collections = getattr(self.db_client, "collections", None)
+        if not callable(list_collections):
+            list_collections = getattr(self.db_client, "list_collections")
+        return any(getattr(collection, "id", None) == table_name for collection in list_collections())
 
     def _get_collection(self, table_type: str, create_collection_if_not_found: Optional[bool] = True):
         """Get or create a collection based on table type.
@@ -231,14 +245,60 @@ class FirestoreDb(BaseDb):
         Returns:
             Optional[CollectionReference]: The collection reference.
         """
+        initialized_attr = f"_{collection_name}_initialized"
         try:
             collection_ref = self.db_client.collection(collection_name)
+            with self._resolve_lock:
+                cache_key = (collection_type, collection_name)
+                if collection_type not in MIGRATABLE_TABLE_TYPES:
+                    if not create_collection_if_not_found and next(iter(collection_ref.stream()), None) is None:
+                        return None
+                    if create_collection_if_not_found and not hasattr(self, initialized_attr):
+                        create_collection_indexes(self.db_client, collection_name, collection_type)
+                        setattr(self, initialized_attr, True)
+                    return collection_ref
 
-            if not hasattr(self, f"_{collection_name}_initialized"):
-                if not create_collection_if_not_found:
-                    return None
-                create_collection_indexes(self.db_client, collection_name, collection_type)
-                setattr(self, f"_{collection_name}_initialized", True)
+                if cache_key in self._schema_versions_checked:
+                    if create_collection_if_not_found and not hasattr(self, initialized_attr):
+                        create_collection_indexes(self.db_client, collection_name, collection_type)
+                        setattr(self, initialized_attr, True)
+                    return collection_ref
+
+                version_ref = self.db_client.collection(self.versions_table_name).document(collection_name)
+                version_snapshot = version_ref.get()
+
+                if version_snapshot.exists:
+                    self._validate_schema_version(collection_name, collection_type)
+                else:
+                    first_document = next(iter(collection_ref.stream()), None)
+                    if first_document is not None:
+                        # An unstamped collection containing documents is a
+                        # legacy store. MigrationManager bypasses this check;
+                        # normal requests fail closed.
+                        self._validate_schema_version(collection_name, collection_type)
+                    elif not create_collection_if_not_found:
+                        return None
+                    else:
+                        from agno.db.migrations.manager import MigrationManager
+
+                        latest_version = MigrationManager(self).latest_schema_version.public
+                        version_data = {
+                            "table_name": collection_name,
+                            "version": latest_version,
+                            "updated_at": int(time.time()),
+                        }
+                        try:
+                            # A version document is the atomic ownership claim
+                            # for an otherwise empty Firestore namespace.
+                            version_ref.create(version_data)
+                        except AlreadyExists:
+                            self._validate_schema_version(collection_name, collection_type)
+                        else:
+                            self._validate_schema_version(collection_name, collection_type)
+
+                if create_collection_if_not_found and not hasattr(self, initialized_attr):
+                    create_collection_indexes(self.db_client, collection_name, collection_type)
+                    setattr(self, initialized_attr, True)
 
             return collection_ref
 
@@ -621,6 +681,7 @@ class FirestoreDb(BaseDb):
         self.db_client.collection(self.versions_table_name).document(table_name).set(
             {"table_name": table_name, "version": version, "updated_at": int(time.time())}
         )
+        self._invalidate_schema_version_check(table_name)
 
     def delete_sessions(self, session_ids: List[str], user_id: Optional[str] = None) -> None:
         """Delete multiple sessions from the database.

--- a/libs/agno/agno/db/json/json_db.py
+++ b/libs/agno/agno/db/json/json_db.py
@@ -87,8 +87,25 @@ class JsonDb(BaseDb):
         self.db_path = Path(db_path or os.path.join(os.getcwd(), "agno_json_db"))
 
     def table_exists(self, table_name: str) -> bool:
-        """JSON implementation, always returns True."""
-        return True
+        """Return whether the JSON file backing ``table_name`` exists."""
+        return (self.db_path / f"{table_name}.json").is_file()
+
+    def _table_type_for_filename(self, filename: str) -> Optional[str]:
+        """Map a configured JSON filename back to its logical table type."""
+        table_names = (
+            ("sessions", self.session_table_name),
+            ("runs", self.runs_table_name),
+            ("memories", self.memory_table_name),
+            ("metrics", self.metrics_table_name),
+            ("evals", self.eval_table_name),
+            ("knowledge", self.knowledge_table_name),
+            ("traces", self.trace_table_name),
+            ("spans", self.span_table_name),
+        )
+        for table_type, table_name in table_names:
+            if filename == table_name:
+                return table_type
+        return None
 
     def _read_json_file(self, filename: str, create_table_if_not_found: Optional[bool] = True) -> List[Dict[str, Any]]:
         """Read data from a JSON file, creating it if it doesn't exist.
@@ -104,22 +121,38 @@ class JsonDb(BaseDb):
         """
         file_path = self.db_path / f"{filename}.json"
 
-        # Create directory if it doesn't exist
-        self.db_path.mkdir(parents=True, exist_ok=True)
+        # The versions file is metadata, not a guarded user table. In
+        # particular, reading a missing stamp must remain side-effect-free.
+        table_type = None if filename == self.versions_table_name else self._table_type_for_filename(filename)
 
-        try:
-            with open(file_path, "r", encoding="utf-8") as f:
-                return json.load(f)
+        with self._resolve_lock:
+            if file_path.is_file():
+                if table_type is not None:
+                    self._validate_schema_version(filename, table_type)
+            elif not create_table_if_not_found:
+                return []
+            else:
+                self.db_path.mkdir(parents=True, exist_ok=True)
+                try:
+                    # Exclusive creation proves this caller owns the fresh
+                    # file. A peer that wins the race is treated as existing
+                    # and must carry a current version stamp.
+                    with open(file_path, "x", encoding="utf-8") as f:
+                        json.dump([], f)
+                except FileExistsError:
+                    if table_type is not None:
+                        self._validate_schema_version(filename, table_type)
+                else:
+                    if table_type is not None:
+                        self._stamp_schema_version(filename, table_type)
 
-        except FileNotFoundError:
-            if create_table_if_not_found:
-                with open(file_path, "w", encoding="utf-8") as f:
-                    json.dump([], f)
-            return []
+            try:
+                with open(file_path, "r", encoding="utf-8") as f:
+                    return json.load(f)
 
-        except json.JSONDecodeError as e:
-            log_error(f"Error reading the {file_path} JSON file: {str(e)}")
-            raise e
+            except json.JSONDecodeError as e:
+                log_error(f"Error reading the {file_path} JSON file: {str(e)}")
+                raise e
 
     def _write_json_file(self, filename: str, data: List[Dict[str, Any]]) -> None:
         """Write data to a JSON file.
@@ -133,16 +166,31 @@ class JsonDb(BaseDb):
         """
         file_path = self.db_path / f"{filename}.json"
 
-        # Create directory if it doesn't exist
-        self.db_path.mkdir(parents=True, exist_ok=True)
+        table_type = None if filename == self.versions_table_name else self._table_type_for_filename(filename)
 
-        try:
-            with open(file_path, "w", encoding="utf-8") as f:
-                json.dump(data, f, indent=2, default=str)
+        with self._resolve_lock:
+            if file_path.is_file():
+                if table_type is not None:
+                    self._validate_schema_version(filename, table_type)
+            else:
+                self.db_path.mkdir(parents=True, exist_ok=True)
+                try:
+                    with open(file_path, "x", encoding="utf-8") as f:
+                        json.dump([], f)
+                except FileExistsError:
+                    if table_type is not None:
+                        self._validate_schema_version(filename, table_type)
+                else:
+                    if table_type is not None:
+                        self._stamp_schema_version(filename, table_type)
 
-        except Exception as e:
-            log_error(f"Error writing to the {file_path} JSON file: {str(e)}")
-            raise e
+            try:
+                with open(file_path, "w", encoding="utf-8") as f:
+                    json.dump(data, f, indent=2, default=str)
+
+            except Exception as e:
+                log_error(f"Error writing to the {file_path} JSON file: {str(e)}")
+                raise e
 
     def get_latest_schema_version(self, table_name: str = "") -> Optional[str]:
         """Get the schema version stamped for the given table.
@@ -150,7 +198,7 @@ class JsonDb(BaseDb):
         Defaults to "2.0.0" when nothing is stamped so the MigrationManager
         runs migrations instead of skipping the table.
         """
-        rows = self._read_json_file(self.versions_table_name, create_table_if_not_found=True)
+        rows = self._read_json_file(self.versions_table_name, create_table_if_not_found=False)
         for row in rows:
             if row.get("table_name") == table_name:
                 return row.get("version") or "2.0.0"
@@ -158,11 +206,13 @@ class JsonDb(BaseDb):
 
     def upsert_schema_version(self, table_name: str = "", version: str = "") -> None:
         """Record the schema version stamp for the given table."""
-        rows = self._read_json_file(self.versions_table_name, create_table_if_not_found=True)
-        entry = {"table_name": table_name, "version": version, "updated_at": int(time.time())}
-        rows = [row for row in rows if row.get("table_name") != table_name]
-        rows.append(entry)
-        self._write_json_file(self.versions_table_name, rows)
+        with self._resolve_lock:
+            rows = self._read_json_file(self.versions_table_name, create_table_if_not_found=True)
+            entry = {"table_name": table_name, "version": version, "updated_at": int(time.time())}
+            rows = [row for row in rows if row.get("table_name") != table_name]
+            rows.append(entry)
+            self._write_json_file(self.versions_table_name, rows)
+            self._invalidate_schema_version_check(table_name)
 
     # -- Run methods --
 

--- a/libs/agno/agno/db/migrations/manager.py
+++ b/libs/agno/agno/db/migrations/manager.py
@@ -4,7 +4,7 @@ from typing import Optional, Union
 from packaging import version as packaging_version
 from packaging.version import Version
 
-from agno.db.base import AsyncBaseDb, BaseDb
+from agno.db.base import AsyncBaseDb, BaseDb, suspend_schema_version_checks
 from agno.utils.log import log_error, log_info, log_warning
 
 
@@ -32,6 +32,10 @@ class MigrationManager:
             invalidate(table_name)
 
     async def up(self, target_version: Optional[str] = None, table_type: Optional[str] = None, force: bool = False):
+        with suspend_schema_version_checks():
+            await self._up(target_version=target_version, table_type=table_type, force=force)
+
+    async def _up(self, target_version: Optional[str] = None, table_type: Optional[str] = None, force: bool = False):
         """Handle executing an up migration.
 
         Args:
@@ -151,6 +155,10 @@ class MigrationManager:
             raise
 
     async def down(self, target_version: str, table_type: Optional[str] = None, force: bool = False):
+        with suspend_schema_version_checks():
+            await self._down(target_version=target_version, table_type=table_type, force=force)
+
+    async def _down(self, target_version: str, table_type: Optional[str] = None, force: bool = False):
         """Handle executing a down migration.
 
         Args:

--- a/libs/agno/agno/db/mongo/async_mongo.py
+++ b/libs/agno/agno/db/mongo/async_mongo.py
@@ -69,7 +69,7 @@ except ImportError:
 
 try:
     from pymongo import ReturnDocument
-    from pymongo.errors import OperationFailure
+    from pymongo.errors import CollectionInvalid, OperationFailure
 except ImportError:
     raise ImportError("`pymongo` not installed. Please install it using `pip install -U pymongo`")
 
@@ -273,7 +273,7 @@ class AsyncMongoDb(AsyncBaseDb):
         ]
 
         for collection_type, collection_name in collections_to_create:
-            if collection_name and not await self.table_exists(collection_name):
+            if collection_name:
                 await self._get_collection(collection_type, create_collection_if_not_found=True)
 
     async def close(self) -> None:
@@ -394,6 +394,27 @@ class AsyncMongoDb(AsyncBaseDb):
 
         # Check if collections need to be reset due to event loop change
         reset_cache = self._should_reset_collection_cache()
+        collection_bindings = {
+            "sessions": (self.session_table_name, "session_collection"),
+            "runs": (self.runs_table_name, "runs_collection"),
+            "memories": (self.memory_table_name, "memory_collection"),
+            "metrics": (self.metrics_table_name, "metrics_collection"),
+            "evals": (self.eval_table_name, "eval_collection"),
+            "knowledge": (self.knowledge_table_name, "knowledge_collection"),
+            "traces": (self.trace_table_name, "traces_collection"),
+            "spans": (self.span_table_name, "spans_collection"),
+            "learnings": (self.learnings_table_name, "learnings_collection"),
+            "schedules": (self.schedules_table_name, "schedules_collection"),
+            "schedule_runs": (self.schedule_runs_table_name, "schedule_runs_collection"),
+        }
+        binding = collection_bindings.get(table_type)
+        if (
+            not reset_cache
+            and binding is not None
+            and binding[0] is not None
+            and getattr(self, binding[1], None) is not None
+        ):
+            await self._validate_schema_version(binding[0], table_type)
 
         if table_type == "sessions":
             if reset_cache or getattr(self, "session_collection", None) is None:
@@ -531,20 +552,37 @@ class AsyncMongoDb(AsyncBaseDb):
         Returns:
             Union[AsyncIOMotorCollection, AsyncCollection]: The collection object.
         """
+        initialized_attr = f"_{collection_name}_initialized"
         try:
-            collection = self.database[collection_name]
-
-            if not hasattr(self, f"_{collection_name}_initialized"):
-                if not create_collection_if_not_found:
+            async with self._resolve_lock_async:
+                created = False
+                if await self.table_exists(collection_name):
+                    await self._validate_schema_version(collection_name, collection_type)
+                    collection = self.database[collection_name]
+                elif not create_collection_if_not_found:
                     return None
-                # Create indexes asynchronously for async MongoDB collections
-                await create_collection_indexes_async(collection, collection_type)
-                setattr(self, f"_{collection_name}_initialized", True)
-                log_debug(f"Initialized collection '{collection_name}'")
-            else:
-                log_debug(f"Collection '{collection_name}' already initialized")
+                else:
+                    try:
+                        collection = await self.database.create_collection(collection_name)
+                    except (CollectionInvalid, OperationFailure):
+                        if not await self.table_exists(collection_name):
+                            raise
+                        collection = self.database[collection_name]
+                        await self._validate_schema_version(collection_name, collection_type)
+                    else:
+                        created = True
 
-            return collection
+                if create_collection_if_not_found and not hasattr(self, initialized_attr):
+                    await create_collection_indexes_async(collection, collection_type)
+                    setattr(self, initialized_attr, True)
+                    log_debug(f"Initialized collection '{collection_name}'")
+                else:
+                    log_debug(f"Collection '{collection_name}' already initialized")
+
+                if created:
+                    await self._stamp_schema_version(collection_name, collection_type)
+
+                return collection
 
         except Exception as e:
             log_error(f"Error getting collection {collection_name}: {str(e)}")
@@ -577,6 +615,7 @@ class AsyncMongoDb(AsyncBaseDb):
             {"$set": {"table_name": table_name, "version": version, "updated_at": int(time.time())}},
             upsert=True,
         )
+        self._invalidate_schema_version_check(table_name)
 
     async def cleanup_legacy_runs_field(self, force: bool = False) -> bool:
         """Unset the legacy ``runs`` field from session documents.

--- a/libs/agno/agno/db/mongo/mongo.py
+++ b/libs/agno/agno/db/mongo/mongo.py
@@ -50,7 +50,7 @@ try:
     from pymongo.collection import Collection
     from pymongo.database import Database
     from pymongo.driver_info import DriverInfo
-    from pymongo.errors import OperationFailure
+    from pymongo.errors import CollectionInvalid, OperationFailure
 except ImportError:
     raise ImportError("`pymongo` not installed. Please install it using `pip install pymongo`")
 
@@ -178,7 +178,7 @@ class MongoDb(BaseDb):
         ]
 
         for collection_type, collection_name in collections_to_create:
-            if collection_name and not self.table_exists(collection_name):
+            if collection_name:
                 self._get_collection(collection_type, create_collection_if_not_found=True)
 
     def _get_collection(
@@ -192,8 +192,25 @@ class MongoDb(BaseDb):
         Returns:
             Collection: The collection object.
         """
+        collection_bindings = {
+            "sessions": (self.session_table_name, "session_collection"),
+            "runs": (self.runs_table_name, "runs_collection"),
+            "memories": (self.memory_table_name, "memory_collection"),
+            "metrics": (self.metrics_table_name, "metrics_collection"),
+            "evals": (self.eval_table_name, "eval_collection"),
+            "knowledge": (self.knowledge_table_name, "knowledge_collection"),
+            "traces": (self.trace_table_name, "traces_collection"),
+            "spans": (self.span_table_name, "spans_collection"),
+            "learnings": (self.learnings_table_name, "learnings_collection"),
+            "schedules": (self.schedules_table_name, "schedules_collection"),
+            "schedule_runs": (self.schedule_runs_table_name, "schedule_runs_collection"),
+        }
+        binding = collection_bindings.get(table_type)
+        if binding is not None and binding[0] is not None and getattr(self, binding[1], None) is not None:
+            self._validate_schema_version(binding[0], table_type)
+
         if table_type == "sessions":
-            if not hasattr(self, "session_collection"):
+            if getattr(self, "session_collection", None) is None:
                 if self.session_table_name is None:
                     raise ValueError("Session collection was not provided on initialization")
                 self.session_collection = self._get_or_create_collection(
@@ -216,7 +233,7 @@ class MongoDb(BaseDb):
             return self.runs_collection
 
         if table_type == "memories":
-            if not hasattr(self, "memory_collection"):
+            if getattr(self, "memory_collection", None) is None:
                 if self.memory_table_name is None:
                     raise ValueError("Memory collection was not provided on initialization")
                 self.memory_collection = self._get_or_create_collection(
@@ -227,7 +244,7 @@ class MongoDb(BaseDb):
             return self.memory_collection
 
         if table_type == "metrics":
-            if not hasattr(self, "metrics_collection"):
+            if getattr(self, "metrics_collection", None) is None:
                 if self.metrics_table_name is None:
                     raise ValueError("Metrics collection was not provided on initialization")
                 self.metrics_collection = self._get_or_create_collection(
@@ -238,7 +255,7 @@ class MongoDb(BaseDb):
             return self.metrics_collection
 
         if table_type == "evals":
-            if not hasattr(self, "eval_collection"):
+            if getattr(self, "eval_collection", None) is None:
                 if self.eval_table_name is None:
                     raise ValueError("Eval collection was not provided on initialization")
                 self.eval_collection = self._get_or_create_collection(
@@ -249,7 +266,7 @@ class MongoDb(BaseDb):
             return self.eval_collection
 
         if table_type == "knowledge":
-            if not hasattr(self, "knowledge_collection"):
+            if getattr(self, "knowledge_collection", None) is None:
                 if self.knowledge_table_name is None:
                     raise ValueError("Knowledge collection was not provided on initialization")
                 self.knowledge_collection = self._get_or_create_collection(
@@ -260,7 +277,7 @@ class MongoDb(BaseDb):
             return self.knowledge_collection
 
         if table_type == "traces":
-            if not hasattr(self, "traces_collection"):
+            if getattr(self, "traces_collection", None) is None:
                 if self.trace_table_name is None:
                     raise ValueError("Traces collection was not provided on initialization")
                 self.traces_collection = self._get_or_create_collection(
@@ -271,7 +288,7 @@ class MongoDb(BaseDb):
             return self.traces_collection
 
         if table_type == "spans":
-            if not hasattr(self, "spans_collection"):
+            if getattr(self, "spans_collection", None) is None:
                 if self.span_table_name is None:
                     raise ValueError("Spans collection was not provided on initialization")
                 self.spans_collection = self._get_or_create_collection(
@@ -295,7 +312,7 @@ class MongoDb(BaseDb):
             return self.learnings_collection
 
         if table_type == "schedules":
-            if not hasattr(self, "schedules_collection"):
+            if getattr(self, "schedules_collection", None) is None:
                 if self.schedules_table_name is None:
                     raise ValueError("Schedules collection was not provided on initialization")
                 self.schedules_collection = self._get_or_create_collection(
@@ -306,7 +323,7 @@ class MongoDb(BaseDb):
             return self.schedules_collection
 
         if table_type == "schedule_runs":
-            if not hasattr(self, "schedule_runs_collection"):
+            if getattr(self, "schedule_runs_collection", None) is None:
                 if self.schedule_runs_table_name is None:
                     raise ValueError("Schedule runs collection was not provided on initialization")
                 self.schedule_runs_collection = self._get_or_create_collection(
@@ -331,19 +348,41 @@ class MongoDb(BaseDb):
         Returns:
             Optional[Collection]: The collection object.
         """
+        initialized_attr = f"_{collection_name}_initialized"
         try:
-            collection = self.database[collection_name]
-
-            if not hasattr(self, f"_{collection_name}_initialized"):
-                if not create_collection_if_not_found:
+            with self._resolve_lock:
+                created = False
+                if self.table_exists(collection_name):
+                    self._validate_schema_version(collection_name, collection_type)
+                    collection = self.database[collection_name]
+                elif not create_collection_if_not_found:
                     return None
-                create_collection_indexes(collection, collection_type)
-                setattr(self, f"_{collection_name}_initialized", True)
-                log_debug(f"Initialized collection '{collection_name}'")
-            else:
-                log_debug(f"Collection '{collection_name}' already initialized")
+                else:
+                    try:
+                        collection = self.database.create_collection(collection_name)
+                    except (CollectionInvalid, OperationFailure):
+                        # A peer may have won the create race. Confirm the
+                        # collection now exists before treating it as legacy.
+                        if not self.table_exists(collection_name):
+                            raise
+                        collection = self.database[collection_name]
+                        self._validate_schema_version(collection_name, collection_type)
+                    else:
+                        created = True
 
-            return collection
+                if create_collection_if_not_found and not hasattr(self, initialized_attr):
+                    create_collection_indexes(collection, collection_type)
+                    setattr(self, initialized_attr, True)
+                    log_debug(f"Initialized collection '{collection_name}'")
+                else:
+                    log_debug(f"Collection '{collection_name}' already initialized")
+
+                if created:
+                    # Stamp only after collection and index creation both
+                    # succeed. A partial failure remains fail-closed.
+                    self._stamp_schema_version(collection_name, collection_type)
+
+                return collection
 
         except Exception as e:
             log_error(f"Error getting collection {collection_name}: {str(e)}")
@@ -367,6 +406,7 @@ class MongoDb(BaseDb):
             {"$set": {"table_name": table_name, "version": version, "updated_at": int(time.time())}},
             upsert=True,
         )
+        self._invalidate_schema_version_check(table_name)
 
     def cleanup_legacy_runs_field(self, force: bool = False) -> bool:
         """Unset the legacy ``runs`` field from session documents.

--- a/libs/agno/agno/db/redis/redis.py
+++ b/libs/agno/agno/db/redis/redis.py
@@ -27,6 +27,7 @@ from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.schemas.memory import UserMemory
 from agno.db.utils import (
+    MIGRATABLE_TABLE_TYPES,
     build_single_run_row,
     deserialize_run,
     deserialize_session,
@@ -158,6 +159,47 @@ class RedisDb(BaseDb):
         else:
             raise ValueError(f"Unknown table type: {table_type}")
 
+    def _ensure_schema_version(self, table_type: str) -> None:
+        """Validate or initialize the version stamp for a Redis namespace."""
+        if table_type not in MIGRATABLE_TABLE_TYPES:
+            return
+
+        table_name = self._get_table_name(table_type)
+        cache_key = (table_type, table_name)
+        if cache_key in self._schema_versions_checked:
+            return
+
+        with self._resolve_lock:
+            if cache_key in self._schema_versions_checked:
+                return
+
+            version_key = self._schema_version_key(table_name)
+            if self.redis_client.get(version_key) is not None:
+                self._validate_schema_version(table_name, table_type)
+                return
+
+            # Redis has no physical table creation. Any record or index key
+            # proves this is an existing namespace and therefore must not be
+            # blessed as fresh merely because its version stamp is missing.
+            namespace_pattern = f"{self.db_prefix}:{table_type}:*"
+            if next(self.redis_client.scan_iter(match=namespace_pattern), None) is not None:
+                self._validate_schema_version(table_name, table_type)
+                return
+
+            from agno.db.migrations.manager import MigrationManager
+
+            latest_version = MigrationManager(self).latest_schema_version.public
+            created = self.redis_client.set(version_key, latest_version, nx=True)
+            if created:
+                # Reuse the common validator so cache population follows the
+                # same parse/compare path as an existing stamp.
+                self._validate_schema_version(table_name, table_type)
+                return
+
+            # A peer initialized the namespace between our empty scan and
+            # conditional SET. It owns the stamp; validate what it wrote.
+            self._validate_schema_version(table_name, table_type)
+
     def _store_record(
         self, table_type: str, record_id: str, data: Dict[str, Any], index_fields: Optional[List[str]] = None
     ) -> bool:
@@ -172,6 +214,7 @@ class RedisDb(BaseDb):
         Returns:
             bool: True if the record was stored successfully, False otherwise.
         """
+        self._ensure_schema_version(table_type)
         try:
             key = generate_redis_key(prefix=self.db_prefix, table_type=table_type, key_id=record_id)
             serialized_data = serialize_data(data)
@@ -204,6 +247,7 @@ class RedisDb(BaseDb):
         Returns:
             Optional[Dict[str, Any]]: The record data if found, None otherwise.
         """
+        self._ensure_schema_version(table_type)
         try:
             key = generate_redis_key(prefix=self.db_prefix, table_type=table_type, key_id=record_id)
 
@@ -231,6 +275,7 @@ class RedisDb(BaseDb):
         Raises:
             Exception: If any error occurs while deleting the record.
         """
+        self._ensure_schema_version(table_type)
         try:
             # Handle index deletion first
             if index_fields:
@@ -268,6 +313,7 @@ class RedisDb(BaseDb):
         Raises:
             Exception: If any error occurs while getting the records.
         """
+        self._ensure_schema_version(table_type)
         try:
             keys = get_all_keys_for_table(redis_client=self.redis_client, prefix=self.db_prefix, table_type=table_type)
 
@@ -303,7 +349,9 @@ class RedisDb(BaseDb):
 
         No TTL: the stamp must outlive ``self.expire``.
         """
-        self.redis_client.set(self._schema_version_key(table_name), version)
+        if not self.redis_client.set(self._schema_version_key(table_name), version):
+            raise RuntimeError(f"Failed to store schema version for {table_name}")
+        self._invalidate_schema_version_check(table_name)
 
     # -- Run methods --
 
@@ -1342,6 +1390,7 @@ class RedisDb(BaseDb):
         Raises:
             Exception: If an error occurs during deletion.
         """
+        self._ensure_schema_version("memories")
         try:
             # Get all keys for memories table
             keys = get_all_keys_for_table(redis_client=self.redis_client, prefix=self.db_prefix, table_type="memories")

--- a/libs/agno/agno/db/surrealdb/surrealdb.py
+++ b/libs/agno/agno/db/surrealdb/surrealdb.py
@@ -199,8 +199,15 @@ class SurrealDb(BaseDb):
         else:
             raise NotImplementedError(f"Unknown table type: {table_type}")
 
-        if create_table_if_not_found and not self.table_exists(table_name):
-            self._create_table(table_type, table_name)
+        with self._resolve_lock:
+            if self.table_exists(table_name):
+                self._validate_schema_version(table_name, table_type)
+            elif create_table_if_not_found:
+                # The local lock prevents two callers on this instance from
+                # both claiming creation. Surreal DEFINE TABLE is idempotent,
+                # so peer instances converge on the same current-version stamp.
+                self._create_table(table_type, table_name)
+                self._stamp_schema_version(table_name, table_type)
 
         return table_name
 
@@ -227,6 +234,7 @@ class SurrealDb(BaseDb):
                 "content": {"table_name": table_name, "version": version, "updated_at": int(time.time())},
             },
         )
+        self._invalidate_schema_version_check(table_name)
 
     def _query(
         self,

--- a/libs/agno/tests/unit/db/test_async_mongo.py
+++ b/libs/agno/tests/unit/db/test_async_mongo.py
@@ -1,11 +1,41 @@
 import asyncio
-from unittest.mock import AsyncMock, Mock, PropertyMock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, PropertyMock, patch
 
 import pytest
 from pymongo import AsyncMongoClient
 
 from agno.db.base import SessionType
 from agno.db.mongo import AsyncMongoDb
+
+
+def _install_offline_database(db: AsyncMongoDb) -> None:
+    """Give event-loop tests a Mongo surface without requiring a live server."""
+    collections = {}
+
+    def get_collection(name):
+        if name not in collections:
+            collection = MagicMock()
+            collection.index_information = AsyncMock(return_value={})
+            collection.create_index = AsyncMock(return_value="index")
+            collection.find_one = AsyncMock(return_value=None)
+            collection.update_one = AsyncMock(return_value=None)
+            collections[name] = collection
+        return collections[name]
+
+    async def create_collection(name):
+        return get_collection(name)
+
+    database = MagicMock()
+    database.__getitem__.side_effect = get_collection
+    database.list_collection_names = AsyncMock(side_effect=lambda: list(collections))
+    database.create_collection = AsyncMock(side_effect=create_collection)
+
+    client = MagicMock()
+    client.close.return_value = None
+
+    db._client = client
+    db._database = database
+    db._event_loop = asyncio.get_running_loop()
 
 
 def test_id_is_deterministic():
@@ -97,6 +127,7 @@ async def test_initialization_flags_cleared_on_event_loop_change():
     calls were made.
     """
     db = AsyncMongoDb(db_url="mongodb://localhost:27017", db_name="test_event_loop_fix")
+    _install_offline_database(db)
 
     # First operation - create collections
     await db._get_collection("sessions", create_collection_if_not_found=True)
@@ -139,6 +170,7 @@ async def test_indexes_awaited_properly():
     unawaited futures from being left on the event loop.
     """
     db = AsyncMongoDb(db_url="mongodb://localhost:27017", db_name="test_await_indexes")
+    _install_offline_database(db)
 
     # This should complete without hanging or leaving pending futures
     collection = await db._get_collection("sessions", create_collection_if_not_found=True)
@@ -168,6 +200,7 @@ async def test_indexes_awaited_properly():
 async def test_collection_cache_reset_on_event_loop_change():
     """Test that all collection caches are reset on event loop change"""
     db = AsyncMongoDb(db_url="mongodb://localhost:27017", db_name="test_cache_reset")
+    _install_offline_database(db)
 
     # Create collections
     await db._get_collection("sessions", create_collection_if_not_found=True)

--- a/libs/agno/tests/unit/db/test_async_mongo_schema_version_guard.py
+++ b/libs/agno/tests/unit/db/test_async_mongo_schema_version_guard.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, Optional
+
+import pytest
+
+pytest.importorskip("pymongo")
+
+from agno.db.mongo import AsyncMongoDb  # noqa: E402
+from agno.exceptions import MigrationRequiredError  # noqa: E402
+
+
+class _FakeAsyncCollection:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.documents: Dict[str, Dict[str, Any]] = {}
+        self.find_one_calls = 0
+        self.update_one_calls = 0
+
+    async def index_information(self) -> Dict[str, Any]:
+        return {}
+
+    async def create_index(self, *_args: Any, **_kwargs: Any) -> str:
+        return "index"
+
+    async def find_one(self, query: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        self.find_one_calls += 1
+        return self.documents.get(str(query.get("table_name")))
+
+    async def update_one(self, query: Dict[str, Any], update: Dict[str, Any], *, upsert: bool = False) -> None:
+        self.update_one_calls += 1
+        assert upsert is True
+        self.documents[str(query["table_name"])] = dict(update["$set"])
+
+
+class _FakeAsyncDatabase:
+    def __init__(self, *, existing: Optional[set[str]] = None) -> None:
+        self.collections: Dict[str, _FakeAsyncCollection] = {
+            name: _FakeAsyncCollection(name) for name in (existing or set())
+        }
+        self.create_calls = 0
+
+    def __getitem__(self, name: str) -> _FakeAsyncCollection:
+        return self.collections.setdefault(name, _FakeAsyncCollection(name))
+
+    async def list_collection_names(self) -> list[str]:
+        return list(self.collections)
+
+    async def create_collection(self, name: str) -> _FakeAsyncCollection:
+        self.create_calls += 1
+        collection = _FakeAsyncCollection(name)
+        self.collections[name] = collection
+        return collection
+
+
+def _new_db(database: _FakeAsyncDatabase) -> AsyncMongoDb:
+    db = AsyncMongoDb(db_url="mongodb://unused", db_name="test")
+    db._client = object()
+    db._database = database
+    db._event_loop = asyncio.get_running_loop()
+    return db
+
+
+@pytest.mark.asyncio
+async def test_concurrent_fresh_collection_is_created_and_stamped_once() -> None:
+    database = _FakeAsyncDatabase()
+    db = _new_db(database)
+
+    collections = await asyncio.gather(*(db._get_collection("sessions") for _ in range(8)))
+
+    assert all(collection is collections[0] for collection in collections)
+    assert database.create_calls == 1
+    versions = database[db.versions_table_name]
+    assert versions.update_one_calls == 1
+    assert await db.get_latest_schema_version(db.session_table_name) == "3.0.0"
+
+
+@pytest.mark.asyncio
+async def test_stale_collection_refuses_then_same_instance_accepts_migrated_stamp() -> None:
+    database = _FakeAsyncDatabase(existing={"agno_sessions"})
+    db = _new_db(database)
+
+    with pytest.raises(MigrationRequiredError):
+        await db._get_collection("sessions")
+
+    await db.upsert_schema_version(db.session_table_name, "3.0.0")
+    collection = await db._get_collection("sessions")
+
+    assert collection is database[db.session_table_name]
+    find_calls = database[db.versions_table_name].find_one_calls
+    assert await db._get_collection("sessions") is collection
+    assert database[db.versions_table_name].find_one_calls == find_calls
+
+
+@pytest.mark.asyncio
+async def test_absent_read_only_probe_does_not_create_or_stamp() -> None:
+    database = _FakeAsyncDatabase()
+    db = _new_db(database)
+
+    assert await db._get_collection("sessions", create_collection_if_not_found=False) is None
+    assert database.create_calls == 0
+    assert db.versions_table_name not in database.collections

--- a/libs/agno/tests/unit/db/test_delete_run_scrubs_legacy_blob.py
+++ b/libs/agno/tests/unit/db/test_delete_run_scrubs_legacy_blob.py
@@ -15,6 +15,7 @@ to every doc adapter.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import tempfile
@@ -23,7 +24,7 @@ import pytest
 
 from agno.db.in_memory.in_memory_db import InMemoryDb
 from agno.db.json.json_db import JsonDb
-from agno.db.migrations.versions.v3_0_0 import _migrate_jsondb
+from agno.db.migrations.manager import MigrationManager
 
 
 @pytest.fixture
@@ -49,7 +50,7 @@ def json_db_partially_migrated():
     sessions_file = os.path.join(tmp, "agno_sessions.json")
     with open(sessions_file, "w") as f:
         json.dump([session_row], f)
-    _migrate_jsondb(db, "sessions", "agno_sessions")
+    asyncio.run(MigrationManager(db).up(table_type="sessions"))
     return db, tmp, sessions_file
 
 

--- a/libs/agno/tests/unit/db/test_dynamo_table_creation.py
+++ b/libs/agno/tests/unit/db/test_dynamo_table_creation.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("boto3")
+
+from agno.db.dynamo.utils import create_table_if_not_exists
+
+
+class _ResourceNotFound(Exception):
+    pass
+
+
+class _ClientError(Exception):
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.response = {"Error": {"Code": code}}
+
+
+def _client() -> MagicMock:
+    client = MagicMock()
+    client.exceptions.ResourceNotFoundException = _ResourceNotFound
+    return client
+
+
+def test_existing_table_is_not_reported_as_created() -> None:
+    client = _client()
+
+    assert create_table_if_not_exists(client, "sessions", {"TableName": "sessions"}) is False
+    client.create_table.assert_not_called()
+
+
+def test_creator_waits_for_table_and_reports_ownership() -> None:
+    client = _client()
+    client.describe_table.side_effect = _ResourceNotFound()
+
+    assert create_table_if_not_exists(client, "sessions", {"TableName": "sessions"}) is True
+    client.create_table.assert_called_once_with(TableName="sessions")
+    client.get_waiter.return_value.wait.assert_called_once_with(TableName="sessions")
+
+
+def test_resource_in_use_race_loser_waits_but_does_not_claim_creation() -> None:
+    client = _client()
+    client.describe_table.side_effect = _ResourceNotFound()
+    client.create_table.side_effect = _ClientError("ResourceInUseException")
+
+    assert create_table_if_not_exists(client, "sessions", {"TableName": "sessions"}) is False
+    client.get_waiter.return_value.wait.assert_called_once_with(TableName="sessions")
+
+
+def test_real_creation_failure_propagates() -> None:
+    client = _client()
+    client.describe_table.side_effect = _ResourceNotFound()
+    client.create_table.side_effect = _ClientError("AccessDeniedException")
+
+    with pytest.raises(_ClientError):
+        create_table_if_not_exists(client, "sessions", {"TableName": "sessions"})
+    client.get_waiter.assert_not_called()

--- a/libs/agno/tests/unit/db/test_surrealdb_schema_version_guard.py
+++ b/libs/agno/tests/unit/db/test_surrealdb_schema_version_guard.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import asyncio
+import re
+from typing import Any, Dict, Optional
+
+import pytest
+
+pytest.importorskip("surrealdb")
+
+from agno.db.migrations.manager import MigrationManager  # noqa: E402
+from agno.db.surrealdb.surrealdb import SurrealDb  # noqa: E402
+from agno.exceptions import MigrationRequiredError  # noqa: E402
+
+
+class _FakeSurrealClient:
+    def __init__(self, *, tables: Optional[set[str]] = None) -> None:
+        self.tables = set(tables or set())
+        self.versions: Dict[str, str] = {}
+
+    @staticmethod
+    def _record_id(record: Any) -> str:
+        record_id = getattr(record, "id", None)
+        if record_id is not None:
+            return str(record_id)
+        return str(record).rsplit(":", 1)[-1].strip("⟨⟩")
+
+    def query(self, query: str, vars: Optional[Dict[str, Any]] = None) -> Any:
+        vars = vars or {}
+        if query == "INFO FOR DB":
+            return {"tables": {table_name: {} for table_name in self.tables}}
+        if query.startswith("SELECT version FROM ONLY"):
+            table_name = self._record_id(vars["record"])
+            version = self.versions.get(table_name)
+            return {"version": version} if version is not None else None
+        if query.startswith("UPSERT ONLY"):
+            content = vars["content"]
+            if "table_name" in content and "version" in content:
+                self.versions[str(content["table_name"])] = str(content["version"])
+            return content
+        if query.startswith("SELECT * FROM"):
+            return []
+
+        for table_name in re.findall(r"DEFINE TABLE(?: OVERWRITE)?\s+([A-Za-z0-9_]+)", query):
+            self.tables.add(table_name)
+        return None
+
+
+def _new_db(client: _FakeSurrealClient) -> SurrealDb:
+    return SurrealDb(
+        client=client,  # type: ignore[arg-type]
+        db_url="memory://schema-guard",
+        db_creds={},
+        db_ns="test",
+        db_db="test",
+    )
+
+
+def test_fresh_table_is_stamped() -> None:
+    client = _FakeSurrealClient()
+    db = _new_db(client)
+
+    assert db._get_table("sessions") == db.session_table_name
+    assert db.session_table_name in client.tables
+    assert db.get_latest_schema_version(db.session_table_name) == "3.0.0"
+
+
+def test_stale_table_refuses_then_migration_restores_access() -> None:
+    client = _FakeSurrealClient(tables={"agno_sessions"})
+    db = _new_db(client)
+
+    with pytest.raises(MigrationRequiredError):
+        db._get_table("sessions")
+
+    asyncio.run(MigrationManager(db).up(table_type="sessions"))
+
+    assert db.get_latest_schema_version(db.session_table_name) == "3.0.0"
+    assert db._get_table("sessions") == db.session_table_name
+
+
+def test_non_migratable_table_is_not_blocked() -> None:
+    client = _FakeSurrealClient(tables={"agno_runs"})
+    db = _new_db(client)
+
+    assert db._get_table("runs", create_table_if_not_found=False) == db.runs_table_name
+    assert db.get_latest_schema_version(db.runs_table_name) == "2.0.0"

--- a/libs/agno/tests/unit/db/test_v3_dynamo_migration_compat.py
+++ b/libs/agno/tests/unit/db/test_v3_dynamo_migration_compat.py
@@ -6,6 +6,7 @@ account is needed.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import time
 from typing import Any, Dict, List, Optional
@@ -13,6 +14,8 @@ from typing import Any, Dict, List, Optional
 import pytest
 
 from agno.db.base import SessionType
+from agno.db.migrations.manager import MigrationManager
+from agno.exceptions import MigrationRequiredError
 from agno.models.message import Message
 from agno.run.agent import RunOutput
 from agno.run.base import RunStatus
@@ -274,6 +277,11 @@ def _insert_legacy_session(db, session_id: str, runs: List[Dict[str, Any]]) -> N
     db.client._tables[db.session_table_name][session_id] = item
 
 
+def _mark_table_unstamped(db, table_name: str) -> None:
+    db.client._tables[db.versions_table_name].pop(table_name, None)
+    db._invalidate_schema_version_check(table_name)
+
+
 def test_fresh_schema_round_trip():
     db = _new_db()
     session = AgentSession(session_id="s1", agent_id="agent-1", user_id="u1")
@@ -296,9 +304,10 @@ def test_fresh_schema_round_trip():
     loaded = db.get_session("s1", SessionType.AGENT)
     assert [r.run_id for r in loaded.runs] == ["r1", "r2"]
     assert loaded.runs[0].messages[0].content == "q-one"
+    assert db.get_latest_schema_version(db.session_table_name) == "3.0.0"
 
 
-def test_legacy_blob_fallback_on_read():
+def test_migrated_legacy_blob_fallback_on_read():
     db = _new_db()
     runs = [_make_run(f"r{i}", "s2", f"c{i}").to_dict() for i in range(3)]
     _insert_legacy_session(db, "s2", runs)
@@ -311,10 +320,11 @@ def test_v3_migration_is_non_destructive():
     db = _new_db()
     legacy = [_make_run(f"r{i}", "s6", f"c{i}").to_dict() for i in range(2)]
     _insert_legacy_session(db, "s6", legacy)
+    _mark_table_unstamped(db, db.session_table_name)
+    with pytest.raises(MigrationRequiredError):
+        db.get_session("s6", SessionType.AGENT)
 
-    from agno.db.migrations.versions.v3_0_0 import up as v3_up
-
-    v3_up(db, table_type="sessions", table_name=db.session_table_name)
+    asyncio.run(MigrationManager(db).up(table_type="sessions"))
 
     # Runs table now has 2 entries
     assert len(db.client._tables[db.runs_table_name]) == 2
@@ -322,6 +332,7 @@ def test_v3_migration_is_non_destructive():
     # Legacy `runs` attribute is preserved on the session item
     sess_item = db.client._tables[db.session_table_name]["s6"]
     assert sess_item.get("runs") is not None
+    assert db.get_latest_schema_version(db.session_table_name) == "3.0.0"
 
 
 def test_cleanup_refuses_when_legacy_runs_still_present():

--- a/libs/agno/tests/unit/db/test_v3_firestore_migration_compat.py
+++ b/libs/agno/tests/unit/db/test_v3_firestore_migration_compat.py
@@ -8,6 +8,7 @@ adapter code can run unchanged.
 
 from __future__ import annotations
 
+import asyncio
 import time
 from typing import Any, Dict, List
 
@@ -79,6 +80,16 @@ def _patched_batch(self):
 
 MockFirestore.batch = _patched_batch  # type: ignore[method-assign]
 
+# Newer google-cloud-firestore exposes atomic DocumentReference.create().
+# Add the same surface to older mock-firestore releases used by this suite.
+_mock_document_type = type(MockFirestore().collection("_probe").document("_probe"))
+if not hasattr(_mock_document_type, "create"):
+
+    def _create(self, data):
+        return self.set(data)
+
+    _mock_document_type.create = _create
+
 # The adapter imports `DELETE_FIELD` and `FieldFilter` from google.cloud.firestore.
 # Provide a stand-in if google-cloud-firestore isn't installed in the dev env.
 try:
@@ -106,6 +117,8 @@ except ImportError:
 
 from agno.db.base import SessionType  # noqa: E402
 from agno.db.firestore.firestore import FirestoreDb  # noqa: E402
+from agno.db.migrations.manager import MigrationManager  # noqa: E402
+from agno.exceptions import MigrationRequiredError  # noqa: E402
 from agno.models.message import Message  # noqa: E402
 from agno.run.agent import RunOutput  # noqa: E402
 from agno.run.base import RunStatus  # noqa: E402
@@ -131,7 +144,9 @@ def _new_db() -> FirestoreDb:
     return FirestoreDb(db_client=client, session_collection="agno_sessions", runs_collection="agno_runs")
 
 
-def _insert_legacy_session(db: FirestoreDb, session_id: str, runs: List[Dict[str, Any]]) -> None:
+def _insert_legacy_session(
+    db: FirestoreDb, session_id: str, runs: List[Dict[str, Any]], *, stamp_current: bool = True
+) -> None:
     db.db_client.collection("agno_sessions").add(
         {
             "session_id": session_id,
@@ -144,6 +159,34 @@ def _insert_legacy_session(db: FirestoreDb, session_id: str, runs: List[Dict[str
             "updated_at": int(time.time()),
         }
     )
+    if stamp_current:
+        db.upsert_schema_version(db.session_table_name, "3.0.0")
+
+
+@pytest.mark.parametrize("method_name", ["collections", "list_collections"])
+def test_table_exists_supports_official_and_legacy_collection_enumeration(method_name):
+    class Collection:
+        def __init__(self, collection_id):
+            self.id = collection_id
+
+    class Client:
+        def collection(self, name):
+            raise AssertionError(f"collection({name}) should not be needed")
+
+    client = Client()
+    setattr(
+        client,
+        method_name,
+        lambda: [Collection("agno_sessions"), Collection("agno_runs")],
+    )
+    db = FirestoreDb(
+        db_client=client,  # type: ignore[arg-type]
+        session_collection="agno_sessions",
+        runs_collection="agno_runs",
+    )
+
+    assert db.table_exists("agno_sessions") is True
+    assert db.table_exists("missing") is False
 
 
 def test_fresh_schema_round_trip():
@@ -165,9 +208,10 @@ def test_fresh_schema_round_trip():
     loaded = db.get_session("s1", SessionType.AGENT)
     assert [r.run_id for r in loaded.runs] == ["r1", "r2"]
     assert loaded.runs[0].messages[0].content == "q-one"
+    assert db.get_latest_schema_version(db.session_table_name) == "3.0.0"
 
 
-def test_legacy_blob_fallback_on_read():
+def test_migrated_legacy_blob_fallback_on_read():
     db = _new_db()
     runs = [_make_run(f"r{i}", "s2", f"c{i}").to_dict() for i in range(3)]
     _insert_legacy_session(db, "s2", runs)
@@ -203,17 +247,19 @@ def test_partial_state_merges_collection_and_blob():
 def test_v3_migration_is_non_destructive():
     db = _new_db()
     legacy = [_make_run(f"r{i}", "s6", f"c{i}").to_dict() for i in range(2)]
-    _insert_legacy_session(db, "s6", legacy)
+    _insert_legacy_session(db, "s6", legacy, stamp_current=False)
 
-    from agno.db.migrations.versions.v3_0_0 import up as v3_up
+    with pytest.raises(MigrationRequiredError):
+        db.get_session("s6", SessionType.AGENT)
 
-    v3_up(db, table_type="sessions", table_name="agno_sessions")
+    asyncio.run(MigrationManager(db).up(table_type="sessions"))
 
     assert len(list(db.db_client.collection("agno_runs").stream())) == 2
 
     raw_docs = list(db.db_client.collection("agno_sessions").stream())
     raw = raw_docs[0].to_dict()
     assert raw is not None and raw.get("runs") is not None
+    assert db.get_latest_schema_version(db.session_table_name) == "3.0.0"
 
 
 def test_get_run_get_runs_apis():

--- a/libs/agno/tests/unit/db/test_v3_json_migration_compat.py
+++ b/libs/agno/tests/unit/db/test_v3_json_migration_compat.py
@@ -2,14 +2,19 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import tempfile
 import time
 from pathlib import Path
 from typing import Any, Dict, List
 
-from agno.db.base import SessionType
+import pytest
+
+from agno.db.base import SessionType, suspend_schema_version_checks
 from agno.db.json.json_db import JsonDb
+from agno.db.migrations.manager import MigrationManager
+from agno.exceptions import MigrationRequiredError
 from agno.models.message import Message
 from agno.run.agent import RunOutput
 from agno.run.base import RunStatus
@@ -34,7 +39,9 @@ def _new_db() -> JsonDb:
     return JsonDb(db_path=tempfile.mkdtemp())
 
 
-def _insert_legacy_session(db: JsonDb, session_id: str, runs: List[Dict[str, Any]]) -> None:
+def _insert_legacy_session(
+    db: JsonDb, session_id: str, runs: List[Dict[str, Any]], *, stamp_current: bool = True
+) -> None:
     sessions_path = Path(db.db_path) / f"{db.session_table_name}.json"
     sessions_path.parent.mkdir(parents=True, exist_ok=True)
     existing = []
@@ -55,6 +62,8 @@ def _insert_legacy_session(db: JsonDb, session_id: str, runs: List[Dict[str, Any
     )
     with open(sessions_path, "w") as f:
         json.dump(existing, f, default=str)
+    if stamp_current:
+        db.upsert_schema_version(db.session_table_name, "3.0.0")
 
 
 def test_fresh_schema_round_trip():
@@ -79,9 +88,10 @@ def test_fresh_schema_round_trip():
     loaded = db.get_session("s1", SessionType.AGENT)
     assert [r.run_id for r in loaded.runs] == ["r1", "r2"]
     assert loaded.runs[0].messages[0].content == "q-one"
+    assert db.get_latest_schema_version(db.session_table_name) == "3.0.0"
 
 
-def test_legacy_blob_fallback_on_read():
+def test_migrated_legacy_blob_fallback_on_read():
     db = _new_db()
     runs = [_make_run(f"r{i}", "s2", f"c{i}").to_dict() for i in range(3)]
     _insert_legacy_session(db, "s2", runs)
@@ -120,23 +130,23 @@ def test_partial_state_merges():
 def test_v3_migration_is_non_destructive():
     db = _new_db()
     legacy = [_make_run(f"r{i}", "s6", f"c{i}").to_dict() for i in range(2)]
-    _insert_legacy_session(db, "s6", legacy)
+    _insert_legacy_session(db, "s6", legacy, stamp_current=False)
 
-    from agno.db.migrations.versions.v3_0_0 import up as v3_up
+    with pytest.raises(MigrationRequiredError):
+        db.get_session("s6", SessionType.AGENT)
 
-    v3_up(db, table_type="sessions", table_name=db.session_table_name)
+    asyncio.run(MigrationManager(db).up(table_type="sessions"))
 
     assert len(db._read_runs_file()) == 2
 
     sessions = db._read_json_file(db.session_table_name)
     assert sessions[0].get("runs") is not None
+    assert db.get_latest_schema_version(db.session_table_name) == "3.0.0"
 
 
 def test_cleanup_refuses_when_legacy_runs_still_present():
     db = _new_db()
     _insert_legacy_session(db, "s7", [_make_run("r1", "s7", "x").to_dict()])
-
-    import pytest
 
     with pytest.raises(RuntimeError, match="Refusing to unset"):
         db.cleanup_legacy_runs_field()
@@ -166,15 +176,10 @@ def test_get_run_get_runs_apis():
     assert len(db._read_runs_file()) == 0
 
 
-def test_upgrade_without_migration_preserves_runs_on_write():
-    """Regression: upgrading to v3 and continuing a pre-v3 session before running
-    the migration must not silently drop the legacy runs blob.
+def test_current_store_preserves_migrated_legacy_backup_on_write():
+    """A current-version store may retain the legacy runs blob as a backup.
 
-    Bug shape: session.to_dict(include_runs=False) omits `runs`; a bare
-    ``sessions[i] = session_dict`` replace erases anything the legacy blob
-    was holding. Read then merges an empty legacy blob with an empty runs
-    table -> history gone. Only cleanup_legacy_runs_field() should drop it,
-    explicitly.
+    Normal v3 writes must not erase that backup before explicit cleanup.
     """
     db = _new_db()
     legacy = [_make_run(f"r{i}", "s_upgrade", f"c{i}").to_dict() for i in range(3)]
@@ -202,3 +207,54 @@ def test_upgrade_without_migration_preserves_runs_on_write():
     )
     # And the metadata write actually landed.
     assert after.metadata == {"touched_by_v3": True}
+
+
+def test_schema_version_read_is_side_effect_free() -> None:
+    db = _new_db()
+    versions_path = Path(db.db_path) / f"{db.versions_table_name}.json"
+
+    assert db.get_latest_schema_version(db.session_table_name) == "2.0.0"
+    assert not versions_path.exists()
+
+
+def test_successful_schema_check_is_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    db = _new_db()
+    db._read_json_file(db.session_table_name)
+    second_instance = JsonDb(db_path=str(db.db_path))
+    calls = 0
+    original = second_instance.get_latest_schema_version
+
+    def counted_get_latest(table_name: str = ""):
+        nonlocal calls
+        calls += 1
+        return original(table_name)
+
+    monkeypatch.setattr(second_instance, "get_latest_schema_version", counted_get_latest)
+
+    second_instance._read_json_file(second_instance.session_table_name)
+    second_instance._read_json_file(second_instance.session_table_name)
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_migration_bypass_is_context_local() -> None:
+    db = _new_db()
+    _insert_legacy_session(db, "stale", [], stamp_current=False)
+    bypass_entered = asyncio.Event()
+    normal_finished = asyncio.Event()
+
+    async def migration_task() -> None:
+        with suspend_schema_version_checks():
+            bypass_entered.set()
+            await normal_finished.wait()
+            assert db._read_json_file(db.session_table_name, create_table_if_not_found=False)
+
+    async def normal_task() -> None:
+        await bypass_entered.wait()
+        try:
+            with pytest.raises(MigrationRequiredError):
+                db._read_json_file(db.session_table_name, create_table_if_not_found=False)
+        finally:
+            normal_finished.set()
+
+    await asyncio.gather(migration_task(), normal_task())

--- a/libs/agno/tests/unit/db/test_v3_migration_idempotent.py
+++ b/libs/agno/tests/unit/db/test_v3_migration_idempotent.py
@@ -11,6 +11,7 @@ JsonDb — the reviewer's exact scenario.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import tempfile
@@ -18,6 +19,7 @@ import tempfile
 import pytest
 
 from agno.db.json.json_db import JsonDb
+from agno.db.migrations.manager import MigrationManager
 from agno.db.migrations.versions.v3_0_0 import _migrate_jsondb
 
 
@@ -39,7 +41,7 @@ def partially_migrated_json_db():
     }
     with open(os.path.join(tmp, "agno_sessions.json"), "w") as f:
         json.dump([session_row], f)
-    _migrate_jsondb(db, "sessions", "agno_sessions")
+    asyncio.run(MigrationManager(db).up(table_type="sessions"))
     return db
 
 

--- a/libs/agno/tests/unit/db/test_v3_mongo_migration_compat.py
+++ b/libs/agno/tests/unit/db/test_v3_mongo_migration_compat.py
@@ -6,6 +6,7 @@ adapter via mongomock so no real MongoDB instance is needed.
 
 from __future__ import annotations
 
+import asyncio
 import time
 from typing import Any, Dict, List
 
@@ -14,7 +15,9 @@ import pytest
 mongomock = pytest.importorskip("mongomock")
 
 from agno.db.base import SessionType  # noqa: E402
+from agno.db.migrations.manager import MigrationManager  # noqa: E402
 from agno.db.mongo.mongo import MongoDb  # noqa: E402
+from agno.exceptions import MigrationRequiredError  # noqa: E402
 from agno.models.message import Message  # noqa: E402
 from agno.run.agent import RunOutput  # noqa: E402
 from agno.run.base import RunStatus  # noqa: E402
@@ -47,7 +50,9 @@ def _new_db() -> MongoDb:
     return db
 
 
-def _insert_legacy_session(db: MongoDb, session_id: str, runs: List[Dict[str, Any]]) -> None:
+def _insert_legacy_session(
+    db: MongoDb, session_id: str, runs: List[Dict[str, Any]], *, stamp_current: bool = True
+) -> None:
     """Directly write a session document with a legacy `runs` array (simulates v2.x)."""
     db._database["agno_sessions"].insert_one(
         {
@@ -61,6 +66,8 @@ def _insert_legacy_session(db: MongoDb, session_id: str, runs: List[Dict[str, An
             "updated_at": int(time.time()),
         }
     )
+    if stamp_current:
+        db.upsert_schema_version(db.session_table_name, "3.0.0")
 
 
 def test_fresh_schema_round_trip():
@@ -78,9 +85,10 @@ def test_fresh_schema_round_trip():
     loaded = db.get_session("s1", SessionType.AGENT)
     assert [r.run_id for r in loaded.runs] == ["r1", "r2"]
     assert loaded.runs[0].messages[0].content == "q-one"
+    assert db.get_latest_schema_version(db.session_table_name) == "3.0.0"
 
 
-def test_legacy_blob_fallback_on_read():
+def test_migrated_legacy_blob_fallback_on_read():
     db = _new_db()
     runs = [_make_run(f"r{i}", "s2", f"c{i}").to_dict() for i in range(3)]
     _insert_legacy_session(db, "s2", runs)
@@ -160,16 +168,18 @@ def test_partial_state_collection_wins_over_blob_on_conflict():
 def test_v3_migration_is_non_destructive():
     db = _new_db()
     legacy = [_make_run(f"r{i}", "s6", f"c{i}").to_dict() for i in range(2)]
-    _insert_legacy_session(db, "s6", legacy)
+    _insert_legacy_session(db, "s6", legacy, stamp_current=False)
 
-    from agno.db.migrations.versions.v3_0_0 import up as v3_up
+    with pytest.raises(MigrationRequiredError):
+        db.get_session("s6", SessionType.AGENT)
 
-    v3_up(db, table_type="sessions", table_name="agno_sessions")
+    asyncio.run(MigrationManager(db).up(table_type="sessions"))
 
     assert db._database["agno_runs"].count_documents({"session_id": "s6"}) == 2
 
     raw = db._database["agno_sessions"].find_one({"session_id": "s6"})
     assert raw is not None and raw.get("runs") is not None
+    assert db.get_latest_schema_version(db.session_table_name) == "3.0.0"
 
 
 def test_cleanup_refuses_when_legacy_runs_still_present():
@@ -190,11 +200,9 @@ def test_cleanup_after_migration_requires_force():
     as a frozen backup. Non-force cleanup refuses; force=True reclaims it."""
     db = _new_db()
     legacy = [_make_run("r1", "s8", "x").to_dict()]
-    _insert_legacy_session(db, "s8", legacy)
+    _insert_legacy_session(db, "s8", legacy, stamp_current=False)
 
-    from agno.db.migrations.versions.v3_0_0 import up as v3_up
-
-    v3_up(db, table_type="sessions", table_name="agno_sessions")
+    asyncio.run(MigrationManager(db).up(table_type="sessions"))
 
     # Touching the session no longer unsets the legacy field (frozen backup).
     session = db.get_session("s8", SessionType.AGENT)

--- a/libs/agno/tests/unit/db/test_v3_redis_migration_compat.py
+++ b/libs/agno/tests/unit/db/test_v3_redis_migration_compat.py
@@ -5,6 +5,7 @@ Uses ``fakeredis`` so no real Redis instance is needed.
 
 from __future__ import annotations
 
+import asyncio
 import time
 from typing import Any, Dict, List
 
@@ -13,8 +14,10 @@ import pytest
 fakeredis = pytest.importorskip("fakeredis")
 
 from agno.db.base import SessionType  # noqa: E402
+from agno.db.migrations.manager import MigrationManager  # noqa: E402
 from agno.db.redis.redis import RedisDb  # noqa: E402
 from agno.db.redis.utils import generate_redis_key, serialize_data  # noqa: E402
+from agno.exceptions import MigrationRequiredError  # noqa: E402
 from agno.models.message import Message  # noqa: E402
 from agno.run.agent import RunOutput  # noqa: E402
 from agno.run.base import RunStatus  # noqa: E402
@@ -39,7 +42,9 @@ def _new_db() -> RedisDb:
     return RedisDb(redis_client=fakeredis.FakeRedis(decode_responses=True), db_prefix="agno")
 
 
-def _insert_legacy_session(db: RedisDb, session_id: str, runs: List[Dict[str, Any]]) -> None:
+def _insert_legacy_session(
+    db: RedisDb, session_id: str, runs: List[Dict[str, Any]], *, stamp_current: bool = True
+) -> None:
     """Write a v2.x-shaped session record directly (with inline `runs` field)."""
     data = {
         "session_id": session_id,
@@ -53,6 +58,8 @@ def _insert_legacy_session(db: RedisDb, session_id: str, runs: List[Dict[str, An
     }
     key = generate_redis_key(prefix=db.db_prefix, table_type="sessions", key_id=session_id)
     db.redis_client.set(key, serialize_data(data))
+    if stamp_current:
+        db.upsert_schema_version(db.session_table_name, "3.0.0")
 
 
 def test_fresh_schema_round_trip():
@@ -78,9 +85,10 @@ def test_fresh_schema_round_trip():
     loaded = db.get_session("s1", SessionType.AGENT)
     assert [r.run_id for r in loaded.runs] == ["r1", "r2"]
     assert loaded.runs[0].messages[0].content == "q-one"
+    assert db.get_latest_schema_version(db.session_table_name) == "3.0.0"
 
 
-def test_legacy_blob_fallback_on_read():
+def test_migrated_legacy_blob_fallback_on_read():
     db = _new_db()
     runs = [_make_run(f"r{i}", "s2", f"c{i}").to_dict() for i in range(3)]
     _insert_legacy_session(db, "s2", runs)
@@ -117,11 +125,12 @@ def test_partial_state_merges_collection_and_blob():
 def test_v3_migration_is_non_destructive():
     db = _new_db()
     legacy = [_make_run(f"r{i}", "s6", f"c{i}").to_dict() for i in range(2)]
-    _insert_legacy_session(db, "s6", legacy)
+    _insert_legacy_session(db, "s6", legacy, stamp_current=False)
 
-    from agno.db.migrations.versions.v3_0_0 import up as v3_up
+    with pytest.raises(MigrationRequiredError):
+        db.get_session("s6", SessionType.AGENT)
 
-    v3_up(db, table_type="sessions", table_name="agno_sessions")
+    asyncio.run(MigrationManager(db).up(table_type="sessions"))
 
     # Runs are in the runs keys
     rows, total = db.get_runs(session_id="s6", deserialize=False)
@@ -130,6 +139,7 @@ def test_v3_migration_is_non_destructive():
     # Legacy field is preserved on the session record
     raw = db._get_record("sessions", "s6")
     assert raw is not None and raw.get("runs") is not None
+    assert db.get_latest_schema_version(db.session_table_name) == "3.0.0"
 
 
 def test_cleanup_refuses_when_legacy_runs_still_present():
@@ -196,9 +206,9 @@ def test_ids_containing_the_index_marker_stay_visible():
         assert db.get_session(sid, SessionType.AGENT) is not None
 
 
-def test_upgrade_without_migration_preserves_runs_on_write():
-    """Option A regression: continuing a legacy session WITHOUT running the migration
-    must not drop the pre-existing runs. RedisDb replaces the whole session record on
+def test_current_store_preserves_migrated_legacy_backup_on_write():
+    """A current store may retain the migrated legacy backup. RedisDb replaces the
+    whole session record on
     write, so it carries the legacy blob forward as a frozen backup."""
     db = _new_db()
     legacy = [_make_run(f"r{i}", "s9", f"c{i}").to_dict() for i in range(3)]


### PR DESCRIPTION
## Summary

Fixes #9677.

Non-SQL adapters now refuse normal access to a migratable table whose stored schema version is behind the current Agno migration version. The implementation:

- adds cached first-access validation to `BaseDb` / `AsyncBaseDb`;
- uses a context-local bypass while `MigrationManager.up()` / `down()` is actively repairing stale storage, without disabling checks in concurrent requests;
- distinguishes existing storage from freshly created storage in MongoDB (sync/async), SurrealDB, JSON, DynamoDB, Redis, and Firestore;
- stamps only storage that this process can prove is fresh, and validates existing/race-loser storage before index creation or mutation;
- keeps version discovery side-effect-free for JSON and DynamoDB;
- fixes DynamoDB create-error propagation and Firestore's official `Client.collections()` enumeration path.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (not applicable; adapter behavior only)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach (no matching open PR found)
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Validation performed in a clean Python 3.12 Linux container:

- `./scripts/format.sh`: passed (Agno, agnoctl, agno-infra, cookbook)
- `./scripts/validate.sh`: all Ruff, agnoctl mypy, and cookbook checks passed; the Agno-wide mypy step retains one target-branch error in untouched `agno/tools/google/bigquery.py` (`google.cloud` has no `bigquery` attribute)
- isolated mypy for all 10 changed production modules: passed
- `tests/unit/db`: **1372 passed, 97 skipped**

Five optional Mongo/Firestore v3 compatibility cases were deselected from the aggregate command after confirming that they fail identically on untouched target commit `5ba70f5`; they expect `upsert_session()` to persist runs even though the v3 adapter contract persists runs through `upsert_run()`. All new and modified schema-version tests pass.

The create/stamp sequence intentionally fails closed during cross-process races: a peer that observes storage before the creator's version stamp validates it as stale rather than unconditionally blessing it. Migration bypass is context-local, so concurrent normal requests remain blocked.

AI assistance disclosure: implemented with OpenAI Codex assistance and reviewed through targeted diff inspection, baseline comparison, full database-unit regression, lint, and type checks.
