### PR TITLE
fix: surface completed-run persistence failures

### DIFF
--- a/libs/agno/agno/agent/_storage.py
+++ b/libs/agno/agno/agent/_storage.py
@@ -413,16 +413,9 @@ def upsert_session(
         session: The session to upsert.
     """
 
-    try:
-        if not agent.db:
-            raise ValueError("Db not initialized")
-        return agent.db.upsert_session(session=session)  # type: ignore
-    except Exception as e:
-        import traceback
-
-        traceback.print_exc(limit=3)
-        log_warning(f"Error upserting session into db: {str(e)}")
-        return None
+    if not agent.db:
+        raise ValueError("Db not initialized")
+    return agent.db.upsert_session(session=session)  # type: ignore
 
 
 async def aupsert_session(
@@ -439,19 +432,11 @@ async def aupsert_session(
     """
     from agno.agent import _init
 
-    try:
-        if not agent.db:
-            raise ValueError("Db not initialized")
-        if _init.has_async_db(agent):
-            return await agent.db.upsert_session(session=session)  # type: ignore
-        else:
-            return agent.db.upsert_session(session=session)  # type: ignore
-    except Exception as e:
-        import traceback
-
-        traceback.print_exc(limit=3)
-        log_warning(f"Error upserting session into db: {str(e)}")
-        return None
+    if not agent.db:
+        raise ValueError("Db not initialized")
+    if _init.has_async_db(agent):
+        return await agent.db.upsert_session(session=session)  # type: ignore
+    return agent.db.upsert_session(session=session)  # type: ignore
 
 
 def upsert_run(
@@ -490,11 +475,6 @@ def upsert_run(
         # Adapter has not been ported to v3 storage; runs are persisted inline
         # via upsert_session instead. Silent no-op.
         log_debug(f"{type(agent.db).__name__} does not implement upsert_run; skipping per-run write")
-    except Exception as e:
-        import traceback
-
-        traceback.print_exc(limit=3)
-        log_warning(f"Error upserting run into db: {str(e)}")
 
 
 async def aupsert_run(
@@ -537,11 +517,6 @@ async def aupsert_run(
             agent.db.upsert_run(run=run, session_id=session_id, user_id=user_id, run_index=run_index)  # type: ignore[union-attr]
     except NotImplementedError:
         log_debug(f"{type(agent.db).__name__} does not implement upsert_run; skipping per-run write")
-    except Exception as e:
-        import traceback
-
-        traceback.print_exc(limit=3)
-        log_warning(f"Error upserting run into db: {str(e)}")
 
 
 # ---------------------------------------------------------------------------

--- a/libs/agno/agno/team/_storage.py
+++ b/libs/agno/agno/team/_storage.py
@@ -230,30 +230,20 @@ async def _aread_session(
 
 def _upsert_session(team: "Team", session: TeamSession) -> Optional[TeamSession]:
     """Upsert a Session into the database."""
-
-    try:
-        if not team.db:
-            raise ValueError("Db not initialized")
-        return team.db.upsert_session(session=session)  # type: ignore
-    except Exception as e:
-        log_warning(f"Error upserting session into db: {str(e)}")
-    return None
+    if not team.db:
+        raise ValueError("Db not initialized")
+    return team.db.upsert_session(session=session)  # type: ignore
 
 
 async def _aupsert_session(team: "Team", session: TeamSession) -> Optional[TeamSession]:
     """Upsert a Session into the database."""
     from agno.team._init import _has_async_db
 
-    try:
-        if not team.db:
-            raise ValueError("Db not initialized")
-        if _has_async_db(team):
-            return await team.db.upsert_session(session=session)  # type: ignore
-        else:
-            return team.db.upsert_session(session=session)  # type: ignore
-    except Exception as e:
-        log_warning(f"Error upserting session into db: {str(e)}")
-    return None
+    if not team.db:
+        raise ValueError("Db not initialized")
+    if _has_async_db(team):
+        return await team.db.upsert_session(session=session)  # type: ignore
+    return team.db.upsert_session(session=session)  # type: ignore
 
 
 def _upsert_run(
@@ -280,8 +270,6 @@ def _upsert_run(
         team.db.upsert_run(run=run, session_id=session_id, user_id=user_id, run_index=run_index)  # type: ignore[union-attr]
     except NotImplementedError:
         log_debug(f"{type(team.db).__name__} does not implement upsert_run; skipping per-run write")
-    except Exception as e:
-        log_warning(f"Error upserting run into db: {str(e)}")
 
 
 async def _aupsert_run(
@@ -309,8 +297,6 @@ async def _aupsert_run(
             team.db.upsert_run(run=run, session_id=session_id, user_id=user_id, run_index=run_index)  # type: ignore[union-attr]
     except NotImplementedError:
         log_debug(f"{type(team.db).__name__} does not implement upsert_run; skipping per-run write")
-    except Exception as e:
-        log_warning(f"Error upserting run into db: {str(e)}")
 
 
 def _read_or_create_session(team: "Team", session_id: str, user_id: Optional[str] = None) -> TeamSession:

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -2046,14 +2046,10 @@ class Workflow:
 
     async def _aupsert_session(self, session: WorkflowSession) -> Optional[WorkflowSession]:
         """Upsert a Session into the database."""
-        try:
-            if not self.db:
-                raise ValueError("Db not initialized")
-            result = await self.db.upsert_session(session=session)  # type: ignore
-            return result if isinstance(result, (WorkflowSession, type(None))) else None
-        except Exception as e:
-            log_warning(f"Error upserting session into db: {str(e)}")
-            return None
+        if not self.db:
+            raise ValueError("Db not initialized")
+        result = await self.db.upsert_session(session=session)  # type: ignore
+        return result if isinstance(result, (WorkflowSession, type(None))) else None
 
     def _upsert_session(self, session: WorkflowSession) -> Optional[WorkflowSession]:
         """Upsert a Session into the database."""
@@ -2062,14 +2058,10 @@ class Workflow:
                 "Cannot use sync _upsert_session() with an async database. Use _aupsert_session() instead."
             )
 
-        try:
-            if not self.db:
-                raise ValueError("Db not initialized")
-            result = self.db.upsert_session(session=session)
-            return result if isinstance(result, (WorkflowSession, type(None))) else None
-        except Exception as e:
-            log_warning(f"Error upserting session into db: {str(e)}")
-            return None
+        if not self.db:
+            raise ValueError("Db not initialized")
+        result = self.db.upsert_session(session=session)
+        return result if isinstance(result, (WorkflowSession, type(None))) else None
 
     def save_run(
         self,
@@ -2099,8 +2091,6 @@ class Workflow:
             self.db.upsert_run(run=run, session_id=session_id, user_id=user_id, run_index=run_index)  # type: ignore[union-attr]
         except NotImplementedError:
             log_debug(f"{type(self.db).__name__} does not implement upsert_run; skipping per-run write")
-        except Exception as e:
-            log_warning(f"Error upserting run into db: {str(e)}")
 
     async def asave_run(
         self,
@@ -2129,8 +2119,6 @@ class Workflow:
                 self.db.upsert_run(run=run, session_id=session_id, user_id=user_id, run_index=run_index)  # type: ignore[union-attr]
         except NotImplementedError:
             log_debug(f"{type(self.db).__name__} does not implement upsert_run; skipping per-run write")
-        except Exception as e:
-            log_warning(f"Error upserting run into db: {str(e)}")
 
     def _scrub_run_media_copy(self, run: "WorkflowRunOutput") -> "WorkflowRunOutput":
         """Drop media from a deep copy of ``run`` before it is written to the runs table.
@@ -2790,6 +2778,7 @@ class Workflow:
         workflow_run_response.status = RunStatus.running
 
         if callable(self.steps):
+            execution_error: Optional[Exception] = None
             try:
                 if iscoroutinefunction(self.steps) or isasyncgenfunction(self.steps):
                     raise ValueError("Cannot use async function with synchronous execution")
@@ -2813,6 +2802,9 @@ class Workflow:
                 logger.info(f"Workflow run {workflow_run_response.run_id} was cancelled")
                 workflow_run_response.status = RunStatus.cancelled
                 workflow_run_response.content = _normalize_workflow_cancellation_reason(workflow_run_response, e)
+            except Exception as e:
+                execution_error = e
+                raise
             finally:
                 if workflow_run_response.metrics:
                     workflow_run_response.metrics.stop_timer()
@@ -2821,10 +2813,13 @@ class Workflow:
                     session.upsert_run(run=workflow_run_response)
                     self._persist_session_and_run(session=session, run=workflow_run_response)
                 except Exception as store_err:
+                    if execution_error is None:
+                        raise
                     log_warning(f"Failed to persist workflow run: {store_err}")
                 cleanup_run(workflow_run_response.run_id)  # type: ignore
                 cleanup_member_runs(workflow_run_response.run_id)  # type: ignore
         else:
+            execution_error = None
             try:
                 # Track outputs from each step for enhanced data flow
                 collected_step_outputs: List[Union[StepOutput, List[StepOutput]]] = []
@@ -3090,6 +3085,7 @@ class Workflow:
                         workflow_run_response.metrics,  # type: ignore[arg-type]
                     )
             except Exception as e:
+                execution_error = e
                 import traceback
 
                 traceback.print_exc()
@@ -3108,6 +3104,8 @@ class Workflow:
                     session.upsert_run(run=workflow_run_response)
                     self._persist_session_and_run(session=session, run=workflow_run_response)
                 except Exception as store_err:
+                    if execution_error is None:
+                        raise
                     log_warning(f"Failed to persist workflow run: {store_err}")
                 # Always clean up the run tracking
                 cleanup_run(workflow_run_response.run_id)  # type: ignore
@@ -3705,7 +3703,7 @@ class Workflow:
             metadata=workflow_run_response.metadata,
             run_output=workflow_run_response,  # Include full run output for nested workflows
         )
-        yield self._handle_event(workflow_completed_event, workflow_run_response)
+        handled_completed_event = self._handle_event(workflow_completed_event, workflow_run_response)
 
         # Stop timer on error
         if workflow_run_response.metrics:
@@ -3715,6 +3713,7 @@ class Workflow:
         self._update_session_metrics(session=session, workflow_run_response=workflow_run_response)
         session.upsert_run(run=workflow_run_response)
         self._persist_session_and_run(session=session, run=workflow_run_response)
+        yield handled_completed_event
 
         # Always clean up the run tracking
         cleanup_run(workflow_run_response.run_id)  # type: ignore
@@ -4791,7 +4790,7 @@ class Workflow:
             metadata=workflow_run_response.metadata,
             run_output=workflow_run_response,  # Include full run output for nested workflows
         )
-        yield self._handle_event(workflow_completed_event, workflow_run_response)
+        handled_completed_event = self._handle_event(workflow_completed_event, workflow_run_response)
 
         # Stop timer on error
         if workflow_run_response.metrics:
@@ -4801,6 +4800,7 @@ class Workflow:
         self._update_session_metrics(session=workflow_session, workflow_run_response=workflow_run_response)
         workflow_session.upsert_run(run=workflow_run_response)
         await self._apersist_session_and_run(session=workflow_session, run=workflow_run_response)
+        yield handled_completed_event
 
         # Log Workflow Telemetry
         if self.telemetry:

--- a/libs/agno/tests/unit/run/test_persistence_failure_visibility.py
+++ b/libs/agno/tests/unit/run/test_persistence_failure_visibility.py
@@ -83,6 +83,21 @@ def test_completed_run_surfaces_run_persistence_failure(kind: str, tmp_path: Any
 
 
 @pytest.mark.parametrize("kind", ["agent", "team", "workflow"])
+def test_failed_second_run_leaves_previous_durable_run_visible(kind: str, tmp_path: Any) -> None:
+    db = SqliteDb(db_file=str(tmp_path / f"{kind}-stale.db"))
+    component = _component(kind, db)
+
+    first = component.run("first", session_id="session", metadata={"amount": "12.34"})
+    before = [run.run_id for run in db.get_runs(session_id="session")]
+
+    with pytest.raises(StatementError, match="Decimal"):
+        component.run("second", session_id="session", metadata={"amount": Decimal("12.34")})
+
+    assert before == [first.run_id]
+    assert [run.run_id for run in db.get_runs(session_id="session")] == before
+
+
+@pytest.mark.parametrize("kind", ["agent", "team", "workflow"])
 async def test_async_completed_run_surfaces_run_persistence_failure(kind: str, tmp_path: Any) -> None:
     db = SqliteDb(db_file=str(tmp_path / f"{kind}-async.db"))
     component = _component(kind, db)

--- a/libs/agno/tests/unit/run/test_persistence_failure_visibility.py
+++ b/libs/agno/tests/unit/run/test_persistence_failure_visibility.py
@@ -1,0 +1,205 @@
+"""Persistence failures must not be reported as successful runs."""
+
+from collections.abc import AsyncIterator, Iterator
+from decimal import Decimal
+from typing import Any
+
+import pytest
+from sqlalchemy.exc import StatementError
+
+from agno.agent import Agent
+from agno.db.in_memory import InMemoryDb
+from agno.db.sqlite import AsyncSqliteDb, SqliteDb
+from agno.models.base import Model
+from agno.models.message import MessageMetrics
+from agno.models.response import ModelResponse
+from agno.run.base import RunStatus
+from agno.run.workflow import WorkflowCompletedEvent
+from agno.team import Team
+from agno.workflow import Workflow
+
+
+class MockModel(Model):
+    def __init__(self) -> None:
+        super().__init__(id="test-model", name="test-model", provider="test")
+        self.instructions = None
+        self._response = ModelResponse(content="ok", role="assistant", response_usage=MessageMetrics())
+
+    def get_instructions_for_model(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def get_system_message_for_model(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    async def aget_instructions_for_model(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    async def aget_system_message_for_model(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def parse_args(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {}
+
+    def invoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return self._response
+
+    async def ainvoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return self._response
+
+    def invoke_stream(self, *args: Any, **kwargs: Any) -> Iterator[ModelResponse]:
+        yield self._response
+
+    async def ainvoke_stream(self, *args: Any, **kwargs: Any) -> AsyncIterator[ModelResponse]:
+        yield self._response
+
+    def _parse_provider_response(self, response: Any, **kwargs: Any) -> ModelResponse:
+        return self._response
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return self._response
+
+
+def _workflow_step(workflow: Workflow, execution_input: Any, **kwargs: Any) -> Any:
+    return "ok"
+
+
+def _component(kind: str, db: Any) -> Any:
+    if kind == "agent":
+        return Agent(id="agent", model=MockModel(), db=db, telemetry=False)
+    if kind == "team":
+        return Team(id="team", name="team", members=[], model=MockModel(), db=db, telemetry=False)
+    return Workflow(id="workflow", name="workflow", steps=_workflow_step, db=db, telemetry=False)
+
+
+@pytest.mark.parametrize("kind", ["agent", "team", "workflow"])
+def test_completed_run_surfaces_run_persistence_failure(kind: str, tmp_path: Any) -> None:
+    db = SqliteDb(db_file=str(tmp_path / f"{kind}.db"))
+    component = _component(kind, db)
+
+    with pytest.raises(StatementError, match="Decimal"):
+        component.run("hello", session_id="session", metadata={"amount": Decimal("12.34")})
+
+    assert db.get_runs(session_id="session") == []
+
+
+@pytest.mark.parametrize("kind", ["agent", "team", "workflow"])
+async def test_async_completed_run_surfaces_run_persistence_failure(kind: str, tmp_path: Any) -> None:
+    db = SqliteDb(db_file=str(tmp_path / f"{kind}-async.db"))
+    component = _component(kind, db)
+
+    with pytest.raises(StatementError, match="Decimal"):
+        await component.arun("hello", session_id="session", metadata={"amount": Decimal("12.34")})
+
+    assert db.get_runs(session_id="session") == []
+
+
+@pytest.mark.parametrize("kind", ["agent", "team", "workflow"])
+async def test_async_db_completed_run_surfaces_run_persistence_failure(kind: str, tmp_path: Any) -> None:
+    db = AsyncSqliteDb(db_file=str(tmp_path / f"{kind}-native-async.db"))
+    component = _component(kind, db)
+
+    try:
+        with pytest.raises(StatementError, match="Decimal"):
+            await component.arun("hello", session_id="session", metadata={"amount": Decimal("12.34")})
+
+        assert await db.get_runs(session_id="session") == []
+    finally:
+        await db.close()
+
+
+def test_streaming_workflow_persists_before_completed_event(tmp_path: Any) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "workflow-stream.db"))
+    workflow = _component("workflow", db)
+    events = []
+
+    with pytest.raises(StatementError, match="Decimal"):
+        events.extend(workflow.run("hello", session_id="session", metadata={"amount": Decimal("12.34")}, stream=True))
+
+    assert not any(isinstance(event, WorkflowCompletedEvent) for event in events)
+
+
+async def test_async_streaming_workflow_persists_before_completed_event(tmp_path: Any) -> None:
+    db = AsyncSqliteDb(db_file=str(tmp_path / "workflow-stream-async.db"))
+    workflow = _component("workflow", db)
+    events = []
+
+    try:
+        with pytest.raises(StatementError, match="Decimal"):
+            async for event in workflow.arun(
+                "hello", session_id="session", metadata={"amount": Decimal("12.34")}, stream=True
+            ):
+                events.append(event)
+
+        assert not any(isinstance(event, WorkflowCompletedEvent) for event in events)
+    finally:
+        await db.close()
+
+
+class FailingSessionDb(InMemoryDb):
+    def upsert_session(self, *args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("session commit failed")
+
+
+@pytest.mark.parametrize("kind", ["agent", "team", "workflow"])
+def test_session_persistence_failure_propagates(kind: str) -> None:
+    component = _component(kind, FailingSessionDb())
+
+    with pytest.raises(RuntimeError, match="session commit failed"):
+        component.run("hello", session_id="session")
+
+
+@pytest.mark.parametrize("kind", ["agent", "team", "workflow"])
+async def test_async_session_persistence_failure_propagates(kind: str) -> None:
+    component = _component(kind, FailingSessionDb())
+
+    with pytest.raises(RuntimeError, match="session commit failed"):
+        await component.arun("hello", session_id="session")
+
+
+class FailingAsyncSessionDb(AsyncSqliteDb):
+    async def upsert_session(self, *args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("async session commit failed")
+
+
+@pytest.mark.parametrize("kind", ["agent", "team", "workflow"])
+async def test_async_db_session_persistence_failure_propagates(kind: str, tmp_path: Any) -> None:
+    db = FailingAsyncSessionDb(db_file=str(tmp_path / f"{kind}-session-async.db"))
+    component = _component(kind, db)
+
+    try:
+        with pytest.raises(RuntimeError, match="async session commit failed"):
+            await component.arun("hello", session_id="session")
+    finally:
+        await db.close()
+
+
+class LegacyRunDb(InMemoryDb):
+    def upsert_run(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+
+@pytest.mark.parametrize("kind", ["agent", "team", "workflow"])
+def test_legacy_adapter_without_run_store_remains_supported(kind: str) -> None:
+    component = _component(kind, LegacyRunDb())
+
+    result = component.run("hello", session_id="session")
+
+    assert result.status == RunStatus.completed
+
+
+class LegacyAsyncRunDb(AsyncSqliteDb):
+    async def upsert_run(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+
+@pytest.mark.parametrize("kind", ["agent", "team", "workflow"])
+async def test_legacy_async_adapter_without_run_store_remains_supported(kind: str, tmp_path: Any) -> None:
+    db = LegacyAsyncRunDb(db_file=str(tmp_path / f"{kind}-legacy-async.db"))
+    component = _component(kind, db)
+
+    try:
+        result = await component.arun("hello", session_id="session")
+
+        assert result.status == RunStatus.completed
+    finally:
+        await db.close()


### PR DESCRIPTION
## Summary

A completed Agent, Team, or Workflow run can currently return normal success after the database rejects both the session snapshot and the v3 run-row write. This leaves callers believing state is durable while storage is absent or stale. A concrete SQLite reproduction is `metadata={"amount": Decimal("12.34")}`: the run returns `RunStatus.completed`, while `get_runs()` remains empty.

This change makes completed-run persistence fail closed:

- propagate session and per-run database errors across Agent, Team, and Workflow, in sync and async execution;
- retain the existing `NotImplementedError` compatibility path for adapters that do not implement the v3 runs table;
- emit Workflow stream completion only after the session and run writes succeed, matching Agent/Team commit-before-ack behavior;
- preserve the original Workflow execution exception when error-path persistence also fails, so a secondary storage failure does not replace the root cause.

Fixes #9399

### Before / after

Before: execution succeeds, persistence raises internally, the exception is logged and swallowed, and the caller receives ordinary completion despite an absent or stale durable row.

After: the same call surfaces the backend persistence exception and no Workflow completed event is emitted before the durable write. Legacy adapters that explicitly signal unsupported per-run storage with `NotImplementedError` continue to complete normally.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation reviewed; no public API documentation change is required
- [x] Examples and guides reviewed; no cookbook change is required for this failure-mode fix
- [x] Tested in a clean local environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I searched existing open pull requests and confirmed that no other PR addresses #9399
- [x] No similar PR exists that requires an approach comparison
- [x] This PR was developed with AI assistance (Codex); the reproduction, compatibility cases, and reported test commands were executed against the submitted tree

---

## Additional Notes

Validation performed:

- `./scripts/format.sh`
- `./scripts/validate.sh` (Ruff, Mypy over 1,013 Agno source files and 21 agnoctl source files, cookbook pattern checks)
- `.venv/bin/python -m pytest libs/agno/tests/unit/agent libs/agno/tests/unit/team libs/agno/tests/unit/workflow libs/agno/tests/unit/run -q -o log_cli=false` (`2250 passed, 9 skipped`)
- focused persistence and Workflow error-path regression tests (`34 passed`)

The regression matrix covers Agent, Team, and Workflow; sync execution; async execution with both sync and native async databases; session-write and run-write failures; stream completion ordering; and legacy adapters without a separate run store.
