### PR TITLE
chore: bump agno to 3.0.0a3

### DIFF
--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agno"
-version = "3.0.0a2"
+version = "3.0.0a3"
 description = "The programming language for agentic software."
 requires-python = ">=3.9,<4"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Bump the `agno` package version from `3.0.0a2` to `3.0.0a3` for the third 3.0.0 alpha release. This is the only change needed for the release:

- `agnoctl` (0.1.3) and `agno-infra` (1.1.1) have zero commits since v3.0.0a2 and their current versions are already on PyPI, so the release workflow will skip them.
- 37 commits land in this alpha since v3.0.0a2, including the anthropic 1.0.0 compatibility fix (#9686), CodeMode and result offloading (#9436, #9684), media offloading to S3/GCS (#9340), LearningMachine as the only Studio memory surface (#9695), the import-time and hot-path performance work (#9678, #9689, #9693), and the long-conversation session-save fixes (#9700).

After this merges, publishing the `v3.0.0a3` GitHub release (target `feat/v3.0`, pre-release) triggers the Release Agno workflow, which builds and publishes `agno==3.0.0a3` to PyPI.

## Type of change

- [x] Other: release version bump

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Verified before opening this PR:
- Hosted Validation workflow green on `06bd6c068`; the `6f4112c06` tip re-run is cookbook-only on top of that.
- Local: ruff + mypy clean, agnoctl suite 344 passed, sdist + wheel build cleanly.
- Live-model Main Validation matrix is re-running on the new tip after the cookbook merge; recommend letting it finish before publishing the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)