### PR TITLE
fix: refuse a run into a session owned by another user

### DIFF
--- a/libs/agno/agno/os/interfaces/a2a/router.py
+++ b/libs/agno/agno/os/interfaces/a2a/router.py
@@ -29,7 +29,14 @@ from agno.os.interfaces.a2a.utils import (
     map_run_output_to_a2a_task,
     stream_a2a_response_with_error_handling,
 )
-from agno.os.middleware.user_scope import get_scoped_user_id, resolve_run_user_id, verify_run_in_session
+from agno.db.base import SessionType
+from agno.os.middleware.user_scope import (
+    assert_session_writable,
+    caller_is_admin,
+    get_scoped_user_id,
+    resolve_run_user_id,
+    verify_run_in_session,
+)
 from agno.os.utils import get_agent_by_id, get_request_kwargs, get_team_by_id, get_workflow_by_id
 from agno.team import RemoteTeam, Team
 from agno.workflow import RemoteWorkflow, Workflow
@@ -147,6 +154,17 @@ def attach_routes(
 
         # 3. Check if non-blocking execution is requested
         blocking = request_body.get("params", {}).get("configuration", {}).get("blocking", True)
+
+        # A run may not enter a session another user owns. Raised before the
+        # ``try`` below on purpose: its blanket ``except`` turns anything raised
+        # inside into a 200 carrying a failed Task.
+        await assert_session_writable(
+            getattr(agent, "db", None),
+            context_id,
+            user_id or getattr(agent, "user_id", None),
+            session_type=SessionType.AGENT,
+            is_admin=caller_is_admin(request),
+        )
 
         # 4. Run the Agent
         try:
@@ -348,6 +366,17 @@ def attach_routes(
         context_id = request_body.get("params", {}).get("message", {}).get("contextId")
         user_id = _resolve_a2a_user_id(request, request_body)
 
+        # A run may not enter a session another user owns. Raised before the
+        # ``try`` below on purpose: its blanket ``except`` turns anything raised
+        # inside into a 200 carrying a failed Task.
+        await assert_session_writable(
+            getattr(agent, "db", None),
+            context_id,
+            user_id or getattr(agent, "user_id", None),
+            session_type=SessionType.AGENT,
+            is_admin=caller_is_admin(request),
+        )
+
         # 3. Run the Agent and stream the response
         try:
             event_stream = agent.arun(
@@ -458,6 +487,17 @@ def attach_routes(
 
         # 3. Check if non-blocking execution is requested
         blocking = request_body.get("params", {}).get("configuration", {}).get("blocking", True)
+
+        # A run may not enter a session another user owns. Raised before the
+        # ``try`` below on purpose: its blanket ``except`` turns anything raised
+        # inside into a 200 carrying a failed Task.
+        await assert_session_writable(
+            getattr(team, "db", None),
+            context_id,
+            user_id or getattr(team, "user_id", None),
+            session_type=SessionType.TEAM,
+            is_admin=caller_is_admin(request),
+        )
 
         # 4. Run the Team
         try:
@@ -655,6 +695,17 @@ def attach_routes(
         context_id = request_body.get("params", {}).get("message", {}).get("contextId")
         user_id = _resolve_a2a_user_id(request, request_body)
 
+        # A run may not enter a session another user owns. Raised before the
+        # ``try`` below on purpose: its blanket ``except`` turns anything raised
+        # inside into a 200 carrying a failed Task.
+        await assert_session_writable(
+            getattr(team, "db", None),
+            context_id,
+            user_id or getattr(team, "user_id", None),
+            session_type=SessionType.TEAM,
+            is_admin=caller_is_admin(request),
+        )
+
         # 3. Run the Team and stream the response
         try:
             event_stream = team.arun(
@@ -763,6 +814,17 @@ def attach_routes(
         context_id = request_body.get("params", {}).get("message", {}).get("contextId")
         user_id = _resolve_a2a_user_id(request, request_body)
 
+        # A run may not enter a session another user owns. Raised before the
+        # ``try`` below on purpose: its blanket ``except`` turns anything raised
+        # inside into a 200 carrying a failed Task.
+        await assert_session_writable(
+            getattr(workflow, "db", None),
+            context_id,
+            user_id or getattr(workflow, "user_id", None),
+            session_type=SessionType.WORKFLOW,
+            is_admin=caller_is_admin(request),
+        )
+
         # 3. Run the Workflow
         try:
             response = await workflow.arun(
@@ -845,6 +907,17 @@ def attach_routes(
         run_input = await map_a2a_request_to_run_input(request_body, stream=True)
         context_id = request_body.get("params", {}).get("message", {}).get("contextId")
         user_id = _resolve_a2a_user_id(request, request_body)
+
+        # A run may not enter a session another user owns. Raised before the
+        # ``try`` below on purpose: its blanket ``except`` turns anything raised
+        # inside into a 200 carrying a failed Task.
+        await assert_session_writable(
+            getattr(workflow, "db", None),
+            context_id,
+            user_id or getattr(workflow, "user_id", None),
+            session_type=SessionType.WORKFLOW,
+            is_admin=caller_is_admin(request),
+        )
 
         # 3. Run the Workflow and stream the response
         try:

--- a/libs/agno/agno/os/interfaces/agui/router.py
+++ b/libs/agno/agno/os/interfaces/agui/router.py
@@ -31,7 +31,8 @@ from agno.os.interfaces.agui.input import (
 )
 from agno.os.interfaces.agui.resume import resume_paused_run
 from agno.os.interfaces.agui.stream import async_stream_agno_response_as_agui_events
-from agno.os.middleware.user_scope import resolve_run_user_id
+from agno.db.base import SessionType
+from agno.os.middleware.user_scope import assert_session_writable, caller_is_admin, resolve_run_user_id
 from agno.run.base import RunContext
 from agno.team.remote import RemoteTeam
 from agno.team.team import Team
@@ -138,6 +139,18 @@ def attach_routes(
         # Resolve identity before streaming so rejection is a proper 403
         client_user_id = run_input.forwarded_props.get("user_id") if run_input.forwarded_props else None
         user_id = resolve_run_user_id(request, client_user_id)
+
+        # A run may not enter a session another user owns. ``thread_id`` is the
+        # client's session id. Checked here rather than inside ``run_entity``,
+        # whose ``except`` would emit the refusal as a RunErrorEvent inside a
+        # 200 SSE stream instead of a 404.
+        await assert_session_writable(
+            getattr(entity, "db", None),
+            run_input.thread_id,
+            user_id or getattr(entity, "user_id", None),
+            session_type=SessionType.TEAM if isinstance(entity, (Team, RemoteTeam)) else SessionType.AGENT,
+            is_admin=caller_is_admin(request),
+        )
 
         async def event_generator():
             async for event in run_entity(entity, run_input, user_id=user_id):  # type: ignore

--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -573,6 +573,37 @@ def _session_id_or_new(session_id: Optional[str]) -> str:
     return session_id
 
 
+async def _assert_session_writable_for_tool(
+    os: "AgentOS",
+    component: Any,
+    session_id: Optional[str],
+    user_id: Optional[str],
+    session_type: SessionType,
+) -> None:
+    """Refuse a run into a session another user owns, as a plain tool error.
+
+    The REST run routes raise ``HTTPException``; MCP tools surface plain
+    exceptions, so an unmapped one would reach the client as an opaque internal
+    error. ``_resolve_run_component`` maps its own resolver errors inside its
+    own try/except and does not cover anything a tool body calls afterwards.
+    """
+    from fastapi import HTTPException
+
+    from agno.os.middleware.user_scope import assert_session_writable, caller_is_admin
+
+    request = _http_request_or_none()
+    try:
+        await assert_session_writable(
+            getattr(component, "db", None) or os.db,
+            session_id,
+            user_id or getattr(component, "user_id", None),
+            session_type=session_type,
+            is_admin=caller_is_admin(request) if request is not None else False,
+        )
+    except HTTPException as e:
+        raise Exception(e.detail if isinstance(e.detail, str) else str(e.detail))
+
+
 def _classify_lifecycle_target(
     agent_id: Optional[str], team_id: Optional[str], workflow_id: Optional[str]
 ) -> "tuple[Literal['agents', 'teams', 'workflows'], str]":
@@ -859,6 +890,7 @@ def build_mcp_server(
         _require_tool_scopes("POST", f"/agents/{agent_id}/runs")
         user_id = _resolve_user_id(user_id)
         agent = await _resolve_run_component(os, "agents", agent_id, user_id=user_id, session_id=session_id)
+        await _assert_session_writable_for_tool(os, agent, session_id, user_id, SessionType.AGENT)
         # Mint a fresh session per call when omitted (matches REST), never the sticky default.
         session_id = _session_id_or_new(session_id)
         run_output = await _run_agentic_component(
@@ -885,6 +917,7 @@ def build_mcp_server(
         _require_tool_scopes("POST", f"/teams/{team_id}/runs")
         user_id = _resolve_user_id(user_id)
         team = await _resolve_run_component(os, "teams", team_id, user_id=user_id, session_id=session_id)
+        await _assert_session_writable_for_tool(os, team, session_id, user_id, SessionType.TEAM)
         # Mint a fresh session per call when omitted (matches REST), never the sticky default.
         session_id = _session_id_or_new(session_id)
         run_output = await _run_agentic_component(
@@ -914,6 +947,7 @@ def build_mcp_server(
         _require_tool_scopes("POST", f"/workflows/{workflow_id}/runs")
         user_id = _resolve_user_id(user_id)
         workflow = await _resolve_run_component(os, "workflows", workflow_id, user_id=user_id, session_id=session_id)
+        await _assert_session_writable_for_tool(os, workflow, session_id, user_id, SessionType.WORKFLOW)
         # Mint a fresh session per call when omitted (matches REST), never the sticky default.
         session_id = _session_id_or_new(session_id)
         # Detach from FastMCP's tool-call span so the workflow run is its own root trace.

--- a/libs/agno/agno/os/middleware/user_scope.py
+++ b/libs/agno/agno/os/middleware/user_scope.py
@@ -53,6 +53,7 @@ from agno.utils.log import log_warning
 
 if TYPE_CHECKING:
     from agno.agent import Agent, RemoteAgent
+    from agno.db.base import SessionType
     from agno.agent.protocol import AgentProtocol
     from agno.os.app import AgentOS
     from agno.team import RemoteTeam, Team
@@ -67,6 +68,7 @@ WORKFLOW_ID_REQUIRED_RECONNECT = "workflow_id is required to reconnect to a work
 SESSION_ID_REQUIRED_RECONNECT = "session_id is required to reconnect to a workflow run"
 INSUFFICIENT_PERMISSIONS_WS_RECONNECT = "Insufficient permissions to reconnect to this workflow"
 MISSING_USER_IDENTITY = "Authenticated request is missing a user identity"
+SESSION_NOT_FOUND = "Session not found"
 
 
 def _has_admin_scope(scopes: List[str], admin_scope: Optional[str] = None) -> bool:
@@ -76,6 +78,21 @@ def _has_admin_scope(scopes: List[str], admin_scope: Optional[str] = None) -> bo
     request.state.admin_scope) and falls back to the default ``agent_os:admin``.
     """
     return (admin_scope or AgentOSScope.ADMIN.value) in scopes
+
+
+def caller_is_admin(request: Request) -> bool:
+    """True when the caller holds the configured (or default) admin scope.
+
+    A public wrapper over ``_has_admin_scope`` for callers that need the admin
+    answer on its own. ``get_scoped_user_id`` cannot stand in for this: it
+    returns ``None`` for admins *and* for every caller on a deployment with
+    isolation off, so it cannot tell the two apart.
+    """
+    admin_scope_raw = getattr(request.state, "admin_scope", None)
+    return _has_admin_scope(
+        list(getattr(request.state, "scopes", None) or []),
+        admin_scope=admin_scope_raw if isinstance(admin_scope_raw, str) else None,
+    )
 
 
 def get_scoped_user_id(request: Request) -> Optional[str]:
@@ -475,6 +492,76 @@ async def verify_run_in_session_via_db(
         raise HTTPException(status_code=404, detail="Run not found")
     if not run_matches_component(run, component_type, component_id):
         raise HTTPException(status_code=404, detail="Run not found")
+
+
+async def assert_session_writable(
+    db: Union["BaseDb", "AsyncBaseDb", "RemoteDb", None],
+    session_id: Optional[str],
+    effective_user_id: Optional[str],
+    *,
+    session_type: Optional["SessionType"] = None,
+    is_admin: bool = False,
+) -> None:
+    """Raise 404 if ``session_id`` already exists and belongs to a different user.
+
+    Mirrors the ownership predicate every adapter's ``upsert_session`` already
+    applies on ON CONFLICT (``user_id = :uid OR user_id IS NULL``), so a run
+    entrypoint refuses what the session write would have silently dropped
+    instead of letting the run land in the runs table, where no such predicate
+    exists and the history read that follows filters on ``session_id`` alone.
+
+    ``effective_user_id`` is the id the run will actually be attributed with:
+    the caller's resolved ``user_id`` when there is one, else the component's
+    own ``user_id`` default. Passing the raw route value instead guts this
+    guard — a component that sets ``user_id`` owns the session row it creates,
+    so every second run would 404.
+
+    No-ops (allows the run) when there is no db or no ``session_id``, when the
+    caller holds admin scope, when the db is a ``RemoteDb`` (the downstream
+    AgentOS enforces its own ownership and already receives the forwarded
+    bearer), when the session row does not exist, when the row is unowned
+    (``user_id IS NULL`` — the shared-session case the storage predicate
+    already admits, and the one anonymous dev runs and evals ride), or when the
+    row is owned by ``effective_user_id``.
+
+    Deliberately NOT on that list: ``effective_user_id is None``. An
+    identity-less run into an *owned* session is refused, because that caller
+    reads the owner's whole history on the spot — ``get_session`` applies no
+    owner filter when ``user_id`` is None. An identity-less run into an
+    *unowned* session stays allowed by the ``owner is None`` branch above,
+    which is what keeps dev mode and the eval suite working.
+    """
+    if db is None or not session_id or is_admin:
+        return
+    if isinstance(db, RemoteDb):
+        return
+
+    # ``user_id`` is deliberately not passed: the probe must see the row whoever
+    # owns it, which is the whole point. ``deserialize=False`` keeps it a raw
+    # dict; ``runs_limit=1`` bounds the run attach on adapters that push the
+    # limit down to the query (a session still carrying a legacy ``runs`` blob,
+    # and adapters that slice in Python, load more).
+    if isinstance(db, AsyncBaseDb):
+        row = await db.get_session(session_id=session_id, session_type=session_type, deserialize=False, runs_limit=1)
+    else:
+        row = db.get_session(session_id=session_id, session_type=session_type, deserialize=False, runs_limit=1)
+    if not row:
+        return
+
+    owner = row.get("user_id") if isinstance(row, dict) else getattr(row, "user_id", None)
+    # Only a non-empty string identifies an owner. NULL is the unclaimed row the
+    # storage predicate already admits; the empty string is the same thing, since
+    # the session writers map it to the component default before stamping. Any
+    # other shape means this row cannot answer the ownership question, and a
+    # value that is not an id must never be read as "owned by someone else".
+    if not isinstance(owner, str) or not owner or owner == effective_user_id:
+        return
+
+    log_warning(
+        f"user_scope: refused a run into session_id={session_id!r} owned by "
+        f"user_id={owner!r} from a caller scoped to user_id={effective_user_id!r}."
+    )
+    raise HTTPException(status_code=404, detail=SESSION_NOT_FOUND)
 
 
 def resolve_owned_agent(os: "AgentOS") -> Callable:

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -21,7 +21,7 @@ from agno.agent.agent import Agent
 from agno.agent.factory import AgentFactory
 from agno.agent.protocol import AgentProtocol
 from agno.agent.remote import RemoteAgent
-from agno.db.base import BaseDb
+from agno.db.base import BaseDb, SessionType
 from agno.db.schemas.jobs import QueuedJob
 from agno.exceptions import (
     ComponentRehydrationError,
@@ -55,6 +55,8 @@ from agno.os.job_queue import (
 from agno.os.middleware.user_scope import (
     SESSION_ID_REQUIRED,
     assert_session_matches_component,
+    assert_session_writable,
+    caller_is_admin,
     get_scoped_user_id,
     run_matches_component,
     verify_run_in_session,
@@ -730,6 +732,17 @@ def get_agent_router(
         # the run itself (run metadata), so the lifecycle routes can reload
         # the SAME version later instead of whatever is current by then.
         stamp_component_version(kwargs, version)
+
+        # A run may not enter a session another user owns. The id the run will
+        # actually be attributed with is the route's resolved user_id, or the
+        # component's own default when the route resolved none.
+        await assert_session_writable(
+            getattr(agent, "db", None) or os.db,
+            session_id,
+            user_id or getattr(agent, "user_id", None),
+            session_type=SessionType.AGENT,
+            is_admin=caller_is_admin(request),
+        )
 
         if session_id is None or session_id == "":
             log_debug("Creating new session")

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -17,7 +17,7 @@ from fastapi import (
 )
 from fastapi.responses import JSONResponse, StreamingResponse
 
-from agno.db.base import BaseDb
+from agno.db.base import BaseDb, SessionType
 from agno.db.schemas.jobs import QueuedJob
 from agno.exceptions import (
     ComponentRehydrationError,
@@ -51,6 +51,8 @@ from agno.os.job_queue import (
 from agno.os.middleware.user_scope import (
     SESSION_ID_REQUIRED,
     assert_session_matches_component,
+    assert_session_writable,
+    caller_is_admin,
     get_scoped_user_id,
     run_matches_component,
     verify_run_in_session,
@@ -701,6 +703,17 @@ def get_team_router(
         # Without this, API continue cannot reliably reload member tool state from the DB.
         if not isinstance(team, RemoteTeam):
             team.store_member_responses = True
+
+        # A run may not enter a session another user owns. The id the run will
+        # actually be attributed with is the route's resolved user_id, or the
+        # component's own default when the route resolved none.
+        await assert_session_writable(
+            getattr(team, "db", None) or os.db,
+            session_id,
+            user_id or getattr(team, "user_id", None),
+            session_type=SessionType.TEAM,
+            is_admin=caller_is_admin(request),
+        )
 
         if session_id is not None and session_id != "":
             logger.debug(f"Continuing session: {session_id}")

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -19,7 +19,7 @@ from fastapi import (
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel
 
-from agno.db.base import BaseDb
+from agno.db.base import BaseDb, SessionType
 from agno.db.schemas.jobs import QueuedJob
 from agno.exceptions import (
     ComponentRehydrationError,
@@ -53,6 +53,8 @@ from agno.os.middleware.user_scope import (
     SESSION_ID_REQUIRED_RECONNECT,
     WORKFLOW_ID_REQUIRED_RECONNECT,
     assert_session_matches_component,
+    assert_session_writable,
+    caller_is_admin,
     get_scoped_user_id,
     get_scoped_user_id_for_ws,
     run_matches_component,
@@ -301,6 +303,24 @@ async def handle_workflow_via_websocket(
                 session_id = workflow.session_id
             else:
                 session_id = str(uuid4())
+
+        # A run may not enter a session another user owns. Checked after the
+        # default above so the component's own sticky session_id is covered
+        # too, and before the queue submission below so one guard serves both
+        # the durable and the inline path.
+        try:
+            await assert_session_writable(
+                getattr(workflow, "db", None) or os.db,
+                session_id,
+                user_id or getattr(workflow, "user_id", None),
+                session_type=SessionType.WORKFLOW,
+                is_admin=bool(ws_auth and ws_auth.is_admin),
+            )
+        except HTTPException as e:
+            await websocket.send_text(
+                json.dumps({"event": "error", "error": e.detail if isinstance(e.detail, str) else str(e.detail)})
+            )
+            return
 
         # Durable WS submission: the queue row is the acceptance, execution
         # happens on whichever worker claims it, and this socket becomes a
@@ -1712,6 +1732,17 @@ def get_workflow_router(
         # the run itself (run metadata), so the lifecycle routes can reload
         # the SAME version later instead of whatever is current by then.
         stamp_component_version(kwargs, version)
+
+        # A run may not enter a session another user owns. The id the run will
+        # actually be attributed with is the route's resolved user_id, or the
+        # component's own default when the route resolved none.
+        await assert_session_writable(
+            getattr(workflow, "db", None) or os.db,
+            session_id,
+            user_id or getattr(workflow, "user_id", None),
+            session_type=SessionType.WORKFLOW,
+            is_admin=caller_is_admin(request),
+        )
 
         if session_id:
             logger.debug(f"Continuing session: {session_id}")

--- a/libs/agno/tests/integration/os/test_session_write_ownership_surfaces.py
+++ b/libs/agno/tests/integration/os/test_session_write_ownership_surfaces.py
@@ -1,0 +1,413 @@
+"""Session-write ownership on the run surfaces that do not go through the REST run routes.
+
+``POST /agents|teams|workflows/{id}/runs`` is not the only way to create a run
+against a caller-supplied ``session_id``. The workflow WebSocket, the A2A
+interface, the AG-UI interface and the MCP run tools all pin the caller's
+identity server-side and then take the session id straight from the request —
+the same shape, and the same bleed, as the REST routes.
+
+These are regressions for session-cross-user-history-bleed: a fix that only
+guards the REST routes leaves every surface below open.
+"""
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+
+from agno.agent.agent import Agent
+from agno.models.base import Model
+from agno.models.message import MessageMetrics
+from agno.models.response import ModelResponse
+from agno.os import AgentOS
+from agno.os.config import AuthorizationConfig
+from agno.workflow.step import Step
+from agno.workflow.workflow import Workflow
+
+JWT_SECRET = "test-secret-for-write-ownership"
+TEST_OS_ID = "test-write-ownership-os"
+SECRET_TEXT = "wire-transfer PIN GRIMSBY-8807"
+
+
+class ScriptedModel(Model):
+    """A model that answers without a provider call."""
+
+    def __init__(self, model_id: str, reply: str):
+        super().__init__(id=model_id, name=model_id, provider="test")
+        self._reply = reply
+
+    def _resp(self) -> ModelResponse:
+        return ModelResponse(content=self._reply, role="assistant", response_usage=MessageMetrics())
+
+    def invoke(self, *args, **kwargs):
+        return self._resp()
+
+    async def ainvoke(self, *args, **kwargs):
+        return self._resp()
+
+    def invoke_stream(self, *args, **kwargs):
+        yield self._resp()
+
+    async def ainvoke_stream(self, *args, **kwargs):
+        yield self._resp()
+
+    def parse_args(self, *args, **kwargs):
+        return {}
+
+    def _parse_provider_response(self, response, **kwargs):
+        return self._resp()
+
+    def _parse_provider_response_delta(self, response):
+        return self._resp()
+
+
+def create_token(user_id: str, scopes: list[str] | None = None) -> str:
+    payload = {
+        "sub": user_id,
+        "aud": TEST_OS_ID,
+        "scopes": scopes
+        or [
+            "agents:read",
+            "agents:run",
+            "teams:read",
+            "teams:run",
+            "workflows:read",
+            "workflows:run",
+            "sessions:read",
+            "sessions:write",
+        ],
+        "exp": datetime.now(UTC) + timedelta(hours=1),
+        "iat": datetime.now(UTC),
+    }
+    return jwt.encode(payload, JWT_SECRET, algorithm="HS256")
+
+
+def auth_header(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def history_agent(shared_db):
+    return Agent(
+        id="history-agent",
+        name="history-agent",
+        db=shared_db,
+        model=ScriptedModel("scripted-1", "ok"),
+        add_history_to_context=True,
+        num_history_runs=5,
+    )
+
+
+@pytest.fixture
+def history_workflow(shared_db, history_agent):
+    return Workflow(
+        id="history-workflow",
+        name="history-workflow",
+        db=shared_db,
+        steps=[Step(name="step1", description="noop", agent=history_agent)],
+    )
+
+
+def _auth_config(user_isolation: bool) -> AuthorizationConfig:
+    return AuthorizationConfig(verification_keys=[JWT_SECRET], algorithm="HS256", user_isolation=user_isolation)
+
+
+def _run_user_ids(db, session_id: str) -> set:
+    return {r["user_id"] for r in db.get_runs(session_id=session_id, deserialize=False)[0]}
+
+
+def _ws_start_workflow(client: TestClient, user: str, session_id: str, message: str) -> list:
+    """Authenticate on the workflow socket, submit a run, and collect the frames."""
+    frames: list = []
+    with client.websocket_connect("/workflows/ws") as ws:
+        ws.send_text(json.dumps({"action": "authenticate", "token": create_token(user)}))
+        ws.send_text(
+            json.dumps(
+                {
+                    "action": "start-workflow",
+                    "workflow_id": "history-workflow",
+                    "session_id": session_id,
+                    "message": message,
+                }
+            )
+        )
+        for _ in range(8):
+            try:
+                frames.append(json.loads(ws.receive_text()))
+            except Exception:
+                break
+            if frames[-1].get("event") == "error":
+                break
+    return frames
+
+
+# ---------------------------------------------------------------------------
+# Workflow WebSocket — mounted on every AgentOS, no feature flag
+# ---------------------------------------------------------------------------
+
+
+class TestWorkflowWebSocketOwnership:
+    @pytest.mark.parametrize("isolation", [True, False])
+    def test_start_workflow_refuses_a_foreign_session(self, history_workflow, isolation):
+        agent_os = AgentOS(
+            id=TEST_OS_ID,
+            workflows=[history_workflow],
+            db=history_workflow.db,
+            telemetry=False,
+            authorization=True,
+            authorization_config=_auth_config(isolation),
+        )
+        client = TestClient(agent_os.get_app())
+        sid = "ws-owned-by-c"
+
+        assert (
+            client.post(
+                "/workflows/history-workflow/runs",
+                data={"message": "opened by C", "stream": "false", "session_id": sid},
+                headers=auth_header(create_token("user-c")),
+            ).status_code
+            == 200
+        )
+
+        frames = _ws_start_workflow(client, "user-d", sid, f"My private {SECRET_TEXT}")
+
+        assert any(f.get("error") == "Session not found" for f in frames), frames
+        assert _run_user_ids(history_workflow.db, sid) == {"user-c"}
+
+    def test_owner_may_start_a_workflow_over_the_socket(self, history_workflow):
+        """No-regression guard: the socket must still work for the session's owner."""
+        agent_os = AgentOS(
+            id=TEST_OS_ID,
+            workflows=[history_workflow],
+            db=history_workflow.db,
+            telemetry=False,
+            authorization=True,
+            authorization_config=_auth_config(True),
+        )
+        client = TestClient(agent_os.get_app())
+        sid = "ws-owned-by-c-2"
+        client.post(
+            "/workflows/history-workflow/runs",
+            data={"message": "opened by C", "stream": "false", "session_id": sid},
+            headers=auth_header(create_token("user-c")),
+        )
+
+        frames = _ws_start_workflow(client, "user-c", sid, "second turn")
+
+        assert not any(f.get("error") == "Session not found" for f in frames), frames
+
+
+# ---------------------------------------------------------------------------
+# A2A — client-supplied contextId becomes the session id
+# ---------------------------------------------------------------------------
+
+
+def _a2a_send(client: TestClient, user: str, context_id: str, text: str):
+    return client.post(
+        "/a2a/agents/history-agent/v1/message:send",
+        headers=auth_header(create_token(user)),
+        json={
+            "jsonrpc": "2.0",
+            "id": "1",
+            "method": "message/send",
+            "params": {
+                "message": {
+                    "role": "user",
+                    "parts": [{"kind": "text", "text": text}],
+                    "messageId": "m1",
+                    "contextId": context_id,
+                }
+            },
+        },
+    )
+
+
+class TestA2AOwnership:
+    @pytest.mark.parametrize("isolation", [True, False])
+    def test_a2a_refuses_a_foreign_context_id(self, history_agent, isolation):
+        pytest.importorskip("a2a")
+        from agno.os.interfaces.a2a import A2A
+
+        agent_os = AgentOS(
+            id=TEST_OS_ID,
+            agents=[history_agent],
+            db=history_agent.db,
+            telemetry=False,
+            interfaces=[A2A(agents=[history_agent])],
+            authorization=True,
+            authorization_config=_auth_config(isolation),
+        )
+        client = TestClient(agent_os.get_app())
+        sid = "a2a-owned-by-c"
+
+        assert _a2a_send(client, "user-c", sid, "opened by C").status_code == 200
+        resp = _a2a_send(client, "user-d", sid, f"My private {SECRET_TEXT}")
+
+        # A real 404, not a 200 carrying a failed Task: the guard must sit
+        # outside the handler's blanket ``except Exception``.
+        assert resp.status_code == 404, resp.text
+        assert resp.json()["detail"] == "Session not found"
+        assert _run_user_ids(history_agent.db, sid) == {"user-c"}
+
+    def test_a2a_owner_may_continue(self, history_agent):
+        pytest.importorskip("a2a")
+        from agno.os.interfaces.a2a import A2A
+
+        agent_os = AgentOS(
+            id=TEST_OS_ID,
+            agents=[history_agent],
+            db=history_agent.db,
+            telemetry=False,
+            interfaces=[A2A(agents=[history_agent])],
+            authorization=True,
+            authorization_config=_auth_config(True),
+        )
+        client = TestClient(agent_os.get_app())
+        sid = "a2a-owned-by-c-2"
+        assert _a2a_send(client, "user-c", sid, "one").status_code == 200
+        assert _a2a_send(client, "user-c", sid, "two").status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# AG-UI — client-supplied threadId becomes the session id
+# ---------------------------------------------------------------------------
+
+
+def _agui_send(client: TestClient, user: str, thread_id: str, text: str):
+    return client.post(
+        "/agui",
+        headers=auth_header(create_token(user)),
+        json={
+            "threadId": thread_id,
+            "runId": f"run-{user}",
+            "messages": [{"id": "1", "role": "user", "content": text}],
+            "tools": [],
+            "context": [],
+            "state": {},
+            "forwardedProps": {},
+        },
+    )
+
+
+class TestAGUIOwnership:
+    @pytest.mark.parametrize("isolation", [True, False])
+    def test_agui_refuses_a_foreign_thread_id(self, history_agent, isolation):
+        pytest.importorskip("ag_ui")
+        from agno.os.interfaces.agui import AGUI
+
+        agent_os = AgentOS(
+            id=TEST_OS_ID,
+            agents=[history_agent],
+            db=history_agent.db,
+            telemetry=False,
+            interfaces=[AGUI(agent=history_agent)],
+            authorization=True,
+            authorization_config=_auth_config(isolation),
+        )
+        client = TestClient(agent_os.get_app())
+        sid = "agui-owned-by-c"
+
+        assert _agui_send(client, "user-c", sid, "opened by C").status_code == 200
+        resp = _agui_send(client, "user-d", sid, f"My private {SECRET_TEXT}")
+
+        # A real 404, not a RunErrorEvent inside a 200 SSE stream: the guard must
+        # sit in the route handler, not inside ``run_entity``.
+        assert resp.status_code == 404, resp.text
+        assert _run_user_ids(history_agent.db, sid) == {"user-c"}
+
+    def test_agui_owner_may_continue(self, history_agent):
+        pytest.importorskip("ag_ui")
+        from agno.os.interfaces.agui import AGUI
+
+        agent_os = AgentOS(
+            id=TEST_OS_ID,
+            agents=[history_agent],
+            db=history_agent.db,
+            telemetry=False,
+            interfaces=[AGUI(agent=history_agent)],
+            authorization=True,
+            authorization_config=_auth_config(True),
+        )
+        client = TestClient(agent_os.get_app())
+        sid = "agui-owned-by-c-2"
+        assert _agui_send(client, "user-c", sid, "one").status_code == 200
+        assert _agui_send(client, "user-c", sid, "two").status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# MCP run tools
+# ---------------------------------------------------------------------------
+
+
+class TestMCPRunToolOwnership:
+    """The MCP run tools do not go through the REST run routes; a router-only
+    fix leaves ``/mcp`` bleeding."""
+
+    @pytest.mark.asyncio
+    async def test_run_agent_refuses_a_foreign_session(self, history_agent):
+        pytest.importorskip("fastmcp")
+        from fastmcp import Client
+
+        from agno.os import MCPServerConfig
+        from agno.os.mcp import build_mcp_server
+
+        agent_os = AgentOS(
+            id=TEST_OS_ID,
+            agents=[history_agent],
+            db=history_agent.db,
+            telemetry=False,
+            mcp_server=MCPServerConfig(),
+        )
+        sid = "mcp-owned-by-c"
+
+        async with Client(build_mcp_server(agent_os)) as client:
+            await client.call_tool(
+                "run_agent",
+                {"agent_id": "history-agent", "message": "opened by C", "user_id": "user-c", "session_id": sid},
+            )
+            with pytest.raises(Exception, match="Session not found"):
+                await client.call_tool(
+                    "run_agent",
+                    {
+                        "agent_id": "history-agent",
+                        "message": f"My private {SECRET_TEXT}",
+                        "user_id": "user-d",
+                        "session_id": sid,
+                    },
+                )
+
+        assert _run_user_ids(history_agent.db, sid) == {"user-c"}
+
+    @pytest.mark.asyncio
+    async def test_run_agent_allows_the_owner_and_a_new_session(self, history_agent):
+        pytest.importorskip("fastmcp")
+        from fastmcp import Client
+
+        from agno.os import MCPServerConfig
+        from agno.os.mcp import build_mcp_server
+
+        agent_os = AgentOS(
+            id=TEST_OS_ID,
+            agents=[history_agent],
+            db=history_agent.db,
+            telemetry=False,
+            mcp_server=MCPServerConfig(),
+        )
+        sid = "mcp-owned-by-c-2"
+
+        async with Client(build_mcp_server(agent_os)) as client:
+            await client.call_tool(
+                "run_agent",
+                {"agent_id": "history-agent", "message": "one", "user_id": "user-c", "session_id": sid},
+            )
+            # The owner continues...
+            await client.call_tool(
+                "run_agent",
+                {"agent_id": "history-agent", "message": "two", "user_id": "user-c", "session_id": sid},
+            )
+            # ...and omitting session_id still mints a fresh one.
+            await client.call_tool("run_agent", {"agent_id": "history-agent", "message": "three", "user_id": "user-d"})
+
+        assert _run_user_ids(history_agent.db, sid) == {"user-c"}

--- a/libs/agno/tests/integration/os/test_user_isolation_01.py
+++ b/libs/agno/tests/integration/os/test_user_isolation_01.py
@@ -20,6 +20,9 @@ import pytest
 from fastapi.testclient import TestClient
 
 from agno.agent.agent import Agent
+from agno.models.base import Model
+from agno.models.message import MessageMetrics
+from agno.models.response import ModelResponse
 from agno.os import AgentOS
 from agno.os.config import AuthorizationConfig
 from agno.team.team import Team
@@ -525,3 +528,343 @@ class TestListingEndpointRbacByAction:
         assert resp.status_code == 200, resp.text
         ids = [a.get("id") for a in resp.json()]
         assert "test-agent" in ids
+
+
+# ---------------------------------------------------------------------------
+# Session write ownership — regression for session-cross-user-history-bleed
+# ---------------------------------------------------------------------------
+
+SECRET_TEXT = "wire-transfer PIN GRIMSBY-8807"
+
+
+class ScriptedModel(Model):
+    """A model that answers without a provider call.
+
+    The shared ``test_agent`` fixture has no model and no
+    ``add_history_to_context``, neither of which is enough to observe a replay.
+    """
+
+    def __init__(self, model_id: str, reply: str):
+        super().__init__(id=model_id, name=model_id, provider="test")
+        self._reply = reply
+
+    def _resp(self) -> ModelResponse:
+        return ModelResponse(content=self._reply, role="assistant", response_usage=MessageMetrics())
+
+    def invoke(self, *args, **kwargs):
+        return self._resp()
+
+    async def ainvoke(self, *args, **kwargs):
+        return self._resp()
+
+    def invoke_stream(self, *args, **kwargs):
+        yield self._resp()
+
+    async def ainvoke_stream(self, *args, **kwargs):
+        yield self._resp()
+
+    def parse_args(self, *args, **kwargs):
+        return {}
+
+    def _parse_provider_response(self, response, **kwargs):
+        return self._resp()
+
+    def _parse_provider_response_delta(self, response):
+        return self._resp()
+
+
+@pytest.fixture
+def history_agent(shared_db):
+    """Replays history and needs no provider."""
+    return Agent(
+        id="history-agent",
+        name="history-agent",
+        db=shared_db,
+        model=ScriptedModel("scripted-1", "ok"),
+        add_history_to_context=True,
+        num_history_runs=5,
+    )
+
+
+@pytest.fixture
+def history_team(shared_db, history_agent):
+    return Team(id="history-team", name="history-team", members=[history_agent], db=shared_db)
+
+
+@pytest.fixture
+def history_workflow(shared_db, history_agent):
+    return Workflow(
+        id="history-workflow",
+        name="history-workflow",
+        db=shared_db,
+        steps=[Step(name="step1", description="noop", agent=history_agent)],
+    )
+
+
+def _ownership_client(*, user_isolation: bool, agents=None, teams=None, workflows=None, db=None) -> TestClient:
+    agent_os = AgentOS(
+        id=TEST_OS_ID,
+        agents=agents,
+        teams=teams,
+        workflows=workflows,
+        db=db,
+        telemetry=False,
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[JWT_SECRET],
+            algorithm="HS256",
+            user_isolation=user_isolation,
+        ),
+    )
+    return TestClient(agent_os.get_app())
+
+
+def _open_client(*, agents=None, teams=None, workflows=None, db=None) -> TestClient:
+    """No authorization middleware — ``user_id`` is whatever the form field says,
+    or absent. The configuration the identity-less variant needs."""
+    agent_os = AgentOS(id=TEST_OS_ID, agents=agents, teams=teams, workflows=workflows, db=db, telemetry=False)
+    return TestClient(agent_os.get_app(), raise_server_exceptions=False)
+
+
+def _run(client, path, token=None, **fields):
+    data = {"stream": "false", **fields}
+    headers = auth_header(token) if token else {}
+    return client.post(path, data=data, headers=headers)
+
+
+def _history(response):
+    return [m for m in (response.json().get("messages") or []) if m.get("from_history")]
+
+
+class TestSessionWriteOwnership:
+    """A run posted to another user's ``session_id`` must be refused, and must
+    never reach the owner's history.
+
+    Both isolation states are exercised on purpose: the defect reproduced under
+    ``user_isolation=True`` as well, because the missing check was on
+    ``session_id``, not on ``user_id``.
+    """
+
+    @pytest.mark.parametrize("isolation", [True, False])
+    def test_non_owner_run_into_foreign_session_is_refused(self, history_agent, isolation):
+        client = _ownership_client(user_isolation=isolation, agents=[history_agent], db=history_agent.db)
+        sid = "owned-by-c"
+        assert (
+            _run(client, "/agents/history-agent/runs", create_token("user-c"), message="opened by C", session_id=sid)
+        ).status_code == 200
+
+        resp = _run(
+            client,
+            "/agents/history-agent/runs",
+            create_token("user-d"),
+            message=f"My private {SECRET_TEXT}",
+            session_id=sid,
+        )
+        assert resp.status_code == 404, resp.text
+        assert resp.json()["detail"] == "Session not found"
+        # The refusal must not disclose who does own it.
+        assert "user-c" not in resp.text
+
+    @pytest.mark.parametrize("isolation", [True, False])
+    def test_owner_history_never_carries_a_foreign_turn(self, history_agent, isolation):
+        client = _ownership_client(user_isolation=isolation, agents=[history_agent], db=history_agent.db)
+        sid = "owned-by-c-2"
+        _run(client, "/agents/history-agent/runs", create_token("user-c"), message="opened by C", session_id=sid)
+        _run(
+            client,
+            "/agents/history-agent/runs",
+            create_token("user-d"),
+            message=f"My private {SECRET_TEXT}",
+            session_id=sid,
+        )
+
+        resp = _run(
+            client, "/agents/history-agent/runs", create_token("user-c"), message="what did I say?", session_id=sid
+        )
+        assert resp.status_code == 200, resp.text
+        history = _history(resp)
+        assert history, "owner must still replay their own history"
+        assert not any(SECRET_TEXT in str(m.get("content")) for m in history)
+
+    @pytest.mark.parametrize("isolation", [True, False])
+    def test_no_foreign_run_row_reaches_the_session(self, history_agent, isolation):
+        """Storage-level twin: the refusal happens before ``upsert_run``, not
+        only before the history read."""
+        client = _ownership_client(user_isolation=isolation, agents=[history_agent], db=history_agent.db)
+        sid = "owned-by-c-3"
+        _run(client, "/agents/history-agent/runs", create_token("user-c"), message="opened by C", session_id=sid)
+        _run(
+            client,
+            "/agents/history-agent/runs",
+            create_token("user-d"),
+            message=f"My private {SECRET_TEXT}",
+            session_id=sid,
+        )
+        runs = history_agent.db.get_runs(session_id=sid, deserialize=False)[0]
+        assert {r["user_id"] for r in runs} == {"user-c"}
+
+    @pytest.mark.parametrize("stream", ["true", "false"])
+    def test_refusal_is_a_plain_404_on_every_variant(self, history_agent, stream):
+        """``stream`` defaults to True on these routes: the guard must sit before
+        the streaming and background branches, so the refusal is a JSON 404 and
+        never an SSE frame or a queued ticket."""
+        client = _ownership_client(user_isolation=True, agents=[history_agent], db=history_agent.db)
+        sid = "owned-by-c-stream"
+        _run(client, "/agents/history-agent/runs", create_token("user-c"), message="opened by C", session_id=sid)
+
+        resp = client.post(
+            "/agents/history-agent/runs",
+            data={"message": "intrude", "stream": stream, "session_id": sid},
+            headers=auth_header(create_token("user-d")),
+        )
+        assert resp.status_code == 404, resp.text
+        assert resp.headers["content-type"].startswith("application/json")
+
+    def test_owner_can_still_continue_their_own_session(self, history_agent):
+        """Regression guard: the common path must not become a 404."""
+        client = _ownership_client(user_isolation=True, agents=[history_agent], db=history_agent.db)
+        sid = "owned-by-c-4"
+        token = create_token("user-c")
+        assert _run(client, "/agents/history-agent/runs", token, message="one", session_id=sid).status_code == 200
+        resp = _run(client, "/agents/history-agent/runs", token, message="two", session_id=sid)
+        assert resp.status_code == 200
+        assert any("one" in str(m.get("content")) for m in _history(resp))
+
+    def test_new_session_id_is_created_not_refused(self, history_agent):
+        """A session id nobody owns must 200 and create — the guard must not turn
+        every client-supplied id into a 404."""
+        client = _ownership_client(user_isolation=True, agents=[history_agent], db=history_agent.db)
+        resp = _run(
+            client, "/agents/history-agent/runs", create_token("user-c"), message="hello", session_id="brand-new-id"
+        )
+        assert resp.status_code == 200, resp.text
+
+    def test_admin_may_run_into_any_session(self, history_agent):
+        """Admins bypass scoping everywhere else on this surface; keep it true here."""
+        client = _ownership_client(user_isolation=True, agents=[history_agent], db=history_agent.db)
+        sid = "owned-by-c-5"
+        _run(client, "/agents/history-agent/runs", create_token("user-c"), message="opened by C", session_id=sid)
+        resp = _run(client, "/agents/history-agent/runs", create_admin_token(), message="admin here", session_id=sid)
+        assert resp.status_code == 200, resp.text
+
+    def test_unowned_session_is_claimed_by_the_first_identified_writer(self, history_agent):
+        """``user_id IS NULL`` is writable by anyone — but only until someone
+        identified writes, because ``upsert_session`` carries ``user_id`` in its
+        ON CONFLICT SET list. The guard then treats the row as owned, which is
+        the same rule storage applies."""
+        db = history_agent.db
+        open_client = _open_client(agents=[history_agent], db=db)
+        sid = "unowned-then-claimed"
+        # An identity-less run creates the row unowned...
+        assert _run(open_client, "/agents/history-agent/runs", message="anon one", session_id=sid).status_code == 200
+        assert db.get_session(session_id=sid, deserialize=False)["user_id"] is None
+
+        auth_client = _ownership_client(user_isolation=True, agents=[history_agent], db=db)
+        # ...the first identified writer is admitted, and claims it...
+        assert (
+            _run(auth_client, "/agents/history-agent/runs", create_token("user-c"), message="c", session_id=sid)
+        ).status_code == 200
+        assert db.get_session(session_id=sid, deserialize=False)["user_id"] == "user-c"
+        # ...and the next identified writer is a non-owner.
+        assert (
+            _run(auth_client, "/agents/history-agent/runs", create_token("user-d"), message="d", session_id=sid)
+        ).status_code == 404
+
+    def test_guard_uses_the_component_db_when_agentos_has_none(self, history_agent):
+        """Components commonly carry their own db while ``AgentOS`` gets none.
+        An implementation that reads only ``os.db`` silently no-ops there."""
+        client = _ownership_client(user_isolation=True, agents=[history_agent], db=None)
+        sid = "component-db-only"
+        assert (
+            _run(client, "/agents/history-agent/runs", create_token("user-c"), message="opened by C", session_id=sid)
+        ).status_code == 200
+        resp = _run(client, "/agents/history-agent/runs", create_token("user-d"), message="intrude", session_id=sid)
+        assert resp.status_code == 404, resp.text
+
+    @pytest.mark.parametrize("isolation", [True, False])
+    def test_team_route_refuses_a_foreign_session(self, history_team, isolation):
+        client = _ownership_client(user_isolation=isolation, teams=[history_team], db=history_team.db)
+        sid = "team-owned-by-c"
+        assert (
+            _run(client, "/teams/history-team/runs", create_token("user-c"), message="opened by C", session_id=sid)
+        ).status_code == 200
+        resp = _run(client, "/teams/history-team/runs", create_token("user-d"), message="intrude", session_id=sid)
+        assert resp.status_code == 404, resp.text
+        runs = history_team.db.get_runs(session_id=sid, deserialize=False)[0]
+        assert {r["user_id"] for r in runs} == {"user-c"}
+
+    @pytest.mark.parametrize("isolation", [True, False])
+    def test_workflow_route_refuses_a_foreign_session(self, history_workflow, isolation):
+        client = _ownership_client(user_isolation=isolation, workflows=[history_workflow], db=history_workflow.db)
+        sid = "wf-owned-by-c"
+        assert (
+            _run(
+                client,
+                "/workflows/history-workflow/runs",
+                create_token("user-c"),
+                message="opened by C",
+                session_id=sid,
+            )
+        ).status_code == 200
+        resp = _run(
+            client, "/workflows/history-workflow/runs", create_token("user-d"), message="intrude", session_id=sid
+        )
+        assert resp.status_code == 404, resp.text
+        runs = history_workflow.db.get_runs(session_id=sid, deserialize=False)[0]
+        assert {r["user_id"] for r in runs} == {"user-c"}
+
+
+class TestIdentityLessRunOwnership:
+    """The identity-less variant. A run carrying no ``user_id`` skips the
+    read-side owner filter too, so the intruder reads the owner's history in
+    their own response and their run row is stamped with the owner's id — which
+    is why the guard must not short-circuit on ``effective_user_id is None``.
+    """
+
+    def test_identity_less_run_into_owned_session_is_refused(self, history_agent):
+        client = _open_client(agents=[history_agent], db=history_agent.db)
+        sid = "owned-by-c-6"
+        _run(client, "/agents/history-agent/runs", message="opened by C", session_id=sid, user_id="specUserC")
+        before = history_agent.db.get_session(session_id=sid, deserialize=False)
+
+        resp = _run(client, "/agents/history-agent/runs", message=f"My private {SECRET_TEXT}", session_id=sid)
+
+        assert resp.status_code == 404, resp.text
+        assert not _history(resp)
+        runs = history_agent.db.get_runs(session_id=sid, deserialize=False)[0]
+        assert len(runs) == 1
+        # The refused caller must not have rewritten the owner's session row
+        # either — an identity-less write passes upsert_session's predicate.
+        after = history_agent.db.get_session(session_id=sid, deserialize=False)
+        assert after["user_id"] == before["user_id"] == "specUserC"
+        assert after.get("session_data") == before.get("session_data")
+
+    def test_identity_less_run_into_unowned_session_still_works(self, history_agent):
+        """The branch that keeps dev mode and the eval suite alive: a session
+        created with no identity stores ``user_id`` NULL, so the owner-is-None
+        branch admits every later identity-less run."""
+        client = _open_client(agents=[history_agent], db=history_agent.db)
+        sid = "nobody-owns-this"
+        assert _run(client, "/agents/history-agent/runs", message="one", session_id=sid).status_code == 200
+        resp = _run(client, "/agents/history-agent/runs", message="two", session_id=sid)
+        assert resp.status_code == 200, resp.text
+        assert any("one" in str(m.get("content")) for m in _history(resp))
+
+    def test_component_user_id_default_is_not_locked_out(self, shared_db):
+        """The component carries ``user_id`` while the route resolves None, so
+        the session row is owned by that default. The guard must compare against
+        the EFFECTIVE id or every second run of such a component 404s."""
+        agent = Agent(
+            id="history-agent",
+            name="history-agent",
+            db=shared_db,
+            model=ScriptedModel("scripted-1", "ok"),
+            user_id="anonymous-user",
+            add_history_to_context=True,
+            num_history_runs=5,
+        )
+        client = _open_client(agents=[agent], db=shared_db)
+        sid = "template-session"
+        assert _run(client, "/agents/history-agent/runs", message="one", session_id=sid).status_code == 200
+        assert shared_db.get_session(session_id=sid, deserialize=False)["user_id"] == "anonymous-user"
+        assert _run(client, "/agents/history-agent/runs", message="two", session_id=sid).status_code == 200

--- a/libs/agno/tests/unit/os/test_user_scope_helpers.py
+++ b/libs/agno/tests/unit/os/test_user_scope_helpers.py
@@ -7,20 +7,25 @@ isolation-flag short-circuit — are now expressed as explicit calls to the
 helpers in routers, so the unit tests follow the helpers.
 """
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi import HTTPException
 
+from agno.db.base import AsyncBaseDb, SessionType
 from agno.db.schemas.scheduler import SCHEDULE_OWNER_HEADER
 from agno.os.auth import INTERNAL_SCHEDULER_USER_ID
 from agno.os.middleware.user_scope import (
+    SESSION_NOT_FOUND,
     apply_scope_to_kwargs,
+    assert_session_writable,
+    caller_is_admin,
     enforce_owner_on_entity,
     get_scoped_user_id,
     get_scoped_user_id_for_ws,
     resolve_db_and_scope,
 )
+from agno.remote.base import RemoteDb
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -489,3 +494,185 @@ class TestGetScopedUserIdFromParts:
     def test_no_user_id_is_unscoped_when_isolation_off(self):
         assert get_scoped_user_id_for_ws(None, jwt_enabled=True, is_admin=False, user_isolation_enabled=False) is None
         assert get_scoped_user_id_for_ws(None, jwt_enabled=False, is_admin=False, user_isolation_enabled=True) is None
+
+
+# ---------------------------------------------------------------------------
+# caller_is_admin
+# ---------------------------------------------------------------------------
+
+
+class TestCallerIsAdmin:
+    """The admin answer on its own — ``get_scoped_user_id`` cannot stand in for
+    it, because that returns None for admins *and* for every caller on a
+    deployment with isolation off."""
+
+    def test_default_admin_scope(self):
+        assert caller_is_admin(_make_request(user_id="u", scopes=["agent_os:admin"])) is True
+
+    def test_plain_caller_is_not_admin(self):
+        assert caller_is_admin(_make_request(user_id="u", scopes=["agents:run"])) is False
+
+    def test_configured_admin_scope_is_honoured(self):
+        request = _make_request(user_id="u", scopes=["custom:admin"])
+        request.state.admin_scope = "custom:admin"
+        assert caller_is_admin(request) is True
+        # ...and the default name no longer grants it
+        assert caller_is_admin(_make_request(user_id="u", scopes=["agent_os:admin"])) is True
+
+    def test_missing_state_fails_closed(self):
+        request = MagicMock()
+        request.state = MagicMock(spec=[])
+        assert caller_is_admin(request) is False
+
+
+# ---------------------------------------------------------------------------
+# assert_session_writable
+# ---------------------------------------------------------------------------
+
+
+def _sync_db(row):
+    db = MagicMock()
+    db.get_session = MagicMock(return_value=row)
+    return db
+
+
+class TestAssertSessionWritable:
+    """Pins the ownership predicate the run entrypoints apply before dispatching.
+
+    The rule mirrors what every adapter's ``upsert_session`` already enforces on
+    ON CONFLICT: a run may enter a session that does not exist, that is unowned,
+    or that the run's effective user already owns. Anything else is a 404.
+    """
+
+    @pytest.mark.asyncio
+    async def test_missing_session_is_allowed(self):
+        db = _sync_db(None)
+        assert await assert_session_writable(db, "s1", "user-a", session_type=SessionType.AGENT) is None
+
+    @pytest.mark.asyncio
+    async def test_owner_is_allowed(self):
+        db = _sync_db({"user_id": "user-a"})
+        assert await assert_session_writable(db, "s1", "user-a", session_type=SessionType.AGENT) is None
+
+    @pytest.mark.asyncio
+    async def test_unowned_session_is_allowed(self):
+        # user_id IS NULL is the shared case the storage predicate already admits.
+        db = _sync_db({"user_id": None})
+        assert await assert_session_writable(db, "s1", "user-a", session_type=SessionType.AGENT) is None
+
+    @pytest.mark.asyncio
+    async def test_foreign_session_raises_404(self):
+        db = _sync_db({"user_id": "user-b"})
+        with pytest.raises(HTTPException) as exc:
+            await assert_session_writable(db, "s1", "user-a", session_type=SessionType.AGENT)
+        assert exc.value.status_code == 404
+        assert exc.value.detail == SESSION_NOT_FOUND
+
+    @pytest.mark.asyncio
+    async def test_foreign_session_never_raises_403(self):
+        # 403 is spoken for on these routes by RBAC; reusing it would make
+        # "your token lacks the scope" and "that session is not yours"
+        # indistinguishable in client code.
+        db = _sync_db({"user_id": "user-b"})
+        with pytest.raises(HTTPException) as exc:
+            await assert_session_writable(db, "s1", "user-a", session_type=SessionType.AGENT)
+        assert exc.value.status_code != 403
+
+    @pytest.mark.asyncio
+    async def test_refusal_body_does_not_name_the_owner(self):
+        db = _sync_db({"user_id": "user-b"})
+        with pytest.raises(HTTPException) as exc:
+            await assert_session_writable(db, "s1", "user-a", session_type=SessionType.AGENT)
+        assert "user-b" not in str(exc.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_identity_less_caller_into_owned_session_raises_404(self):
+        # The identity-less variant: with user_id=None the read side applies no
+        # owner filter, so this caller would read the owner's whole history.
+        # An implementation that short-circuits on ``effective_user_id is None``
+        # passes every other row in this class and still leaks.
+        db = _sync_db({"user_id": "user-b"})
+        with pytest.raises(HTTPException) as exc:
+            await assert_session_writable(db, "s1", None, session_type=SessionType.AGENT)
+        assert exc.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_identity_less_caller_into_unowned_session_is_allowed(self):
+        # Dev mode and the eval suite ride this branch, not a None short-circuit.
+        db = _sync_db({"user_id": None})
+        assert await assert_session_writable(db, "s1", None, session_type=SessionType.AGENT) is None
+
+    @pytest.mark.asyncio
+    async def test_admin_bypasses_without_touching_the_db(self):
+        db = _sync_db({"user_id": "user-b"})
+        assert await assert_session_writable(db, "s1", "user-a", is_admin=True) is None
+        db.get_session.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_db_is_allowed(self):
+        assert await assert_session_writable(None, "s1", "user-a") is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("session_id", [None, ""])
+    async def test_blank_session_id_is_allowed(self, session_id):
+        db = _sync_db({"user_id": "user-b"})
+        assert await assert_session_writable(db, session_id, "user-a") is None
+        db.get_session.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_probe_does_not_filter_by_user_id(self):
+        # The probe must see the row whoever owns it. A probe scoped to the
+        # caller can never see a foreign owner, which is the whole point.
+        db = _sync_db({"user_id": "user-a"})
+        await assert_session_writable(db, "s1", "user-a", session_type=SessionType.AGENT)
+        call = db.get_session.call_args
+        assert call.kwargs.get("user_id") is None
+        # ...and not positionally either: user_id is get_session's 3rd parameter.
+        assert call.args == ()
+
+    @pytest.mark.asyncio
+    async def test_probe_is_bounded(self):
+        db = _sync_db({"user_id": "user-a"})
+        await assert_session_writable(db, "s1", "user-a", session_type=SessionType.AGENT)
+        assert db.get_session.call_args.kwargs["runs_limit"] == 1
+        assert db.get_session.call_args.kwargs["deserialize"] is False
+
+    @pytest.mark.asyncio
+    async def test_async_db_is_awaited(self):
+        db = MagicMock(spec=AsyncBaseDb)
+        db.get_session = AsyncMock(return_value={"user_id": "user-b"})
+        with pytest.raises(HTTPException) as exc:
+            await assert_session_writable(db, "s1", "user-a", session_type=SessionType.AGENT)
+        assert exc.value.status_code == 404
+        db.get_session.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_remote_db_is_skipped(self):
+        # The downstream AgentOS enforces its own ownership and already receives
+        # the forwarded bearer; a second check here needs a second round trip.
+        db = MagicMock(spec=RemoteDb)
+        assert await assert_session_writable(db, "s1", "user-a") is None
+        db.get_session.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_row_without_user_id_key_is_allowed(self):
+        # A partial row (an adapter that projects, a legacy shape) must not be
+        # read as "owned by someone else".
+        db = _sync_db({"session_id": "s1"})
+        assert await assert_session_writable(db, "s1", "user-a") is None
+
+    @pytest.mark.asyncio
+    async def test_empty_string_owner_is_treated_as_unowned(self):
+        # The session writers map "" to the component default before stamping,
+        # so a row holding "" is unclaimed. Reading it as an owner would make
+        # the session permanently unreachable for everyone.
+        db = _sync_db({"user_id": ""})
+        assert await assert_session_writable(db, "s1", "user-a") is None
+
+    @pytest.mark.asyncio
+    async def test_non_string_owner_is_not_read_as_a_foreign_owner(self):
+        # An object row whose attribute is not an id (a stub, a projection, an
+        # ORM sentinel) cannot answer the ownership question, and must not 404 a
+        # legitimate run.
+        db = _sync_db(MagicMock(spec=[]))
+        assert await assert_session_writable(db, "s1", "user-a") is None


### PR DESCRIPTION
## Summary

A run posted with a `session_id` belonging to another user was written into that session and replayed verbatim into the owner's next model context.

The framework's ownership concept is applied on the **session row** and on **history reads**, but not on the **runs table**. `upsert_session`'s ON CONFLICT carries `WHERE user_id = :uid OR user_id IS NULL` (`postgres.py:1817`, `sqlite.py:1787`), so a non-owner's session write silently no-ops and the row keeps its original owner. The non-owner's run row is then inserted into `agno_runs` with the victim's `session_id` and **no ownership predicate at all** (`postgres.py:1035`), and `get_session` re-attaches runs filtered by `session_id` alone (`_get_session_runs_data`). The owner's next run loads the intruder's turn as `from_history: true`.

`AuthorizationConfig(user_isolation=True)` did **not** close this. Isolation pins `user_id` to the verified subject; the missing check was on `session_id`. Reproduced under both settings:

```
user_isolation=False   D write -> 200   history in C's run: 4   LEAKED: True
user_isolation=True    D write -> 200   history in C's run: 4   LEAKED: True
agno_sessions: [('probe-session-1', 'user-c')]
agno_runs:     [(user-c, 0), (user-d, 0), (user-c, 2)]
```

There is a second, lower-effort variant: a run carrying **no `user_id` at all` ** skips the read-side owner filter too (`read_session` adds the `user_id` predicate only when it is not None), so the caller reads the owner's whole history in their own response, and their run row is stamped with the *owner's* id. Any implementation that treats "no identity" as "nothing to check" leaves that open.

### The fix

A new `assert_session_writable` in `agno/os/middleware/user_scope.py` enforces, at the entrypoints, the rule the storage layer already expresses:

> A run may enter session `S` when `S` does not exist, when `S.user_id` is unclaimed, or when `S.user_id` equals the run's effective `user_id`. Otherwise it is refused.

Making the run entrypoints agree with the predicate the DB already applies is a bug fix, not a policy change — which is why the guard is unconditional and needs no new config flag.

Three details are load-bearing:

- **The probe is unscoped.** It deliberately does not pass `user_id`; a probe filtered by the caller could never see a foreign owner.
- **No `effective_user_id is None` short-circuit.** An identity-less run into an *owned* session is refused (the second variant above). An identity-less run into an *unowned* session is still allowed by the `owner is unclaimed` branch, which is what keeps dev mode and the eval suite working.
- **The comparison is against the effective id** — `user_id or component.user_id` — because that is what actually stamps the session row (`agent/_session.py:64-65`, `team/_init.py:774`, `workflow.py:857`). Comparing against the raw route value would 404 the second run of every component that sets a `user_id` default.

### Nine entrypoints, not three

Every surface that takes a caller-supplied `session_id` with a server-established identity is guarded:

| Surface | Where |
|---|---|
| `POST /agents/{id}/runs` | `routers/agents/router.py` |
| `POST /teams/{id}/runs` | `routers/teams/router.py` |
| `POST /workflows/{id}/runs` | `routers/workflows/router.py` |
| MCP `run_agent` / `run_team` / `run_workflow` | `os/mcp.py` |
| Workflow WebSocket `start-workflow` | `routers/workflows/router.py` |
| A2A `message:send` / `message:stream` × agent, team, workflow | `interfaces/a2a/router.py` |
| AG-UI `POST /agui` | `interfaces/agui/router.py` |

The last three reach `arun` directly and never touch the REST routes, so a router-only fix would leave them bleeding **even under `user_isolation=True`** — the WebSocket surface in particular is mounted on every AgentOS with no feature flag (`os/app.py:699`). Each needed its guard placed carefully: A2A's handlers wrap `arun` in a blanket `except Exception` that turns anything raised inside into a **200** carrying a failed Task, and AG-UI's `run_entity` would emit the refusal as a `RunErrorEvent` inside a 200 SSE stream. Both guards sit outside those handlers so the refusal is a real 404.

### 404, not 403

`403` is already spoken for on these routes by RBAC (`require_resource_access`, and `get_scoped_user_id`'s identity-less 403), so reusing it would make "your token lacks the scope" and "that session is not yours" indistinguishable in client code. `404` also matches every other cross-user session refusal on this surface (`verify_run_in_session`, `assert_session_matches_component`, `GET /sessions/{id}`). The debuggability the 404 costs the client is recovered server-side by a `log_warning` naming the session id, the row's owner, and the caller.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`ruff format` / `ruff check` / `mypy` on the changed files — clean; the 2 remaining mypy errors in the tree are pre-existing in `os/event_streams/redis.py`, which this PR does not touch)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable) — n/a
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Tests

`libs/agno/tests/unit/os/test_user_scope_helpers.py` — `TestAssertSessionWritable` (18 cases) and `TestCallerIsAdmin`. Pins the no-op conditions, the unscoped probe (`test_probe_does_not_filter_by_user_id` checks kwargs *and* that nothing is passed positionally, since `user_id` is `get_session`'s third parameter), the bounded probe, the sync/async dispatch, the `RemoteDb` skip, and `test_foreign_session_never_raises_403`.

`libs/agno/tests/integration/os/test_user_isolation_01.py` — `TestSessionWriteOwnership` and `TestIdentityLessRunOwnership`, alongside the existing isolation regressions.

`libs/agno/tests/integration/os/test_session_write_ownership_surfaces.py` (new) — the WebSocket, A2A, AG-UI and MCP surfaces.

**Verified failing before the change and passing after** — the guard was stubbed out and the suites re-run:

```
test_user_isolation_01.py   15 failed, 5 passed   (the 5 are the no-regression guards)
surfaces.py                  7 failed, 4 passed   (the 4 are the no-regression guards)
```

The five/four that pass in both states are deliberate: owner-continues-their-own-session, brand-new-session-id, admin bypass, identity-less into an unowned session, and the component-`user_id`-default case. Those must never turn into 404s, so they guard the fix rather than the bug.

After: `3591 passed, 8 skipped` across `tests/unit/os` and `tests/integration/os` (the 8 skips are pre-existing and unchanged), including the five suites this touches: `test_user_isolation_01.py`, `test_user_isolation_02.py`, `test_per_request_isolation.py`, `test_router_user_id_threading.py`, `test_user_scope_helpers.py`.

Coverage is asserted from four angles so a partial fix cannot pass: the **wire** (404, not 200 — on `stream=true` and `stream=false` alike, as a JSON body and never an SSE frame), **storage** (`get_runs(session_id=S)` yields no foreign row), **context** (the owner's next run replays no turn they did not write), and the **identity-less** variant of all three.

---

## Additional Notes

**Behaviour changes worth a release note.**

- **PATs.** `get_scoped_user_id` self-scopes any `sa:` principal even when `user_isolation` is off, so a PAT that today continues a session a JWT user started now gets a 404. This is correct — the PAT is a different principal and was reading that user's history — but `uvx agno connect` mints exactly such tokens for Claude Code / Cursor / Codex. The remedy is to let the PAT run its own sessions (the default when `session_id` is omitted), or to mint it with admin scope, which is already the documented escape hatch.
- **MCP OAuth connectors.** claude.ai and ChatGPT authenticate as different `__oauth__:<client_id>` principals. Continuing a session started from one connector in the other becomes an explicit 404 instead of a silently-empty session.
- **Unowned sessions are claimed by the first identified writer.** A row with `user_id` unclaimed is writable by anyone — but `upsert_session` carries `user_id` in its ON CONFLICT SET list, so the first identified writer takes ownership and later writers are non-owners. That is the storage layer's existing rule, now visible at the entrypoint. `test_unowned_session_is_claimed_by_the_first_identified_writer` pins it.

**Scope honesty.** This closes the disclosure on every deployment where the run's identity is established by the server — `user_isolation=True`, and `user_isolation=False` behind JWT or a PAT, where `request.state.user_id` overrides the form field. On an **unauthenticated** AgentOS the run's `user_id` is a caller-asserted form field, so an attacker who names the victim passes; there the guard is a consistency check, not an access control. That is not a defect in the guard — an unauthenticated deployment has no identity to enforce — but it should not be sold as more than it is. The same is true of the `os_security_key` auth mode, which authenticates a shared unscoped root and sets no `user_id`.

**Deliberately out of scope** (each a separate issue):

1. **The `continue_*_run` routes.** Their only ownership check is gated behind `if scoped_user_id is not None` (`agents/router.py:1404`, `teams:1398`, `workflows:2091`), which is `None` whenever `user_isolation=False` — the default. Measured on that configuration: user-d POSTs `/agents/{id}/runs/{user-c's run_id}/continue` and gets **200**; `upsert_run`'s unpredicated ON CONFLICT rewrites the victim's row (`user_id` c→d, `status` COMPLETED→ERROR), and since `RunStatus.error` is in `HISTORY_SKIP_STATUSES` the owner's history for that session goes from 2 messages to 0. That is integrity loss rather than disclosure, it has a different fix, and it deserves its own PR and its own regression tests.
2. **A `where=` on `upsert_run`.** Defence in depth at the storage layer would need an INSERT-time owner check across every adapter, and it would silently *drop* a second participant's turn rather than refusing it.
3. **Slack multi-participant threads.** Genuinely broken today in the mirror direction — the thread session row is stamped with the first sender's `user_id`, so every later participant reads zero history while their turns still land in the thread. Untouched here, and deliberately so: `arun` has no HTTP boundary and no untrusted caller, and raising there would turn a today-works path into an exception. The repair is to create thread sessions unowned, which also means the handler must stop passing the per-participant `user_id`.
4. **Existing leaked rows.** No data-repair sweep. Note that the obvious owner-mismatch query misses the identity-less variant entirely, because those rows carry the victim's own `user_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
