### PR TITLE
fix(gemini): separate tool result media parts

### DIFF
--- a/libs/agno/agno/models/google/gemini.py
+++ b/libs/agno/agno/models/google/gemini.py
@@ -905,13 +905,36 @@ class Gemini(Model):
                 log_debug(f"Skipping message with role '{role}' that has no parts")
                 continue
 
-            final_message = Content(role=role, parts=message_parts)
-            formatted_messages.append(final_message)
+            # Gemini 3.7 treats a function response as a completed turn. Keep
+            # media returned by the tool in a following user turn instead of
+            # placing it in the same Content object.
+            if (
+                message.role == "tool"
+                and len(message_parts) > 1
+                and getattr(message_parts[0], "function_response", None) is not None
+            ):
+                formatted_messages.append(Content(role=role, parts=message_parts[:1]))
+                formatted_messages.append(Content(role=role, parts=message_parts[1:]))
+            else:
+                formatted_messages.append(Content(role=role, parts=message_parts))
 
         # Merge consecutive messages with the same role (Gemini API rejects consecutive same-role messages)
         merged: List[Content] = []
         for msg in formatted_messages:
-            if merged and merged[-1].role == msg.role:
+            previous_has_function_response = (
+                any(getattr(part, "function_response", None) is not None for part in merged[-1].parts)
+                if merged
+                else False
+            )
+            current_has_media = any(
+                getattr(part, "inline_data", None) is not None or getattr(part, "file_data", None) is not None
+                for part in msg.parts
+            )
+            if (
+                merged
+                and merged[-1].role == msg.role
+                and not (previous_has_function_response and current_has_media)
+            ):
                 merged[-1].parts.extend(msg.parts)
             else:
                 merged.append(msg)

--- a/libs/agno/tests/unit/models/google/test_gemini_tool_result_media.py
+++ b/libs/agno/tests/unit/models/google/test_gemini_tool_result_media.py
@@ -1,0 +1,40 @@
+from agno.media import Image
+from agno.models.google.gemini import Gemini
+from agno.models.message import Message
+
+
+def test_tool_result_media_is_sent_in_a_following_user_turn():
+    messages = [
+        Message(role="assistant", content="", tool_calls=[{"function": {"name": "read_file", "arguments": "{}"}}]),
+        Message(
+            role="tool",
+            tool_call_id="call-1",
+            tool_name="read_file",
+            content="File is ready",
+            images=[Image(content=b"image-bytes", mime_type="image/png")],
+        ),
+    ]
+
+    formatted, _ = Gemini()._format_messages(messages)
+
+    assert len(formatted) == 3
+    assert formatted[1].role == "user"
+    assert formatted[1].parts[0].function_response is not None
+    assert formatted[2].role == "user"
+    assert formatted[2].parts[0].inline_data is not None
+
+
+def test_tool_results_without_media_still_merge_with_adjacent_user_content():
+    messages = [
+        Message(role="user", content="before"),
+        Message(role="tool", tool_call_id="call-1", tool_name="read_file", content="File is ready"),
+        Message(role="user", content="after"),
+    ]
+
+    formatted, _ = Gemini()._format_messages(messages)
+
+    assert len(formatted) == 1
+    assert formatted[0].role == "user"
+    assert formatted[0].parts[0].text == "before"
+    assert formatted[0].parts[1].function_response is not None
+    assert formatted[0].parts[2].text == "after"


### PR DESCRIPTION
## Summary
- Split Gemini tool function responses from returned media into separate user turns.
- Preserve existing same-role merging when no media is present.
- Add deterministic regression coverage for media and non-media tool results.

## Issue
Closes #9630

## Validation
- `python -m pytest -q tests/unit/models/google/test_gemini_tool_result_media.py` (2 passed)
- `python -m ruff check agno/models/google/gemini.py tests/unit/models/google/test_gemini_tool_result_media.py` (passed)
- `git diff --check` (passed)
- `uv run --frozen` was unavailable because this checkout has no `uv.lock`; dependency resolution without `--frozen` was blocked by the repository's Python 3.14 extras conflict involving `brave-search` and `a2a-sdk`.
- `mypy` did not complete within the local 30-second validation window.
