### PR TITLE
feat: context compaction events, stats migration, and fixes

### DIFF
--- a/cookbook/02_agents/14_advanced/TEST_LOG.md
+++ b/cookbook/02_agents/14_advanced/TEST_LOG.md
@@ -185,3 +185,37 @@
 **Observation:** Running the earlier version of this cookbook (all runs sharing the agent's default session) reproduced the known shared-session status-clobbering bug on cue - runs stuck at PENDING forever with free slots (different victims each run: 1 then 2). The transition-site fix ships in the durable run queue PR chain; the cookbook now uses one session per run, which is also the realistic shape.
 
 ---
+
+### compression_events.py
+
+**Status:** FAIL
+**Date:** 2026-08-20
+**Timeout:** 60s
+
+**What was tested:**
+- Started the compression events cookbook with `.venvs/demo/bin/python`.
+- Verified event stream startup through `RunStarted` and `ModelRequestStarted`.
+
+**Observations:**
+- Exited in about 4s without timing out.
+
+**Issues found:**
+- OpenAI API returned an organization spend-limit error before tool calls or compression events could complete.
+
+---
+
+### context_compaction.py
+
+**Status:** FAIL
+**Date:** 2026-08-20
+
+**What was tested:**
+- Reviewed context compaction manager wiring.
+
+**Observations:**
+- The cookbook passes `ContextCompactionManager` directly to `Agent(compaction_manager=...)`.
+
+**Issues found:**
+- `Agent.compaction_manager` is typed for `CompactionManager`; direct `ContextCompactionManager` construction leaves `agent.compact_context` false and does not use the unified manager path correctly.
+
+---

--- a/cookbook/03_teams/10_context_compression/context_compaction.py
+++ b/cookbook/03_teams/10_context_compression/context_compaction.py
@@ -1,0 +1,145 @@
+"""
+Team Context Compaction
+=======================
+Automatic history compression for long-running teams.
+
+Teams with web search or research tools accumulate large results quickly.
+Context compaction summarizes older exchanges while keeping recent findings
+intact, enabling multi-hour research sessions without hitting context limits.
+
+This differs from tool_call_compression.py which compresses individual tool
+results. Context compaction compresses the entire conversation history.
+
+See also: context_compaction_custom.py (in agents) for custom instructions.
+"""
+
+import asyncio
+from textwrap import dedent
+
+from agno.agent import Agent
+from agno.compression import CompactionManager
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIResponses
+from agno.team import Team
+from agno.tools.duckduckgo import DuckDuckGoTools
+
+# ---------------------------------------------------------------------------
+# Create Members
+# ---------------------------------------------------------------------------
+
+researcher = Agent(
+    name="Researcher",
+    role="Technology Researcher",
+    model=OpenAIResponses(id="gpt-5.5"),
+    instructions=dedent("""
+        You specialize in technology and AI research.
+        - Focus on latest developments, trends, and breakthroughs
+        - Provide concise, data-driven insights
+        - Cite your sources
+    """).strip(),
+)
+
+analyst = Agent(
+    name="Analyst",
+    role="Business Analyst",
+    model=OpenAIResponses(id="gpt-5.5"),
+    instructions=dedent("""
+        You specialize in business and market analysis.
+        - Focus on companies, markets, and economic trends
+        - Provide actionable business insights
+        - Include relevant data and statistics
+    """).strip(),
+)
+
+# ---------------------------------------------------------------------------
+# Create Team
+# ---------------------------------------------------------------------------
+
+db = SqliteDb(db_file="tmp/research_team_compaction.db")
+
+research_team = Team(
+    name="Research Team",
+    model=OpenAIResponses(id="gpt-5.5"),
+    members=[researcher, analyst],
+    tools=[DuckDuckGoTools()],
+    description="Research team that investigates topics comprehensively.",
+    instructions=dedent("""
+        You are a research coordinator.
+
+        Process:
+        1. Search for information on the topic
+        2. Delegate analysis to the appropriate specialist
+        3. Synthesize findings into a comprehensive response
+
+        Guidelines:
+        - Start with web research
+        - Choose the right specialist (tech vs business)
+        - Provide well-sourced responses
+    """).strip(),
+    db=db,
+    add_history_to_context=True,
+    # Context compaction with minimal config
+    compaction_manager=CompactionManager(
+        compact_history=True,
+        model=OpenAIResponses(id="gpt-5-mini"),
+        token_limit=60_000,
+    ),
+    markdown=True,
+    show_members_responses=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Demo
+# ---------------------------------------------------------------------------
+
+
+async def run_research_session():
+    session_id = "market-research"
+
+    # Turn 1: Initial research
+    print("\n" + "=" * 60)
+    print("TURN 1: Initial landscape")
+    print("=" * 60 + "\n")
+
+    await research_team.aprint_response(
+        "Map the agentic AI framework landscape. Who are the main players?",
+        session_id=session_id,
+        stream=True,
+    )
+
+    # Turn 2: Deep dive
+    print("\n" + "=" * 60)
+    print("TURN 2: Pricing analysis")
+    print("=" * 60 + "\n")
+
+    await research_team.aprint_response(
+        "Compare pricing and licensing for the top three frameworks.",
+        session_id=session_id,
+        stream=True,
+    )
+
+    # Turn 3: Final synthesis (may trigger compaction)
+    print("\n" + "=" * 60)
+    print("TURN 3: Final brief (may trigger compaction)")
+    print("=" * 60 + "\n")
+
+    response = await research_team.arun(
+        "Write a final comparison brief with your recommendations.",
+        session_id=session_id,
+    )
+    print(response.content)
+
+    # Show compaction stats
+    print("\n" + "-" * 40)
+    print("Compaction Stats")
+    print("-" * 40)
+    if response.compaction_state:
+        print(f"  Total compactions: {response.compaction_state.total_compactions}")
+        print(f"  Messages compacted: {response.compaction_state.compacted_count}")
+        print(f"  Tokens saved: {response.compaction_state.total_tokens_saved}")
+    else:
+        print("  No compaction triggered (history within limits)")
+
+
+if __name__ == "__main__":
+    asyncio.run(run_research_session())

--- a/cookbook/03_teams/10_context_compression/context_compaction_files.py
+++ b/cookbook/03_teams/10_context_compression/context_compaction_files.py
@@ -1,0 +1,147 @@
+"""
+Team Context Compaction with File Reading
+=========================================
+Demonstrates team context compaction triggered by reading source files.
+
+A code review team with specialized agents reads multiple files to analyze
+architecture. File contents quickly fill the context, triggering compaction.
+
+The team summarizes findings while discarding raw file contents, keeping
+the conversation within limits while preserving architectural insights.
+"""
+
+import asyncio
+from pathlib import Path
+from textwrap import dedent
+
+from agno.agent import Agent
+from agno.compression import CompactionManager
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIResponses
+from agno.team import Team
+from agno.tools.file import FileTools
+
+# ---------------------------------------------------------------------------
+# Create Members (different OpenAI models for variety)
+# ---------------------------------------------------------------------------
+
+architect = Agent(
+    name="Architect",
+    role="Software Architect",
+    model=OpenAIResponses(id="o3-mini"),  # Reasoning model for architecture
+    instructions=dedent("""
+        You analyze software architecture and design patterns.
+        - Identify architectural decisions and their rationale
+        - Spot design patterns and anti-patterns
+        - Keep analysis brief and actionable
+    """).strip(),
+)
+
+reviewer = Agent(
+    name="Reviewer",
+    role="Code Reviewer",
+    model=OpenAIResponses(id="gpt-5-mini"),  # Fast model for code review
+    instructions=dedent("""
+        You review code for quality and maintainability.
+        - Focus on code organization and clarity
+        - Identify potential issues or improvements
+        - Keep feedback concise
+    """).strip(),
+)
+
+# ---------------------------------------------------------------------------
+# Create Team
+# ---------------------------------------------------------------------------
+
+# Point FileTools at the agno source directory
+cookbook_dir = Path(__file__).resolve().parent
+agno_source = cookbook_dir.parents[2] / "libs" / "agno" / "agno"
+
+db = SqliteDb(db_file="tmp/code_review_team.db")
+
+review_team = Team(
+    name="Code Review Team",
+    mode="coordinate",
+    model=OpenAIResponses(id="gpt-5.5"),
+    members=[architect, reviewer],
+    tools=[FileTools(base_dir=agno_source, enable_save_file=False)],
+    description="Code review team that analyzes architecture and code quality.",
+    instructions=dedent("""
+        You coordinate code reviews.
+
+        Process:
+        1. Read requested files to understand the code
+        2. Delegate to Architect for design analysis
+        3. Delegate to Reviewer for code quality feedback
+        4. Synthesize findings
+
+        Keep all responses brief - 2-3 paragraphs max.
+    """).strip(),
+    db=db,
+    add_history_to_context=True,
+    # Low token limit to trigger compaction with file reads
+    compaction_manager=CompactionManager(
+        compact_history=True,
+        model=OpenAIResponses(id="gpt-5-mini"),
+        token_limit=25_000,  # Low limit - file reads trigger quickly
+        keep_recent=8,
+    ),
+    markdown=True,
+    show_members_responses=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Demo
+# ---------------------------------------------------------------------------
+
+
+async def run_code_review():
+    session_id = "knowledge-review"
+
+    # Turn 1: Read knowledge base
+    print("\n" + "=" * 60)
+    print("TURN 1: Review knowledge/knowledge.py")
+    print("=" * 60 + "\n")
+
+    await review_team.aprint_response(
+        "Read knowledge/knowledge.py and analyze the Knowledge class design.",
+        session_id=session_id,
+        stream=True,
+    )
+
+    # Turn 2: Read document module (should trigger compaction)
+    print("\n" + "=" * 60)
+    print("TURN 2: Review knowledge/document (should trigger compaction)")
+    print("=" * 60 + "\n")
+
+    await review_team.aprint_response(
+        "Now list and read the files in knowledge/document/ to understand document handling.",
+        session_id=session_id,
+        stream=True,
+    )
+
+    # Turn 3: Synthesize
+    print("\n" + "=" * 60)
+    print("TURN 3: Explain how knowledge works in Agno")
+    print("=" * 60 + "\n")
+
+    response = await review_team.arun(
+        "Explain how knowledge works in Agno - from document loading to agent retrieval.",
+        session_id=session_id,
+    )
+    print(response.content)
+
+    # Show compaction stats
+    print("\n" + "-" * 40)
+    print("Compaction Stats")
+    print("-" * 40)
+    if response.compaction_state:
+        print(f"  Total compactions: {response.compaction_state.total_compactions}")
+        print(f"  Messages compacted: {response.compaction_state.compacted_count}")
+        print(f"  Tokens saved: {response.compaction_state.total_tokens_saved}")
+    else:
+        print("  No compaction triggered (history within limits)")
+
+
+if __name__ == "__main__":
+    asyncio.run(run_code_review())

--- a/libs/agno/agno/agent/_response.py
+++ b/libs/agno/agno/agent/_response.py
@@ -1055,19 +1055,7 @@ def handle_model_response_stream(
 
     from agno.agent._run import build_after_tool_results_callback, build_compaction_callback
 
-    # Pre-loop compaction: compress history BEFORE first model call
-    if agent.compaction_manager is not None and agent.compaction_manager.compact_context:
-        log_debug(f"[STREAM-SYNC] Pre-loop compaction check: {len(run_messages.messages)} messages")
-        compaction_result = agent.compaction_manager.compact(
-            run_messages.messages,
-            run_response=run_response,
-            run_metrics=run_response.metrics,
-        )
-        if compaction_result.summary:
-            run_messages.compacted_messages = compaction_result.compacted_messages
-            log_debug(
-                f"[STREAM-SYNC] Pre-loop compaction: {len(run_messages.messages)} -> {len(run_messages.compacted_messages)}"
-            )
+    # Pre-loop compaction now handled in _run.py (emits events there)
 
     for model_response_event in call_model_stream_with_fallback(
         agent.model,
@@ -1232,19 +1220,7 @@ async def ahandle_model_response_stream(
 
     from agno.agent._run import abuild_after_tool_results_callback, abuild_compaction_callback
 
-    # Pre-loop compaction: compress history BEFORE first model call
-    if agent.compaction_manager is not None and agent.compaction_manager.compact_context:
-        log_debug(f"[STREAM-ASYNC] Pre-loop compaction check: {len(run_messages.messages)} messages")
-        compaction_result = await agent.compaction_manager.acompact(
-            run_messages.messages,
-            run_response=run_response,
-            run_metrics=run_response.metrics,
-        )
-        if compaction_result.summary:
-            run_messages.compacted_messages = compaction_result.compacted_messages
-            log_debug(
-                f"[STREAM-ASYNC] Pre-loop compaction: {len(run_messages.messages)} -> {len(run_messages.compacted_messages)}"
-            )
+    # Pre-loop compaction now handled in _run.py (emits events there)
 
     model_response_stream = acall_model_stream_with_fallback(
         agent.model,

--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -2526,7 +2526,9 @@ async def _arun_stream(
                                 store_events=agent.store_events,
                             )
                         run_messages.compacted_messages = compaction_result.compacted_messages
-                        tokens_saved = run_response.compaction_state.total_tokens_saved if run_response.compaction_state else 0
+                        tokens_saved = (
+                            run_response.compaction_state.total_tokens_saved if run_response.compaction_state else 0
+                        )
                         if stream_events:
                             yield handle_event(  # type: ignore
                                 create_compaction_completed_event(
@@ -4161,7 +4163,9 @@ def _continue_run_stream(
                                 store_events=agent.store_events,
                             )
                         run_messages.compacted_messages = compaction_result.compacted_messages
-                        tokens_saved = run_response.compaction_state.total_tokens_saved if run_response.compaction_state else 0
+                        tokens_saved = (
+                            run_response.compaction_state.total_tokens_saved if run_response.compaction_state else 0
+                        )
                         if stream_events:
                             yield handle_event(  # type: ignore
                                 create_compaction_completed_event(
@@ -5740,7 +5744,9 @@ async def _acontinue_run_stream(
                                 store_events=agent.store_events,
                             )
                         run_messages.compacted_messages = compaction_result.compacted_messages
-                        tokens_saved = run_response.compaction_state.total_tokens_saved if run_response.compaction_state else 0
+                        tokens_saved = (
+                            run_response.compaction_state.total_tokens_saved if run_response.compaction_state else 0
+                        )
                         if stream_events:
                             yield handle_event(  # type: ignore
                                 create_compaction_completed_event(

--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -5051,7 +5051,9 @@ async def _acontinue_run(
 
                 # Pre-loop compaction: compress history BEFORE model call
                 if agent.compaction_manager is not None and agent.compaction_manager.compact_context:
-                    log_debug(f"[AGENT-CONTINUE-ASYNC] Pre-loop compaction check: {len(run_messages.messages)} messages")
+                    log_debug(
+                        f"[AGENT-CONTINUE-ASYNC] Pre-loop compaction check: {len(run_messages.messages)} messages"
+                    )
                     compaction_result = await agent.compaction_manager.acompact(
                         run_messages.messages,
                         run_response=run_response,

--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -101,6 +101,8 @@ from agno.utils.agent import (
 )
 from agno.utils.events import (
     add_error_event,
+    create_compaction_completed_event,
+    create_compaction_started_event,
     create_run_cancelled_event,
     create_run_completed_event,
     create_run_content_completed_event,
@@ -964,7 +966,47 @@ def _run_stream(
                 # Check for cancellation before model processing
                 raise_if_cancelled(run_response.run_id)  # type: ignore
 
-                # 9. Process model response
+                # 9. Pre-loop compaction: compress history BEFORE first model call
+                if agent.compaction_manager is not None and agent.compaction_manager.compact_context:
+                    messages_before = len(run_messages.messages)
+                    compaction_result = agent.compaction_manager.compact(
+                        run_messages.messages,
+                        run_response=run_response,
+                        run_metrics=run_response.metrics,
+                    )
+                    if compaction_result.summary:
+                        if stream_events:
+                            yield handle_event(  # type: ignore
+                                create_compaction_started_event(
+                                    from_run_response=run_response,
+                                    messages_before=messages_before,
+                                    messages_to_compact=messages_before - len(compaction_result.compacted_messages),
+                                ),
+                                run_response,
+                                events_to_skip=agent.events_to_skip,  # type: ignore
+                                store_events=agent.store_events,
+                            )
+                        run_messages.compacted_messages = compaction_result.compacted_messages
+                        tokens_saved = (
+                            run_response.compaction_state.total_tokens_saved if run_response.compaction_state else 0
+                        )
+                        if stream_events:
+                            yield handle_event(  # type: ignore
+                                create_compaction_completed_event(
+                                    from_run_response=run_response,
+                                    messages_after=len(compaction_result.compacted_messages),
+                                    messages_compacted=messages_before - len(compaction_result.compacted_messages),
+                                    tokens_saved=tokens_saved,
+                                    summary_preview=compaction_result.summary[:200]
+                                    if compaction_result.summary
+                                    else None,
+                                ),
+                                run_response,
+                                events_to_skip=agent.events_to_skip,  # type: ignore
+                                store_events=agent.store_events,
+                            )
+
+                # 10. Process model response
                 if agent.output_model is None:
                     for event in handle_model_response_stream(
                         agent,
@@ -2463,7 +2505,45 @@ async def _arun_stream(
 
                 await araise_if_cancelled(run_response.run_id)  # type: ignore
 
-                # 9. Generate a response from the Model
+                # 9. Pre-loop compaction: compress history BEFORE first model call
+                if agent.compaction_manager is not None and agent.compaction_manager.compact_context:
+                    messages_before = len(run_messages.messages)
+                    compaction_result = await agent.compaction_manager.acompact(
+                        run_messages.messages,
+                        run_response=run_response,
+                        run_metrics=run_response.metrics,
+                    )
+                    if compaction_result.summary:
+                        if stream_events:
+                            yield handle_event(  # type: ignore
+                                create_compaction_started_event(
+                                    from_run_response=run_response,
+                                    messages_before=messages_before,
+                                    messages_to_compact=messages_before - len(compaction_result.compacted_messages),
+                                ),
+                                run_response,
+                                events_to_skip=agent.events_to_skip,  # type: ignore
+                                store_events=agent.store_events,
+                            )
+                        run_messages.compacted_messages = compaction_result.compacted_messages
+                        tokens_saved = run_response.compaction_state.total_tokens_saved if run_response.compaction_state else 0
+                        if stream_events:
+                            yield handle_event(  # type: ignore
+                                create_compaction_completed_event(
+                                    from_run_response=run_response,
+                                    messages_after=len(compaction_result.compacted_messages),
+                                    messages_compacted=messages_before - len(compaction_result.compacted_messages),
+                                    tokens_saved=tokens_saved,
+                                    summary_preview=compaction_result.summary[:200]
+                                    if compaction_result.summary
+                                    else None,
+                                ),
+                                run_response,
+                                events_to_skip=agent.events_to_skip,  # type: ignore
+                                store_events=agent.store_events,
+                            )
+
+                # 10. Generate a response from the Model
                 if agent.output_model is None:
                     async for event in ahandle_model_response_stream(
                         agent,
@@ -4057,7 +4137,48 @@ def _continue_run_stream(
                         raise_if_cancelled(run_response.run_id)  # type: ignore
                     yield event
 
-                # 3. Process model response
+                # Check for cancellation before model processing
+                raise_if_cancelled(run_response.run_id)  # type: ignore
+
+                # 3. Pre-loop compaction: compress history BEFORE model call
+                if agent.compaction_manager is not None and agent.compaction_manager.compact_context:
+                    messages_before = len(run_messages.messages)
+                    compaction_result = agent.compaction_manager.compact(
+                        run_messages.messages,
+                        run_response=run_response,
+                        run_metrics=run_response.metrics,
+                    )
+                    if compaction_result.summary:
+                        if stream_events:
+                            yield handle_event(  # type: ignore
+                                create_compaction_started_event(
+                                    from_run_response=run_response,
+                                    messages_before=messages_before,
+                                    messages_to_compact=messages_before - len(compaction_result.compacted_messages),
+                                ),
+                                run_response,
+                                events_to_skip=agent.events_to_skip,  # type: ignore
+                                store_events=agent.store_events,
+                            )
+                        run_messages.compacted_messages = compaction_result.compacted_messages
+                        tokens_saved = run_response.compaction_state.total_tokens_saved if run_response.compaction_state else 0
+                        if stream_events:
+                            yield handle_event(  # type: ignore
+                                create_compaction_completed_event(
+                                    from_run_response=run_response,
+                                    messages_after=len(compaction_result.compacted_messages),
+                                    messages_compacted=messages_before - len(compaction_result.compacted_messages),
+                                    tokens_saved=tokens_saved,
+                                    summary_preview=compaction_result.summary[:200]
+                                    if compaction_result.summary
+                                    else None,
+                                ),
+                                run_response,
+                                events_to_skip=agent.events_to_skip,  # type: ignore
+                                store_events=agent.store_events,
+                            )
+
+                # 4. Process model response
                 for event in handle_model_response_stream(
                     agent,
                     session=session,
@@ -5595,7 +5716,48 @@ async def _acontinue_run_stream(
                         await araise_if_cancelled(run_response.run_id)  # type: ignore
                     yield event
 
-                # 8. Process model response
+                # Check for cancellation before model processing
+                await araise_if_cancelled(run_response.run_id)  # type: ignore
+
+                # 8. Pre-loop compaction: compress history BEFORE model call
+                if agent.compaction_manager is not None and agent.compaction_manager.compact_context:
+                    messages_before = len(run_messages.messages)
+                    compaction_result = await agent.compaction_manager.acompact(
+                        run_messages.messages,
+                        run_response=run_response,
+                        run_metrics=run_response.metrics,
+                    )
+                    if compaction_result.summary:
+                        if stream_events:
+                            yield handle_event(  # type: ignore
+                                create_compaction_started_event(
+                                    from_run_response=run_response,
+                                    messages_before=messages_before,
+                                    messages_to_compact=messages_before - len(compaction_result.compacted_messages),
+                                ),
+                                run_response,
+                                events_to_skip=agent.events_to_skip,  # type: ignore
+                                store_events=agent.store_events,
+                            )
+                        run_messages.compacted_messages = compaction_result.compacted_messages
+                        tokens_saved = run_response.compaction_state.total_tokens_saved if run_response.compaction_state else 0
+                        if stream_events:
+                            yield handle_event(  # type: ignore
+                                create_compaction_completed_event(
+                                    from_run_response=run_response,
+                                    messages_after=len(compaction_result.compacted_messages),
+                                    messages_compacted=messages_before - len(compaction_result.compacted_messages),
+                                    tokens_saved=tokens_saved,
+                                    summary_preview=compaction_result.summary[:200]
+                                    if compaction_result.summary
+                                    else None,
+                                ),
+                                run_response,
+                                events_to_skip=agent.events_to_skip,  # type: ignore
+                                store_events=agent.store_events,
+                            )
+
+                # 9. Process model response
                 if agent.output_model is None:
                     async for event in ahandle_model_response_stream(
                         agent,

--- a/libs/agno/agno/compression/_context.py
+++ b/libs/agno/agno/compression/_context.py
@@ -120,6 +120,7 @@ class CompactionResult:
 
     compacted_messages: List[Message]
     summary: Optional[str] = None
+    stats: Dict[str, Any] = field(default_factory=dict)
 
 
 # --- Pure functions ---

--- a/libs/agno/agno/compression/_context.py
+++ b/libs/agno/agno/compression/_context.py
@@ -351,7 +351,10 @@ def _build_summarization_prompt(
     if existing_summary:
         prompt.append(Message(role="user", content=f"Previous summary to update:\n{existing_summary}"))
 
-    prompt.extend(old_messages)
+    # Strip provider_data to avoid model chaining (OpenAI Responses API)
+    for msg in old_messages:
+        prompt.append(Message(role=msg.role, content=msg.content or ""))
+
     prompt.append(Message(role="user", content="Now provide a concise summary of the conversation above."))
     return prompt
 

--- a/libs/agno/agno/compression/manager.py
+++ b/libs/agno/agno/compression/manager.py
@@ -1,6 +1,6 @@
 """Unified compaction manager for tool results and conversation history."""
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
 
 from pydantic import BaseModel
@@ -73,8 +73,6 @@ class CompactionManager:
     compact_context_keep_recent: int = 10
     compact_context_preserve_user_budget: Optional[int] = None
     compact_context_instructions: Optional[str] = None
-
-    stats: Dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         # Handle deprecated compress_tool_results -> compact_tools
@@ -177,31 +175,29 @@ class CompactionManager:
         self,
         messages: List[Message],
         run_metrics: Optional["RunMetrics"] = None,
-    ) -> None:
-        """Compress uncompressed tool results."""
-        stats = compact_tools(
+    ) -> Dict[str, Any]:
+        """Compress uncompressed tool results. Returns stats for this call."""
+        return compact_tools(
             messages=messages,
             model=self.model,
             compact_tools_enabled=self.compact_tools,
             instructions=self.compact_tools_instructions,
             run_metrics=run_metrics,
         )
-        self._merge_stats(stats)
 
     async def acompact_tool_results(
         self,
         messages: List[Message],
         run_metrics: Optional["RunMetrics"] = None,
-    ) -> None:
-        """Async compress uncompressed tool results."""
-        stats = await acompact_tools(
+    ) -> Dict[str, Any]:
+        """Async compress uncompressed tool results. Returns stats for this call."""
+        return await acompact_tools(
             messages=messages,
             model=self.model,
             compact_tools_enabled=self.compact_tools,
             instructions=self.compact_tools_instructions,
             run_metrics=run_metrics,
         )
-        self._merge_stats(stats)
 
     # --- Context compaction (delegates to _context.py) ---
 
@@ -277,12 +273,17 @@ class CompactionManager:
             run_metrics=run_metrics,
         )
 
-    # --- Stats ---
+    # --- Stats (deprecated - now returned per-call for async safety) ---
 
-    def _merge_stats(self, stats: Dict[str, Any]) -> None:
-        """Merge stats from tool compaction."""
-        for key, value in stats.items():
-            self.stats[key] = self.stats.get(key, 0) + value
+    @property
+    def stats(self) -> Dict[str, Any]:
+        """Deprecated: stats are now returned per-call from compact_tool_results().
+
+        Returns empty dict for backward compatibility with print_response code
+        that reads this property. In async environments, use the stats returned
+        from each compact_tool_results() call instead.
+        """
+        return {}
 
     # --- Deprecated method aliases (backward compat) ---
 
@@ -310,17 +311,17 @@ class CompactionManager:
         self,
         messages: List[Message],
         run_metrics: Optional["RunMetrics"] = None,
-    ) -> None:
+    ) -> Dict[str, Any]:
         """Deprecated: use compact_tool_results()."""
-        self.compact_tool_results(messages, run_metrics)
+        return self.compact_tool_results(messages, run_metrics)
 
     async def acompress(
         self,
         messages: List[Message],
         run_metrics: Optional["RunMetrics"] = None,
-    ) -> None:
+    ) -> Dict[str, Any]:
         """Deprecated: use acompact_tool_results()."""
-        await self.acompact_tool_results(messages, run_metrics)
+        return await self.acompact_tool_results(messages, run_metrics)
 
 
 # Backward compatibility alias

--- a/libs/agno/agno/environments/runner.py
+++ b/libs/agno/agno/environments/runner.py
@@ -514,12 +514,16 @@ def _cache_off_copy(model_like: Any) -> Any:
 def _isolated_manager_copy(manager: Any, db: Any = None, reset_stats: bool = False) -> Any:
     """An attempt-local shallow copy of a manager: resolution binds db and model
     onto the copy, never onto the caller's instance. `db` rebinds the copy's
-    store; a model already set on the manager gets the cache-off treatment."""
+    store; a model already set on the manager gets the cache-off treatment.
+
+    Note: stats are no longer accumulated on the manager (async-safety fix).
+    They are returned per-call and stored on run_response.compression_stats.
+    The reset_stats parameter is kept for API compatibility but is now a no-op.
+    """
     manager_copy = copy.copy(manager)
     if db is not None:
         manager_copy.db = db
-    if reset_stats and hasattr(manager_copy, "stats"):
-        manager_copy.stats = {}
+    # reset_stats is now a no-op - stats are per-run, not on manager
     manager_model = getattr(manager_copy, "model", None)
     if manager_model is not None and hasattr(manager_model, "cache_response"):
         manager_copy.model = _cache_off_copy(manager_model)

--- a/libs/agno/agno/environments/runner.py
+++ b/libs/agno/agno/environments/runner.py
@@ -517,7 +517,7 @@ def _isolated_manager_copy(manager: Any, db: Any = None, reset_stats: bool = Fal
     store; a model already set on the manager gets the cache-off treatment.
 
     Note: stats are no longer accumulated on the manager (async-safety fix).
-    They are returned per-call and stored on run_response.compression_stats.
+    They are returned per-call and stored in run_response.metrics.additional_metrics.
     The reset_stats parameter is kept for API compatibility but is now a no-op.
     """
     manager_copy = copy.copy(manager)

--- a/libs/agno/agno/metrics.py
+++ b/libs/agno/agno/metrics.py
@@ -831,3 +831,57 @@ def merge_background_metrics(
                     metrics.additional_metrics[k] += v
                 else:
                     metrics.additional_metrics[k] = v
+
+
+# ---------------------------------------------------------------------------
+# Compaction Stats Helpers
+# ---------------------------------------------------------------------------
+
+COMPACTION_STATS_PREFIX = "compaction_"
+
+
+def accumulate_compaction_stats(
+    run_metrics: Optional["RunMetrics"],
+    stats: Dict[str, Any],
+) -> None:
+    """Accumulate compaction stats into run_metrics.additional_metrics.
+
+    Stats keys are prefixed with 'compaction_' to avoid collisions with other
+    metrics in additional_metrics (e.g., eval_duration).
+
+    Args:
+        run_metrics: The run's metrics object. If None, does nothing.
+        stats: Dict with keys like 'tool_results_compressed', 'original_size', etc.
+    """
+    if not stats or run_metrics is None:
+        return
+    if run_metrics.additional_metrics is None:
+        run_metrics.additional_metrics = {}
+    am = run_metrics.additional_metrics
+    for key, value in stats.items():
+        prefixed_key = f"{COMPACTION_STATS_PREFIX}{key}"
+        if isinstance(value, (int, float)):
+            am[prefixed_key] = am.get(prefixed_key, 0) + value
+        else:
+            am[prefixed_key] = value
+
+
+def get_compaction_stats(run_metrics: Optional["RunMetrics"]) -> Dict[str, Any]:
+    """Extract compaction stats from run_metrics.additional_metrics.
+
+    Returns stats with the 'compaction_' prefix stripped, for use in events
+    and display code that expects the original key names.
+
+    Args:
+        run_metrics: The run's metrics object. If None, returns empty dict.
+
+    Returns:
+        Dict with keys like 'tool_results_compressed', 'original_size', etc.
+    """
+    if run_metrics is None or run_metrics.additional_metrics is None:
+        return {}
+    return {
+        k.removeprefix(COMPACTION_STATS_PREFIX): v
+        for k, v in run_metrics.additional_metrics.items()
+        if k.startswith(COMPACTION_STATS_PREFIX)
+    }

--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -698,15 +698,18 @@ class Model(ABC):
 
         _compress_tool_results = bool(compaction_manager is not None and compaction_manager.compact_tools)
         _compaction_manager = compaction_manager if _compress_tool_results else None
+        _compaction_stats: Dict[str, Any] = {}
 
         while True:
             # Compress tool results if compression is enabled and threshold is met
             if _compaction_manager is not None and _compaction_manager.should_compact_tools(
                 messages, tools, model=self, response_format=response_format
             ):
-                _compaction_manager.compact_tool_results(
+                stats = _compaction_manager.compact_tool_results(
                     messages, run_metrics=run_response.metrics if run_response is not None else None
                 )
+                for key, value in stats.items():
+                    _compaction_stats[key] = _compaction_stats.get(key, 0) + value
 
             # Get response from model
             assistant_message = Message(role=self.assistant_message_role)
@@ -876,6 +879,10 @@ class Model(ABC):
         if self.cache_response:
             self._save_model_response_to_cache(cache_key, model_response, is_streaming=False)
 
+        # Store compression stats on run_response (async-safe, per-run)
+        if run_response is not None and _compaction_stats:
+            run_response.compression_stats = _compaction_stats
+
         return model_response
 
     async def aresponse(
@@ -922,17 +929,20 @@ class Model(ABC):
 
         _compress_tool_results = bool(compaction_manager is not None and compaction_manager.compact_tools)
         _compaction_manager = compaction_manager if _compress_tool_results else None
+        _compaction_stats: Dict[str, Any] = {}
 
         function_call_count = 0
 
         while True:
             # Compress existing tool results BEFORE making API call to avoid context overflow
-            if _compaction_manager is not None and await _compaction_manager.ashould_compress(
+            if _compaction_manager is not None and await _compaction_manager.ashould_compact_tools(
                 messages, tools, model=self, response_format=response_format
             ):
-                await _compaction_manager.acompress(
+                stats = await _compaction_manager.acompact_tool_results(
                     messages, run_metrics=run_response.metrics if run_response is not None else None
                 )
+                for key, value in stats.items():
+                    _compaction_stats[key] = _compaction_stats.get(key, 0) + value
 
             # Get response from model
             assistant_message = Message(role=self.assistant_message_role)
@@ -1100,6 +1110,10 @@ class Model(ABC):
         # Save to cache if enabled
         if self.cache_response:
             self._save_model_response_to_cache(cache_key, model_response, is_streaming=False)
+
+        # Store compression stats on run_response (async-safe, per-run)
+        if run_response is not None and _compaction_stats:
+            run_response.compression_stats = _compaction_stats
 
         return model_response
 
@@ -1415,23 +1429,26 @@ class Model(ABC):
 
         _compress_tool_results = bool(compaction_manager is not None and compaction_manager.compact_tools)
         _compaction_manager = compaction_manager if _compress_tool_results else None
+        _compaction_stats: Dict[str, Any] = {}
 
         function_call_count = 0
 
         while True:
             # Compress existing tool results BEFORE invoke
-            if _compaction_manager is not None and _compaction_manager.should_compress(
+            if _compaction_manager is not None and _compaction_manager.should_compact_tools(
                 messages, tools, model=self, response_format=response_format
             ):
                 # Emit compression started event
                 yield ModelResponse(event=ModelResponseEvent.compression_started.value)
-                _compaction_manager.compress(
+                stats = _compaction_manager.compact_tool_results(
                     messages, run_metrics=run_response.metrics if run_response is not None else None
                 )
+                for key, value in stats.items():
+                    _compaction_stats[key] = _compaction_stats.get(key, 0) + value
                 # Emit compression completed event with stats
                 yield ModelResponse(
                     event=ModelResponseEvent.compression_completed.value,
-                    compression_stats=_compaction_manager.stats.copy(),
+                    compression_stats=_compaction_stats.copy(),
                 )
 
             assistant_message = Message(role=self.assistant_message_role)
@@ -1698,23 +1715,26 @@ class Model(ABC):
 
         _compress_tool_results = bool(compaction_manager is not None and compaction_manager.compact_tools)
         _compaction_manager = compaction_manager if _compress_tool_results else None
+        _compaction_stats: Dict[str, Any] = {}
 
         function_call_count = 0
 
         while True:
             # Compress existing tool results BEFORE making API call to avoid context overflow
-            if _compaction_manager is not None and await _compaction_manager.ashould_compress(
+            if _compaction_manager is not None and await _compaction_manager.ashould_compact_tools(
                 messages, tools, model=self, response_format=response_format
             ):
                 # Emit compression started event
                 yield ModelResponse(event=ModelResponseEvent.compression_started.value)
-                await _compaction_manager.acompress(
+                stats = await _compaction_manager.acompact_tool_results(
                     messages, run_metrics=run_response.metrics if run_response is not None else None
                 )
+                for key, value in stats.items():
+                    _compaction_stats[key] = _compaction_stats.get(key, 0) + value
                 # Emit compression completed event with stats
                 yield ModelResponse(
                     event=ModelResponseEvent.compression_completed.value,
-                    compression_stats=_compaction_manager.stats.copy(),
+                    compression_stats=_compaction_stats.copy(),
                 )
 
             # Create assistant message and stream data

--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -39,7 +39,7 @@ from agno.exceptions import (
     RunCancelledException,
 )
 from agno.media import Audio, File, Image, Video
-from agno.metrics import MessageMetrics, ModelType, ToolCallMetrics
+from agno.metrics import MessageMetrics, ModelType, ToolCallMetrics, accumulate_compaction_stats
 from agno.models.message import Citations, Message
 from agno.models.response import ModelResponse, ModelResponseEvent, ToolExecution
 from agno.run.agent import RUN_OUTPUT_EVENT_TYPES, CustomEvent, RunContentEvent, RunOutput, RunOutputEvent
@@ -698,7 +698,6 @@ class Model(ABC):
 
         _compress_tool_results = bool(compaction_manager is not None and compaction_manager.compact_tools)
         _compaction_manager = compaction_manager if _compress_tool_results else None
-        _compaction_stats: Dict[str, Any] = {}
 
         while True:
             # Compress tool results if compression is enabled and threshold is met
@@ -708,8 +707,7 @@ class Model(ABC):
                 stats = _compaction_manager.compact_tool_results(
                     messages, run_metrics=run_response.metrics if run_response is not None else None
                 )
-                for key, value in stats.items():
-                    _compaction_stats[key] = _compaction_stats.get(key, 0) + value
+                accumulate_compaction_stats(run_response.metrics if run_response else None, stats)
 
             # Get response from model
             assistant_message = Message(role=self.assistant_message_role)
@@ -879,10 +877,6 @@ class Model(ABC):
         if self.cache_response:
             self._save_model_response_to_cache(cache_key, model_response, is_streaming=False)
 
-        # Store compression stats on run_response (async-safe, per-run)
-        if run_response is not None and _compaction_stats:
-            run_response.compression_stats = _compaction_stats
-
         return model_response
 
     async def aresponse(
@@ -929,7 +923,6 @@ class Model(ABC):
 
         _compress_tool_results = bool(compaction_manager is not None and compaction_manager.compact_tools)
         _compaction_manager = compaction_manager if _compress_tool_results else None
-        _compaction_stats: Dict[str, Any] = {}
 
         function_call_count = 0
 
@@ -941,8 +934,7 @@ class Model(ABC):
                 stats = await _compaction_manager.acompact_tool_results(
                     messages, run_metrics=run_response.metrics if run_response is not None else None
                 )
-                for key, value in stats.items():
-                    _compaction_stats[key] = _compaction_stats.get(key, 0) + value
+                accumulate_compaction_stats(run_response.metrics if run_response else None, stats)
 
             # Get response from model
             assistant_message = Message(role=self.assistant_message_role)
@@ -1110,10 +1102,6 @@ class Model(ABC):
         # Save to cache if enabled
         if self.cache_response:
             self._save_model_response_to_cache(cache_key, model_response, is_streaming=False)
-
-        # Store compression stats on run_response (async-safe, per-run)
-        if run_response is not None and _compaction_stats:
-            run_response.compression_stats = _compaction_stats
 
         return model_response
 
@@ -1429,7 +1417,6 @@ class Model(ABC):
 
         _compress_tool_results = bool(compaction_manager is not None and compaction_manager.compact_tools)
         _compaction_manager = compaction_manager if _compress_tool_results else None
-        _compaction_stats: Dict[str, Any] = {}
 
         function_call_count = 0
 
@@ -1443,12 +1430,11 @@ class Model(ABC):
                 stats = _compaction_manager.compact_tool_results(
                     messages, run_metrics=run_response.metrics if run_response is not None else None
                 )
-                for key, value in stats.items():
-                    _compaction_stats[key] = _compaction_stats.get(key, 0) + value
-                # Emit compression completed event with stats
+                accumulate_compaction_stats(run_response.metrics if run_response else None, stats)
+                # Emit compression completed event with this pass's stats
                 yield ModelResponse(
                     event=ModelResponseEvent.compression_completed.value,
-                    compression_stats=_compaction_stats.copy(),
+                    compression_stats=stats,
                 )
 
             assistant_message = Message(role=self.assistant_message_role)
@@ -1715,7 +1701,6 @@ class Model(ABC):
 
         _compress_tool_results = bool(compaction_manager is not None and compaction_manager.compact_tools)
         _compaction_manager = compaction_manager if _compress_tool_results else None
-        _compaction_stats: Dict[str, Any] = {}
 
         function_call_count = 0
 
@@ -1729,12 +1714,11 @@ class Model(ABC):
                 stats = await _compaction_manager.acompact_tool_results(
                     messages, run_metrics=run_response.metrics if run_response is not None else None
                 )
-                for key, value in stats.items():
-                    _compaction_stats[key] = _compaction_stats.get(key, 0) + value
-                # Emit compression completed event with stats
+                accumulate_compaction_stats(run_response.metrics if run_response else None, stats)
+                # Emit compression completed event with this pass's stats
                 yield ModelResponse(
                     event=ModelResponseEvent.compression_completed.value,
-                    compression_stats=_compaction_stats.copy(),
+                    compression_stats=stats,
                 )
 
             # Create assistant message and stream data

--- a/libs/agno/agno/models/response.py
+++ b/libs/agno/agno/models/response.py
@@ -227,6 +227,9 @@ class ModelResponse:
 
             data["response_usage"] = _MessageMetrics.from_dict(data["response_usage"])
 
+        # Remove legacy compression_stats from old cache files (now in metrics.additional_metrics)
+        data.pop("compression_stats", None)
+
         return cls(**data)
 
 

--- a/libs/agno/agno/os/interfaces/a2a/utils.py
+++ b/libs/agno/agno/os/interfaces/a2a/utils.py
@@ -5,6 +5,8 @@ from uuid import uuid4
 from fastapi import HTTPException
 from typing_extensions import AsyncIterator, List, Union
 
+from agno.run.team import CompactionCompletedEvent as TeamCompactionCompletedEvent
+from agno.run.team import CompactionStartedEvent as TeamCompactionStartedEvent
 from agno.run.team import MemoryUpdateCompletedEvent as TeamMemoryUpdateCompletedEvent
 from agno.run.team import MemoryUpdateStartedEvent as TeamMemoryUpdateStartedEvent
 from agno.run.team import ReasoningCompletedEvent as TeamReasoningCompletedEvent
@@ -65,6 +67,8 @@ except ImportError as e:
 
 from agno.media import Audio, File, Image, Video
 from agno.run.agent import (
+    CompactionCompletedEvent,
+    CompactionStartedEvent,
     MemoryUpdateCompletedEvent,
     MemoryUpdateStartedEvent,
     ReasoningCompletedEvent,
@@ -474,6 +478,34 @@ async def stream_a2a_response(
                 status=TaskStatus(state=TaskState.working),
                 final=False,
                 metadata={"agno_event_type": "memory_update_completed"},
+            )
+            response = SendStreamingMessageSuccessResponse(id=request_id, result=status_event)
+            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"
+
+        # Send compaction events
+        elif isinstance(event, (CompactionStartedEvent, TeamCompactionStartedEvent)):
+            status_event = TaskStatusUpdateEvent(
+                task_id=task_id,
+                context_id=context_id,
+                status=TaskStatus(state=TaskState.working),
+                final=False,
+                metadata={"agno_event_type": "compaction_started"},
+            )
+            response = SendStreamingMessageSuccessResponse(id=request_id, result=status_event)
+            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"
+
+        elif isinstance(event, (CompactionCompletedEvent, TeamCompactionCompletedEvent)):
+            metadata: Dict[str, Any] = {"agno_event_type": "compaction_completed"}
+            if hasattr(event, "tokens_saved"):
+                metadata["tokens_saved"] = event.tokens_saved
+            if hasattr(event, "messages_compacted"):
+                metadata["messages_compacted"] = event.messages_compacted
+            status_event = TaskStatusUpdateEvent(
+                task_id=task_id,
+                context_id=context_id,
+                status=TaskStatus(state=TaskState.working),
+                final=False,
+                metadata=metadata,
             )
             response = SendStreamingMessageSuccessResponse(id=request_id, result=status_event)
             yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"

--- a/libs/agno/agno/os/interfaces/slack/events.py
+++ b/libs/agno/agno/os/interfaces/slack/events.py
@@ -264,6 +264,18 @@ async def _on_memory_update_completed(chunk: BaseRunOutputEvent, state: StreamSt
     return False
 
 
+async def _on_compaction_started(chunk: BaseRunOutputEvent, state: StreamState, stream: AsyncChatStream) -> bool:
+    state.track_task("compaction", "Compacting context")
+    await _emit_task(stream, "compaction", "Compacting context", "in_progress")
+    return False
+
+
+async def _on_compaction_completed(chunk: BaseRunOutputEvent, state: StreamState, stream: AsyncChatStream) -> bool:
+    state.complete_task("compaction")
+    await _emit_task(stream, "compaction", "Compacting context", "complete")
+    return False
+
+
 async def _on_run_completed(chunk: BaseRunOutputEvent, state: StreamState, stream: AsyncChatStream) -> bool:
     return False  # Finalization handled by caller after stream ends
 
@@ -415,6 +427,8 @@ HANDLERS: Dict[str, _EventHandler] = {
     RunEvent.run_intermediate_content.value: _on_run_intermediate_content,
     RunEvent.memory_update_started.value: _on_memory_update_started,
     RunEvent.memory_update_completed.value: _on_memory_update_completed,
+    RunEvent.compaction_started.value: _on_compaction_started,
+    RunEvent.compaction_completed.value: _on_compaction_completed,
     RunEvent.run_completed.value: _on_run_completed,
     RunEvent.run_error.value: _on_run_error,
     RunEvent.run_cancelled.value: _on_run_error,  # Treat cancellation as terminal error

--- a/libs/agno/agno/os/interfaces/telegram/events.py
+++ b/libs/agno/agno/os/interfaces/telegram/events.py
@@ -225,6 +225,8 @@ HANDLERS: Dict[str, _EventHandler] = {
     RunEvent.run_cancelled.value: _on_run_error,
     RunEvent.memory_update_started.value: _status_handler("Updating memory", started=True),
     RunEvent.memory_update_completed.value: _status_handler("Updating memory", started=False),
+    RunEvent.compaction_started.value: _status_handler("Compacting context", started=True),
+    RunEvent.compaction_completed.value: _status_handler("Compacting context", started=False),
     WorkflowRunEvent.workflow_started.value: _on_workflow_started,
     WorkflowRunEvent.workflow_completed.value: _on_workflow_completed,
     WorkflowRunEvent.workflow_error.value: _on_workflow_error,

--- a/libs/agno/agno/os/schema.py
+++ b/libs/agno/agno/os/schema.py
@@ -596,6 +596,7 @@ class RunSchema(BaseModel):
     )
     reasoning_messages: Optional[List[dict]] = Field(None, description="Reasoning process messages")
     session_state: Optional[dict] = Field(None, description="Session state at the end of the run")
+    compaction: Optional[dict] = Field(None, description="Context compaction state (summary, tokens saved, etc.)")
     images: Optional[List[dict]] = Field(None, description="Images included in the run")
     videos: Optional[List[dict]] = Field(None, description="Videos included in the run")
     audio: Optional[List[dict]] = Field(None, description="Audio files included in the run")
@@ -646,6 +647,7 @@ class RunSchema(BaseModel):
             citations=run_dict.get("citations", None),
             reasoning_messages=run_dict.get("reasoning_messages", []),
             session_state=run_dict.get("session_state"),
+            compaction=run_dict.get("compaction"),
             images=run_dict.get("images", []),
             videos=run_dict.get("videos", []),
             audio=run_dict.get("audio", []),
@@ -683,6 +685,7 @@ class TeamRunSchema(BaseModel):
     )
     reasoning_messages: Optional[List[dict]] = Field(None, description="Reasoning process messages")
     session_state: Optional[dict] = Field(None, description="Session state at the end of the run")
+    compaction: Optional[dict] = Field(None, description="Context compaction state (summary, tokens saved, etc.)")
     input_media: Optional[Dict[str, Any]] = Field(None, description="Input media attachments")
     images: Optional[List[dict]] = Field(None, description="Images included in the run")
     videos: Optional[List[dict]] = Field(None, description="Videos included in the run")
@@ -732,6 +735,7 @@ class TeamRunSchema(BaseModel):
             citations=run_dict.get("citations", None),
             reasoning_messages=run_dict.get("reasoning_messages", []),
             session_state=run_dict.get("session_state"),
+            compaction=run_dict.get("compaction"),
             images=run_dict.get("images", []),
             videos=run_dict.get("videos", []),
             audio=run_dict.get("audio", []),

--- a/libs/agno/agno/run/agent.py
+++ b/libs/agno/agno/run/agent.py
@@ -663,6 +663,8 @@ class RunOutput:
 
     # Point-in-time compaction state for continue_run time travel
     compaction_state: Optional["CompactionState"] = None
+    # Per-run compression stats (async-safe, not shared across runs)
+    compression_stats: Optional[Dict[str, Any]] = None
 
     created_at: int = field(default_factory=lambda: int(time()))
 

--- a/libs/agno/agno/run/agent.py
+++ b/libs/agno/agno/run/agent.py
@@ -663,8 +663,6 @@ class RunOutput:
 
     # Point-in-time compaction state for continue_run time travel
     compaction_state: Optional["CompactionState"] = None
-    # Per-run compression stats (async-safe, not shared across runs)
-    compression_stats: Optional[Dict[str, Any]] = None
 
     created_at: int = field(default_factory=lambda: int(time()))
 

--- a/libs/agno/agno/run/agent.py
+++ b/libs/agno/agno/run/agent.py
@@ -189,6 +189,9 @@ class RunEvent(str, Enum):
     compression_started = "CompressionStarted"
     compression_completed = "CompressionCompleted"
 
+    compaction_started = "CompactionStarted"
+    compaction_completed = "CompactionCompleted"
+
     followups_started = "FollowupsStarted"
     followups_completed = "FollowupsCompleted"
 
@@ -501,6 +504,26 @@ class CompressionCompletedEvent(BaseAgentRunEvent):
 
 
 @dataclass
+class CompactionStartedEvent(BaseAgentRunEvent):
+    """Event sent when context compaction is about to start"""
+
+    event: str = RunEvent.compaction_started.value
+    messages_before: int = 0
+    messages_to_compact: int = 0
+
+
+@dataclass
+class CompactionCompletedEvent(BaseAgentRunEvent):
+    """Event sent when context compaction has completed"""
+
+    event: str = RunEvent.compaction_completed.value
+    messages_after: int = 0
+    messages_compacted: int = 0
+    tokens_saved: int = 0
+    summary_preview: Optional[str] = None
+
+
+@dataclass
 class FollowupsStartedEvent(BaseAgentRunEvent):
     event: str = RunEvent.followups_started.value
 
@@ -556,6 +579,8 @@ RunOutputEvent = Union[
     ModelRequestCompletedEvent,
     CompressionStartedEvent,
     CompressionCompletedEvent,
+    CompactionStartedEvent,
+    CompactionCompletedEvent,
     FollowupsStartedEvent,
     FollowupsCompletedEvent,
     CustomEvent,
@@ -601,6 +626,8 @@ RUN_EVENT_TYPE_REGISTRY = {
     RunEvent.model_request_completed.value: ModelRequestCompletedEvent,
     RunEvent.compression_started.value: CompressionStartedEvent,
     RunEvent.compression_completed.value: CompressionCompletedEvent,
+    RunEvent.compaction_started.value: CompactionStartedEvent,
+    RunEvent.compaction_completed.value: CompactionCompletedEvent,
     RunEvent.followups_started.value: FollowupsStartedEvent,
     RunEvent.followups_completed.value: FollowupsCompletedEvent,
     RunEvent.custom_event.value: CustomEvent,

--- a/libs/agno/agno/run/team.py
+++ b/libs/agno/agno/run/team.py
@@ -793,6 +793,8 @@ class TeamRunOutput:
 
     # Point-in-time compaction state for continue_run time travel
     compaction_state: Optional["CompactionState"] = None
+    # Per-run compression stats (async-safe, not shared across runs)
+    compression_stats: Optional[Dict[str, Any]] = None
 
     created_at: int = field(default_factory=lambda: int(time()))
 

--- a/libs/agno/agno/run/team.py
+++ b/libs/agno/agno/run/team.py
@@ -175,6 +175,9 @@ class TeamRunEvent(str, Enum):
     compression_started = "TeamCompressionStarted"
     compression_completed = "TeamCompressionCompleted"
 
+    compaction_started = "TeamCompactionStarted"
+    compaction_completed = "TeamCompactionCompleted"
+
     followups_started = "TeamFollowupsStarted"
     followups_completed = "TeamFollowupsCompleted"
 
@@ -515,6 +518,26 @@ class CompressionCompletedEvent(BaseTeamRunEvent):
 
 
 @dataclass
+class CompactionStartedEvent(BaseTeamRunEvent):
+    """Event sent when context compaction is about to start"""
+
+    event: str = TeamRunEvent.compaction_started.value
+    messages_before: int = 0
+    messages_to_compact: int = 0
+
+
+@dataclass
+class CompactionCompletedEvent(BaseTeamRunEvent):
+    """Event sent when context compaction has completed"""
+
+    event: str = TeamRunEvent.compaction_completed.value
+    messages_after: int = 0
+    messages_compacted: int = 0
+    tokens_saved: int = 0
+    summary_preview: Optional[str] = None
+
+
+@dataclass
 class FollowupsStartedEvent(BaseTeamRunEvent):
     event: str = TeamRunEvent.followups_started.value
 
@@ -674,6 +697,8 @@ TeamRunOutputEvent = Union[
     ModelRequestCompletedEvent,
     CompressionStartedEvent,
     CompressionCompletedEvent,
+    CompactionStartedEvent,
+    CompactionCompletedEvent,
     FollowupsStartedEvent,
     FollowupsCompletedEvent,
     TaskIterationStartedEvent,
@@ -723,6 +748,8 @@ TEAM_RUN_EVENT_TYPE_REGISTRY = {
     TeamRunEvent.model_request_completed.value: ModelRequestCompletedEvent,
     TeamRunEvent.compression_started.value: CompressionStartedEvent,
     TeamRunEvent.compression_completed.value: CompressionCompletedEvent,
+    TeamRunEvent.compaction_started.value: CompactionStartedEvent,
+    TeamRunEvent.compaction_completed.value: CompactionCompletedEvent,
     TeamRunEvent.followups_started.value: FollowupsStartedEvent,
     TeamRunEvent.followups_completed.value: FollowupsCompletedEvent,
     TeamRunEvent.task_iteration_started.value: TaskIterationStartedEvent,

--- a/libs/agno/agno/run/team.py
+++ b/libs/agno/agno/run/team.py
@@ -793,8 +793,6 @@ class TeamRunOutput:
 
     # Point-in-time compaction state for continue_run time travel
     compaction_state: Optional["CompactionState"] = None
-    # Per-run compression stats (async-safe, not shared across runs)
-    compression_stats: Optional[Dict[str, Any]] = None
 
     created_at: int = field(default_factory=lambda: int(time()))
 

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -109,6 +109,8 @@ from agno.utils.agent import (
 )
 from agno.utils.events import (
     add_team_error_event,
+    create_team_compaction_completed_event,
+    create_team_compaction_started_event,
     create_team_run_cancelled_event,
     create_team_run_completed_event,
     create_team_run_content_completed_event,
@@ -363,16 +365,40 @@ def _run_tasks(
 
         # Pre-loop compaction: compress history BEFORE first model call
         if team.compaction_manager is not None and team.compaction_manager.compact_context:
-            log_debug(f"[TEAM-TASKS-SYNC] Pre-loop compaction check: {len(run_messages.messages)} messages")
+            messages_before = len(run_messages.messages)
+            log_debug(f"[TEAM-TASKS-SYNC] Pre-loop compaction check: {messages_before} messages")
             compaction_result = team.compaction_manager.compact(
                 run_messages.messages,
                 run_response=run_response,
                 run_metrics=run_response.metrics,
             )
             if compaction_result.summary:
+                handle_event(
+                    create_team_compaction_started_event(
+                        from_run_response=run_response,
+                        messages_before=messages_before,
+                        messages_to_compact=messages_before - len(compaction_result.compacted_messages),
+                    ),
+                    run_response,
+                    events_to_skip=team.events_to_skip,
+                    store_events=team.store_events,
+                )
                 run_messages.compacted_messages = compaction_result.compacted_messages
+                tokens_saved = run_response.compaction_state.total_tokens_saved if run_response.compaction_state else 0
+                handle_event(
+                    create_team_compaction_completed_event(
+                        from_run_response=run_response,
+                        messages_after=len(compaction_result.compacted_messages),
+                        messages_compacted=messages_before - len(compaction_result.compacted_messages),
+                        tokens_saved=tokens_saved,
+                        summary_preview=compaction_result.summary[:200],
+                    ),
+                    run_response,
+                    events_to_skip=team.events_to_skip,
+                    store_events=team.store_events,
+                )
                 log_debug(
-                    f"[TEAM-TASKS-SYNC] Pre-loop compaction: {len(run_messages.messages)} -> {len(run_messages.compacted_messages)}"
+                    f"[TEAM-TASKS-SYNC] Pre-loop compaction: {messages_before} -> {len(run_messages.compacted_messages)}"
                 )
 
         # Use accumulated messages for the iterative loop
@@ -1273,15 +1299,41 @@ def _run(
                 # 6. Pre-loop compaction: compress history BEFORE first model call
                 if team.compaction_manager is not None and team.compaction_manager.compact_context:
                     log_debug(f"[TEAM-RUN-SYNC] Pre-loop compaction check: {len(run_messages.messages)} messages")
+                    messages_before = len(run_messages.messages)
                     compaction_result = team.compaction_manager.compact(
                         run_messages.messages,
                         run_response=run_response,
                         run_metrics=run_response.metrics,
                     )
                     if compaction_result.summary:
+                        handle_event(
+                            create_team_compaction_started_event(
+                                from_run_response=run_response,
+                                messages_before=messages_before,
+                                messages_to_compact=messages_before - len(compaction_result.compacted_messages),
+                            ),
+                            run_response,
+                            events_to_skip=team.events_to_skip,
+                            store_events=team.store_events,
+                        )
                         run_messages.compacted_messages = compaction_result.compacted_messages
+                        tokens_saved = (
+                            run_response.compaction_state.total_tokens_saved if run_response.compaction_state else 0
+                        )
+                        handle_event(
+                            create_team_compaction_completed_event(
+                                from_run_response=run_response,
+                                messages_after=len(compaction_result.compacted_messages),
+                                messages_compacted=messages_before - len(compaction_result.compacted_messages),
+                                tokens_saved=tokens_saved,
+                                summary_preview=compaction_result.summary[:200],
+                            ),
+                            run_response,
+                            events_to_skip=team.events_to_skip,
+                            store_events=team.store_events,
+                        )
                         log_debug(
-                            f"[TEAM-RUN-SYNC] Pre-loop compaction: {len(run_messages.messages)} -> {len(run_messages.compacted_messages)}"
+                            f"[TEAM-RUN-SYNC] Pre-loop compaction: {messages_before} -> {len(run_messages.compacted_messages)}"
                         )
 
                 # 7. Get the model response for the team leader
@@ -2295,16 +2347,40 @@ async def _arun_tasks(
 
         # Pre-loop compaction: compress history BEFORE first model call
         if team.compaction_manager is not None and team.compaction_manager.compact_context:
-            log_debug(f"[TEAM-TASKS-ASYNC] Pre-loop compaction check: {len(run_messages.messages)} messages")
+            messages_before = len(run_messages.messages)
+            log_debug(f"[TEAM-TASKS-ASYNC] Pre-loop compaction check: {messages_before} messages")
             compaction_result = await team.compaction_manager.acompact(
                 run_messages.messages,
                 run_response=run_response,
                 run_metrics=run_response.metrics,
             )
             if compaction_result.summary:
+                handle_event(
+                    create_team_compaction_started_event(
+                        from_run_response=run_response,
+                        messages_before=messages_before,
+                        messages_to_compact=messages_before - len(compaction_result.compacted_messages),
+                    ),
+                    run_response,
+                    events_to_skip=team.events_to_skip,
+                    store_events=team.store_events,
+                )
                 run_messages.compacted_messages = compaction_result.compacted_messages
+                tokens_saved = run_response.compaction_state.total_tokens_saved if run_response.compaction_state else 0
+                handle_event(
+                    create_team_compaction_completed_event(
+                        from_run_response=run_response,
+                        messages_after=len(compaction_result.compacted_messages),
+                        messages_compacted=messages_before - len(compaction_result.compacted_messages),
+                        tokens_saved=tokens_saved,
+                        summary_preview=compaction_result.summary[:200],
+                    ),
+                    run_response,
+                    events_to_skip=team.events_to_skip,
+                    store_events=team.store_events,
+                )
                 log_debug(
-                    f"[TEAM-TASKS-ASYNC] Pre-loop compaction: {len(run_messages.messages)} -> {len(run_messages.compacted_messages)}"
+                    f"[TEAM-TASKS-ASYNC] Pre-loop compaction: {messages_before} -> {len(run_messages.compacted_messages)}"
                 )
 
         # Use accumulated messages for the iterative loop
@@ -3296,15 +3372,41 @@ async def _arun(
                 # 6. Pre-loop compaction: compress history BEFORE first model call
                 if team.compaction_manager is not None and team.compaction_manager.compact_context:
                     log_debug(f"[TEAM-RUN-ASYNC] Pre-loop compaction check: {len(run_messages.messages)} messages")
+                    messages_before = len(run_messages.messages)
                     compaction_result = await team.compaction_manager.acompact(
                         run_messages.messages,
                         run_response=run_response,
                         run_metrics=run_response.metrics,
                     )
                     if compaction_result.summary:
+                        handle_event(
+                            create_team_compaction_started_event(
+                                from_run_response=run_response,
+                                messages_before=messages_before,
+                                messages_to_compact=messages_before - len(compaction_result.compacted_messages),
+                            ),
+                            run_response,
+                            events_to_skip=team.events_to_skip,
+                            store_events=team.store_events,
+                        )
                         run_messages.compacted_messages = compaction_result.compacted_messages
+                        tokens_saved = (
+                            run_response.compaction_state.total_tokens_saved if run_response.compaction_state else 0
+                        )
+                        handle_event(
+                            create_team_compaction_completed_event(
+                                from_run_response=run_response,
+                                messages_after=len(compaction_result.compacted_messages),
+                                messages_compacted=messages_before - len(compaction_result.compacted_messages),
+                                tokens_saved=tokens_saved,
+                                summary_preview=compaction_result.summary[:200],
+                            ),
+                            run_response,
+                            events_to_skip=team.events_to_skip,
+                            store_events=team.store_events,
+                        )
                         log_debug(
-                            f"[TEAM-RUN-ASYNC] Pre-loop compaction: {len(run_messages.messages)} -> {len(run_messages.compacted_messages)}"
+                            f"[TEAM-RUN-ASYNC] Pre-loop compaction: {messages_before} -> {len(run_messages.compacted_messages)}"
                         )
 
                 # 7. Get the model response for the team leader

--- a/libs/agno/agno/utils/events.py
+++ b/libs/agno/agno/utils/events.py
@@ -5,6 +5,8 @@ from agno.models.message import Citations
 from agno.models.response import ToolExecution
 from agno.reasoning.step import ReasoningStep
 from agno.run.agent import (
+    CompactionCompletedEvent,
+    CompactionStartedEvent,
     CompressionCompletedEvent,
     CompressionStartedEvent,
     FollowupsCompletedEvent,
@@ -44,6 +46,8 @@ from agno.run.agent import (
     ToolCallStartedEvent,
 )
 from agno.run.requirement import RunRequirement
+from agno.run.team import CompactionCompletedEvent as TeamCompactionCompletedEvent
+from agno.run.team import CompactionStartedEvent as TeamCompactionStartedEvent
 from agno.run.team import CompressionCompletedEvent as TeamCompressionCompletedEvent
 from agno.run.team import CompressionStartedEvent as TeamCompressionStartedEvent
 from agno.run.team import FollowupsCompletedEvent as TeamFollowupsCompletedEvent
@@ -971,6 +975,40 @@ def create_compression_completed_event(
     )
 
 
+def create_compaction_started_event(
+    from_run_response: RunOutput,
+    messages_before: int = 0,
+    messages_to_compact: int = 0,
+) -> CompactionStartedEvent:
+    return CompactionStartedEvent(
+        session_id=from_run_response.session_id,
+        agent_id=from_run_response.agent_id,  # type: ignore
+        agent_name=from_run_response.agent_name,  # type: ignore
+        run_id=from_run_response.run_id,
+        messages_before=messages_before,
+        messages_to_compact=messages_to_compact,
+    )
+
+
+def create_compaction_completed_event(
+    from_run_response: RunOutput,
+    messages_after: int = 0,
+    messages_compacted: int = 0,
+    tokens_saved: int = 0,
+    summary_preview: Optional[str] = None,
+) -> CompactionCompletedEvent:
+    return CompactionCompletedEvent(
+        session_id=from_run_response.session_id,
+        agent_id=from_run_response.agent_id,  # type: ignore
+        agent_name=from_run_response.agent_name,  # type: ignore
+        run_id=from_run_response.run_id,
+        messages_after=messages_after,
+        messages_compacted=messages_compacted,
+        tokens_saved=tokens_saved,
+        summary_preview=summary_preview,
+    )
+
+
 def create_team_compression_started_event(
     from_run_response: TeamRunOutput,
 ) -> TeamCompressionStartedEvent:
@@ -996,6 +1034,40 @@ def create_team_compression_completed_event(
         tool_results_compressed=tool_results_compressed,
         original_size=original_size,
         compressed_size=compressed_size,
+    )
+
+
+def create_team_compaction_started_event(
+    from_run_response: TeamRunOutput,
+    messages_before: int = 0,
+    messages_to_compact: int = 0,
+) -> TeamCompactionStartedEvent:
+    return TeamCompactionStartedEvent(
+        session_id=from_run_response.session_id,
+        team_id=from_run_response.team_id,  # type: ignore
+        team_name=from_run_response.team_name,  # type: ignore
+        run_id=from_run_response.run_id,
+        messages_before=messages_before,
+        messages_to_compact=messages_to_compact,
+    )
+
+
+def create_team_compaction_completed_event(
+    from_run_response: TeamRunOutput,
+    messages_after: int = 0,
+    messages_compacted: int = 0,
+    tokens_saved: int = 0,
+    summary_preview: Optional[str] = None,
+) -> TeamCompactionCompletedEvent:
+    return TeamCompactionCompletedEvent(
+        session_id=from_run_response.session_id,
+        team_id=from_run_response.team_id,  # type: ignore
+        team_name=from_run_response.team_name,  # type: ignore
+        run_id=from_run_response.run_id,
+        messages_after=messages_after,
+        messages_compacted=messages_compacted,
+        tokens_saved=tokens_saved,
+        summary_preview=summary_preview,
     )
 
 

--- a/libs/agno/agno/utils/print_response/agent.py
+++ b/libs/agno/agno/utils/print_response/agent.py
@@ -11,6 +11,7 @@ from rich.text import Text
 
 from agno.filters import FilterExpr
 from agno.media import Audio, File, Image, Video
+from agno.metrics import get_compaction_stats
 from agno.models.message import Message
 from agno.reasoning.step import ReasoningStep
 from agno.run.agent import RunEvent, RunOutput, RunOutputEvent, RunPausedEvent
@@ -195,7 +196,6 @@ def print_response_stream(
                 show_reasoning=show_reasoning,
                 show_full_reasoning=show_full_reasoning,
                 accumulated_tool_calls=accumulated_tool_calls,
-                compaction_manager=agent.compaction_manager,
             )
             panels.extend(additional_panels)
             if panels:
@@ -220,10 +220,6 @@ def print_response_stream(
             panels.append(summary_panel)
             live_log.update(Group(*panels))
             agent.session_summary_manager.summaries_updated = False
-
-        # Clear compression stats after final display
-        if agent.compaction_manager is not None:
-            agent.compaction_manager.stats.clear()
 
         response_timer.stop()
 
@@ -402,7 +398,6 @@ async def aprint_response_stream(
                 show_reasoning=show_reasoning,
                 show_full_reasoning=show_full_reasoning,
                 accumulated_tool_calls=accumulated_tool_calls,
-                compaction_manager=agent.compaction_manager,
             )
             panels.extend(additional_panels)
             if panels:
@@ -428,10 +423,6 @@ async def aprint_response_stream(
             live_log.update(Group(*panels))
             agent.session_summary_manager.summaries_updated = False
 
-        # Clear compression stats after final display
-        if agent.compaction_manager is not None:
-            agent.compaction_manager.stats.clear()
-
         response_timer.stop()
 
         # Final update to remove the "Working..." status
@@ -448,7 +439,6 @@ def build_panels_stream(
     show_reasoning: bool = True,
     show_full_reasoning: bool = False,
     accumulated_tool_calls: Optional[List] = None,
-    compaction_manager: Optional[Any] = None,
 ):
     from rich.markdown import Markdown
 
@@ -493,13 +483,8 @@ def build_panels_stream(
 
         tool_calls_text = tool_calls_content.plain.rstrip()
 
-        # Add compression stats if available (don't clear - caller will clear after final display)
-        if compaction_manager is not None and compaction_manager.stats:
-            stats = compaction_manager.stats
-            saved = stats.get("original_size", 0) - stats.get("compressed_size", 0)
-            orig = stats.get("original_size", 1)
-            if stats.get("tool_results_compressed", 0) > 0:
-                tool_calls_text += f"\n\ncompressed: {stats.get('tool_results_compressed', 0)} | Saved: {saved:,} chars ({saved / orig * 100:.0f}%)"
+        # Compression stats are now on run_response.metrics (not available during streaming)
+        # Stats will be shown in the final non-streaming summary if needed
 
         tool_calls_panel = create_panel(
             content=tool_calls_text,
@@ -642,7 +627,6 @@ def print_response(
             show_full_reasoning=show_full_reasoning,
             tags_to_include_in_markdown=tags_to_include_in_markdown,
             markdown=markdown,
-            compaction_manager=agent.compaction_manager,
         )
         panels.extend(additional_panels)
 
@@ -762,7 +746,6 @@ async def aprint_response(
             show_full_reasoning=show_full_reasoning,
             tags_to_include_in_markdown=tags_to_include_in_markdown,
             markdown=markdown,
-            compaction_manager=agent.compaction_manager,
         )
         panels.extend(additional_panels)
 
@@ -856,14 +839,13 @@ def build_panels(
 
         tool_calls_text = tool_calls_content.plain.rstrip()
 
-        # Add compression stats if available
-        if compaction_manager is not None and compaction_manager.stats:
-            stats = compaction_manager.stats
+        # Add compression stats if available (read from run_response.metrics)
+        stats = get_compaction_stats(run_response.metrics) if isinstance(run_response, RunOutput) else {}
+        if stats:
             saved = stats.get("original_size", 0) - stats.get("compressed_size", 0)
             orig = stats.get("original_size", 1)
             if stats.get("tool_results_compressed", 0) > 0:
                 tool_calls_text += f"\n\ncompressed: {stats.get('tool_results_compressed', 0)} | Saved: {saved:,} chars ({saved / orig * 100:.0f}%)"
-            compaction_manager.stats.clear()
 
         tool_calls_panel = create_panel(
             content=tool_calls_text,

--- a/libs/agno/agno/utils/print_response/agent.py
+++ b/libs/agno/agno/utils/print_response/agent.py
@@ -846,6 +846,8 @@ def build_panels(
             orig = stats.get("original_size", 1)
             if stats.get("tool_results_compressed", 0) > 0:
                 tool_calls_text += f"\n\ncompressed: {stats.get('tool_results_compressed', 0)} | Saved: {saved:,} chars ({saved / orig * 100:.0f}%)"
+            if stats.get("messages_compacted", 0) > 0:
+                tool_calls_text += f"\n\ncompacted: {stats.get('messages_compacted', 0)} msgs | Saved: {stats.get('tokens_saved', 0):,} tokens"
 
         tool_calls_panel = create_panel(
             content=tool_calls_text,

--- a/libs/agno/agno/utils/print_response/team.py
+++ b/libs/agno/agno/utils/print_response/team.py
@@ -278,14 +278,7 @@ def print_response(
                     # Join with blank lines between items
                     tool_calls_text = "\n\n".join(lines)
 
-                    # Compression stats are now on run_response.metrics (not available during streaming)
-
-                    # Add compaction stats
-                    if team.context_compaction_manager is not None and team.context_compaction_manager.stats:
-                        stats = team.context_compaction_manager.stats
-                        if stats.get("messages_compacted", 0) > 0:
-                            tool_calls_text += f"\n\ncompacted: {stats.get('messages_compacted', 0)} msgs | Saved: {stats.get('tokens_saved', 0):,} tokens"
-                        team.context_compaction_manager.stats.clear()
+                    # Compression and compaction stats are on run_response.metrics (not available during streaming)
 
                     team_tool_calls_panel = create_panel(
                         content=tool_calls_text,
@@ -658,13 +651,7 @@ def print_response_stream(
                     # Join with blank lines between items
                     tool_calls_text = "\n\n".join(lines)
 
-                    # Compression stats are now on run_response.metrics (not available during streaming)
-
-                    # Add compaction stats
-                    if team.context_compaction_manager is not None and team.context_compaction_manager.stats:
-                        stats = team.context_compaction_manager.stats
-                        if stats.get("messages_compacted", 0) > 0:
-                            tool_calls_text += f"\n\ncompacted: {stats.get('messages_compacted', 0)} msgs | Saved: {stats.get('tokens_saved', 0):,} tokens"
+                    # Compression and compaction stats are on run_response.metrics (not available during streaming)
 
                     team_tool_calls_panel = create_panel(
                         content=tool_calls_text,
@@ -894,7 +881,7 @@ def print_response_stream(
 
                 tool_calls_text = "\n\n".join(lines)
 
-                # Add compression stats (read from run_response.metrics)
+                # Add compression and compaction stats (read from run_response.metrics)
                 stats: Dict[str, Any] = (
                     get_compaction_stats(run_response.metrics) if isinstance(run_response, TeamRunOutput) else {}
                 )
@@ -903,10 +890,6 @@ def print_response_stream(
                     orig = stats.get("original_size", 1)
                     if stats.get("tool_results_compressed", 0) > 0:
                         tool_calls_text += f"\n\ncompressed: {stats.get('tool_results_compressed', 0)} | Saved: {saved:,} chars ({saved / orig * 100:.0f}%)"
-
-                # Add compaction stats
-                if team.context_compaction_manager is not None and team.context_compaction_manager.stats:
-                    stats = team.context_compaction_manager.stats
                     if stats.get("messages_compacted", 0) > 0:
                         tool_calls_text += f"\n\ncompacted: {stats.get('messages_compacted', 0)} msgs | Saved: {stats.get('tokens_saved', 0):,} tokens"
 
@@ -1589,13 +1572,7 @@ async def aprint_response_stream(
                     # Join with blank lines between items
                     tool_calls_text = "\n\n".join(lines)
 
-                    # Compression stats are now on run_response.metrics (not available during streaming)
-
-                    # Add compaction stats
-                    if team.context_compaction_manager is not None and team.context_compaction_manager.stats:
-                        stats = team.context_compaction_manager.stats
-                        if stats.get("messages_compacted", 0) > 0:
-                            tool_calls_text += f"\n\ncompacted: {stats.get('messages_compacted', 0)} msgs | Saved: {stats.get('tokens_saved', 0):,} tokens"
+                    # Compression and compaction stats are on run_response.metrics (not available during streaming)
 
                     team_tool_calls_panel = create_panel(
                         content=tool_calls_text,
@@ -1843,7 +1820,7 @@ async def aprint_response_stream(
 
                 tool_calls_text = "\n\n".join(lines)
 
-                # Add compression stats (read from run_response.metrics)
+                # Add compression and compaction stats (read from run_response.metrics)
                 stats: Dict[str, Any] = (
                     get_compaction_stats(run_response.metrics) if isinstance(run_response, TeamRunOutput) else {}
                 )
@@ -1852,10 +1829,6 @@ async def aprint_response_stream(
                     orig = stats.get("original_size", 1)
                     if stats.get("tool_results_compressed", 0) > 0:
                         tool_calls_text += f"\n\ncompressed: {stats.get('tool_results_compressed', 0)} | Saved: {saved:,} chars ({saved / orig * 100:.0f}%)"
-
-                # Add compaction stats
-                if team.context_compaction_manager is not None and team.context_compaction_manager.stats:
-                    stats = team.context_compaction_manager.stats
                     if stats.get("messages_compacted", 0) > 0:
                         tool_calls_text += f"\n\ncompacted: {stats.get('messages_compacted', 0)} msgs | Saved: {stats.get('tokens_saved', 0):,} tokens"
 

--- a/libs/agno/agno/utils/print_response/team.py
+++ b/libs/agno/agno/utils/print_response/team.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 
 from agno.filters import FilterExpr
 from agno.media import Audio, File, Image, Video
+from agno.metrics import get_compaction_stats
 from agno.models.message import Message
 from agno.models.response import ToolExecution
 from agno.reasoning.step import ReasoningStep
@@ -277,14 +278,7 @@ def print_response(
                     # Join with blank lines between items
                     tool_calls_text = "\n\n".join(lines)
 
-                    # Add compression stats at end of tool calls
-                    if team.compaction_manager is not None and team.compaction_manager.stats:
-                        stats = team.compaction_manager.stats
-                        saved = stats.get("original_size", 0) - stats.get("compressed_size", 0)
-                        orig = stats.get("original_size", 1)
-                        if stats.get("tool_results_compressed", 0) > 0:
-                            tool_calls_text += f"\n\ncompressed: {stats.get('tool_results_compressed', 0)} | Saved: {saved:,} chars ({saved / orig * 100:.0f}%)"
-                        team.compaction_manager.stats.clear()
+                    # Compression stats are now on run_response.metrics (not available during streaming)
 
                     team_tool_calls_panel = create_panel(
                         content=tool_calls_text,
@@ -657,13 +651,7 @@ def print_response_stream(
                     # Join with blank lines between items
                     tool_calls_text = "\n\n".join(lines)
 
-                    # Add compression stats if available (don't clear - will be cleared in final_panels)
-                    if team.compaction_manager is not None and team.compaction_manager.stats:
-                        stats = team.compaction_manager.stats
-                        saved = stats.get("original_size", 0) - stats.get("compressed_size", 0)
-                        orig = stats.get("original_size", 1)
-                        if stats.get("tool_results_compressed", 0) > 0:
-                            tool_calls_text += f"\n\ncompressed: {stats.get('tool_results_compressed', 0)} | Saved: {saved:,} chars ({saved / orig * 100:.0f}%)"
+                    # Compression stats are now on run_response.metrics (not available during streaming)
 
                     team_tool_calls_panel = create_panel(
                         content=tool_calls_text,
@@ -893,14 +881,15 @@ def print_response_stream(
 
                 tool_calls_text = "\n\n".join(lines)
 
-                # Add compression stats at end of tool calls
-                if team.compaction_manager is not None and team.compaction_manager.stats:
-                    stats = team.compaction_manager.stats
+                # Add compression stats (read from run_response.metrics)
+                stats: Dict[str, Any] = (
+                    get_compaction_stats(run_response.metrics) if isinstance(run_response, TeamRunOutput) else {}
+                )
+                if stats:
                     saved = stats.get("original_size", 0) - stats.get("compressed_size", 0)
                     orig = stats.get("original_size", 1)
                     if stats.get("tool_results_compressed", 0) > 0:
                         tool_calls_text += f"\n\ncompressed: {stats.get('tool_results_compressed', 0)} | Saved: {saved:,} chars ({saved / orig * 100:.0f}%)"
-                    team.compaction_manager.stats.clear()
 
                 team_tool_calls_panel = create_panel(
                     content=tool_calls_text,
@@ -1210,14 +1199,7 @@ async def aprint_response(
 
                     tool_calls_text = "\n\n".join(lines)
 
-                    # Add compression stats at end of tool calls
-                    if team.compaction_manager is not None and team.compaction_manager.stats:
-                        stats = team.compaction_manager.stats
-                        saved = stats.get("original_size", 0) - stats.get("compressed_size", 0)
-                        orig = stats.get("original_size", 1)
-                        if stats.get("tool_results_compressed", 0) > 0:
-                            tool_calls_text += f"\n\ncompressed: {stats.get('tool_results_compressed', 0)} | Saved: {saved:,} chars ({saved / orig * 100:.0f}%)"
-                        team.compaction_manager.stats.clear()
+                    # Compression stats are now on run_response.metrics (not available during streaming)
 
                     team_tool_calls_panel = create_panel(
                         content=tool_calls_text,
@@ -1588,13 +1570,7 @@ async def aprint_response_stream(
                     # Join with blank lines between items
                     tool_calls_text = "\n\n".join(lines)
 
-                    # Add compression stats if available (don't clear - will be cleared in final_panels)
-                    if team.compaction_manager is not None and team.compaction_manager.stats:
-                        stats = team.compaction_manager.stats
-                        saved = stats.get("original_size", 0) - stats.get("compressed_size", 0)
-                        orig = stats.get("original_size", 1)
-                        if stats.get("tool_results_compressed", 0) > 0:
-                            tool_calls_text += f"\n\ncompressed: {stats.get('tool_results_compressed', 0)} | Saved: {saved:,} chars ({saved / orig * 100:.0f}%)"
+                    # Compression stats are now on run_response.metrics (not available during streaming)
 
                     team_tool_calls_panel = create_panel(
                         content=tool_calls_text,
@@ -1842,14 +1818,15 @@ async def aprint_response_stream(
 
                 tool_calls_text = "\n\n".join(lines)
 
-                # Add compression stats at end of tool calls
-                if team.compaction_manager is not None and team.compaction_manager.stats:
-                    stats = team.compaction_manager.stats
+                # Add compression stats (read from run_response.metrics)
+                stats: Dict[str, Any] = (
+                    get_compaction_stats(run_response.metrics) if isinstance(run_response, TeamRunOutput) else {}
+                )
+                if stats:
                     saved = stats.get("original_size", 0) - stats.get("compressed_size", 0)
                     orig = stats.get("original_size", 1)
                     if stats.get("tool_results_compressed", 0) > 0:
                         tool_calls_text += f"\n\ncompressed: {stats.get('tool_results_compressed', 0)} | Saved: {saved:,} chars ({saved / orig * 100:.0f}%)"
-                    team.compaction_manager.stats.clear()
 
                 team_tool_calls_panel = create_panel(
                     content=tool_calls_text,

--- a/libs/agno/agno/utils/print_response/team.py
+++ b/libs/agno/agno/utils/print_response/team.py
@@ -280,6 +280,13 @@ def print_response(
 
                     # Compression stats are now on run_response.metrics (not available during streaming)
 
+                    # Add compaction stats
+                    if team.context_compaction_manager is not None and team.context_compaction_manager.stats:
+                        stats = team.context_compaction_manager.stats
+                        if stats.get("messages_compacted", 0) > 0:
+                            tool_calls_text += f"\n\ncompacted: {stats.get('messages_compacted', 0)} msgs | Saved: {stats.get('tokens_saved', 0):,} tokens"
+                        team.context_compaction_manager.stats.clear()
+
                     team_tool_calls_panel = create_panel(
                         content=tool_calls_text,
                         title="Team Tool Calls",
@@ -653,6 +660,12 @@ def print_response_stream(
 
                     # Compression stats are now on run_response.metrics (not available during streaming)
 
+                    # Add compaction stats
+                    if team.context_compaction_manager is not None and team.context_compaction_manager.stats:
+                        stats = team.context_compaction_manager.stats
+                        if stats.get("messages_compacted", 0) > 0:
+                            tool_calls_text += f"\n\ncompacted: {stats.get('messages_compacted', 0)} msgs | Saved: {stats.get('tokens_saved', 0):,} tokens"
+
                     team_tool_calls_panel = create_panel(
                         content=tool_calls_text,
                         title="Team Tool Calls",
@@ -890,6 +903,12 @@ def print_response_stream(
                     orig = stats.get("original_size", 1)
                     if stats.get("tool_results_compressed", 0) > 0:
                         tool_calls_text += f"\n\ncompressed: {stats.get('tool_results_compressed', 0)} | Saved: {saved:,} chars ({saved / orig * 100:.0f}%)"
+
+                # Add compaction stats
+                if team.context_compaction_manager is not None and team.context_compaction_manager.stats:
+                    stats = team.context_compaction_manager.stats
+                    if stats.get("messages_compacted", 0) > 0:
+                        tool_calls_text += f"\n\ncompacted: {stats.get('messages_compacted', 0)} msgs | Saved: {stats.get('tokens_saved', 0):,} tokens"
 
                 team_tool_calls_panel = create_panel(
                     content=tool_calls_text,
@@ -1572,6 +1591,12 @@ async def aprint_response_stream(
 
                     # Compression stats are now on run_response.metrics (not available during streaming)
 
+                    # Add compaction stats
+                    if team.context_compaction_manager is not None and team.context_compaction_manager.stats:
+                        stats = team.context_compaction_manager.stats
+                        if stats.get("messages_compacted", 0) > 0:
+                            tool_calls_text += f"\n\ncompacted: {stats.get('messages_compacted', 0)} msgs | Saved: {stats.get('tokens_saved', 0):,} tokens"
+
                     team_tool_calls_panel = create_panel(
                         content=tool_calls_text,
                         title="Team Tool Calls",
@@ -1827,6 +1852,12 @@ async def aprint_response_stream(
                     orig = stats.get("original_size", 1)
                     if stats.get("tool_results_compressed", 0) > 0:
                         tool_calls_text += f"\n\ncompressed: {stats.get('tool_results_compressed', 0)} | Saved: {saved:,} chars ({saved / orig * 100:.0f}%)"
+
+                # Add compaction stats
+                if team.context_compaction_manager is not None and team.context_compaction_manager.stats:
+                    stats = team.context_compaction_manager.stats
+                    if stats.get("messages_compacted", 0) > 0:
+                        tool_calls_text += f"\n\ncompacted: {stats.get('messages_compacted', 0)} msgs | Saved: {stats.get('tokens_saved', 0):,} tokens"
 
                 team_tool_calls_panel = create_panel(
                     content=tool_calls_text,

--- a/libs/agno/tests/unit/environments/test_runner.py
+++ b/libs/agno/tests/unit/environments/test_runner.py
@@ -1096,7 +1096,7 @@ async def test_hermetic_real_agent_full_override_set(tmp_path):
     caller_db = InMemoryDb()
     reasoning_db = InMemoryDb()
     summary_manager = SessionSummaryManager()
-    compression_manager = CompressionManager()
+    compaction_manager = CompressionManager()
     skills = Skills(loaders=[])
     save_path = tmp_path / "response.txt"
     caller = Agent(
@@ -1106,7 +1106,7 @@ async def test_hermetic_real_agent_full_override_set(tmp_path):
         followup_model=followup_model,
         fallback_models=[fallback_model],
         session_summary_manager=summary_manager,
-        compression_manager=compression_manager,
+        compaction_manager=compaction_manager,
         skills=skills,
         reasoning_agent=Agent(model=sub_model, db=reasoning_db, telemetry=False),
         save_response_to_file=str(save_path),
@@ -1142,9 +1142,9 @@ async def test_hermetic_real_agent_full_override_set(tmp_path):
         # read flag unresolved -- exactly what a fresh production run would see.
         assert attempt_agent.add_memories_to_context is None
         assert attempt_agent.add_session_summary_to_context is True
-        assert attempt_agent.compression_manager is not compression_manager
-        assert attempt_agent.compression_manager.stats == {}
-        assert attempt_agent.compression_manager.stats is not compression_manager.stats
+        assert attempt_agent.compaction_manager is not compaction_manager
+        assert attempt_agent.compaction_manager.stats == {}
+        assert attempt_agent.compaction_manager.stats is not compaction_manager.stats
         assert attempt_agent.reasoning_agent is not caller.reasoning_agent
         assert isinstance(attempt_agent.reasoning_agent.db, InMemoryDb)
         assert attempt_agent.reasoning_agent.db is not reasoning_db
@@ -1741,7 +1741,7 @@ async def test_write_isolation_deep_freeze(tmp_path):
         fallback_models=[fallback_model],
         memory_manager=MemoryManager(),
         session_summary_manager=SessionSummaryManager(),
-        compression_manager=CompressionManager(),
+        compaction_manager=CompressionManager(),
         learning=LearningMachine(
             learned_knowledge=LearnedKnowledgeConfig(knowledge=learned_store, mode=LearningMode.ALWAYS)
         ),


### PR DESCRIPTION
## Summary

Follow-up PR that consolidates all compaction-related changes from multiple feature branches:

- **Async-safe stats**: Migrated compression stats from shared `compaction_manager.stats` to per-run `metrics.additional_metrics` (thread-safe)
- **Compaction events**: Added `CompactionStarted`/`CompactionCompleted` events for Agent and Team streaming paths
- **Stats display**: API exposure in RunSchema for compaction stats
- **Double-compaction fix**: Removed duplicate pre-loop compaction from `_response.py` (was running twice per streaming turn)
- **Provider_data fix**: Strip provider_data when building summarization prompt to prevent model chaining
- **Stale attribute cleanup**: Fixed all references to deprecated `context_compaction_manager` → `compaction_manager`

## Key Changes

### Stats Migration
Stats now stored in `run_response.metrics.additional_metrics` with `compaction_` prefix:
- `accumulate_compaction_stats()` - accumulates stats during run
- `get_compaction_stats()` - retrieves stats for display

### Event Emissions
New events emitted around compaction operations:
- `CompactionStartedEvent` - before compaction (messages_before, messages_to_compact)
- `CompactionCompletedEvent` - after compaction (messages_after, tokens_saved, summary_preview)

### Attribute Translation Applied
All cherry-picked commits updated for current API:
- `context_compaction_manager` → `compaction_manager` (+ `.compact_context` guard)
- `run_response.compaction` → `run_response.compaction_state`
- `compact_history` → `compact_context`

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Formatted and validated (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] No breaking changes to public API
- [x] Events added for both Agent and Team paths
- [x] Stats display works in print_response for both Agent and Team