### PR TITLE
fix: extend the session run-object cache to team and workflow sessions

### DIFF
--- a/libs/agno/agno/db/in_memory/in_memory_db.py
+++ b/libs/agno/agno/db/in_memory/in_memory_db.py
@@ -17,10 +17,12 @@ from agno.db.schemas.memory import UserMemory
 from agno.db.utils import (
     deserialize_history_run,
     deserialize_session,
+    deserialize_session_by_type,
     deserialize_sessions,
     drop_legacy_metrics,
     filter_context_runs,
     metrics_starting_date_from_records,
+    run_cache_eligible,
 )
 from agno.session import AgentSession, Session, TeamSession, WorkflowSession
 from agno.utils.log import log_debug, log_error, log_info, log_warning
@@ -159,12 +161,8 @@ class InMemoryDb(BaseDb):
                 runs_window = filter_context_runs(session_data.get("runs") or [])[-runs_limit:]
                 session_data_copy = deepcopy({**session_data, "runs": runs_window})
             else:
-                if (
-                    deserialize
-                    and session_data.get("session_type") == SessionType.AGENT.value
-                    and (session_type is None or session_type == SessionType.AGENT)
-                ):
-                    session_obj = self._agent_session_with_cached_runs(session_id, session_data)
+                if deserialize and run_cache_eligible(session_data.get("session_type"), session_type):
+                    session_obj = self._session_with_cached_runs(session_id, session_data)
                     if session_obj is not None:
                         return session_obj
                 session_data_copy = deepcopy(session_data)
@@ -181,17 +179,22 @@ class InMemoryDb(BaseDb):
             log_error(f"Exception reading session: {str(e)}")
             raise e
 
-    def _agent_session_with_cached_runs(self, session_id: str, session_data: Dict[str, Any]) -> Optional[AgentSession]:
-        """An AgentSession whose history runs come from the run-object cache.
+    def _session_with_cached_runs(
+        self, session_id: str, session_data: Dict[str, Any]
+    ) -> Optional[Union[AgentSession, TeamSession, WorkflowSession]]:
+        """A session whose history runs come from the run-object cache.
 
         The session row is deep-copied and rebuilt fresh per read, so row
         state (session_data, metadata, summary) stays isolated exactly as
         before. History run objects are built once per stored run dict and
         SHARED by every read of the session; see the cache comment in
-        __init__ for the invalidation and immutability contract.
+        __init__ for the invalidation and immutability contract. The per-run
+        dispatch follows the row's stored session type, so a workflow
+        session's step runs are skipped exactly as its from_dict would.
         """
+        row_session_type = session_data.get("session_type")
         row_copy = deepcopy({**session_data, "runs": None})
-        session = AgentSession.from_dict(row_copy)
+        session = deserialize_session_by_type(row_copy)
         if session is None:
             return None
 
@@ -210,7 +213,7 @@ class InMemoryDb(BaseDb):
             if entry is None or entry[0] is not run_dict:
                 # from_dict pops keys from its input, so it gets its own copy;
                 # the object then shares nothing with the stored dict.
-                entry = (run_dict, deserialize_history_run(deepcopy(run_dict)))
+                entry = (run_dict, deserialize_history_run(deepcopy(run_dict), session_type=row_session_type))
             if run_id is not None:
                 fresh_cache[run_id] = entry
             if entry[1] is not None:

--- a/libs/agno/agno/db/mysql/async_mysql.py
+++ b/libs/agno/agno/db/mysql/async_mysql.py
@@ -34,6 +34,7 @@ from agno.db.utils import (
     json_serializer,
     merge_runs_table_with_legacy_blob,
     metrics_starting_date_from_days,
+    run_cache_eligible,
     run_index_lock_name,
     table_schema_mismatch_error,
     validate_pagination,
@@ -991,10 +992,9 @@ class AsyncMySQLDb(AsyncBaseDb):
                     runs_table is not None
                     and not legacy_runs
                     and deserialize
-                    and session.get("session_type") == SessionType.AGENT.value
-                    and (session_type is None or session_type == SessionType.AGENT)
+                    and run_cache_eligible(session.get("session_type"), session_type)
                 ):
-                    # Fully-migrated agent session on the per-turn path: fetch
+                    # Fully-migrated session on the per-turn path: fetch
                     # the rows raw and serve run objects from the cache instead
                     # of rebuilding every run on every read.
                     run_rows = await self._get_session_run_rows(sess=sess, runs_table=runs_table, session_id=session_id)
@@ -1020,7 +1020,9 @@ class AsyncMySQLDb(AsyncBaseDb):
 
             if run_rows is not None:
                 session_obj = deserialize_session(session_type, session)
-                session_obj.runs = self._run_object_cache.runs_from_rows(session_id, run_rows)  # type: ignore[union-attr]
+                session_obj.runs = self._run_object_cache.runs_from_rows(
+                    session_id, run_rows, session_type=session.get("session_type")
+                )  # type: ignore[union-attr]
                 return session_obj
             return deserialize_session(session_type, session)
 

--- a/libs/agno/agno/db/mysql/mysql.py
+++ b/libs/agno/agno/db/mysql/mysql.py
@@ -34,6 +34,7 @@ from agno.db.utils import (
     json_serializer,
     merge_runs_table_with_legacy_blob,
     metrics_starting_date_from_days,
+    run_cache_eligible,
     run_index_lock_name,
     table_schema_mismatch_error,
     validate_pagination,
@@ -987,10 +988,9 @@ class MySQLDb(BaseDb):
                     runs_table is not None
                     and not legacy_runs
                     and deserialize
-                    and session.get("session_type") == SessionType.AGENT.value
-                    and (session_type is None or session_type == SessionType.AGENT)
+                    and run_cache_eligible(session.get("session_type"), session_type)
                 ):
-                    # Fully-migrated agent session on the per-turn path: fetch
+                    # Fully-migrated session on the per-turn path: fetch
                     # the rows raw and serve run objects from the cache instead
                     # of rebuilding every run on every read.
                     run_rows = self._get_session_run_rows(sess=sess, runs_table=runs_table, session_id=session_id)
@@ -1014,7 +1014,9 @@ class MySQLDb(BaseDb):
 
             if run_rows is not None:
                 session_obj = deserialize_session(session_type, session)
-                session_obj.runs = self._run_object_cache.runs_from_rows(session_id, run_rows)  # type: ignore[union-attr]
+                session_obj.runs = self._run_object_cache.runs_from_rows(
+                    session_id, run_rows, session_type=session.get("session_type")
+                )  # type: ignore[union-attr]
                 return session_obj
             return deserialize_session(session_type, session)
 

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -39,6 +39,7 @@ from agno.db.utils import (
     learning_search_patterns,
     merge_runs_table_with_legacy_blob,
     metrics_starting_date_from_days,
+    run_cache_eligible,
     table_schema_mismatch_error,
     validate_pagination,
 )
@@ -1342,10 +1343,9 @@ class AsyncPostgresDb(AsyncBaseDb):
                     runs_table is not None
                     and not legacy_runs
                     and deserialize
-                    and session.get("session_type") == SessionType.AGENT.value
-                    and (session_type is None or session_type == SessionType.AGENT)
+                    and run_cache_eligible(session.get("session_type"), session_type)
                 ):
-                    # Fully-migrated agent session on the per-turn path: fetch
+                    # Fully-migrated session on the per-turn path: fetch
                     # the rows raw and serve run objects from the cache instead
                     # of rebuilding every run on every read.
                     run_rows = await self._get_session_run_rows(sess=sess, runs_table=runs_table, session_id=session_id)
@@ -1371,7 +1371,9 @@ class AsyncPostgresDb(AsyncBaseDb):
 
             if run_rows is not None:
                 session_obj = deserialize_session(session_type, session)
-                session_obj.runs = self._run_object_cache.runs_from_rows(session_id, run_rows)  # type: ignore[union-attr]
+                session_obj.runs = self._run_object_cache.runs_from_rows(
+                    session_id, run_rows, session_type=session.get("session_type")
+                )  # type: ignore[union-attr]
                 return session_obj
             return deserialize_session(session_type, session)
 

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -63,6 +63,7 @@ from agno.db.utils import (
     learning_search_patterns,
     merge_runs_table_with_legacy_blob,
     metrics_starting_date_from_days,
+    run_cache_eligible,
     table_schema_mismatch_error,
     validate_pagination,
 )
@@ -1534,10 +1535,9 @@ class PostgresDb(BaseDb):
                     runs_table is not None
                     and not legacy_runs
                     and deserialize
-                    and session.get("session_type") == SessionType.AGENT.value
-                    and (session_type is None or session_type == SessionType.AGENT)
+                    and run_cache_eligible(session.get("session_type"), session_type)
                 ):
-                    # Fully-migrated agent session on the per-turn path: fetch
+                    # Fully-migrated session on the per-turn path: fetch
                     # the rows raw and serve run objects from the cache instead
                     # of rebuilding every run on every read.
                     run_rows = self._get_session_run_rows(sess=sess, runs_table=runs_table, session_id=session_id)
@@ -1561,7 +1561,9 @@ class PostgresDb(BaseDb):
 
             if run_rows is not None:
                 session_obj = deserialize_session(session_type, session)
-                session_obj.runs = self._run_object_cache.runs_from_rows(session_id, run_rows)  # type: ignore[union-attr]
+                session_obj.runs = self._run_object_cache.runs_from_rows(
+                    session_id, run_rows, session_type=session.get("session_type")
+                )  # type: ignore[union-attr]
                 return session_obj
             return deserialize_session(session_type, session)
 

--- a/libs/agno/agno/db/singlestore/singlestore.py
+++ b/libs/agno/agno/db/singlestore/singlestore.py
@@ -34,6 +34,7 @@ from agno.db.utils import (
     json_serializer,
     merge_runs_table_with_legacy_blob,
     metrics_starting_date_from_days,
+    run_cache_eligible,
     table_schema_mismatch_error,
     validate_pagination,
 )
@@ -1042,10 +1043,9 @@ class SingleStoreDb(BaseDb):
                     runs_table is not None
                     and not legacy_runs
                     and deserialize
-                    and session.get("session_type") == SessionType.AGENT.value
-                    and (session_type is None or session_type == SessionType.AGENT)
+                    and run_cache_eligible(session.get("session_type"), session_type)
                 ):
-                    # Fully-migrated agent session on the per-turn path: fetch
+                    # Fully-migrated session on the per-turn path: fetch
                     # the rows raw and serve run objects from the cache instead
                     # of rebuilding every run on every read.
                     run_rows = self._get_session_run_rows(sess=sess, runs_table=runs_table, session_id=session_id)
@@ -1069,7 +1069,9 @@ class SingleStoreDb(BaseDb):
 
             if run_rows is not None:
                 session_obj = deserialize_session(session_type, session)
-                session_obj.runs = self._run_object_cache.runs_from_rows(session_id, run_rows)  # type: ignore[union-attr]
+                session_obj.runs = self._run_object_cache.runs_from_rows(
+                    session_id, run_rows, session_type=session.get("session_type")
+                )  # type: ignore[union-attr]
                 return session_obj
             return deserialize_session(session_type, session)
 

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -41,6 +41,7 @@ from agno.db.utils import (
     json_serializer,
     merge_runs_table_with_legacy_blob,
     metrics_starting_date_from_days,
+    run_cache_eligible,
     serialize_session_json_fields,
     table_schema_mismatch_error,
     validate_pagination,
@@ -1345,10 +1346,9 @@ class AsyncSqliteDb(AsyncBaseDb):
                         runs_table is not None
                         and not legacy_runs
                         and deserialize
-                        and session_raw.get("session_type") == SessionType.AGENT.value
-                        and (session_type is None or session_type == SessionType.AGENT)
+                        and run_cache_eligible(session_raw.get("session_type"), session_type)
                     ):
-                        # Fully-migrated agent session on the per-turn path: fetch
+                        # Fully-migrated session on the per-turn path: fetch
                         # the rows raw and serve run objects from the cache instead
                         # of rebuilding every run on every read.
                         run_rows = await self._get_session_run_rows(
@@ -1376,7 +1376,9 @@ class AsyncSqliteDb(AsyncBaseDb):
 
             if run_rows is not None:
                 session_obj = deserialize_session(session_type, session_raw)
-                session_obj.runs = self._run_object_cache.runs_from_rows(session_id, run_rows)  # type: ignore[union-attr]
+                session_obj.runs = self._run_object_cache.runs_from_rows(
+                    session_id, run_rows, session_type=session_raw.get("session_type")
+                )  # type: ignore[union-attr]
                 return session_obj
             return deserialize_session(session_type, session_raw)
 

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -64,6 +64,7 @@ from agno.db.utils import (
     learning_search_patterns,
     merge_runs_table_with_legacy_blob,
     metrics_starting_date_from_days,
+    run_cache_eligible,
     serialize_session_json_fields,
     table_schema_mismatch_error,
     validate_pagination,
@@ -1557,10 +1558,9 @@ class SqliteDb(BaseDb):
                         runs_table is not None
                         and not legacy_runs
                         and deserialize
-                        and session_raw.get("session_type") == SessionType.AGENT.value
-                        and (session_type is None or session_type == SessionType.AGENT)
+                        and run_cache_eligible(session_raw.get("session_type"), session_type)
                     ):
-                        # Fully-migrated agent session on the per-turn path: fetch
+                        # Fully-migrated session on the per-turn path: fetch
                         # the rows raw and serve run objects from the cache instead
                         # of rebuilding every run on every read.
                         run_rows = self._get_session_run_rows(sess=sess, runs_table=runs_table, session_id=session_id)
@@ -1584,7 +1584,9 @@ class SqliteDb(BaseDb):
 
             if run_rows is not None:
                 session_obj = deserialize_session(session_type, session_raw)
-                session_obj.runs = self._run_object_cache.runs_from_rows(session_id, run_rows)  # type: ignore[union-attr]
+                session_obj.runs = self._run_object_cache.runs_from_rows(
+                    session_id, run_rows, session_type=session_raw.get("session_type")
+                )  # type: ignore[union-attr]
                 return session_obj
             return deserialize_session(session_type, session_raw)
 

--- a/libs/agno/agno/db/utils.py
+++ b/libs/agno/agno/db/utils.py
@@ -99,17 +99,40 @@ def detect_session_type(record: Dict[str, Any]) -> str:
     return "agent"
 
 
-def deserialize_history_run(run_dict: Dict[str, Any]) -> Optional[Any]:
-    """One stored run dict as a run object, mirroring AgentSession.from_dict's
-    per-run dispatch (a dict matching neither shape is skipped there too)."""
+def deserialize_history_run(run_dict: Dict[str, Any], session_type: Optional[str] = None) -> Optional[Any]:
+    """One stored run dict as a run object, mirroring the owning session
+    class's per-run dispatch (a dict matching neither shape is skipped there
+    too). Agent and team sessions key on the id the run dict carries; a
+    workflow session keeps only workflow runs — a step's agent or team run
+    shares the workflow's session id and is dropped on deserialization."""
+    from agno.db.base import SessionType
     from agno.run.agent import RunOutput
     from agno.run.team import TeamRunOutput
 
+    if session_type == SessionType.WORKFLOW.value:
+        from agno.run.workflow import WorkflowRunOutput
+
+        if get_run_type(run_dict) != "workflow":
+            return None
+        return WorkflowRunOutput.from_dict(run_dict)
     if "agent_id" in run_dict:
         return RunOutput.from_dict(run_dict)
     if "team_id" in run_dict:
         return TeamRunOutput.from_dict(run_dict)
     return None
+
+
+def run_cache_eligible(row_session_type: Optional[str], requested: Optional["SessionType"]) -> bool:
+    """True when a session row can serve its runs from the run-object cache:
+    the row's type is one the per-type run dispatch above knows, and the
+    caller either did not constrain the type or asked for the row's own.
+    A mismatched request keeps the pre-cache full-load path, which resolves
+    the conflict the same way it always has."""
+    from agno.db.base import SessionType
+
+    if row_session_type not in (SessionType.AGENT.value, SessionType.TEAM.value, SessionType.WORKFLOW.value):
+        return False
+    return requested is None or requested.value == row_session_type
 
 
 class SessionRunObjectCache:
@@ -141,8 +164,16 @@ class SessionRunObjectCache:
         self._per_session: "OrderedDict[str, Dict[str, Tuple[Tuple[int, int], Any]]]" = OrderedDict()
         self._max_sessions = max_sessions
 
-    def runs_from_rows(self, session_id: str, rows: Sequence[Tuple[str, str]]) -> List[Any]:
-        """The run objects for ``rows`` of (run_id, raw run_data text), in order."""
+    def runs_from_rows(
+        self, session_id: str, rows: Sequence[Tuple[str, str]], session_type: Optional[str] = None
+    ) -> List[Any]:
+        """The run objects for ``rows`` of (run_id, raw run_data text), in
+        order. ``session_type`` is the ROW's stored type: it picks the same
+        per-run dispatch the session class's from_dict would use, so a
+        workflow session's step runs are skipped here exactly as they are on
+        the uncached path. A row's type never changes in place (upserts leave
+        it alone, deletes drop the cache entry), so entries built under one
+        type are never served under another."""
         cache = self._per_session.pop(session_id, None) or {}
         fresh: Dict[str, Tuple[Tuple[int, int], Any]] = {}
         objects: List[Any] = []
@@ -150,7 +181,7 @@ class SessionRunObjectCache:
             token = (hash(text), len(text))
             entry = cache.get(run_id)
             if entry is None or entry[0] != token:
-                entry = (token, deserialize_history_run(json.loads(text)))
+                entry = (token, deserialize_history_run(json.loads(text), session_type=session_type))
             fresh[run_id] = entry
             if entry[1] is not None:
                 objects.append(entry[1])

--- a/libs/agno/agno/db/utils.py
+++ b/libs/agno/agno/db/utils.py
@@ -183,7 +183,16 @@ class SessionRunObjectCache:
             token = (hash(text), len(text))
             entry = cache.get(run_id)
             if entry is None or entry[0] != token:
-                entry = (token, deserialize_history_run(json.loads(text), session_type=session_type))
+                parsed = json.loads(text)
+                if isinstance(parsed, str):
+                    # A row written as a pre-encoded string into a JSON column
+                    # is double-encoded; the uncached read path parses it in
+                    # two steps too.
+                    parsed = json.loads(parsed)
+                run_obj = (
+                    deserialize_history_run(parsed, session_type=session_type) if isinstance(parsed, dict) else None
+                )
+                entry = (token, run_obj)
             fresh[run_id] = entry
             if entry[1] is not None:
                 objects.append(entry[1])

--- a/libs/agno/agno/db/utils.py
+++ b/libs/agno/agno/db/utils.py
@@ -122,17 +122,19 @@ def deserialize_history_run(run_dict: Dict[str, Any], session_type: Optional[str
     return None
 
 
-def run_cache_eligible(row_session_type: Optional[str], requested: Optional["SessionType"]) -> bool:
+def run_cache_eligible(row_session_type: Optional[str], requested: Optional[Union["SessionType", str]]) -> bool:
     """True when a session row can serve its runs from the run-object cache:
     the row's type is one the per-type run dispatch above knows, and the
     caller either did not constrain the type or asked for the row's own.
     A mismatched request keeps the pre-cache full-load path, which resolves
-    the conflict the same way it always has."""
+    the conflict the same way it always has. Callers pass the requested type
+    as a SessionType or its plain string value; both are honored, as the
+    adapters' own comparisons always have."""
     from agno.db.base import SessionType
 
     if row_session_type not in (SessionType.AGENT.value, SessionType.TEAM.value, SessionType.WORKFLOW.value):
         return False
-    return requested is None or requested.value == row_session_type
+    return requested is None or getattr(requested, "value", requested) == row_session_type
 
 
 class SessionRunObjectCache:

--- a/libs/agno/agno/run/workflow.py
+++ b/libs/agno/agno/run/workflow.py
@@ -100,15 +100,21 @@ class BaseWorkflowRunOutputEvent(BaseRunOutputEvent):
     nested_depth: int = 0
 
     def to_dict(self) -> Dict[str, Any]:
-        # Temporarily clear the DEEP fields before asdict(): it traverses
-        # every dataclass field BEFORE the post-hoc filter can drop a key,
-        # and these object graphs can reach back to this very event -
-        # run_output.events contains it, and
+        # Clear the DEEP fields before asdict(): it traverses every dataclass
+        # field BEFORE the post-hoc filter can drop a key, and these object
+        # graphs can reach back to this very event - run_output.events
+        # contains it, and
         # step_requirements[].step_input.workflow_session.runs[].events
         # contains it too (the WS HITL continue leg produces exactly that
         # shape once the event lands on the live run). asdict() has no cycle
         # detection, so traversal is fatal; each cleared field is
-        # re-serialized below through its own cycle-safe to_dict.
+        # re-serialized below through its own cycle-safe to_dict. The fields
+        # are cleared on a shallow copy, never on self: events on a stored
+        # run are shared between readers of the session, and a
+        # null-then-restore on the shared object corrupts any concurrent
+        # serialization of the same event.
+        import copy as _copy
+
         _deep_fields = (
             "run_output",
             "step_requirements",
@@ -117,17 +123,11 @@ class BaseWorkflowRunOutputEvent(BaseRunOutputEvent):
             "step_response",
             "iteration_results",
         )
-        _saved: Dict[str, Any] = {}
+        light_copy = _copy.copy(self)
         for _name in _deep_fields:
-            _value = getattr(self, _name, None)
-            if _value is not None:
-                _saved[_name] = _value
-                object.__setattr__(self, _name, None)
-        try:
-            _dict = {k: v for k, v in asdict(self).items() if v is not None and k not in ("run_output", "metrics")}
-        finally:
-            for _name, _value in _saved.items():
-                object.__setattr__(self, _name, _value)
+            if getattr(light_copy, _name, None) is not None:
+                object.__setattr__(light_copy, _name, None)
+        _dict = {k: v for k, v in asdict(light_copy).items() if v is not None and k not in ("run_output", "metrics")}
 
         if hasattr(self, "content") and self.content and isinstance(self.content, BaseModel):
             _dict["content"] = self.content.model_dump(exclude_none=True)

--- a/libs/agno/agno/session/team.py
+++ b/libs/agno/agno/session/team.py
@@ -95,9 +95,20 @@ class TeamSession:
         )
 
     def get_run(self, run_id: str) -> Optional[Union[TeamRunOutput, RunOutput]]:
+        """The run with this id, as the caller's own copy.
+
+        History run objects are shared between session reads, and get_run's
+        callers mutate what they fetch -- background continue flips status,
+        HITL surfaces write answers into requirements and tools -- before
+        persisting. Handing out the shared object would publish those
+        mutations to every reader of the session before (or without) a store
+        write, so each caller gets a run of its own.
+        """
+        from copy import deepcopy
+
         for run in self.runs or []:
             if run.run_id == run_id:
-                return run
+                return deepcopy(run)
         return None
 
     def upsert_run(self, run_response: Union[TeamRunOutput, RunOutput]):

--- a/libs/agno/agno/session/workflow.py
+++ b/libs/agno/agno/session/workflow.py
@@ -135,9 +135,20 @@ class WorkflowSession:
             self.updated_at = current_time
 
     def get_run(self, run_id: str) -> Optional[WorkflowRunOutput]:
+        """The run with this id, as the caller's own copy.
+
+        History run objects are shared between session reads, and get_run's
+        callers mutate what they fetch -- the continue pipeline truncates and
+        resumes it, the queue worker flips status -- before persisting.
+        Handing out the shared object would publish those mutations to every
+        reader of the session before (or without) a store write, so each
+        caller gets a run of its own.
+        """
+        from copy import deepcopy
+
         for run in self.runs or []:
             if run.run_id == run_id:
-                return run
+                return deepcopy(run)
         return None
 
     def upsert_run(self, run: WorkflowRunOutput) -> None:

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -4997,9 +4997,10 @@ def _persist_team_run_in_session(
     if not team.store_media:
         isolate_media_scrub_targets(storage_copy)
     if storage_copy.member_responses and team.store_member_responses:
-        # save_session -> _scrub_member_responses scrubs each member in place;
-        # deep-copy so it operates on the storage copy, not the live member runs.
-        # The embedded copies hold envelopes like the session's member rows.
+        # The member offload (envelope substitution) and the team-level scrub
+        # below mutate what they are given; deep-copy so they operate on the
+        # storage copy, not the live member runs. The embedded copies hold
+        # envelopes like the session's member rows.
         storage_copy.member_responses = [
             _member_run_for_storage(team, session, member_run)
             for member_run in copy.deepcopy(storage_copy.member_responses)
@@ -5057,9 +5058,10 @@ async def _apersist_team_run_in_session(
     if not team.store_media:
         isolate_media_scrub_targets(storage_copy)
     if storage_copy.member_responses and team.store_member_responses:
-        # save_session -> _scrub_member_responses scrubs each member in place;
-        # deep-copy so it operates on the storage copy, not the live member runs.
-        # The embedded copies hold envelopes like the session's member rows.
+        # The member offload (envelope substitution) and the team-level scrub
+        # below mutate what they are given; deep-copy so they operate on the
+        # storage copy, not the live member runs. The embedded copies hold
+        # envelopes like the session's member rows.
         storage_copy.member_responses = [
             await _amember_run_for_storage(team, session, member_run)
             for member_run in copy.deepcopy(storage_copy.member_responses)
@@ -6328,6 +6330,8 @@ def _resolve_member_run_output_for_continue(
        requirement — the deep member's paused run lives inside it, persisted
        there by save_session's paused-run exemption.
     """
+    from copy import deepcopy
+
     from agno.team.team import Team
     from agno.utils.team import get_member_id
 
@@ -6359,18 +6363,31 @@ def _resolve_member_run_output_for_continue(
         if member_run_output is None and session is not None and session.runs:
             for session_run in session.runs:
                 if getattr(session_run, "run_id", None) == member_run_id:
-                    member_run_output = session_run  # type: ignore[assignment]
+                    # Session-held history runs are shared between session
+                    # reads, and the member's continue completes the run it is
+                    # handed in place -- so hand it a run of its own. The
+                    # routing loop upserts the completed run back into the
+                    # session, so nothing relies on the original's identity.
+                    member_run_output = deepcopy(session_run)  # type: ignore[assignment]
                     break
         if member_run_output is None and routed_to_team:
-            candidates: List[Union[TeamRunOutput, RunOutput]] = list(run_response.member_responses or [])
-            if session is not None and session.runs:
-                candidates.extend(r for r in session.runs if getattr(r, "parent_run_id", None) == run_response.run_id)
-            for candidate in candidates:
+            for candidate in run_response.member_responses or []:
                 if not isinstance(candidate, TeamRunOutput) or candidate.run_id == run_response.run_id:
                     continue
                 if _team_run_references_member_run(candidate, member_run_id):
                     member_run_output = candidate
                     break
+            if member_run_output is None and session is not None and session.runs:
+                for candidate in session.runs:
+                    if getattr(candidate, "parent_run_id", None) != run_response.run_id:
+                        continue
+                    if not isinstance(candidate, TeamRunOutput) or candidate.run_id == run_response.run_id:
+                        continue
+                    if _team_run_references_member_run(candidate, member_run_id):
+                        # Shared session object: same copy-at-acquisition as the
+                        # direct member_run_id hit above.
+                        member_run_output = deepcopy(candidate)
+                        break
 
     return member_run_output
 
@@ -7354,17 +7371,24 @@ def _mark_team_run_regenerated(
     explicit ``save_run`` here the DB row keeps its old status and history
     builders still surface the parent — producing duplicate content after
     regenerate."""
+    from copy import copy as shallow_copy
+
     from agno.team._session import save_run
 
-    for r in session.runs or []:
+    for i, r in enumerate(session.runs or []):
         if r.run_id == original_run_id:
-            r.status = RunStatus.regenerated
+            # Flip on a copy, never on the loaded run: history run objects are
+            # shared between reads of the same session, so an in-place write
+            # would surface mid-flight on another reader's session.
+            flipped = shallow_copy(r)
+            flipped.status = RunStatus.regenerated
+            session.runs[i] = flipped  # type: ignore[index]
             save_run(
                 team,
-                run=r,
+                run=flipped,
                 session_id=session.session_id,
                 user_id=session.user_id,
-                run_index=resolve_run_index(session, r),
+                run_index=resolve_run_index(session, flipped),
             )
             return
 
@@ -7375,17 +7399,24 @@ async def _amark_team_run_regenerated(
     original_run_id: str,
 ) -> None:
     """Async variant of :func:`_mark_team_run_regenerated`."""
+    from copy import copy as shallow_copy
+
     from agno.team._session import asave_run
 
-    for r in session.runs or []:
+    for i, r in enumerate(session.runs or []):
         if r.run_id == original_run_id:
-            r.status = RunStatus.regenerated
+            # Flip on a copy, never on the loaded run: history run objects are
+            # shared between reads of the same session, so an in-place write
+            # would surface mid-flight on another reader's session.
+            flipped = shallow_copy(r)
+            flipped.status = RunStatus.regenerated
+            session.runs[i] = flipped  # type: ignore[index]
             await asave_run(
                 team,
-                run=r,
+                run=flipped,
                 session_id=session.session_id,
                 user_id=session.user_id,
-                run_index=resolve_run_index(session, r),
+                run_index=resolve_run_index(session, flipped),
             )
             return
 
@@ -7629,6 +7660,13 @@ def continue_run_dispatch(
         run_response = next((r for r in runs if r.run_id == run_id), None)  # type: ignore
         if run_response is None:
             raise RunNotFoundError(f"No runs found for run ID {run_id}")
+        # The continued run is mutated through the whole continue pipeline
+        # (message truncation, member resumes, status). History run objects are
+        # shared between reads of the same session, so continue works on its
+        # own copy.
+        from copy import deepcopy as _deepcopy_run
+
+        run_response = _deepcopy_run(run_response)
 
     run_response = cast(TeamRunOutput, run_response)
 
@@ -8831,9 +8869,14 @@ async def _acontinue_run_background_stream(
     def _get_session_run(session: TeamSession) -> Optional[TeamRunOutput]:
         # Prefer the concrete run list: mocked or third-party session objects
         # do not always implement get_run with the same fidelity.
+        # The status writes below mutate what this returns, and history run
+        # objects are shared between session reads -- hand back a run of the
+        # caller's own (get_run copies on its own).
+        from copy import deepcopy as _deepcopy_run
+
         for candidate in getattr(session, "runs", None) or []:
             if getattr(candidate, "run_id", None) == _run_id:
-                return cast(TeamRunOutput, candidate)
+                return cast(TeamRunOutput, _deepcopy_run(candidate))
         return cast(Optional[TeamRunOutput], session.get_run(_run_id))
 
     stored_run = _get_session_run(team_session)
@@ -9069,6 +9112,10 @@ async def _acontinue_run_background_stream(
                                 await apersist_run_transition(team, "team", session_id, fresh_run, user_id=user_id)
                                 persist_run.status = cast(RunStatus, restore_status)
                                 if team.cache_session:
+                                    # fresh_run is the caller's own copy, so the
+                                    # flip must be written back before this
+                                    # session becomes the cached one.
+                                    fresh_session.upsert_run(run_response=fresh_run)
                                     team._set_cached_session(fresh_session)
                 except Exception:
                     log_error(
@@ -9104,6 +9151,10 @@ async def _acontinue_run_background_stream(
                                 await apersist_run_transition(team, "team", session_id, fresh_run, user_id=user_id)
                                 persist_run.status = RunStatus.error
                                 if team.cache_session:
+                                    # fresh_run is the caller's own copy, so the
+                                    # flip must be written back before this
+                                    # session becomes the cached one.
+                                    fresh_session.upsert_run(run_response=fresh_run)
                                     team._set_cached_session(fresh_session)
                 except Exception:
                     log_error(
@@ -9480,6 +9531,13 @@ async def _acontinue_run(
                     run_response = next((r for r in runs if r.run_id == run_id), None)  # type: ignore
                     if run_response is None:
                         raise RunNotFoundError(f"No runs found for run ID {run_id}")
+                    # The continued run is mutated through the whole continue
+                    # pipeline (message truncation, member resumes, status).
+                    # History run objects are shared between reads of the same
+                    # session, so continue works on its own copy.
+                    from copy import deepcopy as _deepcopy_run
+
+                    run_response = _deepcopy_run(run_response)
 
                 run_response = cast(TeamRunOutput, run_response)
 
@@ -9961,6 +10019,13 @@ async def _acontinue_run_stream(
                     run_response = next((r for r in runs if r.run_id == run_id), None)  # type: ignore
                     if run_response is None:
                         raise RunNotFoundError(f"No runs found for run ID {run_id}")
+                    # The continued run is mutated through the whole continue
+                    # pipeline (message truncation, member resumes, status).
+                    # History run objects are shared between reads of the same
+                    # session, so continue works on its own copy.
+                    from copy import deepcopy as _deepcopy_run
+
+                    run_response = _deepcopy_run(run_response)
 
                 run_response = cast(TeamRunOutput, run_response)
 

--- a/libs/agno/agno/team/_session.py
+++ b/libs/agno/agno/team/_session.py
@@ -37,7 +37,7 @@ from agno.utils.agent import (
     set_session_name_util,
     update_session_state_util,
 )
-from agno.utils.log import log_debug, log_warning
+from agno.utils.log import log_debug, log_info, log_warning
 
 # ---------------------------------------------------------------------------
 # Session read / write
@@ -333,6 +333,94 @@ def _scrub_member_responses_keeping_paused(
     return run
 
 
+def _member_responses_storage_view(
+    team: "Team",
+    member_responses: List[Union[TeamRunOutput, "RunOutput"]],
+) -> Optional[List[Union[TeamRunOutput, "RunOutput"]]]:
+    """A copy of ``member_responses`` with each response scrubbed per its own
+    member's storage flags, or None when scrubbing would change nothing.
+
+    Storage-view twin of the in-place ``Team._scrub_member_responses``: same
+    member resolution, same scrub calls, same nested-team recursion — but a
+    response the scrub would change is scrubbed on an isolated copy, so the run
+    tree the caller holds keeps its member data. History runs reloaded from the
+    store were scrubbed before they were written, so for them every level
+    reports "nothing to remove" and no copies are made.
+    """
+    from copy import copy
+
+    from agno.agent._run import scrub_run_output_for_storage
+    from agno.team._tools import _find_member_by_id
+    from agno.team.team import Team
+    from agno.utils.agent import (
+        history_scrub_would_change,
+        isolate_media_scrub_targets,
+        media_scrub_would_change,
+        tool_scrub_would_change,
+    )
+
+    changed = False
+    views: List[Union[TeamRunOutput, "RunOutput"]] = []
+    for member_response in member_responses:
+        member_id = None
+        if isinstance(member_response, RunOutput):
+            member_id = member_response.agent_id
+        elif isinstance(member_response, TeamRunOutput):
+            member_id = member_response.team_id
+
+        member = None
+        if not member_id:
+            log_info("Skipping member response with no ID")
+        else:
+            member_result = _find_member_by_id(team, member_id)
+            if member_result is None:
+                log_debug(f"Could not find member with ID: {member_id}")
+            else:
+                _, member = member_result
+
+        view = member_response
+        if member is not None:
+            if (
+                (not member.store_media and media_scrub_would_change(view))
+                or (not member.store_tool_messages and tool_scrub_would_change(view))
+                or (not member.store_history_messages and history_scrub_would_change(view))
+            ):
+                view = copy(member_response)
+                # The scrubs rewrite Message/RunInput objects and the nested
+                # member-response tree in place; give the copy its own.
+                isolate_media_scrub_targets(view)
+                scrub_run_output_for_storage(member, view)  # type: ignore[arg-type]
+            if isinstance(member, Team) and isinstance(view, TeamRunOutput) and view.member_responses:
+                nested = _member_responses_storage_view(member, view.member_responses)
+                if nested is not None:
+                    if view is member_response:
+                        view = copy(member_response)
+                    view.member_responses = nested
+        if view is not member_response:
+            changed = True
+        views.append(view)
+    return views if changed else None
+
+
+def _scrub_member_responses_storage_view(
+    team: "Team", run: Union[TeamRunOutput, "RunOutput"]
+) -> Union[TeamRunOutput, "RunOutput"]:
+    """A storage view of ``run`` with member responses scrubbed per member
+    storage flags (the ``store_member_responses=True`` save path), copying only
+    the levels a scrub changes; ``run`` itself is returned when nothing does."""
+    from copy import copy
+
+    member_responses = getattr(run, "member_responses", None)
+    if not member_responses:
+        return run
+    views = _member_responses_storage_view(team, member_responses)
+    if views is None:
+        return run
+    run = copy(run)
+    run.member_responses = views  # type: ignore[union-attr]
+    return run
+
+
 def save_session(team: "Team", session: TeamSession) -> None:
     """
     Save the TeamSession to storage
@@ -343,7 +431,6 @@ def save_session(team: "Team", session: TeamSession) -> None:
     from copy import copy
 
     from agno.team._init import _has_async_db
-    from agno.team._run import _scrub_member_responses
     from agno.team._storage import _upsert_session
 
     if _has_async_db(team):
@@ -375,10 +462,17 @@ def save_session(team: "Team", session: TeamSession) -> None:
                     for run in session.runs
                 ]
             else:
-                for run in session.runs:
-                    if hasattr(run, "member_responses"):
-                        # Scrub individual member responses based on their storage flags
-                        _scrub_member_responses(team, run.member_responses)
+                # Per-member-flag scrub, also as a view on a session of its
+                # own: scrubbing the caller's runs in place would strip member
+                # data off the shared run objects a cached session (and every
+                # other reader of it) still holds. History runs reloaded from
+                # the store are already scrubbed, so only runs with fresh
+                # member data are copied.
+                storage_session = copy(session)
+                storage_session.runs = [
+                    _scrub_member_responses_storage_view(team, run) if hasattr(run, "member_responses") else run
+                    for run in session.runs
+                ]
         _upsert_session(team, session=storage_session)
         log_debug(f"Created or updated TeamSession record: {session.session_id}")
 
@@ -393,7 +487,6 @@ async def asave_session(team: "Team", session: TeamSession) -> None:
     from copy import copy
 
     from agno.team._init import _has_async_db
-    from agno.team._run import _scrub_member_responses
     from agno.team._storage import _aupsert_session, _upsert_session
 
     if team.db is not None and team.parent_team_id is None and team.workflow_id is None:
@@ -417,10 +510,14 @@ async def asave_session(team: "Team", session: TeamSession) -> None:
                     for run in session.runs
                 ]
             else:
-                for run in session.runs:
-                    if hasattr(run, "member_responses"):
-                        # Scrub individual member responses based on their storage flags
-                        _scrub_member_responses(team, run.member_responses)
+                # See save_session: the per-member-flag scrub is a view too —
+                # in-place scrubbing would strip member data off the shared run
+                # objects other readers of this session hold.
+                storage_session = copy(session)
+                storage_session.runs = [
+                    _scrub_member_responses_storage_view(team, run) if hasattr(run, "member_responses") else run
+                    for run in session.runs
+                ]
 
         if _has_async_db(team):
             await _aupsert_session(team, session=storage_session)
@@ -441,7 +538,6 @@ def save_run(
     Use this instead of save_session() when only a single run has changed.
     """
     from agno.team._init import _has_async_db
-    from agno.team._run import _scrub_member_responses
     from agno.team._storage import _upsert_run
 
     if _has_async_db(team):
@@ -453,7 +549,7 @@ def save_run(
             if not team.store_member_responses:
                 storage_run = _scrub_member_responses_keeping_paused(team, run)
             else:
-                _scrub_member_responses(team, run.member_responses)  # type: ignore[union-attr]
+                storage_run = _scrub_member_responses_storage_view(team, run)
         _upsert_run(team, run=storage_run, session_id=session_id, user_id=user_id, run_index=run_index)
         log_debug(f"Saved run {getattr(run, 'run_id', '?')} to session {session_id}")
 
@@ -466,7 +562,6 @@ async def asave_run(
     run_index: Optional[int] = None,
 ) -> None:
     """Async version of ``save_run``."""
-    from agno.team._run import _scrub_member_responses
     from agno.team._storage import _aupsert_run
 
     if team.db is not None and team.parent_team_id is None and team.workflow_id is None:
@@ -475,7 +570,7 @@ async def asave_run(
             if not team.store_member_responses:
                 storage_run = _scrub_member_responses_keeping_paused(team, run)
             else:
-                _scrub_member_responses(team, run.member_responses)  # type: ignore[union-attr]
+                storage_run = _scrub_member_responses_storage_view(team, run)
         await _aupsert_run(team, run=storage_run, session_id=session_id, user_id=user_id, run_index=run_index)
         log_debug(f"Saved run {getattr(run, 'run_id', '?')} to session {session_id}")
 

--- a/libs/agno/agno/utils/agent.py
+++ b/libs/agno/agno/utils/agent.py
@@ -627,10 +627,7 @@ def media_scrub_would_change(run_response: Union[RunOutput, TeamRunOutput]) -> b
     scrubbed on a previous save reports False at every level.
     """
     if run_response.input is not None and (
-        run_response.input.images
-        or run_response.input.videos
-        or run_response.input.audios
-        or run_response.input.files
+        run_response.input.images or run_response.input.videos or run_response.input.audios or run_response.input.files
     ):
         return True
     for message_list in (run_response.messages, run_response.additional_input, run_response.reasoning_messages):

--- a/libs/agno/agno/utils/agent.py
+++ b/libs/agno/agno/utils/agent.py
@@ -616,6 +616,62 @@ def scrub_history_messages_from_run_output(run_response: Union[RunOutput, TeamRu
         run_response.messages = [msg for msg in run_response.messages if not msg.from_history]
 
 
+def media_scrub_would_change(run_response: Union[RunOutput, TeamRunOutput]) -> bool:
+    """True when ``scrub_media_from_run_output(..., keep_references=False)`` would
+    change the run's stored form.
+
+    The judgment must match how each field serializes, or a skipped scrub writes
+    different bytes than a performed one: Message media and top-level run media
+    serialize only when truthy / not None (the scrub nulls them), while RunInput
+    media serialize only when non-empty (the scrub empties them). A run already
+    scrubbed on a previous save reports False at every level.
+    """
+    if run_response.input is not None and (
+        run_response.input.images
+        or run_response.input.videos
+        or run_response.input.audios
+        or run_response.input.files
+    ):
+        return True
+    for message_list in (run_response.messages, run_response.additional_input, run_response.reasoning_messages):
+        for message in message_list or []:
+            if (
+                message.images
+                or message.videos
+                or message.audio
+                or message.files
+                or message.audio_output is not None
+                or message.image_output is not None
+                or message.video_output is not None
+            ):
+                return True
+    if (
+        run_response.images is not None
+        or run_response.videos is not None
+        or run_response.audio is not None
+        or run_response.files is not None
+    ):
+        return True
+    for member_response in getattr(run_response, "member_responses", None) or []:
+        if media_scrub_would_change(member_response):
+            return True
+    return False
+
+
+def tool_scrub_would_change(run_response: Union[RunOutput, TeamRunOutput]) -> bool:
+    """True when ``scrub_tool_results_from_run_output`` would change the run's
+    stored form. The scrub removes tool-result messages plus the assistant
+    messages that issued those calls, so nothing changes unless at least one
+    tool-result message is present."""
+    return any(message.role == "tool" for message in run_response.messages or [])
+
+
+def history_scrub_would_change(run_response: Union[RunOutput, TeamRunOutput]) -> bool:
+    """True when ``scrub_history_messages_from_run_output`` would change the
+    run's stored form: it drops the messages tagged ``from_history``."""
+    return any(message.from_history for message in run_response.messages or [])
+
+
 def isolate_media_scrub_targets(run_response: Union[RunOutput, TeamRunOutput]) -> None:
     """Give ``run_response`` its own shallow copies of the collections that media
     scrubbing mutates in place (Message objects and RunInput).

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -5548,10 +5548,9 @@ class Workflow:
             else:
                 session = self.db.get_session(session_id=_session_id, session_type=SessionType.WORKFLOW)
             if session and isinstance(session, WorkflowSession) and session.runs:
-                # Find the run by ID
-                for run in session.runs:
-                    if run.run_id == run_id:
-                        return run
+                # get_run hands back a copy of the caller's own: history run
+                # objects are shared between session reads.
+                return session.get_run(run_id)
 
         return None
 
@@ -5566,10 +5565,9 @@ class Workflow:
         if self.db is not None and _session_id is not None:
             session = self.db.get_session(session_id=_session_id, session_type=SessionType.WORKFLOW)
             if session and isinstance(session, WorkflowSession) and session.runs:
-                # Find the run by ID
-                for run in session.runs:
-                    if run.run_id == run_id:
-                        return run
+                # get_run hands back a copy of the caller's own: history run
+                # objects are shared between session reads.
+                return session.get_run(run_id)
 
         return None
 
@@ -5814,8 +5812,14 @@ class Workflow:
             reloaded_session = self.get_session(session_id=session.session_id)
 
             if reloaded_session and reloaded_session.runs and len(reloaded_session.runs) > 0:
-                # Get the last run (which is the one just created by the tool)
-                last_run = reloaded_session.runs[-1]
+                # Get the last run (which is the one just created by the tool).
+                # The write below goes on this call's own copy: history run
+                # objects are shared between session reads. Swap the copy into
+                # the reloaded session so the persist sees a consistent list.
+                from copy import deepcopy as _deepcopy_run
+
+                last_run = _deepcopy_run(reloaded_session.runs[-1])
+                reloaded_session.runs[-1] = last_run
 
                 # Yield WorkflowAgentCompletedEvent
                 agent_completed_event = WorkflowAgentCompletedEvent(
@@ -5936,8 +5940,14 @@ class Workflow:
             reloaded_session = self.get_session(session_id=session.session_id)
 
             if reloaded_session and reloaded_session.runs and len(reloaded_session.runs) > 0:
-                # Get the last run (which is the one just created by the tool)
-                last_run = reloaded_session.runs[-1]
+                # Get the last run (which is the one just created by the tool).
+                # The write below goes on this call's own copy: history run
+                # objects are shared between session reads. Swap the copy into
+                # the reloaded session so the persist sees a consistent list.
+                from copy import deepcopy as _deepcopy_run
+
+                last_run = _deepcopy_run(reloaded_session.runs[-1])
+                reloaded_session.runs[-1] = last_run
 
                 # Update the last run directly with workflow_agent_run
                 last_run.workflow_agent_run = agent_response
@@ -6229,8 +6239,14 @@ class Workflow:
                 reloaded_session = self.get_session(session_id=session.session_id)
 
             if reloaded_session and reloaded_session.runs and len(reloaded_session.runs) > 0:
-                # Get the last run (which is the one just created by the tool)
-                last_run = reloaded_session.runs[-1]
+                # Get the last run (which is the one just created by the tool).
+                # The write below goes on this call's own copy: history run
+                # objects are shared between session reads. Swap the copy into
+                # the reloaded session so the persist sees a consistent list.
+                from copy import deepcopy as _deepcopy_run
+
+                last_run = _deepcopy_run(reloaded_session.runs[-1])
+                reloaded_session.runs[-1] = last_run
 
                 # Yield WorkflowAgentCompletedEvent
                 agent_completed_event = WorkflowAgentCompletedEvent(
@@ -6360,8 +6376,14 @@ class Workflow:
                 reloaded_session = self.get_session(session_id=session.session_id)
 
             if reloaded_session and reloaded_session.runs and len(reloaded_session.runs) > 0:
-                # Get the last run (which is the one just created by the tool)
-                last_run = reloaded_session.runs[-1]
+                # Get the last run (which is the one just created by the tool).
+                # The write below goes on this call's own copy: history run
+                # objects are shared between session reads. Swap the copy into
+                # the reloaded session so the persist sees a consistent list.
+                from copy import deepcopy as _deepcopy_run
+
+                last_run = _deepcopy_run(reloaded_session.runs[-1])
+                reloaded_session.runs[-1] = last_run
                 log_debug(f"Retrieved latest workflow run: {last_run.run_id}")
                 log_debug(f"Total workflow runs in session: {len(reloaded_session.runs)}")
 

--- a/libs/agno/tests/unit/db/test_run_object_cache.py
+++ b/libs/agno/tests/unit/db/test_run_object_cache.py
@@ -19,7 +19,7 @@ from agno.models.message import MessageMetrics
 from agno.models.response import ModelResponse
 from agno.run.agent import RunOutput
 from agno.run.base import RunStatus
-from agno.session import AgentSession
+from agno.session import AgentSession, TeamSession, WorkflowSession
 
 
 class MockModel(Model):
@@ -472,3 +472,345 @@ class TestHardenedMutators:
         assert len(shared.messages or []) == message_count_before
         stored = db.get_session("s1", session_type=SessionType.AGENT).get_run("r-mid")
         assert stored.status != status_before
+
+
+# ---------------------------------------------------------------------------
+# Team sessions
+# ---------------------------------------------------------------------------
+
+
+def _member_response_dict(idx: int) -> dict:
+    """A member response carrying data every member storage flag can scrub.
+
+    Message and media ids are explicit: deserialization mints fresh ids for
+    entries without one, and the rebuild-equality tests compare two
+    independent deserializations."""
+    return {
+        "run_id": f"m{idx}",
+        "agent_id": "member-agent",
+        "content": f"member answer {idx}",
+        "status": "COMPLETED",
+        "images": [{"id": f"img-{idx}", "url": "http://x/out.png"}],
+        "messages": [
+            {"id": f"msg-{idx}-0", "role": "assistant", "tool_calls": [{"id": f"tc{idx}", "type": "function"}]},
+            {"id": f"msg-{idx}-1", "role": "tool", "tool_call_id": f"tc{idx}", "content": "tool result"},
+            {"id": f"msg-{idx}-2", "role": "assistant", "content": f"member answer {idx}"},
+            {"id": f"msg-{idx}-3", "role": "user", "content": "old turn", "from_history": True},
+        ],
+    }
+
+
+def _seed_team(db, session_id: str = "t1", n_runs: int = 3, with_member_data: bool = False) -> None:
+    db.upsert_session(TeamSession(session_id=session_id, team_id="tm1", user_id="u1"))
+    for i in range(n_runs):
+        run = {"run_id": f"r{i}", "team_id": "tm1", "content": f"content {i}", "status": "COMPLETED"}
+        if with_member_data:
+            run["member_responses"] = [_member_response_dict(i)]
+        db.upsert_run(run, session_id=session_id)
+
+
+class TestTeamRunObjectCache:
+    def test_reads_share_history_run_objects(self):
+        db = InMemoryDb()
+        _seed_team(db)
+        first = db.get_session("t1", session_type=SessionType.TEAM)
+        second = db.get_session("t1", session_type=SessionType.TEAM)
+        assert first is not second
+        assert first.runs is not second.runs
+        assert [id(r) for r in first.runs] == [id(r) for r in second.runs]
+
+    def test_content_matches_the_uncached_rebuild(self):
+        """Team runs with member responses and a member agent run at the top
+        level come back byte-for-byte what a fresh rebuild yields."""
+        db = InMemoryDb()
+        _seed_team(db, with_member_data=True)
+        db.upsert_run(
+            {"run_id": "ma1", "agent_id": "member-agent", "content": "standalone", "status": "COMPLETED"},
+            session_id="t1",
+        )
+        cached = db.get_session("t1", session_type=SessionType.TEAM)
+        raw = db.get_session("t1", session_type=SessionType.TEAM, deserialize=False)
+        rebuilt = TeamSession.from_dict(raw)
+        assert [r.to_dict() for r in cached.runs] == [r.to_dict() for r in rebuilt.runs]
+
+    def test_updating_a_run_invalidates_only_that_run(self):
+        db = InMemoryDb()
+        _seed_team(db)
+        first = db.get_session("t1", session_type=SessionType.TEAM)
+        db.upsert_run({"run_id": "r1", "team_id": "tm1", "content": "rewritten", "status": "COMPLETED"}, "t1")
+        second = db.get_session("t1", session_type=SessionType.TEAM)
+        assert second.runs[1].content == "rewritten"
+        assert first.runs[1].content == "content 1"
+        assert second.runs[0] is first.runs[0]
+        assert second.runs[2] is first.runs[2]
+
+    def test_mutating_a_returned_run_never_reaches_the_stored_dicts(self):
+        db = InMemoryDb()
+        _seed_team(db, with_member_data=True)
+        session = db.get_session("t1", session_type=SessionType.TEAM)
+        session.runs[0].content = "caller vandalism"
+        session.runs[0].member_responses[0].content = "member vandalism"
+        raw = db.get_session("t1", session_type=SessionType.TEAM, deserialize=False)
+        assert raw["runs"][0]["content"] == "content 0"
+        assert raw["runs"][0]["member_responses"][0]["content"] == "member answer 0"
+
+    def test_get_run_returns_a_copy(self):
+        """The team background continue, HITL surfaces and the job-queue
+        sweeper fetch via get_run and mutate before persisting; the shared
+        object must not carry those mutations."""
+        db = InMemoryDb()
+        _seed_team(db)
+        session = db.get_session("t1", session_type=SessionType.TEAM)
+        fetched = session.get_run("r1")
+        fetched.status = RunStatus.cancelled
+        fetched.content = "sweeper text"
+
+        later = db.get_session("t1", session_type=SessionType.TEAM)
+        assert later.runs[1].status != RunStatus.cancelled
+        assert later.runs[1].content == "content 1"
+
+
+class TestTeamSaveScrubIsolation:
+    """save_session/save_run with store_member_responses=True scrub member
+    responses per member storage flags on a storage view, never on the loaded
+    (shared) run objects."""
+
+    def _team(self, db):
+        from agno.team import Team
+
+        member = Agent(
+            name="member",
+            id="member-agent",
+            store_media=False,
+            store_tool_messages=False,
+            store_history_messages=False,
+        )
+        return Team(id="tm1", members=[member], db=db, store_member_responses=True, telemetry=False)
+
+    def test_save_session_scrubs_the_store_not_the_shared_runs(self):
+        db = InMemoryDb()
+        # Stored runs carry member data the member's current flags would
+        # scrub (written before the flags were turned off).
+        _seed_team(db, with_member_data=True)
+        team = self._team(db)
+
+        session = db.get_session("t1", session_type=SessionType.TEAM)
+        shared_member = session.runs[0].member_responses[0]
+        # Deleting the row first routes this save through the one path where
+        # upsert_session serializes the session's own runs (a v3 update
+        # carries the stored list forward instead), so the storage view is
+        # observable in the store.
+        db.delete_session("t1")
+        team.save_session(session=session)
+
+        # The shared run objects keep their member data...
+        assert any(m.role == "tool" for m in shared_member.messages or [])
+        assert any(m.from_history for m in shared_member.messages or [])
+        assert shared_member.images
+        # ...while the store holds the scrubbed view.
+        raw = db.get_session("t1", session_type=SessionType.TEAM, deserialize=False)
+        stored_member = raw["runs"][0]["member_responses"][0]
+        assert all(m.get("role") != "tool" for m in stored_member.get("messages") or [])
+        assert all(not m.get("from_history") for m in stored_member.get("messages") or [])
+        assert not stored_member.get("images")
+
+    def test_save_run_scrubs_the_store_not_the_shared_run(self):
+        from agno.team._session import save_run
+
+        db = InMemoryDb()
+        _seed_team(db, with_member_data=True)
+        team = self._team(db)
+
+        session = db.get_session("t1", session_type=SessionType.TEAM)
+        shared_run = session.runs[1]
+        save_run(team, run=shared_run, session_id="t1", user_id="u1")
+
+        assert any(m.role == "tool" for m in shared_run.member_responses[0].messages or [])
+        raw = db.get_session("t1", session_type=SessionType.TEAM, deserialize=False)
+        stored_member = raw["runs"][1]["member_responses"][0]
+        assert all(m.get("role") != "tool" for m in stored_member.get("messages") or [])
+
+    def test_already_scrubbed_history_is_reused_not_copied(self):
+        """A save of already-scrubbed history detects nothing to remove and
+        reuses the loaded run objects for the storage view."""
+        from agno.team._session import _scrub_member_responses_storage_view, save_run
+
+        db = InMemoryDb()
+        _seed_team(db, with_member_data=True)
+        team = self._team(db)
+        session = db.get_session("t1", session_type=SessionType.TEAM)
+        for i, run in enumerate(session.runs):
+            save_run(team, run=run, session_id="t1", user_id="u1", run_index=i)
+
+        reloaded = db.get_session("t1", session_type=SessionType.TEAM)
+        for run in reloaded.runs:
+            assert _scrub_member_responses_storage_view(team, run) is run
+
+
+class TestSqliteTeamRunObjectCache:
+    @pytest.fixture
+    def sqlite_db(self, tmp_path):
+        from agno.db.sqlite import SqliteDb
+
+        return SqliteDb(db_file=str(tmp_path / "team-cache.db"))
+
+    def test_reads_share_history_run_objects(self, sqlite_db):
+        _seed_team(sqlite_db)
+        first = sqlite_db.get_session("t1", session_type=SessionType.TEAM)
+        second = sqlite_db.get_session("t1", session_type=SessionType.TEAM)
+        assert first.runs is not second.runs
+        assert [id(r) for r in first.runs] == [id(r) for r in second.runs]
+
+    def test_updating_a_run_invalidates_only_that_run(self, sqlite_db):
+        _seed_team(sqlite_db)
+        first = sqlite_db.get_session("t1", session_type=SessionType.TEAM)
+        sqlite_db.upsert_run({"run_id": "r1", "team_id": "tm1", "content": "rewritten", "status": "COMPLETED"}, "t1")
+        second = sqlite_db.get_session("t1", session_type=SessionType.TEAM)
+        assert second.runs[1].content == "rewritten"
+        assert first.runs[1].content == "content 1"
+        assert second.runs[0] is first.runs[0]
+        assert second.runs[2] is first.runs[2]
+
+    def test_another_writer_to_the_same_file_is_seen(self, sqlite_db, tmp_path):
+        from agno.db.sqlite import SqliteDb
+
+        _seed_team(sqlite_db)
+        sqlite_db.get_session("t1", session_type=SessionType.TEAM)
+
+        other = SqliteDb(db_file=str(tmp_path / "team-cache.db"))
+        other.upsert_run(
+            {"run_id": "r1", "team_id": "tm1", "content": "written elsewhere", "status": "COMPLETED"}, "t1"
+        )
+
+        again = sqlite_db.get_session("t1", session_type=SessionType.TEAM)
+        assert again.runs[1].content == "written elsewhere"
+
+    def test_content_matches_the_uncached_rebuild(self, sqlite_db):
+        _seed_team(sqlite_db, with_member_data=True)
+        cached = sqlite_db.get_session("t1", session_type=SessionType.TEAM)
+        raw = sqlite_db.get_session("t1", session_type=SessionType.TEAM, deserialize=False)
+        rebuilt = TeamSession.from_dict(raw)
+        assert [r.to_dict() for r in cached.runs] == [r.to_dict() for r in rebuilt.runs]
+
+
+class TestTeamHardenedMutators:
+    def test_team_regenerate_flips_status_on_a_copy(self):
+        from unittest.mock import MagicMock
+
+        from agno.team._run import _mark_team_run_regenerated
+
+        db = InMemoryDb()
+        _seed_team(db)
+        team = MagicMock()
+        team.db = db
+        team.parent_team_id = None
+        team.workflow_id = None
+        team.store_member_responses = True
+
+        before = db.get_session("t1", session_type=SessionType.TEAM)
+        target_run = before.runs[0]
+        session_view = db.get_session("t1", session_type=SessionType.TEAM)
+
+        _mark_team_run_regenerated(team, session_view, target_run.run_id)
+
+        # The other reader's object is untouched; the store has the flip.
+        assert target_run.status != RunStatus.regenerated
+        after = db.get_session("t1", session_type=SessionType.TEAM)
+        assert after.runs[0].status == RunStatus.regenerated
+        # The mutated session view sees its own flip.
+        assert session_view.runs[0].status == RunStatus.regenerated
+
+
+# ---------------------------------------------------------------------------
+# Workflow sessions
+# ---------------------------------------------------------------------------
+
+
+def _seed_workflow(db, session_id: str = "w1", n_runs: int = 3) -> None:
+    db.upsert_session(WorkflowSession(session_id=session_id, workflow_id="wf1", user_id="u1"))
+    for i in range(n_runs):
+        db.upsert_run(
+            {"run_id": f"wr{i}", "workflow_id": "wf1", "content": f"content {i}", "status": "COMPLETED"},
+            session_id=session_id,
+        )
+        # A step's agent run shares the workflow's session id; the session's
+        # own runs list must not surface it.
+        db.upsert_run(
+            {
+                "run_id": f"sr{i}",
+                "agent_id": "step-agent",
+                "content": f"step {i}",
+                "status": "COMPLETED",
+                "parent_run_id": f"wr{i}",
+            },
+            session_id=session_id,
+        )
+
+
+class TestWorkflowRunObjectCache:
+    def test_reads_share_history_run_objects(self):
+        db = InMemoryDb()
+        _seed_workflow(db)
+        first = db.get_session("w1", session_type=SessionType.WORKFLOW)
+        second = db.get_session("w1", session_type=SessionType.WORKFLOW)
+        assert first is not second
+        assert [id(r) for r in first.runs] == [id(r) for r in second.runs]
+
+    def test_step_runs_are_filtered_like_the_uncached_rebuild(self):
+        db = InMemoryDb()
+        _seed_workflow(db)
+        cached = db.get_session("w1", session_type=SessionType.WORKFLOW)
+        raw = db.get_session("w1", session_type=SessionType.WORKFLOW, deserialize=False)
+        rebuilt = WorkflowSession.from_dict(raw)
+        assert [r.run_id for r in cached.runs] == ["wr0", "wr1", "wr2"]
+        assert [r.to_dict() for r in cached.runs] == [r.to_dict() for r in rebuilt.runs]
+
+    def test_mutating_a_returned_run_never_reaches_the_stored_dicts(self):
+        db = InMemoryDb()
+        _seed_workflow(db)
+        session = db.get_session("w1", session_type=SessionType.WORKFLOW)
+        session.runs[0].content = "caller vandalism"
+        raw = db.get_session("w1", session_type=SessionType.WORKFLOW, deserialize=False)
+        stored = {r["run_id"]: r for r in raw["runs"]}
+        assert stored["wr0"]["content"] == "content 0"
+
+    def test_get_run_returns_a_copy(self):
+        """The workflow continue pipeline and the queue worker fetch via
+        get_run and mutate before persisting; the shared object must not
+        carry those mutations."""
+        db = InMemoryDb()
+        _seed_workflow(db)
+        session = db.get_session("w1", session_type=SessionType.WORKFLOW)
+        fetched = session.get_run("wr1")
+        fetched.status = RunStatus.cancelled
+        fetched.content = "sweeper text"
+
+        later = db.get_session("w1", session_type=SessionType.WORKFLOW)
+        assert later.get_run("wr1").status != RunStatus.cancelled
+
+    def test_sqlite_reads_share_and_invalidate_per_run(self, tmp_path):
+        from agno.db.sqlite import SqliteDb
+
+        db = SqliteDb(db_file=str(tmp_path / "wf-cache.db"))
+        _seed_workflow(db)
+        first = db.get_session("w1", session_type=SessionType.WORKFLOW)
+        second = db.get_session("w1", session_type=SessionType.WORKFLOW)
+        assert [id(r) for r in first.runs] == [id(r) for r in second.runs]
+
+        db.upsert_run({"run_id": "wr1", "workflow_id": "wf1", "content": "rewritten", "status": "COMPLETED"}, "w1")
+        third = db.get_session("w1", session_type=SessionType.WORKFLOW)
+        assert [r.run_id for r in third.runs] == ["wr0", "wr1", "wr2"]
+        assert third.runs[1].content == "rewritten"
+        assert first.runs[1].content == "content 1"
+        assert third.runs[0] is first.runs[0]
+        assert third.runs[2] is first.runs[2]
+
+    def test_sqlite_content_matches_the_uncached_rebuild(self, tmp_path):
+        from agno.db.sqlite import SqliteDb
+
+        db = SqliteDb(db_file=str(tmp_path / "wf-rebuild.db"))
+        _seed_workflow(db)
+        cached = db.get_session("w1", session_type=SessionType.WORKFLOW)
+        raw = db.get_session("w1", session_type=SessionType.WORKFLOW, deserialize=False)
+        rebuilt = WorkflowSession.from_dict(raw)
+        assert [r.to_dict() for r in cached.runs] == [r.to_dict() for r in rebuilt.runs]

--- a/libs/agno/tests/unit/db/test_run_object_cache.py
+++ b/libs/agno/tests/unit/db/test_run_object_cache.py
@@ -692,6 +692,35 @@ class TestSqliteTeamRunObjectCache:
         rebuilt = TeamSession.from_dict(raw)
         assert [r.to_dict() for r in cached.runs] == [r.to_dict() for r in rebuilt.runs]
 
+    def test_double_encoded_run_rows_are_normalized(self, sqlite_db):
+        """A run_data value written as a pre-encoded JSON string is double
+        encoded in the JSON column; the fast path must parse it in two steps
+        exactly as the uncached read does."""
+        import json
+        import time
+
+        sessions_table = sqlite_db._get_table(table_type="sessions", create_table_if_not_found=True)
+        runs_table = sqlite_db._get_table(table_type="runs", create_table_if_not_found=True)
+        with sqlite_db.Session() as sess, sess.begin():
+            sess.execute(
+                sessions_table.insert().values(session_id="s-raw", session_type="team", created_at=int(time.time()))
+            )
+            sess.execute(
+                runs_table.insert().values(
+                    run_id="r-raw",
+                    session_id="s-raw",
+                    run_type="team",
+                    team_id="tm1",
+                    status="COMPLETED",
+                    run_index=0,
+                    run_data=json.dumps({"run_id": "r-raw", "team_id": "tm1", "content": "raw", "status": "COMPLETED"}),
+                    created_at=int(time.time()),
+                )
+            )
+        session = sqlite_db.get_session("s-raw", session_type=SessionType.TEAM)
+        assert [r.run_id for r in session.runs] == ["r-raw"]
+        assert session.runs[0].content == "raw"
+
 
 class TestTeamHardenedMutators:
     def test_team_regenerate_flips_status_on_a_copy(self):

--- a/libs/agno/tests/unit/team/test_continue_run_requirements.py
+++ b/libs/agno/tests/unit/team/test_continue_run_requirements.py
@@ -884,7 +884,17 @@ class TestContinueRunApprovalResolution:
             )
 
         assert result is sentinel
-        mock_apply.assert_called_once_with(team.db, "run-1", run_response)
+        mock_apply.assert_called_once()
+        apply_args = mock_apply.call_args.args
+        assert apply_args[0] is team.db
+        assert apply_args[1] == "run-1"
+        assert apply_args[2].run_id == "run-1"
+        # The dispatch resolves approvals on its own copy of the stored run:
+        # history run objects are shared between session reads, so the
+        # session-held object must not carry the resolution.
+        assert apply_args[2] is not run_response
+        assert apply_args[2].requirements[0].confirmation is True
+        assert requirement.confirmation is None
         mock_continue.assert_called_once()
 
     def test_acontinue_run_uses_resolved_admin_approval_without_requirements(self):
@@ -946,7 +956,17 @@ class TestContinueRunApprovalResolution:
                 )
 
             assert result is sentinel
-            mock_apply.assert_called_once_with(team.db, "run-1", run_response)
+            mock_apply.assert_called_once()
+            apply_args = mock_apply.call_args.args
+            assert apply_args[0] is team.db
+            assert apply_args[1] == "run-1"
+            assert apply_args[2].run_id == "run-1"
+            # The dispatch resolves approvals on its own copy of the stored
+            # run: history run objects are shared between session reads, so
+            # the session-held object must not carry the resolution.
+            assert apply_args[2] is not run_response
+            assert apply_args[2].requirements[0].confirmation is True
+            assert requirement.confirmation is None
 
         asyncio.run(_exercise())
 

--- a/libs/agno/tests/unit/team/test_paused_member_persistence.py
+++ b/libs/agno/tests/unit/team/test_paused_member_persistence.py
@@ -6058,3 +6058,42 @@ def test_a_routing_failure_restores_the_callers_team_level_requirements(tmp_path
 
     names = [r.tool_execution.tool_name for r in (run1.requirements or [])]
     assert names.count("publish") == 1, f"the caller's run object carries: {names}"
+
+
+def test_continue_does_not_mutate_the_shared_history_object(tmp_path):
+    """History run objects are shared between reads of one adapter (the
+    db-level run-object cache). The continue pipeline works on a copy of the
+    stored paused run, so a session view read before the continue keeps its
+    paused state and member responses, while the store advances."""
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "shared-history.db")
+    session_id = "s-shared-history"
+
+    db = SqliteDb(db_file=db_file)
+    team1 = _build_flat_team(db, resuming=False)
+    run1 = team1.run("Email a@example.com", session_id=session_id)
+    assert run1.is_paused
+
+    # Another reader on the SAME adapter holds the shared paused run object.
+    session_view = db.get_session(session_id=session_id, session_type="team")
+    shared = next(r for r in session_view.runs if r.run_id == run1.run_id)
+    assert shared.status == RunStatus.paused
+    spared_member_ids = [m.run_id for m in shared.member_responses]
+    assert spared_member_ids, "the paused member run rides the stored team run"
+
+    team2 = _build_flat_team(db, resuming=True)
+    run2 = team2.continue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+    )
+    assert run2.status == RunStatus.completed
+    assert _EXECUTED == ["a@example.com"]
+
+    # The reader's shared object never moved...
+    assert shared.status == RunStatus.paused
+    assert [m.run_id for m in shared.member_responses] == spared_member_ids
+    assert all(getattr(m, "is_paused", False) for m in shared.member_responses)
+    # ...and a fresh read serves the completed run.
+    stored = next(
+        r for r in (db.get_session(session_id=session_id, session_type="team").runs or []) if r.run_id == run1.run_id
+    )
+    assert stored.status == RunStatus.completed


### PR DESCRIPTION
## Summary

Follow-up to #9775. That PR introduced the session run-object cache (history run objects built once per stored run and shared between reads) but excluded TEAM and WORKFLOW sessions, because their save/continue paths still mutated loaded history runs in place. This PR removes those mutations and extends the cache to team and workflow rows.

**1. Team `store_member_responses=True` saves scrub on a storage view, not in place.**
`save_session`/`asave_session`/`save_run`/`asave_run` used to call `_scrub_member_responses(team, run.member_responses)`, which strips member media / tool messages / history messages off EVERY run in `session.runs` in place. Under `cache_session=True` this was already a latent bug: one save with the flags off permanently stripped member data from the long-lived cached session (and from the run object the caller holds). The branch now builds a copied storage view, exactly like the `store_member_responses=False` branch already did.

To avoid O(history) copies per save, the view is change-detecting: `media_scrub_would_change` / `tool_scrub_would_change` / `history_scrub_would_change` (in `utils/agent.py`, next to the scrubs they mirror) judge per response whether the scrub would alter its stored form, with the same None/empty distinctions each field serializes under. History runs reloaded from the store were scrubbed before they were written, so they report "nothing to remove" at every level and no copies are made; only runs with fresh member data (typically the current one) are copied and scrubbed.

**2. Every team/workflow path that mutates a loaded history run now copies at acquisition** (two exhaustive audit sweeps over the team and workflow surfaces; agent-side equivalents were hardened in #9775):

- Team continue-by-`run_id` (sync dispatch + both async executors) deep-copies the run extracted from `session.runs` before the continue pipeline truncates/resumes it — mirror of the agent-side fix.
- `TeamSession.get_run` and `WorkflowSession.get_run` return a deep copy, like `AgentSession.get_run`. This covers the queue worker's status flips, the Slack HITL approval writes, `get_run_output`, the workflow continue acquisition (`Workflow.get_run_output`/`aget_run_output`), and the WS continue route that writes `step_requirements` onto the fetched run.
- `_mark_team_run_regenerated`/async flip status on a shallow copy swapped into the session list (mirror of `_mark_run_regenerated`).
- The team background-continue wrapper's `_get_session_run` closure (which deliberately bypasses `get_run` for mocked sessions) copies the scanned candidate; its refusal/error restore paths write the flipped copy back into the fresh session before caching it.
- Member-HITL routing (`_resolve_member_run_output_for_continue`) copies a paused member run resolved out of `session.runs` before handing it to the member's `continue_run` (which completes it in place by contract). The routing loop upserts the completed run back into the session, so nothing relied on the original's identity.
- The workflow-agent path's four `reloaded_session.runs[-1].workflow_agent_run = ...` writes go on a copy swapped into the reloaded session.
- `BaseWorkflowRunOutputEvent.to_dict` used to null its deep fields on `self` and restore them in a `finally` — with shared run objects, two concurrent serializations of the same stored event could permanently null those fields on each other. It now nulls them on a shallow copy (the same pattern `RunOutput.to_dict` uses).

**3. The cache gate now admits TEAM and WORKFLOW rows** in `InMemoryDb` and the seven SQL adapters (sqlite, async_sqlite, postgres, async_postgres, mysql, async_mysql, singlestore). `deserialize_history_run` takes the row's stored session type and mirrors the owning session class's per-run dispatch — in particular, a workflow session's step agent/team runs (which share its session id) are skipped exactly as `WorkflowSession.from_dict` skips them. `run_cache_eligible` centralizes the gate; a request whose type mismatches the row keeps the pre-cache full-load path.

### Measured (sqlite, 50 stored runs, µs/read; same probe on main vs this branch)

| read | main | this PR |
|---|---|---|
| team `get_session` (runs with messages + member responses) | 1191 | 248 |
| workflow `get_session` | 441 | 217 |

### Verification

- New isolation suites in `tests/unit/db/test_run_object_cache.py` port the agent cache pins to team and workflow sessions: shared reads, per-run invalidation, cross-instance visibility, store isolation, byte-equality with an uncached rebuild, step-run filtering, `get_run` copies, storage-view scrub isolation, and view reuse on already-scrubbed history.
- `tests/unit/team/test_paused_member_persistence.py` (142 tests pinning the paused-member resume contract, including fresh-process continues) now runs entirely on top of the team cache and passes unchanged; one new test pins that a continue completes on its own copy while another reader's shared paused run object never moves.
- Two pre-existing mock-identity assertions in `test_continue_run_requirements.py` were realigned to the copy-at-acquisition contract (the dispatch resolves approvals on its own copy of the stored run), matching the agent-side realignment in #9775.
- Full `tests/unit` differential vs `main`: identical failure sets (95 failures + 371 collection errors on both sides, all pre-existing environment gaps from missing optional deps; this branch passes 14,333 vs main's 14,313 — the delta is the new tests). The sweep also caught that the fast path must normalize double-encoded `run_data` rows (a pre-encoded JSON string written into a JSON column) the way the uncached two-step read does; fixed with a regression test.
- An executed differential probe confirmed the `store_member_responses=True` storage bytes are identical to main's in-place scrub (flat and nested sub-team trees, `save_session` and `save_run`), while the live run tree keeps its member data.

## Type of change

- [x] Bug fix
- [x] Improvement

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

The scrub predicates in `utils/agent.py` must stay exact mirrors of the scrub functions beside them: if a scrub learns to remove a new field, its `*_would_change` twin needs the same field, or an already-loaded run could skip a scrub that now matters. They live in the same file to keep that pairing visible in review.

Legacy adapters that were never gated (redis, firestore, dynamo, gcs, valkey, surrealdb, mongo) are unaffected: they still rebuild runs per read, and the copy-at-acquisition changes are strictly safer there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
