### PR TITLE
fix: apply @approval on plain functions given to a Team

### DIFF
--- a/libs/agno/agno/team/_tools.py
+++ b/libs/agno/agno/team/_tools.py
@@ -463,6 +463,22 @@ def _determine_tools_for_model(
             # We add the tools, which are callable functions
             try:
                 _func = Function.from_callable(tool, strict=strict)
+                # Detect @approval sentinel on raw callable
+                _approval_type = getattr(tool, "_agno_approval_type", None)
+                if _approval_type is not None:
+                    _func.approval_type = _approval_type
+                    if _approval_type == "required" and not any(
+                        [_func.requires_user_input, _func.requires_confirmation, _func.external_execution]
+                    ):
+                        _func.requires_confirmation = True
+                    elif _approval_type == "audit" and not any(
+                        [_func.requires_user_input, _func.requires_confirmation, _func.external_execution]
+                    ):
+                        raise ValueError(
+                            "@approval(type='audit') requires at least one HITL flag "
+                            "('requires_confirmation', 'requires_user_input', or 'external_execution') "
+                            "to be set on @tool()."
+                        )
                 _func = _func.model_copy(deep=True)
                 if _func.name in _function_names:
                     log_warning(

--- a/libs/agno/tests/unit/tools/test_approval_decorator.py
+++ b/libs/agno/tests/unit/tools/test_approval_decorator.py
@@ -1,5 +1,7 @@
 """Unit tests for the @approval decorator and its interaction with @tool."""
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from agno.approval import ApprovalType, approval
@@ -274,3 +276,94 @@ def test_toolkit_propagation():
     assert isinstance(func, Function)
     assert func.approval_type == "required"
     assert func.requires_confirmation is True
+
+
+# =============================================================================
+# Test 11: @approval on a bare callable survives agent and team tool parsing
+# =============================================================================
+
+
+def _parse_agent_tools(tools):
+    from agno.agent._tools import parse_tools
+    from agno.agent.agent import Agent
+    from agno.run.base import RunContext
+
+    agent = Agent(name="approval-agent", tools=tools)
+    return parse_tools(
+        agent,
+        tools=tools,
+        model=MagicMock(supports_native_structured_outputs=False),
+        run_context=RunContext(run_id="test-run", session_id="test-session"),
+    )
+
+
+def _parse_team_tools(tools):
+    from agno.run.base import RunContext
+    from agno.run.team import TeamRunOutput
+    from agno.session import TeamSession
+    from agno.team._tools import _determine_tools_for_model
+    from agno.team.team import Team
+
+    team = Team(name="approval-team", members=[], tools=tools)
+    return _determine_tools_for_model(
+        team=team,
+        model=MagicMock(supports_native_structured_outputs=False),
+        run_response=TeamRunOutput(run_id="test-run", session_id="test-session", team_id="test-team"),
+        run_context=RunContext(run_id="test-run", session_id="test-session"),
+        team_run_context={},
+        session=TeamSession(session_id="test-session"),
+        async_mode=False,
+    )
+
+
+def test_agent_raw_callable_sentinel():
+    """A bare callable decorated only with @approval (no @tool wrapper) must
+    come out of the agent parse loop with the approval gate applied."""
+
+    @approval
+    def delete_file(path: str) -> str:
+        """Delete a file at the given path."""
+        return f"deleted {path}"
+
+    functions = _parse_agent_tools([delete_file])
+    func = next(f for f in functions if isinstance(f, Function) and f.name == "delete_file")
+    assert func.approval_type == "required"
+    assert func.requires_confirmation is True
+
+
+def test_team_raw_callable_sentinel():
+    """A bare callable decorated only with @approval (no @tool wrapper) must
+    come out of the team parse loop with the approval gate applied — without
+    this, an approval-gated tool registered on a Team executes ungated."""
+
+    @approval
+    def delete_file(path: str) -> str:
+        """Delete a file at the given path."""
+        return f"deleted {path}"
+
+    functions = _parse_team_tools([delete_file])
+    func = next(f for f in functions if isinstance(f, Function) and f.name == "delete_file")
+    assert func.approval_type == "required"
+    assert func.requires_confirmation is True
+
+
+# =============================================================================
+# Test 12: audit-without-HITL on a bare callable is dropped, not run ungated
+# =============================================================================
+
+
+def test_raw_callable_audit_without_hitl_is_dropped():
+    """A bare callable can never carry a HITL flag, so @approval(type='audit')
+    on one is a misconfiguration. Both parse loops raise internally, catch in
+    the callable branch's handler, and skip the tool — it must not register."""
+
+    @approval(type="audit")
+    def bare_audit(x: int) -> int:
+        """Audit without HITL."""
+        return x
+
+    agent_functions = _parse_agent_tools([bare_audit])
+    assert not any(isinstance(f, Function) and f.name == "bare_audit" for f in agent_functions)
+
+    team_functions = _parse_team_tools([bare_audit])
+    assert not any(isinstance(f, Function) and f.name == "bare_audit" for f in team_functions)


### PR DESCRIPTION
## Summary

A function marked with `@approval` and given straight to a `Team` ran without asking for approval.

`@approval` can be used in two ways. On top of `@tool()` it sets the approval fields on the `Function` object right away. On a plain function it leaves a marker on the function instead, and the framework reads that marker later when it builds the tool list.

The Agent code reads the marker. The Team code did not. So this tool asked for approval on an Agent, and ran on its own on a Team:

```python
from agno.approval import approval

@approval
def delete_file(path: str) -> str:
    """Delete a file at the given path."""
    ...

Agent(tools=[delete_file])   # asks for approval
Team(tools=[delete_file])    # ran with no approval
```

A probe on the current `main` code confirms it. The Agent returns `approval_type='required'` and `requires_confirmation=True`. The Team returned `None` and `None`.

This copies the marker block from the Agent code into the Team code, so both surfaces behave the same.

Only plain functions were affected. `@approval` on top of `@tool()`, and tools inside a `Toolkit`, always carried the approval fields on the `Function` object itself, and those paths were already correct on a Team.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Security impact.** An approval gate that is silently dropped is a fail-open bug. The user asks for a stop before a sensitive tool runs, and no stop happens. There is no error and no warning, so the missing gate is easy to miss.

**Tests.** Three tests were added to `libs/agno/tests/unit/tools/test_approval_decorator.py`:

1. A plain `@approval` function on an Agent keeps the approval gate. This path was correct but had no test.
2. The same function on a Team keeps the approval gate. This is the fix.
3. `@approval(type="audit")` on a plain function is dropped on both surfaces.

Test 3 covers a setup mistake. `type="audit"` records an approval after a human-in-the-loop step finishes, so it needs one of `requires_confirmation`, `requires_user_input` or `external_execution` to be set. A plain function can never carry one of those flags, because there is no `@tool()` call to set them on. Both surfaces raise inside the tool loop, the loop's own error handler catches it, and the tool is left out of the tool list with a warning. The tool does not run, which is the safe outcome. The test pins the drop rather than a raised error, because that is the behaviour a caller sees.

**Verification.** Each new test was run against the unfixed code. Both Team tests fail without the fix and pass with it.

Test runs on this branch:

- `tests/unit/tools/test_approval_decorator.py`: 13 passed
- `tests/unit/agent` plus the core tools tests: 938 passed
- `tests/unit/team`: 783 passed, 2 skipped

The team suite has one failure that is also present on the base commit without this change: `test_team_skills.py::test_system_message_contains_skills_snippet`. It looks for a cookbook skills folder using a path relative to the current directory, and that folder is not present when the suite is run from `libs/agno`. It is not related to this change.

**Other places that build a tool from a plain function.** Every other call to `Function.from_callable` in the library was checked. The rest either build framework tools that the user never marks with `@approval`, or they only turn a tool into a dictionary for storage or for an API response. Neither kind is an execution gate, so no other surface needs this block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
