### PR TITLE
fix(team): resolve dependencies after continue modifiers on async continue

### DIFF
--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -189,11 +189,13 @@ async def _asetup_session(
     session_id: str,
     user_id: Optional[str],
     run_id: Optional[str],
+    resolve_dependencies: bool = True,
 ) -> TeamSession:
-    """Read/create session, load state from DB, and resolve callable dependencies.
+    """Read/create session, load state from DB, and optionally resolve callable dependencies.
 
-    Shared setup for _arun() and _arun_stream(). Mirrors what the sync
-    run_dispatch() does inline before calling _run()/_run_stream().
+    Shared setup for _arun() / _arun_stream() and the async continue paths.
+    Continue callers pass ``resolve_dependencies=False`` and resolve after
+    ``_apply_continue_modifiers_team`` so factories see the forked run id.
     """
     # Read or create session
     from agno.team._init import _has_async_db, _initialize_session_state
@@ -225,8 +227,9 @@ async def _asetup_session(
             team, session=team_session, session_state=run_context.session_state
         )
 
-    # Resolve callable dependencies AFTER state is loaded
-    if run_context.dependencies is not None:
+    # Resolve callable dependencies AFTER state is loaded. Continue paths skip
+    # this and resolve after `_apply_continue_modifiers_team` instead.
+    if resolve_dependencies and run_context.dependencies is not None:
         await _aresolve_run_dependencies(team, run_context=run_context)
 
     return team_session
@@ -9483,13 +9486,16 @@ async def _acontinue_run(
                 # Bind run_messages early — cancellation can fire before run_messages
                 # is built, and the cancellation handler reads it.
                 run_messages: Optional[RunMessages] = None
-                # Setup session
+                # Setup session. Resolve dependencies after continue modifiers
+                # (below), not here — `_asetup_session` would consume factories
+                # against the parent run id.
                 team_session = await _asetup_session(
                     team=team,
                     run_context=run_context,
                     session_id=session_id,
                     user_id=user_id,
                     run_id=run_id,
+                    resolve_dependencies=False,
                 )
 
                 # Fall back to the owner the run paused with, so the resume retrieves under
@@ -9547,6 +9553,14 @@ async def _acontinue_run(
                     run_response.regenerated_from = original_run_id_for_lineage
                     if replace_original is not False and run_response.forked_from_run_id:
                         await _amark_team_run_regenerated(team, team_session, original_run_id_for_lineage)
+
+                # Resolve dependencies AFTER the fork. A callable dependency may
+                # derive run-scoped values from run_context, and continuing a
+                # completed run forks a sibling with a new run_id; resolving
+                # first would hand every factory the PARENT's id. Mirrors the
+                # agent async continue bodies and the team sync dispatch.
+                if run_context.dependencies is not None:
+                    await _aresolve_run_dependencies(team, run_context=run_context)
 
                 # Append input/additional_instructions as a user message.
                 if input:
@@ -9964,13 +9978,16 @@ async def _acontinue_run_stream(
                 # Bind run_messages early — cancellation can fire before run_messages
                 # is built, and the cancellation handler reads it.
                 run_messages: Optional[RunMessages] = None
-                # Setup session
+                # Setup session. Resolve dependencies after continue modifiers
+                # (below), not here — `_asetup_session` would consume factories
+                # against the parent run id.
                 team_session = await _asetup_session(
                     team=team,
                     run_context=run_context,
                     session_id=session_id,
                     user_id=user_id,
                     run_id=run_id,
+                    resolve_dependencies=False,
                 )
 
                 # Fall back to the owner the run paused with, so the resume retrieves under
@@ -10028,6 +10045,14 @@ async def _acontinue_run_stream(
                     run_response.regenerated_from = original_run_id_for_lineage
                     if replace_original is not False and run_response.forked_from_run_id:
                         await _amark_team_run_regenerated(team, team_session, original_run_id_for_lineage)
+
+                # Resolve dependencies AFTER the fork. A callable dependency may
+                # derive run-scoped values from run_context, and continuing a
+                # completed run forks a sibling with a new run_id; resolving
+                # first would hand every factory the PARENT's id. Mirrors the
+                # agent async continue bodies and the team sync dispatch.
+                if run_context.dependencies is not None:
+                    await _aresolve_run_dependencies(team, run_context=run_context)
 
                 # Append input/additional_instructions as a user message.
                 if input:

--- a/libs/agno/tests/unit/team/test_acontinue_run_resolve_dependencies.py
+++ b/libs/agno/tests/unit/team/test_acontinue_run_resolve_dependencies.py
@@ -1,0 +1,164 @@
+"""Team async continue paths must resolve callable dependencies after fork.
+
+`team.run()` / `team.arun()` and the sync `continue_run` dispatch resolve
+callable factories on `run_context.dependencies`. `_acontinue_run` and
+`_acontinue_run_stream` must do the same, and they must do it *after*
+`_apply_continue_modifiers_team` so a factory that reads `run_context`
+sees the forked run. Resolving inside `_asetup_session` first consumes
+every factory against the parent run id.
+"""
+
+from typing import Any, AsyncIterator, Iterator, List, Optional
+
+import pytest
+
+from agno.agent import Agent
+from agno.models.base import Model
+from agno.models.response import ModelResponse
+from agno.run.base import RunContext
+from agno.team import Team
+from agno.team import _run as team_run
+
+
+class ScriptedModel(Model):
+    """Returns one scripted ModelResponse per provider call, in order."""
+
+    def __init__(self, script: List[ModelResponse]) -> None:
+        super().__init__(id="scripted", name="scripted", provider="test")
+        self.script = list(script)
+        self.calls = 0
+
+    def __deepcopy__(self, memo: Any) -> "ScriptedModel":
+        return self
+
+    def _next(self) -> ModelResponse:
+        response = self.script[min(self.calls, len(self.script) - 1)]
+        self.calls += 1
+        return response
+
+    def invoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return self._next()
+
+    async def ainvoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return self._next()
+
+    def invoke_stream(self, *args: Any, **kwargs: Any) -> Iterator[ModelResponse]:
+        yield self._next()
+
+    async def ainvoke_stream(self, *args: Any, **kwargs: Any) -> AsyncIterator[ModelResponse]:
+        yield self._next()
+
+    def _parse_provider_response(self, response: Any, **kwargs: Any) -> ModelResponse:
+        return response
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return response
+
+
+def _text(content: str) -> ModelResponse:
+    return ModelResponse(role="assistant", content=content)
+
+
+def _tool_call(name: str, call_id: str) -> ModelResponse:
+    import json
+
+    return ModelResponse(
+        role="assistant",
+        tool_calls=[
+            {
+                "id": call_id,
+                "type": "function",
+                "function": {"name": name, "arguments": json.dumps({})},
+            }
+        ],
+    )
+
+
+def _token_factory() -> str:
+    return "resolved-token"
+
+
+def _dependency_probe(seen: List[Any]):
+    def probe_state(run_context: Optional[RunContext] = None) -> str:
+        """Record the dependency value the continuation handed the tool."""
+        deps = (run_context.dependencies or {}) if run_context else {}
+        seen.append(deps.get("token"))
+        return "probed"
+
+    return probe_state
+
+
+def _probe_script() -> List[ModelResponse]:
+    return [
+        _tool_call("probe_state", "call-1"),
+        _text("first run done"),
+        _tool_call("probe_state", "call-2"),
+        _text("continuation done"),
+    ]
+
+
+def _make_team(seen: List[Any], factory) -> Team:
+    member = Agent(name="member", model=ScriptedModel([_text("member done")]))
+    return Team(
+        members=[member],
+        model=ScriptedModel(_probe_script()),
+        tools=[_dependency_probe(seen)],
+        dependencies={"token": factory},
+    )
+
+
+def _track_apply_vs_factory(monkeypatch, order: List[str], factory):
+    original_apply = team_run._apply_continue_modifiers_team
+
+    def tracking_apply(*args, **kwargs):
+        order.append("apply")
+        return original_apply(*args, **kwargs)
+
+    monkeypatch.setattr(team_run, "_apply_continue_modifiers_team", tracking_apply)
+
+    def tracked_factory(*args, **kwargs):
+        order.append("factory")
+        return factory(*args, **kwargs)
+
+    return tracked_factory
+
+
+def _assert_resolved_after_apply(order: List[str], seen: List[Any], *, path: str) -> None:
+    assert "apply" in order, f"{path} never applied continue modifiers"
+    assert "factory" in order, f"{path} never invoked the dependency factory"
+    assert order.index("apply") < order.index("factory"), (
+        f"{path} resolved the factory before _apply_continue_modifiers_team: {order}"
+    )
+    assert not callable(seen[-1]), f"{path} left the factory unresolved: {seen[-1]}"
+    assert seen[-1] == "resolved-token"
+    assert len(seen) == 2
+
+
+@pytest.mark.asyncio
+async def test_acontinue_run_resolves_callable_dependencies(monkeypatch):
+    """An async continuation must invoke the factory after continue modifiers."""
+    seen: List[Any] = []
+    order: List[str] = []
+    factory = _track_apply_vs_factory(monkeypatch, order, _token_factory)
+    team = _make_team(seen, factory)
+    first = await team.arun("probe once")
+    order.clear()
+    continued = await team.acontinue_run(run_response=first, input="probe again")
+    assert continued is not None
+    _assert_resolved_after_apply(order, seen, path="acontinue_run")
+
+
+@pytest.mark.asyncio
+async def test_acontinue_run_stream_resolves_callable_dependencies(monkeypatch):
+    """Streaming async continuation must resolve factories after continue modifiers too."""
+    seen: List[Any] = []
+    order: List[str] = []
+    factory = _track_apply_vs_factory(monkeypatch, order, _token_factory)
+    team = _make_team(seen, factory)
+    first = await team.arun("probe once")
+    order.clear()
+    events = []
+    async for event in team.acontinue_run(run_response=first, input="probe again", stream=True):
+        events.append(event)
+    assert events
+    _assert_resolved_after_apply(order, seen, path="acontinue_run_stream")


### PR DESCRIPTION
## Summary

Team `_acontinue_run` / `_acontinue_run_stream` resolved callable dependencies inside `_asetup_session` before `_apply_continue_modifiers_team`. That consumes factories against the parent run id when a continuation forks a sibling run.

Continue paths now pass `resolve_dependencies=False` into `_asetup_session` and call `_aresolve_run_dependencies` after `_apply_continue_modifiers_team`, matching agent async continue and the team sync `continue_run` dispatch.

Fixes #9806

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Local verification:

```bash
cd libs/agno && pytest tests/unit/team/test_acontinue_run_resolve_dependencies.py -q
```

Both new tests pass (non-stream and stream async continue). Implementation assisted by AI tooling; changes reviewed and tests verified locally before opening.