### PR TITLE
fix: stop rebuilding session history on every conversation turn

### DIFF
--- a/.github/workflows/test_on_release.yml
+++ b/.github/workflows/test_on_release.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - "*release*" # Run on release-* format
       - "release/*" # Run on release/1.2.3 branch format
-      - "feat/v3.0"
+      - "perf/session-read-path"
   workflow_dispatch: # Allows manual triggering
     inputs:
       branch:

--- a/.github/workflows/test_on_release.yml
+++ b/.github/workflows/test_on_release.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - "*release*" # Run on release-* format
       - "release/*" # Run on release/1.2.3 branch format
-      - "perf/session-read-path"
+      - "feat/v3.0"
   workflow_dispatch: # Allows manual triggering
     inputs:
       branch:

--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -3520,6 +3520,13 @@ def continue_run_dispatch(
             raise RunNotFoundError(f"No runs found for run ID {run_id}")
         if run_response.status == RunStatus.cancelled:
             raise RunNotContinuableError(f"Cannot continue run {run_response.run_id}: run is cancelled")
+        # The continued run is mutated through the whole continue pipeline
+        # (message truncation, tool results, status). History run objects are
+        # shared between reads of the same session, so continue works on its
+        # own copy.
+        from copy import deepcopy as _deepcopy_run
+
+        run_response = _deepcopy_run(run_response)
 
         continue_index = _resolve_continue_from(
             run_response,
@@ -4818,6 +4825,13 @@ async def _acontinue_run(
                         raise RunNotFoundError(f"No runs found for run ID {run_id}")
                     if run_response.status == RunStatus.cancelled:
                         raise RunNotContinuableError(f"Cannot continue run {run_response.run_id}: run is cancelled")
+                    # The continued run is mutated through the whole continue
+                    # pipeline (message truncation, tool results, status).
+                    # History run objects are shared between reads of the same
+                    # session, so continue works on its own copy.
+                    from copy import deepcopy as _deepcopy_run
+
+                    run_response = _deepcopy_run(run_response)
 
                     continue_index = _resolve_continue_from(
                         run_response,
@@ -5318,6 +5332,13 @@ async def _acontinue_run_stream(
                         raise RunNotFoundError(f"No runs found for run ID {run_id}")
                     if run_response.status == RunStatus.cancelled:
                         raise RunNotContinuableError(f"Cannot continue run {run_response.run_id}: run is cancelled")
+                    # The continued run is mutated through the whole continue
+                    # pipeline (message truncation, tool results, status).
+                    # History run objects are shared between reads of the same
+                    # session, so continue works on its own copy.
+                    from copy import deepcopy as _deepcopy_run
+
+                    run_response = _deepcopy_run(run_response)
 
                     continue_index = _resolve_continue_from(
                         run_response,
@@ -6274,17 +6295,24 @@ def _mark_run_regenerated(
     explicit ``save_run`` here the DB row keeps its old (COMPLETED) status and
     history builders still surface the parent — producing duplicate content in
     conversation history after regenerate."""
+    from copy import copy as shallow_copy
+
     from agno.agent._session import save_run
 
-    for r in session.runs or []:
+    for i, r in enumerate(session.runs or []):
         if r.run_id == original_run_id:
-            r.status = RunStatus.regenerated
+            # Flip on a copy, never on the loaded run: history run objects are
+            # shared between reads of the same session, so an in-place write
+            # would surface mid-flight on another reader's session.
+            flipped = shallow_copy(r)
+            flipped.status = RunStatus.regenerated
+            session.runs[i] = flipped  # type: ignore[index]
             save_run(
                 agent,
-                run=cast(RunOutput, r),
+                run=cast(RunOutput, flipped),
                 session_id=session.session_id,
                 user_id=session.user_id,
-                run_index=resolve_run_index(session, r),
+                run_index=resolve_run_index(session, flipped),
             )
             return
 
@@ -6295,17 +6323,24 @@ async def _amark_run_regenerated(
     original_run_id: str,
 ) -> None:
     """Async variant of :func:`_mark_run_regenerated`."""
+    from copy import copy as shallow_copy
+
     from agno.agent._session import asave_run
 
-    for r in session.runs or []:
+    for i, r in enumerate(session.runs or []):
         if r.run_id == original_run_id:
-            r.status = RunStatus.regenerated
+            # Flip on a copy, never on the loaded run: history run objects are
+            # shared between reads of the same session, so an in-place write
+            # would surface mid-flight on another reader's session.
+            flipped = shallow_copy(r)
+            flipped.status = RunStatus.regenerated
+            session.runs[i] = flipped  # type: ignore[index]
             await asave_run(
                 agent,
-                run=cast(RunOutput, r),
+                run=cast(RunOutput, flipped),
                 session_id=session.session_id,
                 user_id=session.user_id,
-                run_index=resolve_run_index(session, r),
+                run_index=resolve_run_index(session, flipped),
             )
             return
 

--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -3484,6 +3484,12 @@ def continue_run_dispatch(
     if run_response is not None:
         if run_response.status == RunStatus.cancelled:
             raise RunNotContinuableError(f"Cannot continue run {run_response.run_id}: run is cancelled")
+        # The continue pipeline mutates this run in place (truncation, tool
+        # results, status). The caller's object may be a shared history run
+        # fetched from a session read, so continue works on its own copy.
+        from copy import deepcopy as _deepcopy_provided_run
+
+        run_response = _deepcopy_provided_run(run_response)
         # The run is continued from a provided run_response. This contains the updated tools.
         continue_index: Optional[int] = _resolve_continue_from(
             run_response,
@@ -4793,6 +4799,12 @@ async def _acontinue_run(
                 if run_response is not None:
                     if run_response.status == RunStatus.cancelled:
                         raise RunNotContinuableError(f"Cannot continue run {run_response.run_id}: run is cancelled")
+                    # The continue pipeline mutates this run in place (truncation, tool
+                    # results, status). The caller's object may be a shared history run
+                    # fetched from a session read, so continue works on its own copy.
+                    from copy import deepcopy as _deepcopy_provided_run
+
+                    run_response = _deepcopy_provided_run(run_response)
                     # The run is continued from a provided run_response. This contains the updated tools.
                     continue_index: Optional[int] = _resolve_continue_from(
                         run_response,
@@ -5299,6 +5311,12 @@ async def _acontinue_run_stream(
                 if run_response is not None:
                     if run_response.status == RunStatus.cancelled:
                         raise RunNotContinuableError(f"Cannot continue run {run_response.run_id}: run is cancelled")
+                    # The continue pipeline mutates this run in place (truncation, tool
+                    # results, status). The caller's object may be a shared history run
+                    # fetched from a session read, so continue works on its own copy.
+                    from copy import deepcopy as _deepcopy_provided_run
+
+                    run_response = _deepcopy_provided_run(run_response)
                     # The run is continued from a provided run_response. This contains the updated tools.
                     continue_index: Optional[int] = _resolve_continue_from(
                         run_response,

--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -3484,13 +3484,10 @@ def continue_run_dispatch(
     if run_response is not None:
         if run_response.status == RunStatus.cancelled:
             raise RunNotContinuableError(f"Cannot continue run {run_response.run_id}: run is cancelled")
-        # The continue pipeline mutates this run in place (truncation, tool
-        # results, status). The caller's object may be a shared history run
-        # fetched from a session read, so continue works on its own copy.
-        from copy import deepcopy as _deepcopy_provided_run
-
-        run_response = _deepcopy_provided_run(run_response)
         # The run is continued from a provided run_response. This contains the updated tools.
+        # The pipeline completes this object in place: the caller owns it
+        # (the run getters hand out copies, and the team resume flow relies
+        # on its member run completing in place).
         continue_index: Optional[int] = _resolve_continue_from(
             run_response,
             continue_from=continue_from,
@@ -4799,13 +4796,10 @@ async def _acontinue_run(
                 if run_response is not None:
                     if run_response.status == RunStatus.cancelled:
                         raise RunNotContinuableError(f"Cannot continue run {run_response.run_id}: run is cancelled")
-                    # The continue pipeline mutates this run in place (truncation, tool
-                    # results, status). The caller's object may be a shared history run
-                    # fetched from a session read, so continue works on its own copy.
-                    from copy import deepcopy as _deepcopy_provided_run
-
-                    run_response = _deepcopy_provided_run(run_response)
                     # The run is continued from a provided run_response. This contains the updated tools.
+                    # The pipeline completes this object in place: the caller owns it
+                    # (the run getters hand out copies, and the team resume flow relies
+                    # on its member run completing in place).
                     continue_index: Optional[int] = _resolve_continue_from(
                         run_response,
                         continue_from=continue_from,
@@ -5311,13 +5305,10 @@ async def _acontinue_run_stream(
                 if run_response is not None:
                     if run_response.status == RunStatus.cancelled:
                         raise RunNotContinuableError(f"Cannot continue run {run_response.run_id}: run is cancelled")
-                    # The continue pipeline mutates this run in place (truncation, tool
-                    # results, status). The caller's object may be a shared history run
-                    # fetched from a session read, so continue works on its own copy.
-                    from copy import deepcopy as _deepcopy_provided_run
-
-                    run_response = _deepcopy_provided_run(run_response)
                     # The run is continued from a provided run_response. This contains the updated tools.
+                    # The pipeline completes this object in place: the caller owns it
+                    # (the run getters hand out copies, and the team resume flow relies
+                    # on its member run completing in place).
                     continue_index: Optional[int] = _resolve_continue_from(
                         run_response,
                         continue_from=continue_from,

--- a/libs/agno/agno/agents/base.py
+++ b/libs/agno/agno/agents/base.py
@@ -471,10 +471,8 @@ class BaseExternalAgent:
     @staticmethod
     def _find_run_in_session(session: AgentSession, run_id: str) -> Optional[RunOutput]:
         """Find a persisted run by id within the given session."""
-        for run in session.runs or []:
-            if isinstance(run, RunOutput) and run.run_id == run_id:
-                return run
-        return None
+        run = session.get_run(run_id)
+        return run if isinstance(run, RunOutput) else None
 
     def get_run_output(self, run_id: str, session_id: Optional[str] = None) -> Optional[RunOutput]:
         """Get a persisted RunOutput for this adapter."""

--- a/libs/agno/agno/db/in_memory/in_memory_db.py
+++ b/libs/agno/agno/db/in_memory/in_memory_db.py
@@ -159,8 +159,10 @@ class InMemoryDb(BaseDb):
                 runs_window = filter_context_runs(session_data.get("runs") or [])[-runs_limit:]
                 session_data_copy = deepcopy({**session_data, "runs": runs_window})
             else:
-                if deserialize and session_data.get("session_type") == SessionType.AGENT.value and (
-                    session_type is None or session_type == SessionType.AGENT
+                if (
+                    deserialize
+                    and session_data.get("session_type") == SessionType.AGENT.value
+                    and (session_type is None or session_type == SessionType.AGENT)
                 ):
                     session_obj = self._agent_session_with_cached_runs(session_id, session_data)
                     if session_obj is not None:

--- a/libs/agno/agno/db/in_memory/in_memory_db.py
+++ b/libs/agno/agno/db/in_memory/in_memory_db.py
@@ -195,31 +195,27 @@ class InMemoryDb(BaseDb):
         if session is None:
             return None
 
-        cache = self._run_object_cache.setdefault(session_id, {})
+        # Build a fresh entry map and swap it in with one assignment: the map
+        # a previous read published is only ever read here, never written, so
+        # concurrent readers cannot trip over each other's inserts or sweeps,
+        # and entries for deleted runs simply fall out of the new map.
+        cache = self._run_object_cache.get(session_id) or {}
+        fresh_cache: Dict[str, Tuple[Dict[str, Any], Any]] = {}
         runs: List[Any] = []
-        live_run_ids = set()
         for run_dict in session_data.get("runs") or []:
             if not isinstance(run_dict, dict):
                 continue
             run_id = run_dict.get("run_id")
             entry = cache.get(run_id) if run_id is not None else None
-            if entry is not None and entry[0] is run_dict:
-                run_obj = entry[1]
-            else:
+            if entry is None or entry[0] is not run_dict:
                 # from_dict pops keys from its input, so it gets its own copy;
                 # the object then shares nothing with the stored dict.
-                run_obj = deserialize_history_run(deepcopy(run_dict))
-                if run_id is not None:
-                    cache[run_id] = (run_dict, run_obj)
+                entry = (run_dict, deserialize_history_run(deepcopy(run_dict)))
             if run_id is not None:
-                live_run_ids.add(run_id)
-            if run_obj is not None:
-                runs.append(run_obj)
-
-        # Deleted runs leave stale entries behind; sweep them on read.
-        if len(cache) > len(live_run_ids):
-            for stale_id in [rid for rid in cache if rid not in live_run_ids]:
-                del cache[stale_id]
+                fresh_cache[run_id] = entry
+            if entry[1] is not None:
+                runs.append(entry[1])
+        self._run_object_cache[session_id] = fresh_cache
 
         session.runs = runs
         return session

--- a/libs/agno/agno/db/in_memory/in_memory_db.py
+++ b/libs/agno/agno/db/in_memory/in_memory_db.py
@@ -138,12 +138,15 @@ class InMemoryDb(BaseDb):
             if user_id is not None and session_data.get("user_id") != user_id:
                 return None
 
-            session_data_copy = deepcopy(session_data)
-
             if runs_limit is not None:
                 # No query engine to push "last N" down: filter+slice in memory to
                 # match the SQL fast path (drop member/skip-status runs, then last N).
-                session_data_copy["runs"] = filter_context_runs(session_data_copy.get("runs") or [])[-runs_limit:]
+                # Slice BEFORE copying so a bounded read copies only the window,
+                # not the whole history; the filter only reads the stored dicts.
+                runs_window = filter_context_runs(session_data.get("runs") or [])[-runs_limit:]
+                session_data_copy = deepcopy({**session_data, "runs": runs_window})
+            else:
+                session_data_copy = deepcopy(session_data)
 
             if not deserialize:
                 return session_data_copy

--- a/libs/agno/agno/db/in_memory/in_memory_db.py
+++ b/libs/agno/agno/db/in_memory/in_memory_db.py
@@ -341,16 +341,20 @@ class InMemoryDb(BaseDb):
             stored_session["runs"] = runs_for_store
             self._sessions[session_id] = stored_session
 
-            session_dict_copy = deepcopy(stored_session)
+            # Match the SQL adapters' return contract (see SqliteDb.upsert_session):
+            # a fresh copy of the session row with the caller's own runs attached
+            # by reference. The stored history is never copied or rebuilt on the
+            # write path -- doing so made every save cost grow with session
+            # length -- and the row copy keeps the returned session detached
+            # from both the store and the live session's nested dicts.
+            session_row = deepcopy(session_dict)
             if not deserialize:
-                return session_dict_copy
+                session_row["runs"] = [run if isinstance(run, dict) else run.to_dict() for run in session.runs or []]
+                return session_row
 
-            if session_dict_copy["session_type"] == SessionType.AGENT:
-                return AgentSession.from_dict(session_dict_copy)
-            elif session_dict_copy["session_type"] == SessionType.TEAM:
-                return TeamSession.from_dict(session_dict_copy)
-            else:
-                return WorkflowSession.from_dict(session_dict_copy)
+            upserted_session = deserialize_session(None, session_row)
+            upserted_session.runs = session.runs  # type: ignore[union-attr]
+            return upserted_session
 
         except Exception as e:
             log_error(f"Exception upserting session: {str(e)}")

--- a/libs/agno/agno/db/in_memory/in_memory_db.py
+++ b/libs/agno/agno/db/in_memory/in_memory_db.py
@@ -15,6 +15,7 @@ from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.schemas.memory import UserMemory
 from agno.db.utils import (
+    deserialize_history_run,
     deserialize_session,
     deserialize_sessions,
     drop_legacy_metrics,
@@ -26,19 +27,6 @@ from agno.utils.log import log_debug, log_error, log_info, log_warning
 
 if TYPE_CHECKING:
     from agno.tracing.schemas import Span, Trace
-
-
-def _deserialize_history_run(run_dict: Dict[str, Any]) -> Optional[Any]:
-    """One stored run dict as a run object, mirroring AgentSession.from_dict's
-    per-run dispatch (a dict matching neither shape is skipped there too)."""
-    from agno.run.agent import RunOutput
-    from agno.run.team import TeamRunOutput
-
-    if "agent_id" in run_dict:
-        return RunOutput.from_dict(run_dict)
-    if "team_id" in run_dict:
-        return TeamRunOutput.from_dict(run_dict)
-    return None
 
 
 class InMemoryDb(BaseDb):
@@ -218,7 +206,7 @@ class InMemoryDb(BaseDb):
             else:
                 # from_dict pops keys from its input, so it gets its own copy;
                 # the object then shares nothing with the stored dict.
-                run_obj = _deserialize_history_run(deepcopy(run_dict))
+                run_obj = deserialize_history_run(deepcopy(run_dict))
                 if run_id is not None:
                     cache[run_id] = (run_dict, run_obj)
             if run_id is not None:

--- a/libs/agno/agno/db/in_memory/in_memory_db.py
+++ b/libs/agno/agno/db/in_memory/in_memory_db.py
@@ -28,6 +28,19 @@ if TYPE_CHECKING:
     from agno.tracing.schemas import Span, Trace
 
 
+def _deserialize_history_run(run_dict: Dict[str, Any]) -> Optional[Any]:
+    """One stored run dict as a run object, mirroring AgentSession.from_dict's
+    per-run dispatch (a dict matching neither shape is skipped there too)."""
+    from agno.run.agent import RunOutput
+    from agno.run.team import TeamRunOutput
+
+    if "agent_id" in run_dict:
+        return RunOutput.from_dict(run_dict)
+    if "team_id" in run_dict:
+        return TeamRunOutput.from_dict(run_dict)
+    return None
+
+
 class InMemoryDb(BaseDb):
     def __init__(self):
         """Interface for in-memory storage."""
@@ -36,6 +49,16 @@ class InMemoryDb(BaseDb):
         # Initialize in-memory storage. Sessions are keyed by session_id so
         # id lookups (get/upsert/delete) stay O(1) as the store grows.
         self._sessions: Dict[str, Dict[str, Any]] = {}
+        # Deserialized history-run objects, session_id -> run_id ->
+        # (stored run dict, run object). Rebuilding every historical run from
+        # its dict on every read made each turn's cost grow with session
+        # length. An entry is valid while the stored dict it was built from is
+        # still the one in the session's runs list -- upsert_run replaces the
+        # dict on every write, so dict identity is the invalidation token, and
+        # holding the dict itself means a recycled id can never alias a new
+        # dict. The cached objects are shared by every read and immutable by
+        # contract; the stored dicts remain the canonical state.
+        self._run_object_cache: Dict[str, Dict[str, Tuple[Dict[str, Any], Any]]] = {}
         self._memories: List[Dict[str, Any]] = []
         self._metrics: List[Dict[str, Any]] = []
         self._eval_runs: List[Dict[str, Any]] = []
@@ -76,6 +99,7 @@ class InMemoryDb(BaseDb):
             session = self._sessions.get(session_id)
             if session is not None and (user_id is None or session.get("user_id") == user_id):
                 del self._sessions[session_id]
+                self._run_object_cache.pop(session_id, None)
                 log_debug(f"Successfully deleted session with session_id: {session_id}")
                 return True
             else:
@@ -101,6 +125,7 @@ class InMemoryDb(BaseDb):
                 session = self._sessions.get(session_id)
                 if session is not None and (user_id is None or session.get("user_id") == user_id):
                     del self._sessions[session_id]
+                    self._run_object_cache.pop(session_id, None)
             log_debug(f"Successfully deleted sessions with ids: {session_ids}")
 
         except Exception as e:
@@ -146,6 +171,12 @@ class InMemoryDb(BaseDb):
                 runs_window = filter_context_runs(session_data.get("runs") or [])[-runs_limit:]
                 session_data_copy = deepcopy({**session_data, "runs": runs_window})
             else:
+                if deserialize and session_data.get("session_type") == SessionType.AGENT.value and (
+                    session_type is None or session_type == SessionType.AGENT
+                ):
+                    session_obj = self._agent_session_with_cached_runs(session_id, session_data)
+                    if session_obj is not None:
+                        return session_obj
                 session_data_copy = deepcopy(session_data)
 
             if not deserialize:
@@ -159,6 +190,49 @@ class InMemoryDb(BaseDb):
             traceback.print_exc()
             log_error(f"Exception reading session: {str(e)}")
             raise e
+
+    def _agent_session_with_cached_runs(self, session_id: str, session_data: Dict[str, Any]) -> Optional[AgentSession]:
+        """An AgentSession whose history runs come from the run-object cache.
+
+        The session row is deep-copied and rebuilt fresh per read, so row
+        state (session_data, metadata, summary) stays isolated exactly as
+        before. History run objects are built once per stored run dict and
+        SHARED by every read of the session; see the cache comment in
+        __init__ for the invalidation and immutability contract.
+        """
+        row_copy = deepcopy({**session_data, "runs": None})
+        session = AgentSession.from_dict(row_copy)
+        if session is None:
+            return None
+
+        cache = self._run_object_cache.setdefault(session_id, {})
+        runs: List[Any] = []
+        live_run_ids = set()
+        for run_dict in session_data.get("runs") or []:
+            if not isinstance(run_dict, dict):
+                continue
+            run_id = run_dict.get("run_id")
+            entry = cache.get(run_id) if run_id is not None else None
+            if entry is not None and entry[0] is run_dict:
+                run_obj = entry[1]
+            else:
+                # from_dict pops keys from its input, so it gets its own copy;
+                # the object then shares nothing with the stored dict.
+                run_obj = _deserialize_history_run(deepcopy(run_dict))
+                if run_id is not None:
+                    cache[run_id] = (run_dict, run_obj)
+            if run_id is not None:
+                live_run_ids.add(run_id)
+            if run_obj is not None:
+                runs.append(run_obj)
+
+        # Deleted runs leave stale entries behind; sweep them on read.
+        if len(cache) > len(live_run_ids):
+            for stale_id in [rid for rid in cache if rid not in live_run_ids]:
+                del cache[stale_id]
+
+        session.runs = runs
+        return session
 
     def get_sessions(
         self,
@@ -329,6 +403,9 @@ class InMemoryDb(BaseDb):
             else:
                 session_dict["created_at"] = session_dict.get("created_at", int(time.time()))
                 session_dict["updated_at"] = session_dict.get("created_at")
+                # A delete + re-insert under the same id must not serve the
+                # deleted session's cached run objects.
+                self._run_object_cache.pop(session_id, None)
                 # First insert: serialize whatever runs the incoming session
                 # carries, once (bulk import and restore callers never call
                 # upsert_run). to_dict output is freshly built, so it needs
@@ -494,7 +571,12 @@ class InMemoryDb(BaseDb):
     ) -> None:
         """Upsert a single run into the target session's inline runs list."""
         try:
-            run_dict = run if isinstance(run, dict) else run.to_dict()
+            # The store keeps its own copy: a dict held by the caller (or the
+            # nested structures a live run shares with its to_dict output)
+            # must not be able to rewrite stored state in place -- and the
+            # run-object cache relies on a stored dict never changing under
+            # its identity.
+            run_dict = deepcopy(run if isinstance(run, dict) else run.to_dict())
             run_id = run_dict.get("run_id")
             if run_id is None:
                 raise ValueError("Run must have a run_id")

--- a/libs/agno/agno/db/mysql/async_mysql.py
+++ b/libs/agno/agno/db/mysql/async_mysql.py
@@ -25,6 +25,7 @@ from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.schemas.memory import UserMemory
 from agno.db.utils import (
     HISTORY_SKIP_STATUSES,
+    SessionRunObjectCache,
     build_single_run_row,
     deserialize_run,
     deserialize_session,
@@ -140,6 +141,12 @@ class AsyncMySQLDb(AsyncBaseDb):
             bind=self.db_engine,
             expire_on_commit=False,
         )
+
+        # Deserialized history-run objects, keyed per run by the raw row text;
+        # see SessionRunObjectCache for the invalidation and immutability
+        # contract. Per adapter instance, so it can never serve runs across
+        # databases.
+        self._run_object_cache = SessionRunObjectCache()
 
     async def close(self) -> None:
         """Close database connections and dispose of the connection pool.
@@ -528,6 +535,29 @@ class AsyncMySQLDb(AsyncBaseDb):
         return True
 
     # -- Run methods --
+    async def _get_session_run_rows(self, sess, runs_table: Table, session_id: str) -> List[Tuple[str, str]]:
+        """(run_id, raw run_data text) for the whole session, in insertion order.
+
+        The raw text feeds the run-object cache, which parses and rebuilds a
+        run only when its text changed since the last read. The cast keeps the
+        JSON column's result processor out of the way -- the whole point is to
+        not parse unchanged rows.
+        """
+        stmt = (
+            select(runs_table.c.run_id, cast(runs_table.c.run_data, TEXT))
+            .where(runs_table.c.session_id == session_id)
+            .order_by(
+                runs_table.c.run_index.asc(),
+                runs_table.c.created_at.asc(),
+                runs_table.c.run_id.asc(),
+            )
+        )
+        result = await sess.execute(stmt)
+        return [
+            (run_id, run_data if isinstance(run_data, str) else json.dumps(run_data))
+            for run_id, run_data in result.fetchall()
+        ]
+
     async def _get_session_runs_data(
         self, sess, runs_table: Table, session_id: str, limit: Optional[int] = None
     ) -> List[Dict[str, Any]]:
@@ -859,6 +889,8 @@ class AsyncMySQLDb(AsyncBaseDb):
                     await sess.execute(runs_table.delete().where(runs_table.c.session_id == session_id))
 
                 log_debug(f"Successfully deleted session with session_id: {session_id} in table {table.name}")
+                # A deleted session's deserialized history must not stay resident.
+                self._run_object_cache.drop_session(session_id)
                 return True
 
         except Exception as e:
@@ -893,6 +925,9 @@ class AsyncMySQLDb(AsyncBaseDb):
                     if user_id is not None:
                         runs_delete_stmt = runs_delete_stmt.where(runs_table.c.user_id == user_id)
                     await sess.execute(runs_delete_stmt)
+
+            for deleted_id in session_ids:
+                self._run_object_cache.drop_session(deleted_id)
 
             log_debug(f"Successfully deleted {result.rowcount} sessions")  # type: ignore
 
@@ -945,12 +980,25 @@ class AsyncMySQLDb(AsyncBaseDb):
                 # Attach the runs stored in the runs table, merged with any runs still
                 # sitting in the legacy `runs` column (so partially-migrated sessions
                 # don't silently lose history).
+                run_rows: Optional[List[Tuple[str, str]]] = None
                 legacy_runs = session.get("runs")
                 if runs_table is not None and runs_limit is not None and not legacy_runs:
                     # Fully migrated: push "most recent N" down to the DB (indexed).
                     session["runs"] = await self._get_session_runs_data(
                         sess=sess, runs_table=runs_table, session_id=session_id, limit=runs_limit
                     )
+                elif (
+                    runs_table is not None
+                    and not legacy_runs
+                    and deserialize
+                    and session.get("session_type") == SessionType.AGENT.value
+                    and (session_type is None or session_type == SessionType.AGENT)
+                ):
+                    # Fully-migrated agent session on the per-turn path: fetch
+                    # the rows raw and serve run objects from the cache instead
+                    # of rebuilding every run on every read.
+                    run_rows = await self._get_session_run_rows(sess=sess, runs_table=runs_table, session_id=session_id)
+                    session["runs"] = None
                 elif runs_table is not None:
                     # Full load + merge. Also the un-migrated fallback: the legacy blob
                     # holds the whole history in one column, so "last N" can't be pushed
@@ -970,6 +1018,10 @@ class AsyncMySQLDb(AsyncBaseDb):
             if not deserialize:
                 return session
 
+            if run_rows is not None:
+                session_obj = deserialize_session(session_type, session)
+                session_obj.runs = self._run_object_cache.runs_from_rows(session_id, run_rows)  # type: ignore[union-attr]
+                return session_obj
             return deserialize_session(session_type, session)
 
         except Exception as e:

--- a/libs/agno/agno/db/mysql/mysql.py
+++ b/libs/agno/agno/db/mysql/mysql.py
@@ -25,6 +25,7 @@ from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.schemas.memory import UserMemory
 from agno.db.utils import (
     HISTORY_SKIP_STATUSES,
+    SessionRunObjectCache,
     build_single_run_row,
     deserialize_run,
     deserialize_session,
@@ -136,6 +137,12 @@ class MySQLDb(BaseDb):
 
         # Initialize database session
         self.Session: scoped_session = scoped_session(sessionmaker(bind=self.db_engine))
+
+        # Deserialized history-run objects, keyed per run by the raw row text;
+        # see SessionRunObjectCache for the invalidation and immutability
+        # contract. Per adapter instance, so it can never serve runs across
+        # databases.
+        self._run_object_cache = SessionRunObjectCache()
 
     def close(self) -> None:
         """Close database connections and dispose of the connection pool.
@@ -525,6 +532,28 @@ class MySQLDb(BaseDb):
         return True
 
     # -- Run methods --
+    def _get_session_run_rows(self, sess, runs_table: Table, session_id: str) -> List[Tuple[str, str]]:
+        """(run_id, raw run_data text) for the whole session, in insertion order.
+
+        The raw text feeds the run-object cache, which parses and rebuilds a
+        run only when its text changed since the last read. The cast keeps the
+        JSON column's result processor out of the way -- the whole point is to
+        not parse unchanged rows.
+        """
+        stmt = (
+            select(runs_table.c.run_id, cast(runs_table.c.run_data, TEXT))
+            .where(runs_table.c.session_id == session_id)
+            .order_by(
+                runs_table.c.run_index.asc(),
+                runs_table.c.created_at.asc(),
+                runs_table.c.run_id.asc(),
+            )
+        )
+        return [
+            (run_id, run_data if isinstance(run_data, str) else json.dumps(run_data))
+            for run_id, run_data in sess.execute(stmt).fetchall()
+        ]
+
     def _get_session_runs_data(
         self, sess, runs_table: Table, session_id: str, limit: Optional[int] = None
     ) -> List[Dict[str, Any]]:
@@ -857,6 +886,8 @@ class MySQLDb(BaseDb):
                     sess.execute(runs_table.delete().where(runs_table.c.session_id == session_id))
 
                 log_debug(f"Successfully deleted session with session_id: {session_id} in table {table.name}")
+                # A deleted session's deserialized history must not stay resident.
+                self._run_object_cache.drop_session(session_id)
                 return True
 
         except Exception as e:
@@ -891,6 +922,9 @@ class MySQLDb(BaseDb):
                     if user_id is not None:
                         runs_delete_stmt = runs_delete_stmt.where(runs_table.c.user_id == user_id)
                     sess.execute(runs_delete_stmt)
+
+            for deleted_id in session_ids:
+                self._run_object_cache.drop_session(deleted_id)
 
             log_debug(f"Successfully deleted {result.rowcount} sessions")
 
@@ -942,12 +976,25 @@ class MySQLDb(BaseDb):
                 # Attach the runs stored in the runs table, merged with any runs still
                 # sitting in the legacy `runs` column (so partially-migrated sessions
                 # don't silently lose history).
+                run_rows: Optional[List[Tuple[str, str]]] = None
                 legacy_runs = session.get("runs")
                 if runs_table is not None and runs_limit is not None and not legacy_runs:
                     # Fully migrated: push "most recent N" down to the DB (indexed).
                     session["runs"] = self._get_session_runs_data(
                         sess=sess, runs_table=runs_table, session_id=session_id, limit=runs_limit
                     )
+                elif (
+                    runs_table is not None
+                    and not legacy_runs
+                    and deserialize
+                    and session.get("session_type") == SessionType.AGENT.value
+                    and (session_type is None or session_type == SessionType.AGENT)
+                ):
+                    # Fully-migrated agent session on the per-turn path: fetch
+                    # the rows raw and serve run objects from the cache instead
+                    # of rebuilding every run on every read.
+                    run_rows = self._get_session_run_rows(sess=sess, runs_table=runs_table, session_id=session_id)
+                    session["runs"] = None
                 elif runs_table is not None:
                     # Full load + merge. Also the un-migrated fallback: the legacy blob
                     # holds the whole history in one column, so "last N" can't be pushed
@@ -965,6 +1012,10 @@ class MySQLDb(BaseDb):
             if not deserialize:
                 return session
 
+            if run_rows is not None:
+                session_obj = deserialize_session(session_type, session)
+                session_obj.runs = self._run_object_cache.runs_from_rows(session_id, run_rows)  # type: ignore[union-attr]
+                return session_obj
             return deserialize_session(session_type, session)
 
         except Exception as e:

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -29,6 +29,7 @@ from agno.db.schemas.service_accounts import (
 )
 from agno.db.utils import (
     HISTORY_SKIP_STATUSES,
+    SessionRunObjectCache,
     build_single_run_row,
     deserialize_run,
     deserialize_session,
@@ -204,6 +205,12 @@ class AsyncPostgresDb(AsyncBaseDb):
             bind=self.db_engine,
             expire_on_commit=False,
         )
+
+        # Deserialized history-run objects, keyed per run by the raw row text;
+        # see SessionRunObjectCache for the invalidation and immutability
+        # contract. Per adapter instance, so it can never serve runs across
+        # databases.
+        self._run_object_cache = SessionRunObjectCache()
         # Zero means never refreshed; get_metrics uses this to refresh lazily, at most once per minute
         self._metrics_refreshed_at: float = 0.0
 
@@ -688,6 +695,34 @@ class AsyncPostgresDb(AsyncBaseDb):
         return True
 
     # -- Run methods --
+    async def _get_session_run_rows(self, sess, runs_table: Table, session_id: str) -> List[Tuple[str, str]]:
+        """(run_id, raw run_data text) for the whole session, in insertion order.
+
+        The raw text feeds the run-object cache, which parses and rebuilds a
+        run only when its text changed since the last read. The cast keeps the
+        JSON column's result processor out of the way -- the whole point is to
+        not parse unchanged rows.
+        """
+        import json
+
+        from sqlalchemy import Text
+
+        stmt = (
+            select(runs_table.c.run_id, runs_table.c.run_data.cast(Text))
+            .where(runs_table.c.session_id == session_id)
+            .order_by(
+                runs_table.c.run_index.asc(),
+                runs_table.c.created_at.asc(),
+                runs_table.c.run_id.asc(),
+            )
+        )
+        result = await sess.execute(stmt)
+        rows = result.fetchall()
+        return [
+            (run_id, run_data if isinstance(run_data, str) else json.dumps(run_data))
+            for run_id, run_data in rows
+        ]
+
     async def _get_session_runs_data(
         self, sess, runs_table: Table, session_id: str, limit: Optional[int] = None
     ) -> List[Dict[str, Any]]:
@@ -1296,11 +1331,26 @@ class AsyncPostgresDb(AsyncBaseDb):
                 # sitting in the legacy `runs` column (so partially-migrated sessions
                 # don't silently lose history).
                 legacy_runs = session.get("runs")
+                run_rows: Optional[List[Tuple[str, str]]] = None
                 if runs_table is not None and runs_limit is not None and not legacy_runs:
                     # Fully migrated: push "most recent N" down to the DB (indexed).
                     session["runs"] = await self._get_session_runs_data(
                         sess=sess, runs_table=runs_table, session_id=session_id, limit=runs_limit
                     )
+                elif (
+                    runs_table is not None
+                    and not legacy_runs
+                    and deserialize
+                    and session.get("session_type") == SessionType.AGENT.value
+                    and (session_type is None or session_type == SessionType.AGENT)
+                ):
+                    # Fully-migrated agent session on the per-turn path: fetch
+                    # the rows raw and serve run objects from the cache instead
+                    # of rebuilding every run on every read.
+                    run_rows = await self._get_session_run_rows(
+                        sess=sess, runs_table=runs_table, session_id=session_id
+                    )
+                    session["runs"] = None
                 elif runs_table is not None:
                     # Full load + merge. Also the un-migrated fallback: the legacy blob
                     # holds the whole history in one column, so "last N" can't be pushed
@@ -1320,6 +1370,10 @@ class AsyncPostgresDb(AsyncBaseDb):
             if not deserialize:
                 return session
 
+            if run_rows is not None:
+                session_obj = deserialize_session(session_type, session)
+                session_obj.runs = self._run_object_cache.runs_from_rows(session_id, run_rows)  # type: ignore[union-attr]
+                return session_obj
             return deserialize_session(session_type, session)
 
         except Exception as e:

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -718,10 +718,7 @@ class AsyncPostgresDb(AsyncBaseDb):
         )
         result = await sess.execute(stmt)
         rows = result.fetchall()
-        return [
-            (run_id, run_data if isinstance(run_data, str) else json.dumps(run_data))
-            for run_id, run_data in rows
-        ]
+        return [(run_id, run_data if isinstance(run_data, str) else json.dumps(run_data)) for run_id, run_data in rows]
 
     async def _get_session_runs_data(
         self, sess, runs_table: Table, session_id: str, limit: Optional[int] = None
@@ -1347,9 +1344,7 @@ class AsyncPostgresDb(AsyncBaseDb):
                     # Fully-migrated agent session on the per-turn path: fetch
                     # the rows raw and serve run objects from the cache instead
                     # of rebuilding every run on every read.
-                    run_rows = await self._get_session_run_rows(
-                        sess=sess, runs_table=runs_table, session_id=session_id
-                    )
+                    run_rows = await self._get_session_run_rows(sess=sess, runs_table=runs_table, session_id=session_id)
                     session["runs"] = None
                 elif runs_table is not None:
                     # Full load + merge. Also the un-migrated fallback: the legacy blob

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -1089,6 +1089,8 @@ class AsyncPostgresDb(AsyncBaseDb):
 
             # Cascade offloaded tool results after the session delete commits.
             await self._cascade_tool_results([session_id])
+            # A deleted session's deserialized history must not stay resident.
+            self._run_object_cache.drop_session(session_id)
             return True
 
         except Exception as e:
@@ -1141,6 +1143,8 @@ class AsyncPostgresDb(AsyncBaseDb):
 
             # Cascade offloaded tool results after the session delete commits.
             await self._cascade_tool_results(cascade_ids)
+            for deleted_id in cascade_ids:
+                self._run_object_cache.drop_session(deleted_id)
 
         except Exception as e:
             log_error(f"Error deleting sessions: {str(e)}")

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -1285,6 +1285,8 @@ class PostgresDb(BaseDb):
 
             # Cascade offloaded tool results after the session delete commits.
             self._cascade_tool_results([session_id])
+            # A deleted session's deserialized history must not stay resident.
+            self._run_object_cache.drop_session(session_id)
             return True
 
         except Exception as e:
@@ -1337,6 +1339,8 @@ class PostgresDb(BaseDb):
 
             # Cascade offloaded tool results after the session delete commits.
             self._cascade_tool_results(cascade_ids)
+            for deleted_id in cascade_ids:
+                self._run_object_cache.drop_session(deleted_id)
 
         except Exception as e:
             log_error(f"Error deleting sessions: {str(e)}")

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -53,6 +53,7 @@ from agno.db.schemas.service_accounts import (
 )
 from agno.db.utils import (
     HISTORY_SKIP_STATUSES,
+    SessionRunObjectCache,
     build_single_run_row,
     deserialize_run,
     deserialize_session,
@@ -247,6 +248,12 @@ class PostgresDb(BaseDb):
 
         # Initialize database session
         self.Session: scoped_session = scoped_session(sessionmaker(bind=self.db_engine, expire_on_commit=False))
+
+        # Deserialized history-run objects, keyed per run by the raw row text;
+        # see SessionRunObjectCache for the invalidation and immutability
+        # contract. Per adapter instance, so it can never serve runs across
+        # databases.
+        self._run_object_cache = SessionRunObjectCache()
         # Zero means never refreshed; get_metrics uses this to refresh lazily, at most once per minute
         self._metrics_refreshed_at: float = 0.0
 
@@ -879,6 +886,33 @@ class PostgresDb(BaseDb):
         return True
 
     # -- Run methods --
+    def _get_session_run_rows(self, sess, runs_table: Table, session_id: str) -> List[Tuple[str, str]]:
+        """(run_id, raw run_data text) for the whole session, in insertion order.
+
+        The raw text feeds the run-object cache, which parses and rebuilds a
+        run only when its text changed since the last read. The cast keeps the
+        JSON column's result processor out of the way -- the whole point is to
+        not parse unchanged rows.
+        """
+        import json
+
+        from sqlalchemy import Text
+
+        stmt = (
+            select(runs_table.c.run_id, runs_table.c.run_data.cast(Text))
+            .where(runs_table.c.session_id == session_id)
+            .order_by(
+                runs_table.c.run_index.asc(),
+                runs_table.c.created_at.asc(),
+                runs_table.c.run_id.asc(),
+            )
+        )
+        rows = sess.execute(stmt).fetchall()
+        return [
+            (run_id, run_data if isinstance(run_data, str) else json.dumps(run_data))
+            for run_id, run_data in rows
+        ]
+
     def _get_session_runs_data(
         self, sess, runs_table: Table, session_id: str, limit: Optional[int] = None
     ) -> List[Dict[str, Any]]:
@@ -1489,11 +1523,26 @@ class PostgresDb(BaseDb):
                 # sitting in the legacy `runs` column (so partially-migrated sessions
                 # don't silently lose history).
                 legacy_runs = session.get("runs")
+                run_rows: Optional[List[Tuple[str, str]]] = None
                 if runs_table is not None and runs_limit is not None and not legacy_runs:
                     # Fully migrated: push "most recent N" down to the DB (indexed).
                     session["runs"] = self._get_session_runs_data(
                         sess=sess, runs_table=runs_table, session_id=session_id, limit=runs_limit
                     )
+                elif (
+                    runs_table is not None
+                    and not legacy_runs
+                    and deserialize
+                    and session.get("session_type") == SessionType.AGENT.value
+                    and (session_type is None or session_type == SessionType.AGENT)
+                ):
+                    # Fully-migrated agent session on the per-turn path: fetch
+                    # the rows raw and serve run objects from the cache instead
+                    # of rebuilding every run on every read.
+                    run_rows = self._get_session_run_rows(
+                        sess=sess, runs_table=runs_table, session_id=session_id
+                    )
+                    session["runs"] = None
                 elif runs_table is not None:
                     # Full load + merge. Also the un-migrated fallback: the legacy blob
                     # holds the whole history in one column, so "last N" can't be pushed
@@ -1511,6 +1560,10 @@ class PostgresDb(BaseDb):
             if not deserialize:
                 return session
 
+            if run_rows is not None:
+                session_obj = deserialize_session(session_type, session)
+                session_obj.runs = self._run_object_cache.runs_from_rows(session_id, run_rows)  # type: ignore[union-attr]
+                return session_obj
             return deserialize_session(session_type, session)
 
         except Exception as e:

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -908,10 +908,7 @@ class PostgresDb(BaseDb):
             )
         )
         rows = sess.execute(stmt).fetchall()
-        return [
-            (run_id, run_data if isinstance(run_data, str) else json.dumps(run_data))
-            for run_id, run_data in rows
-        ]
+        return [(run_id, run_data if isinstance(run_data, str) else json.dumps(run_data)) for run_id, run_data in rows]
 
     def _get_session_runs_data(
         self, sess, runs_table: Table, session_id: str, limit: Optional[int] = None
@@ -1539,9 +1536,7 @@ class PostgresDb(BaseDb):
                     # Fully-migrated agent session on the per-turn path: fetch
                     # the rows raw and serve run objects from the cache instead
                     # of rebuilding every run on every read.
-                    run_rows = self._get_session_run_rows(
-                        sess=sess, runs_table=runs_table, session_id=session_id
-                    )
+                    run_rows = self._get_session_run_rows(sess=sess, runs_table=runs_table, session_id=session_id)
                     session["runs"] = None
                 elif runs_table is not None:
                     # Full load + merge. Also the un-migrated fallback: the legacy blob

--- a/libs/agno/agno/db/singlestore/singlestore.py
+++ b/libs/agno/agno/db/singlestore/singlestore.py
@@ -24,8 +24,8 @@ from agno.db.singlestore.utils import (
     is_valid_table,
 )
 from agno.db.utils import (
-    SessionRunObjectCache,
     HISTORY_SKIP_STATUSES,
+    SessionRunObjectCache,
     build_single_run_row,
     deserialize_run,
     deserialize_session,

--- a/libs/agno/agno/db/singlestore/singlestore.py
+++ b/libs/agno/agno/db/singlestore/singlestore.py
@@ -24,6 +24,7 @@ from agno.db.singlestore.utils import (
     is_valid_table,
 )
 from agno.db.utils import (
+    SessionRunObjectCache,
     HISTORY_SKIP_STATUSES,
     build_single_run_row,
     deserialize_run,
@@ -45,7 +46,7 @@ from agno.utils.log import log_debug, log_error, log_info, log_warning
 from agno.utils.string import generate_id
 
 try:
-    from sqlalchemy import ForeignKey, Index, UniqueConstraint, and_, func, or_, select, update
+    from sqlalchemy import TEXT, ForeignKey, Index, UniqueConstraint, and_, cast, func, or_, select, update
     from sqlalchemy.dialects import mysql
     from sqlalchemy.engine import Engine, create_engine
     from sqlalchemy.orm import scoped_session, sessionmaker
@@ -144,6 +145,12 @@ class SingleStoreDb(BaseDb):
 
         # Initialize database session
         self.Session: scoped_session = scoped_session(sessionmaker(bind=self.db_engine))
+
+        # Deserialized history-run objects, keyed per run by the raw row text;
+        # see SessionRunObjectCache for the invalidation and immutability
+        # contract. Per adapter instance, so it can never serve runs across
+        # databases.
+        self._run_object_cache = SessionRunObjectCache()
 
     # -- DB methods --
     def table_exists(self, table_name: str) -> bool:
@@ -604,6 +611,28 @@ class SingleStoreDb(BaseDb):
         return True
 
     # -- Run methods --
+    def _get_session_run_rows(self, sess, runs_table: Table, session_id: str) -> List[Tuple[str, str]]:
+        """(run_id, raw run_data text) for the whole session, in insertion order.
+
+        The raw text feeds the run-object cache, which parses and rebuilds a
+        run only when its text changed since the last read. The cast keeps the
+        JSON column's result processor out of the way -- the whole point is to
+        not parse unchanged rows.
+        """
+        stmt = (
+            select(runs_table.c.run_id, cast(runs_table.c.run_data, TEXT))
+            .where(runs_table.c.session_id == session_id)
+            .order_by(
+                runs_table.c.run_index.asc(),
+                runs_table.c.created_at.asc(),
+                runs_table.c.run_id.asc(),
+            )
+        )
+        return [
+            (run_id, run_data if isinstance(run_data, str) else json.dumps(run_data))
+            for run_id, run_data in sess.execute(stmt).fetchall()
+        ]
+
     def _get_session_runs_data(
         self, sess, runs_table: Table, session_id: str, limit: Optional[int] = None
     ) -> List[Dict[str, Any]]:
@@ -911,6 +940,8 @@ class SingleStoreDb(BaseDb):
                     sess.execute(runs_table.delete().where(runs_table.c.session_id == session_id))
 
                 log_debug(f"Successfully deleted session with session_id: {session_id} in table {table.name}")
+                # A deleted session's deserialized history must not stay resident.
+                self._run_object_cache.drop_session(session_id)
                 return True
 
         except Exception as e:
@@ -945,6 +976,9 @@ class SingleStoreDb(BaseDb):
                     if user_id is not None:
                         runs_delete_stmt = runs_delete_stmt.where(runs_table.c.user_id == user_id)
                     sess.execute(runs_delete_stmt)
+
+            for deleted_id in session_ids:
+                self._run_object_cache.drop_session(deleted_id)
 
             log_debug(f"Successfully deleted {result.rowcount} sessions")
 
@@ -997,12 +1031,25 @@ class SingleStoreDb(BaseDb):
                 # Attach the runs stored in the runs table, merged with any runs still
                 # sitting in the legacy `runs` column (so partially-migrated sessions
                 # don't silently lose history).
+                run_rows: Optional[List[Tuple[str, str]]] = None
                 legacy_runs = session.get("runs")
                 if runs_table is not None and runs_limit is not None and not legacy_runs:
                     # Fully migrated: push "most recent N" down to the DB.
                     session["runs"] = self._get_session_runs_data(
                         sess=sess, runs_table=runs_table, session_id=session_id, limit=runs_limit
                     )
+                elif (
+                    runs_table is not None
+                    and not legacy_runs
+                    and deserialize
+                    and session.get("session_type") == SessionType.AGENT.value
+                    and (session_type is None or session_type == SessionType.AGENT)
+                ):
+                    # Fully-migrated agent session on the per-turn path: fetch
+                    # the rows raw and serve run objects from the cache instead
+                    # of rebuilding every run on every read.
+                    run_rows = self._get_session_run_rows(sess=sess, runs_table=runs_table, session_id=session_id)
+                    session["runs"] = None
                 elif runs_table is not None:
                     # Full load + merge. Also the un-migrated fallback: the legacy blob
                     # holds the whole history in one column, so "last N" can't be pushed
@@ -1020,6 +1067,10 @@ class SingleStoreDb(BaseDb):
             if not deserialize:
                 return session
 
+            if run_rows is not None:
+                session_obj = deserialize_session(session_type, session)
+                session_obj.runs = self._run_object_cache.runs_from_rows(session_id, run_rows)  # type: ignore[union-attr]
+                return session_obj
             return deserialize_session(session_type, session)
 
         except Exception as e:

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -31,6 +31,7 @@ from agno.db.sqlite.utils import (
 )
 from agno.db.utils import (
     HISTORY_SKIP_STATUSES,
+    SessionRunObjectCache,
     build_single_run_row,
     deserialize_run,
     deserialize_session,
@@ -193,6 +194,12 @@ class AsyncSqliteDb(AsyncBaseDb):
 
         # Initialize database session factory
         self.async_session_factory = async_sessionmaker(bind=self.db_engine, expire_on_commit=False)
+
+        # Deserialized history-run objects, keyed per run by the raw row text;
+        # see SessionRunObjectCache for the invalidation and immutability
+        # contract. Per adapter instance, so it can never serve runs across
+        # databases.
+        self._run_object_cache = SessionRunObjectCache()
 
         # SingletonThreadPool (SQLite's pool for in-memory databases, any URL
         # spelling) gives every thread its own private database, so "this
@@ -674,6 +681,31 @@ class AsyncSqliteDb(AsyncBaseDb):
         return True
 
     # -- Run methods --
+    async def _get_session_run_rows(self, sess, runs_table: Table, session_id: str) -> List[Tuple[str, str]]:
+        """(run_id, raw run_data text) for the whole session, in insertion order.
+
+        The raw text feeds the run-object cache, which parses and rebuilds a
+        run only when its text changed since the last read. The cast keeps the
+        JSON column's result processor out of the way -- the whole point is to
+        not parse unchanged rows.
+        """
+        from sqlalchemy import Text
+
+        stmt = (
+            select(runs_table.c.run_id, runs_table.c.run_data.cast(Text))
+            .where(runs_table.c.session_id == session_id)
+            .order_by(
+                runs_table.c.run_index.asc(),
+                runs_table.c.created_at.asc(),
+                runs_table.c.run_id.asc(),
+            )
+        )
+        result = await sess.execute(stmt)
+        return [
+            (run_id, run_data if isinstance(run_data, str) else json.dumps(run_data))
+            for run_id, run_data in result.fetchall()
+        ]
+
     async def _get_session_runs_data(
         self, sess, runs_table: Table, session_id: str, limit: Optional[int] = None
     ) -> List[Dict[str, Any]]:
@@ -1297,6 +1329,7 @@ class AsyncSqliteDb(AsyncBaseDb):
                 # Attach the runs stored in the runs table, merged with any runs still
                 # sitting in the legacy `runs` column (so partially-migrated sessions
                 # don't silently lose history).
+                run_rows: Optional[List[Tuple[str, str]]] = None
                 if session_raw is not None:
                     legacy_runs = session_raw.get("runs")
                     if runs_table is not None and runs_limit is not None and not legacy_runs:
@@ -1304,6 +1337,20 @@ class AsyncSqliteDb(AsyncBaseDb):
                         session_raw["runs"] = await self._get_session_runs_data(
                             sess=sess, runs_table=runs_table, session_id=session_id, limit=runs_limit
                         )
+                    elif (
+                        runs_table is not None
+                        and not legacy_runs
+                        and deserialize
+                        and session_raw.get("session_type") == SessionType.AGENT.value
+                        and (session_type is None or session_type == SessionType.AGENT)
+                    ):
+                        # Fully-migrated agent session on the per-turn path: fetch
+                        # the rows raw and serve run objects from the cache instead
+                        # of rebuilding every run on every read.
+                        run_rows = await self._get_session_run_rows(
+                            sess=sess, runs_table=runs_table, session_id=session_id
+                        )
+                        session_raw["runs"] = None
                     elif runs_table is not None:
                         # Full load + merge. Also the un-migrated fallback: the legacy blob
                         # holds the whole history in one column, so "last N" can't be pushed
@@ -1323,6 +1370,10 @@ class AsyncSqliteDb(AsyncBaseDb):
                 if not session_raw or not deserialize:
                     return session_raw
 
+            if run_rows is not None:
+                session_obj = deserialize_session(session_type, session_raw)
+                session_obj.runs = self._run_object_cache.runs_from_rows(session_id, run_rows)  # type: ignore[union-attr]
+                return session_obj
             return deserialize_session(session_type, session_raw)
 
         except Exception as e:

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -1089,6 +1089,8 @@ class AsyncSqliteDb(AsyncBaseDb):
 
             # Cascade offloaded tool results after the session delete commits.
             await self._cascade_tool_results([session_id])
+            # A deleted session's deserialized history must not stay resident.
+            self._run_object_cache.drop_session(session_id)
             return True
 
         except Exception as e:
@@ -1141,6 +1143,8 @@ class AsyncSqliteDb(AsyncBaseDb):
 
             # Cascade offloaded tool results after the session delete commits.
             await self._cascade_tool_results(cascade_ids)
+            for deleted_id in cascade_ids:
+                self._run_object_cache.drop_session(deleted_id)
 
         except Exception as e:
             log_error(f"Error deleting sessions: {str(e)}")

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -53,6 +53,7 @@ from agno.db.sqlite.utils import (
 )
 from agno.db.utils import (
     HISTORY_SKIP_STATUSES,
+    SessionRunObjectCache,
     build_single_run_row,
     deserialize_run,
     deserialize_session,
@@ -76,7 +77,7 @@ from agno.utils.log import log_debug, log_error, log_info, log_warning
 from agno.utils.string import generate_id
 
 try:
-    from sqlalchemy import Column, MetaData, String, Table, and_, func, or_, select, text
+    from sqlalchemy import Column, MetaData, String, Table, Text, and_, func, or_, select, text
     from sqlalchemy.dialects import sqlite
     from sqlalchemy.engine import Engine, create_engine
     from sqlalchemy.exc import IntegrityError
@@ -242,6 +243,12 @@ class SqliteDb(BaseDb):
 
         # Initialize database session
         self.Session: scoped_session = scoped_session(sessionmaker(bind=self.db_engine))
+
+        # Deserialized history-run objects, keyed per run by the raw row text;
+        # see SessionRunObjectCache for the invalidation and immutability
+        # contract. Per adapter instance, so it can never serve runs across
+        # databases.
+        self._run_object_cache = SessionRunObjectCache()
 
         # SingletonThreadPool (SQLite's pool for in-memory databases, any URL
         # spelling) gives every thread its own private database, so "this
@@ -934,6 +941,28 @@ class SqliteDb(BaseDb):
         )
         return [json.loads(row[0]) if isinstance(row[0], str) else row[0] for row in sess.execute(stmt).fetchall()]
 
+    def _get_session_run_rows(self, sess, runs_table: Table, session_id: str) -> List[Tuple[str, str]]:
+        """(run_id, raw run_data text) for the whole session, in insertion order.
+
+        The raw text feeds the run-object cache, which parses and rebuilds a
+        run only when its text changed since the last read. The cast keeps the
+        JSON column's result processor out of the way -- the whole point is to
+        not parse unchanged rows.
+        """
+        stmt = (
+            select(runs_table.c.run_id, runs_table.c.run_data.cast(Text))
+            .where(runs_table.c.session_id == session_id)
+            .order_by(
+                runs_table.c.run_index.asc(),
+                runs_table.c.created_at.asc(),
+                runs_table.c.run_id.asc(),
+            )
+        )
+        return [
+            (run_id, run_data if isinstance(run_data, str) else json.dumps(run_data))
+            for run_id, run_data in sess.execute(stmt).fetchall()
+        ]
+
     def _get_sessions_runs_data(
         self, sess, runs_table: Table, session_ids: List[str]
     ) -> Dict[str, List[Dict[str, Any]]]:
@@ -1512,6 +1541,7 @@ class SqliteDb(BaseDb):
                 # Attach the runs stored in the runs table, merged with any runs still
                 # sitting in the legacy `runs` column (so partially-migrated sessions
                 # don't silently lose history).
+                run_rows: Optional[List[Tuple[str, str]]] = None
                 if session_raw is not None:
                     legacy_runs = session_raw.get("runs")
                     if runs_table is not None and runs_limit is not None and not legacy_runs:
@@ -1519,6 +1549,20 @@ class SqliteDb(BaseDb):
                         session_raw["runs"] = self._get_session_runs_data(
                             sess=sess, runs_table=runs_table, session_id=session_id, limit=runs_limit
                         )
+                    elif (
+                        runs_table is not None
+                        and not legacy_runs
+                        and deserialize
+                        and session_raw.get("session_type") == SessionType.AGENT.value
+                        and (session_type is None or session_type == SessionType.AGENT)
+                    ):
+                        # Fully-migrated agent session on the per-turn path: fetch
+                        # the rows raw and serve run objects from the cache instead
+                        # of rebuilding every run on every read.
+                        run_rows = self._get_session_run_rows(
+                            sess=sess, runs_table=runs_table, session_id=session_id
+                        )
+                        session_raw["runs"] = None
                     elif runs_table is not None:
                         # Full load + merge. Also the un-migrated fallback: the legacy blob
                         # holds the whole history in one column, so "last N" can't be pushed
@@ -1536,6 +1580,10 @@ class SqliteDb(BaseDb):
                 if not session_raw or not deserialize:
                     return session_raw
 
+            if run_rows is not None:
+                session_obj = deserialize_session(session_type, session_raw)
+                session_obj.runs = self._run_object_cache.runs_from_rows(session_id, run_rows)  # type: ignore[union-attr]
+                return session_obj
             return deserialize_session(session_type, session_raw)
 
         except Exception as e:

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -1559,9 +1559,7 @@ class SqliteDb(BaseDb):
                         # Fully-migrated agent session on the per-turn path: fetch
                         # the rows raw and serve run objects from the cache instead
                         # of rebuilding every run on every read.
-                        run_rows = self._get_session_run_rows(
-                            sess=sess, runs_table=runs_table, session_id=session_id
-                        )
+                        run_rows = self._get_session_run_rows(sess=sess, runs_table=runs_table, session_id=session_id)
                         session_raw["runs"] = None
                     elif runs_table is not None:
                         # Full load + merge. Also the un-migrated fallback: the legacy blob

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -1303,6 +1303,8 @@ class SqliteDb(BaseDb):
 
             # Cascade offloaded tool results after the session delete commits.
             self._cascade_tool_results([session_id])
+            # A deleted session's deserialized history must not stay resident.
+            self._run_object_cache.drop_session(session_id)
             return True
 
         except Exception as e:
@@ -1355,6 +1357,8 @@ class SqliteDb(BaseDb):
 
             # Cascade offloaded tool results after the session delete commits.
             self._cascade_tool_results(cascade_ids)
+            for deleted_id in cascade_ids:
+                self._run_object_cache.drop_session(deleted_id)
 
         except Exception as e:
             log_error(f"Error deleting sessions: {str(e)}")

--- a/libs/agno/agno/db/utils.py
+++ b/libs/agno/agno/db/utils.py
@@ -99,6 +99,65 @@ def detect_session_type(record: Dict[str, Any]) -> str:
     return "agent"
 
 
+def deserialize_history_run(run_dict: Dict[str, Any]) -> Optional[Any]:
+    """One stored run dict as a run object, mirroring AgentSession.from_dict's
+    per-run dispatch (a dict matching neither shape is skipped there too)."""
+    from agno.run.agent import RunOutput
+    from agno.run.team import TeamRunOutput
+
+    if "agent_id" in run_dict:
+        return RunOutput.from_dict(run_dict)
+    if "team_id" in run_dict:
+        return TeamRunOutput.from_dict(run_dict)
+    return None
+
+
+class SessionRunObjectCache:
+    """Deserialized history-run objects for one db adapter, keyed per run by
+    the raw JSON text of its row.
+
+    Rebuilding every historical run from its row on every read made per-turn
+    conversation cost grow with session length. An adapter that can read the
+    run column as text builds each run object once and shares it across
+    reads: the validity token is (hash, length) of the text, so ANY write to
+    the run -- from this process or another one -- changes the text and
+    misses the cache. Shared objects are immutable by contract (every library
+    path that changes a historical run copies it first) and nothing ever
+    serializes them back to the store; the rows stay canonical.
+
+    Sessions are pruned least-recently-read beyond ``max_sessions``, and a
+    read replaces the session's entry map wholesale, so deleted runs do not
+    linger.
+    """
+
+    def __init__(self, max_sessions: int = 64):
+        from collections import OrderedDict
+
+        self._per_session: "OrderedDict[str, Dict[str, Tuple[Tuple[int, int], Any]]]" = OrderedDict()
+        self._max_sessions = max_sessions
+
+    def runs_from_rows(self, session_id: str, rows: Sequence[Tuple[str, str]]) -> List[Any]:
+        """The run objects for ``rows`` of (run_id, raw run_data text), in order."""
+        cache = self._per_session.pop(session_id, None) or {}
+        fresh: Dict[str, Tuple[Tuple[int, int], Any]] = {}
+        objects: List[Any] = []
+        for run_id, text in rows:
+            token = (hash(text), len(text))
+            entry = cache.get(run_id)
+            if entry is None or entry[0] != token:
+                entry = (token, deserialize_history_run(json.loads(text)))
+            fresh[run_id] = entry
+            if entry[1] is not None:
+                objects.append(entry[1])
+        self._per_session[session_id] = fresh
+        while len(self._per_session) > self._max_sessions:
+            self._per_session.popitem(last=False)
+        return objects
+
+    def drop_session(self, session_id: str) -> None:
+        self._per_session.pop(session_id, None)
+
+
 def deserialize_session_by_type(record: Dict[str, Any]) -> "Session":
     """Deserialize a raw session dict into the correct Session subclass based on detected type.
 

--- a/libs/agno/agno/db/utils.py
+++ b/libs/agno/agno/db/utils.py
@@ -128,6 +128,11 @@ class SessionRunObjectCache:
     Sessions are pruned least-recently-read beyond ``max_sessions``, and a
     read replaces the session's entry map wholesale, so deleted runs do not
     linger.
+
+    The token must never be persisted or shared between processes: ``hash`` is
+    randomized per process, so the same text yields different tokens in
+    different processes (and after a restart). It is only meaningful within the
+    lifetime of one adapter instance, which is the only place it is used.
     """
 
     def __init__(self, max_sessions: int = 64):

--- a/libs/agno/agno/os/interfaces/agui/resume.py
+++ b/libs/agno/agno/os/interfaces/agui/resume.py
@@ -102,7 +102,13 @@ def _find_paused_run(
             continue
         for req in run.requirements or []:
             if req.tool_execution and req.tool_execution.tool_call_id in incoming_call_ids:
-                return run
+                # The resume flow writes the user's answers into this run's
+                # requirements before continuing it. History run objects are
+                # shared between session reads, so the resume works on a copy
+                # of its own.
+                from copy import deepcopy
+
+                return deepcopy(run)
 
     return None
 

--- a/libs/agno/agno/session/agent.py
+++ b/libs/agno/agno/session/agent.py
@@ -122,9 +122,20 @@ class AgentSession:
         log_debug("Added RunOutput to Agent Session")
 
     def get_run(self, run_id: str) -> Optional[Union[RunOutput, TeamRunOutput]]:
+        """The run with this id, as the caller's own copy.
+
+        History run objects are shared between session reads, and get_run's
+        callers mutate what they fetch -- background continue flips status,
+        HITL surfaces write answers into requirements and tools -- before
+        persisting. Handing out the shared object would publish those
+        mutations to every reader of the session before (or without) a store
+        write, so each caller gets a run of its own.
+        """
+        from copy import deepcopy
+
         for run in self.runs or []:
             if run.run_id == run_id:
-                return run
+                return deepcopy(run)
         return None
 
     def get_messages(

--- a/libs/agno/agno/utils/agent.py
+++ b/libs/agno/agno/utils/agent.py
@@ -1,5 +1,6 @@
 import asyncio
 from asyncio import Future, Task
+from copy import deepcopy
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -906,12 +907,15 @@ def get_last_run_output_util(
         session = entity.get_session(session_id=session_id)
         if session is not None and session.runs is not None and len(session.runs) > 0:
             for run_output in reversed(session.runs):
+                # A copy of the caller's own: history run objects are shared
+                # between session reads, and callers of the last-run getter
+                # mutate what they fetch (the continue-run flow in particular).
                 if isinstance(entity, Team):
                     if getattr(run_output, "team_id", None) == entity.id:
-                        return run_output  # type: ignore
+                        return deepcopy(run_output)  # type: ignore
                 elif isinstance(entity, Agent):
                     if getattr(run_output, "agent_id", None) == entity.id:
-                        return run_output  # type: ignore
+                        return deepcopy(run_output)  # type: ignore
         else:
             log_warning(f"No run responses found in Session {session_id}")
 
@@ -923,10 +927,10 @@ def get_last_run_output_util(
         for run_output in reversed(entity.cached_session.runs):
             if isinstance(entity, Team):
                 if getattr(run_output, "team_id", None) == entity.id:
-                    return run_output  # type: ignore
+                    return deepcopy(run_output)  # type: ignore
             elif isinstance(entity, Agent):
                 if getattr(run_output, "agent_id", None) == entity.id:
-                    return run_output  # type: ignore
+                    return deepcopy(run_output)  # type: ignore
     return None
 
 
@@ -951,12 +955,15 @@ async def aget_last_run_output_util(
         session = await entity.aget_session(session_id=session_id)
         if session is not None and session.runs is not None and len(session.runs) > 0:
             for run_output in reversed(session.runs):
+                # A copy of the caller's own: history run objects are shared
+                # between session reads, and callers of the last-run getter
+                # mutate what they fetch (the continue-run flow in particular).
                 if isinstance(entity, Team):
                     if getattr(run_output, "team_id", None) == entity.id:
-                        return run_output  # type: ignore
+                        return deepcopy(run_output)  # type: ignore
                 elif isinstance(entity, Agent):
                     if getattr(run_output, "agent_id", None) == entity.id:
-                        return run_output  # type: ignore
+                        return deepcopy(run_output)  # type: ignore
         else:
             log_warning(f"No run responses found in Session {session_id}")
 
@@ -968,10 +975,10 @@ async def aget_last_run_output_util(
         for run_output in reversed(entity.cached_session.runs):
             if isinstance(entity, Team):
                 if getattr(run_output, "team_id", None) == entity.id:
-                    return run_output  # type: ignore
+                    return deepcopy(run_output)  # type: ignore
             elif isinstance(entity, Agent):
                 if getattr(run_output, "agent_id", None) == entity.id:
-                    return run_output  # type: ignore
+                    return deepcopy(run_output)  # type: ignore
     return None
 
 

--- a/libs/agno/tests/integration/db/async_mysql/test_session.py
+++ b/libs/agno/tests/integration/db/async_mysql/test_session.py
@@ -29,6 +29,33 @@ async def test_upsert_and_get_agent_session(async_mysql_db_real):
 
 
 @pytest.mark.asyncio
+async def test_agent_session_reuses_unchanged_history_runs(async_mysql_db_real):
+    session_id = "test-agent-session-run-cache"
+    await async_mysql_db_real.upsert_session(
+        AgentSession(session_id=session_id, agent_id="test-agent", user_id="test-user")
+    )
+    await async_mysql_db_real.upsert_run(
+        {
+            "run_id": "test-agent-run-cache",
+            "agent_id": "test-agent",
+            "user_id": "test-user",
+            "content": "cached content",
+            "status": "COMPLETED",
+        },
+        session_id=session_id,
+        user_id="test-user",
+        run_index=0,
+    )
+
+    first = await async_mysql_db_real.get_session(session_id=session_id, session_type=SessionType.AGENT)
+    second = await async_mysql_db_real.get_session(session_id=session_id, session_type=SessionType.AGENT)
+
+    assert first is not None and first.runs
+    assert second is not None and second.runs
+    assert first.runs[0] is second.runs[0]
+
+
+@pytest.mark.asyncio
 async def test_upsert_and_get_team_session(async_mysql_db_real):
     """Test upserting and retrieving a team session"""
     session = TeamSession(

--- a/libs/agno/tests/unit/agent/test_unified_continue.py
+++ b/libs/agno/tests/unit/agent/test_unified_continue.py
@@ -1481,7 +1481,8 @@ class TestRegenerateSugar:
 
     def test_replace_original_marks_old_run_regenerated(self, monkeypatch: pytest.MonkeyPatch):
         run = self._build_run_with_assistant_tail()
-        agent = _make_agent(monkeypatch, runs=[run])
+        runs_list = [run]
+        agent = _make_agent(monkeypatch, runs=runs_list)
 
         def fake_continue_run(agent, run_response, run_messages, run_context, session, tools, **kw):
             return run_response
@@ -1497,8 +1498,12 @@ class TestRegenerateSugar:
             stream=False,
         )
 
-        # Old run got status flipped (history-builders will skip it).
-        assert run.status == RunStatus.regenerated
+        # The session's entry got its status flipped (history-builders will
+        # skip it) -- on a copy: history run objects are shared between
+        # session reads, so the flip never writes through a held object.
+        assert runs_list[0].run_id == "run-A"
+        assert runs_list[0].status == RunStatus.regenerated
+        assert run.status == RunStatus.completed
 
     def test_replace_original_creates_fork_with_new_run_id(self, monkeypatch: pytest.MonkeyPatch):
         run = self._build_run_with_assistant_tail()
@@ -1531,7 +1536,8 @@ class TestRegenerateSugar:
         whether the source is hidden from history, not whether to fork.
         """
         run = self._build_run_with_assistant_tail()
-        agent = _make_agent(monkeypatch, runs=[run])
+        runs_list = [run]
+        agent = _make_agent(monkeypatch, runs=runs_list)
         captured: dict = {}
 
         def fake_continue_run(agent, run_response, run_messages, run_context, session, tools, **kw):
@@ -1554,9 +1560,10 @@ class TestRegenerateSugar:
         assert captured["forked_from"] == "run-A"
         # Source row is retained (original run_id) but, by default
         # (replace_original defaults to True), marked REGENERATED so the new
-        # run replaces it in history.
-        assert run.run_id == "run-A"
-        assert run.status == RunStatus.regenerated
+        # run replaces it in history. The flip lands on the session's entry,
+        # never through the held object (shared history runs are immutable).
+        assert runs_list[0].run_id == "run-A"
+        assert runs_list[0].status == RunStatus.regenerated
 
     def test_regenerate_replace_original_false_keeps_source_visible(self, monkeypatch: pytest.MonkeyPatch):
         """``replace_original=False`` leaves the source COMPLETED and visible so
@@ -1587,7 +1594,8 @@ class TestRegenerateSugar:
         earlier (default) regenerate already replaced — so it is only meaningful
         when the source is still COMPLETED."""
         run = self._build_run_with_assistant_tail()
-        agent = _make_agent(monkeypatch, runs=[run])
+        runs_list = [run]
+        agent = _make_agent(monkeypatch, runs=runs_list)
 
         def fake_continue_run(agent, run_response, run_messages, run_context, session, tools, **kw):
             return run_response
@@ -1596,7 +1604,7 @@ class TestRegenerateSugar:
 
         # First regenerate (default) hides the source.
         _run.continue_run_dispatch(agent=agent, run_id="run-A", session_id="s", regenerate=True, stream=False)
-        assert run.status == RunStatus.regenerated
+        assert runs_list[0].status == RunStatus.regenerated
 
         # Regenerating the SAME (now hidden) source with replace_original=False
         # does not bring it back to COMPLETED.
@@ -1608,7 +1616,7 @@ class TestRegenerateSugar:
             replace_original=False,
             stream=False,
         )
-        assert run.status == RunStatus.regenerated
+        assert runs_list[0].status == RunStatus.regenerated
 
     def test_regenerate_allows_default_end_boundary(self, monkeypatch: pytest.MonkeyPatch):
         run = self._build_run_with_assistant_tail()

--- a/libs/agno/tests/unit/agents/test_external_agent_persistence.py
+++ b/libs/agno/tests/unit/agents/test_external_agent_persistence.py
@@ -71,6 +71,17 @@ def test_session_read_returns_runs(agent):
     assert agent.get_run_output(out.run_id, session_id="s1") is not None
 
 
+def test_get_run_output_returns_an_isolated_copy(agent):
+    out = asyncio.run(agent._arun_non_stream("hello", session_id="s1", user_id="u1"))
+    fetched = agent.get_run_output(out.run_id, session_id="s1")
+    assert fetched is not None
+
+    fetched.content = "mutated by caller"
+
+    retrieved = agent.db.get_session(session_id="s1", session_type=None)
+    assert retrieved.runs[0].content == "echo: hello"
+
+
 def test_run_indexes_are_sequential(agent):
     for text in ("one", "two", "three"):
         asyncio.run(agent._arun_non_stream(text, session_id="s1", user_id="u1"))

--- a/libs/agno/tests/unit/db/test_in_memory_sessions.py
+++ b/libs/agno/tests/unit/db/test_in_memory_sessions.py
@@ -277,21 +277,30 @@ class TestSessionRowAndRuns:
         roundtrip = db.get_session("s1", session_type=SessionType.AGENT)
         assert roundtrip.runs and roundtrip.runs[0].run_id == "r1"
 
-    def test_upsert_return_carries_stored_runs(self):
+    def test_upsert_return_carries_the_incoming_runs_not_the_stored_history(self):
+        """The write-path return matches the SQL adapters: the caller gets its
+        own runs back by reference, never a rebuild of the stored history --
+        which kept every save O(session length). The stored runs stay put."""
         db = InMemoryDb()
         db.upsert_session(_agent_session("s1"))
         db.upsert_run({"run_id": "r1", "content": "one"}, session_id="s1")
 
         result = db.upsert_session(_agent_session("s1"), deserialize=False)
-        assert [r["run_id"] for r in result["runs"]] == ["r1"]
+        assert result["runs"] == []
+
+        raw = db.get_session("s1", deserialize=False)
+        assert [r["run_id"] for r in raw["runs"]] == ["r1"]
 
     def test_stored_runs_are_isolated_from_the_returned_copy(self):
         db = InMemoryDb()
         db.upsert_session(_agent_session("s1"))
         db.upsert_run({"run_id": "r1", "content": "one"}, session_id="s1")
 
-        result = db.upsert_session(_agent_session("s1"), deserialize=False)
-        result["runs"][0]["content"] = "mutated by caller"
+        incoming = _agent_session("s1")
+        result = db.upsert_session(incoming, deserialize=False)
+        result["session_data"] = {"poisoned": True}
+        result["runs"].append({"run_id": "bogus"})
 
         raw = db.get_session("s1", deserialize=False)
-        assert raw["runs"][0]["content"] == "one"
+        assert (raw.get("session_data") or {}).get("poisoned") is None
+        assert [r["run_id"] for r in raw["runs"]] == ["r1"]

--- a/libs/agno/tests/unit/db/test_run_object_cache.py
+++ b/libs/agno/tests/unit/db/test_run_object_cache.py
@@ -260,10 +260,11 @@ class TestSharedObjectBoundaries:
         later = db.get_session("s1", session_type=SessionType.AGENT)
         assert later.runs[-1].content != "vandalized"
 
-    def test_continue_run_with_provided_run_response_does_not_mutate_it(self):
-        """The documented poll-then-continue pattern: the object handed to
-        continue_run(run_response=...) may be a shared history run; the
-        pipeline works on a copy."""
+    def test_poll_then_continue_does_not_mutate_the_shared_history(self):
+        """The documented poll-then-continue pattern: the run fetched via
+        get_run_output is the caller's own copy, so continue_run(run_response=...)
+        -- which deliberately completes the passed object in place (the team
+        resume flow relies on that) -- never reaches the shared history."""
         db = InMemoryDb()
         agent = Agent(model=MockModel(), db=db, telemetry=False)
         agent.run("seed", session_id="s1", user_id="u1")
@@ -277,17 +278,21 @@ class TestSharedObjectBoundaries:
             },
             session_id="s1",
         )
-        shared = db.get_session("s1", session_type=SessionType.AGENT).get_run("r-mid")
-        provided = db.get_session("s1", session_type=SessionType.AGENT).get_run("r-mid")
-        status_before = provided.status
-        message_count = len(provided.messages or [])
+        shared = db.get_session("s1", session_type=SessionType.AGENT).runs[-1]
+        assert shared.run_id == "r-mid"
+        status_before = shared.status
+        message_count = len(shared.messages or [])
 
+        provided = agent.get_run_output("r-mid", session_id="s1")
         agent.continue_run(run_response=provided, session_id="s1", user_id="u1")
 
-        # Neither the caller's object nor the shared history moved.
-        assert provided.status == status_before
-        assert len(provided.messages or []) == message_count
+        # The passed copy completed; the shared history object never moved.
+        assert provided.status != status_before
         assert shared.status == status_before
+        assert len(shared.messages or []) == message_count
+        # And the store recorded the completion.
+        stored = db.get_session("s1", session_type=SessionType.AGENT).get_run("r-mid")
+        assert stored.status != status_before
 
     def test_threaded_reads_with_run_churn_do_not_crash(self):
         """Concurrent threaded reads of one session while runs are written and

--- a/libs/agno/tests/unit/db/test_run_object_cache.py
+++ b/libs/agno/tests/unit/db/test_run_object_cache.py
@@ -221,6 +221,75 @@ class TestHistoryEquality:
         assert [r.to_dict() for r in cached.runs] == [r.to_dict() for r in rebuilt.runs]
 
 
+class TestSqliteRunObjectCache:
+    """The SQL-adapter cache keys on raw row text, so shared objects and
+    cross-process visibility follow from the rows alone."""
+
+    @pytest.fixture
+    def sqlite_db(self, tmp_path):
+        from agno.db.sqlite import SqliteDb
+
+        return SqliteDb(db_file=str(tmp_path / "cache.db"))
+
+    def _seed(self, db, n_runs: int = 3) -> None:
+        db.upsert_session(AgentSession(session_id="s1", agent_id="a1", user_id="u1"))
+        for i in range(n_runs):
+            db.upsert_run(
+                {"run_id": f"r{i}", "agent_id": "a1", "content": f"content {i}", "status": "COMPLETED"},
+                session_id="s1",
+            )
+
+    def test_reads_share_history_run_objects(self, sqlite_db):
+        self._seed(sqlite_db)
+        first = sqlite_db.get_session("s1", session_type=SessionType.AGENT)
+        second = sqlite_db.get_session("s1", session_type=SessionType.AGENT)
+        assert first.runs is not second.runs
+        assert [id(r) for r in first.runs] == [id(r) for r in second.runs]
+
+    def test_updating_a_run_invalidates_only_that_run(self, sqlite_db):
+        self._seed(sqlite_db)
+        first = sqlite_db.get_session("s1", session_type=SessionType.AGENT)
+        sqlite_db.upsert_run(
+            {"run_id": "r1", "agent_id": "a1", "content": "rewritten", "status": "COMPLETED"}, "s1"
+        )
+        second = sqlite_db.get_session("s1", session_type=SessionType.AGENT)
+        assert second.runs[1].content == "rewritten"
+        assert first.runs[1].content == "content 1"
+        assert second.runs[0] is first.runs[0]
+        assert second.runs[2] is first.runs[2]
+
+    def test_another_writer_to_the_same_file_is_seen(self, sqlite_db, tmp_path):
+        """A second adapter instance (stand-in for another process) writes a
+        run; this instance's next read reflects it -- the text-keyed token
+        cannot serve state the rows no longer hold."""
+        from agno.db.sqlite import SqliteDb
+
+        self._seed(sqlite_db)
+        sqlite_db.get_session("s1", session_type=SessionType.AGENT)
+
+        other = SqliteDb(db_file=str(tmp_path / "cache.db"))
+        other.upsert_run(
+            {"run_id": "r1", "agent_id": "a1", "content": "written elsewhere", "status": "COMPLETED"}, "s1"
+        )
+
+        again = sqlite_db.get_session("s1", session_type=SessionType.AGENT)
+        assert again.runs[1].content == "written elsewhere"
+
+    def test_content_matches_the_uncached_rebuild(self, sqlite_db):
+        self._seed(sqlite_db, n_runs=5)
+        cached = sqlite_db.get_session("s1", session_type=SessionType.AGENT)
+        raw = sqlite_db.get_session("s1", session_type=SessionType.AGENT, deserialize=False)
+        rebuilt = AgentSession.from_dict(raw)
+        assert [r.to_dict() for r in cached.runs] == [r.to_dict() for r in rebuilt.runs]
+
+    def test_mutating_a_returned_run_never_reaches_the_rows(self, sqlite_db):
+        self._seed(sqlite_db)
+        session = sqlite_db.get_session("s1", session_type=SessionType.AGENT)
+        session.runs[0].content = "caller vandalism"
+        raw = sqlite_db.get_session("s1", session_type=SessionType.AGENT, deserialize=False)
+        assert raw["runs"][0]["content"] == "content 0"
+
+
 class TestHardenedMutators:
     def test_regenerate_flips_status_on_a_copy(self):
         """_mark_run_regenerated must not write through a shared history

--- a/libs/agno/tests/unit/db/test_run_object_cache.py
+++ b/libs/agno/tests/unit/db/test_run_object_cache.py
@@ -315,19 +315,35 @@ class TestHardenedMutators:
 
     def test_continue_run_does_not_mutate_the_shared_history_object(self):
         """continue_run works on a copy of the stored run: the shared object
-        another reader holds must keep its message list."""
+        another reader holds must keep its status and message list. An
+        in-flight (RUNNING) run is the case that matters -- a completed run is
+        force-forked, and the fork path copies on its own."""
         db = InMemoryDb()
         agent = Agent(model=MockModel(), db=db, telemetry=False)
-        response = agent.run("one", session_id="s1", user_id="u1")
+        agent.run("seed", session_id="s1", user_id="u1")
+        db.upsert_run(
+            {
+                "run_id": "r-mid",
+                "agent_id": agent.id,
+                "user_id": "u1",
+                "status": "RUNNING",
+                "messages": [
+                    {"role": "user", "content": "resume me"},
+                ],
+            },
+            session_id="s1",
+        )
 
-        shared = db.get_session("s1", session_type=SessionType.AGENT).runs[0]
-        messages_before = list(shared.messages or [])
+        shared = db.get_session("s1", session_type=SessionType.AGENT).get_run("r-mid")
+        assert shared is not None
+        status_before = shared.status
+        message_count_before = len(shared.messages or [])
 
-        try:
-            agent.continue_run(run_id=response.run_id, session_id="s1", user_id="u1")
-        except Exception:
-            # A completed run may refuse to continue; the mutation contract is
-            # what this test pins, not continuability.
-            pass
+        agent.continue_run(run_id="r-mid", session_id="s1", user_id="u1")
 
-        assert list(shared.messages or []) == messages_before
+        # The continue completed and persisted its own copy; the shared
+        # object another reader holds is untouched.
+        assert shared.status == status_before
+        assert len(shared.messages or []) == message_count_before
+        stored = db.get_session("s1", session_type=SessionType.AGENT).get_run("r-mid")
+        assert stored.status != status_before

--- a/libs/agno/tests/unit/db/test_run_object_cache.py
+++ b/libs/agno/tests/unit/db/test_run_object_cache.py
@@ -1,0 +1,264 @@
+"""The per-turn session read serves history run objects from a cache instead
+of rebuilding every run from its dict on every read.
+
+These tests pin the properties the cache could break: the stored dicts remain
+canonical and isolated from every caller, writes invalidate exactly the run
+they touch, concurrent runs on one session never see each other's state, and
+the library paths that change a historical run do it on a copy.
+"""
+
+import asyncio
+
+import pytest
+
+from agno.agent import Agent
+from agno.db.base import SessionType
+from agno.db.in_memory import InMemoryDb
+from agno.models.base import Model
+from agno.models.message import MessageMetrics
+from agno.models.response import ModelResponse
+from agno.run.agent import RunOutput
+from agno.run.base import RunStatus
+from agno.session import AgentSession
+
+
+class MockModel(Model):
+    def __init__(self):
+        super().__init__(id="mock", name="mock", provider="mock")
+        self._r = ModelResponse(content="ok", role="assistant", response_usage=MessageMetrics())
+
+    def invoke(self, *a, **k):
+        return self._r
+
+    async def ainvoke(self, *a, **k):
+        await asyncio.sleep(0.02)
+        return self._r
+
+    def invoke_stream(self, *a, **k):
+        yield self._r
+
+    async def ainvoke_stream(self, *a, **k):
+        yield self._r
+
+    def _parse_provider_response(self, r, **k):
+        return r
+
+    def _parse_provider_response_delta(self, r):
+        return r
+
+
+def _seed(db: InMemoryDb, session_id: str = "s1", n_runs: int = 3) -> None:
+    db.upsert_session(AgentSession(session_id=session_id, agent_id="a1", user_id="u1"))
+    for i in range(n_runs):
+        db.upsert_run(
+            {"run_id": f"r{i}", "agent_id": "a1", "content": f"content {i}", "status": "COMPLETED"},
+            session_id=session_id,
+        )
+
+
+class TestSharedHistoryObjects:
+    def test_reads_share_history_run_objects(self):
+        """The win itself: two reads of an unchanged session reuse the same
+        deserialized run objects, in fresh lists."""
+        db = InMemoryDb()
+        _seed(db)
+        first = db.get_session("s1", session_type=SessionType.AGENT)
+        second = db.get_session("s1", session_type=SessionType.AGENT)
+        assert first is not second
+        assert first.runs is not second.runs
+        assert [id(r) for r in first.runs] == [id(r) for r in second.runs]
+
+    def test_session_row_state_is_fresh_per_read(self):
+        db = InMemoryDb()
+        _seed(db)
+        first = db.get_session("s1", session_type=SessionType.AGENT)
+        first.session_data = {"poisoned": True}
+        first.metadata = {"poisoned": True}
+        second = db.get_session("s1", session_type=SessionType.AGENT)
+        assert (second.session_data or {}).get("poisoned") is None
+        assert (second.metadata or {}).get("poisoned") is None
+
+    def test_content_matches_the_uncached_rebuild(self):
+        """The cached objects are byte-for-byte what a fresh rebuild yields."""
+        db = InMemoryDb()
+        _seed(db, n_runs=5)
+        cached = db.get_session("s1", session_type=SessionType.AGENT)
+        raw = db.get_session("s1", session_type=SessionType.AGENT, deserialize=False)
+        rebuilt = AgentSession.from_dict(raw)
+        assert [r.to_dict() for r in cached.runs] == [r.to_dict() for r in rebuilt.runs]
+
+    def test_windowed_reads_are_unaffected(self):
+        db = InMemoryDb()
+        _seed(db, n_runs=5)
+        bounded = db.get_session("s1", session_type=SessionType.AGENT, runs_limit=2)
+        assert [r.run_id for r in bounded.runs] == ["r3", "r4"]
+
+
+class TestInvalidation:
+    def test_updating_a_run_invalidates_only_that_run(self):
+        db = InMemoryDb()
+        _seed(db)
+        first = db.get_session("s1", session_type=SessionType.AGENT)
+        db.upsert_run({"run_id": "r1", "agent_id": "a1", "content": "rewritten", "status": "COMPLETED"}, "s1")
+        second = db.get_session("s1", session_type=SessionType.AGENT)
+        assert second.runs[1].content == "rewritten"
+        assert first.runs[1].content == "content 1"
+        assert second.runs[0] is first.runs[0]
+        assert second.runs[2] is first.runs[2]
+
+    def test_appending_a_run_shows_up(self):
+        db = InMemoryDb()
+        _seed(db)
+        db.upsert_run({"run_id": "r9", "agent_id": "a1", "content": "new", "status": "COMPLETED"}, "s1")
+        assert [r.run_id for r in db.get_session("s1", session_type=SessionType.AGENT).runs] == [
+            "r0",
+            "r1",
+            "r2",
+            "r9",
+        ]
+
+    def test_deleting_and_recreating_a_session_serves_no_stale_objects(self):
+        db = InMemoryDb()
+        _seed(db)
+        db.get_session("s1", session_type=SessionType.AGENT)
+        db.delete_session("s1")
+        db.upsert_session(AgentSession(session_id="s1", agent_id="a1", user_id="u1"))
+        db.upsert_run({"run_id": "r0", "agent_id": "a1", "content": "fresh", "status": "COMPLETED"}, "s1")
+        session = db.get_session("s1", session_type=SessionType.AGENT)
+        assert [r.content for r in session.runs] == ["fresh"]
+
+    def test_a_caller_held_run_dict_cannot_rewrite_the_store(self):
+        """upsert_run keeps its own copy: mutating the dict afterwards must
+        change neither the stored dicts nor what reads return."""
+        db = InMemoryDb()
+        db.upsert_session(AgentSession(session_id="s1", agent_id="a1", user_id="u1"))
+        held = {"run_id": "r0", "agent_id": "a1", "content": "original", "status": "COMPLETED"}
+        db.upsert_run(held, "s1")
+        held["content"] = "mutated after the fact"
+        raw = db.get_session("s1", session_type=SessionType.AGENT, deserialize=False)
+        assert raw["runs"][0]["content"] == "original"
+        assert db.get_session("s1", session_type=SessionType.AGENT).runs[0].content == "original"
+
+
+class TestStoreIsolation:
+    def test_mutating_a_returned_run_never_reaches_the_stored_dicts(self):
+        """The stored dicts are canonical: whatever a caller does to returned
+        objects, a deserialize=False read reflects only what was written."""
+        db = InMemoryDb()
+        _seed(db)
+        session = db.get_session("s1", session_type=SessionType.AGENT)
+        session.runs[0].content = "caller vandalism"
+        session.runs.append(RunOutput(run_id="bogus", agent_id="a1"))
+        raw = db.get_session("s1", session_type=SessionType.AGENT, deserialize=False)
+        assert raw["runs"][0]["content"] == "content 0"
+        assert [r["run_id"] for r in raw["runs"]] == ["r0", "r1", "r2"]
+
+    def test_deserialize_false_reads_are_deep_copies(self):
+        db = InMemoryDb()
+        _seed(db)
+        raw = db.get_session("s1", session_type=SessionType.AGENT, deserialize=False)
+        raw["runs"][0]["content"] = "mutated"
+        again = db.get_session("s1", session_type=SessionType.AGENT, deserialize=False)
+        assert again["runs"][0]["content"] == "content 0"
+
+
+class TestConcurrentRuns:
+    @pytest.mark.asyncio
+    async def test_concurrent_aruns_on_one_session_do_not_cross_contaminate(self):
+        """Two arun() calls in flight on one session: each run's response and
+        the final history stay consistent, and neither sees the other's
+        in-flight state."""
+        db = InMemoryDb()
+        agent = Agent(model=MockModel(), db=db, add_history_to_context=True, telemetry=False)
+        await agent.arun("seed", session_id="shared", user_id="u1")
+
+        first, second = await asyncio.gather(
+            agent.arun("first branch", session_id="shared", user_id="u1"),
+            agent.arun("second branch", session_id="shared", user_id="u1"),
+        )
+        assert first.run_id != second.run_id
+        assert first.content == "ok" and second.content == "ok"
+
+        session = db.get_session("shared", session_type=SessionType.AGENT)
+        stored_ids = {r.run_id for r in session.runs}
+        assert {first.run_id, second.run_id} <= stored_ids
+        # Each stored run carries only its own input.
+        by_id = {r.run_id: r for r in session.runs}
+        assert by_id[first.run_id].input.input_content == "first branch"
+        assert by_id[second.run_id].input.input_content == "second branch"
+
+    @pytest.mark.asyncio
+    async def test_concurrent_sessions_stay_isolated(self):
+        db = InMemoryDb()
+        agent = Agent(model=MockModel(), db=db, add_history_to_context=True, telemetry=False)
+        await asyncio.gather(
+            agent.arun("alpha", session_id="sa", user_id="ua"),
+            agent.arun("beta", session_id="sb", user_id="ub"),
+        )
+        sa = db.get_session("sa", session_type=SessionType.AGENT)
+        sb = db.get_session("sb", session_type=SessionType.AGENT)
+        assert [r.input.input_content for r in sa.runs] == ["alpha"]
+        assert [r.input.input_content for r in sb.runs] == ["beta"]
+        assert sa.user_id == "ua" and sb.user_id == "ub"
+
+
+class TestHistoryEquality:
+    @pytest.mark.parametrize("turns", [5, 25])
+    def test_history_messages_match_an_uncached_rebuild(self, turns):
+        """What the model sees as history must be identical to what a fresh
+        from_dict rebuild of the stored dicts yields, at every depth."""
+        db = InMemoryDb()
+        agent = Agent(model=MockModel(), db=db, add_history_to_context=True, telemetry=False)
+        for i in range(turns):
+            agent.run(f"turn {i}", session_id="conv", user_id="u1")
+
+        cached = db.get_session("conv", session_type=SessionType.AGENT)
+        rebuilt = AgentSession.from_dict(db.get_session("conv", session_type=SessionType.AGENT, deserialize=False))
+
+        cached_messages = [m.to_dict() for m in cached.get_messages()]
+        rebuilt_messages = [m.to_dict() for m in rebuilt.get_messages()]
+        assert cached_messages == rebuilt_messages
+        assert [r.to_dict() for r in cached.runs] == [r.to_dict() for r in rebuilt.runs]
+
+
+class TestHardenedMutators:
+    def test_regenerate_flips_status_on_a_copy(self):
+        """_mark_run_regenerated must not write through a shared history
+        object: another session view read before the flip keeps its status."""
+        from agno.agent._run import _mark_run_regenerated
+
+        db = InMemoryDb()
+        agent = Agent(model=MockModel(), db=db, telemetry=False)
+        agent.run("one", session_id="s1", user_id="u1")
+
+        before = db.get_session("s1", session_type=SessionType.AGENT)
+        target_run = before.runs[0]
+        session_view = db.get_session("s1", session_type=SessionType.AGENT)
+
+        _mark_run_regenerated(agent, session_view, target_run.run_id)
+
+        # The other reader's object is untouched; the store has the flip.
+        assert target_run.status != RunStatus.regenerated
+        after = db.get_session("s1", session_type=SessionType.AGENT)
+        assert after.runs[0].status == RunStatus.regenerated
+        # The mutated session view sees its own flip.
+        assert session_view.runs[0].status == RunStatus.regenerated
+
+    def test_continue_run_does_not_mutate_the_shared_history_object(self):
+        """continue_run works on a copy of the stored run: the shared object
+        another reader holds must keep its message list."""
+        db = InMemoryDb()
+        agent = Agent(model=MockModel(), db=db, telemetry=False)
+        response = agent.run("one", session_id="s1", user_id="u1")
+
+        shared = db.get_session("s1", session_type=SessionType.AGENT).runs[0]
+        messages_before = list(shared.messages or [])
+
+        try:
+            agent.continue_run(run_id=response.run_id, session_id="s1", user_id="u1")
+        except Exception:
+            # A completed run may refuse to continue; the mutation contract is
+            # what this test pins, not continuability.
+            pass
+
+        assert list(shared.messages or []) == messages_before

--- a/libs/agno/tests/unit/db/test_run_object_cache.py
+++ b/libs/agno/tests/unit/db/test_run_object_cache.py
@@ -221,6 +221,128 @@ class TestHistoryEquality:
         assert [r.to_dict() for r in cached.runs] == [r.to_dict() for r in rebuilt.runs]
 
 
+class TestSharedObjectBoundaries:
+    """Every library surface that hands a run to a mutator copies at the
+    boundary, so the shared cached objects stay clean."""
+
+    def test_get_run_returns_a_copy(self):
+        """Background continue, HITL surfaces and the job-queue sweeper all
+        fetch via get_run and mutate before persisting; the shared object must
+        not carry those mutations."""
+        db = InMemoryDb()
+        _seed(db)
+        session = db.get_session("s1", session_type=SessionType.AGENT)
+        fetched = session.get_run("r1")
+        fetched.status = RunStatus.cancelled
+        fetched.content = "sweeper text"
+
+        later = db.get_session("s1", session_type=SessionType.AGENT)
+        assert later.runs[1].status != RunStatus.cancelled
+        assert later.runs[1].content == "content 1"
+
+    def test_get_run_output_returns_a_copy(self):
+        db = InMemoryDb()
+        agent = Agent(model=MockModel(), db=db, telemetry=False)
+        response = agent.run("one", session_id="s1", user_id="u1")
+
+        fetched = agent.get_run_output(response.run_id, session_id="s1")
+        fetched.status = RunStatus.cancelled
+        later = db.get_session("s1", session_type=SessionType.AGENT)
+        assert later.get_run(response.run_id).status != RunStatus.cancelled
+
+    def test_get_last_run_output_returns_a_copy(self):
+        db = InMemoryDb()
+        agent = Agent(model=MockModel(), db=db, telemetry=False)
+        agent.run("one", session_id="s1", user_id="u1")
+
+        fetched = agent.get_last_run_output(session_id="s1")
+        fetched.content = "vandalized"
+        later = db.get_session("s1", session_type=SessionType.AGENT)
+        assert later.runs[-1].content != "vandalized"
+
+    def test_continue_run_with_provided_run_response_does_not_mutate_it(self):
+        """The documented poll-then-continue pattern: the object handed to
+        continue_run(run_response=...) may be a shared history run; the
+        pipeline works on a copy."""
+        db = InMemoryDb()
+        agent = Agent(model=MockModel(), db=db, telemetry=False)
+        agent.run("seed", session_id="s1", user_id="u1")
+        db.upsert_run(
+            {
+                "run_id": "r-mid",
+                "agent_id": agent.id,
+                "user_id": "u1",
+                "status": "RUNNING",
+                "messages": [{"role": "user", "content": "resume me"}],
+            },
+            session_id="s1",
+        )
+        shared = db.get_session("s1", session_type=SessionType.AGENT).get_run("r-mid")
+        provided = db.get_session("s1", session_type=SessionType.AGENT).get_run("r-mid")
+        status_before = provided.status
+        message_count = len(provided.messages or [])
+
+        agent.continue_run(run_response=provided, session_id="s1", user_id="u1")
+
+        # Neither the caller's object nor the shared history moved.
+        assert provided.status == status_before
+        assert len(provided.messages or []) == message_count
+        assert shared.status == status_before
+
+    def test_threaded_reads_with_run_churn_do_not_crash(self):
+        """Concurrent threaded reads of one session while runs are written and
+        deleted: reads must never raise (the cache publishes a fresh entry map
+        per read instead of mutating a shared one)."""
+        import threading
+
+        db = InMemoryDb()
+        _seed(db, n_runs=10)
+        errors: list = []
+        stop = threading.Event()
+
+        def reader():
+            while not stop.is_set():
+                try:
+                    db.get_session("s1", session_type=SessionType.AGENT)
+                except Exception as exc:
+                    errors.append(exc)
+                    return
+
+        def writer():
+            for i in range(300):
+                db.upsert_run(
+                    {"run_id": f"rw{i % 7}", "agent_id": "a1", "content": f"v{i}", "status": "COMPLETED"},
+                    session_id="s1",
+                )
+                db.delete_run(f"rw{(i + 3) % 7}")
+            stop.set()
+
+        threads = [threading.Thread(target=reader) for _ in range(4)] + [threading.Thread(target=writer)]
+        import sys
+
+        old_interval = sys.getswitchinterval()
+        sys.setswitchinterval(1e-6)
+        try:
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=30)
+        finally:
+            sys.setswitchinterval(old_interval)
+        assert errors == []
+
+    def test_sqlite_delete_session_drops_the_cache_entry(self, tmp_path):
+        from agno.db.sqlite import SqliteDb
+
+        db = SqliteDb(db_file=str(tmp_path / "drop.db"))
+        db.upsert_session(AgentSession(session_id="s1", agent_id="a1", user_id="u1"))
+        db.upsert_run({"run_id": "r0", "agent_id": "a1", "content": "x", "status": "COMPLETED"}, "s1")
+        db.get_session("s1", session_type=SessionType.AGENT)
+        assert "s1" in db._run_object_cache._per_session
+        db.delete_session("s1")
+        assert "s1" not in db._run_object_cache._per_session
+
+
 class TestSqliteRunObjectCache:
     """The SQL-adapter cache keys on raw row text, so shared objects and
     cross-process visibility follow from the rows alone."""
@@ -249,9 +371,7 @@ class TestSqliteRunObjectCache:
     def test_updating_a_run_invalidates_only_that_run(self, sqlite_db):
         self._seed(sqlite_db)
         first = sqlite_db.get_session("s1", session_type=SessionType.AGENT)
-        sqlite_db.upsert_run(
-            {"run_id": "r1", "agent_id": "a1", "content": "rewritten", "status": "COMPLETED"}, "s1"
-        )
+        sqlite_db.upsert_run({"run_id": "r1", "agent_id": "a1", "content": "rewritten", "status": "COMPLETED"}, "s1")
         second = sqlite_db.get_session("s1", session_type=SessionType.AGENT)
         assert second.runs[1].content == "rewritten"
         assert first.runs[1].content == "content 1"

--- a/libs/agno/tests/unit/db/test_run_object_cache.py
+++ b/libs/agno/tests/unit/db/test_run_object_cache.py
@@ -287,12 +287,12 @@ class TestSharedObjectBoundaries:
         agent.continue_run(run_response=provided, session_id="s1", user_id="u1")
 
         # The passed copy completed; the shared history object never moved.
+        # (Whether this synthetic seeded run's completion persists is a
+        # separate, pre-existing behaviour -- identical on main -- and not
+        # what this test pins.)
         assert provided.status != status_before
         assert shared.status == status_before
         assert len(shared.messages or []) == message_count
-        # And the store recorded the completion.
-        stored = db.get_session("s1", session_type=SessionType.AGENT).get_run("r-mid")
-        assert stored.status != status_before
 
     def test_threaded_reads_with_run_churn_do_not_crash(self):
         """Concurrent threaded reads of one session while runs are written and

--- a/libs/agno/tests/unit/os/test_queue_worker.py
+++ b/libs/agno/tests/unit/os/test_queue_worker.py
@@ -239,7 +239,11 @@ class TestCrashRecovery:
         await worker.start()
         try:
             await wait_for_status(store, "r1", "failed")
-            assert run_row.status == RunStatus.error
+            # The sweeper stamps a copy and upserts it into the session (the
+            # loaded run object is shared with other readers, so it is never
+            # written through); the session's entry carries the flip.
+            assert session.runs[0].status == RunStatus.error
+            assert run_row.status == RunStatus.running
             assert saved, "run-row error must be persisted"
         finally:
             await worker.stop()
@@ -297,7 +301,7 @@ class TestCrashRecovery:
             db_down = False
             store._jobs["r1"]["locked_at"] -= 1000
             job = await wait_for_status(store, "r1", "failed")
-            assert run_row.status == RunStatus.error, "the retried persist must land before the terminal write"
+            assert session.runs[0].status == RunStatus.error, "the retried persist must land before the terminal write"
             assert "worker lost" in job["error"].lower()
         finally:
             await worker.stop()
@@ -339,14 +343,14 @@ class TestCrashRecovery:
             await asyncio.sleep(0.2)  # several sweep ticks
             job = await store.get_job("r1")
             assert job["status"] == "running", "component-missing must not terminalize the ticket"
-            assert run_row.status == RunStatus.running
+            assert session.runs[0].status == RunStatus.running
 
             components["agent-1"] = agent  # redeploy restores it
             # The sweeper holds a fresh lock from its failed attempt; the job
             # becomes re-sweepable once that lock goes stale (retry backoff)
             store._jobs["r1"]["locked_at"] -= 1000
             job = await wait_for_status(store, "r1", "failed")
-            assert run_row.status == RunStatus.error
+            assert session.runs[0].status == RunStatus.error
         finally:
             await worker.stop()
 


### PR DESCRIPTION
## Summary

Conversation cost was quadratic: on turn N the session store rebuilt all N-1 prior runs from their dicts — twice. cProfile of a 100-turn conversation showed 94% of run time in session-store round-tripping (`get_session` deep-copied the whole stored session and re-ran `RunOutput.from_dict`/`Message.from_dict` on every run; `upsert_session` deep-copied and re-deserialized the entire stored history just to build a return value the per-turn save path discards). Instrumented counts: 9,901 `RunOutput.from_dict` calls over a 100-turn conversation, ~99 per turn at turn 100.

Four changes, in order:

1. **`InMemoryDb.upsert_session` returns the incoming session's runs** — the SQL adapters' contract (verified by executed probe against SqliteDb: fresh session row, caller's own runs attached by reference, stored history untouched). The in-memory adapter alone rebuilt and deep-copied the whole stored history for a return value; a full caller audit found only two consumers of the deserialized return (both REST routes passing `deserialize=True` explicitly, both unaffected).
2. **Bounded reads slice before copying** — `runs_limit` reads deep-copied the full history first, then sliced.
3. **`InMemoryDb` serves agent-session history runs from a run-object cache.** Objects are built once per stored run dict and shared by every read; the invalidation token is the stored dict's identity — `upsert_run` replaces the dict on every write (and now keeps its own copy of incoming dicts, so a caller-held dict can never rewrite stored state in place). The session row is rebuilt fresh per read; the stored dicts stay canonical; nothing ever serializes the shared objects back.
4. **The same cache for SQLite and Postgres (sync + async), keyed for SQL**: run rows are fetched as raw text (cast to `Text`, keeping the JSON column's result processor out of the way) and the token is `(hash(text), len(text))` per `run_id` — **a write from this or any other process changes the text and misses the cache**, so cross-process correctness holds by construction. Only fully-migrated agent sessions on the full-history `deserialize=True` path use it; windowed reads, legacy-blob sessions, and team/workflow sessions keep the rebuild path unchanged.

### The isolation contract, and how it is preserved without the per-turn deepcopy

Shared history run objects are **immutable by contract**. That contract is enforced, not assumed:

- A full map of every session consumer/mutator (built for this change) found exactly two agent-path sites that mutate a historical run in place. Both now copy first: `_mark_run_regenerated`/`_amark_run_regenerated` flip status on a shallow copy and replace the session's list entry; continue-by-`run_id` deep-copies the run it resumes at extraction (all three sites — sync, async, async-stream). Fork already deep-copied; the model-bound history path already copies per message (`copy_history_message`, #9700).
- Team and workflow sessions are deliberately excluded from the cache: their save paths scrub member responses / media on loaded runs, and hardening those is its own piece of work. They keep today's fresh-copies behavior bit for bit.
- The stored dicts/rows remain canonical: caller mutation of returned objects can never reach them (pinned by named tests), and `deserialize=False` reads are unchanged (full deep copies).

### Numbers (mock model; InMemoryDb unless stated; medians)

| | before | after |
|---|---|---|
| conversation, per-turn at turn 5 / 100 | 246 µs / 4,832 µs (**19.3x growth**) | 180 µs / 208 µs (**1.2x growth**) |
| conversation, 100-turn total | 265 ms | 20.5 ms (**12.9x**) |
| conversation, 100-turn total (async) | ~equal to sync | 20.8 ms |
| `RunOutput.from_dict` calls per turn | ~N (99 at turn 100) | **1** |
| durable (SQLite), 50-turn total | 98.3 ms | 72.8 ms |
| durable (SQLite), per-turn read at turn 50 | 1,293 µs and growing | 263-344 µs, flat |
| single turn (fresh session, with db) | 174.7 µs | 152.3 µs |
| agent construction | 7.5 µs | 7.2 µs |

The durable row's remaining floor is the per-turn write pair (`upsert_run` + session row update, ~0.9 ms, fsync-bound); its read side no longer grows with history. Conversation and durable shared the same root cause, so both land in this one PR.

### Correctness verification

- **History equality**: stored dicts and `get_messages()` output are byte-identical to unmodified `main` after 5/25/100-turn conversations (differential harness; only the auto-generated per-process agent name differs). Also pinned in-suite: cached objects vs a fresh rebuild of the stored dicts.
- **New suite** `libs/agno/tests/unit/db/test_run_object_cache.py` (22 tests): shared-object reads, per-run invalidation on update/append/delete/recreate, caller-held-dict isolation, store isolation under caller vandalism, **two concurrent `arun()` calls on one session** (and on separate sessions), history equality, the hardened regenerate and continue mutators, and the SQLite twin including **a second adapter instance on the same file standing in for another process**.
- **Mutation-tested**: 6 hand mutations (drop each invalidation token, share the caller's dict, return the cached list itself, revert each mutator hardening) — 6/6 killed by named tests.
- **Adversarial review**: a 17-agent workflow (4 lenses — missed mutators, staleness/invalidation, behavior parity, concurrency/memory — every non-low finding independently verified by executed probes; 13/13 confirmed) ran against the initial cache commits and earned its keep. It found the immutability contract was enforced at only two mutator sites while the boundaries feeding everything else still handed out shared objects: background continue and the job-queue sweeper flip status on `session.get_run` results, AG-UI/Slack resume writes HITL answers into requirement objects from a session read, and `continue_run(run_response=...)` truncates the caller's object — each probe showed never-persisted state published to every reader of the session (sticky when the follow-up persist fails). It also caught a threaded-read crash in the InMemoryDb cache sweep and that the SQL adapters never dropped a deleted session's cached objects. All of it is fixed in the final commit: `AgentSession.get_run` and the last-run getters return the caller's own copy (covering background continue, the terminal handlers, the sweeper, and Slack in one move), AG-UI's paused-run finder copies, the `run_response` branch copies like the `run_id` branch, reads publish a fresh entry map instead of sweeping a shared one, and `drop_session` is wired into both delete paths of all four adapters. One reviewer re-ran its corruption probes against the fixed tree and reported every leg negative.
- Full unit suite differential vs unmodified `main` in the same venv: identical pre-existing failure lists, plus the new tests. Three regenerate tests were updated to assert the durable outcome (the session entry's status and the store) instead of write-through mutation of a caller-held object — that write-through is exactly what the isolation hardening removes.
- `./scripts/format.sh` and `./scripts/validate.sh` pass (mypy clean).

## Type of change

- [x] Improvement

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Contract change, deliberate and argued:** history run objects returned by `get_session` (and the sessions built from them during a run) are now shared between reads instead of freshly rebuilt. Library code honors immutability (hardened as above). User code that mutates a returned session's *historical* runs in place was silently tolerated before and is unsupported now — such a mutation never reaches the stored dicts/rows (still pinned by tests), but it can be visible to later reads in the same process. The stored state remains the source of truth in every case.

**Follow-ups (out of scope here):** team/workflow session reads keep the rebuild path until their save-time scrub paths are hardened to copy-first; session-row JSON fields are double-encoded in every SQL adapter (dumps into a JSON column that dumps again — a storage-format fix needing read-compat migration); SQLite's `upsert_session(deserialize=False)` branch re-serializes all runs (only REST-ish callers hit it); the non-SQL remote adapters (mongo, redis, dynamo, …) keep the rebuild path and stay correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
