### PR TITLE
[fix] compare WhatsApp verify token in constant time

### DIFF
--- a/libs/agno/agno/os/interfaces/whatsapp/router.py
+++ b/libs/agno/agno/os/interfaces/whatsapp/router.py
@@ -1,5 +1,6 @@
 import asyncio
 import hashlib
+import hmac
 from base64 import urlsafe_b64decode, urlsafe_b64encode
 from time import time
 from typing import Any, Literal, NamedTuple, Optional, Type, Union
@@ -171,7 +172,15 @@ def attach_routes(
         if not config.verify_token:
             raise HTTPException(status_code=500, detail="WHATSAPP_VERIFY_TOKEN is not set")
 
-        if mode == "subscribe" and token == config.verify_token:
+        # Constant-time comparison (same pattern as slack/telegram/whatsapp signature checks)
+        if (
+            mode == "subscribe"
+            and token is not None
+            and hmac.compare_digest(
+                token.encode("utf-8", "surrogateescape"),
+                config.verify_token.encode("utf-8", "surrogateescape"),
+            )
+        ):
             if not challenge:
                 raise HTTPException(status_code=400, detail="No challenge received")
             return PlainTextResponse(content=challenge)

--- a/libs/agno/tests/unit/os/routers/test_whatsapp_router.py
+++ b/libs/agno/tests/unit/os/routers/test_whatsapp_router.py
@@ -164,6 +164,49 @@ def test_webhook_verification_invalid_token():
         assert response.status_code == 403
 
 
+def test_webhook_verification_compares_token_in_constant_time():
+    """GET /webhook must compare hub.verify_token with hmac.compare_digest."""
+    import hmac
+
+    import agno.os.interfaces.whatsapp.router as router_module
+
+    calls = []
+    real_compare_digest = hmac.compare_digest
+
+    def recording_compare_digest(a, b):
+        calls.append((a, b))
+        return real_compare_digest(a, b)
+
+    agent_mock = _make_agent_mock()
+    with (
+        patch("agno.os.interfaces.whatsapp.router.validate_webhook_signature", return_value=True),
+        patch.dict("os.environ", WHATSAPP_ENV),
+        patch.object(router_module.hmac, "compare_digest", side_effect=recording_compare_digest),
+    ):
+        app = _build_app(agent_mock)
+        client = TestClient(app)
+        response = client.get(
+            "/webhook",
+            params={
+                "hub.mode": "subscribe",
+                "hub.verify_token": "wrong-token",
+                "hub.challenge": "challenge_123",
+            },
+        )
+        assert response.status_code == 403
+
+    expected = WHATSAPP_ENV["WHATSAPP_VERIFY_TOKEN"].encode("utf-8", "surrogateescape")
+    provided = b"wrong-token"
+    assert any(
+        (
+            a if isinstance(a, bytes) else a.encode("utf-8", "surrogateescape"),
+            b if isinstance(b, bytes) else b.encode("utf-8", "surrogateescape"),
+        )
+        == (provided, expected)
+        for a, b in calls
+    ), f"expected compare_digest(wrong-token, verify_token); got {calls!r}"
+
+
 # === Webhook Signature (POST) ===
 
 


### PR DESCRIPTION
## Summary

Fixes #9742

The WhatsApp GET `/webhook` handshake compared `hub.verify_token` with `==`. That short-circuits on the first differing byte, so response timing can leak how much of `WHATSAPP_VERIFY_TOKEN` was correct. This endpoint is anonymous (`authenticates_own_requests` only covers the POST HMAC path), so the compare is the only auth on the handshake.

Slack, Telegram, and the WhatsApp signature validator already use `hmac.compare_digest`. This switches the GET path to the same pattern (bytes via utf-8/`surrogateescape`, matching #9740).

Behaviour otherwise unchanged: valid token + challenge still returns the challenge; bad token still 403; missing env still 500.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`ruff format` / `ruff check` on touched files; full `./scripts/validate.sh` not run)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Related to #9741 / #9740 (REST + WebSocket security key). Different file and endpoint; #9740 left this WhatsApp GET case out on purpose.

New test pins that the reject path goes through `hmac.compare_digest`. Existing verify accept/reject cases still pass.

AI assistance disclosure (per CONTRIBUTING.md): developed with AI assistance; I reviewed the diff and ran the WhatsApp webhook verification unit tests locally.