### PR TITLE
fix: give every eval run its own run_id

### DIFF
--- a/cookbook/05_agent_os/03_python_client/05_evals.py
+++ b/cookbook/05_agent_os/03_python_client/05_evals.py
@@ -55,8 +55,8 @@ async def run_evaluations() -> None:
     )
     print(f"Stored evaluations: {len(eval_runs.data)}")
 
-    for eval_id in (accuracy.id, reliability.id):
-        detail = await client.get_eval_run(eval_id)
+    for run_id in (accuracy.id, reliability.id):
+        detail = await client.get_eval_run(run_id)
         print(f"Fetched {detail.id}: {detail.eval_type.value}")
 
 

--- a/cookbook/05_agent_os/24_showcase/TEST_LOG.md
+++ b/cookbook/05_agent_os/24_showcase/TEST_LOG.md
@@ -1,7 +1,9 @@
 # Test Log: 24_showcase
 
 Tested on 2026-07-24 against Agno source commit
-`45bfff9f2aa6ec11b7386c3cd3bf6d1141d005dc`.
+`45bfff9f2aa6ec11b7386c3cd3bf6d1141d005dc`, and `demo.py` re-tested on
+2026-08-24 after its eval persistence check moved from
+`accuracy_evaluation.eval_id` to `result.run_id`.
 
 The lesson was loaded from the rewrite worktree and exercised with the demo
 Python environment, PostgreSQL with pgvector on port 5532, `gpt-5.5`, and
@@ -52,23 +54,21 @@ their results into a sourced table with timing caveats.
 
 **Test mode:** LIVE
 
-**Description:** Ran the documented module entrypoint with `SHOWCASE_PORT=17877`,
-prepared knowledge, ran the real accuracy evaluation, and exercised
-authentication, discovery, an Agent run, knowledge, sessions, traces, and
-evals.
+**Description:** Re-tested 2026-08-24 on `SHOWCASE_PORT=17879` after the eval
+persistence check moved to `result.run_id`: prepared knowledge, ran the real
+accuracy evaluation, and exercised authentication and the eval endpoints.
 
-**Result:** Module-entrypoint AccuracyEval
-`0a7df9c3-aecc-4ee5-bc2e-fa7165bb234a` scored `10/10`. The
-post-run persistence assertion was then exercised with eval
-`47325c0e-73c5-4477-87e7-38dc4f5323ce`; its stored name and `10/10`
-average were read back from PostgreSQL. Anonymous `GET /config` returned
-`401`; the Bearer-authenticated request returned `200` and exactly
-`agno-assist`, `sage`, and `finance-team`. Authenticated Agent run
-`46f18a31-9a8e-4db5-810b-c63e14275ec0` completed after a knowledge
-search. Trace `f43d8d4a65e4c0218fc6f84ef9df77a2` was read back with 4
-Agent, model, and tool spans. The knowledge, session, trace, and eval list
-endpoints returned `200`. The validation server shut down cleanly, and port
-17877 had no remaining listener.
+**Result:** AccuracyEval `da6e8c87-0250-40d3-aec3-2c8398810a51` scored `10/10`
+with the `claude-sonnet-4-6` judge, and the persistence assertion read its row
+back by `result.run_id`. Anonymous `GET /config` returned `401`, authenticated
+`200`, and the eval list returned three stored runs, each under its own id. The
+server shut down cleanly with no remaining listener. The 2026-07-24 pass on
+`17877` covered more surface: AccuracyEval
+`0a7df9c3-aecc-4ee5-bc2e-fa7165bb234a` at `10/10`, persistence via eval
+`47325c0e-73c5-4477-87e7-38dc4f5323ce`, discovery returning exactly
+`agno-assist`, `sage`, and `finance-team`, Agent run
+`46f18a31-9a8e-4db5-810b-c63e14275ec0` after a knowledge search, and trace
+`f43d8d4a65e4c0218fc6f84ef9df77a2` with 4 spans.
 
 ---
 

--- a/cookbook/05_agent_os/24_showcase/demo.py
+++ b/cookbook/05_agent_os/24_showcase/demo.py
@@ -91,7 +91,7 @@ def run_accuracy_evaluation() -> AccuracyResult:
     )
     if result is None or not result.results:
         raise RuntimeError("The showcase AccuracyEval produced no result")
-    if showcase_db.get_eval_run(accuracy_evaluation.eval_id) is None:
+    if showcase_db.get_eval_run(result.run_id) is None:
         raise RuntimeError("The showcase AccuracyEval was not stored")
     print(
         f"AccuracyEval stored {len(result.results)} result(s); "

--- a/cookbook/09_evals/TEST_LOG.md
+++ b/cookbook/09_evals/TEST_LOG.md
@@ -1,43 +1,541 @@
 # Test Log: 09_evals
 
-> Tests not yet run. Run each file and update this log.
+**Test date:** 2026-08-24
+**Branch:** eval-run-id (per-execution `run_id`; the per-instance `eval_id` field has been removed from `AccuracyEval` / `PerformanceEval` / `ReliabilityEval`)
 
-### accuracy/*
+## How this log was produced
 
-**Status:** PENDING
+Every `.py` file under `cookbook/09_evals/` was executed once from the repo root with a 300s
+per-file timeout, stdin closed, and stdout+stderr captured. Statuses below are taken from the
+real process output, not from inspection.
 
-**Description:** Accuracy evaluation examples for agents, teams, and evaluator configurations.
+**Environment caveats — read before trusting a status:**
+
+- **Interpreter:** `.venv/bin/python` (Python 3.12.12). `CLAUDE.md` prescribes `.venvs/demo`, but
+  that virtualenv does not exist in this worktree, so the dev venv was used instead. The dev venv
+  does **not** carry the third-party agent frameworks, which is why every file under
+  `performance/comparison/` fails on import here.
+- **Library versions:** `agno 3.0.0a2`, `openai 3.3.1`, `anthropic 0.76.0`, `psycopg 3.3.4`,
+  `sqlalchemy 2.0.52`. `anthropic` is installed but unused — every cookbook in this folder runs on
+  OpenAI models only.
+- **Postgres:** `cookbook/scripts/run_pgvector.sh` publishes the container on host port **5532**.
+  The cookbooks are split on which port they ask for: the three `db_logging.py` files hardcode
+  `localhost:5432`, while `agent_as_judge_basic.py` and the three `performance/team_response_*`
+  files use `localhost:5532`. On this machine 5532 serves `ai/ai/ai` correctly; port 5432 is a
+  different, unrelated Postgres that rejects the `ai` user. The three `db_logging.py` files are
+  therefore recorded as FAIL for exactly that reason. They were not edited.
+- **API keys:** `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` were present in the environment.
+
+## Summary
+
+| Result | Count |
+|--------|-------|
+| PASS | 33 |
+| FAIL | 9 |
+| TIMEOUT | 0 |
+| NOT RUN | 0 |
+| Package markers (`__init__.py`, empty, exit 0) | 10 |
+| **Total `.py` files** | **52** |
+
+The 9 failures are the 6 `performance/comparison/*` files (missing third-party frameworks in this
+venv) and the 3 `db_logging.py` files (Postgres port 5432 vs 5532).
+
+## Findings relevant to the `run_id` change
+
+1. **No cookbook in this folder still references `eval_id`.** A full-text search over
+   `cookbook/09_evals/` returns zero hits. The five call sites that print an identifier already read
+   the new field (`latest.run_id`).
+2. **Reruns create a distinct row — no duplicate-key swallow.** Re-running
+   `agent_as_judge/agent_as_judge_batch.py` took `tmp/agent_as_judge_batch.db` from 1 to 2
+   `agno_eval_runs` rows with distinct ids (`7931dc33-…` then `05715e6d-…`). On the real Postgres at
+   5532, `ai.agno_eval_runs` holds four separate rows for the eval named `Explanation Quality`
+   (2026-08-19, 08-23, and two on 08-24), each with its own `run_id`.
+3. **The `Eval ID:` lines printed the wrong run once a DB held more than one row -- fixed here.**
+   Seven sites across six files took `eval_runs[-1]` after `db.get_eval_runs()`:
+   `agent_as_judge_basic.py` (twice), `agent_as_judge_batch.py`, `agent_as_judge_post_hook.py`,
+   `agent_as_judge_team.py`, `agent_as_judge_team_post_hook.py` and
+   `agent_as_judge_with_guidelines.py`. That helper orders `created_at` descending, so `[-1]`
+   was the *oldest* run, not the newest. Observed live before the fix: the batch rerun stored
+   `05715e6d-…` while printing `Eval ID: 7931dc33-…` from the previous run, and
+   `agent_as_judge_basic.py` printed a `run_id` first written on 2026-08-19. The two post-hook
+   files print a score rather than an id, so they were reading the oldest run's `eval_data`.
+   All seven now index `[0]`, and the five that print an id say `Run ID:` -- `eval_id` no longer
+   exists on `EvalRunRecord`. Re-verified by running two of them twice: `agent_as_judge_batch.py`
+   printed `c71235c9-…` and `agent_as_judge_with_guidelines.py` printed `b50b2d90-…`, each the
+   row that run had just written.
+4. **No cookbook anywhere under `cookbook/` sets `file_path_to_save_results`,** so this folder gives
+   the placeholder no coverage. Probed out-of-tree instead: `{run_id}` resolves to the
+   per-execution UUID (file written as `<name>_<uuid>.json`, and the eval `name` is interpolated
+   verbatim, spaces included), and the legacy `{eval_id}` spelling still resolves to the same
+   value. Both files were written to disk.
+5. **DB failures are non-fatal.** All three `db_logging.py` files exit 0 with the connection error
+   only logged as `ERROR`/`WARNING`, so a broken DB target does not fail the process — the reason
+   they are marked FAIL here on evidence rather than on exit code.
 
 ---
 
-### agent_as_judge/*
+## accuracy/
 
-**Status:** PENDING
+### accuracy_9_11_bigger_or_9_99.py
 
-**Description:** Agent-as-judge examples covering scoring modes, hooks, and team cases.
+**Status:** PASS
 
----
+**Description:** Single-iteration `AccuracyEval` asking whether 9.11 or 9.9 is bigger.
 
-### performance/*
-
-**Status:** PENDING
-
-**Description:** Performance benchmark examples for runtime and memory impact.
+**Result:** Ran in 6.7s. Output "9.9 is bigger than 9.11", Accuracy Score 10/10, summary reports 1 run with average/min/max 10.00 and std dev 0.00.
 
 ---
 
-### performance/comparison/*
+### accuracy_basic.py
 
-**Status:** PENDING
+**Status:** PASS
 
-**Description:** Framework comparison benchmarks for agent instantiation.
+**Description:** Three-iteration `AccuracyEval` over a calculator agent ("What is 10*5 then to the power of 2?").
+
+**Result:** Ran in 28.2s. All three iterations scored 10/10; summary reports Number of Runs 3, Average Score 10.00, Std Dev 0.00.
 
 ---
 
-### reliability/*
+### accuracy_eval_metrics.py
 
-**Status:** PENDING
+**Status:** PASS
 
-**Description:** Reliability examples for expected tool-call behavior.
+**Description:** Accuracy eval that then prints the combined agent + evaluator token metrics.
+
+**Result:** Ran in 3.6s. Score 10/10; "Total tokens (agent + eval): 604", agent 32 / eval 572, with the full `details` breakdown printed for both `gpt-4o-mini` entries (`model` and `eval_model`).
+
+---
+
+### accuracy_team.py
+
+**Status:** PASS
+
+**Description:** `AccuracyEval` against a Team, checking the language-restriction reply to "Comment allez-vous?".
+
+**Result:** Ran in 4.5s. Team output matched the expected string word-for-word, Accuracy Score 10/10, 1 run averaging 10.00.
+
+---
+
+### accuracy_with_given_answer.py
+
+**Status:** PASS
+
+**Description:** Scores a pre-supplied answer string instead of running an agent.
+
+**Result:** Ran in 4.0s. Output "2500" vs expected "2500", Accuracy Score 10/10, 1 run averaging 10.00.
+
+---
+
+### accuracy_with_tools.py
+
+**Status:** PASS
+
+**Description:** Accuracy eval over an agent with `CalculatorTools` ("What is 10!?").
+
+**Result:** Ran in 6.3s. Output "10! = 3,628,800", Accuracy Score 10/10 (judge explicitly excused the comma formatting), 1 run averaging 10.00.
+
+---
+
+### db_logging.py
+
+**Status:** FAIL
+
+**Description:** Meant to store an `AccuracyEval` result in PostgreSQL via `PostgresDb(eval_table="eval_runs_cookbook")`.
+
+**Result:** Ran in 7.4s and exited 0, but logged nothing. The file hardcodes `postgresql+psycopg://ai:ai@localhost:5432/ai` while the repo's `run_pgvector.sh` publishes 5532, so every DB call failed with `(psycopg.OperationalError) connection failed: connection to server at "127.0.0.1", port 5432 failed: FATAL: password authentication failed for user "ai"` — repeated as `Error checking if table exists`, `Could not create schema ai`, `Could not create table ai.eval_runs_cookbook`, `Error creating eval run`, and finally `WARNING Could not log eval run`. The eval itself scored 10/10 before the DB writes were attempted. Not edited; failing purely on the port mismatch.
+
+---
+
+### evaluator_agent.py
+
+**Status:** PASS
+
+**Description:** Accuracy eval driven by a custom evaluator agent rather than a bare model.
+
+**Result:** Ran in 10.0s. Agent produced the step-by-step 2500 answer, Accuracy Score 10/10, 1 run averaging 10.00.
+
+---
+
+## agent_as_judge/
+
+### agent_as_judge_basic.py
+
+**Status:** PASS
+
+**Description:** Sync judge backed by `PostgresDb` on port 5532 plus an async judge backed by `AsyncSqliteDb`, both with an `on_fail` callback.
+
+**Result:** Ran in 16.1s. Sync: Score 9/10 PASSED (threshold 7), then "Total evaluations stored: 5" from Postgres. Async: Score 9/10 against threshold 10, so the `on_fail` callback fired and printed "Evaluation failed - Score: 9/10" and the summary showed Pass Rate 0.0% — that is the demo behaving as written, not an error. `tmp/agent_as_judge_async.db` ended with 2 `agno_eval_runs` rows. Caveat: the printed `Eval ID: 09ddcbe2-…` is the *oldest* Postgres row (first written 2026-08-19), not this run — see finding 3.
+
+---
+
+### agent_as_judge_batch.py
+
+**Status:** PASS
+
+**Description:** Batch judge over three customer-service responses, persisted to `tmp/agent_as_judge_batch.db`.
+
+**Result:** Ran in 11.3s. All three cases PASSED, "Pass rate: 100.0%", "Passed: 3/3", "Cases evaluated: 3", one `agno_eval_runs` row written. Re-run to test the `run_id` change: row count went 1 → 2 with a new id (`05715e6d-…`), no duplicate-key warning — but the script still printed the previous run's id because of the `[-1]` indexing described in finding 3.
+
+---
+
+### agent_as_judge_binary.py
+
+**Status:** PASS
+
+**Description:** Binary (pass/fail) scoring strategy on a support reply, stored in `tmp/agent_as_judge_binary.db`.
+
+**Result:** Ran in 6.3s. Status PASSED, Pass Rate 100.0%, final line "Result: PASSED"; 1 eval row persisted.
+
+---
+
+### agent_as_judge_custom_evaluator.py
+
+**Status:** PASS
+
+**Description:** Judge configured with a custom evaluator agent.
+
+**Result:** Ran in 6.0s. Score 9/10, Status PASSED, trailing prints "Score: 9/10" and "Passed: True".
+
+---
+
+### agent_as_judge_eval_metrics.py
+
+**Status:** PASS
+
+**Description:** Prints the token/latency metrics attached to an agent-as-judge result.
+
+**Result:** Ran in 4.1s. "Total tokens (agent + eval): 378" (agent 31 / eval 347), evaluator identified as `gpt-4o-mini (OpenAI Chat)`, full metrics dict printed including `additional_metrics.eval_duration`.
+
+---
+
+### agent_as_judge_post_hook.py
+
+**Status:** PASS
+
+**Description:** Runs the judge from an agent post-hook, in both a sync (`SqliteDb`) and an async (`AsyncSqliteDb`) variant.
+
+**Result:** Ran in 19.6s. Sync: "Evaluation Results: Score: 9/10 / Status: PASSED". Async: "Async Evaluation Results: Score: 9/10 / Status: PASSED". One `agno_eval_runs` row in each of `tmp/agent_as_judge_post_hook.db` and `tmp/agent_as_judge_post_hook_async.db`.
+
+---
+
+### agent_as_judge_team.py
+
+**Status:** PASS
+
+**Description:** Judges a Team response about quantum computing and reads the stored run back out of `tmp/agent_as_judge_team.db`.
+
+**Result:** Ran in 23.6s. Status PASSED, Pass Rate 100.0%, "Total evaluations stored: 1", "Team: Research Team". The DB file ended with 1 eval row and 3 agent/team runs.
+
+---
+
+### agent_as_judge_team_post_hook.py
+
+**Status:** PASS
+
+**Description:** Team post-hook variant of the judge.
+
+**Result:** Ran in 27.6s. "Evaluation Results: Score: 8/10 / Status: PASSED"; 1 eval row and 3 runs written to `tmp/agent_as_judge_team_post_hook.db`.
+
+---
+
+### agent_as_judge_with_guidelines.py
+
+**Status:** PASS
+
+**Description:** Judge with three `additional_guidelines`, persisted to `tmp/agent_as_judge_guidelines.db`.
+
+**Result:** Ran in 8.0s. Score 8/10, Status PASSED, "Total evaluations stored: 1", "Additional guidelines used: 3".
+
+---
+
+### agent_as_judge_with_tools.py
+
+**Status:** PASS
+
+**Description:** Judges a calculator agent's answer to "What is 15 * 23 + 47?" against a criteria demanding visible intermediate steps.
+
+**Result:** Ran in 7.2s and exited 0. The judge verdict was Score 3/10, Status FAILED — the agent answered "392" without showing steps. The script only asserts `result is not None`, so a low score is a legitimate demo outcome, not a script error. Verdict is model-dependent and may differ per run.
+
+---
+
+## performance/
+
+### async_function.py
+
+**Status:** PASS
+
+**Description:** `PerformanceEval` over an awaited async agent call, 10 iterations.
+
+**Result:** Ran in 31.2s. All 10 runs tabulated; Average 0.901684s / 0.375205 MiB, Min 0.834768s, Max 1.002490s, Std Dev 0.052949.
+
+---
+
+### db_logging.py
+
+**Status:** FAIL
+
+**Description:** Meant to store a `PerformanceEval` result in PostgreSQL via `PostgresDb(eval_table="eval_runs_cookbook")`.
+
+**Result:** Ran in 4.0s and exited 0; the benchmark itself completed (1 run, 1.466058s / 1.047235 MiB) but nothing was persisted. Hardcodes `localhost:5432` while the repo script publishes 5532, so the run ended with `ERROR Error creating eval run: (psycopg.OperationalError) connection failed: connection to server at "127.0.0.1", port 5432 failed: FATAL: password authentication failed for user "ai"` followed by `WARNING Could not log eval run: …`. Not edited.
+
+---
+
+### instantiate_agent.py
+
+**Status:** PASS
+
+**Description:** 1000-iteration benchmark of bare `Agent` instantiation.
+
+**Result:** Ran in 6.0s. Average 0.000004s / 0.004965 MiB, Min 0.000004s, Max 0.000008s, Std Dev 0.000000.
+
+---
+
+### instantiate_agent_with_tool.py
+
+**Status:** PASS
+
+**Description:** 1000-iteration benchmark of `Agent` instantiation with a tool attached.
+
+**Result:** Ran in 21.7s. Average 0.000007s / 0.006649 MiB, Min 0.000006s, Max 0.000054s.
+
+---
+
+### instantiate_team.py
+
+**Status:** PASS
+
+**Description:** 1000-iteration benchmark of `Team` instantiation.
+
+**Result:** Ran in 21.3s. Average 0.000010s / 0.005750 MiB, Min 0.000010s, Max 0.000056s.
+
+---
+
+### response_with_memory_updates.py
+
+**Status:** PASS
+
+**Description:** 5-iteration benchmark of an agent run with memory updates against `tmp/memory.db`.
+
+**Result:** Ran in 15.6s. Agent replied "Hi Tom—nice to meet you…"; Average 1.524017s / 0.349082 MiB, Min 1.080109s, Max 2.913651s (first run warm-up dominates).
+
+---
+
+### response_with_storage.py
+
+**Status:** PASS
+
+**Description:** Single-iteration benchmark of an agent run persisted to `tmp/storage.db`.
+
+**Result:** Ran in 6.5s. Four agent responses printed (capital of France / population); 1 run at 2.455465s / 0.282310 MiB.
+
+---
+
+### simple_response.py
+
+**Status:** PASS
+
+**Description:** Single-iteration benchmark of a plain agent response.
+
+**Result:** Ran in 3.3s. Two "Agent response:" lines printed; 1 run at 1.070905s / 1.046144 MiB.
+
+---
+
+### team_response_with_memory_and_reasoning.py
+
+**Status:** PASS
+
+**Description:** Memory-growth benchmark (`measure_runtime=False`) of a Team with memory and reasoning, backed by Postgres on 5532.
+
+**Result:** Ran in 1.9s and exited 0, printing 5 memory rows (Average 0.086880 MiB, Min 0.013934, Max 0.378652). The process succeeded, but **the benchmark does no work**: lines 1064–1075 call `team.arun(...)` four times and assign the result to `_` without awaiting it, so no model call is ever made. The near-zero memory deltas and the 1.9s wall clock confirm it. Reported, not fixed.
+
+---
+
+### team_response_with_memory_multi_user.py
+
+**Status:** PASS
+
+**Description:** Memory-growth benchmark of concurrent multi-user Team runs against Postgres on 5532; this is the one file in the trio that does `await team.arun(...)` and `asyncio.gather`.
+
+**Result:** Ran in 63.5s — real model traffic. 5 runs: Average 6.397702 MiB, Min 2.237964, Max 22.724978 (first iteration), Median 2.309915.
+
+---
+
+### team_response_with_memory_simple.py
+
+**Status:** PASS
+
+**Description:** Memory-growth benchmark of a Team with memory enabled, Postgres on 5532.
+
+**Result:** Ran in 1.9s and exited 0 with 5 memory rows (Average 0.078935 MiB, Min 0.005336, Max 0.373071). Same defect as the reasoning variant: `run_team()` does `_ = team.arun(..., stream=True, stream_events=True)` and never consumes the stream, so no team run actually executes and the numbers measure nothing. Reported, not fixed.
+
+---
+
+## performance/comparison/
+
+All six files fail identically in this worktree: the dev venv (`.venv`) has none of the competing
+agent frameworks installed, and `.venvs/demo` — the environment `CLAUDE.md` intends for cookbooks —
+does not exist here. Nothing about these files is specific to the `run_id` change.
+
+The FAIL statuses below are therefore about this environment, not about the files. Re-run in a
+throwaway virtualenv carrying agno 3.0.0a4 built from this worktree plus langgraph 1.2.11,
+crewai 1.6.1, pydantic-ai-slim 2.31.1, openai-agents 0.20.0, smolagents 1.26.0 and
+autogen-agentchat 0.7.5, all six complete 1000 measured iterations with no exceptions:
+
+| File | Median (s) | p95 (s) | Median memory (MiB) |
+|---|---|---|---|
+| `openai_agents_instantiation.py` | 0.000355 | 0.000440 | 0.057710 |
+| `langgraph_instantiation.py` | 0.001562 | 0.001878 | 0.142066 |
+| `smolagents_instantiation.py` | 0.003669 | 0.004106 | 0.259882 |
+| `autogen_instantiation.py` | 0.004035 | 0.004786 | 0.024355 |
+| `pydantic_ai_instantiation.py` | 0.004084 | 0.005308 | 0.042462 |
+| `crewai_instantiation.py` | 0.004670 | 0.006230 | 1.491657 |
+
+For scale, `instantiate_agent_with_tool.py` measured 0.000006 s median / 0.006653 MiB in that
+same venv and session. `langgraph_instantiation.py` also emits one deprecation warning:
+`create_react_agent has been moved to langchain.agents` (LangGraph V1.0, removal in V2.0).
+
+### autogen_instantiation.py
+
+**Status:** FAIL
+
+**Description:** Benchmarks AutoGen `AssistantAgent` instantiation for comparison against Agno.
+
+**Result:** Exited 1 in 0.3s: `ModuleNotFoundError: No module named 'autogen_agentchat'` at line 11, `from autogen_agentchat.agents import AssistantAgent`.
+
+---
+
+### crewai_instantiation.py
+
+**Status:** FAIL
+
+**Description:** Benchmarks CrewAI `Agent` instantiation.
+
+**Result:** Exited 1 in 0.3s: `ModuleNotFoundError: No module named 'crewai'` at line 11, `from crewai.agent import Agent`.
+
+---
+
+### langgraph_instantiation.py
+
+**Status:** FAIL
+
+**Description:** Benchmarks LangGraph react-agent instantiation.
+
+**Result:** Exited 1 in 0.3s: `ModuleNotFoundError: No module named 'langchain_core'` at line 11, `from langchain_core.tools import tool`.
+
+---
+
+### openai_agents_instantiation.py
+
+**Status:** FAIL
+
+**Description:** Benchmarks OpenAI Agents SDK agent instantiation.
+
+**Result:** Exited 1 in 0.2s. The file's own guard raised at line 15: `ImportError: OpenAI agents not installed. Please install it using 'uv pip install openai-agents'.`
+
+---
+
+### pydantic_ai_instantiation.py
+
+**Status:** FAIL
+
+**Description:** Benchmarks Pydantic-AI `Agent` instantiation.
+
+**Result:** Exited 1 in 0.2s: `ModuleNotFoundError: No module named 'pydantic_ai'` at line 11, `from pydantic_ai import Agent`.
+
+---
+
+### smolagents_instantiation.py
+
+**Status:** FAIL
+
+**Description:** Benchmarks smolagents `ToolCallingAgent` instantiation.
+
+**Result:** Exited 1 in 0.2s: `ModuleNotFoundError: No module named 'smolagents'` at line 9, `from smolagents import InferenceClientModel, Tool, ToolCallingAgent`.
+
+---
+
+## reliability/
+
+### db_logging.py
+
+**Status:** FAIL
+
+**Description:** Meant to store a `ReliabilityEval` result in PostgreSQL via `PostgresDb(eval_table="eval_runs")`.
+
+**Result:** Ran in 4.3s and exited 0. The reliability check itself passed — "Evaluation Status PASSED, Failed Tool Calls [], Passed Tool Calls ['factorial']" — but every DB call failed against the hardcoded `localhost:5432` (repo script publishes 5532): `ERROR Error checking if table exists`, `WARNING Could not create schema ai`, `ERROR Error creating eval run`, `WARNING Could not log eval run`, each with `(psycopg.OperationalError) connection failed: connection to server at "127.0.0.1", port 5432 failed: FATAL: password authentication failed for user "ai"`. Not edited.
+
+---
+
+### reliability_async.py
+
+**Status:** PASS
+
+**Description:** `ReliabilityEval.arun` asserting the agent called `factorial`.
+
+**Result:** Ran in 4.4s. Evaluation Status PASSED, Failed Tool Calls `[]`, Passed Tool Calls `['factorial']`.
+
+---
+
+### multiple_tool_calls/calculator.py
+
+**Status:** PASS
+
+**Description:** Reliability over a multi-step calculator request, including an "additional tool calls" variant.
+
+**Result:** Ran in 8.7s. First check PASSED with Passed Tool Calls `['multiply', 'exponentiate']`; second check PASSED with Passed `['multiply']` and Additional Tool Calls `['exponentiate']`.
+
+---
+
+### single_tool_calls/calculator.py
+
+**Status:** PASS
+
+**Description:** Reliability over single tool calls, second case also asserting call arguments.
+
+**Result:** Ran in 5.5s. First check PASSED with `['factorial']`; second check PASSED with Passed Tool Calls `['multiply']` and Passed Argument Checks `['multiply']`.
+
+---
+
+### team/ai_news.py
+
+**Status:** PASS
+
+**Description:** Reliability over a Team that must delegate and search for AI news.
+
+**Result:** Ran in 17.2s. Evaluation Status PASSED, Failed Tool Calls `[]`, Passed Tool Calls `['delegate_task_to_member', 'search_news']`.
+
+---
+
+## suite/
+
+### suite_basic.py
+
+**Status:** PASS
+
+**Description:** Two `Case`s (judge + reliability) driven through the built-in `cli()` entry point, run with no CLI arguments.
+
+**Result:** Ran in 12.0s, exit 0. `factorial_uses_calculator` — tools fired `factorial`, Judge PASS, Reliability PASS. `explains_compound_interest` — Judge PASS. Eval Summary table shows both rows PASS; final line "2/2 passed".
+
+---
+
+### suite_team_scoring.py
+
+**Status:** PASS
+
+**Description:** Same suite shape but with a Team as the subject, including delegation reliability.
+
+**Result:** Ran in 21.6s, exit 0. `team_uses_calculator` — Judge PASS, Reliability PASS (tools fired `delegate_task_to_member`). `team_explains_clearly` — Judge PASS. Final line "2/2 passed".
+
+---
+
+## Package markers
+
+### __init__.py (10 files)
+
+**Status:** PASS
+
+**Description:** `cookbook/09_evals/__init__.py` plus the `accuracy/`, `agent_as_judge/`, `performance/`, `performance/comparison/`, `reliability/`, `reliability/multiple_tool_calls/`, `reliability/single_tool_calls/`, `reliability/team/` and `suite/` package markers.
+
+**Result:** All ten are 0 bytes and each exits 0 when executed. Nothing to test.
 
 ---

--- a/cookbook/09_evals/agent_as_judge/agent_as_judge_basic.py
+++ b/cookbook/09_evals/agent_as_judge/agent_as_judge_basic.py
@@ -77,8 +77,8 @@ async def run_async_evaluation():
     async_eval_runs = await async_db.get_eval_runs()
     print(f"Total evaluations stored: {len(async_eval_runs)}")
     if async_eval_runs:
-        latest = async_eval_runs[-1]
-        print(f"Eval ID: {latest.run_id}")
+        latest = async_eval_runs[0]
+        print(f"Run ID: {latest.run_id}")
         print(f"Name: {latest.name}")
 
 
@@ -98,8 +98,8 @@ if __name__ == "__main__":
     sync_eval_runs = sync_db.get_eval_runs()
     print(f"Total evaluations stored: {len(sync_eval_runs)}")
     if sync_eval_runs:
-        latest = sync_eval_runs[-1]
-        print(f"Eval ID: {latest.run_id}")
+        latest = sync_eval_runs[0]
+        print(f"Run ID: {latest.run_id}")
         print(f"Name: {latest.name}")
 
     asyncio.run(run_async_evaluation())

--- a/cookbook/09_evals/agent_as_judge/agent_as_judge_batch.py
+++ b/cookbook/09_evals/agent_as_judge/agent_as_judge_batch.py
@@ -53,6 +53,6 @@ if __name__ == "__main__":
     eval_runs = db.get_eval_runs()
     print(f"Total evaluations stored: {len(eval_runs)}")
     if eval_runs:
-        latest = eval_runs[-1]
-        print(f"Eval ID: {latest.run_id}")
+        latest = eval_runs[0]
+        print(f"Run ID: {latest.run_id}")
         print(f"Cases evaluated: {len(result.results)}")

--- a/cookbook/09_evals/agent_as_judge/agent_as_judge_post_hook.py
+++ b/cookbook/09_evals/agent_as_judge/agent_as_judge_post_hook.py
@@ -57,7 +57,7 @@ async_agent = Agent(
 
 def print_latest_result(eval_runs):
     if eval_runs:
-        latest = eval_runs[-1]
+        latest = eval_runs[0]
         if latest.eval_data and "results" in latest.eval_data:
             result = latest.eval_data["results"][0]
             print(f"Score: {result.get('score', 'N/A')}/10")

--- a/cookbook/09_evals/agent_as_judge/agent_as_judge_team.py
+++ b/cookbook/09_evals/agent_as_judge/agent_as_judge_team.py
@@ -67,6 +67,6 @@ if __name__ == "__main__":
     eval_runs = db.get_eval_runs()
     print(f"Total evaluations stored: {len(eval_runs)}")
     if eval_runs:
-        latest = eval_runs[-1]
-        print(f"Eval ID: {latest.run_id}")
+        latest = eval_runs[0]
+        print(f"Run ID: {latest.run_id}")
         print(f"Team: {research_team.name}")

--- a/cookbook/09_evals/agent_as_judge/agent_as_judge_team_post_hook.py
+++ b/cookbook/09_evals/agent_as_judge/agent_as_judge_team_post_hook.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     print("Evaluation Results:")
     eval_runs = db.get_eval_runs()
     if eval_runs:
-        latest = eval_runs[-1]
+        latest = eval_runs[0]
         if latest.eval_data and "results" in latest.eval_data:
             result = latest.eval_data["results"][0]
             print(f"Score: {result.get('score', 'N/A')}/10")

--- a/cookbook/09_evals/agent_as_judge/agent_as_judge_with_guidelines.py
+++ b/cookbook/09_evals/agent_as_judge/agent_as_judge_with_guidelines.py
@@ -59,6 +59,6 @@ if __name__ == "__main__":
     eval_runs = db.get_eval_runs()
     print(f"Total evaluations stored: {len(eval_runs)}")
     if eval_runs:
-        latest = eval_runs[-1]
-        print(f"Eval ID: {latest.run_id}")
+        latest = eval_runs[0]
+        print(f"Run ID: {latest.run_id}")
         print(f"Additional guidelines used: {len(evaluation.additional_guidelines)}")

--- a/cookbook/performance/TEST_LOG.md
+++ b/cookbook/performance/TEST_LOG.md
@@ -202,6 +202,58 @@ Reference table durable row and discussion updated in README.md.
 
 ---
 
+## 2026-08-24 (run_id re-test)
+
+`PerformanceResult` now requires `run_id` (eval runs are stored under a
+per-execution id). The three direct constructions in this suite were updated to
+pass `run_id=name`, so those three results are keyed by their metric name rather
+than a fresh UUID. This does not make the committed baselines deterministic:
+`save_result()` in `_bench.py` writes `asdict(result)`, so every entry produced
+by `run_benchmarks()` now carries a per-run UUID alongside the `measured_at`
+timestamp and the raw per-iteration samples, both of which already differ on
+each regeneration.
+
+### memory_footprint.py
+
+**Status:** PASS
+
+**Description:** Live run after `PerformanceResult(run_id=name, ...)` replaced the
+two-argument construction; 1000 agents per sample, 5 samples.
+
+**Result:** `memory_per_agent` median 3.66 KiB and `memory_per_agent_with_tools`
+median 3.67 KiB per live agent.
+
+---
+
+### import_time.py
+
+**Status:** PASS
+
+**Description:** Live run with the same constructor change; interpreter startup
+subtracted from each sample.
+
+**Result:** `import_agno` median 23.0 ms, `import_agno_agent` median 209.0 ms.
+
+---
+
+### comparison/import_time_comparison.py
+
+**Status:** PASS
+
+**Description:** The comparison targets need the competitor frameworks, which the dev
+venv does not carry, so this ran in a throwaway virtualenv holding agno 3.0.0a4 built
+from this worktree plus langgraph 1.2.11, pydantic-ai-slim 2.31.1 and crewai 1.6.1.
+10 samples per target, interpreter startup subtracted.
+
+**Result:** Interpreter startup median 15.2 ms. `import_compare_agno` median 516.5 ms
+(p95 532.2), `import_compare_langgraph` 1198.2 ms (p95 1257.6),
+`import_compare_pydantic_ai` 786.1 ms (p95 827.7), `import_compare_crewai` 1483.8 ms
+(p95 1557.0). These four are comparable to each other but not to the `import_time.py`
+medians above: different virtualenv, and each target imports its framework's agent
+construction path rather than the bare package.
+
+---
+
 ## Notes
 
 - 2026-08-21: First version of `_bench.py` stored the mock's requested tool name as

--- a/cookbook/performance/comparison/import_time_comparison.py
+++ b/cookbook/performance/comparison/import_time_comparison.py
@@ -37,7 +37,7 @@ def main():
     for name, code in IMPORT_TARGETS.items():
         samples = measure(code, SAMPLES)
         adjusted = [max(0.0, s - baseline) for s in samples]
-        result = PerformanceResult(run_times=adjusted, memory_usages=[])
+        result = PerformanceResult(run_id=name, run_times=adjusted, memory_usages=[])
         print(name + ": median " + format(result.median_run_time * 1000, ".1f") + " ms")
         save_result(
             name=name,

--- a/cookbook/performance/import_time.py
+++ b/cookbook/performance/import_time.py
@@ -94,7 +94,7 @@ def main():
     for name, code in IMPORT_TARGETS.items():
         samples = measure(code, SAMPLES)
         adjusted = [max(0.0, s - baseline) for s in samples]
-        result = PerformanceResult(run_times=adjusted, memory_usages=[])
+        result = PerformanceResult(run_id=name, run_times=adjusted, memory_usages=[])
         print(
             name
             + ": median "

--- a/cookbook/performance/memory_footprint.py
+++ b/cookbook/performance/memory_footprint.py
@@ -64,7 +64,7 @@ def main():
         ("memory_per_agent_with_tools", tooled_agent),
     ]:
         usages = [per_agent_footprint(factory) for _ in range(SAMPLES)]
-        result = PerformanceResult(run_times=[], memory_usages=usages)
+        result = PerformanceResult(run_id=name, run_times=[], memory_usages=usages)
         print(
             name
             + ": median "

--- a/libs/agno/agno/eval/accuracy.py
+++ b/libs/agno/agno/eval/accuracy.py
@@ -68,6 +68,7 @@ class AccuracyEvaluation:
 
 @dataclass
 class AccuracyResult:
+    run_id: str
     results: List[AccuracyEvaluation] = field(default_factory=list)
     avg_score: Optional[float] = field(init=False)
     mean_score: Optional[float] = field(init=False)
@@ -166,11 +167,9 @@ class AccuracyEval:
 
     # Evaluation name
     name: Optional[str] = None
-    # Evaluation UUID
-    eval_id: str = field(default_factory=lambda: str(uuid4()))
     # Number of iterations to run
     num_iterations: int = 1
-    # Result of the evaluation
+    # Result of the last run. Each run method returns its own result object
     result: Optional[AccuracyResult] = None
 
     # Model for the evaluator agent
@@ -190,6 +189,7 @@ class AccuracyEval:
     # console (e.g. the suite runner) disable it.
     show_spinner: bool = True
     # If set, results will be saved in the given file path
+    # Supports the {name} and {run_id} placeholders
     file_path_to_save_results: Optional[str] = None
     # Enable debug logs
     debug_mode: bool = getenv("AGNO_DEBUG", "false").lower() == "true"
@@ -376,11 +376,14 @@ Remember: You must only compare the agent_output to the expected_output. The exp
         from rich.console import Console
         from rich.status import Status
 
+        # Generate unique run_id for this execution
+        run_id = str(uuid4())
+
         set_log_level_to_debug() if self.debug_mode else set_log_level_to_info()
 
-        self.result = AccuracyResult()
+        result = AccuracyResult(run_id=run_id)
 
-        logger.debug(f"************ Evaluation Start: {self.eval_id} ************")
+        logger.debug(f"************ Evaluation Start: {run_id} ************")
 
         # Add a spinner while running the evaluations
         console = Console()
@@ -393,7 +396,7 @@ Remember: You must only compare the agent_output to the expected_output. The exp
                 status = Status(f"Running evaluation {i + 1}...", spinner="dots", speed=1.0, refresh_per_second=10)
                 live_log.update(status)
 
-                agent_session_id = f"eval_{self.eval_id}_{i + 1}"
+                agent_session_id = f"eval_{run_id}_{i + 1}"
 
                 run_response: Optional[Any] = None
                 if self.agent is not None:
@@ -421,7 +424,7 @@ Remember: You must only compare the agent_output to the expected_output. The exp
                     </agent_output>\
                     """)
                 logger.debug(f"Agent output #{i + 1}: {output}")
-                result = self.evaluate_answer(
+                evaluation = self.evaluate_answer(
                     input=eval_input,
                     evaluator_agent=evaluator_agent,
                     evaluation_input=evaluation_input,
@@ -429,30 +432,30 @@ Remember: You must only compare the agent_output to the expected_output. The exp
                     agent_output=output,
                     run_metrics=run_response.metrics if run_response is not None else None,
                 )
-                if result is None:
+                if evaluation is None:
                     log_error(f"Failed to evaluate accuracy on iteration {i + 1}")
                     continue
 
-                self.result.results.append(result)
-                self.result.compute_stats()
+                result.results.append(evaluation)
+                result.compute_stats()
                 status.update(f"Eval iteration {i + 1} finished")
 
             status.stop()
 
         # Save result to file if requested
-        if self.file_path_to_save_results is not None and self.result is not None:
+        if self.file_path_to_save_results is not None:
             store_result_in_file(
                 file_path=self.file_path_to_save_results,
                 name=self.name,
-                eval_id=self.eval_id,
-                result=self.result,
+                run_id=run_id,
+                result=result,
             )
 
         # Print results if requested
         if self.print_results or print_results:
-            self.result.print_results(console)
+            result.print_results(console)
         if self.print_summary or print_summary:
-            self.result.print_summary(console)
+            result.print_summary(console)
 
         # Log results to the Agno DB if requested
         if self.agent is not None:
@@ -479,8 +482,8 @@ Remember: You must only compare the agent_output to the expected_output. The exp
 
             log_eval_run(
                 db=self.db,
-                run_id=self.eval_id,  # type: ignore
-                run_data=asdict(self.result),
+                run_id=run_id,
+                run_data=asdict(result),
                 eval_type=EvalType.ACCURACY,
                 agent_id=agent_id,
                 team_id=team_id,
@@ -492,10 +495,11 @@ Remember: You must only compare the agent_output to the expected_output. The exp
             )
 
         if self.telemetry:
-            log_eval_telemetry(run_id=self.eval_id, eval_type=EvalType.ACCURACY, get_data=self._get_telemetry_data)
+            log_eval_telemetry(run_id=run_id, eval_type=EvalType.ACCURACY, get_data=self._get_telemetry_data)
 
-        logger.debug(f"*********** Evaluation {self.eval_id} Finished ***********")
-        return self.result
+        logger.debug(f"*********** Evaluation End: {run_id} ***********")
+        self.result = result
+        return result
 
     async def arun(
         self,
@@ -514,11 +518,14 @@ Remember: You must only compare the agent_output to the expected_output. The exp
         from rich.console import Console
         from rich.status import Status
 
+        # Generate unique run_id for this execution
+        run_id = str(uuid4())
+
         set_log_level_to_debug() if self.debug_mode else set_log_level_to_info()
 
-        self.result = AccuracyResult()
+        result = AccuracyResult(run_id=run_id)
 
-        logger.debug(f"************ Evaluation Start: {self.eval_id} ************")
+        logger.debug(f"************ Evaluation Start: {run_id} ************")
 
         # Add a spinner while running the evaluations
         console = Console()
@@ -531,7 +538,7 @@ Remember: You must only compare the agent_output to the expected_output. The exp
                 status = Status(f"Running evaluation {i + 1}...", spinner="dots", speed=1.0, refresh_per_second=10)
                 live_log.update(status)
 
-                agent_session_id = f"eval_{self.eval_id}_{i + 1}"
+                agent_session_id = f"eval_{run_id}_{i + 1}"
 
                 run_response: Optional[Any] = None
                 if self.agent is not None:
@@ -559,7 +566,7 @@ Remember: You must only compare the agent_output to the expected_output. The exp
                     </agent_output>\
                     """)
                 logger.debug(f"Agent output #{i + 1}: {output}")
-                result = await self.aevaluate_answer(
+                evaluation = await self.aevaluate_answer(
                     input=eval_input,
                     evaluator_agent=evaluator_agent,
                     evaluation_input=evaluation_input,
@@ -567,30 +574,30 @@ Remember: You must only compare the agent_output to the expected_output. The exp
                     agent_output=output,
                     run_metrics=run_response.metrics if run_response is not None else None,
                 )
-                if result is None:
+                if evaluation is None:
                     log_error(f"Failed to evaluate accuracy on iteration {i + 1}")
                     continue
 
-                self.result.results.append(result)
-                self.result.compute_stats()
+                result.results.append(evaluation)
+                result.compute_stats()
                 status.update(f"Eval iteration {i + 1} finished")
 
             status.stop()
 
         # Save result to file if requested
-        if self.file_path_to_save_results is not None and self.result is not None:
+        if self.file_path_to_save_results is not None:
             store_result_in_file(
                 file_path=self.file_path_to_save_results,
                 name=self.name,
-                eval_id=self.eval_id,
-                result=self.result,
+                run_id=run_id,
+                result=result,
             )
 
         # Print results if requested
         if self.print_results or print_results:
-            self.result.print_results(console)
+            result.print_results(console)
         if self.print_summary or print_summary:
-            self.result.print_summary(console)
+            result.print_summary(console)
 
         if self.agent is not None:
             agent_id = self.agent.id
@@ -616,8 +623,8 @@ Remember: You must only compare the agent_output to the expected_output. The exp
             }
             await async_log_eval(
                 db=self.db,
-                run_id=self.eval_id,  # type: ignore
-                run_data=asdict(self.result),
+                run_id=run_id,
+                run_data=asdict(result),
                 eval_type=EvalType.ACCURACY,
                 agent_id=agent_id,
                 model_id=model_id,
@@ -631,11 +638,12 @@ Remember: You must only compare the agent_output to the expected_output. The exp
 
         if self.telemetry:
             await async_log_eval_telemetry(
-                run_id=self.eval_id, eval_type=EvalType.ACCURACY, get_data=self._get_telemetry_data
+                run_id=run_id, eval_type=EvalType.ACCURACY, get_data=self._get_telemetry_data
             )
 
-        logger.debug(f"*********** Evaluation {self.eval_id} Finished ***********")
-        return self.result
+        logger.debug(f"*********** Evaluation End: {run_id} ***********")
+        self.result = result
+        return result
 
     def run_with_output(
         self,
@@ -645,12 +653,12 @@ Remember: You must only compare the agent_output to the expected_output. The exp
         print_results: bool = True,
     ) -> Optional[AccuracyResult]:
         """Run the evaluation logic against the given answer, instead of generating an answer with the Agent"""
-        # Generate unique run_id for this execution (don't modify self.eval_id due to concurrency)
+        # Generate unique run_id for this execution
         run_id = str(uuid4())
 
         set_log_level_to_debug() if self.debug_mode else set_log_level_to_info()
 
-        self.result = AccuracyResult()
+        result = AccuracyResult(run_id=run_id)
 
         logger.debug(f"************ Evaluation Start: {run_id} ************")
 
@@ -672,7 +680,7 @@ Remember: You must only compare the agent_output to the expected_output. The exp
             </agent_output>\
             """)
 
-        result = self.evaluate_answer(
+        evaluation = self.evaluate_answer(
             input=eval_input,
             evaluator_agent=evaluator_agent,
             evaluation_input=evaluation_input,
@@ -680,23 +688,23 @@ Remember: You must only compare the agent_output to the expected_output. The exp
             agent_output=output,
         )
 
-        if result is not None:
-            self.result.results.append(result)
-            self.result.compute_stats()
+        if evaluation is not None:
+            result.results.append(evaluation)
+            result.compute_stats()
 
             # Print results if requested
             if self.print_results or print_results:
-                self.result.print_results()
+                result.print_results()
             if self.print_summary or print_summary:
-                self.result.print_summary()
+                result.print_summary()
 
             # Save result to file if requested
             if self.file_path_to_save_results is not None:
                 store_result_in_file(
                     file_path=self.file_path_to_save_results,
                     name=self.name,
-                    eval_id=self.eval_id,
-                    result=self.result,
+                    run_id=run_id,
+                    result=result,
                 )
         # Log results to the Agno DB if requested
         if self.db:
@@ -733,8 +741,8 @@ Remember: You must only compare the agent_output to the expected_output. The exp
 
                 log_eval_run(
                     db=self.db,
-                    run_id=self.eval_id,  # type: ignore
-                    run_data=asdict(self.result),
+                    run_id=run_id,
+                    run_data=asdict(result),
                     eval_type=EvalType.ACCURACY,
                     name=self.name if self.name is not None else None,
                     agent_id=agent_id,
@@ -747,10 +755,11 @@ Remember: You must only compare the agent_output to the expected_output. The exp
                 )
 
         if self.telemetry:
-            log_eval_telemetry(run_id=self.eval_id, eval_type=EvalType.ACCURACY, get_data=self._get_telemetry_data)
+            log_eval_telemetry(run_id=run_id, eval_type=EvalType.ACCURACY, get_data=self._get_telemetry_data)
 
         logger.debug(f"*********** Evaluation End: {run_id} ***********")
-        return self.result
+        self.result = result
+        return result
 
     async def arun_with_output(
         self,
@@ -760,12 +769,12 @@ Remember: You must only compare the agent_output to the expected_output. The exp
         print_results: bool = True,
     ) -> Optional[AccuracyResult]:
         """Run the evaluation logic against the given answer, instead of generating an answer with the Agent"""
-        # Generate unique run_id for this execution (don't modify self.eval_id due to concurrency)
+        # Generate unique run_id for this execution
         run_id = str(uuid4())
 
         set_log_level_to_debug() if self.debug_mode else set_log_level_to_info()
 
-        self.result = AccuracyResult()
+        result = AccuracyResult(run_id=run_id)
 
         logger.debug(f"************ Evaluation Start: {run_id} ************")
 
@@ -787,7 +796,7 @@ Remember: You must only compare the agent_output to the expected_output. The exp
             </agent_output>\
             """)
 
-        result = await self.aevaluate_answer(
+        evaluation = await self.aevaluate_answer(
             input=eval_input,
             evaluator_agent=evaluator_agent,
             evaluation_input=evaluation_input,
@@ -795,23 +804,23 @@ Remember: You must only compare the agent_output to the expected_output. The exp
             agent_output=output,
         )
 
-        if result is not None:
-            self.result.results.append(result)
-            self.result.compute_stats()
+        if evaluation is not None:
+            result.results.append(evaluation)
+            result.compute_stats()
 
             # Print results if requested
             if self.print_results or print_results:
-                self.result.print_results()
+                result.print_results()
             if self.print_summary or print_summary:
-                self.result.print_summary()
+                result.print_summary()
 
             # Save result to file if requested
             if self.file_path_to_save_results is not None:
                 store_result_in_file(
                     file_path=self.file_path_to_save_results,
                     name=self.name,
-                    eval_id=self.eval_id,
-                    result=self.result,
+                    run_id=run_id,
+                    result=result,
                 )
         # Log results to the Agno DB if requested
         if self.db:
@@ -827,6 +836,12 @@ Remember: You must only compare the agent_output to the expected_output. The exp
                 model_id = self.team.model.id if self.team.model is not None else None
                 model_provider = self.team.model.provider if self.team.model is not None else None
                 evaluated_component_name = self.team.name
+            else:
+                agent_id = None
+                team_id = None
+                model_id = None
+                model_provider = None
+                evaluated_component_name = None
 
             log_eval_input = {
                 "additional_guidelines": self.additional_guidelines,
@@ -838,8 +853,8 @@ Remember: You must only compare the agent_output to the expected_output. The exp
 
             await async_log_eval(
                 db=self.db,
-                run_id=self.eval_id,  # type: ignore
-                run_data=asdict(self.result),
+                run_id=run_id,
+                run_data=asdict(result),
                 eval_type=EvalType.ACCURACY,
                 name=self.name if self.name is not None else None,
                 agent_id=agent_id,
@@ -851,8 +866,14 @@ Remember: You must only compare the agent_output to the expected_output. The exp
                 eval_input=log_eval_input,
             )
 
+        if self.telemetry:
+            await async_log_eval_telemetry(
+                run_id=run_id, eval_type=EvalType.ACCURACY, get_data=self._get_telemetry_data
+            )
+
         logger.debug(f"*********** Evaluation End: {run_id} ***********")
-        return self.result
+        self.result = result
+        return result
 
     def _get_telemetry_data(self) -> Dict[str, Any]:
         """Get the telemetry data for the evaluation"""

--- a/libs/agno/agno/eval/agent_as_judge.py
+++ b/libs/agno/agno/eval/agent_as_judge.py
@@ -210,6 +210,8 @@ class AgentAsJudgeEval(BaseEval):
     # Render the transient progress spinner. Embedders that must not write to the
     # console (e.g. the suite runner) disable it.
     show_spinner: bool = True
+    # If set, results will be saved in the given file path
+    # Supports the {name} and {run_id} placeholders
     file_path_to_save_results: Optional[str] = None
     debug_mode: bool = getenv("AGNO_DEBUG", "false").lower() == "true"
     db: Optional[Union[BaseDb, AsyncBaseDb]] = None
@@ -552,7 +554,7 @@ class AgentAsJudgeEval(BaseEval):
             store_result_in_file(
                 file_path=self.file_path_to_save_results,
                 result=result,
-                eval_id=run_id,
+                run_id=run_id,
                 name=self.name,
             )
 
@@ -652,7 +654,7 @@ class AgentAsJudgeEval(BaseEval):
             store_result_in_file(
                 file_path=self.file_path_to_save_results,
                 result=result,
-                eval_id=run_id,
+                run_id=run_id,
                 name=self.name,
             )
 
@@ -721,7 +723,7 @@ class AgentAsJudgeEval(BaseEval):
             store_result_in_file(
                 file_path=self.file_path_to_save_results,
                 result=result,
-                eval_id=run_id,
+                run_id=run_id,
                 name=self.name,
             )
 
@@ -790,7 +792,7 @@ class AgentAsJudgeEval(BaseEval):
             store_result_in_file(
                 file_path=self.file_path_to_save_results,
                 result=result,
-                eval_id=run_id,
+                run_id=run_id,
                 name=self.name,
             )
 

--- a/libs/agno/agno/eval/performance.py
+++ b/libs/agno/agno/eval/performance.py
@@ -31,6 +31,8 @@ class PerformanceResult:
     for a more robust understanding.
     """
 
+    run_id: str
+
     # Run time performance in seconds
     run_times: List[float] = field(default_factory=list)
     avg_run_time: float = field(init=False)
@@ -205,13 +207,11 @@ class PerformanceEval:
 
     # Evaluation name
     name: Optional[str] = None
-    # Evaluation UUID
-    eval_id: str = field(default_factory=lambda: str(uuid4()))
     # Number of warm-up runs (not included in final stats)
     warmup_runs: Optional[int] = 10
     # Number of measured iterations
     num_iterations: int = 50
-    # Result of the evaluation
+    # Result of the last run. Each run method returns its own result object
     result: Optional[PerformanceResult] = None
 
     # Print summary of results
@@ -233,6 +233,7 @@ class PerformanceEval:
     model_provider: Optional[str] = None
 
     # If set, results will be saved in the given file path
+    # Supports the {name} and {run_id} placeholders
     file_path_to_save_results: Optional[str] = None
     # Enable debug logs
     debug_mode: bool = getenv("AGNO_DEBUG", "false").lower() == "true"
@@ -296,29 +297,29 @@ class PerformanceEval:
 
         return adjusted_usage
 
-    def _parse_eval_run_data(self) -> dict:
+    def _parse_eval_run_data(self, result: Optional[PerformanceResult]) -> dict:
         """Parse the evaluation result into a dictionary with the data we want for monitoring."""
-        if self.result is None:
+        if result is None:
             return {}
 
         return {
             "result": {
-                "avg_run_time": self.result.avg_run_time,
-                "min_run_time": self.result.min_run_time,
-                "max_run_time": self.result.max_run_time,
-                "std_dev_run_time": self.result.std_dev_run_time,
-                "median_run_time": self.result.median_run_time,
-                "p95_run_time": self.result.p95_run_time,
-                "avg_memory_usage": self.result.avg_memory_usage,
-                "min_memory_usage": self.result.min_memory_usage,
-                "max_memory_usage": self.result.max_memory_usage,
-                "std_dev_memory_usage": self.result.std_dev_memory_usage,
-                "median_memory_usage": self.result.median_memory_usage,
-                "p95_memory_usage": self.result.p95_memory_usage,
+                "avg_run_time": result.avg_run_time,
+                "min_run_time": result.min_run_time,
+                "max_run_time": result.max_run_time,
+                "std_dev_run_time": result.std_dev_run_time,
+                "median_run_time": result.median_run_time,
+                "p95_run_time": result.p95_run_time,
+                "avg_memory_usage": result.avg_memory_usage,
+                "min_memory_usage": result.min_memory_usage,
+                "max_memory_usage": result.max_memory_usage,
+                "std_dev_memory_usage": result.std_dev_memory_usage,
+                "median_memory_usage": result.median_memory_usage,
+                "p95_memory_usage": result.p95_memory_usage,
             },
             "runs": [
                 {"runtime": runtime, "memory": memory_usage}
-                for runtime, memory_usage in zip(self.result.run_times, self.result.memory_usages)
+                for runtime, memory_usage in zip(result.run_times, result.memory_usages)
             ],
         }
 
@@ -512,7 +513,7 @@ class PerformanceEval:
         from rich.console import Console
         from rich.status import Status
 
-        # Generate unique run_id for this execution (don't modify self.eval_id due to concurrency)
+        # Generate unique run_id for this execution
         run_id = str(uuid4())
 
         run_times = []
@@ -585,22 +586,23 @@ class PerformanceEval:
                     status.stop()
 
         # 4. Collect results
-        self.result = PerformanceResult(run_times=run_times, memory_usages=memory_usages)
+        result = PerformanceResult(run_id=run_id, run_times=run_times, memory_usages=memory_usages)
+        self.result = result
 
         # 5. Save result to file if requested
-        if self.file_path_to_save_results is not None and self.result is not None:
+        if self.file_path_to_save_results is not None:
             store_result_in_file(
                 file_path=self.file_path_to_save_results,
                 name=self.name,
-                eval_id=self.eval_id,
-                result=self.result,
+                run_id=run_id,
+                result=result,
             )
 
         # 6. Print results if requested
         if self.print_results or print_results:
-            self.result.print_results(console, measure_memory=self.measure_memory, measure_runtime=self.measure_runtime)
+            result.print_results(console, measure_memory=self.measure_memory, measure_runtime=self.measure_runtime)
         if self.print_summary or print_summary:
-            self.result.print_summary(console, measure_memory=self.measure_memory, measure_runtime=self.measure_runtime)
+            result.print_summary(console, measure_memory=self.measure_memory, measure_runtime=self.measure_runtime)
 
         # 7. Log results to the Agno platform if requested
         if self.db:
@@ -611,8 +613,8 @@ class PerformanceEval:
 
             log_eval_run(
                 db=self.db,
-                run_id=self.eval_id,  # type: ignore
-                run_data=self._parse_eval_run_data(),
+                run_id=run_id,
+                run_data=self._parse_eval_run_data(result),
                 eval_type=EvalType.PERFORMANCE,
                 name=self.name if self.name is not None else None,
                 evaluated_component_name=self.func.__name__,
@@ -624,10 +626,10 @@ class PerformanceEval:
             )
 
         if self.telemetry:
-            log_eval_telemetry(run_id=self.eval_id, eval_type=EvalType.PERFORMANCE, get_data=self._get_telemetry_data)
+            log_eval_telemetry(run_id=run_id, eval_type=EvalType.PERFORMANCE, get_data=self._get_telemetry_data)
 
         log_debug(f"*********** Evaluation End: {run_id} ***********")
-        return self.result
+        return result
 
     async def arun(
         self, *, print_summary: bool = False, print_results: bool = False, memory_growth_tracking: bool = False
@@ -651,7 +653,7 @@ class PerformanceEval:
         from rich.console import Console
         from rich.status import Status
 
-        # Generate unique run_id for this execution (don't modify self.eval_id due to concurrency)
+        # Generate unique run_id for this execution
         run_id = str(uuid4())
 
         run_times = []
@@ -724,22 +726,23 @@ class PerformanceEval:
                     status.stop()
 
         # 4. Collect results
-        self.result = PerformanceResult(run_times=run_times, memory_usages=memory_usages)
+        result = PerformanceResult(run_id=run_id, run_times=run_times, memory_usages=memory_usages)
+        self.result = result
 
         # 5. Save result to file if requested
-        if self.file_path_to_save_results is not None and self.result is not None:
+        if self.file_path_to_save_results is not None:
             store_result_in_file(
                 file_path=self.file_path_to_save_results,
                 name=self.name,
-                eval_id=self.eval_id,
-                result=self.result,
+                run_id=run_id,
+                result=result,
             )
 
         # 6. Print results if requested
         if self.print_results or print_results:
-            self.result.print_results(console, measure_memory=self.measure_memory, measure_runtime=self.measure_runtime)
+            result.print_results(console, measure_memory=self.measure_memory, measure_runtime=self.measure_runtime)
         if self.print_summary or print_summary:
-            self.result.print_summary(console, measure_memory=self.measure_memory, measure_runtime=self.measure_runtime)
+            result.print_summary(console, measure_memory=self.measure_memory, measure_runtime=self.measure_runtime)
 
         # 7. Log results to the Agno platform if requested
         if self.db:
@@ -750,8 +753,8 @@ class PerformanceEval:
 
             await async_log_eval(
                 db=self.db,
-                run_id=self.eval_id,  # type: ignore
-                run_data=self._parse_eval_run_data(),
+                run_id=run_id,
+                run_data=self._parse_eval_run_data(result),
                 eval_type=EvalType.PERFORMANCE,
                 name=self.name if self.name is not None else None,
                 evaluated_component_name=self.func.__name__,
@@ -764,11 +767,11 @@ class PerformanceEval:
 
         if self.telemetry:
             await async_log_eval_telemetry(
-                run_id=self.eval_id, eval_type=EvalType.PERFORMANCE, get_data=self._get_telemetry_data
+                run_id=run_id, eval_type=EvalType.PERFORMANCE, get_data=self._get_telemetry_data
             )
 
         log_debug(f"*********** Evaluation End: {run_id} ***********")
-        return self.result
+        return result
 
     def _get_telemetry_data(self) -> Dict[str, Any]:
         """Get the telemetry data for the evaluation"""

--- a/libs/agno/agno/eval/reliability.py
+++ b/libs/agno/agno/eval/reliability.py
@@ -25,6 +25,7 @@ from agno.utils.log import logger
 
 @dataclass
 class ReliabilityResult:
+    run_id: str
     eval_status: str
     failed_tool_calls: List[str]
     passed_tool_calls: List[str]
@@ -81,8 +82,6 @@ class ReliabilityEval:
 
     # Evaluation name
     name: Optional[str] = None
-    # Evaluation UUID
-    eval_id: str = field(default_factory=lambda: str(uuid4()))
 
     # Agent response
     agent_response: Optional[RunOutput] = None
@@ -96,7 +95,7 @@ class ReliabilityEval:
     # Single check: {"multiply": {"a": 10, "b": 5}}
     # Multiple checks: {"add": [{"a": 2, "b": 2}, {"a": 3, "b": 3}]}
     expected_tool_call_arguments: Optional[Dict[str, Union[Dict[str, Any], List[Dict[str, Any]]]]] = None
-    # Result of the evaluation
+    # Result of the last run. Each run method returns its own result object
     result: Optional[ReliabilityResult] = None
 
     # Print detailed results
@@ -105,6 +104,7 @@ class ReliabilityEval:
     # console (e.g. the suite runner) disable it.
     show_spinner: bool = True
     # If set, results will be saved in the given file path
+    # Supports the {name} and {run_id} placeholders
     file_path_to_save_results: Optional[str] = None
     # Enable debug logs
     debug_mode: bool = getenv("AGNO_DEBUG", "false").lower() == "true"
@@ -116,7 +116,7 @@ class ReliabilityEval:
     # This helps us improve our Evals and provide better support
     telemetry: bool = True
 
-    def _evaluate(self) -> ReliabilityResult:
+    def _evaluate(self, run_id: str) -> ReliabilityResult:
         """Core evaluation logic: tool evidence comes from executions, not requests.
 
         New in 2.8.0: an expectation is satisfied only by a clean execution -- an entry
@@ -250,6 +250,7 @@ class ReliabilityEval:
         eval_passed = len(failed_tool_calls) == 0 and len(missing_tool_calls) == 0 and len(failed_argument_checks) == 0
 
         return ReliabilityResult(
+            run_id=run_id,
             eval_status="PASSED" if eval_passed else "FAILED",
             failed_tool_calls=failed_tool_calls,
             passed_tool_calls=passed_tool_calls,
@@ -284,7 +285,7 @@ class ReliabilityEval:
         from rich.console import Console
         from rich.status import Status
 
-        # Generate unique run_id for this execution (don't modify self.eval_id due to concurrency)
+        # Generate unique run_id for this execution
         run_id = str(uuid4())
 
         # Add a spinner while running the evaluations
@@ -293,20 +294,21 @@ class ReliabilityEval:
             status = Status("Running evaluation...", spinner="dots", speed=1.0, refresh_per_second=10)
             live_log.update(status)
 
-            self.result = self._evaluate()
+            result = self._evaluate(run_id)
+            self.result = result
 
         # Save result to file if requested
-        if self.file_path_to_save_results is not None and self.result is not None:
+        if self.file_path_to_save_results is not None:
             store_result_in_file(
                 file_path=self.file_path_to_save_results,
                 name=self.name,
-                eval_id=self.eval_id,
-                result=self.result,
+                run_id=run_id,
+                result=result,
             )
 
         # Print results if requested
         if self.print_results or print_results:
-            self.result.print_eval(console)
+            result.print_eval(console)
 
         # Log results to the Agno platform if requested
         if self.db:
@@ -329,8 +331,8 @@ class ReliabilityEval:
 
             log_eval_run(
                 db=self.db,
-                run_id=self.eval_id,  # type: ignore
-                run_data=asdict(self.result),
+                run_id=run_id,
+                run_data=asdict(result),
                 eval_type=EvalType.RELIABILITY,
                 name=self.name if self.name is not None else None,
                 agent_id=agent_id,
@@ -341,10 +343,10 @@ class ReliabilityEval:
             )
 
         if self.telemetry:
-            log_eval_telemetry(run_id=self.eval_id, eval_type=EvalType.RELIABILITY, get_data=self._get_telemetry_data)
+            log_eval_telemetry(run_id=run_id, eval_type=EvalType.RELIABILITY, get_data=self._get_telemetry_data)
 
         logger.debug(f"*********** Evaluation End: {run_id} ***********")
-        return self.result
+        return result
 
     async def arun(self, *, print_results: bool = False) -> Optional[ReliabilityResult]:
         if self.agent_response is None and self.team_response is None:
@@ -358,7 +360,7 @@ class ReliabilityEval:
         from rich.console import Console
         from rich.status import Status
 
-        # Generate unique run_id for this execution (don't modify self.eval_id due to concurrency)
+        # Generate unique run_id for this execution
         run_id = str(uuid4())
 
         # Add a spinner while running the evaluations
@@ -367,20 +369,21 @@ class ReliabilityEval:
             status = Status("Running evaluation...", spinner="dots", speed=1.0, refresh_per_second=10)
             live_log.update(status)
 
-            self.result = self._evaluate()
+            result = self._evaluate(run_id)
+            self.result = result
 
         # Save result to file if requested
-        if self.file_path_to_save_results is not None and self.result is not None:
+        if self.file_path_to_save_results is not None:
             store_result_in_file(
                 file_path=self.file_path_to_save_results,
                 name=self.name,
-                eval_id=self.eval_id,
-                result=self.result,
+                run_id=run_id,
+                result=result,
             )
 
         # Print results if requested
         if self.print_results or print_results:
-            self.result.print_eval(console)
+            result.print_eval(console)
 
         # Log results to the Agno platform if requested
         if self.db:
@@ -403,8 +406,8 @@ class ReliabilityEval:
 
             await async_log_eval(
                 db=self.db,
-                run_id=self.eval_id,  # type: ignore
-                run_data=asdict(self.result),
+                run_id=run_id,
+                run_data=asdict(result),
                 eval_type=EvalType.RELIABILITY,
                 name=self.name if self.name is not None else None,
                 agent_id=agent_id,
@@ -416,8 +419,8 @@ class ReliabilityEval:
 
         if self.telemetry:
             await async_log_eval_telemetry(
-                run_id=self.eval_id, eval_type=EvalType.RELIABILITY, get_data=self._get_telemetry_data
+                run_id=run_id, eval_type=EvalType.RELIABILITY, get_data=self._get_telemetry_data
             )
 
         logger.debug(f"*********** Evaluation End: {run_id} ***********")
-        return self.result
+        return result

--- a/libs/agno/agno/eval/utils.py
+++ b/libs/agno/agno/eval/utils.py
@@ -229,14 +229,19 @@ async def async_log_eval_telemetry(
 def store_result_in_file(
     file_path: str,
     result: Union["AccuracyResult", "AgentAsJudgeResult", "PerformanceResult", "ReliabilityResult"],
-    eval_id: Optional[str] = None,
+    run_id: Optional[str] = None,
     name: Optional[str] = None,
 ):
-    """Store the given result in the given file path"""
+    """Store the given result in the given file path.
+
+    ``file_path`` accepts the ``{name}`` and ``{run_id}`` placeholders, in the filename or
+    in a directory segment. An unknown placeholder raises and is logged below, so nothing
+    is written.
+    """
     try:
         import json
 
-        fn_path = Path(file_path.format(name=name, eval_id=eval_id))
+        fn_path = Path(file_path.format(name=name, run_id=run_id))
         if not fn_path.parent.exists():
             fn_path.parent.mkdir(parents=True, exist_ok=True)
         fn_path.write_text(json.dumps(asdict(result), indent=4))

--- a/libs/agno/agno/os/routers/evals/schemas.py
+++ b/libs/agno/agno/os/routers/evals/schemas.py
@@ -98,7 +98,7 @@ class EvalSchema(BaseModel):
             else None
         )
         return cls(
-            id=accuracy_eval.eval_id,
+            id=result.run_id,
             name=accuracy_eval.name,
             agent_id=accuracy_eval.agent.id if accuracy_eval.agent else None,
             team_id=accuracy_eval.team.id if accuracy_eval.team else None,
@@ -142,7 +142,7 @@ class EvalSchema(BaseModel):
         team_id: Optional[str] = None,
     ) -> "EvalSchema":
         return cls(
-            id=performance_eval.eval_id,
+            id=result.run_id,
             name=performance_eval.name,
             agent_id=agent_id,
             team_id=team_id,
@@ -164,7 +164,7 @@ class EvalSchema(BaseModel):
         team_id: Optional[str] = None,
     ) -> "EvalSchema":
         return cls(
-            id=reliability_eval.eval_id,
+            id=result.run_id,
             name=reliability_eval.name,
             agent_id=agent_id,
             team_id=team_id,

--- a/libs/agno/tests/unit/eval/test_accuracy_eval.py
+++ b/libs/agno/tests/unit/eval/test_accuracy_eval.py
@@ -1,9 +1,16 @@
 """Unit tests for AccuracyEval"""
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
+from agno.agent import Agent
+from agno.db.in_memory import InMemoryDb
+from agno.db.sqlite import SqliteDb
 from agno.eval.accuracy import AccuracyAgentResponse, AccuracyEval
 from agno.run.agent import RunOutput
+from agno.team import Team
 
 
 def _mock_evaluator(eval_instance: AccuracyEval, score: int = 8):
@@ -92,3 +99,144 @@ async def test_async_all_iterations_fail_returns_none_stats():
     assert result is not None
     assert len(result.results) == 0
     assert result.avg_score is None
+
+
+# ---------------------------------------------------------------------------
+# run_id is per execution: one run() call, one row, one id
+# ---------------------------------------------------------------------------
+
+
+async def test_arun_with_output_logs_distinct_run_id_per_execution():
+    """Async path also stores a distinct run_id per execution.
+
+    Also guards the db-logging branch for an eval with no agent/team: arun_with_output
+    used to raise UnboundLocalError there (its sync twin had the else branch, it did not)."""
+    db = InMemoryDb()
+    eval = AccuracyEval(input="What is 2 + 2?", expected_output="4", db=db, telemetry=False)
+    _mock_evaluator(eval, score=8)
+
+    first = await eval.arun_with_output(output="4", print_results=False, print_summary=False)
+    second = await eval.arun_with_output(output="4", print_results=False, print_summary=False)
+
+    runs = db.get_eval_runs()
+    assert len(runs) == 2
+    assert first.run_id != second.run_id
+    assert {run.run_id for run in runs} == {first.run_id, second.run_id}
+
+
+def test_run_uses_a_fresh_agent_session_per_execution():
+    """Each run talks to the agent under test in its own session, keyed by run_id, so a rerun of
+    the same eval instance never sees the previous run's conversation as history."""
+    agent = Agent()
+    agent.run = MagicMock(return_value=RunOutput(content="4"))
+    eval = AccuracyEval(agent=agent, input="What is 2 + 2?", expected_output="4", telemetry=False, show_spinner=False)
+    _mock_evaluator(eval, score=8)
+
+    first = eval.run(print_results=False, print_summary=False)
+    second = eval.run(print_results=False, print_summary=False)
+
+    assert first.run_id != second.run_id
+    session_ids = [call.kwargs["session_id"] for call in agent.run.call_args_list]
+    assert session_ids == [f"eval_{first.run_id}_1", f"eval_{second.run_id}_1"]
+
+
+async def test_concurrent_aruns_return_their_own_results():
+    """Concurrent runs on one instance each return their own result object, holding only that
+    run's iterations and the run_id of that caller's row (self.result aliases the last run)."""
+    db = InMemoryDb()
+    eval = AccuracyEval(input="What is 2 + 2?", expected_output="4", db=db, telemetry=False)
+    _mock_evaluator(eval, score=8)
+
+    first, second = await asyncio.gather(
+        eval.arun_with_output(output="4", print_results=False, print_summary=False),
+        eval.arun_with_output(output="4", print_results=False, print_summary=False),
+    )
+
+    assert first is not second
+    assert first.run_id != second.run_id
+    assert len(first.results) == 1
+    assert len(second.results) == 1
+    assert {run.run_id for run in db.get_eval_runs()} == {first.run_id, second.run_id}
+
+
+async def test_arun_logs_distinct_run_id_per_execution():
+    """Async twin of the primary path."""
+    db = InMemoryDb()
+    agent = Agent()
+    agent.arun = AsyncMock(return_value=RunOutput(content="4"))
+    eval = AccuracyEval(
+        agent=agent, input="What is 2 + 2?", expected_output="4", db=db, telemetry=False, show_spinner=False
+    )
+    _mock_evaluator(eval, score=8)
+
+    first = await eval.arun(print_results=False, print_summary=False)
+    second = await eval.arun(print_results=False, print_summary=False)
+
+    runs = db.get_eval_runs()
+    assert len(runs) == 2
+    assert first.run_id != second.run_id
+    assert {run.run_id for run in runs} == {first.run_id, second.run_id}
+
+
+def test_team_subject_logs_distinct_run_id_per_execution():
+    """A team subject takes the elif branch on the way to the same per-run row."""
+    db = InMemoryDb()
+    team = Team(members=[Agent(id="member")])
+    team.run = MagicMock(return_value=RunOutput(content="4"))
+    eval = AccuracyEval(
+        team=team, input="What is 2 + 2?", expected_output="4", db=db, telemetry=False, show_spinner=False
+    )
+    _mock_evaluator(eval, score=8)
+
+    first = eval.run(print_results=False, print_summary=False)
+    second = eval.run(print_results=False, print_summary=False)
+
+    runs = db.get_eval_runs()
+    assert len(runs) == 2
+    assert {run.run_id for run in runs} == {first.run_id, second.run_id}
+    assert {run.team_id for run in runs} == {team.id}
+
+
+def test_result_is_published_only_once_the_run_completes():
+    """self.result is a snapshot of the last COMPLETED run: a run that raises part-way
+    must not leave a partial result (with its confident stats) on the eval object."""
+    db = InMemoryDb()
+    agent = Agent()
+    agent.run = MagicMock(side_effect=[RunOutput(content="4"), RuntimeError("agent unavailable")])
+    eval = AccuracyEval(
+        agent=agent,
+        input="What is 2 + 2?",
+        expected_output="4",
+        num_iterations=2,
+        db=db,
+        telemetry=False,
+        show_spinner=False,
+    )
+    _mock_evaluator(eval, score=8)
+
+    with pytest.raises(RuntimeError):
+        eval.run(print_results=False, print_summary=False)
+
+    assert eval.result is None
+
+
+def test_rerun_stores_a_row_and_a_file_per_run(tmp_path):
+    """run_id is the evals table primary key and create_eval_run is a plain insert, so a reused
+    id made the second write raise and be swallowed. The file sink is keyed the same way, so one
+    rerun is enough to cover both. InMemoryDb has no uniqueness and cannot show the failure."""
+    db = SqliteDb(db_file=str(tmp_path / "evals.db"))
+    eval = AccuracyEval(
+        input="What is 2 + 2?",
+        expected_output="4",
+        db=db,
+        telemetry=False,
+        file_path_to_save_results=str(tmp_path / "{run_id}.json"),
+    )
+    _mock_evaluator(eval, score=8)
+
+    first = eval.run_with_output(output="4", print_results=False, print_summary=False)
+    second = eval.run_with_output(output="4", print_results=False, print_summary=False)
+
+    assert {run.run_id for run in db.get_eval_runs()} == {first.run_id, second.run_id}
+    assert (tmp_path / f"{first.run_id}.json").exists()
+    assert (tmp_path / f"{second.run_id}.json").exists()

--- a/libs/agno/tests/unit/eval/test_agent_as_judge_eval.py
+++ b/libs/agno/tests/unit/eval/test_agent_as_judge_eval.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 from agno.agent import Agent
 from agno.db.in_memory import InMemoryDb
+from agno.db.sqlite import SqliteDb
 from agno.eval.agent_as_judge import AgentAsJudgeEval, BinaryJudgeResponse, NumericJudgeResponse
 from agno.models.openai import OpenAIChat
 from agno.run.agent import RunOutput
@@ -552,3 +553,51 @@ async def test_binary_mode_basic_async():
     assert len(result.results) == 1
     assert result.results[0].score is None  # Binary mode doesn't have scores
     assert isinstance(result.results[0].passed, bool)
+
+
+# ---------------------------------------------------------------------------
+# run_id is per execution: one run() call, one row, one id
+# ---------------------------------------------------------------------------
+
+
+def test_rerun_stores_a_row_and_a_file_per_run(tmp_path):
+    """run_id is the evals table primary key and create_eval_run is a plain insert, so a reused
+    id made the second write raise and be swallowed. The file sink is keyed the same way, so one
+    rerun is enough to cover both. InMemoryDb has no uniqueness and cannot show the failure."""
+    db = SqliteDb(db_file=str(tmp_path / "evals.db"))
+    eval = AgentAsJudgeEval(
+        criteria="Response must be helpful",
+        scoring_strategy="numeric",
+        db=db,
+        telemetry=False,
+        show_spinner=False,
+        file_path_to_save_results=str(tmp_path / "{run_id}.json"),
+    )
+    _mock_evaluator_numeric(eval, score=8)
+
+    first = eval.run(input="What is Python?", output="A language.", print_results=False)
+    second = eval.run(input="What is Python?", output="A language.", print_results=False)
+
+    assert {run.run_id for run in db.get_eval_runs()} == {first.run_id, second.run_id}
+    assert (tmp_path / f"{first.run_id}.json").exists()
+    assert (tmp_path / f"{second.run_id}.json").exists()
+
+
+async def test_arun_logs_distinct_run_id_per_execution():
+    """Async path also stores a distinct run_id per execution."""
+    db = InMemoryDb()
+    eval = AgentAsJudgeEval(
+        criteria="Response must be helpful", scoring_strategy="numeric", db=db, telemetry=False, show_spinner=False
+    )
+    evaluator = eval.get_evaluator_agent()
+    evaluator.model = MagicMock()
+    evaluator.arun = AsyncMock(return_value=RunOutput(content=NumericJudgeResponse(score=8, reason="Mocked.")))
+    eval.evaluator_agent = evaluator
+
+    first = await eval.arun(input="What is Python?", output="A language.", print_results=False)
+    second = await eval.arun(input="What is Python?", output="A language.", print_results=False)
+
+    runs = db.get_eval_runs()
+    assert len(runs) == 2
+    assert first.run_id != second.run_id
+    assert {run.run_id for run in runs} == {first.run_id, second.run_id}

--- a/libs/agno/tests/unit/eval/test_eval_utils.py
+++ b/libs/agno/tests/unit/eval/test_eval_utils.py
@@ -1,10 +1,12 @@
 """Unit tests for eval utils (agno.eval.utils)."""
 
 import asyncio
+import json
 import threading
 
 from agno.db.schemas.evals import EvalType
-from agno.eval.utils import async_log_eval, spinner_live
+from agno.eval.accuracy import AccuracyResult
+from agno.eval.utils import async_log_eval, spinner_live, store_result_in_file
 
 
 class RecordingSyncDb:
@@ -130,3 +132,23 @@ def test_spinner_live_disabled_emits_nothing(capsys):
         # And no auto-refresh: nothing renders, so no render thread either
         assert live.auto_refresh is False
     assert capsys.readouterr().out == ""
+
+
+def test_store_result_in_file_formats_run_id_template(tmp_path):
+    result = AccuracyResult(run_id="run-1")
+
+    store_result_in_file(str(tmp_path / "{run_id}.json"), result=result, run_id="run-1")
+
+    saved = json.loads((tmp_path / "run-1.json").read_text())
+    assert saved["run_id"] == "run-1"
+
+
+def test_store_result_in_file_rejects_the_removed_eval_id_template(tmp_path):
+    """{eval_id} went with the field it named. A pre-3.0 template now raises KeyError inside
+    store_result_in_file, which logs "Failed to save result to file: \'eval_id\'" and writes
+    nothing -- a named warning and a one-word fix, not a silent stop."""
+    result = AccuracyResult(run_id="run-1")
+
+    store_result_in_file(str(tmp_path / "{eval_id}.json"), result=result, run_id="run-1")
+
+    assert list(tmp_path.iterdir()) == []

--- a/libs/agno/tests/unit/eval/test_performance_eval.py
+++ b/libs/agno/tests/unit/eval/test_performance_eval.py
@@ -1,6 +1,8 @@
-"""Unit tests for PerformanceResult statistics"""
+"""Unit tests for PerformanceEval and PerformanceResult"""
 
-from agno.eval.performance import PerformanceResult
+from agno.db.in_memory import InMemoryDb
+from agno.db.sqlite import SqliteDb
+from agno.eval.performance import PerformanceEval, PerformanceResult
 
 # ---------------------------------------------------------------------------
 # p95 percentile for small samples
@@ -8,23 +10,100 @@ from agno.eval.performance import PerformanceResult
 
 
 def test_single_sample_p95_matches_sample():
-    result = PerformanceResult(run_times=[1.0], memory_usages=[10.0])
+    result = PerformanceResult(run_id="run-1", run_times=[1.0], memory_usages=[10.0])
     assert result.p95_run_time == 1.0
     assert result.p95_memory_usage == 10.0
 
 
 def test_small_sample_p95_stays_within_observed_range():
-    result = PerformanceResult(run_times=[1.0, 2.0], memory_usages=[10.0, 20.0])
+    result = PerformanceResult(run_id="run-1", run_times=[1.0, 2.0], memory_usages=[10.0, 20.0])
     assert result.min_run_time <= result.p95_run_time <= result.max_run_time
     assert result.min_memory_usage <= result.p95_memory_usage <= result.max_memory_usage
 
 
 def test_identical_samples_p95_equals_value():
-    result = PerformanceResult(run_times=[5.0, 5.0, 5.0])
+    result = PerformanceResult(run_id="run-1", run_times=[5.0, 5.0, 5.0])
     assert result.p95_run_time == 5.0
 
 
 def test_empty_run_times_p95_is_zero():
-    result = PerformanceResult(run_times=[], memory_usages=[])
+    result = PerformanceResult(run_id="run-1", run_times=[], memory_usages=[])
     assert result.p95_run_time == 0
     assert result.p95_memory_usage == 0
+
+
+# ---------------------------------------------------------------------------
+# run_id is per execution: one run() call, one row, one id
+# ---------------------------------------------------------------------------
+
+
+def _perf_eval(db: InMemoryDb, telemetry: bool = False) -> PerformanceEval:
+    """Build a minimal PerformanceEval that logs to the given db."""
+    return PerformanceEval(
+        func=lambda: None,
+        db=db,
+        telemetry=telemetry,
+        warmup_runs=0,
+        num_iterations=1,
+        show_spinner=False,
+    )
+
+
+async def test_arun_logs_distinct_run_id_per_execution():
+    """Async path also stores a distinct run_id per execution."""
+
+    async def sample_func():
+        return None
+
+    db = InMemoryDb()
+    evaluation = PerformanceEval(
+        func=sample_func,
+        db=db,
+        telemetry=False,
+        warmup_runs=0,
+        num_iterations=1,
+        show_spinner=False,
+    )
+
+    first = await evaluation.arun()
+    second = await evaluation.arun()
+
+    runs = db.get_eval_runs()
+    assert len(runs) == 2
+    assert first.run_id != second.run_id
+    assert {run.run_id for run in runs} == {first.run_id, second.run_id}
+
+
+def test_positional_construction_binds_run_id_first():
+    """run_id is deliberately the first field, so a pre-3.0 positional
+    PerformanceResult(run_times, memory_usages) now binds run_times into run_id and shifts
+    the rest. Keyword construction is the documented form; this pins the order so it is
+    never reshuffled by accident."""
+    result = PerformanceResult("run-1", [1.0, 3.0], [10.0, 30.0])
+
+    assert result.run_id == "run-1"
+    assert result.run_times == [1.0, 3.0]
+    assert result.memory_usages == [10.0, 30.0]
+
+
+def test_rerun_stores_a_row_and_a_file_per_run(tmp_path):
+    """run_id is the evals table primary key and create_eval_run is a plain insert, so a reused
+    id made the second write raise and be swallowed. The file sink is keyed the same way, so one
+    rerun is enough to cover both. InMemoryDb has no uniqueness and cannot show the failure."""
+    db = SqliteDb(db_file=str(tmp_path / "evals.db"))
+    evaluation = PerformanceEval(
+        func=lambda: None,
+        db=db,
+        telemetry=False,
+        warmup_runs=0,
+        num_iterations=1,
+        show_spinner=False,
+        file_path_to_save_results=str(tmp_path / "{run_id}.json"),
+    )
+
+    first = evaluation.run()
+    second = evaluation.run()
+
+    assert {run.run_id for run in db.get_eval_runs()} == {first.run_id, second.run_id}
+    assert (tmp_path / f"{first.run_id}.json").exists()
+    assert (tmp_path / f"{second.run_id}.json").exists()

--- a/libs/agno/tests/unit/eval/test_reliability_eval.py
+++ b/libs/agno/tests/unit/eval/test_reliability_eval.py
@@ -11,6 +11,8 @@ from unittest.mock import patch
 
 import pytest
 
+from agno.db.in_memory import InMemoryDb
+from agno.db.sqlite import SqliteDb
 from agno.eval.reliability import ReliabilityEval
 from agno.models.message import Message
 from agno.models.response import ToolExecution
@@ -652,3 +654,50 @@ def test_still_paused_call_fails():
     # self-contradictory payload).
     assert any("delete_file" in entry for entry in result.missing_tool_calls)
     assert "delete_file" not in result.passed_tool_calls
+
+
+# ---------------------------------------------------------------------------
+# run_id is per execution: one run() call, one row, one id
+# ---------------------------------------------------------------------------
+
+
+async def test_arun_logs_distinct_run_id_per_execution():
+    """Async path also stores a distinct run_id per execution."""
+    db = InMemoryDb()
+    evaluation = ReliabilityEval(
+        agent_response=_make_response(_make_execution("multiply")),
+        expected_tool_calls=["multiply"],
+        db=db,
+        telemetry=False,
+        show_spinner=False,
+    )
+
+    first = await evaluation.arun(print_results=False)
+    second = await evaluation.arun(print_results=False)
+
+    runs = db.get_eval_runs()
+    assert len(runs) == 2
+    assert first.run_id != second.run_id
+    assert {run.run_id for run in runs} == {first.run_id, second.run_id}
+
+
+def test_rerun_stores_a_row_and_a_file_per_run(tmp_path):
+    """run_id is the evals table primary key and create_eval_run is a plain insert, so a reused
+    id made the second write raise and be swallowed. The file sink is keyed the same way, so one
+    rerun is enough to cover both. InMemoryDb has no uniqueness and cannot show the failure."""
+    db = SqliteDb(db_file=str(tmp_path / "evals.db"))
+    evaluation = ReliabilityEval(
+        agent_response=_make_response(_make_execution("multiply")),
+        expected_tool_calls=["multiply"],
+        db=db,
+        telemetry=False,
+        show_spinner=False,
+        file_path_to_save_results=str(tmp_path / "{run_id}.json"),
+    )
+
+    first = evaluation.run(print_results=False)
+    second = evaluation.run(print_results=False)
+
+    assert {run.run_id for run in db.get_eval_runs()} == {first.run_id, second.run_id}
+    assert (tmp_path / f"{first.run_id}.json").exists()
+    assert (tmp_path / f"{second.run_id}.json").exists()

--- a/libs/agno/tests/unit/os/routers/test_evals_router.py
+++ b/libs/agno/tests/unit/os/routers/test_evals_router.py
@@ -1,0 +1,128 @@
+"""Tests for the evals REST API router.
+
+The id returned by ``POST /eval-runs`` must be the id the run was persisted under: the
+per-execution ``run_id`` carried on the eval result.
+Everything downstream keys off that id: ``GET /eval-runs/{id}``, the owner stamp under
+user isolation, rename and delete.
+"""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+
+from agno.agent.agent import Agent
+from agno.db.in_memory import InMemoryDb
+from agno.models.response import ToolExecution
+from agno.os import AgentOS
+from agno.os.config import AuthorizationConfig
+from agno.run.agent import RunOutput
+
+JWT_SECRET = "test-secret-for-evals-router"
+TEST_OS_ID = "test-evals-router-os"
+
+
+def create_token(user_id: str, scopes: list[str] | None = None) -> str:
+    payload = {
+        "sub": user_id,
+        "aud": TEST_OS_ID,
+        "scopes": scopes or ["evals:read", "evals:write", "evals:delete"],
+        "exp": datetime.now(UTC) + timedelta(hours=1),
+        "iat": datetime.now(UTC),
+    }
+    return jwt.encode(payload, JWT_SECRET, algorithm="HS256")
+
+
+def auth_header(user_id: str) -> dict:
+    return {"Authorization": f"Bearer {create_token(user_id)}"}
+
+
+def _tool_run_output() -> RunOutput:
+    """A run that cleanly executed the expected tool, so the reliability eval needs no model."""
+    return RunOutput(
+        content="50",
+        tools=[ToolExecution(tool_call_id="call_multiply", tool_name="multiply", tool_args={"a": 10, "b": 5})],
+    )
+
+
+RELIABILITY_BODY = {
+    "eval_type": "reliability",
+    "agent_id": "assistant",
+    "input": "Use the calculator to multiply 10 by 5.",
+    "expected_tool_calls": ["multiply"],
+}
+
+
+@pytest.fixture
+def db():
+    return InMemoryDb()
+
+
+@pytest.fixture
+def client(db):
+    """Isolation-enabled client: the router stamps the caller as the run's owner."""
+    agent = Agent(id="assistant", name="Assistant", db=db)
+    agent_os = AgentOS(
+        id=TEST_OS_ID,
+        agents=[agent],
+        db=db,
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[JWT_SECRET],
+            algorithm="HS256",
+            user_isolation=True,
+        ),
+    )
+    return TestClient(agent_os.get_app())
+
+
+def _post_reliability_eval(client):
+    with patch.object(Agent, "arun", new=AsyncMock(return_value=_tool_run_output())):
+        return client.post("/eval-runs", json=RELIABILITY_BODY, headers=auth_header("alice"))
+
+
+def test_run_eval_returns_the_persisted_run_id(client, db):
+    """The id in the response is the row's run_id, so GET by that id works."""
+    resp = _post_reliability_eval(client)
+    assert resp.status_code == 200
+    run_id = resp.json()["id"]
+
+    rows, _ = db.get_eval_runs(deserialize=False)
+    assert [row["run_id"] for row in rows] == [run_id]
+
+    get = client.get(f"/eval-runs/{run_id}", headers=auth_header("alice"))
+    assert get.status_code == 200
+    assert get.json()["id"] == run_id
+
+
+def test_run_eval_stamps_the_caller_as_owner(client, db):
+    """The owner stamp targets the persisted id, so the run shows up in the caller's own list."""
+    resp = _post_reliability_eval(client)
+    run_id = resp.json()["id"]
+
+    rows, _ = db.get_eval_runs(deserialize=False)
+    assert rows[0]["user_id"] == "alice"
+    assert resp.json()["user_id"] == "alice"
+
+    listed = client.get("/eval-runs", headers=auth_header("alice")).json()["data"]
+    assert [row["id"] for row in listed] == [run_id]
+    # and it is not visible to another user
+    assert client.get("/eval-runs", headers=auth_header("bob")).json()["data"] == []
+
+
+def test_repeated_run_eval_calls_persist_distinct_runs(client, db):
+    """Two executions are two rows with two ids, each retrievable and renamable by its own id."""
+    first = _post_reliability_eval(client).json()["id"]
+    second = _post_reliability_eval(client).json()["id"]
+    assert first != second
+
+    rows, total = db.get_eval_runs(deserialize=False)
+    assert total == 2
+    assert {row["run_id"] for row in rows} == {first, second}
+
+    renamed = client.patch(f"/eval-runs/{second}", json={"name": "second run"}, headers=auth_header("alice"))
+    assert renamed.status_code == 200
+    assert renamed.json()["name"] == "second run"
+    assert client.get(f"/eval-runs/{first}", headers=auth_header("alice")).json()["name"] != "second run"

--- a/libs/agno/tests/unit/telemetry/test_eval_telemetry.py
+++ b/libs/agno/tests/unit/telemetry/test_eval_telemetry.py
@@ -18,12 +18,13 @@ def test_accuracy_evals_telemetry():
     # Mock the API call that gets made when telemetry is enabled
     with patch("agno.api.evals.create_eval_run_telemetry") as mock_create:
         agent.model = MagicMock()
-        accuracy_eval.run(print_summary=False, print_results=False)
+        result = accuracy_eval.run(print_summary=False, print_results=False)
 
         # Verify API was called with correct parameters
         mock_create.assert_called_once()
         call_args = mock_create.call_args[1]["eval_run"]
-        assert call_args.run_id == accuracy_eval.eval_id
+        # run_id is the per-execution id carried on the result.
+        assert call_args.run_id == result.run_id
         assert call_args.eval_type.value == "accuracy"
 
 
@@ -40,12 +41,13 @@ def test_performance_evals_telemetry():
 
     # Mock the API call that gets made when telemetry is enabled
     with patch("agno.api.evals.create_eval_run_telemetry") as mock_create:
-        performance_eval.run()
+        result = performance_eval.run()
 
         # Verify API was called with correct parameters
         mock_create.assert_called_once()
         call_args = mock_create.call_args[1]["eval_run"]
-        assert call_args.run_id == performance_eval.eval_id
+        # run_id is the per-execution id carried on the result.
+        assert call_args.run_id == result.run_id
         assert call_args.eval_type.value == "performance"
 
 
@@ -68,12 +70,13 @@ def test_reliability_evals_telemetry():
 
     # Mock the API call that gets made when telemetry is enabled
     with patch("agno.api.evals.create_eval_run_telemetry") as mock_create:
-        reliability_eval.run(print_results=False)
+        result = reliability_eval.run(print_results=False)
 
         # Verify API was called with correct parameters
         mock_create.assert_called_once()
         call_args = mock_create.call_args[1]["eval_run"]
-        assert call_args.run_id == reliability_eval.eval_id
+        # run_id is the per-execution id carried on the result.
+        assert call_args.run_id == result.run_id
         assert call_args.eval_type.value == "reliability"
 
 

--- a/libs/agno/tests/unit/tools/test_agentos.py
+++ b/libs/agno/tests/unit/tools/test_agentos.py
@@ -654,12 +654,12 @@ class TestGetEvalHistory:
 
         # Seed through the writer's own shape so this breaks if it changes again
         perf = PerformanceEval(func=lambda: None)
-        perf.result = PerformanceResult(run_times=[1.0, 3.0])
+        perf.result = PerformanceResult(run_id="eval-perf", run_times=[1.0, 3.0])
         db.create_eval_run(
             EvalRunRecord(
                 run_id="eval-perf",
                 eval_type=EvalType.PERFORMANCE,
-                eval_data=perf._parse_eval_run_data(),
+                eval_data=perf._parse_eval_run_data(perf.result),
                 agent_id="agent-1",
                 name="perf check",
             )


### PR DESCRIPTION
## Summary

`AccuracyEval`, `PerformanceEval` and `ReliabilityEval` minted a single `eval_id` when the eval
object was constructed, and used that one id as the primary key of every row the object ever
wrote. Running the same eval instance twice therefore wrote the second run under the first run's
key. `log_eval_run` catches and warns instead of raising, so the loss was never surfaced:

- SQL and Mongo backends raised a unique-constraint error, swallowed to a warning — the second run is lost
- Dynamo, Firestore and Redis overwrote the first row
- the in-memory and JSON backends stored two rows under one id, so `get_eval_run(id)` can only ever return one of them

`AgentAsJudgeEval` never had this problem — it has always minted a `run_id` per execution and
carried it on its result. This change brings the other three onto the same shape and deletes
`eval_id`.

Issue: #8657

### `libs/agno/agno/eval/accuracy.py`

- `AccuracyResult` gains a required first field `run_id: str`.
- `eval_id` deleted from `AccuracyEval`.
- All four run methods (`run`, `arun`, `run_with_output`, `arun_with_output`) mint their own
  `run_id`. `run()` and `arun()` had no per-run id at all; the other two already minted one and
  used it only in a debug log line.
- The run's aggregate moved from `self.result` to a local `result`, so overlapping runs no longer
  append into one shared object. `self.result` is still assigned, now immediately before the
  return, so it only ever exposes a completed run.
- The per-iteration variable renamed `result` -> `evaluation` to free the name.
- The agent-under-test's session id is now keyed by `run_id` (`eval_{run_id}_{i+1}`), so a rerun
  does not reuse the previous run's sessions.
- `arun_with_output` gains the `else` branch its sync twin already had (previously
  `UnboundLocalError` when a db was set with no agent or team) and the telemetry call the other
  three methods already made.

### `libs/agno/agno/eval/performance.py`

- `PerformanceResult` gains a required first field `run_id: str`; `eval_id` deleted.
- `_parse_eval_run_data(self)` becomes `_parse_eval_run_data(self, result)` and reads the passed
  result instead of `self.result`, so the row's body and the row's key come from the same object.
- `run`/`arun` build a local result, key the file, DB and telemetry sinks on `run_id`, and return it.

### `libs/agno/agno/eval/reliability.py`

- `ReliabilityResult` gains a required first field `run_id: str`; `eval_id` deleted.
- `_evaluate(self)` becomes `_evaluate(self, run_id)` and stamps the id onto the result it builds.
- `run`/`arun` key the file, DB and telemetry sinks on `run_id` and return a local result.

### `libs/agno/agno/eval/agent_as_judge.py`

- Four `store_result_in_file(..., eval_id=run_id, ...)` calls become `run_id=run_id`. The value was
  already correct; only the parameter name was wrong.

### `libs/agno/agno/eval/utils.py`

- `store_result_in_file`'s `eval_id` parameter renamed to `run_id`.
- `{eval_id}` is no longer accepted in `file_path_to_save_results` templates; `{run_id}` replaces it.
- Docstring now states the accepted placeholders.

### `libs/agno/agno/os/routers/evals/schemas.py`

- `from_accuracy_eval`, `from_performance_eval` and `from_reliability_eval` return
  `id=result.run_id` instead of the eval object's `eval_id`, so the id returned by
  `POST /eval-runs` is the id the row was stored under. `from_agent_as_judge_eval` already did this.

### Cookbooks

- `05_agent_os/24_showcase/demo.py` — reads its row back by `result.run_id`.
- `05_agent_os/03_python_client/05_evals.py` — loop variable renamed `eval_id` -> `run_id`.
- `performance/memory_footprint.py`, `performance/import_time.py`,
  `performance/comparison/import_time_comparison.py` — these build a `PerformanceResult` directly
  to use its statistics, and now pass `run_id=name`. The metric name is deliberate: it keeps saved
  baselines diffable rather than changing on every regeneration.
- `09_evals/agent_as_judge/` (6 files, 7 sites) — `eval_runs[-1]` -> `eval_runs[0]`.
  `get_eval_runs()` orders `created_at` descending, so `[-1]` printed the oldest stored run rather
  than the one just written. The five sites that print it now label it `Run ID:`.
- `TEST_LOG.md` updated for `05_agent_os/24_showcase`, `performance` and `09_evals`.

### Tests

The same two tests exist for all four eval types:

- `test_rerun_stores_a_row_and_a_file_per_run` — two runs of one instance on `SqliteDb` produce
  two rows under two ids and two result files. `SqliteDb` rather than `InMemoryDb` because only a
  primary-key backend can exhibit the original failure.
- `test_arun_logs_distinct_run_id_per_execution` — the async twin.

Behaviour that only one eval type has is tested only there:

- accuracy — a fresh agent session per run, a team subject, concurrent runs returning their own
  results rather than one merged object, and `self.result` staying unset while a run is in flight
  and after a run raises part-way.
- performance — `test_positional_construction_binds_run_id_first` pins the new field order.

Cross-cutting:

- `test_evals_router.py` (new) — the id returned by `POST /eval-runs` is the persisted `run_id`,
  `GET` by it succeeds, the caller is stamped as owner and another user cannot see the row, and two
  posts produce two independently addressable runs.
- `test_eval_utils.py` — `{run_id}` resolves; the removed `{eval_id}` writes no file.
- `test_eval_telemetry.py`, `test_agentos.py` — updated for the new result field and the
  `_parse_eval_run_data` signature.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

### Breaking changes

Three of these stop execution; two do not and are called out.

1. `AccuracyEval`, `PerformanceEval`, `ReliabilityEval` no longer accept or expose `eval_id` —
   `TypeError` on construction, `AttributeError` on access. Replacement is `result.run_id`, the id
   the row was stored under. No alias is provided: `eval_id` was an instance identity and there is
   no per-execution id at instance level to alias to, so an alias would return an id matching no row.
2. `AccuracyResult`, `PerformanceResult` and `ReliabilityResult` gained a required first field
   `run_id`, matching `AgentAsJudgeResult`. `ReliabilityResult` fails loudly. **`AccuracyResult` and
   `PerformanceResult` constructed positionally rebind silently** — `PerformanceResult(run_times,
   memory_usages)` now binds `run_times` into `run_id`, producing plausible but wrong statistics with
   no error. Keyword construction, the form used in the library and in every cookbook, is unaffected;
   the order is pinned by `test_positional_construction_binds_run_id_first`.
3. `store_result_in_file(..., eval_id=...)` renamed to `run_id=` — `TypeError`.
4. `{eval_id}` in `file_path_to_save_results` is removed in favour of `{run_id}`. **This one warns
   and continues rather than raising:** the `KeyError` is caught inside `store_result_in_file`, so
   the process exits 0 and only the result file stops appearing. The log line to grep for is
   `Failed to save result to file: 'eval_id'`.

### Related, not included

- `agno-docs` still lists `eval_id` as a constructor parameter in `reference/evals/accuracy.mdx`,
  `performance.mdx` and `reliability.mdx`, and no `*Result` field table lists `run_id`.
- `POST /eval-runs` and `GET /eval-runs/{id}` return different `eval_data` shapes for performance
  evals (`asdict(result)` versus the stored `{result, runs}`). Pre-existing and unchanged here.
