### PR TITLE
chore: bump agno to 3.0.0a5

### DIFF
--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agno"
-version = "3.0.0a4"
+version = "3.0.0a5"
 description = "The programming language for agentic software."
 requires-python = ">=3.9,<4"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Cuts the fifth 3.0.0 alpha. Unlike #9735, this is a **single edit** — `libs/agno/pyproject.toml` `3.0.0a4` -> `3.0.0a5`. Nothing else in the release triple moves, and each of those three was checked rather than assumed:

| file | line | state | why it stays |
| --- | --- | --- | --- |
| `libs/agno/pyproject.toml` | `version` | **changed** | the release itself |
| `libs/agno/pyproject.toml` | `agnoctl>=0.2.0a1` | unchanged | the floor already matches what is published |
| `libs/agnoctl/pyproject.toml` | `0.2.0a1` | unchanged | `git log a60be9eb3..HEAD -- libs/agnoctl/` is empty — zero commits since the a4 cut |
| `libs/agno/requirements.txt` | `agnoctl==0.2.0a1` | unchanged | the pin resolves; `agnoctl 0.2.0a1` is on PyPI |

`agnoctl 0.2.0a1` and `agno 3.0.0a4` both return 200 from the PyPI JSON API; `agno 3.0.0a5` returns 404, so the version is free. `release.yml` checks each project's published version before building, so the `release-agnoctl` and `release-agno-infra` jobs will both no-op (agno-infra is unchanged at `1.1.1`, already published) and only `release-agno` publishes.

The dependency floor was re-verified rather than carried on trust: `>=0.2.0a1` reports `prereleases=True` and matches `Version("0.2.0a1")`, so the published wheel stays installable without `--pre`.

There is no version constant to keep in step. `agno/__init__.py` reads `__version__` from installed package metadata via `importlib.metadata.version("agno")`, so the `pyproject.toml` line is the single source of truth. The two other `3.0.0a4` strings in the tree are a cookbook test-log entry and a test comment, both historical records of what was run, not version declarations.

## What ships in this alpha

Twelve commits since the a4 cut (`a60be9eb3..33e9abc79`), all fixes:

- #9736 — stop three suites reading process-global state they do not control
- #9737 — state the team leader's delegation rule as need, not as a self-comparison
- #9745 — refuse dispatch cycles and bound dispatch depth in the Studio dispatch tools
- #9746 — end a no-task tasks run by answering; forbid joined member ids on nested rosters
- #9744 — answer 422 with the validator's message when request validation fails
- #9739 — give every eval run its own `run_id`
- #9749 — opt-in `self_dispatch` knob for the Studio dispatch guard
- #9752 — complete the workspace credential excludes; stop Studio taking version 0 literally
- #9754 — hide inner sub-team member ids from the outer roster; open with the leader's purpose
- `d0d61bc10` / `6823e62a2` — refuse a run into a session owned by another user
- #9756 — close a fail-open in the Studio edit guard; make the bigger exclude list affordable

## Merge order

#9750 (`fix: stop the knowledge config advertising readers this install cannot run`) is still open against `feat/v3.0`. Merge it **before** tagging so it lands in the alpha; it does not conflict with this PR (disjoint files), so the two can merge in either order.

## Type of change

- [x] Other: release version bump

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`) — no-op for this diff: the only change is a TOML version string, which neither `ruff` nor `mypy` reads
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
