### PR TITLE
fix: answer 422 with the validator's message when request validation fails

### DIFF
--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Literal, Optional, 
 from uuid import uuid4
 
 from fastapi import APIRouter, FastAPI, HTTPException
+from fastapi.exception_handlers import request_validation_exception_handler
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from fastapi.routing import APIRoute
@@ -1422,12 +1423,14 @@ class AgentOS:
         if not self._app_set:
 
             @fastapi_app.exception_handler(RequestValidationError)
-            async def validation_exception_handler(_: Request, exc: RequestValidationError) -> JSONResponse:
+            async def validation_exception_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
                 log_error(f"Validation error (422): {exc.errors()}")
-                return JSONResponse(
-                    status_code=422,
-                    content={"detail": exc.errors()},
-                )
+                # Delegate the body to FastAPI's own handler: pydantic v2 puts the live
+                # exception object in ``ctx["error"]`` for any validator that raised
+                # ValueError, so the errors list must be run through ``jsonable_encoder``
+                # before it can be a JSON body. Building it here by hand is what made every
+                # custom validator answer 500 instead of 422.
+                return await request_validation_exception_handler(request, exc)
 
             @fastapi_app.exception_handler(HTTPException)
             async def http_exception_handler(_, exc: HTTPException) -> JSONResponse:

--- a/libs/agno/tests/unit/os/routers/test_schedules_router.py
+++ b/libs/agno/tests/unit/os/routers/test_schedules_router.py
@@ -1,4 +1,9 @@
-"""Tests for the schedule REST API router."""
+"""Tests for the schedule REST API router.
+
+The ``client`` fixture mounts the router on a bare ``FastAPI()``, so these tests
+exercise FastAPI's default exception handlers, not agno's. The owned-app contract
+(AgentOS's own handlers) is pinned in ``tests/unit/os/test_validation_error_body.py``.
+"""
 
 import time
 from unittest.mock import MagicMock, patch
@@ -228,6 +233,13 @@ class TestUpdateSchedule:
         assert resp.status_code == 200
         mock_db.update_schedule.assert_not_called()
 
+    def test_update_invalid_endpoint_full_url(self, client, mock_db):
+        # ScheduleUpdate has its own copy of the full-URL branch; cover it like the
+        # create-side one. The value starts with "/" and contains "://".
+        resp = client.patch("/schedules/sched-1", json={"endpoint": "/proxy?u=http://example.com"})
+        assert resp.status_code == 422
+        assert "Endpoint must be a path, not a full URL" in resp.text
+
 
 # =============================================================================
 # Tests: DELETE /schedules/{schedule_id}
@@ -423,15 +435,18 @@ class TestScheduleCreateValidation:
         assert resp.status_code == 422
 
     def test_invalid_endpoint_full_url(self, client, mock_db):
+        # Starts with "/" and contains "://" so it reaches the full-URL branch;
+        # a bare "http://..." trips the leading-slash check first.
         resp = client.post(
             "/schedules",
             json={
                 "name": "test",
                 "cron_expr": "0 9 * * *",
-                "endpoint": "http://example.com/test",
+                "endpoint": "/proxy?u=http://example.com",
             },
         )
         assert resp.status_code == 422
+        assert "Endpoint must be a path, not a full URL" in resp.text
 
     def test_invalid_method(self, client, mock_db):
         resp = client.post(

--- a/libs/agno/tests/unit/os/routers/test_service_accounts_router.py
+++ b/libs/agno/tests/unit/os/routers/test_service_accounts_router.py
@@ -1,4 +1,9 @@
-"""Tests for the service accounts REST API router."""
+"""Tests for the service accounts REST API router.
+
+``_authenticated_app`` builds a bare ``FastAPI()``, so these tests exercise
+FastAPI's default exception handlers, not agno's. The owned-app contract
+(AgentOS's own handlers) is pinned in ``tests/unit/os/test_validation_error_body.py``.
+"""
 
 import time
 from unittest.mock import MagicMock

--- a/libs/agno/tests/unit/os/test_validation_error_body.py
+++ b/libs/agno/tests/unit/os/test_validation_error_body.py
@@ -103,6 +103,40 @@ class TestNonValidatorPathsUnchanged:
         assert "secret" not in resp.text, "the 500 body must not echo the exception message"
 
 
+class TestValidatorInDependencyOwnedModel:
+    """The handler must also cover body models agno does not author: interface
+    routes validate request models from dependencies (here ag_ui's RunAgentInput),
+    whose validators can change underneath agno without any agno diff."""
+
+    def test_agui_dependency_validator_is_422_with_message(self, tmp_path):
+        pytest.importorskip("ag_ui", reason="ag_ui not installed")
+        from agno.os.interfaces.agui import AGUI
+
+        db = SqliteDb(db_file=str(tmp_path / "agui.db"))
+        agent = Agent(id="qa-agent", name="QA Agent", db=db)
+        agent_os = AgentOS(agents=[agent], db=db, telemetry=False, interfaces=[AGUI(agent=agent)])
+        client = TestClient(agent_os.get_app(), raise_server_exceptions=False)
+        # A binary content item with no id, url, or data trips BinaryInputContent's
+        # model_validator inside the ag_ui dependency.
+        bad_content = [{"type": "binary", "mimeType": "application/octet-stream"}]
+        resp = client.post(
+            "/agui",
+            json={
+                "threadId": "t1",
+                "runId": "r1",
+                "state": {},
+                "messages": [{"id": "m1", "role": "user", "content": bad_content}],
+                "tools": [],
+                "context": [],
+                "forwardedProps": {},
+            },
+        )
+        assert resp.status_code == 422, f"expected 422, got {resp.status_code}: {resp.text[:200]}"
+        assert "BinaryInputContent requires id, url, or data" in resp.text, (
+            f"message missing from body: {resp.text[:300]}"
+        )
+
+
 class TestOwnedAndBorrowedAppsAgree:
     """The invariant that would have caught this at review time: the owned app
     must answer exactly what a caller-supplied base_app answers."""

--- a/libs/agno/tests/unit/os/test_validation_error_body.py
+++ b/libs/agno/tests/unit/os/test_validation_error_body.py
@@ -1,0 +1,119 @@
+"""A validator's ValueError is a 422 that names the field, not a 500.
+
+AgentOS installs its own RequestValidationError handler on an app it owns and built
+the body from the raw ``exc.errors()``. Pydantic v2 puts the live exception object in
+``ctx["error"]`` for every validator that raised ValueError, so ``json.dumps`` failed
+inside the handler and the catch-all answered 500 "Internal server error (TypeError)" —
+silencing every custom validator on the platform. The router tests missed it because
+they mount routers on a bare FastAPI(), which uses FastAPI's correct default handler.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.os import AgentOS
+
+# Starts with "/" and contains "://": reaches validate_endpoint's full-URL branch.
+# A bare "http://..." would trip the earlier "must start with '/'" check instead.
+BAD_SCHEDULE = {"name": "x", "cron_expr": "0 3 * * *", "endpoint": "/proxy?u=http://evil.example.com"}
+
+
+def _os_client(tmp_path, name, base_app=None):
+    db = SqliteDb(db_file=str(tmp_path / f"{name}.db"))
+    agent = Agent(id="qa-agent", name="QA Agent", db=db)
+    kwargs = {"agents": [agent], "db": db, "telemetry": False}
+    if base_app is not None:
+        kwargs["base_app"] = base_app
+    # raise_server_exceptions=False or the handler's own TypeError is re-raised
+    # out of ServerErrorMiddleware and no response is ever asserted on.
+    return TestClient(AgentOS(**kwargs).get_app(), raise_server_exceptions=False)
+
+
+@pytest.fixture()
+def harness(tmp_path):
+    return SimpleNamespace(client=_os_client(tmp_path, "owned"))
+
+
+class TestValidatorErrorsAnswer422:
+    """Each of these FAILS on the unpatched handler and passes after the fix."""
+
+    def test_field_validator_value_error_is_422_with_message(self, harness):
+        resp = harness.client.post("/schedules", json=BAD_SCHEDULE)
+        assert resp.status_code == 422, f"expected 422, got {resp.status_code}: {resp.text[:200]}"
+        assert "Endpoint must be a path, not a full URL" in resp.text, f"message missing from body: {resp.text[:200]}"
+        assert resp.json()["detail"][0]["loc"] == ["body", "endpoint"]
+
+    def test_model_validator_value_error_is_422_with_message(self, harness):
+        resp = harness.client.patch("/schedules/does-not-exist", json={"method": None})
+        assert resp.status_code == 422, f"expected 422, got {resp.status_code}: {resp.text[:200]}"
+        assert "cannot be set to null" in resp.text, f"message missing from body: {resp.text[:200]}"
+
+    def test_service_account_validator_is_422_with_message(self, harness):
+        resp = harness.client.post("/service-accounts", json={"name": "BAD NAME!!"})
+        assert resp.status_code == 422, f"expected 422, got {resp.status_code}: {resp.text[:200]}"
+        assert "lowercase slug" in resp.text, f"message missing from body: {resp.text[:200]}"
+
+    def test_component_guard_validator_is_422_with_message(self, harness):
+        resp = harness.client.patch("/components/does-not-exist", json={"guard": {"current_version": True}})
+        assert resp.status_code == 422, f"expected 422, got {resp.status_code}: {resp.text[:200]}"
+        assert "version guards must be integers" in resp.text, f"message missing from body: {resp.text[:200]}"
+        assert resp.json()["detail"][0]["loc"] == ["body", "guard", "current_version"]
+
+    def test_error_body_is_json_and_has_no_exception_repr(self, harness):
+        resp = harness.client.post("/schedules", json=BAD_SCHEDULE)
+        body = resp.json()
+        assert isinstance(body["detail"], list), f"detail must be a list, got: {resp.text[:200]}"
+        for entry in body["detail"]:
+            assert "type" in entry and "loc" in entry and "msg" in entry, f"malformed entry: {entry}"
+        assert "ValueError(" not in resp.text, "the encoded body must not leak a Python repr"
+
+
+class TestNonValidatorPathsUnchanged:
+    """These PASS today and must keep passing (regression guard for the fix itself)."""
+
+    def test_builtin_coercion_error_still_422(self, harness):
+        resp = harness.client.get("/sessions?limit=abc")
+        assert resp.status_code == 422, f"expected 422, got {resp.status_code}: {resp.text[:200]}"
+        assert resp.json()["detail"][0]["type"] == "int_parsing"
+
+    def test_missing_required_field_still_422(self, harness):
+        resp = harness.client.post("/schedules", json={"name": "x"})
+        assert resp.status_code == 422, f"expected 422, got {resp.status_code}: {resp.text[:200]}"
+        assert any(entry["type"] == "missing" for entry in resp.json()["detail"])
+
+    def test_internal_error_still_500_without_echo(self, harness, monkeypatch):
+        """A downstream ValueError is a SERVER failure. The fix must not turn
+        every ValueError into a client error: only the ones pydantic wrapped
+        into a RequestValidationError change status."""
+
+        async def broken_arun(self, **kwargs):
+            raise ValueError("db not initialized at postgresql://ai:secret@db.internal/ai")
+
+        monkeypatch.setattr(Agent, "arun", broken_arun)
+        resp = harness.client.post(
+            "/agents/qa-agent/runs",
+            data={"message": "hello", "stream": "false", "background": "false"},
+        )
+        assert resp.status_code == 500, f"expected 500, got {resp.status_code}: {resp.text[:200]}"
+        assert "secret" not in resp.text, "the 500 body must not echo the exception message"
+
+
+class TestOwnedAndBorrowedAppsAgree:
+    """The invariant that would have caught this at review time: the owned app
+    must answer exactly what a caller-supplied base_app answers."""
+
+    def test_owned_app_matches_default_fastapi_handler(self, tmp_path):
+        owned = _os_client(tmp_path, "owned")
+        borrowed = _os_client(tmp_path, "borrowed", base_app=FastAPI())
+        owned_resp = owned.post("/schedules", json=BAD_SCHEDULE)
+        borrowed_resp = borrowed.post("/schedules", json=BAD_SCHEDULE)
+        assert owned_resp.status_code == borrowed_resp.status_code == 422, (
+            f"owned {owned_resp.status_code} vs borrowed {borrowed_resp.status_code}: "
+            f"{owned_resp.text[:200]} | {borrowed_resp.text[:200]}"
+        )
+        assert owned_resp.json()["detail"] == borrowed_resp.json()["detail"]


### PR DESCRIPTION
## Summary

Any pydantic validator that raises `ValueError` made AgentOS answer `500 {"detail":"Internal server error (TypeError)"}` instead of a 422 naming the field.

**Mechanism.** AgentOS's own `RequestValidationError` handler built its 422 body from the raw `exc.errors()` list. Pydantic v2 puts the **live exception object** in each error's `ctx["error"]` whenever a validator raised `ValueError`, so `JSONResponse`'s `json.dumps` raised `TypeError: Object of type ValueError is not JSON serializable` *inside the handler*. The failure escaped to the catch-all `Exception` handler, which answered 500. The chain:

> validator raises `ValueError` → pydantic wraps it with the object in `ctx` → FastAPI raises `RequestValidationError` → agno's 422 handler builds an unserializable `JSONResponse` → `TypeError` → `ServerErrorMiddleware` → agno's `Exception` handler → `500 "Internal server error (TypeError)"`

This hit every custom validator on the platform — `POST /schedules`, `PATCH /schedules/{id}`, `POST /service-accounts`, the guarded `/components*` writes, interface routes with dependency-owned body models, and any route a user mounts on the app. Clients could never learn which field was wrong, and a 5xx tells them a permanently-invalid request is retryable. Built-in coercion errors (`int_parsing`, `missing`, …) carry no exception object and were unaffected.

**Fix.** Delegate the response to `fastapi.exception_handlers.request_validation_exception_handler`, which runs the errors list through `jsonable_encoder`. One behavioural line (plus the import and a parameter rename); the `log_error` line is kept, so operators still get the full detail including the live exception. The owned app now answers exactly what a caller-supplied `base_app` app always answered — FastAPI's published 422 contract, which every other 422 on the platform already uses.

**Why the suite never caught it.** Both router test files mount their routers on a bare `FastAPI()`, which uses FastAPI's correct default handler, so their 422 assertions pass while the real app 500s. The new suite goes through `AgentOS(...).get_app()`.

## Changes

- `libs/agno/agno/os/app.py` — `validation_exception_handler` delegates to FastAPI's default handler (import added, `_` renamed to `request`, hand-built `JSONResponse` replaced). The other three handlers are untouched.
- `libs/agno/tests/unit/os/test_validation_error_body.py` (new) — 10 tests: validator errors answer 422 with the validator's own message across three routers (field validator, `model_validator(mode="after")`, and a nested body model with `loc == ["body","guard","current_version"]`) and on a dependency-owned body model (the AGUI route's `RunAgentInput` from `ag_ui`, whose validators can change underneath agno without any agno diff); coercion/missing-field 422s and the no-echo internal-error 500 are unchanged; and the owned app's response is equal (status and body) to a `base_app=FastAPI()` app's — the invariant that would have caught this at review time.
- `libs/agno/tests/unit/os/routers/test_schedules_router.py` — `test_invalid_endpoint_full_url` repointed at the branch its name claims: its old payload (`http://example.com/test`) tripped the leading-slash check first, leaving the full-URL branch with zero coverage. Added the twin case for `ScheduleUpdate`'s copy of that branch. Module docstring now notes the bare-`FastAPI()` fixture exercises FastAPI's handlers, not agno's.
- `libs/agno/tests/unit/os/routers/test_service_accounts_router.py` — same docstring note.

## Verification

- New suite on the unpatched tree: **7 failed / 3 passed** — all five validator-path tests plus the AGUI dependency-model test fail with `500 {"detail":"Internal server error (TypeError)"}`, and so does the owned-vs-borrowed parity test; the three regression guards pass. With the fix: **10 passed**. (Proven by restoring the base `app.py` and re-running.)
- Full `tests/unit/os/`: **2856 passed, 8 skipped** on the fixed tree before the AGUI test landed (baseline 2846 + 10 new/changed tests; skips are optional-dependency, unchanged), plus the AGUI test verified green individually.
- `./scripts/format.sh`: no diff. `./scripts/validate.sh`: ruff fully clean; mypy reports the same 72 pre-existing errors in 14 files before and after the patch (set-identical, none in touched files — they come from locally-installed typed optional deps and are unrelated to this change).
- The fixed body is byte-identical (status, headers, body) to FastAPI's default on a differential probe of validator error / malformed JSON body / query coercion / missing field / non-dict body. `ctx.error` encodes to `{}` (a plain `ValueError` has an empty `__dict__`); the validator's message survives in `msg`.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

- Status codes change 500 → 422 on validator failures — that is the fix. No existing test asserted the old behaviour (all `status_code == 500` assertions under `tests/unit/os/` are downstream-failure cases, each checked). The 422 body shape is unchanged from every other 422 on the platform.
- The 422 now (correctly) echoes the submitted `input` back to the caller, as FastAPI's default and the `base_app` path always did. A `ValueError` **subclass** carrying attributes would serialize those attributes into `ctx.error`; every agno validator raises plain `ValueError` (encodes to `{}`), but validators should not stash anything in exception attributes they would not want returned.
- Exception handlers are outside OpenAPI schema generation, so the documented `HTTPValidationError` 422 is unchanged — runtime now matches the docs. Operators alerting on 5xx rates will see validator-driven 500s disappear, which is the intended cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
