### PR TITLE
feat: add grep_content and tool_name_prefix for Workspace

### DIFF
--- a/cookbook/12_context/13_workspace.py
+++ b/cookbook/12_context/13_workspace.py
@@ -5,7 +5,8 @@ Workspace Context Provider
 WorkspaceContextProvider wraps a project directory and gives the agent
 a single `query_<id>` tool. The tool routes through a read-only sub-agent
 that has the `Workspace` toolkit scoped to the root: list files, search
-content, and read files with line numbers.
+content (substring), grep content (regex with line numbers), and read
+files with line numbers.
 
 Use this for repository roots and active project workspaces. It skips
 common dependency directories, build outputs, caches, virtualenvs, and

--- a/cookbook/91_tools/workspace_tools/README.md
+++ b/cookbook/91_tools/workspace_tools/README.md
@@ -45,7 +45,8 @@ raises `ValueError`. The full alias mapping:
 | -------- | -------------------- | --------------------------------------- |
 | `read`   | `read_file`          | Read a file (line-numbered, optional range) |
 | `list`   | `list_files`         | List a directory (optional glob, optional recursive with `max_depth`) |
-| `search` | `search_content`     | Recursive content grep                  |
+| `search` | `search_content`     | Recursive content search (substring)    |
+| `grep`   | `grep_content`       | Regex search with line numbers          |
 | `write`  | `write_file`         | Create or overwrite a file (atomic)     |
 | `edit`   | `edit_file`          | Replace a substring (with `replace_all`)|
 | `move`   | `move_file`          | Move or rename a file                   |
@@ -95,6 +96,8 @@ tools = [Workspace(".", allow_paths=[".env.example"])]
   confirmations disabled so the demo runs end-to-end.
 - `with_confirmation.py` — same agent with the default safety on; you
   approve each write at the console.
+- `grep_content.py` — demonstrates regex search with line numbers, context
+  lines, and files-only mode for code navigation.
 
 ## Running
 

--- a/cookbook/91_tools/workspace_tools/grep_content.py
+++ b/cookbook/91_tools/workspace_tools/grep_content.py
@@ -1,14 +1,13 @@
 """
-Workspace — grep_content (regex search)
-=======================================
+Workspace — grep_content (regex search with line numbers)
+=========================================================
 
-Demonstrates grep_content, which provides regex search with line numbers.
-This is the missing piece for code/docs navigation agents.
+grep_content fills the gap between search_content (substring, one snippet per
+file) and what code navigation agents need: regex patterns, every matching
+line with its line number, and optional context lines.
 
-Unlike search_content (substring, one snippet per file), grep_content returns:
-- Every matching line with its line number
-- Optional context lines around each match
-- Files-only mode for quick discovery
+This example shows a docs-agent pattern: discover files, search with regex,
+then read specific sections based on line numbers from grep results.
 
 Requires: OPENAI_API_KEY
 """
@@ -19,48 +18,37 @@ from agno.agent import Agent
 from agno.models.openai import OpenAIResponses
 from agno.tools.workspace import Workspace
 
-# Point at the agno source code
+# Point at the agno libs directory
 project_root = Path(__file__).resolve().parents[3]
-agno_src = project_root / "libs" / "agno" / "agno"
+libs_dir = project_root / "libs" / "agno" / "agno"
 
 agent = Agent(
     model=OpenAIResponses(id="gpt-5.4"),
     tools=[
         Workspace(
-            str(agno_src),
+            str(libs_dir),
             allowed=["read", "list", "search", "grep"],
             confirm=[],
         )
     ],
+    instructions="""\
+You are a code navigation assistant. Use the workspace tools to answer questions:
+
+- list_files: discover what files exist (supports glob patterns, recursive)
+- search_content: quick substring search to find which files mention something
+- grep_content: regex search with line numbers — use this when you need exact locations
+- read_file: read file contents, optionally with line ranges from grep results
+
+When answering questions about code, cite file:line references from grep results.
+""",
     markdown=True,
 )
 
 
 if __name__ == "__main__":
-    # Demo 1: Find all async def run methods
-    print("Demo 1: Find async run methods")
-    print("-" * 40)
+    # A practical code navigation task
     agent.print_response(
-        "Use grep_content to find all 'async def run' methods in the agent/ directory. "
-        "Show the file and line number for each match."
-    )
-
-    print("\n")
-
-    # Demo 2: Find class definitions with context
-    print("Demo 2: Find Agent class with context")
-    print("-" * 40)
-    agent.print_response(
-        "Use grep_content with context_lines=2 to find where 'class Agent' is defined. "
-        "Show the surrounding lines to understand its structure."
-    )
-
-    print("\n")
-
-    # Demo 3: Files-only mode for discovery
-    print("Demo 3: Files-only discovery")
-    print("-" * 40)
-    agent.print_response(
-        "Use grep_content with files_only=True to find which files contain 'ContextProvider'. "
-        "Just list the file names, don't show the content."
+        "Find all the context providers in this codebase. "
+        "Use grep_content to find classes that inherit from ContextProvider, "
+        "then summarize what each one does based on its location and name."
     )

--- a/cookbook/91_tools/workspace_tools/grep_content.py
+++ b/cookbook/91_tools/workspace_tools/grep_content.py
@@ -6,10 +6,28 @@ grep_content fills the gap between search_content (substring, one snippet per
 file) and what code navigation agents need: regex patterns, every matching
 line with its line number, and optional context lines.
 
-This example shows a docs-agent pattern: discover files, search with regex,
-then read specific sections based on line numbers from grep results.
+This example demonstrates a rename pre-flight sweep — finding all occurrences
+of a method name before refactoring. The key insight: substring search would
+falsely match `asearch_content` when looking for `search_content`, but the
+word-boundary regex `\\bsearch_content\\b` filters precisely.
+
+Features demonstrated:
+- `files_only=True`: quick blast-radius check before expensive content search
+- `ignore_case=False`: case-sensitive matching (the default)
+- `context_lines=1`: see surrounding code to classify each occurrence
+- Line numbers: every match is cited as file:line for precise navigation
+
+Workflow:
+1. files_only pass → "how big is this refactor?"
+2. grep with context → classify: definition, call site, docstring, test
+3. read_file with line range → verify specific occurrences
 
 Requires: OPENAI_API_KEY
+
+Prompts to try:
+- "Find all TODO comments with grep_content pattern 'TODO|FIXME|HACK'"
+- "Search for deprecated warnings using pattern 'warnings\\.warn'"
+- "Find exception handlers with pattern 'except[^:]*:' and 2 context lines"
 """
 
 from pathlib import Path
@@ -23,7 +41,7 @@ project_root = Path(__file__).resolve().parents[3]
 libs_dir = project_root / "libs" / "agno" / "agno"
 
 agent = Agent(
-    model=OpenAIResponses(id="gpt-5.4"),
+    model=OpenAIResponses(id="gpt-5.5"),
     tools=[
         Workspace(
             str(libs_dir),
@@ -32,23 +50,40 @@ agent = Agent(
         )
     ],
     instructions="""\
-You are a code navigation assistant. Use the workspace tools to answer questions:
+You are a refactoring assistant helping prepare a method rename.
 
-- list_files: discover what files exist (supports glob patterns, recursive)
-- search_content: quick substring search to find which files mention something
-- grep_content: regex search with line numbers — use this when you need exact locations
-- read_file: read file contents, optionally with line ranges from grep results
+Workflow for rename pre-flight:
+1. **Blast radius first.** Use grep_content with files_only=True to list affected
+   files before fetching content — this answers "how big is this refactor?"
+2. **Grep with context.** Use grep_content with context_lines=1 to see surrounding
+   code. Classify each occurrence: definition, call site, docstring, or test.
+3. **Verify ambiguous cases.** Use read_file with a line range when you need more
+   context than grep provides.
 
-When answering questions about code, cite file:line references from grep results.
+Important: Use word-boundary regex (\\b) to avoid false positives. For example,
+`\\bsearch_content\\b` matches the sync method but not `asearch_content`.
+
+Cite every finding as file:line so the developer can navigate directly.
 """,
     markdown=True,
 )
 
 
 if __name__ == "__main__":
-    # A practical code navigation task
-    agent.print_response(
-        "Find all the context providers in this codebase. "
-        "Use grep_content to find classes that inherit from ContextProvider, "
-        "then summarize what each one does based on its location and name."
-    )
+    # Rename pre-flight: find all search_content occurrences
+    # This is a real scenario — agno has both search_content and asearch_content
+    prompt = """\
+We're planning to rename the sync method `search_content` (the async variant
+`asearch_content` keeps its name).
+
+1. First use grep_content with files_only=True to show the blast radius
+2. Then search with the word-boundary pattern `\\bsearch_content\\b` and 1 context line
+3. Classify each occurrence as: definition, call site, docstring/comment, or test
+
+Note: A plain substring search would falsely include `asearch_content` — that's
+why we need the regex word boundary.
+
+Produce a rename checklist with file:line citations.
+"""
+    print(f"> {prompt}\n")
+    agent.print_response(prompt)

--- a/cookbook/91_tools/workspace_tools/grep_content.py
+++ b/cookbook/91_tools/workspace_tools/grep_content.py
@@ -1,0 +1,66 @@
+"""
+Workspace — grep_content (regex search)
+=======================================
+
+Demonstrates grep_content, which provides regex search with line numbers.
+This is the missing piece for code/docs navigation agents.
+
+Unlike search_content (substring, one snippet per file), grep_content returns:
+- Every matching line with its line number
+- Optional context lines around each match
+- Files-only mode for quick discovery
+
+Requires: OPENAI_API_KEY
+"""
+
+from pathlib import Path
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.tools.workspace import Workspace
+
+# Point at the agno source code
+project_root = Path(__file__).resolve().parents[3]
+agno_src = project_root / "libs" / "agno" / "agno"
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.4"),
+    tools=[
+        Workspace(
+            str(agno_src),
+            allowed=["read", "list", "search", "grep"],
+            confirm=[],
+        )
+    ],
+    markdown=True,
+)
+
+
+if __name__ == "__main__":
+    # Demo 1: Find all async def run methods
+    print("Demo 1: Find async run methods")
+    print("-" * 40)
+    agent.print_response(
+        "Use grep_content to find all 'async def run' methods in the agent/ directory. "
+        "Show the file and line number for each match."
+    )
+
+    print("\n")
+
+    # Demo 2: Find class definitions with context
+    print("Demo 2: Find Agent class with context")
+    print("-" * 40)
+    agent.print_response(
+        "Use grep_content with context_lines=2 to find where 'class Agent' is defined. "
+        "Show the surrounding lines to understand its structure."
+    )
+
+    print("\n")
+
+    # Demo 3: Files-only mode for discovery
+    print("Demo 3: Files-only discovery")
+    print("-" * 40)
+    agent.print_response(
+        "Use grep_content with files_only=True to find which files contain 'ContextProvider'. "
+        "Just list the file names, don't show the content."
+    )

--- a/cookbook/91_tools/workspace_tools/grep_content.py
+++ b/cookbook/91_tools/workspace_tools/grep_content.py
@@ -1,0 +1,61 @@
+"""
+Workspace — grep_content (regex search with line numbers)
+
+grep_content is for precise code search: regex patterns, every matching line
+with its line number, and optional context lines. Returns JSON with file:line
+citations for direct navigation.
+
+This example demonstrates a rename pre-flight sweep — finding all occurrences
+of a method name before refactoring.
+"""
+
+from pathlib import Path
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.tools.workspace import Workspace
+
+project_root = Path(__file__).resolve().parents[3]
+libs_dir = project_root / "libs" / "agno" / "agno"
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.5"),
+    tools=[
+        Workspace(
+            libs_dir,
+            allowed=["read", "list", "search", "grep"],
+            confirm=[],
+        )
+    ],
+    instructions="""\
+You are a refactoring assistant helping prepare a method rename.
+
+Workflow:
+1. Use grep_content to find all occurrences with line numbers
+2. Use context_lines if you need surrounding code to classify matches
+3. Use read_file with a line range when you need more context
+
+Use word-boundary regex (\\b) to avoid false positives. For example,
+`\\bsearch_content\\b` matches the sync method but not `asearch_content`.
+
+Cite every finding as file:line so the developer can navigate directly.
+""",
+    markdown=True,
+)
+
+
+if __name__ == "__main__":
+    prompt = """\
+We're planning to rename the sync method `search_content` (the async variant
+`asearch_content` keeps its name).
+
+1. Search with the word-boundary pattern `\\bsearch_content\\b` and 1 context line
+2. Classify each occurrence as: definition, call site, docstring/comment, or test
+
+Note: A plain substring search would falsely include `asearch_content` — that's
+why we need the regex word boundary.
+
+Produce a rename checklist with file:line citations.
+"""
+    print(f"> {prompt}\n")
+    agent.print_response(prompt)

--- a/cookbook/91_tools/workspace_tools/multi_workspace.py
+++ b/cookbook/91_tools/workspace_tools/multi_workspace.py
@@ -62,7 +62,7 @@ def main():
         print(f"Collisions: {collision if collision else 'None'}")
 
         # Check toolkit metadata
-        print(f"\n=== Toolkit Metadata ===")
+        print("\n=== Toolkit Metadata ===")
         print(f"Docs toolkit name: {docs_toolkit.name}, id: {docs_toolkit.id}")
         print(f"Code toolkit name: {code_toolkit.name}, id: {code_toolkit.id}")
 
@@ -80,7 +80,7 @@ def main():
         )
 
         # Check instructions include prefixed tool names
-        print(f"\n=== Docs Toolkit Instructions ===")
+        print("\n=== Docs Toolkit Instructions ===")
         if docs_toolkit.instructions:
             print(docs_toolkit.instructions[:500])
 

--- a/cookbook/91_tools/workspace_tools/multi_workspace.py
+++ b/cookbook/91_tools/workspace_tools/multi_workspace.py
@@ -19,13 +19,20 @@ from agno.tools.workspace import Workspace
 
 def main():
     # Create two temp directories to simulate docs and code workspaces
-    with tempfile.TemporaryDirectory() as docs_dir, tempfile.TemporaryDirectory() as code_dir:
+    with (
+        tempfile.TemporaryDirectory() as docs_dir,
+        tempfile.TemporaryDirectory() as code_dir,
+    ):
         docs_path = Path(docs_dir)
         code_path = Path(code_dir)
 
         # Create sample files in docs workspace
-        (docs_path / "getting-started.md").write_text("# Getting Started\n\nWelcome to the docs!")
-        (docs_path / "api-reference.md").write_text("# API Reference\n\n## Agent class\n...")
+        (docs_path / "getting-started.md").write_text(
+            "# Getting Started\n\nWelcome to the docs!"
+        )
+        (docs_path / "api-reference.md").write_text(
+            "# API Reference\n\n## Agent class\n..."
+        )
 
         # Create sample files in code workspace
         (code_path / "agent.py").write_text("class Agent:\n    def run(self): pass")

--- a/cookbook/91_tools/workspace_tools/multi_workspace.py
+++ b/cookbook/91_tools/workspace_tools/multi_workspace.py
@@ -1,0 +1,86 @@
+"""
+Multi-Workspace Example: Using tool_name_prefix for namespacing.
+
+Demonstrates how to use multiple Workspace toolkits on the same agent
+without tool name collisions. Each toolkit gets a prefix (e.g., docs_read_file,
+code_read_file) so tools from different workspaces can coexist.
+
+Use case: An agent that can access both documentation and source code,
+with clear separation of which workspace each tool operates on.
+"""
+
+import tempfile
+from pathlib import Path
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.tools.workspace import Workspace
+
+
+def main():
+    # Create two temp directories to simulate docs and code workspaces
+    with tempfile.TemporaryDirectory() as docs_dir, tempfile.TemporaryDirectory() as code_dir:
+        docs_path = Path(docs_dir)
+        code_path = Path(code_dir)
+
+        # Create sample files in docs workspace
+        (docs_path / "getting-started.md").write_text("# Getting Started\n\nWelcome to the docs!")
+        (docs_path / "api-reference.md").write_text("# API Reference\n\n## Agent class\n...")
+
+        # Create sample files in code workspace
+        (code_path / "agent.py").write_text("class Agent:\n    def run(self): pass")
+        (code_path / "utils.py").write_text("def helper(): return 42")
+
+        # Create two Workspace toolkits with different prefixes
+        docs_toolkit = Workspace(
+            root=docs_path,
+            allowed=Workspace.READ_TOOLS,
+            tool_name_prefix="docs",  # Tools: docs_read_file, docs_list_files, etc.
+        )
+
+        code_toolkit = Workspace(
+            root=code_path,
+            allowed=Workspace.READ_TOOLS,
+            tool_name_prefix="code",  # Tools: code_read_file, code_list_files, etc.
+        )
+
+        # Verify no tool name collisions
+        docs_tools = set(docs_toolkit.functions.keys())
+        code_tools = set(code_toolkit.functions.keys())
+        collision = docs_tools & code_tools
+
+        print("=== Tool Registration ===")
+        print(f"Docs toolkit: {sorted(docs_tools)}")
+        print(f"Code toolkit: {sorted(code_tools)}")
+        print(f"Collisions: {collision if collision else 'None'}")
+
+        # Check toolkit metadata
+        print(f"\n=== Toolkit Metadata ===")
+        print(f"Docs toolkit name: {docs_toolkit.name}, id: {docs_toolkit.id}")
+        print(f"Code toolkit name: {code_toolkit.name}, id: {code_toolkit.id}")
+
+        # Create agent with both toolkits
+        agent = Agent(
+            model=OpenAIResponses(id="gpt-5.6-luna"),
+            tools=[docs_toolkit, code_toolkit],
+            instructions=(
+                "You have access to two workspaces:\n"
+                "- docs_* tools: Documentation files\n"
+                "- code_* tools: Source code files\n"
+                "Use the appropriate prefix based on which workspace you need."
+            ),
+            markdown=True,
+        )
+
+        # Check instructions include prefixed tool names
+        print(f"\n=== Docs Toolkit Instructions ===")
+        if docs_toolkit.instructions:
+            print(docs_toolkit.instructions[:500])
+
+        # Test the agent
+        print("\n=== Agent Test ===")
+        agent.print_response("List files in both workspaces")
+
+
+if __name__ == "__main__":
+    main()

--- a/libs/agno/agno/context/workspace/provider.py
+++ b/libs/agno/agno/context/workspace/provider.py
@@ -75,7 +75,7 @@ class WorkspaceContextProvider(ContextProvider):
         if self.mode == ContextMode.tools:
             return (
                 f"`{self.name}`: inspect project files under {self.root}. Use read-only "
-                "`list_files`, `search_content`, and `read_file`. Paths are relative to "
+                "`list_files`, `search_content`, `grep_content`, and `read_file`. Paths are relative to "
                 f"the workspace root. {self._exclusion_sentence()}"
             )
         return (
@@ -147,9 +147,9 @@ You answer questions by inspecting project files under {root}.
 Workflow:
 1. **Map the workspace first.** Use `list_files(recursive=True)` with a
    modest `max_depth` to identify likely source, docs, and cookbook paths.
-2. **Search narrowly.** Use `search_content(query, directory=...)` once you
-   know the relevant subtree. Avoid whole-workspace searches unless the user
-   asks for a broad audit.
+2. **Search narrowly.** Use `search_content(query, directory=...)` for substring
+   search, or `grep_content(pattern, directory=...)` for regex search with line
+   numbers. Scope to the relevant subtree once you know it.
 3. **Read before citing.** Use `read_file(path)` or a line range for the
    files you rely on. Cite paths relative to the workspace root.
 4. **Ignore generated noise.** {exclusion}

--- a/libs/agno/agno/context/workspace/provider.py
+++ b/libs/agno/agno/context/workspace/provider.py
@@ -81,11 +81,9 @@ class WorkspaceContextProvider(ContextProvider):
 
     def instructions(self) -> str:
         if self.mode == ContextMode.tools:
-            # Tool names are prefixed with provider id when mode=tools
-            prefix = f"{self.id}_"
             return (
                 f"`{self.name}`: inspect project files under {self.root}. Use read-only "
-                f"`{prefix}list_files`, `{prefix}search_content`, `{prefix}grep_content`, and `{prefix}read_file`. "
+                "`list_files`, `search_content`, `grep_content`, and `read_file`. "
                 f"Paths are relative to the workspace root. {self._exclusion_sentence()}"
             )
         return (
@@ -112,6 +110,14 @@ class WorkspaceContextProvider(ContextProvider):
 
     def _default_tools(self) -> list:
         return [self._query_tool()]
+
+    def _query_tool(self):
+        query_tool = super()._query_tool()
+        query_tool.description = (
+            f"Explore project files under {self.root} with a natural-language question. "
+            "Read-only: lists directories, searches/greps code, and reads file contents."
+        )
+        return query_tool
 
     def _all_tools(self) -> list:
         return [self._build_workspace_tools()]
@@ -148,7 +154,6 @@ class WorkspaceContextProvider(ContextProvider):
             allow_paths=list(self.allow_paths),
             max_file_lines=self.max_file_lines,
             max_file_length=self.max_file_length,
-            **self._toolkit_prefix_kwargs(),
         )
 
 

--- a/libs/agno/agno/context/workspace/provider.py
+++ b/libs/agno/agno/context/workspace/provider.py
@@ -81,10 +81,12 @@ class WorkspaceContextProvider(ContextProvider):
 
     def instructions(self) -> str:
         if self.mode == ContextMode.tools:
+            # Tool names are prefixed with provider id when mode=tools
+            prefix = f"{self.id}_"
             return (
                 f"`{self.name}`: inspect project files under {self.root}. Use read-only "
-                "`list_files`, `search_content`, and `read_file`. Paths are relative to "
-                f"the workspace root. {self._exclusion_sentence()}"
+                f"`{prefix}list_files`, `{prefix}search_content`, `{prefix}grep_content`, and `{prefix}read_file`. "
+                f"Paths are relative to the workspace root. {self._exclusion_sentence()}"
             )
         return (
             f"`{self.name}`: call `{self.query_tool_name}(question)` to inspect project "
@@ -146,6 +148,7 @@ class WorkspaceContextProvider(ContextProvider):
             allow_paths=list(self.allow_paths),
             max_file_lines=self.max_file_lines,
             max_file_length=self.max_file_length,
+            **self._toolkit_prefix_kwargs(),
         )
 
 
@@ -155,9 +158,9 @@ You answer questions by inspecting project files under {root}.
 Workflow:
 1. **Map the workspace first.** Use `list_files(recursive=True)` with a
    modest `max_depth` to identify likely source, docs, and cookbook paths.
-2. **Search narrowly.** Use `search_content(query, directory=...)` once you
-   know the relevant subtree. Avoid whole-workspace searches unless the user
-   asks for a broad audit.
+2. **Search narrowly.** Use `search_content(query, directory=...)` for substring
+   search, or `grep_content(pattern, directory=...)` for regex search with line
+   numbers. Scope to the relevant subtree once you know it.
 3. **Read before citing.** Use `read_file(path)` or a line range for the
    files you rely on. Cite paths relative to the workspace root.
 4. **Ignore generated noise.** {exclusion}

--- a/libs/agno/agno/tools/gandr.py
+++ b/libs/agno/agno/tools/gandr.py
@@ -128,7 +128,6 @@ class GandrTools(Toolkit):
             )
 
         try:
-
             log_info(f"Using voice: {effective_voice} for text_to_speech.")
             log_info(f"Using model: {self.model_id} and response_format: {effective_format} for text_to_speech.")
 

--- a/libs/agno/agno/tools/toolkit.py
+++ b/libs/agno/agno/tools/toolkit.py
@@ -131,6 +131,7 @@ class Toolkit:
         cache_dir: Optional[str] = None,
         timeout: Optional[int] = None,
         auto_register: bool = True,
+        tool_name_prefix: Optional[str] = None,
     ):
         """Initialize a new Toolkit.
 
@@ -189,6 +190,7 @@ class Toolkit:
         self.cache_results: bool = cache_results
         self.cache_ttl: int = cache_ttl
         self.cache_dir: Optional[str] = cache_dir
+        self.tool_name_prefix: Optional[str] = tool_name_prefix
 
         # Only assign timeout when the caller explicitly passed one, or when the
         # subclass hasn't already set it before calling super().__init__(). This
@@ -302,8 +304,11 @@ class Toolkit:
             if self.exclude_tools is not None and tool_name in self.exclude_tools:
                 return
 
+            # Apply prefix after filter checks (filters match unprefixed names)
+            registered_name = f"{self.tool_name_prefix}_{tool_name}" if self.tool_name_prefix else tool_name
+
             f = Function(
-                name=tool_name,
+                name=registered_name,
                 entrypoint=function,
                 cache_results=self.cache_results,
                 cache_dir=self.cache_dir,
@@ -405,9 +410,12 @@ class Toolkit:
         requires_confirmation = function.requires_confirmation or tool_name in self.requires_confirmation_tools
         external_execution = function.external_execution or tool_name in self.external_execution_required_tools
 
+        # Apply prefix after filter checks (filters match unprefixed names)
+        registered_name = f"{self.tool_name_prefix}_{tool_name}" if self.tool_name_prefix else tool_name
+
         # Create new Function with bound method, preserving decorator settings
         f = Function(
-            name=tool_name,
+            name=registered_name,
             description=function.description,
             title=function.title,
             annotations=function.annotations,

--- a/libs/agno/agno/tools/workspace.py
+++ b/libs/agno/agno/tools/workspace.py
@@ -302,7 +302,8 @@ class Workspace(Toolkit):
     | -------- | -------------------- | --------------------------------------- |
     | ``read``   | ``read_file``        | Read a file (line-numbered)             |
     | ``list``   | ``list_files``       | List a directory (recursive option)     |
-    | ``search`` | ``search_content``   | Recursive content grep                  |
+    | ``search`` | ``search_content``   | Recursive content search (substring)    |
+    | ``grep``   | ``grep_content``     | Regex search with line numbers          |
     | ``write``  | ``write_file``       | Create or overwrite a file (atomic)     |
     | ``edit``   | ``edit_file``        | Replace a substring (with ``replace_all``)|
     | ``move``   | ``move_file``        | Move or rename a file                   |
@@ -363,7 +364,7 @@ class Workspace(Toolkit):
     this session. Catches the "agent hallucinated the file's contents" bug class.
     """
 
-    READ_TOOLS: List[str] = ["read", "list", "search"]
+    READ_TOOLS: List[str] = ["read", "list", "search", "grep"]
     WRITE_TOOLS: List[str] = ["write", "edit", "move", "delete", "shell"]
     ALL_TOOLS: List[str] = READ_TOOLS + WRITE_TOOLS
 
@@ -372,6 +373,7 @@ class Workspace(Toolkit):
         "read": "read_file",
         "list": "list_files",
         "search": "search_content",
+        "grep": "grep_content",
         "write": "write_file",
         "edit": "edit_file",
         "move": "move_file",
@@ -850,6 +852,134 @@ class Workspace(Toolkit):
             log_error(f"search_content failed: {e}")
             return f"Error searching content: {e}"
 
+    def grep_content(
+        self,
+        pattern: str,
+        directory: str = ".",
+        ignore_case: bool = False,
+        context_lines: int = 0,
+        files_only: bool = False,
+        limit: int = 100,
+    ) -> str:
+        """Regex search with line numbers across text files in the workspace.
+
+        Returns matches in ``path:line:text`` format, grouped by file with context lines.
+        Use ``files_only=True`` for a quick list of matching files without content.
+
+        :param pattern: Regex pattern to search for.
+        :param directory: Subdirectory to scope the search to (default ".").
+        :param ignore_case: Case-insensitive matching (default False).
+        :param context_lines: Lines of context before and after each match (default 0).
+        :param files_only: Return only file paths, not matching lines (default False).
+        :param limit: Maximum number of matches to return (default 100).
+        :return: Matching lines as ``path:line:text``, or file paths if ``files_only``.
+        """
+        try:
+            if not pattern or not pattern.strip():
+                return "Error: pattern cannot be empty"
+
+            # 1. Compile regex
+            flags = re.IGNORECASE if ignore_case else 0
+            try:
+                rx = re.compile(pattern, flags)
+            except re.error as exc:
+                return f"Error: invalid regex pattern: {exc}"
+
+            # 2. Resolve directory
+            err, search_dir = self._resolve(directory, what="directory")
+            if err:
+                return err
+            if not search_dir.is_dir():
+                return f"Error: not a directory: {directory}"
+
+            max_file_size = 500 * 1024
+            out_lines: List[str] = []
+            files_with_matches: List[str] = []
+            total_matches = 0
+
+            # 3. Walk the directory tree
+            for dirpath, dirnames, filenames in os.walk(search_dir):
+                if total_matches >= limit:
+                    break
+                # Prune excluded directories
+                dirnames[:] = [name for name in dirnames if not self._is_excluded(Path(dirpath) / name)]
+
+                for filename in filenames:
+                    if total_matches >= limit:
+                        break
+                    file_path = Path(dirpath) / filename
+
+                    # Skip hidden/excluded files
+                    if self._hidden(file_path):
+                        continue
+                    if file_path.suffix.lower() not in TEXT_EXTENSIONS:
+                        continue
+                    try:
+                        if file_path.stat().st_size > max_file_size:
+                            continue
+                    except OSError:
+                        continue
+
+                    # Read and search
+                    try:
+                        content = file_path.read_text(encoding="utf-8", errors="ignore")
+                    except Exception:
+                        continue
+
+                    lines = content.splitlines()
+                    hits = [idx for idx, line in enumerate(lines) if rx.search(line)]
+
+                    if not hits:
+                        continue
+
+                    rel_path = file_path.relative_to(self.root).as_posix()
+                    files_with_matches.append(rel_path)
+
+                    if files_only:
+                        continue
+
+                    # Collect matches with context
+                    shown: Set[int] = set()
+                    file_output: List[str] = []
+
+                    for hit in hits:
+                        if total_matches >= limit:
+                            break
+                        # Calculate context range
+                        start = max(0, hit - context_lines)
+                        end = min(len(lines), hit + context_lines + 1)
+
+                        for j in range(start, end):
+                            if j not in shown:
+                                shown.add(j)
+                                file_output.append(f"{rel_path}:{j + 1}:{lines[j]}")
+
+                        total_matches += 1
+
+                    if file_output:
+                        out_lines.extend(file_output)
+                        if context_lines > 0:
+                            out_lines.append("--")
+
+            # 4. Format output
+            if files_only:
+                if files_with_matches:
+                    result = "\n".join(files_with_matches)
+                    return f"{result}\n({len(files_with_matches)} files)"
+                return f"No files match pattern: {pattern}"
+
+            if out_lines:
+                # Remove trailing separator
+                if out_lines and out_lines[-1] == "--":
+                    out_lines.pop()
+                truncated = f"\n(showing {total_matches} matches, limit={limit})" if total_matches >= limit else ""
+                return "\n".join(out_lines) + truncated
+            return f"No matches for pattern: {pattern}"
+
+        except Exception as e:
+            log_error(f"grep_content failed: {e}")
+            return f"Error in grep: {e}"
+
     # ------------------------------------------------------------------
     # Write operations (require confirmation by default)
     # ------------------------------------------------------------------
@@ -1075,6 +1205,20 @@ class Workspace(Toolkit):
     async def asearch_content(self, query: str, directory: str = ".", limit: int = 10) -> str:
         """Async variant of ``search_content``."""
         return await asyncio.to_thread(self.search_content, query, directory, limit)
+
+    async def agrep_content(
+        self,
+        pattern: str,
+        directory: str = ".",
+        ignore_case: bool = False,
+        context_lines: int = 0,
+        files_only: bool = False,
+        limit: int = 100,
+    ) -> str:
+        """Async variant of ``grep_content``."""
+        return await asyncio.to_thread(
+            self.grep_content, pattern, directory, ignore_case, context_lines, files_only, limit
+        )
 
     async def awrite_file(self, path: str, content: str, overwrite: bool = True, encoding: str = "utf-8") -> str:
         """Async variant of ``write_file``."""

--- a/libs/agno/agno/tools/workspace.py
+++ b/libs/agno/agno/tools/workspace.py
@@ -980,8 +980,9 @@ class Workspace(Toolkit):
             if not pattern or not pattern.strip():
                 return "Error: pattern cannot be empty"
 
-            # Clamp limit to constructor-defined max
-            limit = min(limit, self.max_grep_matches)
+            # Clamp parameters to valid ranges
+            context_lines = max(0, context_lines)
+            limit = max(1, min(limit, self.max_grep_matches))
 
             # 1. Compile regex (always case-insensitive)
             try:

--- a/libs/agno/agno/tools/workspace.py
+++ b/libs/agno/agno/tools/workspace.py
@@ -446,10 +446,14 @@ class Workspace(Toolkit):
             sections.append(text)
 
         if "move_file" in enabled:
-            sections.append(f"**{tool_prefix}move_file** — move or rename a file.\nWhen to use: reorganizing, renaming.")
+            sections.append(
+                f"**{tool_prefix}move_file** — move or rename a file.\nWhen to use: reorganizing, renaming."
+            )
 
         if "delete_file" in enabled:
-            sections.append(f"**{tool_prefix}delete_file** — delete a file.\nWhen to use: removing files. Use with caution.")
+            sections.append(
+                f"**{tool_prefix}delete_file** — delete a file.\nWhen to use: removing files. Use with caution."
+            )
 
         if "run_command" in enabled:
             sections.append(

--- a/libs/agno/agno/tools/workspace.py
+++ b/libs/agno/agno/tools/workspace.py
@@ -383,73 +383,77 @@ class Workspace(Toolkit):
     }
 
     @classmethod
-    def _build_instructions(cls, tool_names: List[str]) -> str:
+    def _build_instructions(cls, tool_names: List[str], prefix: Optional[str] = None) -> str:
         """Build instructions based on which tools are actually enabled.
 
         Only references tools the LLM can call — never mentions disabled tools.
+        When prefix is set, tool names in instructions are prefixed (e.g., docs_read_file).
         """
         enabled = set(tool_names)
         sections: List[str] = []
 
+        def t(name: str) -> str:
+            return f"{prefix}_{name}" if prefix else name
+
         # Read tools
         if "read_file" in enabled:
             sections.append(
-                "**read_file** — read a file with line numbers.\n"
+                f"**{t('read_file')}** — read a file with line numbers.\n"
                 "When to use: examining file contents, checking code, getting context.\n"
                 "Always read before editing or citing."
             )
 
         if "list_files" in enabled:
             sections.append(
-                "**list_files** — list directory contents.\n"
+                f"**{t('list_files')}** — list directory contents.\n"
                 "When to use: discovering project structure, finding files.\n"
                 "Use `recursive=True` with `max_depth` for broad exploration."
             )
 
         if "search_content" in enabled:
             text = (
-                "**search_content** — substring search across files.\n"
+                f"**{t('search_content')}** — substring search across files.\n"
                 "When to use: finding text, locating usages, discovering code."
             )
             if "grep_content" in enabled:
-                text += "\nFor regex patterns or line numbers, use grep_content instead."
+                text += f"\nFor regex patterns or line numbers, use {t('grep_content')} instead."
             sections.append(text)
 
         if "grep_content" in enabled:
             text = (
-                "**grep_content** — regex search with line numbers and context.\n"
+                f"**{t('grep_content')}** — regex search with line numbers and context.\n"
                 "When to use: pattern matching, finding code with surrounding context."
             )
             if "search_content" in enabled:
-                text += "\nFor simple substring search, use search_content instead."
+                text += f"\nFor simple substring search, use {t('search_content')} instead."
             sections.append(text)
 
         # Write tools
         if "write_file" in enabled:
             sections.append(
-                "**write_file** — create or overwrite a file.\n"
+                f"**{t('write_file')}** — create or overwrite a file.\n"
                 "When to use: creating new files, replacing entire file contents."
             )
 
         if "edit_file" in enabled:
             text = (
-                "**edit_file** — replace a substring in a file.\n"
+                f"**{t('edit_file')}** — replace a substring in a file.\n"
                 "When to use: modifying existing code.\n"
-                "IMPORTANT: Always read_file first — use the exact substring from the output."
+                f"IMPORTANT: Always {t('read_file')} first — use the exact substring from the output."
             )
             if "write_file" in enabled:
-                text += "\nUse write_file for new files; edit_file for modifications."
+                text += f"\nUse {t('write_file')} for new files; {t('edit_file')} for modifications."
             sections.append(text)
 
         if "move_file" in enabled:
-            sections.append("**move_file** — move or rename a file.\nWhen to use: reorganizing, renaming.")
+            sections.append(f"**{t('move_file')}** — move or rename a file.\nWhen to use: reorganizing, renaming.")
 
         if "delete_file" in enabled:
-            sections.append("**delete_file** — delete a file.\nWhen to use: removing files. Use with caution.")
+            sections.append(f"**{t('delete_file')}** — delete a file.\nWhen to use: removing files. Use with caution.")
 
         if "run_command" in enabled:
             sections.append(
-                "**run_command** — run a shell command in the workspace.\n"
+                f"**{t('run_command')}** — run a shell command in the workspace.\n"
                 "When to use: running tests, builds, or other commands.\n"
                 "Note: runs with cwd=workspace root."
             )
@@ -462,13 +466,13 @@ class Workspace(Toolkit):
         # Routing guidance
         routing: List[str] = []
         if "list_files" in enabled:
-            routing.append("- Discover structure → list_files")
+            routing.append(f"- Discover structure → {t('list_files')}")
         if "search_content" in enabled or "grep_content" in enabled:
-            routing.append("- Find code/text → search_content or grep_content")
+            routing.append(f"- Find code/text → {t('search_content')} or {t('grep_content')}")
         if "read_file" in enabled:
-            routing.append("- Examine contents → read_file")
+            routing.append(f"- Examine contents → {t('read_file')}")
         if "edit_file" in enabled:
-            routing.append("- Modify code → read_file first, then edit_file")
+            routing.append(f"- Modify code → {t('read_file')} first, then {t('edit_file')}")
 
         if routing:
             result += "\n\n## Workflow\n" + "\n".join(routing)
@@ -524,8 +528,9 @@ class Workspace(Toolkit):
 
         # Build instructions dynamically based on enabled tools
         toolkit_kwargs: dict = {}
+        prefix = kwargs.get("tool_name_prefix")
         if kwargs.get("instructions") is None:
-            built = self._build_instructions(registered)
+            built = self._build_instructions(registered, prefix=prefix)
             if built:
                 toolkit_kwargs["instructions"] = built
                 toolkit_kwargs.setdefault("add_instructions", True)

--- a/libs/agno/agno/tools/workspace.py
+++ b/libs/agno/agno/tools/workspace.py
@@ -392,68 +392,68 @@ class Workspace(Toolkit):
         enabled = set(tool_names)
         sections: List[str] = []
 
-        def t(name: str) -> str:
-            return f"{prefix}_{name}" if prefix else name
+        # Compute prefix once (follows MCPTools pattern)
+        p = f"{prefix}_" if prefix else ""
 
         # Read tools
         if "read_file" in enabled:
             sections.append(
-                f"**{t('read_file')}** — read a file with line numbers.\n"
+                f"**{p}read_file** — read a file with line numbers.\n"
                 "When to use: examining file contents, checking code, getting context.\n"
                 "Always read before editing or citing."
             )
 
         if "list_files" in enabled:
             sections.append(
-                f"**{t('list_files')}** — list directory contents.\n"
+                f"**{p}list_files** — list directory contents.\n"
                 "When to use: discovering project structure, finding files.\n"
                 "Use `recursive=True` with `max_depth` for broad exploration."
             )
 
         if "search_content" in enabled:
             text = (
-                f"**{t('search_content')}** — substring search across files.\n"
+                f"**{p}search_content** — substring search across files.\n"
                 "When to use: finding text, locating usages, discovering code."
             )
             if "grep_content" in enabled:
-                text += f"\nFor regex patterns or line numbers, use {t('grep_content')} instead."
+                text += f"\nFor regex patterns or line numbers, use {p}grep_content instead."
             sections.append(text)
 
         if "grep_content" in enabled:
             text = (
-                f"**{t('grep_content')}** — regex search with line numbers and context.\n"
+                f"**{p}grep_content** — regex search with line numbers and context.\n"
                 "When to use: pattern matching, finding code with surrounding context."
             )
             if "search_content" in enabled:
-                text += f"\nFor simple substring search, use {t('search_content')} instead."
+                text += f"\nFor simple substring search, use {p}search_content instead."
             sections.append(text)
 
         # Write tools
         if "write_file" in enabled:
             sections.append(
-                f"**{t('write_file')}** — create or overwrite a file.\n"
+                f"**{p}write_file** — create or overwrite a file.\n"
                 "When to use: creating new files, replacing entire file contents."
             )
 
         if "edit_file" in enabled:
             text = (
-                f"**{t('edit_file')}** — replace a substring in a file.\n"
+                f"**{p}edit_file** — replace a substring in a file.\n"
                 "When to use: modifying existing code.\n"
-                f"IMPORTANT: Always {t('read_file')} first — use the exact substring from the output."
+                f"IMPORTANT: Always {p}read_file first — use the exact substring from the output."
             )
             if "write_file" in enabled:
-                text += f"\nUse {t('write_file')} for new files; {t('edit_file')} for modifications."
+                text += f"\nUse {p}write_file for new files; {p}edit_file for modifications."
             sections.append(text)
 
         if "move_file" in enabled:
-            sections.append(f"**{t('move_file')}** — move or rename a file.\nWhen to use: reorganizing, renaming.")
+            sections.append(f"**{p}move_file** — move or rename a file.\nWhen to use: reorganizing, renaming.")
 
         if "delete_file" in enabled:
-            sections.append(f"**{t('delete_file')}** — delete a file.\nWhen to use: removing files. Use with caution.")
+            sections.append(f"**{p}delete_file** — delete a file.\nWhen to use: removing files. Use with caution.")
 
         if "run_command" in enabled:
             sections.append(
-                f"**{t('run_command')}** — run a shell command in the workspace.\n"
+                f"**{p}run_command** — run a shell command in the workspace.\n"
                 "When to use: running tests, builds, or other commands.\n"
                 "Note: runs with cwd=workspace root."
             )
@@ -466,13 +466,13 @@ class Workspace(Toolkit):
         # Routing guidance
         routing: List[str] = []
         if "list_files" in enabled:
-            routing.append(f"- Discover structure → {t('list_files')}")
+            routing.append(f"- Discover structure → {p}list_files")
         if "search_content" in enabled or "grep_content" in enabled:
-            routing.append(f"- Find code/text → {t('search_content')} or {t('grep_content')}")
+            routing.append(f"- Find code/text → {p}search_content or {p}grep_content")
         if "read_file" in enabled:
-            routing.append(f"- Examine contents → {t('read_file')}")
+            routing.append(f"- Examine contents → {p}read_file")
         if "edit_file" in enabled:
-            routing.append(f"- Modify code → {t('read_file')} first, then {t('edit_file')}")
+            routing.append(f"- Modify code → {p}read_file first, then {p}edit_file")
 
         if routing:
             result += "\n\n## Workflow\n" + "\n".join(routing)

--- a/libs/agno/agno/tools/workspace.py
+++ b/libs/agno/agno/tools/workspace.py
@@ -735,9 +735,10 @@ class Workspace(Toolkit):
             return None
         if file_path in self._read_paths:
             return None
+        read_tool = f"{self.tool_name_prefix}_read_file" if self.tool_name_prefix else "read_file"
         return (
             f"Error: require_read_before_write is enabled and {file_path.name} hasn't "
-            f"been read this session. Call read_file first to confirm contents before "
+            f"been read this session. Call {read_tool} first to confirm contents before "
             f"the {op}."
         )
 
@@ -778,8 +779,9 @@ class Workspace(Toolkit):
             self._read_paths.add(file_path)
             if start_line is None and end_line is None:
                 # Only suggest search_content if it's actually enabled
+                search_tool = f"{self.tool_name_prefix}_search_content" if self.tool_name_prefix else "search_content"
                 search_hint = (
-                    ", or use search_content to find specific text first" if "search_content" in self.functions else ""
+                    f", or use {search_tool} to find specific text first" if search_tool in self.functions else ""
                 )
                 if len(contents) > self.max_file_length:
                     return (

--- a/libs/agno/agno/tools/workspace.py
+++ b/libs/agno/agno/tools/workspace.py
@@ -392,68 +392,68 @@ class Workspace(Toolkit):
         enabled = set(tool_names)
         sections: List[str] = []
 
-        # Compute prefix once (follows MCPTools pattern)
-        p = f"{prefix}_" if prefix else ""
+        # Compute prefix once (follows MCPTools pattern at mcp/mcp.py:786-788)
+        tool_prefix = f"{prefix}_" if prefix else ""
 
         # Read tools
         if "read_file" in enabled:
             sections.append(
-                f"**{p}read_file** — read a file with line numbers.\n"
+                f"**{tool_prefix}read_file** — read a file with line numbers.\n"
                 "When to use: examining file contents, checking code, getting context.\n"
                 "Always read before editing or citing."
             )
 
         if "list_files" in enabled:
             sections.append(
-                f"**{p}list_files** — list directory contents.\n"
+                f"**{tool_prefix}list_files** — list directory contents.\n"
                 "When to use: discovering project structure, finding files.\n"
                 "Use `recursive=True` with `max_depth` for broad exploration."
             )
 
         if "search_content" in enabled:
             text = (
-                f"**{p}search_content** — substring search across files.\n"
+                f"**{tool_prefix}search_content** — substring search across files.\n"
                 "When to use: finding text, locating usages, discovering code."
             )
             if "grep_content" in enabled:
-                text += f"\nFor regex patterns or line numbers, use {p}grep_content instead."
+                text += f"\nFor regex patterns or line numbers, use {tool_prefix}grep_content instead."
             sections.append(text)
 
         if "grep_content" in enabled:
             text = (
-                f"**{p}grep_content** — regex search with line numbers and context.\n"
+                f"**{tool_prefix}grep_content** — regex search with line numbers and context.\n"
                 "When to use: pattern matching, finding code with surrounding context."
             )
             if "search_content" in enabled:
-                text += f"\nFor simple substring search, use {p}search_content instead."
+                text += f"\nFor simple substring search, use {tool_prefix}search_content instead."
             sections.append(text)
 
         # Write tools
         if "write_file" in enabled:
             sections.append(
-                f"**{p}write_file** — create or overwrite a file.\n"
+                f"**{tool_prefix}write_file** — create or overwrite a file.\n"
                 "When to use: creating new files, replacing entire file contents."
             )
 
         if "edit_file" in enabled:
             text = (
-                f"**{p}edit_file** — replace a substring in a file.\n"
+                f"**{tool_prefix}edit_file** — replace a substring in a file.\n"
                 "When to use: modifying existing code.\n"
-                f"IMPORTANT: Always {p}read_file first — use the exact substring from the output."
+                f"IMPORTANT: Always {tool_prefix}read_file first — use the exact substring from the output."
             )
             if "write_file" in enabled:
-                text += f"\nUse {p}write_file for new files; {p}edit_file for modifications."
+                text += f"\nUse {tool_prefix}write_file for new files; {tool_prefix}edit_file for modifications."
             sections.append(text)
 
         if "move_file" in enabled:
-            sections.append(f"**{p}move_file** — move or rename a file.\nWhen to use: reorganizing, renaming.")
+            sections.append(f"**{tool_prefix}move_file** — move or rename a file.\nWhen to use: reorganizing, renaming.")
 
         if "delete_file" in enabled:
-            sections.append(f"**{p}delete_file** — delete a file.\nWhen to use: removing files. Use with caution.")
+            sections.append(f"**{tool_prefix}delete_file** — delete a file.\nWhen to use: removing files. Use with caution.")
 
         if "run_command" in enabled:
             sections.append(
-                f"**{p}run_command** — run a shell command in the workspace.\n"
+                f"**{tool_prefix}run_command** — run a shell command in the workspace.\n"
                 "When to use: running tests, builds, or other commands.\n"
                 "Note: runs with cwd=workspace root."
             )
@@ -466,13 +466,13 @@ class Workspace(Toolkit):
         # Routing guidance
         routing: List[str] = []
         if "list_files" in enabled:
-            routing.append(f"- Discover structure → {p}list_files")
+            routing.append(f"- Discover structure → {tool_prefix}list_files")
         if "search_content" in enabled or "grep_content" in enabled:
-            routing.append(f"- Find code/text → {p}search_content or {p}grep_content")
+            routing.append(f"- Find code/text → {tool_prefix}search_content or {tool_prefix}grep_content")
         if "read_file" in enabled:
-            routing.append(f"- Examine contents → {p}read_file")
+            routing.append(f"- Examine contents → {tool_prefix}read_file")
         if "edit_file" in enabled:
-            routing.append(f"- Modify code → {p}read_file first, then {p}edit_file")
+            routing.append(f"- Modify code → {tool_prefix}read_file first, then {tool_prefix}edit_file")
 
         if routing:
             result += "\n\n## Workflow\n" + "\n".join(routing)

--- a/libs/agno/agno/tools/workspace.py
+++ b/libs/agno/agno/tools/workspace.py
@@ -389,6 +389,7 @@ class Workspace(Toolkit):
         require_read_before_write: bool = False,
         max_file_lines: int = 100_000,
         max_file_length: int = 10_000_000,
+        max_grep_matches: int = 500,
         exclude_patterns: Optional[List[str]] = None,
         allow_paths: Optional[List[str]] = None,
         **kwargs,
@@ -401,6 +402,7 @@ class Workspace(Toolkit):
 
         self.max_file_lines = max_file_lines
         self.max_file_length = max_file_length
+        self.max_grep_matches = max_grep_matches
         self.require_read_before_write = require_read_before_write
         self.exclude_patterns: List[str] = _validate_exclude_patterns(exclude_patterns)
         _resolve_allow_paths(self.root, allow_paths)
@@ -871,12 +873,15 @@ class Workspace(Toolkit):
         :param ignore_case: Case-insensitive matching (default False).
         :param context_lines: Lines of context before and after each match (default 0).
         :param files_only: Return only file paths, not matching lines (default False).
-        :param limit: Maximum number of matches to return (default 100).
+        :param limit: Maximum number of matches to return (default 100, capped by max_grep_matches).
         :return: Matching lines as ``path:line:text``, or file paths if ``files_only``.
         """
         try:
             if not pattern or not pattern.strip():
                 return "Error: pattern cannot be empty"
+
+            # Clamp limit to constructor-defined max
+            limit = min(limit, self.max_grep_matches)
 
             # 1. Compile regex
             flags = re.IGNORECASE if ignore_case else 0

--- a/libs/agno/agno/tools/workspace.py
+++ b/libs/agno/agno/tools/workspace.py
@@ -382,6 +382,99 @@ class Workspace(Toolkit):
         "shell": "run_command",
     }
 
+    @classmethod
+    def _build_instructions(cls, tool_names: List[str]) -> str:
+        """Build instructions based on which tools are actually enabled.
+
+        Only references tools the LLM can call — never mentions disabled tools.
+        """
+        enabled = set(tool_names)
+        sections: List[str] = []
+
+        # Read tools
+        if "read_file" in enabled:
+            sections.append(
+                "**read_file** — read a file with line numbers.\n"
+                "When to use: examining file contents, checking code, getting context.\n"
+                "Always read before editing or citing."
+            )
+
+        if "list_files" in enabled:
+            sections.append(
+                "**list_files** — list directory contents.\n"
+                "When to use: discovering project structure, finding files.\n"
+                "Use `recursive=True` with `max_depth` for broad exploration."
+            )
+
+        if "search_content" in enabled:
+            text = (
+                "**search_content** — substring search across files.\n"
+                "When to use: finding text, locating usages, discovering code."
+            )
+            if "grep_content" in enabled:
+                text += "\nFor regex patterns or line numbers, use grep_content instead."
+            sections.append(text)
+
+        if "grep_content" in enabled:
+            text = (
+                "**grep_content** — regex search with line numbers and context.\n"
+                "When to use: pattern matching, finding code with surrounding context."
+            )
+            if "search_content" in enabled:
+                text += "\nFor simple substring search, use search_content instead."
+            sections.append(text)
+
+        # Write tools
+        if "write_file" in enabled:
+            sections.append(
+                "**write_file** — create or overwrite a file.\n"
+                "When to use: creating new files, replacing entire file contents."
+            )
+
+        if "edit_file" in enabled:
+            text = (
+                "**edit_file** — replace a substring in a file.\n"
+                "When to use: modifying existing code.\n"
+                "IMPORTANT: Always read_file first — use the exact substring from the output."
+            )
+            if "write_file" in enabled:
+                text += "\nUse write_file for new files; edit_file for modifications."
+            sections.append(text)
+
+        if "move_file" in enabled:
+            sections.append("**move_file** — move or rename a file.\nWhen to use: reorganizing, renaming.")
+
+        if "delete_file" in enabled:
+            sections.append("**delete_file** — delete a file.\nWhen to use: removing files. Use with caution.")
+
+        if "run_command" in enabled:
+            sections.append(
+                "**run_command** — run a shell command in the workspace.\n"
+                "When to use: running tests, builds, or other commands.\n"
+                "Note: runs with cwd=workspace root."
+            )
+
+        if len(sections) < 2:
+            return ""
+
+        result = "## Workspace Tools\n\n" + "\n\n".join(sections)
+
+        # Routing guidance
+        routing: List[str] = []
+        if "list_files" in enabled:
+            routing.append("- Discover structure → list_files")
+        if "search_content" in enabled or "grep_content" in enabled:
+            routing.append("- Find code/text → search_content or grep_content")
+        if "read_file" in enabled:
+            routing.append("- Examine contents → read_file")
+        if "edit_file" in enabled:
+            routing.append("- Modify code → read_file first, then edit_file")
+
+        if routing:
+            result += "\n\n## Workflow\n" + "\n".join(routing)
+
+        return result
+
     def __init__(
         self,
         root: Optional[Union[str, Path]] = None,
@@ -429,23 +522,16 @@ class Workspace(Toolkit):
         sync_tools = [getattr(self, name) for name in registered]
         async_tools = [(getattr(self, "a" + name), name) for name in registered]
 
-        # Only nudge the agent about edit_file when edit_file is actually
-        # available — read-only surfaces (e.g. WikiContextProvider's read
-        # sub-agent) shouldn't be told how to use a tool they don't have.
-        edit_registered = "edit" in resolved_allowed_aliases or "edit" in resolved_confirm_aliases
+        # Build instructions dynamically based on enabled tools
         toolkit_kwargs: dict = {}
-        if edit_registered:
-            toolkit_kwargs["instructions"] = (
-                "Always read_file before editing — the line-numbered output gives you "
-                "the exact substring to pass to edit_file's old_str parameter. "
-                "Do not guess file contents or pass line numbers to edit_file."
-            )
-            toolkit_kwargs["add_instructions"] = True
+        if kwargs.get("instructions") is None:
+            built = self._build_instructions(registered)
+            if built:
+                toolkit_kwargs["instructions"] = built
+                toolkit_kwargs.setdefault("add_instructions", True)
 
-        # Allow name override via kwargs (for prefixed tools in context providers)
-        toolkit_name = kwargs.pop("name", "workspace")
         super().__init__(
-            name=toolkit_name,
+            name="workspace",
             tools=sync_tools,
             async_tools=async_tools,
             requires_confirmation_tools=resolved_confirm_methods,
@@ -682,18 +768,20 @@ class Workspace(Toolkit):
             contents = file_path.read_text(encoding=encoding)
             self._read_paths.add(file_path)
             if start_line is None and end_line is None:
+                # Only suggest search_content if it's actually enabled
+                search_hint = (
+                    ", or use search_content to find specific text first" if "search_content" in self.functions else ""
+                )
                 if len(contents) > self.max_file_length:
                     return (
                         f"Error: file too long ({len(contents)} chars > {self.max_file_length}). "
-                        "Use start_line/end_line to read a chunk, "
-                        "or use search_content to find specific text first."
+                        f"Use start_line/end_line to read a chunk{search_hint}."
                     )
                 line_count = contents.count("\n") + 1
                 if line_count > self.max_file_lines:
                     return (
                         f"Error: file too long ({line_count} lines > {self.max_file_lines}). "
-                        "Use start_line/end_line to read a chunk, "
-                        "or use search_content to find specific text first."
+                        f"Use start_line/end_line to read a chunk{search_hint}."
                     )
                 return _format_with_line_numbers(contents, start_line=1)
             lines = contents.split("\n")

--- a/libs/agno/agno/tools/workspace.py
+++ b/libs/agno/agno/tools/workspace.py
@@ -41,6 +41,7 @@ from agno.utils.path_safety import safe_join_relative_path
 TEXT_EXTENSIONS = {
     # Markup and data
     ".md",
+    ".mdx",
     ".txt",
     ".csv",
     ".json",
@@ -302,7 +303,8 @@ class Workspace(Toolkit):
     | -------- | -------------------- | --------------------------------------- |
     | ``read``   | ``read_file``        | Read a file (line-numbered)             |
     | ``list``   | ``list_files``       | List a directory (recursive option)     |
-    | ``search`` | ``search_content``   | Recursive content grep                  |
+    | ``search`` | ``search_content``   | Recursive content search (substring)    |
+    | ``grep``   | ``grep_content``     | Regex search with line numbers          |
     | ``write``  | ``write_file``       | Create or overwrite a file (atomic)     |
     | ``edit``   | ``edit_file``        | Replace a substring (with ``replace_all``)|
     | ``move``   | ``move_file``        | Move or rename a file                   |
@@ -363,7 +365,7 @@ class Workspace(Toolkit):
     this session. Catches the "agent hallucinated the file's contents" bug class.
     """
 
-    READ_TOOLS: List[str] = ["read", "list", "search"]
+    READ_TOOLS: List[str] = ["read", "list", "search", "grep"]
     WRITE_TOOLS: List[str] = ["write", "edit", "move", "delete", "shell"]
     ALL_TOOLS: List[str] = READ_TOOLS + WRITE_TOOLS
 
@@ -372,6 +374,7 @@ class Workspace(Toolkit):
         "read": "read_file",
         "list": "list_files",
         "search": "search_content",
+        "grep": "grep_content",
         "write": "write_file",
         "edit": "edit_file",
         "move": "move_file",
@@ -387,6 +390,8 @@ class Workspace(Toolkit):
         require_read_before_write: bool = False,
         max_file_lines: int = 100_000,
         max_file_length: int = 10_000_000,
+        max_grep_matches: int = 500,
+        max_search_file_size: int = 500 * 1024,
         exclude_patterns: Optional[List[str]] = None,
         allow_paths: Optional[List[str]] = None,
         **kwargs,
@@ -399,6 +404,8 @@ class Workspace(Toolkit):
 
         self.max_file_lines = max_file_lines
         self.max_file_length = max_file_length
+        self.max_grep_matches = max_grep_matches
+        self.max_search_file_size = max_search_file_size
         self.require_read_before_write = require_read_before_write
         self.exclude_patterns: List[str] = _validate_exclude_patterns(exclude_patterns)
         _resolve_allow_paths(self.root, allow_paths)
@@ -435,8 +442,10 @@ class Workspace(Toolkit):
             )
             toolkit_kwargs["add_instructions"] = True
 
+        # Allow name override via kwargs (for prefixed tools in context providers)
+        toolkit_name = kwargs.pop("name", "workspace")
         super().__init__(
-            name="workspace",
+            name=toolkit_name,
             tools=sync_tools,
             async_tools=async_tools,
             requires_confirmation_tools=resolved_confirm_methods,
@@ -811,7 +820,7 @@ class Workspace(Toolkit):
 
             lower_query = query.lower()
             matches: List[dict] = []
-            max_file_size = 500 * 1024
+            max_file_size = self.max_search_file_size
             walk_done = False
 
             for dirpath, dirnames, filenames in os.walk(search_dir):
@@ -849,6 +858,115 @@ class Workspace(Toolkit):
         except Exception as e:
             log_error(f"search_content failed: {e}")
             return f"Error searching content: {e}"
+
+    def grep_content(
+        self,
+        pattern: str,
+        directory: str = ".",
+        context_lines: int = 0,
+        limit: int = 100,
+    ) -> str:
+        """Regex search with line numbers across text files in the workspace.
+
+        Matching is always case-insensitive.
+
+        :param pattern: Regex pattern to search for.
+        :param directory: Subdirectory to scope the search to (default ".").
+        :param context_lines: Lines of context before and after each match (default 0).
+        :param limit: Maximum number of matches to return (default 100, capped by max_grep_matches).
+        :return: JSON with keys ``pattern``, ``total_matches``, ``truncated``, and ``matches``
+            (list of ``{"file", "line", "text"}``).
+        """
+        try:
+            if not pattern or not pattern.strip():
+                return "Error: pattern cannot be empty"
+
+            # Clamp limit to constructor-defined max
+            limit = min(limit, self.max_grep_matches)
+
+            # 1. Compile regex (always case-insensitive)
+            try:
+                rx = re.compile(pattern, re.IGNORECASE)
+            except re.error as exc:
+                return f"Error: invalid regex pattern: {exc}"
+
+            # 2. Resolve directory
+            err, search_dir = self._resolve(directory, what="directory")
+            if err:
+                return err
+            if not search_dir.is_dir():
+                return f"Error: not a directory: {directory}"
+
+            max_file_size = self.max_search_file_size
+            matches: List[dict] = []
+            total_matches = 0
+
+            # 3. Walk the directory tree
+            for dirpath, dirnames, filenames in os.walk(search_dir):
+                if total_matches >= limit:
+                    break
+                # Prune excluded directories
+                dirnames[:] = [name for name in dirnames if not self._is_excluded(Path(dirpath) / name)]
+
+                for filename in filenames:
+                    if total_matches >= limit:
+                        break
+                    file_path = Path(dirpath) / filename
+
+                    # Skip hidden/excluded files
+                    if self._hidden(file_path):
+                        continue
+                    if file_path.suffix.lower() not in TEXT_EXTENSIONS:
+                        continue
+                    try:
+                        if file_path.stat().st_size > max_file_size:
+                            continue
+                    except OSError:
+                        continue
+
+                    # Read and search
+                    try:
+                        content = file_path.read_text(encoding="utf-8", errors="ignore")
+                    except Exception:
+                        continue
+
+                    file_lines = content.splitlines()
+                    hits = [idx for idx, line in enumerate(file_lines) if rx.search(line)]
+
+                    if not hits:
+                        continue
+
+                    rel_path = file_path.relative_to(self.root).as_posix()
+
+                    # Collect matches with context
+                    shown: Set[int] = set()
+
+                    for hit in hits:
+                        if total_matches >= limit:
+                            break
+                        # Calculate context range
+                        start = max(0, hit - context_lines)
+                        end = min(len(file_lines), hit + context_lines + 1)
+
+                        for j in range(start, end):
+                            if j not in shown:
+                                shown.add(j)
+                                matches.append({"file": rel_path, "line": j + 1, "text": file_lines[j]})
+
+                        total_matches += 1
+
+            # 4. Format output as JSON
+            result = {
+                "pattern": pattern,
+                "total_matches": total_matches,
+                "truncated": total_matches >= limit,
+                "matches": matches,
+            }
+            return json.dumps(result, indent=2)
+
+        except Exception as e:
+            log_error(f"grep_content failed: {e}")
+            return f"Error in grep: {e}"
 
     # ------------------------------------------------------------------
     # Write operations (require confirmation by default)
@@ -1075,6 +1193,16 @@ class Workspace(Toolkit):
     async def asearch_content(self, query: str, directory: str = ".", limit: int = 10) -> str:
         """Async variant of ``search_content``."""
         return await asyncio.to_thread(self.search_content, query, directory, limit)
+
+    async def agrep_content(
+        self,
+        pattern: str,
+        directory: str = ".",
+        context_lines: int = 0,
+        limit: int = 100,
+    ) -> str:
+        """Async variant of ``grep_content``."""
+        return await asyncio.to_thread(self.grep_content, pattern, directory, context_lines, limit)
 
     async def awrite_file(self, path: str, content: str, overwrite: bool = True, encoding: str = "utf-8") -> str:
         """Async variant of ``write_file``."""

--- a/libs/agno/tests/unit/agent/test_run_regressions.py
+++ b/libs/agno/tests/unit/agent/test_run_regressions.py
@@ -3,11 +3,10 @@ from typing import Any, Optional
 
 import pytest
 
-from agno.exceptions import RunNotFoundError
-
 from agno.agent import _init, _messages, _response, _run, _session, _storage, _tools
 from agno.agent.agent import Agent
 from agno.db.base import SessionType
+from agno.exceptions import RunNotFoundError
 from agno.run import RunContext
 from agno.run.agent import RunErrorEvent, RunOutput
 from agno.run.base import RunStatus

--- a/libs/agno/tests/unit/context/test_providers.py
+++ b/libs/agno/tests/unit/context/test_providers.py
@@ -112,7 +112,7 @@ def test_workspace_default_surface_is_single_query_tool(tmp_path: Path):
 def test_workspace_tools_mode_is_read_only(tmp_path: Path):
     p = WorkspaceContextProvider(root=tmp_path, mode=ContextMode.tools)
     workspace = p.get_tools()[0]
-    assert sorted(workspace.functions.keys()) == ["list_files", "read_file", "search_content"]
+    assert sorted(workspace.functions.keys()) == ["grep_content", "list_files", "read_file", "search_content"]
 
 
 def test_workspace_context_excludes_agent_scratch_and_plural_venvs(tmp_path: Path):

--- a/libs/agno/tests/unit/context/test_wiki_provider.py
+++ b/libs/agno/tests/unit/context/test_wiki_provider.py
@@ -245,7 +245,7 @@ def test_provider_tools_mode_is_read_only(tmp_path: Path):
     p = WikiContextProvider(backend=FileSystemBackend(path=tmp_path), mode=ContextMode.tools)
     workspace = p.get_tools()[0]
     # Only the read aliases should be registered — no write/edit/delete.
-    assert sorted(workspace.functions.keys()) == ["list_files", "read_file", "search_content"]
+    assert sorted(workspace.functions.keys()) == ["grep_content", "list_files", "read_file", "search_content"]
 
 
 def test_provider_tools_mode_instructions_call_out_read_only(tmp_path: Path):

--- a/libs/agno/tests/unit/tools/test_toolkit.py
+++ b/libs/agno/tests/unit/tools/test_toolkit.py
@@ -986,3 +986,73 @@ def test_explicit_tools_argument_preserved():
 
     assert example_func in toolkit.tools
     assert "example_func" in toolkit.functions
+
+
+# =============================================================================
+# tool_name_prefix tests
+# =============================================================================
+
+
+def test_tool_name_prefix_basic():
+    """tool_name_prefix prepends prefix to all registered tool names."""
+    toolkit = Toolkit(name="test", tools=[example_func, another_func], tool_name_prefix="myprefix")
+
+    assert "myprefix_example_func" in toolkit.functions
+    assert "myprefix_another_func" in toolkit.functions
+    assert "example_func" not in toolkit.functions
+    assert "another_func" not in toolkit.functions
+
+
+def test_tool_name_prefix_none_uses_original_names():
+    """When tool_name_prefix is None, tool names are unchanged."""
+    toolkit = Toolkit(name="test", tools=[example_func], tool_name_prefix=None)
+
+    assert "example_func" in toolkit.functions
+    assert "myprefix_example_func" not in toolkit.functions
+
+
+def test_tool_name_prefix_with_include_tools():
+    """Filters match on unprefixed names, prefix applied after filtering."""
+    toolkit = Toolkit(
+        name="test",
+        tools=[example_func, another_func, third_func],
+        include_tools=["example_func", "third_func"],
+        tool_name_prefix="docs",
+    )
+
+    assert "docs_example_func" in toolkit.functions
+    assert "docs_third_func" in toolkit.functions
+    assert "docs_another_func" not in toolkit.functions
+
+
+def test_tool_name_prefix_with_exclude_tools():
+    """Filters match on unprefixed names, prefix applied after filtering."""
+    toolkit = Toolkit(
+        name="test",
+        tools=[example_func, another_func],
+        exclude_tools=["another_func"],
+        tool_name_prefix="code",
+    )
+
+    assert "code_example_func" in toolkit.functions
+    assert "code_another_func" not in toolkit.functions
+
+
+def test_tool_name_prefix_function_object_has_correct_name():
+    """The Function object's name attribute has the prefix."""
+    toolkit = Toolkit(name="test", tools=[example_func], tool_name_prefix="myapp")
+
+    func = toolkit.functions["myapp_example_func"]
+    assert func.name == "myapp_example_func"
+
+
+def test_tool_name_prefix_multiple_toolkits_no_collision():
+    """Multiple toolkits with different prefixes can have same-named tools."""
+    toolkit1 = Toolkit(name="docs", tools=[example_func], tool_name_prefix="docs")
+    toolkit2 = Toolkit(name="code", tools=[example_func], tool_name_prefix="code")
+
+    assert "docs_example_func" in toolkit1.functions
+    assert "code_example_func" in toolkit2.functions
+    # Each toolkit has its own prefixed version
+    assert toolkit1.functions["docs_example_func"].name == "docs_example_func"
+    assert toolkit2.functions["code_example_func"].name == "code_example_func"

--- a/libs/agno/tests/unit/tools/test_workspace.py
+++ b/libs/agno/tests/unit/tools/test_workspace.py
@@ -13,13 +13,14 @@ ALL_METHODS = [
     "read_file",
     "list_files",
     "search_content",
+    "grep_content",
     "write_file",
     "edit_file",
     "move_file",
     "delete_file",
     "run_command",
 ]
-READ_METHODS = ["read_file", "list_files", "search_content"]
+READ_METHODS = ["read_file", "list_files", "search_content", "grep_content"]
 WRITE_METHODS = ["write_file", "edit_file", "move_file", "delete_file", "run_command"]
 
 
@@ -474,6 +475,134 @@ def test_search_content_empty_query():
     with tempfile.TemporaryDirectory() as tmp_dir:
         ws = Workspace(tmp_dir)
         assert ws.search_content(query="").startswith("Error")
+
+
+# ------------------------------------------------------------------
+# grep_content (regex with line numbers)
+# ------------------------------------------------------------------
+
+
+def test_grep_content_basic():
+    """grep_content returns path:line:text format."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ws = Workspace(tmp_dir)
+        base = Path(tmp_dir)
+        (base / "code.py").write_text("def foo():\n    pass\n\ndef bar():\n    return 1")
+
+        result = ws.grep_content(pattern="def ")
+        assert "code.py:1:def foo():" in result
+        assert "code.py:4:def bar():" in result
+
+
+def test_grep_content_regex():
+    """grep_content supports regex patterns."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ws = Workspace(tmp_dir)
+        base = Path(tmp_dir)
+        (base / "code.py").write_text("async def run():\n    pass\ndef sync_run():\n    pass")
+
+        # Match only async def
+        result = ws.grep_content(pattern=r"async\s+def")
+        assert "code.py:1:async def run():" in result
+        assert "sync_run" not in result
+
+
+def test_grep_content_ignore_case():
+    """grep_content ignore_case flag works."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ws = Workspace(tmp_dir)
+        base = Path(tmp_dir)
+        (base / "doc.md").write_text("TODO: fix this\nTodo: later\ntodo: now")
+
+        result = ws.grep_content(pattern="TODO", ignore_case=True)
+        assert result.count("doc.md:") == 3
+
+        result = ws.grep_content(pattern="TODO", ignore_case=False)
+        assert result.count("doc.md:") == 1
+
+
+def test_grep_content_context_lines():
+    """grep_content context_lines shows surrounding lines."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ws = Workspace(tmp_dir)
+        base = Path(tmp_dir)
+        (base / "code.py").write_text("# header\ndef target():\n    pass\n# footer")
+
+        result = ws.grep_content(pattern="def target", context_lines=1)
+        assert "code.py:1:# header" in result
+        assert "code.py:2:def target():" in result
+        assert "code.py:3:    pass" in result
+
+
+def test_grep_content_files_only():
+    """grep_content files_only=True returns only file names."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ws = Workspace(tmp_dir)
+        base = Path(tmp_dir)
+        (base / "a.py").write_text("def foo(): pass")
+        (base / "b.py").write_text("def bar(): pass")
+        (base / "c.txt").write_text("nothing special here")
+
+        result = ws.grep_content(pattern="def ", files_only=True)
+        assert "a.py" in result
+        assert "b.py" in result
+        assert "c.txt" not in result
+        assert "(2 files)" in result
+
+
+def test_grep_content_respects_limit():
+    """grep_content respects the limit parameter."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ws = Workspace(tmp_dir)
+        base = Path(tmp_dir)
+        (base / "code.py").write_text("\n".join(f"line{i}" for i in range(100)))
+
+        result = ws.grep_content(pattern="line", limit=5)
+        assert "(showing 5 matches, limit=5)" in result
+
+
+def test_grep_content_invalid_regex():
+    """grep_content returns error for invalid regex."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ws = Workspace(tmp_dir)
+        result = ws.grep_content(pattern="[invalid")
+        assert result.startswith("Error: invalid regex")
+
+
+def test_grep_content_no_matches():
+    """grep_content returns message when no matches."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ws = Workspace(tmp_dir)
+        base = Path(tmp_dir)
+        (base / "file.py").write_text("nothing here")
+
+        result = ws.grep_content(pattern="NOTFOUND")
+        assert "No matches for pattern" in result
+
+
+def test_grep_content_skips_excluded():
+    """grep_content skips excluded directories."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ws = Workspace(tmp_dir)
+        base = Path(tmp_dir)
+        (base / "real.py").write_text("def real(): pass")
+        (base / ".venv").mkdir()
+        (base / ".venv" / "hidden.py").write_text("def hidden(): pass")
+
+        result = ws.grep_content(pattern="def ")
+        assert "real.py" in result
+        assert ".venv" not in result
+
+
+def test_agrep_content_async():
+    """agrep_content async variant works."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ws = Workspace(tmp_dir)
+        base = Path(tmp_dir)
+        (base / "code.py").write_text("def foo(): pass")
+
+        result = asyncio.run(ws.agrep_content(pattern="def "))
+        assert "code.py:1:def foo():" in result
 
 
 # ------------------------------------------------------------------

--- a/libs/agno/tests/unit/tools/test_workspace.py
+++ b/libs/agno/tests/unit/tools/test_workspace.py
@@ -1852,3 +1852,52 @@ def test_empty_deny_list_with_only_exemptions_excludes_nothing():
         _write(base, ".env", "SECRET=1\n")
         ws = Workspace(tmp_dir, exclude_patterns=["!.env.example"])
         assert "SECRET=1" in ws.read_file(".env")
+
+
+# =============================================================================
+# tool_name_prefix tests
+# =============================================================================
+
+
+def test_tool_name_prefix_prefixes_tool_names(tmp_path):
+    """tool_name_prefix prepends prefix to all tool names."""
+    workspace = Workspace(root=tmp_path, tool_name_prefix="docs")
+
+    assert "docs_read_file" in workspace.functions
+    assert "docs_list_files" in workspace.functions
+    assert "read_file" not in workspace.functions
+
+
+def test_tool_name_prefix_updates_instructions(tmp_path):
+    """Instructions reference prefixed tool names when prefix is set."""
+    workspace = Workspace(root=tmp_path, tool_name_prefix="myapp")
+
+    # Check that instructions reference prefixed names
+    assert workspace.instructions is not None
+    assert "myapp_read_file" in workspace.instructions
+    assert "myapp_list_files" in workspace.instructions
+    # Should not have unprefixed names
+    assert "**read_file**" not in workspace.instructions
+
+
+def test_tool_name_prefix_none_keeps_original_names(tmp_path):
+    """When tool_name_prefix is None, names and instructions are unchanged."""
+    workspace = Workspace(root=tmp_path, tool_name_prefix=None)
+
+    assert "read_file" in workspace.functions
+    assert "docs_read_file" not in workspace.functions
+    if workspace.instructions:
+        assert "**read_file**" in workspace.instructions
+
+
+def test_multiple_workspaces_different_prefixes(tmp_path):
+    """Multiple Workspace instances can coexist with different prefixes."""
+    docs = Workspace(root=tmp_path, tool_name_prefix="docs")
+    code = Workspace(root=tmp_path, tool_name_prefix="code")
+
+    # Each has its own prefixed tools
+    assert "docs_read_file" in docs.functions
+    assert "code_read_file" in code.functions
+    # No collision
+    assert "docs_read_file" not in code.functions
+    assert "code_read_file" not in docs.functions

--- a/libs/agno/tests/unit/tools/test_workspace.py
+++ b/libs/agno/tests/unit/tools/test_workspace.py
@@ -561,6 +561,19 @@ def test_grep_content_respects_limit():
         assert "(showing 5 matches, limit=5)" in result
 
 
+def test_grep_content_max_grep_matches_clamps_limit():
+    """grep_content clamps limit to max_grep_matches from constructor."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        # Constructor sets max_grep_matches=10, LLM requests limit=50
+        ws = Workspace(tmp_dir, max_grep_matches=10)
+        base = Path(tmp_dir)
+        (base / "code.py").write_text("\n".join(f"match{i}" for i in range(100)))
+
+        # Even though limit=50 is requested, max_grep_matches=10 wins
+        result = ws.grep_content(pattern="match", limit=50)
+        assert "(showing 10 matches, limit=10)" in result
+
+
 def test_grep_content_invalid_regex():
     """grep_content returns error for invalid regex."""
     with tempfile.TemporaryDirectory() as tmp_dir:

--- a/libs/agno/tests/unit/tools/test_workspace.py
+++ b/libs/agno/tests/unit/tools/test_workspace.py
@@ -13,13 +13,14 @@ ALL_METHODS = [
     "read_file",
     "list_files",
     "search_content",
+    "grep_content",
     "write_file",
     "edit_file",
     "move_file",
     "delete_file",
     "run_command",
 ]
-READ_METHODS = ["read_file", "list_files", "search_content"]
+READ_METHODS = ["read_file", "list_files", "search_content", "grep_content"]
 WRITE_METHODS = ["write_file", "edit_file", "move_file", "delete_file", "run_command"]
 
 
@@ -474,6 +475,157 @@ def test_search_content_empty_query():
     with tempfile.TemporaryDirectory() as tmp_dir:
         ws = Workspace(tmp_dir)
         assert ws.search_content(query="").startswith("Error")
+
+
+# ------------------------------------------------------------------
+# grep_content (regex with line numbers, JSON output)
+# ------------------------------------------------------------------
+
+
+def test_grep_content_basic():
+    """grep_content returns JSON with matches."""
+    import json
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ws = Workspace(tmp_dir)
+        base = Path(tmp_dir)
+        (base / "code.py").write_text("def foo():\n    pass\n\ndef bar():\n    return 1")
+
+        result = json.loads(ws.grep_content(pattern="def "))
+        assert result["pattern"] == "def "
+        assert result["total_matches"] == 2
+        files = [m["file"] for m in result["matches"]]
+        lines = [m["line"] for m in result["matches"]]
+        assert "code.py" in files[0]
+        assert 1 in lines
+        assert 4 in lines
+
+
+def test_grep_content_regex():
+    """grep_content supports regex patterns."""
+    import json
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ws = Workspace(tmp_dir)
+        base = Path(tmp_dir)
+        (base / "code.py").write_text("async def run():\n    pass\ndef sync_run():\n    pass")
+
+        result = json.loads(ws.grep_content(pattern=r"async\s+def"))
+        assert result["total_matches"] == 1
+        assert result["matches"][0]["line"] == 1
+        assert "async def run" in result["matches"][0]["text"]
+
+
+def test_grep_content_case_insensitive():
+    """grep_content is always case-insensitive."""
+    import json
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ws = Workspace(tmp_dir)
+        base = Path(tmp_dir)
+        (base / "doc.md").write_text("TODO: fix this\nTodo: later\ntodo: now")
+
+        result = json.loads(ws.grep_content(pattern="TODO"))
+        assert result["total_matches"] == 3
+
+
+def test_grep_content_context_lines():
+    """grep_content context_lines shows surrounding lines."""
+    import json
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ws = Workspace(tmp_dir)
+        base = Path(tmp_dir)
+        (base / "code.py").write_text("# header\ndef target():\n    pass\n# footer")
+
+        result = json.loads(ws.grep_content(pattern="def target", context_lines=1))
+        lines = [m["line"] for m in result["matches"]]
+        assert 1 in lines  # header (context)
+        assert 2 in lines  # target (match)
+        assert 3 in lines  # pass (context)
+
+
+def test_grep_content_respects_limit():
+    """grep_content respects the limit parameter."""
+    import json
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ws = Workspace(tmp_dir)
+        base = Path(tmp_dir)
+        (base / "code.py").write_text("\n".join(f"line{i}" for i in range(100)))
+
+        result = json.loads(ws.grep_content(pattern="line", limit=5))
+        assert result["total_matches"] == 5
+        assert result["truncated"] is True
+
+
+def test_grep_content_max_grep_matches_clamps_limit():
+    """grep_content clamps limit to max_grep_matches from constructor."""
+    import json
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        # Constructor sets max_grep_matches=10, LLM requests limit=50
+        ws = Workspace(tmp_dir, max_grep_matches=10)
+        base = Path(tmp_dir)
+        (base / "code.py").write_text("\n".join(f"match{i}" for i in range(100)))
+
+        # Even though limit=50 is requested, max_grep_matches=10 wins
+        result = json.loads(ws.grep_content(pattern="match", limit=50))
+        assert result["total_matches"] == 10
+        assert result["truncated"] is True
+
+
+def test_grep_content_invalid_regex():
+    """grep_content returns error for invalid regex."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ws = Workspace(tmp_dir)
+        result = ws.grep_content(pattern="[invalid")
+        assert result.startswith("Error: invalid regex")
+
+
+def test_grep_content_no_matches():
+    """grep_content returns empty matches when no matches."""
+    import json
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ws = Workspace(tmp_dir)
+        base = Path(tmp_dir)
+        (base / "file.py").write_text("nothing here")
+
+        result = json.loads(ws.grep_content(pattern="NOTFOUND"))
+        assert result["total_matches"] == 0
+        assert result["matches"] == []
+
+
+def test_grep_content_skips_excluded():
+    """grep_content skips excluded directories."""
+    import json
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ws = Workspace(tmp_dir)
+        base = Path(tmp_dir)
+        (base / "real.py").write_text("def real(): pass")
+        (base / ".venv").mkdir()
+        (base / ".venv" / "hidden.py").write_text("def hidden(): pass")
+
+        result = json.loads(ws.grep_content(pattern="def "))
+        files = [m["file"] for m in result["matches"]]
+        assert any("real.py" in f for f in files)
+        assert not any(".venv" in f for f in files)
+
+
+def test_agrep_content_async():
+    """agrep_content async variant works."""
+    import json
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ws = Workspace(tmp_dir)
+        base = Path(tmp_dir)
+        (base / "code.py").write_text("def foo(): pass")
+
+        result = json.loads(asyncio.run(ws.agrep_content(pattern="def ")))
+        assert result["total_matches"] == 1
+        assert result["matches"][0]["file"] == "code.py"
 
 
 # ------------------------------------------------------------------

--- a/libs/agno/tests/unit/tools/test_workspace.py
+++ b/libs/agno/tests/unit/tools/test_workspace.py
@@ -122,24 +122,31 @@ def test_custom_partition_works():
         assert ws.functions["delete_file"].requires_confirmation is True
 
 
-def test_edit_instruction_only_added_when_edit_registered():
-    """The 'always read_file before editing' nudge is gated on edit_file actually being available."""
+def test_instructions_built_dynamically_from_enabled_tools():
+    """Instructions are built dynamically based on which tools are enabled."""
     with tempfile.TemporaryDirectory() as tmp_dir:
+        # Read-only tools get instructions about read/search/grep workflow
         read_only = Workspace(tmp_dir, allowed=Workspace.READ_TOOLS, confirm=[])
         assert "edit_file" not in read_only.functions
-        assert read_only.instructions is None
-        assert read_only.add_instructions is False
+        assert read_only.instructions is not None
+        assert "read_file" in read_only.instructions
+        assert "search_content" in read_only.instructions
+        assert "grep_content" in read_only.instructions
+        assert "edit_file" not in read_only.instructions
+        assert read_only.add_instructions is True
 
+        # With edit, instructions include edit guidance
         with_edit_allowed = Workspace(tmp_dir, allowed=["read", "edit"], confirm=[])
         assert "edit_file" in with_edit_allowed.functions
         assert with_edit_allowed.instructions is not None
         assert "edit_file" in with_edit_allowed.instructions
+        assert "Always read_file first" in with_edit_allowed.instructions
         assert with_edit_allowed.add_instructions is True
 
-        with_edit_confirm = Workspace(tmp_dir, allowed=["read"], confirm=["edit"])
-        assert "edit_file" in with_edit_confirm.functions
-        assert with_edit_confirm.instructions is not None
-        assert with_edit_confirm.add_instructions is True
+        # Single tool = no instructions (no routing needed)
+        single_tool = Workspace(tmp_dir, allowed=["read"], confirm=[])
+        assert single_tool.instructions is None
+        assert single_tool.add_instructions is False
 
 
 def test_root_kwarg_is_optional_positional():


### PR DESCRIPTION
## Summary

Two workspace enhancements:
1. **`grep_content`** — regex search with line numbers and context
2. **`tool_name_prefix`** — namespace tools to avoid collisions when using multiple toolkits

## Features

### grep_content

New regex search tool for Workspace toolkit:

```python
workspace.grep_content(r"\bclass\s+Agent\b", context_lines=2)
# Returns matches with line numbers and surrounding context
```

- Case-insensitive regex via `re.IGNORECASE`
- `context_lines` param for surrounding context
- `max_grep_matches` constructor param (default 500)
- Async variant `agrep_content()`

### tool_name_prefix

Namespace tool names when using multiple toolkits:

```python
docs = Workspace(root="./docs", tool_name_prefix="docs")
code = Workspace(root="./src", tool_name_prefix="code")

# Creates: docs_read_file, docs_list_files, code_read_file, code_list_files...
# No collision when both are added to an agent
```

- Filters (`include_tools`, `exclude_tools`) match on unprefixed names
- Instructions automatically reference prefixed tool names
- Follows MCPTools pattern

## Files Changed

| File | Change |
|------|--------|
| `libs/agno/agno/tools/toolkit.py` | +10 lines — `tool_name_prefix` param |
| `libs/agno/agno/tools/workspace.py` | +200 lines — `grep_content` + prefixed instructions |
| `libs/agno/agno/context/workspace/provider.py` | Dynamic instructions |
| `libs/agno/tests/unit/tools/test_toolkit.py` | +65 lines — prefix tests |
| `libs/agno/tests/unit/tools/test_workspace.py` | +180 lines — grep + prefix tests |
| `cookbook/91_tools/workspace_tools/grep_content.py` | Example |
| `cookbook/91_tools/workspace_tools/multi_workspace.py` | Multi-toolkit example |

## Test Plan

- [x] Tests for `grep_content` (sync, async, limits, exclusions)
- [x] Tests for `tool_name_prefix` in Toolkit and Workspace
- [x] Cookbook examples run successfully
- [x] All existing tests pass

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Formatted and validated (`./scripts/format.sh`, `./scripts/validate.sh`)
- [x] Tests added for new functionality
- [x] Cookbooks demonstrate features working end-to-end
