### PR TITLE
fix: end a no-task tasks run by answering, and forbid joined member ids on nested rosters

### DIFF
--- a/libs/agno/agno/team/_messages.py
+++ b/libs/agno/agno/team/_messages.py
@@ -154,7 +154,7 @@ def _get_opening_prompt() -> str:
     )
 
 
-def _get_mode_instructions(team: "Team") -> str:
+def _get_mode_instructions(team: "Team", has_sub_team: bool = False) -> str:
     """Return the mode-specific <delegation> block."""
     from agno.team.mode import TeamMode
 
@@ -183,10 +183,10 @@ def _get_mode_instructions(team: "Team") -> str:
             "not state.\n"
             "- `mark_all_complete` ends the loop; the summary you pass it is bookkeeping, not the reply. "
             "Write the answer as your own message in the same turn — that message is what reaches the "
-            "user. A list whose tasks have all completed also ends the loop, but an empty one never "
-            "does, so a request that needed no tasks at all — a greeting, a question you can simply "
-            "answer — still has to call it. Call it too when the goal is out of reach: a partial "
-            "outcome stated plainly beats looping.\n"
+            "user. A list whose tasks have all completed also ends the loop. For a request that needs "
+            "no tasks at all — a greeting, a question you can simply answer — write the answer and call "
+            "`mark_all_complete` in the same turn: that finishes at once instead of after a reminder. "
+            "Call it too when the goal is out of reach: a partial outcome stated plainly beats looping.\n"
         )
     elif team.mode == TeamMode.route:
         content += (
@@ -255,7 +255,16 @@ def _get_mode_instructions(team: "Team") -> str:
 
     # Broadcast reaches every member with one call and takes no member id.
     if team.mode != TeamMode.broadcast:
-        content += "Member ids are the ids shown in the roster above, used exactly as written.\n"
+        if has_sub_team:
+            # A nested roster invites joined ids like "sub-team.member"; the lookup is exact,
+            # so every such call fails and costs a round trip before the leader recovers.
+            content += (
+                "Member ids are the ids shown in the roster above, used exactly as written — never joined "
+                "or prefixed. Delegate to a sub-team by the sub-team's own id; its leader hands work to "
+                "the members inside it.\n"
+            )
+        else:
+            content += "Member ids are the ids shown in the roster above, used exactly as written.\n"
 
     content += "</delegation>\n"
     return content
@@ -288,7 +297,10 @@ def _build_team_context(
         # Tasks mode takes the task-tool branch, which never attaches this one.
         if team.get_member_information_tool and team.mode != TeamMode.tasks:
             content += "Call `get_member_information` at any time to re-read this list.\n"
-        content += _get_mode_instructions(team)
+        from agno.team.team import Team
+
+        has_sub_team = any(isinstance(member, Team) for member in resolved_members)
+        content += _get_mode_instructions(team, has_sub_team=has_sub_team)
         content += "</team>\n\n"
     return content
 

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -365,7 +365,9 @@ def _run_tasks(
         model_response: Optional[ModelResponse] = None
 
         # === Iterative task loop ===
+        idle_answer_turns = 0
         for iteration in range(team.max_iterations):
+            n_tools_before_iteration = len(run_response.tools or [])
             log_debug(f"Task iteration {iteration + 1}/{team.max_iterations}")
 
             # On subsequent iterations, inject current task state as a user message
@@ -431,6 +433,20 @@ def _run_tasks(
                     break
                 # If there are failures, continue to let model handle them
                 log_debug("All tasks terminal but some failed, continuing to let model handle.")
+
+            # A run that needs no tasks ends by answering: with an empty list, one reminder still
+            # goes out, and a second turn that writes text but calls no tool is final. Without this,
+            # an empty list never satisfies all_terminal and a greeting burns max_iterations.
+            if not task_list.tasks:
+                if len(run_response.tools or []) == n_tools_before_iteration:
+                    idle_answer_turns += 1
+                    if idle_answer_turns >= 2:
+                        log_debug("No tasks and no tool calls for a second turn; treating the written answer as final.")
+                        break
+                else:
+                    idle_answer_turns = 0
+            else:
+                idle_answer_turns = 0
         else:
             # Loop exhausted without completing
             task_list = load_task_list(run_context.session_state)
@@ -712,7 +728,9 @@ def _run_tasks_stream(
         accumulated_messages = run_messages.messages
 
         # === Iterative task loop ===
+        idle_answer_turns = 0
         for iteration in range(team.max_iterations):
+            n_tools_before_iteration = len(run_response.tools or [])
             log_debug(f"Task iteration {iteration + 1}/{team.max_iterations}")
 
             # Yield task iteration started event
@@ -864,6 +882,20 @@ def _run_tasks_stream(
                     break
                 # If there are failures, continue to let model handle them
                 log_debug("All tasks terminal but some failed, continuing to let model handle.")
+
+            # A run that needs no tasks ends by answering: with an empty list, one reminder still
+            # goes out, and a second turn that writes text but calls no tool is final. Without this,
+            # an empty list never satisfies all_terminal and a greeting burns max_iterations.
+            if not task_list.tasks:
+                if len(run_response.tools or []) == n_tools_before_iteration:
+                    idle_answer_turns += 1
+                    if idle_answer_turns >= 2:
+                        log_debug("No tasks and no tool calls for a second turn; treating the written answer as final.")
+                        break
+                else:
+                    idle_answer_turns = 0
+            else:
+                idle_answer_turns = 0
         else:
             # Loop exhausted without completing
             task_list = load_task_list(run_context.session_state)
@@ -2224,7 +2256,9 @@ async def _arun_tasks(
         model_response: Optional[ModelResponse] = None
 
         # === Iterative task loop ===
+        idle_answer_turns = 0
         for iteration in range(team.max_iterations):
+            n_tools_before_iteration = len(run_response.tools or [])
             log_debug(f"Task iteration {iteration + 1}/{team.max_iterations}")
 
             # On subsequent iterations, inject current task state as a user message
@@ -2288,6 +2322,20 @@ async def _arun_tasks(
                     log_debug("All tasks completed successfully, finishing task loop.")
                     break
                 log_debug("All tasks terminal but some failed, continuing to let model handle.")
+
+            # A run that needs no tasks ends by answering: with an empty list, one reminder still
+            # goes out, and a second turn that writes text but calls no tool is final. Without this,
+            # an empty list never satisfies all_terminal and a greeting burns max_iterations.
+            if not task_list.tasks:
+                if len(run_response.tools or []) == n_tools_before_iteration:
+                    idle_answer_turns += 1
+                    if idle_answer_turns >= 2:
+                        log_debug("No tasks and no tool calls for a second turn; treating the written answer as final.")
+                        break
+                else:
+                    idle_answer_turns = 0
+            else:
+                idle_answer_turns = 0
         else:
             # Loop exhausted without completing
             task_list = load_task_list(run_context.session_state)
@@ -2606,7 +2654,9 @@ async def _arun_tasks_stream(
         accumulated_messages = run_messages.messages
 
         # === Iterative task loop ===
+        idle_answer_turns = 0
         for iteration in range(team.max_iterations):
+            n_tools_before_iteration = len(run_response.tools or [])
             log_debug(f"Task iteration {iteration + 1}/{team.max_iterations}")
 
             # Yield task iteration started event
@@ -2757,6 +2807,20 @@ async def _arun_tasks_stream(
                     log_debug("All tasks completed successfully, finishing task loop.")
                     break
                 log_debug("All tasks terminal but some failed, continuing to let model handle.")
+
+            # A run that needs no tasks ends by answering: with an empty list, one reminder still
+            # goes out, and a second turn that writes text but calls no tool is final. Without this,
+            # an empty list never satisfies all_terminal and a greeting burns max_iterations.
+            if not task_list.tasks:
+                if len(run_response.tools or []) == n_tools_before_iteration:
+                    idle_answer_turns += 1
+                    if idle_answer_turns >= 2:
+                        log_debug("No tasks and no tool calls for a second turn; treating the written answer as final.")
+                        break
+                else:
+                    idle_answer_turns = 0
+            else:
+                idle_answer_turns = 0
         else:
             # Loop exhausted without completing
             task_list = load_task_list(run_context.session_state)

--- a/libs/agno/tests/unit/team/test_tasks_loop_termination.py
+++ b/libs/agno/tests/unit/team/test_tasks_loop_termination.py
@@ -1,0 +1,82 @@
+"""A tasks-mode run that creates no tasks must end by answering, not by burning
+max_iterations: an empty list never satisfies all_terminal, so before the idle-turn
+check a greeting looped ten times."""
+
+from typing import Iterator
+
+import pytest
+
+from agno.agent import Agent
+from agno.metrics import MessageMetrics
+from agno.models.base import Model
+from agno.models.response import ModelResponse
+from agno.team.team import Team
+
+
+class CountingMockModel(Model):
+    """Offline model that answers with plain text, never calls a tool, and counts invocations."""
+
+    def __init__(self):
+        super().__init__(id="test-model", name="test-model", provider="test")
+        self.instructions = None
+        self.invocations = 0
+
+    def get_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    def get_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    def parse_args(self, *args, **kwargs):
+        return {}
+
+    def _parse_provider_response(self, response, **kwargs) -> ModelResponse:
+        return response
+
+    def _parse_provider_response_delta(self, response) -> ModelResponse:
+        return response
+
+    def _response(self) -> ModelResponse:
+        self.invocations += 1
+        return ModelResponse(content="Hello there.", role="assistant", response_usage=MessageMetrics())
+
+    def invoke(self, *args, **kwargs) -> ModelResponse:
+        return self._response()
+
+    async def ainvoke(self, *args, **kwargs) -> ModelResponse:
+        return self._response()
+
+    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+        yield self._response()
+
+    async def ainvoke_stream(self, *args, **kwargs):
+        yield self._response()
+
+
+def _tasks_team(model: Model) -> Team:
+    member = Agent(name="Helper", id="helper", model=model)
+    return Team(model=model, members=[member], mode="tasks", telemetry=False)
+
+
+def test_no_task_run_ends_after_the_reminder_turn():
+    model = CountingMockModel()
+    team = _tasks_team(model)
+    output = team.run("Hi! Say hello.")
+    assert output.content
+    # First answer, one reminder turn, done — never the full max_iterations (10).
+    assert model.invocations <= 3, model.invocations
+
+
+@pytest.mark.asyncio
+async def test_no_task_run_ends_after_the_reminder_turn_async():
+    model = CountingMockModel()
+    team = _tasks_team(model)
+    output = await team.arun("Hi! Say hello.")
+    assert output.content
+    assert model.invocations <= 3, model.invocations

--- a/libs/agno/tests/unit/team/test_team_system_prompt.py
+++ b/libs/agno/tests/unit/team/test_team_system_prompt.py
@@ -216,3 +216,37 @@ def test_opening_makes_no_identity_claim(mode):
     assert opening.startswith("You have a team of specialists")
     for claim in ("You are", "You coordinate", "You act as"):
         assert claim not in opening
+
+
+def test_sub_team_roster_adds_the_id_join_rule():
+    """A nested roster invites joined ids like 'sub-team.member'; the closer forbids them.
+
+    The lookup is exact, so a joined id always fails and costs a round trip. A flat
+    roster keeps the shorter closer: the rule would name a sub-team that is not there.
+    """
+    sub = Team(
+        name="Research Team",
+        id="research-team",
+        model=OpenAIChat("gpt-4o"),
+        role="Handles all research",
+        members=[Agent(name="R", id="r", model=OpenAIChat("gpt-4o"))],
+    )
+    for mode in MODES:
+        nested = _team(members=[sub], mode=mode).get_system_message(session=_session()).content
+        flat = _team(mode=mode).get_system_message(session=_session()).content
+        if mode == TeamMode.broadcast.value:
+            # Broadcast takes no member id, so neither roster renders an ids closer.
+            assert "Member ids are the ids shown" not in nested
+            assert "never joined or prefixed" not in nested
+            continue
+        assert "never joined or prefixed" in nested, mode
+        assert "sub-team's own id" in nested, mode
+        assert "Member ids are the ids shown in the roster above, used exactly as written.\n" in flat, mode
+        assert "never joined or prefixed" not in flat, mode
+
+
+def test_tasks_block_matches_the_loop_it_runs():
+    """The loop now ends a no-task run after the reminder; the prompt may not claim otherwise."""
+    content = _team(mode=TeamMode.tasks.value).get_system_message(session=_session()).content
+    assert "an empty one never" not in content
+    assert "finishes at once instead of after a reminder" in content


### PR DESCRIPTION
## Summary

Round 2 of the live-probe study of the team leader (post-#9731/#9737 tip vs the pre-rewrite baseline; 321 `team.run` calls, JSONL-audited, both models) surfaced two defects with proven fixes. This PR ships exactly those two. Full study report: internal artifact "Team Leader Probes".

### 1. A tasks-mode run that needs no tasks burned `max_iterations`

`TaskList.all_terminal()` is `False` for an empty list, so a tasks-mode run that created no tasks — a greeting, a question the leader simply answers — kept receiving the continuation reminder until `max_iterations` (default 10) unless the model remembered to call `mark_all_complete`. #9731 documented this trap and steered around it in prompt text; measured, the steering held in only 7 of 12 gpt-4o-mini runs, and the worst run spent **11 turns and 48,338 tokens saying hello**.

All four task loops (sync/async × stream/non-stream) now count consecutive iterations that hold no tasks *and* made no tool call, and treat the second one's written answer as final:

- the model keeps its one nudge — a leader that narrates before acting (observed live) still gets pushed to act;
- `mark_all_complete` in the same turn remains the fast path (1 turn) and is what the prompt now recommends;
- the prompt sentence claiming "an empty one never does [end the loop]" is rewritten — the prompt may not describe a runtime we no longer ship.

Re-probed on this branch (8 runs): every run answered, worst case 7 turns / 8.3k tokens, median 3 turns. Runs that do create tasks are unaffected — 8/8 regression-guard probes (`research_write`, `sales_failure` in tasks mode) executed normally, including `execute_tasks_parallel` batches and failure relays.

### 2. Nested rosters invited joined member ids

With a sub-team on the roster, the leader invented ids like `news-team.reporter`. `_find_member_by_id` is exact-and-recursive, so every such call fails and re-prints the whole roster into context before the leader recovers. Measured on tip: **10 failed id calls across 6 of 9 runs**. #9731 removed the docstring sentence that warned against exactly this ("not the ID of the team followed by the ID of the member").

The roster-ids closer now reads, **only when the roster actually holds a sub-team**:

> Member ids are the ids shown in the roster above, used exactly as written — never joined or prefixed. Delegate to a sub-team by the sub-team's own id; its leader hands work to the members inside it.

Flat rosters keep the existing line byte-for-byte (verified against the probe corpus), so every flat-team measurement in both study rounds still applies to this branch.

| arm | clean runs (right ids only) | failed id calls | sub-team leader bypassed |
|---|---|---|---|
| baseline (pre-#9731) | 0/8 | 0 | 8/8 (bare `reporter`) |
| tip | 3/9 | 10 | 0 |
| this branch | **6/8** | **4** | 0 |

The baseline's 0 failed calls is not health: it delegated straight to the sub-team's inner member, silently cutting out the sub-team's own leader. gpt-5-mini still does that on tip; whether bare inner-member ids should resolve at all is a design question this PR deliberately does not decide — the closer states the intended path without changing the lookup.

## Probe evidence discipline

- One JSONL record per probe (variant, mode, model, scenario, rep, sha of the exact prompt and tool schema the leader saw, raw delegation list, member outputs). Harness: `.context/team_prompt_probe/` (gitignored).
- The nested-roster wording was first proven as a text variant (`ids_nested`: 3/9 → 6/8 clean, 10 → 4 failed calls), then re-proven on this branch's actual rendered bytes — the variant run had also altered the sub-team leader's own closer, which the conditional implementation does not; re-probing the shipped bytes closed that gap and reproduced the result exactly.
- Round-2 follow-ups this PR runs on: ~24 probes on this branch, within the study's declared 500-call cap (346 used in total).

## Unit coverage and mutation checks

- `test_tasks_loop_termination.py` (new): a no-task run ends within 3 model invocations, sync and async. Reverting the loop fix makes both fail with exactly `invocations == 10` — the reported burn.
- `test_team_system_prompt.py`: the nested closer renders both fragments in coordinate/route/tasks and neither on flat rosters or broadcast; the tasks block no longer claims an empty list loops forever. Both fail 2/2 with the code reverted.
- Full `tests/unit/team`: 795 passed.

## Deliberately not in this PR

- **Broadcast fabrication** — the study's worst finding (a member that verifiably replies only "I cannot comment on this topic" still gets a full perspective written into 24/24 gpt-4o-mini syntheses, both prompts). Prompt sentences demonstrably do not stop it; the likely fix is the delegate tool result marking refused/failed member outputs distinctly, which is a runtime design decision to make deliberately, not to slip into this PR.
- **`advisors` under-consultation** (tip 2/8 vs baseline 7/8 consulting all three tool-less advisors): no proven wording yet; the bisect that would attribute it (~40 probes) hasn't been run.
- **Making bare inner-member ids resolve or not** — see above.
- **`_update_run_response` appending per-iteration** (answers concatenating across task iterations): orthogonal, noted in #9731's deferrals.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

`ruff format --check` and `ruff check` clean on the four changed files (run targeted to keep formatting churn out of the diff). `validate.sh` mypy reports the same pre-existing 72 errors in 14 files documented in #9731 and #9737, none in a file this PR touches. The tasks-mode behaviour change is observable: a tasks-mode team that answers without creating tasks now completes after the reminder turn instead of after `max_iterations`; teams that relied on the old busy-loop to give the model up to ten reminders would see at most one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
