### PR TITLE
fix: skip empty stream tool call deltas

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -1973,7 +1973,7 @@ class Model(ABC):
                     stream_data.response_provider_data[key] = value
 
         # Update stream_data tool calls
-        if model_response_delta.tool_calls is not None:
+        if model_response_delta.tool_calls:
             if stream_data.response_tool_calls is None:
                 stream_data.response_tool_calls = []
             stream_data.response_tool_calls.extend(model_response_delta.tool_calls)

--- a/libs/agno/tests/unit/models/test_stream_data.py
+++ b/libs/agno/tests/unit/models/test_stream_data.py
@@ -1,0 +1,49 @@
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+
+from agno.models.base import MessageData, Model
+from agno.models.response import ModelResponse
+
+
+class _DummyModel(Model):
+    def invoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return ModelResponse()
+
+    async def ainvoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return ModelResponse()
+
+    def invoke_stream(self, *args: Any, **kwargs: Any) -> Iterator[ModelResponse]:
+        return iter(())
+
+    async def ainvoke_stream(self, *args: Any, **kwargs: Any) -> AsyncIterator[ModelResponse]:
+        if False:
+            yield ModelResponse()
+
+    def _parse_provider_response(self, response: Any, **kwargs: Any) -> ModelResponse:
+        return ModelResponse()
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return ModelResponse()
+
+
+def test_empty_tool_call_delta_is_not_yielded() -> None:
+    model = _DummyModel(id="test")
+    stream_data = MessageData()
+    delta = ModelResponse(tool_calls=[])
+
+    yielded = list(model._populate_stream_data(stream_data, delta))
+
+    assert yielded == []
+    assert stream_data.response_tool_calls == []
+
+
+def test_non_empty_tool_call_delta_is_yielded() -> None:
+    model = _DummyModel(id="test")
+    stream_data = MessageData()
+    tool_call = {"id": "call_1", "type": "function", "function": {"name": "search", "arguments": "{}"}}
+    delta = ModelResponse(tool_calls=[tool_call])
+
+    yielded = list(model._populate_stream_data(stream_data, delta))
+
+    assert yielded == [delta]
+    assert stream_data.response_tool_calls == [tool_call]


### PR DESCRIPTION
## Summary

Fixes #9490.

`_populate_stream_data()` treated `tool_calls=[]` as a stream delta worth yielding because the guard only checked for `is not None`. `ModelResponse.tool_calls` defaults to an empty list, so empty provider metadata chunks could get surfaced as zero-payload stream events.

This changes the guard to only accumulate and yield when `tool_calls` is non-empty, while preserving the existing behavior for real tool call deltas.

## Verification

Ran from `libs/agno`:

- `python3 -m pytest tests/unit/models/test_stream_data.py -q`
- `python3 -m pytest tests/unit/models/test_stream_data.py tests/unit/models/test_response.py -q`
- `python3 -m ruff check agno/models/base.py tests/unit/models/test_stream_data.py`
- `python3 -m ruff format --check agno/models/base.py tests/unit/models/test_stream_data.py`
- `git diff --check`

## Risk

Scoped to stream aggregation for empty `tool_calls` deltas. Non-empty tool call deltas, text content, reasoning content, citations, media, and provider data paths are unchanged.