### PR TITLE
fix: complete the workspace credential excludes, and stop Studio taking version 0 literally

### DIFF
--- a/libs/agno/agno/tools/_local_file_utils.py
+++ b/libs/agno/agno/tools/_local_file_utils.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from fnmatch import fnmatch
 from pathlib import Path
-from typing import Sequence
+from typing import List, Sequence, Tuple
+
+# A pattern starting with this prefix names an exemption rather than an exclusion:
+# a path component matching it is never excluded, whichever pattern it also matches.
+EXEMPT_PREFIX = "!"
 
 DEFAULT_EXCLUDE_PATTERNS = [
     # Agent and local scratch state
@@ -19,6 +23,115 @@ DEFAULT_EXCLUDE_PATTERNS = [
     "venv",
     ".env*",
     "*.env",
+    # A committed env template holds placeholders by definition and is where a repo
+    # documents its variables, so it stays readable while real env files do not.
+    # Without these the same file is served or refused depending on a leading dot:
+    # `env.example` matches neither pattern above, `.env.example` matches both.
+    "!.env.example",
+    "!.env.sample",
+    "!.env.template",
+    "!.env.dist",
+    "!example.env",
+    "!env.example",
+    # Private keys, certificates and keystores
+    "*.pem",
+    "*.key",
+    "*.crt",
+    "*.cer",
+    "*.der",
+    "*.p8",
+    "*.p12",
+    "*.pfx",
+    "*.jks",
+    "*.jceks",
+    "*.keystore",
+    "*.asc",
+    "*.gpg",
+    "*.ppk",
+    "*.kdbx",
+    "*.keytab",
+    "id_rsa*",
+    "id_dsa*",
+    "id_ecdsa*",
+    "id_ed25519*",
+    "known_hosts",
+    "authorized_keys",
+    # Directories a credential-writing CLI keeps in a home directory. Patterns match a
+    # single component and cannot name a path, so the directory is the only way to reach
+    # the files inside it (`.aws/credentials`, `.kube/config`, `.docker/config.json`).
+    ".ssh",
+    ".aws",
+    ".gnupg",
+    ".kube",
+    ".docker",
+    ".azure",
+    ".m2",
+    ".cargo",
+    ".composer",
+    # Registry, database and host tokens
+    ".npmrc",
+    ".pypirc",
+    ".netrc",
+    "_netrc",
+    ".git-credentials",
+    ".dockercfg",
+    ".pgpass",
+    ".my.cnf",
+    ".boto",
+    ".s3cfg",
+    "rclone.conf",
+    "kubeconfig",
+    ".htpasswd",
+    "htpasswd",
+    # Credential and secret data files. Deliberately not `credentials.*` or `secrets.*`:
+    # those also match ordinary source -- credentials.py, secrets.py, credentials.test.js,
+    # docs/secrets.md -- and reading source is what these toolkits exist for. Bare
+    # `credentials` is left out for the same reason: it would match a `credentials/`
+    # package directory and hide every file under it.
+    "credentials.json",
+    "credentials.yaml",
+    "credentials.yml",
+    "credentials.ini",
+    "credentials.cfg",
+    "credentials.csv",
+    "credentials.toml",
+    "credentials.xml",
+    "credentials.properties",
+    "*-credentials.json",
+    "*-credentials.yaml",
+    "*-credentials.yml",
+    "*-credentials.ini",
+    "*-credentials.csv",
+    "*_credentials.json",
+    "*_credentials.yaml",
+    "*_credentials.yml",
+    "*_credentials.csv",
+    "secret.json",
+    "secret.yaml",
+    "secret.yml",
+    "secrets.json",
+    "secrets.yaml",
+    "secrets.yml",
+    "secrets.ini",
+    "secrets.cfg",
+    "secrets.toml",
+    "secrets.properties",
+    "*-secrets.json",
+    "*-secrets.yaml",
+    "*-secrets.yml",
+    "token.json",
+    "tokens.json",
+    "accessKeys.csv",
+    "azureProfile.json",
+    # Cloud service accounts, in every spelling the providers hand out
+    "service_account*.json",
+    "serviceAccount*.json",
+    "service-account*.json",
+    "*-service-account*.json",
+    "*_service_account*.json",
+    # Terraform inputs
+    "*.tfvars",
+    "*.tfvars.json",
     # Version control
     ".git",
     ".hg",
@@ -76,12 +189,34 @@ DEFAULT_EXCLUDE_PATTERNS = [
 ]
 
 
+def split_exclude_patterns(exclude_patterns: Sequence[str]) -> Tuple[List[str], List[str]]:
+    """Split exclude patterns into the deny list and the exemption list.
+
+    An entry starting with ``!`` names an exemption: a path component matching it is
+    never excluded, whatever deny pattern it also matches. Exemptions are
+    order-independent — an exemption always wins. A bare ``!`` names no pattern and is
+    treated as a literal deny entry.
+    """
+    deny: List[str] = []
+    exempt: List[str] = []
+    for pattern in exclude_patterns:
+        if len(pattern) > 1 and pattern.startswith(EXEMPT_PREFIX):
+            exempt.append(pattern[1:])
+        else:
+            deny.append(pattern)
+    return deny, exempt
+
+
 def path_matches_exclude(path: Path, root: Path, exclude_patterns: Sequence[str]) -> bool:
-    """Return True when any path component matches an exclude pattern."""
+    """Return True when a path component matches a deny pattern and no exemption."""
     if not exclude_patterns:
         return False
     try:
         rel = path.relative_to(root)
     except ValueError:
         return False
-    return any(fnmatch(part, pattern) for part in rel.parts for pattern in exclude_patterns)
+    deny, exempt = split_exclude_patterns(exclude_patterns)
+    return any(
+        any(fnmatch(part, pattern) for pattern in deny) and not any(fnmatch(part, pattern) for pattern in exempt)
+        for part in rel.parts
+    )

--- a/libs/agno/agno/tools/file.py
+++ b/libs/agno/agno/tools/file.py
@@ -73,7 +73,10 @@ class FileTools(Toolkit):
     Each pattern is matched with ``fnmatch`` against *any path component* of the
     file's path relative to ``base_dir``. A file is excluded if any component
     matches any pattern, so ``.git`` will exclude both ``.git/`` at the root
-    and ``vendor/thing/.git/`` nested deep.
+    and ``vendor/thing/.git/`` nested deep. An entry prefixed with ``!`` is an
+    exemption: a component matching it is never excluded, whatever else it
+    matches. The defaults use this to keep committed env templates
+    (``.env.example`` and friends) listed while real env files stay hidden.
 
     Note: ``exclude_patterns`` does not parse ``.gitignore`` files — it only
     applies the literal patterns provided.

--- a/libs/agno/agno/tools/studio.py
+++ b/libs/agno/agno/tools/studio.py
@@ -109,6 +109,27 @@ _NAME_MATCH_LIMIT = 20
 _NAME_MATCH_PAGES = 10
 
 
+def _version_or_latest(version: Optional[int]) -> Optional[int]:
+    """Read a "which version" argument, treating 0 as omitted.
+
+    Version numbers start at 1, so on an argument that selects a version 0 is never
+    valid and only ever means the model defaulted an optional integer it should have
+    left out. Every such argument is documented "omit for the latest", so 0 is answered
+    the way omitting it is answered rather than with a version that does not exist.
+
+    Booleans are not versions: ``False == 0`` in Python and a lax JSON coercion can
+    deliver one, so it is refused here the same way the live-pointer guard refuses it.
+
+    This is only for arguments that name a version to act on. It must never be applied
+    to ``expected_current_version``, where 0 is the compare-and-set spelling for "I
+    expect no live version" (``agno.db.base.NO_LIVE_VERSION``) and carries a real guard.
+    """
+    if isinstance(version, bool) or version != 0:
+        return version
+    log_debug("StudioTools: version=0 is not a version; reading it as omitted (the latest).")
+    return None
+
+
 def _own_row_across_pages(list_components, actor: Optional[str], **query: Any) -> tuple:
     """(rows, total) for a name query, paged until the actor's own row is seen.
 
@@ -1753,6 +1774,7 @@ class StudioTools(Toolkit):
             steps, context flags). 'tools' lists exactly what is stored: a
             single function stays a single function, never its whole toolkit.
         """
+        version = _version_or_latest(version)
         actor = _actor_id(_agno_run_context)
         code_tiers = (
             ("agent", self._iter_agents),
@@ -2591,6 +2613,10 @@ class StudioTools(Toolkit):
         append a new version (draft, or published when ``publish``). ``warnings``
         is the list ``mutate`` appends its disclosures to; it rides on the
         success envelope."""
+        # expected_version compares against the latest stored version, and anything
+        # editable has at least v1, so 0 can only ever be a guard that no writer can
+        # satisfy -- an unset argument, not a compare-and-set the caller meant.
+        expected_version = _version_or_latest(expected_version)
         db_err = self._require_db()
         if db_err is not None:
             return db_err
@@ -3002,15 +3028,19 @@ class StudioTools(Toolkit):
             component_id (str): Exact component id.
             version (Optional[int]): The draft to publish; omit for the latest draft.
             expected_current_version (Optional[int]): Compare-and-set guard on
-                the live pointer being replaced; omit to skip the check. A
-                component that has never been published has no live pointer,
-                so on a first publish omit this or pass 0 ("nothing is live
-                yet"); any other value can never match.
+                the live pointer being replaced. Omit it unless you are
+                deliberately guarding against a concurrent publish. A component
+                that has never been published has no live pointer, so on a
+                first publish the only value that can ever match is 0.
 
         Returns:
             str: StudioResult JSON; data is {id, version}; status "published" or
             "already_published".
         """
+        # `version` names the draft to publish, so 0 reads as omitted. The
+        # expected_current_version guard beside it does NOT: 0 is its "nothing is
+        # live yet" spelling and stays a guard.
+        version = _version_or_latest(version)
         db_err = self._require_db()
         if db_err is not None:
             return db_err
@@ -3258,9 +3288,10 @@ class StudioTools(Toolkit):
             component_id (str): Exact id of a stored component. Display names
                 do not resolve for destructive operations.
             expected_current_version (Optional[int]): Compare-and-set guard on
-                the live pointer; omit to skip the check. A component that has
-                never been published has no live pointer, so pass 0 ("nothing
-                is live") or omit it; any other value can never match.
+                the live pointer. Omit it unless you are deliberately guarding
+                against a concurrent write. A component that has never been
+                published has no live pointer, so for one of those the only
+                value that can ever match is 0.
 
         Returns:
             str: StudioResult JSON; data is {id}; warnings report side effects.
@@ -3402,6 +3433,7 @@ class StudioTools(Toolkit):
             valid: true} on success; validation_failed carries the exact
             problem otherwise.
         """
+        version = _version_or_latest(version)
         row, resolved_id, err = self._component_row(component_id, _actor_id(_agno_run_context))
         if err is not None:
             return err
@@ -3503,6 +3535,7 @@ class StudioTools(Toolkit):
         caller_agent: Any = None,
         caller_team: Any = None,
     ) -> str:
+        version = _version_or_latest(version)
         runner_calls = {
             "agent": self._runner_tools.run_agent,
             "team": self._runner_tools.run_team,
@@ -3582,6 +3615,7 @@ class StudioTools(Toolkit):
         run being pushed to a thread; only the sync DB reads are off-loaded."""
         import asyncio
 
+        version = _version_or_latest(version)
         runner_calls = {
             "agent": self._runner_tools.arun_agent,
             "team": self._runner_tools.arun_team,

--- a/libs/agno/agno/tools/workspace.py
+++ b/libs/agno/agno/tools/workspace.py
@@ -34,7 +34,7 @@ from typing import Dict, List, Optional, Set, Tuple, Union
 
 from agno.exceptions import PathSecurityError
 from agno.tools import Toolkit
-from agno.tools._local_file_utils import DEFAULT_EXCLUDE_PATTERNS
+from agno.tools._local_file_utils import DEFAULT_EXCLUDE_PATTERNS, EXEMPT_PREFIX, split_exclude_patterns
 from agno.utils.log import log_debug, log_error, log_info, log_warning
 from agno.utils.path_safety import safe_join_relative_path
 
@@ -56,6 +56,12 @@ TEXT_EXTENSIONS = {
     ".ini",
     ".env",
     ".editorconfig",
+    # Committed template suffixes: `.env.example` has suffix `.example`, so without
+    # these search_content skips the very files the exclude exemptions make readable.
+    ".example",
+    ".sample",
+    ".template",
+    ".dist",
     # Python
     ".py",
     ".pyi",
@@ -191,10 +197,16 @@ def _validate_exclude_patterns(exclude_patterns: Optional[List[str]]) -> List[st
     """Return ``exclude_patterns`` as a list, or the defaults when ``None``.
 
     Raises ``ValueError`` for a pattern containing a path separator: patterns are matched
-    against single path components, so such a pattern can never match.
+    against single path components, so such a pattern can never match. Also raises for a
+    bare ``!``, which names no pattern to exempt.
     """
     patterns = list(exclude_patterns) if exclude_patterns is not None else list(DEFAULT_EXCLUDE_PATTERNS)
     for pattern in patterns:
+        if pattern == EXEMPT_PREFIX:
+            raise ValueError(
+                "exclude_patterns entry '!' names no pattern. A leading '!' exempts the rest of the "
+                "entry from exclusion, for example '!.env.example'."
+            )
         if "/" in pattern or "\\" in pattern:
             raise ValueError(
                 f"exclude_patterns entry {pattern!r} contains a path separator. Patterns are matched against "
@@ -318,8 +330,22 @@ class Workspace(Toolkit):
     containing a path separator raises ``ValueError``. Hard links to an excluded file are
     not detected. The default set covers common noise directories
     (``.venv``, ``.venvs``, ``.context``, ``.git``, ``__pycache__``, ``node_modules``,
-    etc.) and env files (``.env*``, ``*.env``). Pass ``exclude_patterns=[...]`` to
-    override, or ``exclude_patterns=[]`` to disable.
+    etc.), env files (``.env*``, ``*.env``) and the credential files a repository or a
+    home directory conventionally holds — private keys and keystores (``*.pem``,
+    ``*.key``, ``id_rsa*``), credential directories (``.ssh``, ``.aws``, ``.kube``),
+    registry and host tokens (``.npmrc``, ``.netrc``, ``.git-credentials``), credential
+    data files (``credentials.json``, ``secrets.yaml``, ``service_account*.json``) and
+    Terraform inputs (``*.tfvars``). Deliberately absent are ``credentials.*`` and
+    ``secrets.*``, which would also refuse ordinary source such as ``credentials.py``.
+    Pass ``exclude_patterns=[...]`` to override, or ``exclude_patterns=[]`` to disable.
+
+    An entry prefixed with ``!`` is an exemption: a component matching it is never
+    excluded, whatever else it matches. The defaults use this to keep committed env
+    templates readable (``!.env.example``, ``!.env.sample``, ``!.env.template``,
+    ``!.env.dist``, ``!example.env``, ``!env.example``) while real env files stay
+    refused. Exemptions are order-independent and always win; a bare ``!`` raises
+    ``ValueError``. To drop them, filter the defaults:
+    ``[p for p in DEFAULT_EXCLUDE_PATTERNS if not p.startswith("!")]``.
 
     ``allow_paths`` names workspace-relative files or directories that stay visible and
     reachable even when they match an exclude pattern, for example ``[".env.example"]``.
@@ -380,6 +406,11 @@ class Workspace(Toolkit):
         # Components below root of each allow_paths entry, as written and resolved; rebuilt when allow_paths changes.
         self._allow_snapshot: Optional[Tuple[str, ...]] = None
         self._allowed_parts: List[Tuple[str, ...]] = []
+        # Deny/exempt halves of exclude_patterns; rebuilt when exclude_patterns changes.
+        # exclude_patterns is public and mutable, so this cannot be a one-shot __init__ split.
+        self._pattern_snapshot: Optional[Tuple[str, ...]] = None
+        self._deny_patterns: List[str] = []
+        self._exempt_patterns: List[str] = []
         # Whether names that differ only by case are the same entry on root's filesystem.
         self._fold_case: Optional[bool] = None
         # Tracks which paths have been read this session — used by require_read_before_write.
@@ -508,6 +539,21 @@ class Workspace(Toolkit):
             return fnmatchcase(part.casefold(), pattern.casefold())
         return fnmatch(part, pattern)
 
+    def _split_patterns(self) -> Tuple[List[str], List[str]]:
+        """Deny and exempt halves of ``exclude_patterns``, recomputed when it changes."""
+        snapshot = tuple(self.exclude_patterns)
+        if snapshot != self._pattern_snapshot:
+            self._deny_patterns, self._exempt_patterns = split_exclude_patterns(snapshot)
+            self._pattern_snapshot = snapshot
+        return self._deny_patterns, self._exempt_patterns
+
+    def _component_excluded(self, part: str) -> bool:
+        """Whether one path component is excluded: it matches a deny pattern and no exemption."""
+        deny, exempt = self._split_patterns()
+        if not any(self._matches(part, pattern) for pattern in deny):
+            return False
+        return not any(self._matches(part, pattern) for pattern in exempt)
+
     def _relative_parts(self, path: Path) -> Optional[Tuple[str, ...]]:
         """Components of ``path`` below ``root``, or ``None`` when ``path`` is not under ``root``."""
         try:
@@ -531,6 +577,7 @@ class Workspace(Toolkit):
     def _is_excluded(self, path: Path) -> bool:
         """Return True if a component of ``path`` below ``root`` matches an exclude pattern.
 
+        A component matching a ``!``-prefixed entry is exempt and never excluded.
         Components at or above an ``allow_paths`` entry covering ``path`` are not tested;
         components beneath a directory entry still are. On a case-insensitive filesystem
         patterns and ``allow_paths`` match case-insensitively.
@@ -538,12 +585,12 @@ class Workspace(Toolkit):
         parts = self._relative_parts(path)
         if not parts or not self.exclude_patterns:
             return False
-        if not any(self._matches(part, pattern) for part in parts for pattern in self.exclude_patterns):
+        if not any(self._component_excluded(part) for part in parts):
             return False
         depth = self._allowed_depth(parts)
         if depth == 0:
             return True
-        return any(self._matches(part, pattern) for part in parts[depth:] for pattern in self.exclude_patterns)
+        return any(self._component_excluded(part) for part in parts[depth:])
 
     def _hidden(self, entry: Path) -> bool:
         """Return True if a listing or search must skip ``entry``.

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -224,6 +224,7 @@ markdown = ["unstructured<0.18.31", "nltk!=3.10.1", "markdown", "aiofiles"]
 pdf = ["pypdf", "rapidocr_onnxruntime"]
 pptx = ["python-pptx"]
 text = ["aiofiles"]
+website = ["beautifulsoup4"]
 
 # Dependencies for AG-UI integration
 agui = ["ag-ui-protocol>=0.1.15", "jsonpatch>=1.33"]
@@ -383,6 +384,7 @@ knowledge = [
   "agno[pdf]",
   "agno[pptx]",
   "agno[text]",
+  "agno[website]",
 ]
 
 # All embedders

--- a/libs/agno/tests/unit/tools/test_filetools.py
+++ b/libs/agno/tests/unit/tools/test_filetools.py
@@ -416,6 +416,39 @@ def test_default_excludes_env_family():
         assert listed == ["env.yaml", "environment.py", "keep.txt"]
 
 
+def test_default_excludes_credential_files():
+    """The default list is shared with Workspace, where it is an access boundary."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        file_tools = FileTools(base_dir=base_dir)
+
+        for name in ("id_rsa", "server.pem", "credentials.json", "secrets.yaml", ".npmrc", "terraform.tfvars"):
+            (base_dir / name).write_text("SECRET=1")
+        # Ordinary source with a credential-shaped name stays visible: the patterns are
+        # deliberately not `credentials.*` / `secrets.*`.
+        for name in ("credentials.py", "secrets.py", "key.py", "keep.txt"):
+            (base_dir / name).write_text("import os")
+
+        listed = sorted(json.loads(file_tools.list_files()))
+        assert listed == ["credentials.py", "keep.txt", "key.py", "secrets.py"]
+
+
+def test_default_excludes_keep_committed_env_templates_visible():
+    """A '!' entry exempts a component from every exclude pattern."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        file_tools = FileTools(base_dir=base_dir)
+
+        (base_dir / ".env").write_text("SECRET=1")
+        (base_dir / ".env.production").write_text("SECRET=2")
+        (base_dir / ".env.example").write_text("OPENAI_API_KEY=")
+        (base_dir / ".env.sample").write_text("OPENAI_API_KEY=")
+        (base_dir / "example.env").write_text("OPENAI_API_KEY=")
+
+        listed = sorted(json.loads(file_tools.list_files()))
+        assert listed == [".env.example", ".env.sample", "example.env"]
+
+
 def test_default_excludes_agent_scratch_and_plural_venvs():
     with tempfile.TemporaryDirectory() as tmp_dir:
         base_dir = Path(tmp_dir)

--- a/libs/agno/tests/unit/tools/test_studio.py
+++ b/libs/agno/tests/unit/tools/test_studio.py
@@ -2376,6 +2376,166 @@ class TestVersioning:
 
 
 # ----------------------------------------------------------------------
+# version: 0 -- models fill an Optional[int] documented "omit for the
+# latest" with 0. Versions start at 1, so on a "which version" argument 0
+# only ever means "unset"; on the expected_current_version guard it means
+# "nothing is live" and must keep meaning that.
+# ----------------------------------------------------------------------
+
+
+class TestVersionZero:
+    def _published(self, studio, name="tutor"):
+        studio.create_agent(name=name, instructions="orig", model_id="gpt-5.4", publish=True)
+
+    def test_get_component_treats_version_zero_as_latest(self, studio):
+        """0 reads like an omitted argument instead of failing version_not_found."""
+        self._published(studio)
+        data = _data(studio.get_component("tutor", version=0))
+        assert data["version"] == 1
+        assert data["instructions"] == "orig"
+
+    def test_get_component_version_zero_matches_omitting_it(self, studio):
+        """Same answer as the documented spelling, drafts included."""
+        self._published(studio)
+        studio.edit_agent("tutor", instructions="updated")
+        assert _data(studio.get_component("tutor", version=0)) == _data(studio.get_component("tutor"))
+
+    def test_explicit_version_still_pins(self, studio):
+        """The coercion is for 0 alone: a real version still selects itself."""
+        self._published(studio)
+        studio.edit_agent("tutor", instructions="updated")
+        assert _data(studio.get_component("tutor", version=1))["instructions"] == "orig"
+        assert _data(studio.get_component("tutor", version=2))["instructions"] == "updated"
+
+    def test_negative_version_is_still_an_error(self, studio):
+        """-1 is a wrong number, not an unset argument; it must not be coerced."""
+        self._published(studio)
+        assert _error(studio.get_component("tutor", version=-1))["code"] == "version_not_found"
+
+    def test_unknown_version_is_still_an_error(self, studio):
+        self._published(studio)
+        assert _error(studio.get_component("tutor", version=99))["code"] == "version_not_found"
+
+    @pytest.mark.asyncio
+    async def test_aget_component_treats_version_zero_as_latest(self, studio):
+        self._published(studio)
+        assert _data(await studio.aget_component("tutor", version=0))["version"] == 1
+
+    def test_publish_component_treats_version_zero_as_latest_draft(self, studio):
+        """publish_component(version=0) publishes the newest draft, the same
+        as omitting it, instead of failing version_not_found."""
+        self._published(studio)
+        studio.edit_agent("tutor", instructions="updated")
+        assert _data(studio.publish_component("tutor", version=0))["version"] == 2
+
+    @pytest.mark.asyncio
+    async def test_apublish_component_treats_version_zero_as_latest_draft(self, studio):
+        self._published(studio)
+        studio.edit_agent("tutor", instructions="updated")
+        assert _data(await studio.apublish_component("tutor", version=0))["version"] == 2
+
+    def test_validate_component_treats_version_zero_as_latest(self, studio):
+        studio.create_agent(name="clean", instructions="i", model_id="gpt-5.4")
+        data = _data(studio.validate_component("clean", version=0))
+        assert data["valid"] is True
+        assert data["version"] == 1
+
+    @pytest.mark.asyncio
+    async def test_avalidate_component_treats_version_zero_as_latest(self, studio):
+        studio.create_agent(name="clean", instructions="i", model_id="gpt-5.4")
+        assert _data(await studio.avalidate_component("clean", version=0))["version"] == 1
+
+    @pytest.mark.parametrize("tool_name", ["edit_agent", "edit_team", "edit_workflow"])
+    def test_edit_expected_version_zero_is_treated_as_unset(self, studio, tool_name):
+        """expected_version compares against the LATEST version, which is at
+        least 1 for anything editable, so 0 could only ever be a failed CAS
+        against a component the caller meant to edit unguarded."""
+        studio.create_agent(name="member", instructions="m", model_id="gpt-5.4", publish=True)
+        targets = {
+            "edit_agent": lambda: studio.create_agent(name="cas", instructions="i", model_id="gpt-5.4"),
+            "edit_team": lambda: studio.create_team(name="cas", instructions="i", member_ids=["member"]),
+            "edit_workflow": lambda: studio.create_workflow(name="cas", steps=[{"name": "s1", "agent_id": "member"}]),
+        }
+        targets[tool_name]()
+        data = _data(getattr(studio, tool_name)("cas", description="second", expected_version=0))
+        assert data["draft_version"] == 2
+
+    def test_edit_expected_version_still_guards(self, studio):
+        """The coercion must not blunt a real compare-and-set."""
+        studio.create_agent(name="cas", instructions="i", model_id="gpt-5.4")
+        assert _error(studio.edit_agent("cas", description="x", expected_version=7))["code"] == "version_conflict"
+        assert _data(studio.edit_agent("cas", description="x", expected_version=1))["draft_version"] == 2
+
+    @pytest.mark.asyncio
+    async def test_aedit_agent_expected_version_zero_is_treated_as_unset(self, studio):
+        studio.create_agent(name="cas", instructions="i", model_id="gpt-5.4")
+        assert _data(await studio.aedit_agent("cas", description="x", expected_version=0))["draft_version"] == 2
+
+    def test_run_agent_version_zero_dispatches_unpinned(self, studio, monkeypatch):
+        """The run tools take the same "omit for the latest" argument. 0 must
+        reach the ordinary dispatch, not the exact-version preview path that
+        answers version_not_found."""
+        studio.create_agent(name="member", instructions="m", model_id="gpt-5.4", publish=True)
+        seen = []
+
+        def _runner(identifier, message, **kwargs):
+            seen.append((identifier, message))
+            return json.dumps({"agent_id": identifier, "content": "ok"})
+
+        monkeypatch.setattr(studio._runner_tools, "run_agent", _runner)
+        out = _loads(studio.run_agent("member", "hi", version=0))
+        assert seen == [("member", "hi")]
+        assert out["content"] == "ok"
+
+    @pytest.mark.asyncio
+    async def test_arun_agent_version_zero_dispatches_unpinned(self, studio, monkeypatch):
+        """The async twin has its own dispatch body, so it needs its own pin."""
+        studio.create_agent(name="member", instructions="m", model_id="gpt-5.4", publish=True)
+        seen = []
+
+        async def _runner(identifier, message, **kwargs):
+            seen.append((identifier, message))
+            return json.dumps({"agent_id": identifier, "content": "ok"})
+
+        monkeypatch.setattr(studio._runner_tools, "arun_agent", _runner)
+        out = _loads(await studio.arun_agent("member", "hi", version=0))
+        assert seen == [("member", "hi")]
+        assert out["content"] == "ok"
+
+    def test_run_agent_explicit_version_still_previews(self, studio):
+        """Guard against the coercion swallowing a real pin."""
+        studio.create_agent(name="member", instructions="m", model_id="gpt-5.4", publish=True)
+        assert _error(studio.run_agent("member", "hi", version=9))["code"] == "version_not_found"
+
+    def test_first_publish_guard_zero_still_means_nothing_is_live(self, studio):
+        """expected_current_version is NOT a "which version" argument: 0 is
+        the documented "I expect no live version" guard and stays a guard."""
+        studio.create_agent(name="tutor", instructions="i", model_id="gpt-5.4")
+        assert _data(studio.publish_component("tutor", version=1, expected_current_version=0))["version"] == 1
+
+    def test_archive_guard_zero_still_conflicts_against_a_live_pointer(self, studio):
+        """The counterpart: 0 against a published component is a real
+        conflict, not a skipped check."""
+        self._published(studio)
+        error = _error(studio.archive_component("tutor", expected_current_version=0))
+        assert error["code"] == "version_conflict"
+        assert studio.db.get_component("tutor") is not None
+
+    def test_required_version_argument_rejects_zero(self, studio):
+        """set_current_version and delete_version name a version to act on and
+        have no "latest" default, so 0 stays the error it is."""
+        self._published(studio)
+        assert _error(studio.set_current_version("tutor", 0))["code"] == "version_not_found"
+        assert _error(studio.delete_version("tutor", 0))["code"] == "version_not_found"
+
+    def test_version_zero_coercion_does_not_swallow_false(self, studio):
+        """False == 0 in Python but a boolean is not an omitted version; the
+        sentinel helper already refuses it and the coercion must too."""
+        self._published(studio)
+        assert _error(studio.get_component("tutor", version=False))["code"] == "version_not_found"
+
+
+# ----------------------------------------------------------------------
 # Validation (dry-run rebuild)
 # ----------------------------------------------------------------------
 

--- a/libs/agno/tests/unit/tools/test_workspace.py
+++ b/libs/agno/tests/unit/tools/test_workspace.py
@@ -1292,3 +1292,308 @@ def test_allow_paths_does_not_cover_siblings_or_parents():
         assert "ok" in ws.read_file(".venv/lib/ok.py")
         assert ws.read_file(".venv/pyvenv.cfg") == "Error: path is excluded from this workspace: .venv/pyvenv.cfg"
         assert ws.list_files(".venv") == "Error: directory is excluded from this workspace: .venv"
+
+
+# ------------------------------------------------------------------
+# Default credential excludes: the default list is the access boundary
+# ------------------------------------------------------------------
+
+# Files a real repository or home directory conventionally keeps credentials in.
+CREDENTIAL_PATHS = [
+    "id_rsa",
+    "id_rsa.pub",
+    "id_dsa",
+    "id_ecdsa",
+    "id_ed25519",
+    "server.pem",
+    "private.key",
+    "server.crt",
+    "ca.cer",
+    "ca.der",
+    "signing.p8",
+    "cert.p12",
+    "cert.pfx",
+    "keystore.jks",
+    "store.jceks",
+    "my.keystore",
+    "privkey.asc",
+    "private.gpg",
+    "server.ppk",
+    "vault.kdbx",
+    "krb5.keytab",
+    "known_hosts",
+    "authorized_keys",
+    ".npmrc",
+    ".pypirc",
+    ".netrc",
+    "_netrc",
+    ".git-credentials",
+    ".dockercfg",
+    ".pgpass",
+    ".my.cnf",
+    ".boto",
+    ".s3cfg",
+    "rclone.conf",
+    "kubeconfig",
+    ".htpasswd",
+    "htpasswd",
+    "credentials.json",
+    "credentials.yaml",
+    "credentials.yml",
+    "credentials.ini",
+    "credentials.cfg",
+    "credentials.csv",
+    "credentials.toml",
+    "credentials.xml",
+    "credentials.properties",
+    "aws-credentials.json",
+    "db_credentials.yaml",
+    "application_default_credentials.json",
+    "secret.json",
+    "secret.yaml",
+    "secret.yml",
+    "secrets.json",
+    "secrets.yaml",
+    "secrets.yml",
+    "secrets.ini",
+    "secrets.cfg",
+    "secrets.toml",
+    "secrets.properties",
+    "app-secrets.yaml",
+    "token.json",
+    "tokens.json",
+    "accessKeys.csv",
+    "azureProfile.json",
+    "service_account.json",
+    "service_account_key.json",
+    "serviceAccount.json",
+    "serviceAccountKey.json",
+    "service-account.json",
+    "gcp-service-account.json",
+    "terraform.tfvars",
+    "prod.tfvars.json",
+    ".ssh/id_ed25519",
+    ".aws/credentials",
+    ".gnupg/secring.gpg",
+    ".kube/config",
+    ".docker/config.json",
+    ".azure/azureProfile.json",
+    ".m2/settings.xml",
+    ".cargo/credentials.toml",
+    ".composer/auth.json",
+    "config/credentials.json",
+]
+
+# Ordinary source and documentation. A workspace toolkit exists to read these, and the
+# obvious `credentials.*` / `secrets.*` spelling of the patterns above would refuse them.
+SOURCE_PATHS = [
+    "credentials.py",
+    "credentials.ts",
+    "credentials.go",
+    "credentials.rs",
+    "credentials.md",
+    "credentials.test.js",
+    "credentials_test.go",
+    "secrets.py",
+    "secrets.ts",
+    "secrets.tf",
+    "secrets.md",
+    "secrets_manager.py",
+    "aws-credentials.md",
+    "app/auth/credentials.py",
+    "docs/secrets.md",
+    "src/credentials/loader.py",
+    "lib/credentials/__init__.py",
+    "keystore.py",
+    "keystore/index.ts",
+    "key.py",
+    "keys.py",
+    "cert.ts",
+    "pem.md",
+    "crt.go",
+    "docs/keys.md",
+    "terraform.tfvars.example",
+]
+
+# Committed env templates: placeholders by definition, and where a repo documents its
+# environment variables.
+ENV_TEMPLATES = [
+    ".env.example",
+    ".env.sample",
+    ".env.template",
+    ".env.dist",
+    "example.env",
+    "env.example",
+    "packages/api/.env.example",
+]
+
+ENV_SECRETS = [".env", ".env.local", ".env.production", ".env.development", ".env.vault", ".envrc"]
+
+
+def _write(base: Path, rel: str, content: str) -> Path:
+    path = base / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    return path
+
+
+@pytest.mark.parametrize("rel", CREDENTIAL_PATHS)
+def test_default_excludes_block_conventional_credential_files(rel):
+    """Since exclusion refuses reads, the default list is the control. Content must not
+    reach the tool result through any of the three read surfaces."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = Path(tmp_dir).resolve()
+        _write(base, rel, "ZQMARKER-SECRET\n")
+        ws = Workspace(tmp_dir)
+
+        assert ws.read_file(rel) == f"Error: path is excluded from this workspace: {rel}"
+        assert "ZQMARKER-SECRET" not in ws.read_file(rel)
+        listed = [e["path"] for e in json.loads(ws.list_files(recursive=True))["files"]]
+        assert rel not in listed
+        found = json.loads(ws.search_content("ZQMARKER-SECRET"))
+        assert found["matches_found"] == 0
+
+
+@pytest.mark.parametrize("rel", SOURCE_PATHS)
+def test_default_excludes_do_not_block_source_files(rel):
+    """The trap: `credentials.*` and `secrets.*` are the obvious spelling and would
+    refuse every one of these. A bare `credentials` entry would take the two package
+    directories with it."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = Path(tmp_dir).resolve()
+        _write(base, rel, "ZQMARKER-SOURCE\n")
+        ws = Workspace(tmp_dir)
+
+        assert "ZQMARKER-SOURCE" in ws.read_file(rel)
+        listed = [e["path"] for e in json.loads(ws.list_files(recursive=True))["files"]]
+        assert rel in listed
+
+
+def test_credential_refusal_covers_every_path_spelling():
+    """A refusal that only knows the bare name is not a boundary."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = Path(tmp_dir).resolve()
+        _write(base, "credentials.json", "ZQMARKER-SECRET\n")
+        _write(base, "src/app.py", "print('app')\n")
+        ws = Workspace(tmp_dir, allowed=Workspace.ALL_TOOLS)
+
+        for spelling in (
+            "credentials.json",
+            "./credentials.json",
+            "src/../credentials.json",
+            str(base / "credentials.json"),
+        ):
+            out = ws.read_file(spelling)
+            assert out == f"Error: path is excluded from this workspace: {spelling}"
+            assert "ZQMARKER-SECRET" not in out
+        assert ws.write_file("credentials.json", "X").startswith("Error: path is excluded")
+        assert ws.delete_file("credentials.json").startswith("Error: path is excluded")
+
+
+def test_credential_directories_are_refused_as_directories():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = Path(tmp_dir).resolve()
+        _write(base, ".ssh/id_ed25519", "ZQMARKER-SECRET\n")
+        ws = Workspace(tmp_dir)
+        assert ws.list_files(".ssh") == "Error: directory is excluded from this workspace: .ssh"
+        assert ws.search_content("ZQMARKER", directory=".ssh") == (
+            "Error: directory is excluded from this workspace: .ssh"
+        )
+
+
+def test_allow_paths_still_re_admits_an_excluded_credential_file():
+    """The escape hatch for anyone whose agent legitimately reads one of these."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = Path(tmp_dir).resolve()
+        _write(base, "credentials.json", "ZQMARKER-ALLOWED\n")
+        _write(base, "secrets.yaml", "ZQMARKER-STILL-BLOCKED\n")
+        ws = Workspace(tmp_dir, allow_paths=["credentials.json"])
+        assert "ZQMARKER-ALLOWED" in ws.read_file("credentials.json")
+        assert ws.read_file("secrets.yaml") == "Error: path is excluded from this workspace: secrets.yaml"
+
+
+# ------------------------------------------------------------------
+# Exemptions: "!" entries keep committed env templates readable
+# ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("rel", ENV_TEMPLATES)
+def test_committed_env_templates_are_readable(rel):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = Path(tmp_dir).resolve()
+        _write(base, rel, "OPENAI_API_KEY=\n")
+        ws = Workspace(tmp_dir)
+
+        assert "OPENAI_API_KEY" in ws.read_file(rel)
+        listed = [e["path"] for e in json.loads(ws.list_files(recursive=True))["files"]]
+        assert rel in listed
+        assert json.loads(ws.search_content("OPENAI_API_KEY"))["matches_found"] == 1
+
+
+@pytest.mark.parametrize("rel", ENV_SECRETS)
+def test_real_env_files_stay_blocked(rel):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = Path(tmp_dir).resolve()
+        _write(base, rel, "OPENAI_API_KEY=sk-live-secret\n")
+        ws = Workspace(tmp_dir)
+        assert ws.read_file(rel) == f"Error: path is excluded from this workspace: {rel}"
+        assert json.loads(ws.search_content("sk-live-secret"))["matches_found"] == 0
+
+
+def test_exemption_does_not_reach_inside_an_excluded_directory():
+    """An exemption clears the component it names, not the directory above it."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = Path(tmp_dir).resolve()
+        _write(base, ".venv/cfg/.env.example", "OPENAI_API_KEY=\n")
+        ws = Workspace(tmp_dir)
+        assert ws.read_file(".venv/cfg/.env.example") == (
+            "Error: path is excluded from this workspace: .venv/cfg/.env.example"
+        )
+
+
+def test_exemptions_can_be_dropped_by_filtering_the_defaults():
+    from agno.tools._local_file_utils import DEFAULT_EXCLUDE_PATTERNS
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = Path(tmp_dir).resolve()
+        _write(base, ".env.example", "OPENAI_API_KEY=\n")
+        strict = [p for p in DEFAULT_EXCLUDE_PATTERNS if not p.startswith("!")]
+        ws = Workspace(tmp_dir, exclude_patterns=strict)
+        assert ws.read_file(".env.example") == "Error: path is excluded from this workspace: .env.example"
+
+
+def test_custom_exclude_patterns_get_no_exemptions_they_did_not_ask_for():
+    """You took control: the surface is exactly what you specified."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = Path(tmp_dir).resolve()
+        _write(base, ".env.example", "OPENAI_API_KEY=\n")
+        ws = Workspace(tmp_dir, exclude_patterns=[".env*"])
+        assert ws.read_file(".env.example") == "Error: path is excluded from this workspace: .env.example"
+
+
+def test_bare_exemption_prefix_is_rejected():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        with pytest.raises(ValueError, match="names no pattern"):
+            Workspace(tmp_dir, exclude_patterns=["!"])
+
+
+def test_exemption_wins_regardless_of_order():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = Path(tmp_dir).resolve()
+        _write(base, "keep.json", "ZQMARKER\n")
+        after = Workspace(tmp_dir, exclude_patterns=["*.json", "!keep.json"])
+        before = Workspace(tmp_dir, exclude_patterns=["!keep.json", "*.json"])
+        assert "ZQMARKER" in after.read_file("keep.json")
+        assert "ZQMARKER" in before.read_file("keep.json")
+
+
+def test_mutating_exclude_patterns_after_construction_takes_effect():
+    """exclude_patterns is public and mutable, so the deny/exempt split cannot be a
+    one-shot snapshot taken in __init__."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = Path(tmp_dir).resolve()
+        _write(base, ".env.example", "OPENAI_API_KEY=\n")
+        ws = Workspace(tmp_dir)
+        assert "OPENAI_API_KEY" in ws.read_file(".env.example")
+        ws.exclude_patterns = [".env*"]
+        assert ws.read_file(".env.example") == "Error: path is excluded from this workspace: .env.example"


### PR DESCRIPTION
## Summary

Two independent defects from the 1,386-probe sweep against 3.0.0a4, plus a packaging gap. Every claim below was measured against the live toolkit at this branch's base.

### 1. `DEFAULT_EXCLUDE_PATTERNS` became a security control and was incomplete

#9730 made `exclude_patterns` refuse reads, not just filter listings. That made the default list the control — and it covered only `.env*` and build directories. Measured on the live toolkit: **41 of 42** conventional credential files read fine, including `id_rsa`, `.ssh/id_ed25519`, `.aws/credentials`, `*.pem`, `.npmrc`, `.netrc`, `credentials.json`, `secrets.yaml`, `service_account.json` and `*.tfvars`. Content reaches the tool result, the persisted run row and `/sessions/{id}/runs`, and `search_content` surfaces it with no agent decision at all.

The list now covers private keys and keystores, credential directories (`.ssh`, `.aws`, `.gnupg`, `.kube`, `.docker`, `.azure`, `.m2`, `.cargo`, `.composer`), registry/host/database tokens, credential data files, cloud service accounts in every spelling, and Terraform inputs.

**The patterns are deliberately not `credentials.*` / `secrets.*`.** Measured, that spelling refuses `credentials.py`, `secrets.py`, `credentials.test.js`, `docs/secrets.md` — 12 of 20 realistic source filenames — and a workspace toolkit exists to read source. It also *misses* more than it catches (26 of 42 credential files still read). `test_default_excludes_do_not_block_source_files` pins that trap.

Bare `credentials` is left out for the same reason: it matches a **directory** component, so a `credentials/` package would disappear entirely (the Anthropic Python SDK ships one). `.aws` covers the real `.aws/credentials` case.

### 2. `.env*` refused every committed env template

| Path | Before | After |
|---|---|---|
| `.env`, `.env.local`, `.env.production`, `.envrc`, `.env.vault` | refused | refused |
| `.env.example`, `.env.sample`, `.env.template`, `.env.dist`, `example.env` | **refused** | readable |
| `env.example` | readable | readable |

The last row was the tell: the same file readable or not depending on a leading dot. Templates hold placeholders by definition and are where a repo documents its variables.

`fnmatch` has no alternation and patterns match a single path component, so **no positive pattern can carve the templates out of `.env*`** — an exhaustive search over 87,164 candidate patterns of that shape found zero that block every real env file without leaking a template. `.env.[!est]*` leaks `.env.dist`; adding `d` un-blocks `.env.development`.

So `exclude_patterns` now understands a leading `!` as an **exemption**: a component matching it is never excluded, whatever else it matches. Exemptions are order-independent, travel with whatever list is in force (a custom `exclude_patterns` gets none it did not ask for), and are dropped with `[p for p in DEFAULT_EXCLUDE_PATTERNS if not p.startswith("!")]`. A bare `"!"` raises `ValueError`. The `!` namespace was measured unclaimed — zero occurrences across `libs/` and `cookbook/`.

`.example`, `.sample`, `.template` and `.dist` join `TEXT_EXTENSIONS`, because `Path(".env.example").suffix == ".example"` and without them `search_content` would skip the very files the exemptions make readable.

### 3. Studio took `version: 0` literally

Models fill `version: Optional[int] = None` documented "omit for the latest" with `0`: measured **22/58** `get_component`, **10/13** `archive_component`, **4/4** `publish_component`. Versions start at 1, so nothing matched and the call failed — aborting valid work, and on the confirmation-gated `archive_component` failing *after* a human had already approved. Three separate prompt framings failed to stop it; a prompt is a weak control against a defaulted optional integer.

Arguments that **name a version to act on** now read `0` as omitted: `get_component`, `publish_component`, `validate_component`, `run_agent`/`run_team`/`run_workflow`, plus `expected_version` on `edit_agent`/`edit_team`/`edit_workflow` — and every async twin (`_arun_component` has its own dispatch body, so it needs its own coercion). An explicit version still pins; a negative version is still an error; `set_current_version`/`delete_version` take a required `version` with no "latest" default, so `0` stays the error it is.

> [!IMPORTANT]
> **`expected_current_version` is deliberately NOT coerced, contrary to the spec's AC1.** #9728 (merged the day before the spec was written) shipped `NO_LIVE_VERSION = 0` in `agno/db/base.py:107` — `0` is the compare-and-set spelling for "I expect no live version", and both docstrings instructed the model to pass it. Coercing it to `None` removes the SQL predicate entirely (every adapter site is wrapped in `if expected_current_version is not None:`), so a guarded first publish becomes an unguarded write.
>
> Probed: with `ecv=0`, writer B publishing over writer A gets `version_conflict` and the pointer stays at 1; coerced, B silently clobbers A and the pointer moves to 2. Same shape on `archive_component` (`deleted_at` set) and `set_current_version` (unguarded rollback). Twelve existing tests pin this behaviour, including `test_first_publish_guard_zero_is_a_real_guard` ("0 is not 'skip the check'") and `test_archive_guard_on_published_component_is_a_real_conflict` — which is precisely the interaction the spec reports as a bug.
>
> Instead, the two docstrings that actively invited `pass 0` now lead with omitting it. That is the only lever left for the burned-approval path, and its benefit is **unmeasured** — see Additional Notes.

### 4. Packaging: `beautifulsoup4` was never declared

The `website` and `llms_txt` readers import `bs4` at module level and no extra declared it. It arrived only *transitively*, via `docling-slim[standard]` and `unstructured` under `agno[knowledge]` — so the addendum's "`pip install agno[knowledge]` cannot ingest a URL" is **false today**, but the capability rests on two unrelated packages' dependency choices. Now declared as a `website` extra, included in `knowledge`. A bare requirement matches house style (158 of 205 requirements are unpinned) and the readers work back to bs4 4.7.1, far below anything a consumer resolves.

(If applicable, issue number: #____)

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

### Tests

Written before the fix, and measured failing without it:

| Suite | Before | After |
|---|---|---|
| `test_workspace.py` | 95 failed, 139 passed | **234 passed, 1 skipped** |
| `test_studio.py::TestVersionZero` | 13 failed, 9 passed | **22 passed** |
| `test_filetools.py` | — | **26 passed** |

The 9 studio tests that passed beforehand are the guard tests that must *not* change. The 1 skip is the pre-existing `test_case_sensitive_fs_matches_patterns_exactly`, which cannot run on a case-insensitive filesystem — **the exemption's case behaviour is only covered by Linux CI.**

Full `tools/ + context/ + knowledge/` sweep: **5362 passed, 27 skipped**, plus 3 pre-existing failures (`test_gmail_tools.py` ×2, `test_google_base.py` — they need a local `tmp/service-account.json`) and the pre-existing `test_crawl4ai.py` collection error (missing optional dep). All identical before and after this change. `validate.sh` reports the same 72 pre-existing mypy errors in 14 files before and after; none are in the touched files.

### Breaking change — release note needed

An agent that reads one of these files today starts getting a refusal. That is the point, but it needs calling out, and `allow_paths` is the escape hatch:

```python
Workspace(".", allow_paths=["config/credentials.json"])
```

Committed env templates go the other way — from refused to served.

### Known limits, measured

- **Hard links bypass the boundary.** A hard link to an excluded file is readable and greppable. Already documented at `workspace.py`; no name-based pattern can fix it, so the spec's AC1 is not fully achievable by this mechanism. Symlinks *are* caught.
- **Case sensitivity cuts both ways.** On Linux (every container agno ships into) `Credentials.json` and `SECRETS.YAML` stay readable; on macOS/Windows a .NET `app/Credentials/Store.cs` is wrongly refused. Inherent to the existing documented fold rule.
- **Six credential paths are unexpressible** — `.docker/config.json`, `.kube/config`, `.m2/settings.xml`, `.cargo/credentials.toml`, `.composer/auth.json`, `.config/gh/hosts.yml` — because patterns cannot contain a separator. Blocked here via the parent directory, the same way the spec handled `.ssh`/`.aws`. `.config` was **not** added: too broad.
- **Accepted false positives**, each with `allow_paths` as the remedy: `*.crt`/`*.pem` also refuse public CA bundles; `*.key` also refuses Keynote and i18n key files (but catches Rails `config/master.key`); `id_rsa*` is a prefix glob; `.aws/` refuses AWS's own `task-definition.json` ECS layout.
- **Still readable and not addressed here**: `.yarnrc.yml` (commonly committed, can hold `npmAuthToken`), `*.ovpn`, `*.mobileprovision`.

### Deliberately scoped out

- **The JSON-Schema `minimum: 1` complement** (spec option 3). It is not cheap: agno's schema builder erases `Annotated` metadata entirely, so `Field(ge=1)`, `conint` and `PositiveInt` all emit a bare `{"type": "integer"}`. Making it work needs `include_extras=True` at `function.py:986,1173` plus an `Annotated` branch in `utils/json_schema.py:99` — a framework-wide change with a measured blast radius (`Annotated[Image, ...]` params stop being excluded from tool schemas unless `_unwrap_annotation` is patched in the same commit). It also costs +196 schema chars against 921 chars of headroom, and is **unmeasured as a fix** — given prompt framings went 0/3, a schema keyword may fare no better. The boundary coercion works regardless of whether a model honours JSON Schema.
- **The docstring hypothesis is suggestive, not proven.** The two tools whose docstrings said "pass 0" emitted it at 10/13 and 4/4; `get_component`, whose docstring never mentions 0, at 22/58. But that counts *zeros*, not *harmful* zeros — `expected_current_version=0` is correct and harmless on a component with no live version, which is the common state in a draft-heavy session. The harm rate conditional on a live pointer existing was never measured. The reword is cheap and removes a channel we were actively feeding the model; do not read it as a quantified fix.
- **`web_search` reader still cannot run under `agno[knowledge]`** — it needs `ddgs`, which lives in the `ddg` tools extra. Same family as this packaging gap, different dependency; not folded in.
- **`expected_latest_version` has no "nothing exists yet" spelling**, so a first-config append cannot be guarded at all — the gap #9728 closed for `current_version`, still open here. Worth knowing before anyone closes it symmetrically with `0`, which would collide with the `expected_version` coercion in this PR. `_version_or_latest` names that constraint in its docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
