### PR TITLE
feat: allow bounded JSON-pointer reads from offloaded results

### DIFF
--- a/cookbook/02_agents/22_result_offloading/02_result_store.py
+++ b/cookbook/02_agents/22_result_offloading/02_result_store.py
@@ -18,12 +18,20 @@ until the session is deleted, and deleting a session removes both the index
 rows and the stored bytes.
 """
 
+import json
+
 from agno.db.sqlite import SqliteDb
 from agno.offload import ResultStore
 
 REPORT = "\n".join(
     f"{i:04d}: measurement {i * 3 % 17} at station {'NSEW'[i % 4]}"
     for i in range(1, 2001)
+)
+JSON_REPORT = json.dumps(
+    {
+        "summary": {"rows": 3},
+        "items": [{"id": "A-1", "status": "ready"}, {"id": "A-2", "status": "held"}],
+    }
 )
 
 # ---------------------------------------------------------------------------
@@ -54,6 +62,19 @@ if __name__ == "__main__":
     print("\nfirst five lines:")
     print(page.text)
     print("next_start_line:", page.next_start_line, "| truncated:", page.truncated)
+
+    # A JSON result can be projected before the same page cap is applied.
+    json_ref = store.offload(
+        session_id="demo-session",
+        run_id="run-1",
+        tool_call_id="call-json",
+        tool_name="fetch_json_report",
+        tool_args={},
+        output=JSON_REPORT,
+    )
+    json_page = store.read(json_ref.result_id, json_pointer="/items/1")
+    print("\nJSON pointer /items/1:")
+    print(json_page.text)
 
     # Search is capped at 20 matches, each line clipped.
     matches = store.search(ref.result_id, r"station N$")

--- a/cookbook/02_agents/22_result_offloading/README.md
+++ b/cookbook/02_agents/22_result_offloading/README.md
@@ -19,6 +19,14 @@ Nothing is summarized away, there is no model call on the write path, and
 every read back is capped. Substitution happens before the tool message is
 built, so the persisted session row carries the envelope too.
 
+JSON results can be read selectively without loading the whole document into
+the model context. Pass an [RFC 6901 JSON Pointer](https://www.rfc-editor.org/rfc/rfc6901)
+to `read_result`; `""` selects the root and `/data/items/0` selects the first
+item. The selected subtree is serialized and then goes through the same
+16,000-character / 400-line page limits. If the reply says that more follows,
+repeat the same `json_pointer` together with the returned line or character
+offset on the next call.
+
 Pass a `ResultStore` to change the defaults:
 
 ```python
@@ -58,7 +66,7 @@ Teams offload member answers the same way: see
 | Example | What it shows |
 |---|---|
 | [`01_offload_tool_results.py`](./01_offload_tool_results.py) | A tool returns 143KB; the transcript holds under 1KB and the model still answers correctly. |
-| [`02_result_store.py`](./02_result_store.py) | `ResultStore` used directly: offload, read a page, search, `live_ids()`, paging through a whole payload, cleanup. |
+| [`02_result_store.py`](./02_result_store.py) | `ResultStore` used directly: offload, read a page, JSON-pointer projection, search, `live_ids()`, paging through a whole payload, cleanup. |
 | [`03_where_results_live.py`](./03_where_results_live.py) | The three places a result lands: the envelope in the session row, the index row in `agno_tool_results`, the payload in AgentFS (`agno_fs`), counted with plain SQL. |
 | [`04_custom_store_settings.py`](./04_custom_store_settings.py) | Threshold, preview size and a one-hour lifetime through `ResultStore(...)`; the bound copy on `agent.result_store`; the expiry sweep. |
 | [`05_payloads_on_disk.py`](./05_payloads_on_disk.py) | `ResultStore(fs=...)` sends payloads to a local directory while the index stays on the db; the delete cascade removes the files. |

--- a/cookbook/02_agents/22_result_offloading/TEST_LOG.md
+++ b/cookbook/02_agents/22_result_offloading/TEST_LOG.md
@@ -22,6 +22,21 @@ Tested 2026-08-20 against `gpt-5.5` (OpenAIResponses), SQLite, with the worktree
 
 ---
 
+Tested 2026-08-26 with the branch's Python and the local `libs/agno` source.
+
+### 02_result_store.py (JSON pointer)
+
+**Status:** PASS
+
+**Description:** The direct `ResultStore` example stores a small JSON result and
+reads `/items/1` with `json_pointer` alongside the existing text paging and
+regex search paths.
+
+**Result:** The projection returned the expected `A-2` / `held` object, and the
+final cleanup removed both stored results. No warnings, no traceback.
+
+---
+
 Tested 2026-08-21 against `gpt-5.5` (OpenAIResponses), SQLite and PostgreSQL (pgvector container on 5532), with the branch's Python.
 
 ### 03_where_results_live.py

--- a/libs/agno/agno/offload/store.py
+++ b/libs/agno/agno/offload/store.py
@@ -311,6 +311,83 @@ def _looks_like_json(output: str) -> bool:
         return False
 
 
+def _json_pointer_tokens(json_pointer: str) -> List[str]:
+    """Decode an RFC 6901 JSON pointer into its path tokens.
+
+    JSON Pointer is deliberately implemented here instead of adding another
+    runtime dependency.  The read-back path is model-facing, so malformed
+    pointers must become a useful tool error rather than an exception from a
+    third-party parser.
+    """
+    if not isinstance(json_pointer, str):
+        raise TypeError("json_pointer must be a string")
+    if json_pointer == "":
+        return []
+    if not json_pointer.startswith("/"):
+        raise ValueError("invalid JSON pointer: it must be empty or start with '/'")
+
+    tokens: List[str] = []
+    for raw_token in json_pointer[1:].split("/"):
+        token: List[str] = []
+        index = 0
+        while index < len(raw_token):
+            character = raw_token[index]
+            if character != "~":
+                token.append(character)
+                index += 1
+                continue
+            if index + 1 >= len(raw_token) or raw_token[index + 1] not in "01":
+                raise ValueError(f"invalid JSON pointer escape in token {raw_token!r}; only '~0' and '~1' are valid")
+            token.append("~" if raw_token[index + 1] == "0" else "/")
+            index += 2
+        tokens.append("".join(token))
+    return tokens
+
+
+def _project_json_pointer(content: str, json_pointer: str) -> str:
+    """Select a JSON subtree and serialize it for bounded ``read_result`` output.
+
+    The complete payload is already bounded by the ResultStore quota.  The
+    selected value is serialized with stable, readable indentation and is
+    then passed through the normal line/character page limits.  A pointer is
+    intentionally a read-only projection: it never changes the stored bytes.
+    """
+    try:
+        document = json.loads(content)
+    except (ValueError, RecursionError) as error:
+        raise ValueError("result is not valid JSON; omit json_pointer to read it as text") from error
+
+    value: Any = document
+    for token in _json_pointer_tokens(json_pointer):
+        if isinstance(value, dict):
+            if token not in value:
+                raise ValueError(f"JSON pointer {json_pointer!r} does not resolve at token {token!r}")
+            value = value[token]
+        elif isinstance(value, list):
+            # RFC 6901 uses a decimal array index without leading zeroes;
+            # '-' is only an append operation in JSON Patch and is not valid
+            # for a read-only pointer.
+            if (
+                token == "-"
+                or not token
+                or not token.isascii()
+                or not token.isdigit()
+                or (len(token) > 1 and token.startswith("0"))
+            ):
+                raise ValueError(f"JSON pointer token {token!r} is not a valid array index")
+            array_index = int(token)
+            if array_index >= len(value):
+                raise ValueError(f"JSON pointer {json_pointer!r} is outside the array bounds")
+            value = value[array_index]
+        else:
+            raise ValueError(f"JSON pointer {json_pointer!r} traverses a non-container value")
+
+    try:
+        return json.dumps(value, ensure_ascii=False, indent=2)
+    except (TypeError, ValueError, RecursionError) as error:
+        raise ValueError("selected JSON value could not be serialized") from error
+
+
 def _safe_segment(value: str) -> str:
     """Make a caller-supplied id safe as one path segment."""
     cleaned = re.sub(r"[\\/\x00-\x1f]", "_", value) or "_"
@@ -844,23 +921,56 @@ class ResultStore:
         return await self._aread_payload(row)
 
     def read(
-        self, result_id: str, start_line: int = 1, end_line: Optional[int] = None, start_char: int = 0
+        self,
+        result_id: str,
+        start_line: int = 1,
+        end_line: Optional[int] = None,
+        start_char: int = 0,
+        json_pointer: Optional[str] = None,
     ) -> ResultPage:
         """Read a page of a stored result. Lines are 1-indexed and inclusive;
-        ``start_char`` is the 0-indexed offset into ``start_line`` to begin at."""
+        ``start_char`` is the 0-indexed offset into ``start_line`` to begin at.
+
+        When ``json_pointer`` is provided, the result must be indexed as JSON
+        and contain valid JSON; the pointer is resolved using RFC 6901 before
+        the normal page limits are applied. The empty pointer (``""``) selects
+        the JSON document root.
+        Paging a projection always uses line numbers from that projection;
+        callers must pass the same pointer on continuation calls.
+        ``None`` preserves the original text-read behavior.
+        """
         row = self.get_row(result_id)
         if row is None:
             raise KeyError(f"unknown result id {result_id}")
-        return self._page_from_content(self._read_payload(row), start_line, end_line, start_char)
+        if json_pointer is not None:
+            if row.get("content_type") != "json":
+                raise ValueError("json_pointer is only supported for stored JSON results; omit it to read text")
+        content = self._read_payload(row)
+        if json_pointer is not None:
+            content = _project_json_pointer(content, json_pointer)
+        return self._page_from_content(content, start_line, end_line, start_char)
 
     async def aread(
-        self, result_id: str, start_line: int = 1, end_line: Optional[int] = None, start_char: int = 0
+        self,
+        result_id: str,
+        start_line: int = 1,
+        end_line: Optional[int] = None,
+        start_char: int = 0,
+        json_pointer: Optional[str] = None,
     ) -> ResultPage:
         """Async variant of ``read``."""
         row = await self.aget_row(result_id)
         if row is None:
             raise KeyError(f"unknown result id {result_id}")
+        if json_pointer is not None:
+            # JSON parsing and serialization can be significant for an
+            # offloaded payload, so keep the event loop free just like the
+            # existing page calculation.
+            if row.get("content_type") != "json":
+                raise ValueError("json_pointer is only supported for stored JSON results; omit it to read text")
         content = await self._aread_payload(row)
+        if json_pointer is not None:
+            content = await asyncio.to_thread(_project_json_pointer, content, json_pointer)
         return await asyncio.to_thread(self._page_from_content, content, start_line, end_line, start_char)
 
     def _matches_from_content(self, content: str, pattern: str, context_lines: int) -> List[ResultMatch]:

--- a/libs/agno/agno/offload/tools.py
+++ b/libs/agno/agno/offload/tools.py
@@ -6,6 +6,7 @@ off it at call time so a store built later in the run is still picked up.
 
 from __future__ import annotations
 
+import json
 import re
 from typing import Any, Dict, Optional
 
@@ -16,7 +17,9 @@ OFFLOAD_INSTRUCTION = (
     "Large tool results are stored as files and shown to you as a short preview with a "
     "result id. The preview is not the whole result. Use search_result to locate what you "
     "need and read_result to read that range; do not answer from the preview when the "
-    "preview was truncated."
+    "preview was truncated. For JSON results, read_result also accepts an RFC 6901 "
+    "json_pointer such as '/items/0' to read one nested value. Repeat the same pointer "
+    "when following a paginated response."
 )
 
 
@@ -45,30 +48,46 @@ def get_read_result_function(owner: Any, run_context: RunContext, async_mode: bo
     def _resolve(result_id: str, row: Optional[Dict[str, Any]]) -> Optional[str]:
         return _access_error(result_id, row, run_context)
 
-    def _render(result_id: str, page: Any) -> str:
-        header = f"Result {result_id}, lines {page.start_line}-{page.end_line} of {page.line_count}."
+    def _render(result_id: str, page: Any, json_pointer: Optional[str] = None) -> str:
+        pointer_note = ""
+        if json_pointer is not None:
+            pointer_note = f", JSON pointer {json.dumps(json_pointer, ensure_ascii=False)}"
+        header = f"Result {result_id}{pointer_note}, lines {page.start_line}-{page.end_line} of {page.line_count}."
+        continuation_pointer = ""
+        if json_pointer is not None:
+            continuation_pointer = f" and json_pointer={json.dumps(json_pointer, ensure_ascii=False)}"
         if page.next_start_line is not None:
             if page.next_start_char:
                 header += (
                     f" More follows: line {page.next_start_line} continues; read from line "
-                    f"{page.next_start_line} with start_char={page.next_start_char}."
+                    f"{page.next_start_line} with start_char={page.next_start_char}{continuation_pointer}."
                 )
             else:
-                header += f" More follows: read from line {page.next_start_line}."
+                header += f" More follows: read from line {page.next_start_line}{continuation_pointer}."
         return f"{header}\n{page.text}"
 
-    def read_result(result_id: str, start_line: int = 1, end_line: Optional[int] = None, start_char: int = 0) -> str:
+    def read_result(
+        result_id: str,
+        start_line: int = 1,
+        end_line: Optional[int] = None,
+        start_char: int = 0,
+        json_pointer: Optional[str] = None,
+    ) -> str:
         """Read a stored tool result. Lines are 1-indexed and inclusive.
 
         Output is capped at 400 lines or 16000 characters, whichever comes first;
         the reply names where to continue when there is more. A line longer than
         one page is read in pieces: continue with the start_char the reply names.
+        For JSON results, ``json_pointer`` is an optional RFC 6901 pointer to
+        project before paging (``""`` selects the document root). Repeat the
+        pointer on continuation calls.
 
         Args:
             result_id: The id from the result envelope, e.g. "res_a91c4f20b3".
             start_line: First line to read (1-indexed, default 1).
             end_line: Last line to read (inclusive). Defaults to the end.
             start_char: Character offset into start_line to begin at (0-indexed, default 0).
+            json_pointer: Optional RFC 6901 pointer, e.g. "/data/items/0".
 
         Returns:
             str: The requested lines, or an error message starting with "Error".
@@ -80,24 +99,40 @@ def get_read_result_function(owner: Any, run_context: RunContext, async_mode: bo
             error = _resolve(result_id, store.get_row(result_id))
             if error is not None:
                 return error
-            return _render(result_id, store.read(result_id, start_line, end_line, start_char))
+            if json_pointer is None:
+                page = store.read(result_id, start_line, end_line, start_char)
+            else:
+                page = store.read(result_id, start_line, end_line, start_char, json_pointer=json_pointer)
+            return _render(
+                result_id,
+                page,
+                json_pointer,
+            )
         except Exception as e:
             return f"Error reading result: {e}"
 
     async def aread_result(
-        result_id: str, start_line: int = 1, end_line: Optional[int] = None, start_char: int = 0
+        result_id: str,
+        start_line: int = 1,
+        end_line: Optional[int] = None,
+        start_char: int = 0,
+        json_pointer: Optional[str] = None,
     ) -> str:
         """Read a stored tool result. Lines are 1-indexed and inclusive.
 
         Output is capped at 400 lines or 16000 characters, whichever comes first;
         the reply names where to continue when there is more. A line longer than
         one page is read in pieces: continue with the start_char the reply names.
+        For JSON results, ``json_pointer`` is an optional RFC 6901 pointer to
+        project before paging (``""`` selects the document root). Repeat the
+        pointer on continuation calls.
 
         Args:
             result_id: The id from the result envelope, e.g. "res_a91c4f20b3".
             start_line: First line to read (1-indexed, default 1).
             end_line: Last line to read (inclusive). Defaults to the end.
             start_char: Character offset into start_line to begin at (0-indexed, default 0).
+            json_pointer: Optional RFC 6901 pointer, e.g. "/data/items/0".
 
         Returns:
             str: The requested lines, or an error message starting with "Error".
@@ -109,7 +144,15 @@ def get_read_result_function(owner: Any, run_context: RunContext, async_mode: bo
             error = _resolve(result_id, await store.aget_row(result_id))
             if error is not None:
                 return error
-            return _render(result_id, await store.aread(result_id, start_line, end_line, start_char))
+            if json_pointer is None:
+                page = await store.aread(result_id, start_line, end_line, start_char)
+            else:
+                page = await store.aread(result_id, start_line, end_line, start_char, json_pointer=json_pointer)
+            return _render(
+                result_id,
+                page,
+                json_pointer,
+            )
         except Exception as e:
             return f"Error reading result: {e}"
 

--- a/libs/agno/tests/integration/offload/test_agent_offloading.py
+++ b/libs/agno/tests/integration/offload/test_agent_offloading.py
@@ -865,6 +865,35 @@ def test_read_result_refuses_a_result_belonging_to_another_user(db):
     assert "different user" in reply
 
 
+def test_read_result_can_project_a_stored_json_pointer(db):
+    from agno.offload.tools import get_read_result_function
+    from agno.run import RunContext
+
+    agent = Agent(model=ScriptedToolModel(), db=db, tools=[fetch_page], offload_tool_results=True)
+    agent.initialize_agent()
+    session_id = _sid()
+    payload = json.dumps({"meta": {"total": 2}, "data": {"items": [{"id": 1}, {"id": 2}]}})
+    ref = agent.result_store.offload(
+        session_id=session_id,
+        run_id="json-run",
+        tool_call_id="json-call",
+        tool_name="fetch_json",
+        tool_args={},
+        output=payload,
+    )
+
+    read_tool = get_read_result_function(
+        agent,
+        run_context=RunContext(session_id=session_id, run_id="read-run"),
+    )
+    reply = read_tool.entrypoint(result_id=ref.result_id, json_pointer="/data/items/1")
+
+    assert 'JSON pointer "/data/items/1"' in reply
+    assert '"id": 2' in reply
+    assert "json_pointer" in read_tool.parameters["properties"]
+    assert "json_pointer" not in read_tool.parameters["required"]
+
+
 def test_the_read_back_tools_do_not_spend_the_tool_call_limit(db):
     agent = Agent(
         model=ScriptedToolModel(),

--- a/libs/agno/tests/unit/offload/test_result_store.py
+++ b/libs/agno/tests/unit/offload/test_result_store.py
@@ -216,6 +216,147 @@ def test_read_range_is_inclusive(store):
     assert page.text == "line 2\nline 3\nline 4"
 
 
+def test_read_json_pointer_projects_an_object_subtree_without_changing_payload(store):
+    payload = json.dumps(
+        {
+            "meta": {"count": 2},
+            "data": {"items": [{"name": "éclair", "active": True}, {"name": "tea"}]},
+        }
+    )
+    ref = _offload(store, payload)
+
+    page = store.read(ref.result_id, json_pointer="/data/items/0")
+
+    assert json.loads(page.text) == {"name": "éclair", "active": True}
+    assert page.line_count == 4
+    assert store._read_payload(store.get_row(ref.result_id)) == payload
+
+
+def test_read_json_pointer_supports_root_arrays_and_escaped_keys(store):
+    payload = json.dumps({"": "empty-key", "a/b": {"~key": ["first", "second"]}})
+    ref = _offload(store, payload)
+
+    empty_key = store.read(ref.result_id, json_pointer="/")
+    selected = store.read(ref.result_id, json_pointer="/a~1b/~0key/1")
+    root = store.read(ref.result_id, json_pointer="")
+
+    assert json.loads(empty_key.text) == "empty-key"
+    assert json.loads(selected.text) == "second"
+    assert json.loads(root.text) == json.loads(payload)
+    assert root.text.startswith("{") and "\n" in root.text
+
+
+@pytest.mark.parametrize(
+    "pointer, message",
+    [
+        ("data/items", "start with"),
+        ("/data/~2items", "only '~0' and '~1'"),
+        ("/data/items/-", "array index"),
+        ("/data/items/9", "outside the array"),
+        ("/data/missing", "does not resolve"),
+    ],
+)
+def test_read_json_pointer_rejects_invalid_or_missing_paths(store, pointer, message):
+    ref = _offload(store, json.dumps({"data": {"items": ["one"]}}))
+
+    with pytest.raises(ValueError, match=message):
+        store.read(ref.result_id, json_pointer=pointer)
+
+
+def test_read_json_pointer_rejects_non_json_payload(store):
+    ref = _offload(store, "plain text that is deliberately long enough to store")
+
+    with pytest.raises(ValueError, match="only supported for stored JSON"):
+        store.read(ref.result_id, json_pointer="/data")
+
+
+def test_read_json_pointer_reports_corrupt_json_indexed_as_json(store, monkeypatch):
+    ref = _offload(store, "{not valid json")
+    row = store.get_row(ref.result_id)
+    assert row is not None
+    row["content_type"] = "json"
+    monkeypatch.setattr(store, "get_row", lambda _result_id: row)
+
+    with pytest.raises(ValueError, match="not valid JSON"):
+        store.read(ref.result_id, json_pointer="")
+
+
+def test_read_json_pointer_pages_the_projection_and_requires_the_same_pointer(store):
+    payload = json.dumps({"metadata": "do not return", "items": [f"item-{i:04d}" for i in range(3000)]})
+    ref = _offload(store, payload)
+    pointer = "/items"
+
+    first = store.read(ref.result_id, json_pointer=pointer)
+    assert first.truncated is True
+    assert first.next_start_line is not None
+    assert '"metadata"' not in first.text
+
+    second = store.read(ref.result_id, start_line=first.next_start_line, json_pointer=pointer)
+    assert second.text
+    assert second.text != first.text
+    assert '"metadata"' not in second.text
+
+    # Omitting the pointer intentionally reads the original document, not a
+    # continuation of the projected view.
+    original = store.read(ref.result_id, start_line=1)
+    assert '"metadata"' in original.text
+
+
+@pytest.mark.asyncio
+async def test_aread_json_pointer_matches_sync_projection(store):
+    payload = json.dumps({"data": {"items": [{"id": 1}, {"id": 2}]}})
+    ref = _offload(store, payload)
+
+    sync_page = store.read(ref.result_id, json_pointer="/data/items")
+    async_page = await store.aread(ref.result_id, json_pointer="/data/items")
+
+    assert async_page.text == sync_page.text
+    assert async_page.line_count == sync_page.line_count
+
+
+def test_async_read_result_tool_projects_json_pointer(store):
+    import asyncio
+
+    from agno.offload.tools import get_read_result_function
+    from agno.run import RunContext
+
+    class Owner:
+        _result_store = store
+
+    payload = json.dumps({"data": {"name": "async"}})
+    ref = _offload(store, payload)
+    tool = get_read_result_function(
+        Owner(),
+        run_context=RunContext(session_id="S1", run_id="read-run"),
+        async_mode=True,
+    )
+
+    reply = asyncio.run(tool.entrypoint(result_id=ref.result_id, json_pointer="/data/name"))
+
+    assert 'JSON pointer "/data/name"' in reply
+    assert '"async"' in reply
+
+
+def test_read_result_tool_repeats_pointer_in_pagination_hint(store):
+    from agno.offload.tools import get_read_result_function
+    from agno.run import RunContext
+
+    class Owner:
+        _result_store = store
+
+    payload = json.dumps({"items": [f"item-{i:05d}" for i in range(4000)]})
+    ref = _offload(store, payload)
+    tool = get_read_result_function(
+        Owner(),
+        run_context=RunContext(session_id="S1", run_id="read-run"),
+    )
+
+    reply = tool.entrypoint(result_id=ref.result_id, json_pointer="/items")
+
+    assert "More follows:" in reply
+    assert 'json_pointer="/items"' in reply
+
+
 def test_round_trip_returns_the_exact_original_bytes(store):
     payload = "unicode é ü 😀\nsecond line\n\ttabbed\n" * 200
     ref = _offload(store, payload)


### PR DESCRIPTION
## Summary

Adds bounded structured access to JSON tool results that are already stored by
`ResultStore`.

- `ResultStore.read` and `aread` accept an optional RFC 6901 `json_pointer`.
- The model-facing `read_result` tool exposes the same argument on sync and
  async entry points, and repeats it in pagination hints.
- The selected subtree is read-only, serialized for the model, and then passed
  through the existing 400-line / 16,000-character limits.
- Calls without `json_pointer` keep the existing text-read path unchanged.

This is a follow-up to the result offloading work in #9436 and complements
#9770 (the separate offloading + compression compatibility fix); it does not
duplicate item 5 in #9680.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` passed; the full
  mypy gate is blocked by 32 pre-existing errors in unrelated modules)
- [x] Self-review completed
- [x] Documentation updated (comments and docstrings)
- [x] Examples and guides: the direct `ResultStore` cookbook now demonstrates
  `/items/1`
- [ ] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I searched existing [open pull requests](../../pulls); no existing PR
  provides a structured selector for `read_result`.
- [x] This PR is intentionally narrower than application-specific query,
  fuzzy-search, or Python-evaluation APIs.
- [x] This change was AI-assisted; the implementation and test results were
  reviewed before submission.

## Verification

- `python -m pytest libs/agno/tests/unit/offload libs/agno/tests/unit/compression -q`
  — 97 passed.
- `python -m pytest libs/agno/tests/integration/offload/test_agent_offloading.py
  -q -k 'sqlite' --disable-warnings` — 49 passed, 1 skipped.
- `PYTHONPATH=libs/agno python cookbook/02_agents/22_result_offloading/02_result_store.py`
  — passed, including the JSON-pointer projection and cleanup.
- `./scripts/validate.sh` — ruff and cookbook checks passed; full mypy is
  blocked by the unrelated main-branch errors noted above.
- PostgreSQL integration was not available locally (the test service on
  `localhost:5532` was not running).

## Additional Notes

Only indexed JSON results accept a pointer. The implementation supports the
RFC 6901 empty root pointer, object keys, array indices, and `~0` / `~1`
escaping. It deliberately has no wildcard, slice, arbitrary-code, or database
schema behavior; `search_result` remains the existing regex/text tool.
