### PR TITLE
fix: refuse dispatch cycles and bound dispatch depth in the Studio dispatch tools

### DIFF
--- a/libs/agno/agno/db/schemas/scheduler.py
+++ b/libs/agno/agno/db/schemas/scheduler.py
@@ -56,7 +56,7 @@ COMPONENT_VERSION_METADATA_KEY = "agno_component_version"
 # component already running in this dispatch tree, oldest first, each entry
 # "<type>:<id>" (membership is the cycle test), and the number of runner
 # dispatches that produced it (the depth test). Two keys, because the lineage
-# carries wielders as well as targets, so its length is NOT the hop count.
+# carries callers as well as targets, so its length is NOT the hop count.
 # Written by StudioRunnerTools/StudioTools on dispatch, read back by the nested
 # run's own runner tools. Runtime-owned: a caller or a stored config may never
 # supply either.

--- a/libs/agno/agno/db/schemas/scheduler.py
+++ b/libs/agno/agno/db/schemas/scheduler.py
@@ -52,21 +52,38 @@ STUDIO_SCHEDULE_MANAGED_BY = "studio"
 # continues on the SAME version instead of whatever is current by then.
 COMPONENT_VERSION_METADATA_KEY = "agno_component_version"
 
+# Run-metadata keys recording the dispatch lineage a run belongs to: every
+# component already running in this dispatch tree, oldest first, each entry
+# "<type>:<id>" (membership is the cycle test), and the number of runner
+# dispatches that produced it (the depth test). Two keys, because the lineage
+# carries wielders as well as targets, so its length is NOT the hop count.
+# Written by StudioRunnerTools/StudioTools on dispatch, read back by the nested
+# run's own runner tools. Runtime-owned: a caller or a stored config may never
+# supply either.
+DISPATCH_CHAIN_METADATA_KEY = "agno_dispatch_chain"
+DISPATCH_DEPTH_METADATA_KEY = "agno_dispatch_depth"
+
+# Every run-metadata key the runtime owns. Component metadata is merged OVER
+# call-site metadata, so a stored config carrying one of these would overwrite
+# the value the runtime just wrote: a forged version stamp would continue a
+# paused run on the wrong version, and a forged (or emptied) dispatch lineage
+# would reset the cycle guard on every hop and re-open unbounded self-dispatch.
+RESERVED_RUN_METADATA_KEYS = frozenset(
+    {COMPONENT_VERSION_METADATA_KEY, DISPATCH_CHAIN_METADATA_KEY, DISPATCH_DEPTH_METADATA_KEY}
+)
+
 
 def strip_reserved_run_metadata(metadata: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
     """A component's stored metadata without the keys the runtime owns.
 
-    ``agno_component_version`` records which version a run actually started
-    with, and the lifecycle routes trust it to continue a run on that same
-    version. Component metadata is merged OVER call-site metadata, so a stored
-    config carrying this key would both forge a stamp onto runs that were never
-    pinned and overwrite the one the route just wrote. Configs are user-supplied
-    and round-trip through the catalog, so the key is stripped where it enters
-    the object rather than trusted not to be there.
+    Configs are user-supplied and round-trip through the catalog, so the
+    reserved keys are stripped where they enter the object rather than trusted
+    not to be there (see ``RESERVED_RUN_METADATA_KEYS`` for what each forgery
+    would do).
     """
-    if not isinstance(metadata, dict) or COMPONENT_VERSION_METADATA_KEY not in metadata:
+    if not isinstance(metadata, dict) or not RESERVED_RUN_METADATA_KEYS.intersection(metadata):
         return metadata
-    cleaned = {key: value for key, value in metadata.items() if key != COMPONENT_VERSION_METADATA_KEY}
+    cleaned = {key: value for key, value in metadata.items() if key not in RESERVED_RUN_METADATA_KEYS}
     return cleaned or None
 
 

--- a/libs/agno/agno/os/routers/session/session.py
+++ b/libs/agno/agno/os/routers/session/session.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, Request
 
 from agno.db.base import AsyncBaseDb, BaseDb, SessionType
+from agno.db.schemas.scheduler import strip_reserved_run_metadata
 from agno.db.utils import deserialize_session_by_type, resolve_session_type
 from agno.exceptions import AgnoError
 from agno.media.storage.base import AsyncMediaStorage, MediaStorage
@@ -262,6 +263,13 @@ def attach_routes(
     ) -> Union[AgentSessionDetailSchema, TeamSessionDetailSchema, WorkflowSessionDetailSchema]:
         db, _ = await resolve_db_and_scope(request, dbs, db_id)
 
+        # Session metadata merges into every run of the session and, on
+        # conflicting keys, wins over call-site metadata -- so a reserved key
+        # persisted here would forge a version stamp or reset the dispatch
+        # lineage from a caller-writable field. Scrub it the way the run-start
+        # routes and the scheduler executor already do.
+        sanitized_metadata = strip_reserved_run_metadata(create_session_request.metadata)
+
         # Get user_id from request state if available (from auth middleware).
         # For non-admin scoped callers the JWT sub wins via enforce_owner below.
         user_id = create_session_request.user_id
@@ -276,7 +284,7 @@ def attach_routes(
                 session_id=create_session_request.session_id,
                 session_name=create_session_request.session_name,
                 session_state=create_session_request.session_state,
-                metadata=create_session_request.metadata,
+                metadata=sanitized_metadata,
                 user_id=user_id,
                 agent_id=create_session_request.agent_id,
                 team_id=create_session_request.team_id,
@@ -357,7 +365,7 @@ def attach_routes(
                 agent_id=create_session_request.agent_id,
                 user_id=user_id,
                 session_data=session_data if session_data else None,
-                metadata=create_session_request.metadata,
+                metadata=sanitized_metadata,
                 created_at=current_time,
                 updated_at=current_time,
             )
@@ -367,7 +375,7 @@ def attach_routes(
                 team_id=create_session_request.team_id,
                 user_id=user_id,
                 session_data=session_data if session_data else None,
-                metadata=create_session_request.metadata,
+                metadata=sanitized_metadata,
                 created_at=current_time,
                 updated_at=current_time,
             )
@@ -377,7 +385,7 @@ def attach_routes(
                 workflow_id=create_session_request.workflow_id,
                 user_id=user_id,
                 session_data=session_data if session_data else None,
-                metadata=create_session_request.metadata,
+                metadata=sanitized_metadata,
                 created_at=current_time,
                 updated_at=current_time,
             )
@@ -1166,6 +1174,10 @@ def attach_routes(
     ) -> Union[AgentSessionDetailSchema, TeamSessionDetailSchema, WorkflowSessionDetailSchema]:
         db, effective_user_id = await resolve_db_and_scope(request, dbs, db_id, table, fallback_user_id=user_id)
 
+        # Same scrub as create_session: session metadata wins the merge into
+        # every run of this session, so reserved keys never enter through it.
+        sanitized_metadata = strip_reserved_run_metadata(update_data.metadata)
+
         if isinstance(db, RemoteDb):
             auth_token = get_auth_token_from_request(request)
             headers = {"Authorization": f"Bearer {auth_token}"} if auth_token else None
@@ -1174,7 +1186,7 @@ def attach_routes(
                 session_type=session_type,
                 session_name=update_data.session_name,
                 session_state=update_data.session_state,
-                metadata=update_data.metadata,
+                metadata=sanitized_metadata,
                 summary=update_data.summary,
                 user_id=effective_user_id,
                 db_id=db_id,
@@ -1213,7 +1225,7 @@ def attach_routes(
             existing_session.session_data["session_state"] = update_data.session_state  # type: ignore
 
         if update_data.metadata is not None:
-            existing_session.metadata = update_data.metadata  # type: ignore
+            existing_session.metadata = sanitized_metadata  # type: ignore
 
         if update_data.summary is not None:
             from agno.session.summary import SessionSummary

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -2671,7 +2671,7 @@ def stringify_input_content(input_content: Union[str, Dict[str, Any], List[Any],
 # High-level resolvers with error handling for routers
 # ---------------------------------------------------------------------------
 
-from agno.db.schemas.scheduler import COMPONENT_VERSION_METADATA_KEY  # noqa: E402
+from agno.db.schemas.scheduler import COMPONENT_VERSION_METADATA_KEY, RESERVED_RUN_METADATA_KEYS  # noqa: E402
 
 
 def stamp_component_version(kwargs: Dict[str, Any], version: Optional[int]) -> None:
@@ -2681,13 +2681,14 @@ def stamp_component_version(kwargs: Dict[str, Any], version: Optional[int]) -> N
     ``metadata`` dict (a copy - the request-state dict is never mutated).
 
     The stamp is authoritative for lifecycle re-resolution, so a caller must
-    never supply it. ``metadata`` is a caller-writable form field, so ANY
-    inbound ``agno_component_version`` is stripped first - otherwise a forged
-    key survives an unpinned run and lets ``/continue`` dispatch a draft the
-    caller was refused at run-start. The key is (re)written only when a
-    version was pinned via the route's own ``version`` parameter. No pinned
-    version means no stamp, so unpinned runs keep their legacy shape unless
-    the caller sent their own (now-sanitized) metadata.
+    never supply it. ``metadata`` is a caller-writable form field, so every
+    inbound runtime-owned key is stripped first - a forged version stamp
+    survives an unpinned run and lets ``/continue`` dispatch a draft the
+    caller was refused at run-start, and a forged dispatch lineage would
+    pre-seed or reset the runner's cycle guard. The version key is (re)written
+    only when a version was pinned via the route's own ``version`` parameter.
+    No pinned version means no stamp, so unpinned runs keep their legacy shape
+    unless the caller sent their own (now-sanitized) metadata.
     """
     inbound = kwargs.get("metadata")
     if inbound is not None and not isinstance(inbound, dict):
@@ -2702,8 +2703,10 @@ def stamp_component_version(kwargs: Dict[str, Any], version: Optional[int]) -> N
         inbound = None
     had_metadata = inbound is not None
     metadata = dict(inbound or {})
-    # Strip any forged stamp before trusting the route's own pinned version.
-    metadata.pop(COMPONENT_VERSION_METADATA_KEY, None)
+    # Strip every forged runtime key before trusting the route's own pinned
+    # version; only the version key is (conditionally) rewritten below.
+    for reserved_key in RESERVED_RUN_METADATA_KEYS:
+        metadata.pop(reserved_key, None)
     if version is not None:
         metadata[COMPONENT_VERSION_METADATA_KEY] = version
     # Only touch kwargs when there is a stamp to write or metadata to sanitize;

--- a/libs/agno/agno/scheduler/executor.py
+++ b/libs/agno/agno/scheduler/executor.py
@@ -8,7 +8,7 @@ from urllib.parse import quote
 from uuid import uuid4
 
 from agno.db.schemas.scheduler import (
-    COMPONENT_VERSION_METADATA_KEY,
+    RESERVED_RUN_METADATA_KEYS,
     RUN_ENDPOINT_RE,
     SCHEDULE_OWNER_HEADER,
     Schedule,
@@ -339,7 +339,10 @@ class ScheduleExecutor:
             # metadata (``agno_component_version``), which the run-start route
             # carries onto the run, so scrub it from any forwarded metadata -
             # and from the top level - or a crafted schedule smuggles a draft
-            # preview the lifecycle routes would then re-resolve.
+            # preview the lifecycle routes would then re-resolve. The other
+            # runtime-owned keys (the dispatch lineage pair) get the same
+            # scrub: schedule payloads are builder-writable, so they are an
+            # inbound channel for a forged chain.
             sanitized_payload = dict(payload)
             raw_metadata = sanitized_payload.get("metadata")
             if isinstance(raw_metadata, str):
@@ -349,7 +352,7 @@ class ScheduleExecutor:
                     raw_metadata = None
             if isinstance(raw_metadata, dict):
                 sanitized_payload["metadata"] = {
-                    k: v for k, v in raw_metadata.items() if k != COMPONENT_VERSION_METADATA_KEY
+                    k: v for k, v in raw_metadata.items() if k not in RESERVED_RUN_METADATA_KEYS
                 }
             elif "metadata" in sanitized_payload:
                 # The run routes accept only a JSON object here and answer 4xx
@@ -365,7 +368,7 @@ class ScheduleExecutor:
             form_payload = {
                 k: _to_form_value(v)
                 for k, v in sanitized_payload.items()
-                if k not in ("stream", "background", "version", COMPONENT_VERSION_METADATA_KEY)
+                if k not in ("stream", "background", "version", *RESERVED_RUN_METADATA_KEYS)
             }
             form_payload["stream"] = "false"
             form_payload["background"] = "true"

--- a/libs/agno/agno/tools/studio.py
+++ b/libs/agno/agno/tools/studio.py
@@ -244,10 +244,10 @@ class StudioTools(Toolkit):
         create_workflows: bool = True,
         versions: bool = True,
         schedules: bool = False,
-        max_dispatch_depth: int = 2,
         list_limit: int = 100,
         allowed_tools: Optional[List[str]] = None,
         denied_tools: Optional[List[str]] = None,
+        max_dispatch_depth: int = 2,
         **kwargs: Any,
     ):
         self.registry = registry
@@ -3500,8 +3500,8 @@ class StudioTools(Toolkit):
         message: str,
         version: Optional[int],
         run_context: Optional[RunContext],
-        wielder_agent: Any = None,
-        wielder_team: Any = None,
+        caller_agent: Any = None,
+        caller_team: Any = None,
     ) -> str:
         runner_calls = {
             "agent": self._runner_tools.run_agent,
@@ -3517,8 +3517,8 @@ class StudioTools(Toolkit):
                     identifier,
                     message,
                     _agno_run_context=run_context,
-                    _agno_agent=wielder_agent,
-                    _agno_team=wielder_team,
+                    _agno_agent=caller_agent,
+                    _agno_team=caller_team,
                 )
             )
         # Preview: run an exact version, drafts included. Owner-gated like the
@@ -3535,7 +3535,7 @@ class StudioTools(Toolkit):
         # left open to unbounded self-dispatch.
         try:
             dispatch_metadata = self._runner_tools._dispatch_metadata(
-                run_context, component_type, resolved_id, wielder_agent=wielder_agent, wielder_team=wielder_team
+                run_context, component_type, resolved_id, caller_agent=caller_agent, caller_team=caller_team
             )
         except StudioRunnerError as e:
             return error_result("dispatch_refused", str(e))
@@ -3574,8 +3574,8 @@ class StudioTools(Toolkit):
         message: str,
         version: Optional[int],
         run_context: Optional[RunContext],
-        wielder_agent: Any = None,
-        wielder_team: Any = None,
+        caller_agent: Any = None,
+        caller_team: Any = None,
     ) -> str:
         """Async mirror of _run_component: the target's arun actually runs on
         the event loop (async hooks and tools included) instead of the sync
@@ -3596,8 +3596,8 @@ class StudioTools(Toolkit):
                     identifier,
                     message,
                     _agno_run_context=run_context,
-                    _agno_agent=wielder_agent,
-                    _agno_team=wielder_team,
+                    _agno_agent=caller_agent,
+                    _agno_team=caller_team,
                 )
             )
         row, resolved_id, err = await asyncio.to_thread(self._component_row, identifier, _actor_id(run_context))
@@ -3612,7 +3612,7 @@ class StudioTools(Toolkit):
         # left open to unbounded self-dispatch. Pure in-memory work; no thread hop.
         try:
             dispatch_metadata = self._runner_tools._dispatch_metadata(
-                run_context, component_type, resolved_id, wielder_agent=wielder_agent, wielder_team=wielder_team
+                run_context, component_type, resolved_id, caller_agent=caller_agent, caller_team=caller_team
             )
         except StudioRunnerError as e:
             return error_result("dispatch_refused", str(e))
@@ -3669,7 +3669,7 @@ class StudioTools(Toolkit):
             and, when paused, the unresolved requirements to continue with.
         """
         return self._run_component(
-            "agent", agent_id, message, version, _agno_run_context, wielder_agent=_agno_agent, wielder_team=_agno_team
+            "agent", agent_id, message, version, _agno_run_context, caller_agent=_agno_agent, caller_team=_agno_team
         )
 
     def run_team(
@@ -3694,7 +3694,7 @@ class StudioTools(Toolkit):
             and, when paused, the unresolved requirements.
         """
         return self._run_component(
-            "team", team_id, message, version, _agno_run_context, wielder_agent=_agno_agent, wielder_team=_agno_team
+            "team", team_id, message, version, _agno_run_context, caller_agent=_agno_agent, caller_team=_agno_team
         )
 
     def run_workflow(
@@ -3724,8 +3724,8 @@ class StudioTools(Toolkit):
             message,
             version,
             _agno_run_context,
-            wielder_agent=_agno_agent,
-            wielder_team=_agno_team,
+            caller_agent=_agno_agent,
+            caller_team=_agno_team,
         )
 
     # ------------------------------------------------------------------
@@ -4101,7 +4101,7 @@ class StudioTools(Toolkit):
     ) -> str:
         """Async variant of run_agent."""
         return await self._arun_component(
-            "agent", agent_id, message, version, _agno_run_context, wielder_agent=_agno_agent, wielder_team=_agno_team
+            "agent", agent_id, message, version, _agno_run_context, caller_agent=_agno_agent, caller_team=_agno_team
         )
 
     async def arun_team(
@@ -4115,7 +4115,7 @@ class StudioTools(Toolkit):
     ) -> str:
         """Async variant of run_team."""
         return await self._arun_component(
-            "team", team_id, message, version, _agno_run_context, wielder_agent=_agno_agent, wielder_team=_agno_team
+            "team", team_id, message, version, _agno_run_context, caller_agent=_agno_agent, caller_team=_agno_team
         )
 
     async def arun_workflow(
@@ -4134,8 +4134,8 @@ class StudioTools(Toolkit):
             message,
             version,
             _agno_run_context,
-            wielder_agent=_agno_agent,
-            wielder_team=_agno_team,
+            caller_agent=_agno_agent,
+            caller_team=_agno_team,
         )
 
     def create_schedule(

--- a/libs/agno/agno/tools/studio.py
+++ b/libs/agno/agno/tools/studio.py
@@ -244,6 +244,7 @@ class StudioTools(Toolkit):
         create_workflows: bool = True,
         versions: bool = True,
         schedules: bool = False,
+        max_dispatch_depth: int = 2,
         list_limit: int = 100,
         allowed_tools: Optional[List[str]] = None,
         denied_tools: Optional[List[str]] = None,
@@ -308,6 +309,9 @@ class StudioTools(Toolkit):
             # components is the point rather than an accident. A standalone runner
             # mounted on a router gets the narrower default.
             include_all_components=True,
+            # That same reach is what makes an unbounded dispatch chain
+            # reachable from one message, so the bound rides along with it.
+            max_dispatch_depth=max_dispatch_depth,
             list_limit=list_limit,
         )
 
@@ -3469,7 +3473,7 @@ class StudioTools(Toolkit):
 
     @staticmethod
     def _version_stamp(version: Optional[int]) -> Dict[str, Any]:
-        """Run kwargs that record the pinned version on the run itself.
+        """Run-metadata entries that record the pinned version on the run itself.
 
         A preview of an exact version must stay pinned for the whole run: the
         continue/resume surfaces re-resolve the component from this stamp, and
@@ -3477,17 +3481,17 @@ class StudioTools(Toolkit):
         resumes on the published version. An unpinned run carries no stamp, so
         it keeps re-resolving the live version as before.
 
-        The dict is built here rather than merged into caller-supplied
-        metadata, so there is no inbound stamp to strip: the toolkit's own
-        pinned version is the only source. Only the key is imported, because
-        the writer that sanitizes caller metadata lives in the server package
-        and the toolkit must keep working without it installed.
+        Merged OVER the dispatch metadata, which has already stripped any
+        inbound stamp as a runtime-reserved key: the toolkit's own pinned
+        version is the only source. Only the key is imported, because the
+        writer that sanitizes caller metadata lives in the server package and
+        the toolkit must keep working without it installed.
         """
         from agno.db.schemas.scheduler import COMPONENT_VERSION_METADATA_KEY
 
         if version is None:
             return {}
-        return {"metadata": {COMPONENT_VERSION_METADATA_KEY: version}}
+        return {COMPONENT_VERSION_METADATA_KEY: version}
 
     def _run_component(
         self,
@@ -3496,6 +3500,8 @@ class StudioTools(Toolkit):
         message: str,
         version: Optional[int],
         run_context: Optional[RunContext],
+        wielder_agent: Any = None,
+        wielder_team: Any = None,
     ) -> str:
         runner_calls = {
             "agent": self._runner_tools.run_agent,
@@ -3503,7 +3509,18 @@ class StudioTools(Toolkit):
             "workflow": self._runner_tools.run_workflow,
         }
         if version is None:
-            return self._alias_runner_result(runner_calls[component_type](identifier, message, run_context))
+            # By keyword: the runner's own injected parameters share these
+            # names, and a positional fourth argument would land in the wrong
+            # slot without an error the day either signature grows.
+            return self._alias_runner_result(
+                runner_calls[component_type](
+                    identifier,
+                    message,
+                    _agno_run_context=run_context,
+                    _agno_agent=wielder_agent,
+                    _agno_team=wielder_team,
+                )
+            )
         # Preview: run an exact version, drafts included. Owner-gated like the
         # REST preview: a scoped actor may only preview components it owns.
         row, resolved_id, err = self._component_row(identifier, _actor_id(run_context))
@@ -3512,6 +3529,16 @@ class StudioTools(Toolkit):
         actor = _actor_id(run_context)
         if not self._pin_allowed(resolved_id, version, row, actor):
             return error_result("component_not_found", f"Component not found: {identifier}")
+        # The preview dispatches the component directly rather than through the
+        # runner's run tools, so it carries the same dispatch lineage and
+        # refusals itself -- otherwise a pinned version would be the one door
+        # left open to unbounded self-dispatch.
+        try:
+            dispatch_metadata = self._runner_tools._dispatch_metadata(
+                run_context, component_type, resolved_id, wielder_agent=wielder_agent, wielder_team=wielder_team
+            )
+        except StudioRunnerError as e:
+            return error_result("dispatch_refused", str(e))
         loaders = {
             "agent": self._runner_tools._load_agent_from_db,
             "team": self._runner_tools._load_team_from_db,
@@ -3525,13 +3552,15 @@ class StudioTools(Toolkit):
             return self._error_from_exception(e, f"Failed to load {component_type} '{identifier}' v{version}")
         if component is None:
             return error_result("version_not_found", f"Version not found: {resolved_id} v{version}")
+        sub_run_id = self._runner_tools._registered_sub_run_id(run_context)
         try:
             response = component.run(
                 message,
                 stream=False,
                 user_id=self._runner_tools._caller_user_id(run_context, component),
                 session_id=self._runner_tools._sub_session_id(run_context, component_type, resolved_id),
-                **self._version_stamp(version),
+                run_id=sub_run_id,
+                metadata={**dispatch_metadata, **self._version_stamp(version)},
             )
             payload = self._runner_tools._run_payload(f"{component_type}_id", resolved_id, response)
             return self._alias_runner_result(payload)
@@ -3545,6 +3574,8 @@ class StudioTools(Toolkit):
         message: str,
         version: Optional[int],
         run_context: Optional[RunContext],
+        wielder_agent: Any = None,
+        wielder_team: Any = None,
     ) -> str:
         """Async mirror of _run_component: the target's arun actually runs on
         the event loop (async hooks and tools included) instead of the sync
@@ -3557,13 +3588,34 @@ class StudioTools(Toolkit):
             "workflow": self._runner_tools.arun_workflow,
         }
         if version is None:
-            return self._alias_runner_result(await runner_calls[component_type](identifier, message, run_context))
+            # By keyword: the runner's own injected parameters share these
+            # names, and a positional fourth argument would land in the wrong
+            # slot without an error the day either signature grows.
+            return self._alias_runner_result(
+                await runner_calls[component_type](
+                    identifier,
+                    message,
+                    _agno_run_context=run_context,
+                    _agno_agent=wielder_agent,
+                    _agno_team=wielder_team,
+                )
+            )
         row, resolved_id, err = await asyncio.to_thread(self._component_row, identifier, _actor_id(run_context))
         if err is not None:
             return err
         actor = _actor_id(run_context)
         if not await asyncio.to_thread(self._pin_allowed, resolved_id, version, row, actor):
             return error_result("component_not_found", f"Component not found: {identifier}")
+        # The preview dispatches the component directly rather than through the
+        # runner's run tools, so it carries the same dispatch lineage and
+        # refusals itself -- otherwise a pinned version would be the one door
+        # left open to unbounded self-dispatch. Pure in-memory work; no thread hop.
+        try:
+            dispatch_metadata = self._runner_tools._dispatch_metadata(
+                run_context, component_type, resolved_id, wielder_agent=wielder_agent, wielder_team=wielder_team
+            )
+        except StudioRunnerError as e:
+            return error_result("dispatch_refused", str(e))
         loaders = {
             "agent": self._runner_tools._load_agent_from_db,
             "team": self._runner_tools._load_team_from_db,
@@ -3579,13 +3631,15 @@ class StudioTools(Toolkit):
             return self._error_from_exception(e, f"Failed to load {component_type} '{identifier}' v{version}")
         if component is None:
             return error_result("version_not_found", f"Version not found: {resolved_id} v{version}")
+        sub_run_id = await self._runner_tools._aregistered_sub_run_id(run_context)
         try:
             response = await component.arun(
                 message,
                 stream=False,
                 user_id=self._runner_tools._caller_user_id(run_context, component),
                 session_id=self._runner_tools._sub_session_id(run_context, component_type, resolved_id),
-                **self._version_stamp(version),
+                run_id=sub_run_id,
+                metadata={**dispatch_metadata, **self._version_stamp(version)},
             )
             payload = self._runner_tools._run_payload(f"{component_type}_id", resolved_id, response)
             return self._alias_runner_result(payload)
@@ -3598,6 +3652,8 @@ class StudioTools(Toolkit):
         message: str,
         version: Optional[int] = None,
         _agno_run_context: Optional[RunContext] = None,
+        _agno_agent: Optional[Any] = None,
+        _agno_team: Optional[Any] = None,
     ) -> str:
         """Run an agent as the current user. Omit version to run the live
         published version; pass one to preview an exact version, drafts
@@ -3612,7 +3668,9 @@ class StudioTools(Toolkit):
             str: JSON with agent_id, id, run_id, session_id, status, content
             and, when paused, the unresolved requirements to continue with.
         """
-        return self._run_component("agent", agent_id, message, version, _agno_run_context)
+        return self._run_component(
+            "agent", agent_id, message, version, _agno_run_context, wielder_agent=_agno_agent, wielder_team=_agno_team
+        )
 
     def run_team(
         self,
@@ -3620,6 +3678,8 @@ class StudioTools(Toolkit):
         message: str,
         version: Optional[int] = None,
         _agno_run_context: Optional[RunContext] = None,
+        _agno_agent: Optional[Any] = None,
+        _agno_team: Optional[Any] = None,
     ) -> str:
         """Run a team as the current user. Omit version to run the live
         published version; pass one to preview an exact version.
@@ -3633,7 +3693,9 @@ class StudioTools(Toolkit):
             str: JSON with team_id, id, run_id, session_id, status, content
             and, when paused, the unresolved requirements.
         """
-        return self._run_component("team", team_id, message, version, _agno_run_context)
+        return self._run_component(
+            "team", team_id, message, version, _agno_run_context, wielder_agent=_agno_agent, wielder_team=_agno_team
+        )
 
     def run_workflow(
         self,
@@ -3641,6 +3703,8 @@ class StudioTools(Toolkit):
         message: str,
         version: Optional[int] = None,
         _agno_run_context: Optional[RunContext] = None,
+        _agno_agent: Optional[Any] = None,
+        _agno_team: Optional[Any] = None,
     ) -> str:
         """Run a workflow as the current user. Omit version to run the live
         published version; pass one to preview an exact version.
@@ -3654,7 +3718,15 @@ class StudioTools(Toolkit):
             str: JSON with workflow_id, id, run_id, session_id, status, content
             and, when paused, the unresolved requirements.
         """
-        return self._run_component("workflow", workflow_id, message, version, _agno_run_context)
+        return self._run_component(
+            "workflow",
+            workflow_id,
+            message,
+            version,
+            _agno_run_context,
+            wielder_agent=_agno_agent,
+            wielder_team=_agno_team,
+        )
 
     # ------------------------------------------------------------------
     # Async variants (same names on the model surface)
@@ -4024,9 +4096,13 @@ class StudioTools(Toolkit):
         message: str,
         version: Optional[int] = None,
         _agno_run_context: Optional[RunContext] = None,
+        _agno_agent: Optional[Any] = None,
+        _agno_team: Optional[Any] = None,
     ) -> str:
         """Async variant of run_agent."""
-        return await self._arun_component("agent", agent_id, message, version, _agno_run_context)
+        return await self._arun_component(
+            "agent", agent_id, message, version, _agno_run_context, wielder_agent=_agno_agent, wielder_team=_agno_team
+        )
 
     async def arun_team(
         self,
@@ -4034,9 +4110,13 @@ class StudioTools(Toolkit):
         message: str,
         version: Optional[int] = None,
         _agno_run_context: Optional[RunContext] = None,
+        _agno_agent: Optional[Any] = None,
+        _agno_team: Optional[Any] = None,
     ) -> str:
         """Async variant of run_team."""
-        return await self._arun_component("team", team_id, message, version, _agno_run_context)
+        return await self._arun_component(
+            "team", team_id, message, version, _agno_run_context, wielder_agent=_agno_agent, wielder_team=_agno_team
+        )
 
     async def arun_workflow(
         self,
@@ -4044,9 +4124,19 @@ class StudioTools(Toolkit):
         message: str,
         version: Optional[int] = None,
         _agno_run_context: Optional[RunContext] = None,
+        _agno_agent: Optional[Any] = None,
+        _agno_team: Optional[Any] = None,
     ) -> str:
         """Async variant of run_workflow."""
-        return await self._arun_component("workflow", workflow_id, message, version, _agno_run_context)
+        return await self._arun_component(
+            "workflow",
+            workflow_id,
+            message,
+            version,
+            _agno_run_context,
+            wielder_agent=_agno_agent,
+            wielder_team=_agno_team,
+        )
 
     def create_schedule(
         self,

--- a/libs/agno/agno/tools/studio_runner.py
+++ b/libs/agno/agno/tools/studio_runner.py
@@ -287,9 +287,9 @@ class StudioRunnerTools(Toolkit):
         include_agents: Optional[List["Agent"]] = None,
         include_teams: Optional[List["Team"]] = None,
         include_workflows: Optional[List["Workflow"]] = None,
-        agents: bool = True,
-        teams: bool = True,
-        workflows: bool = True,
+        run_agents: bool = True,
+        run_teams: bool = True,
+        run_workflows: bool = True,
         include_all_components: bool = False,
         max_dispatch_depth: int = 2,
         list_limit: int = 100,
@@ -312,25 +312,32 @@ class StudioRunnerTools(Toolkit):
         self.include_agents = include_agents
         self.include_teams = include_teams
         self.include_workflows = include_workflows
-        self.enable_agents = agents
-        self.enable_teams = teams
-        self.enable_workflows = workflows
+        # Each run_* flag exposes that kind's whole surface, list tool
+        # included: the list reports exactly what dispatch admits, so a kind
+        # that cannot run has nothing to list either.
+        self.enable_agents = run_agents
+        self.enable_teams = run_teams
+        self.enable_workflows = run_workflows
         self.include_all_components = include_all_components
         self.list_limit = list_limit
 
         tools: List[Callable] = []
         async_tools: List[tuple[Callable[..., Any], str]] = []
-        if agents:
+        if run_agents:
             tools.extend([self.list_agents, self.run_agent])
             async_tools.extend([(self.alist_agents, "list_agents"), (self.arun_agent, "run_agent")])
-        if teams:
+        if run_teams:
             tools.extend([self.list_teams, self.run_team])
             async_tools.extend([(self.alist_teams, "list_teams"), (self.arun_team, "run_team")])
-        if workflows:
+        if run_workflows:
             tools.extend([self.list_workflows, self.run_workflow])
             async_tools.extend([(self.alist_workflows, "list_workflows"), (self.arun_workflow, "run_workflow")])
 
-        enabled = [label for flag, label in ((agents, "agents"), (teams, "teams"), (workflows, "workflows")) if flag]
+        enabled = [
+            label
+            for flag, label in ((run_agents, "agents"), (run_teams, "teams"), (run_workflows, "workflows"))
+            if flag
+        ]
         instruction_lines: List[str] = []
         if enabled:
             list_names = "/".join(f"list_{label}" for label in enabled)

--- a/libs/agno/agno/tools/studio_runner.py
+++ b/libs/agno/agno/tools/studio_runner.py
@@ -100,9 +100,16 @@ from __future__ import annotations
 import asyncio
 import json
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple
+from uuid import uuid4
 
+from agno.db.schemas.scheduler import (
+    DISPATCH_CHAIN_METADATA_KEY,
+    DISPATCH_DEPTH_METADATA_KEY,
+    strip_reserved_run_metadata,
+)
 from agno.exceptions import ComponentPinError, ComponentRehydrationError
 from agno.run import RunContext
+from agno.run.cancel import aregister_member_run, register_member_run
 from agno.run.utils import run_status_string, serialized_paused_requirements
 from agno.tools.toolkit import Toolkit
 from agno.utils.log import logger
@@ -187,6 +194,35 @@ class DispatchCopyError(StudioRunnerError, RuntimeError):
     deep_copy that rebuilds it, or store the component in the database."""
 
 
+class DispatchCycleError(ComponentNotDispatchableError):
+    """The dispatch target is already running in this dispatch lineage.
+
+    Every dispatched run carries the components already running in its
+    dispatch tree in run metadata, and the wielding component joins that set
+    at dispatch time. Re-entering one of them can only repeat work, and
+    unchecked it is a self-sustaining loop: one message can keep a component
+    re-dispatching itself indefinitely, outliving the HTTP caller and stopping
+    only with the process. A nested run has no other signal that it is nested,
+    so the refusal has to live here in the runtime, not in the prompt."""
+
+
+class DispatchDepthExceededError(ComponentNotDispatchableError):
+    """The dispatch tree is already ``max_dispatch_depth`` hops deep.
+
+    The cycle guard refuses re-entry; this bounds trees that never repeat a
+    component. Raise ``max_dispatch_depth`` on the toolkit when a deployment
+    genuinely composes deeper."""
+
+
+class DispatchStateError(ComponentNotDispatchableError):
+    """The inbound dispatch lineage or hop count is malformed.
+
+    Both keys are runtime-written, so a value of the wrong shape is evidence
+    of tampering or corruption, and treating it as absent would reset the
+    counter -- exactly what a forged value would want. Absent keys are NOT
+    malformed: that is the ordinary top-level run."""
+
+
 def _reference_configs(component_type: str, config: Dict[str, Any]) -> List[Dict[str, Any]]:
     """The dicts in a stored config that can name another component.
 
@@ -255,10 +291,17 @@ class StudioRunnerTools(Toolkit):
         teams: bool = True,
         workflows: bool = True,
         include_all_components: bool = False,
+        max_dispatch_depth: int = 2,
         list_limit: int = 100,
         name: str = "studio_runners",
         **kwargs: Any,
     ):
+        # 0 disables dispatch outright and is a valid posture; "unlimited" is
+        # deliberately not offered, because an unbounded dispatch chain is a
+        # self-sustaining loop waiting for one message (see DispatchCycleError).
+        if max_dispatch_depth < 0:
+            raise ValueError(f"max_dispatch_depth must be >= 0, got {max_dispatch_depth}")
+        self.max_dispatch_depth = max_dispatch_depth
         self.registry = registry
         # The explicit db wins; otherwise the registry's is adopted lazily on
         # first access (see the db property). An __init__ snapshot would be
@@ -305,6 +348,12 @@ class StudioRunnerTools(Toolkit):
                 "repeat runs continue where they left off. Call a given component sequentially within a "
                 "turn: parallel calls to the same component share one session and can overwrite each other.",
             ]
+            if len(enabled) > 1:
+                instruction_lines.append(
+                    "Agents, teams and workflows are separate rosters and a run tool searches only its "
+                    "own. When you do not know which kind a name is, check every list tool before "
+                    "concluding it does not exist."
+                )
 
         # Toolkit instructions are only injected into the system message when
         # add_instructions is set, so default it on.
@@ -2196,10 +2245,13 @@ class StudioRunnerTools(Toolkit):
         Returns:
             str: JSON object with 'agents' (each {id, name, description}; a row
                 with status 'draft' has no published version yet, so it will
-                not dispatch until published), 'count' (returned) and 'total'
+                not dispatch until published), 'count' (returned), 'total'
                 (every component this runner can run; total > count means the
                 list is capped -- components beyond the cap still run by
-                exact id).
+                exact id) and 'other_components' (how many runnable teams and
+                workflows exist -- this list is agents only, so check the
+                sibling list tools before concluding a component does not
+                exist).
         """
         return self._list_payload("agent", "agents", actor=getattr(_agno_run_context, "user_id", None))
 
@@ -2213,10 +2265,13 @@ class StudioRunnerTools(Toolkit):
         Returns:
             str: JSON object with 'teams' (each {id, name, description}; a row
                 with status 'draft' has no published version yet, so it will
-                not dispatch until published), 'count' (returned) and 'total'
+                not dispatch until published), 'count' (returned), 'total'
                 (every component this runner can run; total > count means the
                 list is capped -- components beyond the cap still run by
-                exact id).
+                exact id) and 'other_components' (how many runnable agents and
+                workflows exist -- this list is teams only, so check the
+                sibling list tools before concluding a component does not
+                exist).
         """
         return self._list_payload("team", "teams", actor=getattr(_agno_run_context, "user_id", None))
 
@@ -2230,10 +2285,13 @@ class StudioRunnerTools(Toolkit):
         Returns:
             str: JSON object with 'workflows' (each {id, name, description}; a row
                 with status 'draft' has no published version yet, so it will
-                not dispatch until published), 'count' (returned) and 'total'
+                not dispatch until published), 'count' (returned), 'total'
                 (every component this runner can run; total > count means the
                 list is capped -- components beyond the cap still run by
-                exact id).
+                exact id) and 'other_components' (how many runnable agents and
+                teams exist -- this list is workflows only, so check the
+                sibling list tools before concluding a component does not
+                exist).
         """
         return self._list_payload("workflow", "workflows", actor=getattr(_agno_run_context, "user_id", None))
 
@@ -2243,7 +2301,9 @@ class StudioRunnerTools(Toolkit):
             # A code allowlist runs without a database, so it has to be findable
             # without one too; only the database half is unavailable here.
             if admitted:
-                return json.dumps({key: admitted, "count": len(admitted), "total": len(admitted)})
+                payload = {key: admitted, "count": len(admitted), "total": len(admitted)}
+                payload.update(self._sibling_namespace_disclosure(component_type, actor=actor))
+                return json.dumps(payload)
             return json.dumps({"error": "StudioRunnerTools has no db configured; cannot list components."})
         try:
             items, total = self._list_db_component_rows(component_type, user_id=actor)
@@ -2259,10 +2319,44 @@ class StudioRunnerTools(Toolkit):
             items = admitted + [entry for entry in items if entry.get("id") not in seen_ids]
             # A code component shadows the stored one it shares an id with, so
             # the pair is one component to run, not two to count.
-            return json.dumps({key: items, "count": len(items), "total": total + len(admitted) - shadowed})
+            payload = {key: items, "count": len(items), "total": total + len(admitted) - shadowed}
+            payload.update(self._sibling_namespace_disclosure(component_type, actor=actor))
+            return json.dumps(payload)
         except Exception as e:
             logger.exception("Failed to list %s", key)
             return json.dumps({"error": str(e) or type(e).__name__})
+
+    def _sibling_namespace_disclosure(self, component_type: str, actor: Optional[str] = None) -> Dict[str, Any]:
+        """{"other_components": {"teams": 1, ...}} for the OTHER namespaces this
+        toolkit registered run tools for, or {} when there are none.
+
+        Agents, teams and workflows are separate namespaces with separate list
+        tools, and a caller who lists one gets a plausible-looking roster with
+        no signal that it has seen a third of the components -- so it concludes
+        "not on the roster" means "does not exist". A count is enough to break
+        that false negative; the sibling's own list tool holds the roster.
+        Counts use the same arithmetic as that tool's total. A count that
+        cannot be computed is omitted rather than failing the listing."""
+        counts: Dict[str, int] = {}
+        namespaces: List[Tuple[str, str, bool]] = [
+            ("agent", "agents", self.enable_agents),
+            ("team", "teams", self.enable_teams),
+            ("workflow", "workflows", self.enable_workflows),
+        ]
+        for sibling_type, plural, enabled in namespaces:
+            if sibling_type == component_type or not enabled:
+                continue
+            try:
+                admitted = self._admitted_code_components(sibling_type)
+                total = len(admitted)
+                if self.db is not None:
+                    _, db_total = self._list_db_component_rows(sibling_type, user_id=actor)
+                    shadowed = sum(1 for entry in admitted if self._db_component_exists(sibling_type, entry["id"]))
+                    total += db_total - shadowed
+                counts[plural] = total
+            except Exception:
+                logger.warning("Failed to count %s for list disclosure", plural, exc_info=True)
+        return {"other_components": counts} if counts else {}
 
     def _admitted_code_components(self, component_type: str) -> List[Dict[str, Any]]:
         """The code-defined components this runner will dispatch, as list rows.
@@ -2297,13 +2391,218 @@ class StudioRunnerTools(Toolkit):
     # Execution
     # ------------------------------------------------------------------
 
-    def run_agent(self, agent_id: str, message: str, _agno_run_context: Optional[RunContext] = None) -> str:
+    # The dispatch guard, shared by all six run tools here and by StudioTools'
+    # version-pinned dispatch branch. Lineage semantics: the inbound metadata
+    # carries every component already running in this dispatch tree (the
+    # lineage; membership is the cycle test) and the number of dispatches that
+    # produced this run (the hop count; the depth test). They are two keys
+    # because the lineage records wielders as well as targets, so its length
+    # is not the hop count. The wielding component arrives through the
+    # framework's identity injection (_agno_agent/_agno_team) and joins the
+    # lineage at dispatch time -- an inherited-only chain is empty at the top
+    # level, which is exactly the reported repro (a team dispatching itself
+    # from a run a human started).
+
+    @staticmethod
+    def _dedup(tokens: List[str]) -> List[str]:
+        return list(dict.fromkeys(tokens))
+
+    @staticmethod
+    def _wielder_tokens(wielder_agent: Any, wielder_team: Any) -> List[str]:
+        """Lineage tokens for the components wielding this toolkit.
+
+        A toolkit on a team leader contributes the team; a toolkit on a member
+        agent contributes both its parent team and itself, outer frame first --
+        both are genuinely running and both are cycle targets. A wielder with
+        no usable id contributes nothing."""
+        tokens: List[str] = []
+        for component_type, wielder in (("team", wielder_team), ("agent", wielder_agent)):
+            component_id = getattr(wielder, "id", None)
+            if isinstance(component_id, str) and component_id:
+                tokens.append(f"{component_type}:{component_id}")
+        return tokens
+
+    def _inherited_dispatch_state(self, run_context: Optional[RunContext]) -> Tuple[List[str], int]:
+        """The (lineage, hop count) this run inherited, ([], 0) for a top-level
+        run. Raises DispatchStateError -- refusing, not resetting -- when either
+        value is malformed: both keys are runtime-written, so a wrong shape is
+        tampering or corruption, and treating it as absent would zero the
+        counter, which is exactly what a forged value would want. Only the
+        ABSENT pair (or absent metadata) is the ordinary top-level run; a half
+        pair is refused too, because the runtime always writes both."""
+        metadata = getattr(run_context, "metadata", None)
+        if not isinstance(metadata, dict):
+            return [], 0
+        if DISPATCH_CHAIN_METADATA_KEY not in metadata and DISPATCH_DEPTH_METADATA_KEY not in metadata:
+            return [], 0
+        chain = metadata.get(DISPATCH_CHAIN_METADATA_KEY)
+        if not isinstance(chain, list) or not all(isinstance(entry, str) for entry in chain):
+            raise DispatchStateError(
+                f"Refusing to dispatch: this run's '{DISPATCH_CHAIN_METADATA_KEY}' metadata is malformed. "
+                "The dispatch lineage is written by the runtime; do not supply or edit it. Do not retry."
+            )
+        depth = metadata.get(DISPATCH_DEPTH_METADATA_KEY)
+        if isinstance(depth, bool) or not isinstance(depth, int) or depth < 0:
+            raise DispatchStateError(
+                f"Refusing to dispatch: this run's '{DISPATCH_DEPTH_METADATA_KEY}' metadata is malformed. "
+                "The dispatch hop count is written by the runtime; do not supply or edit it. Do not retry."
+            )
+        return list(chain), depth
+
+    def _require_dispatch_budget(self, depth: int, component_type: str, identifier: str) -> None:
+        """Refuses when the inherited hop count has spent ``max_dispatch_depth``.
+
+        Runs before resolution: the hop count needs no target id, and
+        resolution deep-copies or rebuilds the component, which a refused
+        dispatch should never pay for."""
+        if depth >= self.max_dispatch_depth:
+            raise DispatchDepthExceededError(
+                f"Refusing to dispatch {component_type} '{identifier}': this dispatch tree is already "
+                f"{depth} hop(s) deep and this runner allows at most {self.max_dispatch_depth}. "
+                "Answer with the results you already have; do not retry this call. A deployment that "
+                "composes deeper sets max_dispatch_depth on StudioRunnerTools."
+            )
+
+    @staticmethod
+    def _require_no_cycle(running: List[str], component_type: str, component_id: str) -> str:
+        """The target's lineage token, after refusing re-entry.
+
+        Tests the RESOLVED id, so a display name or slug alias cannot evade
+        the guard, against the running set (inherited lineage plus wielders):
+        a component may not be dispatched while it is already running in this
+        tree, at any depth."""
+        target = f"{component_type}:{component_id}"
+        if target in running:
+            raise DispatchCycleError(
+                f"Refusing to dispatch {component_type} '{component_id}': it is already running this "
+                f"request ({' -> '.join([*running, target])}). Answer directly, delegate to a different "
+                "component, or tell the user to start a separate conversation with it. Do not retry this call."
+            )
+        return target
+
+    def _outgoing_metadata(
+        self,
+        run_context: Optional[RunContext],
+        running: List[str],
+        depth: int,
+        target: str,
+    ) -> Dict[str, Any]:
+        """The child run's metadata: the caller's metadata minus the keys the
+        runtime owns, the lineage extended with the running set and the target
+        (so the wielder is recorded, not just the target -- an inherited-only
+        chain would allow A -> B -> A), and the hop count incremented by one.
+
+        The version pin (``agno_component_version``) is deliberately not
+        forwarded: it describes the CALLER's run, and forwarding it would
+        stamp the child's run row so the lifecycle routes continue a paused
+        child on the wrong version of the child."""
+        inbound = getattr(run_context, "metadata", None)
+        if not isinstance(inbound, dict):
+            inbound = {}
+        child = dict(strip_reserved_run_metadata(inbound) or {})
+        child[DISPATCH_CHAIN_METADATA_KEY] = self._dedup([*running, target])
+        child[DISPATCH_DEPTH_METADATA_KEY] = depth + 1
+        return child
+
+    @staticmethod
+    def _registered_sub_run_id(run_context: Optional[RunContext]) -> str:
+        """A pre-minted run id for the dispatch, registered under the caller's
+        run when there is one, so a team or workflow caller's cancel_run
+        cascades into the dispatched sub-run the way it already does for
+        delegated member runs and workflow steps (Agent.cancel_run has no
+        cascade today). Registration precedes dispatch, mirroring member
+        delegation; the registry is TTL-bounded, so a dispatch that fails to
+        start leaves no lasting entry."""
+        sub_run_id = str(uuid4())
+        parent_run_id = getattr(run_context, "run_id", None)
+        if parent_run_id:
+            register_member_run(parent_run_id, sub_run_id)
+        return sub_run_id
+
+    @staticmethod
+    async def _aregistered_sub_run_id(run_context: Optional[RunContext]) -> str:
+        """Async twin of _registered_sub_run_id, on the async registrar."""
+        sub_run_id = str(uuid4())
+        parent_run_id = getattr(run_context, "run_id", None)
+        if parent_run_id:
+            await aregister_member_run(parent_run_id, sub_run_id)
+        return sub_run_id
+
+    def _dispatch_metadata(
+        self,
+        run_context: Optional[RunContext],
+        component_type: str,
+        component_id: str,
+        wielder_agent: Any = None,
+        wielder_team: Any = None,
+    ) -> Dict[str, Any]:
+        """The whole guard in dispatch order: inherited state (fail-closed),
+        depth budget, cycle test on the resolved id, outgoing metadata.
+        Raises the DispatchStateError / DispatchDepthExceededError /
+        DispatchCycleError family, which the run tools return as JSON errors,
+        never raise to the caller. The run tools call the pieces separately so
+        the depth test runs before resolution; this composition serves callers
+        that already hold the resolved id (StudioTools' version-pinned path)."""
+        inherited, depth = self._inherited_dispatch_state(run_context)
+        self._require_dispatch_budget(depth, component_type, component_id)
+        running = self._dedup([*inherited, *self._wielder_tokens(wielder_agent, wielder_team)])
+        target = self._require_no_cycle(running, component_type, component_id)
+        return self._outgoing_metadata(run_context, running, depth, target)
+
+    def _cross_namespace_hint(self, component_type: str, identifier: str, actor: Optional[str] = None) -> str:
+        """A pointer at the sibling run tool when the identifier resolves in
+        another namespace, or ''. run_agent/run_team/run_workflow resolve in
+        separate namespaces, so without this a caller who asks for a team by
+        way of run_agent gets a bare not-found and concludes the component
+        does not exist.
+
+        Only namespaces this toolkit registered tools for, and only components
+        the probe can resolve for dispatch, produce a hint -- the hint must
+        never name a component the caller cannot actually run. Probe failures
+        of any kind produce no hint rather than a second error: the hint is
+        best-effort decoration on an error path."""
+        probes: List[Tuple[str, bool, Callable[..., Any], str, str]] = [
+            ("agent", self.enable_agents, self._find_agent, "run_agent", "agent_id"),
+            ("team", self.enable_teams, self._find_team, "run_team", "team_id"),
+            ("workflow", self.enable_workflows, self._find_workflow, "run_workflow", "workflow_id"),
+        ]
+        for sibling_type, enabled, find, run_tool, param in probes:
+            if sibling_type == component_type or not enabled:
+                continue
+            try:
+                sibling = find(identifier, for_dispatch=True, actor=actor)
+            except Exception:
+                continue
+            if sibling is None:
+                continue
+            sibling_id = getattr(sibling, "id", None) or identifier
+            article = "An" if sibling_type == "agent" else "A"
+            # Appended to "X not found: <id>", which carries no trailing period.
+            return f". {article} {sibling_type} with this identifier exists -- use {run_tool}({param}='{sibling_id}')."
+        return ""
+
+    def _not_found_message(self, component_type: str, identifier: str, actor: Optional[str] = None) -> str:
+        """The not-found error for a run tool, with the sideways hint when the
+        identifier resolves in a sibling namespace the caller could run."""
+        hint = self._cross_namespace_hint(component_type, identifier, actor=actor)
+        return f"{component_type.capitalize()} not found: {identifier}{hint}"
+
+    def run_agent(
+        self,
+        agent_id: str,
+        message: str,
+        _agno_run_context: Optional[RunContext] = None,
+        _agno_agent: Optional[Any] = None,
+        _agno_team: Optional[Any] = None,
+    ) -> str:
         """Run an agent and return its result.
 
         The run executes as the current user and continues that user's
         per-conversation session with this agent. A PAUSED status means the run
         awaits human approval: the result carries the unresolved requirements
-        plus the run_id and session_id a continue call must address.
+        plus the run_id and session_id a continue call must address. A dispatch
+        refused for a cycle or the depth limit returns an error naming the
+        lineage; relay it -- do not retry.
 
         Args:
             agent_id (str): Id of the agent to run (a display name or its slug also resolves).
@@ -2313,8 +2612,14 @@ class StudioRunnerTools(Toolkit):
             str: JSON object with 'agent_id', 'run_id', 'session_id', 'status',
                 'content' and, when paused, 'requirements'.
         """
+        actor = getattr(_agno_run_context, "user_id", None)
         try:
-            agent = self._agent_for_run(agent_id, actor=getattr(_agno_run_context, "user_id", None))
+            # Depth first: a spent budget refuses before resolution pays for a
+            # copy or rebuild. Inside this try so a refusal is returned like
+            # every other deliberate refusal, never logged as a crash.
+            inherited, depth = self._inherited_dispatch_state(_agno_run_context)
+            self._require_dispatch_budget(depth, "agent", agent_id)
+            agent = self._agent_for_run(agent_id, actor=actor)
         except StudioRunnerError as e:
             # Deliberate refusals with an actionable message; not failures to log.
             return json.dumps({"error": str(e)})
@@ -2322,27 +2627,46 @@ class StudioRunnerTools(Toolkit):
             logger.exception("Failed to resolve agent")
             return json.dumps({"error": f"Failed to resolve agent '{agent_id}': {str(e) or type(e).__name__}"})
         if agent is None:
-            return json.dumps({"error": f"Agent not found: {agent_id}"})
+            return json.dumps({"error": self._not_found_message("agent", agent_id, actor=actor)})
         component_id = getattr(agent, "id", None) or agent_id
+        try:
+            running = self._dedup([*inherited, *self._wielder_tokens(_agno_agent, _agno_team)])
+            target = self._require_no_cycle(running, "agent", component_id)
+        except StudioRunnerError as e:
+            # Deliberate refusals with an actionable message; not failures to log.
+            return json.dumps({"error": str(e)})
+        dispatch_metadata = self._outgoing_metadata(_agno_run_context, running, depth, target)
+        sub_run_id = self._registered_sub_run_id(_agno_run_context)
         try:
             response = agent.run(
                 message,
                 stream=False,
                 user_id=self._caller_user_id(_agno_run_context, agent),
                 session_id=self._sub_session_id(_agno_run_context, "agent", component_id),
+                run_id=sub_run_id,
+                metadata=dispatch_metadata,
             )
             return self._run_payload("agent_id", component_id, response)
         except Exception as e:
             logger.exception("Failed to run agent")
             return json.dumps({"error": str(e) or type(e).__name__})
 
-    def run_team(self, team_id: str, message: str, _agno_run_context: Optional[RunContext] = None) -> str:
+    def run_team(
+        self,
+        team_id: str,
+        message: str,
+        _agno_run_context: Optional[RunContext] = None,
+        _agno_agent: Optional[Any] = None,
+        _agno_team: Optional[Any] = None,
+    ) -> str:
         """Run a team and return its result.
 
         The run executes as the current user and continues that user's
         per-conversation session with this team. A PAUSED status means the run
         awaits human approval: the result carries the unresolved requirements
-        plus the run_id and session_id a continue call must address.
+        plus the run_id and session_id a continue call must address. A dispatch
+        refused for a cycle or the depth limit returns an error naming the
+        lineage; relay it -- do not retry.
 
         Args:
             team_id (str): Id of the team to run (a display name or its slug also resolves).
@@ -2352,8 +2676,14 @@ class StudioRunnerTools(Toolkit):
             str: JSON object with 'team_id', 'run_id', 'session_id', 'status',
                 'content' and, when paused, 'requirements'.
         """
+        actor = getattr(_agno_run_context, "user_id", None)
         try:
-            team = self._team_for_run(team_id, actor=getattr(_agno_run_context, "user_id", None))
+            # Depth first: a spent budget refuses before resolution pays for a
+            # copy or rebuild. Inside this try so a refusal is returned like
+            # every other deliberate refusal, never logged as a crash.
+            inherited, depth = self._inherited_dispatch_state(_agno_run_context)
+            self._require_dispatch_budget(depth, "team", team_id)
+            team = self._team_for_run(team_id, actor=actor)
         except StudioRunnerError as e:
             # Deliberate refusals with an actionable message; not failures to log.
             return json.dumps({"error": str(e)})
@@ -2361,27 +2691,46 @@ class StudioRunnerTools(Toolkit):
             logger.exception("Failed to resolve team")
             return json.dumps({"error": f"Failed to resolve team '{team_id}': {str(e) or type(e).__name__}"})
         if team is None:
-            return json.dumps({"error": f"Team not found: {team_id}"})
+            return json.dumps({"error": self._not_found_message("team", team_id, actor=actor)})
         component_id = getattr(team, "id", None) or team_id
+        try:
+            running = self._dedup([*inherited, *self._wielder_tokens(_agno_agent, _agno_team)])
+            target = self._require_no_cycle(running, "team", component_id)
+        except StudioRunnerError as e:
+            # Deliberate refusals with an actionable message; not failures to log.
+            return json.dumps({"error": str(e)})
+        dispatch_metadata = self._outgoing_metadata(_agno_run_context, running, depth, target)
+        sub_run_id = self._registered_sub_run_id(_agno_run_context)
         try:
             response = team.run(
                 message,
                 stream=False,
                 user_id=self._caller_user_id(_agno_run_context, team),
                 session_id=self._sub_session_id(_agno_run_context, "team", component_id),
+                run_id=sub_run_id,
+                metadata=dispatch_metadata,
             )
             return self._run_payload("team_id", component_id, response)
         except Exception as e:
             logger.exception("Failed to run team")
             return json.dumps({"error": str(e) or type(e).__name__})
 
-    def run_workflow(self, workflow_id: str, message: str, _agno_run_context: Optional[RunContext] = None) -> str:
+    def run_workflow(
+        self,
+        workflow_id: str,
+        message: str,
+        _agno_run_context: Optional[RunContext] = None,
+        _agno_agent: Optional[Any] = None,
+        _agno_team: Optional[Any] = None,
+    ) -> str:
         """Run a workflow and return its final result.
 
         The run executes as the current user and continues that user's
         per-conversation session with this workflow. A PAUSED status means the
         run awaits human approval: the result carries the unresolved
         requirements plus the run_id and session_id a continue call must address.
+        A dispatch refused for a cycle or the depth limit returns an error
+        naming the lineage; relay it -- do not retry.
 
         Args:
             workflow_id (str): Id of the workflow to run (a display name or its slug also resolves).
@@ -2391,8 +2740,14 @@ class StudioRunnerTools(Toolkit):
             str: JSON object with 'workflow_id', 'run_id', 'session_id', 'status',
                 'content' and, when paused, 'requirements'.
         """
+        actor = getattr(_agno_run_context, "user_id", None)
         try:
-            wf = self._workflow_for_run(workflow_id, actor=getattr(_agno_run_context, "user_id", None))
+            # Depth first: a spent budget refuses before resolution pays for a
+            # copy or rebuild. Inside this try so a refusal is returned like
+            # every other deliberate refusal, never logged as a crash.
+            inherited, depth = self._inherited_dispatch_state(_agno_run_context)
+            self._require_dispatch_budget(depth, "workflow", workflow_id)
+            wf = self._workflow_for_run(workflow_id, actor=actor)
         except StudioRunnerError as e:
             # Deliberate refusals with an actionable message; not failures to log.
             return json.dumps({"error": str(e)})
@@ -2400,21 +2755,38 @@ class StudioRunnerTools(Toolkit):
             logger.exception("Failed to resolve workflow")
             return json.dumps({"error": f"Failed to resolve workflow '{workflow_id}': {str(e) or type(e).__name__}"})
         if wf is None:
-            return json.dumps({"error": f"Workflow not found: {workflow_id}"})
+            return json.dumps({"error": self._not_found_message("workflow", workflow_id, actor=actor)})
         component_id = getattr(wf, "id", None) or workflow_id
+        try:
+            running = self._dedup([*inherited, *self._wielder_tokens(_agno_agent, _agno_team)])
+            target = self._require_no_cycle(running, "workflow", component_id)
+        except StudioRunnerError as e:
+            # Deliberate refusals with an actionable message; not failures to log.
+            return json.dumps({"error": str(e)})
+        dispatch_metadata = self._outgoing_metadata(_agno_run_context, running, depth, target)
+        sub_run_id = self._registered_sub_run_id(_agno_run_context)
         try:
             response = wf.run(
                 input=message,
                 stream=False,
                 user_id=self._caller_user_id(_agno_run_context, wf),
                 session_id=self._sub_session_id(_agno_run_context, "workflow", component_id),
+                run_id=sub_run_id,
+                metadata=dispatch_metadata,
             )
             return self._run_payload("workflow_id", component_id, response)
         except Exception as e:
             logger.exception("Failed to run workflow")
             return json.dumps({"error": str(e) or type(e).__name__})
 
-    async def arun_agent(self, agent_id: str, message: str, _agno_run_context: Optional[RunContext] = None) -> str:
+    async def arun_agent(
+        self,
+        agent_id: str,
+        message: str,
+        _agno_run_context: Optional[RunContext] = None,
+        _agno_agent: Optional[Any] = None,
+        _agno_team: Optional[Any] = None,
+    ) -> str:
         """Async variant of run_agent.
 
         Args:
@@ -2422,10 +2794,13 @@ class StudioRunnerTools(Toolkit):
             message (str): The message to send.
         """
         # Resolution hits the DB synchronously; keep it off the event loop.
+        actor = getattr(_agno_run_context, "user_id", None)
         try:
-            agent = await asyncio.to_thread(
-                self._agent_for_run, agent_id, actor=getattr(_agno_run_context, "user_id", None)
-            )
+            # Depth first, before resolution -- pure in-memory work, no thread
+            # hop needed; a refusal is returned, never logged as a crash.
+            inherited, depth = self._inherited_dispatch_state(_agno_run_context)
+            self._require_dispatch_budget(depth, "agent", agent_id)
+            agent = await asyncio.to_thread(self._agent_for_run, agent_id, actor=actor)
         except StudioRunnerError as e:
             # Deliberate refusals with an actionable message; not failures to log.
             return json.dumps({"error": str(e)})
@@ -2433,31 +2808,54 @@ class StudioRunnerTools(Toolkit):
             logger.exception("Failed to resolve agent")
             return json.dumps({"error": f"Failed to resolve agent '{agent_id}': {str(e) or type(e).__name__}"})
         if agent is None:
-            return json.dumps({"error": f"Agent not found: {agent_id}"})
+            # The probe reads the DB; keep it off the event loop like resolution.
+            return json.dumps(
+                {"error": await asyncio.to_thread(self._not_found_message, "agent", agent_id, actor=actor)}
+            )
         component_id = getattr(agent, "id", None) or agent_id
+        try:
+            running = self._dedup([*inherited, *self._wielder_tokens(_agno_agent, _agno_team)])
+            target = self._require_no_cycle(running, "agent", component_id)
+        except StudioRunnerError as e:
+            # Deliberate refusals with an actionable message; not failures to log.
+            return json.dumps({"error": str(e)})
+        dispatch_metadata = self._outgoing_metadata(_agno_run_context, running, depth, target)
+        sub_run_id = await self._aregistered_sub_run_id(_agno_run_context)
         try:
             response = await agent.arun(
                 message,
                 stream=False,
                 user_id=self._caller_user_id(_agno_run_context, agent),
                 session_id=self._sub_session_id(_agno_run_context, "agent", component_id),
+                run_id=sub_run_id,
+                metadata=dispatch_metadata,
             )
             return self._run_payload("agent_id", component_id, response)
         except Exception as e:
             logger.exception("Failed to run agent")
             return json.dumps({"error": str(e) or type(e).__name__})
 
-    async def arun_team(self, team_id: str, message: str, _agno_run_context: Optional[RunContext] = None) -> str:
+    async def arun_team(
+        self,
+        team_id: str,
+        message: str,
+        _agno_run_context: Optional[RunContext] = None,
+        _agno_agent: Optional[Any] = None,
+        _agno_team: Optional[Any] = None,
+    ) -> str:
         """Async variant of run_team.
 
         Args:
             team_id (str): Id of the team to run (a display name or its slug also resolves).
             message (str): The message to send.
         """
+        actor = getattr(_agno_run_context, "user_id", None)
         try:
-            team = await asyncio.to_thread(
-                self._team_for_run, team_id, actor=getattr(_agno_run_context, "user_id", None)
-            )
+            # Depth first, before resolution -- pure in-memory work, no thread
+            # hop needed; a refusal is returned, never logged as a crash.
+            inherited, depth = self._inherited_dispatch_state(_agno_run_context)
+            self._require_dispatch_budget(depth, "team", team_id)
+            team = await asyncio.to_thread(self._team_for_run, team_id, actor=actor)
         except StudioRunnerError as e:
             # Deliberate refusals with an actionable message; not failures to log.
             return json.dumps({"error": str(e)})
@@ -2465,14 +2863,25 @@ class StudioRunnerTools(Toolkit):
             logger.exception("Failed to resolve team")
             return json.dumps({"error": f"Failed to resolve team '{team_id}': {str(e) or type(e).__name__}"})
         if team is None:
-            return json.dumps({"error": f"Team not found: {team_id}"})
+            # The probe reads the DB; keep it off the event loop like resolution.
+            return json.dumps({"error": await asyncio.to_thread(self._not_found_message, "team", team_id, actor=actor)})
         component_id = getattr(team, "id", None) or team_id
+        try:
+            running = self._dedup([*inherited, *self._wielder_tokens(_agno_agent, _agno_team)])
+            target = self._require_no_cycle(running, "team", component_id)
+        except StudioRunnerError as e:
+            # Deliberate refusals with an actionable message; not failures to log.
+            return json.dumps({"error": str(e)})
+        dispatch_metadata = self._outgoing_metadata(_agno_run_context, running, depth, target)
+        sub_run_id = await self._aregistered_sub_run_id(_agno_run_context)
         try:
             response = await team.arun(
                 message,
                 stream=False,
                 user_id=self._caller_user_id(_agno_run_context, team),
                 session_id=self._sub_session_id(_agno_run_context, "team", component_id),
+                run_id=sub_run_id,
+                metadata=dispatch_metadata,
             )
             return self._run_payload("team_id", component_id, response)
         except Exception as e:
@@ -2480,7 +2889,12 @@ class StudioRunnerTools(Toolkit):
             return json.dumps({"error": str(e) or type(e).__name__})
 
     async def arun_workflow(
-        self, workflow_id: str, message: str, _agno_run_context: Optional[RunContext] = None
+        self,
+        workflow_id: str,
+        message: str,
+        _agno_run_context: Optional[RunContext] = None,
+        _agno_agent: Optional[Any] = None,
+        _agno_team: Optional[Any] = None,
     ) -> str:
         """Async variant of run_workflow.
 
@@ -2488,10 +2902,13 @@ class StudioRunnerTools(Toolkit):
             workflow_id (str): Id of the workflow to run (a display name or its slug also resolves).
             message (str): Input to pass to the first step.
         """
+        actor = getattr(_agno_run_context, "user_id", None)
         try:
-            wf = await asyncio.to_thread(
-                self._workflow_for_run, workflow_id, actor=getattr(_agno_run_context, "user_id", None)
-            )
+            # Depth first, before resolution -- pure in-memory work, no thread
+            # hop needed; a refusal is returned, never logged as a crash.
+            inherited, depth = self._inherited_dispatch_state(_agno_run_context)
+            self._require_dispatch_budget(depth, "workflow", workflow_id)
+            wf = await asyncio.to_thread(self._workflow_for_run, workflow_id, actor=actor)
         except StudioRunnerError as e:
             # Deliberate refusals with an actionable message; not failures to log.
             return json.dumps({"error": str(e)})
@@ -2499,14 +2916,27 @@ class StudioRunnerTools(Toolkit):
             logger.exception("Failed to resolve workflow")
             return json.dumps({"error": f"Failed to resolve workflow '{workflow_id}': {str(e) or type(e).__name__}"})
         if wf is None:
-            return json.dumps({"error": f"Workflow not found: {workflow_id}"})
+            # The probe reads the DB; keep it off the event loop like resolution.
+            return json.dumps(
+                {"error": await asyncio.to_thread(self._not_found_message, "workflow", workflow_id, actor=actor)}
+            )
         component_id = getattr(wf, "id", None) or workflow_id
+        try:
+            running = self._dedup([*inherited, *self._wielder_tokens(_agno_agent, _agno_team)])
+            target = self._require_no_cycle(running, "workflow", component_id)
+        except StudioRunnerError as e:
+            # Deliberate refusals with an actionable message; not failures to log.
+            return json.dumps({"error": str(e)})
+        dispatch_metadata = self._outgoing_metadata(_agno_run_context, running, depth, target)
+        sub_run_id = await self._aregistered_sub_run_id(_agno_run_context)
         try:
             response = await wf.arun(
                 input=message,
                 stream=False,
                 user_id=self._caller_user_id(_agno_run_context, wf),
                 session_id=self._sub_session_id(_agno_run_context, "workflow", component_id),
+                run_id=sub_run_id,
+                metadata=dispatch_metadata,
             )
             return self._run_payload("workflow_id", component_id, response)
         except Exception as e:

--- a/libs/agno/agno/tools/studio_runner.py
+++ b/libs/agno/agno/tools/studio_runner.py
@@ -198,7 +198,7 @@ class DispatchCycleError(ComponentNotDispatchableError):
     """The dispatch target is already running in this dispatch lineage.
 
     Every dispatched run carries the components already running in its
-    dispatch tree in run metadata, and the wielding component joins that set
+    dispatch tree in run metadata, and the calling component joins that set
     at dispatch time. Re-entering one of them can only repeat work, and
     unchecked it is a self-sustaining loop: one message can keep a component
     re-dispatching itself indefinitely, outliving the HTTP caller and stopping
@@ -2396,8 +2396,8 @@ class StudioRunnerTools(Toolkit):
     # carries every component already running in this dispatch tree (the
     # lineage; membership is the cycle test) and the number of dispatches that
     # produced this run (the hop count; the depth test). They are two keys
-    # because the lineage records wielders as well as targets, so its length
-    # is not the hop count. The wielding component arrives through the
+    # because the lineage records callers as well as targets, so its length
+    # is not the hop count. The calling component arrives through the
     # framework's identity injection (_agno_agent/_agno_team) and joins the
     # lineage at dispatch time -- an inherited-only chain is empty at the top
     # level, which is exactly the reported repro (a team dispatching itself
@@ -2408,16 +2408,16 @@ class StudioRunnerTools(Toolkit):
         return list(dict.fromkeys(tokens))
 
     @staticmethod
-    def _wielder_tokens(wielder_agent: Any, wielder_team: Any) -> List[str]:
-        """Lineage tokens for the components wielding this toolkit.
+    def _caller_tokens(caller_agent: Any, caller_team: Any) -> List[str]:
+        """Lineage tokens for the components calling through this toolkit.
 
         A toolkit on a team leader contributes the team; a toolkit on a member
         agent contributes both its parent team and itself, outer frame first --
-        both are genuinely running and both are cycle targets. A wielder with
+        both are genuinely running and both are cycle targets. A caller with
         no usable id contributes nothing."""
         tokens: List[str] = []
-        for component_type, wielder in (("team", wielder_team), ("agent", wielder_agent)):
-            component_id = getattr(wielder, "id", None)
+        for component_type, caller in (("team", caller_team), ("agent", caller_agent)):
+            component_id = getattr(caller, "id", None)
             if isinstance(component_id, str) and component_id:
                 tokens.append(f"{component_type}:{component_id}")
         return tokens
@@ -2468,7 +2468,7 @@ class StudioRunnerTools(Toolkit):
         """The target's lineage token, after refusing re-entry.
 
         Tests the RESOLVED id, so a display name or slug alias cannot evade
-        the guard, against the running set (inherited lineage plus wielders):
+        the guard, against the running set (inherited lineage plus the calling components):
         a component may not be dispatched while it is already running in this
         tree, at any depth."""
         target = f"{component_type}:{component_id}"
@@ -2489,7 +2489,7 @@ class StudioRunnerTools(Toolkit):
     ) -> Dict[str, Any]:
         """The child run's metadata: the caller's metadata minus the keys the
         runtime owns, the lineage extended with the running set and the target
-        (so the wielder is recorded, not just the target -- an inherited-only
+        (so the caller is recorded, not just the target -- an inherited-only
         chain would allow A -> B -> A), and the hop count incremented by one.
 
         The version pin (``agno_component_version``) is deliberately not
@@ -2533,8 +2533,8 @@ class StudioRunnerTools(Toolkit):
         run_context: Optional[RunContext],
         component_type: str,
         component_id: str,
-        wielder_agent: Any = None,
-        wielder_team: Any = None,
+        caller_agent: Any = None,
+        caller_team: Any = None,
     ) -> Dict[str, Any]:
         """The whole guard in dispatch order: inherited state (fail-closed),
         depth budget, cycle test on the resolved id, outgoing metadata.
@@ -2545,7 +2545,7 @@ class StudioRunnerTools(Toolkit):
         that already hold the resolved id (StudioTools' version-pinned path)."""
         inherited, depth = self._inherited_dispatch_state(run_context)
         self._require_dispatch_budget(depth, component_type, component_id)
-        running = self._dedup([*inherited, *self._wielder_tokens(wielder_agent, wielder_team)])
+        running = self._dedup([*inherited, *self._caller_tokens(caller_agent, caller_team)])
         target = self._require_no_cycle(running, component_type, component_id)
         return self._outgoing_metadata(run_context, running, depth, target)
 
@@ -2630,7 +2630,7 @@ class StudioRunnerTools(Toolkit):
             return json.dumps({"error": self._not_found_message("agent", agent_id, actor=actor)})
         component_id = getattr(agent, "id", None) or agent_id
         try:
-            running = self._dedup([*inherited, *self._wielder_tokens(_agno_agent, _agno_team)])
+            running = self._dedup([*inherited, *self._caller_tokens(_agno_agent, _agno_team)])
             target = self._require_no_cycle(running, "agent", component_id)
         except StudioRunnerError as e:
             # Deliberate refusals with an actionable message; not failures to log.
@@ -2694,7 +2694,7 @@ class StudioRunnerTools(Toolkit):
             return json.dumps({"error": self._not_found_message("team", team_id, actor=actor)})
         component_id = getattr(team, "id", None) or team_id
         try:
-            running = self._dedup([*inherited, *self._wielder_tokens(_agno_agent, _agno_team)])
+            running = self._dedup([*inherited, *self._caller_tokens(_agno_agent, _agno_team)])
             target = self._require_no_cycle(running, "team", component_id)
         except StudioRunnerError as e:
             # Deliberate refusals with an actionable message; not failures to log.
@@ -2758,7 +2758,7 @@ class StudioRunnerTools(Toolkit):
             return json.dumps({"error": self._not_found_message("workflow", workflow_id, actor=actor)})
         component_id = getattr(wf, "id", None) or workflow_id
         try:
-            running = self._dedup([*inherited, *self._wielder_tokens(_agno_agent, _agno_team)])
+            running = self._dedup([*inherited, *self._caller_tokens(_agno_agent, _agno_team)])
             target = self._require_no_cycle(running, "workflow", component_id)
         except StudioRunnerError as e:
             # Deliberate refusals with an actionable message; not failures to log.
@@ -2814,7 +2814,7 @@ class StudioRunnerTools(Toolkit):
             )
         component_id = getattr(agent, "id", None) or agent_id
         try:
-            running = self._dedup([*inherited, *self._wielder_tokens(_agno_agent, _agno_team)])
+            running = self._dedup([*inherited, *self._caller_tokens(_agno_agent, _agno_team)])
             target = self._require_no_cycle(running, "agent", component_id)
         except StudioRunnerError as e:
             # Deliberate refusals with an actionable message; not failures to log.
@@ -2867,7 +2867,7 @@ class StudioRunnerTools(Toolkit):
             return json.dumps({"error": await asyncio.to_thread(self._not_found_message, "team", team_id, actor=actor)})
         component_id = getattr(team, "id", None) or team_id
         try:
-            running = self._dedup([*inherited, *self._wielder_tokens(_agno_agent, _agno_team)])
+            running = self._dedup([*inherited, *self._caller_tokens(_agno_agent, _agno_team)])
             target = self._require_no_cycle(running, "team", component_id)
         except StudioRunnerError as e:
             # Deliberate refusals with an actionable message; not failures to log.
@@ -2922,7 +2922,7 @@ class StudioRunnerTools(Toolkit):
             )
         component_id = getattr(wf, "id", None) or workflow_id
         try:
-            running = self._dedup([*inherited, *self._wielder_tokens(_agno_agent, _agno_team)])
+            running = self._dedup([*inherited, *self._caller_tokens(_agno_agent, _agno_team)])
             target = self._require_no_cycle(running, "workflow", component_id)
         except StudioRunnerError as e:
             # Deliberate refusals with an actionable message; not failures to log.

--- a/libs/agno/agno/tools/studio_schema.py
+++ b/libs/agno/agno/tools/studio_schema.py
@@ -49,6 +49,10 @@ StudioErrorCode = Literal[
     # migration, not configuration, and the message carries the command.
     "db_schema_stale",
     "validation_failed",
+    # The target is already on this dispatch chain, or the chain is at
+    # max_dispatch_depth. Deliberately not retryable: retrying the same
+    # dispatch is the loop the refusal exists to stop.
+    "dispatch_refused",
     "internal_error",
 ]
 

--- a/libs/agno/tests/unit/db/test_reserved_run_metadata.py
+++ b/libs/agno/tests/unit/db/test_reserved_run_metadata.py
@@ -1,20 +1,30 @@
-"""A stored config cannot claim which version a run started on.
+"""A stored config cannot claim what the runtime writes into run metadata.
 
 ``agno_component_version`` is written by the run-start routes when a caller
 pins a version explicitly, and read back by the lifecycle routes so a paused
-run continues on the SAME version. Component metadata is merged OVER
-call-site metadata, so a config carrying that key would both forge a stamp
-onto runs that were never pinned and overwrite the one the route just wrote.
+run continues on the SAME version. ``_agno_dispatch_chain`` is written by
+StudioRunnerTools on dispatch and read back by the nested run's own runner
+tools to refuse cycles and bound depth. Component metadata is merged OVER
+call-site metadata, so a config carrying the version key would forge a stamp
+onto runs that were never pinned, and one carrying the chain key (say, an
+empty list) would reset the cycle guard on every hop and re-open unbounded
+self-dispatch.
 
-Configs are user-supplied and round-trip through the catalog, so the key is
-stripped where it enters the object.
+Configs are user-supplied and round-trip through the catalog, so the keys are
+stripped where they enter the object.
 """
 
 import pytest
 
 from agno.agent.agent import Agent
 from agno.db.base import ComponentType
-from agno.db.schemas.scheduler import COMPONENT_VERSION_METADATA_KEY, strip_reserved_run_metadata
+from agno.db.schemas.scheduler import (
+    COMPONENT_VERSION_METADATA_KEY,
+    DISPATCH_CHAIN_METADATA_KEY,
+    DISPATCH_DEPTH_METADATA_KEY,
+    RESERVED_RUN_METADATA_KEYS,
+    strip_reserved_run_metadata,
+)
 from agno.db.sqlite import SqliteDb
 from agno.team.team import Team
 from agno.workflow.workflow import Workflow
@@ -29,8 +39,25 @@ class TestTheHelper:
     def test_the_reserved_key_is_removed(self):
         assert strip_reserved_run_metadata({COMPONENT_VERSION_METADATA_KEY: 7, "team": "growth"}) == {"team": "growth"}
 
+    def test_the_dispatch_keys_are_removed(self):
+        stripped = strip_reserved_run_metadata(
+            {DISPATCH_CHAIN_METADATA_KEY: ["team:a"], DISPATCH_DEPTH_METADATA_KEY: 1, "team": "growth"}
+        )
+        assert stripped == {"team": "growth"}
+
+    def test_all_reserved_keys_go_together(self):
+        loaded = {key: "forged" for key in RESERVED_RUN_METADATA_KEYS}
+        loaded["team"] = "growth"
+        assert strip_reserved_run_metadata(loaded) == {"team": "growth"}
+
     def test_a_metadata_of_only_the_reserved_key_becomes_none(self):
         assert strip_reserved_run_metadata({COMPONENT_VERSION_METADATA_KEY: 7}) is None
+
+    def test_a_metadata_of_only_the_dispatch_keys_becomes_none(self):
+        assert (
+            strip_reserved_run_metadata({DISPATCH_CHAIN_METADATA_KEY: ["team:a"], DISPATCH_DEPTH_METADATA_KEY: 0})
+            is None
+        )
 
     def test_other_metadata_is_untouched(self):
         assert strip_reserved_run_metadata({"team": "growth"}) == {"team": "growth"}
@@ -79,3 +106,45 @@ class TestTheKeyCannotRideAStoredConfig:
         )
         workflow = Workflow.from_dict(db.get_config("forger-flow")["config"])
         assert workflow.metadata == {"k": "v"}
+
+    def test_an_agent_config_cannot_carry_the_chain(self, db):
+        # A zero-depth lineage on a component's own metadata wins the merge
+        # over the call-site value and resets every sub-run to depth zero, so
+        # each of the three rebuild paths must strip it or that component type
+        # becomes the guard's blind spot.
+        self._stored(
+            db,
+            "chain-agent",
+            ComponentType.AGENT,
+            {
+                "name": "chain-agent",
+                "metadata": {DISPATCH_CHAIN_METADATA_KEY: [], DISPATCH_DEPTH_METADATA_KEY: 0, "team": "growth"},
+            },
+        )
+        assert Agent.from_dict(db.get_config("chain-agent")["config"]).metadata == {"team": "growth"}
+
+    def test_a_team_config_cannot_carry_the_chain(self, db):
+        self._stored(
+            db,
+            "chain-team",
+            ComponentType.TEAM,
+            {
+                "name": "chain-team",
+                "members": [],
+                "metadata": {DISPATCH_CHAIN_METADATA_KEY: [], DISPATCH_DEPTH_METADATA_KEY: 0},
+            },
+        )
+        assert Team.from_dict(db.get_config("chain-team")["config"]).metadata is None
+
+    def test_a_workflow_config_cannot_carry_the_chain(self, db):
+        self._stored(
+            db,
+            "chain-flow",
+            ComponentType.WORKFLOW,
+            {
+                "name": "chain-flow",
+                "steps": [],
+                "metadata": {DISPATCH_CHAIN_METADATA_KEY: [], DISPATCH_DEPTH_METADATA_KEY: 0, "k": "v"},
+            },
+        )
+        assert Workflow.from_dict(db.get_config("chain-flow")["config"]).metadata == {"k": "v"}

--- a/libs/agno/tests/unit/os/test_preview_stamp_forgery.py
+++ b/libs/agno/tests/unit/os/test_preview_stamp_forgery.py
@@ -33,6 +33,7 @@ from fastapi.testclient import TestClient
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from agno.agent.agent import Agent
+from agno.db.schemas.scheduler import DISPATCH_CHAIN_METADATA_KEY, DISPATCH_DEPTH_METADATA_KEY
 from agno.db.sqlite import SqliteDb
 from agno.models.base import Model
 from agno.models.message import MessageMetrics
@@ -197,6 +198,34 @@ class TestForgedStampStrippedAtRunStart:
         meta = start.json().get("metadata") or {}
         assert meta.get("trace") == "keep"
         assert COMPONENT_VERSION_METADATA_KEY not in meta
+
+    def test_a_forged_dispatch_chain_is_stripped_at_run_start(self, db, registry, model_v1, model_v2):
+        # Defence in depth: a caller forging the dispatch lineage can only
+        # shorten their own reach (the guard fails closed on garbage and a
+        # pre-seeded chain only restricts), but the runtime-owned keys still
+        # never enter through a caller-writable form field.
+        agent_id = _save_agent(db, model_v1, model_v2)
+        client = _client(AgentOS(db=db, registry=registry, telemetry=False).get_app(), _BOB)
+
+        start = client.post(
+            f"/agents/{agent_id}/runs",
+            data={
+                "message": "hi",
+                "stream": "false",
+                "metadata": '{"agno_dispatch_chain": ["team:x"], "agno_dispatch_depth": 0, "trace": "keep"}',
+            },
+        )
+        assert start.status_code == 200, start.text
+        body = start.json()
+        meta = body.get("metadata") or {}
+        assert meta.get("trace") == "keep"
+        assert DISPATCH_CHAIN_METADATA_KEY not in meta
+        assert DISPATCH_DEPTH_METADATA_KEY not in meta
+
+        stored = client.get(f"/agents/{agent_id}/runs/{body['run_id']}", params={"session_id": body["session_id"]})
+        stored_meta = stored.json().get("metadata") or {}
+        assert DISPATCH_CHAIN_METADATA_KEY not in stored_meta
+        assert DISPATCH_DEPTH_METADATA_KEY not in stored_meta
 
     def test_team_forged_metadata_stamp_does_not_survive(self, db, registry, model_v1, model_v2):
         team_id = _save_team(db, model_v1, model_v2)
@@ -495,7 +524,15 @@ class TestSchedulerExecutorScrubsStamp:
         executor = ScheduleExecutor(base_url="http://localhost:8000", internal_service_token="tok")
         schedule = self._schedule(
             user_id="alice",
-            payload={"message": "hi", "metadata": {"agno_component_version": 2, "trace": "keep"}},
+            payload={
+                "message": "hi",
+                "metadata": {
+                    "agno_component_version": 2,
+                    "agno_dispatch_chain": ["team:x"],
+                    "agno_dispatch_depth": 0,
+                    "trace": "keep",
+                },
+            },
         )
         with patch.object(executor, "_background_run", new=AsyncMock(return_value={})) as bg:
             await executor._call_endpoint(schedule)
@@ -503,15 +540,87 @@ class TestSchedulerExecutorScrubsStamp:
         form_payload = bg.await_args.args[3]
         forwarded_metadata = json.loads(form_payload["metadata"])
         assert COMPONENT_VERSION_METADATA_KEY not in forwarded_metadata
+        assert DISPATCH_CHAIN_METADATA_KEY not in forwarded_metadata
+        assert DISPATCH_DEPTH_METADATA_KEY not in forwarded_metadata
         assert forwarded_metadata["trace"] == "keep"
 
     async def test_top_level_payload_stamp_is_not_forwarded(self):
         from agno.scheduler.executor import ScheduleExecutor
 
         executor = ScheduleExecutor(base_url="http://localhost:8000", internal_service_token="tok")
-        schedule = self._schedule(user_id="alice", payload={"message": "hi", "agno_component_version": 2})
+        schedule = self._schedule(
+            user_id="alice",
+            payload={"message": "hi", "agno_component_version": 2, "agno_dispatch_chain": ["team:x"]},
+        )
         with patch.object(executor, "_background_run", new=AsyncMock(return_value={})) as bg:
             await executor._call_endpoint(schedule)
 
         form_payload = bg.await_args.args[3]
         assert COMPONENT_VERSION_METADATA_KEY not in form_payload
+        assert DISPATCH_CHAIN_METADATA_KEY not in form_payload
+
+
+# ---------------------------------------------------------------------------
+# Session metadata is a caller-writable channel that merges into every run of
+# the session and WINS conflicting keys, so the reserved keys are scrubbed at
+# the session routes exactly like the run-start routes and the executor.
+# ---------------------------------------------------------------------------
+
+
+class TestForgedSessionMetadataScrubbed:
+    def test_create_session_scrubs_reserved_keys(self, db, registry, model_v1, model_v2):
+        agent_id = _save_agent(db, model_v1, model_v2)
+        client = _client(AgentOS(db=db, registry=registry, telemetry=False).get_app(), _BOB)
+
+        created = client.post(
+            "/sessions",
+            params={"type": "agent"},
+            json={
+                "agent_id": agent_id,
+                "metadata": {
+                    "agno_component_version": 2,
+                    "agno_dispatch_chain": [],
+                    "agno_dispatch_depth": 0,
+                    "trace": "keep",
+                },
+            },
+        )
+        assert created.status_code == 201, created.text
+        meta = created.json().get("metadata") or {}
+        assert meta.get("trace") == "keep"
+        assert COMPONENT_VERSION_METADATA_KEY not in meta
+        assert DISPATCH_CHAIN_METADATA_KEY not in meta
+        assert DISPATCH_DEPTH_METADATA_KEY not in meta
+
+        session_id = created.json()["session_id"]
+        stored = client.get(f"/sessions/{session_id}", params={"type": "agent"})
+        stored_meta = stored.json().get("metadata") or {}
+        assert stored_meta.get("trace") == "keep"
+        assert DISPATCH_CHAIN_METADATA_KEY not in stored_meta
+
+    def test_update_session_scrubs_reserved_keys(self, db, registry, model_v1, model_v2):
+        agent_id = _save_agent(db, model_v1, model_v2)
+        client = _client(AgentOS(db=db, registry=registry, telemetry=False).get_app(), _BOB)
+
+        created = client.post("/sessions", params={"type": "agent"}, json={"agent_id": agent_id})
+        assert created.status_code == 201, created.text
+        session_id = created.json()["session_id"]
+
+        updated = client.patch(
+            f"/sessions/{session_id}",
+            params={"type": "agent"},
+            json={
+                "metadata": {
+                    "agno_component_version": 2,
+                    "agno_dispatch_chain": [],
+                    "agno_dispatch_depth": 0,
+                    "trace": "keep",
+                }
+            },
+        )
+        assert updated.status_code == 200, updated.text
+        meta = updated.json().get("metadata") or {}
+        assert meta.get("trace") == "keep"
+        assert COMPONENT_VERSION_METADATA_KEY not in meta
+        assert DISPATCH_CHAIN_METADATA_KEY not in meta
+        assert DISPATCH_DEPTH_METADATA_KEY not in meta

--- a/libs/agno/tests/unit/tools/test_studio.py
+++ b/libs/agno/tests/unit/tools/test_studio.py
@@ -3040,10 +3040,10 @@ class _StubAgent:
     id = "stub"
     name = "Stub"
 
-    def run(self, message, stream=None, user_id=None, session_id=None):
+    def run(self, message, stream=None, user_id=None, session_id=None, metadata=None, run_id=None):
         return _StubRunOutput()
 
-    async def arun(self, message, stream=None, user_id=None, session_id=None):
+    async def arun(self, message, stream=None, user_id=None, session_id=None, metadata=None, run_id=None):
         return _StubRunOutput()
 
     def deep_copy(self):
@@ -3960,3 +3960,105 @@ class TestRoundThreeStudioFixes:
         out = _loads(studio.edit_agent("w", name="Loser", instructions="v2", publish=True, expected_version=99))
         assert out["error"]["code"] == "version_conflict"
         assert studio.db.get_component("w")["name"] == "Winner"
+
+
+# ----------------------------------------------------------------------
+# Dispatch guard on the StudioTools surface
+# ----------------------------------------------------------------------
+
+
+class _GuardStubTeam:
+    id = "stub-team"
+    name = "Stub Team"
+
+    def __init__(self):
+        self.seen = None
+        self.seen_metadata = None
+
+    def run(self, message, stream=None, user_id=None, session_id=None, metadata=None, run_id=None):
+        self.seen = {"message": message}
+        self.seen_metadata = metadata
+        return type("Out", (), {"run_id": "r", "session_id": "s", "status": "COMPLETED", "content": "done"})()
+
+    async def arun(self, message, stream=None, user_id=None, session_id=None, metadata=None, run_id=None):
+        return self.run(message, stream=stream, user_id=user_id, session_id=session_id, metadata=metadata)
+
+    def deep_copy(self):
+        clone = object.__new__(type(self))
+        clone.__dict__ = self.__dict__
+        return clone
+
+
+class TestStudioToolsDispatchGuard:
+    """StudioTools is a second dispatch surface: its unversioned tools forward
+    to the runner, and its version-pinned branch dispatches directly. Both
+    halves must carry the guard, or holders of this toolkit keep the original
+    unbounded self-dispatch."""
+
+    def test_studio_run_team_refuses_top_level_self_dispatch(self, registry, db):
+        stub = _GuardStubTeam()
+        studio = StudioTools(registry=registry, db=db, include_teams=[stub])
+        out = _loads(studio.run_team("stub-team", "hi", _agno_team=stub))
+        assert "already running" in out["error"]
+        assert stub.seen is None
+
+    @pytest.mark.asyncio
+    async def test_studio_arun_team_refuses_top_level_self_dispatch(self, registry, db):
+        stub = _GuardStubTeam()
+        studio = StudioTools(registry=registry, db=db, include_teams=[stub])
+        out = _loads(await studio.arun_team("stub-team", "hi", _agno_team=stub))
+        assert "already running" in out["error"]
+        assert stub.seen is None
+
+    def test_studio_version_pinned_run_is_guarded(self, registry, db):
+        # The version-pinned branch never reaches the runner's run tools, so
+        # an unguarded preview is the one door left open: version=N would walk
+        # straight past a runner-only guard.
+        studio = StudioTools(registry=registry, db=db)
+        created = _loads(studio.create_agent(name="loop-preview", instructions="i", model_id="gpt-5.4", publish=True))
+        assert created["data"]["id"] == "loop-preview"
+
+        wielder = type("W", (), {"id": "loop-preview"})()
+        out = _loads(studio.run_agent("loop-preview", "hi", version=1, _agno_agent=wielder))
+        assert out["error"]["code"] == "dispatch_refused"
+        assert "already running" in out["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_studio_async_version_pinned_run_is_guarded(self, registry, db):
+        studio = StudioTools(registry=registry, db=db)
+        studio.create_agent(name="loop-preview", instructions="i", model_id="gpt-5.4", publish=True)
+
+        wielder = type("W", (), {"id": "loop-preview"})()
+        out = _loads(await studio.arun_agent("loop-preview", "hi", version=1, _agno_agent=wielder))
+        assert out["error"]["code"] == "dispatch_refused"
+
+    def test_studio_version_pinned_depth_is_guarded(self, registry, db):
+        from agno.db.schemas.scheduler import DISPATCH_CHAIN_METADATA_KEY, DISPATCH_DEPTH_METADATA_KEY
+        from agno.run import RunContext
+
+        studio = StudioTools(registry=registry, db=db)
+        studio.create_agent(name="deep-preview", instructions="i", model_id="gpt-5.4", publish=True)
+
+        context = RunContext(
+            run_id="caller-run",
+            session_id="caller-sess",
+            metadata={DISPATCH_CHAIN_METADATA_KEY: ["team:o1", "agent:o2"], DISPATCH_DEPTH_METADATA_KEY: 2},
+        )
+        out = _loads(studio.run_agent("deep-preview", "hi", version=1, _agno_run_context=context))
+        assert out["error"]["code"] == "dispatch_refused"
+
+    def test_studio_forwards_the_wielder_by_keyword(self, registry, db):
+        # The runner's injected parameters are keyword channels; a future
+        # positional call site would drop the wielder without an error.
+        from unittest.mock import patch
+
+        stub = _GuardStubTeam()
+        studio = StudioTools(registry=registry, db=db, include_teams=[stub])
+        with patch.object(studio._runner_tools, "run_team", return_value='{"ok": true}') as spy:
+            studio.run_team("stub-team", "hi", _agno_team=stub)
+        assert spy.call_count == 1
+        args, kwargs = spy.call_args
+        assert args == ("stub-team", "hi")
+        assert kwargs["_agno_team"] is stub
+        assert kwargs["_agno_agent"] is None
+        assert "_agno_run_context" in kwargs

--- a/libs/agno/tests/unit/tools/test_studio.py
+++ b/libs/agno/tests/unit/tools/test_studio.py
@@ -4018,8 +4018,8 @@ class TestStudioToolsDispatchGuard:
         created = _loads(studio.create_agent(name="loop-preview", instructions="i", model_id="gpt-5.4", publish=True))
         assert created["data"]["id"] == "loop-preview"
 
-        wielder = type("W", (), {"id": "loop-preview"})()
-        out = _loads(studio.run_agent("loop-preview", "hi", version=1, _agno_agent=wielder))
+        caller = type("W", (), {"id": "loop-preview"})()
+        out = _loads(studio.run_agent("loop-preview", "hi", version=1, _agno_agent=caller))
         assert out["error"]["code"] == "dispatch_refused"
         assert "already running" in out["error"]["message"]
 
@@ -4028,8 +4028,8 @@ class TestStudioToolsDispatchGuard:
         studio = StudioTools(registry=registry, db=db)
         studio.create_agent(name="loop-preview", instructions="i", model_id="gpt-5.4", publish=True)
 
-        wielder = type("W", (), {"id": "loop-preview"})()
-        out = _loads(await studio.arun_agent("loop-preview", "hi", version=1, _agno_agent=wielder))
+        caller = type("W", (), {"id": "loop-preview"})()
+        out = _loads(await studio.arun_agent("loop-preview", "hi", version=1, _agno_agent=caller))
         assert out["error"]["code"] == "dispatch_refused"
 
     def test_studio_version_pinned_depth_is_guarded(self, registry, db):
@@ -4047,9 +4047,9 @@ class TestStudioToolsDispatchGuard:
         out = _loads(studio.run_agent("deep-preview", "hi", version=1, _agno_run_context=context))
         assert out["error"]["code"] == "dispatch_refused"
 
-    def test_studio_forwards_the_wielder_by_keyword(self, registry, db):
+    def test_studio_forwards_the_caller_by_keyword(self, registry, db):
         # The runner's injected parameters are keyword channels; a future
-        # positional call site would drop the wielder without an error.
+        # positional call site would drop the caller identity without an error.
         from unittest.mock import patch
 
         stub = _GuardStubTeam()

--- a/libs/agno/tests/unit/tools/test_studio_preview_stamp.py
+++ b/libs/agno/tests/unit/tools/test_studio_preview_stamp.py
@@ -19,12 +19,17 @@ from typing import Any, AsyncIterator, Dict, Iterator, Optional
 import pytest
 
 from agno.agent.agent import Agent
-from agno.db.schemas.scheduler import COMPONENT_VERSION_METADATA_KEY
+from agno.db.schemas.scheduler import (
+    COMPONENT_VERSION_METADATA_KEY,
+    DISPATCH_CHAIN_METADATA_KEY,
+    DISPATCH_DEPTH_METADATA_KEY,
+)
 from agno.db.sqlite import SqliteDb
 from agno.models.base import Model
 from agno.models.message import MessageMetrics
 from agno.models.response import ModelResponse
 from agno.registry import Registry
+from agno.run import RunContext
 from agno.team.team import Team
 from agno.tools.studio import StudioTools
 from agno.workflow.step import Step
@@ -182,7 +187,7 @@ class TestTheStampNeedsNoServerStack:
             sys.meta_path.insert(0, Blocker())
             from agno.tools.studio import StudioTools
 
-            print(StudioTools._version_stamp(2)["metadata"]["agno_component_version"])
+            print(StudioTools._version_stamp(2)["agno_component_version"])
             print(StudioTools._version_stamp(None))
             assert "agno.os.utils" not in sys.modules
             """
@@ -208,3 +213,125 @@ class TestTheStampDrivesContinuation:
         run = next(r for r in (session.runs or []) if getattr(r, "run_id", None) == payload["run_id"])
         # This is the reader every continue/resume surface re-resolves from.
         assert stamped_component_version(run) == 2
+
+
+def _chained_context(*chain: str) -> RunContext:
+    return RunContext(
+        run_id="caller-run",
+        session_id="caller-sess",
+        metadata={DISPATCH_CHAIN_METADATA_KEY: list(chain), DISPATCH_DEPTH_METADATA_KEY: len(chain)},
+    )
+
+
+class TestDispatchesCarryTheChain:
+    """These are real runs, not stubs: the lineage must survive the whole
+    resolve -> run -> persist path and land on the stored child run row, or a
+    nested run has no signal that it is nested and the cycle guard reads an
+    empty lineage on every hop."""
+
+    @pytest.mark.parametrize("tool_name,component_id,session_type", SURFACES)
+    def test_a_dispatched_run_row_records_its_chain(self, studio, db, tool_name, component_id, session_type):
+        payload = _payload(getattr(studio, tool_name)(component_id, "hi"))
+        metadata = _stored_metadata(db, payload["session_id"], payload["run_id"], session_type) or {}
+        assert metadata.get(DISPATCH_CHAIN_METADATA_KEY) == [f"{session_type}:{component_id}"]
+        assert metadata.get(DISPATCH_DEPTH_METADATA_KEY) == 1
+
+    @pytest.mark.parametrize("tool_name,component_id,session_type", SURFACES)
+    def test_a_pinned_preview_carries_chain_and_stamp_together(self, studio, db, tool_name, component_id, session_type):
+        payload = _payload(getattr(studio, tool_name)(component_id, "hi", version=2))
+        metadata = _stored_metadata(db, payload["session_id"], payload["run_id"], session_type) or {}
+        assert metadata.get(DISPATCH_CHAIN_METADATA_KEY) == [f"{session_type}:{component_id}"]
+        assert metadata.get(DISPATCH_DEPTH_METADATA_KEY) == 1
+        assert metadata.get(COMPONENT_VERSION_METADATA_KEY) == 2
+
+    @pytest.mark.parametrize("tool_name,component_id,session_type", SURFACES)
+    def test_an_async_pinned_preview_carries_chain_and_stamp_together(
+        self, studio, db, tool_name, component_id, session_type
+    ):
+        # The async pinned branch is separate code dispatching component.arun
+        # directly; without this, it could stop threading the lineage while
+        # every refusal test stays green (refusals fire before the run).
+        payload = _payload(asyncio.run(getattr(studio, f"a{tool_name}")(component_id, "hi", version=2)))
+        metadata = _stored_metadata(db, payload["session_id"], payload["run_id"], session_type) or {}
+        assert metadata.get(DISPATCH_CHAIN_METADATA_KEY) == [f"{session_type}:{component_id}"]
+        assert metadata.get(DISPATCH_DEPTH_METADATA_KEY) == 1
+        assert metadata.get(COMPONENT_VERSION_METADATA_KEY) == 2
+
+    @pytest.mark.parametrize("tool_name,component_id,session_type", SURFACES)
+    def test_a_pinned_preview_registers_for_cancel_cascade(self, studio, db, tool_name, component_id, session_type):
+        # The pinned branch is the dispatch path that bypasses the runner's
+        # run tools, so its registration must be pinned separately or an
+        # escaped preview run is unstoppable from the caller's cancel_run.
+        from agno.run.cancel import get_member_run_ids
+
+        context = RunContext(run_id="cascade-parent", session_id="caller-sess")
+        payload = _payload(getattr(studio, tool_name)(component_id, "hi", version=2, _agno_run_context=context))
+        assert payload["run_id"] in get_member_run_ids("cascade-parent")
+
+    @pytest.mark.parametrize("tool_name,component_id,session_type", SURFACES)
+    def test_an_async_pinned_preview_registers_for_cancel_cascade(
+        self, studio, db, tool_name, component_id, session_type
+    ):
+        from agno.run.cancel import get_member_run_ids
+
+        context = RunContext(run_id="cascade-parent-async", session_id="caller-sess")
+        payload = _payload(
+            asyncio.run(getattr(studio, f"a{tool_name}")(component_id, "hi", version=2, _agno_run_context=context))
+        )
+        assert payload["run_id"] in get_member_run_ids("cascade-parent-async")
+
+    @pytest.mark.parametrize("tool_name,component_id,session_type", SURFACES)
+    def test_the_stored_chain_composes_into_a_refusal(self, studio, db, tool_name, component_id, session_type):
+        # The loop the guard exists for: run, read back the chain exactly as a
+        # nested run's tools would see it, dispatch the same component again.
+        payload = _payload(getattr(studio, tool_name)(component_id, "hi"))
+        metadata = _stored_metadata(db, payload["session_id"], payload["run_id"], session_type)
+        nested_context = RunContext(run_id="nested-run", session_id="nested-sess", metadata=dict(metadata or {}))
+
+        out = json.loads(getattr(studio, tool_name)(component_id, "hi again", _agno_run_context=nested_context))
+        # Unversioned runs go through the embedded runner, whose errors pass
+        # through as {"error": <message>} rather than the studio envelope.
+        assert f"{session_type}:{component_id}" in out["error"]
+        assert "already running" in out["error"]
+
+
+class TestPinnedPreviewsAreGuardedToo:
+    """run_*(version=N) dispatches the component directly rather than through
+    the runner's run tools, so an unguarded preview would be the one door left
+    open to unbounded self-dispatch."""
+
+    @pytest.mark.parametrize("tool_name,component_id,session_type", SURFACES)
+    def test_sync_preview_refuses_a_cycle(self, studio, db, tool_name, component_id, session_type):
+        out = json.loads(
+            getattr(studio, tool_name)(
+                component_id, "hi", version=2, _agno_run_context=_chained_context(f"{session_type}:{component_id}")
+            )
+        )
+        assert out["ok"] is False
+        assert out["error"]["code"] == "dispatch_refused"
+        assert "already running" in out["error"]["message"]
+
+    @pytest.mark.parametrize("tool_name,component_id,session_type", SURFACES)
+    def test_async_preview_refuses_a_cycle(self, studio, db, tool_name, component_id, session_type):
+        out = json.loads(
+            asyncio.run(
+                getattr(studio, f"a{tool_name}")(
+                    component_id,
+                    "hi",
+                    version=2,
+                    _agno_run_context=_chained_context(f"{session_type}:{component_id}"),
+                )
+            )
+        )
+        assert out["ok"] is False
+        assert out["error"]["code"] == "dispatch_refused"
+
+    @pytest.mark.parametrize("tool_name,component_id,session_type", SURFACES)
+    def test_preview_refuses_past_the_depth_cap(self, studio, db, tool_name, component_id, session_type):
+        out = json.loads(
+            getattr(studio, tool_name)(
+                component_id, "hi", version=2, _agno_run_context=_chained_context("team:o1", "agent:o2")
+            )
+        )
+        assert out["ok"] is False
+        assert out["error"]["code"] == "dispatch_refused"

--- a/libs/agno/tests/unit/tools/test_studio_runner.py
+++ b/libs/agno/tests/unit/tools/test_studio_runner.py
@@ -12,6 +12,11 @@ from typing import Any, Dict, List, Optional
 import pytest
 from pydantic import BaseModel
 
+from agno.db.schemas.scheduler import (
+    COMPONENT_VERSION_METADATA_KEY,
+    DISPATCH_CHAIN_METADATA_KEY,
+    DISPATCH_DEPTH_METADATA_KEY,
+)
 from agno.db.sqlite import SqliteDb
 from agno.models.openai import OpenAIResponses
 from agno.registry import Registry
@@ -20,6 +25,13 @@ from agno.run.base import RunStatus
 from agno.tools.function import FunctionCall
 from agno.tools.studio import StudioTools
 from agno.tools.studio_runner import StudioRunnerTools
+
+# Asserted as literals, not just used symbolically: the keys are persisted in
+# run metadata, so renaming either would orphan the lineage on stored runs.
+_CHAIN_KEY = "agno_dispatch_chain"
+_DEPTH_KEY = "agno_dispatch_depth"
+assert DISPATCH_CHAIN_METADATA_KEY == _CHAIN_KEY
+assert DISPATCH_DEPTH_METADATA_KEY == _DEPTH_KEY
 
 # ----------------------------------------------------------------------
 # Fixtures and stubs
@@ -46,6 +58,21 @@ def _loads(s: str) -> Dict[str, Any]:
 
 def _context(user_id: Optional[str] = "ash", session_id: str = "caller-sess") -> RunContext:
     return RunContext(run_id="caller-run", session_id=session_id, user_id=user_id)
+
+
+def _dispatched_context(
+    chain: Any, depth: Any = None, user_id: Optional[str] = "ash", session_id: str = "caller-sess"
+) -> RunContext:
+    """A caller that itself arrived through the runner.
+
+    ``depth`` defaults to len(chain) for the common well-formed case; pass it
+    explicitly to build a lineage and a hop count that disagree."""
+    context = _context(user_id=user_id, session_id=session_id)
+    context.metadata = {
+        _CHAIN_KEY: chain,
+        _DEPTH_KEY: len(chain) if depth is None and isinstance(chain, list) else depth,
+    }
+    return context
 
 
 def _sub_session(component_type: str, component_id: str, caller_session: str = "caller-sess") -> Optional[str]:
@@ -98,14 +125,20 @@ class _StubAgent:
     def __init__(self, output: Any = None):
         self._output = output or _StubRunOutput()
         self.seen: Optional[Dict[str, Any]] = None
+        self.seen_metadata: Optional[Dict[str, Any]] = None
+        self.seen_run_id: Optional[str] = None
         self.copied = False
 
-    def run(self, message, stream=None, user_id=None, session_id=None):
+    def run(self, message, stream=None, user_id=None, session_id=None, metadata=None, run_id=None):
         self.seen = {"message": message, "stream": stream, "user_id": user_id, "session_id": session_id}
+        self.seen_metadata = metadata
+        self.seen_run_id = run_id
         return self._output
 
-    async def arun(self, message, stream=None, user_id=None, session_id=None):
+    async def arun(self, message, stream=None, user_id=None, session_id=None, metadata=None, run_id=None):
         self.seen = {"message": message, "stream": stream, "user_id": user_id, "session_id": session_id}
+        self.seen_metadata = metadata
+        self.seen_run_id = run_id
         return self._output
 
     def deep_copy(self):
@@ -123,14 +156,20 @@ class _StubTeam:
 
     def __init__(self):
         self.seen: Optional[Dict[str, Any]] = None
+        self.seen_metadata: Optional[Dict[str, Any]] = None
+        self.seen_run_id: Optional[str] = None
         self.copied = False
 
-    def run(self, message, stream=None, user_id=None, session_id=None):
+    def run(self, message, stream=None, user_id=None, session_id=None, metadata=None, run_id=None):
         self.seen = {"message": message, "stream": stream, "user_id": user_id, "session_id": session_id}
+        self.seen_metadata = metadata
+        self.seen_run_id = run_id
         return _StubRunOutput()
 
-    async def arun(self, message, stream=None, user_id=None, session_id=None):
+    async def arun(self, message, stream=None, user_id=None, session_id=None, metadata=None, run_id=None):
         self.seen = {"message": message, "stream": stream, "user_id": user_id, "session_id": session_id}
+        self.seen_metadata = metadata
+        self.seen_run_id = run_id
         return _StubRunOutput()
 
     def deep_copy(self):
@@ -148,14 +187,20 @@ class _StubWorkflow:
 
     def __init__(self):
         self.seen: Optional[Dict[str, Any]] = None
+        self.seen_metadata: Optional[Dict[str, Any]] = None
+        self.seen_run_id: Optional[str] = None
         self.copied = False
 
-    def run(self, input=None, stream=None, user_id=None, session_id=None):
+    def run(self, input=None, stream=None, user_id=None, session_id=None, metadata=None, run_id=None):
         self.seen = {"input": input, "stream": stream, "user_id": user_id, "session_id": session_id}
+        self.seen_metadata = metadata
+        self.seen_run_id = run_id
         return _StubRunOutput()
 
-    async def arun(self, input=None, stream=None, user_id=None, session_id=None):
+    async def arun(self, input=None, stream=None, user_id=None, session_id=None, metadata=None, run_id=None):
         self.seen = {"input": input, "stream": stream, "user_id": user_id, "session_id": session_id}
+        self.seen_metadata = metadata
+        self.seen_run_id = run_id
         return _StubRunOutput()
 
     def deep_copy(self):
@@ -438,6 +483,38 @@ class TestInjectionGuard:
         assert stub.seen is not None
         assert stub.seen["user_id"] == "ash"
 
+    def test_a_model_supplied_wielder_is_discarded(self, db):
+        # The wielder identity drives the cycle guard, so a model that could
+        # null it out would talk its way past the refusal. The injected value
+        # must win over anything in the tool-call arguments.
+        stub = _StubTeam()
+        runner = StudioRunnerTools(db=db, include_teams=[stub])
+        function = runner.functions["run_team"]
+        function.process_entrypoint()
+        function._run_context = _context()
+        function._team = stub
+        call = FunctionCall(
+            function=function,
+            arguments={"team_id": "stub-team", "message": "hi", "_agno_team": None},
+        )
+        result = call.execute()
+        assert result.status == "success"
+        assert "already running" in str(call.result)
+        assert stub.seen is None
+
+    def test_the_wielder_params_stay_out_of_the_model_schema(self, db):
+        # The description assertion is the tripwire for the annotation hazard:
+        # a forward-ref annotation on the injected params makes schema
+        # generation fail silently, shipping the tool with empty parameters
+        # AND an empty description at once.
+        runner = StudioRunnerTools(db=db)
+        for functions in (runner.functions, runner.async_functions):
+            function = functions["run_team"]
+            function.process_entrypoint()
+            properties = (function.parameters or {}).get("properties") or {}
+            assert set(properties) == {"team_id", "message"}
+            assert function.description
+
     def test_schema_visible_param_named_like_an_injected_one_keeps_the_model_value(self):
         # A tool whose schema declares a non-identity injected name -- a wrapper exposing
         # the wrapped tool's own "files" argument -- keeps the model-supplied value.
@@ -499,6 +576,89 @@ class TestResolution:
         runner = StudioRunnerTools(registry=registry, db=db)
         out = _loads(runner.run_agent("squad", "hi"))
         assert "error" in out
+
+    def test_run_agent_points_at_team_when_id_is_a_team(self, db):
+        stub = _StubTeam()
+        runner = StudioRunnerTools(db=db, include_teams=[stub])
+        out = _loads(runner.run_agent("stub-team", "hi"))
+        assert out == {
+            "error": "Agent not found: stub-team."
+            " A team with this identifier exists -- use run_team(team_id='stub-team')."
+        }
+        assert stub.seen is None
+
+    def test_run_team_points_at_agent_when_id_is_an_agent(self, db):
+        stub = _StubAgent()
+        runner = StudioRunnerTools(db=db, include_agents=[stub])
+        out = _loads(runner.run_team("stub", "hi"))
+        assert out == {
+            "error": "Team not found: stub. An agent with this identifier exists -- use run_agent(agent_id='stub')."
+        }
+
+    def test_run_workflow_points_at_sibling(self, db):
+        stub = _StubAgent()
+        runner = StudioRunnerTools(db=db, include_agents=[stub])
+        out = _loads(runner.run_workflow("stub", "hi"))
+        assert "use run_agent(agent_id='stub')" in out["error"]
+
+    @pytest.mark.asyncio
+    async def test_async_miss_points_at_sibling_too(self, db):
+        stub = _StubTeam()
+        runner = StudioRunnerTools(db=db, include_teams=[stub])
+        out = _loads(await runner.arun_agent("stub-team", "hi"))
+        assert "use run_team(team_id='stub-team')" in out["error"]
+
+    def test_hint_resolves_display_name_to_exact_id(self, db):
+        # The hint's whole job is to hand back a call that works, so it carries
+        # the resolved id even when the miss used a display name.
+        stub = _StubTeam()
+        runner = StudioRunnerTools(db=db, include_teams=[stub])
+        out = _loads(runner.run_agent("Stub Team", "hi"))
+        assert "use run_team(team_id='stub-team')" in out["error"]
+
+    def test_cross_hint_respects_dispatchability(self, registry, db):
+        # "squad" exists as a team but only as a draft, which dispatch refuses;
+        # a hint would name a component the caller cannot actually run.
+        studio = StudioTools(registry=registry, db=db)
+        studio.create_agent(name="member", instructions="i", model_id="gpt-5.4")
+        studio.create_team(name="squad", instructions="i", member_ids=["member"], model_id="gpt-5.4")
+
+        runner = StudioRunnerTools(registry=registry, db=db)
+        out = _loads(runner.run_agent("squad", "hi"))
+        assert out == {"error": "Agent not found: squad"}
+
+    def test_cross_hint_respects_include_all_opt_in(self, registry, db):
+        # A registry team is resolvable but not dispatchable without
+        # include_all_components; the hint follows dispatch, not resolution.
+        stub = _StubTeam()
+        registry.teams.append(stub)
+        runner = StudioRunnerTools(registry=registry, db=db)
+        out = _loads(runner.run_agent("stub-team", "hi"))
+        assert out == {"error": "Agent not found: stub-team"}
+
+        opted_in = StudioRunnerTools(registry=registry, db=db, include_all_components=True)
+        out = _loads(opted_in.run_agent("stub-team", "hi"))
+        assert "use run_team(team_id='stub-team')" in out["error"]
+
+    def test_a_disabled_type_is_never_suggested(self, db):
+        # With the team tools off, run_team does not exist on this toolkit; a
+        # hint naming it would point at a door that is not there.
+        stub = _StubTeam()
+        runner = StudioRunnerTools(db=db, include_teams=[stub], teams=False)
+        out = _loads(runner.run_agent("stub-team", "hi"))
+        assert out == {"error": "Agent not found: stub-team"}
+
+    def test_an_unknown_id_keeps_the_plain_message(self, db):
+        # No sibling resolves, so the hint machinery must add nothing.
+        runner = StudioRunnerTools(db=db)
+        assert _loads(runner.run_agent("nobody", "hi")) == {"error": "Agent not found: nobody"}
+        assert _loads(runner.run_team("nobody", "hi")) == {"error": "Team not found: nobody"}
+        assert _loads(runner.run_workflow("nobody", "hi")) == {"error": "Workflow not found: nobody"}
+
+    def test_the_instructions_say_the_rosters_are_separate(self, db):
+        assert "separate rosters" in StudioRunnerTools(db=db).instructions
+        # With a single kind enabled there is no sibling roster to point at.
+        assert "separate rosters" not in StudioRunnerTools(db=db, teams=False, workflows=False).instructions
 
     def test_exact_id_beats_code_defined_display_name(self, db):
         shadow = _StubAgent()
@@ -850,6 +1010,413 @@ class TestDispatchIsolation:
 
 
 # ----------------------------------------------------------------------
+# Dispatch cycle guard and depth cap
+# ----------------------------------------------------------------------
+
+
+_STUB_CLASSES = {"agent": _StubAgent, "team": _StubTeam, "workflow": _StubWorkflow}
+_INCLUDE_KWARG = {"agent": "include_agents", "team": "include_teams", "workflow": "include_workflows"}
+
+# Every dispatch tool, sync and async: the async paths are separate code, and
+# one left unguarded would reproduce the original runaway exactly.
+_DISPATCH_TOOLS = [
+    pytest.param("agent", False, id="run_agent"),
+    pytest.param("team", False, id="run_team"),
+    pytest.param("workflow", False, id="run_workflow"),
+    pytest.param("agent", True, id="arun_agent"),
+    pytest.param("team", True, id="arun_team"),
+    pytest.param("workflow", True, id="arun_workflow"),
+]
+
+# The two component kinds that can WIELD a toolkit (workflows hold no tools),
+# for the top-level self-dispatch case where the wielder IS the target.
+_WIELDER_TOOLS = [
+    pytest.param("agent", False, id="run_agent"),
+    pytest.param("team", False, id="run_team"),
+    pytest.param("agent", True, id="arun_agent"),
+    pytest.param("team", True, id="arun_team"),
+]
+
+
+def _guarded_stub(kind: str, db, **runner_kwargs):
+    stub = _STUB_CLASSES[kind]()
+    runner = StudioRunnerTools(db=db, **{_INCLUDE_KWARG[kind]: [stub]}, **runner_kwargs)
+    return stub, runner
+
+
+def _wielder_kwargs(kind: str, stub) -> Dict[str, Any]:
+    return {"wielder_agent": stub} if kind == "agent" else {"wielder_team": stub}
+
+
+async def _dispatch(
+    runner,
+    kind: str,
+    use_async: bool,
+    identifier: Optional[str] = None,
+    context=None,
+    wielder_agent=None,
+    wielder_team=None,
+):
+    identifier = identifier if identifier is not None else _STUB_CLASSES[kind].id
+    tool = getattr(runner, f"arun_{kind}" if use_async else f"run_{kind}")
+    result = tool(identifier, "go", _agno_run_context=context, _agno_agent=wielder_agent, _agno_team=wielder_team)
+    if use_async:
+        result = await result
+    return _loads(result)
+
+
+class TestDispatchCycleGuard:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind,use_async", _WIELDER_TOOLS)
+    async def test_top_level_self_dispatch_is_refused(self, db, kind, use_async):
+        # The reported repro: the wielding component dispatches ITSELF from a
+        # run a human started, where the inherited lineage is empty. Only the
+        # injected wielder identity can catch this.
+        stub, runner = _guarded_stub(kind, db)
+        out = await _dispatch(runner, kind, use_async, context=_context(), **_wielder_kwargs(kind, stub))
+        assert stub.id in out["error"]
+        assert "already running" in out["error"]
+        assert stub.seen is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind,use_async", _DISPATCH_TOOLS)
+    async def test_self_dispatch_from_an_inherited_chain_is_refused(self, db, kind, use_async):
+        stub, runner = _guarded_stub(kind, db)
+        target = f"{kind}:{stub.id}"
+        out = await _dispatch(runner, kind, use_async, context=_dispatched_context([target]))
+        assert stub.id in out["error"]
+        assert target in out["error"]
+        assert stub.seen is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("use_async", [False, True], ids=["sync", "async"])
+    async def test_a_member_agent_refuses_to_dispatch_its_parent_team(self, db, use_async):
+        # A toolkit on a member agent wields BOTH the member and its parent
+        # team: the parent is genuinely running, so it is a cycle target.
+        team, runner = _guarded_stub("team", db)
+        agent = _StubAgent()
+        out = await _dispatch(runner, "team", use_async, context=_context(), wielder_agent=agent, wielder_team=team)
+        assert "already running" in out["error"]
+        assert team.seen is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind,use_async", _DISPATCH_TOOLS)
+    async def test_indirect_cycle_is_refused(self, db, kind, use_async):
+        # The target sits below the top of the lineage, and the depth limit
+        # alone would still admit this dispatch: only the cycle check refuses.
+        stub, runner = _guarded_stub(kind, db, max_dispatch_depth=5)
+        target = f"{kind}:{stub.id}"
+        out = await _dispatch(runner, kind, use_async, context=_dispatched_context([target, "team:radar"]))
+        assert "already running" in out["error"]
+        assert f"{target} -> team:radar -> {target}" in out["error"]
+        assert stub.seen is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind,use_async", _DISPATCH_TOOLS)
+    async def test_the_wielder_is_written_into_the_outgoing_lineage(self, db, kind, use_async):
+        # The wielder is recorded, not just the target: an inherited-only
+        # outgoing chain never contains the caller, so A -> B -> A stays open.
+        stub, runner = _guarded_stub(kind, db)
+        outer = _StubTeam()
+        outer.id = "outer"
+        out = await _dispatch(runner, kind, use_async, context=_context(), wielder_team=outer)
+        assert "error" not in out
+        assert stub.seen_metadata is not None
+        assert stub.seen_metadata[_CHAIN_KEY] == ["team:outer", f"{kind}:{stub.id}"]
+        assert stub.seen_metadata[_DEPTH_KEY] == 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("use_async", [False, True], ids=["sync", "async"])
+    async def test_a_b_a_ping_pong_is_refused(self, db, use_async):
+        # The lineage must refuse re-entry across hops, not just direct
+        # self-dispatch: a's token rides the metadata a wrote into b's run, so
+        # when b turns around and dispatches a, the cycle is visible.
+        a = _StubTeam()
+        a.id = "a"
+        a.name = "A"
+        b = _StubTeam()
+        b.id = "b"
+        b.name = "B"
+        runner = StudioRunnerTools(db=db, include_teams=[a, b], max_dispatch_depth=3)
+
+        out = await _dispatch(runner, "team", use_async, identifier="b", context=_context(), wielder_team=a)
+        assert "error" not in out
+        assert b.seen_metadata == {_CHAIN_KEY: ["team:a", "team:b"], _DEPTH_KEY: 1}
+
+        nested = _context()
+        nested.metadata = dict(b.seen_metadata)
+        out = await _dispatch(runner, "team", use_async, identifier="a", context=nested, wielder_team=b)
+        assert "already running" in out["error"]
+        assert a.seen is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind,use_async", _DISPATCH_TOOLS)
+    async def test_lineage_is_threaded_to_child(self, db, kind, use_async):
+        stub, runner = _guarded_stub(kind, db)
+        out = await _dispatch(runner, kind, use_async, context=_context())
+        assert "error" not in out
+        assert stub.seen is not None
+        assert stub.seen_metadata == {_CHAIN_KEY: [f"{kind}:{stub.id}"], _DEPTH_KEY: 1}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind,use_async", _DISPATCH_TOOLS)
+    async def test_lineage_appends_not_replaces(self, db, kind, use_async):
+        stub, runner = _guarded_stub(kind, db, max_dispatch_depth=3)
+        out = await _dispatch(runner, kind, use_async, context=_dispatched_context(["team:outer"]))
+        assert "error" not in out
+        assert stub.seen_metadata is not None
+        assert stub.seen_metadata[_CHAIN_KEY] == ["team:outer", f"{kind}:{stub.id}"]
+        assert stub.seen_metadata[_DEPTH_KEY] == 2
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind,use_async", _DISPATCH_TOOLS)
+    async def test_lineage_entries_are_deduped(self, db, kind, use_async):
+        # A wielder already in the inherited lineage appears once, and the hop
+        # count still moves by exactly 1: it is its own key, not len(chain).
+        stub, runner = _guarded_stub(kind, db, max_dispatch_depth=3)
+        outer = _StubTeam()
+        outer.id = "outer"
+        out = await _dispatch(runner, kind, use_async, context=_dispatched_context(["team:outer"]), wielder_team=outer)
+        assert "error" not in out
+        assert stub.seen_metadata is not None
+        assert stub.seen_metadata[_CHAIN_KEY] == ["team:outer", f"{kind}:{stub.id}"]
+        assert stub.seen_metadata[_DEPTH_KEY] == 2
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind,use_async", _DISPATCH_TOOLS)
+    async def test_user_metadata_is_preserved(self, db, kind, use_async):
+        stub, runner = _guarded_stub(kind, db)
+        context = _context()
+        context.metadata = {"tenant": "acme"}
+        out = await _dispatch(runner, kind, use_async, context=context)
+        assert "error" not in out
+        assert stub.seen_metadata == {"tenant": "acme", _CHAIN_KEY: [f"{kind}:{stub.id}"], _DEPTH_KEY: 1}
+        # The caller's own metadata is read, never written: the lineage grows
+        # on the copy handed to the child.
+        assert context.metadata == {"tenant": "acme"}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind,use_async", _WIELDER_TOOLS)
+    async def test_resolved_id_is_used_not_alias(self, db, kind, use_async):
+        # The lineage carries resolved ids; dispatching the wielder by display
+        # name must hit the same guard, or an alias walks straight around it.
+        stub, runner = _guarded_stub(kind, db)
+        out = await _dispatch(
+            runner, kind, use_async, identifier=stub.name, context=_context(), **_wielder_kwargs(kind, stub)
+        )
+        assert "error" in out
+        assert stub.seen is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind,use_async", _DISPATCH_TOOLS)
+    async def test_inherited_alias_does_not_evade_either(self, db, kind, use_async):
+        stub, runner = _guarded_stub(kind, db)
+        out = await _dispatch(
+            runner, kind, use_async, identifier=stub.name, context=_dispatched_context([f"{kind}:{stub.id}"])
+        )
+        assert "error" in out
+        assert stub.seen is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind,use_async", _DISPATCH_TOOLS)
+    async def test_sessionless_caller_still_dispatches(self, db, kind, use_async):
+        # No caller context: the lineage starts empty, and the child still
+        # gets a one-element lineage so ITS dispatches are bounded.
+        stub, runner = _guarded_stub(kind, db)
+        out = await _dispatch(runner, kind, use_async, context=None)
+        assert "error" not in out
+        assert stub.seen is not None
+        assert stub.seen_metadata == {_CHAIN_KEY: [f"{kind}:{stub.id}"], _DEPTH_KEY: 1}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind,use_async", _DISPATCH_TOOLS)
+    async def test_a_malformed_chain_fails_closed(self, db, kind, use_async):
+        # Both keys are runtime-written; a wrong shape is tampering or
+        # corruption, and treating it as absent would reset the counter --
+        # exactly what a forged value would want.
+        stub, runner = _guarded_stub(kind, db)
+        for bad_chain, depth in (("not-a-list", 0), ([1, 2], 2)):
+            out = await _dispatch(runner, kind, use_async, context=_dispatched_context(bad_chain, depth=depth))
+            assert _CHAIN_KEY in out["error"]
+            assert stub.seen is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind,use_async", _DISPATCH_TOOLS)
+    async def test_a_malformed_depth_fails_closed(self, db, kind, use_async):
+        stub, runner = _guarded_stub(kind, db)
+        for bad_depth in ("1", -1, True):
+            out = await _dispatch(runner, kind, use_async, context=_dispatched_context([], depth=bad_depth))
+            assert _DEPTH_KEY in out["error"]
+            assert stub.seen is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind,use_async", _DISPATCH_TOOLS)
+    async def test_a_half_pair_fails_closed(self, db, kind, use_async):
+        # The runtime always writes both keys, so one without the other is as
+        # much evidence of tampering as a wrong shape.
+        stub, runner = _guarded_stub(kind, db)
+        chain_only = _context()
+        chain_only.metadata = {_CHAIN_KEY: ["team:outer"]}
+        out = await _dispatch(runner, kind, use_async, context=chain_only)
+        assert _DEPTH_KEY in out["error"]
+        assert stub.seen is None
+
+        depth_only = _context()
+        depth_only.metadata = {_DEPTH_KEY: 1}
+        out = await _dispatch(runner, kind, use_async, context=depth_only)
+        assert _CHAIN_KEY in out["error"]
+        assert stub.seen is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind,use_async", _DISPATCH_TOOLS)
+    async def test_absent_keys_are_not_malformed(self, db, kind, use_async):
+        # Metadata with neither key is the ordinary top-level run.
+        stub, runner = _guarded_stub(kind, db)
+        context = _context()
+        context.metadata = {"tenant": "acme"}
+        out = await _dispatch(runner, kind, use_async, context=context)
+        assert "error" not in out
+        assert stub.seen_metadata is not None and stub.seen_metadata[_DEPTH_KEY] == 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("use_async", [False, True], ids=["sync", "async"])
+    async def test_a_different_component_is_unaffected(self, db, use_async):
+        stub = _StubAgent()
+        runner = StudioRunnerTools(db=db, include_agents=[stub])
+        out = await _dispatch(runner, "agent", use_async, context=_context(), wielder_team=_StubTeam())
+        assert out["status"] == "COMPLETED"
+        assert stub.seen is not None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind,use_async", _DISPATCH_TOOLS)
+    async def test_reserved_version_key_is_not_forwarded(self, db, kind, use_async):
+        # The version pin describes the CALLER's run. Forwarded, it would
+        # stamp the child's run row, and the lifecycle routes would continue a
+        # paused child on the wrong version of the child.
+        stub, runner = _guarded_stub(kind, db)
+        context = _context()
+        context.metadata = {COMPONENT_VERSION_METADATA_KEY: 7, "tenant": "acme"}
+        out = await _dispatch(runner, kind, use_async, context=context)
+        assert "error" not in out
+        assert stub.seen_metadata == {"tenant": "acme", _CHAIN_KEY: [f"{kind}:{stub.id}"], _DEPTH_KEY: 1}
+
+    def test_stored_config_cannot_forge_or_reset_the_chain(self, registry, db):
+        # Component metadata is merged OVER call-site metadata on run, so a
+        # stored config carrying the dispatch keys would reset the lineage on
+        # every hop and re-open unbounded self-dispatch. The rebuild strips
+        # them.
+        studio = StudioTools(registry=registry, db=db)
+        studio.create_agent(name="member", instructions="i", model_id="gpt-5.4", publish=True)
+        created = _loads(
+            studio.create_team(
+                name="forged",
+                instructions="i",
+                member_ids=["member"],
+                model_id="gpt-5.4",
+                metadata={_CHAIN_KEY: [], _DEPTH_KEY: 0, "tenant": "acme"},
+                publish=True,
+            )
+        )
+        assert created["data"]["id"] == "forged"
+
+        runner = StudioRunnerTools(registry=registry, db=db)
+        team = runner._team_for_run("forged")
+        assert team is not None
+        # The forged keys are gone; the config's own metadata survives, which
+        # also proves metadata reached the stored config at all.
+        assert team.metadata == {"tenant": "acme"}
+
+
+class TestDispatchDepthCap:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind,use_async", _DISPATCH_TOOLS)
+    async def test_default_depth_allows_two_hops(self, db, kind, use_async):
+        stub, runner = _guarded_stub(kind, db)
+        assert runner.max_dispatch_depth == 2
+        out = await _dispatch(runner, kind, use_async, context=_dispatched_context(["team:outer"]))
+        assert "error" not in out
+        assert stub.seen_metadata is not None and stub.seen_metadata[_DEPTH_KEY] == 2
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind,use_async", _DISPATCH_TOOLS)
+    async def test_depth_limit_refuses_third_hop(self, db, kind, use_async):
+        stub, runner = _guarded_stub(kind, db)
+        out = await _dispatch(runner, kind, use_async, context=_dispatched_context(["team:o1", "agent:o2"]))
+        assert "2 hop(s) deep" in out["error"]
+        assert "at most 2" in out["error"]
+        assert stub.seen is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind,use_async", _DISPATCH_TOOLS)
+    async def test_max_dispatch_depth_one_refuses_nested(self, db, kind, use_async):
+        stub, runner = _guarded_stub(kind, db, max_dispatch_depth=1)
+        out = await _dispatch(runner, kind, use_async, context=_context())
+        assert "error" not in out
+
+        stub.seen = None
+        out = await _dispatch(runner, kind, use_async, context=_dispatched_context(["team:outer"]))
+        assert "at most 1" in out["error"]
+        assert stub.seen is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind,use_async", _DISPATCH_TOOLS)
+    async def test_max_dispatch_depth_zero_refuses_all_dispatch_but_not_listing(self, db, kind, use_async):
+        # 0 means dispatch is off, never "unlimited"; the sessionless path is
+        # covered too, or a missing context would be a bypass. Discovery keeps
+        # working: the posture is "look but do not run".
+        stub, runner = _guarded_stub(kind, db, max_dispatch_depth=0)
+        out = await _dispatch(runner, kind, use_async, context=_context())
+        assert "at most 0" in out["error"]
+        assert stub.seen is None
+
+        out = await _dispatch(runner, kind, use_async, context=None)
+        assert "at most 0" in out["error"]
+        assert stub.seen is None
+
+        listed = _loads(getattr(runner, f"list_{kind}s")())
+        assert listed["count"] == 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind,use_async", _DISPATCH_TOOLS)
+    async def test_depth_not_lineage_length_governs(self, db, kind, use_async):
+        # A member-agent first hop writes three wielder tokens plus the
+        # target; the cap must read the hop counter, not len(chain), or that
+        # legitimate second hop is refused.
+        stub, runner = _guarded_stub(kind, db)
+        lineage = ["team:t1", "agent:m1", "team:t2", "agent:m2"]
+        out = await _dispatch(runner, kind, use_async, context=_dispatched_context(lineage, depth=1))
+        assert "error" not in out
+        assert stub.seen_metadata is not None and stub.seen_metadata[_DEPTH_KEY] == 2
+
+    def test_negative_depth_rejected_at_construction(self, db):
+        with pytest.raises(ValueError, match="max_dispatch_depth"):
+            StudioRunnerTools(db=db, max_dispatch_depth=-1)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind,use_async", _DISPATCH_TOOLS)
+    async def test_refusal_is_returned_not_raised(self, db, kind, use_async, caplog):
+        # A raised refusal costs the calling run its retries and can kill it,
+        # and one routed through logger.exception prints a traceback for a
+        # deliberate refusal. The contract is a plain JSON error result.
+        import logging
+
+        stub, runner = _guarded_stub(kind, db)
+        tool = getattr(runner, f"arun_{kind}" if use_async else f"run_{kind}")
+        with caplog.at_level(logging.WARNING):
+            raw = tool(stub.id, "go", _agno_run_context=_dispatched_context([f"{kind}:{stub.id}"]))
+            if use_async:
+                raw = await raw
+        assert isinstance(raw, str)
+        assert "error" in json.loads(raw)
+        assert not any(record.exc_info for record in caplog.records)
+        assert not any(record.levelno >= logging.ERROR for record in caplog.records)
+
+    def test_studio_tools_embedded_runner_carries_the_default(self, registry, db):
+        assert StudioTools(registry=registry, db=db)._runner_tools.max_dispatch_depth == 2
+        assert StudioTools(registry=registry, db=db, max_dispatch_depth=5)._runner_tools.max_dispatch_depth == 5
+
+
+# ----------------------------------------------------------------------
 # Discovery
 # ----------------------------------------------------------------------
 
@@ -937,7 +1504,52 @@ class TestDiscovery:
 
         runner = StudioRunnerTools(db=InMemoryDb())
         out = _loads(runner.list_agents())
-        assert out == {"agents": [], "count": 0, "total": 0}
+        assert out == {"agents": [], "count": 0, "total": 0, "other_components": {"teams": 0, "workflows": 0}}
+
+    def test_each_list_tool_discloses_the_other_namespaces(self, db):
+        # Three namespaces, three separate list tools: a model that calls one
+        # gets a plausible roster and no signal that it has seen a third of the
+        # components -- so "not on the roster" reads as "does not exist". The
+        # counts break that false negative.
+        runner = StudioRunnerTools(
+            db=db,
+            include_agents=[_StubAgent()],
+            include_teams=[_StubTeam()],
+            include_workflows=[_StubWorkflow()],
+        )
+        assert _loads(runner.list_agents())["other_components"] == {"teams": 1, "workflows": 1}
+        assert _loads(runner.list_teams())["other_components"] == {"agents": 1, "workflows": 1}
+        assert _loads(runner.list_workflows())["other_components"] == {"agents": 1, "teams": 1}
+
+    def test_disclosure_counts_stored_components_too(self, registry, db):
+        studio = StudioTools(registry=registry, db=db)
+        studio.create_agent(name="member", instructions="i", model_id="gpt-5.4", publish=True)
+        studio.create_team(name="squad", instructions="i", member_ids=["member"], model_id="gpt-5.4")
+
+        runner = StudioRunnerTools(registry=registry, db=db)
+        out = _loads(runner.list_workflows())
+        assert out["other_components"] == {"agents": 1, "teams": 1}
+
+    def test_disclosure_omits_disabled_namespaces(self, db):
+        # run_team is not registered on this toolkit, so a team count would
+        # advertise components the caller has no tool to run.
+        runner = StudioRunnerTools(db=db, include_agents=[_StubAgent()], include_teams=[_StubTeam()], teams=False)
+        out = _loads(runner.list_agents())
+        assert out["other_components"] == {"workflows": 0}
+
+    def test_disclosure_survives_a_missing_db(self):
+        # The code-allowlist half works without a database, and so must the
+        # disclosure riding on it.
+        runner = StudioRunnerTools(include_agents=[_StubAgent()], include_teams=[_StubTeam()])
+        out = _loads(runner.list_agents())
+        assert out["count"] == 1
+        assert out["other_components"] == {"teams": 1, "workflows": 0}
+
+    @pytest.mark.asyncio
+    async def test_async_list_discloses_too(self, db):
+        runner = StudioRunnerTools(db=db, include_teams=[_StubTeam()])
+        out = _loads(await runner.alist_agents())
+        assert out["other_components"] == {"teams": 1, "workflows": 0}
 
 
 def _nested_child_step(step_input):
@@ -3585,3 +4197,164 @@ class TestNestedWorkflowIsolationSpellings:
             lambda step: [Step(name="x", executor=lambda step_input: None)],
             workflow_agent=StickyAgent(id="wf_agent", name="WA"),
         )
+
+
+# ----------------------------------------------------------------------
+# End to end: a real team dispatching itself through the real tool loop
+# ----------------------------------------------------------------------
+
+
+def _build_self_dispatch_model():
+    from typing import AsyncIterator, Iterator
+
+    from agno.models.base import Model
+    from agno.models.message import MessageMetrics
+    from agno.models.response import ModelResponse
+
+    class SelfDispatchModel(Model):
+        """Drives the observed pathology: every fresh run immediately asks to
+        dispatch team 'looper' again, and only a tool RESULT makes it answer.
+
+        The final answer names what the tool result was, so the test can read
+        each nesting level's outcome off the shared recorder. The provider-call
+        ceiling turns an unbounded recursion (the unguarded behavior) into a
+        loud failure instead of a hang."""
+
+        def __init__(self, recorder=None):
+            super().__init__(id="self-dispatch-test", name="self-dispatch-test", provider="test")
+            self.recorder = recorder if recorder is not None else {"provider_calls": 0, "finals": []}
+
+        def __deepcopy__(self, memo):
+            # Dispatch runs on a deep copy of the team; the recorder must stay
+            # shared or the nested levels become invisible to the test.
+            return type(self)(recorder=self.recorder)
+
+        def _respond(self, messages) -> ModelResponse:
+            self.recorder["provider_calls"] += 1
+            if self.recorder["provider_calls"] > 12:
+                raise AssertionError("runaway self-dispatch: the guard did not stop the loop")
+            tool_results = [
+                str(getattr(m, "content", "")) for m in (messages or []) if getattr(m, "role", None) == "tool"
+            ]
+            if tool_results:
+                verdict = "saw-refusal" if "Refusing to dispatch" in tool_results[-1] else "saw-success"
+                self.recorder["finals"].append(verdict)
+                return ModelResponse(content=verdict, role="assistant", response_usage=MessageMetrics())
+            return ModelResponse(
+                role="assistant",
+                tool_calls=[
+                    {
+                        "id": "dispatch-1",
+                        "type": "function",
+                        "function": {
+                            "name": "run_team",
+                            "arguments": json.dumps({"team_id": "looper", "message": "keep going"}),
+                        },
+                    }
+                ],
+                response_usage=MessageMetrics(),
+            )
+
+        def invoke(self, messages=None, *args, **kwargs) -> ModelResponse:
+            return self._respond(messages)
+
+        async def ainvoke(self, messages=None, *args, **kwargs) -> ModelResponse:
+            return self._respond(messages)
+
+        def invoke_stream(self, messages=None, *args, **kwargs) -> Iterator[ModelResponse]:
+            yield self._respond(messages)
+
+        async def ainvoke_stream(self, messages=None, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+            yield self._respond(messages)
+
+        def parse_args(self, *args, **kwargs):
+            return {}
+
+        def _parse_provider_response(self, response, **kwargs) -> ModelResponse:
+            return response
+
+        def _parse_provider_response_delta(self, response) -> ModelResponse:
+            return response
+
+    return SelfDispatchModel()
+
+
+class TestEndToEndSelfDispatch:
+    def test_the_observed_loop_never_starts(self, db, tmp_path):
+        # The 3.0.0a4 pathology in miniature: a team whose runner toolkit can
+        # reach the team itself, driven by a model that re-dispatches whenever
+        # it has no tool result yet. Unguarded, every nesting level starts
+        # another; the recorder's ceiling fails the test loudly if that comes
+        # back. Guarded, the framework injects the wielding team into the tool
+        # call, so the very FIRST self-dispatch is refused and no nested run
+        # ever exists -- this is the reported top-level repro, end to end
+        # through the real injection machinery.
+        from agno.agent.agent import Agent
+        from agno.team.team import Team
+
+        model = _build_self_dispatch_model()
+        member = Agent(id="bystander", name="Bystander", model=model.__deepcopy__({}))
+        dispatchable: List[Any] = []
+        toolkit = StudioRunnerTools(db=db, include_teams=dispatchable)
+        team = Team(
+            id="looper",
+            name="Looper",
+            model=model,
+            members=[member],
+            tools=[toolkit],
+            db=db,
+        )
+        dispatchable.append(team)
+
+        output = team.run("go", session_id="probe-sess", user_id="probe", stream=False)
+
+        # One run reached a model, twice: the dispatch attempt, then the final
+        # answer over the refusal. No nested run ever produced a final.
+        assert model.recorder["finals"] == ["saw-refusal"]
+        assert output.content == "saw-refusal"
+        assert model.recorder["provider_calls"] == 2
+
+
+# ----------------------------------------------------------------------
+# Cancel cascade: dispatched sub-runs register under the caller's run
+# ----------------------------------------------------------------------
+
+
+class TestDispatchCancelCascade:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind,use_async", _DISPATCH_TOOLS)
+    async def test_sub_run_registers_under_the_caller_run(self, db, kind, use_async):
+        # A team or workflow caller's cancel_run cascades through
+        # get_member_run_ids; without registration an escaped dispatch is
+        # unstoppable from the outside, which is how the observed runaway
+        # outlived its HTTP client.
+        from agno.run.cancel import get_member_run_ids
+
+        stub, runner = _guarded_stub(kind, db)
+        out = await _dispatch(runner, kind, use_async, context=_context())
+        assert "error" not in out
+        assert isinstance(stub.seen_run_id, str) and stub.seen_run_id
+        assert stub.seen_run_id in get_member_run_ids("caller-run")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind,use_async", _DISPATCH_TOOLS)
+    async def test_sessionless_dispatch_still_gets_a_run_id(self, db, kind, use_async):
+        from agno.run.cancel import get_member_run_ids
+
+        stub, runner = _guarded_stub(kind, db)
+        out = await _dispatch(runner, kind, use_async, context=None)
+        assert "error" not in out
+        assert isinstance(stub.seen_run_id, str) and stub.seen_run_id
+        assert get_member_run_ids("caller-run") == set()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind,use_async", _DISPATCH_TOOLS)
+    async def test_refused_dispatch_registers_nothing(self, db, kind, use_async):
+        from agno.run.cancel import get_member_run_ids
+
+        stub, runner = _guarded_stub(kind, db)
+        out = await _dispatch(
+            runner, kind, use_async, context=_dispatched_context([f"{kind}:{_STUB_CLASSES[kind].id}"])
+        )
+        assert "error" in out
+        assert get_member_run_ids("caller-run") == set()

--- a/libs/agno/tests/unit/tools/test_studio_runner.py
+++ b/libs/agno/tests/unit/tools/test_studio_runner.py
@@ -225,7 +225,7 @@ class TestRegistration:
         assert expected == set(runner.async_functions.keys())
 
     def test_flags_scope_the_surface(self, db):
-        runner = StudioRunnerTools(db=db, teams=False, workflows=False)
+        runner = StudioRunnerTools(db=db, run_teams=False, run_workflows=False)
         assert {"list_agents", "run_agent"} == set(runner.functions.keys())
         assert {"list_agents", "run_agent"} == set(runner.async_functions.keys())
 
@@ -644,7 +644,7 @@ class TestResolution:
         # With the team tools off, run_team does not exist on this toolkit; a
         # hint naming it would point at a door that is not there.
         stub = _StubTeam()
-        runner = StudioRunnerTools(db=db, include_teams=[stub], teams=False)
+        runner = StudioRunnerTools(db=db, include_teams=[stub], run_teams=False)
         out = _loads(runner.run_agent("stub-team", "hi"))
         assert out == {"error": "Agent not found: stub-team"}
 
@@ -658,7 +658,7 @@ class TestResolution:
     def test_the_instructions_say_the_rosters_are_separate(self, db):
         assert "separate rosters" in StudioRunnerTools(db=db).instructions
         # With a single kind enabled there is no sibling roster to point at.
-        assert "separate rosters" not in StudioRunnerTools(db=db, teams=False, workflows=False).instructions
+        assert "separate rosters" not in StudioRunnerTools(db=db, run_teams=False, run_workflows=False).instructions
 
     def test_exact_id_beats_code_defined_display_name(self, db):
         shadow = _StubAgent()
@@ -1533,7 +1533,7 @@ class TestDiscovery:
     def test_disclosure_omits_disabled_namespaces(self, db):
         # run_team is not registered on this toolkit, so a team count would
         # advertise components the caller has no tool to run.
-        runner = StudioRunnerTools(db=db, include_agents=[_StubAgent()], include_teams=[_StubTeam()], teams=False)
+        runner = StudioRunnerTools(db=db, include_agents=[_StubAgent()], include_teams=[_StubTeam()], run_teams=False)
         out = _loads(runner.list_agents())
         assert out["other_components"] == {"workflows": 0}
 

--- a/libs/agno/tests/unit/tools/test_studio_runner.py
+++ b/libs/agno/tests/unit/tools/test_studio_runner.py
@@ -483,8 +483,8 @@ class TestInjectionGuard:
         assert stub.seen is not None
         assert stub.seen["user_id"] == "ash"
 
-    def test_a_model_supplied_wielder_is_discarded(self, db):
-        # The wielder identity drives the cycle guard, so a model that could
+    def test_a_model_supplied_caller_identity_is_discarded(self, db):
+        # The caller identity drives the cycle guard, so a model that could
         # null it out would talk its way past the refusal. The injected value
         # must win over anything in the tool-call arguments.
         stub = _StubTeam()
@@ -502,7 +502,7 @@ class TestInjectionGuard:
         assert "already running" in str(call.result)
         assert stub.seen is None
 
-    def test_the_wielder_params_stay_out_of_the_model_schema(self, db):
+    def test_the_caller_params_stay_out_of_the_model_schema(self, db):
         # The description assertion is the tripwire for the annotation hazard:
         # a forward-ref annotation on the injected params makes schema
         # generation fail silently, shipping the tool with empty parameters
@@ -1028,9 +1028,9 @@ _DISPATCH_TOOLS = [
     pytest.param("workflow", True, id="arun_workflow"),
 ]
 
-# The two component kinds that can WIELD a toolkit (workflows hold no tools),
-# for the top-level self-dispatch case where the wielder IS the target.
-_WIELDER_TOOLS = [
+# The two component kinds that can hold a toolkit (workflows hold no tools),
+# for the top-level self-dispatch case where the caller IS the target.
+_CALLER_TOOLS = [
     pytest.param("agent", False, id="run_agent"),
     pytest.param("team", False, id="run_team"),
     pytest.param("agent", True, id="arun_agent"),
@@ -1044,8 +1044,8 @@ def _guarded_stub(kind: str, db, **runner_kwargs):
     return stub, runner
 
 
-def _wielder_kwargs(kind: str, stub) -> Dict[str, Any]:
-    return {"wielder_agent": stub} if kind == "agent" else {"wielder_team": stub}
+def _caller_kwargs(kind: str, stub) -> Dict[str, Any]:
+    return {"caller_agent": stub} if kind == "agent" else {"caller_team": stub}
 
 
 async def _dispatch(
@@ -1054,12 +1054,12 @@ async def _dispatch(
     use_async: bool,
     identifier: Optional[str] = None,
     context=None,
-    wielder_agent=None,
-    wielder_team=None,
+    caller_agent=None,
+    caller_team=None,
 ):
     identifier = identifier if identifier is not None else _STUB_CLASSES[kind].id
     tool = getattr(runner, f"arun_{kind}" if use_async else f"run_{kind}")
-    result = tool(identifier, "go", _agno_run_context=context, _agno_agent=wielder_agent, _agno_team=wielder_team)
+    result = tool(identifier, "go", _agno_run_context=context, _agno_agent=caller_agent, _agno_team=caller_team)
     if use_async:
         result = await result
     return _loads(result)
@@ -1067,13 +1067,13 @@ async def _dispatch(
 
 class TestDispatchCycleGuard:
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("kind,use_async", _WIELDER_TOOLS)
+    @pytest.mark.parametrize("kind,use_async", _CALLER_TOOLS)
     async def test_top_level_self_dispatch_is_refused(self, db, kind, use_async):
-        # The reported repro: the wielding component dispatches ITSELF from a
+        # The reported repro: the calling component dispatches ITSELF from a
         # run a human started, where the inherited lineage is empty. Only the
-        # injected wielder identity can catch this.
+        # injected caller identity can catch this.
         stub, runner = _guarded_stub(kind, db)
-        out = await _dispatch(runner, kind, use_async, context=_context(), **_wielder_kwargs(kind, stub))
+        out = await _dispatch(runner, kind, use_async, context=_context(), **_caller_kwargs(kind, stub))
         assert stub.id in out["error"]
         assert "already running" in out["error"]
         assert stub.seen is None
@@ -1091,11 +1091,11 @@ class TestDispatchCycleGuard:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("use_async", [False, True], ids=["sync", "async"])
     async def test_a_member_agent_refuses_to_dispatch_its_parent_team(self, db, use_async):
-        # A toolkit on a member agent wields BOTH the member and its parent
+        # A toolkit on a member agent carries BOTH the member and its parent
         # team: the parent is genuinely running, so it is a cycle target.
         team, runner = _guarded_stub("team", db)
         agent = _StubAgent()
-        out = await _dispatch(runner, "team", use_async, context=_context(), wielder_agent=agent, wielder_team=team)
+        out = await _dispatch(runner, "team", use_async, context=_context(), caller_agent=agent, caller_team=team)
         assert "already running" in out["error"]
         assert team.seen is None
 
@@ -1113,13 +1113,13 @@ class TestDispatchCycleGuard:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("kind,use_async", _DISPATCH_TOOLS)
-    async def test_the_wielder_is_written_into_the_outgoing_lineage(self, db, kind, use_async):
-        # The wielder is recorded, not just the target: an inherited-only
+    async def test_the_caller_is_written_into_the_outgoing_lineage(self, db, kind, use_async):
+        # The caller is recorded, not just the target: an inherited-only
         # outgoing chain never contains the caller, so A -> B -> A stays open.
         stub, runner = _guarded_stub(kind, db)
         outer = _StubTeam()
         outer.id = "outer"
-        out = await _dispatch(runner, kind, use_async, context=_context(), wielder_team=outer)
+        out = await _dispatch(runner, kind, use_async, context=_context(), caller_team=outer)
         assert "error" not in out
         assert stub.seen_metadata is not None
         assert stub.seen_metadata[_CHAIN_KEY] == ["team:outer", f"{kind}:{stub.id}"]
@@ -1139,13 +1139,13 @@ class TestDispatchCycleGuard:
         b.name = "B"
         runner = StudioRunnerTools(db=db, include_teams=[a, b], max_dispatch_depth=3)
 
-        out = await _dispatch(runner, "team", use_async, identifier="b", context=_context(), wielder_team=a)
+        out = await _dispatch(runner, "team", use_async, identifier="b", context=_context(), caller_team=a)
         assert "error" not in out
         assert b.seen_metadata == {_CHAIN_KEY: ["team:a", "team:b"], _DEPTH_KEY: 1}
 
         nested = _context()
         nested.metadata = dict(b.seen_metadata)
-        out = await _dispatch(runner, "team", use_async, identifier="a", context=nested, wielder_team=b)
+        out = await _dispatch(runner, "team", use_async, identifier="a", context=nested, caller_team=b)
         assert "already running" in out["error"]
         assert a.seen is None
 
@@ -1171,12 +1171,12 @@ class TestDispatchCycleGuard:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("kind,use_async", _DISPATCH_TOOLS)
     async def test_lineage_entries_are_deduped(self, db, kind, use_async):
-        # A wielder already in the inherited lineage appears once, and the hop
+        # A caller already in the inherited lineage appears once, and the hop
         # count still moves by exactly 1: it is its own key, not len(chain).
         stub, runner = _guarded_stub(kind, db, max_dispatch_depth=3)
         outer = _StubTeam()
         outer.id = "outer"
-        out = await _dispatch(runner, kind, use_async, context=_dispatched_context(["team:outer"]), wielder_team=outer)
+        out = await _dispatch(runner, kind, use_async, context=_dispatched_context(["team:outer"]), caller_team=outer)
         assert "error" not in out
         assert stub.seen_metadata is not None
         assert stub.seen_metadata[_CHAIN_KEY] == ["team:outer", f"{kind}:{stub.id}"]
@@ -1196,13 +1196,13 @@ class TestDispatchCycleGuard:
         assert context.metadata == {"tenant": "acme"}
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("kind,use_async", _WIELDER_TOOLS)
+    @pytest.mark.parametrize("kind,use_async", _CALLER_TOOLS)
     async def test_resolved_id_is_used_not_alias(self, db, kind, use_async):
-        # The lineage carries resolved ids; dispatching the wielder by display
+        # The lineage carries resolved ids; dispatching the caller by display
         # name must hit the same guard, or an alias walks straight around it.
         stub, runner = _guarded_stub(kind, db)
         out = await _dispatch(
-            runner, kind, use_async, identifier=stub.name, context=_context(), **_wielder_kwargs(kind, stub)
+            runner, kind, use_async, identifier=stub.name, context=_context(), **_caller_kwargs(kind, stub)
         )
         assert "error" in out
         assert stub.seen is None
@@ -1283,7 +1283,7 @@ class TestDispatchCycleGuard:
     async def test_a_different_component_is_unaffected(self, db, use_async):
         stub = _StubAgent()
         runner = StudioRunnerTools(db=db, include_agents=[stub])
-        out = await _dispatch(runner, "agent", use_async, context=_context(), wielder_team=_StubTeam())
+        out = await _dispatch(runner, "agent", use_async, context=_context(), caller_team=_StubTeam())
         assert out["status"] == "COMPLETED"
         assert stub.seen is not None
 
@@ -1379,7 +1379,7 @@ class TestDispatchDepthCap:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("kind,use_async", _DISPATCH_TOOLS)
     async def test_depth_not_lineage_length_governs(self, db, kind, use_async):
-        # A member-agent first hop writes three wielder tokens plus the
+        # A member-agent first hop writes three caller tokens plus the
         # target; the cap must read the hop counter, not len(chain), or that
         # legitimate second hop is refused.
         stub, runner = _guarded_stub(kind, db)
@@ -4285,7 +4285,7 @@ class TestEndToEndSelfDispatch:
         # reach the team itself, driven by a model that re-dispatches whenever
         # it has no tool result yet. Unguarded, every nesting level starts
         # another; the recorder's ceiling fails the test loudly if that comes
-        # back. Guarded, the framework injects the wielding team into the tool
+        # back. Guarded, the framework injects the calling team into the tool
         # call, so the very FIRST self-dispatch is refused and no nested run
         # ever exists -- this is the reported top-level repro, end to end
         # through the real injection machinery.


### PR DESCRIPTION
## Summary

One user message could put a component reachable from its own dispatch set into a self-sustaining `run_team` loop. Measured on 3.0.0a4: 65 nested calls inside a 300s window, 83 over 20 minutes, still firing 18 minutes after the HTTP client disconnected, stopped only by a process restart. A second defect in the same file made the natural phrasing fail: `run_agent` and `run_team` are separate resolution namespaces with no cross-reference, so "run yourself" against a team-led platform returned a bare `Agent not found`.

Neither is fixable by prompt: the nested run carried no signal that it was nested (`parent_run_id` NULL, no depth or caller field anywhere in the run context).

### The fix

**Dispatch lineage + hop counter in run metadata.** Every dispatch through `StudioRunnerTools` (and `StudioTools`) now threads two runtime-reserved keys through the child run's metadata: `agno_dispatch_chain` (every component already running in this dispatch tree, `"<type>:<id>"` entries — membership is the cycle test) and `agno_dispatch_depth` (the hop count — the depth test). Two keys because the lineage records wielders as well as targets, so its length is not the hop count.

**The calling component joins the lineage.** The run tools declare `_agno_agent` / `_agno_team` (annotated `Optional[Any]` — a forward-ref annotation silently empties the tool schema, and a tripwire test pins that), so the framework's existing identity injection tells the guard which components are on the live call stack (internally threaded as `caller_agent`/`caller_team`, matching the file's `_caller_user_id` vocabulary). This is what closes the reported repro: a team dispatching **itself from a top-level run**, where the inherited chain is empty. The outgoing lineage extends the running set (inherited + callers), not the inherited chain alone, so `A -> B -> A` ping-pong is refused at any depth.

**`max_dispatch_depth=2` bounds the hop count** (configurable; `1` = dispatched components may not dispatch on; `0` = dispatch off, listing intact; negative rejected with `ValueError`; no "unlimited" option — unlimited is the bug). The cycle guard is always on regardless.

**Both dispatch surfaces are guarded.** `StudioTools`' unversioned run tools forward the caller identity by keyword into the embedded runner; its **version-pinned branch dispatches `component.run()` directly and never reaches the runner's run tools**, so the same guard runs in place there and the lineage merges into the version-stamp metadata (one dict, `dispatch_refused` error code). `StudioTools` also forwards `max_dispatch_depth` (grouped with `allowed_tools`/`denied_tools` -- the policy knobs together).

**Forgery is closed at every seam that already scrubs the version key — plus one it missed.** Component metadata merges OVER call-site metadata, so a stored config carrying `{"agno_dispatch_chain": [], "agno_dispatch_depth": 0}` would reset every sub-run to depth zero. `strip_reserved_run_metadata` now strips a `RESERVED_RUN_METADATA_KEYS` frozenset (all three rebuild paths); `stamp_component_version` pops all reserved keys at the four run-start routes; the scheduler executor scrubs them from builder-writable schedule payloads; and the session create/update routes scrub them too — session metadata merges into every run of the session and wins conflicting keys, so it was an unscrubbed caller-writable channel for the reserved keys (including the pre-existing `agno_component_version` forgery class). An independent adversarial verify pass established that channel could only reset the guard one hop per caller-paid API call (the derived sub-session ids form a non-repeating hash chain), so this is defence-in-depth, not a reopened loop — but the invariant is now enforced consistently. A malformed inbound lineage or depth **fails closed** (refused, naming the key) — treating it as absent would zero the counter, which is exactly what a forged value would want. Absent keys are the ordinary top-level run.

**Refusals are returned, never raised**: JSON `{"error": ...}` in the runner's existing refusal idiom, naming the full lineage and telling the model not to retry; never routed through `logger.exception`. Depth is checked before resolution (no copy/rebuild cost for a refused dispatch); the cycle is checked on the **resolved** id, so display names and slugs cannot evade it.

**Cancel cascade.** Dispatched sub-runs mint their run id up front and register it under the caller's run via `register_member_run`/`aregister_member_run` (the delegate-task and workflow-step pattern), so a team or workflow caller's `cancel_run` cascades into the dispatch. Known limit: `Agent.cancel_run` is the bare global with no cascade, so this covers team and workflow callers only.

**Cross-namespace resolution.** A `run_agent` miss now probes the sibling namespaces and answers `Agent not found: Agno. A team with this identifier exists -- use run_team(team_id='agno')` — only for enabled tool kinds and only for components the caller could actually dispatch (drafts and non-admitted registry components produce no hint; probe failures never replace the real refusal). Each list tool discloses the other enabled namespaces' counts (`other_components`), and the toolkit instructions state that the three rosters are separate.

### Regression proof (baselines recorded on unmodified `a60be9eb3`)

```
1. top-level self-dispatch:   {"team_id": "stub-team", ..., "status": "COMPLETED"}; stub executed
2. A -> B -> A ping-pong:     both dispatches COMPLETED
3. third hop, depth-2 inbound: COMPLETED (metadata ignored)
4. StudioTools.run_agent params: ['self','agent_id','message','version','_agno_run_context']
   (no caller-identity channel; version-pinned branch dispatches unguarded)
5. run_agent on a team id:    {"error": "Agent not found: stub-team"}
```

All five now refuse/hint as specified. The original single-test proof also ran first and failed on unmodified code (dispatch proceeded with `status: COMPLETED`).

An end-to-end test drives the observed pathology with a real `Team`, a scripted tool-calling model, and the real identity-injection machinery: the very first self-dispatch is refused and no nested run ever exists (the unguarded code recurses into the test's runaway ceiling — verified by mutation).

### Verification

- **837 tests** across the gated suites (1,771 including the full os/routers tree) (`test_studio_runner.py` 366, `test_studio.py`, `test_studio_preview_stamp.py`, `test_reserved_run_metadata.py`, `test_preview_stamp_forgery.py`, result-shape/zero-config/draft-resolution/registry-workflow suites), all green; full unit suite green apart from pre-existing environment-dependent failures (litellm half-install, gmail/google auth, xai credential-in-env — all fail identically on unmodified `a60be9eb3`).
- **28 targeted mutations, all killed**, each with the expected blast radius: cycle guard off, depth guard off, chain not extended, caller identity ignored, outgoing chain from inherited-only, depth read from `len(chain)`, malformed-fails-open, alias keying, strip losing either key, both preview branches unguarded, async paths unguarded, caller identity dropped/positional in StudioTools, stamp/executor seams reverted, cascade registration removed, forward-ref annotation (caught by the schema tripwire), and more.
- An independent multi-agent adversarial review (4 lenses, per-finding refutation) ran over the final diff: two findings confirmed (both test gaps: async pinned-preview lineage threading, pinned-preview cancel-cascade registration) and fixed with mutation-verified tests; the session-metadata channel was confirmed mechanically but its loop-reopening impact refuted, and hardened anyway; one low finding refuted.
- `./scripts/format.sh` clean; `./scripts/validate.sh` ruff clean, mypy identical to the base-branch baseline (72 pre-existing errors in third-party-typed adapters, none in touched files).

### Deliberate judgement calls

- **The lineage rides `RunContext.metadata`** (per the spec's closed decision): no dataclass or signature churn, and it inherits the parent→child forwarding the framework already does for member delegation, `continue_run`, and workflow steps. It is persisted on the run row and surfaced in payloads **deliberately** — a dispatched run row today shows nothing about where it came from; this is provenance, not leakage, and it is not stripped on read.
- **One shared guard implementation** (`_inherited_dispatch_state` / `_require_dispatch_budget` / `_wielder_tokens` / `_require_no_cycle` / `_outgoing_metadata`) used by all six runner tools, both StudioTools pinned branches, and composed as `_dispatch_metadata` for callers that already hold a resolved id. The async paths call the same pure in-memory helpers inline — separate code paths, same logic, each independently pinned by parametrized tests.
- **One deviation from the spec's criterion 8** ("caller metadata survives apart from the two reserved keys"): the forwarded copy also strips `agno_component_version`. That key describes the *caller's* run; forwarded, it would stamp the child's run row and the lifecycle routes would continue a paused child on the wrong version *of the child*. Pinned by `test_reserved_version_key_is_not_forwarded`.
- **A half pair fails closed** (chain without depth or vice versa) — the runtime always writes both, so one alone is the same tampering evidence as a wrong shape. The spec's table did not cover it.
- **Dispatched sub-runs now receive the caller's metadata** (minus reserved keys) — a behaviour change mirroring `delegate_task_to_member`; anything reading `run_context.metadata` inside a dispatched component starts seeing the caller's keys.

### What this does NOT bound (stated per spec)

- **Fan-out.** The lineage is per-branch: one run may still dispatch `b` distinct components, each dispatching `b` more — up to `b^d` model-calling runs inside the depth cap. The depth-driven runaway is closed; a breadth-driven one needs a per-run dispatch budget (follow-up).
- **Cancellation on client disconnect.** No AgentOS route watches for disconnects; the cascade registration makes an escaped run stoppable via `cancel_run`, not automatic.
- **`Agent.cancel_run`** has no member cascade, so cascade coverage is team/workflow callers.
- The §2.1a/§2.1b live-platform re-run was not executed here (no platform container in this environment); it is composed instead from the end-to-end team test plus the stored-chain-composes-into-a-refusal tests, which exercise the same dispatch → persist → re-read path with real components.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

- The error-code vocabulary gains `dispatch_refused` (deliberately `retryable: false` in spirit: retrying the same dispatch is the loop the refusal exists to stop).
- `RESERVED_RUN_METADATA_KEYS` becomes public API of `agno.db.schemas.scheduler`; `COMPONENT_VERSION_METADATA_KEY` keeps its name and value.
- `StudioTools._version_stamp` now returns metadata *content* (merged with the dispatch metadata into one `metadata=` kwarg) instead of run-kwargs; the no-fastapi subprocess test was updated to the new shape with identical asserted values.
- The list tools' payload gains `other_components`; one exact-shape test was updated for the documented additive key.
- New constructor parameters are keyword-defaulted (`StudioRunnerTools(max_dispatch_depth=2)` beside `include_all_components`; `StudioTools(max_dispatch_depth=2)` after `denied_tools`, grouping the policy knobs).
- **Alpha-channel rename (review feedback):** `StudioRunnerTools`' kind flags `agents`/`teams`/`workflows` are now `run_agents`/`run_teams`/`run_workflows` -- mirroring `StudioTools`' `create_*`, and removing a silent misconfiguration (the bare `agents` bool sat beside `include_agents` while `Registry(agents=[...])` takes a list, so an intended allowlist passed as `agents=[...]` coerced truthy and changed nothing). Each flag exposes the kind's whole surface, list tool included. 3.0 is unreleased; no stable API is affected.