### PR TITLE
fix: preserve user identity when resuming HITL runs

### DIFF
--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -3320,6 +3320,8 @@ def continue_run_dispatch(
 
     session_id = run_response.session_id if run_response else session_id
     run_id: str = run_response.run_id if run_response else run_id  # type: ignore
+    if not user_id and run_response is not None:
+        user_id = run_response.user_id
 
     session_id, user_id = initialize_session(
         agent,
@@ -4191,6 +4193,8 @@ def acontinue_run_dispatch(  # type: ignore
 
     session_id = run_response.session_id if run_response else session_id
     run_id: str = run_response.run_id if run_response else run_id  # type: ignore
+    if not user_id and run_response is not None:
+        user_id = run_response.user_id
 
     session_id, user_id = initialize_session(
         agent,

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -6875,6 +6875,8 @@ def continue_run_dispatch(
 
     session_id = run_response.session_id if run_response else session_id
     run_id_resolved: str = run_response.run_id if run_response else run_id  # type: ignore
+    if not user_id and run_response is not None:
+        user_id = run_response.user_id
 
     session_id, user_id = _initialize_session(team, session_id=session_id, user_id=user_id)
 
@@ -8445,6 +8447,8 @@ def acontinue_run_dispatch(  # type: ignore
 
     session_id_resolved = run_response.session_id if run_response else session_id
     run_id_resolved: str = run_response.run_id if run_response else run_id  # type: ignore
+    if not user_id and run_response is not None:
+        user_id = run_response.user_id
 
     session_id_resolved, user_id = _initialize_session(team, session_id=session_id_resolved, user_id=user_id)
 

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -6629,10 +6629,12 @@ class Workflow:
 
         # Apply resolved requirements to the paused run_response (update tool states)
         _apply_requirements_to_run_response(paused_run_response, requirements)
+        continue_user_id = paused_run_response.user_id or workflow_run_response.user_id
 
         # Call executor's continue_run with the stored run_response
         continued_response = executor.continue_run(
             run_response=paused_run_response,
+            user_id=continue_user_id,
         )
 
         # Store executor response for potential chained HITL
@@ -6688,10 +6690,12 @@ class Workflow:
         # Find the paused executor run and apply resolved requirements
         paused_run_response = _find_paused_executor_run(workflow_run_response, step_req.executor_run_id)
         _apply_requirements_to_run_response(paused_run_response, requirements)
+        continue_user_id = paused_run_response.user_id or workflow_run_response.user_id
 
         # Call executor's continue_run with the stored run_response (streaming).
         response_stream = executor.continue_run(
             run_response=paused_run_response,
+            user_id=continue_user_id,
             stream=True,
             stream_events=True,
             yield_run_output=True,
@@ -6776,11 +6780,13 @@ class Workflow:
         # Find the paused executor run and apply resolved requirements
         paused_run_response = _find_paused_executor_run(workflow_run_response, step_req.executor_run_id)
         _apply_requirements_to_run_response(paused_run_response, requirements)
+        continue_user_id = paused_run_response.user_id or workflow_run_response.user_id
 
         # Call executor's acontinue_run with the stored run_response (streaming).
         # stream_events=True ensures RunCompleted/RunError lifecycle events are emitted.
         response_stream = executor.acontinue_run(
             run_response=paused_run_response,
+            user_id=continue_user_id,
             stream=True,
             stream_events=True,
             yield_run_output=True,
@@ -6860,10 +6866,12 @@ class Workflow:
         # Find the paused executor run and apply resolved requirements
         paused_run_response = _find_paused_executor_run(workflow_run_response, step_req.executor_run_id)
         _apply_requirements_to_run_response(paused_run_response, requirements)
+        continue_user_id = paused_run_response.user_id or workflow_run_response.user_id
 
         # Call executor's acontinue_run with the stored run_response
         continued_response = await executor.acontinue_run(
             run_response=paused_run_response,
+            user_id=continue_user_id,
         )
 
         # Store executor response for potential chained HITL

--- a/libs/agno/tests/unit/agent/test_unified_continue.py
+++ b/libs/agno/tests/unit/agent/test_unified_continue.py
@@ -111,6 +111,31 @@ class TestEmptyBodyResume:
         # The loaded run state passes through unchanged
         assert captured["run_response"].tools == [completed_tool]
 
+    def test_resume_restores_user_id_from_run_response(self, monkeypatch: pytest.MonkeyPatch):
+        """A resumed run keeps its original identity when user_id is omitted."""
+        paused_run = RunOutput(
+            run_id="run-user",
+            session_id="session-1",
+            user_id="user-from-run",
+            status=RunStatus.running,
+            tools=[],
+            requirements=None,
+            messages=[],
+        )
+        agent = _make_agent(monkeypatch, runs=[paused_run])
+        captured: dict[str, Any] = {}
+
+        def fake_continue_run(agent, run_response, run_messages, run_context, session, tools, **kw):
+            captured["user_id"] = run_context.user_id
+            run_response.status = RunStatus.completed
+            return run_response
+
+        monkeypatch.setattr(_run, "_continue_run", fake_continue_run)
+
+        _run.continue_run_dispatch(agent=agent, run_response=paused_run, stream=False)
+
+        assert captured["user_id"] == "user-from-run"
+
     def test_resume_error_run_with_empty_body(self, monkeypatch: pytest.MonkeyPatch):
         """An ERROR run with no unresolved requirements can be retried with empty body."""
         errored_run = RunOutput(


### PR DESCRIPTION
## Summary

Fixes #9288 by preserving the original `user_id` when a paused Agent or Team run is resumed without an explicit identity. Workflow executor resume paths now forward the paused executor identity, falling back to the workflow identity when nested output does not contain one.

## Root cause

The continue dispatchers initialized sessions only from the explicit argument or the entity default, ignoring `RunOutput.user_id`. Workflow executor routing also omitted `user_id` when calling the executor's continue methods.

## Validation

- Added an offline regression test covering Agent continue dispatch and `RunContext.user_id` restoration.
- `python -m compileall` passed for all changed Python files.
- `git diff --check` passed.
- Focused pytest could not run: the repository has no `uv.lock`, and dependency resolution under Python 3.14 is blocked by incompatible existing `agno[a2a]`/`agno[brave]` extras; the local venv has no pytest installed.
- Ruff was run on changed files but reports existing repository-wide violations (2010 findings); no unrelated cleanup was included.