### PR TITLE
feat: add Synthorai model provider

### DIFF
--- a/cookbook/90_models/synthorai/README.md
+++ b/cookbook/90_models/synthorai/README.md
@@ -1,0 +1,9 @@
+# Synthorai
+
+Cookbook examples for `cookbook/90_models/synthorai`.
+
+Run examples with:
+
+```bash
+.venvs/demo/bin/python cookbook/90_models/synthorai/<example>.py
+```

--- a/cookbook/90_models/synthorai/basic.py
+++ b/cookbook/90_models/synthorai/basic.py
@@ -1,0 +1,25 @@
+"""
+Synthorai Basic
+===============
+
+Cookbook example for `synthorai/basic.py`.
+"""
+
+from agno.agent import Agent
+from agno.models.synthorai import Synthorai
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+agent = Agent(model=Synthorai(id="claude-opus-5"), markdown=True)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    # --- Sync ---
+    agent.print_response("Share a 2 sentence horror story.")
+
+    # --- Sync + Streaming ---
+    agent.print_response("Share a 2 sentence horror story.", stream=True)

--- a/cookbook/90_models/synthorai/tool_use.py
+++ b/cookbook/90_models/synthorai/tool_use.py
@@ -1,0 +1,29 @@
+"""
+Synthorai Tool Use
+==================
+
+Cookbook example for `synthorai/tool_use.py`.
+"""
+
+from agno.agent import Agent
+from agno.models.synthorai import Synthorai
+from agno.tools.websearch import WebSearchTools
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+agent = Agent(
+    model=Synthorai(id="claude-opus-5"),
+    markdown=True,
+    tools=[WebSearchTools()],
+)
+
+agent.print_response("What is happening in France?", stream=True)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    pass

--- a/libs/agno/agno/models/synthorai/__init__.py
+++ b/libs/agno/agno/models/synthorai/__init__.py
@@ -1,0 +1,3 @@
+from agno.models.synthorai.synthorai import Synthorai
+
+__all__ = ["Synthorai"]

--- a/libs/agno/agno/models/synthorai/synthorai.py
+++ b/libs/agno/agno/models/synthorai/synthorai.py
@@ -1,0 +1,57 @@
+from dataclasses import dataclass, field
+from os import getenv
+from typing import Any, Dict, Optional
+
+from agno.exceptions import ModelAuthenticationError
+from agno.models.openai.like import OpenAILike
+
+
+@dataclass
+class Synthorai(OpenAILike):
+    """
+    A class for interacting with Synthorai models.
+
+    Attributes:
+        id (str): The model id. Defaults to "claude-opus-5".
+        name (str): The model name. Defaults to "Synthorai".
+        provider (str): The provider name. Defaults to "Synthorai".
+        api_key (Optional[str]): The API key.
+        base_url (str): The base URL. Defaults to "https://synthorai.io/v1".
+    """
+
+    id: str = "claude-opus-5"
+    name: str = "Synthorai"
+    provider: str = "Synthorai"
+
+    api_key: Optional[str] = field(default_factory=lambda: getenv("SYNTHORAI_API_KEY"))
+    base_url: str = "https://synthorai.io/v1"
+
+    def _get_client_params(self) -> Dict[str, Any]:
+        # Fetch API key from env if not already set
+        if not self.api_key:
+            self.api_key = getenv("SYNTHORAI_API_KEY")
+            if not self.api_key:
+                # Raise error immediately if key is missing
+                raise ModelAuthenticationError(
+                    message="SYNTHORAI_API_KEY not set. Please set the SYNTHORAI_API_KEY environment variable.",
+                    model_name=self.name,
+                )
+
+        # Define base client params
+        base_params = {
+            "api_key": self.api_key,
+            "organization": self.organization,
+            "base_url": self.base_url,
+            "timeout": self.timeout,
+            "max_retries": self.max_retries,
+            "default_headers": self.default_headers,
+            "default_query": self.default_query,
+        }
+
+        # Create client_params dict with non-None values
+        client_params = {k: v for k, v in base_params.items() if v is not None}
+
+        # Add additional client params if provided
+        if self.client_params:
+            client_params.update(self.client_params)
+        return client_params

--- a/libs/agno/agno/models/utils.py
+++ b/libs/agno/agno/models/utils.py
@@ -65,6 +65,7 @@ _PROVIDERS: Dict[str, Tuple[str, str, str, str]] = {
     "requesty": ("agno.models.requesty", "Requesty", "Requesty", "requesty"),
     "sambanova": ("agno.models.sambanova", "Sambanova", "Sambanova", "sambanova"),
     "siliconflow": ("agno.models.siliconflow", "Siliconflow", "Siliconflow", "siliconflow"),
+    "synthorai": ("agno.models.synthorai", "Synthorai", "Synthorai", "synthorai"),
     "together": ("agno.models.together", "Together", "Together", "together"),
     "tokenlab": ("agno.models.tokenlab", "TokenLab", "TokenLab", "tokenlab"),
     "trustedrouter": ("agno.models.trustedrouter", "TrustedRouter", "TrustedRouter", "trustedrouter"),

--- a/libs/agno/tests/unit/models/test_synthorai.py
+++ b/libs/agno/tests/unit/models/test_synthorai.py
@@ -1,0 +1,36 @@
+import os
+from unittest.mock import patch
+
+import pytest
+
+from agno.exceptions import ModelAuthenticationError
+from agno.models.synthorai import Synthorai
+
+
+def test_synthorai_initialization_with_api_key():
+    model = Synthorai(id="claude-opus-5", api_key="test-api-key")
+    assert model.id == "claude-opus-5"
+    assert model.api_key == "test-api-key"
+    assert model.base_url == "https://synthorai.io/v1"
+
+
+def test_synthorai_initialization_without_api_key():
+    with patch.dict(os.environ, {}, clear=True):
+        model = Synthorai(id="claude-opus-5")
+        client_params = None
+        with pytest.raises(ModelAuthenticationError):
+            client_params = model._get_client_params()
+        assert client_params is None
+
+
+def test_synthorai_initialization_with_env_api_key():
+    with patch.dict(os.environ, {"SYNTHORAI_API_KEY": "env-api-key"}):
+        model = Synthorai(id="claude-opus-5")
+        assert model.api_key == "env-api-key"
+
+
+def test_synthorai_client_params():
+    model = Synthorai(id="claude-opus-5", api_key="test-api-key")
+    client_params = model._get_client_params()
+    assert client_params["api_key"] == "test-api-key"
+    assert client_params["base_url"] == "https://synthorai.io/v1"


### PR DESCRIPTION
Adds Synthorai (https://synthorai.io) as a model provider, following the same pattern as the recent n1n.ai integration (#6056).

Synthorai is an OpenAI/Anthropic-compatible LLM gateway routing to 113 models across 11 upstream providers (Claude, GPT, Gemini, GLM, Kimi, DeepSeek, Qwen, etc.) at direct upstream pricing, no markup. Docs: https://synthorai.io/docs

## Changes

- `libs/agno/agno/models/synthorai/synthorai.py` — `Synthorai` class extending `OpenAILike` (base_url `https://synthorai.io/v1`, `SYNTHORAI_API_KEY` env var)
- `libs/agno/agno/models/synthorai/__init__.py`
- `libs/agno/agno/models/utils.py` — registered in the model-string lookup table
- `libs/agno/tests/unit/models/test_synthorai.py` — unit tests mirroring the n1n test suite
- `cookbook/90_models/synthorai/basic.py`, `tool_use.py`, `README.md` — cookbook examples

No custom protocol handling needed — plain OpenAI-compatible surface, same shape as n1n/OpenRouter.