### PR TITLE
feat: opt-in self_dispatch knob for the Studio dispatch guard

### DIFF
--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -3214,6 +3214,21 @@ def _resolve_continue_from(
     raise ValueError("`continue_from` must be an integer message index, 'end', or 'last_user'.")
 
 
+def _restore_continue_context_metadata(run_context, run_response, run_id, session) -> None:
+    """Reserved run-metadata for a resume comes from the paused run row, never
+    from caller input: a rebuilt lineage presents a nested run as top-level and
+    resets the dispatch guard one approval at a time. Safe at every continue
+    entry point -- restoring the same stored values twice is a no-op."""
+    from agno.db.schemas.scheduler import restore_reserved_run_metadata
+
+    stored_run = (
+        run_response
+        if run_response is not None
+        else next((r for r in getattr(session, "runs", None) or [] if getattr(r, "run_id", None) == run_id), None)
+    )
+    run_context.metadata = restore_reserved_run_metadata(run_context.metadata, getattr(stored_run, "metadata", None))
+
+
 def _resolve_continue_owner(
     run_response: Optional[RunOutput],
     *,
@@ -3410,6 +3425,21 @@ def continue_run_dispatch(
 
     # Initialize session state. Get it from DB if relevant.
     session_state = load_session_state(agent, session=agent_session, session_state={})
+
+    # A resumed run keeps its runtime-owned metadata: the dispatch lineage,
+    # hop count and version stamp live on the paused run row, and rebuilding
+    # them from caller input would present a nested run as top-level --
+    # resetting the dispatch guard one human approval at a time. The stored
+    # values win, and caller-supplied reserved keys are dropped the way every
+    # other seam drops them.
+    from agno.db.schemas.scheduler import restore_reserved_run_metadata
+
+    _stored_run = (
+        run_response
+        if run_response is not None
+        else next((r for r in agent_session.runs or [] if r.run_id == run_id), None)
+    )
+    metadata = restore_reserved_run_metadata(metadata, getattr(_stored_run, "metadata", None))
 
     # Resolve all run options centrally
     opts = resolve_run_options(
@@ -4431,6 +4461,10 @@ async def _acontinue_run_background_stream(
         if user_id is not None:
             run_context.user_id = user_id
 
+    # Same restore as the executors: the background wrapper persists and
+    # schedules with this run_context, so it must carry the stored lineage.
+    _restore_continue_context_metadata(run_context, run_response=run_response, run_id=_run_id, session=agent_session)
+
     update_metadata(agent, session=agent_session)
 
     # HITL continues may arrive with run_response=None (router passes only
@@ -4714,6 +4748,14 @@ async def _acontinue_run(
                     user_id = _resolve_continue_owner(run_response, run_id=run_id, session=agent_session)
                     if user_id is not None:
                         run_context.user_id = user_id
+
+                # A resumed run keeps its runtime-owned metadata (dispatch
+                # lineage, hop count, version stamp); on the async path the
+                # session may only be readable here, so the restore happens at
+                # the load point. Idempotent with the dispatch-time restore.
+                _restore_continue_context_metadata(
+                    run_context, run_response=run_response, run_id=run_id, session=agent_session
+                )
 
                 # 2. Resolve dependencies
                 if run_context.dependencies is not None:
@@ -5200,6 +5242,14 @@ async def _acontinue_run_stream(
                     user_id = _resolve_continue_owner(run_response, run_id=run_id, session=agent_session)
                     if user_id is not None:
                         run_context.user_id = user_id
+
+                # A resumed run keeps its runtime-owned metadata (dispatch
+                # lineage, hop count, version stamp); on the async path the
+                # session may only be readable here, so the restore happens at
+                # the load point. Idempotent with the dispatch-time restore.
+                _restore_continue_context_metadata(
+                    run_context, run_response=run_response, run_id=run_id, session=agent_session
+                )
 
                 # 2. Update session state and metadata
                 update_metadata(agent, session=agent_session)

--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -3214,7 +3214,12 @@ def _resolve_continue_from(
     raise ValueError("`continue_from` must be an integer message index, 'end', or 'last_user'.")
 
 
-def _restore_continue_context_metadata(run_context, run_response, run_id, session) -> None:
+def _restore_continue_context_metadata(
+    run_context: RunContext,
+    run_response: Optional[RunOutput],
+    run_id: Optional[str],
+    session: Optional[AgentSession],
+) -> None:
     """Reserved run-metadata for a resume comes from the paused run row, never
     from caller input: a rebuilt lineage presents a nested run as top-level and
     resets the dispatch guard one approval at a time. Safe at every continue

--- a/libs/agno/agno/db/schemas/scheduler.py
+++ b/libs/agno/agno/db/schemas/scheduler.py
@@ -87,6 +87,25 @@ def strip_reserved_run_metadata(metadata: Optional[Dict[str, Any]]) -> Optional[
     return cleaned or None
 
 
+def restore_reserved_run_metadata(
+    metadata: Optional[Dict[str, Any]], stored_run_metadata: Any
+) -> Optional[Dict[str, Any]]:
+    """Caller metadata for a resume, with the paused run's reserved keys restored.
+
+    The runtime-owned keys describe the run being resumed -- its dispatch
+    lineage, hop count and version pin -- and are persisted on the paused run
+    row. A resume that rebuilt them from caller input would present a nested
+    run as top-level, resetting the dispatch guard one approval at a time, so
+    the stored values win and caller-supplied reserved keys are dropped the
+    way every other seam drops them."""
+    stored = stored_run_metadata if isinstance(stored_run_metadata, dict) else {}
+    restored = {key: stored[key] for key in RESERVED_RUN_METADATA_KEYS if key in stored}
+    cleaned = strip_reserved_run_metadata(metadata)
+    base = dict(cleaned) if isinstance(cleaned, dict) else {}
+    base.update(restored)
+    return base or None
+
+
 # The columns a generic update_schedule may write. Everything else - ownership,
 # provenance, trigger and lock state - moves only through dedicated primitives,
 # so a name-keyed upsert can never repoint who a schedule belongs to or which

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -7207,7 +7207,12 @@ def _resolve_continue_from_team(
     raise ValueError("`continue_from` must be an integer message index, 'end', or 'last_user'.")
 
 
-def _restore_continue_context_metadata_team(run_context, run_response, run_id, session) -> None:
+def _restore_continue_context_metadata_team(
+    run_context: RunContext,
+    run_response: Optional["TeamRunOutput"],
+    run_id: Optional[str],
+    session: Optional[TeamSession],
+) -> None:
     """Reserved run-metadata for a resume comes from the paused run row, never
     from caller input: a rebuilt lineage presents a nested run as top-level and
     resets the dispatch guard one approval at a time. Safe at every continue

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -7207,6 +7207,21 @@ def _resolve_continue_from_team(
     raise ValueError("`continue_from` must be an integer message index, 'end', or 'last_user'.")
 
 
+def _restore_continue_context_metadata_team(run_context, run_response, run_id, session) -> None:
+    """Reserved run-metadata for a resume comes from the paused run row, never
+    from caller input: a rebuilt lineage presents a nested run as top-level and
+    resets the dispatch guard one approval at a time. Safe at every continue
+    entry point -- restoring the same stored values twice is a no-op."""
+    from agno.db.schemas.scheduler import restore_reserved_run_metadata
+
+    stored_run = (
+        run_response
+        if run_response is not None
+        else next((r for r in getattr(session, "runs", None) or [] if getattr(r, "run_id", None) == run_id), None)
+    )
+    run_context.metadata = restore_reserved_run_metadata(run_context.metadata, getattr(stored_run, "metadata", None))
+
+
 def _resolve_continue_owner_team(
     run_response: Optional["TeamRunOutput"],
     *,
@@ -7547,6 +7562,21 @@ def continue_run_dispatch(
 
     # Load session state
     session_state = _load_session_state(team, session=team_session, session_state={})
+
+    # A resumed run keeps its runtime-owned metadata: the dispatch lineage,
+    # hop count and version stamp live on the paused run row, and rebuilding
+    # them from caller input would present a nested run as top-level --
+    # resetting the dispatch guard one human approval at a time. The stored
+    # values win, and caller-supplied reserved keys are dropped the way every
+    # other seam drops them.
+    from agno.db.schemas.scheduler import restore_reserved_run_metadata
+
+    _stored_run = (
+        run_response
+        if run_response is not None
+        else next((r for r in team_session.runs or [] if r.run_id == run_id_resolved), None)
+    )
+    metadata = restore_reserved_run_metadata(metadata, getattr(_stored_run, "metadata", None))
 
     # Resolve run options
     opts = resolve_run_options(
@@ -8785,6 +8815,12 @@ async def _acontinue_run_background_stream(
         if user_id is not None:
             run_context.user_id = user_id
 
+    # Same restore as the executors: the background wrapper persists and
+    # schedules with this run_context, so it must carry the stored lineage.
+    _restore_continue_context_metadata_team(
+        run_context, run_response=run_response, run_id=_run_id, session=team_session
+    )
+
     _update_metadata(team, session=team_session)
 
     def _get_session_run(session: TeamSession) -> Optional[TeamRunOutput]:
@@ -9425,6 +9461,14 @@ async def _acontinue_run(
                     if user_id is not None:
                         run_context.user_id = user_id
 
+                # A resumed run keeps its runtime-owned metadata (dispatch
+                # lineage, hop count, version stamp); on the async path the
+                # session may only be readable here, so the restore happens at
+                # the load point. Idempotent with the dispatch-time restore.
+                _restore_continue_context_metadata_team(
+                    run_context, run_response=run_response, run_id=run_id, session=team_session
+                )
+
                 # Resolve run_response from run_id if needed
                 if run_response is None and run_id is not None:
                     runs = team_session.runs or []
@@ -9897,6 +9941,14 @@ async def _acontinue_run_stream(
                     user_id = _resolve_continue_owner_team(run_response, run_id=run_id, session=team_session)
                     if user_id is not None:
                         run_context.user_id = user_id
+
+                # A resumed run keeps its runtime-owned metadata (dispatch
+                # lineage, hop count, version stamp); on the async path the
+                # session may only be readable here, so the restore happens at
+                # the load point. Idempotent with the dispatch-time restore.
+                _restore_continue_context_metadata_team(
+                    run_context, run_response=run_response, run_id=run_id, session=team_session
+                )
 
                 # Resolve run_response from run_id if needed
                 if run_response is None and run_id is not None:

--- a/libs/agno/agno/tools/studio.py
+++ b/libs/agno/agno/tools/studio.py
@@ -74,7 +74,7 @@ from __future__ import annotations
 
 import inspect
 import json
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, Set, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, Sequence, Set, Union
 
 from agno.exceptions import SchemaMismatchError
 from agno.run import RunContext
@@ -228,6 +228,19 @@ class StudioTools(Toolkit):
             deliberately. denied_tools still wins over both.
         denied_tools: Names no caller may build with, whatever their source.
             A denied toolkit covers its member functions too.
+        max_dispatch_depth: How many runner-dispatch hops one request may
+            chain through the run tools (default 2). 1 means components this
+            toolkit runs may not dispatch further; 0 disables dispatch while
+            keeping discovery. Bounds depth, not fan-out. The cycle guard --
+            no component runs again while it is already running in the same
+            dispatch tree -- is always on regardless.
+        self_dispatch: "never" (default) refuses a component dispatching
+            itself outright. "once" allows a self-run one nested level deep
+            (a clean-context self-consult on its own derived session); the
+            nested run inherits its caller in the dispatch lineage, so it can
+            never re-enter, and indirect cycles stay refused in both modes.
+            Per dispatch call, not per conversation: a run that calls the
+            tool twice starts two such bounded self-runs.
     """
 
     def __init__(
@@ -248,6 +261,7 @@ class StudioTools(Toolkit):
         allowed_tools: Optional[List[str]] = None,
         denied_tools: Optional[List[str]] = None,
         max_dispatch_depth: int = 2,
+        self_dispatch: Literal["never", "once"] = "never",
         **kwargs: Any,
     ):
         self.registry = registry
@@ -312,6 +326,7 @@ class StudioTools(Toolkit):
             # That same reach is what makes an unbounded dispatch chain
             # reachable from one message, so the bound rides along with it.
             max_dispatch_depth=max_dispatch_depth,
+            self_dispatch=self_dispatch,
             list_limit=list_limit,
         )
 

--- a/libs/agno/agno/tools/studio_runner.py
+++ b/libs/agno/agno/tools/studio_runner.py
@@ -99,7 +99,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, Set, Tuple
 from uuid import uuid4
 
 from agno.db.schemas.scheduler import (
@@ -292,6 +292,7 @@ class StudioRunnerTools(Toolkit):
         run_workflows: bool = True,
         include_all_components: bool = False,
         max_dispatch_depth: int = 2,
+        self_dispatch: Literal["never", "once"] = "never",
         list_limit: int = 100,
         name: str = "studio_runners",
         **kwargs: Any,
@@ -302,6 +303,15 @@ class StudioRunnerTools(Toolkit):
         if max_dispatch_depth < 0:
             raise ValueError(f"max_dispatch_depth must be >= 0, got {max_dispatch_depth}")
         self.max_dispatch_depth = max_dispatch_depth
+        # "once" lets the calling component dispatch ITSELF one nested level
+        # deep -- a clean-context self-consult on its own derived session. The
+        # nested run inherits the caller in its lineage, so it can never
+        # re-enter; "never" refuses even that first hop. There is no deeper
+        # setting: self re-entry past one level is the runaway this toolkit
+        # refuses by design.
+        if self_dispatch not in ("never", "once"):
+            raise ValueError(f"self_dispatch must be 'never' or 'once', got {self_dispatch!r}")
+        self.self_dispatch = self_dispatch
         self.registry = registry
         # The explicit db wins; otherwise the registry's is adopted lazily on
         # first access (see the db property). An __init__ snapshot would be
@@ -2470,16 +2480,24 @@ class StudioRunnerTools(Toolkit):
                 "composes deeper sets max_dispatch_depth on StudioRunnerTools."
             )
 
-    @staticmethod
-    def _require_no_cycle(running: List[str], component_type: str, component_id: str) -> str:
+    def _require_no_cycle(
+        self, running: List[str], inherited: List[str], component_type: str, component_id: str
+    ) -> str:
         """The target's lineage token, after refusing re-entry.
 
         Tests the RESOLVED id, so a display name or slug alias cannot evade
-        the guard, against the running set (inherited lineage plus the calling components):
-        a component may not be dispatched while it is already running in this
-        tree, at any depth."""
+        the guard, against the running set (inherited lineage plus the calling
+        components): a component may not be dispatched while it is already
+        running in this tree, at any depth.
+
+        Under self_dispatch="once" the calling components are exempt from the
+        membership test, so a component may dispatch ITSELF from a top-level
+        run -- but they still ride the outgoing lineage, so the nested run
+        inherits the caller and can never re-enter it, and A -> B -> A stays
+        closed in both modes."""
         target = f"{component_type}:{component_id}"
-        if target in running:
+        blocked = inherited if self.self_dispatch == "once" else running
+        if target in blocked:
             raise DispatchCycleError(
                 f"Refusing to dispatch {component_type} '{component_id}': it is already running this "
                 f"request ({' -> '.join([*running, target])}). Answer directly, delegate to a different "
@@ -2553,7 +2571,7 @@ class StudioRunnerTools(Toolkit):
         inherited, depth = self._inherited_dispatch_state(run_context)
         self._require_dispatch_budget(depth, component_type, component_id)
         running = self._dedup([*inherited, *self._caller_tokens(caller_agent, caller_team)])
-        target = self._require_no_cycle(running, component_type, component_id)
+        target = self._require_no_cycle(running, inherited, component_type, component_id)
         return self._outgoing_metadata(run_context, running, depth, target)
 
     def _cross_namespace_hint(self, component_type: str, identifier: str, actor: Optional[str] = None) -> str:
@@ -2638,7 +2656,7 @@ class StudioRunnerTools(Toolkit):
         component_id = getattr(agent, "id", None) or agent_id
         try:
             running = self._dedup([*inherited, *self._caller_tokens(_agno_agent, _agno_team)])
-            target = self._require_no_cycle(running, "agent", component_id)
+            target = self._require_no_cycle(running, inherited, "agent", component_id)
         except StudioRunnerError as e:
             # Deliberate refusals with an actionable message; not failures to log.
             return json.dumps({"error": str(e)})
@@ -2702,7 +2720,7 @@ class StudioRunnerTools(Toolkit):
         component_id = getattr(team, "id", None) or team_id
         try:
             running = self._dedup([*inherited, *self._caller_tokens(_agno_agent, _agno_team)])
-            target = self._require_no_cycle(running, "team", component_id)
+            target = self._require_no_cycle(running, inherited, "team", component_id)
         except StudioRunnerError as e:
             # Deliberate refusals with an actionable message; not failures to log.
             return json.dumps({"error": str(e)})
@@ -2766,7 +2784,7 @@ class StudioRunnerTools(Toolkit):
         component_id = getattr(wf, "id", None) or workflow_id
         try:
             running = self._dedup([*inherited, *self._caller_tokens(_agno_agent, _agno_team)])
-            target = self._require_no_cycle(running, "workflow", component_id)
+            target = self._require_no_cycle(running, inherited, "workflow", component_id)
         except StudioRunnerError as e:
             # Deliberate refusals with an actionable message; not failures to log.
             return json.dumps({"error": str(e)})
@@ -2822,7 +2840,7 @@ class StudioRunnerTools(Toolkit):
         component_id = getattr(agent, "id", None) or agent_id
         try:
             running = self._dedup([*inherited, *self._caller_tokens(_agno_agent, _agno_team)])
-            target = self._require_no_cycle(running, "agent", component_id)
+            target = self._require_no_cycle(running, inherited, "agent", component_id)
         except StudioRunnerError as e:
             # Deliberate refusals with an actionable message; not failures to log.
             return json.dumps({"error": str(e)})
@@ -2875,7 +2893,7 @@ class StudioRunnerTools(Toolkit):
         component_id = getattr(team, "id", None) or team_id
         try:
             running = self._dedup([*inherited, *self._caller_tokens(_agno_agent, _agno_team)])
-            target = self._require_no_cycle(running, "team", component_id)
+            target = self._require_no_cycle(running, inherited, "team", component_id)
         except StudioRunnerError as e:
             # Deliberate refusals with an actionable message; not failures to log.
             return json.dumps({"error": str(e)})
@@ -2930,7 +2948,7 @@ class StudioRunnerTools(Toolkit):
         component_id = getattr(wf, "id", None) or workflow_id
         try:
             running = self._dedup([*inherited, *self._caller_tokens(_agno_agent, _agno_team)])
-            target = self._require_no_cycle(running, "workflow", component_id)
+            target = self._require_no_cycle(running, inherited, "workflow", component_id)
         except StudioRunnerError as e:
             # Deliberate refusals with an actionable message; not failures to log.
             return json.dumps({"error": str(e)})

--- a/libs/agno/tests/unit/tools/test_dispatch_lineage_resume.py
+++ b/libs/agno/tests/unit/tools/test_dispatch_lineage_resume.py
@@ -1,0 +1,251 @@
+"""The dispatch guard's state must survive a HITL pause.
+
+The dispatch lineage and hop counter ride RunContext.metadata and are
+persisted on the run row. A resume that rebuilds metadata from caller input
+presents a genuinely nested run as top-level: the cycle guard and the depth
+cap read an empty lineage, and one human approval per hop re-opens the
+runaway the guard exists to refuse. The resume path is the fifth seam where
+the runtime-owned keys must win over caller input.
+"""
+
+import json
+from typing import Any, AsyncIterator, Dict, Iterator, List, Optional
+
+import pytest
+
+from agno.agent import Agent
+from agno.db.schemas.scheduler import (
+    DISPATCH_CHAIN_METADATA_KEY,
+    DISPATCH_DEPTH_METADATA_KEY,
+)
+from agno.db.sqlite import SqliteDb
+from agno.models.base import Model
+from agno.models.response import ModelResponse, ModelResponseEvent
+from agno.run import RunContext
+from agno.run.requirement import RunRequirement
+from agno.team import Team
+from agno.tools import tool
+from agno.tools.studio_runner import StudioRunnerTools
+
+_CHAIN = DISPATCH_CHAIN_METADATA_KEY
+_DEPTH = DISPATCH_DEPTH_METADATA_KEY
+
+
+class _ScriptedModel(Model):
+    """Emits scripted turns offline: ('tool', name, args, id) or ('content', text)."""
+
+    def __init__(self, model_id: str, script: List[tuple]):
+        super().__init__(id=model_id, name=model_id, provider="test")
+        self._script = list(script)
+        self._i = 0
+
+    def _next(self) -> ModelResponse:
+        from agno.metrics import MessageMetrics
+
+        turn = self._script[min(self._i, len(self._script) - 1)]
+        self._i += 1
+        if turn[0] == "tool":
+            _, name, args, tcid = turn
+            r = ModelResponse(role="assistant")
+            r.tool_calls = [{"id": tcid, "type": "function", "function": {"name": name, "arguments": json.dumps(args)}}]
+        else:
+            r = ModelResponse(content=turn[1], role="assistant")
+            r.event = ModelResponseEvent.assistant_response.value
+        r.response_usage = MessageMetrics(input_tokens=10, output_tokens=5, total_tokens=15)
+        return r
+
+    def invoke(self, *a, **k):
+        return self._next()
+
+    async def ainvoke(self, *a, **k):
+        return self._next()
+
+    def invoke_stream(self, *a, **k) -> Iterator[ModelResponse]:
+        yield self._next()
+
+    async def ainvoke_stream(self, *a, **k) -> AsyncIterator[ModelResponse]:
+        yield self._next()
+
+    def _parse_provider_response(self, response: Any, **k) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+
+_CAPTURED: List[Optional[Dict[str, Any]]] = []
+
+
+@tool(requires_confirmation=True)
+def gated_probe(run_context: Optional[RunContext] = None) -> str:
+    """A confirmation-gated tool that records the metadata of the run it
+    finally executes on -- which, after a pause, is the CONTINUED run."""
+    metadata = getattr(run_context, "metadata", None)
+    _CAPTURED.append(dict(metadata) if isinstance(metadata, dict) else None)
+    return "probed"
+
+
+class _StubTeam:
+    def __init__(self, team_id: str = "a"):
+        self.id = team_id
+        self.name = team_id.upper()
+        self.seen: Optional[Dict[str, Any]] = None
+        self.seen_metadata: Optional[Dict[str, Any]] = None
+
+    def run(self, message, stream=None, user_id=None, session_id=None, metadata=None, run_id=None):
+        self.seen = {"message": message}
+        self.seen_metadata = metadata
+        return type("Out", (), {"run_id": "r", "session_id": "s", "status": "COMPLETED", "content": "sub-done"})()
+
+    async def arun(self, message, stream=None, user_id=None, session_id=None, metadata=None, run_id=None):
+        return self.run(message, stream=stream, user_id=user_id, session_id=session_id, metadata=metadata)
+
+    def deep_copy(self):
+        clone = object.__new__(type(self))
+        clone.__dict__ = self.__dict__
+        return clone
+
+
+class _StubAgent(_StubTeam):
+    def __init__(self, agent_id: str = "solo"):
+        super().__init__(agent_id)
+
+
+def _confirmed(requirements) -> List[RunRequirement]:
+    """Round-trip requirements through their wire format and confirm them,
+    the way a frontend or a fresh process would send them back."""
+    confirmed = []
+    for data in [r.to_dict() for r in requirements or []]:
+        req = RunRequirement.from_dict(data)
+        req.confirm()
+        confirmed.append(req)
+    return confirmed
+
+
+def _probe_component(kind: str, db: SqliteDb, extra_tools: Optional[List[Any]] = None, script: Optional[List] = None):
+    """An agent or team whose first turn pauses on the gated probe."""
+    script = script or [("tool", "gated_probe", {}, "tc-probe"), ("content", "done")]
+    model = _ScriptedModel(f"m-{kind}", script)
+    tools: List[Any] = [gated_probe, *(extra_tools or [])]
+    if kind == "agent":
+        return Agent(id="prober", name="Prober", model=model, tools=tools, db=db, telemetry=False)
+    member = Agent(id="bystander", name="Bystander", model=_ScriptedModel("m-member", [("content", "hi")]))
+    return Team(id="prober", name="Prober", model=model, members=[member], tools=tools, db=db, telemetry=False)
+
+
+_DISPATCHED = {_CHAIN: ["team:outer"], _DEPTH: 1, "tenant": "acme"}
+
+
+async def _pause_then_resume(component, kind: str, use_async: bool, run_metadata, resume_kwargs=None):
+    run1 = component.run("go", session_id=f"s-{kind}", metadata=dict(run_metadata) if run_metadata else None)
+    assert run1.is_paused, "the gated probe should pause the first run"
+    kwargs = dict(
+        run_id=run1.run_id,
+        session_id=f"s-{kind}",
+        requirements=_confirmed(run1.requirements),
+        **(resume_kwargs or {}),
+    )
+    if use_async:
+        return await component.acontinue_run(**kwargs)
+    return component.continue_run(**kwargs)
+
+
+class TestDispatchLineageSurvivesContinue:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind", ["agent", "team"])
+    @pytest.mark.parametrize("use_async", [False, True], ids=["sync", "async"])
+    async def test_dispatch_lineage_survives_continue(self, tmp_path, kind, use_async):
+        _CAPTURED.clear()
+        db = SqliteDb(db_file=str(tmp_path / "resume.db"))
+        component = _probe_component(kind, db)
+
+        run2 = await _pause_then_resume(component, kind, use_async, _DISPATCHED)
+        assert run2.status.value == "COMPLETED"
+        assert len(_CAPTURED) == 1
+        captured = _CAPTURED[0] or {}
+        assert captured.get(_CHAIN) == ["team:outer"]
+        assert captured.get(_DEPTH) == 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind", ["agent", "team"])
+    async def test_caller_cannot_override_restored_lineage(self, tmp_path, kind):
+        _CAPTURED.clear()
+        db = SqliteDb(db_file=str(tmp_path / "override.db"))
+        component = _probe_component(kind, db)
+
+        forged = {_CHAIN: ["team:forged"], _DEPTH: 0, "note": "kept"}
+        run2 = await _pause_then_resume(component, kind, False, _DISPATCHED, resume_kwargs={"metadata": forged})
+        assert run2.status.value == "COMPLETED"
+        captured = (_CAPTURED or [None])[0] or {}
+        # The stored reserved keys win; the caller's other metadata may ride.
+        assert captured.get(_CHAIN) == ["team:outer"]
+        assert captured.get(_DEPTH) == 1
+        assert captured.get("note") == "kept"
+
+
+def _dispatching_component(kind: str, db: SqliteDb, stubs: List[Any], self_dispatch: str, target_id: str):
+    """Pauses on the gated probe, then (post-resume) dispatches ``target_id``."""
+    runner = StudioRunnerTools(
+        include_teams=[s for s in stubs if isinstance(s, _StubTeam) and not isinstance(s, _StubAgent)] or None,
+        include_agents=[s for s in stubs if isinstance(s, _StubAgent)] or None,
+        self_dispatch=self_dispatch,
+    )  # type: ignore[arg-type]
+    run_tool = "run_agent" if any(isinstance(s, _StubAgent) for s in stubs) else "run_team"
+    arg = "agent_id" if run_tool == "run_agent" else "team_id"
+    script = [
+        ("tool", "gated_probe", {}, "tc-probe"),
+        ("tool", run_tool, {arg: target_id, "message": "go deeper"}, "tc-dispatch"),
+        ("content", "finished"),
+    ]
+    return _probe_component(kind, db, extra_tools=[runner], script=script)
+
+
+class TestGuardHoldsAcrossAPause:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("mode", ["never", "once"])
+    @pytest.mark.parametrize("kind,use_async", [("agent", False), ("agent", True), ("team", False)])
+    async def test_cycle_guard_holds_across_a_pause(self, tmp_path, mode, kind, use_async):
+        # The run was dispatched by team 'a' (it is on the inherited lineage);
+        # after pause+resume it dispatches 'a' back. A -> B -> A must stay
+        # refused -- in BOTH modes: this is inherited-lineage blocking, which
+        # "once" does not exempt.
+        _CAPTURED.clear()
+        db = SqliteDb(db_file=str(tmp_path / "cycle.db"))
+        a = _StubTeam("a")
+        component = _dispatching_component(kind, db, [a], mode, target_id="a")
+
+        nested = {_CHAIN: ["team:a", f"{kind}:prober"], _DEPTH: 1}
+        run2 = await _pause_then_resume(component, kind, use_async, nested)
+        assert run2.status.value == "COMPLETED"
+        assert a.seen is None, "the resumed run re-entered its own dispatcher"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind,use_async", [("agent", False), ("team", True)])
+    async def test_depth_cap_holds_across_a_pause(self, tmp_path, kind, use_async):
+        # At the default cap (2), a run that inherited depth 2 may not
+        # dispatch at all -- including after a pause.
+        _CAPTURED.clear()
+        db = SqliteDb(db_file=str(tmp_path / "depth.db"))
+        c = _StubTeam("c")
+        component = _dispatching_component(kind, db, [c], "never", target_id="c")
+
+        at_cap = {_CHAIN: ["team:x", "team:y"], _DEPTH: 2}
+        run2 = await _pause_then_resume(component, kind, use_async, at_cap)
+        assert run2.status.value == "COMPLETED"
+        assert c.seen is None, "the resumed run dispatched past the depth cap"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("use_async", [False, True], ids=["sync", "async"])
+    async def test_self_dispatch_once_is_still_once_across_a_pause(self, tmp_path, use_async):
+        # This run IS the one self-run "once" permits (its own token is on the
+        # inherited lineage). Pausing and resuming must not recharge the
+        # exemption into a second self-run.
+        _CAPTURED.clear()
+        db = SqliteDb(db_file=str(tmp_path / "once.db"))
+        solo = _StubAgent("prober")
+        component = _dispatching_component("agent", db, [solo], "once", target_id="prober")
+
+        self_run = {_CHAIN: ["agent:prober"], _DEPTH: 1}
+        run2 = await _pause_then_resume(component, "agent", use_async, self_run)
+        assert run2.status.value == "COMPLETED"
+        assert solo.seen is None, "'once' recharged across a pause"

--- a/libs/agno/tests/unit/tools/test_studio_preview_stamp.py
+++ b/libs/agno/tests/unit/tools/test_studio_preview_stamp.py
@@ -335,3 +335,32 @@ class TestPinnedPreviewsAreGuardedToo:
         )
         assert out["ok"] is False
         assert out["error"]["code"] == "dispatch_refused"
+
+
+class TestSelfDispatchOnceOnThePinnedPath:
+    """The version-pinned branch dispatches directly, bypassing the runner's
+    run tools; the opt-in must behave identically there or version=N becomes
+    the door where "once" silently means "always" (or "never")."""
+
+    def test_a_pinned_self_preview_runs_once_then_refuses(self, studio, registry, db):
+        once_studio = StudioTools(registry=registry, db=db, self_dispatch="once")
+        caller = type("W", (), {"id": "pv-agent"})()
+
+        first = _payload(once_studio.run_agent("pv-agent", "hi", version=2, _agno_agent=caller))
+        assert first["content"] == "answer from v2"
+        metadata = _stored_metadata(db, first["session_id"], first["run_id"], "agent") or {}
+        assert metadata.get(DISPATCH_CHAIN_METADATA_KEY) == ["agent:pv-agent"]
+        assert metadata.get(DISPATCH_DEPTH_METADATA_KEY) == 1
+
+        nested = RunContext(run_id="nested-run", session_id="nested-sess", metadata=dict(metadata))
+        out = json.loads(
+            once_studio.run_agent("pv-agent", "hi again", version=2, _agno_run_context=nested, _agno_agent=caller)
+        )
+        assert out["ok"] is False
+        assert out["error"]["code"] == "dispatch_refused"
+
+    def test_the_default_still_refuses_the_first_pinned_self_preview(self, studio, db):
+        caller = type("W", (), {"id": "pv-agent"})()
+        out = json.loads(studio.run_agent("pv-agent", "hi", version=2, _agno_agent=caller))
+        assert out["ok"] is False
+        assert out["error"]["code"] == "dispatch_refused"

--- a/libs/agno/tests/unit/tools/test_studio_runner.py
+++ b/libs/agno/tests/unit/tools/test_studio_runner.py
@@ -4358,3 +4358,116 @@ class TestDispatchCancelCascade:
         )
         assert "error" in out
         assert get_member_run_ids("caller-run") == set()
+
+
+# ----------------------------------------------------------------------
+# self_dispatch="once": one nested self-run, never a second
+# ----------------------------------------------------------------------
+
+
+class TestSelfDispatchOnce:
+    def test_never_is_the_default(self, db):
+        assert StudioRunnerTools(db=db).self_dispatch == "never"
+
+    def test_invalid_value_rejected_at_construction(self, db):
+        with pytest.raises(ValueError, match="self_dispatch"):
+            StudioRunnerTools(db=db, self_dispatch="always")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind,use_async", _CALLER_TOOLS)
+    async def test_once_allows_the_first_self_dispatch(self, db, kind, use_async):
+        # The caller is exempt from the membership test exactly once: the
+        # top-level run inherited nothing, so its own token does not block it.
+        stub, runner = _guarded_stub(kind, db, self_dispatch="once")
+        out = await _dispatch(runner, kind, use_async, context=_context(), **_caller_kwargs(kind, stub))
+        assert "error" not in out
+        assert stub.seen is not None
+        assert stub.seen_metadata == {_CHAIN_KEY: [f"{kind}:{stub.id}"], _DEPTH_KEY: 1}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind,use_async", _CALLER_TOOLS)
+    async def test_once_refuses_the_second_self_dispatch(self, db, kind, use_async):
+        # The first self-run inherits its caller in the lineage, so the same
+        # dispatch from INSIDE it is a cycle, not another "once".
+        stub, runner = _guarded_stub(kind, db, self_dispatch="once")
+        out = await _dispatch(runner, kind, use_async, context=_context(), **_caller_kwargs(kind, stub))
+        assert "error" not in out
+
+        nested = _context()
+        nested.metadata = dict(stub.seen_metadata)
+        stub.seen = None
+        out = await _dispatch(runner, kind, use_async, context=nested, **_caller_kwargs(kind, stub))
+        assert "already running" in out["error"]
+        assert stub.seen is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("use_async", [False, True], ids=["sync", "async"])
+    async def test_once_keeps_ping_pong_closed(self, db, use_async):
+        # "once" exempts only the CALLER's own token; a component already in
+        # the inherited lineage stays refused, so A -> B -> A is a cycle in
+        # both modes.
+        a = _StubTeam()
+        a.id, a.name = "a", "A"
+        b = _StubTeam()
+        b.id, b.name = "b", "B"
+        runner = StudioRunnerTools(db=db, include_teams=[a, b], max_dispatch_depth=3, self_dispatch="once")
+
+        out = await _dispatch(runner, "team", use_async, identifier="b", context=_context(), caller_team=a)
+        assert "error" not in out
+
+        nested = _context()
+        nested.metadata = dict(b.seen_metadata)
+        out = await _dispatch(runner, "team", use_async, identifier="a", context=nested, caller_team=b)
+        assert "already running" in out["error"]
+        assert a.seen is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("use_async", [False, True], ids=["sync", "async"])
+    async def test_once_covers_a_member_agents_parent_team(self, db, use_async):
+        # Both caller tokens are exempt: a member agent's toolkit may start
+        # one nested run of its own parent team.
+        team, runner = _guarded_stub("team", db, self_dispatch="once")
+        agent = _StubAgent()
+        out = await _dispatch(runner, "team", use_async, context=_context(), caller_agent=agent, caller_team=team)
+        assert "error" not in out
+        # The member's own token rides the outgoing lineage too, so the nested
+        # team cannot dispatch the member back either.
+        assert team.seen_metadata[_CHAIN_KEY] == ["team:stub-team", "agent:stub"]
+
+    def test_studio_tools_forwards_self_dispatch(self, registry, db):
+        assert StudioTools(registry=registry, db=db)._runner_tools.self_dispatch == "never"
+        assert StudioTools(registry=registry, db=db, self_dispatch="once")._runner_tools.self_dispatch == "once"
+
+
+class TestEndToEndSelfDispatchOnce:
+    def test_once_terminates_at_exactly_one_nested_level(self, db, tmp_path):
+        # Same driver as TestEndToEndSelfDispatch, with the opt-in: the
+        # top-level self-dispatch now executes, the nested run's re-dispatch
+        # is refused as a cycle, and the tree ends there -- one consult, no
+        # loop. The recorder's ceiling still fails loudly if unbounded
+        # recursion ever comes back.
+        from agno.agent.agent import Agent
+        from agno.team.team import Team
+
+        model = _build_self_dispatch_model()
+        member = Agent(id="bystander", name="Bystander", model=model.__deepcopy__({}))
+        dispatchable: List[Any] = []
+        toolkit = StudioRunnerTools(db=db, include_teams=dispatchable, self_dispatch="once")
+        team = Team(
+            id="looper",
+            name="Looper",
+            model=model,
+            members=[member],
+            tools=[toolkit],
+            db=db,
+        )
+        dispatchable.append(team)
+
+        output = team.run("go", session_id="probe-sess", user_id="probe", stream=False)
+
+        # The nested level finished first, and it finished REFUSED; the top
+        # level completed normally on the nested result. Four provider calls:
+        # two runs, two calls each.
+        assert model.recorder["finals"] == ["saw-refusal", "saw-success"]
+        assert output.content == "saw-success"
+        assert model.recorder["provider_calls"] == 4


### PR DESCRIPTION
## Summary

Follow-up to #9745. The dispatch guard refuses every self-dispatch, including the first hop from a top-level run. This adds the deliberate, bounded exception #9745's review discussion identified as a real pattern: `self_dispatch: "never" | "once"` on `StudioRunnerTools` and `StudioTools` (forwarded to the embedded runner), default `"never"` — unchanged behavior.

Under `"once"`, a component may dispatch **itself** one nested level deep — a clean-context self-consult: the nested run gets its own derived session, so it is a fresh-eyes pass without the conversation's baggage.

### How it stays bounded

The guard tracks the caller's identity in two places: it writes it into the **outgoing** lineage the child inherits, and it includes it in the **membership test** for the current dispatch. `"once"` relaxes only the membership test — the caller's tokens are exempt — while they still ride the outgoing lineage. So:

- `agno → agno` — allowed (top-level run inherited nothing).
- nested `agno → agno` — refused: the nested run inherited `team:agno`, and inherited lineage is blocked in both modes.
- `agno → radar → agno` — still refused in both modes: the caller rides the outgoing chain, so ping-pong never opened up.
- A member agent's toolkit may start one nested run of its own parent team; **both** its tokens (parent team and itself) still ride the child's lineage, so the nested team can dispatch neither back.
- The depth cap applies on top: the self-run consumes a hop like any dispatch.

There is deliberately no deeper setting (`"twice"`, a count): self re-entry past one level is the runaway the guard exists to refuse.

**Semantics note, stated honestly:** "once" is per **dispatch call**, not per conversation — a run that calls the tool twice starts two independent, individually bounded self-runs. That is the same fan-out caveat #9745 documents (`b^d` within the cap); the per-run dispatch budget remains the follow-up that addresses breadth.

### Changes

- `StudioRunnerTools(self_dispatch: Literal["never", "once"] = "never")` beside `max_dispatch_depth`; invalid values rejected with `ValueError`. `_require_no_cycle` becomes an instance method taking the inherited lineage separately, so the blocked set is `inherited` under `"once"` and the full running set under `"never"` — one line of policy, shared by all six run tools and both `StudioTools` version-pinned branches.
- `StudioTools(self_dispatch=...)` forwards to the embedded runner, so the pinned-preview path honors the knob identically.
- Docstring gap from #9745 closed along the way: `StudioTools`' class docstring now documents `max_dispatch_depth` (it was never added there) plus the new knob.

### Verification

- 855 tests green across the #9745 gate suites plus the new ones; the full pre-existing guard suite passes untouched under the default.
- New coverage: first-self-dispatch allowed / second refused (parametrized sync+async, agent and team callers), ping-pong still closed under `"once"`, member-agent parent-team case, `StudioTools` forwarding, both pinned-preview cases (opt-in runs once then refuses; default still refuses the first), invalid-value rejection, and an end-to-end test driving the real pathology with a real `Team` and scripted tool-calling model: one nested run, its re-dispatch refused, terminated — with the runaway ceiling still armed so unbounded recursion ever returning fails loudly.
- 6 targeted mutations, all killed: knob ignored (once behaves as never), once fails open (blocked set emptied — killed by both the runner tests and the pinned-path test), `StudioTools` forward dropped (killed by both), validation removed.
- ruff clean; mypy identical to the base baseline (no errors in touched files).

## Second commit: the lineage now survives a pause (blocker from the probe sweep)

The template session's probe sweep found that the guard state did not survive a HITL pause — **a defect in shipped #9745, not just this PR**: the lineage and hop counter are persisted on the run row, but every resume path rebuilt `RunContext.metadata` from caller input. A resumed nested run presented as top-level: `A -> B -> A` and the depth cap were defeated across a pause in the default mode, and `"once"` became rechargeable — an independent repro drove `solo -> solo` five levels deep at `max_dispatch_depth=2`, one human approval per hop.

**Fix (`d17bedab2`):** the paused run's reserved metadata keys now win the resume merge at every continue entry point — the sync dispatches for agent and team, the async executors (where an async DB first reads the session), and the background wrappers. Caller-supplied reserved keys are dropped on resume the way every other seam drops them (this is the sixth seam). A `restore_reserved_run_metadata` helper lives beside `strip_reserved_run_metadata`; the version stamp is restored along with the dispatch keys, so a run row rewrite can never shed it either.

**Spec acceptance criteria, reported:**
1. A resumed run carries the lineage and depth it paused with — `test_dispatch_lineage_survives_continue`, agent+team × sync+async. ✅
2. `A -> B -> A` refused across a pause **in both modes** — `test_cycle_guard_holds_across_a_pause`; confirmed failing in both modes pre-fix (the dispatch executed), as the spec demanded. ✅
3. Depth cap holds through pauses — `test_depth_cap_holds_across_a_pause`. ✅
4. `"once"` is once per lineage, not once per resume — `test_self_dispatch_once_is_still_once_across_a_pause`, sync+async. ✅
5. Caller-supplied reserved keys cannot replace restored values — `test_caller_cannot_override_restored_lineage` (forged chain loses, caller's other metadata rides). ✅

All five tests were written first and confirmed failing for the spec's stated reasons on unmodified code (the sync seams alone left every async case failing, which is how the separate async dispatch blocks were found). Regression sweep: 3,154 tests across `tests/unit/team`, `tests/unit/agent`, the studio gate, and `os/routers` — zero failures.

## Type of change

- [x] New feature

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Purely additive and opt-in: no default behavior changes, no stored config changes, no migration. An independent adversarial review (2 lenses with per-finding refutation) ran over the final diff before push.