### PR TITLE
fix: address session cache review findings

### DIFF
--- a/.github/workflows/test_on_release.yml
+++ b/.github/workflows/test_on_release.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - "*release*" # Run on release-* format
       - "release/*" # Run on release/1.2.3 branch format
-      - "perf/session-read-path"
+      - "feat/v3.0"
   workflow_dispatch: # Allows manual triggering
     inputs:
       branch:

--- a/libs/agno/agno/agents/base.py
+++ b/libs/agno/agno/agents/base.py
@@ -471,10 +471,8 @@ class BaseExternalAgent:
     @staticmethod
     def _find_run_in_session(session: AgentSession, run_id: str) -> Optional[RunOutput]:
         """Find a persisted run by id within the given session."""
-        for run in session.runs or []:
-            if isinstance(run, RunOutput) and run.run_id == run_id:
-                return run
-        return None
+        run = session.get_run(run_id)
+        return run if isinstance(run, RunOutput) else None
 
     def get_run_output(self, run_id: str, session_id: Optional[str] = None) -> Optional[RunOutput]:
         """Get a persisted RunOutput for this adapter."""

--- a/libs/agno/agno/db/mysql/async_mysql.py
+++ b/libs/agno/agno/db/mysql/async_mysql.py
@@ -25,6 +25,7 @@ from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.schemas.memory import UserMemory
 from agno.db.utils import (
     HISTORY_SKIP_STATUSES,
+    SessionRunObjectCache,
     build_single_run_row,
     deserialize_run,
     deserialize_session,
@@ -140,6 +141,12 @@ class AsyncMySQLDb(AsyncBaseDb):
             bind=self.db_engine,
             expire_on_commit=False,
         )
+
+        # Deserialized history-run objects, keyed per run by the raw row text;
+        # see SessionRunObjectCache for the invalidation and immutability
+        # contract. Per adapter instance, so it can never serve runs across
+        # databases.
+        self._run_object_cache = SessionRunObjectCache()
 
     async def close(self) -> None:
         """Close database connections and dispose of the connection pool.
@@ -528,6 +535,29 @@ class AsyncMySQLDb(AsyncBaseDb):
         return True
 
     # -- Run methods --
+    async def _get_session_run_rows(self, sess, runs_table: Table, session_id: str) -> List[Tuple[str, str]]:
+        """(run_id, raw run_data text) for the whole session, in insertion order.
+
+        The raw text feeds the run-object cache, which parses and rebuilds a
+        run only when its text changed since the last read. The cast keeps the
+        JSON column's result processor out of the way -- the whole point is to
+        not parse unchanged rows.
+        """
+        stmt = (
+            select(runs_table.c.run_id, cast(runs_table.c.run_data, TEXT))
+            .where(runs_table.c.session_id == session_id)
+            .order_by(
+                runs_table.c.run_index.asc(),
+                runs_table.c.created_at.asc(),
+                runs_table.c.run_id.asc(),
+            )
+        )
+        result = await sess.execute(stmt)
+        return [
+            (run_id, run_data if isinstance(run_data, str) else json.dumps(run_data))
+            for run_id, run_data in result.fetchall()
+        ]
+
     async def _get_session_runs_data(
         self, sess, runs_table: Table, session_id: str, limit: Optional[int] = None
     ) -> List[Dict[str, Any]]:
@@ -859,6 +889,8 @@ class AsyncMySQLDb(AsyncBaseDb):
                     await sess.execute(runs_table.delete().where(runs_table.c.session_id == session_id))
 
                 log_debug(f"Successfully deleted session with session_id: {session_id} in table {table.name}")
+                # A deleted session's deserialized history must not stay resident.
+                self._run_object_cache.drop_session(session_id)
                 return True
 
         except Exception as e:
@@ -893,6 +925,9 @@ class AsyncMySQLDb(AsyncBaseDb):
                     if user_id is not None:
                         runs_delete_stmt = runs_delete_stmt.where(runs_table.c.user_id == user_id)
                     await sess.execute(runs_delete_stmt)
+
+            for deleted_id in session_ids:
+                self._run_object_cache.drop_session(deleted_id)
 
             log_debug(f"Successfully deleted {result.rowcount} sessions")  # type: ignore
 
@@ -945,12 +980,25 @@ class AsyncMySQLDb(AsyncBaseDb):
                 # Attach the runs stored in the runs table, merged with any runs still
                 # sitting in the legacy `runs` column (so partially-migrated sessions
                 # don't silently lose history).
+                run_rows: Optional[List[Tuple[str, str]]] = None
                 legacy_runs = session.get("runs")
                 if runs_table is not None and runs_limit is not None and not legacy_runs:
                     # Fully migrated: push "most recent N" down to the DB (indexed).
                     session["runs"] = await self._get_session_runs_data(
                         sess=sess, runs_table=runs_table, session_id=session_id, limit=runs_limit
                     )
+                elif (
+                    runs_table is not None
+                    and not legacy_runs
+                    and deserialize
+                    and session.get("session_type") == SessionType.AGENT.value
+                    and (session_type is None or session_type == SessionType.AGENT)
+                ):
+                    # Fully-migrated agent session on the per-turn path: fetch
+                    # the rows raw and serve run objects from the cache instead
+                    # of rebuilding every run on every read.
+                    run_rows = await self._get_session_run_rows(sess=sess, runs_table=runs_table, session_id=session_id)
+                    session["runs"] = None
                 elif runs_table is not None:
                     # Full load + merge. Also the un-migrated fallback: the legacy blob
                     # holds the whole history in one column, so "last N" can't be pushed
@@ -970,6 +1018,10 @@ class AsyncMySQLDb(AsyncBaseDb):
             if not deserialize:
                 return session
 
+            if run_rows is not None:
+                session_obj = deserialize_session(session_type, session)
+                session_obj.runs = self._run_object_cache.runs_from_rows(session_id, run_rows)  # type: ignore[union-attr]
+                return session_obj
             return deserialize_session(session_type, session)
 
         except Exception as e:

--- a/libs/agno/agno/db/singlestore/singlestore.py
+++ b/libs/agno/agno/db/singlestore/singlestore.py
@@ -24,8 +24,8 @@ from agno.db.singlestore.utils import (
     is_valid_table,
 )
 from agno.db.utils import (
-    SessionRunObjectCache,
     HISTORY_SKIP_STATUSES,
+    SessionRunObjectCache,
     build_single_run_row,
     deserialize_run,
     deserialize_session,

--- a/libs/agno/tests/integration/db/async_mysql/test_session.py
+++ b/libs/agno/tests/integration/db/async_mysql/test_session.py
@@ -29,6 +29,33 @@ async def test_upsert_and_get_agent_session(async_mysql_db_real):
 
 
 @pytest.mark.asyncio
+async def test_agent_session_reuses_unchanged_history_runs(async_mysql_db_real):
+    session_id = "test-agent-session-run-cache"
+    await async_mysql_db_real.upsert_session(
+        AgentSession(session_id=session_id, agent_id="test-agent", user_id="test-user")
+    )
+    await async_mysql_db_real.upsert_run(
+        {
+            "run_id": "test-agent-run-cache",
+            "agent_id": "test-agent",
+            "user_id": "test-user",
+            "content": "cached content",
+            "status": "COMPLETED",
+        },
+        session_id=session_id,
+        user_id="test-user",
+        run_index=0,
+    )
+
+    first = await async_mysql_db_real.get_session(session_id=session_id, session_type=SessionType.AGENT)
+    second = await async_mysql_db_real.get_session(session_id=session_id, session_type=SessionType.AGENT)
+
+    assert first is not None and first.runs
+    assert second is not None and second.runs
+    assert first.runs[0] is second.runs[0]
+
+
+@pytest.mark.asyncio
 async def test_upsert_and_get_team_session(async_mysql_db_real):
     """Test upserting and retrieving a team session"""
     session = TeamSession(

--- a/libs/agno/tests/unit/agents/test_external_agent_persistence.py
+++ b/libs/agno/tests/unit/agents/test_external_agent_persistence.py
@@ -71,6 +71,17 @@ def test_session_read_returns_runs(agent):
     assert agent.get_run_output(out.run_id, session_id="s1") is not None
 
 
+def test_get_run_output_returns_an_isolated_copy(agent):
+    out = asyncio.run(agent._arun_non_stream("hello", session_id="s1", user_id="u1"))
+    fetched = agent.get_run_output(out.run_id, session_id="s1")
+    assert fetched is not None
+
+    fetched.content = "mutated by caller"
+
+    retrieved = agent.db.get_session(session_id="s1", session_type=None)
+    assert retrieved.runs[0].content == "echo: hello"
+
+
 def test_run_indexes_are_sequential(agent):
     for text in ("one", "two", "three"):
         asyncio.run(agent._arun_non_stream(text, session_id="s1", user_id="u1"))


### PR DESCRIPTION
## Summary

Addresses the blocking review findings on #9775:

- restores the release-validation workflow trigger instead of committing the temporary PR branch trigger
- routes external-agent run lookup through `AgentSession.get_run()` so callers receive an isolated copy rather than a shared cached object
- adds run-object cache parity to `AsyncMySQLDb`, including raw-row reads and session-delete invalidation
- adds regression coverage for external-agent isolation and async MySQL cache reuse

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (not applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

This is a focused follow-up targeting #9775's `perf/session-read-path` branch and is intended to be merged into that PR before #9775 lands.

Validation performed:

- `./scripts/format.sh`: passed
- repository-wide Ruff checks: passed
- targeted mypy for the changed implementation files: passed
- cache and external-agent unit tests: 33 passed
- AsyncMySQL raw-row query compiled and executed against a mocked async result

`./scripts/validate.sh` reached mypy but the repository-wide mypy step reported 106 unrelated dependency-version errors in existing Mistral, A2A, Gemini, Anthropic, AWS, and Firestore files. Neither changed implementation file appears in that error set. The new AsyncMySQL integration test requires the repository's MySQL test service and is left for CI.
