### PR TITLE
[fix] honour kwargs a tool hook hands to next_func

### DIFF
--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -2023,6 +2023,7 @@ class FunctionCall(BaseModel):
         cached_result: Optional[Any] = None,
         raw_results: Optional[List[Any]] = None,
         cache_key: Optional[str] = None,
+        effective_call_args: Optional[Dict[str, Any]] = None,
     ):
         """Build a nested chain of hook executions with the entrypoint at the center.
 
@@ -2045,11 +2046,22 @@ class FunctionCall(BaseModel):
 
         def execute_entrypoint(name, func, args):
             """Execute the entrypoint function."""
-            if cached_result is not None and not self._moved_its_key(cache_key, entrypoint_args):
-                return _detached(cached_result)
             arguments = entrypoint_args.copy()
             if self.arguments is not None:
                 arguments.update(self.arguments)
+            if args:
+                # A hook may hand the next link a fresh dict instead of mutating
+                # the one it received; those overrides are what the tool is then
+                # asked, so the entrypoint runs on them and the key they name.
+                arguments.update(args)
+            call_args_view = dict(self.arguments or {})
+            if args:
+                call_args_view.update(args)
+            if effective_call_args is not None:
+                effective_call_args.clear()
+                effective_call_args.update(call_args_view)
+            if cached_result is not None and not self._moved_its_key(cache_key, entrypoint_args, call_args_view):
+                return _detached(cached_result)
             slot = _start_entrypoint_call(raw_results) if raw_results is not None else -1
             result = self.function.entrypoint(**arguments)  # type: ignore
             if raw_results is not None:
@@ -2088,20 +2100,35 @@ class FunctionCall(BaseModel):
         chain = reduce(create_hook_wrapper, hooks, execute_entrypoint)
         return chain
 
-    def _moved_its_key(self, cache_key: Optional[str], entrypoint_args: Dict[str, Any]) -> bool:
+    def _moved_its_key(
+        self,
+        cache_key: Optional[str],
+        entrypoint_args: Dict[str, Any],
+        call_args: Optional[Dict[str, Any]] = None,
+    ) -> bool:
         """Whether anything the key is built from changed since the lookup.
 
         Hooks hold the live arguments and the run context, so by the time the
         entrypoint is reached the call may be asking something other than what
         the key names. Such a call is neither answered from the entry under
-        that key nor stored under it.
+        that key nor stored under it. ``call_args`` is the effective model
+        arguments once hook overrides are applied; when omitted, the live
+        ``self.arguments`` answers for calls whose hooks only mutate in place.
         """
         if cache_key is None:
             return False
-        return self.function._get_cache_key(entrypoint_args, self.arguments) != cache_key
+        return (
+            self.function._get_cache_key(entrypoint_args, call_args if call_args is not None else self.arguments)
+            != cache_key
+        )
 
     def _save_entrypoint_result(
-        self, cache_key: str, cache_file: str, entrypoint_args: Dict[str, Any], raw_results: List[Any]
+        self,
+        cache_key: str,
+        cache_file: str,
+        entrypoint_args: Dict[str, Any],
+        raw_results: List[Any],
+        call_args_view: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Store what the entrypoint returned, so a hit replays the hooks over
         the same value the miss handed them.
@@ -2138,7 +2165,7 @@ class FunctionCall(BaseModel):
         if isgenerator(result_to_cache) or isasyncgen(result_to_cache):
             return
 
-        if self._moved_its_key(cache_key, entrypoint_args):
+        if self._moved_its_key(cache_key, entrypoint_args, call_args_view):
             log_debug(
                 f"Skipping cache for {self.function.name}: the call changed what it was asked, "
                 "so the result does not answer the question the key names"
@@ -2191,6 +2218,7 @@ class FunctionCall(BaseModel):
         exception_to_raise = None
 
         raw_results: List[Any] = []
+        effective_call_args: Dict[str, Any] = {}
         try:
             # Build and execute the nested chain of hooks
             if self.function.tool_hooks is not None:
@@ -2199,6 +2227,7 @@ class FunctionCall(BaseModel):
                     cached_result=cached_result,
                     raw_results=raw_results if cacheable else None,
                     cache_key=cache_key if cacheable else None,
+                    effective_call_args=effective_call_args,
                 )
                 result = execution_chain(self.function.name, self.function.entrypoint, self.arguments or {})
             elif from_cache:
@@ -2224,7 +2253,13 @@ class FunctionCall(BaseModel):
                 # Only cache non-generator results, and never re-save a result
                 # that was just served from cache
                 if cacheable and not from_cache:
-                    self._save_entrypoint_result(cache_key, cache_file, entrypoint_args, raw_results)
+                    self._save_entrypoint_result(
+                        cache_key,
+                        cache_file,
+                        entrypoint_args,
+                        raw_results,
+                        call_args_view=dict(effective_call_args) or None,
+                    )
 
                 updated_session_state = None
                 run_context = entrypoint_args.get("run_context") or entrypoint_args.get("_agno_run_context")
@@ -2325,6 +2360,7 @@ class FunctionCall(BaseModel):
         cached_result: Optional[Any] = None,
         raw_results: Optional[List[Any]] = None,
         cache_key: Optional[str] = None,
+        effective_call_args: Optional[Dict[str, Any]] = None,
     ):
         """Build a nested chain of async hook executions with the entrypoint at the center.
 
@@ -2336,12 +2372,22 @@ class FunctionCall(BaseModel):
 
         async def execute_entrypoint_async(name, func, args):
             """Execute the entrypoint function asynchronously."""
-            if cached_result is not None and not self._moved_its_key(cache_key, entrypoint_args):
-                return _detached(cached_result)
             arguments = entrypoint_args.copy()
             if self.arguments is not None:
                 arguments.update(self.arguments)
-
+            if args:
+                # A hook may hand the next link a fresh dict instead of mutating
+                # the one it received; those overrides are what the tool is then
+                # asked, so the entrypoint runs on them and the key they name.
+                arguments.update(args)
+            call_args_view = dict(self.arguments or {})
+            if args:
+                call_args_view.update(args)
+            if effective_call_args is not None:
+                effective_call_args.clear()
+                effective_call_args.update(call_args_view)
+            if cached_result is not None and not self._moved_its_key(cache_key, entrypoint_args, call_args_view):
+                return _detached(cached_result)
             slot = _start_entrypoint_call(raw_results) if raw_results is not None else -1
             result = self.function.entrypoint(**arguments)  # type: ignore
             if iscoroutinefunction(self.function.entrypoint) and not isasyncgenfunction(self.function.entrypoint):
@@ -2352,11 +2398,20 @@ class FunctionCall(BaseModel):
 
         def execute_entrypoint(name, func, args):
             """Execute the entrypoint function synchronously."""
-            if cached_result is not None and not self._moved_its_key(cache_key, entrypoint_args):
-                return _detached(cached_result)
             arguments = entrypoint_args.copy()
             if self.arguments is not None:
                 arguments.update(self.arguments)
+            if args:
+                # Same contract as the async executor above.
+                arguments.update(args)
+            call_args_view = dict(self.arguments or {})
+            if args:
+                call_args_view.update(args)
+            if effective_call_args is not None:
+                effective_call_args.clear()
+                effective_call_args.update(call_args_view)
+            if cached_result is not None and not self._moved_its_key(cache_key, entrypoint_args, call_args_view):
+                return _detached(cached_result)
             slot = _start_entrypoint_call(raw_results) if raw_results is not None else -1
             result = self.function.entrypoint(**arguments)  # type: ignore
             if raw_results is not None:
@@ -2449,6 +2504,7 @@ class FunctionCall(BaseModel):
         exception_to_raise = None
 
         raw_results: List[Any] = []
+        effective_call_args: Dict[str, Any] = {}
         try:
             # Build and execute the nested chain of hooks
             if self.function.tool_hooks is not None:
@@ -2457,6 +2513,7 @@ class FunctionCall(BaseModel):
                     cached_result=cached_result,
                     raw_results=raw_results if cacheable else None,
                     cache_key=cache_key if cacheable else None,
+                    effective_call_args=effective_call_args,
                 )
                 self.result = await execution_chain(self.function.name, self.function.entrypoint, self.arguments or {})
             elif from_cache:
@@ -2480,7 +2537,13 @@ class FunctionCall(BaseModel):
             # Only cache if not a generator, and never re-save a result that
             # was just served from cache
             if cacheable and not from_cache:
-                self._save_entrypoint_result(cache_key, cache_file, entrypoint_args, raw_results)
+                self._save_entrypoint_result(
+                    cache_key,
+                    cache_file,
+                    entrypoint_args,
+                    raw_results,
+                    call_args_view=dict(effective_call_args) or None,
+                )
 
             # For generators, don't capture updated_session_state -
             # session_state is passed by reference, so mutations made during

--- a/libs/agno/tests/unit/tools/test_functions.py
+++ b/libs/agno/tests/unit/tools/test_functions.py
@@ -4217,3 +4217,106 @@ async def test_a_warm_entry_is_not_served_once_a_hook_rewrites_the_argument_asyn
     assert first.result == "data for 123"
     assert second.result == "data for profile-v2"
     assert executions == ["123", "profile-v2"]
+
+
+def test_tool_hook_next_func_kwargs_reach_entrypoint():
+    """A hook may hand next_func a fresh dict; those overrides reach the entrypoint.
+
+    The innermost executor used to rebuild its arguments from the model's
+    original call, so a new-dict rewrite was silently discarded.
+    """
+
+    def rewrite(function_name: str, function_call: Callable, arguments: Dict[str, Any]):
+        rewritten = dict(arguments)
+        rewritten["param1"] = "rewritten"
+        return function_call(**rewritten)
+
+    executions = []
+
+    def echo(param1: str) -> str:
+        executions.append(param1)
+        return f"echo {param1}"
+
+    func = Function(name="echo", entrypoint=echo, tool_hooks=[rewrite])
+    result = FunctionCall(function=func, arguments={"param1": "original"}).execute()
+
+    assert result.status == "success"
+    assert result.result == "echo rewritten"
+    assert executions == ["rewritten"]
+
+
+def test_tool_hook_in_place_mutation_still_reaches_entrypoint():
+    """The documented in-place mutation form keeps working beside the fresh-dict form."""
+
+    def mutate(function_name: str, function_call: Callable, arguments: Dict[str, Any]):
+        arguments["param1"] = "mutated"
+        return function_call(**arguments)
+
+    def echo(param1: str) -> str:
+        return f"echo {param1}"
+
+    func = Function(name="echo", entrypoint=echo, tool_hooks=[mutate])
+    result = FunctionCall(function=func, arguments={"param1": "original"}).execute()
+
+    assert result.status == "success"
+    assert result.result == "echo mutated"
+
+
+@pytest.mark.asyncio
+async def test_tool_hook_async_next_func_kwargs_reach_entrypoint():
+    """Same contract through the async chain with an async hook and entrypoint."""
+
+    async def rewrite(function_name: str, function_call: Callable, arguments: Dict[str, Any]):
+        rewritten = dict(arguments)
+        rewritten["param1"] = "rewritten"
+        return await function_call(**rewritten)
+
+    async def echo(param1: str) -> str:
+        return f"echo {param1}"
+
+    func = Function(name="echo_async", entrypoint=echo, tool_hooks=[rewrite])
+    result = await FunctionCall(function=func, arguments={"param1": "original"}).aexecute()
+
+    assert result.status == "success"
+    assert result.result == "echo rewritten"
+
+
+@pytest.mark.asyncio
+async def test_cached_call_with_next_func_override_never_serves_or_stores_stale(tmp_path):
+    """A kwargs-form rewrite moves what the tool is asked, like an in-place one:
+    the cached answer under the lookup key is not served, and the rewritten
+    answer is not stored under that key either."""
+
+    calls = []
+
+    async def rewrite(function_name: str, function_call: Callable, arguments: Dict[str, Any]):
+        rewritten = dict(arguments)
+        if rewritten.get("customer") == "override":
+            rewritten["customer"] = "rewritten"
+        return await function_call(**rewritten)
+
+    async def lookup(customer: str) -> str:
+        calls.append(customer)
+        return f"data for {customer}"
+
+    func = Function(
+        name="lookup_kwargs_cache",
+        entrypoint=lookup,
+        cache_results=True,
+        cache_dir=str(tmp_path),
+        tool_hooks=[rewrite],
+    )
+
+    base = await FunctionCall(function=func, arguments={"customer": "123"}).aexecute()
+    hit = await FunctionCall(function=func, arguments={"customer": "123"}).aexecute()
+    assert base.result == "data for 123"
+    assert hit.result == "data for 123"  # served from cache
+    assert calls == ["123"]
+
+    first = await FunctionCall(function=func, arguments={"customer": "override"}).aexecute()
+    again = await FunctionCall(function=func, arguments={"customer": "override"}).aexecute()
+    assert first.result == "data for rewritten"
+    assert again.result == "data for rewritten"
+    # Both override calls ran for real: neither answered from key("override")
+    # nor stored anything under it.
+    assert calls == ["123", "rewritten", "rewritten"]


### PR DESCRIPTION
## Summary

Fixes #9682.

`execute_entrypoint` — the innermost link of `_build_nested_execution_chain` — ignored its `args` parameter and rebuilt the call from `entrypoint_args` + `self.arguments`. A tool hook that builds a fresh arguments dict and calls `next_func(**new_args)` was therefore silently discarded, and the entrypoint ran on the model's original arguments. Only in-place mutation of the dict the chain handed over reached the tool, while the cookbook documents hooks as able to modify args before the call.

**Fix:** all three executors (sync chain; async chain's async and sync entrypoints) now apply the overrides they receive on top of the injected + model arguments:

```python
if args:
    arguments.update(args)
```

**Cache semantics stay consistent between the two rewrite forms.** An in-place rewrite already moved what the cache key names (it mutates the live `self.arguments`). A kwargs-form rewrite now does too: `_moved_its_key` accepts the effective model arguments once overrides are applied (`call_args` view), so an overridden call is neither served a stale hit under the looked-up key nor has its answer stored under that key — matching the documented "such a call is neither answered from the entry under that key nor stored under it" contract. `execute`/`aexecute` capture the final effective view via an out-param and pass it into `_save_entrypoint_result`.

Calls without hooks are untouched: with no overrides the effective view is identical to `self.arguments`, and the no-hook branches keep their existing code paths.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (pinned `ruff==0.15.20`: format + check clean on both touched files)
- [x] Self-review completed
- [x] Documentation updated (docstrings for `_moved_its_key`, executors, and the new out-param)
- [ ] Examples and guides: not applicable
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue (#9682 has no linked PR)
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Testing

4 regression tests added to `libs/agno/tests/unit/tools/test_functions.py`:

| test | pre-fix | post-fix |
|---|---|---|
| `test_tool_hook_next_func_kwargs_reach_entrypoint` | FAIL (tool saw original args) | PASS |
| `test_tool_hook_async_next_func_kwargs_reach_entrypoint` | FAIL | PASS |
| `test_cached_call_with_next_func_override_never_serves_or_stores_stale` | FAIL (stale hit served) | PASS |
| `test_tool_hook_in_place_mutation_still_reaches_entrypoint` (guard) | PASS | PASS |

Full file: **189 passed** (includes the existing hook/cache suite). Verified against current `main`; repro from #9682 confirmed failing before and passing after.