### PR TITLE
fix: enforce Workspace exclude_patterns as an access boundary

### DIFF
--- a/cookbook/91_tools/workspace_tools/README.md
+++ b/cookbook/91_tools/workspace_tools/README.md
@@ -67,6 +67,27 @@ so the LLM tool spec is self-explanatory.
 - **`require_read_before_write=True`** (opt-in) blocks `write_file` / `edit_file` /
   `move_file` / `delete_file` on existing files until the agent has read them
   this session. Catches the "agent hallucinated the file's contents" bug.
+- **`exclude_patterns` is an access boundary, not just a listing filter.** A path
+  is excluded when any component of the path as written, or of the file it
+  resolves to, matches a pattern (`.env*`, `*.env`, `.git`, `.venv`,
+  `node_modules`, ...). Excluded paths are hidden from `list_files` /
+  `search_content` and refused by `read_file`, `write_file`, `edit_file`,
+  `move_file` (either end), and `delete_file` with
+  `Error: <argument> is excluded from this workspace: <path>`. On a
+  case-insensitive filesystem (macOS and Windows defaults) patterns match
+  case-insensitively, so `.ENV` is refused there. Each pattern matches one path
+  component; `dist/` raises `ValueError`, use `dist`. `run_command` is a process,
+  not a path, and is outside this boundary; gate it with `confirm`.
+- **`allow_paths=[...]`** names workspace-relative files or directories that stay
+  visible and reachable even when they match an exclude pattern. Entries are
+  literal paths. A directory entry covers the files beneath it, and exclude
+  patterns still apply beneath the entry: `allow_paths=["build"]` reaches
+  `build/index.html` but not `build/.env`.
+
+```python
+# Let the agent write the committed template while the real .env stays refused.
+tools = [Workspace(".", allow_paths=[".env.example"])]
+```
 
 ## Examples in this folder
 

--- a/libs/agno/agno/context/workspace/provider.py
+++ b/libs/agno/agno/context/workspace/provider.py
@@ -19,7 +19,7 @@ from agno.context._utils import answer_from_run
 from agno.context.mode import ContextMode
 from agno.context.provider import Answer, ContextProvider, Status
 from agno.run import RunContext
-from agno.tools.workspace import DEFAULT_EXCLUDE_PATTERNS, Workspace
+from agno.tools.workspace import DEFAULT_EXCLUDE_PATTERNS, Workspace, _resolve_allow_paths, _validate_exclude_patterns
 
 if TYPE_CHECKING:
     from agno.models.base import Model
@@ -38,6 +38,7 @@ class WorkspaceContextProvider(ContextProvider):
         mode: ContextMode = ContextMode.default,
         model: Model | None = None,
         exclude_patterns: list[str] | None = None,
+        allow_paths: list[str] | None = None,
         max_file_lines: int = 100_000,
         max_file_length: int = 10_000_000,
         stream_sub_agent_events: bool = True,
@@ -45,7 +46,9 @@ class WorkspaceContextProvider(ContextProvider):
         super().__init__(id=id, name=name, mode=mode, model=model, stream_sub_agent_events=stream_sub_agent_events)
         self.root = Path(root).expanduser().resolve() if root is not None else Path.cwd().resolve()
         self.instructions_text = instructions if instructions is not None else DEFAULT_WORKSPACE_INSTRUCTIONS
-        self.exclude_patterns = exclude_patterns if exclude_patterns is not None else list(DEFAULT_EXCLUDE_PATTERNS)
+        self.exclude_patterns = _validate_exclude_patterns(exclude_patterns)
+        _resolve_allow_paths(self.root, allow_paths)
+        self.allow_paths = list(allow_paths) if allow_paths else []
         self.max_file_lines = max_file_lines
         self.max_file_length = max_file_length
         self._agent: Agent | None = None
@@ -73,14 +76,21 @@ class WorkspaceContextProvider(ContextProvider):
             return (
                 f"`{self.name}`: inspect project files under {self.root}. Use read-only "
                 "`list_files`, `search_content`, and `read_file`. Paths are relative to "
-                "the workspace root; common dependency, build, and agent scratch folders "
-                "are excluded."
+                f"the workspace root. {self._exclusion_sentence()}"
             )
         return (
             f"`{self.name}`: call `{self.query_tool_name}(question)` to inspect project "
-            f"files under {self.root}. Common dependency, build, and agent scratch folders "
-            "are excluded."
+            f"files under {self.root}. {self._exclusion_sentence()}"
         )
+
+    def _exclusion_sentence(self) -> str:
+        if not self.exclude_patterns:
+            return "No paths are excluded."
+        if list(self.exclude_patterns) == list(DEFAULT_EXCLUDE_PATTERNS):
+            what = "Common dependency, build, and agent scratch folders and env files"
+        else:
+            what = "Paths matching the configured exclude patterns"
+        return f"{what} are excluded: they are hidden from listings and cannot be read by name."
 
     # ------------------------------------------------------------------
     # Mode resolution
@@ -109,7 +119,9 @@ class WorkspaceContextProvider(ContextProvider):
             id=self.id,
             name=self.name,
             model=self.model,
-            instructions=self.instructions_text.replace("{root}", str(self.root)),
+            instructions=self.instructions_text.replace("{root}", str(self.root)).replace(
+                "{exclusion}", self._exclusion_sentence()
+            ),
             tools=[self._build_workspace_tools()],
             markdown=True,
         )
@@ -119,6 +131,7 @@ class WorkspaceContextProvider(ContextProvider):
             root=self.root,
             allowed=Workspace.READ_TOOLS,
             exclude_patterns=list(self.exclude_patterns),
+            allow_paths=list(self.allow_paths),
             max_file_lines=self.max_file_lines,
             max_file_length=self.max_file_length,
         )
@@ -135,8 +148,7 @@ Workflow:
    asks for a broad audit.
 3. **Read before citing.** Use `read_file(path)` or a line range for the
    files you rely on. Cite paths relative to the workspace root.
-4. **Ignore generated noise.** Dependency directories, virtualenvs, build
-   outputs, caches, and agent scratch folders are excluded by default.
+4. **Ignore generated noise.** {exclusion}
 
 You are read-only. No save, edit, delete, move, or shell tools are available.
 If a query does not match any project file, say so plainly.

--- a/libs/agno/agno/tools/workspace.py
+++ b/libs/agno/agno/tools/workspace.py
@@ -23,15 +23,18 @@ Quick start:
 import asyncio
 import json
 import os
+import posixpath
 import re
 import subprocess
-from fnmatch import fnmatch
+import sys
+import unicodedata
+from fnmatch import fnmatch, fnmatchcase
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple, Union
 
 from agno.exceptions import PathSecurityError
 from agno.tools import Toolkit
-from agno.tools._local_file_utils import DEFAULT_EXCLUDE_PATTERNS, path_matches_exclude
+from agno.tools._local_file_utils import DEFAULT_EXCLUDE_PATTERNS
 from agno.utils.log import log_debug, log_error, log_info, log_warning
 from agno.utils.path_safety import safe_join_relative_path
 
@@ -184,6 +187,84 @@ def _format_with_line_numbers(text: str, start_line: int = 1) -> str:
     return "\n".join(f"{i + start_line:6d}\t{line}" for i, line in enumerate(lines))
 
 
+def _validate_exclude_patterns(exclude_patterns: Optional[List[str]]) -> List[str]:
+    """Return ``exclude_patterns`` as a list, or the defaults when ``None``.
+
+    Raises ``ValueError`` for a pattern containing a path separator: patterns are matched
+    against single path components, so such a pattern can never match.
+    """
+    patterns = list(exclude_patterns) if exclude_patterns is not None else list(DEFAULT_EXCLUDE_PATTERNS)
+    for pattern in patterns:
+        if "/" in pattern or "\\" in pattern:
+            raise ValueError(
+                f"exclude_patterns entry {pattern!r} contains a path separator. Patterns are matched against "
+                "single path components and cannot name a path; use the component name instead."
+            )
+    return patterns
+
+
+def _resolve_allow_paths(root: Path, allow_paths: Optional[List[str]]) -> List[Tuple[Path, Path]]:
+    """Validate ``allow_paths`` for a workspace rooted at ``root``.
+
+    Returns one ``(as_written, resolved)`` pair per entry, both absolute under ``root``.
+    Raises ``TypeError`` when ``allow_paths`` is not a list, and ``ValueError`` when an entry
+    is not a relative path inside ``root`` or names ``root`` itself.
+    """
+    if allow_paths is None:
+        return []
+    if not isinstance(allow_paths, (list, tuple)):
+        raise TypeError(
+            f"`allow_paths` must be a list of workspace-relative paths, got {type(allow_paths).__name__}: {allow_paths!r}"
+        )
+    pairs: List[Tuple[Path, Path]] = []
+    for raw in allow_paths:
+        try:
+            entry = os.fspath(raw)
+            resolved = safe_join_relative_path(root, entry)
+        except (TypeError, PathSecurityError, OSError) as e:
+            raise ValueError(f"allow_paths entry {raw!r} is not a valid path inside the workspace root: {e}")
+        if resolved == root:
+            raise ValueError(
+                f"allow_paths entry {raw!r} names the workspace root; pass exclude_patterns=[] to disable exclusion"
+            )
+        pairs.append((_lexical_join(root, entry), resolved))
+    return pairs
+
+
+def _lexical_join(root: Path, path: str) -> Path:
+    """Join ``path`` under ``root`` as written: no symlink resolution, ``.`` and ``..`` collapsed lexically."""
+    normalized = posixpath.normpath(unicodedata.normalize("NFKC", path).replace("\\", "/"))
+    parts = [part for part in normalized.split("/") if part not in ("", ".", "..")]
+    return root.joinpath(*parts)
+
+
+def _is_case_insensitive_fs(root: Path) -> bool:
+    """Return True when the filesystem holding ``root`` treats names differing only by case as one entry.
+
+    Probes a lettered entry inside ``root``, then ``root`` itself. When nothing can be probed,
+    macOS and Windows are assumed case-insensitive and other platforms case-sensitive.
+    """
+    candidates: List[Path] = []
+    try:
+        with os.scandir(root) as entries:
+            for entry in entries:
+                if entry.name.swapcase() != entry.name:
+                    candidates.append(Path(entry.path))
+                    break
+    except OSError:
+        pass
+    if root.name.swapcase() != root.name:
+        candidates.append(root)
+    for candidate in candidates:
+        try:
+            return os.path.samefile(candidate, candidate.with_name(candidate.name.swapcase()))
+        except FileNotFoundError:
+            return False
+        except OSError:
+            continue
+    return sys.platform in ("darwin", "win32")
+
+
 class Workspace(Toolkit):
     """Local-machine toolkit for read/write/edit/search/shell access to a directory tree.
 
@@ -224,10 +305,32 @@ class Workspace(Toolkit):
     - When only one is set: the other defaults to ``[]`` — you've taken control,
       and the surface is exactly what you specified.
 
-    Listing results from ``list_files`` and ``search_content`` skip common noise directories
-    (``.venv``, ``.venvs``, ``.context``, ``.git``, ``__pycache__``,
-    ``node_modules``, etc.) by default. Pass ``exclude_patterns=[]`` to disable,
-    or ``exclude_patterns=[...]`` to override.
+    ``exclude_patterns`` is an access boundary for every path the agent names. A path is
+    excluded when any component of the path as written, or of the file it resolves to,
+    matches a pattern. Excluded paths are hidden from ``list_files`` and ``search_content``
+    and are refused by ``read_file``, ``write_file``, ``edit_file``, ``move_file`` (source
+    and destination), and ``delete_file`` with
+    ``Error: <argument> is excluded from this workspace: <path>``. Naming an excluded
+    directory in ``list_files`` or ``search_content`` is refused the same way. On a
+    case-insensitive filesystem (macOS and Windows defaults) patterns match
+    case-insensitively, so ``.ENV`` is refused there and a file stored as ``BUILD``
+    matches the pattern ``build``. Each pattern matches one path component; a pattern
+    containing a path separator raises ``ValueError``. Hard links to an excluded file are
+    not detected. The default set covers common noise directories
+    (``.venv``, ``.venvs``, ``.context``, ``.git``, ``__pycache__``, ``node_modules``,
+    etc.) and env files (``.env*``, ``*.env``). Pass ``exclude_patterns=[...]`` to
+    override, or ``exclude_patterns=[]`` to disable.
+
+    ``allow_paths`` names workspace-relative files or directories that stay visible and
+    reachable even when they match an exclude pattern, for example ``[".env.example"]``.
+    Entries are literal paths, not patterns. A directory entry covers the files beneath
+    it, and exclude patterns still apply to names beneath the entry:
+    ``allow_paths=["build"]`` reaches ``build/index.html`` but not ``build/.env``. An
+    allowed path beneath an excluded directory is reachable by name; recursive listings
+    still prune the excluded directory.
+
+    ``run_command`` runs a process with ``cwd=root`` and is outside the path and exclude
+    checks; gate it with ``confirm``.
 
     Optional ``require_read_before_write=True`` blocks ``write_file`` / ``edit_file`` /
     ``move_file`` / ``delete_file`` on existing files until the agent has read them in
@@ -259,6 +362,7 @@ class Workspace(Toolkit):
         max_file_lines: int = 100_000,
         max_file_length: int = 10_000_000,
         exclude_patterns: Optional[List[str]] = None,
+        allow_paths: Optional[List[str]] = None,
         **kwargs,
     ):
         # Resolve root to an absolute path once — never re-read cwd later (reload-safe).
@@ -270,9 +374,14 @@ class Workspace(Toolkit):
         self.max_file_lines = max_file_lines
         self.max_file_length = max_file_length
         self.require_read_before_write = require_read_before_write
-        self.exclude_patterns: List[str] = (
-            exclude_patterns if exclude_patterns is not None else list(DEFAULT_EXCLUDE_PATTERNS)
-        )
+        self.exclude_patterns: List[str] = _validate_exclude_patterns(exclude_patterns)
+        _resolve_allow_paths(self.root, allow_paths)
+        self.allow_paths: List[str] = list(allow_paths) if allow_paths else []
+        # Components below root of each allow_paths entry, as written and resolved; rebuilt when allow_paths changes.
+        self._allow_snapshot: Optional[Tuple[str, ...]] = None
+        self._allowed_parts: List[Tuple[str, ...]] = []
+        # Whether names that differ only by case are the same entry on root's filesystem.
+        self._fold_case: Optional[bool] = None
         # Tracks which paths have been read this session — used by require_read_before_write.
         # Resolved absolute paths so move/rename interactions are unambiguous.
         self._read_paths: Set[Path] = set()
@@ -371,9 +480,109 @@ class Workspace(Toolkit):
             )
         return list(allowed), list(confirm)
 
+    def _resolved_allow_parts(self) -> List[Tuple[str, ...]]:
+        """Components below ``root`` of every ``allow_paths`` entry, as written and resolved."""
+        snapshot = tuple(self.allow_paths)
+        if snapshot != self._allow_snapshot:
+            parts: List[Tuple[str, ...]] = []
+            for pair in _resolve_allow_paths(self.root, list(snapshot)):
+                for allowed in pair:
+                    allowed_parts = self._relative_parts(allowed)
+                    if allowed_parts and allowed_parts not in parts:
+                        parts.append(allowed_parts)
+            self._allowed_parts = parts
+            self._allow_snapshot = snapshot
+        return self._allowed_parts
+
+    def _case_insensitive(self) -> bool:
+        """Whether ``root`` sits on a case-insensitive filesystem; probed once the root exists."""
+        if self._fold_case is None:
+            if not self.root.exists():
+                return sys.platform in ("darwin", "win32")
+            self._fold_case = _is_case_insensitive_fs(self.root)
+        return self._fold_case
+
+    def _matches(self, part: str, pattern: str) -> bool:
+        """Match one path component against one exclude pattern."""
+        if self._case_insensitive():
+            return fnmatchcase(part.casefold(), pattern.casefold())
+        return fnmatch(part, pattern)
+
+    def _relative_parts(self, path: Path) -> Optional[Tuple[str, ...]]:
+        """Components of ``path`` below ``root``, or ``None`` when ``path`` is not under ``root``."""
+        try:
+            return path.relative_to(self.root).parts
+        except ValueError:
+            return None
+
+    def _same_name(self, a: str, b: str) -> bool:
+        return a.casefold() == b.casefold() if self._case_insensitive() else a == b
+
+    def _allowed_depth(self, parts: Tuple[str, ...]) -> int:
+        """Number of leading ``parts`` covered by the deepest ``allow_paths`` entry, or 0."""
+        depth = 0
+        for allowed_parts in self._resolved_allow_parts():
+            if len(allowed_parts) > len(parts) or len(allowed_parts) <= depth:
+                continue
+            if all(self._same_name(a, b) for a, b in zip(allowed_parts, parts)):
+                depth = len(allowed_parts)
+        return depth
+
     def _is_excluded(self, path: Path) -> bool:
-        """Return True if any component of ``path`` (relative to ``root``) matches an exclude pattern."""
-        return path_matches_exclude(path, self.root, self.exclude_patterns)
+        """Return True if a component of ``path`` below ``root`` matches an exclude pattern.
+
+        Components at or above an ``allow_paths`` entry covering ``path`` are not tested;
+        components beneath a directory entry still are. On a case-insensitive filesystem
+        patterns and ``allow_paths`` match case-insensitively.
+        """
+        parts = self._relative_parts(path)
+        if not parts or not self.exclude_patterns:
+            return False
+        if not any(self._matches(part, pattern) for part in parts for pattern in self.exclude_patterns):
+            return False
+        depth = self._allowed_depth(parts)
+        if depth == 0:
+            return True
+        return any(self._matches(part, pattern) for part in parts[depth:] for pattern in self.exclude_patterns)
+
+    def _hidden(self, entry: Path) -> bool:
+        """Return True if a listing or search must skip ``entry``.
+
+        An entry is hidden when it escapes ``root``, when its own path is excluded, or when
+        a symlink in its path leads to an excluded target.
+        """
+        try:
+            target = safe_join_relative_path(self.root, entry.relative_to(self.root).as_posix())
+        except (PathSecurityError, ValueError):
+            return True
+        if self._is_excluded(entry):
+            return True
+        return target != entry and self._is_excluded(target)
+
+    def _resolve(self, path: str, what: str = "path") -> Tuple[Optional[str], Path]:
+        """Resolve a caller-supplied path inside ``root`` and apply the exclude boundary.
+
+        Returns ``(error, resolved)``. ``error`` is ``None`` when the path may be used;
+        otherwise it is the message to return to the caller. ``what`` names the argument
+        in the message (``path``, ``directory``, ``src``, ``dst``). Root escapes and
+        exclusions return distinct messages. The exclusion check tests the resolved target
+        and, unless an ``allow_paths`` entry covers that target, the path as written. It
+        runs before any existence check, so a refusal does not reveal whether the path
+        exists.
+        """
+        safe, resolved = self._check_path(path, self.root)
+        if not safe:
+            log_error(f"Path escapes workspace: {path}")
+            return f"Error: {what} escapes workspace root", resolved
+        excluded = self._is_excluded(resolved)
+        if not excluded:
+            resolved_parts = self._relative_parts(resolved)
+            covered = resolved_parts is not None and self._allowed_depth(resolved_parts) > 0
+            excluded = not covered and self._is_excluded(_lexical_join(self.root, path))
+        if excluded:
+            log_warning(f"Refused excluded path: {path}")
+            return f"Error: {what} is excluded from this workspace: {path}", resolved
+        return None, resolved
 
     def _check_read_before_write(self, file_path: Path, op: str) -> Optional[str]:
         """If require_read_before_write is on, verify the file was read this session.
@@ -422,10 +631,9 @@ class Workspace(Toolkit):
         """
         try:
             log_debug(f"read_file: {path}")
-            safe, file_path = self._check_path(path, self.root)
-            if not safe:
-                log_error(f"Path escapes workspace: {path}")
-                return "Error: path escapes workspace root"
+            err, file_path = self._resolve(path)
+            if err:
+                return err
             if not file_path.is_file():
                 return f"Error: file not found: {path}"
             contents = file_path.read_text(encoding=encoding)
@@ -470,8 +678,9 @@ class Workspace(Toolkit):
         ``size`` is a human-readable string for files and ``null`` for directories.
 
         For tree-style exploration of a project use ``recursive=True`` (defaults to
-        depth 3). Default-excluded directories (``.venv``, ``.venvs``,
-        ``.context``, ``.git``, ``node_modules``, etc.) are always pruned.
+        depth 3). Excluded directories (``.venv``, ``.venvs``, ``.context``, ``.git``,
+        ``node_modules``, etc.) are pruned unless covered by ``allow_paths``; naming one
+        directly returns an error.
 
         :param directory: Subdirectory relative to the workspace root (default ".").
         :param pattern: Optional glob pattern to filter by (e.g. ``"*.py"``). When
@@ -483,9 +692,9 @@ class Workspace(Toolkit):
             ``files`` (list of entry objects).
         """
         try:
-            safe, d = self._check_path(directory, self.root)
-            if not safe:
-                return "Error: directory escapes workspace root"
+            err, d = self._resolve(directory, what="directory")
+            if err:
+                return err
             if not d.is_dir():
                 return f"Error: not a directory: {directory}"
 
@@ -506,33 +715,15 @@ class Workspace(Toolkit):
                         visible_dirs = list(dirnames)
                     for name in filenames + visible_dirs:
                         full = Path(dirpath) / name
-                        try:
-                            safe_join_relative_path(self.root, full.relative_to(self.root).as_posix())
-                        except PathSecurityError:
-                            continue
-                        if self._is_excluded(full):
+                        if self._hidden(full):
                             continue
                         if pattern and not fnmatch(name, pattern):
                             continue
                         entries.append(full)
             elif pattern:
-                entries = []
-                for p in d.glob(pattern):
-                    try:
-                        safe_join_relative_path(self.root, p.relative_to(self.root).as_posix())
-                    except PathSecurityError:
-                        continue
-                    if not self._is_excluded(p):
-                        entries.append(p)
+                entries = [p for p in d.glob(pattern) if not self._hidden(p)]
             else:
-                entries = []
-                for p in d.iterdir():
-                    try:
-                        safe_join_relative_path(self.root, p.relative_to(self.root).as_posix())
-                    except PathSecurityError:
-                        continue
-                    if not self._is_excluded(p):
-                        entries.append(p)
+                entries = [p for p in d.iterdir() if not self._hidden(p)]
 
             files = []
             for p in sorted(entries):
@@ -578,9 +769,9 @@ class Workspace(Toolkit):
         try:
             if not query or not query.strip():
                 return "Error: query cannot be empty"
-            safe, search_dir = self._check_path(directory, self.root)
-            if not safe:
-                return "Error: directory escapes workspace root"
+            err, search_dir = self._resolve(directory, what="directory")
+            if err:
+                return err
             if not search_dir.is_dir():
                 return f"Error: not a directory: {directory}"
 
@@ -598,11 +789,7 @@ class Workspace(Toolkit):
                         walk_done = True
                         break
                     file_path = Path(dirpath) / filename
-                    try:
-                        safe_join_relative_path(self.root, file_path.relative_to(self.root).as_posix())
-                    except PathSecurityError:
-                        continue
-                    if self._is_excluded(file_path):
+                    if self._hidden(file_path):
                         continue
                     if file_path.suffix.lower() not in TEXT_EXTENSIONS:
                         continue
@@ -646,10 +833,9 @@ class Workspace(Toolkit):
         :return: Success message including the path and byte count, or an error message.
         """
         try:
-            safe, file_path = self._check_path(path, self.root)
-            if not safe:
-                log_error(f"Path escapes workspace: {path}")
-                return "Error: path escapes workspace root"
+            err, file_path = self._resolve(path)
+            if err:
+                return err
             if file_path.exists() and not overwrite:
                 return f"Error: file exists and overwrite=False: {path}"
             check_err = self._check_read_before_write(file_path, op="write")
@@ -698,9 +884,9 @@ class Workspace(Toolkit):
         try:
             if not old_str:
                 return "Error: old_str cannot be empty"
-            safe, file_path = self._check_path(path, self.root)
-            if not safe:
-                return "Error: path escapes workspace root"
+            err, file_path = self._resolve(path)
+            if err:
+                return err
             if not file_path.is_file():
                 return f"Error: file not found: {path}"
             check_err = self._check_read_before_write(file_path, op="edit")
@@ -742,12 +928,12 @@ class Workspace(Toolkit):
             or dst exists and overwrite is False.
         """
         try:
-            safe_src, src_path = self._check_path(src, self.root)
-            if not safe_src:
-                return "Error: src escapes workspace root"
-            safe_dst, dst_path = self._check_path(dst, self.root)
-            if not safe_dst:
-                return "Error: dst escapes workspace root"
+            err, src_path = self._resolve(src, what="src")
+            if err:
+                return err
+            err, dst_path = self._resolve(dst, what="dst")
+            if err:
+                return err
             if not src_path.exists():
                 return f"Error: src not found: {src}"
             if src_path.is_dir():
@@ -776,9 +962,9 @@ class Workspace(Toolkit):
         :return: Success message, or an error if the path doesn't exist or is a directory.
         """
         try:
-            safe, file_path = self._check_path(path, self.root)
-            if not safe:
-                return "Error: path escapes workspace root"
+            err, file_path = self._resolve(path)
+            if err:
+                return err
             if not file_path.exists():
                 return f"Error: file not found: {path}"
             if file_path.is_dir():

--- a/libs/agno/tests/unit/context/test_providers.py
+++ b/libs/agno/tests/unit/context/test_providers.py
@@ -130,6 +130,64 @@ def test_workspace_context_excludes_agent_scratch_and_plural_venvs(tmp_path: Pat
     assert result["files"][0]["file"] == "src/app.py"
 
 
+def test_workspace_context_refuses_excluded_paths_by_name(tmp_path: Path):
+    (tmp_path / ".env").write_text("OPENAI_API_KEY=sk-live-secret\n")
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.py").write_text("# app")
+
+    p = WorkspaceContextProvider(root=tmp_path, mode=ContextMode.tools)
+    workspace = p.get_tools()[0]
+    out = workspace.read_file(".env")
+    assert out == "Error: path is excluded from this workspace: .env"
+    assert "sk-live-secret" not in out
+    assert ".env" not in [e["path"] for e in json.loads(workspace.list_files())["files"]]
+    assert "# app" in workspace.read_file("src/app.py")
+
+
+def test_workspace_context_allow_paths_passes_through(tmp_path: Path):
+    (tmp_path / ".env").write_text("OPENAI_API_KEY=sk-live-secret\n")
+    (tmp_path / ".env.example").write_text("OPENAI_API_KEY=\n")
+
+    p = WorkspaceContextProvider(root=tmp_path, mode=ContextMode.tools, allow_paths=[".env.example"])
+    workspace = p.get_tools()[0]
+    assert "OPENAI_API_KEY=" in workspace.read_file(".env.example")
+    assert workspace.read_file(".env") == "Error: path is excluded from this workspace: .env"
+
+
+def test_workspace_context_instructions_describe_excludes_as_access_boundary(tmp_path: Path):
+    tools_mode = WorkspaceContextProvider(root=tmp_path, mode=ContextMode.tools)
+    default_mode = WorkspaceContextProvider(root=tmp_path)
+    assert "cannot be read by name" in tools_mode.instructions()
+    assert "cannot be read by name" in default_mode.instructions()
+    assert "cannot be read by name" in default_mode._build_agent().instructions
+
+
+def test_workspace_context_instructions_follow_exclusion_config(tmp_path: Path):
+    none = WorkspaceContextProvider(root=tmp_path, mode=ContextMode.tools, exclude_patterns=[])
+    assert "No paths are excluded." in none.instructions()
+    assert "cannot be read by name" not in none.instructions()
+    assert "No paths are excluded." in none._build_agent().instructions
+    assert "cannot be read by name" not in none._build_agent().instructions
+    custom = WorkspaceContextProvider(root=tmp_path, exclude_patterns=["secrets.*"])
+    assert "configured exclude patterns" in custom.instructions()
+    assert "cannot be read by name" in custom.instructions()
+    assert "configured exclude patterns" in custom._build_agent().instructions
+
+
+def test_workspace_context_rejects_exclude_pattern_with_separator(tmp_path: Path):
+    with pytest.raises(ValueError, match="path separator"):
+        WorkspaceContextProvider(root=tmp_path, exclude_patterns=["dist/"])
+
+
+def test_workspace_context_validates_allow_paths_at_construction(tmp_path: Path):
+    with pytest.raises(TypeError, match="allow_paths"):
+        WorkspaceContextProvider(root=tmp_path, allow_paths=".env.example")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="allow_paths"):
+        WorkspaceContextProvider(root=tmp_path, allow_paths=["../outside"])
+    with pytest.raises(ValueError, match="names the workspace root"):
+        WorkspaceContextProvider(root=tmp_path, allow_paths=["."])
+
+
 # ---------------------------------------------------------------------------
 # Web / ExaBackend
 # ---------------------------------------------------------------------------

--- a/libs/agno/tests/unit/tools/test_workspace.py
+++ b/libs/agno/tests/unit/tools/test_workspace.py
@@ -839,3 +839,456 @@ def test_empty_exclude_patterns_opts_out():
         result = json.loads(ws.list_files(pattern="**/*.py"))
         paths = [e["path"] for e in result["files"]]
         assert any(".venv" in p for p in paths)
+
+
+# ------------------------------------------------------------------
+# Exclude enforcement: excluded paths are refused by name, not just hidden
+# ------------------------------------------------------------------
+
+
+def _secrets_repo(tmp_dir: str) -> Path:
+    """A fixture repo with a live-looking .env, a local.env, a .git dir, and one ordinary file."""
+    base = Path(tmp_dir).resolve()
+    (base / ".env").write_text("OPENAI_API_KEY=sk-live-secret\n")
+    (base / "local.env").write_text("OPENAI_API_KEY=sk-local-secret\n")
+    (base / ".git").mkdir()
+    (base / ".git" / "config").write_text("[core]\n")
+    (base / "app.py").write_text("print('app')\n")
+    return base
+
+
+def _fs_is_case_insensitive(base: Path) -> bool:
+    probe = base / "CaseProbe.txt"
+    probe.write_text("x")
+    try:
+        return (base / "caseprobe.TXT").exists()
+    finally:
+        probe.unlink()
+
+
+def test_read_file_refuses_excluded_path():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        _secrets_repo(tmp_dir)
+        ws = Workspace(tmp_dir)
+        out = ws.read_file(".env")
+        assert out == "Error: path is excluded from this workspace: .env"
+        assert "sk-live-secret" not in out
+        assert ws.read_file(".git/config") == "Error: path is excluded from this workspace: .git/config"
+        # Unexcluded files still read normally.
+        assert "print('app')" in ws.read_file("app.py")
+
+
+def test_default_workspace_cannot_read_env_in_fixture_repo():
+    """Regression: the default configuration must not return a repo's .env."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = _secrets_repo(tmp_dir)
+        ws = Workspace(tmp_dir)
+        assert "OPENAI_API_KEY" not in ws.read_file(".env")
+        assert "OPENAI_API_KEY" not in ws.read_file("./.env")
+        assert "OPENAI_API_KEY" not in ws.read_file("app.py/../.env")
+        listed = [e["path"] for e in json.loads(ws.list_files())["files"]]
+        assert ".env" not in listed
+        assert "local.env" not in listed
+        assert json.loads(ws.search_content("OPENAI_API_KEY"))["matches_found"] == 0
+        assert "sk-local-secret" not in ws.read_file("local.env")
+        # The file itself is untouched.
+        assert (base / ".env").read_text() == "OPENAI_API_KEY=sk-live-secret\n"
+
+
+def test_read_file_refusal_does_not_reveal_existence():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ws = Workspace(tmp_dir)
+        missing = ws.read_file(".env")
+        (Path(tmp_dir) / ".env").write_text("X=1")
+        present = ws.read_file(".env")
+        assert missing == present == "Error: path is excluded from this workspace: .env"
+
+
+def test_read_file_refused_path_is_not_marked_as_read():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = _secrets_repo(tmp_dir)
+        ws = Workspace(tmp_dir, require_read_before_write=True)
+        ws.read_file(".env")
+        assert (base / ".env") not in ws._read_paths
+
+
+def test_write_file_refuses_excluded_path():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = _secrets_repo(tmp_dir)
+        ws = Workspace(tmp_dir, allowed=Workspace.ALL_TOOLS)
+        assert ws.write_file(".env", "X=1") == "Error: path is excluded from this workspace: .env"
+        assert (base / ".env").read_text() == "OPENAI_API_KEY=sk-live-secret\n"
+        assert ws.write_file(".env.local", "X=1") == "Error: path is excluded from this workspace: .env.local"
+        assert not (base / ".env.local").exists()
+        assert ws.write_file(".git/hooks/pre-commit", "#!/bin/sh") == (
+            "Error: path is excluded from this workspace: .git/hooks/pre-commit"
+        )
+        assert not (base / ".git" / "hooks").exists()
+
+
+def test_edit_file_refuses_excluded_path():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = _secrets_repo(tmp_dir)
+        ws = Workspace(tmp_dir, allowed=Workspace.ALL_TOOLS)
+        assert ws.edit_file(".env", "secret", "leak") == "Error: path is excluded from this workspace: .env"
+        assert (base / ".env").read_text() == "OPENAI_API_KEY=sk-live-secret\n"
+
+
+def test_delete_file_refuses_excluded_path():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = _secrets_repo(tmp_dir)
+        ws = Workspace(tmp_dir, allowed=Workspace.ALL_TOOLS)
+        assert ws.delete_file(".env") == "Error: path is excluded from this workspace: .env"
+        assert (base / ".env").exists()
+
+
+def test_move_file_refuses_excluded_src():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = _secrets_repo(tmp_dir)
+        ws = Workspace(tmp_dir, allowed=Workspace.ALL_TOOLS)
+        assert ws.move_file(".env", "env.txt") == "Error: src is excluded from this workspace: .env"
+        assert (base / ".env").exists()
+        assert not (base / "env.txt").exists()
+        # The laundered name never appears in listings.
+        assert "env.txt" not in [e["path"] for e in json.loads(ws.list_files())["files"]]
+
+
+def test_move_file_refuses_excluded_dst():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = _secrets_repo(tmp_dir)
+        ws = Workspace(tmp_dir, allowed=Workspace.ALL_TOOLS)
+        assert ws.move_file("app.py", ".env.bak") == "Error: dst is excluded from this workspace: .env.bak"
+        assert (base / "app.py").exists()
+        assert not (base / ".env.bak").exists()
+        assert ws.move_file("app.py", "build/app.py") == "Error: dst is excluded from this workspace: build/app.py"
+        assert not (base / "build").exists()
+
+
+def test_move_file_unexcluded_to_unexcluded_still_works():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = _secrets_repo(tmp_dir)
+        ws = Workspace(tmp_dir, allowed=Workspace.ALL_TOOLS)
+        assert ws.move_file("app.py", "src/main.py") == "Moved app.py -> src/main.py"
+        assert (base / "src" / "main.py").read_text() == "print('app')\n"
+
+
+def test_list_files_refuses_excluded_directory():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        _secrets_repo(tmp_dir)
+        ws = Workspace(tmp_dir)
+        assert ws.list_files(".git") == "Error: directory is excluded from this workspace: .git"
+        assert ws.list_files(".git", recursive=True) == "Error: directory is excluded from this workspace: .git"
+
+
+def test_search_content_refuses_excluded_directory():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        _secrets_repo(tmp_dir)
+        ws = Workspace(tmp_dir)
+        assert ws.search_content("core", directory=".git") == "Error: directory is excluded from this workspace: .git"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks require admin on Windows")
+def test_excluded_path_behind_symlink_is_refused():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = _secrets_repo(tmp_dir)
+        ws = Workspace(tmp_dir, allowed=Workspace.ALL_TOOLS)
+        (base / "link.txt").symlink_to(base / ".env")
+        out = ws.read_file("link.txt")
+        assert out == "Error: path is excluded from this workspace: link.txt"
+        assert "sk-live-secret" not in out
+        assert ws.write_file("link.txt", "X=1") == "Error: path is excluded from this workspace: link.txt"
+        assert ws.edit_file("link.txt", "secret", "x") == "Error: path is excluded from this workspace: link.txt"
+        assert ws.move_file("link.txt", "copy.txt") == "Error: src is excluded from this workspace: link.txt"
+        assert (
+            ws.move_file("app.py", "link.txt", overwrite=True) == "Error: dst is excluded from this workspace: link.txt"
+        )
+        assert ws.delete_file("link.txt") == "Error: path is excluded from this workspace: link.txt"
+        assert (base / ".env").read_text() == "OPENAI_API_KEY=sk-live-secret\n"
+        assert (base / "app.py").exists()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks require admin on Windows")
+def test_symlink_aliases_are_hidden_from_listing_and_search():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = _secrets_repo(tmp_dir)
+        (base / "link.txt").symlink_to(base / ".env")
+        (base / "gl").symlink_to(base / ".git")
+        ws = Workspace(tmp_dir)
+        listed = [e["path"] for e in json.loads(ws.list_files())["files"]]
+        assert "link.txt" not in listed
+        assert "gl" not in listed
+        assert [e["path"] for e in json.loads(ws.list_files(recursive=True))["files"]] == ["app.py"]
+        assert json.loads(ws.list_files(pattern="gl/*"))["files"] == []
+        assert json.loads(ws.list_files(pattern="*.txt"))["files"] == []
+        assert json.loads(ws.search_content("OPENAI_API_KEY"))["matches_found"] == 0
+        assert ws.read_file("gl/config") == "Error: path is excluded from this workspace: gl/config"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks require admin on Windows")
+def test_excluded_name_linking_to_unexcluded_file_is_refused():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = _secrets_repo(tmp_dir)
+        (base / ".env.link").symlink_to(base / "app.py")
+        ws = Workspace(tmp_dir, allowed=Workspace.ALL_TOOLS)
+        assert ws.read_file(".env.link") == "Error: path is excluded from this workspace: .env.link"
+        assert ws.write_file(".env.link", "Z") == "Error: path is excluded from this workspace: .env.link"
+        assert (base / "app.py").read_text() == "print('app')\n"
+        assert ".env.link" not in [e["path"] for e in json.loads(ws.list_files())["files"]]
+
+
+def test_case_variant_never_leaks_on_any_filesystem():
+    """A case variant never reads, edits, moves, or deletes the excluded file.
+
+    On a case-insensitive filesystem the variant is refused; on a case-sensitive one it
+    names a different, absent file.
+    """
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = _secrets_repo(tmp_dir)
+        (base / "sub").mkdir()
+        (base / "sub" / ".env").write_text("SUB_SECRET=1\n")
+        ws = Workspace(tmp_dir, allowed=Workspace.ALL_TOOLS)
+        for typed in (".ENV", ".Env", ".GIT/config", "sub/.ENV", "SUB/.env", "LOCAL.ENV"):
+            out = ws.read_file(typed)
+            assert out.startswith("Error: "), typed
+            assert "secret" not in out.lower() and "[core]" not in out, typed
+        assert ws.edit_file(".ENV", "secret", "x").startswith("Error: ")
+        assert ws.move_file(".ENV", "env.txt").startswith("Error: ")
+        assert ws.delete_file(".ENV").startswith("Error: ")
+        assert ws.list_files(".GIT").startswith("Error: ")
+        assert ws.search_content("core", directory=".GIT").startswith("Error: ")
+        if _fs_is_case_insensitive(base):
+            assert ws.write_file(".ENV", "PWNED=1") == "Error: path is excluded from this workspace: .ENV"
+        else:
+            assert ws.write_file(".ENV", "PWNED=1") == "Wrote 7 chars to .ENV"
+            assert (base / ".ENV").read_text() == "PWNED=1"
+        assert (base / ".env").read_text() == "OPENAI_API_KEY=sk-live-secret\n"
+        assert (base / "sub" / ".env").read_text() == "SUB_SECRET=1\n"
+        assert not (base / "env.txt").exists()
+
+
+def test_case_variant_returns_exclusion_error_on_case_insensitive_fs():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = _secrets_repo(tmp_dir)
+        if not _fs_is_case_insensitive(base):
+            pytest.skip("needs a case-insensitive filesystem")
+        ws = Workspace(tmp_dir, allowed=Workspace.ALL_TOOLS)
+        assert ws.read_file(".ENV") == "Error: path is excluded from this workspace: .ENV"
+        assert ws.read_file(".GIT/config") == "Error: path is excluded from this workspace: .GIT/config"
+        assert ws.write_file(".ENV", "PWNED=1") == "Error: path is excluded from this workspace: .ENV"
+        assert ws.move_file(".ENV", "env.txt") == "Error: src is excluded from this workspace: .ENV"
+        assert ws.list_files(".GIT") == "Error: directory is excluded from this workspace: .GIT"
+        # A file stored in upper case is the same name to this filesystem.
+        (base / "BUILD").write_text("bazel")
+        assert ws.read_file("BUILD") == "Error: path is excluded from this workspace: BUILD"
+        assert "BUILD" not in [e["path"] for e in json.loads(ws.list_files())["files"]]
+        # allow_paths entries match the stored file whatever case the caller types.
+        ws2 = Workspace(tmp_dir, allow_paths=["local.env"])
+        assert "sk-local-secret" in ws2.read_file("LOCAL.ENV")
+
+
+def test_case_sensitive_fs_matches_patterns_exactly():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = _secrets_repo(tmp_dir)
+        if _fs_is_case_insensitive(base):
+            pytest.skip("needs a case-sensitive filesystem")
+        (base / "BUILD").write_text("bazel")
+        ws = Workspace(tmp_dir)
+        assert "bazel" in ws.read_file("BUILD")
+        assert "BUILD" in [e["path"] for e in json.loads(ws.list_files())["files"]]
+        assert ws.read_file(".ENV") == "Error: file not found: .ENV"
+
+
+def test_case_folding_when_root_is_detected_case_insensitive(monkeypatch):
+    """Pins the folded match on every platform by forcing the filesystem probe."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = _secrets_repo(tmp_dir)
+        (base / "BUILD").write_text("bazel")
+        (base / "infra").mkdir()
+        (base / "infra" / ".env").write_text("INFRA=1")
+        monkeypatch.setattr("agno.tools.workspace._is_case_insensitive_fs", lambda root: True)
+        ws = Workspace(tmp_dir, allowed=Workspace.ALL_TOOLS, allow_paths=["infra/.env"])
+        assert ws.read_file(".ENV") == "Error: path is excluded from this workspace: .ENV"
+        assert ws.write_file(".ENV", "PWNED=1") == "Error: path is excluded from this workspace: .ENV"
+        assert ws.list_files(".GIT") == "Error: directory is excluded from this workspace: .GIT"
+        assert ws.read_file("BUILD") == "Error: path is excluded from this workspace: BUILD"
+        assert "BUILD" not in [e["path"] for e in json.loads(ws.list_files())["files"]]
+        # allow_paths compare case-insensitively too: the variant passes the boundary
+        # (and reads the file where the filesystem really is case-insensitive).
+        out = ws.read_file("INFRA/.ENV")
+        assert not out.startswith("Error: path is excluded")
+        assert "INFRA=1" in out or out == "Error: file not found: INFRA/.ENV"
+        assert "INFRA=1" in ws.read_file("infra/.env")
+
+
+def test_case_folding_off_when_root_is_detected_case_sensitive(monkeypatch):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = _secrets_repo(tmp_dir)
+        (base / "BUILD").write_text("bazel")
+        monkeypatch.setattr("agno.tools.workspace._is_case_insensitive_fs", lambda root: False)
+        ws = Workspace(tmp_dir)
+        assert "bazel" in ws.read_file("BUILD")
+        assert ws.read_file(".env") == "Error: path is excluded from this workspace: .env"
+
+
+# ------------------------------------------------------------------
+# allow_paths: named exceptions to the exclude boundary
+# ------------------------------------------------------------------
+
+
+def test_allow_paths_restores_access_for_named_path_only():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = _secrets_repo(tmp_dir)
+        ws = Workspace(tmp_dir, allowed=Workspace.ALL_TOOLS, allow_paths=[".env.example"])
+        assert ws.write_file(".env.example", "OPENAI_API_KEY=\n") == "Wrote 16 chars to .env.example"
+        assert (base / ".env.example").read_text() == "OPENAI_API_KEY=\n"
+        assert "OPENAI_API_KEY=" in ws.read_file(".env.example")
+        # .env matches the same pattern and stays refused.
+        assert ws.read_file(".env") == "Error: path is excluded from this workspace: .env"
+        assert ws.read_file(".git/config") == "Error: path is excluded from this workspace: .git/config"
+
+
+def test_allow_paths_entry_is_visible_in_listing_and_search():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        _secrets_repo(tmp_dir)
+        # local.env matches the default "*.env" pattern and has a searchable text suffix.
+        ws = Workspace(tmp_dir, allow_paths=["local.env"])
+        paths = [e["path"] for e in json.loads(ws.list_files())["files"]]
+        assert "local.env" in paths
+        assert ".env" not in paths
+        hits = json.loads(ws.search_content("OPENAI_API_KEY"))
+        assert [h["file"] for h in hits["files"]] == ["local.env"]
+
+
+def test_allow_paths_directory_covers_children():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = Path(tmp_dir).resolve()
+        (base / "build").mkdir()
+        (base / "build" / "index.html").write_text("<html>")
+        (base / "dist").mkdir()
+        (base / "dist" / "bundle.js").write_text("x")
+        ws = Workspace(tmp_dir, allowed=Workspace.ALL_TOOLS, allow_paths=["build"])
+        assert "<html>" in ws.read_file("build/index.html")
+        assert ws.write_file("build/new.txt", "n") == "Wrote 1 chars to build/new.txt"
+        paths = [e["path"] for e in json.loads(ws.list_files("build"))["files"]]
+        assert "build/index.html" in paths
+        assert ws.read_file("dist/bundle.js") == "Error: path is excluded from this workspace: dist/bundle.js"
+
+
+def test_allow_paths_entry_must_stay_inside_root():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        with pytest.raises(ValueError, match="allow_paths"):
+            Workspace(tmp_dir, allow_paths=["../outside"])
+        with pytest.raises(ValueError, match="allow_paths"):
+            Workspace(tmp_dir, allow_paths=[""])
+
+
+def test_allow_paths_rejects_non_list():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        with pytest.raises(TypeError, match="allow_paths"):
+            Workspace(tmp_dir, allow_paths=".env.example")  # type: ignore[arg-type]
+
+
+def test_allow_paths_entry_naming_root_is_rejected():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        for entry in (".", "./", "sub/.."):
+            with pytest.raises(ValueError, match="names the workspace root"):
+                Workspace(tmp_dir, allow_paths=[entry])
+
+
+def test_allow_paths_directory_entry_keeps_patterns_beneath_it():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = Path(tmp_dir).resolve()
+        (base / "infra").mkdir()
+        (base / "infra" / "main.tf").write_text("tf")
+        (base / "infra" / ".env").write_text("INFRA_KEY=sk-infra\n")
+        (base / "infra" / "node_modules").mkdir()
+        (base / "infra" / "node_modules" / "m.js").write_text("m")
+        ws = Workspace(tmp_dir, allowed=Workspace.ALL_TOOLS, allow_paths=["infra"])
+        assert "tf" in ws.read_file("infra/main.tf")
+        assert ws.read_file("infra/.env") == "Error: path is excluded from this workspace: infra/.env"
+        assert ws.read_file("infra/node_modules/m.js") == (
+            "Error: path is excluded from this workspace: infra/node_modules/m.js"
+        )
+        assert [e["path"] for e in json.loads(ws.list_files("infra"))["files"]] == ["infra/main.tf"]
+        # The nested file can be named explicitly.
+        ws2 = Workspace(tmp_dir, allow_paths=["infra/.env"])
+        assert "INFRA_KEY" in ws2.read_file("infra/.env")
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks require admin on Windows")
+def test_allow_paths_entry_that_is_a_symlink_works_as_written_and_resolved():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = Path(tmp_dir).resolve()
+        (base / "out").mkdir()
+        (base / "out" / "index.html").write_text("<html>")
+        (base / "build").symlink_to(base / "out")
+        ws = Workspace(tmp_dir, allow_paths=["build"])
+        assert "<html>" in ws.read_file("build/index.html")
+        assert "<html>" in ws.read_file("out/index.html")
+        listed = [e["path"] for e in json.loads(ws.list_files())["files"]]
+        assert "build" in listed and "out" in listed
+        # An allowed file reached through a symlinked parent directory is allowed.
+        (base / "infra").mkdir()
+        (base / "infra" / ".env").write_text("INFRA=1")
+        (base / "lnk").symlink_to(base / "infra")
+        ws2 = Workspace(tmp_dir, allow_paths=["infra/.env"])
+        assert "INFRA=1" in ws2.read_file("lnk/.env")
+        assert ws2.read_file("lnk/../.env") == "Error: path is excluded from this workspace: lnk/../.env"
+
+
+def test_allowed_target_reached_through_dot_dot_is_allowed():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = _secrets_repo(tmp_dir)
+        (base / "sub").mkdir()
+        (base / ".env.example").write_text("OPENAI_API_KEY=\n")
+        ws = Workspace(tmp_dir, allow_paths=[".env.example"])
+        assert "OPENAI_API_KEY=" in ws.read_file("sub/../.env.example")
+        assert "print('app')" in ws.read_file("build/../app.py")
+        assert ws.read_file("sub/../.env") == "Error: path is excluded from this workspace: sub/../.env"
+
+
+def test_allow_paths_accepts_path_objects():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        _secrets_repo(tmp_dir)
+        ws = Workspace(tmp_dir, allow_paths=[Path("local.env")])  # type: ignore[list-item]
+        assert "sk-local-secret" in ws.read_file("local.env")
+        with pytest.raises(ValueError, match="allow_paths"):
+            Workspace(tmp_dir, allow_paths=[42])  # type: ignore[list-item]
+
+
+def test_exclude_patterns_generator_is_materialized():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        _secrets_repo(tmp_dir)
+        ws = Workspace(tmp_dir, exclude_patterns=(p for p in [".env*"]))  # type: ignore[arg-type]
+        assert ws.exclude_patterns == [".env*"]
+        assert ws.read_file(".env") == "Error: path is excluded from this workspace: .env"
+
+
+def test_allow_paths_is_read_live():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        _secrets_repo(tmp_dir)
+        ws = Workspace(tmp_dir)
+        assert ws.read_file("local.env") == "Error: path is excluded from this workspace: local.env"
+        ws.allow_paths.append("local.env")
+        assert "sk-local-secret" in ws.read_file("local.env")
+        ws.allow_paths = []
+        assert ws.read_file("local.env") == "Error: path is excluded from this workspace: local.env"
+
+
+def test_exclude_pattern_with_path_separator_is_rejected():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        for pattern in ("dist/", "config/secrets.yaml", "**/secrets.yaml", "config\\secrets.yaml"):
+            with pytest.raises(ValueError, match="path separator"):
+                Workspace(tmp_dir, exclude_patterns=[pattern])
+
+
+def test_allow_paths_does_not_cover_siblings_or_parents():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = Path(tmp_dir).resolve()
+        (base / ".venv" / "lib").mkdir(parents=True)
+        (base / ".venv" / "lib" / "ok.py").write_text("ok")
+        (base / ".venv" / "pyvenv.cfg").write_text("home = x")
+        ws = Workspace(tmp_dir, allow_paths=[".venv/lib/ok.py"])
+        assert "ok" in ws.read_file(".venv/lib/ok.py")
+        assert ws.read_file(".venv/pyvenv.cfg") == "Error: path is excluded from this workspace: .venv/pyvenv.cfg"
+        assert ws.list_files(".venv") == "Error: directory is excluded from this workspace: .venv"


### PR DESCRIPTION
## Summary

`Workspace.exclude_patterns` filtered discovery but not access. `list_files` and `search_content` hid excluded paths; `read_file`, `write_file`, `edit_file`, `move_file`, and `delete_file` reached them by name. The default pattern set includes `.env*` and `*.env`, so an agent with the workspace's read tools returned the caller's live `.env` on request. `move_file` could also rename `.env` to a name outside the pattern, after which even listings showed it. Found while auditing the 3.0 AgentOS templates and reproduced in-container.

This PR makes `exclude_patterns` an access boundary.

**What changes**

- Every path-addressed tool resolves its argument through one helper, `Workspace._resolve`, which applies root containment and then the exclude check. Excluded paths are refused with `Error: <argument> is excluded from this workspace: <path>` (`path`, `directory`, `src`, `dst`). The root-escape message is unchanged and distinct, so a refusal is never mistaken for a missing file.
- The check runs before any existence check, so a refusal does not reveal whether the path exists. It tests the resolved target and, unless an `allow_paths` entry covers that target, the path as written, so a symlink to an excluded file is refused, and an excluded name that links to an unexcluded file is refused too.
- On a case-insensitive filesystem (macOS and Windows defaults) patterns and `allow_paths` match case-insensitively. The workspace probes its root once to decide. `read_file(".ENV")` used to return `.env` on macOS; it is now refused. On that filesystem a file stored as `BUILD` is the same name as `build` and matches the pattern; Bazel repos on macOS should drop `build` from `exclude_patterns` or name the files in `allow_paths`. On Linux nothing changes: `BUILD` and `build` stay different names.
- `move_file` checks both source and destination. This closes the rename path.
- `list_files` and `search_content` refuse an excluded directory named directly (before, `list_files(".git")` returned an empty listing) and skip entries whose symlink target is excluded (before, `search_content` returned a snippet of `.env` through `link.txt -> .env`, and `list_files(pattern="gl/*")` listed names inside `.git` through `gl -> .git`). Their filtering of ordinary entries is unchanged.
- New `allow_paths: list[str]` on `Workspace` names workspace-relative files or directories that stay visible and reachable even when they match an exclude pattern, for a deliberate exception such as `.env.example`. Entries are literal paths. A directory entry covers the files beneath it, and exclude patterns still apply beneath the entry: `allow_paths=["build"]` reaches `build/index.html` but not `build/.env`. `allow_paths` must be a list (a bare string raises `TypeError`); an entry that escapes the root, is empty, or names the root raises `ValueError`. Changing `ws.allow_paths` after construction takes effect, like `exclude_patterns`.
- An `exclude_patterns` entry containing a path separator (`dist/`, `config/secrets.yaml`) can never match a single path component and now raises `ValueError` instead of silently doing nothing.
- `WorkspaceContextProvider` gains `allow_paths`, validates it at construction, and passes it through. Its generated instructions describe the configured exclusion: the default sentence says excluded paths are hidden from listings and cannot be read by name; `exclude_patterns=[]` says no paths are excluded.
- `run_command` has no path argument and stays outside this boundary. The class docstring and cookbook README say so. Gate it with `confirm`.

**Design notes**

- The spec offered two opt-outs: a global `enforce_excludes: bool` and an `allow_paths` allowlist, and recommended `allow_paths` if only one lands. This PR ships `allow_paths` only. Removing a pattern from `exclude_patterns` already restores today's access for anyone who depends on it. `allow_paths` covers the case pattern editing cannot express: `.env.example` may be written while `.env` (same `.env*` pattern) stays refused. A global off-switch would describe the old gap as a feature and is easy to add later if a consumer needs it.
- Enforcement lives in a `Workspace`-level helper, not in `Toolkit._check_path`. `_check_path` is shared by `FileTools`, `CodingTools`, `PythonTools`, and `LocalFileSystemTools`, and returns only `(ok, path)`, so the exclusion refusal could not carry its own message from there.
- `FileTools` uses the same exclude helper for `list_files` / `search_files` / `search_content` only and documents it as a listing filter. It is not changed here.

**Behaviour change for callers**

Any caller that today reads or writes an excluded path by name gets the refusal instead. Nothing in the library or the cookbooks does this. A caller who wants the path can drop the pattern from `exclude_patterns` or name the path in `allow_paths`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Tests** (`libs/agno/tests/unit/tools/test_workspace.py`, `libs/agno/tests/unit/context/test_providers.py`): 34 new unit tests plus 6 provider tests.

- `read_file` / `write_file` / `edit_file` / `delete_file` on an excluded path return the exclusion error and leave the file untouched.
- `move_file` refuses an excluded source and an excluded destination; an ordinary move still works.
- `list_files` and `search_content` refuse an excluded directory named directly.
- Root-escape errors are unchanged and distinct from the exclusion error.
- Symlinks: an alias to `.env` is refused by every tool and hidden from listings and search; a symlinked directory does not leak names through a glob; an excluded name linking to an unexcluded file is refused.
- Case: `.ENV`, `.GIT/config`, `sub/.ENV` never leak on any filesystem; on a case-insensitive filesystem they return the exclusion error; on a case-sensitive one they name an absent file. The folded matching is also pinned on every platform by forcing the filesystem probe, so Linux CI exercises it. I ran `test_workspace.py` in a Linux container (`agnohq/python:3.14`): 104 passed, 1 skipped (the real-case-insensitive-filesystem test).
- `allow_paths` entries that are symlinks work as written and as resolved; an allowed file reached through a symlinked parent or through `..` is allowed.
- The refusal does not reveal whether the path exists, and a refused read does not mark the path as read for `require_read_before_write`.
- Every async twin returns the same refusal.
- `allow_paths` restores access for the named path only, makes it visible in listings and search, covers children of a directory entry while patterns still apply beneath it, does not cover siblings or parents, is read live, rejects a bare string, an escape, an empty entry, and the root.
- An exclude pattern with a path separator raises `ValueError`.
- A fixture repo with `.env` and `local.env` holding fake keys: the default `Workspace` and the default `WorkspaceContextProvider` cannot read or search them.
- Provider: `allow_paths` is validated at construction; instructions follow the exclusion config.

**Mutation check**: 36 in-place mutations, one per guard (exclusion check, as-written check and its allow-coverage rule, case folding for patterns and for `allow_paths`, symlink targets in listings, each tool's route through the resolver, nested-allow semantics, `allow_paths` type, entry type, and root checks, separator check, `..` collapsing, generator materialisation, live `allow_paths`, provider validation, passthrough, and both instruction sentences). Every mutation failed at least one named test.

**Review**: two adversarial multi-agent rounds on my own diff (37 agents). Round 1 found the case-insensitive bypass, the symlink leaks in listing and search, nested-allow over-reach, the bare-string `allow_paths` hole, and the separator-pattern no-op. Round 2 found that my first case fix (canonicalising to the on-disk spelling) failed open on unlistable directories, missed some Unicode folds, could abort a listing on `PermissionError`, and had one test red on Linux; I replaced it with the probe-once case-folding design above.

**Perf** (5k-file tree, macOS): recursive `list_files` and `search_content` unchanged (the pre-existing per-entry `resolve()` dominates); `read_file` gains about 0.4 ms for the two pattern passes.

**Security**: this closes a secrets-exposure path in the default configuration. The default excludes now guarantee that an agent with `Workspace` read tools cannot return `.env` by name.

**Follow-ups, not in this PR**
- `FileTools` (and `FilesystemContextProvider`, which is built on it) use the same `DEFAULT_EXCLUDE_PATTERNS` for listing and search only; `read_file` there still reaches `.env` by name. Its docstring describes the filter as listing-only, so it is not a doc lie, but it is the same gap. Tracked separately.
- `WikiContextProvider` builds its `Workspace` with the default patterns and exposes no `exclude_patterns` / `allow_paths` knob. A wiki folder named `build`, `dist`, `venv`, or `_build`, or a page named `*.env`, now gets an explicit refusal instead of being silently hidden from listings. A passthrough is a small follow-up if a consumer needs it.
- The `.env*` default also catches `.env.example`, and `.claude` / `.cursor` / `.codex` catch committed agent-config directories, so a coding agent on the default surface needs `allow_paths` or a trimmed `exclude_patterns` to write those. The defaults are unchanged here.
- The `agentos-*` template `AGENTS.md` files describe the excludes as access control; that sentence is true once this ships. The docs site rows for `exclude_patterns` still say "patterns skipped by list_files/search_content" and need an `allow_paths` row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MsM1RxR82iJ8Pk9NnSfW5w
