### PR TITLE
test: pin ffmpeg in the docling media tests instead of inheriting the machine's

### DIFF
--- a/libs/agno/tests/unit/knowledge/test_reader_availability.py
+++ b/libs/agno/tests/unit/knowledge/test_reader_availability.py
@@ -85,6 +85,25 @@ def _package_absent(package: str, *reimport: str):
                 sys.modules[name] = module
 
 
+def _ffmpeg(present: bool):
+    """Force the answer for the ffmpeg binary, leaving every other lookup alone.
+
+    Pinned in both directions on purpose: docling's media formats need the binary as well as
+    a speech package, so a test that let PATH decide would assert one thing on a developer
+    machine that has ffmpeg and another on a runner that does not.
+    """
+    import shutil as shutil_module
+
+    real_which = shutil_module.which
+
+    def fake(name, *args, **kwargs):
+        if name == "ffmpeg":
+            return "/usr/bin/ffmpeg" if present else None
+        return real_which(name, *args, **kwargs)
+
+    return patch("agno.knowledge.reader.docling_reader.shutil.which", side_effect=fake)
+
+
 def test_excel_reader_is_not_advertised_when_neither_engine_is_installed():
     with _specs(absent=("openpyxl", "xlrd")):
         with pytest.raises(ValueError, match=r"^Reader 'excel' has missing dependencies:.*openpyxl"):
@@ -257,7 +276,7 @@ def test_every_hard_function_scoped_reader_import_is_declared():
 
 def test_docling_does_not_advertise_audio_it_cannot_transcribe():
     """docling loads its speech engine at read time, so the class import proves nothing."""
-    with _specs(absent=("whisper", "mlx_whisper", "whisper_s2t")):
+    with _ffmpeg(present=True), _specs(absent=("whisper", "mlx_whisper", "whisper_s2t")):
         info = get_reader_info("docling")
 
     assert ContentType.AUDIO_MP3.value not in info["content_types"]
@@ -266,7 +285,7 @@ def test_docling_does_not_advertise_audio_it_cannot_transcribe():
 
 
 def test_docling_advertises_audio_when_the_engine_is_installed():
-    with _specs(present=("whisper",)):
+    with _ffmpeg(present=True), _specs(present=("whisper",)):
         info = get_reader_info("docling")
 
     assert ContentType.AUDIO_MP3.value in info["content_types"]
@@ -360,20 +379,9 @@ def test_availability_is_answered_by_a_single_sweep():
     assert len(available) + len(unavailable) == len(calls)
 
 
-def _no_ffmpeg():
-    """PATH without ffmpeg, leaving every other lookup alone."""
-    import shutil as shutil_module
-
-    real_which = shutil_module.which
-    return patch(
-        "agno.knowledge.reader.docling_reader.shutil.which",
-        side_effect=lambda name, *a, **kw: None if name == "ffmpeg" else real_which(name, *a, **kw),
-    )
-
-
 def test_docling_media_needs_ffmpeg_not_just_a_speech_package():
     """Docling fails outright without the binary, whatever Python packages are installed."""
-    with _no_ffmpeg(), _specs(present=("whisper",)):
+    with _ffmpeg(present=False), _specs(present=("whisper",)):
         info = get_reader_info("docling")
 
     assert ContentType.AUDIO_WAV.value not in info["content_types"]
@@ -384,7 +392,7 @@ def test_docling_media_needs_ffmpeg_not_just_a_speech_package():
 
 def test_docling_media_accepts_any_speech_backend():
     """Docling picks its backend by hardware, so requiring one package would hide a working one."""
-    with _specs(absent=("whisper", "whisper_s2t"), present=("mlx_whisper",)):
+    with _ffmpeg(present=True), _specs(absent=("whisper", "whisper_s2t"), present=("mlx_whisper",)):
         info = get_reader_info("docling")
 
     assert ContentType.AUDIO_WAV.value in info["content_types"]
@@ -392,7 +400,7 @@ def test_docling_media_accepts_any_speech_backend():
 
 
 def test_docling_media_names_a_backend_that_works_everywhere():
-    with _specs(absent=("whisper", "mlx_whisper", "whisper_s2t")):
+    with _ffmpeg(present=True), _specs(absent=("whisper", "mlx_whisper", "whisper_s2t")):
         info = get_reader_info("docling")
 
     assert ContentType.AUDIO_WAV.value not in info["content_types"]


### PR DESCRIPTION
## Summary

Four tests added in #9750 fail on CI (`tests (2/5)`, [run 32723171248](https://github.com/agno-agi/agno/actions/runs/32723171248/job/97418843746)):

```
test_docling_does_not_advertise_audio_it_cannot_transcribe   FAILED
test_docling_advertises_audio_when_the_engine_is_installed   FAILED
test_docling_media_accepts_any_speech_backend                FAILED
test_docling_media_names_a_backend_that_works_everywhere     FAILED
```

```
E  AssertionError: assert ['ffmpeg', 'openai-whisper'] == ['openai-whisper']
E  AssertionError: assert '.wav' in info["content_types"]
```

**The production behaviour is correct and unchanged.** `DoclingReader` withdraws its audio and video formats unless the `ffmpeg` binary is on PATH *and* a speech backend is importable — a runner with no ffmpeg genuinely cannot transcribe, so not advertising those formats is the right answer.

The tests were wrong, in one specific way: they pinned the *packages* with `_specs(...)` but let PATH decide the *binary*. ffmpeg is installed on my machine and not on the GitHub runner, so the same assertions meant different things in the two places. The fifth test in that group, `test_docling_media_needs_ffmpeg_not_just_a_speech_package`, passed on CI precisely because it was the one that patched `shutil.which`.

`_no_ffmpeg()` becomes `_ffmpeg(present: bool)`, and every docling media test now states the binary in the direction it means, exactly as it already states the packages.

## Verification

| run | result |
|---|---|
| ffmpeg on PATH (dev machine) | 23 passed |
| `PATH=/usr/bin:/bin:/usr/sbin:/sbin` — reproduces the runner | 23 passed |
| same restricted PATH, **without** this fix | **4 failed**, 19 passed — CI's exact four |

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Test-only; no `agno/` file changes. The lesson is the general one — a test that reads an ambient fact about the machine asserts something different on every machine, and `shutil.which` is as much an environment read as an import is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)