### PR TITLE
fix: stop the startup debug log reporting non-events

### DIFF
--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -242,7 +242,6 @@ class TableResolutionCache:
             )
             return
         self._tables[(table_type, table_name)] = table
-        log_debug(f"Table cache: stored '{table_name}' ({table_type})")
 
     def invalidate(self, table_name: str, metadata: Any) -> None:
         """Forget a resolved table after a schema change (ALTER/DROP).
@@ -389,12 +388,12 @@ class BaseDb(ABC):
         if cached is not None:
             return cached
         if not create_table_if_not_found and not self.table_exists(table_name):
+            log_debug(f"Table '{table_name}' does not exist")
             return None
         with self._resolve_lock:
             cached = self._table_cache.get(table_type, table_name)
             if cached is not None:
                 return cached
-            log_debug(f"Table cache: miss for '{table_name}' ({table_type}); resolving from database")
             return self._resolve_table(
                 table_name=table_name, table_type=table_type, create_table_if_not_found=create_table_if_not_found
             )
@@ -2168,12 +2167,12 @@ class AsyncBaseDb(ABC):
         if cached is not None:
             return cached
         if not create_table_if_not_found and not await self.table_exists(table_name):
+            log_debug(f"Table '{table_name}' does not exist")
             return None
         async with self._resolve_lock_async:
             cached = self._table_cache.get(table_type, table_name)
             if cached is not None:
                 return cached
-            log_debug(f"Table cache: miss for '{table_name}' ({table_type}); resolving from database")
             return await self._resolve_table(
                 table_name=table_name, table_type=table_type, create_table_if_not_found=create_table_if_not_found
             )

--- a/libs/agno/agno/db/mysql/async_mysql.py
+++ b/libs/agno/agno/db/mysql/async_mysql.py
@@ -280,9 +280,6 @@ class AsyncMySQLDb(AsyncBaseDb):
                         )
                         exists = result.scalar() is not None
                         if exists:
-                            log_debug(
-                                f"Index {idx.name} already exists in {self.db_schema}.{table_name}, skipping creation"
-                            )
                             continue
 
                     async with self.db_engine.begin() as conn:

--- a/libs/agno/agno/db/mysql/mysql.py
+++ b/libs/agno/agno/db/mysql/mysql.py
@@ -276,9 +276,6 @@ class MySQLDb(BaseDb):
                             is not None
                         )
                         if exists:
-                            log_debug(
-                                f"Index {idx.name} already exists in {self.db_schema}.{table_name}, skipping creation"
-                            )
                             continue
 
                     idx.create(self.db_engine)

--- a/libs/agno/agno/db/mysql/utils.py
+++ b/libs/agno/agno/db/mysql/utils.py
@@ -84,9 +84,6 @@ def is_table_available(session: Session, table_name: str, db_schema: str) -> boo
             "SELECT 1 FROM information_schema.tables WHERE table_schema = :schema AND table_name = :table"
         )
         exists = session.execute(exists_query, {"schema": db_schema, "table": table_name}).scalar() is not None
-        if not exists:
-            log_debug(f"Table {db_schema}.{table_name} {'exists' if exists else 'does not exist'}")
-
         return exists
 
     except Exception as e:
@@ -414,9 +411,6 @@ async def ais_table_available(session: AsyncSession, table_name: str, db_schema:
         )
         result = await session.execute(exists_query, {"schema": db_schema, "table": table_name})
         exists = result.scalar() is not None
-        if not exists:
-            log_debug(f"Table {db_schema}.{table_name} {'exists' if exists else 'does not exist'}")
-
         return exists
 
     except Exception as e:

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -384,9 +384,6 @@ class AsyncPostgresDb(AsyncBaseDb):
                         result = await sess.execute(exists_query, {"schema": self.db_schema, "index_name": idx.name})
                         exists = result.scalar() is not None
                         if exists:
-                            log_debug(
-                                f"Index {idx.name} already exists in {self.db_schema}.{table_name}, skipping creation"
-                            )
                             continue
 
                     async with self.db_engine.begin() as conn:

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -524,9 +524,6 @@ class PostgresDb(BaseDb):
                             is not None
                         )
                         if exists:
-                            log_debug(
-                                f"Index {idx.name} already exists in {self.db_schema}.{table_name}, skipping creation"
-                            )
                             continue
 
                     idx.create(self.db_engine)

--- a/libs/agno/agno/db/singlestore/singlestore.py
+++ b/libs/agno/agno/db/singlestore/singlestore.py
@@ -379,7 +379,6 @@ class SingleStoreDb(BaseDb):
                             )
                             exists = sess.execute(exists_query, {"index_name": idx.name}).scalar() is not None
                         if exists:
-                            log_debug(f"Index {idx.name} already exists in {table_ref}, skipping creation")
                             continue
 
                     idx.create(self.db_engine)

--- a/libs/agno/agno/db/singlestore/utils.py
+++ b/libs/agno/agno/db/singlestore/utils.py
@@ -88,17 +88,12 @@ def is_table_available(session: Session, table_name: str, db_schema: Optional[st
                 "SELECT 1 FROM information_schema.tables WHERE table_schema = :schema AND table_name = :table"
             )
             exists = session.execute(exists_query, {"schema": db_schema, "table": table_name}).scalar() is not None
-            table_ref = f"{db_schema}.{table_name}"
         else:
             # Check in current database/schema
             exists_query = text(
                 "SELECT 1 FROM information_schema.tables WHERE table_name = :table AND table_schema = DATABASE()"
             )
             exists = session.execute(exists_query, {"table": table_name}).scalar() is not None
-            table_ref = table_name
-
-        if not exists:
-            log_debug(f"Table {table_ref} {'exists' if exists else 'does not exist'}")
 
         return exists
 

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -389,7 +389,6 @@ class AsyncSqliteDb(AsyncBaseDb):
                         result = await sess.execute(exists_query, {"index_name": idx.name})
                         exists = result.scalar() is not None
                         if exists:
-                            log_debug(f"Index {idx.name} already exists in table {table_name}, skipping creation")
                             continue
 
                     async with self.db_engine.begin() as conn:

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -532,7 +532,6 @@ class SqliteDb(BaseDb):
                         exists_query = text("SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = :index_name")
                         exists = sess.execute(exists_query, {"index_name": idx.name}).scalar() is not None
                         if exists:
-                            log_debug(f"Index {idx.name} already exists in table {table_name}, skipping creation")
                             continue
 
                     idx.create(self.db_engine)

--- a/libs/agno/agno/db/sqlite/utils.py
+++ b/libs/agno/agno/db/sqlite/utils.py
@@ -71,8 +71,6 @@ def is_table_available(session: Session, table_name: str, db_schema: Optional[st
         # SQLite uses sqlite_master instead of information_schema
         exists_query = text("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = :table")
         exists = session.execute(exists_query, {"table": table_name}).scalar() is not None
-        if not exists:
-            log_debug(f"Table {table_name} {'exists' if exists else 'does not exist'}")
         return exists
     except Exception as e:
         log_error(f"Error checking if table exists: {str(e)}")
@@ -90,8 +88,6 @@ async def ais_table_available(session: AsyncSession, table_name: str, db_schema:
     try:
         exists_query = text("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = :table")
         exists = (await session.execute(exists_query, {"table": table_name})).scalar() is not None
-        if not exists:
-            log_debug(f"Table {table_name} {'exists' if exists else 'does not exist'}")
         return exists
     except Exception as e:
         log_error(f"Error checking if table exists: {str(e)}")

--- a/libs/agno/agno/knowledge/utils.py
+++ b/libs/agno/agno/knowledge/utils.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, List, Optional, Tuple, Type
 from agno.knowledge.reader.base import Reader
 from agno.knowledge.reader.reader_factory import ReaderFactory
 from agno.knowledge.types import ContentType
-from agno.utils.log import log_debug
 
 RESERVED_AGNO_KEY = "_agno"
 
@@ -229,18 +228,6 @@ def get_reader_info_from_instance(reader: Reader, reader_id: str) -> Dict:
         raise ValueError(f"Failed to get info for reader '{reader_id}': {str(e)}")
 
 
-# A reader's availability cannot change inside a running process, so the same skip is logged
-# once rather than on every /knowledge/config request. The full set is in the response payload.
-_logged_skips: set = set()
-
-
-def _log_skip_once(message: str) -> None:
-    if message in _logged_skips:
-        return
-    _logged_skips.add(message)
-    log_debug(message)
-
-
 def _first_backticked_token(text: str) -> Optional[str]:
     """The first backticked token in an import failure, which is where agno puts the package.
 
@@ -296,7 +283,6 @@ def get_readers_availability(knowledge_instance: Optional[Any] = None) -> Tuple[
                     continue
                 except ValueError as e:
                     reason = str(e)
-                    _log_skip_once(f"Skipping custom reader '{reader_id}': {reason}")
 
                 unavailable_info.append(
                     {
@@ -318,7 +304,6 @@ def get_readers_availability(knowledge_instance: Optional[Any] = None) -> Tuple[
             continue
         except ValueError as e:
             reason = str(e)
-            _log_skip_once(f"Skipping reader '{key}': {reason}")
 
         missing_packages = ReaderFactory.get_missing_read_time_packages(key)
         if not missing_packages:
@@ -495,7 +480,8 @@ def get_all_chunkers_info() -> List[Dict]:
         try:
             chunker_info = get_chunker_info(key)
             chunkers_info.append(chunker_info)
-        except ValueError as e:
-            log_debug(f"Skipping chunker '{key}': {e}")
+        except ValueError:
+            # A chunker whose optional dependency is absent is simply not offered.
+            # That is the normal shape of a lean install, not a fault to report.
             continue
     return chunkers_info

--- a/libs/agno/tests/unit/knowledge/test_reader_availability.py
+++ b/libs/agno/tests/unit/knowledge/test_reader_availability.py
@@ -320,28 +320,6 @@ def test_a_declaration_keyed_by_a_plain_string_is_honoured():
     assert StringKeyedReader.get_available_content_types() == []
 
 
-def test_a_skipped_reader_is_logged_once_per_process():
-    """Availability cannot change inside a process, so the same skip is not logged per request."""
-    import agno.knowledge.utils as knowledge_utils
-
-    saved = set(knowledge_utils._logged_skips)
-    knowledge_utils._logged_skips.clear()
-    try:
-        with patch.object(knowledge_utils, "log_debug") as log:
-            with _specs(absent=("openpyxl", "xlrd")):
-                knowledge_utils.get_all_readers_info()
-                knowledge_utils.get_all_readers_info()
-                knowledge_utils.get_all_readers_info()
-
-        excel_lines = [call.args[0] for call in log.call_args_list if "'excel'" in call.args[0]]
-    finally:
-        knowledge_utils._logged_skips.clear()
-        knowledge_utils._logged_skips.update(saved)
-
-    assert len(excel_lines) == 1
-    assert "openpyxl" in excel_lines[0]
-
-
 def test_availability_is_answered_by_a_single_sweep():
     """The sweep imports every reader module, so both halves come from one pass."""
     import agno.knowledge.utils as knowledge_utils


### PR DESCRIPTION
## Summary

Debug logging that reports non-events. It is loudest on a fresh install, which is exactly where a new user is least able to tell "this is fine" from "this is broken" -- the reported symptom was a wall of `Skipping chunker ...` and `Table cache: ...` lines on a first run.

Measured on SQLite with the standard 9 tables:

| sweep | before | after |
| --- | --- | --- |
| cold start (tables created) | 121 lines | **9** -- one `Successfully created table` each |
| reader availability | 15 lines | **0** |
| chunker availability | 3 lines | **0** |

Warm start was already silent and is unchanged: a table that exists is reflected, never routed through the create path.

## What was removed, and why each was a non-event

**1. Table cache bookkeeping** (`db/base.py`)

`Table cache: stored 'X'` and `Table cache: miss for 'X'; resolving from database`. A miss is immediately followed by the resolution it announces, which already logs `Successfully created table` (or reflects silently). Introduced in #9622; this is my noise.

The two rare lines are kept, because they report something genuinely unusual: `refused stale store` (a resolver suspended across an invalidation) and `invalidated` (a schema change evicting entries).

**2. The existence probe** (`db/{sqlite,mysql,singlestore}/utils.py`)

```python
if not exists:
    log_debug(f"Table {table_name} {'exists' if exists else 'does not exist'}")
```

Two defects in three lines. The `'exists'` half of the ternary is unreachable -- the guard is `if not exists`. And it fired **twice per table** on the create path (once from `_resolve_table`, once from `_create_table`), on a path where table creation already reports itself.

Rather than delete the signal, it moved to the one place where a missing table is the final answer and nothing else speaks: the read path in `BaseDb._get_or_create_table` / `AsyncBaseDb`, which returns `None`. That path now logs exactly once:

```
DEBUG Table 'agno_sessions' does not exist
```

Verified that nothing else goes dark: every direct `_resolve_table` caller (the FK-parent resolution from #9622) passes `create_table_if_not_found=True`, so a missing table there is created and logged as created.

**3. Per-index "already exists"** (7 surfaces: sqlite, postgres, mysql sync+async, singlestore)

`table.create()` already creates the indexes attached to the table. The loop that follows therefore found every index present and logged `Index idx_X already exists in table Y, skipping creation` -- directly after `Successfully created table 'Y'`, which reads as a contradiction. This was the single largest source (35 of the 121 lines).

Only the line reporting the no-op is gone. The existence check and the `continue` are untouched, so behaviour is identical -- this PR is logging-only by construction. (The redundant `SELECT` per index is left alone deliberately; it is a behaviour change and belongs in its own PR. Noted under Follow-ups.)

**4. Reader and chunker skips** (`knowledge/utils.py`)

An optional dependency that is not installed is the normal shape of a lean install, not a fault to report:

```
DEBUG Skipping chunker 'SemanticChunker': ... `numpy` not installed ...
DEBUG Skipping reader 'website': ... `bs4` package is not installed ...
```

For readers the information is **not lost**. `get_readers_availability()` already returns every unavailable reader as structured data, which is what `/knowledge/config` surfaces to the UI:

```python
{'id': 'website', 'name': ..., 'description': ...,
 'missing_packages': ['bs4'],
 'reason': "Reader 'website' has missing dependencies: The `bs4` package is not installed. ..."}
```

The log line was therefore redundant with data the same response already carries. `_log_skip_once` and `_logged_skips` were the machinery behind it and are now unused, so both are gone.

### One test was deliberately removed

`test_a_skipped_reader_is_logged_once_per_process` pinned the once-per-process de-duplication of that reader log. It was added in #9750 (merged today) and is obsolete now that the log itself is gone -- keeping it would pin behaviour this PR intentionally removes. Called out explicitly rather than left to a reviewer to notice.

## Verification

- `./scripts/format.sh` and `./scripts/validate.sh` -- clean (ruff caught a dead `table_ref` in `singlestore/utils.py` left behind by the removal; fixed)
- `libs/agno/tests/unit/db/` -- 1089 passed, 211 skipped
- `libs/agno/tests/unit/knowledge/` -- 39 failed / 437 passed, against a **39 failed / 438 passed** baseline on `feat/v3.0` measured by stashing this diff. Identical failures; the one-pass difference is the deliberately removed test. Those 39 and the collection errors are pre-existing optional-dependency gaps in the local venv, untouched by this PR.
- Signals confirmed still present after the change: read path on a missing table logs once; unavailable readers still returned with `missing_packages` and verbatim `reason`.

## Follow-up (not in this PR)

The per-index existence `SELECT` on the create path is redundant for the same reason its log line was -- `table.create()` already made those indexes. Skipping the loop when `table_created` is true would save one round-trip per index per cold start (~35 on SQLite). That is a behaviour change and wants its own tests.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable) -- one obsolete test removed, explained above

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
