### PR TITLE
feat(mcp): auto-flatten Toolkit into individual MCP tools

### DIFF
--- a/cookbook/05_agent_os/14_mcp/toolkit_tools.py
+++ b/cookbook/05_agent_os/14_mcp/toolkit_tools.py
@@ -1,0 +1,73 @@
+"""
+Expose a Toolkit as MCP tools
+=============================
+
+Pass a Toolkit directly to MCPServerConfig.tools — it auto-flattens into
+individual MCP tools, same as Agent.parse_tools() does internally.
+
+This example exposes Workspace's read-only tools (read_file, list_files,
+search_content, grep_content) as MCP tools that any MCP client can call.
+
+Prerequisites: none (no API key needed for file operations)
+Run: .venvs/demo/bin/python cookbook/05_agent_os/14_mcp/toolkit_tools.py
+Try: connect an MCP client to http://localhost:7777/mcp and call read_file
+"""
+
+import tempfile
+from pathlib import Path
+
+from agno.os import AgentOS, MCPServerConfig
+from agno.tools.workspace import Workspace
+
+# ---------------------------------------------------------------------------
+# Create a sample workspace with some files
+# ---------------------------------------------------------------------------
+
+tmp_dir = tempfile.mkdtemp(prefix="mcp_toolkit_")
+sample_dir = Path(tmp_dir)
+
+(sample_dir / "README.md").write_text("# Sample Project\n\nThis is a demo workspace.")
+(sample_dir / "main.py").write_text("def hello():\n    return 'Hello, MCP!'\n")
+(sample_dir / "utils.py").write_text(
+    "# TODO: Add utility functions\ndef add(a, b):\n    return a + b\n"
+)
+
+print(f"Created sample workspace at: {tmp_dir}")
+
+# ---------------------------------------------------------------------------
+# Create Workspace toolkit with read-only tools
+# ---------------------------------------------------------------------------
+
+workspace = Workspace(
+    root=tmp_dir,
+    allowed=["read", "list", "search", "grep"],
+)
+
+# ---------------------------------------------------------------------------
+# Expose the toolkit as MCP tools
+# ---------------------------------------------------------------------------
+
+agent_os = AgentOS(
+    id="toolkit-mcp-os",
+    description="AgentOS exposing Workspace toolkit as MCP tools.",
+    mcp_server=MCPServerConfig(
+        tools=[workspace],  # Toolkit auto-flattens into individual tools
+        enable_builtin_tools=False,
+    ),
+)
+app = agent_os.get_app()
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    print("\nMCP tools available:")
+    print("  - read_file(path, start_line, end_line, encoding)")
+    print("  - list_files(directory, pattern, recursive, max_depth)")
+    print("  - search_content(query, directory, limit)")
+    print(
+        "  - grep_content(pattern, directory, ignore_case, context_lines, files_only, limit)"
+    )
+    print("\nConnect an MCP client to http://localhost:7777/mcp")
+    agent_os.serve(app=app)

--- a/cookbook/05_agent_os/14_mcp/toolkit_tools.py
+++ b/cookbook/05_agent_os/14_mcp/toolkit_tools.py
@@ -5,8 +5,18 @@ Expose a Toolkit as MCP tools
 Pass a Toolkit directly to MCPServerConfig.tools — it auto-flattens into
 individual MCP tools, same as Agent.parse_tools() does internally.
 
-This example exposes Workspace's read-only tools (read_file, list_files,
-search_content, grep_content) as MCP tools that any MCP client can call.
+Two equivalent patterns:
+
+    # Pattern 1: Direct Toolkit
+    workspace = Workspace("./src", allowed=["read", "list", "search", "grep"])
+    MCPServerConfig(tools=[workspace])
+
+    # Pattern 2: Via ContextProvider.get_tools()
+    provider = WorkspaceContextProvider("./src", mode=ContextMode.tools)
+    MCPServerConfig(tools=provider.get_tools())
+
+Both auto-flatten into individual MCP tools: read_file, list_files,
+search_content, grep_content.
 
 Prerequisites: none (no API key needed for file operations)
 Run: .venvs/demo/bin/python cookbook/05_agent_os/14_mcp/toolkit_tools.py
@@ -16,6 +26,8 @@ Try: connect an MCP client to http://localhost:7777/mcp and call read_file
 import tempfile
 from pathlib import Path
 
+from agno.context.mode import ContextMode
+from agno.context.workspace import WorkspaceContextProvider
 from agno.os import AgentOS, MCPServerConfig
 from agno.tools.workspace import Workspace
 
@@ -35,13 +47,27 @@ sample_dir = Path(tmp_dir)
 print(f"Created sample workspace at: {tmp_dir}")
 
 # ---------------------------------------------------------------------------
-# Create Workspace toolkit with read-only tools
+# Pattern 1: Direct Toolkit
 # ---------------------------------------------------------------------------
 
 workspace = Workspace(
     root=tmp_dir,
     allowed=["read", "list", "search", "grep"],
 )
+
+# ---------------------------------------------------------------------------
+# Pattern 2: Via ContextProvider (same result)
+# ---------------------------------------------------------------------------
+
+provider = WorkspaceContextProvider(
+    root=tmp_dir,
+    mode=ContextMode.tools,  # Returns [Workspace] instead of [query_tool]
+)
+
+# All patterns work:
+# tools = [workspace]                          # Direct Toolkit
+# tools = provider.get_tools()                 # Via ContextProvider
+# tools = [*provider1.get_tools(), *provider2.get_tools()]  # Multiple providers
 
 # ---------------------------------------------------------------------------
 # Expose the toolkit as MCP tools
@@ -51,7 +77,7 @@ agent_os = AgentOS(
     id="toolkit-mcp-os",
     description="AgentOS exposing Workspace toolkit as MCP tools.",
     mcp_server=MCPServerConfig(
-        tools=[workspace],  # Toolkit auto-flattens into individual tools
+        tools=[workspace],  # Or: tools=provider.get_tools()
         enable_builtin_tools=False,
     ),
 )

--- a/cookbook/05_agent_os/14_mcp/toolkit_tools.py
+++ b/cookbook/05_agent_os/14_mcp/toolkit_tools.py
@@ -26,6 +26,7 @@ Try: connect an MCP client to http://localhost:7777/mcp and call read_file
 import tempfile
 from pathlib import Path
 
+from agno.agent import Agent
 from agno.context.mode import ContextMode
 from agno.context.workspace import WorkspaceContextProvider
 from agno.os import AgentOS, MCPServerConfig
@@ -73,9 +74,19 @@ provider = WorkspaceContextProvider(
 # Expose the toolkit as MCP tools
 # ---------------------------------------------------------------------------
 
+# Agent that uses the same workspace tools (accessible via run_agent MCP tool)
+workspace_agent = Agent(
+    id="workspace-agent",
+    name="Workspace Agent",
+    tools=[workspace],
+    instructions="You help users explore and understand the workspace files.",
+    markdown=True,
+)
+
 agent_os = AgentOS(
     id="toolkit-mcp-os",
     description="AgentOS exposing Workspace toolkit as MCP tools.",
+    agents=[workspace_agent],
     mcp_server=MCPServerConfig(
         tools=[workspace],  # Or: tools=provider.get_tools()
         enable_builtin_tools=False,

--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -99,8 +99,16 @@ def _register_custom_tools(mcp: FastMCP, config: "Optional[MCPServerConfig]") ->
 
 
 def _register_custom_tool(mcp: FastMCP, tool: Any) -> None:
-    """Register a single custom tool, supporting plain callables and Agno tools/Functions."""
+    """Register a single custom tool, supporting plain callables, Agno tools/Functions, and Toolkits."""
     from fastmcp.tools import Tool
+
+    from agno.tools import Toolkit
+
+    # Toolkit: flatten into individual Functions and register each.
+    if isinstance(tool, Toolkit):
+        for func in tool.get_async_functions().values():
+            _register_custom_tool(mcp, func)
+        return
 
     # Agno tool / Function: a callable ``entrypoint`` plus name/description metadata.
     entrypoint = getattr(tool, "entrypoint", None)
@@ -116,7 +124,7 @@ def _register_custom_tool(mcp: FastMCP, tool: Any) -> None:
         return
 
     raise TypeError(
-        f"Cannot register MCP tool of type {type(tool).__name__!r}; expected a callable or an Agno tool/Function."
+        f"Cannot register MCP tool of type {type(tool).__name__!r}; expected a callable, Agno tool/Function, or Toolkit."
     )
 
 

--- a/libs/agno/tests/unit/os/test_mcp_server.py
+++ b/libs/agno/tests/unit/os/test_mcp_server.py
@@ -148,6 +148,23 @@ async def test_unregisterable_custom_tool_raises():
         build_mcp_server(AgentOS(agents=[_agent()], mcp_server=MCPServerConfig(tools=[object()])))
 
 
+async def test_toolkit_is_flattened_into_individual_tools():
+    """A Toolkit is auto-flattened into its individual Functions, same as Agent.parse_tools."""
+    import tempfile
+
+    from agno.tools.workspace import Workspace
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        workspace = Workspace(tmp_dir, allowed=["read", "list"])
+        os = AgentOS(
+            agents=[_agent()],
+            mcp_server=MCPServerConfig(tools=[workspace], enable_builtin_tools=False),
+        )
+        tool_names = await _tool_names(os)
+        assert "read_file" in tool_names
+        assert "list_files" in tool_names
+
+
 # ==================== Scoping the built-ins ====================
 
 


### PR DESCRIPTION
## Summary
- Add Toolkit support to `_register_custom_tool` — auto-flattens into individual MCP tools
- Same pattern as `Agent.parse_tools()` — Toolkits are transparent containers

## Changes
- `libs/agno/agno/os/mcp.py` — add Toolkit branch in `_register_custom_tool`
- `libs/agno/tests/unit/os/test_mcp_server.py` — test Toolkit flattening
- `cookbook/05_agent_os/14_mcp/toolkit_tools.py` — example showing the pattern

## Usage

Before (manual flattening):
```python
MCPServerConfig(tools=list(workspace.functions.values()))
```

After (auto-flattens):
```python
MCPServerConfig(tools=[workspace])  # Just works
```

Also works with ContextProvider:
```python
provider = WorkspaceContextProvider("./src", mode=ContextMode.tools)
MCPServerConfig(tools=provider.get_tools())
```

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] Tests pass locally (`pytest`)
- [x] Code formatted (`./scripts/format.sh`)
- [x] Code validated (`./scripts/validate.sh`)