### PR TITLE
fix: use httpx for location lookup instead of undeclared requests

### DIFF
--- a/libs/agno/agno/utils/location.py
+++ b/libs/agno/agno/utils/location.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict
 
-import requests
+import httpx
 
 from agno.utils.log import log_warning
 
@@ -8,12 +8,15 @@ from agno.utils.log import log_warning
 def get_location() -> Dict[str, Any]:
     """Get approximate location using IP geolocation."""
     try:
-        response = requests.get("https://api.ipify.org?format=json", timeout=5)
+        response = httpx.get("https://api.ipify.org?format=json", timeout=5)
         ip = response.json()["ip"]
-        response = requests.get(f"http://ip-api.com/json/{ip}", timeout=5)
+        response = httpx.get(f"http://ip-api.com/json/{ip}", timeout=5)
         if response.status_code == 200:
             data = response.json()
             return {"city": data.get("city"), "region": data.get("region"), "country": data.get("country")}
     except Exception as e:
+        # Location is decoration on the system message, so no lookup failure --
+        # network, malformed payload, or anything the client raises -- may
+        # escape into the run that is building that message.
         log_warning(f"Failed to get location: {str(e)}")
     return {}

--- a/libs/agno/tests/unit/agent/test_location_context.py
+++ b/libs/agno/tests/unit/agent/test_location_context.py
@@ -1,0 +1,48 @@
+"""Tests for `add_location_to_context` on the system message path."""
+
+from unittest.mock import MagicMock, Mock
+
+import httpx
+
+from agno.agent import Agent
+from agno.session.agent import AgentSession
+
+
+def _agent_with_mock_model() -> Agent:
+    mock_model = MagicMock()
+    mock_model.get_instructions_for_model = MagicMock(return_value=None)
+    mock_model.get_system_message_for_model = MagicMock(return_value=None)
+    agent = Agent(add_location_to_context=True)
+    agent.model = mock_model
+    return agent
+
+
+def test_add_location_to_context_builds_system_message(monkeypatch):
+    ip_response = Mock()
+    ip_response.json.return_value = {"ip": "203.0.113.7"}
+    location_response = Mock(status_code=200)
+    location_response.json.return_value = {"city": "Paris", "region": "Ile-de-France", "country": "France"}
+    monkeypatch.setattr(httpx, "get", Mock(side_effect=[ip_response, location_response]))
+
+    message = _agent_with_mock_model().get_system_message(session=AgentSession(session_id="location-context"))
+
+    assert message is not None
+    assert "Your approximate location is: Paris, Ile-de-France, France." in message.content
+
+
+def test_a_failed_lookup_drops_the_location_line_and_not_the_run(monkeypatch):
+    """The helper runs inline while the system message is assembled, so a
+    failed lookup has to leave the message buildable without a location line
+    rather than raise into the run."""
+    monkeypatch.setattr(httpx, "get", Mock(side_effect=httpx.ConnectError("offline")))
+    agent = Agent(add_location_to_context=True, description="A helpful assistant.")
+    mock_model = MagicMock()
+    mock_model.get_instructions_for_model = MagicMock(return_value=None)
+    mock_model.get_system_message_for_model = MagicMock(return_value=None)
+    agent.model = mock_model
+
+    message = agent.get_system_message(session=AgentSession(session_id="location-offline"))
+
+    assert message is not None
+    assert "A helpful assistant." in message.content
+    assert "Your approximate location is" not in message.content

--- a/libs/agno/tests/unit/utils/test_location.py
+++ b/libs/agno/tests/unit/utils/test_location.py
@@ -1,0 +1,88 @@
+"""Tests for the IP geolocation helper."""
+
+from unittest.mock import Mock
+
+import httpx
+import pytest
+
+from agno.utils.location import get_location
+
+
+def test_get_location_returns_ip_geolocation(monkeypatch):
+    ip_response = Mock()
+    ip_response.json.return_value = {"ip": "203.0.113.7"}
+    location_response = Mock(status_code=200)
+    location_response.json.return_value = {"city": "Paris", "region": "Ile-de-France", "country": "France"}
+    mock_get = Mock(side_effect=[ip_response, location_response])
+    monkeypatch.setattr(httpx, "get", mock_get)
+
+    assert get_location() == {"city": "Paris", "region": "Ile-de-France", "country": "France"}
+    assert mock_get.call_args_list[0].args == ("https://api.ipify.org?format=json",)
+    assert mock_get.call_args_list[1].args == ("http://ip-api.com/json/203.0.113.7",)
+
+
+def test_get_location_returns_empty_dict_on_http_error(monkeypatch):
+    monkeypatch.setattr(httpx, "get", Mock(side_effect=httpx.ConnectError("offline")))
+
+    assert get_location() == {}
+
+
+def test_get_location_returns_empty_dict_when_lookup_is_not_ok(monkeypatch):
+    """A non-200 from the geolocation host is a miss, not a location."""
+    ip_response = Mock()
+    ip_response.json.return_value = {"ip": "203.0.113.7"}
+    location_response = Mock(status_code=503)
+    monkeypatch.setattr(httpx, "get", Mock(side_effect=[ip_response, location_response]))
+
+    assert get_location() == {}
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        httpx.ConnectError("offline"),
+        httpx.ConnectTimeout("slow"),
+        httpx.InvalidURL("bad url"),
+        httpx.CookieConflict("conflict"),
+        httpx.StreamError("stream"),
+        ValueError("not json"),
+        KeyError("ip"),
+        RuntimeError("anything else"),
+    ],
+    ids=[
+        "connect-error",
+        "timeout",
+        "invalid-url",
+        "cookie-conflict",
+        "stream-error",
+        "bad-json",
+        "missing-ip-key",
+        "unexpected",
+    ],
+)
+def test_get_location_swallows_every_failure(monkeypatch, error):
+    """`get_location()` runs inline while a system message is being built, so
+    every failure has to come back as an empty dict. `httpx.InvalidURL`,
+    `CookieConflict` and `StreamError` are not `httpx.HTTPError` subclasses,
+    so catching only `HTTPError` would let them reach the run."""
+    monkeypatch.setattr(httpx, "get", Mock(side_effect=error))
+
+    assert get_location() == {}
+
+
+def test_get_location_survives_a_malformed_geolocation_payload(monkeypatch):
+    """The second response parses but carries none of the expected keys."""
+    ip_response = Mock()
+    ip_response.json.return_value = {"ip": "203.0.113.7"}
+    location_response = Mock(status_code=200)
+    location_response.json.return_value = {}
+    monkeypatch.setattr(httpx, "get", Mock(side_effect=[ip_response, location_response]))
+
+    assert get_location() == {"city": None, "region": None, "country": None}
+
+
+def test_get_location_does_not_import_requests():
+    """The fix exists because `requests` is not a declared dependency."""
+    import agno.utils.location as location_module
+
+    assert not hasattr(location_module, "requests")


### PR DESCRIPTION
## Summary

`agno.utils.location` imported `requests`, which is not a declared dependency of the core package. `add_location_to_context=True` loads the helper while the system message is being built, so a core-only install hit `ModuleNotFoundError` on the first run.

This switches the helper to `httpx` — already a core dependency (`httpx[http2]`) — and adds coverage for the helper itself and for the `Agent(add_location_to_context=True).get_system_message(...)` path.

Issue number: #9772

### Relationship to #9738

This supersedes #9738, which carries the same `requests` -> `httpx` switch from @Elioooon (authorship preserved on the commit here). That PR is from a fork with "Allow edits from maintainers" disabled, so it could not be rebased or amended in place — its CI has been stuck on a two-day-old base since Aug 24, with one shard failing on an unrelated flaky test and `fail-fast: true` cancelling the other four.

One deliberate difference from #9738. That PR also narrowed the exception clause:

```python
except (httpx.HTTPError, KeyError, ValueError) as e:
```

`get_location()` runs inline while a system message is assembled, and its result only decorates that message, so any failure must come back as an empty dict rather than reach the run. Three httpx exceptions do **not** subclass `httpx.HTTPError`:

- `httpx.InvalidURL`
- `httpx.CookieConflict`
- `httpx.StreamError`

Under the narrowed clause each of those escapes `get_location()` and breaks `get_system_message()` for every agent and team with `add_location_to_context=True`. This PR keeps the broad `except Exception` and adds a comment explaining why it is intentional rather than an oversight.

### Tests

`libs/agno/tests/unit/utils/test_location.py` (13) and `libs/agno/tests/unit/agent/test_location_context.py` (2). Beyond the two happy-path tests from #9738:

| Test | Covers |
|---|---|
| `test_get_location_swallows_every_failure` | 8 parametrized failures, incl. the three non-`HTTPError` httpx types |
| `test_get_location_returns_empty_dict_when_lookup_is_not_ok` | non-200 from the geolocation host |
| `test_get_location_survives_a_malformed_geolocation_payload` | 200 with none of the expected keys |
| `test_get_location_does_not_import_requests` | guards the actual regression |
| `test_a_failed_lookup_drops_the_location_line_and_not_the_run` | system message still builds when the lookup fails |

Verified against three versions of the helper:

- original `requests` version — 13 fail (the module cannot be mocked via `httpx`)
- #9738's narrowed-clause version — 4 fail, all in `test_get_location_swallows_every_failure`
- this PR — 15 pass

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

`libs/agno/tests/unit/utils/` and `libs/agno/tests/unit/agent/` pass in full (1179 tests). `ruff check`, `ruff format --check` and `mypy` pass on all three changed files.

#9738 also changed `Dict[str, Any]` to `dict[str, Any]` and `{str(e)}` to `{e!s}`. Both are fine on the supported floor (`requires-python = ">=3.9"`), but the surrounding `agno/utils/` modules consistently use `typing.Dict`, so this PR keeps the existing style to hold the diff to the actual fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
