### PR TITLE
fix: hide inner sub-team member ids from the outer roster, and open with the leader's purpose

### DIFF
--- a/libs/agno/agno/team/_messages.py
+++ b/libs/agno/agno/team/_messages.py
@@ -110,8 +110,15 @@ def get_members_system_message_content(
     for member in resolved_members:
         member_id = get_member_id(member)
 
+        # Only a directly delegable member shows an id: an inner member's id is not a valid
+        # delegation target here, and a leader shown one joins it into ids like
+        # "sub-team.member" that always fail. The sub-team's own prompt still shows its
+        # members' ids, because there they are at the top level.
         if isinstance(member, Team):
-            content += f'{pad}<member id="{member_id}" name="{member.name}" type="team">\n'
+            if indent == 0:
+                content += f'{pad}<member id="{member_id}" name="{member.name}" type="team">\n'
+            else:
+                content += f'{pad}<member name="{member.name}" type="team">\n'
             if member.role is not None:
                 content += f"{pad}  Role: {member.role}\n"
             if member.description is not None:
@@ -122,7 +129,10 @@ def get_members_system_message_content(
                 )
             content += f"{pad}</member>\n"
         else:
-            content += f'{pad}<member id="{member_id}" name="{member.name}">\n'
+            if indent == 0:
+                content += f'{pad}<member id="{member_id}" name="{member.name}">\n'
+            else:
+                content += f'{pad}<member name="{member.name}">\n'
             if member.role is not None:
                 content += f"{pad}  Role: {member.role}\n"
             if member.description is not None:
@@ -139,8 +149,11 @@ def get_members_system_message_content(
 def _get_opening_prompt() -> str:
     """Capability statement for a leader that has members available.
 
-    States what the leader has, not who it is. An identity claim here would compete
-    with the description, role and instructions the user wrote.
+    States the leader's job and what it has, never who it is. A persona claim here would
+    compete with the description, role and instructions the user wrote — which render
+    before this block, so a statement of purpose does not stand ahead of them. The
+    coordinator sentence is load-bearing on small models: without it a leader consulting
+    a panel of similar members stops at the first one or two.
 
     The delegation rule is stated as need, never as a comparison with the leader's own
     ability. Asked whether a member fits a sub-task "better than yours", a small model
@@ -148,6 +161,7 @@ def _get_opening_prompt() -> str:
     named for it; asked whether the member is needed, it follows the request.
     """
     return (
+        "You coordinate this team to fulfill the user's request. "
         "You have a team of specialists, listed below. "
         "Delegate to members when their expertise or tools are needed; "
         "answer directly — including with your own tools — when they are not.\n"

--- a/libs/agno/tests/unit/team/test_team_system_prompt.py
+++ b/libs/agno/tests/unit/team/test_team_system_prompt.py
@@ -208,13 +208,20 @@ def test_opening_states_delegation_as_need_not_as_self_assessment(mode):
 
 
 @pytest.mark.parametrize("mode", MODES)
-def test_opening_makes_no_identity_claim(mode):
-    """The opening states what the leader has, not who it is; identity is the user's."""
+def test_opening_states_purpose_never_persona(mode):
+    """The opening may say what the leader's job is, never who the leader is.
+
+    The user's description, role and instructions render before this block, so a purpose
+    statement does not stand ahead of them. The coordinator sentence is load-bearing on
+    small models: without it a leader consulting a panel of similar members stops early.
+    A persona claim ("You are ...") is still the user's alone.
+    """
     content = _team(mode=mode, description="A team that researches.").get_system_message(session=_session()).content
     opening = content[content.index("<team>") + len("<team>\n") :].split("\n", 1)[0]
 
-    assert opening.startswith("You have a team of specialists")
-    for claim in ("You are", "You coordinate", "You act as"):
+    assert opening.startswith("You coordinate this team to fulfill the user's request.")
+    assert content.index("A team that researches.") < content.index("<team>")
+    for claim in ("You are", "You act as", "Your name is"):
         assert claim not in opening
 
 
@@ -250,3 +257,29 @@ def test_tasks_block_matches_the_loop_it_runs():
     content = _team(mode=TeamMode.tasks.value).get_system_message(session=_session()).content
     assert "an empty one never" not in content
     assert "finishes at once instead of after a reminder" in content
+
+
+def test_inner_members_of_a_sub_team_render_without_ids():
+    """Only a directly delegable member shows an id.
+
+    An inner member's id is not a valid delegation target for the outer leader, and a
+    leader shown one joins it into ids like "sub-team.member" that always fail.
+    """
+    sub = Team(
+        name="Research Team",
+        id="research-team",
+        model=OpenAIChat("gpt-4o"),
+        role="Handles all research",
+        members=[Agent(name="Inner", id="inner", model=OpenAIChat("gpt-4o"), role="Digs")],
+    )
+    content = _team(members=[sub]).get_system_message(session=_session()).content
+    roster = content[content.index("<team_members>") : content.index("</team_members>")]
+
+    assert 'id="research-team"' in roster
+    assert 'id="inner"' not in roster
+    assert '<member name="Inner">' in roster
+    assert "Role: Digs" in roster
+
+    # The sub-team's own prompt keeps its members' ids: there they are delegable.
+    sub_content = sub.get_system_message(session=_session()).content
+    assert 'id="inner"' in sub_content


### PR DESCRIPTION
## Summary

The two prompt fixes from round 3 of the team-leader probe study (report: internal artifact "Team Leader Probes") — the ones clean enough to land now. Both are proven on the exact bytes this branch renders (the study's variant bytes were diffed against this branch's output before pushing).

### 1. Inner sub-team members no longer show an id in the outer roster

With a sub-team on the roster the leader copies inner ids into joined forms like `news-team.reporter`; the lookup is exact, so every such call fails and re-prints the roster. The #9746 closer holds at one sub-team (9/10 clean) but two sub-teams overwhelm it: 3/8 clean, 10 failed calls. Hiding inner members' `id=` (names and roles stay) removes the copy source:

| arm | clean runs | joined-id calls | sub-team leader bypassed |
|---|---|---|---|
| tip, two sub-teams | 3/8 | 10 | 0 |
| tip, one sub-team | 9/10 | 2 | 0 |
| **inner ids hidden (this branch)** | **14/14** | **0** | **0** |

Rendering rule: `id=` only at the top level of the prompt being built. Each sub-team's own prompt still shows its members' ids — there they are the delegable ones. The runtime lookup is untouched: bare inner ids still resolve today; whether they should is a separate decision this PR does not make.

### 2. The opening states the leader's purpose

> **You coordinate this team to fulfill the user's request.** You have a team of specialists, listed below. Delegate to members when their expertise or tools are needed; answer directly — including with your own tools — when they are not.

This deliberately revises the #9731 decision that removed the coordinator sentence, and the evidence is the reason:

- A gpt-4o-mini leader asked for a panel's views consulted all three tool-less advisors **0/10** on the current opening and **8/10** with this sentence (pre-rewrite baseline: 7/8; gpt-5-mini: 6/6 either way).
- The substitutes were measured and refuted: a purpose clause without the coordinator word (3/10), an explicit "delegate to each of those members" rule (4/10).
- Regression guards all green with the sentence: factorial 8/8 both-members-analyst-first, greeting 6/6 answered directly, single-domain 6/6 no over-delegation.
- The original objection — framework voice ahead of the user's persona — no longer applies as stated: #9731 itself moved `description`/`role`/`instructions` above this block, so a purpose statement never precedes the first authored word. It is purpose, not persona: the prompt still never says who the leader *is*.

The #9737 guard test is revised accordingly and honestly: `test_opening_makes_no_identity_claim` becomes `test_opening_states_purpose_never_persona` — it now pins that the user's description renders before `<team>`, that the opening leads with the purpose sentence, and that persona claims ("You are", "You act as", "Your name is") stay forbidden. This is a deliberate property change argued here, not a test weakened to get past CI: with the code reverted, the revised tests fail 5/5.

## Evidence discipline

Probe study rounds 1–3: ~1,140 live `team.run` calls, ~$1.00, JSONL-audited with per-probe prompt/tool-schema hashes; harness in `.context/team_prompt_probe/` (gitignored). This branch's rendered advisors prompt is byte-identical to the probed `adv_identity` arm, and its nested roster byte-identical to the probed `hide_inner_ids2` arm. The two changes were probed separately, not in combination; they touch disjoint prompt sections, and the combined render passes all 36 prompt unit tests.

## Unit coverage

- New: `test_inner_members_of_a_sub_team_render_without_ids` — outer roster hides inner ids and keeps names/roles; the sub-team's own prompt keeps its members' ids.
- Revised: `test_opening_states_purpose_never_persona` (see above).
- Mutation check: revert the code, changed/new tests fail 5/5. Full `tests/unit/team`: 796 passed.

## Deliberately not in this PR

- **The streaming attribution fix** — the study's biggest finding (broadcast refusal relayed 0/22 streamed vs 6/10 non-streamed because streaming accumulates member content without names or separators). The sync path is straightforward but the async broadcast interleaves concurrent members' deltas, so attribution there needs a real design pass, not a 10-minute patch. Highest-value next PR.
- **Whether bare inner-member ids should resolve** in `_find_member_by_id`.
- **The route no-fit honesty sentence** (leaders sensibly answer/decline out-of-scope requests on both prompts while the text claims they always hand over) — cosmetic, kept out to keep this diff reviewable.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

`ruff format --check` and `ruff check` clean on both changed files; mypy reports zero errors in them (the repo-wide 72 pre-existing errors documented in #9731/#9737/#9746 stand). Behaviour note: every team with a nested sub-team gets a slightly different roster rendering, and every team's system message gains one leading sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
