### PR TITLE
test: stop three suites reading state they do not control

### DIFF
--- a/libs/agno/tests/integration/db/async_postgres/test_metrics.py
+++ b/libs/agno/tests/integration/db/async_postgres/test_metrics.py
@@ -1,7 +1,7 @@
 """Integration tests for the Metrics related methods of the AsyncPostgresDb class"""
 
 import time
-from datetime import date
+from datetime import date, datetime, timedelta, timezone
 
 import pytest
 import pytest_asyncio
@@ -152,8 +152,11 @@ async def test_get_metrics_with_date_filter(async_postgres_db_real: AsyncPostgre
     # Calculate metrics
     await async_postgres_db_real.calculate_metrics()
 
-    # Get metrics for yesterday
-    yesterday = date.fromordinal(date.today().toordinal() - 1)
+    # Get metrics for yesterday. The session above is placed 24 hours back and
+    # the metrics are bucketed by UTC date, so the day asked for has to be a UTC
+    # day too: date.today() is the local date and names the wrong day whenever
+    # the machine is not on UTC.
+    yesterday = datetime.now(timezone.utc).date() - timedelta(days=1)
     metrics, latest_updated_at = await async_postgres_db_real.get_metrics(
         starting_date=yesterday, ending_date=yesterday
     )

--- a/libs/agno/tests/integration/db/postgres/test_metrics.py
+++ b/libs/agno/tests/integration/db/postgres/test_metrics.py
@@ -1,6 +1,5 @@
 """Integration tests for the Metrics related methods of the PostgresDb class"""
 
-import time
 from datetime import date, datetime, timedelta, timezone
 from typing import List
 
@@ -31,6 +30,18 @@ def cleanup_metrics_and_sessions(postgres_db_real: PostgresDb):
             session.rollback()
 
 
+def _noon_utc(days_ago: int) -> int:
+    """Midday UTC, ``days_ago`` days back.
+
+    The suites below lay sessions an hour apart from this point and assert which
+    UTC day each one lands in. Counting back from the current clock keeps the
+    current time of day, so a run started late in the UTC day pushes the later
+    sessions past midnight into the next day and the per-day counts split.
+    """
+    day = datetime.now(timezone.utc).date() - timedelta(days=days_ago)
+    return int(datetime(day.year, day.month, day.day, 12, tzinfo=timezone.utc).timestamp())
+
+
 def _persist(db: PostgresDb, session) -> None:
     """Store a session the way v3 does: the row, then each run in the runs table.
 
@@ -45,7 +56,7 @@ def _persist(db: PostgresDb, session) -> None:
 @pytest.fixture
 def sample_agent_sessions_for_metrics() -> List[AgentSession]:
     """Fixture returning sample AgentSessions for metrics testing"""
-    base_time = int(time.time()) - 86400  # 1 day ago
+    base_time = _noon_utc(1)
     sessions = []
 
     for i in range(3):
@@ -258,7 +269,7 @@ def test_metrics_flow(postgres_db_real: PostgresDb, sample_agent_sessions_for_me
 def sample_multi_day_sessions() -> List[AgentSession]:
     """Fixture returning sessions spread across multiple days"""
     sessions = []
-    base_time = int(time.time()) - (3 * 86400)  # 3 days ago
+    base_time = _noon_utc(3)
 
     # Day 1: 2 sessions
     for i in range(2):
@@ -374,7 +385,7 @@ def test_calculate_metrics_multiple_days(postgres_db_real: PostgresDb, sample_mu
 
 def test_calculate_metrics_mixed_session_types_multiple_days(postgres_db_real: PostgresDb):
     """Test metrics calculation with different session types across multiple days"""
-    base_time = int(time.time()) - (2 * 86400)  # 2 days ago
+    base_time = _noon_utc(2)
     sessions = []
 
     # Day 1: Agent and Team sessions
@@ -505,7 +516,7 @@ def test_get_metrics_date_range_multiple_days(postgres_db_real: PostgresDb, samp
 
 def test_metrics_calculation_multiple_days(postgres_db_real: PostgresDb):
     """Ensure that metrics calculation can handle calculating metrics for multiple days at once"""
-    base_time = int(time.time()) - (2 * 86400)  # 2 days ago
+    base_time = _noon_utc(2)
 
     # Add sessions for Day 1
     day1_sessions = []

--- a/libs/agno/tests/unit/tools/test_functions.py
+++ b/libs/agno/tests/unit/tools/test_functions.py
@@ -3296,22 +3296,36 @@ def test_cache_files_are_readable_by_their_owner_only(tmp_path):
 
 def test_a_result_that_cannot_be_copied_is_not_cached(tmp_path):
     """The cache keeps a copy of the tool's return because the hooks run after
-    it and may edit it in place. A value too deeply nested to copy leaves
-    nothing safe to keep, so the call is not cached rather than cached with the
-    hook's edit folded in."""
+    it and may edit it in place. A value that cannot be copied leaves nothing
+    safe to keep, so the call is not cached rather than cached with the hook's
+    edit folded in."""
+
+    class Unfoldable(dict):
+        """A value that refuses to be copied.
+
+        Nesting past the recursion limit would refuse a copy too, but that limit
+        is process-wide and any imported library may raise it: py_ecc, which
+        web3 pulls in, sets it to 100000 on import. Depth therefore pins
+        nothing, and refusing outright does."""
+
+        def __deepcopy__(self, memo):
+            raise TypeError("no copy")
 
     def enrich(function_name: str, function_call: Callable, arguments: Dict[str, Any]):
         result = function_call(**arguments)
         result["items"].append("enriched")
         return result
 
-    def nested() -> dict:
-        deep: Any = []
-        for _ in range(600):
-            deep = [deep]
-        return {"items": ["raw"], "deep": deep}
+    def uncopyable() -> dict:
+        return {"items": ["raw"], "handle": Unfoldable(kind="live")}
 
-    func = Function(name="nested", entrypoint=nested, cache_results=True, cache_dir=str(tmp_path), tool_hooks=[enrich])
+    func = Function(
+        name="uncopyable",
+        entrypoint=uncopyable,
+        cache_results=True,
+        cache_dir=str(tmp_path),
+        tool_hooks=[enrich],
+    )
 
     reported = []
     original = function_module.log_exception


### PR DESCRIPTION
## Summary

`feat/v3.0` went red in two different workflows, neither from a code change in this
repo. Both failures come from tests that read process- or machine-wide state they do
not control. A third test with the same flaw was found while verifying, and is fixed
here too.

### 1. `Validation / tests (4/5)` — the recursion limit is not ours to rely on

```
libs/agno/tests/unit/tools/test_functions.py::test_a_result_that_cannot_be_copied_is_not_cached
AssertionError: assert [PosixPath('.../functions/v2/nested/e3a4c3fefb85e06acf07e468385dbe91.json')] == []
```

The test built a 600-deep nested list so that `copy.deepcopy` would overflow the
stack, which is what makes `_record_entrypoint_result` refuse to cache the call
(`libs/agno/agno/tools/function.py:238`). That only holds while the recursion limit
is the default 1000, and the limit is process-wide:

- `eth-account 0.14.0` was published **2026-08-23 01:42 UTC** and moved its floor to
  `eth-keyfile>=0.10`. The previous resolution, `eth-account 0.13.7`, pinned
  `eth-keyfile<0.9.0` → `0.8.1`, which does **not** depend on `py_ecc`. `eth-keyfile`
  0.9.0+ does.
- `py_ecc/__init__.py:13` runs `sys.setrecursionlimit(max(100000, ...))` on import.
- Collecting `tests/unit/tools/test_evm.py` imports `agno.tools.evm` → `eth_account`
  → `eth_keyfile` → `py_ecc`, in every shard, before any test runs.

At limit 100000 the copy succeeds, the result *is* cached, and the "no cache file"
assertion fails. Timeline: last green Validation `32575403106` (08-22 13:18 UTC),
eth-account 0.14.0 published 08-23 01:42, first red `32642583262` (08-23 13:31), red
on every run since.

The value now refuses the copy outright instead of relying on how deep a copy can go.

### 2. `Main Validation / test-db (3.12)` — an anchor that walks with the clock

```
libs/agno/tests/integration/db/postgres/test_metrics.py::test_calculate_metrics_multiple_days   assert 2 == 3
libs/agno/tests/integration/db/postgres/test_metrics.py::test_metrics_calculation_multiple_days assert 2 == 1
```

The fixtures anchored at `int(time.time()) - N * 86400` and then laid sessions an hour
apart. That anchor keeps the current time of day, so a run started after 22:00 UTC
pushes the later sessions past midnight and the per-day counts split. Metrics are
bucketed by UTC date (`agno/db/postgres/utils.py:408`), so this is purely about when
CI starts: the same commit passed at 13:30 UTC (`32642579940`, all green) and failed
at 22:41 and 22:47 UTC. The `test-db` job is new (#9712), which is why it only started
showing now.

The fixtures now anchor at midday UTC, which leaves room for the offsets whatever
time the run starts.

### 3. `async_postgres` metrics — local date vs UTC bucket (found while verifying)

`test_get_metrics_with_date_filter` places a session 24 hours back (bucketed by UTC
date) but asks for the day using `date.today()`, which is the **local** date. On a UTC
runner the two agree, so CI never saw it; on any machine with a non-zero offset it
fails for part of the day. Now derived from `datetime.now(timezone.utc)`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [x] Other: test-only; no library code changes

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**How each fix was verified, executed rather than argued:**

- The cache test was run under both conditions: at the default limit, and with
  `py_ecc`'s `setrecursionlimit(100000)` applied first. Before the change the second
  run reproduced CI exactly, down to the cache filename
  (`e3a4c3fefb85e06acf07e468385dbe91.json`). After, both pass.
- Mutation check on the rewritten test: removing the copy guard from
  `_record_entrypoint_result` makes it fail, so it still pins the behaviour it names.
- The metrics fix was verified inside the failing window. At **23:42 UTC** the
  unchanged suite failed 4 tests against a real Postgres; with the new anchor all 15
  pass. The anchor invariant was also checked exhaustively: over every start time in
  the day, the old anchor splits a day-group 18 times out of 216, the new one never.
- The whole `test-db` CI scope was re-run in both `TZ=UTC` and `TZ=Europe/London`.

**Not changed on purpose:** the two other `date.today()` uses in
`postgres/test_metrics.py` (lines 183, 222) only assert a type and an empty result for
an inverted range, so the day they name does not affect the outcome.

**Worth knowing:** `fail-fast: true` on the shard matrix means shards 1–3 have not
completed on the current tip — they were cancelled at 37% / 84% / 19% when shard 4
failed. They showed no failures in what they did run, but they are unproven rather
than proven clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
