### PR TITLE
[fix] Exclude dynamic framework parameters from strict schemas

### DIFF
--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -1429,6 +1429,7 @@ class Function(BaseModel):
             if name not in ("return", "self")
             and name not in FRAMEWORK_INJECTED_PARAMS
             and name not in AGNO_INJECTED_PARAMS
+            and name not in (self._framework_params or set())
         ]
 
     @staticmethod

--- a/libs/agno/tests/unit/tools/test_functions.py
+++ b/libs/agno/tests/unit/tools/test_functions.py
@@ -1744,6 +1744,32 @@ def test_strict_processing_does_not_require_an_injected_parameter():
     assert func.parameters["required"] == ["query"]
 
 
+def test_strict_processing_does_not_require_typed_framework_parameters():
+    """Dynamic framework parameters must remain optional in strict schemas."""
+
+    def fn(query: str, ctx: Optional[RunContext] = None) -> str:
+        return query
+
+    func = Function(
+        name="fn",
+        entrypoint=fn,
+        parameters={
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"},
+                "ctx": {"type": "object"},
+            },
+            "required": ["query"],
+        },
+        skip_entrypoint_processing=True,
+    )
+    func._framework_params = {"ctx"}
+
+    func.process_schema_for_strict()
+
+    assert func.parameters["required"] == ["query"]
+
+
 # ----------------------------------------------------------------------
 # Regression: the guard must also engage on the from_callable path
 # (Agent(tools=[fn]) registers plain callables without process_entrypoint)


### PR DESCRIPTION
Fixes #9454. Excludes dynamically detected _framework_params when rebuilding strict tool schema required fields, preventing models from fabricating framework-owned values. Adds regression coverage. Focused strict-processing tests: 2 passed. Ruff check/format, mypy on function.py, and git diff --check passed. Full test file was attempted but stopped because the local mocker fixture/plugin is unavailable; 5 tests passed before that setup error. Prepared with AI assistance and manually reviewed.