### PR TITLE
fix: close a fail-open in the Studio edit guard, and make the bigger exclude list affordable

### DIFF
--- a/libs/agno/agno/context/workspace/provider.py
+++ b/libs/agno/agno/context/workspace/provider.py
@@ -87,7 +87,11 @@ class WorkspaceContextProvider(ContextProvider):
         if not self.exclude_patterns:
             return "No paths are excluded."
         if list(self.exclude_patterns) == list(DEFAULT_EXCLUDE_PATTERNS):
-            what = "Common dependency, build, and agent scratch folders and env files"
+            what = (
+                "Common dependency, build, and agent scratch folders, env files, and credential "
+                "files (private keys and certificates, .ssh/.aws/.kube directories, registry and "
+                "host tokens, credentials/secrets data files, service accounts, Terraform inputs)"
+            )
         else:
             what = "Paths matching the configured exclude patterns"
         return f"{what} are excluded: they are hidden from listings and cannot be read by name."

--- a/libs/agno/agno/os/interfaces/a2a/router.py
+++ b/libs/agno/agno/os/interfaces/a2a/router.py
@@ -29,7 +29,13 @@ from agno.os.interfaces.a2a.utils import (
     map_run_output_to_a2a_task,
     stream_a2a_response_with_error_handling,
 )
-from agno.os.middleware.user_scope import assert_session_writable, caller_is_admin, get_scoped_user_id, resolve_run_user_id, verify_run_in_session
+from agno.os.middleware.user_scope import (
+    assert_session_writable,
+    caller_is_admin,
+    get_scoped_user_id,
+    resolve_run_user_id,
+    verify_run_in_session,
+)
 from agno.os.utils import get_agent_by_id, get_request_kwargs, get_team_by_id, get_workflow_by_id
 from agno.team import RemoteTeam, Team
 from agno.workflow import RemoteWorkflow, Workflow

--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -554,7 +554,9 @@ def _http_request_or_none() -> Optional[Any]:
         return None
 
 
-async def _assert_session_writable_mcp(os_app, component, session_id: str, user_id: Optional[str], session_type) -> None:
+async def _assert_session_writable_mcp(
+    os_app, component, session_id: str, user_id: Optional[str], session_type
+) -> None:
     """Refuse an MCP run into a session owned by another user.
 
     Same rule the REST run routes apply. MCP tools surface plain exceptions, so the

--- a/libs/agno/agno/os/middleware/user_scope.py
+++ b/libs/agno/agno/os/middleware/user_scope.py
@@ -459,9 +459,7 @@ async def assert_session_writable(
     # user_id is deliberately NOT passed: the probe must see the row regardless of owner.
     # deserialize=False keeps it a raw dict; runs_limit=1 bounds the run attach.
     if isinstance(db, AsyncBaseDb):
-        row = await db.get_session(
-            session_id=session_id, session_type=session_type, deserialize=False, runs_limit=1
-        )
+        row = await db.get_session(session_id=session_id, session_type=session_type, deserialize=False, runs_limit=1)
     else:
         row = db.get_session(session_id=session_id, session_type=session_type, deserialize=False, runs_limit=1)
     if not row:

--- a/libs/agno/agno/tools/_local_file_utils.py
+++ b/libs/agno/agno/tools/_local_file_utils.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
-from fnmatch import fnmatch
+import re
+from fnmatch import translate
+from functools import lru_cache
+from os.path import normcase
 from pathlib import Path
-from typing import List, Sequence, Tuple
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 # A pattern starting with this prefix names an exemption rather than an exclusion:
 # a path component matching it is never excluded, whichever pattern it also matches.
@@ -32,6 +35,9 @@ DEFAULT_EXCLUDE_PATTERNS = [
     "!.env.template",
     "!.env.dist",
     "!example.env",
+    "!sample.env",
+    "!template.env",
+    "!dist.env",
     "!env.example",
     # Private keys, certificates and keystores
     "*.pem",
@@ -45,7 +51,6 @@ DEFAULT_EXCLUDE_PATTERNS = [
     "*.jks",
     "*.jceks",
     "*.keystore",
-    "*.asc",
     "*.gpg",
     "*.ppk",
     "*.kdbx",
@@ -189,14 +194,10 @@ DEFAULT_EXCLUDE_PATTERNS = [
 ]
 
 
-def split_exclude_patterns(exclude_patterns: Sequence[str]) -> Tuple[List[str], List[str]]:
-    """Split exclude patterns into the deny list and the exemption list.
-
-    An entry starting with ``!`` names an exemption: a path component matching it is
-    never excluded, whatever deny pattern it also matches. Exemptions are
-    order-independent — an exemption always wins. A bare ``!`` names no pattern and is
-    treated as a literal deny entry.
-    """
+@lru_cache(maxsize=32)
+def _split_exclude_patterns(exclude_patterns: Tuple[str, ...]) -> Tuple[List[str], List[str]]:
+    """Cached deny/exempt split, keyed on the pattern tuple: a caller that passes the
+    same list for every path in an ``os.walk`` pays the split once, not per path."""
     deny: List[str] = []
     exempt: List[str] = []
     for pattern in exclude_patterns:
@@ -207,6 +208,54 @@ def split_exclude_patterns(exclude_patterns: Sequence[str]) -> Tuple[List[str], 
     return deny, exempt
 
 
+def split_exclude_patterns(exclude_patterns: Sequence[str]) -> Tuple[List[str], List[str]]:
+    """Split exclude patterns into the deny list and the exemption list.
+
+    An entry starting with ``!`` names an exemption: a path component matching it is
+    never excluded, whatever deny pattern it also matches. Exemptions are
+    order-independent — an exemption always wins. A bare ``!`` names no pattern and is
+    treated as a literal deny entry.
+
+    The ``!`` prefix is reserved, so a component whose name literally begins with ``!``
+    cannot be spelled as a deny pattern and there is no escape for it. Name its parent
+    directory instead, or reach it with a wildcard such as ``?name``.
+
+    The returned lists are cached and shared; callers must not mutate them.
+    """
+    return _split_exclude_patterns(tuple(exclude_patterns))
+
+
+_FOLDS: Dict[str, Callable[[str], str]] = {
+    # fnmatch() folds both operands with normcase; fnmatchcase() folds neither.
+    "normcase": normcase,
+    "casefold": str.casefold,
+    "none": lambda name: name,
+}
+
+
+@lru_cache(maxsize=64)
+def compile_exclude_patterns(exclude_patterns: Tuple[str, ...], fold: str) -> Tuple[Optional[Any], Optional[Any]]:
+    """Compile the deny and exempt halves into one alternation each, so a path component
+    is tested with a single regex match instead of one ``fnmatch`` call per pattern.
+
+    ``fold`` names how the caller normalizes a component before matching: ``normcase``
+    reproduces ``fnmatch``, ``casefold`` a case-insensitive filesystem, ``none`` an exact
+    match. The fold and the translate happen once per (pattern list, fold) rather than
+    once per path, which is what makes a large default list affordable on a tree walk.
+
+    Returns ``(deny, exempt)``, either of which is ``None`` when that half is empty.
+    """
+    fold_name = _FOLDS[fold]
+
+    def compile_half(patterns: List[str]) -> Optional[Any]:
+        if not patterns:
+            return None
+        return re.compile("|".join(translate(fold_name(pattern)) for pattern in patterns))
+
+    deny, exempt = _split_exclude_patterns(exclude_patterns)
+    return compile_half(deny), compile_half(exempt)
+
+
 def path_matches_exclude(path: Path, root: Path, exclude_patterns: Sequence[str]) -> bool:
     """Return True when a path component matches a deny pattern and no exemption."""
     if not exclude_patterns:
@@ -215,8 +264,10 @@ def path_matches_exclude(path: Path, root: Path, exclude_patterns: Sequence[str]
         rel = path.relative_to(root)
     except ValueError:
         return False
-    deny, exempt = split_exclude_patterns(exclude_patterns)
+    deny, exempt = compile_exclude_patterns(tuple(exclude_patterns), "normcase")
+    if deny is None:
+        return False
     return any(
-        any(fnmatch(part, pattern) for pattern in deny) and not any(fnmatch(part, pattern) for pattern in exempt)
-        for part in rel.parts
+        deny.match(folded) is not None and (exempt is None or exempt.match(folded) is None)
+        for folded in (normcase(part) for part in rel.parts)
     )

--- a/libs/agno/agno/tools/file.py
+++ b/libs/agno/agno/tools/file.py
@@ -61,6 +61,15 @@ def _extract_snippet(content: str, query: str, context_chars: int = 200) -> str:
 class FileTools(Toolkit):
     """Toolkit for read/write access to a local directory tree.
 
+    ``exclude_patterns`` here is a **listing filter, not an access boundary**: results
+    from ``list_files``, ``search_files`` and ``search_content`` skip matching paths,
+    but ``read_file``, ``read_file_chunk``, ``save_file``, ``replace_file_chunk`` and
+    ``delete_file`` do not consult it — an agent that names an excluded path directly
+    still reads or writes it. The shared default list includes credential files, so an
+    agent given ``FileTools`` over a directory holding secrets can still read them by
+    name. Use ``agno.tools.workspace.Workspace`` where exclusion has to be enforced:
+    there the same patterns refuse every path the agent names.
+
     By default, results from ``list_files``, ``search_files``, and ``search_content``
     skip common noise directories (``.venv``, ``.venvs``, ``.context``,
     ``.git``, ``__pycache__``, ``node_modules``, etc.). See
@@ -76,7 +85,8 @@ class FileTools(Toolkit):
     and ``vendor/thing/.git/`` nested deep. An entry prefixed with ``!`` is an
     exemption: a component matching it is never excluded, whatever else it
     matches. The defaults use this to keep committed env templates
-    (``.env.example`` and friends) listed while real env files stay hidden.
+    (``.env.example`` and friends) listed while real env files stay out of
+    listings.
 
     Note: ``exclude_patterns`` does not parse ``.gitignore`` files — it only
     applies the literal patterns provided.

--- a/libs/agno/agno/tools/studio.py
+++ b/libs/agno/agno/tools/studio.py
@@ -2628,10 +2628,10 @@ class StudioTools(Toolkit):
         append a new version (draft, or published when ``publish``). ``warnings``
         is the list ``mutate`` appends its disclosures to; it rides on the
         success envelope."""
-        # expected_version compares against the latest stored version, and anything
-        # editable has at least v1, so 0 can only ever be a guard that no writer can
-        # satisfy -- an unset argument, not a compare-and-set the caller meant.
-        expected_version = _version_or_latest(expected_version)
+        # expected_version is NOT coerced here even though 0 can never match a latest
+        # version. Refusing is the safe direction for a compare-and-set: reading 0 as
+        # "unset" would turn a guard the caller asked for into an unguarded append, and
+        # the REST guard (`guard.latest_version`) would still refuse the same value.
         db_err = self._require_db()
         if db_err is not None:
             return db_err
@@ -3055,7 +3055,15 @@ class StudioTools(Toolkit):
         # `version` names the draft to publish, so 0 reads as omitted. The
         # expected_current_version guard beside it does NOT: 0 is its "nothing is
         # live yet" spelling and stays a guard.
-        version = _version_or_latest(version)
+        coerced_version = _version_or_latest(version)
+        # This one moves the live pointer, so a caller whose argument was
+        # reinterpreted hears about it on the envelope, not only in a debug log.
+        version_warnings = (
+            []
+            if coerced_version == version
+            else ["Ignored version=0, which is not a version, and published the latest draft instead."]
+        )
+        version = coerced_version
         db_err = self._require_db()
         if db_err is not None:
             return db_err
@@ -3129,7 +3137,7 @@ class StudioTools(Toolkit):
                 # the live pointer names, so re-projecting this one would make
                 # the row describe a version that is not live; moving the
                 # pointer backwards is set_current_version's job, not publish's.
-                return ok_result("already_published", id=component_id, version=target)
+                return ok_result("already_published", warnings=version_warnings, id=component_id, version=target)
             try:
                 result = self.db.upsert_config(
                     component_id=component_id,
@@ -3148,7 +3156,7 @@ class StudioTools(Toolkit):
                     return self._denied_error(denied)
                 raise
             published_version = result.get("version", target)
-            warnings = self._sync_component_row_after_commit(component_id, published_version)
+            warnings = version_warnings + self._sync_component_row_after_commit(component_id, published_version)
             return ok_result("published", warnings=warnings, id=component_id, version=published_version)
         except Exception as e:
             return self._error_from_exception(e, "Failed to publish component")

--- a/libs/agno/agno/tools/workspace.py
+++ b/libs/agno/agno/tools/workspace.py
@@ -28,13 +28,13 @@ import re
 import subprocess
 import sys
 import unicodedata
-from fnmatch import fnmatch, fnmatchcase
+from fnmatch import fnmatch
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple, Union
 
 from agno.exceptions import PathSecurityError
 from agno.tools import Toolkit
-from agno.tools._local_file_utils import DEFAULT_EXCLUDE_PATTERNS, EXEMPT_PREFIX, split_exclude_patterns
+from agno.tools._local_file_utils import DEFAULT_EXCLUDE_PATTERNS, EXEMPT_PREFIX, compile_exclude_patterns
 from agno.utils.log import log_debug, log_error, log_info, log_warning
 from agno.utils.path_safety import safe_join_relative_path
 
@@ -406,11 +406,6 @@ class Workspace(Toolkit):
         # Components below root of each allow_paths entry, as written and resolved; rebuilt when allow_paths changes.
         self._allow_snapshot: Optional[Tuple[str, ...]] = None
         self._allowed_parts: List[Tuple[str, ...]] = []
-        # Deny/exempt halves of exclude_patterns; rebuilt when exclude_patterns changes.
-        # exclude_patterns is public and mutable, so this cannot be a one-shot __init__ split.
-        self._pattern_snapshot: Optional[Tuple[str, ...]] = None
-        self._deny_patterns: List[str] = []
-        self._exempt_patterns: List[str] = []
         # Whether names that differ only by case are the same entry on root's filesystem.
         self._fold_case: Optional[bool] = None
         # Tracks which paths have been read this session — used by require_read_before_write.
@@ -533,26 +528,18 @@ class Workspace(Toolkit):
             self._fold_case = _is_case_insensitive_fs(self.root)
         return self._fold_case
 
-    def _matches(self, part: str, pattern: str) -> bool:
-        """Match one path component against one exclude pattern."""
-        if self._case_insensitive():
-            return fnmatchcase(part.casefold(), pattern.casefold())
-        return fnmatch(part, pattern)
-
-    def _split_patterns(self) -> Tuple[List[str], List[str]]:
-        """Deny and exempt halves of ``exclude_patterns``, recomputed when it changes."""
-        snapshot = tuple(self.exclude_patterns)
-        if snapshot != self._pattern_snapshot:
-            self._deny_patterns, self._exempt_patterns = split_exclude_patterns(snapshot)
-            self._pattern_snapshot = snapshot
-        return self._deny_patterns, self._exempt_patterns
-
     def _component_excluded(self, part: str) -> bool:
-        """Whether one path component is excluded: it matches a deny pattern and no exemption."""
-        deny, exempt = self._split_patterns()
-        if not any(self._matches(part, pattern) for pattern in deny):
+        """Whether one path component is excluded: it matches a deny pattern and no exemption.
+
+        The patterns are compiled once per (list, case rule) rather than matched one at a
+        time, because this runs for every entry of every listing and tree walk.
+        """
+        fold = "casefold" if self._case_insensitive() else "none"
+        deny, exempt = compile_exclude_patterns(tuple(self.exclude_patterns), fold)
+        if deny is None:
             return False
-        return not any(self._matches(part, pattern) for pattern in exempt)
+        folded = part.casefold() if fold == "casefold" else part
+        return deny.match(folded) is not None and (exempt is None or exempt.match(folded) is None)
 
     def _relative_parts(self, path: Path) -> Optional[Tuple[str, ...]]:
         """Components of ``path`` below ``root``, or ``None`` when ``path`` is not under ``root``."""

--- a/libs/agno/tests/unit/os/test_user_scope_helpers.py
+++ b/libs/agno/tests/unit/os/test_user_scope_helpers.py
@@ -12,9 +12,9 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from fastapi import HTTPException
 
+from agno.db.base import AsyncBaseDb, SessionType
 from agno.db.schemas.scheduler import SCHEDULE_OWNER_HEADER
 from agno.os.auth import INTERNAL_SCHEDULER_USER_ID
-from agno.db.base import AsyncBaseDb, SessionType
 from agno.os.middleware.user_scope import (
     apply_scope_to_kwargs,
     assert_session_writable,

--- a/libs/agno/tests/unit/tools/test_studio.py
+++ b/libs/agno/tests/unit/tools/test_studio.py
@@ -2428,6 +2428,20 @@ class TestVersionZero:
         studio.edit_agent("tutor", instructions="updated")
         assert _data(studio.publish_component("tutor", version=0))["version"] == 2
 
+    def test_publish_component_says_it_reinterpreted_version_zero(self, studio):
+        """Publishing moves the live pointer, so a caller whose argument was
+        reinterpreted hears it on the envelope, not only in a debug log."""
+        self._published(studio)
+        studio.edit_agent("tutor", instructions="updated")
+        out = _loads(studio.publish_component("tutor", version=0))
+        assert any("version=0" in w for w in out["warnings"])
+
+    def test_publish_component_is_silent_when_the_version_was_not_reinterpreted(self, studio):
+        self._published(studio)
+        studio.edit_agent("tutor", instructions="updated")
+        out = _loads(studio.publish_component("tutor", version=2))
+        assert not any("version=0" in w for w in out.get("warnings") or [])
+
     @pytest.mark.asyncio
     async def test_apublish_component_treats_version_zero_as_latest_draft(self, studio):
         self._published(studio)
@@ -2446,10 +2460,11 @@ class TestVersionZero:
         assert _data(await studio.avalidate_component("clean", version=0))["version"] == 1
 
     @pytest.mark.parametrize("tool_name", ["edit_agent", "edit_team", "edit_workflow"])
-    def test_edit_expected_version_zero_is_treated_as_unset(self, studio, tool_name):
-        """expected_version compares against the LATEST version, which is at
-        least 1 for anything editable, so 0 could only ever be a failed CAS
-        against a component the caller meant to edit unguarded."""
+    def test_edit_expected_version_zero_is_still_refused(self, studio, tool_name):
+        """expected_version is a compare-and-set, not a version selector. 0 can
+        never match a latest version, and refusing is the safe direction: reading
+        it as "unset" would turn a guard the caller asked for into an unguarded
+        append."""
         studio.create_agent(name="member", instructions="m", model_id="gpt-5.4", publish=True)
         targets = {
             "edit_agent": lambda: studio.create_agent(name="cas", instructions="i", model_id="gpt-5.4"),
@@ -2457,8 +2472,10 @@ class TestVersionZero:
             "edit_workflow": lambda: studio.create_workflow(name="cas", steps=[{"name": "s1", "agent_id": "member"}]),
         }
         targets[tool_name]()
-        data = _data(getattr(studio, tool_name)("cas", description="second", expected_version=0))
-        assert data["draft_version"] == 2
+        error = _error(getattr(studio, tool_name)("cas", description="second", expected_version=0))
+        assert error["code"] == "version_conflict"
+        # Nothing was appended: the refusal is not a partial write.
+        assert _data(studio.list_versions("cas"))["count"] == 1
 
     def test_edit_expected_version_still_guards(self, studio):
         """The coercion must not blunt a real compare-and-set."""
@@ -2467,9 +2484,10 @@ class TestVersionZero:
         assert _data(studio.edit_agent("cas", description="x", expected_version=1))["draft_version"] == 2
 
     @pytest.mark.asyncio
-    async def test_aedit_agent_expected_version_zero_is_treated_as_unset(self, studio):
+    async def test_aedit_agent_expected_version_zero_is_still_refused(self, studio):
         studio.create_agent(name="cas", instructions="i", model_id="gpt-5.4")
-        assert _data(await studio.aedit_agent("cas", description="x", expected_version=0))["draft_version"] == 2
+        error = _error(await studio.aedit_agent("cas", description="x", expected_version=0))
+        assert error["code"] == "version_conflict"
 
     def test_run_agent_version_zero_dispatches_unpinned(self, studio, monkeypatch):
         """The run tools take the same "omit for the latest" argument. 0 must

--- a/libs/agno/tests/unit/tools/test_workspace.py
+++ b/libs/agno/tests/unit/tools/test_workspace.py
@@ -1316,7 +1316,6 @@ CREDENTIAL_PATHS = [
     "keystore.jks",
     "store.jceks",
     "my.keystore",
-    "privkey.asc",
     "private.gpg",
     "server.ppk",
     "vault.kdbx",
@@ -1423,6 +1422,9 @@ ENV_TEMPLATES = [
     ".env.template",
     ".env.dist",
     "example.env",
+    "sample.env",
+    "template.env",
+    "dist.env",
     "env.example",
     "packages/api/.env.example",
 ]
@@ -1597,3 +1599,97 @@ def test_mutating_exclude_patterns_after_construction_takes_effect():
         assert "OPENAI_API_KEY" in ws.read_file(".env.example")
         ws.exclude_patterns = [".env*"]
         assert ws.read_file(".env.example") == "Error: path is excluded from this workspace: .env.example"
+
+
+def test_compiled_matcher_agrees_with_a_pattern_by_pattern_fnmatch():
+    """The deny/exempt halves are compiled into one alternation each for speed. Pin the
+    equivalence to the loop it replaces, on both case branches, so a translate-level
+    difference cannot slip in unseen."""
+    from fnmatch import fnmatch, fnmatchcase
+
+    from agno.tools._local_file_utils import DEFAULT_EXCLUDE_PATTERNS, split_exclude_patterns
+
+    names = [
+        ".env",
+        ".env.example",
+        ".env.production",
+        "example.env",
+        "dist.env",
+        "env.example",
+        "id_rsa",
+        "id_rsa.pub",
+        "id_rsa_helper.go",
+        "credentials.json",
+        "credentials.py",
+        "credentials",
+        "secrets.py",
+        "secrets.yaml",
+        "server.pem",
+        "key.py",
+        "app.py",
+        ".ssh",
+        ".aws",
+        ".venv",
+        "build",
+        "BUILD",
+        ".ENV",
+        "Credentials.json",
+        "x.TFVARS",
+        "service-account.json",
+        "serviceAccount.json",
+        "known_hosts",
+        "!secret.txt",
+        "README.md",
+        ".DS_Store",
+        "x.egg-info",
+        "[weird]",
+        "a b",
+        "*.py",
+    ]
+    deny, exempt = split_exclude_patterns(DEFAULT_EXCLUDE_PATTERNS)
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        for fold in (True, False):
+            ws = Workspace(tmp_dir)
+            ws._fold_case = fold
+            match = (lambda a, b: fnmatchcase(a.casefold(), b.casefold())) if fold else fnmatch
+            for name in names:
+                expected = any(match(name, d) for d in deny) and not any(match(name, e) for e in exempt)
+                assert ws._component_excluded(name) is expected, (name, fold)
+
+
+def test_path_matches_exclude_agrees_with_a_pattern_by_pattern_fnmatch():
+    """The FileTools half of the same matcher."""
+    from fnmatch import fnmatch
+
+    from agno.tools._local_file_utils import (
+        DEFAULT_EXCLUDE_PATTERNS,
+        path_matches_exclude,
+        split_exclude_patterns,
+    )
+
+    deny, exempt = split_exclude_patterns(DEFAULT_EXCLUDE_PATTERNS)
+    root = Path("/r")
+    for parts in (
+        ("app.py",),
+        (".env",),
+        (".env.example",),
+        ("pkg", ".env.example"),
+        ("credentials", "loader.py"),
+        ("id_rsa",),
+        ("src", "secrets.py"),
+        (".venv", "cfg", ".env.example"),
+        ("!secret.txt",),
+    ):
+        expected = any(
+            any(fnmatch(part, d) for d in deny) and not any(fnmatch(part, e) for e in exempt) for part in parts
+        )
+        assert path_matches_exclude(root.joinpath(*parts), root, DEFAULT_EXCLUDE_PATTERNS) is expected, parts
+
+
+def test_empty_deny_list_with_only_exemptions_excludes_nothing():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = Path(tmp_dir).resolve()
+        _write(base, ".env", "SECRET=1\n")
+        ws = Workspace(tmp_dir, exclude_patterns=["!.env.example"])
+        assert "SECRET=1" in ws.read_file(".env")


### PR DESCRIPTION
## Summary

Follow-ups from the review of #9752, which merged before these landed. One is a genuine fail-open I introduced there; the rest are corrections and a performance fix that the tripled pattern list needs.

### 1. Restore the edit compare-and-set (the one that matters)

#9752 read `expected_version=0` as "unset" on `edit_agent`/`edit_team`/`edit_workflow`, reasoning that `0` can never match a latest version. That reasoning is right but incomplete: **"never matches" is fail-closed**, so coercing it turned a guard the caller asked for into an unguarded append. The REST guard (`guard.latest_version`, `components.py:1214`) still refuses the same value, so the two surfaces disagreed about whether a guard was held.

This is the same axis as the `expected_current_version` / `NO_LIVE_VERSION` decision in #9752 — a compare-and-set must not silently become no compare-and-set — so it gets the same answer. `test_edit_expected_version_zero_is_still_refused` now pins the refusal and asserts nothing was appended.

The **version selectors keep their coercion**: `get_component`, `publish_component.version`, `validate_component`, `run_agent`/`run_team`/`run_workflow`. Those name a version to act on, where `0` only ever means the model defaulted an optional argument, and they carry the measured harm (22/58, 4/4).

### 2. `publish_component` says when it reinterpreted `0`

It is the one coerced argument that **moves the live pointer**. A caller that computed `version` from a 0-based index previously got `version_not_found`; now it publishes the newest draft, which may carry unrelated edits. That reinterpretation now rides the success envelope's `warnings` instead of living only in a `log_debug`.

### 3. Say what FileTools actually enforces

`FileTools` consults `exclude_patterns` from `list_files`, `search_files` and `search_content` **only** — `read_file`, `read_file_chunk`, `save_file`, `replace_file_chunk` and `delete_file` never do. Measured on a temp root with defaults: `list_files()` correctly hides `.env`, and `ft.read_file(".env")` returns `SECRET=abc` anyway.

That is pre-existing and deliberate (#9730 scoped enforcement to `Workspace`), but #9752 put credential files into the shared list, which makes the gap easy to misread as protection — and my docstring there said templates "stay hidden", which reads broader than the enforcement is. The docstring now leads with the limitation and points at `Workspace`.

Related: `WorkspaceContextProvider._exclusion_sentence()` — the sentence handed to the *model* — still said only "dependency, build, and agent scratch folders and env files", so an agent had no way to anticipate a refusal on `server.key` or `.ssh/`. It now names the credential families.

### 4. Pattern corrections

- **Add `!sample.env`, `!template.env`, `!dist.env`.** `*.env` matched all three and only `example.env` was exempted, so the same file with the same intent got opposite answers depending on the word.
- **Drop `*.asc`.** An `.asc` file is an armored **public** key or a detached signature — no confidentiality gain — and the extension also names ESRI ASCII-grid raster data.
- **Document that `!` is reserved.** A component whose name literally begins with `!` cannot be spelled as a deny pattern, and there is no escape (`!!x`, `[!]x` and `?x` all fail or over-match — measured). The docstring now says so and names the workarounds. `Workspace(root, exclude_patterns=["!secret.txt"])` today silently registers an exemption; this documents it rather than adding syntax.

### 5. Make the larger pattern list affordable

The default list went from ~45 to ~148 entries and both matchers tested each component against every pattern in turn — on a tree walk, once per file. Each half is now compiled to a single alternation, cached per `(pattern list, case rule)`:

| | before | after |
|---|---|---|
| `path_matches_exclude` (FileTools walks) | 139 µs/call | **12.2 µs** |
| `Workspace._is_excluded` (the access boundary) | 143 µs/call | **17.5 µs** |

Both are now faster than the *original* ~45-pattern list was (51 µs). `fnmatch` is `fnmatchcase` over `normcase`-folded operands, so the fold moved to compile time and the semantics are unchanged — pinned by two new equivalence tests against the pattern-by-pattern loop, on both case branches. The differential harness ran 78,000 paths (including `[weird]`, `a b`, `*.py`, `!secret.txt`, empty deny lists and exempt-only lists) with **zero divergence**. `Workspace._matches` and the now-redundant per-instance split cache are removed.

(If applicable, issue number: #____)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

`tools/ + context/ + knowledge/`: **5403 passed, 27 skipped**, plus the same 3 pre-existing failures as before this branch (`test_gmail_tools.py` ×2 and `test_google_base.py` — they need a local `tmp/service-account.json`) and the pre-existing `test_crawl4ai.py` collection error (missing optional dep). `validate.sh` reports 73 mypy errors in 15 files both with and without this branch; none are in the touched files.

### Reviewed and deliberately not changed

- **`.docker`, `.kube`, `.m2`, `.cargo`, `.composer` stay excluded as directories.** Review flagged `.docker/` as a common in-repo build-context convention. Measured against it: zero such directories across this machine's `~/code` (and zero across a 1.2M-file scan in the original sweep). Patterns cannot contain a separator, so the directory is the only way to reach `.docker/config.json` at all, and `allow_paths` covers the false-refusal case.
- **`*.crt`, `*.cer`, `*.der`, `known_hosts`, `authorized_keys` stay.** Review is right that these are public artifacts, so the confidentiality gain is small — but `known_hosts`/`authorized_keys` leak host topology, and cert files are not source. Costs an `allow_paths` entry for an agent reviewing a TLS config.
- **`.example`/`.sample`/`.template`/`.dist` stay in `TEXT_EXTENSIONS`.** Review noted this also makes e.g. `secrets.yaml.example` greppable. True, but that file was already fully readable via `read_file` — the deny list uses exact spellings and never covered it — so this widens search over files that were never protected, and those suffixes genuinely name text files.

### Still open

- `FileTools` read/write paths remain unenforced (see §3). Making them an access boundary is the `Workspace`-shaped change #9730 deliberately deferred, not a docstring fix.
- Hard links still bypass the boundary; `.yarnrc.yml`, `*.ovpn` and `*.mobileprovision` are still readable. Both carried over from #9752.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
