### PR TITLE
fix: make ScheduleManager cleanup tolerate partial copies

### DIFF
--- a/libs/agno/agno/scheduler/manager.py
+++ b/libs/agno/agno/scheduler/manager.py
@@ -42,8 +42,9 @@ class ScheduleManager:
 
     def close(self) -> None:
         """Shut down the internal thread pool (if created)."""
-        if self._pool is not None:
-            self._pool.shutdown(wait=False)
+        pool = getattr(self, "_pool", None)
+        if pool is not None:
+            pool.shutdown(wait=False)
             self._pool = None
 
     def __del__(self) -> None:

--- a/libs/agno/tests/unit/scheduler/test_manager.py
+++ b/libs/agno/tests/unit/scheduler/test_manager.py
@@ -59,6 +59,13 @@ def mgr(mock_db):
     return ScheduleManager(mock_db)
 
 
+def test_close_handles_partially_constructed_manager():
+    manager = ScheduleManager.__new__(ScheduleManager)
+
+    manager.close()
+    manager.__del__()
+
+
 # =============================================================================
 # Sync API Tests
 # =============================================================================


### PR DESCRIPTION
Fixes #9614

## Summary

`ScheduleManager.close()` assumed `_pool` always exists. During failed `deepcopy()` of a manager that owns a database engine, Python can allocate a new `ScheduleManager` object with `__new__` and then abort before its instance dictionary is populated. When that half-built object is garbage-collected, `__del__()` calls `close()`, which raised `AttributeError` while trying to read `_pool`.

This makes `close()` tolerate that partial-construction state by reading `_pool` with `getattr(..., None)`. Fully initialized managers still shut down the existing pool and clear it exactly as before.

## Verification

Ran from the repository root:

- `python3 -m pytest libs/agno/tests/unit/scheduler/test_manager.py::test_close_handles_partially_constructed_manager -q`
- `python3 -m pytest libs/agno/tests/unit/scheduler/test_manager.py -q`
- `python3 -m ruff check libs/agno/agno/scheduler/manager.py libs/agno/tests/unit/scheduler/test_manager.py`
- `python3 -m ruff format --check libs/agno/agno/scheduler/manager.py libs/agno/tests/unit/scheduler/test_manager.py`
- `git diff --check`

I also ran a direct `ScheduleManager.__new__(ScheduleManager).__del__()` probe under `gc.collect()` to cover the issue path without requiring a live Postgres engine.

## Risk

Scoped to `ScheduleManager.close()` / `__del__()` cleanup. Normal initialized managers keep the same behavior; only missing `_pool` is treated like no pool was created.