### PR TITLE
fix: stop test-a2a installing a lockfile that names an unpublished agnoctl

### DIFF
--- a/.github/workflows/test_on_release.yml
+++ b/.github/workflows/test_on_release.yml
@@ -1079,8 +1079,11 @@ jobs:
         working-directory: .
         run: |
           VIRTUAL_ENV=.venv uv venv --python 3.12
-          VIRTUAL_ENV=.venv uv pip install -r ./libs/agno/requirements.txt
-          # One resolve for both editables: the local agnoctl satisfies agno's floor
+          # requirements.txt is deliberately not installed here. It is a lockfile
+          # of published versions, and around a release it names an agnoctl that
+          # is not on PyPI yet, so the resolve fails before the editables below
+          # ever run. Those editables install agno's full dependency set anyway.
+          # One resolve for both: the local agnoctl satisfies agno's floor.
           VIRTUAL_ENV=.venv uv pip install -e ./libs/agnoctl -e ./libs/agno[dev,os,integration-tests,openai]
           # TODO: a2a-sdk v1.0+ has breaking changes, update agno for it
           VIRTUAL_ENV=.venv uv pip install "a2a-sdk>=0.3.0,<1.0"


### PR DESCRIPTION
## Summary

`feat/v3.0` is red: `test-a2a` fails in 9 seconds during its setup step. This is a regression from #9712 and this PR fixes it.

#9712 bumped agnoctl to 0.2.0 and regenerated `libs/agno/requirements.txt` to pin it. agnoctl 0.2.0 is not on PyPI yet — it publishes as part of the 3.0 release — so any job that installs that lockfile from the index now fails to resolve:

```
Because there is no version of agnoctl==0.2.0 and you require
agnoctl==0.2.0, we can conclude that your requirements are unsatisfiable.
```

`test-a2a` installed the lockfile as the **first** line of its setup, before the editables that would have supplied agnoctl from the workspace, so the step died before anything else ran.

#9712 removed that same line from `test-clean` and `test-clean-os`, for the related reason that layering the lockfile downgraded the workspace build it had just installed. It missed this third consumer — and here the failure mode is worse, because the resolve dies at the lockfile itself, before the editable install can override anything.

## The fix

The lockfile pin is correct and stays: `release.yml` publishes agnoctl before agno, so `agnoctl==0.2.0` is the right version for the released artifact. What is wrong is a CI job installing a lockfile of *published* versions at a moment when one of them is deliberately unpublished.

So the line is removed from `test-a2a`. The very next line installs `-e ./libs/agnoctl -e ./libs/agno[dev,os,integration-tests,openai]`, which brings agno's full dependency set anyway, so nothing is lost.

I checked for other consumers: `grep -rn "agno/requirements.txt"` across workflows, scripts, toml and docs now returns nothing. The `-r requirements.txt` in `test-agentos-system` is a different file (`libs/agno/tests/system/requirements.txt`) and pins no agno package.

## Verification

Ran the job's exact steps in a clean venv, not just the YAML:

- `uv pip install -r ./libs/agno/requirements.txt` → reproduced the CI failure verbatim.
- After the fix: `uv pip install -e ./libs/agnoctl -e ./libs/agno[dev,os,integration-tests,openai]` then `uv pip install "a2a-sdk>=0.3.0,<1.0"` resolves cleanly — agno 3.0.0a3, **agnoctl 0.2.0 from the editable**, a2a-sdk 0.3.26.
- `pytest ./libs/agno/tests/integration/os/interfaces/test_a2a.py` — **17 passed in 11.22s**.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings) — the removed line is replaced by a comment stating why, so it is not re-added
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment — this is the whole verification, above
- [ ] Tests added/updated (if applicable) — CI configuration only

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

The general lesson, worth remembering for the rest of the release: **between the version bump and the actual publish, the lockfile is not installable from PyPI.** Any new CI step that wants agno's dependencies must install the workspace editables rather than `-r libs/agno/requirements.txt`. There are no remaining consumers, but the constraint applies to anything added before 3.0.0 ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
