### PR TITLE
[fix] allow result offloading with tool-result compression

### DIFF
--- a/libs/agno/agno/agent/_init.py
+++ b/libs/agno/agno/agent/_init.py
@@ -197,18 +197,9 @@ def set_result_store(agent: Agent) -> None:
 
     A None store means offloading is off. The public setting keeps whatever
     the caller passed, so a failure never rewrites their configuration.
+    CompressionManager treats stored-result envelopes as opaque, so the two
+    context-saving features can be enabled together.
     """
-    # Offloading and tool-result compression cannot run together: compression
-    # sends tool messages to a model and rewrites them, which would replace a
-    # stored-result envelope with text whose result id may be gone, while the
-    # payload it pointed at lives on unreferenced. Refuse the combination
-    # loudly instead of silently favouring one of them.
-    if agent.compress_tool_results and (agent.offload_tool_results or agent._result_store is not None):
-        raise ValueError(
-            "offload_tool_results and compress_tool_results cannot be enabled together: "
-            "compression rewrites the tool messages that hold stored-result envelopes. "
-            "Disable one of the two."
-        )
     # A store handed down by a team is the team's to manage.
     if agent._result_store is not None and agent._result_store is agent._inherited_result_store:
         return

--- a/libs/agno/agno/compression/manager.py
+++ b/libs/agno/agno/compression/manager.py
@@ -1,4 +1,5 @@
 import asyncio
+import re
 from dataclasses import dataclass, field
 from textwrap import dedent
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
@@ -48,6 +49,18 @@ DEFAULT_COMPRESSION_PROMPT = dedent("""\
     Be concise while retaining all critical facts.
     """)
 
+# ResultStore envelopes are intentionally plain text because they need to be
+# understood by every model provider.  Keep the recognition here local to the
+# compression manager instead of importing the offload implementation: the
+# manager is initialized for every Agent/Team and importing the storage stack
+# would make an optional feature part of the compression hot path.
+_RESULT_ENVELOPE_PREFIX = "<result "
+_RESULT_ENVELOPE_CLOSE = "</result>"
+_STORED_RESULT_NOTICE = "Full result stored; read with read_result("
+_REFUSED_RESULT_NOTICE = "Full result was NOT stored."
+_RESULT_ID_ATTRIBUTE = re.compile(r"\bid\s*=\s*(['\"])res_[^'\"]+\1")
+_REFUSED_ATTRIBUTE = re.compile(r"\bstored\s*=\s*(['\"])false\1")
+
 
 @dataclass
 class CompressionManager:
@@ -65,6 +78,47 @@ class CompressionManager:
 
     def _is_tool_result_message(self, msg: Message) -> bool:
         return msg.role == "tool"
+
+    @staticmethod
+    def _is_result_envelope(content: Any) -> bool:
+        """Return whether *content* is an opaque ResultStore envelope.
+
+        Offloaded results are represented as a short, protocol-like string
+        rather than a typed message field.  The result-id / ``stored=\"false\"``
+        attributes identify the two envelope variants; the follow-up notice
+        is accepted as a backwards-compatible fallback.
+        """
+        if not isinstance(content, str):
+            return False
+
+        text = content.strip()
+        if not text.startswith(_RESULT_ENVELOPE_PREFIX):
+            return False
+
+        opening_tag_end = text.find(">")
+        closing_tag = text.find(_RESULT_ENVELOPE_CLOSE)
+        if opening_tag_end < 0 or closing_tag < opening_tag_end:
+            return False
+
+        opening_tag = text[: opening_tag_end + 1]
+        has_envelope_attribute = bool(
+            _RESULT_ID_ATTRIBUTE.search(opening_tag) or _REFUSED_ATTRIBUTE.search(opening_tag)
+        )
+        if not has_envelope_attribute:
+            # Keep the notice fallback for forwards-compatible envelopes that
+            # retain the protocol text but change their opening attributes.
+            notice = text[closing_tag + len(_RESULT_ENVELOPE_CLOSE) :]
+            return _STORED_RESULT_NOTICE in notice or _REFUSED_RESULT_NOTICE in notice
+
+        return True
+
+    def _is_compressible_tool_result(self, msg: Message) -> bool:
+        """Return whether a tool message is eligible for model compression."""
+        return (
+            self._is_tool_result_message(msg)
+            and msg.compressed_content is None
+            and not self._is_result_envelope(msg.content)
+        )
 
     def should_compress(
         self,
@@ -93,9 +147,7 @@ class CompressionManager:
 
         # Count-based threshold check
         if self.compress_tool_results_limit is not None:
-            uncompressed_tools_count = len(
-                [m for m in messages if self._is_tool_result_message(m) and m.compressed_content is None]
-            )
+            uncompressed_tools_count = len([m for m in messages if self._is_compressible_tool_result(m)])
             if uncompressed_tools_count >= self.compress_tool_results_limit:
                 log_info(f"Tool count limit hit: {uncompressed_tools_count} >= {self.compress_tool_results_limit}")
                 return True
@@ -107,7 +159,7 @@ class CompressionManager:
         tool_result: Message,
         run_metrics: Optional["RunMetrics"] = None,
     ) -> Optional[str]:
-        if not tool_result:
+        if not tool_result or self._is_result_envelope(tool_result.content):
             return None
 
         tool_content = f"Tool: {tool_result.tool_name or 'unknown'}\n{tool_result.content}"
@@ -148,7 +200,7 @@ class CompressionManager:
         if not self.compress_tool_results:
             return
 
-        uncompressed_tools = [msg for msg in messages if msg.role == "tool" and msg.compressed_content is None]
+        uncompressed_tools = [msg for msg in messages if self._is_compressible_tool_result(msg)]
 
         if not uncompressed_tools:
             return
@@ -197,9 +249,7 @@ class CompressionManager:
 
         # Count-based threshold check
         if self.compress_tool_results_limit is not None:
-            uncompressed_tools_count = len(
-                [m for m in messages if self._is_tool_result_message(m) and m.compressed_content is None]
-            )
+            uncompressed_tools_count = len([m for m in messages if self._is_compressible_tool_result(m)])
             if uncompressed_tools_count >= self.compress_tool_results_limit:
                 log_info(f"Tool count limit hit: {uncompressed_tools_count} >= {self.compress_tool_results_limit}")
                 return True
@@ -212,7 +262,7 @@ class CompressionManager:
         run_metrics: Optional["RunMetrics"] = None,
     ) -> Optional[str]:
         """Async compress a single tool result"""
-        if not tool_result:
+        if not tool_result or self._is_result_envelope(tool_result.content):
             return None
 
         tool_content = f"Tool: {tool_result.tool_name or 'unknown'}\n{tool_result.content}"
@@ -253,7 +303,7 @@ class CompressionManager:
         if not self.compress_tool_results:
             return
 
-        uncompressed_tools = [msg for msg in messages if msg.role == "tool" and msg.compressed_content is None]
+        uncompressed_tools = [msg for msg in messages if self._is_compressible_tool_result(msg)]
 
         if not uncompressed_tools:
             return

--- a/libs/agno/agno/team/_init.py
+++ b/libs/agno/agno/team/_init.py
@@ -594,7 +594,11 @@ def _set_session_summary_manager(team: "Team") -> None:
 
 
 def _bind_member_result_store(team: "Team", member: Union[Agent, "Team"]) -> None:
-    """Give ``member`` the store it runs with inside ``team``."""
+    """Give ``member`` the store it runs with inside ``team``.
+
+    CompressionManager leaves stored-result envelopes untouched, so a member
+    may inherit the team's store while also compressing ordinary tool results.
+    """
     from agno.offload.store import ResultStore
 
     inherited = member._inherited_result_store
@@ -611,16 +615,6 @@ def _bind_member_result_store(team: "Team", member: Union[Agent, "Team"]) -> Non
     store: Optional[ResultStore] = None
     # An explicit False keeps the member out of the team's store.
     if team._result_store is not None and member.offload_tool_results is not False:
-        # A compressing member cannot take the team's store: compression
-        # rewrites the tool messages that hold stored-result envelopes. The
-        # member has to opt out of one of the two.
-        if getattr(member, "compress_tool_results", False):
-            member_name = member.name or member.id or "member"
-            raise ValueError(
-                f"Member '{member_name}' has compress_tool_results enabled and would inherit the "
-                "team's result store; the two cannot run together. Set offload_tool_results=False "
-                "on the member or disable its compression."
-            )
         if declares_own_store:
             from agno.offload.setup import build_result_store
 
@@ -655,14 +649,6 @@ def _set_result_store(team: "Team") -> None:
     """
     from agno.offload.setup import build_result_store
 
-    # Compression rewrites the tool messages that hold stored-result
-    # envelopes, so the two features refuse to run together.
-    if team.compress_tool_results and team.offload_tool_results:
-        raise ValueError(
-            "offload_tool_results and compress_tool_results cannot be enabled together: "
-            "compression rewrites the tool messages that hold stored-result envelopes. "
-            "Disable one of the two."
-        )
     team._result_store = build_result_store(
         setting=team.offload_tool_results, db=team.db, owner=team, owner_kind="team"
     )
@@ -867,17 +853,8 @@ def initialize_team(team: "Team", debug_mode: Optional[bool] = None) -> None:
         _set_session_summary_manager(team)
     if team.compress_tool_results or team.compression_manager is not None:
         _set_compression_manager(team)
-    # Offloading and tool-result compression cannot run together: compression
-    # rewrites the tool messages that hold stored-result envelopes. Refuse the
-    # combination loudly instead of silently favouring one of them.
-    # Resolved when a setting is present or when a store exists.
+    # Resolve the store when a setting is present or when a store exists.
     if team.offload_tool_results or team._result_store is not None:
-        if team.compress_tool_results:
-            raise ValueError(
-                "offload_tool_results and compress_tool_results cannot be enabled together: "
-                "compression rewrites the tool messages that hold stored-result envelopes. "
-                "Disable one of the two."
-            )
         _ensure_result_store(team)
     if team.learning is not None and team.learning is not False:
         _set_learning_machine(team)

--- a/libs/agno/tests/integration/offload/test_agent_offloading.py
+++ b/libs/agno/tests/integration/offload/test_agent_offloading.py
@@ -14,6 +14,7 @@ import pytest
 from sqlalchemy import create_engine, text
 
 from agno.agent import Agent
+from agno.compression.manager import CompressionManager
 from agno.db.base import SessionType
 from agno.db.sqlite import SqliteDb
 from agno.media import Image
@@ -183,6 +184,33 @@ def test_large_result_is_replaced_by_a_small_envelope(db):
     assert "lines omitted ...]" in tool_message.content
     assert tool_message.content.startswith('<result id="res_')
     assert "read_result(" in tool_message.content
+
+
+def test_offloading_and_compression_leave_the_result_envelope_opaque(db, monkeypatch):
+    """Compression may run alongside offloading without consuming the pointer."""
+    compression_manager = CompressionManager(compress_tool_results=True, compress_tool_results_limit=1)
+    compression_calls = []
+
+    def record_compression(tool_result, run_metrics=None):
+        compression_calls.append(tool_result)
+        return "this must not replace an offloaded envelope"
+
+    monkeypatch.setattr(compression_manager, "_compress_tool_result", record_compression)
+    agent = Agent(
+        model=ScriptedToolModel(),
+        db=db,
+        tools=[fetch_page],
+        offload_tool_results=True,
+        compression_manager=compression_manager,
+    )
+    output = agent.run("go", session_id=_sid())
+    tool_message = _tool_messages(output)[0]
+
+    assert tool_message.content.startswith('<result id="res_')
+    assert tool_message.compressed_content is None
+    assert compression_calls == []
+    result_id = tool_message.content.split('id="')[1].split('"')[0]
+    assert agent._result_store.read(result_id, 1, 1).text.startswith("row 1: ")
 
 
 def test_the_persisted_session_row_carries_the_envelope_not_the_payload(db):

--- a/libs/agno/tests/integration/offload/test_team_offloading.py
+++ b/libs/agno/tests/integration/offload/test_team_offloading.py
@@ -15,6 +15,7 @@ import pytest
 from sqlalchemy import create_engine, text
 
 from agno.agent import Agent
+from agno.compression.manager import CompressionManager
 from agno.db.base import SessionType
 from agno.db.sqlite import SqliteDb
 from agno.models.base import Model
@@ -213,6 +214,27 @@ def test_member_response_is_replaced_by_an_envelope(db):
     assert tool_message.content.startswith('<result id="res_')
     assert 'tool="delegate_task_to_member"' in tool_message.content
     assert BIG not in tool_message.content
+
+
+def test_team_compression_leaves_the_member_result_envelope_opaque(db, monkeypatch):
+    """A Team can compress ordinary tool results without rewriting delegation pointers."""
+    compression_manager = CompressionManager(compress_tool_results=True, compress_tool_results_limit=1)
+    compression_calls = []
+
+    def record_compression(tool_result, run_metrics=None):
+        compression_calls.append(tool_result)
+        return "this must not replace an offloaded envelope"
+
+    monkeypatch.setattr(compression_manager, "_compress_tool_result", record_compression)
+    team = _team(db, compress_tool_results=True, compression_manager=compression_manager)
+    output = team.run("go", session_id=_sid())
+    tool_message = _tool_messages(output)[0]
+
+    assert tool_message.content.startswith('<result id="res_')
+    assert tool_message.compressed_content is None
+    assert compression_calls == []
+    result_id = _result_id(tool_message.content)
+    assert team._result_store.read(result_id, 1, 1).text.startswith("finding 1: ")
 
 
 def test_the_stored_payload_is_the_whole_member_response(db):

--- a/libs/agno/tests/unit/compression/test_compression_manager.py
+++ b/libs/agno/tests/unit/compression/test_compression_manager.py
@@ -2,6 +2,19 @@ import pytest
 
 from agno.models.message import Message
 
+STORED_RESULT_ENVELOPE = """<result id="res_abc123" tool="fetch_page" lines="3" size="1KB">
+line 1
+line 2
+</result>
+Full result stored; read with read_result("res_abc123") or search_result("res_abc123", pattern)."""
+
+REFUSED_RESULT_ENVELOPE = """<result tool="fetch_page" lines="3" size="1KB" stored="false" reason="quota">
+line 1
+[... 1 lines omitted ...]
+line 3
+</result>
+Full result was NOT stored. Re-run the tool with a narrower query if you need the rest."""
+
 
 @pytest.mark.asyncio
 async def test_ashould_compress_below_token_limit():
@@ -158,6 +171,85 @@ def test_should_compress_excludes_already_compressed():
     result = cm.should_compress(messages)
 
     assert result is False
+
+
+@pytest.mark.parametrize("content", [STORED_RESULT_ENVELOPE, REFUSED_RESULT_ENVELOPE])
+def test_result_store_envelopes_are_detected(content):
+    from agno.compression.manager import CompressionManager
+
+    assert CompressionManager._is_result_envelope(content) is True
+
+
+def test_result_envelope_detection_requires_complete_marker():
+    from agno.compression.manager import CompressionManager
+
+    assert CompressionManager._is_result_envelope('<result id="res_abc123">preview</result>') is True
+    assert CompressionManager._is_result_envelope('<result stored="false">preview</result>') is True
+    assert CompressionManager._is_result_envelope("<result>plain output</result>") is False
+    assert CompressionManager._is_result_envelope('<result id="res_abc123">plain output') is False
+    assert CompressionManager._is_result_envelope("plain tool output") is False
+
+
+def test_should_compress_excludes_result_store_envelopes_from_count():
+    from agno.compression.manager import CompressionManager
+
+    messages = [Message(role="tool", content=STORED_RESULT_ENVELOPE, tool_name="fetch_page")]
+    cm = CompressionManager(compress_tool_results=True, compress_tool_results_limit=1)
+
+    assert cm.should_compress(messages) is False
+
+
+def test_compress_skips_result_store_envelopes(monkeypatch):
+    from agno.compression.manager import CompressionManager
+
+    envelope = Message(role="tool", content=STORED_RESULT_ENVELOPE, tool_name="fetch_page")
+    ordinary = Message(role="tool", content="ordinary result", tool_name="other_tool")
+    calls = []
+
+    def fake_compress(tool_result, run_metrics=None):
+        calls.append(tool_result)
+        return "compressed ordinary result"
+
+    cm = CompressionManager(compress_tool_results=True, compress_tool_results_limit=1)
+    monkeypatch.setattr(cm, "_compress_tool_result", fake_compress)
+
+    cm.compress([envelope, ordinary])
+
+    assert calls == [ordinary]
+    assert envelope.compressed_content is None
+    assert ordinary.compressed_content == "compressed ordinary result"
+    assert cm.stats == {
+        "tool_results_compressed": 1,
+        "original_size": len("ordinary result"),
+        "compressed_size": len("compressed ordinary result"),
+    }
+
+
+@pytest.mark.asyncio
+async def test_acompress_skips_result_store_envelopes(monkeypatch):
+    from agno.compression.manager import CompressionManager
+
+    envelope = Message(role="tool", content=REFUSED_RESULT_ENVELOPE, tool_name="fetch_page")
+    ordinary = Message(role="tool", content="ordinary result", tool_name="other_tool")
+    calls = []
+
+    async def fake_compress(tool_result, run_metrics=None):
+        calls.append(tool_result)
+        return "compressed ordinary result"
+
+    cm = CompressionManager(compress_tool_results=True, compress_tool_results_limit=1)
+    monkeypatch.setattr(cm, "_acompress_tool_result", fake_compress)
+
+    await cm.acompress([envelope, ordinary])
+
+    assert calls == [ordinary]
+    assert envelope.compressed_content is None
+    assert ordinary.compressed_content == "compressed ordinary result"
+    assert cm.stats == {
+        "tool_results_compressed": 1,
+        "original_size": len("ordinary result"),
+        "compressed_size": len("compressed ordinary result"),
+    }
 
 
 @pytest.mark.asyncio

--- a/libs/agno/tests/unit/offload/test_offload_config.py
+++ b/libs/agno/tests/unit/offload/test_offload_config.py
@@ -1,10 +1,8 @@
-"""Offloading and tool-result compression refuse to run together.
+"""Offloading and tool-result compression can be enabled together.
 
-Compression sends tool messages to a model and rewrites them, which would
-replace a stored-result envelope with text whose result id may be gone while
-the payload lives on unreferenced. The combination is refused at
-initialization, on the agent, on the team, and on a member that would inherit
-the team's store.
+CompressionManager treats ResultStore envelopes as opaque pointers, so
+ordinary tool results remain compressible without removing the read-back
+handle from an offloaded result.
 """
 
 import os
@@ -24,21 +22,21 @@ def db(tmp_path):
     return SqliteDb(db_file=os.path.join(tempfile.mkdtemp(dir=tmp_path), "offload-config.db"))
 
 
-def test_agent_refuses_offloading_with_compression(db):
+def test_agent_allows_offloading_with_compression(db):
     agent = Agent(db=db, compress_tool_results=True, offload_tool_results=True)
-    with pytest.raises(ValueError, match="cannot be enabled together"):
-        agent.initialize_agent()
+    agent.initialize_agent()
+    assert agent._result_store is not None
 
 
-def test_agent_refuses_offloading_with_a_compressing_manager(db):
+def test_agent_allows_offloading_with_a_compressing_manager(db):
     # The manager's own flag enables compression even when the agent's does not.
     agent = Agent(
         db=db,
         compression_manager=CompressionManager(compress_tool_results=True),
         offload_tool_results=ResultStore(threshold_chars=100),
     )
-    with pytest.raises(ValueError, match="cannot be enabled together"):
-        agent.initialize_agent()
+    agent.initialize_agent()
+    assert agent._result_store is not None
 
 
 def test_agent_allows_offloading_with_a_disabled_manager(db):
@@ -57,23 +55,23 @@ def test_agent_allows_compression_without_offloading(db):
     assert agent._result_store is None
 
 
-def test_result_store_property_refuses_the_combination(db):
+def test_result_store_property_allows_the_combination(db):
     agent = Agent(db=db, compress_tool_results=True, offload_tool_results=True)
-    with pytest.raises(ValueError, match="cannot be enabled together"):
-        agent.result_store
+    assert agent.result_store is not None
 
 
-def test_team_refuses_offloading_with_compression(db):
+def test_team_allows_offloading_with_compression(db):
     team = Team(members=[Agent(db=db)], db=db, compress_tool_results=True, offload_tool_results=True)
-    with pytest.raises(ValueError, match="cannot be enabled together"):
-        team.initialize_team()
+    team.initialize_team()
+    assert team._result_store is not None
 
 
-def test_compressing_member_cannot_inherit_the_team_store(db):
+def test_compressing_member_can_inherit_the_team_store(db):
     member = Agent(name="compressor", db=db, compress_tool_results=True)
     team = Team(members=[member], db=db, offload_tool_results=True)
-    with pytest.raises(ValueError, match="compressor"):
-        team.initialize_team()
+    team.initialize_team()
+    assert team._result_store is not None
+    assert member._result_store is team._result_store
 
 
 def test_compressing_member_that_opts_out_is_fine(db):


### PR DESCRIPTION
## Summary

Fixes #9680 (item 5). `offload_tool_results` and `compress_tool_results` can now be enabled together without losing ResultStore pointers.

`CompressionManager` recognizes both successful and refused ResultStore envelopes and treats them as opaque: they are excluded from compression candidates, are never sent to the compression model, and do not affect compression statistics. Ordinary tool results keep the existing compression behavior. The Agent, Team, and Team-member inheritance guards that rejected the combination are removed.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` passed; `./scripts/validate.sh` is blocked by a pre-existing mypy error in `libs/agno/agno/db/in_memory/in_memory_db.py:335`)
- [x] Self-review completed
- [x] Documentation updated (comments and docstrings)
- [ ] Examples and guides: no cookbook behavior change needed
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] Searched existing open pull requests; no other PR addresses item 5
- [x] This change was AI-assisted; the implementation and test results were reviewed before submission

## Verification

- `python -m pytest libs/agno/tests/unit/compression libs/agno/tests/unit/offload -q`: 91 passed
- SQLite offload integration (Agent + Team): 93 passed, 1 skipped
- `python -m pytest libs/agno/tests/unit/agent libs/agno/tests/unit/team -q`: 1450 passed
- Ruff check/format checks passed for all changed files
- PostgreSQL integration was not available locally (no psycopg/PostgreSQL service)

## Additional Notes

The branch is based on the current `main` (including v3.0.0). Result envelopes remain plain text and no public API or database schema changes are introduced.