### PR TITLE
fix: preserve workflow history steps without a database

### DIFF
--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -10930,13 +10930,13 @@ class Workflow:
                     step_name = step.name or f"step_{i + 1}"
                     log_debug(f"Step {i + 1}: Nested Workflow '{step_name}'")
                     prepared_steps.append(Step(name=step_name, description=step.description, workflow=step))
-                elif isinstance(step, Step) and step.add_workflow_history is True and self.db is None:
-                    log_warning(
-                        f"Step '{step.name or f'step_{i + 1}'}' has add_workflow_history=True "
-                        "but no database is configured in the Workflow. "
-                        "History won't be persisted. Add a database to persist runs across executions."
-                    )
                 elif isinstance(step, (Step, Steps, Loop, Parallel, Condition, Router)):
+                    if isinstance(step, Step) and step.add_workflow_history is True and self.db is None:
+                        log_warning(
+                            f"Step '{step.name or f'step_{i + 1}'}' has add_workflow_history=True "
+                            "but no database is configured in the Workflow. "
+                            "History won't be persisted. Add a database to persist runs across executions."
+                        )
                     step_type = type(step).__name__
                     step_name = getattr(step, "name", f"unnamed_{step_type.lower()}")
                     log_debug(f"Step {i + 1}: {step_type} '{step_name}'")

--- a/libs/agno/tests/unit/workflow/test_workflow_step_preparation.py
+++ b/libs/agno/tests/unit/workflow/test_workflow_step_preparation.py
@@ -1,0 +1,12 @@
+from agno.workflow.step import Step
+from agno.workflow.workflow import Workflow
+
+
+def test_prepare_steps_keeps_history_step_without_database():
+    history_step = Step(name="history", executor=lambda: None, add_workflow_history=True)
+    regular_step = Step(name="regular", executor=lambda: None)
+    workflow = Workflow(steps=[history_step, regular_step])
+
+    workflow._prepare_steps()
+
+    assert workflow.steps == [history_step, regular_step]


### PR DESCRIPTION
## Summary

- Keep `Step(add_workflow_history=True)` in the prepared workflow when no database is configured.
- Preserve the existing warning that history cannot be persisted.
- Add a regression test covering step preservation and ordering.

Fixes #9817

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (not applicable)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (not applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Validation

- `PYTHONPATH="$PWD/libs/agno" python3 -m pytest libs/agno/tests/unit/workflow/test_workflow_step_preparation.py -q` — 1 passed
- `python3 -m ruff check libs/agno/agno/workflow/workflow.py libs/agno/tests/unit/workflow/test_workflow_step_preparation.py` — passed
- `python3 -m ruff format --check libs/agno/agno/workflow/workflow.py libs/agno/tests/unit/workflow/test_workflow_step_preparation.py` — passed
- `PYTHONPATH="$PWD/libs/agno" python3 -m mypy libs/agno/agno/workflow/workflow.py --config-file libs/agno/pyproject.toml` — passed
- `./scripts/format.sh` — passed
- `./scripts/validate.sh` — Ruff, agnoctl mypy, and cookbook checks passed; agno-wide mypy reported 38 pre-existing dependency/type mismatches in six unrelated files (including Google GenAI SDK attribute drift). The changed workflow module passes targeted mypy.

## Additional Notes

PR #9818 also touches `_prepare_steps` for its new `Verify` type, but retains the history-warning `elif` and explicitly lists #9817 as a pre-existing bug. This PR is the narrow fix for that issue.

Risk is limited to db-less workflows whose `Step` enables workflow history: the step now executes while persistence remains disabled and the warning remains unchanged.
