### PR TITLE
fix: location lookup dependency

### DIFF
--- a/libs/agno/agno/utils/location.py
+++ b/libs/agno/agno/utils/location.py
@@ -1,19 +1,19 @@
-from typing import Any, Dict
+from typing import Any
 
-import requests
+import httpx
 
 from agno.utils.log import log_warning
 
 
-def get_location() -> Dict[str, Any]:
+def get_location() -> dict[str, Any]:
     """Get approximate location using IP geolocation."""
     try:
-        response = requests.get("https://api.ipify.org?format=json", timeout=5)
+        response = httpx.get("https://api.ipify.org?format=json", timeout=5)
         ip = response.json()["ip"]
-        response = requests.get(f"http://ip-api.com/json/{ip}", timeout=5)
+        response = httpx.get(f"http://ip-api.com/json/{ip}", timeout=5)
         if response.status_code == 200:
             data = response.json()
             return {"city": data.get("city"), "region": data.get("region"), "country": data.get("country")}
-    except Exception as e:
-        log_warning(f"Failed to get location: {str(e)}")
+    except (httpx.HTTPError, KeyError, ValueError) as e:
+        log_warning(f"Failed to get location: {e!s}")
     return {}

--- a/libs/agno/tests/unit/agent/test_location_context.py
+++ b/libs/agno/tests/unit/agent/test_location_context.py
@@ -1,0 +1,25 @@
+from unittest.mock import MagicMock, Mock
+
+import httpx
+
+from agno.agent import Agent
+from agno.session.agent import AgentSession
+
+
+def test_add_location_to_context_builds_system_message(monkeypatch):
+    ip_response = Mock()
+    ip_response.json.return_value = {"ip": "203.0.113.7"}
+    location_response = Mock(status_code=200)
+    location_response.json.return_value = {"city": "Paris", "region": "Ile-de-France", "country": "France"}
+    monkeypatch.setattr(httpx, "get", Mock(side_effect=[ip_response, location_response]))
+
+    mock_model = MagicMock()
+    mock_model.get_instructions_for_model = MagicMock(return_value=None)
+    mock_model.get_system_message_for_model = MagicMock(return_value=None)
+    agent = Agent(add_location_to_context=True)
+    agent.model = mock_model
+
+    message = agent.get_system_message(session=AgentSession(session_id="location-context"))
+
+    assert message is not None
+    assert "Your approximate location is: Paris, Ile-de-France, France." in message.content

--- a/libs/agno/tests/unit/utils/test_location.py
+++ b/libs/agno/tests/unit/utils/test_location.py
@@ -1,0 +1,24 @@
+from unittest.mock import Mock
+
+import httpx
+
+from agno.utils.location import get_location
+
+
+def test_get_location_returns_ip_geolocation(monkeypatch):
+    ip_response = Mock()
+    ip_response.json.return_value = {"ip": "203.0.113.7"}
+    location_response = Mock(status_code=200)
+    location_response.json.return_value = {"city": "Paris", "region": "Ile-de-France", "country": "France"}
+    mock_get = Mock(side_effect=[ip_response, location_response])
+    monkeypatch.setattr(httpx, "get", mock_get)
+
+    assert get_location() == {"city": "Paris", "region": "Ile-de-France", "country": "France"}
+    assert mock_get.call_args_list[0].args == ("https://api.ipify.org?format=json",)
+    assert mock_get.call_args_list[1].args == ("http://ip-api.com/json/203.0.113.7",)
+
+
+def test_get_location_returns_empty_dict_on_http_error(monkeypatch):
+    monkeypatch.setattr(httpx, "get", Mock(side_effect=httpx.ConnectError("offline")))
+
+    assert get_location() == {}


### PR DESCRIPTION
Fixes #9772

## Summary
- use the existing core `httpx` dependency for `agno.utils.location`
- avoid importing undeclared `requests` when `add_location_to_context` loads the location helper
- add focused unit coverage for both the location helper and the `Agent(add_location_to_context=True).get_system_message(...)` path

## Tests
- `ruff format --check libs/agno/agno/utils/location.py libs/agno/tests/unit/utils/test_location.py libs/agno/tests/unit/agent/test_location_context.py`
- `ruff check libs/agno/agno/utils/location.py libs/agno/tests/unit/utils/test_location.py libs/agno/tests/unit/agent/test_location_context.py`
- `pytest libs/agno/tests/unit/utils/test_location.py libs/agno/tests/unit/agent/test_location_context.py -q`
- verified `from agno.agent import Agent` and `from agno.utils.location import get_location` succeed in a temporary core install without `requests`

Note: the repo's `uv run ...` currently fails before running commands because the existing optional `agno[a2a]` and `agno[brave]` dependency sets resolve incompatible `httpx` ranges; the focused checks above were run in an isolated core install.