### PR TITLE
fix: state the team leader's delegation rule as need, not as a comparison with itself

### DIFF
--- a/libs/agno/agno/team/_messages.py
+++ b/libs/agno/agno/team/_messages.py
@@ -141,11 +141,16 @@ def _get_opening_prompt() -> str:
 
     States what the leader has, not who it is. An identity claim here would compete
     with the description, role and instructions the user wrote.
+
+    The delegation rule is stated as need, never as a comparison with the leader's own
+    ability. Asked whether a member fits a sub-task "better than yours", a small model
+    keeps every part it believes it can do itself and skips the member the request
+    named for it; asked whether the member is needed, it follows the request.
     """
     return (
         "You have a team of specialists, listed below. "
-        "Hand work to members when their expertise or tools fit it better than yours; "
-        "answer directly — including with your own tools — when they do not.\n"
+        "Delegate to members when their expertise or tools are needed; "
+        "answer directly — including with your own tools — when they are not.\n"
     )
 
 

--- a/libs/agno/tests/integration/teams/test_event_streaming.py
+++ b/libs/agno/tests/integration/teams/test_event_streaming.py
@@ -793,6 +793,9 @@ def test_intermediate_steps_with_parser_model(shared_db):
 
 
 def test_intermediate_steps_with_member_agents():
+    # gpt-4o-mini on purpose: a weak leader is the one that stops decomposing the request
+    # when the delegation prompt drifts, and a stronger model hides that. This test caught
+    # the leader skipping the Analyst on 8 of 8 runs while gpt-5-mini delegated to both.
     agent_1 = Agent(
         name="Analyst",
         model=OpenAIChat(id="gpt-4o-mini"),

--- a/libs/agno/tests/unit/team/test_team_system_prompt.py
+++ b/libs/agno/tests/unit/team/test_team_system_prompt.py
@@ -188,3 +188,31 @@ def test_sub_team_member_renders_its_role():
     content = _team(members=[sub]).get_system_message(session=_session()).content
     assert 'type="team"' in content
     assert "Role: Handles all research" in content
+
+
+@pytest.mark.parametrize("mode", MODES)
+def test_opening_states_delegation_as_need_not_as_self_assessment(mode):
+    """The opening tells the leader to delegate when a member is needed, not when the
+    member would do it better than the leader.
+
+    A comparison invites the leader to rate its own ability against the roster, and a
+    small model rates itself well enough to keep the parts it thinks it can do and skip
+    the member the request named for them. The need rule ties delegation to the request.
+    """
+    content = _team(mode=mode).get_system_message(session=_session()).content
+    block = content[content.index("<team>") : content.index("<team_members>")]
+
+    assert "Delegate to members when their expertise or tools are needed" in block
+    assert "better than" not in block
+    assert "fit it better" not in content
+
+
+@pytest.mark.parametrize("mode", MODES)
+def test_opening_makes_no_identity_claim(mode):
+    """The opening states what the leader has, not who it is; identity is the user's."""
+    content = _team(mode=mode, description="A team that researches.").get_system_message(session=_session()).content
+    opening = content[content.index("<team>") + len("<team>\n") :].split("\n", 1)[0]
+
+    assert opening.startswith("You have a team of specialists")
+    for claim in ("You are", "You coordinate", "You act as"):
+        assert claim not in opening


### PR DESCRIPTION
## Summary

PR #9731 (`9fcf20e68`) broke `test_event_streaming.py::test_intermediate_steps_with_member_agents` on `feat/v3.0` (Main Validation run 32675504107, job test-teams-2): the coordinate-mode leader on gpt-4o-mini delegated to the Math Agent only and dropped the requested analysis, `assert 1 == 2`. Measured before this work: 8/8 runs with 2 delegations before #9731, 0/8 after, 8/8 on gpt-5-mini either way.

This PR isolates the one sentence responsible with live probes, changes only that sentence, and proves the change with the same harness across all four modes, both models, and 20 scenarios. Nothing else #9731 did is touched: identity still renders first, the `<team>`/`<delegation>` structure, the rewritten mode blocks, the computed member-field selector, the closers and the trimmed delegate docstrings all stay.

### What caused the flip

#9731 replaced the opening's delegation rule

> Delegate to members when their expertise or tools **are needed**.

with

> Hand work to members when their expertise or tools **fit it better than yours**; answer directly — including with your own tools — when they do not.

and, in the same change, removed the coordinator framing ("You coordinate a team of specialized AI agents to fulfill the user's request") that had been counter-balancing the "answer directly" permission. The comparative rule asks the leader to rate its own ability against the roster. gpt-4o-mini rates itself well enough to keep the "analyse" half, then does not do it either: the failing runs' entire answer was *"The result of 10 factorial (10!) is 3,628,800."* The request's first half vanished. With the need rule the leader delegates both halves, analyst first, in one turn.

### Bisect (live, gpt-4o-mini, the exact team of the failing test, 8 runs per arm)

Each row re-applies ONE pre-#9731 element on top of the post-#9731 tree (`all_old` re-applies all of them and was verified byte-for-byte against the pre-#9731 rendering before any probe ran). The "2 delegations" column counts runs that delegated to both members, analyst first, which is what the test asserts.

| variant | what it re-applies on the new tree | 2 delegations |
|---|---|---|
| `before` | pre-#9731 tree, untouched (run with the before worktree on PYTHONPATH) | 8/8 |
| `after` | HEAD (post-#9731) prompt and tools, untouched | 0/8 |
| `all_old` | HEAD tree with the full pre-#9731 coordinate prompt and delegate docstring reconstructed | 8/8 |
| `a_wrap_tag` | drop <team> and rename tag (structure only) | 1/8 |
| `a_open` | old opening sentence | 8/8 |
| `a_coord` | old coordinate block (whole) | 0/8 |
| `a_selector` | 'role and description' -> 'role and tools' | 2/8 |
| `a_closers` | drop the two new closers | 2/8 |
| `a_tooldoc` | old delegate_task_to_member docstring | 0/8 |
| `o_identity` | old identity sentence + new delegation sentence | 8/8 |
| `o_delegate` | new capability opener + old delegate/direct sentences | 1/8 |
| `o_rule_needed` | new opener; 'needed' rule instead of 'fit it better than yours', new direct clause | 8/8 |
| `b_open` | all_old + new opening | 1/8 |
| `after` + stream_member_events=False | control for the sibling test that passed in CI | 0/8 |

Read-out:
- `all_old` recovers 8/8 on the new tree, so the cause is prompt/tool text, not the `_init.py`/`_run.py` changes in #9731.
- The coordinate-block rewrite (`a_coord`), the structure (`a_wrap_tag`), the selector, the closers and the docstring are each innocent: restoring any one of them recovers 0–2/8, indistinguishable from noise. (The user's earlier experiment restoring only "Delegate to multiple members when the request spans different areas of expertise" gave 1/8 and is consistent with this; it was not re-run.)
- The opening sentence alone is load-bearing in both directions: restoring it recovers 8/8 (`a_open`); re-applying the new opening onto the otherwise-old prompt breaks it, 1/8 (`b_open`).
- Inside the opening, either the coordinator identity sentence (`o_identity`) or the need rule (`o_rule_needed`) recovers 8/8 alone. The old direct-answer sentence on the new opener does not (`o_delegate`, 1/8): "answer directly" permissions are what the weak model acts on when nothing frames it as the coordinator.
- `stream_member_events=False` (the sibling test that passed in the same CI run) is 0/8 too. That pass was luck, not a streaming effect.

The fix keeps #9731's decision that the opening states what the leader *has* rather than who it *is* (`o_identity` would have reintroduced the identity claim #9731 removed on purpose), and takes the need rule.

### Before / after #9731 / candidate

Metrics are objective and computed from the raw delegation list of every probe: all expected members delegated to and no wrong member ("right"), exactly one call in route and broadcast, independent sub-tasks batched into one turn ("batched"), a failing member's error relayed without an invented figure ("relayed"/"invented"), and team-level tokens. Every member tool is a deterministic local function, so a probe measures the leader and nothing else.

**Right decomposition by mode and model** (n varies: the bisect and screening budget went to coordinate/gpt-4o-mini; gpt-5-mini's two coordinate misses are both arms asking a clarifying question on `sales_failure` instead of delegating, identical behaviour under either wording):

| mode | model | before #9731 | after #9731 | candidate |
|---|---|---|---|---|
| coordinate | gpt-4o-mini | 76/77 | 64/85 | 73/77 |
| coordinate | gpt-5-mini | - | 6/7 | 9/10 |
| route | gpt-4o-mini | 3/3 | 6/6 | 6/6 |
| route | gpt-5-mini | - | - | 2/2 |
| broadcast | gpt-4o-mini | 1/2 | 3/4 | 4/4 |
| broadcast | gpt-5-mini | - | - | 2/2 |
| tasks | gpt-4o-mini | 2/2 | 3/4 | 4/4 |
| tasks | gpt-5-mini | - | - | 2/2 |

**Coordinate, gpt-4o-mini, by scenario** (right / batched where sub-tasks are independent / failure relayed without an invented figure):

| scenario | before #9731 | after #9731 | candidate |
|---|---|---|---|
| advisors | 6/7, batched 7/7 | 2/7, batched 6/7 | 3/7, batched 6/7 |
| analyse_percent | 4/4 | 4/4 | 4/4 |
| billing | 3/3 | 3/3 | 3/3 |
| brainstorm_critic | 3/3 | 3/3 | 3/3 |
| code_review | 3/3, batched 3/3 | 3/3, batched 3/3 | 3/3, batched 3/3 |
| crash | 3/3 | 3/3 | 3/3 |
| explain_compute | 4/4 | 4/4 | 4/4 |
| factorial | 8/8 | 0/8 | 8/8 |
| factorial_smoff | - | 0/8 | - |
| greeting | 3/3 | 3/3 | 3/3 |
| history_geo | 3/3, batched 3/3 | 3/3, batched 3/3 | 3/3, batched 3/3 |
| hr_legal | 3/3, batched 3/3 | 3/3, batched 3/3 | 3/3, batched 3/3 |
| plan_convert | 4/4 | 4/4 | 4/4 |
| proof_translate | 4/4 | 4/4 | 4/4 |
| research_write | 3/3 | 3/3 | 3/3 |
| review_convert | 4/4 | 4/4 | 4/4 |
| sales_failure | 3/3, relayed 3/3, invented 0/3 | 3/3, relayed 3/3, invented 0/3 | 3/3, relayed 3/3, invented 0/3 |
| single_domain | 3/3 | 3/3 | 3/3 |
| stock_news | 3/3, batched 3/3 | 3/3, batched 3/3 | 3/3, batched 3/3 |
| translate | 3/3 | 3/3 | 3/3 |
| trip | 3/3, batched 3/3 | 3/3, batched 3/3 | 3/3, batched 3/3 |
| write_edit | 3/3 | 3/3 | 3/3 |

**Tokens per run**, coordinate, gpt-4o-mini, team-level metrics as recorded by the run:

| arm | mean total tokens | n |
|---|---|---|
| before #9731 | 2071 | 77 |
| after #9731 | 1758 | 85 |
| candidate | 1916 | 77 |

What the wider study shows, honestly:
- **The regression is narrow.** On 19 of 20 scenarios — including three "overlap" rosters of tool-less members, three trivial two-step requests, and `analyse_percent`, whose leader system prompt is **byte-identical** to the failing test's and differs only in the user message ("what is 15% of 80" instead of "solve 10 factorial") — the post-#9731 prompt decomposes correctly on gpt-4o-mini. The flip is deterministic (0/8 vs 8/8) but it takes a request whose named preliminary step the weak model rates as its own to do.
- **The other scenario with signal is `advisors`** (three tool-less advisors, "give me your view"): the pre-#9731 prompt consulted all three in 6/7 runs, the post-#9731 prompt in 2/7, the candidate in 3/7; the misses consult two of the three (usually skipping Finance), and one candidate run narrated a delegation without making the call. The need rule only partly recovers this. The pre-#9731 opening also carried the coordinator identity sentence; whether that sentence is what closes the rest was not measured within the budget, and this PR does not restore it (see below).
- The candidate loses nothing anywhere the post-#9731 prompt scored 100%, on either model, in any mode.

### The test

The `== 2` assertion, and the analyst-first ordering after it, are real behavioural claims: the user asked for analysis *and then* a solution, the roster has an Analyst and a Math Agent, and a leader that follows the request uses both, in that order. They are not weakened. On the fixed prompt the exact test team gives 2 delegations, analyst first, in 16 of 16 harness runs on gpt-4o-mini; the test itself passed live on this branch. Its sibling `..._streaming_off` failed once live on the ordering assertion (both delegated, Math Agent listed first); that assertion has the same shape on both tests and is stochastic at the margin on every prompt and model measured (gpt-5-mini lists the Math Agent first in 2 of 16 runs across both prompts). CI's `--reruns 1` exists for that margin. I did not touch either assertion.

**The file's gpt-4o-mini pins stay, on purpose.** Moving this test to gpt-5-mini (proven 8/8 on the broken prompt) would have turned CI green *by hiding the regression*: gpt-5-mini decomposes under either wording. A weak leader is the one that stops decomposing when the delegation prompt drifts, which makes this test the canary for exactly this class of change. The comment now on the test says so. Modernising the other 26 pins in the file is a separate, mechanical change and is not mixed into a behavioural fix.

### Unit coverage

`test_team_system_prompt.py` gains two parametrised tests (all four modes):
- the opening states the rule as need (`Delegate to members when their expertise or tools are needed`) and contains no comparison with the leader (`better than`, `fit it better`);
- the opening makes no identity claim (`You are` / `You coordinate` / `You act as`), guarding #9731's win against a future "fix" that restores the old identity sentence.

Both were mutation-checked by reverting the code under them: the need-rule test fails 4/4 on the #9731 text; the identity test fails 4/4 when the opening is swapped for "You coordinate a team of specialized AI agents…". The rendered prompt of this branch was diffed against the bytes the live `candidate` probes actually sent: identical.

### Probe budget

475 live probes in total (452 on gpt-4o-mini, 23 on gpt-5-mini), 0 errors, about $0.30 at list prices from the recorded team-level token metrics (744k/144k input/output tokens on gpt-4o-mini, 81k/38k on gpt-5-mini). One probe = one `team.run` (each is 2–4 model requests plus member runs). Allocation was declared up front (≈120 bisect / ≈200 candidates / ≈120 confirmation) and the harness enforces a hard global cap of 480 with a `dropped.log`; the only drop was `cand_c` (a near-duplicate opener) from the screening. Two more candidate wordings (`cand_b`, per-part decomposition; `cand_d`, purpose clause) were screened on the overlap scenarios and scored the same as the minimal candidate, so the minimal one ships.

Harness (kept out of the tree): `.context/team_prompt_probe/` — `variants.py` (exact-substring replacements, each asserted to match once, self-checked against both trees' rendering before any live call), `scenarios.py`, `probe.py` (one JSONL record per probe with variant/mode/model/scenario/rep, prompt and tool-schema hashes, every metric and the raw delegation list; resumable), `report.py`, `tables.py`, `cost.py`, raw `results*.jsonl` and the prompt texts by hash.

### Hypotheses tested and refuted

- "Restoring the removed multi-member sentence fixes it" — refuted before this work (1/8); consistent with `a_coord` 0/8 here.
- "The coordinate-block rewrite is the cause" — refuted, `a_coord` 0/8.
- "The docstring trim is the cause" — refuted, `a_tooldoc` 0/8.
- "It is a streaming/event artefact, since the streaming-off sibling passed in CI" — refuted, control 0/8.
- "The old delegate/direct sentences are what mattered" — refuted, `o_delegate` 1/8; the comparison clause and the missing coordinator framing are the two halves, and removing the comparison is enough.
- "#9731 broke decomposition generally" — refuted: 19/20 scenarios identical to before on gpt-4o-mini, including one whose system prompt is byte-identical to the failing test's.

### Deliberately not changed

- **The coordinator identity sentence stays out.** It recovers the test too, but it is the framework voice #9731 removed so that the user's `description`/`role`/`instructions` are the first identity the leader reads.
- **Every other #9731 element**: `<team>` wrapper, `<delegation>` tag, all four mode blocks, the `selector`, the two closers, the docstrings, the tasks continuation message, mode normalization. Each was measured innocent.
- **The 26 other gpt-4o-mini pins in `test_event_streaming.py`** and the model-name assertion on line 80. Same reasoning as above; a separate change if wanted.
- **`docs/context/team/overview.mdx`** in the docs repo still quotes the pre-#9731 prompt verbatim in two places; it needs the post-#9731-plus-this-PR text. Separate repo, separate PR.
- **The `advisors` under-consultation on gpt-4o-mini** is only partly recovered; it is a smaller model consulting two of three tool-less advisors, and a wider fix would be a prompt design change beyond a regression repair.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

`./scripts/validate.sh`: ruff format and ruff check clean; mypy reports the same 72 errors in 14 files that #9731 reported, none in a file this PR touches (`redis.py`, `firestore.py`, model SDK wrappers). `format.sh` was run as `ruff format --check` on the three changed files only, to keep formatting churn out of the diff. Unit: `tests/unit/team` 791 passed. Integration: `test_intermediate_steps_with_member_agents` passed live on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
