### PR TITLE
chore: release 3.0.1

### DIFF
--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agno"
-version = "3.0.0"
+version = "3.0.1"
 description = "The programming language for agentic software."
 requires-python = ">=3.9,<4"
 readme = "README.md"


### PR DESCRIPTION
# Changelog

## **Improvements**

- **Faster agent runs with many tools**: Tool schemas are now derived once and cached across runs, cutting per-run overhead for agents that carry large toolkits. (#9771)
- **Faster long conversations**: Session history is loaded incrementally per turn, so response time stays flat as a conversation grows instead of scaling with its length. (#9775)
- **PubMed request timeout**: `PubmedTools` now accepts a `timeout` and passes it to both NCBI E-utilities requests, so a stalled PubMed response cannot hold a tool call indefinitely. (#9463)

## **Bug Fixes**

- **Strict-mode tool schemas without `properties`**: `Function.process_schema_for_strict` no longer raises `KeyError` on schemas that omit `properties` (for example MCP server schemas registered verbatim). (#9578, fixes #9409)
- **Gemini tool-result media**: Images and document blobs returned from tools are now nested inside `FunctionResponse.parts` for Gemini 3 and later models instead of being emitted as sibling `inline_data` parts; legacy models keep the previous representation. URI-backed response media on Vertex AI is only sent when the MIME type is supported. (#9647)
- **Location lookup on core-only installs**: `agno.utils.location` used the undeclared `requests` package, so `add_location_to_context=True` raised `ModuleNotFoundError` without extras installed. It now uses `httpx`. (#9793, fixes #9772)
- **`ScheduleManager` cleanup**: `close()` tolerates a partially constructed manager (for example after a failed `deepcopy`), so garbage collection no longer raises `AttributeError` on a missing `_pool`. (#9792)

## **Cookbooks**

- Added a deterministic side-effect approval flow example. (#9790)
- Added DeepKeep AI Firewall guardrails example. (#9784)
- Documented AgentOS team run states. (#9768)
- Added a Peer Cash MCP agent example. (#9562)
- Fixed stale cookbook paths left over from the directory renumber and in the MCP examples. (#9789, #9783)