### PR TITLE
fix(team): do not yield content event for empty string content

### DIFF
--- a/libs/agno/agno/team/_response.py
+++ b/libs/agno/agno/team/_response.py
@@ -1380,7 +1380,10 @@ def _handle_model_response_chunk(
 
             should_yield = False
             # Process content
-            if model_response_event.content is not None:
+            # Empty string content (e.g. Anthropic MessageStopEvent) should not
+            # trigger a content-event emission; only yield when there is real
+            # content to surface.
+            if model_response_event.content:
                 if parse_structured_output:
                     full_model_response.content = model_response_event.content
                     _convert_response_to_structured_format(team, full_model_response, run_context=run_context)

--- a/libs/agno/tests/unit/team/test_team_response_empty_content.py
+++ b/libs/agno/tests/unit/team/test_team_response_empty_content.py
@@ -1,0 +1,72 @@
+"""Regression test for agno-agi/agno#9491.
+
+Empty-string content on a model response event (e.g. Anthropic MessageStopEvent)
+must not yield a content event.
+"""
+
+from types import SimpleNamespace
+
+from agno.models.response import ModelResponse, ModelResponseEvent
+from agno.run.team import TeamRunOutput
+from agno.session.team import TeamSession
+from agno.team._response import _handle_model_response_chunk
+
+
+def _make_team():
+    return SimpleNamespace(
+        id="team-1",
+        name="Test Team",
+        stream_member_events=True,
+        _member_response_model=None,
+        events_to_skip=[],
+        store_events=True,
+    )
+
+
+def test_empty_string_content_does_not_yield_event():
+    """A MessageStop-style event with content='' should not surface as content."""
+    team = _make_team()
+    session = TeamSession(session_id="session-1", team_id=team.id)
+    run_response = TeamRunOutput(run_id="run-1")
+    full_model_response = ModelResponse()
+    event = ModelResponse(
+        event=ModelResponseEvent.assistant_response.value,
+        content="",
+    )
+
+    events = list(
+        _handle_model_response_chunk(
+            team,
+            session,
+            run_response,
+            full_model_response,
+            event,
+        )
+    )
+
+    assert events == []
+
+
+def test_non_empty_string_content_yields_event():
+    """A normal text delta must still yield a content event."""
+    team = _make_team()
+    session = TeamSession(session_id="session-1", team_id=team.id)
+    run_response = TeamRunOutput(run_id="run-1")
+    full_model_response = ModelResponse()
+    event = ModelResponse(
+        event=ModelResponseEvent.assistant_response.value,
+        content="hello",
+    )
+
+    events = list(
+        _handle_model_response_chunk(
+            team,
+            session,
+            run_response,
+            full_model_response,
+            event,
+        )
+    )
+
+    assert len(events) == 1
+    assert run_response.content == "hello"


### PR DESCRIPTION
### Description

Anthropic `MessageStopEvent` sets `content=""` intentionally so metadata/citations can pass without duplicating previously streamed text. The team response handler in `agno/team/_response.py` was checking `model_response_event.content is not None`, which evaluates to `True` for `""`, causing a `TeamRunOutputContentEvent` with empty content to be yielded.

### Changes

- Changed the content guard from `is not None` to truthiness so empty-string content does not trigger a content-event emission.
- Added regression tests in `tests/unit/team/test_team_response_empty_content.py` covering both empty-string and non-empty-string cases.

### Verification

- New unit tests pass: `pytest tests/unit/team/test_team_response_empty_content.py` (2/2).
- `ruff format` applied to touched files.
- `ruff check` on the changed files reports only pre-existing issues in `_response.py`; the changed line is clean.

Fixes #9491