### PR TITLE
[fix] store UTC timestamps in schema versions table

### DIFF
--- a/libs/agno/agno/db/mysql/async_mysql.py
+++ b/libs/agno/agno/db/mysql/async_mysql.py
@@ -479,7 +479,7 @@ class AsyncMySQLDb(AsyncBaseDb):
         table = await self._get_table(table_type="versions", create_table_if_not_found=True)
         if table is None:
             return
-        current_datetime = datetime.now().isoformat()
+        current_datetime = current_datetime_utc().isoformat()
         async with self.async_session_factory() as sess, sess.begin():
             stmt = mysql.insert(table).values(  # type: ignore
                 table_name=table_name,

--- a/libs/agno/agno/db/mysql/mysql.py
+++ b/libs/agno/agno/db/mysql/mysql.py
@@ -464,7 +464,7 @@ class MySQLDb(BaseDb):
         table = self._get_table(table_type="versions", create_table_if_not_found=True)
         if table is None:
             return
-        current_datetime = datetime.now().isoformat()
+        current_datetime = current_datetime_utc().isoformat()
         with self.Session() as sess, sess.begin():
             stmt = mysql.insert(table).values(  # type: ignore
                 table_name=table_name,

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -630,7 +630,7 @@ class AsyncPostgresDb(AsyncBaseDb):
         table = await self._get_table(table_type="versions", create_table_if_not_found=True)
         if table is None:
             return
-        current_datetime = datetime.now().isoformat()
+        current_datetime = current_datetime_utc().isoformat()
         async with self.async_session_factory() as sess, sess.begin():
             stmt = postgresql.insert(table).values(
                 table_name=table_name,

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -819,7 +819,7 @@ class PostgresDb(BaseDb):
         table = self._get_table(table_type="versions", create_table_if_not_found=True)
         if table is None:
             return
-        current_datetime = datetime.now().isoformat()
+        current_datetime = current_datetime_utc().isoformat()
         with self.Session() as sess, sess.begin():
             stmt = postgresql.insert(table).values(
                 table_name=table_name,

--- a/libs/agno/agno/db/singlestore/singlestore.py
+++ b/libs/agno/agno/db/singlestore/singlestore.py
@@ -555,7 +555,7 @@ class SingleStoreDb(BaseDb):
         table = self._get_table(table_type="versions", create_table_if_not_found=True)
         if table is None:
             return
-        current_datetime = datetime.now().isoformat()
+        current_datetime = current_datetime_utc().isoformat()
         with self.Session() as sess, sess.begin():
             stmt = mysql.insert(table).values(
                 table_name=table_name,

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -617,7 +617,7 @@ class AsyncSqliteDb(AsyncBaseDb):
         table = await self._get_table(table_type="versions", create_table_if_not_found=True)
         if table is None:
             return
-        current_datetime = datetime.now().isoformat()
+        current_datetime = current_datetime_utc().isoformat()
         async with self.async_session_factory() as sess, sess.begin():
             stmt = sqlite.insert(table).values(
                 table_name=table_name,

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -73,6 +73,7 @@ from agno.run.base import RunStatus
 from agno.run.team import TeamRunOutput
 from agno.run.workflow import WorkflowRunOutput
 from agno.session import AgentSession, Session, TeamSession, WorkflowSession
+from agno.utils.dttm import current_datetime_utc
 from agno.utils.log import log_debug, log_error, log_info, log_warning
 from agno.utils.string import generate_id
 
@@ -832,7 +833,7 @@ class SqliteDb(BaseDb):
         table = self._get_table(table_type="versions", create_table_if_not_found=True)
         if table is None:
             return
-        current_datetime = datetime.now().isoformat()
+        current_datetime = current_datetime_utc().isoformat()
         with self.Session() as sess, sess.begin():
             stmt = sqlite.insert(table).values(
                 table_name=table_name,

--- a/libs/agno/tests/integration/db/sqlite/test_db.py
+++ b/libs/agno/tests/integration/db/sqlite/test_db.py
@@ -135,3 +135,21 @@ def test_full_workflow(sqlite_db_real):
 
         assert result is not None
         assert result.session_type == "agent"
+
+
+def test_upsert_schema_version_stores_utc_timestamp(sqlite_db_real):
+    """Test that schema versions table stores timezone-aware UTC timestamps"""
+    sqlite_db_real.upsert_schema_version(table_name="test_schema", version="2.1.0")
+
+    version_table = sqlite_db_real._get_table("versions")
+    with sqlite_db_real.Session() as sess:
+        row = sess.execute(
+            version_table.select().where(version_table.c.table_name == "test_schema")
+        ).fetchone()
+
+        assert row is not None
+        assert row.version == "2.1.0"
+        # Verify timestamps are ISO format and include UTC offset (+00:00 or ending with Z)
+        assert "+00:00" in row.created_at or row.created_at.endswith("Z")
+        assert "+00:00" in row.updated_at or row.updated_at.endswith("Z")
+


### PR DESCRIPTION
## Description
The schema-versions table across all database adapters stored `created_at` and `updated_at` as naive local-time ISO strings via `datetime.now().isoformat()`, while the rest of the database layer stores UTC timestamps. This caused timezone ambiguity depending on the host server location, clock shifts across DST boundaries, and inconsistency with the rest of the UTC schema.

## Solution
Updated `upsert_schema_version` across all 7 database adapters (`postgres`, `async_postgres`, `sqlite`, `async_sqlite`, `mysql`, `async_mysql`, `singlestore`) to use `current_datetime_utc().isoformat()`, ensuring consistent timezone-aware UTC timestamps.

Fixes #9612

## Checklist
- [x] Follows PR title convention: `[fix] ...`
- [x] No duplicate PR exists
- [x] Tested and verified