### PR TITLE
[fix] Refuse stale team continuations over terminal runs

### DIFF
--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -7561,6 +7561,12 @@ def continue_run_dispatch(
     team_session = _read_or_create_session(team, session_id=session_id, user_id=user_id)
     _update_metadata(team, session=team_session)
 
+    # A caller-held run_response is only a snapshot. Read the run row directly
+    # so a cached session or stale caller object cannot hide a durable terminal
+    # transition before the continuation applies approvals or executes tools.
+    durable_run = cast(Any, team.db).get_run(run_id_resolved) if team.db is not None else None
+    _raise_if_stale_terminal_run(run_response, durable_run, fork=fork, regenerate=regenerate)
+
     # Fall back to the owner the run paused with, so the resume retrieves under the same scope
     if user_id is None:
         user_id = _resolve_continue_owner_team(run_response, run_id=run_id_resolved, session=team_session)
@@ -8761,6 +8767,28 @@ def _as_run_status(value: Union[RunStatus, str, None]) -> Union[RunStatus, str, 
         return value
 
 
+def _raise_if_stale_terminal_run(
+    run_response: Optional[TeamRunOutput],
+    durable_run: Optional[Any],
+    *,
+    fork: bool,
+    regenerate: bool,
+) -> None:
+    """Refuse an in-place continue when durable terminal state supersedes a caller snapshot."""
+    if run_response is None or durable_run is None or fork or regenerate:
+        return
+    if getattr(durable_run, "run_id", None) != run_response.run_id:
+        return
+
+    durable_status = _as_run_status(getattr(durable_run, "status", None))
+    caller_status = _as_run_status(run_response.status)
+    if durable_status in (RunStatus.completed, RunStatus.cancelled) and caller_status != durable_status:
+        raise RunNotContinuableError(
+            f"Cannot continue run {run_response.run_id}: caller status {caller_status} conflicts with durable "
+            f"terminal status {durable_status}. The stored run is unchanged."
+        )
+
+
 async def _acontinue_run_background_stream(
     team: Team,
     run_context: RunContext,
@@ -9424,7 +9452,7 @@ async def _acontinue_run(
 ) -> TeamRunOutput:
     """Continue a paused team run (async, non-streaming)."""
     from agno.team._hooks import _aexecute_post_hooks
-    from agno.team._init import _disconnect_connectable_tools, _disconnect_mcp_tools
+    from agno.team._init import _disconnect_connectable_tools, _disconnect_mcp_tools, _has_async_db
     from agno.team._telemetry import alog_team_telemetry
     from agno.team._tools import _aget_learning_tools, _check_and_refresh_mcp_tools, _determine_tools_for_model
 
@@ -9458,6 +9486,14 @@ async def _acontinue_run(
                     user_id=user_id,
                     run_id=run_id,
                 )
+
+                durable_run = None
+                if run_response is not None and team.db is not None:
+                    if _has_async_db(team):
+                        durable_run = await team.db.get_run(run_response.run_id)  # type: ignore[union-attr,misc]
+                    else:
+                        durable_run = team.db.get_run(run_response.run_id)  # type: ignore[union-attr]
+                _raise_if_stale_terminal_run(run_response, durable_run, fork=fork, regenerate=regenerate)
 
                 # Fall back to the owner the run paused with, so the resume retrieves under
                 # the same scope.
@@ -9904,7 +9940,7 @@ async def _acontinue_run_stream(
 ) -> AsyncIterator[Union[TeamRunOutputEvent, RunOutputEvent, TeamRunOutput]]:
     """Continue a paused team run (async, streaming)."""
     from agno.team._hooks import _aexecute_post_hooks
-    from agno.team._init import _disconnect_connectable_tools, _disconnect_mcp_tools
+    from agno.team._init import _disconnect_connectable_tools, _disconnect_mcp_tools, _has_async_db
     from agno.team._response import (
         _ahandle_model_response_stream,
         agenerate_response_with_output_model_stream,
@@ -9939,6 +9975,14 @@ async def _acontinue_run_stream(
                     user_id=user_id,
                     run_id=run_id,
                 )
+
+                durable_run = None
+                if run_response is not None and team.db is not None:
+                    if _has_async_db(team):
+                        durable_run = await team.db.get_run(run_response.run_id)  # type: ignore[union-attr,misc]
+                    else:
+                        durable_run = team.db.get_run(run_response.run_id)  # type: ignore[union-attr]
+                _raise_if_stale_terminal_run(run_response, durable_run, fork=fork, regenerate=regenerate)
 
                 # Fall back to the owner the run paused with, so the resume retrieves under
                 # the same scope.

--- a/libs/agno/tests/unit/team/test_paused_member_persistence.py
+++ b/libs/agno/tests/unit/team/test_paused_member_persistence.py
@@ -6058,3 +6058,310 @@ def test_a_routing_failure_restores_the_callers_team_level_requirements(tmp_path
 
     names = [r.tool_execution.tool_name for r in (run1.requirements or [])]
     assert names.count("publish") == 1, f"the caller's run object carries: {names}"
+
+
+# ---------------------------------------------------------------------------
+# Issue #9447: foreground continue must use the stored terminal status.
+#
+# These tests intentionally describe the safe contract.  On the affected
+# revision the six terminal-state cases are RED and report the persisted status
+# and side effects that crossed the stale caller-object boundary.
+# ---------------------------------------------------------------------------
+
+
+def _issue_9447_state(db_file: str, session_id: str, run_id: str) -> RunStatus:
+    stored = [r for r in _reload_runs(db_file, session_id) if r.run_id == run_id]
+    assert len(stored) == 1
+    return stored[0].status
+
+
+def _issue_9447_assert_refused(
+    *, refused: bool, stored_status: RunStatus, expected_status: RunStatus, expected_executions: List[str]
+) -> None:
+    assert refused and stored_status == expected_status and _EXECUTED == expected_executions, (
+        f"refused={refused}, stored_status={stored_status!r}, executions={_EXECUTED!r}; "
+        f"expected authoritative {expected_status!r} and executions={expected_executions!r}"
+    )
+
+
+def test_issue_9447_sync_stale_paused_object_cannot_reexecute_completed_run(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "issue_9447_sync_completed.db")
+    session_id = "s-issue-9447-sync-completed"
+
+    stale = _build_flat_team(SqliteDb(db_file=db_file), resuming=False).run(
+        "Email a@example.com", session_id=session_id
+    )
+    assert stale.status == RunStatus.paused
+    done = _build_flat_team(SqliteDb(db_file=db_file), resuming=True).continue_run(
+        run_id=stale.run_id,
+        session_id=session_id,
+        requirements=_wire_requirements(stale.requirements),
+    )
+    assert done.status == RunStatus.completed
+    assert stale.status == RunStatus.paused
+    assert _EXECUTED == ["a@example.com"]
+
+    refused = False
+    try:
+        _build_flat_team(SqliteDb(db_file=db_file), resuming=True).continue_run(
+            run_response=stale,
+            session_id=session_id,
+            requirements=_wire_requirements(stale.requirements),
+        )
+    except RunNotContinuableError:
+        refused = True
+
+    _issue_9447_assert_refused(
+        refused=refused,
+        stored_status=_issue_9447_state(db_file, session_id, stale.run_id),
+        expected_status=RunStatus.completed,
+        expected_executions=["a@example.com"],
+    )
+
+
+def test_issue_9447_sync_stale_paused_object_cannot_override_cancelled_run(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "issue_9447_sync_cancelled.db")
+    session_id = "s-issue-9447-sync-cancelled"
+
+    stale = _build_flat_team(SqliteDb(db_file=db_file), resuming=False).run(
+        "Email a@example.com", session_id=session_id
+    )
+    assert stale.status == RunStatus.paused
+    _set_stored_team_run_status(SqliteDb(db_file=db_file), session_id, stale.run_id, RunStatus.cancelled)
+
+    refused = False
+    try:
+        _build_flat_team(SqliteDb(db_file=db_file), resuming=True).continue_run(
+            run_response=stale,
+            session_id=session_id,
+            requirements=_wire_requirements(stale.requirements),
+        )
+    except RunNotContinuableError:
+        refused = True
+
+    _issue_9447_assert_refused(
+        refused=refused,
+        stored_status=_issue_9447_state(db_file, session_id, stale.run_id),
+        expected_status=RunStatus.cancelled,
+        expected_executions=[],
+    )
+
+
+@pytest.mark.asyncio
+async def test_issue_9447_async_stale_paused_object_cannot_reexecute_completed_run(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "issue_9447_async_completed.db")
+    session_id = "s-issue-9447-async-completed"
+
+    stale = await _build_flat_team(SqliteDb(db_file=db_file), resuming=False).arun(
+        "Email a@example.com", session_id=session_id
+    )
+    assert stale.status == RunStatus.paused
+    done = await _build_flat_team(SqliteDb(db_file=db_file), resuming=True).acontinue_run(
+        run_id=stale.run_id,
+        session_id=session_id,
+        requirements=_wire_requirements(stale.requirements),
+    )
+    assert done.status == RunStatus.completed
+    assert stale.status == RunStatus.paused
+    assert _EXECUTED == ["a@example.com"]
+
+    refused = False
+    try:
+        await _build_flat_team(SqliteDb(db_file=db_file), resuming=True).acontinue_run(
+            run_response=stale,
+            session_id=session_id,
+            requirements=_wire_requirements(stale.requirements),
+        )
+    except RunNotContinuableError:
+        refused = True
+
+    _issue_9447_assert_refused(
+        refused=refused,
+        stored_status=_issue_9447_state(db_file, session_id, stale.run_id),
+        expected_status=RunStatus.completed,
+        expected_executions=["a@example.com"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_issue_9447_async_stale_paused_object_cannot_override_cancelled_run(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "issue_9447_async_cancelled.db")
+    session_id = "s-issue-9447-async-cancelled"
+
+    stale = await _build_flat_team(SqliteDb(db_file=db_file), resuming=False).arun(
+        "Email a@example.com", session_id=session_id
+    )
+    assert stale.status == RunStatus.paused
+    _set_stored_team_run_status(SqliteDb(db_file=db_file), session_id, stale.run_id, RunStatus.cancelled)
+
+    refused = False
+    try:
+        await _build_flat_team(SqliteDb(db_file=db_file), resuming=True).acontinue_run(
+            run_response=stale,
+            session_id=session_id,
+            requirements=_wire_requirements(stale.requirements),
+        )
+    except RunNotContinuableError:
+        refused = True
+
+    _issue_9447_assert_refused(
+        refused=refused,
+        stored_status=_issue_9447_state(db_file, session_id, stale.run_id),
+        expected_status=RunStatus.cancelled,
+        expected_executions=[],
+    )
+
+
+@pytest.mark.asyncio
+async def test_issue_9447_async_stream_stale_paused_object_cannot_reexecute_completed_run(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "issue_9447_async_stream_completed.db")
+    session_id = "s-issue-9447-async-stream-completed"
+
+    stale = await _build_flat_team(SqliteDb(db_file=db_file), resuming=False).arun(
+        "Email a@example.com", session_id=session_id
+    )
+    assert stale.status == RunStatus.paused
+    done = await _build_flat_team(SqliteDb(db_file=db_file), resuming=True).acontinue_run(
+        run_id=stale.run_id,
+        session_id=session_id,
+        requirements=_wire_requirements(stale.requirements),
+    )
+    assert done.status == RunStatus.completed
+    assert stale.status == RunStatus.paused
+    assert _EXECUTED == ["a@example.com"]
+
+    refused = False
+    try:
+        async for _ in _build_flat_team(SqliteDb(db_file=db_file), resuming=True).acontinue_run(
+            run_response=stale,
+            session_id=session_id,
+            requirements=_wire_requirements(stale.requirements),
+            stream=True,
+            stream_events=True,
+        ):
+            pass
+    except RunNotContinuableError:
+        refused = True
+
+    _issue_9447_assert_refused(
+        refused=refused,
+        stored_status=_issue_9447_state(db_file, session_id, stale.run_id),
+        expected_status=RunStatus.completed,
+        expected_executions=["a@example.com"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_issue_9447_async_stream_stale_paused_object_cannot_override_cancelled_run(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "issue_9447_async_stream_cancelled.db")
+    session_id = "s-issue-9447-async-stream-cancelled"
+
+    stale = await _build_flat_team(SqliteDb(db_file=db_file), resuming=False).arun(
+        "Email a@example.com", session_id=session_id
+    )
+    assert stale.status == RunStatus.paused
+    _set_stored_team_run_status(SqliteDb(db_file=db_file), session_id, stale.run_id, RunStatus.cancelled)
+
+    refused = False
+    try:
+        async for _ in _build_flat_team(SqliteDb(db_file=db_file), resuming=True).acontinue_run(
+            run_response=stale,
+            session_id=session_id,
+            requirements=_wire_requirements(stale.requirements),
+            stream=True,
+            stream_events=True,
+        ):
+            pass
+    except RunNotContinuableError:
+        refused = True
+
+    _issue_9447_assert_refused(
+        refused=refused,
+        stored_status=_issue_9447_state(db_file, session_id, stale.run_id),
+        expected_status=RunStatus.cancelled,
+        expected_executions=[],
+    )
+
+
+def test_issue_9447_fresh_matching_paused_object_continues_normally(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "issue_9447_fresh_object.db")
+    session_id = "s-issue-9447-fresh-object"
+
+    paused = _build_flat_team(SqliteDb(db_file=db_file), resuming=False).run(
+        "Email a@example.com", session_id=session_id
+    )
+    done = _build_flat_team(SqliteDb(db_file=db_file), resuming=True).continue_run(
+        run_response=paused,
+        session_id=session_id,
+        requirements=_wire_requirements(paused.requirements),
+    )
+
+    assert done.status == RunStatus.completed
+    assert done.run_id == paused.run_id
+    assert _EXECUTED == ["a@example.com"]
+
+
+@pytest.mark.asyncio
+async def test_issue_9447_fresh_matching_paused_object_async_variants_continue_normally(tmp_path):
+    for stream in (False, True):
+        _EXECUTED.clear()
+        suffix = "stream" if stream else "plain"
+        db_file = str(tmp_path / f"issue_9447_fresh_object_async_{suffix}.db")
+        session_id = f"s-issue-9447-fresh-object-async-{suffix}"
+
+        paused = await _build_flat_team(SqliteDb(db_file=db_file), resuming=False).arun(
+            "Email a@example.com", session_id=session_id
+        )
+        result = _build_flat_team(SqliteDb(db_file=db_file), resuming=True).acontinue_run(
+            run_response=paused,
+            session_id=session_id,
+            requirements=_wire_requirements(paused.requirements),
+            stream=stream,
+            stream_events=stream,
+        )
+        if stream:
+            async for _ in result:
+                pass
+            done_status = _issue_9447_state(db_file, session_id, paused.run_id)
+            done_run_id = paused.run_id
+        else:
+            done = await result
+            done_status = done.status
+            done_run_id = done.run_id
+
+        assert done_status == RunStatus.completed
+        assert done_run_id == paused.run_id
+        assert _EXECUTED == ["a@example.com"]
+
+
+def test_issue_9447_run_id_completion_and_auto_fork_semantics_remain(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "issue_9447_run_id_control.db")
+    session_id = "s-issue-9447-run-id-control"
+
+    paused = _build_flat_team(SqliteDb(db_file=db_file), resuming=False).run(
+        "Email a@example.com", session_id=session_id
+    )
+    done = _build_flat_team(SqliteDb(db_file=db_file), resuming=True).continue_run(
+        run_id=paused.run_id,
+        session_id=session_id,
+        requirements=_wire_requirements(paused.requirements),
+    )
+    forked = _build_flat_team(SqliteDb(db_file=db_file), resuming=True).continue_run(
+        run_id=paused.run_id,
+        session_id=session_id,
+    )
+
+    assert done.status == RunStatus.completed
+    assert done.run_id == paused.run_id
+    assert forked.status == RunStatus.completed
+    assert forked.run_id != paused.run_id
+    assert forked.forked_from_run_id == paused.run_id
+    assert _EXECUTED == ["a@example.com"]


### PR DESCRIPTION
## Summary

Fixes #9447.

When a Team continuation receives a caller-supplied `run_response`, that object can be an old `PAUSED` snapshot while the durable run row is already `COMPLETED` or `CANCELLED`. The foreground continuation paths previously trusted the caller snapshot through approval resolution, allowing a gated action to execute again or cancellation to be overwritten.

This patch directly reads the durable run row before approval resolution or side effects and refuses an in-place continuation when its terminal status conflicts with the caller snapshot. The check is shared by the sync dispatcher, async non-streaming path, and async-streaming path. Sync streaming passes through the same dispatcher.

The check does not run for explicit `fork` or `regenerate`. Run-ID-only continuation, matching `PAUSED` continuation, matching `COMPLETED` auto-fork behavior, and matching `CANCELLED` refusal remain unchanged.

A stale caller snapshot cannot revive a completed or cancelled approval-gated action and execute it again.

This change is intentionally limited to #9447. It does not implement #9448, PAUSED-vs-PAUSED serialization, compare-and-swap, locking, generations or revisions, Agent-side changes, or general HITL/concurrency safety.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation reviewed; no documentation change is required
- [x] Examples and guides reviewed; no cookbook change is required
- [x] Tested in an isolated local environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I searched all current open pull requests and confirmed that no other PR addresses #9447
- [x] Similar file overlaps were reviewed and are explained below
- [x] This change was developed with AI assistance

---

## Test evidence

All commands used the repository-local `.venv`, a scrubbed environment, SQLite, scripted models, and no external model or network calls.

- `python -m pytest -p no:cacheprovider -q libs/agno/tests/unit/team/test_paused_member_persistence.py -k 'issue_9447'`
  - 9 passed, 142 deselected
  - Includes all six stale `COMPLETED`/`CANCELLED` cases, matching `PAUSED` controls, Run-ID continuation, and completed-run auto-fork behavior

- `python -m pytest -p no:cacheprovider -q libs/agno/tests/unit/team/test_paused_member_persistence.py libs/agno/tests/unit/team/test_team_checkpointing.py libs/agno/tests/unit/team/test_acontinue_run_background_stream.py libs/agno/tests/unit/team/test_continue_run_requirements.py libs/agno/tests/unit/team/test_team_paused_content.py libs/agno/tests/unit/team/test_background_execution.py`
  - 290 passed
  - Includes existing cancelled-run refusal and #9396 background protections

- `ruff format --check libs/agno/agno/team/_run.py libs/agno/tests/unit/team/test_paused_member_persistence.py`
  - 2 files already formatted

- `ruff check libs/agno/agno/team/_run.py libs/agno/tests/unit/team/test_paused_member_persistence.py`
  - All checks passed

- `python -m compileall -q libs/agno/agno/team/_run.py`
  - Passed

- `git diff --check`
  - Passed

## Checks and boundaries not run

- The full repository test suite and `scripts/test.sh` were not run.
- `scripts/format.sh` was not run because its repository-wide import fixer would modify an unrelated unchanged baseline file. A read-only repository-wide format check reported all 4,723 files formatted; the separate import-order check found one existing `I001` in `libs/agno/tests/unit/agent/test_run_regressions.py`.
- `scripts/validate.sh` was attempted but exited before validation because `mypy` is not installed in the target `.venv`. Mypy was not run.
- PostgreSQL, MySQL, Redis, Valkey, MongoDB, DynamoDB, Firestore, and other adapter matrices were not run.
- Real AgentOS HTTP, real model/provider calls, multi-worker execution, and upstream CI were not run.
- #9448 and general PAUSED-vs-PAUSED concurrency safety were not tested or changed.

## Collision review

The current open-PR set was inspected for direct issue references, semantic ownership, and changed-file overlap. PR #9594 fixes #9448 with a process-local overlapping-resume claim. Other relevant overlaps cover pre-hook ordering, member-response preservation, forked `RunContext` identity, background queue serialization, or persistence-error visibility. None implements or claims the #9447 durable-terminal-versus-caller-snapshot boundary.

## AI assistance

This change and its regression tests were prepared with OpenAI Codex assistance. The submitter reviewed the exact final diff and test evidence and takes responsibility for the contribution and maintainer-facing follow-up.

No security-severity claim is made.
