### PR TITLE
fix(tools): honour kwargs a tool hook passes via next_func

### DIFF
--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -2050,6 +2050,10 @@ class FunctionCall(BaseModel):
             arguments = entrypoint_args.copy()
             if self.arguments is not None:
                 arguments.update(self.arguments)
+            if args:
+                # A tool hook may hand a fresh dict down via next_func(**kwargs);
+                # honour it instead of silently rebuilding the original arguments.
+                arguments.update(args)
             slot = _start_entrypoint_call(raw_results) if raw_results is not None else -1
             result = self.function.entrypoint(**arguments)  # type: ignore
             if raw_results is not None:
@@ -2341,6 +2345,10 @@ class FunctionCall(BaseModel):
             arguments = entrypoint_args.copy()
             if self.arguments is not None:
                 arguments.update(self.arguments)
+            if args:
+                # A tool hook may hand a fresh dict down via next_func(**kwargs);
+                # honour it instead of silently rebuilding the original arguments.
+                arguments.update(args)
 
             slot = _start_entrypoint_call(raw_results) if raw_results is not None else -1
             result = self.function.entrypoint(**arguments)  # type: ignore
@@ -2357,6 +2365,10 @@ class FunctionCall(BaseModel):
             arguments = entrypoint_args.copy()
             if self.arguments is not None:
                 arguments.update(self.arguments)
+            if args:
+                # A tool hook may hand a fresh dict down via next_func(**kwargs);
+                # honour it instead of silently rebuilding the original arguments.
+                arguments.update(args)
             slot = _start_entrypoint_call(raw_results) if raw_results is not None else -1
             result = self.function.entrypoint(**arguments)  # type: ignore
             if raw_results is not None:

--- a/libs/agno/tests/unit/tools/test_functions.py
+++ b/libs/agno/tests/unit/tools/test_functions.py
@@ -582,6 +582,45 @@ def test_function_call_with_tool_hooks():
     assert hook_calls[1][2] == "processed-value1"
 
 
+def test_tool_hook_new_dict_kwargs_reach_entrypoint():
+    """A hook that passes a fresh dict to the next function must not be dropped."""
+
+    def injecting_hook(function_name: str, function_call: Callable, arguments: dict[str, Any]):
+        return function_call(**arguments, injected="via-kwargs")
+
+    @tool(tool_hooks=[injecting_hook])
+    def test_func(param1: str, injected: str = "default") -> str:
+        return f"processed-{param1}-{injected}"
+
+    test_func.process_entrypoint()
+
+    call = FunctionCall(function=test_func, arguments={"param1": "value1"})
+
+    result = call.execute()
+    assert result.status == "success"
+    assert result.result == "processed-value1-via-kwargs"
+
+
+@pytest.mark.asyncio
+async def test_tool_hook_async_new_dict_kwargs_reach_entrypoint():
+    """Async twin: a fresh-dict next_func(**kwargs) call must reach the entrypoint."""
+
+    def injecting_hook(function_name: str, function_call: Callable, arguments: dict[str, Any]):
+        return function_call(**arguments, injected="via-kwargs")
+
+    @tool(tool_hooks=[injecting_hook])
+    async def test_func(param1: str, injected: str = "default") -> str:
+        return f"processed-{param1}-{injected}"
+
+    test_func.process_entrypoint()
+
+    call = FunctionCall(function=test_func, arguments={"param1": "value1"})
+
+    result = await call.aexecute()
+    assert result.status == "success"
+    assert result.result == "processed-value1-via-kwargs"
+
+
 @pytest.mark.asyncio
 async def test_function_call_async_execution():
     """Test async function call execution."""


### PR DESCRIPTION
## Summary

Fixes #9682

`execute_entrypoint` (and both async twins inside `_build_nested_execution_chain_async`) ignored their `args` parameter and rebuilt the call from `entrypoint_args` + `self.arguments`. A tool hook that called `next_func(**new_dict)` therefore had no effect — only in-place mutation of the handed-down dict reached the entrypoint, while the fresh-dict form the cookbook describes was silently discarded.

This change merges the hook-passed `args` into the rebuilt arguments on the miss path, so hooks can pass either form. The cache-hit branch keeps its existing semantics (a hit still answers before the entrypoint runs).

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines (ruff check on changed files: no new findings vs main)
- [x] Ran format/validation scripts — ruff clean; targeted tests executed locally
- [x] Self-review completed
- [x] Documentation updated (inline comments at each fix site)
- [ ] Examples and guides: not applicable (behaviour now matches the existing cookbook description)
- [x] Tested in clean environment
- [x] Tests added/updated: `test_tool_hook_new_dict_kwargs_reach_entrypoint` + async twin; pre-fix they fail with the tool receiving the original args (`processed-value1-default`), post-fix they pass (`processed-value1-via-kwargs`)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach (none found for #9682)
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.): **partially AI-assisted development with human review of all changes**; filed while researching #9682.

## Additional Notes

The fix touches all three entrypoint variants (sync builder, async builder's `execute_entrypoint_async`, and its inner sync twin). No-hooks behaviour is unchanged: the chain is invoked with `self.arguments or {}`, so the extra merge is a no-op there.
