### PR TITLE
[cookbook] Add DeepKeep AI Firewall guardrails

### DIFF
--- a/cookbook/02_agents/08_guardrails/README.md
+++ b/cookbook/02_agents/08_guardrails/README.md
@@ -4,6 +4,7 @@ Examples for input/output safety checks and policy enforcement.
 
 ## Files
 - `custom_guardrail.py` - Demonstrates custom guardrail.
+- `deepkeep_ai_firewall.py` - Demonstrates DeepKeep AI Firewall guardrails.
 - `openai_moderation.py` - Demonstrates openai moderation.
 - `output_guardrail.py` - Demonstrates output guardrail.
 - `pii_detection.py` - Demonstrates pii detection.

--- a/cookbook/02_agents/08_guardrails/deepkeep_ai_firewall.py
+++ b/cookbook/02_agents/08_guardrails/deepkeep_ai_firewall.py
@@ -6,10 +6,17 @@ This example shows how to use DeepKeep AI Firewall as custom guardrails for
 Agno Agents. DeepKeep runs before user input reaches the model and after model
 output is generated.
 
+Requirements:
+- pip install agno-deepkeep
+- DEEPKEEP_API_KEY and DEEPKEEP_BASE_URL set
+
 Set credentials before running:
 
     export DEEPKEEP_API_KEY="dk_..."
     export DEEPKEEP_BASE_URL="https://api.example.deepkeep.ai"
+
+Usage:
+    python cookbook/02_agents/08_guardrails/deepkeep_ai_firewall.py
 """
 
 from agno.agent import Agent

--- a/cookbook/02_agents/08_guardrails/deepkeep_ai_firewall.py
+++ b/cookbook/02_agents/08_guardrails/deepkeep_ai_firewall.py
@@ -1,0 +1,39 @@
+"""
+DeepKeep AI Firewall Guardrails
+===============================
+
+This example shows how to use DeepKeep AI Firewall as custom guardrails for
+Agno Agents. DeepKeep runs before user input reaches the model and after model
+output is generated.
+
+Set credentials before running:
+
+    export DEEPKEEP_API_KEY="dk_..."
+    export DEEPKEEP_BASE_URL="https://api.example.deepkeep.ai"
+"""
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno_deepkeep import DeepKeepGuardrail
+
+
+agent = Agent(
+    name="DeepKeep Protected Agent",
+    model=OpenAIResponses(id="gpt-5.2"),
+    instructions="Answer user questions safely and concisely.",
+    pre_hooks=[
+        DeepKeepGuardrail(
+            pre_model="input-firewall-id",
+        )
+    ],
+    post_hooks=[
+        DeepKeepGuardrail(
+            post_model="output-firewall-id",
+        )
+    ],
+    markdown=True,
+)
+
+
+if __name__ == "__main__":
+    agent.print_response("Explain how to store API keys securely.")

--- a/cookbook/02_agents/README.md
+++ b/cookbook/02_agents/README.md
@@ -13,7 +13,7 @@ Practical examples for building agents with Agno, organized by feature area.
 | 05 | [05_state_and_session](./05_state_and_session/) | Session state, chat history, persistence | 12 |
 | 06 | [06_memory_and_learning](./06_memory_and_learning/) | Memory manager, learning machine | 2 |
 | 07 | [07_knowledge](./07_knowledge/) | RAG, custom retrievers, knowledge filters | 8 |
-| 08 | [08_guardrails](./08_guardrails/) | PII detection, prompt injection, custom guardrails | 5 |
+| 08 | [08_guardrails](./08_guardrails/) | PII detection, prompt injection, custom guardrails | 6 |
 | 09 | [09_hooks](./09_hooks/) | Pre/post hooks, tool hooks, stream hooks | 5 |
 | 10 | [10_human_in_the_loop](./10_human_in_the_loop/) | Confirmation flows, user input, external execution | 7 |
 | 11 | [11_approvals](./11_approvals/) | Approval workflows, audit trails | 11 |
@@ -29,7 +29,7 @@ Practical examples for building agents with Agno, organized by feature area.
 | 21 | [21_fork_session](./21_fork_session/) | Fork a whole session into a new one | 1 |
 | 22 | [22_result_offloading](./22_result_offloading/) | Large tool results stored as files, envelopes in the transcript | 2 |
 
-**Total: 124 files across 22 directories**
+**Total: 125 files across 22 directories**
 
 ## Prerequisites
 


### PR DESCRIPTION
Adds a cookbook example showing how to use DeepKeep AI Firewall as Agno custom guardrails.\n\nThe example uses the external agno-deepkeep package and Agno's native pre_hooks and post_hooks guardrail extension points. It does not add vendor-specific API code to Agno core.\n\nResolves #9785.\n\nVerification:\n- python -m py_compile cookbook/02_agents/08_guardrails/deepkeep_ai_firewall.py\n- agno-deepkeep package tests: 13 passed