### PR TITLE
fix: stop rewriting caller-supplied dict tools during request formatting

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -2,6 +2,7 @@ import asyncio
 import collections.abc
 import json
 from abc import ABC, abstractmethod
+from copy import deepcopy
 from dataclasses import dataclass, field
 from hashlib import md5
 from pathlib import Path
@@ -600,8 +601,10 @@ class Model(ABC):
             if isinstance(tool, Function):
                 _tool_dicts.append({"type": "function", "function": tool.to_dict()})
             else:
-                # If a dict is passed, it is a builtin tool
-                _tool_dicts.append(tool)
+                # If a dict is passed, it is a builtin tool.
+                # Deep copy: provider formatters rewrite tool dicts in place,
+                # and the caller's dict must survive the request unchanged.
+                _tool_dicts.append(deepcopy(tool))
         # Deterministic ordering so prompt caching gets consistent cache hits.
         # Applies across providers — Anthropic, OpenAI, and Gemini prompt/context
         # caching all require stable request prefixes.

--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -1,5 +1,6 @@
 import asyncio
 import time
+from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Any, AsyncIterator, Dict, Iterator, List, Optional, Tuple, Type, Union
 
@@ -543,14 +544,17 @@ class OpenAIResponses(Model):
                             prop["type"] = prop["type"][0]
                     formatted_tools.append(_tool_dict)
                 elif _tool.get("type") == "function":
-                    _tool_dict = _tool.get("function", {})
+                    # Deep copy: the rewrites below must not leak into the caller's dict
+                    _tool_dict = deepcopy(_tool.get("function", {}))
                     _tool_dict["type"] = "function"
                     for prop in _tool_dict.get("parameters", {}).get("properties", {}).values():
                         if isinstance(prop.get("type", ""), list):
                             prop["type"] = prop["type"][0]
                     formatted_tools.append(_tool_dict)
                 else:
-                    formatted_tools.append(_tool)
+                    # Copy: file_search tools get vector_store_ids written below,
+                    # and the caller's dict must stay untouched
+                    formatted_tools.append(deepcopy(_tool))
 
         # Only upload files to vector store when file_search tool is present.
         # Otherwise, files will be embedded inline via _format_messages().

--- a/libs/agno/tests/unit/models/openai/test_dict_tool_immutability.py
+++ b/libs/agno/tests/unit/models/openai/test_dict_tool_immutability.py
@@ -1,0 +1,136 @@
+"""Caller-supplied dict tools are configuration owned by the caller.
+
+Formatting a request must never write into them: the same dict may be shared
+across runs, agents, and providers, so every provider-specific rewrite
+(adding "type", collapsing list-typed properties, stamping vector_store_ids)
+has to happen on a copy.
+"""
+
+import copy
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agno.agent import Agent
+from agno.media import File
+from agno.models.message import Message
+from agno.models.openai import OpenAIResponses
+
+
+def _function_dict_tool() -> dict:
+    return {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get weather",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": ["string", "null"], "description": "City"}},
+                "required": [],
+            },
+        },
+    }
+
+
+def _fake_response() -> SimpleNamespace:
+    return SimpleNamespace(
+        error=None,
+        id="resp_1",
+        status="completed",
+        output=[SimpleNamespace(type="message", content=[])],
+        output_text="hi",
+        usage=None,
+    )
+
+
+def _mock_client() -> MagicMock:
+    client = MagicMock()
+    client.is_closed.return_value = False
+    client.responses.create.return_value = _fake_response()
+    return client
+
+
+def _mock_async_client() -> MagicMock:
+    client = MagicMock()
+    client.is_closed.return_value = False
+    client.responses.create = AsyncMock(return_value=_fake_response())
+    return client
+
+
+class TestFormatToolParamsDoesNotMutate:
+    def test_function_shaped_dict_is_not_mutated(self):
+        model = OpenAIResponses(id="gpt-5.5", api_key="test-key")
+        tool = _function_dict_tool()
+        snapshot = json.dumps(tool)
+
+        formatted = model._format_tool_params(messages=[], tools=[tool])
+
+        assert json.dumps(tool) == snapshot
+        # The request payload still gets the rewritten shape
+        assert formatted[0]["type"] == "function"
+        assert formatted[0]["name"] == "get_weather"
+        assert formatted[0]["parameters"]["properties"]["city"]["type"] == "string"
+
+    def test_file_search_dict_does_not_receive_vector_store_ids(self):
+        model = OpenAIResponses(id="gpt-5.5", api_key="test-key")
+        tool = {"type": "file_search"}
+        snapshot = json.dumps(tool)
+        messages = [Message(role="user", content="hi", files=[File(content=b"data", mime_type="text/plain")])]
+
+        with (
+            patch.object(model, "_upload_file", return_value="file_1"),
+            patch.object(model, "_create_vector_store", return_value="vs_1"),
+        ):
+            formatted = model._format_tool_params(messages=messages, tools=[tool])
+
+        assert formatted[0]["vector_store_ids"] == ["vs_1"]
+        assert json.dumps(tool) == snapshot
+
+    def test_base_format_tools_copies_dict_tools(self):
+        model = OpenAIResponses(id="gpt-5.5", api_key="test-key")
+        tool = _function_dict_tool()
+
+        formatted = model._format_tools([tool])
+
+        assert formatted[0] == tool
+        assert formatted[0] is not tool
+        # Nested containers must be copies too: downstream formatters rewrite them
+        formatted[0]["function"]["parameters"]["properties"]["city"]["type"] = "string"
+        assert tool["function"]["parameters"]["properties"]["city"]["type"] == ["string", "null"]
+
+
+class TestAgentRunLeavesDictToolsIdentical:
+    def test_sync_run(self):
+        model = OpenAIResponses(id="gpt-5.5", api_key="test-key")
+        model.client = _mock_client()
+
+        fn_tool = _function_dict_tool()
+        builtin_tool = {"type": "web_search"}
+        fn_snapshot = copy.deepcopy(fn_tool)
+        builtin_snapshot = copy.deepcopy(builtin_tool)
+
+        agent = Agent(model=model, tools=[fn_tool, builtin_tool], telemetry=False)
+        run = agent.run("hello")
+
+        assert run.content == "hi"
+        assert fn_tool == fn_snapshot
+        assert builtin_tool == builtin_snapshot
+
+    @pytest.mark.asyncio
+    async def test_async_run(self):
+        model = OpenAIResponses(id="gpt-5.5", api_key="test-key")
+        model.async_client = _mock_async_client()
+
+        fn_tool = _function_dict_tool()
+        builtin_tool = {"type": "web_search"}
+        fn_snapshot = copy.deepcopy(fn_tool)
+        builtin_snapshot = copy.deepcopy(builtin_tool)
+
+        agent = Agent(model=model, tools=[fn_tool, builtin_tool], telemetry=False)
+        run = await agent.arun("hello")
+
+        assert run.content == "hi"
+        assert fn_tool == fn_snapshot
+        assert builtin_tool == builtin_snapshot


### PR DESCRIPTION
## Summary

A tool passed to an agent as a plain dict was handed to the model provider by reference, and the OpenAI Responses formatter then rewrote that dict in place. The caller's own config dict was permanently changed by the first run.

Three rewrites leaked into the caller's dict:

- `"type": "function"` was added inside the nested `function` dict.
- A property typed as a list, such as `{"type": ["string", "null"]}`, was collapsed to its first entry.
- `vector_store_ids` was stamped onto a `file_search` tool.

The change survives the run. It is visible on later runs and to any other agent that shares the same dict. A dict reused across an OpenAI agent and an Anthropic agent carries OpenAI-shaped edits into the Anthropic request.

Reproduced before fixing. One run with a mocked client turned this:

```python
tool = {
    "type": "function",
    "function": {
        "name": "get_weather",
        "parameters": {
            "type": "object",
            "properties": {"city": {"type": ["string", "null"]}},
        },
    },
}
agent = Agent(model=OpenAIResponses(id="gpt-5.5"), tools=[tool])
agent.run("hello")
```

into a caller dict whose `function` block had gained `"type": "function"` and whose `city` property had become `{"type": "string"}`.

### The fix

Dict tools are configuration owned by the caller, so formatting copies before it rewrites.

- `Model._format_tools` copies each dict tool. Every provider consumes this output, so one copy also covers the two other in-place writers found while checking the area: the Chat Completions path that removes agno-internal keys from function dicts for OpenAI-compatible providers, and the Anthropic path that adds `cache_control` to the last tool when `cache_tools` is on.
- `OpenAIResponses._format_tool_params` copies in both its function branch and its passthrough branch. This is needed on top of the base copy, because `count_tokens` and `acount_tokens` call this formatter with the raw user tools and never pass through `_format_tools`.

Request payloads are unchanged. The provider still receives the rewritten shape it needs.

### Checked and already correct

Bedrock and the Gemini schema conversion copy internally. The Anthropic tool formatter builds new dicts. The token counting helper only reads. Tools passed as `Function` objects were never affected, because `to_dict()` returns a fresh dict.

### Tests

New file `libs/agno/tests/unit/models/openai/test_dict_tool_immutability.py`, five tests:

- the Responses formatter leaves a function-shaped dict untouched while still emitting the rewritten payload;
- a `file_search` dict does not receive `vector_store_ids`;
- `_format_tools` returns copies deep enough that a downstream rewrite cannot reach the caller's nested schema;
- a full sync run and a full async run against a mocked client leave both a function dict and a builtin dict byte-identical.

All five fail with the fix reverted, so they pin the defect rather than the current behaviour.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Found while mapping the tool schema cache work in #9771. That PR gave `Function` tools a per-run copy; dict tools had no such protection, which is what this PR adds.

Local test runs used the dev venv, which does not carry the provider SDKs (those live in `scripts/test_setup.sh`). The Anthropic and Gemini surfaces named above were verified by reading the code, and CI executes them. Every unit suite that runs locally shows the same failure count before and after this change, with only the five new tests added to the pass count.
