### PR TITLE
fix: compare the WhatsApp webhook verify token in constant time

### DIFF
--- a/libs/agno/agno/os/interfaces/whatsapp/router.py
+++ b/libs/agno/agno/os/interfaces/whatsapp/router.py
@@ -20,7 +20,7 @@ from agno.os.interfaces.whatsapp.helpers import (
     typing_indicator_async,
     upload_and_send_media_async,
 )
-from agno.os.interfaces.whatsapp.security import validate_webhook_signature
+from agno.os.interfaces.whatsapp.security import validate_webhook_signature, verify_token_matches
 from agno.session.agent import AgentSession
 from agno.session.team import TeamSession
 from agno.session.workflow import WorkflowSession
@@ -171,7 +171,7 @@ def attach_routes(
         if not config.verify_token:
             raise HTTPException(status_code=500, detail="WHATSAPP_VERIFY_TOKEN is not set")
 
-        if mode == "subscribe" and token == config.verify_token:
+        if mode == "subscribe" and verify_token_matches(token, config.verify_token):
             if not challenge:
                 raise HTTPException(status_code=400, detail="No challenge received")
             return PlainTextResponse(content=challenge)

--- a/libs/agno/agno/os/interfaces/whatsapp/security.py
+++ b/libs/agno/agno/os/interfaces/whatsapp/security.py
@@ -31,3 +31,20 @@ def validate_webhook_signature(payload: bytes, signature_header: Optional[str]) 
 
     # Constant-time comparison prevents timing side-channels
     return hmac.compare_digest(calculated_signature, expected_signature)
+
+
+def verify_token_matches(provided_token: Optional[str], expected_token: str) -> bool:
+    """Compare the webhook verification token against the configured one in constant time.
+
+    ``hub.verify_token`` is supplied by the caller on an unauthenticated endpoint, so a
+    plain ``==`` short-circuits on the first differing byte and lets the token be
+    recovered one character at a time from response timing. The values are encoded first
+    because ``hmac.compare_digest`` rejects non-ASCII ``str`` input: query params are
+    caller-controlled text and the expected token comes from the environment, so either
+    side can carry non-ASCII characters.
+    """
+    if not provided_token:
+        return False
+    return hmac.compare_digest(
+        provided_token.encode("utf-8", "surrogateescape"), expected_token.encode("utf-8", "surrogateescape")
+    )

--- a/libs/agno/tests/unit/os/interfaces/test_whatsapp_security.py
+++ b/libs/agno/tests/unit/os/interfaces/test_whatsapp_security.py
@@ -106,3 +106,20 @@ def test_app_env_development_does_not_bypass():
     with patch.dict("os.environ", {"WHATSAPP_APP_SECRET": APP_SECRET, "APP_ENV": "development"}):
         assert validate_webhook_signature(payload, None) is False
         assert validate_webhook_signature(payload, "sha256=invalid") is False
+
+
+def test_verify_token_matches_is_constant_time():
+    from agno.os.interfaces.whatsapp.security import verify_token_matches
+
+    with patch("hmac.compare_digest", wraps=hmac.compare_digest) as spy:
+        assert verify_token_matches("s3cret", "s3cret") is True
+        assert spy.called
+
+    assert verify_token_matches("s3crev", "s3cret") is False
+    assert verify_token_matches("s3cret-longer", "s3cret") is False
+    # Missing or empty tokens never verify
+    assert verify_token_matches(None, "s3cret") is False
+    assert verify_token_matches("", "s3cret") is False
+    # Non-ASCII values must not blow up (compare_digest rejects non-ASCII str)
+    assert verify_token_matches("tökén", "tökén") is True
+    assert verify_token_matches("tökén", "s3cret") is False

--- a/libs/agno/tests/unit/os/routers/test_whatsapp_router.py
+++ b/libs/agno/tests/unit/os/routers/test_whatsapp_router.py
@@ -1096,3 +1096,66 @@ async def test_media_download_success_no_skip_notice():
         message_text = agent_mock.arun.call_args[0][0]
         # No skip notice — clean caption only
         assert message_text == "Nice photo"
+
+
+# === Webhook Verification: constant-time token comparison ===
+
+
+def _as_bytes(value) -> bytes:
+    return value if isinstance(value, bytes) else str(value).encode("utf-8", "surrogateescape")
+
+
+def test_webhook_verification_compares_token_in_constant_time():
+    """The verify token must be checked with ``hmac.compare_digest``, not ``==``.
+
+    ``GET /webhook`` is unauthenticated (the WhatsApp interface is excluded from the
+    AgentOS auth layer) and ``hub.verify_token`` is a caller-controlled query param, so a
+    short-circuiting comparison leaks the configured token one byte at a time.
+    """
+    import hmac as hmac_module
+
+    agent_mock = _make_agent_mock()
+    real_compare_digest = hmac_module.compare_digest
+    compared: list = []
+
+    def _spy(a, b):
+        compared.append((_as_bytes(a), _as_bytes(b)))
+        return real_compare_digest(a, b)
+
+    with (
+        patch("agno.os.interfaces.whatsapp.router.validate_webhook_signature", return_value=True),
+        patch.dict("os.environ", WHATSAPP_ENV),
+        patch("hmac.compare_digest", _spy),
+    ):
+        app = _build_app(agent_mock)
+        client = TestClient(app)
+
+        accepted = client.get(
+            "/webhook",
+            params={
+                "hub.mode": "subscribe",
+                "hub.verify_token": "test-verify-token",
+                "hub.challenge": "challenge_123",
+            },
+        )
+        rejected = client.get(
+            "/webhook",
+            params={
+                "hub.mode": "subscribe",
+                "hub.verify_token": "test-verify-tokeM",
+                "hub.challenge": "challenge_123",
+            },
+        )
+
+    # Behaviour is unchanged: the right token still verifies, a wrong one still 403s
+    assert accepted.status_code == 200
+    assert accepted.text == "challenge_123"
+    assert rejected.status_code == 403
+
+    expected = b"test-verify-token"
+    assert any(expected in pair for pair in compared), (
+        "the configured verify token never reached hmac.compare_digest — it is being compared in non-constant time"
+    )
+    assert any(b"test-verify-tokeM" in pair for pair in compared), (
+        "the rejected verify token never reached hmac.compare_digest"
+    )


### PR DESCRIPTION
## Summary

Closes #9742

`GET /whatsapp/webhook` (Meta's webhook verification handshake) compared the caller-supplied `hub.verify_token` against the configured token with `==`:

```python
if mode == "subscribe" and token == config.verify_token:
```

The WhatsApp interface sets `authenticates_own_requests = True`, so `AgentOS` deliberately excludes `/whatsapp/*` from the central auth layer (see `AgentOS._..._excluded_route_paths`). For the verification endpoint the verify token therefore *is* the whole authentication: the request is anonymous, unauthenticated and its query string is fully attacker-controlled. Python's `==` on `str` short-circuits at the first differing byte, so an attacker can recover the token one character at a time from response timing and then complete Meta's handshake against the deployment.

This PR routes that check through a new `verify_token_matches` helper placed next to the existing `validate_webhook_signature` in `agno/os/interfaces/whatsapp/security.py`. The helper wraps `hmac.compare_digest` and encodes both sides first, because `compare_digest` raises on non-ASCII `str` input and both the query param (caller-controlled text) and the expected token (read from `WHATSAPP_VERIFY_TOKEN`) can carry non-ASCII characters — the same reason and the same `encode("utf-8", "surrogateescape")` shape used elsewhere in the codebase.

Behaviour is unchanged: a matching token still returns the challenge (200), a wrong token still 403s, an absent token never verifies, and the missing-config and missing-challenge branches are untouched.

This was the last non-constant-time secret comparison under `agno/os/interfaces/`. The sibling paths already do the right thing — `slack/security.py:37`, `telegram/security.py:28` and the signature check in `whatsapp/security.py:33` all use `hmac.compare_digest`; only the WhatsApp verify-token path was left behind.

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable) — not applicable, no public API or usage change
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**AI assistance disclosure.** Per `CONTRIBUTING.md`: this change was produced with AI assistance (Claude Code). The vulnerable comparison was found by a manual review of secret-comparison sites in `agno/os/`, the fix and tests were drafted with the assistant, and every step (reachability analysis, red/green test runs, full local suite) was verified by a human before opening this PR.

**Related PR, not a duplicate.** I have an open PR, #9740 ("[fix] compare the AgentOS security key in constant time"), which fixes the same class of bug in `agno/os/auth.py` (the REST dependency and `validate_websocket_token`). That PR was kept deliberately minimal and scoped to the auth module. This one is a different file, a different endpoint and a different threat model (an unauthenticated public webhook vs. the bearer-token auth layer), and it is branched from `main` rather than from #9740, so the two can be reviewed and merged in either order with no dependency between them. No other open or closed PR touches this comparison.

**Tests.** Two tests, both failing before the change and passing after:

- `tests/unit/os/routers/test_whatsapp_router.py::test_webhook_verification_compares_token_in_constant_time` — end-to-end through `TestClient`: spies on `hmac.compare_digest` and asserts the verify token actually flows through it, plus behavioural asserts (correct token → 200 + challenge echoed, wrong token differing only in its final byte → 403). This is the test that fails on `main` with "the configured verify token never reached hmac.compare_digest".
- `tests/unit/os/interfaces/test_whatsapp_security.py::test_verify_token_matches_is_constant_time` — unit coverage of the helper: match, mismatch, length mismatch, `None`/empty, and non-ASCII values on both sides (which is what `.encode(...)` guards against).

**Security note.** Timing side-channels over a network are noisy, but this one is unusually favourable to an attacker: the endpoint is unauthenticated, idempotent, cheap, unrate-limited, and returns a stable 403 on failure, so an attacker can average over as many requests as they like. `hmac.compare_digest` costs nothing here.
