### PR TITLE
[feat] Add Serply search toolkit

### DIFF
--- a/cookbook/91_tools/serply_tools.py
+++ b/cookbook/91_tools/serply_tools.py
@@ -1,0 +1,62 @@
+"""
+Serply Tools
+=============================
+
+Demonstrates Serply tools for Google web, Google News, and Google Scholar search.
+
+Requires: SERPLY_API_KEY environment variable.
+Get your key at https://serply.io
+"""
+
+from agno.agent import Agent
+from agno.tools.serply import SerplyTools
+
+# ---------------------------------------------------------------------------
+# Create Agents
+# ---------------------------------------------------------------------------
+
+# Example 1: Google web search (default)
+agent = Agent(
+    tools=[SerplyTools()],
+    description="You are a web search agent that finds accurate, up-to-date information.",
+    instructions=[
+        "Use Serply to find the most relevant results for the user's query.",
+        "Summarize the top results clearly and cite the links.",
+    ],
+)
+
+# Example 2: News search
+news_agent = Agent(
+    tools=[SerplyTools(enable_search_web=False, enable_search_news=True)],
+    description="You are a news agent that finds the latest news on any topic.",
+    instructions=[
+        "Search Google News for recent articles on the given topic.",
+        "Present the top headlines with their sources and publish dates.",
+    ],
+)
+
+# Example 3: Scholar search
+scholar_agent = Agent(
+    tools=[SerplyTools(enable_search_web=False, enable_search_scholar=True)],
+    description="You are a research assistant that finds academic papers.",
+    instructions=[
+        "Search Google Scholar for papers that match the user's request.",
+        "For each paper include the authors, citation count, and a link to the PDF when available.",
+    ],
+)
+
+# ---------------------------------------------------------------------------
+# Run Agents
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    agent.print_response(
+        "What are the latest developments in AI agents?",
+        markdown=True,
+        stream=True,
+    )
+
+    scholar_agent.print_response(
+        "Find 3 recent papers on retrieval augmented generation.",
+        markdown=True,
+        stream=True,
+    )

--- a/cookbook/91_tools/serply_tools.py
+++ b/cookbook/91_tools/serply_tools.py
@@ -27,7 +27,7 @@ agent = Agent(
 
 # Example 2: News search
 news_agent = Agent(
-    tools=[SerplyTools(enable_search_web=False, enable_search_news=True)],
+    tools=[SerplyTools(search_web=False, search_news=True)],
     description="You are a news agent that finds the latest news on any topic.",
     instructions=[
         "Search Google News for recent articles on the given topic.",
@@ -37,7 +37,7 @@ news_agent = Agent(
 
 # Example 3: Scholar search
 scholar_agent = Agent(
-    tools=[SerplyTools(enable_search_web=False, enable_search_scholar=True)],
+    tools=[SerplyTools(search_web=False, search_scholar=True)],
     description="You are a research assistant that finds academic papers.",
     instructions=[
         "Search Google Scholar for papers that match the user's request.",

--- a/libs/agno/agno/tools/serply.py
+++ b/libs/agno/agno/tools/serply.py
@@ -1,0 +1,209 @@
+import json
+from os import getenv
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from agno.tools import Toolkit
+from agno.utils.log import log_debug, log_error, log_warning
+
+
+class SerplyTools(Toolkit):
+    """
+    SerplyTools is a toolkit for searching the web using the Serply API.
+
+    Serply provides Google web, Google News, and Google Scholar results as JSON.
+    Get an API key at https://serply.io and see https://serply.io/docs for the API.
+
+    Args:
+        api_key (Optional[str]): Serply API key. If not provided, uses SERPLY_API_KEY env var.
+        num_results (int): Default number of results to return. Default is 10.
+        timeout (int): Request timeout in seconds. Default is 30.
+        enable_search_web (bool): Enable Google web search. Default is True.
+        enable_search_news (bool): Enable Google News search. Default is False.
+        enable_search_scholar (bool): Enable Google Scholar search. Default is False.
+        all (bool): If True, enable every search tool regardless of the individual flags.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        num_results: int = 10,
+        timeout: int = 30,
+        enable_search_web: bool = True,
+        enable_search_news: bool = False,
+        enable_search_scholar: bool = False,
+        all: bool = False,
+        **kwargs,
+    ):
+        self.api_key = api_key or getenv("SERPLY_API_KEY")
+        if not self.api_key:
+            log_warning("No Serply API key provided. Set the SERPLY_API_KEY environment variable.")
+
+        self.num_results = num_results
+        self.timeout = timeout
+        self.base_url = "https://api.serply.io/v1"
+
+        tools: List[Any] = []
+        if all or enable_search_web:
+            tools.append(self.search_web)
+        if all or enable_search_news:
+            tools.append(self.search_news)
+        if all or enable_search_scholar:
+            tools.append(self.search_scholar)
+
+        super().__init__(name="serply_tools", tools=tools, **kwargs)
+
+    def _make_request(self, endpoint: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Makes a GET request to the Serply API.
+
+        Args:
+            endpoint (str): The API endpoint, e.g. "search", "news" or "scholar".
+            params (Dict[str, Any]): Query parameters.
+
+        Returns:
+            Dict[str, Any]: The parsed JSON response or an error dict.
+        """
+        try:
+            if not self.api_key:
+                return {"error": "No Serply API key provided. Set the SERPLY_API_KEY environment variable."}
+
+            headers = {
+                "X-Api-Key": self.api_key,
+                "Accept": "application/json",
+                "User-Agent": "agno",
+            }
+
+            log_debug(f"Requesting Serply endpoint={endpoint} q={params.get('q')}")
+            response = requests.get(
+                f"{self.base_url}/{endpoint}/", headers=headers, params=params, timeout=self.timeout
+            )
+            response.raise_for_status()
+
+            return response.json()  # type: ignore[no-any-return]
+        except requests.exceptions.HTTPError as e:
+            log_error(f"Serply HTTP error: {e}")
+            return {"error": f"HTTP error: {e}"}
+        except requests.exceptions.RequestException as e:
+            log_error(f"Serply request error: {e}")
+            return {"error": str(e)}
+        except ValueError as e:
+            log_error(f"Serply JSON decode error: {e}")
+            return {"error": f"Invalid JSON response: {e}"}
+
+    def _params(self, query: str, num_results: Optional[int]) -> Dict[str, Any]:
+        return {
+            "q": query,
+            "num": num_results if num_results is not None else self.num_results,
+        }
+
+    def search_web(self, query: str, num_results: Optional[int] = None) -> str:
+        """
+        Search Google for the given query using Serply.
+
+        Args:
+            query (str): The search query.
+            num_results (Optional[int]): Number of results to return. Defaults to instance setting.
+
+        Returns:
+            str: JSON string containing organic results and related searches.
+        """
+        if not query:
+            return json.dumps({"error": "Please provide a query to search for"})
+
+        log_debug(f"Searching Google for: {query}")
+
+        data = self._make_request("search", self._params(query, num_results))
+
+        if "error" in data:
+            return json.dumps({"error": data["error"]})
+
+        result = {
+            "results": [
+                {
+                    "position": r.get("position"),
+                    "title": r.get("title"),
+                    "link": r.get("link"),
+                    "description": r.get("description"),
+                }
+                for r in data.get("results", [])
+            ],
+            "related_searches": data.get("related_searches", []),
+        }
+
+        return json.dumps(result, indent=2)
+
+    def search_news(self, query: str, num_results: Optional[int] = None) -> str:
+        """
+        Search Google News for the given query using Serply.
+
+        Args:
+            query (str): The search query.
+            num_results (Optional[int]): Number of results to return. Defaults to instance setting.
+
+        Returns:
+            str: JSON string containing news articles with title, link, source and publish date.
+        """
+        if not query:
+            return json.dumps({"error": "Please provide a query to search for"})
+
+        log_debug(f"Searching Google News for: {query}")
+
+        params = self._params(query, num_results)
+        data = self._make_request("news", params)
+
+        if "error" in data:
+            return json.dumps({"error": data["error"]})
+
+        # The news endpoint returns the full feed regardless of num, so trim here.
+        result = {
+            "news_results": [
+                {
+                    "title": e.get("title"),
+                    "link": e.get("link"),
+                    "source": (e.get("source") or {}).get("title"),
+                    "published": e.get("published"),
+                }
+                for e in data.get("entries", [])[: params["num"]]
+            ]
+        }
+
+        return json.dumps(result, indent=2)
+
+    def search_scholar(self, query: str, num_results: Optional[int] = None) -> str:
+        """
+        Search Google Scholar for academic papers using Serply.
+
+        Args:
+            query (str): The search query.
+            num_results (Optional[int]): Number of results to return. Defaults to instance setting.
+
+        Returns:
+            str: JSON string containing papers with title, link, authors, citation count and PDF link.
+        """
+        if not query:
+            return json.dumps({"error": "Please provide a query to search for"})
+
+        log_debug(f"Searching Google Scholar for: {query}")
+
+        data = self._make_request("scholar", self._params(query, num_results))
+
+        if "error" in data:
+            return json.dumps({"error": data["error"]})
+
+        result = {
+            "scholar_results": [
+                {
+                    "title": a.get("title"),
+                    "link": a.get("link"),
+                    "description": a.get("description"),
+                    "authors": (a.get("author") or {}).get("names"),
+                    "citations": ((a.get("extras") or {}).get("citations") or {}).get("count"),
+                    "pdf": (a.get("doc") or {}).get("link"),
+                }
+                for a in data.get("articles", [])
+            ]
+        }
+
+        return json.dumps(result, indent=2)

--- a/libs/agno/agno/tools/serply.py
+++ b/libs/agno/agno/tools/serply.py
@@ -19,9 +19,9 @@ class SerplyTools(Toolkit):
         api_key (Optional[str]): Serply API key. If not provided, uses SERPLY_API_KEY env var.
         num_results (int): Default number of results to return. Default is 10.
         timeout (int): Request timeout in seconds. Default is 30.
-        enable_search_web (bool): Enable Google web search. Default is True.
-        enable_search_news (bool): Enable Google News search. Default is False.
-        enable_search_scholar (bool): Enable Google Scholar search. Default is False.
+        search_web (bool): Enable Google web search. Default is True.
+        search_news (bool): Enable Google News search. Default is False.
+        search_scholar (bool): Enable Google Scholar search. Default is False.
         all (bool): If True, enable every search tool regardless of the individual flags.
     """
 
@@ -30,9 +30,9 @@ class SerplyTools(Toolkit):
         api_key: Optional[str] = None,
         num_results: int = 10,
         timeout: int = 30,
-        enable_search_web: bool = True,
-        enable_search_news: bool = False,
-        enable_search_scholar: bool = False,
+        search_web: bool = True,
+        search_news: bool = False,
+        search_scholar: bool = False,
         all: bool = False,
         **kwargs,
     ):
@@ -45,11 +45,11 @@ class SerplyTools(Toolkit):
         self.base_url = "https://api.serply.io/v1"
 
         tools: List[Any] = []
-        if all or enable_search_web:
+        if all or search_web:
             tools.append(self.search_web)
-        if all or enable_search_news:
+        if all or search_news:
             tools.append(self.search_news)
-        if all or enable_search_scholar:
+        if all or search_scholar:
             tools.append(self.search_scholar)
 
         super().__init__(name="serply_tools", tools=tools, **kwargs)

--- a/libs/agno/tests/unit/tools/test_serply.py
+++ b/libs/agno/tests/unit/tools/test_serply.py
@@ -1,0 +1,295 @@
+import json
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+from agno.tools.serply import SerplyTools
+
+
+@pytest.fixture(autouse=True)
+def clear_env(monkeypatch):
+    """Ensure SERPLY_API_KEY is unset unless explicitly needed."""
+    monkeypatch.delenv("SERPLY_API_KEY", raising=False)
+
+
+@pytest.fixture
+def api_tools():
+    """SerplyTools with a known API key for testing."""
+    return SerplyTools(api_key="test_key", num_results=5)
+
+
+def _mock_response(payload):
+    mock = Mock(spec=requests.Response)
+    mock.json.return_value = payload
+    mock.raise_for_status.return_value = None
+    return mock
+
+
+@pytest.fixture
+def mock_search_response():
+    return _mock_response(
+        {
+            "results": [
+                {
+                    "title": "Result 1",
+                    "link": "http://example.com",
+                    "description": "Snippet 1",
+                    "position": 1,
+                    "realPosition": 1,
+                    "result_type": "organic",
+                    "metadata": {"display_url": "example.com"},
+                }
+            ],
+            "related_searches": [{"title": "related query"}],
+            "total": 1,
+        }
+    )
+
+
+@pytest.fixture
+def mock_news_response():
+    return _mock_response(
+        {
+            "entries": [
+                {
+                    "title": "Breaking News",
+                    "link": "http://news.example.com",
+                    "source": {"href": "https://example.com", "title": "Example News"},
+                    "published": "Mon, 24 Aug 2026 17:57:33 GMT",
+                    "summary": "<ol><li>html</li></ol>",
+                }
+            ]
+        }
+    )
+
+
+@pytest.fixture
+def mock_scholar_response():
+    return _mock_response(
+        {
+            "articles": [
+                {
+                    "title": "A Paper",
+                    "link": "http://arxiv.org/abs/1234.5678",
+                    "description": "A. Author, B. Author - Journal, 2024",
+                    "author": {"names": "A. Author, B. Author - Journal, 2024", "authors": []},
+                    "extras": {"citations": {"count": 42, "link": "http://cites.example.com"}},
+                    "doc": {"link": "https://arxiv.org/pdf/1234.5678", "type": "PDF"},
+                }
+            ]
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Initialization
+# ---------------------------------------------------------------------------
+
+
+def test_init_without_api_key(monkeypatch):
+    monkeypatch.delenv("SERPLY_API_KEY", raising=False)
+    tools = SerplyTools()
+    assert tools.api_key is None
+
+
+def test_init_with_env_var(monkeypatch):
+    monkeypatch.setenv("SERPLY_API_KEY", "env_key")
+    tools = SerplyTools()
+    assert tools.api_key == "env_key"
+
+
+def test_init_constructor_key_overrides_env(monkeypatch):
+    monkeypatch.setenv("SERPLY_API_KEY", "env_key")
+    tools = SerplyTools(api_key="direct_key")
+    assert tools.api_key == "direct_key"
+
+
+def test_init_default_params():
+    tools = SerplyTools(api_key="k")
+    assert tools.num_results == 10
+    assert tools.timeout == 30
+
+
+def test_init_only_web_enabled_by_default():
+    tools = SerplyTools(api_key="k")
+    names = [f.name for f in tools.functions.values()]
+    assert names == ["search_web"]
+
+
+def test_init_all_enabled():
+    tools = SerplyTools(api_key="k", all=True)
+    names = [f.name for f in tools.functions.values()]
+    assert names == ["search_web", "search_news", "search_scholar"]
+
+
+def test_init_select_tools():
+    tools = SerplyTools(api_key="k", enable_search_web=False, enable_search_scholar=True)
+    names = [f.name for f in tools.functions.values()]
+    assert names == ["search_scholar"]
+
+
+# ---------------------------------------------------------------------------
+# _make_request
+# ---------------------------------------------------------------------------
+
+
+def test_make_request_no_api_key():
+    tools = SerplyTools()
+    result = tools._make_request("search", {"q": "x"})
+    assert "error" in result
+
+
+def test_make_request_sends_key_header_and_timeout(api_tools, mock_search_response):
+    with patch("requests.get", return_value=mock_search_response) as mock_get:
+        api_tools._make_request("search", {"q": "x", "num": 5})
+    args, kwargs = mock_get.call_args
+    assert args[0] == "https://api.serply.io/v1/search/"
+    assert kwargs["headers"]["X-Api-Key"] == "test_key"
+    assert kwargs["params"] == {"q": "x", "num": 5}
+    assert kwargs["timeout"] == 30
+
+
+def test_make_request_http_error(api_tools):
+    mock_resp = Mock(spec=requests.Response)
+    mock_resp.raise_for_status.side_effect = requests.exceptions.HTTPError("401 Unauthorized")
+    with patch("requests.get", return_value=mock_resp):
+        result = api_tools._make_request("search", {"q": "x"})
+    assert "HTTP error" in result["error"]
+
+
+def test_make_request_connection_error(api_tools):
+    with patch("requests.get", side_effect=requests.exceptions.ConnectionError("No route to host")):
+        result = api_tools._make_request("search", {"q": "x"})
+    assert "No route to host" in result["error"]
+
+
+def test_make_request_invalid_json(api_tools):
+    mock_resp = Mock(spec=requests.Response)
+    mock_resp.raise_for_status.return_value = None
+    mock_resp.json.side_effect = ValueError("bad json")
+    with patch("requests.get", return_value=mock_resp):
+        result = api_tools._make_request("search", {"q": "x"})
+    assert "Invalid JSON" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# search_web
+# ---------------------------------------------------------------------------
+
+
+def test_search_web_empty_query(api_tools):
+    result = json.loads(api_tools.search_web(""))
+    assert "error" in result
+
+
+def test_search_web_no_api_key():
+    tools = SerplyTools()
+    result = json.loads(tools.search_web("test"))
+    assert "error" in result
+
+
+def test_search_web_success(api_tools, mock_search_response):
+    with patch("requests.get", return_value=mock_search_response):
+        result = json.loads(api_tools.search_web("test"))
+    assert result["results"] == [
+        {"position": 1, "title": "Result 1", "link": "http://example.com", "description": "Snippet 1"}
+    ]
+    assert result["related_searches"] == [{"title": "related query"}]
+
+
+def test_search_web_uses_instance_num_results(api_tools, mock_search_response):
+    with patch("requests.get", return_value=mock_search_response) as mock_get:
+        api_tools.search_web("test")
+    assert mock_get.call_args.kwargs["params"] == {"q": "test", "num": 5}
+
+
+def test_search_web_custom_num_results(api_tools, mock_search_response):
+    with patch("requests.get", return_value=mock_search_response) as mock_get:
+        api_tools.search_web("test", num_results=3)
+    assert mock_get.call_args.kwargs["params"]["num"] == 3
+
+
+def test_search_web_zero_num_results_is_respected(api_tools, mock_search_response):
+    with patch("requests.get", return_value=mock_search_response) as mock_get:
+        api_tools.search_web("test", num_results=0)
+    assert mock_get.call_args.kwargs["params"]["num"] == 0
+
+
+def test_search_web_error_response(api_tools):
+    with patch("requests.get", side_effect=requests.exceptions.ConnectionError("down")):
+        result = json.loads(api_tools.search_web("test"))
+    assert result == {"error": "down"}
+
+
+# ---------------------------------------------------------------------------
+# search_news
+# ---------------------------------------------------------------------------
+
+
+def test_search_news_empty_query(api_tools):
+    result = json.loads(api_tools.search_news(""))
+    assert "error" in result
+
+
+def test_search_news_success(api_tools, mock_news_response):
+    with patch("requests.get", return_value=mock_news_response) as mock_get:
+        result = json.loads(api_tools.search_news("test"))
+    assert mock_get.call_args.args[0] == "https://api.serply.io/v1/news/"
+    assert result["news_results"] == [
+        {
+            "title": "Breaking News",
+            "link": "http://news.example.com",
+            "source": "Example News",
+            "published": "Mon, 24 Aug 2026 17:57:33 GMT",
+        }
+    ]
+
+
+def test_search_news_trims_to_num_results(api_tools):
+    entries = [{"title": f"t{i}", "link": f"l{i}"} for i in range(20)]
+    with patch("requests.get", return_value=_mock_response({"entries": entries})):
+        result = json.loads(api_tools.search_news("test", num_results=3))
+    assert [r["title"] for r in result["news_results"]] == ["t0", "t1", "t2"]
+
+
+def test_search_news_missing_source(api_tools):
+    with patch("requests.get", return_value=_mock_response({"entries": [{"title": "t", "link": "l"}]})):
+        result = json.loads(api_tools.search_news("test"))
+    assert result["news_results"][0]["source"] is None
+
+
+# ---------------------------------------------------------------------------
+# search_scholar
+# ---------------------------------------------------------------------------
+
+
+def test_search_scholar_empty_query(api_tools):
+    result = json.loads(api_tools.search_scholar(""))
+    assert "error" in result
+
+
+def test_search_scholar_success(api_tools, mock_scholar_response):
+    with patch("requests.get", return_value=mock_scholar_response) as mock_get:
+        result = json.loads(api_tools.search_scholar("test"))
+    assert mock_get.call_args.args[0] == "https://api.serply.io/v1/scholar/"
+    assert result["scholar_results"] == [
+        {
+            "title": "A Paper",
+            "link": "http://arxiv.org/abs/1234.5678",
+            "description": "A. Author, B. Author - Journal, 2024",
+            "authors": "A. Author, B. Author - Journal, 2024",
+            "citations": 42,
+            "pdf": "https://arxiv.org/pdf/1234.5678",
+        }
+    ]
+
+
+def test_search_scholar_missing_optional_fields(api_tools):
+    payload = {"articles": [{"title": "t", "link": "l", "doc": None, "extras": {}}]}
+    with patch("requests.get", return_value=_mock_response(payload)):
+        result = json.loads(api_tools.search_scholar("test"))
+    item = result["scholar_results"][0]
+    assert item["authors"] is None
+    assert item["citations"] is None
+    assert item["pdf"] is None

--- a/libs/agno/tests/unit/tools/test_serply.py
+++ b/libs/agno/tests/unit/tools/test_serply.py
@@ -124,7 +124,7 @@ def test_init_all_enabled():
 
 
 def test_init_select_tools():
-    tools = SerplyTools(api_key="k", enable_search_web=False, enable_search_scholar=True)
+    tools = SerplyTools(api_key="k", search_web=False, search_scholar=True)
     names = [f.name for f in tools.functions.values()]
     assert names == ["search_scholar"]
 


### PR DESCRIPTION
## Summary

Adds `SerplyTools`, a toolkit for Google web, Google News, and Google Scholar search through the Serply API (https://serply.io/docs). It follows the shape of `SerperTools` and `SearchApiTools`: a `_make_request` helper, one method per endpoint, `enable_*` flags plus `all`, and compact JSON results for the agent.

Closes #9779

- `libs/agno/agno/tools/serply.py`: the toolkit. Reads `SERPLY_API_KEY` or takes `api_key`. Uses `requests`, no new dependencies. The News endpoint returns the full feed regardless of `num`, so that method trims client-side.
- `libs/agno/tests/unit/tools/test_serply.py`: 26 unit tests, network mocked.
- `cookbook/91_tools/serply_tools.py`: example agents for web, news, and scholar.

Serply support is optional; behavior is unchanged when `SERPLY_API_KEY` is unset.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

Written with AI assistance (Claude Code). I reviewed every line, ran the format and validate scripts, and tested the three endpoints against the live API with my own key. Details below.

---

## Additional Notes

Testing, from a fresh `./scripts/dev_setup.sh` venv on Python 3.13:

```
$ pytest libs/agno/tests/unit/tools/test_serply.py libs/agno/tests/unit/tools/test_serper.py libs/agno/tests/unit/tools/test_searchapi.py -q
80 passed, 1 warning in 0.21s

$ ./scripts/validate.sh
    agno
    ok ruff check - All checks passed!
    ok mypy - Success: no issues found in 1014 source files
    cookbook
    ok ruff check - All checks passed!
```

Live check with a real key, `SerplyTools(all=True, num_results=3)`:

```
search_web:     results n=3         first="Agno: The Agent Platform That Builds Itself" https://www.agno.com/
search_news:    news_results n=3    first="U.S. Stocks Mixed on Artificial-Intelligence Jitters - WSJ"
search_scholar: scholar_results n=3 first="Retrieval-Augmented Generation for Large Language Models: A Survey" citations=...
bad key:        {"error": "HTTP error: 401 Client Error: Unauthorized for url: ..."}
```

Happy to open a matching page in agno-agi/docs (`tools/toolkits/search/serply.mdx`) once this lands.

Disclosure: I work with Serply. Happy to adjust scope, naming, or drop this entirely if it isn't a direction you want for the project.
