### PR TITLE
fix: await async connectable tool cleanup

### DIFF
--- a/libs/agno/agno/agent/_init.py
+++ b/libs/agno/agno/agent/_init.py
@@ -384,3 +384,19 @@ def disconnect_connectable_tools(agent: Agent) -> None:
             except Exception as e:
                 log_warning(f"Error disconnecting tool: {str(e)}")
     agent._connectable_tools_initialized_on_run = []
+
+
+async def adisconnect_connectable_tools(agent: Agent) -> None:
+    """Disconnect tools that require connection management in async execution."""
+    for tool in agent._connectable_tools_initialized_on_run:
+        try:
+            aclose = getattr(tool, "aclose", None)
+            if callable(aclose):
+                await aclose()
+                continue
+            close = getattr(tool, "close", None)
+            if callable(close):
+                close()
+        except Exception as e:
+            log_warning(f"Error disconnecting tool: {str(e)}")
+    agent._connectable_tools_initialized_on_run = []

--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -1508,7 +1508,7 @@ async def _arun(
     16. Cleanup and store (scrub, stop timer, save to file, add to session, calculate metrics, save session)
     """
     from agno.agent._hooks import aexecute_post_hooks, aexecute_pre_hooks
-    from agno.agent._init import disconnect_connectable_tools, disconnect_mcp_tools
+    from agno.agent._init import adisconnect_connectable_tools, disconnect_mcp_tools
     from agno.agent._messages import aget_run_messages
     from agno.agent._response import (
         agenerate_followups,
@@ -1888,7 +1888,7 @@ async def _arun(
                 return run_response
     finally:
         # Always disconnect connectable tools
-        disconnect_connectable_tools(agent)
+        await adisconnect_connectable_tools(agent)
         # Always disconnect MCP tools
         await disconnect_mcp_tools(agent)
 
@@ -2258,7 +2258,7 @@ async def _arun_stream(
     13. Cleanup and store (scrub, stop timer, save to file, add to session, calculate metrics, save session)
     """
     from agno.agent._hooks import aexecute_post_hooks, aexecute_pre_hooks
-    from agno.agent._init import disconnect_connectable_tools, disconnect_mcp_tools
+    from agno.agent._init import adisconnect_connectable_tools, disconnect_mcp_tools
     from agno.agent._messages import aget_run_messages
     from agno.agent._response import (
         agenerate_followups_stream,
@@ -2775,7 +2775,7 @@ async def _arun_stream(
                 yield run_error
     finally:
         # Always disconnect connectable tools
-        disconnect_connectable_tools(agent)
+        await adisconnect_connectable_tools(agent)
         # Always disconnect MCP tools
         await disconnect_mcp_tools(agent)
 
@@ -4756,7 +4756,7 @@ async def _acontinue_run(
     14. Cleanup and store (scrub, stop timer, save to file, add to session, calculate metrics, save session)
     """
     from agno.agent._hooks import aexecute_post_hooks
-    from agno.agent._init import disconnect_connectable_tools, disconnect_mcp_tools
+    from agno.agent._init import adisconnect_connectable_tools, disconnect_mcp_tools
     from agno.agent._messages import aget_continue_run_messages
     from agno.agent._response import (
         agenerate_followups,
@@ -5221,7 +5221,7 @@ async def _acontinue_run(
 
     finally:
         # Always disconnect connectable tools
-        disconnect_connectable_tools(agent)
+        await adisconnect_connectable_tools(agent)
         # Always disconnect MCP tools
         await disconnect_mcp_tools(agent)
 
@@ -5268,7 +5268,7 @@ async def _acontinue_run_stream(
     11. Cleanup and store the run response and session
     """
     from agno.agent._hooks import aexecute_post_hooks
-    from agno.agent._init import disconnect_connectable_tools, disconnect_mcp_tools
+    from agno.agent._init import adisconnect_connectable_tools, disconnect_mcp_tools
     from agno.agent._messages import aget_continue_run_messages
     from agno.agent._response import (
         agenerate_followups_stream,
@@ -5850,7 +5850,7 @@ async def _acontinue_run_stream(
                 yield run_error
     finally:
         # Always disconnect connectable tools
-        disconnect_connectable_tools(agent)
+        await adisconnect_connectable_tools(agent)
         # Always disconnect MCP tools
         await disconnect_mcp_tools(agent)
 

--- a/libs/agno/agno/team/_init.py
+++ b/libs/agno/agno/team/_init.py
@@ -970,3 +970,19 @@ def _disconnect_connectable_tools(team: "Team") -> None:
             except Exception as e:
                 log_warning(f"Error disconnecting tool: {str(e)}")
     team._connectable_tools_initialized_on_run = []
+
+
+async def _adisconnect_connectable_tools(team: "Team") -> None:
+    """Disconnect tools that require connection management in async execution."""
+    for tool in team._connectable_tools_initialized_on_run:  # type: ignore[union-attr]
+        try:
+            aclose = getattr(tool, "aclose", None)
+            if callable(aclose):
+                await aclose()
+                continue
+            close = getattr(tool, "close", None)
+            if callable(close):
+                close()
+        except Exception as e:
+            log_warning(f"Error disconnecting tool: {str(e)}")
+    team._connectable_tools_initialized_on_run = []

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -2133,7 +2133,7 @@ async def _arun_tasks(
     the goal is complete or max_iterations is reached.
     """
     from agno.team._hooks import _aexecute_post_hooks, _aexecute_pre_hooks
-    from agno.team._init import _disconnect_connectable_tools, _disconnect_mcp_tools
+    from agno.team._init import _adisconnect_connectable_tools, _disconnect_mcp_tools
     from agno.team._managers import _astart_learning_task, _astart_memory_task
     from agno.team._messages import _aget_run_messages
     from agno.team._response import (
@@ -2471,7 +2471,7 @@ async def _arun_tasks(
         return run_response
 
     finally:
-        _disconnect_connectable_tools(team)
+        await _adisconnect_connectable_tools(team)
         await _disconnect_mcp_tools(team)
         # Cancel background tasks on error
         for task in (memory_task, learning_task):
@@ -2509,7 +2509,7 @@ async def _arun_tasks_stream(
     for each iteration.
     """
     from agno.team._hooks import _aexecute_post_hooks, _aexecute_pre_hooks
-    from agno.team._init import _disconnect_connectable_tools, _disconnect_mcp_tools
+    from agno.team._init import _adisconnect_connectable_tools, _disconnect_mcp_tools
     from agno.team._managers import _astart_learning_task, _astart_memory_task
     from agno.team._messages import _aget_run_messages
     from agno.team._response import (
@@ -3020,7 +3020,7 @@ async def _arun_tasks_stream(
         yield run_error
 
     finally:
-        _disconnect_connectable_tools(team)
+        await _adisconnect_connectable_tools(team)
         await _disconnect_mcp_tools(team)
 
         # Cancel background tasks on error
@@ -3075,7 +3075,7 @@ async def _arun(
     13. Cleanup and store (scrub, add to session, calculate metrics, save session)
     """
     from agno.team._hooks import _aexecute_post_hooks, _aexecute_pre_hooks
-    from agno.team._init import _disconnect_connectable_tools, _disconnect_mcp_tools
+    from agno.team._init import _adisconnect_connectable_tools, _disconnect_mcp_tools
     from agno.team._managers import _astart_learning_task, _astart_memory_task
     from agno.team._messages import _aget_run_messages
     from agno.team._response import (
@@ -3425,7 +3425,7 @@ async def _arun(
                 return run_response
     finally:
         # Always disconnect connectable tools
-        _disconnect_connectable_tools(team)
+        await _adisconnect_connectable_tools(team)
         await _disconnect_mcp_tools(team)
 
         # Cancel background task on error (await_for_open_threads handles waiting on success)
@@ -3787,7 +3787,7 @@ async def _arun_stream(
     10. Cleanup and store (scrub, add to session, calculate metrics, save session)
     """
     from agno.team._hooks import _aexecute_post_hooks, _aexecute_pre_hooks
-    from agno.team._init import _disconnect_connectable_tools, _disconnect_mcp_tools
+    from agno.team._init import _adisconnect_connectable_tools, _disconnect_mcp_tools
     from agno.team._managers import _astart_learning_task, _astart_memory_task
     from agno.team._messages import _aget_run_messages
     from agno.team._response import (
@@ -4247,7 +4247,7 @@ async def _arun_stream(
 
     finally:
         # Always disconnect connectable tools
-        _disconnect_connectable_tools(team)
+        await _adisconnect_connectable_tools(team)
         await _disconnect_mcp_tools(team)
 
         # Cancel background task on error (await_for_thread_tasks_stream handles waiting on success)
@@ -9457,7 +9457,7 @@ async def _acontinue_run(
 ) -> TeamRunOutput:
     """Continue a paused team run (async, non-streaming)."""
     from agno.team._hooks import _aexecute_post_hooks
-    from agno.team._init import _disconnect_connectable_tools, _disconnect_mcp_tools
+    from agno.team._init import _adisconnect_connectable_tools, _disconnect_mcp_tools
     from agno.team._telemetry import alog_team_telemetry
     from agno.team._tools import _aget_learning_tools, _check_and_refresh_mcp_tools, _determine_tools_for_model
 
@@ -9906,7 +9906,7 @@ async def _acontinue_run(
                 return run_response
 
     finally:
-        _disconnect_connectable_tools(team)
+        await _adisconnect_connectable_tools(team)
         await _disconnect_mcp_tools(team)  # type: ignore
         if run_response and run_response.run_id:
             await acleanup_run(run_response.run_id)
@@ -9937,7 +9937,7 @@ async def _acontinue_run_stream(
 ) -> AsyncIterator[Union[TeamRunOutputEvent, RunOutputEvent, TeamRunOutput]]:
     """Continue a paused team run (async, streaming)."""
     from agno.team._hooks import _aexecute_post_hooks
-    from agno.team._init import _disconnect_connectable_tools, _disconnect_mcp_tools
+    from agno.team._init import _adisconnect_connectable_tools, _disconnect_mcp_tools
     from agno.team._response import (
         _ahandle_model_response_stream,
         agenerate_response_with_output_model_stream,
@@ -10622,7 +10622,7 @@ async def _acontinue_run_stream(
                     yield run_response
 
     finally:
-        _disconnect_connectable_tools(team)
+        await _adisconnect_connectable_tools(team)
         await _disconnect_mcp_tools(team)  # type: ignore
         if run_response and run_response.run_id:
             await acleanup_run(run_response.run_id)

--- a/libs/agno/tests/unit/agent/test_async_connectable_cleanup.py
+++ b/libs/agno/tests/unit/agent/test_async_connectable_cleanup.py
@@ -1,0 +1,65 @@
+import inspect
+
+import pytest
+
+from agno.agent import _init, _run
+from agno.agent.agent import Agent
+from agno.tools import Toolkit
+
+
+class AsyncCloseProbe(Toolkit):
+    def __init__(self) -> None:
+        self.aclose_calls = 0
+        self.close_calls = 0
+        super().__init__(name="async_close_probe", tools=[])
+
+    async def aclose(self) -> None:
+        self.aclose_calls += 1
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+class SyncCloseProbe(Toolkit):
+    def __init__(self) -> None:
+        self.close_calls = 0
+        super().__init__(name="sync_close_probe", tools=[])
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+@pytest.mark.asyncio
+async def test_adisconnect_connectable_tools_prefers_async_close() -> None:
+    agent = Agent(name="async-cleanup-test")
+    probe = AsyncCloseProbe()
+    agent._connectable_tools_initialized_on_run = [probe]
+
+    await _init.adisconnect_connectable_tools(agent)
+
+    assert probe.aclose_calls == 1
+    assert probe.close_calls == 0
+    assert agent._connectable_tools_initialized_on_run == []
+
+
+@pytest.mark.asyncio
+async def test_adisconnect_connectable_tools_falls_back_to_sync_close() -> None:
+    agent = Agent(name="sync-cleanup-fallback-test")
+    probe = SyncCloseProbe()
+    agent._connectable_tools_initialized_on_run = [probe]
+
+    await _init.adisconnect_connectable_tools(agent)
+
+    assert probe.close_calls == 1
+    assert agent._connectable_tools_initialized_on_run == []
+
+
+def test_all_async_agent_run_paths_await_connectable_cleanup() -> None:
+    for run_path in (
+        _run._arun,
+        _run._arun_stream,
+        _run._acontinue_run,
+        _run._acontinue_run_stream,
+    ):
+        source = inspect.getsource(run_path)
+        assert "await adisconnect_connectable_tools(agent)" in source

--- a/libs/agno/tests/unit/team/test_async_connectable_cleanup.py
+++ b/libs/agno/tests/unit/team/test_async_connectable_cleanup.py
@@ -1,0 +1,67 @@
+import inspect
+
+import pytest
+
+from agno.team import _init, _run
+from agno.team.team import Team
+from agno.tools import Toolkit
+
+
+class AsyncCloseProbe(Toolkit):
+    def __init__(self) -> None:
+        self.aclose_calls = 0
+        self.close_calls = 0
+        super().__init__(name="async_close_probe", tools=[])
+
+    async def aclose(self) -> None:
+        self.aclose_calls += 1
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+class SyncCloseProbe(Toolkit):
+    def __init__(self) -> None:
+        self.close_calls = 0
+        super().__init__(name="sync_close_probe", tools=[])
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+@pytest.mark.asyncio
+async def test_adisconnect_connectable_tools_prefers_async_close() -> None:
+    team = Team(name="async-cleanup-test", members=[])
+    probe = AsyncCloseProbe()
+    team._connectable_tools_initialized_on_run = [probe]
+
+    await _init._adisconnect_connectable_tools(team)
+
+    assert probe.aclose_calls == 1
+    assert probe.close_calls == 0
+    assert team._connectable_tools_initialized_on_run == []
+
+
+@pytest.mark.asyncio
+async def test_adisconnect_connectable_tools_falls_back_to_sync_close() -> None:
+    team = Team(name="sync-cleanup-fallback-test", members=[])
+    probe = SyncCloseProbe()
+    team._connectable_tools_initialized_on_run = [probe]
+
+    await _init._adisconnect_connectable_tools(team)
+
+    assert probe.close_calls == 1
+    assert team._connectable_tools_initialized_on_run == []
+
+
+def test_all_async_team_run_paths_await_connectable_cleanup() -> None:
+    for run_path in (
+        _run._arun_tasks,
+        _run._arun_tasks_stream,
+        _run._arun,
+        _run._arun_stream,
+        _run._acontinue_run,
+        _run._acontinue_run_stream,
+    ):
+        source = inspect.getsource(run_path)
+        assert "await _adisconnect_connectable_tools(team)" in source


### PR DESCRIPTION
## Summary

Fixes #9829.

Async Agent and Team execution currently tears down connectable tools through the synchronous `close()` path. That is unsafe for tools with meaningful async shutdown semantics. In particular, `CodeMode.close()` intentionally schedules its final snapshot flush in the background when called from an event loop, while `CodeMode.aclose()` awaits that flush. A one-shot async process can therefore return from the run before the final snapshot is durable.

This change:

- adds `adisconnect_connectable_tools()` for Agent and `_adisconnect_connectable_tools()` for Team
- prefers and awaits `aclose()` when a connectable tool exposes it, with `close()` as the compatibility fallback
- uses the async cleanup seam from all 4 Agent async run/stream/continue paths
- uses it from all 6 Team async task/run/stream/continue paths
- leaves every synchronous cleanup path unchanged
- adds focused regression coverage for async-close preference, sync fallback, and every async lifecycle call site

This is the async connectable-tool cleanup follow-up only; it does not change CodeMode internals or connection setup. It corresponds to item 4 of #9680.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (docstrings for the new cleanup seams)
- [ ] Examples and guides: no cookbook behavior change required
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I searched existing open and closed pull requests and did not find another PR implementing this Agent/Team async `aclose()` cleanup path
- [x] AI-assisted: Codex was used for codebase exploration, implementation, and test construction; the resulting diff and verification were reviewed before submission

## Verification

Run on a clean GitHub Actions Ubuntu/Python 3.12 checkout based on current `main`:

```text
guarded transform: 4 Agent async lanes, 6 Team async lanes
focused Agent/Team lifecycle suite: 40 passed in 1.96s
ruff check: passed
ruff format --check: 6 files already formatted
```

The focused suite includes the new cleanup tests plus existing Agent run-regression and Team background-execution coverage.

## Additional Notes

The branch contains one commit and exactly six changed files. No public API signature or database/schema behavior changes.