### PR TITLE
test(agui): cover provider errors in streaming route

### DIFF
--- a/libs/agno/tests/unit/os/interfaces/test_agui_router.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_router.py
@@ -4,6 +4,7 @@ import pytest
 
 pytest.importorskip("ag_ui", reason="ag_ui not installed")
 
+from ag_ui.core import EventType
 from ag_ui.core.types import Tool as AGUITool
 
 from agno.os.interfaces.agui.router import run_entity
@@ -31,6 +32,12 @@ class CaptureKwargsEntity:
         self.captured_kwargs = kwargs
         self.arun_called = True
         return
+        yield
+
+
+class ErrorEntity:
+    async def arun(self, **kwargs):
+        raise RuntimeError("provider unavailable")
         yield
 
 
@@ -150,3 +157,14 @@ async def test_run_entity_fresh_run_calls_arun():
         pass
 
     assert fake_entity.arun_called is True
+
+
+@pytest.mark.asyncio
+async def test_run_entity_emits_error_when_provider_call_fails():
+    events = []
+
+    async for event in run_entity(ErrorEntity(), FakeRunInput()):
+        events.append(event)
+
+    assert [event.type for event in events] == [EventType.RUN_STARTED, EventType.RUN_ERROR]
+    assert events[-1].message == "provider unavailable"


### PR DESCRIPTION
## Summary

- add a regression test for provider failures in the AG-UI streaming route
- verify the stream emits `RUN_STARTED` followed by `RUN_ERROR` with the provider message
- prevent regressions where terminal LLM errors are represented as an apparently successful empty run

Fixes #9486

## Root cause and scope

`run_entity` already catches exceptions from the entity run and emits `RunErrorEvent`, but this error contract was not covered by a unit test. The test exercises the public `run_entity` async generator with a deterministic provider failure and confirms that no `RUN_FINISHED` event is emitted after the error.

## Validation

- `.venv\\Scripts\\python.exe -m pytest tests/unit/os/interfaces/test_agui_router.py -q` — 9 passed
- `ruff check libs/agno/tests/unit/os/interfaces/test_agui_router.py` — passed
- `ruff format --check libs/agno/tests/unit/os/interfaces/test_agui_router.py` — passed
- `git diff --check` — passed

The focused environment is API-key-free and installs only the AG-UI extra. The full optional dependency set was not used because unrelated `brave-search` metadata conflicts with `a2a-sdk` under Python 3.14.