### PR TITLE
[cookbook] Add offline side-effecting tool approval example

### DIFF
--- a/cookbook/02_agents/10_human_in_the_loop/README.md
+++ b/cookbook/02_agents/10_human_in_the_loop/README.md
@@ -10,6 +10,7 @@ Examples for confirmation flows, user input prompts, and external tool handling.
 - `confirmation_toolkit.py` - Confirmation using a toolkit.
 - `external_tool_execution.py` - External tool execution flow.
 - `mixed_external_and_regular_tools.py` - Mixed external and regular tools in a single agent.
+- `side_effect_tool_approval.py` - Credential-free approval and rejection paths for a simulated side-effecting tool.
 - `user_input_required.py` - Tools that require user input.
 - `confirmation_with_session_state.py` - Confirmation flow where the tool modifies session_state before pausing. Verifies that state changes survive the pause/continue round-trip.
 
@@ -17,6 +18,13 @@ Examples for confirmation flows, user input prompts, and external tool handling.
 - Load environment variables with `direnv allow` (including `OPENAI_API_KEY`).
 - Create the demo environment with `./scripts/demo_setup.sh`, then run cookbooks with `.venvs/demo/bin/python`.
 - Some examples require optional local services (for example pgvector) or provider-specific API keys.
+- `side_effect_tool_approval.py` is fully local and needs no API key, credentials, or network access.
 
 ## Run
 - `.venvs/demo/bin/python cookbook/02_agents/10_human_in_the_loop/<file>.py`
+
+For `side_effect_tool_approval.py`, the application records the authenticated
+actor, decision, tool arguments, and timestamp before calling `continue_run()`.
+SQLite stores the paused Agent run, while an in-memory list stands in for the
+application's approval audit log. Production applications should replace that
+list with durable database or audit-log storage.

--- a/cookbook/02_agents/10_human_in_the_loop/TEST_LOG.md
+++ b/cookbook/02_agents/10_human_in_the_loop/TEST_LOG.md
@@ -76,3 +76,15 @@
 **Result:** Expected behavior for interactive file in non-interactive mode.
 
 ---
+
+### side_effect_tool_approval.py
+
+**Tested:** 2026-08-25
+**Environment:** Windows, `.venvs/demo/Scripts/python.exe`, Python 3.12
+**Status:** PASS
+**Tier:** untagged
+**Description:** Runs deterministic rejected and approved paths for a simulated side-effecting email tool without credentials or network access.
+**Result:** Rejected path completed with 0 outbox entries; approved path completed with 1 outbox entry. Targeted Ruff and Mypy checks passed.
+**Repository validation:** Full-library Ruff checks passed. Full-library Mypy reported pre-existing errors outside this cookbook folder. The cookbook-wide Mypy command exited before checking files because `00_quickstart` is not a valid Python package name.
+
+---

--- a/cookbook/02_agents/10_human_in_the_loop/side_effect_tool_approval.py
+++ b/cookbook/02_agents/10_human_in_the_loop/side_effect_tool_approval.py
@@ -1,0 +1,161 @@
+"""Approve or reject a side-effecting tool without API keys or network access.
+
+The local model deterministically requests the same simulated email tool on each
+run. The first scenario rejects the request; the second approves it. Assertions
+verify that only the approved request reaches the simulated outbox.
+"""
+
+import json
+from typing import Any, AsyncIterator, Dict, Iterator, List
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.base import Model
+from agno.models.response import ModelResponse, ModelResponseEvent
+from agno.run.base import RunStatus
+from agno.tools import tool
+
+SIMULATED_OUTBOX: List[Dict[str, str]] = []
+SIMULATED_APPROVAL_LOG: List[Dict[str, str]] = []
+
+
+class DeterministicApprovalModel(Model):
+    """Return one tool call followed by a final response, entirely offline."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            id="deterministic-approval-demo",
+            name="Deterministic approval demo",
+            provider="local",
+        )
+        self._turn = 0
+
+    def _next_response(self) -> ModelResponse:
+        self._turn += 1
+        if self._turn == 1:
+            response = ModelResponse(role="assistant")
+            response.tool_calls = [
+                {
+                    "id": "send-welcome-email",
+                    "type": "function",
+                    "function": {
+                        "name": "send_email",
+                        "arguments": json.dumps(
+                            {
+                                "recipient": "customer@example.com",
+                                "subject": "Welcome",
+                                "body": "Thanks for joining us.",
+                            }
+                        ),
+                    },
+                }
+            ]
+            return response
+
+        response = ModelResponse(
+            content="The approval decision was processed.", role="assistant"
+        )
+        response.event = ModelResponseEvent.assistant_response.value
+        return response
+
+    def invoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return self._next_response()
+
+    async def ainvoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return self._next_response()
+
+    def invoke_stream(self, *args: Any, **kwargs: Any) -> Iterator[ModelResponse]:
+        yield self._next_response()
+
+    async def ainvoke_stream(
+        self, *args: Any, **kwargs: Any
+    ) -> AsyncIterator[ModelResponse]:
+        yield self._next_response()
+
+    def _parse_provider_response(self, response: Any, **kwargs: Any) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+
+@tool(requires_confirmation=True)
+def send_email(recipient: str, subject: str, body: str) -> str:
+    """Add an email to a simulated outbox.
+
+    Args:
+        recipient: Email address that should receive the message.
+        subject: Subject line for the email.
+        body: Body of the email.
+    """
+    SIMULATED_OUTBOX.append({"recipient": recipient, "subject": subject, "body": body})
+    return f"Email queued for {recipient}"
+
+
+def run_scenario(approve: bool) -> None:
+    """Run one isolated approval scenario and verify its side effect."""
+    SIMULATED_OUTBOX.clear()
+    SIMULATED_APPROVAL_LOG.clear()
+
+    agent = Agent(
+        model=DeterministicApprovalModel(),
+        tools=[send_email],
+        db=SqliteDb(db_file="tmp/side_effect_tool_approval.db"),
+        telemetry=False,
+    )
+    paused_response = agent.run("Send the customer a welcome email.")
+
+    if paused_response.status != RunStatus.paused:
+        raise RuntimeError("Expected the run to pause for confirmation")
+    if SIMULATED_OUTBOX:
+        raise RuntimeError("The side effect happened before approval")
+
+    requirements = list(paused_response.active_requirements)
+    if len(requirements) != 1 or not requirements[0].needs_confirmation:
+        raise RuntimeError("Expected exactly one confirmation requirement")
+
+    requirement = requirements[0]
+    tool_execution = requirement.tool_execution
+    if tool_execution is None:
+        raise RuntimeError("The confirmation requirement has no tool execution")
+
+    decision = "approved" if approve else "rejected"
+
+    # Replace this in-memory list with durable application storage. Record the
+    # authenticated actor, decision, tool arguments, and timestamp before resume.
+    SIMULATED_APPROVAL_LOG.append(
+        {
+            "actor": "demo-user",
+            "decision": decision,
+            "tool": tool_execution.tool_name or "unknown",
+            "arguments": json.dumps(tool_execution.tool_args or {}, sort_keys=True),
+        }
+    )
+
+    if approve:
+        requirement.confirm()
+    else:
+        requirement.reject(note="Rejected by demo-user")
+
+    final_response = agent.continue_run(
+        run_id=paused_response.run_id,
+        requirements=paused_response.requirements,
+    )
+
+    if final_response.status != RunStatus.completed:
+        raise RuntimeError("Expected the resumed run to complete")
+
+    expected_outbox_size = 1 if approve else 0
+    if len(SIMULATED_OUTBOX) != expected_outbox_size:
+        raise RuntimeError("The side effect did not match the approval decision")
+    if SIMULATED_APPROVAL_LOG[0]["decision"] != decision:
+        raise RuntimeError("The approval decision was not recorded")
+
+    print(f"Decision: {decision}")
+    print(f"Outbox entries: {len(SIMULATED_OUTBOX)}")
+    print(f"Final status: {final_response.status.value}")
+
+
+if __name__ == "__main__":
+    run_scenario(approve=False)
+    run_scenario(approve=True)


### PR DESCRIPTION
## Summary

- Add a fully local, deterministic example for approving a side-effecting tool.
- Demonstrate both rejected and approved paths in one credential-free script.
- Verify that the simulated side effect only occurs after approval.
- Document where applications should persist approval decisions before resuming a run.

Closes #9760

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [x] Other: Cookbook example

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] A similar PR exists
- [x] This contribution was prepared with AI assistance

---

## Additional Notes

The example runs without API keys, credentials, or network access.

Validation:
- Rejected path: 0 outbox entries, COMPLETED
- Approved path: 1 outbox entry, COMPLETED
- Ruff: passed
- Targeted Mypy: passed
- `git diff --check`: passed

Repository-wide Ruff checks passed. Repository-wide Mypy currently reports
pre-existing errors outside this cookbook folder. Cookbook-wide Mypy exits
before checking files because `00_quickstart` is not a valid Python package name.

AI assistance disclosure: Codex assisted with implementation, repository
inspection, and validation. The resulting changes and test output were reviewed
locally before submission.
