### PR TITLE
feat: run SqliteDb in WAL journal mode and restore the durable benchmark row

### DIFF
--- a/cookbook/performance/README.md
+++ b/cookbook/performance/README.md
@@ -18,7 +18,11 @@ Measured 2026-08-22 on an Apple M4 Max, Python 3.12, all four frameworks
 installed in a single environment, one sequential run, medians reported.
 Framework versions: LangGraph 1.2.11, PydanticAI 2.31.1, CrewAI 1.15.17;
 Agno at the feat/v3.0 tip, which includes the copy-on-write history and
-incremental run-persistence changes.
+incremental run-persistence changes. The durable row was re-measured
+after SqliteDb adopted SQLite's WAL journal mode, matching the journal
+configuration SqliteSaver already used; the other rows are unchanged
+from the prior run, and the conversation rows reproduced within noise
+in the re-measurement session.
 
 | Metric | Agno | LangGraph | PydanticAI | CrewAI |
 |---|---|---|---|---|
@@ -26,7 +30,7 @@ incremental run-persistence changes.
 | Tool-call run (mocked model) | 327 us | 787 us (2.4x) | 2,394 us (7.3x) | excluded |
 | 5-turn conversation, in-memory | 1.0 ms | 3.5 ms (3.4x) | 8.0 ms (7.9x) | 19.0 ms (19x) |
 | 25-turn conversation, in-memory | 12.2 ms | 22.3 ms (1.8x) | 39.2 ms (3.2x) | 92.9 ms (7.6x) |
-| 25-turn conversation, durable (SQLite) | 52.3 ms | 39.0 ms (0.7x) | excluded | excluded |
+| 25-turn conversation, durable (SQLite) | 42.2 ms | 36.5 ms (0.9x) | excluded | excluded |
 | Agent construction (1 tool) | 4.7 us | 1,256 us (269x) | 9,546 us (2,046x) | 19,101 us (4,094x) |
 | Construction memory peak | 7.1 KiB | 146 KiB (21x) | 39 KiB (5.6x) | 24 KiB (3.3x) |
 | Cold import | 147 ms | 313 ms (2.1x) | 419 ms (2.9x) | 1,031 ms (7.0x) |
@@ -50,11 +54,16 @@ paths were rewritten — history messages are copied on write, and the
 in-memory store persists runs incrementally — and the row now measures
 a 1.8x win under the same matched configuration, against LangGraph's
 reference-holding checkpointer with Agno's session cache enabled. Third,
-the durable 25-turn row is the benchmark Agno still loses. Both sides
-serialize every turn to SQLite; Agno's SQL adapter write path spends more
-per turn on serializing session state that grows with length. It is the
-remaining known optimization target, and the row will be re-measured when
-that work lands.
+the durable 25-turn row is the benchmark Agno still loses, though by a
+far narrower margin than earlier revisions reported (52.3 ms against
+39.0 ms). Most of that gap was a journal-mode mismatch rather than
+framework overhead: SqliteSaver configures its connection into WAL mode
+while SqliteDb ran SQLite's DELETE default, paying a journal-file
+create, double fsync, and delete on every commit. SqliteDb now runs WAL
+too (with `synchronous` left at FULL, so commit durability is
+unchanged), and the row compares frameworks on equal footing. The
+remaining difference is Agno's per-turn serialization of session state
+that grows with length — the known optimization target for this row.
 
 ## 1. Environment setup
 

--- a/cookbook/performance/TEST_LOG.md
+++ b/cookbook/performance/TEST_LOG.md
@@ -179,6 +179,29 @@ robustness; every finding independently verified) confirmed 21 findings, all fix
   streaming benchmark asserts error-free content, import failures surface stderr, the runner
   clears stale result files, and quick runs are isolated and labeled in the report.
 
+## 2026-08-22
+
+### comparison/run_all.py (full suite, after SqliteDb WAL journal mode)
+
+**Status:** PASS
+
+**Description:** Full sequential comparison run at commit 6dd178afe (feat/v3.0 plus the
+SqliteDb WAL change) in a fresh perf environment; 10 benchmark files, zero failures,
+summary.json written. Purpose: re-measure the durable 25-turn row now that SqliteDb runs
+WAL journal mode, matching the configuration LangGraph's SqliteSaver already used.
+
+**Result:** Durable 25-turn medians: agno 42.2 ms vs LangGraph 36.5 ms (0.9x) — up from
+52.3 vs 39.0 ms (0.7x) before WAL; most of the previous gap was the journal-mode mismatch
+(DELETE journal's file create, double fsync, and delete per commit). A standalone run of
+durable_conversation_comparison.py in the same environment measured agno at 39.6 ms median,
+at parity with LangGraph — run-to-run variance on this row is a few ms. All other rows
+reproduced the published reference table within noise, except the cold-import rows, which
+are inflated for every framework in this environment by full pydantic-ai pulling logfire
+(its pydantic plugin hooks imports); the import rows were therefore left as published.
+Reference table durable row and discussion updated in README.md.
+
+---
+
 ## Notes
 
 - 2026-08-21: First version of `_bench.py` stored the mock's requested tool name as

--- a/cookbook/performance/comparison/README.md
+++ b/cookbook/performance/comparison/README.md
@@ -50,17 +50,20 @@ advantaged:
   persisted by anyone.
 - **Durable** (25-turn): Agno with `SqliteDb`, LangGraph with
   `SqliteSaver`; both serialize and write to a SQLite file every turn,
-  with a fresh database file per conversation. LangGraph's figure
-  includes one graph compile (the checkpointer binds at compile).
-  PydanticAI ships no persistence layer and CrewAI has no conversation
-  primitive, so neither appears in this row.
+  with a fresh database file per conversation. Both adapters run
+  SQLite's WAL journal mode (SqliteSaver configures it on its
+  connection; SqliteDb enables it on every new connection), so the row
+  compares frameworks rather than journal configurations. LangGraph's
+  figure includes one graph compile (the checkpointer binds at
+  compile). PydanticAI ships no persistence layer and CrewAI has no
+  conversation primitive, so neither appears in this row.
 
-Agno does not currently win the 25-turn benchmark in either
-configuration: its per-turn write path re-serializes conversation state
-that grows with length. The results are published as measured; the growth
-term is a known optimization target. Every variant asserts after the
-final turn that history actually accumulated, so a silently stateless
-conversation fails instead of producing a flattering number.
+Agno wins the 25-turn in-memory configuration and loses the durable one
+by a narrow margin: its per-turn write path re-serializes conversation
+state that grows with length. The results are published as measured;
+the growth term is a known optimization target. Every variant asserts
+after the final turn that history actually accumulated, so a silently
+stateless conversation fails instead of producing a flattering number.
 
 All conversation variants raise Agno's default history cap
 (`num_history_runs=3`) so the full conversation stays in context, matching

--- a/cookbook/performance/comparison/durable_conversation_comparison.py
+++ b/cookbook/performance/comparison/durable_conversation_comparison.py
@@ -14,8 +14,12 @@ included variant uses a fresh database file per conversation so
 per-iteration work is constant, and asserts after the final turn that
 history actually accumulated.
 
-Agno does not currently win this benchmark; the result is published as
-measured and the write-path serialization is a known optimization target.
+Both adapters run SQLite's WAL journal mode (SqliteSaver configures it
+on its connection; SqliteDb enables it on every new connection), so the
+row compares frameworks rather than journal configurations. Agno still
+measures modestly slower here; the result is published as measured and
+the per-turn serialization of growing session state is the known
+optimization target.
 """
 
 import itertools

--- a/cookbook/performance/report.py
+++ b/cookbook/performance/report.py
@@ -196,11 +196,11 @@ def comparison_groups(versions: dict) -> list:
             "ratio_to": "long_conversation_compare_agno",
             "blurb": (
                 "The five-turn benchmark extended to twenty-five turns, so costs "
-                "that grow with history length dominate. Agno does not currently "
-                "win this one: even with its session cache enabled, its per-turn "
-                "write path re-serializes conversation state that LangGraph's "
-                "in-memory checkpointer stores by reference. Published as "
-                "measured; the growth term is a known optimization target."
+                "that grow with history length dominate. Earlier revisions "
+                "reported this as a loss; after the copy-on-write history and "
+                "incremental run-persistence changes it measures a win over "
+                "LangGraph's reference-holding in-memory checkpointer, with "
+                "Agno's session cache enabled in the matched configuration."
             ),
             "rows": [
                 ("long_conversation_compare_agno", agno, "sync"),
@@ -220,10 +220,11 @@ def comparison_groups(versions: dict) -> list:
                 "The twenty-five-turn conversation persisted to a SQLite "
                 "database every turn: Agno with SqliteDb, LangGraph with "
                 "SqliteSaver, both paying real serialization and database "
-                "writes. Agno does not currently win this one either; the "
-                "write path is a known optimization target. PydanticAI ships "
-                "no persistence layer and CrewAI has no conversation "
-                "primitive, so neither appears here."
+                "writes, both running SQLite's WAL journal mode. LangGraph "
+                "still measures modestly faster; the per-turn serialization "
+                "of growing session state is the known optimization target. "
+                "PydanticAI ships no persistence layer and CrewAI has no "
+                "conversation primitive, so neither appears here."
             ),
             "rows": [
                 ("durable_conversation_compare_agno", agno, "sync"),

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -169,10 +169,24 @@ class AsyncSqliteDb(AsyncBaseDb):
         from sqlalchemy import event as _sa_event
 
         @_sa_event.listens_for(self.db_engine.sync_engine, "connect")
-        def _enable_sqlite_fk_pragma(dbapi_connection, connection_record):  # type: ignore[no-redef]
+        def _set_sqlite_pragmas(dbapi_connection, connection_record):  # type: ignore[no-redef]
             try:
                 cursor = dbapi_connection.cursor()
                 cursor.execute("PRAGMA foreign_keys = ON")
+                # WAL replaces the default DELETE journal, which creates, fsyncs
+                # and deletes a journal file on every commit. The mode persists
+                # in the database file, so re-issuing it per connection is an
+                # idempotent no-op. synchronous is left at its default (FULL):
+                # commits still fsync, durability is unchanged. Where SQLite
+                # cannot switch (in-memory databases, filesystems without
+                # shared-memory support such as some network mounts) the pragma
+                # reports the mode actually in effect — keep whatever it gives
+                # back.
+                cursor.execute("PRAGMA journal_mode=WAL")
+                row = cursor.fetchone()
+                mode = row[0] if row else None
+                if isinstance(mode, str) and mode.lower() != "wal":
+                    log_debug(f"SQLite journal_mode=WAL unavailable, running with journal_mode={mode}")
                 cursor.close()
             except Exception:
                 pass

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -215,10 +215,24 @@ class SqliteDb(BaseDb):
         from sqlalchemy import event as _sa_event
 
         @_sa_event.listens_for(self.db_engine, "connect")
-        def _enable_sqlite_fk_pragma(dbapi_connection, connection_record):  # type: ignore[no-redef]
+        def _set_sqlite_pragmas(dbapi_connection, connection_record):  # type: ignore[no-redef]
             try:
                 cursor = dbapi_connection.cursor()
                 cursor.execute("PRAGMA foreign_keys = ON")
+                # WAL replaces the default DELETE journal, which creates, fsyncs
+                # and deletes a journal file on every commit. The mode persists
+                # in the database file, so re-issuing it per connection is an
+                # idempotent no-op. synchronous is left at its default (FULL):
+                # commits still fsync, durability is unchanged. Where SQLite
+                # cannot switch (in-memory databases, filesystems without
+                # shared-memory support such as some network mounts) the pragma
+                # reports the mode actually in effect — keep whatever it gives
+                # back.
+                cursor.execute("PRAGMA journal_mode=WAL")
+                row = cursor.fetchone()
+                mode = row[0] if row else None
+                if isinstance(mode, str) and mode.lower() != "wal":
+                    log_debug(f"SQLite journal_mode=WAL unavailable, running with journal_mode={mode}")
                 cursor.close()
             except Exception:
                 # Not SQLite (someone passed a different db_engine) — ignore.

--- a/libs/agno/tests/unit/db/test_sqlite_wal.py
+++ b/libs/agno/tests/unit/db/test_sqlite_wal.py
@@ -1,0 +1,70 @@
+"""SqliteDb must run its database in WAL journal mode.
+
+SQLite's default DELETE journal creates, fsyncs and deletes a rollback
+journal file on every commit; WAL avoids that per-commit file churn. The
+adapter issues PRAGMA journal_mode=WAL on each new connection — the mode
+persists in the database file, so a completely separate connection must
+report it too. synchronous stays at SQLite's default (FULL) so commits
+keep their durability guarantee, and databases where WAL cannot work
+(e.g. in-memory) must keep operating in whatever mode SQLite falls back
+to.
+"""
+
+import sqlite3
+
+import pytest
+from sqlalchemy import text
+
+from agno.db.sqlite import SqliteDb
+from agno.db.sqlite.async_sqlite import AsyncSqliteDb
+
+
+def _journal_mode_via_separate_connection(db_file: str) -> str:
+    """Read the journal mode the way any other process would see it."""
+    conn = sqlite3.connect(db_file)
+    try:
+        return conn.execute("PRAGMA journal_mode").fetchone()[0]
+    finally:
+        conn.close()
+
+
+def test_fresh_sqlite_db_is_in_wal_mode(tmp_path):
+    db_file = str(tmp_path / "wal.db")
+    db = SqliteDb(db_file=db_file, session_table="sess")
+
+    with db.db_engine.connect():
+        pass
+
+    assert _journal_mode_via_separate_connection(db_file) == "wal"
+
+
+@pytest.mark.asyncio
+async def test_fresh_async_sqlite_db_is_in_wal_mode(tmp_path):
+    db_file = str(tmp_path / "wal_async.db")
+    db = AsyncSqliteDb(db_file=db_file, session_table="sess")
+
+    async with db.db_engine.connect():
+        pass
+    await db.db_engine.dispose()
+
+    assert _journal_mode_via_separate_connection(db_file) == "wal"
+
+
+def test_wal_does_not_weaken_durability(tmp_path):
+    """synchronous must stay at SQLite's default FULL (2) — WAL changes the
+    journal, not how hard commits sync."""
+    db = SqliteDb(db_file=str(tmp_path / "sync.db"), session_table="sess")
+
+    with db.db_engine.connect() as conn:
+        assert conn.execute(text("PRAGMA synchronous")).fetchone()[0] == 2
+
+
+def test_in_memory_database_falls_back_gracefully():
+    """In-memory databases cannot use WAL; the adapter must accept SQLite's
+    fallback mode instead of failing the connection."""
+    db = SqliteDb(db_url="sqlite:///:memory:", session_table="sess")
+
+    with db.db_engine.connect() as conn:
+        mode = conn.execute(text("PRAGMA journal_mode")).fetchone()[0]
+
+    assert mode == "memory"


### PR DESCRIPTION
## Summary

Enables SQLite's WAL journal mode in `SqliteDb` and `AsyncSqliteDb`, and re-measures the durable 25-turn conversation benchmark that the mode mismatch was distorting.

**The adapter change.** An instrumented probe during the `cookbook/performance` durable-conversation benchmark showed `SqliteDb` running SQLite's default DELETE journal — a journal-file create, double fsync, and delete on every commit — while LangGraph's `SqliteSaver` self-configures WAL, so the benchmark compared journal modes as well as frameworks. Both adapters now issue `PRAGMA journal_mode=WAL` from the existing per-connection `connect` listener (the one that already sets `PRAGMA foreign_keys`):

- WAL persists in the database file, so re-issuing it per connection is an idempotent no-op.
- `synchronous` is deliberately left at SQLite's default FULL: commits still fsync, durability semantics are unchanged.
- Where SQLite cannot switch (in-memory databases, filesystems without shared-memory support such as some network mounts), the pragma reports the mode actually in effect; the adapter keeps that mode and logs it at debug level instead of failing.
- Non-SQLite engines passed via `db_engine` are unaffected (the existing try/except path).

**The re-measurement.** Full sequential comparison run (`comparison/run_all.py`, fresh perf environment, Apple M4 Max) at the WAL commit:

| | Agno | LangGraph SqliteSaver |
|---|---|---|
| Before (published) | 52.3 ms | 39.0 ms (0.7x) |
| After WAL | 42.2 ms | 36.5 ms (0.9x) |

Most of the published gap was the journal-mode mismatch, not framework overhead. A standalone run of the durable benchmark in the same environment measured Agno at 39.6 ms median — parity with LangGraph — so run-to-run variance on this row is a few ms; the table records the full-suite session per the suite's protocol. The remaining difference is the per-turn serialization of growing session state, which stays the documented optimization target for this row.

Docs updated accordingly: the reference table and results discussion in `cookbook/performance/README.md`, the fairness notes in `comparison/README.md`, the durable benchmark docstring, the report blurbs (including the stale long-conversation blurb that still described the in-memory 25-turn row as a loss, contradicting the published table), and `TEST_LOG.md`.

**Interaction with #9706.** That open PR excludes the durable row from the headline table precisely because of the journal-mode mismatch, with a note that the row returns when WAL adoption lands. This PR is that WAL adoption; it is based on the current `feat/v3.0` tip where the row is still present, so it keeps the row with refreshed numbers. If #9706 merges first, the merge conflict in `report.py`/`comparison/README.md` should resolve in favor of this PR's restored row. The cold-import rows were left as published: the current full-`pydantic-ai` perf environment inflates every framework's import via logfire (the exact issue #9706 fixes in `perf_setup.sh`).

## Type of change

- [x] Improvement

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Testing.**
- New unit tests (`libs/agno/tests/unit/db/test_sqlite_wal.py`): a fresh `SqliteDb` and a fresh `AsyncSqliteDb` database each report `journal_mode=wal` when read via a completely separate `sqlite3` connection (proving persistence in the file, not just the pragma's connection); `synchronous` stays at FULL (2); an in-memory database keeps operating in SQLite's `memory` fallback mode. All four fail without the adapter change (verified by stashing it).
- `tests/unit/db` sqlite-backed suites: 821 passed, 2 skipped (both skips are provider suites unrelated to this change).
- `tests/integration/db/sqlite`: 101 passed, 1 pre-existing failure (`test_service_accounts.py::test_token_hash_lookup_reraises_on_db_error`) that fails identically on a clean `feat/v3.0` checkout at dbce06eaa with this change stashed — flagged separately, not touched here.
- `validate.sh` mypy reports 73 pre-existing errors, all in files this PR does not touch (redis, genai compat, lancedb, …); the two changed adapter files pass mypy clean.

**Follow-ups (not in this PR).**
- The larger durable-row target from the probe work: per-turn serialization of session state in the SQL write path.
- `agno/fs/db.py` (DbFileSystem) creates its own SQLite engines and still runs the DELETE journal; same treatment could apply if its write path matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
