### PR TITLE
feat: export QueueConfig from agno.os

### DIFF
--- a/cookbook/02_agents/14_advanced/background_streaming_resume.py
+++ b/cookbook/02_agents/14_advanced/background_streaming_resume.py
@@ -16,8 +16,7 @@ The event stream is pluggable (same pattern as run cancellation management).
 The default is in-memory (single process). For multi-container deployments,
 configure Redis Streams so clients can resume from ANY replica:
 
-    from agno.os import AgentOS
-    from agno.job_queue.config import QueueConfig
+    from agno.os import AgentOS, QueueConfig
 
     agent_os = AgentOS(
         agents=[agent],

--- a/cookbook/05_agent_os/background_tasks/durable_continue.py
+++ b/cookbook/05_agent_os/background_tasks/durable_continue.py
@@ -39,9 +39,8 @@ Requirements:
 
 from agno.agent import Agent
 from agno.db.postgres import PostgresDb
-from agno.job_queue.config import QueueConfig
 from agno.models.openai import OpenAIResponses
-from agno.os import AgentOS
+from agno.os import AgentOS, QueueConfig
 from agno.tools import tool
 
 

--- a/cookbook/05_agent_os/background_tasks/durable_queue.py
+++ b/cookbook/05_agent_os/background_tasks/durable_queue.py
@@ -62,9 +62,8 @@ Requirements:
 
 from agno.agent import Agent
 from agno.db.postgres import PostgresDb
-from agno.job_queue.config import QueueConfig
 from agno.models.openai import OpenAIResponses
-from agno.os import AgentOS
+from agno.os import AgentOS, QueueConfig
 
 db = PostgresDb(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai")
 

--- a/cookbook/05_agent_os/background_tasks/redis_event_stream.py
+++ b/cookbook/05_agent_os/background_tasks/redis_event_stream.py
@@ -25,9 +25,8 @@ Requirements:
 
 from agno.agent import Agent
 from agno.db.redis import RedisDb
-from agno.job_queue.config import QueueConfig
 from agno.models.openai import OpenAIResponses
-from agno.os import AgentOS
+from agno.os import AgentOS, QueueConfig
 
 REDIS_URL = "redis://localhost:6379"
 

--- a/libs/agno/agno/os/__init__.py
+++ b/libs/agno/agno/os/__init__.py
@@ -1,12 +1,13 @@
 from typing import TYPE_CHECKING, Any
 
+from agno.job_queue import QueueConfig, RedisCoordination
 from agno.os.app import AgentOS
 from agno.os.config import MCP_BUILTIN_TAGS, MCPBuiltinTag, MCPServerConfig
 
 if TYPE_CHECKING:
     from agno.os.mcp_auth_builtin import AgentOSBuiltinAuth
 
-__all__ = ["AgentOS", "MCPServerConfig", "MCPBuiltinTag", "MCP_BUILTIN_TAGS"]
+__all__ = ["AgentOS", "MCPServerConfig", "MCPBuiltinTag", "MCP_BUILTIN_TAGS", "QueueConfig", "RedisCoordination"]
 
 
 def __getattr__(name: str) -> Any:


### PR DESCRIPTION
## Summary

- Re-export `QueueConfig` and `RedisCoordination` from `agno.os`, so the AgentOS `queue=` argument can be imported alongside `AgentOS` (matching how `MCPServerConfig` is already exposed):
  ```python
  from agno.os import AgentOS, QueueConfig
  ```
- Update the four cookbooks that used `from agno.job_queue.config import QueueConfig` to the shorter import.
- No new dependency or import cycle: `agno.job_queue.config` only imports `dataclasses`/`typing`, and `agno.os.app` already imported it. The old import path continues to work.

## Type of change

- [x] New feature (small, non-breaking API convenience)
- [x] Cookbook update

## Checklist

- [x] `./scripts/format.sh` passes
- [x] `./scripts/validate.sh`: ruff passes; the only mypy failure is pre-existing on `main` (`utils/models/_genai_compat.py`) and unrelated to this change
- [x] `pytest libs/agno/tests/unit/os/test_queue_wiring.py` (26 passed)
- [x] Updated cookbooks compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)