### PR TITLE
feat: verified_tool — per-call prediction contracts

### DIFF
--- a/cookbook/14_verifiers/07_predictions/README.md
+++ b/cookbook/14_verifiers/07_predictions/README.md
@@ -1,0 +1,3 @@
+# Predictions
+
+- `verified_tool.py` — `@verified_tool` lets a tool call carry a falsifiable prediction: a counter tool with a hidden cap, where a wrong prediction prefixes a divergence block and forces a replan from the real value.

--- a/cookbook/14_verifiers/07_predictions/TEST_LOG.md
+++ b/cookbook/14_verifiers/07_predictions/TEST_LOG.md
@@ -1,0 +1,13 @@
+# Test Log
+
+## 2026-08-26 — gpt-5.5, demo venv
+
+### verified_tool.py
+
+**Status:** PASS
+
+**Description:** A counter tool with a hidden cap of +5 per call, decorated with @verified_tool. The model predicted the first call would land on 17; the cap advanced it only to 5; the divergence block reported expected 17 / actual 5; the model replanned from the real value (5 -> 10 -> 15 -> 17) and reached the target in capped steps, then stated what it learned about the tool's behavior.
+
+**Result:** Success — the prediction contract turned a silent wrong assumption into an immediate, evidence-based correction.
+
+---

--- a/cookbook/14_verifiers/07_predictions/verified_tool.py
+++ b/cookbook/14_verifiers/07_predictions/verified_tool.py
@@ -1,0 +1,78 @@
+"""
+Verified Tool
+=============
+A tool call that carries a falsifiable prediction.
+
+The `step` tool advances a counter with one hidden rule: any amount above 5 is capped to 5.
+The tool declares an optional `expect` parameter; the model fills it with its prediction of
+the new counter value, and `verified_tool` compares the prediction with reality after the
+call. A wrong prediction prefixes the result with a divergence block, so the model cannot
+gloss over a plan that stopped matching the world.
+
+verified_tool verifies one call. It cannot stop other calls the model batches into the same
+message, so the instructions ask for exactly one step call per message: the model reads each
+result before it spends the next step, and a divergence forces a replan before the plan is
+finished.
+"""
+
+from typing import Optional
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.verifiers import verified_tool
+
+# ---------------------------------------------------------------------------
+# A stateful tool with a hidden rule, and the prediction check
+# ---------------------------------------------------------------------------
+
+state = {"n": 0, "calls": []}
+
+
+def same_value(result: str, expect: str) -> bool:
+    return result.strip() == expect.strip()
+
+
+@verified_tool(same_value)
+def step(amount: int, expect: Optional[str] = None) -> str:
+    """Advance the counter by `amount` and return the new value.
+
+    Args:
+        amount: How much to add.
+        expect: Your prediction of the new counter value, as a string. Send an empty string
+            when you have no prediction.
+    """
+    state["n"] += min(amount, 5)
+    state["calls"].append((amount, expect, state["n"]))
+    return str(state["n"])
+
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.5"),
+    tools=[step],
+    instructions=[
+        "You drive a counter that starts at 0 with the step tool. Your goal is a counter of exactly 17.",
+        "Use as few step calls as you can: plan the amounts up front, then execute the plan.",
+        "Issue exactly one step call per message. Read its result before deciding the next call.",
+        "Always fill expect with the value you predict the counter will show after the call.",
+        "If a result diverges from your prediction, say what the tool actually does and replan from the real value.",
+        "Keep going until the counter shows 17, then reply with the final value and what you learned about the tool.",
+    ],
+)
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+
+response = agent.run("Take the counter from 0 to exactly 17.")
+
+print("tool calls (amount, expect, new value):")
+for call in state["calls"]:
+    print("  ", call)
+print()
+print("final counter:", state["n"])
+print()
+print(response.content)

--- a/cookbook/14_verifiers/README.md
+++ b/cookbook/14_verifiers/README.md
@@ -36,6 +36,7 @@ The principle: **evidence over prose.** The checks, not the model's summary, def
 | `04_fingerprints/` | `GitWorktreeFingerprint` + `stop_on_noop`: ending runs that change nothing |
 | `05_team/` | A team member that verifies its own work |
 | `06_agentos/` | A verified agent served over AgentOS |
+| `07_predictions/` | `@verified_tool`: a tool call that carries a falsifiable prediction |
 
 ## The pieces
 

--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -2306,6 +2306,20 @@ class FunctionExecutionResult(BaseModel):
     files: Optional[List[File]] = None
 
 
+def _refuse_hooks_on_a_verified_tool(function: "Function") -> None:
+    """Fail closed when hooks would silently defeat an @verified_tool comparison.
+
+    Kept behind a local import so agno.tools never depends on agno.verifiers at module scope.
+    """
+    try:
+        from agno.verifiers.tools import hook_conflict
+    except ImportError:  # narrow on purpose: a broad guard here would hide a real defect
+        return
+    reason = hook_conflict(function)
+    if reason:
+        raise ValueError(reason)
+
+
 class FunctionCall(BaseModel):
     """Model for Function Calls"""
 
@@ -2817,6 +2831,12 @@ class FunctionCall(BaseModel):
 
         raw_results: List[Any] = []
         try:
+            # Hooks can defeat an @verified_tool comparison, so refuse before running anything.
+            # This sits here, not in the chain builder below, because that builder is only
+            # reached when tool_hooks are set - a pre_hook or post_hook alone would never
+            # reach it. Inside the try so it surfaces as a tool failure, not a raised run.
+            _refuse_hooks_on_a_verified_tool(self.function)
+
             # Build and execute the nested chain of hooks
             if self.function.tool_hooks is not None:
                 execution_chain = self._build_nested_execution_chain(
@@ -3075,6 +3095,12 @@ class FunctionCall(BaseModel):
 
         raw_results: List[Any] = []
         try:
+            # Hooks can defeat an @verified_tool comparison, so refuse before running anything.
+            # This sits here, not in the chain builder below, because that builder is only
+            # reached when tool_hooks are set - a pre_hook or post_hook alone would never
+            # reach it. Inside the try so it surfaces as a tool failure, not a raised run.
+            _refuse_hooks_on_a_verified_tool(self.function)
+
             # Build and execute the nested chain of hooks
             if self.function.tool_hooks is not None:
                 execution_chain = await self._build_nested_execution_chain_async(

--- a/libs/agno/agno/verifiers/__init__.py
+++ b/libs/agno/agno/verifiers/__init__.py
@@ -34,6 +34,7 @@ from agno.verifiers.fingerprints import (
 )
 from agno.verifiers.scorer import ScorerVerifier
 from agno.verifiers.shell import ShellVerifier
+from agno.verifiers.tools import DIVERGENCE_DIRECTIVE, divergence_report, verified_tool
 from agno.verifiers.types import (
     REPORT_CAP_BYTES,
     StopReason,
@@ -45,6 +46,7 @@ from agno.verifiers.types import (
 
 __all__ = [
     "DEFAULT_EXCLUDES",
+    "DIVERGENCE_DIRECTIVE",
     "REPORT_CAP_BYTES",
     "CallableFingerprint",
     "GitWorktreeFingerprint",
@@ -58,5 +60,7 @@ __all__ = [
     "VerificationAttempt",
     "VerificationConfig",
     "Verifier",
+    "divergence_report",
+    "verified_tool",
     "verifier",
 ]

--- a/libs/agno/agno/verifiers/tools.py
+++ b/libs/agno/agno/verifiers/tools.py
@@ -1,0 +1,243 @@
+"""verified_tool: a tool call that carries a falsifiable prediction.
+
+The tool declares an optional `expect` parameter so the model-facing schema is honest. When
+the model fills it, the decorator runs the tool, compares the result against the prediction,
+and on mismatch prefixes the result with a divergence block. It verifies one call: it cannot
+stop other calls the model issued in the same turn, so cookbooks that want a bound plan ask
+for one predicted step per turn.
+"""
+
+import functools
+import inspect
+import re
+from typing import Any, Callable, Optional, TypeVar, Union, cast
+
+from agno.verifiers.base import _is_async_callable, _traceback_tail
+from agno.verifiers.types import REPORT_CAP_BYTES, Verdict, cap_text
+
+# The decorated tool keeps its own type. This package ships py.typed, so returning a bare
+# Callable would erase the signature for every downstream caller: a wrong argument type and a
+# wrong assignment from the result would both type-check clean.
+F = TypeVar("F", bound=Callable[..., Any])
+
+DIVERGENCE_DIRECTIVE = (
+    "Your prediction for this call was wrong. Do not continue the plan that produced it; "
+    "re-derive the next step from the actual result below."
+)
+
+
+_CLOSE_TAG = re.compile(r"<\s*/\s*divergence\s*>", re.IGNORECASE)
+
+
+def _escape(text: str) -> str:
+    return _CLOSE_TAG.sub("<\\/divergence>", text)
+
+
+def divergence_report(expected: str, actual: str, context: str = "") -> str:
+    """The standard block: expected, actual, optional context, and the directive. Capped. The
+    tool's own output cannot close the block."""
+    lines = ["<divergence>", f"expected: {_escape(expected)}", f"actual: {_escape(actual)}"]
+    if context:
+        lines.append(_escape(context))
+    lines.extend([DIVERGENCE_DIRECTIVE, "</divergence>"])
+    return cap_text("\n".join(lines), REPORT_CAP_BYTES)
+
+
+def _prediction_present(value: Any) -> bool:
+    return value is not None and str(value).strip() != ""
+
+
+def _result_text(result: Any) -> str:
+    from agno.tools.function import ToolResult
+
+    if result is None:
+        # `Optional[str]` is a legal annotation the decorator accepts, so a None result must
+        # compare as an empty result rather than fail the call it was meant to check.
+        return ""
+    if isinstance(result, ToolResult):
+        return result.content or ""
+    if isinstance(result, str):
+        return result
+    raise TypeError(
+        f"verified_tool requires the tool to return str or ToolResult when a prediction is present; "
+        f"got {type(result).__name__}"
+    )
+
+
+def _with_prefix(result: Any, block: str) -> Any:
+    from agno.tools.function import ToolResult
+
+    if isinstance(result, ToolResult):
+        content = f"{block}\n{result.content}" if result.content else block
+        return result.model_copy(update={"content": content})
+    if result is None:
+        # The tool returned nothing; "None" is not evidence, the block alone is.
+        return block
+    return f"{block}\n{result}"
+
+
+def _apply(compare: Callable[[Any, str], Union[bool, Verdict]], result: Any, expect: str) -> Any:
+    text = _result_text(result)
+    try:
+        outcome = compare(result, expect)
+    except Exception as exc:
+        outcome = Verdict(passed=False, report=f"compare raised {type(exc).__name__}: {exc}\n{_traceback_tail(exc)}")
+    if outcome is True:
+        return result
+    if isinstance(outcome, Verdict):
+        if outcome.passed is True:
+            return result
+        context = outcome.report
+    elif outcome is False:
+        context = ""
+    elif isinstance(outcome, str):
+        context = outcome  # a reason for the mismatch, the same shape a verifier may return
+    else:
+        context = f"compare returned {type(outcome).__name__}; return True, False, a str, or a Verdict"
+    block = divergence_report(expect, cap_text(text, REPORT_CAP_BYTES // 2), context)
+    return _with_prefix(result, block)
+
+
+_PROVABLY_WRONG_RETURNS = (dict, list, tuple, set, frozenset, int, float, bool, bytes)
+
+
+def _check_return_annotation(fn: Callable) -> None:
+    try:
+        import typing
+
+        hints = typing.get_type_hints(fn)
+    except Exception:
+        return
+    annotation = hints.get("return")
+    if annotation is None:
+        return
+    origin = getattr(annotation, "__origin__", annotation)
+    if isinstance(origin, type) and origin is not str and issubclass(origin, _PROVABLY_WRONG_RETURNS):
+        raise TypeError(
+            f"verified_tool requires the tool to return str or ToolResult; "
+            f"{getattr(fn, '__name__', fn)!r} is annotated to return {annotation!r}"
+        )
+
+
+def verified_tool(compare: Callable[[Any, str], Union[bool, Verdict]], param: str = "expect") -> Callable[[F], F]:
+    """Decorate a tool function that declares an optional `expect: Optional[str] = None`.
+
+    Apply it to the plain function, beneath `@tool` when both are used. A prediction is
+    present when `expect` is not None and not blank; then `compare(result, str(expect))`
+    runs after the tool and a mismatch (False, a failing Verdict, an exception, or any other
+    return) prefixes the result with a divergence block. Without a prediction the call is
+    passed through unchanged. The tool body receives `expect` exactly as sent. The wrapper
+    matches the tool's kind (sync or async); generator tools are rejected. Tool exceptions
+    propagate untouched.
+
+    The block is addressed to the model: do not combine with `stop_after_tool_call` or a
+    `show_result` tool used as the final answer, which hand the tool output to the user. With
+    `cache_results=True` a cached call is not re-compared, so a divergence recorded once is
+    replayed for the same arguments and prediction; leave caching off for stateful tools.
+
+    Hooks are refused, not tolerated. `tool_hooks` wrap the decorated function, so a hook can
+    rewrite the prediction, replace the result the comparison produced, or answer without
+    calling the wrapped function at all — in every case the prediction would look checked when
+    it was not. A tool that is both decorated and hooked therefore fails its call with an
+    explanation rather than passing quietly. Check the result inside the hook instead, or keep
+    the hooks off this tool.
+    """
+
+    if _is_async_callable(compare):
+        raise TypeError(
+            "verified_tool runs compare synchronously after the tool returns; an async compare "
+            "would never be awaited and every call would read as a divergence. Make it a plain "
+            "function, or await inside the tool and compare the resolved value."
+        )
+
+    def decorate(fn: F) -> F:
+        from agno.tools.function import Function
+        from agno.tools.toolkit import Toolkit
+
+        if isinstance(fn, (Function, Toolkit)):
+            raise TypeError("verified_tool wraps the function; apply it beneath @tool")
+        if inspect.isgeneratorfunction(fn) or inspect.isasyncgenfunction(fn):
+            raise TypeError(
+                "verified_tool cannot wrap a generator tool: a streamed result has no single value to compare"
+            )
+        sig = inspect.signature(fn)
+        if param not in sig.parameters:
+            raise TypeError(f"verified_tool: {getattr(fn, '__name__', fn)!r} has no parameter named {param!r}")
+
+        # Best-effort early failure for a return type the runtime rule will reject: a tool
+        # annotated to return a dict/list/tuple/set/number decorates fine but would surface
+        # a TypeError as a tool error mid-run the first time the model sends a prediction.
+        _check_return_annotation(fn)
+
+        def prediction(args: tuple, kwargs: dict) -> Any:
+            try:
+                return sig.bind_partial(*args, **kwargs).arguments.get(param)
+            except TypeError:
+                return kwargs.get(param)
+
+        if inspect.iscoroutinefunction(fn):
+
+            @functools.wraps(fn)
+            async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                expect = prediction(args, kwargs)
+                result = await fn(*args, **kwargs)
+                if not _prediction_present(expect):
+                    return result
+                return _apply(compare, result, str(expect))
+
+            async_wrapper.__agno_verified_tool__ = True  # type: ignore[attr-defined]
+            return cast(F, async_wrapper)
+
+        @functools.wraps(fn)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            expect = prediction(args, kwargs)
+            result = fn(*args, **kwargs)
+            if not _prediction_present(expect):
+                return result
+            return _apply(compare, result, str(expect))
+
+        wrapper.__agno_verified_tool__ = True  # type: ignore[attr-defined]
+        return cast(F, wrapper)
+
+    return decorate
+
+
+def is_verified_tool(fn: Any) -> bool:
+    """True when `fn` is a callable produced by `verified_tool`.
+
+    The marker is what lets the tool-execution path refuse to run a verified tool behind hooks
+    that can silently defeat its comparison.
+    """
+    return bool(getattr(fn, "__agno_verified_tool__", False))
+
+
+def hook_conflict(function: Any) -> Optional[str]:
+    """The reason a hook-bearing Function may not wrap a verified tool, or None.
+
+    A hook that rewrites the result replaces the divergence block after the comparison ran, a
+    hook that rewrites `expect` in place changes the prediction being checked, and a hook that
+    answers without calling the wrapped function skips the comparison altogether. Each of those
+    turns a falsifiable prediction back into an unchecked claim, which is the one thing this
+    decorator exists to prevent — so the call fails loudly rather than passing quietly.
+    """
+    if not is_verified_tool(getattr(function, "entrypoint", None)):
+        return None
+    offenders = []
+    if getattr(function, "tool_hooks", None):
+        offenders.append("tool_hooks")
+    if getattr(function, "pre_hook", None):
+        offenders.append("pre_hook")
+    if getattr(function, "post_hook", None):
+        offenders.append("post_hook")
+    if not offenders:
+        return None
+    return (
+        f"{getattr(function, 'name', 'tool')!r} is decorated with @verified_tool and also has "
+        f"{' and '.join(offenders)}. Hooks wrap the decorated function, so they can rewrite the "
+        "prediction, replace the result the comparison produced, or skip the call entirely — the "
+        "prediction would look checked when it was not. Remove the hooks from this tool, or drop "
+        "@verified_tool and check the result inside the hook instead."
+    )
+
+
+__all__ = ["DIVERGENCE_DIRECTIVE", "divergence_report", "verified_tool"]

--- a/libs/agno/tests/unit/verifiers/test_gate_agent.py
+++ b/libs/agno/tests/unit/verifiers/test_gate_agent.py
@@ -381,3 +381,37 @@ def test_stop_after_tool_call_still_verifies_and_reenters():
     assert out.status == RunStatus.completed
     assert out.verification.status == "verified"
     assert len(out.verification.attempts) == 2
+
+
+def test_report_replays_exactly_once_in_next_runs_history(tmp_path):
+    """The report is real transcript: a later run in the same session sees it in history
+    exactly once — no duplicated prefix, no stripping."""
+    from agno.db.sqlite import SqliteDb
+
+    model = ScriptedModel(
+        [
+            _text("claimed done"),
+            _text("actually done"),
+            _text("second run answer"),
+        ]
+    )
+    agent = Agent(
+        model=model,
+        verifiers=[fail_once()],
+        db=SqliteDb(db_file=str(tmp_path / "history.db")),
+        add_history_to_context=True,
+    )
+    first = agent.run("do the work", session_id="hist-1")
+    assert first.verification.status == "verified"
+
+    agent2 = Agent(
+        model=model,
+        db=SqliteDb(db_file=str(tmp_path / "history.db")),
+        add_history_to_context=True,
+    )
+    second = agent2.run("follow up", session_id="hist-1")
+    history_reports = [m for m in (second.messages or []) if m.role == "user" and "<verification" in str(m.content)]
+    assert len(history_reports) == 1, (
+        f"expected the report exactly once in the follow-up run's transcript, got {len(history_reports)}"
+    )
+    assert second.status == RunStatus.completed

--- a/libs/agno/tests/unit/verifiers/test_tools.py
+++ b/libs/agno/tests/unit/verifiers/test_tools.py
@@ -1,0 +1,440 @@
+"""Unit tests for verified_tool and divergence_report.
+
+Behaviour is driven through FunctionCall.execute / aexecute, the way an agent calls tools;
+decoration-time checks and exceptions are asserted on the decorated function directly.
+"""
+
+import inspect
+from typing import Optional
+
+import pytest
+
+from agno.tools.decorator import tool
+from agno.tools.function import Function, FunctionCall, ToolResult
+from agno.verifiers import DIVERGENCE_DIRECTIVE, Verdict, divergence_report, verified_tool
+
+# ---------------------------------------------------------------------------
+# Fixtures: a toy stateful environment with one hidden rule
+# ---------------------------------------------------------------------------
+
+
+def make_counter():
+    state = {"n": 0}
+
+    def step(amount: int, expect: Optional[str] = None) -> str:
+        """Advance the counter.
+
+        Args:
+            amount: How much to add. Values above 5 are capped to 5.
+            expect: Your prediction of the new counter value, as a string. Send an empty string
+                when you have no prediction.
+        """
+        state["n"] += min(amount, 5)
+        return str(state["n"])
+
+    return step, state
+
+
+def same(result, expect):
+    text = result.content if isinstance(result, ToolResult) else result
+    return text == expect
+
+
+def execute(fn, **arguments):
+    return FunctionCall(function=Function.from_callable(fn), arguments=arguments).execute()
+
+
+async def aexecute(fn, **arguments):
+    return await FunctionCall(function=Function.from_callable(fn), arguments=arguments).aexecute()
+
+
+# ---------------------------------------------------------------------------
+# Behaviour through the framework
+# ---------------------------------------------------------------------------
+
+
+def test_no_expect_is_passthrough():
+    plain, _ = make_counter()
+    decorated = verified_tool(same)(make_counter()[0])
+    assert execute(plain, amount=3).result == execute(decorated, amount=3).result == "3"
+
+
+def test_blank_expect_is_passthrough():
+    decorated = verified_tool(same)(make_counter()[0])
+    assert execute(decorated, amount=3, expect="").result == "3"
+    decorated2 = verified_tool(same)(make_counter()[0])
+    assert execute(decorated2, amount=3, expect="   ").result == "3"
+
+
+def test_matching_prediction_is_unchanged():
+    decorated = verified_tool(same)(make_counter()[0])
+    assert execute(decorated, amount=3, expect="3").result == "3"
+
+
+def test_mismatch_prefixes_divergence_block_on_str():
+    decorated = verified_tool(same)(make_counter()[0])
+    out = execute(decorated, amount=9, expect="9")
+    assert out.status == "success"
+    assert out.result.startswith("<divergence>")
+    assert "expected: 9" in out.result and "actual: 5" in out.result
+    assert DIVERGENCE_DIRECTIVE in out.result
+    assert out.result.endswith("</divergence>\n5")
+
+
+def test_mismatch_prefixes_tool_result_content():
+    def probe(expect: Optional[str] = None) -> ToolResult:
+        return ToolResult(content="real", metadata={"k": 1})
+
+    decorated = verified_tool(same)(probe)
+    out = execute(decorated, expect="fake")
+    assert isinstance(out.result, ToolResult)
+    assert out.result.content.startswith("<divergence>")
+    assert out.result.content.endswith("\nreal")
+    assert out.result.metadata == {"k": 1}
+
+
+def test_tool_body_receives_expect_as_sent():
+    seen = {}
+
+    def probe(expect: Optional[str] = None) -> str:
+        seen["expect"] = expect
+        return "x"
+
+    execute(verified_tool(same)(probe), expect="x")
+    assert seen["expect"] == "x"
+
+
+def test_non_str_expect_through_framework_is_schema_validation_failure():
+    # The framework validates arguments against the tool's own signature (expect: Optional[str])
+    # before the decorator runs, so a non-str prediction never reaches compare this way.
+    decorated = verified_tool(same)(make_counter()[0])
+    assert execute(decorated, amount=3, expect=3).status == "failure"
+
+
+def test_non_str_expect_on_direct_call_is_compared_as_string():
+    decorated = verified_tool(same)(make_counter()[0])
+    assert decorated(amount=3, expect=3) == "3"
+    assert decorated(amount=3, expect=7).startswith("<divergence>")
+
+
+def test_compare_verdict_passed_decides_and_report_is_context():
+    def judge(result, expect):
+        return Verdict(passed=False, report="off by one")
+
+    decorated = verified_tool(judge)(make_counter()[0])
+    out = execute(decorated, amount=1, expect="1")
+    assert "off by one" in out.result
+    assert out.result.startswith("<divergence>")
+
+    def lenient(result, expect):
+        return Verdict(passed=True)
+
+    assert execute(verified_tool(lenient)(make_counter()[0]), amount=1, expect="wrong").result == "1"
+
+
+def test_compare_raising_is_a_mismatch_with_traceback():
+    def broken(result, expect):
+        raise ValueError("cannot compare")
+
+    out = execute(verified_tool(broken)(make_counter()[0]), amount=1, expect="1")
+    assert out.result.startswith("<divergence>")
+    assert "compare raised ValueError: cannot compare" in out.result
+
+
+def test_compare_returning_none_is_a_mismatch():
+    def forgot_return(result, expect):
+        result == expect  # noqa: B015
+
+    out = execute(verified_tool(forgot_return)(make_counter()[0]), amount=1, expect="1")
+    assert "compare returned NoneType" in out.result
+
+
+def test_tool_exception_surfaces_as_tool_failure_without_decorator_frame():
+    def explode(expect: Optional[str] = None) -> str:
+        raise RuntimeError("tool broke")
+
+    out = execute(verified_tool(same)(explode), expect="x")
+    assert out.status == "failure"
+    assert "tool broke" in str(out.error)
+    assert "verified_tool" not in str(out.error)
+
+
+def test_wrong_return_annotation_rejected_at_decoration():
+    def gives_dict(expect: Optional[str] = None) -> dict:
+        return {"n": 1}
+
+    with pytest.raises(TypeError, match="annotated to return"):
+        verified_tool(same)(gives_dict)
+
+
+def test_unannotated_non_str_result_with_prediction_is_tool_failure_naming_verified_tool():
+    def gives_dict(expect: Optional[str] = None):
+        return {"n": 1}
+
+    out = execute(verified_tool(same)(gives_dict), expect="x")
+    assert out.status == "failure"
+    assert "verified_tool" in str(out.error)
+    # Without a prediction the dict passes through.
+    assert execute(verified_tool(same)(gives_dict)).result == {"n": 1}
+
+
+def test_str_and_optional_annotations_decorate_fine():
+    def gives_str(expect: Optional[str] = None) -> str:
+        return "ok"
+
+    def gives_optional(expect: Optional[str] = None) -> Optional[str]:
+        return None
+
+    verified_tool(same)(gives_str)
+    verified_tool(same)(gives_optional)
+
+
+@pytest.mark.asyncio
+async def test_async_tool_through_aexecute():
+    state = {"n": 0}
+
+    async def astep(amount: int, expect: Optional[str] = None) -> str:
+        """Async step."""
+        state["n"] += min(amount, 5)
+        return str(state["n"])
+
+    decorated = verified_tool(same)(astep)
+    assert inspect.iscoroutinefunction(decorated)
+    ok = await aexecute(decorated, amount=2, expect="2")
+    assert ok.result == "2"
+    bad = await aexecute(decorated, amount=9, expect="11")
+    assert bad.result.startswith("<divergence>") and bad.result.endswith("\n7")
+    plain = await aexecute(decorated, amount=1)
+    assert plain.result == "8"
+
+
+def test_sync_tool_stays_sync():
+    decorated = verified_tool(same)(make_counter()[0])
+    assert not inspect.iscoroutinefunction(decorated)
+
+
+def test_strict_schema_still_lists_expect():
+    decorated = verified_tool(same)(make_counter()[0])
+    fn = Function.from_callable(decorated, strict=True)
+    fn.process_entrypoint(strict=True)
+    params = fn.parameters["properties"]
+    assert "expect" in params
+    assert "Your prediction" in params["expect"]["description"]
+
+
+def test_schema_shows_original_signature_and_docstring():
+    decorated = verified_tool(same)(make_counter()[0])
+    fn = Function.from_callable(decorated)
+    fn.process_entrypoint()
+    assert fn.name == "step"
+    assert set(fn.parameters["properties"]) == {"amount", "expect"}
+
+
+def test_stacks_beneath_tool_decorator():
+    step, _ = make_counter()
+    decorated = tool(verified_tool(same)(step))
+    assert isinstance(decorated, Function)
+    out = FunctionCall(function=decorated, arguments={"amount": 9, "expect": "9"}).execute()
+    assert out.result.startswith("<divergence>")
+
+
+# ---------------------------------------------------------------------------
+# Decoration-time checks
+# ---------------------------------------------------------------------------
+
+
+def test_applying_above_tool_decorator_raises_ordering_error():
+    step, _ = make_counter()
+    with pytest.raises(TypeError, match="beneath @tool"):
+        verified_tool(same)(tool(step))
+
+
+def test_generator_tool_rejected():
+    def gen(expect: Optional[str] = None):
+        yield "a"
+
+    async def agen(expect: Optional[str] = None):
+        yield "a"
+
+    with pytest.raises(TypeError, match="generator"):
+        verified_tool(same)(gen)
+    with pytest.raises(TypeError, match="generator"):
+        verified_tool(same)(agen)
+
+
+def test_missing_param_rejected():
+    def no_expect(amount: int) -> str:
+        return str(amount)
+
+    with pytest.raises(TypeError, match="expect"):
+        verified_tool(same)(no_expect)
+
+
+def test_custom_param_name():
+    def guess(amount: int, prediction: Optional[str] = None) -> str:
+        return str(amount)
+
+    decorated = verified_tool(same, param="prediction")(guess)
+    assert decorated(amount=2, prediction="2") == "2"
+    assert decorated(amount=2, prediction="3").startswith("<divergence>")
+
+
+def test_direct_call_with_dict_result_and_prediction_raises():
+    def gives_dict(expect: Optional[str] = None):
+        return {"n": 1}
+
+    with pytest.raises(TypeError, match="str or ToolResult"):
+        verified_tool(same)(gives_dict)(expect="x")
+
+
+def test_direct_call_positional_prediction_is_detected():
+    step, _ = make_counter()
+    decorated = verified_tool(same)(step)
+    assert decorated(9, "9").startswith("<divergence>")
+
+
+# ---------------------------------------------------------------------------
+# divergence_report
+# ---------------------------------------------------------------------------
+
+
+def test_divergence_report_shape_and_cap():
+    block = divergence_report("a", "b", "ctx")
+    assert block.splitlines() == [
+        "<divergence>",
+        "expected: a",
+        "actual: b",
+        "ctx",
+        DIVERGENCE_DIRECTIVE,
+        "</divergence>",
+    ]
+    assert len(divergence_report("a", "x" * 50000).encode("utf-8")) <= 6144
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed compare verdicts and hook precedence
+# ---------------------------------------------------------------------------
+
+
+def test_compare_verdict_with_non_bool_passed_is_a_mismatch():
+    def sloppy(result, expect):
+        return Verdict(passed="mismatch", report="looked wrong")
+
+    out = execute(verified_tool(sloppy)(make_counter()[0]), amount=1, expect="1")
+    assert out.result.startswith("<divergence>")
+    assert "only a real bool decides" in out.result
+
+
+def _hooked(decorated, hook):
+    fn = Function.from_callable(decorated)
+    fn.tool_hooks = [hook]
+    return fn
+
+
+def _assert_refused(out):
+    """A verified tool behind hooks must fail its call, not quietly skip the comparison."""
+    assert out.status == "failure", f"expected a refusal, got {out.result!r}"
+    assert "@verified_tool" in str(out.error)
+    assert "tool_hooks" in str(out.error)
+    assert out.result is None
+
+
+def test_argument_rewriting_hook_is_refused():
+    # A tool_hook that rewrites an argument in place would change the prediction the
+    # comparison checks, so a wrong prediction would read as correct.
+    def rewrite_expect(name, func, args):
+        args["expect"] = "5"
+        return func(**args)
+
+    fn = _hooked(verified_tool(same)(make_counter()[0]), rewrite_expect)
+    out = FunctionCall(function=fn, arguments={"amount": 9, "expect": "9"}).execute()
+    _assert_refused(out)
+
+
+def test_result_rewriting_hook_is_refused():
+    # A hook that rewrites the result replaces the divergence block after the comparison
+    # produced it, so the model never sees that its prediction was wrong.
+    def strip_blocks(name, func, args):
+        result = func(**args)
+        return str(result).split("</divergence>")[-1].lstrip()
+
+    fn = _hooked(verified_tool(same)(make_counter()[0]), strip_blocks)
+    out = FunctionCall(function=fn, arguments={"amount": 9, "expect": "9"}).execute()
+    _assert_refused(out)
+
+
+def test_short_circuiting_hook_is_refused():
+    calls = []
+
+    def probe(expect: Optional[str] = None) -> str:
+        calls.append(1)
+        return "real"
+
+    def answer_directly(name, func, args):
+        return "hook answer"
+
+    fn = _hooked(verified_tool(same)(probe), answer_directly)
+    out = FunctionCall(function=fn, arguments={"expect": "real"}).execute()
+    assert out.status == "failure"
+    assert out.result != "hook answer"
+    assert calls == []
+
+
+def test_an_unhooked_verified_tool_still_works():
+    """The refusal must be scoped to hooks, not to every verified tool."""
+    fn = Function.from_callable(verified_tool(same)(make_counter()[0]))
+    out = FunctionCall(function=fn, arguments={"amount": 9, "expect": "9"}).execute()
+    assert out.status != "failure"
+
+
+def test_a_hooked_plain_tool_is_untouched():
+    """And it must not fire for a tool that was never decorated."""
+
+    def plain(amount: int) -> str:
+        return str(amount)
+
+    fn = _hooked(plain, lambda name, func, args: func(**args))
+    out = FunctionCall(function=fn, arguments={"amount": 9}).execute()
+    assert out.status != "failure"
+    assert out.result == "9"
+
+
+def test_an_async_compare_is_rejected_at_decoration_time():
+    async def acompare(result, expect):
+        return True
+
+    with pytest.raises(TypeError, match="async compare"):
+        verified_tool(acompare)
+
+
+def test_an_async_callable_object_as_compare_is_rejected():
+    """`inspect.iscoroutinefunction` is False for an instance whose __call__ is async, so a
+    bare check on the function would let one through to never be awaited."""
+
+    class AsyncCompare:
+        async def __call__(self, result, expect):
+            return True
+
+    with pytest.raises(TypeError, match="async compare"):
+        verified_tool(AsyncCompare())
+
+
+def test_a_compare_returning_a_reason_uses_it_as_the_divergence_context():
+    def why(result, expect):
+        return "the counter is capped at 5"
+
+    fn = Function.from_callable(verified_tool(why)(make_counter()[0]))
+    out = FunctionCall(function=fn, arguments={"amount": 9, "expect": "9"}).execute()
+    assert "the counter is capped at 5" in str(out.result)
+    assert "compare returned str" not in str(out.result)
+
+
+@pytest.mark.parametrize("hook_field", ["pre_hook", "post_hook"])
+def test_a_lone_pre_or_post_hook_is_refused_too(hook_field):
+    """The chain builder is only reached when tool_hooks are set, so a guard placed there would
+    never see a tool carrying only a pre_hook or a post_hook."""
+    fn = Function.from_callable(verified_tool(same)(make_counter()[0]))
+    setattr(fn, hook_field, lambda **kwargs: None)
+    out = FunctionCall(function=fn, arguments={"amount": 9, "expect": "9"}).execute()
+    assert out.status == "failure"
+    assert hook_field in str(out.error)


### PR DESCRIPTION
## Summary

The second primitive of the verifiers program: **per-call prediction contracts**. Where `Agent(verifiers=...)` (#9807) checks claims at completion, `@verified_tool` holds the model to a falsifiable prediction on a single tool call:

```python
@verified_tool(compare=lambda result, expect: str(result) == expect, param="expect")
def step(amount: int, expect: Optional[str] = None) -> str:
    ...
```

When the model supplies a prediction and the comparison fails, the tool result is prefixed with a `<divergence>` block (`expected:` / `actual:` / directive), so a wrong assumption is corrected the moment it is made instead of compounding across a plan. Independent of the run loop; works on any agent anywhere.

Two pieces:

1. **`agno.verifiers.tools`** — the decorator, salvaged intact from the closed #9675 branch (it was loop-agnostic there): wrapper kind matches the tool (sync/async; generators refused at decoration), applied beneath `@tool`, presence iff `str(expect).strip() != ""`, strict result-type rules, `compare` mapping (`Verdict`/`True`/`False`; anything else — including an exception — is a mismatch with the reason in the block), tool exceptions propagate untouched.
2. **The `function.py` hook-refusal guard** — hooks can rewrite a tool's arguments or result and silently defeat the comparison, so `FunctionCall.execute`/`aexecute` refuse hooks on a verified tool before running anything, surfacing as a tool failure (not a raised run). Re-landed from the branch's final state; the guard imports the checker locally so `agno.tools` never depends on `agno.verifiers` at module scope.

## Type of change

- [x] New feature

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: cookbook `14_verifiers/07_predictions/` with a live-model TEST_LOG
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Stacked on #9807** (which is stacked on #9805); retarget as the stack merges.

**Tests**: 38 in `test_tools.py` (the branch's full suite, import-renamed, plus the async-callable-compare rejection that lived in a sibling file there). Mutation-verified: commenting out the guard call flips all five hook-refusal tests red. `tests/unit/tools/` byte-identical pass/fail set with and without the change (the pre-existing failures are missing-optional-dep collection errors in the dev venv). Whole `tests/unit/verifiers/` suite: 276 green. This PR also carries one additional core-gate regression test (report replays exactly once in a follow-up run's history) written alongside.

**Live cookbook evidence** (`07_predictions/TEST_LOG.md`): the model predicted a counter call would land on 17; the tool's hidden +5 cap landed it on 5; the divergence block reported expected 17 / actual 5; the model replanned from the real value and reached 17 in capped steps.

The branch's unrelated `has_side_effects` hunks in `function.py` were deliberately not ported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iCnp8n73UaLGtZXy9AsMV
