### PR TITLE
[fix] preserve delegation child run ids

### DIFF
--- a/libs/agno/agno/team/_default_tools.py
+++ b/libs/agno/agno/team/_default_tools.py
@@ -68,7 +68,7 @@ from agno.run.team import (
     TeamRunOutputEvent,
 )
 from agno.session import TeamSession
-from agno.tools.function import Function
+from agno.tools.function import Function, FunctionCall
 from agno.utils.knowledge import get_agentic_or_user_search_filters, get_user_id_kwarg
 from agno.utils.log import (
     log_debug,
@@ -547,6 +547,7 @@ def _get_delegate_task_function(
         member_agent: Union[Agent, "Team"],
         delegated_task: Union[str, Message],
         member_session_state_copy: Dict[str, Any],
+        tool_call_id: Optional[str] = None,
     ):
         # Add team run id to the member run
 
@@ -556,7 +557,11 @@ def _get_delegate_task_function(
         # Update the top-level team run_response tool call to have the run_id of the member run
         if run_response.tools is not None and member_agent_run_response is not None:
             for tool in run_response.tools:
-                if tool.tool_name and tool.tool_name.lower() == "delegate_task_to_member":
+                if tool_call_id is not None:
+                    matches_tool_call = tool.tool_call_id == tool_call_id
+                else:
+                    matches_tool_call = tool.tool_name and tool.tool_name.lower() == "delegate_task_to_member"
+                if matches_tool_call:
                     tool.child_run_id = member_agent_run_response.run_id  # type: ignore
 
         # Update the team run context
@@ -615,6 +620,7 @@ def _get_delegate_task_function(
         member_agent: Union[Agent, "Team"],
         delegated_task: Union[str, Message],
         member_session_state_copy: Dict[str, Any],
+        tool_call_id: Optional[str] = None,
     ):
         """Async twin of the sync post-processor above.
 
@@ -633,7 +639,11 @@ def _get_delegate_task_function(
         # Update the top-level team run_response tool call to have the run_id of the member run
         if run_response.tools is not None and member_agent_run_response is not None:
             for tool in run_response.tools:
-                if tool.tool_name and tool.tool_name.lower() == "delegate_task_to_member":
+                if tool_call_id is not None:
+                    matches_tool_call = tool.tool_call_id == tool_call_id
+                else:
+                    matches_tool_call = tool.tool_name and tool.tool_name.lower() == "delegate_task_to_member"
+                if matches_tool_call:
                     tool.child_run_id = member_agent_run_response.run_id  # type: ignore
 
         # Update the team run context
@@ -687,7 +697,9 @@ def _get_delegate_task_function(
         if member_agent_run_response is not None:
             _update_team_media(team, member_agent_run_response)  # type: ignore
 
-    def delegate_task_to_member(member_id: str, task: str) -> Iterator[Union[RunOutputEvent, TeamRunOutputEvent, str]]:
+    def delegate_task_to_member(
+        member_id: str, task: str, fc: Optional[FunctionCall] = None
+    ) -> Iterator[Union[RunOutputEvent, TeamRunOutputEvent, str]]:
         """Use this function to delegate a task to the selected team member.
 
         Args:
@@ -811,6 +823,7 @@ def _get_delegate_task_function(
                 member_agent,
                 task,  # type: ignore
                 member_session_state_copy,  # type: ignore
+                fc.call_id if fc is not None else None,
             )
             raise
 
@@ -823,6 +836,7 @@ def _get_delegate_task_function(
                 member_agent,
                 task,  # type: ignore
                 member_session_state_copy,  # type: ignore
+                fc.call_id if fc is not None else None,
             )
             yield f"Member '{member_agent.name}' requires human input before continuing."
             return
@@ -863,10 +877,11 @@ def _get_delegate_task_function(
             member_agent,
             task,  # type: ignore
             member_session_state_copy,  # type: ignore
+            fc.call_id if fc is not None else None,
         )
 
     async def adelegate_task_to_member(
-        member_id: str, task: str
+        member_id: str, task: str, fc: Optional[FunctionCall] = None
     ) -> AsyncIterator[Union[RunOutputEvent, TeamRunOutputEvent, str]]:
         """Use this function to delegate a task to the selected team member.
 
@@ -996,6 +1011,7 @@ def _get_delegate_task_function(
                 member_agent,
                 task,  # type: ignore
                 member_session_state_copy,  # type: ignore
+                fc.call_id if fc is not None else None,
             )
             raise
 
@@ -1008,6 +1024,7 @@ def _get_delegate_task_function(
                 member_agent,
                 task,  # type: ignore
                 member_session_state_copy,  # type: ignore
+                fc.call_id if fc is not None else None,
             )
             yield f"Member '{member_agent.name}' requires human input before continuing."
             return
@@ -1045,6 +1062,7 @@ def _get_delegate_task_function(
             member_agent,
             task,  # type: ignore
             member_session_state_copy,  # type: ignore
+            fc.call_id if fc is not None else None,
         )
 
     # When the task should be delegated to all members

--- a/libs/agno/tests/unit/team/test_delegate_child_run_id.py
+++ b/libs/agno/tests/unit/team/test_delegate_child_run_id.py
@@ -1,0 +1,140 @@
+import asyncio
+from typing import Any, Dict
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agno.models.response import ToolExecution
+from agno.run import RunContext
+from agno.run.agent import RunOutput
+from agno.run.team import TeamRunOutput
+from agno.team._default_tools import _get_delegate_task_function
+from agno.tools.function import FunctionCall
+
+
+def _build_delegate_function(async_mode: bool, members: Dict[str, MagicMock]):
+    team = MagicMock()
+    team.delegate_to_all_members = False
+    team.respond_directly = False
+    team.add_history_to_context = False
+    team.add_team_history_to_members = False
+    team.determine_input_for_members = True
+    team.enable_agentic_knowledge_filters = False
+
+    run_response = TeamRunOutput(
+        run_id="team-run",
+        tools=[
+            ToolExecution(tool_call_id="tool-call-1", tool_name="delegate_task_to_member"),
+            ToolExecution(tool_call_id="tool-call-2", tool_name="delegate_task_to_member"),
+        ],
+    )
+    run_context = RunContext(
+        run_id="team-run",
+        session_id="session",
+        session_state={},
+    )
+    session = MagicMock()
+    session.session_id = "session"
+    team_run_context: Dict[str, Any] = {}
+
+    with (
+        patch("agno.team._init._initialize_member"),
+        patch(
+            "agno.team._tools._find_member_by_id",
+            side_effect=lambda _team, member_id, run_context: (0, members[member_id]),
+        ),
+        patch("agno.team._default_tools.add_interaction_to_team_run_context"),
+        patch("agno.team._run._update_team_media"),
+        patch("agno.team._run._member_run_for_storage", side_effect=lambda _team, _session, response: response),
+        patch("agno.team._run._amember_run_for_storage", new_callable=AsyncMock),
+    ):
+        function = _get_delegate_task_function(
+            team=team,
+            run_response=run_response,
+            run_context=run_context,
+            session=session,
+            team_run_context=team_run_context,
+            async_mode=async_mode,
+        )
+
+    function._team = team
+    function._run_context = run_context
+    return function, run_response
+
+
+def _member(member_id: str) -> MagicMock:
+    member = MagicMock()
+    member.id = member_id
+    member.name = member_id
+    member.store_media = True
+    member.store_tool_messages = True
+    member.store_history_messages = True
+    member.add_history_to_context = False
+    member.knowledge = None
+    member.knowledge_filters = None
+    member.run.return_value = RunOutput(run_id=f"member-run-{member_id}", content=f"{member_id} done")
+    return member
+
+
+def _consume_sync(function, call_id: str, member_id: str) -> None:
+    call = FunctionCall(
+        function=function,
+        call_id=call_id,
+        arguments={"member_id": member_id, "task": f"task for {member_id}"},
+    )
+    result = call.execute()
+    assert result.status == "success"
+    list(result.result)
+
+
+def test_sync_delegate_calls_keep_their_tool_call_child_run_mapping():
+    members = {"one": _member("one"), "two": _member("two")}
+    function, run_response = _build_delegate_function(async_mode=False, members=members)
+
+    _consume_sync(function, "tool-call-1", "one")
+    _consume_sync(function, "tool-call-2", "two")
+
+    assert {tool.tool_call_id: tool.child_run_id for tool in run_response.tools or []} == {
+        "tool-call-1": "member-run-one",
+        "tool-call-2": "member-run-two",
+    }
+
+
+@pytest.mark.asyncio
+async def test_async_delegate_calls_keep_their_tool_call_child_run_mapping_out_of_order():
+    members = {"one": _member("one"), "two": _member("two")}
+
+    async def run_member(member_id: str, *args: Any, **kwargs: Any) -> RunOutput:
+        if member_id == "one":
+            await asyncio.sleep(0.01)
+        return RunOutput(run_id=f"member-run-{member_id}", content=f"{member_id} done")
+
+    for member_id, member in members.items():
+
+        async def arun(*args: Any, _member_id=member_id, **kwargs: Any) -> RunOutput:
+            return await run_member(_member_id)
+
+        member.arun = AsyncMock(side_effect=arun)
+
+    function, run_response = _build_delegate_function(async_mode=True, members=members)
+
+    async def consume(call_id: str, member_id: str) -> None:
+        call = FunctionCall(
+            function=function,
+            call_id=call_id,
+            arguments={"member_id": member_id, "task": f"task for {member_id}"},
+        )
+        result = await call.aexecute()
+        assert result.status == "success"
+        async for _ in result.result:
+            pass
+
+    await asyncio.gather(
+        consume("tool-call-1", "one"),
+        consume("tool-call-2", "two"),
+    )
+
+    assert {tool.tool_call_id: tool.child_run_id for tool in run_response.tools or []} == {
+        "tool-call-1": "member-run-one",
+        "tool-call-2": "member-run-two",
+    }


### PR DESCRIPTION
Fixes #9359

## Summary

Concurrent `delegate_task_to_member` calls previously matched every team tool execution by tool name alone. When members finished in different orders, the last completion overwrote the `child_run_id` for all delegation entries, corrupting parent/child traceability.

This change uses the existing framework-injected `FunctionCall` to carry the current call ID into the sync and async delegation cleanup paths. The post-processors now update only the matching `ToolExecution.tool_call_id`, while retaining the existing name-based fallback for internal calls without a `FunctionCall`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I searched existing open pull requests and found no implementation for #9359.
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] This contribution used AI assistance; I reviewed the implementation and test results.

---

## Additional Notes

Validation evidence:

- Focused regression tests: `2 passed` (sync and async out-of-order completion).
- `./scripts/format.sh`: passed.
- `./scripts/validate.sh`: could not run its mypy stage because `mypy` is not installed in this isolated environment; the repository's existing team suite otherwise produced 751 passed, 35 environment/fixture-dependent failures, and 2 skips. The changed focused tests pass independently.
- Added-line security scan and `git diff --check`: passed.

The fix covers normal, paused, and cancellation cleanup paths for both sync and async delegation. No dependencies, public API models, docs, or non-Python files were changed.