### PR TITLE
fix: keep torch out of agno[knowledge]

### DIFF
--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -218,14 +218,21 @@ chonkie = [
 csv = ["aiofiles"]
 docx = ["python-docx"]
 excel = ["openpyxl", "xlrd"]
-# nltk!=3.10.1: its inisec import hook falsely blocks site-packages imports when
-# the venv lives inside the CWD, breaking the unstructured import chain.
-markdown = ["unstructured<0.18.31", "nltk!=3.10.1", "markdown", "aiofiles"]
-pdf = ["pypdf", "rapidocr_onnxruntime"]
+markdown = ["aiofiles"]
+pdf = ["pypdf"]
 pptx = ["python-pptx"]
 text = ["aiofiles"]
 # The website and llms_txt readers both import bs4 at module scope.
 website = ["beautifulsoup4"]
+
+# Engines a reader loads only for the heavier path, kept out of the plain reader
+# extras above so that reading a file does not install a document-AI stack.
+# MarkdownChunking; MarkdownReader itself falls back to fixed-size chunking without it.
+# nltk!=3.10.1: its inisec import hook falsely blocks site-packages imports when
+# the venv lives inside the CWD, breaking the unstructured import chain.
+markdown-chunking = ["unstructured<0.18.31", "nltk!=3.10.1", "markdown"]
+# OCR for scanned pages, used by PDFImageReader and by PDFReader(read_images=True).
+pdf-ocr = ["rapidocr_onnxruntime"]
 
 # Dependencies for AG-UI integration
 agui = ["ag-ui-protocol>=0.1.15", "jsonpatch>=1.33"]
@@ -374,11 +381,12 @@ vectordbs = [
   "agno[weaviate]",
 ]
 
-# All knowledge
+# The document readers. Deliberately free of OCR, layout and deep-learning engines:
+# installing a way to read a .docx should not install torch. Everything left out is
+# in knowledge-full below.
 knowledge = [
   "agno[chonkie]",
   "agno[csv]",
-  "agno[docling]",  # also a tool; parses docs for knowledge
   "agno[docx]",
   "agno[excel]",
   "agno[markdown]",
@@ -386,6 +394,15 @@ knowledge = [
   "agno[pptx]",
   "agno[text]",
   "agno[website]",
+]
+
+# Every knowledge capability, including the heavy engines: docling's layout and
+# vision models, OCR for scanned PDFs, and unstructured's markdown partitioning.
+knowledge-full = [
+  "agno[knowledge]",
+  "agno[docling]",  # also a tool; parses docs for knowledge
+  "agno[markdown-chunking]",
+  "agno[pdf-ocr]",
 ]
 
 # All embedders
@@ -403,7 +420,8 @@ tests = [
     "agno[tools]",
     "agno[storage]",
     "agno[vectordbs]",
-    "agno[knowledge]",
+    # The full set: CI must exercise docling, OCR and unstructured, not just the light readers.
+    "agno[knowledge-full]",
     "agno[embedders]",
     "agno[performance]",
     "agno[cookbooks]",


### PR DESCRIPTION
## Summary

`pip install "agno[knowledge]"` resolved to **144 packages**, among them `torch`, `torchvision`, `transformers`, `accelerate`, `scipy`, `pandas`, `opencv-python` and `onnxruntime`. Nobody asking for a way to read a `.docx` expects a deep-learning stack.

The three heavy dependencies in that group all turned out to be **optional to the reader rather than required by it** — so this is a regrouping, not a removal. Each was verified before anything moved.

### What was verified

**1. `pdf = ["pypdf", "rapidocr_onnxruntime"]` — OCR is opt-in.**
`pdf_reader.py` imports `pypdf` at module scope (`:15`) but `rapidocr_onnxruntime` only inside the two OCR helpers (`:50`, `:74`), which are reached from `read_images=True`. `PDFReader` — the only class the factory registers under `"pdf"` (`reader_factory.py:337`) — never sets that flag; `PDFImageReader` hardcodes it, and is registered nowhere and exported nowhere, so it is reachable only by direct import. **Executed in a clean env with no rapidocr: a text-layer PDF reads and returns its text.**

**2. `markdown = ["unstructured", "nltk", "markdown", "aiofiles"]` — none of it gates the reader.**
`markdown_reader.py` imports neither `unstructured` nor `nltk`. They gate `MarkdownChunking` (`agno/knowledge/chunking/markdown.py:7-10`), a *chunking strategy* the reader already falls back from — `MARKDOWN_CHUNKER_AVAILABLE = False` and it uses `FixedSizeChunking` (`markdown_reader.py:15-19`, `:58-63`). `nltk` appears **nowhere in `agno/`**; it is `unstructured`'s runtime dependency, pinned around an import-chain bug. The `markdown` package is there for `unstructured.partition.md`, not for agno. **Executed in the clean env: a real `.md` file parses with none of them installed.**

**3. `docling`** genuinely needs its stack, so it moves whole.

### The split

| extra | before | after |
|---|---|---|
| `pdf` | `pypdf`, `rapidocr_onnxruntime` | `pypdf` |
| `pdf-ocr` | — | `rapidocr_onnxruntime` **(new)** |
| `markdown` | `unstructured`, `nltk`, `markdown`, `aiofiles` | `aiofiles` |
| `markdown-chunking` | — | `unstructured<0.18.31`, `nltk!=3.10.1`, `markdown` **(new)** |
| `knowledge` | the reader extras **+ docling** | the nine reader extras |
| `knowledge-full` | — | `knowledge` + `docling` + `markdown-chunking` + `pdf-ocr` **(new)** |

### Measured

Resolved with `uv pip install --dry-run` against the local package, from an **empty** environment (so nothing is masked by what happens to be installed):

| target | before | after |
|---|---|---|
| `agno[knowledge]` | **144** | **62** |
| `agno[knowledge-full]` | — | **144** — the identical set to today's `agno[knowledge]` |
| `agno[pdf]` | 43 | 32 |
| `agno[markdown]` | 69 | 32 |

The 81 packages that leave `knowledge` include `torch`, `torchvision`, `transformers`, `accelerate`, `scipy`, `pandas`, `opencv-python`, `onnxruntime`, `sympy`, `networkx`, `unstructured`, `nltk`, `docling` and its five sibling distributions. Verified absent from the new `agno[knowledge]` by `find_spec` in a clean install.

`agno[knowledge-full]` diffs **clean** against today's `agno[knowledge]` — same 144 packages, so nothing became uninstallable.

### Nothing else in the group hides similar weight

Marginal package count over a bare `agno` (31 packages), measured the same way:

`csv` +1 · `text` +1 · `docx` +2 · `website` +2 · `excel` +3 · `pptx` +4 · `pdf` +1 (after) · **`chonkie` +19** · `markdown` +1 (after) · `docling` +81 (moved) 

`chonkie` is the one remaining ML-adjacent entry: `model2vec`, `tokenizers`, `huggingface-hub`, `safetensors`, `tree-sitter*`. It carries **no torch**, and it gates only `SemanticChunking` and `CodeChunking` — no reader defaults to either. I left it in `knowledge` because it is chunking rather than document AI and it clears the bar this PR is about, but moving it to `knowledge-full` is a one-line follow-up if you would rather `knowledge` be readers-only.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other: packaging

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

### Behaviour change

Anyone relying on `agno[knowledge]` for OCR, docling, or `MarkdownChunking` needs one word:

```
pip install "agno[knowledge-full]"
```

That resolves to exactly the same 144 packages as today's `agno[knowledge]`.

Narrower moves also work: `agno[knowledge,pdf-ocr]` for scanned PDFs only, `agno[knowledge,docling]` for layout parsing only.

### CI

`agno[tests]` now takes `agno[knowledge-full]` rather than `agno[knowledge]`, so CI keeps installing and exercising docling, OCR and unstructured. `agno[tests]` resolves to the same 503 packages as before.

### Why this is safe to notice

The reader and chunker availability work in #9750 makes the split legible instead of silent: on the new light install, `GET /knowledge/config` reports

```
unavailable_readers:  docling  (needs docling)
unavailable_chunkers: MarkdownChunker (needs unstructured)
```

with the install instruction verbatim, rather than dropping them into a DEBUG line. Confirmed by running it in the clean 62-package env, where the advertised extensions were `.csv .docx .json .md .pdf .pptx .txt .xls .xlsx url` and both a real `.md` and a text-layer `.pdf` parsed correctly.

### Stacking

Branched on `fix/knowledge-reader-availability` (#9750), which adds `agno[website]` to this exact block — merge that one first, or rebase this onto `feat/v3.0` if #9750 is dropped. The only shared line is the `website` entry in the `knowledge` list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
