### PR TITLE
fix: make ScheduleManager cleanup tolerate partial copies

### DIFF
--- a/libs/agno/agno/scheduler/manager.py
+++ b/libs/agno/agno/scheduler/manager.py
@@ -42,8 +42,9 @@ class ScheduleManager:
 
     def close(self) -> None:
         """Shut down the internal thread pool (if created)."""
-        if self._pool is not None:
-            self._pool.shutdown(wait=False)
+        pool = getattr(self, "_pool", None)
+        if pool is not None:
+            pool.shutdown(wait=False)
             self._pool = None
 
     def __del__(self) -> None:

--- a/libs/agno/tests/unit/scheduler/test_manager.py
+++ b/libs/agno/tests/unit/scheduler/test_manager.py
@@ -1,6 +1,10 @@
 """Tests for the ScheduleManager Pythonic API."""
 
+import concurrent.futures
+import gc
+import sys
 import time
+from copy import deepcopy
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -57,6 +61,81 @@ def mock_db():
 @pytest.fixture
 def mgr(mock_db):
     return ScheduleManager(mock_db)
+
+
+class TestManagerCleanup:
+    """`__del__` calls `close()`, so `close()` must hold up on an object whose
+    `__init__` never ran. A failed `deepcopy` of a manager leaves exactly that
+    behind: `__new__` allocates the object, the copy aborts before the instance
+    dict is filled, and the collector still calls `__del__` on the result."""
+
+    def test_close_on_manager_that_never_ran_init(self):
+        """A missing `_pool` means no pool was ever created, not an error."""
+        manager = ScheduleManager.__new__(ScheduleManager)
+
+        manager.close()
+
+        assert getattr(manager, "_pool", None) is None
+
+    def test_close_is_idempotent_on_partial_manager(self):
+        """`__del__` can follow an explicit `close()`, so the second call has
+        to stay quiet too."""
+        manager = ScheduleManager.__new__(ScheduleManager)
+
+        manager.close()
+        manager.close()
+
+        assert getattr(manager, "_pool", None) is None
+
+    def test_collecting_a_partial_manager_reports_nothing(self):
+        """The collector swallows whatever `__del__` raises and routes it to
+        `sys.unraisablehook`, so a raising `close()` never fails a test by
+        itself. Capture the hook to see the failure the issue reported."""
+        unraisable = []
+        original = sys.unraisablehook
+        sys.unraisablehook = unraisable.append
+        try:
+            ScheduleManager.__new__(ScheduleManager)
+            gc.collect()
+        finally:
+            sys.unraisablehook = original
+
+        assert unraisable == []
+
+    def test_failed_deepcopy_leaves_nothing_that_raises_on_collection(self):
+        """The reported trigger end to end: copying a manager whose db refuses
+        to be copied, then collecting the debris the failed copy left."""
+
+        class Uncopyable:
+            def __deepcopy__(self, memo):
+                raise TypeError("cannot copy this db handle")
+
+        manager = ScheduleManager(MagicMock())
+        manager.db = Uncopyable()
+
+        unraisable = []
+        original = sys.unraisablehook
+        sys.unraisablehook = unraisable.append
+        try:
+            with pytest.raises(TypeError, match="cannot copy"):
+                deepcopy(manager)
+            gc.collect()
+        finally:
+            sys.unraisablehook = original
+
+        assert unraisable == []
+
+    def test_close_still_shuts_down_a_real_pool(self):
+        """Tolerating a missing pool must not stop a fully built manager from
+        shutting its pool down and clearing the attribute."""
+        manager = ScheduleManager(MagicMock())
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        manager._pool = pool
+
+        manager.close()
+
+        assert manager._pool is None
+        assert pool._shutdown
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

`ScheduleManager.close()` assumed `_pool` always exists. A failed `deepcopy()` of a manager that owns a database engine can leave an object that `__new__` allocated but whose `__init__` never populated. When the collector reaches that half-built object it calls `__del__()`, which calls `close()`, which raised `AttributeError` while reading `_pool`.

`close()` now reads `_pool` through `getattr(..., None)`, treating a missing pool the same as no pool having been created. Fully initialized managers shut down and clear the pool exactly as before.

Issue number: #9614

### Relationship to #9787

This supersedes #9787, which carries the same one-line fix from @Elioooon (authorship preserved on the commit here). That PR is from a fork with "Allow edits from maintainers" disabled, so its test coverage could not be extended in place. This PR keeps the fix and replaces the single smoke test with a fuller set.

The original test was:

```python
def test_close_handles_partially_constructed_manager():
    manager = ScheduleManager.__new__(ScheduleManager)
    manager.close()
    manager.__del__()
```

It does fail without the fix, so it was a real regression test — but it asserts nothing, and the explicit `manager.__del__()` call duplicates the `close()` line above it while not testing the reported scenario. In real use `__del__` runs under the garbage collector, which swallows exceptions and routes them to `sys.unraisablehook`; a failure on that path would print to stderr and still pass. It also never exercised the `deepcopy` path that produces the half-built object in the first place.

`TestManagerCleanup` replaces it with five tests:

| Test | Covers |
|---|---|
| `test_close_on_manager_that_never_ran_init` | `close()` is quiet and leaves `_pool` unset |
| `test_close_is_idempotent_on_partial_manager` | a second `close()` (as `__del__` would make) stays quiet |
| `test_collecting_a_partial_manager_reports_nothing` | the real GC path, via `sys.unraisablehook` |
| `test_failed_deepcopy_leaves_nothing_that_raises_on_collection` | the reported trigger end to end |
| `test_close_still_shuts_down_a_real_pool` | the fix did not break normal shutdown |

Each was run against both versions of `close()`. The first four fail without the fix and pass with it; the fifth passes either way, which is what makes it the guard against over-correcting.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

`libs/agno/tests/unit/scheduler/` passes in full (176 tests). `ruff check` and `ruff format --check` pass on both changed files. `./scripts/validate.sh` reports pre-existing mypy errors elsewhere in the repo; none are in the scheduler, confirmed by re-running against an unmodified tree.

If #9787 is preferred as the merge vehicle, this PR's test file can be applied there instead — but that needs the author to push, since maintainers cannot edit that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
