### PR TITLE
fix: split Gemini tool result media parts

### DIFF
--- a/libs/agno/agno/models/google/gemini.py
+++ b/libs/agno/agno/models/google/gemini.py
@@ -781,7 +781,17 @@ class Gemini(Model):
         formatted_messages: List = []
         system_message = None
 
+        def has_function_response(parts: List[Any]) -> bool:
+            return any(getattr(part, "function_response", None) is not None for part in parts)
+
+        def has_media_part(parts: List[Any]) -> bool:
+            return any(
+                getattr(part, "inline_data", None) is not None or getattr(part, "file_data", None) is not None
+                for part in parts
+            )
+
         for message in messages:
+            message_role = message.role
             role = message.role
             if role in ["system", "developer"]:
                 system_message = message.content
@@ -835,6 +845,14 @@ class Gemini(Model):
                     message_parts = [part]
 
             if role == "user" and message.tool_calls is None:
+                if (
+                    message_role == "tool"
+                    and message_parts
+                    and (message.images or message.videos or message.audio or message.files)
+                ):
+                    formatted_messages.append(Content(role=role, parts=message_parts))
+                    message_parts = []
+
                 # Add images to the message for the model
                 if message.images is not None:
                     for image in message.images:
@@ -911,7 +929,11 @@ class Gemini(Model):
         # Merge consecutive messages with the same role (Gemini API rejects consecutive same-role messages)
         merged: List[Content] = []
         for msg in formatted_messages:
-            if merged and merged[-1].role == msg.role:
+            if (
+                merged
+                and merged[-1].role == msg.role
+                and not (has_function_response(merged[-1].parts) and has_media_part(msg.parts))
+            ):
                 merged[-1].parts.extend(msg.parts)
             else:
                 merged.append(msg)

--- a/libs/agno/tests/unit/models/google/test_gemini.py
+++ b/libs/agno/tests/unit/models/google/test_gemini.py
@@ -8,7 +8,7 @@ import pytest
 pytest.importorskip("google.genai")
 
 from agno.exceptions import ModelProviderError
-from agno.media import File
+from agno.media import File, Image
 from agno.models.google.gemini import Gemini
 from agno.models.message import Message
 
@@ -269,6 +269,37 @@ class TestFormatMessagesEmptyParts:
         assert len(formatted) == 3
         roles = [msg.role for msg in formatted]
         assert roles == ["user", "model", "user"]
+
+    def test_tool_result_media_is_split_from_function_response(self):
+        model = self._make_model()
+        messages = [
+            Message(
+                role="tool",
+                content="Document prepared",
+                tool_call_id="call_1",
+                tool_name="read_document_file",
+                files=[File(content=b"%PDF-1.4", mime_type="application/pdf")],
+            )
+        ]
+
+        formatted, _ = model._format_messages(messages)
+
+        assert len(formatted) == 2
+        assert formatted[0].role == "user"
+        assert len(formatted[0].parts) == 1
+        assert formatted[0].parts[0].function_response is not None
+        assert formatted[1].role == "user"
+        assert len(formatted[1].parts) == 1
+        assert formatted[1].parts[0].inline_data is not None
+
+    def test_regular_user_media_stays_in_one_message(self):
+        model = self._make_model()
+        messages = [Message(role="user", content="Describe this", images=[Image(content=b"img")])]
+
+        formatted, _ = model._format_messages(messages)
+
+        assert len(formatted) == 1
+        assert len(formatted[0].parts) == 2
 
 
 class TestGeminiTimeout:


### PR DESCRIPTION
## Summary

Fixes #9630.

Gemini message formatting currently maps tool result messages to `role="user"`, adds the `function_response` part, and then appends any media attached to the same tool message. That can produce one Gemini content item containing both `function_response` and `inline_data`/file data, which Gemini 3.7 rejects for tool results with returned files or images.

This keeps normal user multimodal messages unchanged, but when a canonical tool result message also carries media, it emits the tool `function_response` as one content item and the media as the following user content item. The consecutive-role merge step now preserves that split instead of merging the media back into the function response.

## Verification

Ran from `libs/agno`:

- `python3 -m pytest tests/unit/models/google/test_gemini.py::TestFormatMessagesEmptyParts::test_tool_result_media_is_split_from_function_response tests/unit/models/google/test_gemini.py::TestFormatMessagesEmptyParts::test_regular_user_media_stays_in_one_message tests/unit/models/google/test_gemini.py::TestFormatMessagesEmptyParts::test_mixed_valid_and_empty_messages -q`
- `python3 -m ruff check agno/models/google/gemini.py tests/unit/models/google/test_gemini.py`
- `python3 -m ruff format --check agno/models/google/gemini.py tests/unit/models/google/test_gemini.py`
- `git diff --check`

I also ran `python3 -m pytest tests/unit/models/google/test_gemini.py -q`; the new tests passed, but the full file has 6 existing `parallel_search` failures in this local environment because the installed `google-genai` does not expose `ToolParallelAiSearch`.

## Risk

Scoped to Gemini message formatting when a tool result message includes media. Plain tool results, ordinary user multimodal messages, assistant tool calls, and non-media consecutive-role merges are unchanged.