### PR TITLE
fix: let the team's own identity open its prompt, and stop the prompt describing a runtime we don't ship

### DIFF
--- a/libs/agno/agno/agent/_messages.py
+++ b/libs/agno/agno/agent/_messages.py
@@ -40,7 +40,7 @@ from agno.utils.agent import (
 from agno.utils.common import is_typed_dict
 from agno.utils.knowledge import get_user_id_kwarg
 from agno.utils.log import log_debug, log_warning
-from agno.utils.message import copy_history_message, filter_tool_calls, get_text_from_message
+from agno.utils.message import copy_history_message, filter_tool_calls, get_text_from_message, render_instructions
 from agno.utils.prompts import get_json_output_prompt, get_response_model_format_prompt
 from agno.utils.timer import Timer
 
@@ -278,20 +278,11 @@ def get_system_message(
         system_message_content += f"\n<your_role>\n{agent.role}\n</your_role>\n\n"
     # 3.3.3 Then add instructions for the Agent
     if len(instructions) > 0:
+        rendered = render_instructions(instructions)
         if agent.use_instruction_tags:
-            system_message_content += "<instructions>"
-            if len(instructions) > 1:
-                for _upi in instructions:
-                    system_message_content += f"\n- {_upi}"
-            else:
-                system_message_content += "\n" + instructions[0]
-            system_message_content += "\n</instructions>\n\n"
+            system_message_content += f"<instructions>\n{rendered}\n</instructions>\n\n"
         else:
-            if len(instructions) > 1:
-                for _upi in instructions:
-                    system_message_content += f"- {_upi}\n"
-            else:
-                system_message_content += instructions[0] + "\n\n"
+            system_message_content += rendered + "\n\n"
     # 3.3.4 Add additional information
     if len(additional_information) > 0:
         system_message_content += "<additional_information>"
@@ -584,20 +575,11 @@ async def aget_system_message(
         system_message_content += f"\n<your_role>\n{agent.role}\n</your_role>\n\n"
     # 3.3.3 Then add instructions for the Agent
     if len(instructions) > 0:
+        rendered = render_instructions(instructions)
         if agent.use_instruction_tags:
-            system_message_content += "<instructions>"
-            if len(instructions) > 1:
-                for _upi in instructions:
-                    system_message_content += f"\n- {_upi}"
-            else:
-                system_message_content += "\n" + instructions[0]
-            system_message_content += "\n</instructions>\n\n"
+            system_message_content += f"<instructions>\n{rendered}\n</instructions>\n\n"
         else:
-            if len(instructions) > 1:
-                for _upi in instructions:
-                    system_message_content += f"- {_upi}\n"
-            else:
-                system_message_content += instructions[0] + "\n\n"
+            system_message_content += rendered + "\n\n"
     # 3.3.4 Add additional information
     if len(additional_information) > 0:
         system_message_content += "<additional_information>"

--- a/libs/agno/agno/team/_default_tools.py
+++ b/libs/agno/agno/team/_default_tools.py
@@ -689,11 +689,10 @@ def _get_delegate_task_function(
 
     def delegate_task_to_member(member_id: str, task: str) -> Iterator[Union[RunOutputEvent, TeamRunOutputEvent, str]]:
         """Use this function to delegate a task to the selected team member.
-        You must provide a clear and concise description of the task the member should achieve AND the expected output.
 
         Args:
-            member_id (str): The ID of the member to delegate the task to. Use only the ID of the member, not the ID of the team followed by the ID of the member.
-            task (str): A clear and concise description of the task the member should achieve.
+            member_id (str): The ID of the member to delegate the task to, exactly as it appears in <team_members>.
+            task (str): A clear and concise description of the task the member should achieve, including what a good result looks like.
         Returns:
             str: The result of the delegated task.
         """
@@ -870,11 +869,10 @@ def _get_delegate_task_function(
         member_id: str, task: str
     ) -> AsyncIterator[Union[RunOutputEvent, TeamRunOutputEvent, str]]:
         """Use this function to delegate a task to the selected team member.
-        You must provide a clear and concise description of the task the member should achieve AND the expected output.
 
         Args:
-            member_id (str): The ID of the member to delegate the task to. Use only the ID of the member, not the ID of the team followed by the ID of the member.
-            task (str): A clear and concise description of the task the member should achieve.
+            member_id (str): The ID of the member to delegate the task to, exactly as it appears in <team_members>.
+            task (str): A clear and concise description of the task the member should achieve, including what a good result looks like.
         Returns:
             str: The result of the delegated task.
         """
@@ -1052,11 +1050,11 @@ def _get_delegate_task_function(
     # When the task should be delegated to all members
     def delegate_task_to_members(task: str) -> Iterator[Union[RunOutputEvent, TeamRunOutputEvent, str]]:
         """
-        Use this function to delegate a task to all the member agents and return a response.
-        You must provide a clear and concise description of the task the member should achieve AND the expected output.
+        Use this function to send one task to every member agent and return their responses.
+        One call reaches all members; do not call it once per member.
 
         Args:
-            task (str): A clear and concise description of the task to send to member agents.
+            task (str): A clear and concise description of the task to send to member agents, including what a good result looks like.
         Returns:
             str: The result of the delegated task.
         """
@@ -1220,11 +1218,11 @@ def _get_delegate_task_function(
 
     # When the task should be delegated to all members
     async def adelegate_task_to_members(task: str) -> AsyncIterator[Union[RunOutputEvent, TeamRunOutputEvent, str]]:
-        """Use this function to delegate a task to all the member agents and return a response.
-        You must provide a clear and concise description of the task to send to member agents.
+        """Use this function to send one task to every member agent and return their responses.
+        One call reaches all members; do not call it once per member.
 
         Args:
-            task (str): A clear and concise description of the task to send to member agents.
+            task (str): A clear and concise description of the task to send to member agents, including what a good result looks like.
         Returns:
             str: The result of the delegated task.
         """

--- a/libs/agno/agno/team/_init.py
+++ b/libs/agno/agno/team/_init.py
@@ -844,6 +844,11 @@ def initialize_team(team: "Team", debug_mode: Optional[bool] = None) -> None:
             "`delegate_to_all_members` and `respond_directly` are both enabled. The task will be delegated to all members, but `respond_directly` will be disabled."
         )
         team.respond_directly = False
+        # The mode has to follow, or the prompt keeps describing route while the run
+        # holds the broadcast tool.
+        from agno.team.mode import TeamMode
+
+        team.mode = TeamMode.broadcast
 
     set_checkpoint(team)
 

--- a/libs/agno/agno/team/_messages.py
+++ b/libs/agno/agno/team/_messages.py
@@ -48,7 +48,7 @@ from agno.utils.log import (
     log_debug,
     log_warning,
 )
-from agno.utils.message import copy_history_message, filter_tool_calls, get_text_from_message
+from agno.utils.message import copy_history_message, filter_tool_calls, get_text_from_message, render_instructions
 from agno.utils.team import (
     get_member_id,
 )
@@ -112,6 +112,8 @@ def get_members_system_message_content(
 
         if isinstance(member, Team):
             content += f'{pad}<member id="{member_id}" name="{member.name}" type="team">\n'
+            if member.role is not None:
+                content += f"{pad}  Role: {member.role}\n"
             if member.description is not None:
                 content += f"{pad}  Description: {member.description}\n"
             if member.members is not None:
@@ -135,88 +137,113 @@ def get_members_system_message_content(
 
 
 def _get_opening_prompt() -> str:
-    """Opening identity statement for the team leader."""
+    """Capability statement for a leader that has members available.
+
+    States what the leader has, not who it is. An identity claim here would compete
+    with the description, role and instructions the user wrote.
+    """
     return (
-        "You coordinate a team of specialized AI agents to fulfill the user's request. "
-        "Delegate to members when their expertise or tools are needed. "
-        "For straightforward requests you can handle directly — including using your own tools — respond without delegating.\n"
+        "You have a team of specialists, listed below. "
+        "Hand work to members when their expertise or tools fit it better than yours; "
+        "answer directly — including with your own tools — when they do not.\n"
     )
 
 
 def _get_mode_instructions(team: "Team") -> str:
-    """Return the mode-specific <how_to_respond> block."""
+    """Return the mode-specific <delegation> block."""
     from agno.team.mode import TeamMode
 
-    content = "\n<how_to_respond>\n"
+    # Name only the member fields the roster actually renders, so the leader is never
+    # asked to select on evidence it was not given.
+    selector = "role, description, and tools" if team.add_member_tools_to_context else "role and description"
+
+    content = "\n<delegation>\n"
 
     if team.mode == TeamMode.tasks:
         content += (
-            "You operate in autonomous task mode. Decompose the user's goal into discrete tasks, "
-            "execute them by delegating to team members, and deliver the final result.\n\n"
-            "Planning:\n"
-            "- Break the goal into tasks with clear, actionable titles and self-contained descriptions. "
-            "Each task should be a single unit of work for one member.\n"
-            "- Assign each task to the member whose role and tools are best suited.\n"
-            "- Set `depends_on` when a task requires another task's output. "
-            "Leave tasks independent when they can run in any order.\n\n"
-            "Execution:\n"
-            "- Use `execute_task` for sequential or dependent tasks.\n"
-            "- Use `execute_tasks_parallel` for groups of independent tasks to maximize throughput.\n"
-            "- Review each result before proceeding. If a task fails, decide whether to retry with the same member, "
-            "reassign to a different member, or adjust the plan.\n\n"
-            "Completion:\n"
-            "- When all tasks are done and results are satisfactory, call `mark_all_complete` with a summary of the outcome.\n"
-            "- Use `list_tasks` to check progress at any point, and `add_task_note` to record observations.\n\n"
-            "Write task descriptions that give the member everything they need: "
-            "the objective, relevant context from the conversation or prior task results, and what a good result looks like.\n"
+            "You work from a shared task list: you create tasks, assign each one to a member, "
+            "execute them, and deliver the result.\n\n"
+            f"- `create_task` sets the assignee — the member whose {selector} fit the work best. "
+            "`execute_tasks_parallel` runs each task against the member it was created with, so a task "
+            "created without an assignee cannot go in a batch. Titles are unique: creating a task under "
+            "an existing title returns that task instead of a new one.\n"
+            "- Set `depends_on` only when a task genuinely needs another task's output.\n"
+            "- Read every result. On a failure, retry, reassign, or change the plan — do not repeat the "
+            "same call unchanged. Record work you did yourself with `update_task_status`, and anything a "
+            "later task will need with `add_task_note`.\n"
+            "- A task result is evidence, not your answer. When a task fails or a member returns nothing, "
+            "say so plainly and name what it reported — never supply a cause or a finding the member did "
+            "not state.\n"
+            "- `mark_all_complete` with a summary ends the run and delivers that summary as your answer. "
+            "A list whose tasks have all completed also ends it, but an empty list never does — so when "
+            "the request needed no tasks at all, a greeting or a question you can simply answer, call "
+            "`mark_all_complete` with your answer as the summary. Call it too when the goal is out of "
+            "reach: a partial outcome stated plainly beats looping.\n"
         )
     elif team.mode == TeamMode.route:
         content += (
-            "You operate in route mode. For requests that need member expertise, "
-            "identify the single best member and delegate to them — their response is returned directly to the user. "
-            "For requests you can handle directly — simple questions, using your own tools, or general conversation — "
-            "respond without delegating.\n\n"
-            "When routing to a member:\n"
-            "- Analyze the request to determine which member's role and tools are the best match.\n"
-            "- Delegate to exactly one member. Use only the member's ID — do not prefix it with the team ID.\n"
-            "- Write the task to faithfully represent the user's full intent. Do not reinterpret or narrow the request.\n"
-            "- If no member is a clear fit, choose the closest match and include any additional context the member might need.\n"
+            "You work in route mode: you hand the request to exactly one member with "
+            "`delegate_task_to_member`, and its reply is returned to the user as written and ends the "
+            "run.\n\n"
+            f"- Pick the member whose {selector} are the closest match; if none is a clear fit, pick the "
+            "closest and carry the shortfall into the task.\n"
+            "- Pass the request whole. Do not reinterpret, narrow, or summarize what the user asked.\n"
+            "- State any requirement on the reply — format, length, structure, tone — in the task itself. "
+            "Your own formatting rules and expected output are not applied to what the member returns.\n"
+            "- Write no text of your own in the turn you hand over: anything you write is prepended to the "
+            "member's reply, and you get no turn to review or correct what it sends.\n"
         )
     elif team.mode == TeamMode.broadcast:
         content += (
-            "You operate in broadcast mode. For requests that benefit from multiple perspectives, "
-            "send the request to all members simultaneously and synthesize their collective responses. "
-            "For requests you can handle directly — simple questions, using your own tools, or general conversation — "
-            "respond without delegating.\n\n"
-            "When broadcasting:\n"
-            "- Call `delegate_task_to_members` exactly once with a clear task description. "
-            "This sends the task to every member in parallel.\n"
-            "- Write the task so each member can respond independently from their own perspective.\n\n"
-            "After receiving member responses:\n"
-            "- Compare perspectives: note agreements, highlight complementary insights, and reconcile any contradictions.\n"
-            "- Synthesize into a unified answer that integrates the strongest contributions thematically — "
-            "do not list each member's response sequentially.\n"
+            "You work in broadcast mode: you put one task to every member at once, then write the answer "
+            "yourself.\n\n"
+            "- Call `delegate_task_to_members` exactly once. One call reaches every member; do not call it "
+            "once per member.\n"
+            "- Write one whole question each member can answer from its own vantage point, not a sub-task "
+            "for one of them.\n"
+            "- A member's output is evidence, not your answer. When a member fails, refuses, or returns "
+            "nothing, say so plainly and name what it reported — never supply a cause, source, or finding "
+            "the member did not state.\n"
+            "- Say each finding once: where members agree that is one finding, not three; where they "
+            "conflict, reconcile it and say which view you took. Integrate the strongest contributions "
+            "thematically — never list the responses in sequence.\n"
         )
     else:
         # coordinate mode (default)
         content += (
-            "You operate in coordinate mode. For requests that need member expertise, "
-            "select the best member(s), delegate with clear task descriptions, and synthesize their outputs "
-            "into a unified response. For requests you can handle directly — simple questions, "
-            "using your own tools, or general conversation — respond without delegating.\n\n"
-            "Delegation:\n"
-            "- Match each sub-task to the member whose role and tools are the best fit. "
-            "Delegate to multiple members when the request spans different areas of expertise.\n"
-            "- Write task descriptions that are self-contained: state the goal, provide relevant context "
-            "from the conversation, and describe what a good result looks like.\n"
-            "- Use only the member's ID when delegating — do not prefix it with the team ID.\n\n"
-            "After receiving member responses:\n"
-            "- If a response is incomplete or off-target, re-delegate with clearer instructions or try a different member.\n"
-            "- Synthesize all results into a single coherent response. Resolve contradictions, fill gaps with your own "
-            "reasoning, and add structure — do not simply concatenate member outputs.\n"
+            "You work in coordinate mode: you hand sub-tasks to members with "
+            "`delegate_task_to_member` and write the answer yourself.\n\n"
+            f"- Match each sub-task to the member whose {selector} fit it best. When sub-tasks do not "
+            "depend on each other, delegate them in the same turn instead of one per turn.\n"
+            "- A member's output is evidence, not your answer. When a member fails, refuses, or returns "
+            "nothing, say so plainly and name what it reported — never supply a cause, source, or finding "
+            "the member did not state.\n"
+            "- If a response is off-target, re-delegate with clearer instructions or try a better-suited "
+            "member. If it still misses, answer with what you have and say what is missing — do not work "
+            "through the roster.\n"
+            "- Write one answer. Resolve contradictions, add structure, and fill gaps only where you can "
+            "state the basis for it. Never concatenate member outputs.\n"
         )
 
-    content += "</how_to_respond>\n\n"
+    # The delegate tools send the raw user input instead of the leader's task text when
+    # determine_input_for_members is off. Task execution always delivers the leader's text.
+    if team.mode != TeamMode.tasks and team.determine_input_for_members is False:
+        content += (
+            "\nMembers do not see this conversation, and each one receives the user's message verbatim "
+            "rather than the text you write. Pass a short label; do not restate or rewrite the request.\n"
+        )
+    else:
+        content += (
+            "\nMembers do not see this conversation. Each one gets only the text you write for it, so "
+            "carry over every name, number and earlier answer it needs, and say what a good result looks "
+            "like.\n"
+        )
+
+    # Broadcast reaches every member with one call and takes no member id.
+    if team.mode != TeamMode.broadcast:
+        content += "Member ids are the ids shown in the roster above, used exactly as written.\n"
+
+    content += "</delegation>\n"
     return content
 
 
@@ -225,7 +252,10 @@ def _build_team_context(
     run_context: Optional["RunContext"] = None,
     async_mode: bool = False,
 ) -> str:
-    """Build the opening + team_members + how_to_respond blocks.
+    """Build the <team> block: capability statement, roster, and delegation instructions.
+
+    One wrapping element so the framework's mechanics read as subordinate to whatever
+    identity the user wrote, rather than as three more top-level siblings alongside it.
 
     Shared between sync and async system-message builders.
     """
@@ -234,13 +264,16 @@ def _build_team_context(
     content = ""
     resolved_members = get_resolved_members(team, run_context)
     if resolved_members is not None and len(resolved_members) > 0:
+        content += "<team>\n"
         content += _get_opening_prompt()
         content += "\n<team_members>\n"
         content += team.get_members_system_message_content(run_context=run_context, async_mode=async_mode)
-        if team.get_member_information_tool:
-            content += "If you need to get information about your team members, you can use the `get_member_information` tool at any time.\n"
         content += "</team_members>\n"
+        # Outside the roster: <team_members> holds member records, not prose.
+        if team.get_member_information_tool:
+            content += "Call `get_member_information` at any time to re-read this list.\n"
         content += _get_mode_instructions(team)
+        content += "</team>\n\n"
     return content
 
 
@@ -260,20 +293,11 @@ def _build_identity_sections(
         content += f"<your_role>\n{team.role}\n</your_role>\n\n"
 
     if len(instructions) > 0:
+        rendered = render_instructions(instructions)
         if team.use_instruction_tags:
-            content += "<instructions>"
-            if len(instructions) > 1:
-                for _upi in instructions:
-                    content += f"\n- {_upi}"
-            else:
-                content += "\n" + instructions[0]
-            content += "\n</instructions>\n\n"
+            content += f"<instructions>\n{rendered}\n</instructions>\n\n"
         else:
-            if len(instructions) > 1:
-                for _upi in instructions:
-                    content += f"- {_upi}\n"
-            else:
-                content += instructions[0] + "\n\n"
+            content += rendered + "\n\n"
     return content
 
 
@@ -372,8 +396,7 @@ def get_system_message(
     """Get the system message for the team.
 
     1. If the system_message is provided, use that.
-    2. If build_context is False, return None.
-    3. Build and return the default system message for the Team.
+    2. Otherwise build and return the default system message for the Team.
     """
 
     # Extract values from run_context
@@ -415,8 +438,8 @@ def get_system_message(
         # type: ignore
         return Message(role=team.system_message_role, content=sys_message_content)
 
-    # 1. Build and return the default system message for the Team.
-    # 1.1 Build the list of instructions for the system message
+    # 2. Build and return the default system message for the Team.
+    # 2.1 Build the list of instructions for the system message
     team.model = cast(Model, team.model)
     instructions: List[str] = []
     if team.instructions is not None:
@@ -493,11 +516,14 @@ def get_system_message(
     # 2 Build the default system message for the Team.
     system_message_content: str = ""
 
-    # 2.1 Opening + team members + mode instructions
-    system_message_content += _build_team_context(team, run_context=run_context)
-
-    # 2.2 Identity sections: description, role, instructions
+    # 2.1 Identity sections first: description, role, instructions.
+    # The user's identity opens the prompt, as it does for an Agent. Framework
+    # mechanics that follow read as instructions to that identity rather than as a
+    # competing one.
     system_message_content += _build_identity_sections(team, instructions)
+
+    # 2.2 Team members + delegation instructions
+    system_message_content += _build_team_context(team, run_context=run_context)
 
     # 2.3 Learning context: guidance + data, concatenated so the automatic door
     # renders exactly what the manual door's instructions() + build_context() would
@@ -666,8 +692,8 @@ async def aget_system_message(
         # type: ignore
         return Message(role=team.system_message_role, content=sys_message_content)
 
-    # 1. Build and return the default system message for the Team.
-    # 1.1 Build the list of instructions for the system message
+    # 2. Build and return the default system message for the Team.
+    # 2.1 Build the list of instructions for the system message
     team.model = cast(Model, team.model)
     instructions: List[str] = []
     if team.instructions is not None:
@@ -744,11 +770,11 @@ async def aget_system_message(
     # 2 Build the default system message for the Team.
     system_message_content: str = ""
 
-    # 2.1 Opening + team members + mode instructions
-    system_message_content += _build_team_context(team, run_context=run_context, async_mode=True)
-
-    # 2.2 Identity sections: description, role, instructions
+    # 2.1 Identity sections first (see the sync twin)
     system_message_content += _build_identity_sections(team, instructions)
+
+    # 2.2 Team members + delegation instructions
+    system_message_content += _build_team_context(team, run_context=run_context, async_mode=True)
 
     # 2.3 Learning context (see the sync twin)
     if team._learning is not None and team.add_learnings_to_context:

--- a/libs/agno/agno/team/_messages.py
+++ b/libs/agno/agno/team/_messages.py
@@ -168,17 +168,20 @@ def _get_mode_instructions(team: "Team") -> str:
             "created without an assignee cannot go in a batch. Titles are unique: creating a task under "
             "an existing title returns that task instead of a new one.\n"
             "- Set `depends_on` only when a task genuinely needs another task's output.\n"
+            "- Run one task with `execute_task`, or a batch of independent ones with "
+            "`execute_tasks_parallel`. `list_tasks` re-reads the board at any point.\n"
             "- Read every result. On a failure, retry, reassign, or change the plan — do not repeat the "
             "same call unchanged. Record work you did yourself with `update_task_status`, and anything a "
             "later task will need with `add_task_note`.\n"
             "- A task result is evidence, not your answer. When a task fails or a member returns nothing, "
             "say so plainly and name what it reported — never supply a cause or a finding the member did "
             "not state.\n"
-            "- `mark_all_complete` with a summary ends the run and delivers that summary as your answer. "
-            "A list whose tasks have all completed also ends it, but an empty list never does — so when "
-            "the request needed no tasks at all, a greeting or a question you can simply answer, call "
-            "`mark_all_complete` with your answer as the summary. Call it too when the goal is out of "
-            "reach: a partial outcome stated plainly beats looping.\n"
+            "- `mark_all_complete` ends the loop; the summary you pass it is bookkeeping, not the reply. "
+            "Write the answer as your own message in the same turn — that message is what reaches the "
+            "user. A list whose tasks have all completed also ends the loop, but an empty one never "
+            "does, so a request that needed no tasks at all — a greeting, a question you can simply "
+            "answer — still has to call it. Call it too when the goal is out of reach: a partial "
+            "outcome stated plainly beats looping.\n"
         )
     elif team.mode == TeamMode.route:
         content += (
@@ -195,8 +198,8 @@ def _get_mode_instructions(team: "Team") -> str:
         )
     elif team.mode == TeamMode.broadcast:
         content += (
-            "You work in broadcast mode: you put one task to every member at once, then write the answer "
-            "yourself.\n\n"
+            "You work in broadcast mode: one call puts the same task to every member, then you write the "
+            "answer yourself.\n\n"
             "- Call `delegate_task_to_members` exactly once. One call reaches every member; do not call it "
             "once per member.\n"
             "- Write one whole question each member can answer from its own vantage point, not a sub-task "
@@ -232,6 +235,12 @@ def _get_mode_instructions(team: "Team") -> str:
             "\nMembers do not see this conversation, and each one receives the user's message verbatim "
             "rather than the text you write. Pass a short label; do not restate or rewrite the request.\n"
         )
+    elif team.add_team_history_to_members or team.share_member_interactions:
+        content += (
+            "\nMembers see only what you pass them plus the shared context this team forwards — not the "
+            "conversation itself. Carry over every name, number and earlier answer the task depends on, "
+            "and say what a good result looks like.\n"
+        )
     else:
         content += (
             "\nMembers do not see this conversation. Each one gets only the text you write for it, so "
@@ -259,6 +268,7 @@ def _build_team_context(
 
     Shared between sync and async system-message builders.
     """
+    from agno.team.mode import TeamMode
     from agno.utils.callables import get_resolved_members
 
     content = ""
@@ -270,7 +280,8 @@ def _build_team_context(
         content += team.get_members_system_message_content(run_context=run_context, async_mode=async_mode)
         content += "</team_members>\n"
         # Outside the roster: <team_members> holds member records, not prose.
-        if team.get_member_information_tool:
+        # Tasks mode takes the task-tool branch, which never attaches this one.
+        if team.get_member_information_tool and team.mode != TeamMode.tasks:
             content += "Call `get_member_information` at any time to re-read this list.\n"
         content += _get_mode_instructions(team)
         content += "</team>\n\n"

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -376,7 +376,7 @@ def _run_tasks(
                     role="user",
                     content=f"<current_task_state>\n{task_summary}\n</current_task_state>\n\n"
                     "Continue working on the tasks. Create, execute, or update tasks as needed. "
-                    "When all tasks are done, call `mark_all_complete` with a summary.",
+                    "When the goal is met, write your answer and call `mark_all_complete`.",
                 )
                 accumulated_messages.append(state_message)
 
@@ -736,7 +736,7 @@ def _run_tasks_stream(
                     role="user",
                     content=f"<current_task_state>\n{task_summary}\n</current_task_state>\n\n"
                     "Continue working on the tasks. Create, execute, or update tasks as needed. "
-                    "When all tasks are done, call `mark_all_complete` with a summary.",
+                    "When the goal is met, write your answer and call `mark_all_complete`.",
                 )
                 accumulated_messages.append(state_message)
 
@@ -2235,7 +2235,7 @@ async def _arun_tasks(
                     role="user",
                     content=f"<current_task_state>\n{task_summary}\n</current_task_state>\n\n"
                     "Continue working on the tasks. Create, execute, or update tasks as needed. "
-                    "When all tasks are done, call `mark_all_complete` with a summary.",
+                    "When the goal is met, write your answer and call `mark_all_complete`.",
                 )
                 accumulated_messages.append(state_message)
 
@@ -2630,7 +2630,7 @@ async def _arun_tasks_stream(
                     role="user",
                     content=f"<current_task_state>\n{task_summary}\n</current_task_state>\n\n"
                     "Continue working on the tasks. Create, execute, or update tasks as needed. "
-                    "When all tasks are done, call `mark_all_complete` with a summary.",
+                    "When the goal is met, write your answer and call `mark_all_complete`.",
                 )
                 accumulated_messages.append(state_message)
 

--- a/libs/agno/agno/team/mode.py
+++ b/libs/agno/agno/team/mode.py
@@ -16,7 +16,9 @@ class TeamMode(str, Enum):
     """Router pattern. Leader routes to a specialist and returns the member's response directly."""
 
     broadcast = "broadcast"
-    """Broadcast pattern. Leader delegates the same task to all members simultaneously."""
+    """Broadcast pattern. Leader delegates the same task to every member.
+
+    ``arun`` runs the members concurrently; ``run`` runs them in sequence."""
 
     tasks = "tasks"
     """Autonomous task-based execution. Leader decomposes goals into a shared task list,

--- a/libs/agno/agno/utils/message.py
+++ b/libs/agno/agno/utils/message.py
@@ -382,6 +382,11 @@ def render_instructions(instructions: List[str]) -> str:
     """
     if len(instructions) == 1:
         return instructions[0]
-    if all("\n" not in _upi for _upi in instructions):
-        return "\n".join(f"- {_upi}" for _upi in instructions)
-    return "\n\n".join(_upi if "\n" in _upi else f"- {_upi}" for _upi in instructions)
+
+    def _is_block(instruction: str) -> bool:
+        # Strip first: a trailing newline does not make a one-line instruction a block.
+        return "\n" in instruction.strip()
+
+    if not any(_is_block(_upi) for _upi in instructions):
+        return "\n".join(f"- {_upi.strip()}" for _upi in instructions)
+    return "\n\n".join(_upi if _is_block(_upi) else f"- {_upi.strip()}" for _upi in instructions)

--- a/libs/agno/agno/utils/message.py
+++ b/libs/agno/agno/utils/message.py
@@ -370,3 +370,18 @@ def get_conversation_text(messages: Sequence[Message]) -> str:
             if content and content.strip():
                 parts.append(f"Assistant: {content}")
     return "\n".join(parts)
+
+
+def render_instructions(instructions: List[str]) -> str:
+    """Render an instruction list into the body of a system message section.
+
+    A multi-line instruction cannot be a list item: its own column-0 bullets and
+    paragraph breaks would render as siblings of the item wrapping it rather than as
+    its content. Multi-line entries are joined as blocks and only single-line entries
+    are bulleted, so a long authored instruction survives sitting next to short ones.
+    """
+    if len(instructions) == 1:
+        return instructions[0]
+    if all("\n" not in _upi for _upi in instructions):
+        return "\n".join(f"- {_upi}" for _upi in instructions)
+    return "\n\n".join(_upi if "\n" in _upi else f"- {_upi}" for _upi in instructions)

--- a/libs/agno/tests/unit/team/test_basic.py
+++ b/libs/agno/tests/unit/team/test_basic.py
@@ -2,11 +2,11 @@ from unittest.mock import MagicMock
 
 import pytest
 
-pytest.importorskip("duckduckgo_search")
+pytest.importorskip("ddgs")
 pytest.importorskip("yfinance")
 
 from agno.agent import Agent
-from agno.metrics import RunMetrics
+from agno.metrics import MessageMetrics, RunMetrics
 from agno.models.message import Message
 from agno.models.openai import OpenAIChat
 from agno.run import RunContext
@@ -40,21 +40,24 @@ def team():
 
 
 def test_team_system_message_content(team):
-    """Test basic functionality of a route team."""
+    """The roster renders one <member> element per member, id and name as attributes."""
 
-    # Get the actual content
     members_content = team.get_members_system_message_content()
 
-    # Check for expected content with fuzzy matching
-    assert "Agent 1:" in members_content
-    assert "ID: web-agent" in members_content
-    assert "Name: Web Agent" in members_content
+    assert '<member id="web-agent" name="Web Agent">' in members_content
     assert "Role: Search the web for information" in members_content
 
-    assert "Agent 2:" in members_content
-    assert "ID: finance-agent" in members_content
-    assert "Name: Finance Agent" in members_content
+    assert '<member id="finance-agent" name="Finance Agent">' in members_content
     assert "Role: Get financial data" in members_content
+
+    assert members_content.count("<member ") == 2
+    assert members_content.count("</member>") == 2
+
+    # Tools are listed only when the team opts in, so the prompt never routes on
+    # evidence the roster withheld.
+    assert "Tools:" not in members_content
+    team.add_member_tools_to_context = True
+    assert "Tools: " in team.get_members_system_message_content()
 
 
 def test_delegate_to_wrong_member(team):
@@ -95,12 +98,15 @@ def test_set_id_from_name():
 
 
 def test_set_id_auto_generated():
+    """An unnamed team gets a readable random id, not a raw UUID."""
     team = Team(
         members=[],
     )
     team.set_id()
     assert team.id is not None
-    assert is_valid_uuid(team.id)
+    # generate_id_from_name falls back to a human-readable id when there is no name.
+    assert not is_valid_uuid(team.id)
+    assert team.id.count("-") >= 2 and team.id.islower()
 
 
 def test_team_calculate_metrics_preserves_duration(team):
@@ -110,16 +116,21 @@ def test_team_calculate_metrics_preserves_duration(team):
     initial_metrics.duration = 5.5
     initial_metrics.time_to_first_token = 0.5
 
-    message_metrics = RunMetrics()
+    initial_metrics.input_tokens = 10
+    initial_metrics.output_tokens = 20
+
+    message_metrics = MessageMetrics()
     message_metrics.input_tokens = 10
     message_metrics.output_tokens = 20
-
     messages = [Message(role="assistant", content="Response", metrics=message_metrics)]
 
     # Pass the initial metrics (containing duration) to the calculation
     calculated = team._calculate_metrics(messages, current_run_metrics=initial_metrics)
 
-    # Tokens should be summed (0 from initial + 10/20 from message)
+    # Token counts are accumulated during the model call, so the running total is
+    # carried forward rather than re-summed from the messages — counting both would
+    # double every token on the run.
+    assert calculated is initial_metrics
     assert calculated.input_tokens == 10
     assert calculated.output_tokens == 20
 
@@ -142,9 +153,11 @@ def test_team_update_session_metrics_accumulates(team):
 
     team._update_session_metrics(session, run_response=run1)
 
+    # session_data carries the serialized form, so metrics survive a round-trip to the DB.
+    # SessionMetrics accumulates tokens and cost; duration stays a run-level metric.
     metrics1 = session.session_data["session_metrics"]
-    assert metrics1.duration == 2.0
-    assert metrics1.input_tokens == 100
+    assert metrics1["input_tokens"] == 100
+    assert "duration" not in metrics1
 
     # Second Run
     run2 = TeamRunOutput(content="run 2")
@@ -157,8 +170,7 @@ def test_team_update_session_metrics_accumulates(team):
 
     metrics2 = session.session_data["session_metrics"]
 
-    assert metrics2.duration == 5.0  # 2.0 + 3.0
-    assert metrics2.input_tokens == 150  # 100 + 50
+    assert metrics2["input_tokens"] == 150  # 100 + 50
 
 
 @pytest.mark.asyncio

--- a/libs/agno/tests/unit/team/test_team_system_prompt.py
+++ b/libs/agno/tests/unit/team/test_team_system_prompt.py
@@ -76,7 +76,8 @@ def test_every_tool_named_in_the_prompt_is_attached(mode):
     This is the check that would have caught the prompt drifting away from the tools
     its own mode attaches.
     """
-    team = _team(mode=mode)
+    # get_member_information_tool on, so the widened <team> window has something to check.
+    team = _team(mode=mode, get_member_information_tool=True)
     team.initialize_team()
     run_context = RunContext(session_state={}, run_id="r1", session_id="s1")
 
@@ -87,18 +88,54 @@ def test_every_tool_named_in_the_prompt_is_attached(mode):
         team_run_context={},
         session=_session(),
     )
-    attached = {getattr(t, "name", None) or (t.get("name") if isinstance(t, dict) else None) for t in tools}
-    attached.discard(None)
+    attached = set()
+    for t in tools:
+        name = getattr(t, "name", None) or (t.get("name") if isinstance(t, dict) else None)
+        if not name:
+            continue
+        attached.add(name)
+        # Argument names are quoted in the prompt too, and drift the same way.
+        params = getattr(t, "parameters", None)
+        if isinstance(params, dict):
+            attached.update(params.get("properties", {}).keys())
 
+    # Scan the whole <team> block, not just <delegation>: the get_member_information
+    # sentence sits between the roster and the delegation block, and drifted there.
     content = team.get_system_message(session=_session()).content
-    delegation = content[content.index("<delegation>") : content.index("</delegation>")]
-    named = set(re.findall(r"`([a-z_][a-z0-9_]*)`", delegation))
-
-    # depends_on is a tool argument, not a tool.
-    named -= {"depends_on"}
+    block = content[content.index("<team>") : content.index("</team>")]
+    named = set(re.findall(r"`([a-z_][a-z0-9_]*)`", block))
 
     assert named, "the delegation block should name the tools it expects to be called"
-    assert named <= attached, f"{mode}: prompt names unattached tools {sorted(named - attached)}"
+    assert named <= attached, f"{mode}: prompt names unattached tools/args {sorted(named - attached)}"
+
+
+def test_get_member_information_is_named_only_where_it_is_attached():
+    """Tasks mode takes the task-tool branch, which never attaches it."""
+    for mode in MODES:
+        content = _team(mode=mode, get_member_information_tool=True).get_system_message(session=_session()).content
+        assert ("get_member_information" in content) is (mode != TeamMode.tasks.value)
+
+
+def test_conflicting_flags_render_the_mode_that_actually_runs():
+    """respond_directly + delegate_to_all_members resolves to broadcast, prompt included."""
+    team = _team(respond_directly=True, delegate_to_all_members=True)
+    team.initialize_team()
+    assert team.mode == TeamMode.broadcast
+
+    content = team.get_system_message(session=_session()).content
+    assert "broadcast mode" in content
+    assert "route mode" not in content
+    assert "`delegate_task_to_member`" not in content
+
+
+def test_member_isolation_claim_tracks_the_context_flags():
+    """The unconditional claim is false once the team forwards history or interactions."""
+    plain = _team().get_system_message(session=_session()).content
+    assert "Members do not see this conversation." in plain
+
+    sharing = _team(add_team_history_to_members=True).get_system_message(session=_session()).content
+    assert "Members do not see this conversation." not in sharing
+    assert "not the conversation itself" in sharing
 
 
 def test_member_ids_line_is_suppressed_for_broadcast():

--- a/libs/agno/tests/unit/team/test_team_system_prompt.py
+++ b/libs/agno/tests/unit/team/test_team_system_prompt.py
@@ -1,0 +1,153 @@
+"""Contract tests for the team leader's generated system message.
+
+These pin the two properties that went unchecked for six months: the user's
+identity opens the prompt, and the prompt never names a tool the run will not
+attach.
+"""
+
+import re
+
+import pytest
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+from agno.run import RunContext
+from agno.run.team import TeamRunOutput
+from agno.session.team import TeamSession
+from agno.team.mode import TeamMode
+from agno.team.team import Team
+
+MODES = [m.value for m in TeamMode]
+
+
+def _team(**kwargs) -> Team:
+    members = [
+        Agent(name="Researcher", id="researcher", model=OpenAIChat("gpt-4o"), role="Search the web"),
+        Agent(name="Writer", id="writer", model=OpenAIChat("gpt-4o"), role="Write prose"),
+    ]
+    kwargs.setdefault("members", members)
+    return Team(name="Content Team", id="content-team", model=OpenAIChat("gpt-4o"), **kwargs)
+
+
+def _session() -> TeamSession:
+    return TeamSession(session_id="s1", team_id="content-team")
+
+
+@pytest.mark.parametrize("mode", MODES)
+def test_user_identity_precedes_framework_block(mode):
+    """description/role/instructions render before <team>, as they do for an Agent."""
+    team = _team(mode=mode, description="A team that researches.", role="Lead", instructions=["Cite sources."])
+    content = team.get_system_message(session=_session()).content
+
+    assert content.startswith("<description>")
+    assert content.index("<description>") < content.index("<your_role>") < content.index("<team>")
+    assert content.index("<team>") > content.index("Cite sources.")
+
+
+@pytest.mark.parametrize("mode", MODES)
+def test_team_block_is_well_formed(mode):
+    team = _team(mode=mode)
+    content = team.get_system_message(session=_session()).content
+
+    for tag in ("team", "team_members", "delegation"):
+        assert content.count(f"<{tag}>") == 1, tag
+        assert content.count(f"</{tag}>") == 1, tag
+        assert content.index(f"<{tag}>") < content.index(f"</{tag}>"), tag
+
+    # The roster holds member records; prose belongs outside it.
+    roster = content[content.index("<team_members>") : content.index("</team_members>")]
+    assert "`" not in roster
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", MODES)
+async def test_sync_and_async_builders_agree(mode):
+    team = _team(mode=mode, description="D", instructions=["I"], get_member_information_tool=True)
+    assert (
+        team.get_system_message(session=_session()).content
+        == (await team.aget_system_message(session=_session())).content
+    )
+
+
+@pytest.mark.parametrize("mode", MODES)
+def test_every_tool_named_in_the_prompt_is_attached(mode):
+    """A backticked identifier in the delegation block must resolve to a real tool.
+
+    This is the check that would have caught the prompt drifting away from the tools
+    its own mode attaches.
+    """
+    team = _team(mode=mode)
+    team.initialize_team()
+    run_context = RunContext(session_state={}, run_id="r1", session_id="s1")
+
+    tools = team._determine_tools_for_model(
+        model=team.model,
+        run_response=TeamRunOutput(run_id="r1"),
+        run_context=run_context,
+        team_run_context={},
+        session=_session(),
+    )
+    attached = {getattr(t, "name", None) or (t.get("name") if isinstance(t, dict) else None) for t in tools}
+    attached.discard(None)
+
+    content = team.get_system_message(session=_session()).content
+    delegation = content[content.index("<delegation>") : content.index("</delegation>")]
+    named = set(re.findall(r"`([a-z_][a-z0-9_]*)`", delegation))
+
+    # depends_on is a tool argument, not a tool.
+    named -= {"depends_on"}
+
+    assert named, "the delegation block should name the tools it expects to be called"
+    assert named <= attached, f"{mode}: prompt names unattached tools {sorted(named - attached)}"
+
+
+def test_member_ids_line_is_suppressed_for_broadcast():
+    """delegate_task_to_members takes no member id, so naming ids there is noise."""
+    for mode in MODES:
+        content = _team(mode=mode).get_system_message(session=_session()).content
+        assert ("Member ids are the ids shown" in content) is (mode != TeamMode.broadcast.value)
+
+
+def test_prompt_names_member_tools_only_when_the_roster_shows_them():
+    without = _team().get_system_message(session=_session()).content
+    assert "role, description, and tools" not in without
+    assert "Tools:" not in without
+
+    with_tools = _team(add_member_tools_to_context=True).get_system_message(session=_session()).content
+    assert "role, description, and tools" in with_tools
+
+
+def test_verbatim_input_closer_tracks_determine_input_for_members():
+    """Tasks mode always delivers the leader's text; the delegate tools may not."""
+    for mode in MODES:
+        content = _team(mode=mode, determine_input_for_members=False).get_system_message(session=_session()).content
+        expected = mode != TeamMode.tasks.value
+        assert ("receives the user's message verbatim" in content) is expected
+
+
+def test_multi_line_instruction_is_not_rendered_as_a_list_item():
+    """A block instruction keeps its own bullets; only single-line entries are bulleted."""
+    block = "You are Agno.\n\nWho you are:\n- The platform.\n- Warm and quick."
+    content = _team(instructions=[block, "File relentlessly."]).get_system_message(session=_session()).content
+
+    assert content.startswith(block)
+    assert "- You are Agno." not in content
+    assert "\n\n- File relentlessly." in content
+
+
+def test_single_line_instructions_are_still_bulleted():
+    content = _team(instructions=["First.", "Second."]).get_system_message(session=_session()).content
+    assert content.startswith("- First.\n- Second.\n\n")
+
+
+def test_sub_team_member_renders_its_role():
+    sub = Team(
+        name="Research Team",
+        id="research-team",
+        model=OpenAIChat("gpt-4o"),
+        role="Handles all research",
+        members=[Agent(name="R", id="r", model=OpenAIChat("gpt-4o"))],
+    )
+    content = _team(members=[sub]).get_system_message(session=_session()).content
+    assert 'type="team"' in content
+    assert "Role: Handles all research" in content


### PR DESCRIPTION
## Summary

The team leader system prompt had not been touched since `c895559ab` (2026-02-11). Reviewing it for 3.0 turned up two separate problems: the framework's voice renders before the user's, and three of the prompt's sentences describe behaviour the code does not have.

### Ordering — the framework introduces itself before your team does

A `Team` assembled the framework's opening sentence, the roster and the whole `<how_to_respond>` block **before** `description`, `role` and `instructions`. An `Agent` does the opposite: `description` is the first thing in its prompt. Same library, opposite convention, nothing reconciling them.

A team with an authored persona therefore read *"You coordinate a team of specialized AI agents to fulfill the user's request"* before it ever reached its own identity — and had no way to fix it, because setting `system_message` returns before the roster is built and so also discards `<team_members>`, learning context, knowledge instructions and memories. Measured against a real 3-member team, 1,581 characters of framework voice stood ahead of the first authored word.

Identity now renders first in both builders. Framework characters ahead of the user's first word: **1,581 → 0**.

### Truthfulness — three claims the runtime contradicted

| The prompt said | The code did |
|---|---|
| broadcast sends the task "to every member in parallel" | `# Run all the members sequentially` (`_default_tools.py:1067`) — only the async twin gathers, and `mode.py` repeated the claim in the public enum docstring |
| "Match each sub-task to the member whose role **and tools** are the best fit" (×4 branches) | `add_member_tools_to_context` defaults `False` (`team.py:184`), so no `Tools:` line is ever rendered |
| delegate docstrings: "a clear description of the task **AND the expected output**" | the signature is `(member_id, task)` — there is no such parameter |

All four mode blocks are rewritten against what each mode actually attaches and does. They also gain what a supervisor cannot infer: relay member failures faithfully instead of inventing a cause, batch independent delegations into one turn, a terminal move for the retry loop, and member isolation stated as a fact rather than as the adjective "self-contained".

Two closers stay honest about configuration: `determine_input_for_members=False` means the member never sees the leader's text at all, and broadcast takes no member id. A `selector` local names member fields only when the roster actually renders them.

`<how_to_respond>` becomes `<delegation>`. It held delegation mechanics, and its old name collided with the user's own instructions about how to respond — the ordering problem in miniature.

### Carried along, because the reorder makes them load-bearing

- **`render_instructions`** (`utils/message.py`): with more than one instruction and `use_instruction_tags` off, every entry was `- ` prefixed, so a multi-line instruction became a single list item whose own column-0 bullets read as siblings of the item wrapping it. Harmless when buried mid-prompt; not harmless now that it renders at character 0. Shared with `Agent` (both twins) so the two cannot diverge again.
- **Sub-team `Role`**: `Team.role` has always existed and the roster silently dropped it.
- **Mode normalization** (`_init.py`): `respond_directly=True` together with `delegate_to_all_members=True` left `mode` on `route` while attaching the broadcast tool, so the prompt described route semantics and named `delegate_task_to_member` for a run holding `delegate_task_to_members`. The mode now follows the flag it resolves to.
- **The tasks continuation message** (`_run.py`, all four loops) is the other half of the tasks prompt and now agrees with it.

## Tests

Nothing in `libs/agno/tests` asserted a single character of this prompt, which is how it went a year stale. The module that should have caught it had been skipped since it was written:

```
pytest.importorskip("duckduckgo_search")   # test_basic.py:5  →  1 skipped in 0.02s
```

No dependency group ships `duckduckgo_search`; they all ship `ddgs`. Guard fixed. Unskipping surfaced three tests still pinning pre-3.0 behaviour — UUID ids (v3.0 generates readable slugs), message-summed metrics (tokens now accumulate during the model call), and session-level `duration` (`SessionMetrics` carries tokens and cost; duration stayed run-level). Each is updated with the reason its expectation moved; none hides a live defect.

New `test_team_system_prompt.py` pins the two properties that went unchecked:

1. the user's identity opens the prompt, in both builders and all four modes;
2. every backticked identifier in the `<team>` block resolves to a tool — or a tool argument — that the run actually attaches for that mode.

The second check earned its place immediately: it caught that coordinate and route named no tool at all, that the id convention was emitting a bare `<team_members>` tag inside `<delegation>`, and that `get_member_information` was named in tasks mode, which never attaches it.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Verification.** Full unit suite green — `17,649 passed, 0 failed`. `format.sh` clean.

**`validate.sh` is not green, and was not green before this branch.** mypy reports **72 errors in 14 files, an identical count with and without this change**, none of them in any file touched here — they are missing type stubs in model SDK wrappers (`cartesia`, `anthropic`, `aws`, `gemini`). This PR neither introduces nor fixes them.

**Behaviour change worth calling out.** Every existing team's system message changes shape: the user's `description`/`role`/`instructions` move to the top, and the framework block is now wrapped in `<team>`. No public API changes, no new kwargs, no storage or serialization changes. Teams that set `system_message` are unaffected — that path still returns early.

**Deliberately not in this PR:**

- **New `Team` kwargs.** An `add_delegation_instructions` opt-out or a `build_context` flag would each need a `_storage.py` writer *and* reader or they vanish across `to_dict`/`from_dict`, plus round-trip tests and OS schema. Not a change to make the week a major ships — and once the block stops asserting an identity, there is much less left in it worth opting out of.
- **`add_member_tools_to_context` default.** Flipping it needs `_get_tool_names` hardened against dicts with no `name`, the `from_dict` default flipped in the same commit, and a bound on large toolkits — and today `run()` renders `get_functions()` while `arun()` renders `get_async_functions()`, so the same team already describes its members differently by entrypoint. The `selector` local makes the prompt honest in both flag states instead.
- **Concurrent sync broadcast.** The prompt no longer claims parallelism; making `run()` actually concurrent is a separate change.
- **Tasks-loop termination.** `all_terminal()` returns `False` for an empty list, so a tasks-mode run that creates no tasks and never calls `mark_all_complete` burns `max_iterations` and — because `_update_run_response` appends rather than assigns — concatenates its answer once per iteration. The prompt now steers around this explicitly; the loop fix belongs with the other runtime items.
- **`execute_tasks_parallel` missing `run_context`** (`_task_tools.py:879`, `:1084`), which makes callable-factory teams abort a batch with a false "member not found".
- **A member-side `<team>` block**, so a delegated agent knows its answer goes to a leader rather than to the end user. Today a member's system prompt is byte-identical whether it runs standalone or delegated-to. This needs a run-scoped seam — `Agent._team` is bound permanently at `_init.py:502` and is the wrong gate.
- **Stale OpenAPI examples** in `os/routers/teams/router.py:1770` and `:1903`, which document a `transfer_task_to_member` tool that no longer exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
