### PR TITLE
[fix] compare the AgentOS security key in constant time

### DIFF
--- a/libs/agno/agno/os/auth.py
+++ b/libs/agno/agno/os/auth.py
@@ -43,6 +43,18 @@ INTERNAL_SERVICE_SCOPES: List[str] = [
 ]
 
 
+def _secret_matches(provided: str, expected: str) -> bool:
+    """Compare a bearer token against a configured secret in constant time.
+
+    A plain ``==`` short-circuits on the first differing byte, which lets a caller
+    recover the security key one character at a time from response timing. The values
+    are encoded first because ``hmac.compare_digest`` rejects non-ASCII ``str``
+    input: header values are latin-1 decoded by the ASGI server and the key comes from
+    the environment, so either side can carry non-ASCII characters.
+    """
+    return hmac.compare_digest(provided.encode("utf-8", "surrogateescape"), expected.encode("utf-8", "surrogateescape"))
+
+
 def get_auth_token_from_request(request: Request) -> Optional[str]:
     """
     Extract the JWT/Bearer token from the Authorization header.
@@ -253,7 +265,7 @@ def get_authentication_dependency(settings: AgnoAPISettings):
             return True
 
         # Verify the token against security key
-        if token != settings.os_security_key:
+        if not _secret_matches(token, settings.os_security_key):
             raise HTTPException(status_code=401, detail="Invalid authentication token")
 
         # A valid security key is a trusted, unscoped root. Mark it authenticated like the
@@ -293,7 +305,7 @@ def validate_websocket_token(token: str, settings: AgnoAPISettings) -> bool:
         return True
 
     # Verify the token matches the configured security key
-    return token == settings.os_security_key
+    return _secret_matches(token, settings.os_security_key)
 
 
 async def verify_websocket_service_account(

--- a/libs/agno/tests/unit/os/test_security_key_constant_time.py
+++ b/libs/agno/tests/unit/os/test_security_key_constant_time.py
@@ -1,0 +1,98 @@
+"""The AgentOS security key must be compared in constant time.
+
+``JWTMiddleware`` already compares ``OS_SECURITY_KEY`` with ``hmac.compare_digest``
+(see ``agno/os/middleware/jwt.py``). These tests pin the REST dependency and the
+WebSocket validator to the same behaviour, so a byte-by-byte ``==`` cannot leak the
+key one character at a time through response timing.
+"""
+
+import hmac
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+
+from agno.os import auth as auth_module
+from agno.os.auth import get_authentication_dependency, validate_websocket_token
+from agno.os.settings import AgnoAPISettings
+
+OS_KEY = "test-os-security-key"
+
+
+@pytest.fixture(autouse=True)
+def no_jwt_env(monkeypatch):
+    """Keep the security-key branch reachable regardless of the ambient environment."""
+    monkeypatch.delenv("JWT_VERIFICATION_KEY", raising=False)
+    monkeypatch.delenv("JWT_JWKS_FILE", raising=False)
+
+
+@pytest.fixture
+def compare_digest_calls(monkeypatch):
+    """Record every ``hmac.compare_digest`` call made while authenticating."""
+    calls = []
+    real_compare_digest = hmac.compare_digest
+
+    def recording_compare_digest(a, b):
+        calls.append((a, b))
+        return real_compare_digest(a, b)
+
+    monkeypatch.setattr(auth_module.hmac, "compare_digest", recording_compare_digest)
+    return calls
+
+
+def _as_bytes(value):
+    return value if isinstance(value, bytes) else value.encode("utf-8", "surrogateescape")
+
+
+def _compared_in_constant_time(calls, token: str, key: str) -> bool:
+    return (_as_bytes(token), _as_bytes(key)) in {(_as_bytes(a), _as_bytes(b)) for a, b in calls}
+
+
+def _request():
+    """Minimal stand-in for a Starlette request with no internal service token set."""
+    return SimpleNamespace(
+        state=SimpleNamespace(),
+        app=SimpleNamespace(state=SimpleNamespace(internal_service_token=None)),
+    )
+
+
+async def test_rest_dependency_compares_security_key_in_constant_time(compare_digest_calls):
+    auth_dependency = get_authentication_dependency(AgnoAPISettings(os_security_key=OS_KEY))
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="wrong-token")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await auth_dependency(_request(), credentials)
+
+    assert exc_info.value.status_code == 401
+    assert _compared_in_constant_time(compare_digest_calls, "wrong-token", OS_KEY)
+
+
+async def test_rest_dependency_still_accepts_the_security_key(compare_digest_calls):
+    auth_dependency = get_authentication_dependency(AgnoAPISettings(os_security_key=OS_KEY))
+    request = _request()
+
+    assert await auth_dependency(request, HTTPAuthorizationCredentials(scheme="Bearer", credentials=OS_KEY)) is True
+    assert request.state.authenticated is True
+    assert _compared_in_constant_time(compare_digest_calls, OS_KEY, OS_KEY)
+
+
+def test_websocket_validator_compares_security_key_in_constant_time(compare_digest_calls):
+    settings = AgnoAPISettings(os_security_key=OS_KEY)
+
+    assert validate_websocket_token("wrong-token", settings) is False
+    assert validate_websocket_token(OS_KEY, settings) is True
+    assert _compared_in_constant_time(compare_digest_calls, "wrong-token", OS_KEY)
+    assert _compared_in_constant_time(compare_digest_calls, OS_KEY, OS_KEY)
+
+
+def test_non_ascii_security_key_still_validates():
+    """``hmac.compare_digest`` rejects non-ASCII ``str``; the key must be encoded first.
+
+    Header values are latin-1 decoded by the ASGI server and the key comes from the
+    environment, so either side can carry non-ASCII characters.
+    """
+    settings = AgnoAPISettings(os_security_key="clé-de-sécurité")
+
+    assert validate_websocket_token("wrong-token", settings) is False
+    assert validate_websocket_token("clé-de-sécurité", settings) is True


### PR DESCRIPTION
## Summary

Closes #9741

`get_authentication_dependency` and `validate_websocket_token` in `libs/agno/agno/os/auth.py` compared the incoming bearer token against `OS_SECURITY_KEY` with `!=` / `==`. CPython short-circuits string comparison on the first differing byte, so the time an AgentOS instance takes to reject a bad token leaks how many leading characters were correct. An unauthenticated caller can walk the key one character at a time over the REST API or the WebSocket handshake — no privileged access required, the token comes straight off the wire.

This is already handled correctly everywhere else in the codebase, which is what makes these two lines stand out:

- `JWTMiddleware` compares the *same* `security_key` with `hmac.compare_digest` (`agno/os/middleware/jwt.py`), in a branch whose comment says it mirrors the REST dependency.
- The internal service token is compared with `hmac.compare_digest` seven lines above the affected check, in the same function.
- The Slack, Telegram and WhatsApp webhook validators and `mcp_auth_builtin` all use `hmac.compare_digest`.

Both call sites now go through a small `_secret_matches` helper built on `hmac.compare_digest`. Both sides are encoded to bytes first: `compare_digest` raises `TypeError` on non-ASCII `str`, and neither side is guaranteed ASCII (header values are latin-1 decoded by the ASGI server, and the key comes from the environment), so encoding keeps the check total instead of turning a bad request into a 500.

Behaviour is otherwise unchanged: a valid key is still accepted and still sets `request.state.authenticated`, an invalid one still gets `401 Invalid authentication token`, and the open / JWT / service-account branches are untouched.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`ruff format --check` and `mypy agno/os/auth.py` clean; full `./scripts/validate.sh` not run — it requires optional extras not installed in this environment)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Tests.** New `libs/agno/tests/unit/os/test_security_key_constant_time.py`. It records every `hmac.compare_digest` call made during authentication and asserts the security key is compared through it, in both the REST dependency and the WebSocket validator, alongside the accept/reject behaviour and a non-ASCII key regression guard. The three constant-time assertions fail on `main` and pass with this change:

```
# before: 3 failed, 1 passed
# after:  4 passed
```

`tests/unit/os` was run with and without the patch (1367 passed); the set of pre-existing failures (missing optional extras such as `fastmcp`, `a2a-sdk`) is identical either way.

**AI assistance disclosure.** Per `CONTRIBUTING.md`, disclosing this: the change was developed with AI assistance (Claude Code). I have reviewed and understand the diff, verified the vulnerable behaviour and the fix locally, and the PR includes the tests required by the contribution guidelines.

**Related, not included.** `agno/os/interfaces/whatsapp/router.py` compares `token == config.verify_token` in the webhook verification with the same pattern. Left out to keep this change minimal; happy to send it as a follow-up.
