### PR TITLE
feat: add contextual queue access for chat tray

### DIFF
--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -5155,6 +5155,8 @@ class AsyncPostgresDb(AsyncBaseDb):
     async def list_jobs(
         self,
         status: Optional[Union[str, List[str]]] = None,
+        session_id: Optional[Union[str, List[str]]] = None,
+        user_id: Optional[str] = None,
         limit: int = 20,
         page: int = 1,
         sort_by: Optional[str] = "created_at",
@@ -5168,6 +5170,11 @@ class AsyncPostgresDb(AsyncBaseDb):
             if status is not None:
                 statuses = [status] if isinstance(status, str) else list(status)
                 stmt = stmt.where(table.c.status.in_(statuses))
+            if session_id is not None:
+                session_ids = [session_id] if isinstance(session_id, str) else list(session_id)
+                stmt = stmt.where(table.c.session_id.in_(session_ids))
+            if user_id is not None:
+                stmt = stmt.where(table.c.user_id == user_id)
             count_stmt = select(func.count()).select_from(stmt.alias())
             stmt = apply_sorting(stmt, table, sort_by, sort_order)
             # Deterministic tiebreaker: timestamps are epoch seconds, so ties
@@ -5179,7 +5186,10 @@ class AsyncPostgresDb(AsyncBaseDb):
                 result = await sess.execute(stmt)
                 return [dict(row._mapping) for row in result.fetchall()], total_count
         except Exception as e:
-            log_warning(f"Job queue store: list_jobs failed (status={status!r}): {e}")
+            log_warning(
+                f"Job queue store: list_jobs failed (status={status!r}, session_id={session_id!r}, "
+                f"user_id={user_id!r}): {e}"
+            )
             return [], 0
 
     async def requeue_job(self, job_id: str) -> bool:

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -7788,6 +7788,8 @@ class PostgresDb(BaseDb):
     def list_jobs(
         self,
         status: Optional[Union[str, List[str]]] = None,
+        session_id: Optional[Union[str, List[str]]] = None,
+        user_id: Optional[str] = None,
         limit: int = 20,
         page: int = 1,
         sort_by: Optional[str] = "created_at",
@@ -7801,6 +7803,11 @@ class PostgresDb(BaseDb):
             if status is not None:
                 statuses = [status] if isinstance(status, str) else list(status)
                 stmt = stmt.where(table.c.status.in_(statuses))
+            if session_id is not None:
+                session_ids = [session_id] if isinstance(session_id, str) else list(session_id)
+                stmt = stmt.where(table.c.session_id.in_(session_ids))
+            if user_id is not None:
+                stmt = stmt.where(table.c.user_id == user_id)
             count_stmt = select(func.count()).select_from(stmt.alias())
             stmt = apply_sorting(stmt, table, sort_by, sort_order)
             # Deterministic tiebreaker: timestamps are epoch seconds, so ties
@@ -7812,7 +7819,10 @@ class PostgresDb(BaseDb):
                 result = sess.execute(stmt)
                 return [dict(row._mapping) for row in result.fetchall()], total_count
         except Exception as e:
-            log_warning(f"Job queue store: list_jobs failed (status={status!r}): {e}")
+            log_warning(
+                f"Job queue store: list_jobs failed (status={status!r}, session_id={session_id!r}, "
+                f"user_id={user_id!r}): {e}"
+            )
             return [], 0
 
     def requeue_job(self, job_id: str) -> bool:

--- a/libs/agno/agno/db/redis/redis.py
+++ b/libs/agno/agno/db/redis/redis.py
@@ -3007,6 +3007,8 @@ class RedisDb(BaseDb):
     def list_jobs(
         self,
         status: Optional[Union[str, List[str]]] = None,
+        session_id: Optional[Union[str, List[str]]] = None,
+        user_id: Optional[str] = None,
         limit: int = 20,
         page: int = 1,
         sort_by: Optional[str] = "created_at",
@@ -3014,17 +3016,23 @@ class RedisDb(BaseDb):
     ) -> Tuple[List[Dict[str, Any]], int]:
         """Paginated job listing: (page of jobs, total matching count).
 
-        status accepts one value or a list (match any). Loads the full index
+        status and session_id accept one value or a list (match any). Loads the full index
         and filters/sorts in Python, like the other Redis list APIs -
         total_count and arbitrary sort fields need the whole set anyway, and
         the index stays small by construction (bounded by max_queue_depth
         plus the retention sweep)."""
         statuses = [status] if isinstance(status, str) else status
+        session_ids = [session_id] if isinstance(session_id, str) else session_id
         jobs: List[Dict[str, Any]] = []
         raw_ids = self.redis_client.zrevrange(self._q_key("all"), 0, -1)
         for raw_id in raw_ids:
             job = self._q_load_job(_q_to_str(raw_id))
-            if job is not None and (statuses is None or job["status"] in statuses):
+            if (
+                job is not None
+                and (statuses is None or job["status"] in statuses)
+                and (session_ids is None or job.get("session_id") in session_ids)
+                and (user_id is None or job.get("user_id") == user_id)
+            ):
                 jobs.append(job)
         total_count = len(jobs)
         jobs = apply_sorting(records=jobs, sort_by=sort_by, sort_order=sort_order)

--- a/libs/agno/agno/job_queue/store.py
+++ b/libs/agno/agno/job_queue/store.py
@@ -247,6 +247,8 @@ class InMemoryQueueStore:
     async def list_jobs(
         self,
         status: Optional[Union[str, List[str]]] = None,
+        session_id: Optional[Union[str, List[str]]] = None,
+        user_id: Optional[str] = None,
         limit: int = 20,
         page: int = 1,
         sort_by: Optional[str] = "created_at",
@@ -254,13 +256,20 @@ class InMemoryQueueStore:
     ) -> Tuple[List[Dict[str, Any]], int]:
         """Paginated job listing: (page of jobs, total matching count).
 
-        status accepts one value or a list (match any). An unknown sort_by is
+        status and session_id accept one value or a list (match any). An unknown sort_by is
         silently ignored (the list-API convention); None-valued sort fields
         group together rather than erroring. Sorting by updated_at falls back
         to created_at when updated_at is None, matching the DB adapters."""
         statuses = [status] if isinstance(status, str) else status
+        session_ids = [session_id] if isinstance(session_id, str) else session_id
         async with self._lock:
-            jobs = [dict(j) for j in self._jobs.values() if statuses is None or j["status"] in statuses]
+            jobs = [
+                dict(j)
+                for j in self._jobs.values()
+                if (statuses is None or j["status"] in statuses)
+                and (session_ids is None or j.get("session_id") in session_ids)
+                and (user_id is None or j.get("user_id") == user_id)
+            ]
         total_count = len(jobs)
         if sort_by and jobs and sort_by in jobs[0]:
 

--- a/libs/agno/agno/os/routers/job_queue/router.py
+++ b/libs/agno/agno/os/routers/job_queue/router.py
@@ -54,6 +54,33 @@ async def _require_queue_admin(request: Request) -> None:
         raise HTTPException(status_code=403, detail="Job queue operations require an admin scope")
 
 
+def _queue_list_user_id(request: Request, session_ids: Optional[List[str]]) -> Optional[str]:
+    """Return the mandatory owner filter for a contextual non-admin list.
+
+    Open/security-key deployments and admin JWT callers retain the operator
+    view. Every other JWT caller must name at least one session and is pinned
+    to its authenticated user_id, regardless of whether global user isolation
+    is enabled. Session IDs are selectors, never authorization boundaries.
+    """
+    from agno.os.middleware.user_scope import _has_admin_scope
+
+    scopes = getattr(request.state, "scopes", None)
+    user_id = getattr(request.state, "user_id", None)
+    jwt_identity_present = isinstance(scopes, list) or user_id is not None
+    if not jwt_identity_present:
+        return None
+
+    admin_scope_raw = getattr(request.state, "admin_scope", None)
+    admin_scope = admin_scope_raw if isinstance(admin_scope_raw, str) else None
+    if _has_admin_scope(scopes or [], admin_scope=admin_scope):
+        return None
+    if not session_ids:
+        raise HTTPException(status_code=403, detail="Non-admin queue reads require at least one session_id")
+    if not isinstance(user_id, str) or not user_id:
+        raise HTTPException(status_code=403, detail="Contextual queue reads require an authenticated user_id")
+    return user_id
+
+
 def _get_store(request: Request):
     worker = getattr(request.app.state, "queue_worker", None)
     if worker is None:
@@ -68,7 +95,7 @@ def _get_store(request: Request):
 
 def get_queue_router(os: "AgentOS", settings: AgnoAPISettings = AgnoAPISettings()) -> APIRouter:
     router = APIRouter(
-        dependencies=[Depends(get_authentication_dependency(settings)), Depends(_require_queue_admin)],
+        dependencies=[Depends(get_authentication_dependency(settings))],
         prefix="/queue",
         tags=["Queue"],
         responses={
@@ -86,9 +113,11 @@ def get_queue_router(os: "AgentOS", settings: AgnoAPISettings = AgnoAPISettings(
         summary="List Queue Jobs",
         response_model=PaginatedResponse[QueueJobSchema],
         description=(
-            "List job queue jobs, optionally filtered by status. Repeat the status param to "
+            "List job queue jobs, optionally filtered by status and session. Repeat either param to "
             "match any of several (e.g. status=failed&status=cancelled for the requeueable "
-            "set; status=failed alone is the dead-letter list). Useful sort_by fields: "
+            "set, or session_id=s1&session_id=s2 for a contextual chat tray). Non-admin JWT "
+            "callers must provide session_id and only receive jobs owned by their authenticated "
+            "user. Useful sort_by fields: "
             "created_at (default), updated_at, completed_at, status, attempt, component_type, "
             "component_id, user_id. Unknown sort fields are ignored."
         ),
@@ -98,6 +127,9 @@ def get_queue_router(os: "AgentOS", settings: AgnoAPISettings = AgnoAPISettings(
         status: Optional[List[str]] = Query(
             default=None, description="Status filter; repeatable to match any of several statuses"
         ),
+        session_id: Optional[List[str]] = Query(
+            default=None, description="Session filter; repeatable to match any of several sessions"
+        ),
         limit: int = Query(default=20, description="Number of jobs to return per page", ge=1, le=1000),
         page: int = Query(default=1, description="Page number for pagination", ge=1),
         sort_by: str = Query(default="created_at", description="Field to sort jobs by"),
@@ -106,9 +138,16 @@ def get_queue_router(os: "AgentOS", settings: AgnoAPISettings = AgnoAPISettings(
         for s in status or []:
             if s not in JOB_STATUSES:
                 raise HTTPException(status_code=400, detail=f"Invalid status {s!r}; expected one of {JOB_STATUSES}")
+        scoped_user_id = _queue_list_user_id(request, session_id)
         store = _get_store(request)
         jobs, total_count = await store.list_jobs(
-            status=status or None, limit=limit, page=page, sort_by=sort_by, sort_order=sort_order.value
+            status=status or None,
+            session_id=session_id or None,
+            user_id=scoped_user_id,
+            limit=limit,
+            page=page,
+            sort_by=sort_by,
+            sort_order=sort_order.value,
         )
         return PaginatedResponse(
             data=[QueueJobSchema(**job) for job in jobs],
@@ -125,6 +164,7 @@ def get_queue_router(os: "AgentOS", settings: AgnoAPISettings = AgnoAPISettings(
         operation_id="get_queue_job",
         summary="Get Queue Job",
         response_model=QueueJobSchema,
+        dependencies=[Depends(_require_queue_admin)],
     )
     async def get_job(request: Request, job_id: str):
         store = _get_store(request)
@@ -138,6 +178,7 @@ def get_queue_router(os: "AgentOS", settings: AgnoAPISettings = AgnoAPISettings(
         operation_id="requeue_queue_job",
         summary="Requeue Failed Queue Job",
         response_model=QueueJobSchema,
+        dependencies=[Depends(_require_queue_admin)],
         description=(
             "Requeue a terminally failed or cancelled job for one more execution "
             "(raises its attempt budget by one). The operator remedy for crashed runs "
@@ -234,6 +275,7 @@ def get_queue_router(os: "AgentOS", settings: AgnoAPISettings = AgnoAPISettings(
         "/stats",
         operation_id="get_queue_stats",
         summary="Queue Stats",
+        dependencies=[Depends(_require_queue_admin)],
         description="Job counts by status and the oldest queued job's age - the queue-health signals to alert on.",
     )
     async def stats(request: Request):

--- a/libs/agno/tests/unit/os/test_queue_list_pagination.py
+++ b/libs/agno/tests/unit/os/test_queue_list_pagination.py
@@ -27,12 +27,13 @@ def harness():
     return SimpleNamespace(store=store, client=TestClient(app, raise_server_exceptions=False))
 
 
-def seed(store, job_id, status="queued", created_at=None, attempt=0):
+def seed(store, job_id, status="queued", created_at=None, attempt=0, session_id="s1", user_id=None):
     job = QueuedJob(
         id=job_id,
         component_type="agent",
         component_id="a1",
-        session_id="s1",
+        session_id=session_id,
+        user_id=user_id,
         payload={"input": "hi"},
         status=status,
         attempt=attempt,
@@ -86,6 +87,21 @@ class TestListJobsPagination:
         # One invalid value among several rejects the request
         resp = harness.client.get("/queue/jobs", params={"status": ["failed", "bogus"]})
         assert resp.status_code == 400
+
+    def test_multi_session_and_status_filters_compose(self, harness):
+        seed(harness.store, "j0", status="queued", session_id="s1")
+        seed(harness.store, "j1", status="running", session_id="s2")
+        seed(harness.store, "j2", status="paused", session_id="s3")
+        seed(harness.store, "j3", status="completed", session_id="s1")
+
+        resp = harness.client.get(
+            "/queue/jobs",
+            params={"session_id": ["s1", "s2"], "status": ["queued", "running", "paused"]},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert {job["id"] for job in body["data"]} == {"j0", "j1"}
+        assert body["meta"]["total_count"] == 2
 
     def test_invalid_params_rejected(self, harness):
         assert harness.client.get("/queue/jobs", params={"status": "bogus"}).status_code == 400

--- a/libs/agno/tests/unit/os/test_queue_wiring.py
+++ b/libs/agno/tests/unit/os/test_queue_wiring.py
@@ -314,6 +314,43 @@ class TestQueueAdminGate:
         await _require_queue_admin(self._request())
 
 
+class TestContextualQueueListGate:
+    def _request(self, scopes=None, user_id=None, admin_scope=None):
+        from types import SimpleNamespace
+
+        state = SimpleNamespace()
+        if scopes is not None:
+            state.scopes = scopes
+        if user_id is not None:
+            state.user_id = user_id
+        if admin_scope is not None:
+            state.admin_scope = admin_scope
+        return SimpleNamespace(state=state)
+
+    def test_non_admin_is_pinned_to_authenticated_user(self):
+        from agno.os.routers.job_queue.router import _queue_list_user_id
+
+        request = self._request(scopes=["agents:run"], user_id="u1")
+        assert _queue_list_user_id(request, ["s1", "s2"]) == "u1"
+
+    def test_non_admin_must_filter_by_session(self):
+        from fastapi import HTTPException
+
+        from agno.os.routers.job_queue.router import _queue_list_user_id
+
+        request = self._request(scopes=["agents:run"], user_id="u1")
+        with pytest.raises(HTTPException) as exc:
+            _queue_list_user_id(request, None)
+        assert exc.value.status_code == 403
+
+    def test_admin_and_open_deployments_remain_unscoped(self):
+        from agno.os.routers.job_queue.router import _queue_list_user_id
+
+        admin = self._request(scopes=["agent_os:admin"], user_id="admin")
+        assert _queue_list_user_id(admin, None) is None
+        assert _queue_list_user_id(self._request(), None) is None
+
+
 class TestUnfencedSessionStoreWarning:
     """A durable queue over a session store without the
     atomic run-persistence primitives must degrade LOUDLY - the fencing


### PR DESCRIPTION
## Summary

Adds the contextual queue-list access required by the Agno OS chat tray.

- Adds repeatable `session_id` filtering to `GET /queue/jobs` and carries the filter through the queue store implementations.
- Allows authenticated non-admin users to list queue jobs only when at least one `session_id` is supplied, and always pins those reads to the authenticated `user_id`.
- Preserves the existing unscoped operator view for admin JWT callers and open/security-key deployments.
- Keeps job detail, queue stats, and requeue operations admin-only after moving authorization off the router-wide dependency.
- Adds coverage for combined session/status filtering and contextual queue-list authorization.

This supports the session-scoped chat queue tray in agno-agi/agno-os#1266.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
  - `./scripts/format.sh` passes.
  - `./scripts/validate.sh` was run; Ruff, agnoctl mypy, and cookbook validation pass, but Agno mypy is currently blocked by 35 existing errors in unrelated reader/model/router compatibility files.
- [x] Self-review completed
- [x] Documentation updated (route descriptions, comments, and docstrings)
- [x] Examples and guides: not applicable; this extends an existing queue API
- [ ] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I searched existing open pull requests and found no PR that already adds contextual session-scoped queue listing for the chat tray
- [x] No duplicate PR requires comparison
- [x] Checked: this was developed and reviewed interactively, not submitted as an unreviewed AI-generated change

---

## Additional Notes

- This is a stacked PR based on `feat/serialize-sessions-per-queue` / #9587 because it extends that durable queue API.
- Focused verification: `34 passed` in `test_queue_list_pagination.py` and `test_queue_wiring.py`.
- Queue session IDs are selectors, not authorization boundaries; non-admin JWT reads are additionally constrained by the authenticated `user_id` in every supported queue store.
