### PR TITLE
feat: add Context.dev toolkit

### DIFF
--- a/cookbook/91_tools/context_tools.py
+++ b/cookbook/91_tools/context_tools.py
@@ -1,0 +1,24 @@
+"""Use Context.dev tools with an Agno agent.
+
+Prerequisites:
+- Create a Context.dev account and API key at https://context.dev
+- Set CONTEXT_API_KEY in your environment
+"""
+
+from agno.agent import Agent
+from agno.tools.context import ContextTools
+
+agent = Agent(
+    tools=[ContextTools(enable_sitemap=True, enable_extract=True, enable_brand=True)],
+    markdown=True,
+)
+
+if __name__ == "__main__":
+    agent.print_response(
+        "Search for Context.dev's latest product updates and cite the source URLs.",
+        stream=True,
+    )
+    agent.print_response(
+        "Extract the plan names and prices from https://www.context.dev/pricing.",
+        stream=True,
+    )

--- a/libs/agno/agno/tools/context.py
+++ b/libs/agno/agno/tools/context.py
@@ -1,0 +1,569 @@
+from os import getenv
+from typing import Any, Dict, List, Literal, Optional, Tuple
+
+from agno.tools import Toolkit
+from agno.tools.context_client import ContextClient
+from agno.utils.log import log_error
+
+
+class ContextTools(Toolkit):
+    """Toolkit for live web data and brand intelligence from Context.dev.
+
+    Args:
+        api_key: Context.dev API key. Falls back to CONTEXT_API_KEY.
+        base_url: Context.dev API base URL.
+        timeout: HTTP timeout in seconds.
+        enable_search: Enable live web search. Default is True.
+        enable_scrape: Enable single-page Markdown scraping. Default is True.
+        enable_crawl: Enable multi-page website crawling. Default is False.
+        enable_sitemap: Enable website URL discovery. Default is False.
+        enable_extract: Enable structured website extraction. Default is False.
+        enable_brand: Enable brand profile retrieval. Default is False.
+        all: Enable every Context.dev tool. Default is False.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: str = "https://api.context.dev/v1",
+        timeout: int = 120,
+        enable_search: bool = True,
+        enable_scrape: bool = True,
+        enable_crawl: bool = False,
+        enable_sitemap: bool = False,
+        enable_extract: bool = False,
+        enable_brand: bool = False,
+        all: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        self.api_key = api_key or getenv("CONTEXT_API_KEY")
+        if not self.api_key:
+            log_error("CONTEXT_API_KEY not set. Please set the CONTEXT_API_KEY environment variable.")
+
+        self.client = ContextClient(
+            api_key=self.api_key,
+            base_url=base_url,
+            timeout=timeout,
+        )
+
+        available_tools = [
+            (enable_search, self.search_web, self.asearch_web, "search_web"),
+            (enable_scrape, self.scrape_url, self.ascrape_url, "scrape_url"),
+            (enable_crawl, self.crawl_website, self.acrawl_website, "crawl_website"),
+            (enable_sitemap, self.find_website_pages, self.afind_website_pages, "find_website_pages"),
+            (enable_extract, self.extract_structured_data, self.aextract_structured_data, "extract_structured_data"),
+            (enable_brand, self.get_brand_profile, self.aget_brand_profile, "get_brand_profile"),
+        ]
+        tools: List[Any] = [sync_tool for enabled, sync_tool, _, _ in available_tools if all or enabled]
+        async_tools: List[Tuple[Any, str]] = [
+            (async_tool, name) for enabled, _, async_tool, name in available_tools if all or enabled
+        ]
+
+        super().__init__(
+            name="context_tools",
+            tools=tools,
+            async_tools=async_tools,
+            timeout=timeout,
+            **kwargs,
+        )
+
+    def search_web(
+        self,
+        query: str,
+        num_results: int = 10,
+        include_domains: Optional[List[str]] = None,
+        exclude_domains: Optional[List[str]] = None,
+        freshness: Optional[Literal["last_24_hours", "last_week", "last_month", "last_year"]] = None,
+        country: Optional[str] = None,
+        include_markdown: bool = False,
+    ) -> str:
+        """Search the live web and return ranked results.
+
+        Args:
+            query: Natural-language search query.
+            num_results: Number of results to return, from 10 to 100.
+            include_domains: Optional domains to restrict the search to.
+            exclude_domains: Optional domains to exclude from the search.
+            freshness: Optional result recency filter.
+            country: Optional two-letter country code for regional results.
+            include_markdown: Include page Markdown with each result.
+
+        Returns:
+            JSON string containing ranked search results.
+        """
+        return self.client.post(
+            "/web/search",
+            _search_payload(
+                query=query,
+                num_results=num_results,
+                include_domains=include_domains,
+                exclude_domains=exclude_domains,
+                freshness=freshness,
+                country=country,
+                include_markdown=include_markdown,
+            ),
+        )
+
+    async def asearch_web(
+        self,
+        query: str,
+        num_results: int = 10,
+        include_domains: Optional[List[str]] = None,
+        exclude_domains: Optional[List[str]] = None,
+        freshness: Optional[Literal["last_24_hours", "last_week", "last_month", "last_year"]] = None,
+        country: Optional[str] = None,
+        include_markdown: bool = False,
+    ) -> str:
+        """Search the live web asynchronously and return ranked results.
+
+        Args:
+            query: Natural-language search query.
+            num_results: Number of results to return, from 10 to 100.
+            include_domains: Optional domains to restrict the search to.
+            exclude_domains: Optional domains to exclude from the search.
+            freshness: Optional result recency filter.
+            country: Optional two-letter country code for regional results.
+            include_markdown: Include page Markdown with each result.
+
+        Returns:
+            JSON string containing ranked search results.
+        """
+        return await self.client.apost(
+            "/web/search",
+            _search_payload(
+                query=query,
+                num_results=num_results,
+                include_domains=include_domains,
+                exclude_domains=exclude_domains,
+                freshness=freshness,
+                country=country,
+                include_markdown=include_markdown,
+            ),
+        )
+
+    def scrape_url(
+        self,
+        url: str,
+        use_main_content_only: bool = True,
+        include_links: bool = True,
+        include_images: bool = False,
+        max_age_ms: int = 86400000,
+    ) -> str:
+        """Scrape one webpage and return clean Markdown.
+
+        Args:
+            url: Full HTTP or HTTPS URL to scrape.
+            use_main_content_only: Remove navigation, headers, footers, and sidebars.
+            include_links: Keep hyperlinks in the Markdown output.
+            include_images: Keep image references in the Markdown output.
+            max_age_ms: Maximum cache age in milliseconds. Use 0 for a fresh fetch.
+
+        Returns:
+            JSON string containing Markdown and page metadata.
+        """
+        return self.client.get(
+            "/web/scrape/markdown",
+            _scrape_params(
+                url=url,
+                use_main_content_only=use_main_content_only,
+                include_links=include_links,
+                include_images=include_images,
+                max_age_ms=max_age_ms,
+            ),
+        )
+
+    async def ascrape_url(
+        self,
+        url: str,
+        use_main_content_only: bool = True,
+        include_links: bool = True,
+        include_images: bool = False,
+        max_age_ms: int = 86400000,
+    ) -> str:
+        """Scrape one webpage asynchronously and return clean Markdown.
+
+        Args:
+            url: Full HTTP or HTTPS URL to scrape.
+            use_main_content_only: Remove navigation, headers, footers, and sidebars.
+            include_links: Keep hyperlinks in the Markdown output.
+            include_images: Keep image references in the Markdown output.
+            max_age_ms: Maximum cache age in milliseconds. Use 0 for a fresh fetch.
+
+        Returns:
+            JSON string containing Markdown and page metadata.
+        """
+        return await self.client.aget(
+            "/web/scrape/markdown",
+            _scrape_params(
+                url=url,
+                use_main_content_only=use_main_content_only,
+                include_links=include_links,
+                include_images=include_images,
+                max_age_ms=max_age_ms,
+            ),
+        )
+
+    def crawl_website(
+        self,
+        url: str,
+        max_pages: int = 25,
+        max_depth: Optional[int] = None,
+        url_regex: Optional[str] = None,
+        follow_subdomains: bool = False,
+    ) -> str:
+        """Crawl linked pages from a website and return their Markdown.
+
+        Args:
+            url: Full HTTP or HTTPS URL where the crawl should begin.
+            max_pages: Maximum number of pages to crawl, from 1 to 500.
+            max_depth: Optional maximum link depth from the starting URL.
+            url_regex: Optional RE2-compatible pattern used to keep matching URLs.
+            follow_subdomains: Allow the crawler to follow subdomains.
+
+        Returns:
+            JSON string containing crawled pages and crawl metadata.
+        """
+        return self.client.post(
+            "/web/crawl",
+            _crawl_payload(
+                url=url,
+                max_pages=max_pages,
+                max_depth=max_depth,
+                url_regex=url_regex,
+                follow_subdomains=follow_subdomains,
+            ),
+        )
+
+    async def acrawl_website(
+        self,
+        url: str,
+        max_pages: int = 25,
+        max_depth: Optional[int] = None,
+        url_regex: Optional[str] = None,
+        follow_subdomains: bool = False,
+    ) -> str:
+        """Crawl linked pages asynchronously and return their Markdown.
+
+        Args:
+            url: Full HTTP or HTTPS URL where the crawl should begin.
+            max_pages: Maximum number of pages to crawl, from 1 to 500.
+            max_depth: Optional maximum link depth from the starting URL.
+            url_regex: Optional RE2-compatible pattern used to keep matching URLs.
+            follow_subdomains: Allow the crawler to follow subdomains.
+
+        Returns:
+            JSON string containing crawled pages and crawl metadata.
+        """
+        return await self.client.apost(
+            "/web/crawl",
+            _crawl_payload(
+                url=url,
+                max_pages=max_pages,
+                max_depth=max_depth,
+                url_regex=url_regex,
+                follow_subdomains=follow_subdomains,
+            ),
+        )
+
+    def find_website_pages(
+        self,
+        domain: str,
+        search: Optional[str] = None,
+        max_links: int = 100,
+        sitemap_url: Optional[str] = None,
+        url_regex: Optional[str] = None,
+    ) -> str:
+        """Discover URLs from a website sitemap without downloading content.
+
+        Args:
+            domain: Website domain to inspect, such as context.dev.
+            search: Optional topic used to rank relevant URLs.
+            max_links: Maximum number of URLs to return.
+            sitemap_url: Optional sitemap URL to use instead of discovery.
+            url_regex: Optional RE2-compatible pattern used to keep matching URLs.
+
+        Returns:
+            JSON string containing discovered page URLs.
+        """
+        return self.client.get(
+            "/web/scrape/sitemap",
+            _sitemap_params(
+                domain=domain,
+                search=search,
+                max_links=max_links,
+                sitemap_url=sitemap_url,
+                url_regex=url_regex,
+            ),
+        )
+
+    async def afind_website_pages(
+        self,
+        domain: str,
+        search: Optional[str] = None,
+        max_links: int = 100,
+        sitemap_url: Optional[str] = None,
+        url_regex: Optional[str] = None,
+    ) -> str:
+        """Discover website URLs asynchronously without downloading content.
+
+        Args:
+            domain: Website domain to inspect, such as context.dev.
+            search: Optional topic used to rank relevant URLs.
+            max_links: Maximum number of URLs to return.
+            sitemap_url: Optional sitemap URL to use instead of discovery.
+            url_regex: Optional RE2-compatible pattern used to keep matching URLs.
+
+        Returns:
+            JSON string containing discovered page URLs.
+        """
+        return await self.client.aget(
+            "/web/scrape/sitemap",
+            _sitemap_params(
+                domain=domain,
+                search=search,
+                max_links=max_links,
+                sitemap_url=sitemap_url,
+                url_regex=url_regex,
+            ),
+        )
+
+    def extract_structured_data(
+        self,
+        url: str,
+        schema: Dict[str, Any],
+        instructions: Optional[str] = None,
+        max_pages: int = 5,
+        max_depth: Optional[int] = None,
+        follow_subdomains: bool = False,
+        fact_check: bool = False,
+    ) -> str:
+        """Extract website data into a caller-provided JSON Schema.
+
+        Args:
+            url: Full HTTP or HTTPS URL where extraction should begin.
+            schema: JSON Schema describing the data to return.
+            instructions: Optional extraction guidance in plain language.
+            max_pages: Maximum number of pages to analyze, from 1 to 50.
+            max_depth: Optional maximum link depth from the starting URL.
+            follow_subdomains: Allow extraction to follow subdomains.
+            fact_check: Validate extracted values against analyzed pages.
+
+        Returns:
+            JSON string containing structured data and source metadata.
+        """
+        return self.client.post(
+            "/web/extract",
+            _extract_payload(
+                url=url,
+                schema=schema,
+                instructions=instructions,
+                max_pages=max_pages,
+                max_depth=max_depth,
+                follow_subdomains=follow_subdomains,
+                fact_check=fact_check,
+            ),
+        )
+
+    async def aextract_structured_data(
+        self,
+        url: str,
+        schema: Dict[str, Any],
+        instructions: Optional[str] = None,
+        max_pages: int = 5,
+        max_depth: Optional[int] = None,
+        follow_subdomains: bool = False,
+        fact_check: bool = False,
+    ) -> str:
+        """Extract website data asynchronously into a JSON Schema.
+
+        Args:
+            url: Full HTTP or HTTPS URL where extraction should begin.
+            schema: JSON Schema describing the data to return.
+            instructions: Optional extraction guidance in plain language.
+            max_pages: Maximum number of pages to analyze, from 1 to 50.
+            max_depth: Optional maximum link depth from the starting URL.
+            follow_subdomains: Allow extraction to follow subdomains.
+            fact_check: Validate extracted values against analyzed pages.
+
+        Returns:
+            JSON string containing structured data and source metadata.
+        """
+        return await self.client.apost(
+            "/web/extract",
+            _extract_payload(
+                url=url,
+                schema=schema,
+                instructions=instructions,
+                max_pages=max_pages,
+                max_depth=max_depth,
+                follow_subdomains=follow_subdomains,
+                fact_check=fact_check,
+            ),
+        )
+
+    def get_brand_profile(
+        self,
+        domain: str,
+        maximum_speed: bool = False,
+        max_age_ms: int = 7776000000,
+    ) -> str:
+        """Retrieve a company profile with logos, colors, and business details.
+
+        Args:
+            domain: Company website domain, such as stripe.com.
+            maximum_speed: Skip slower enrichment for a faster response.
+            max_age_ms: Maximum cache age in milliseconds.
+
+        Returns:
+            JSON string containing the company's brand profile.
+        """
+        return self.client.post(
+            "/brand/retrieve",
+            _brand_payload(
+                domain=domain,
+                maximum_speed=maximum_speed,
+                max_age_ms=max_age_ms,
+            ),
+        )
+
+    async def aget_brand_profile(
+        self,
+        domain: str,
+        maximum_speed: bool = False,
+        max_age_ms: int = 7776000000,
+    ) -> str:
+        """Retrieve a company brand profile asynchronously.
+
+        Args:
+            domain: Company website domain, such as stripe.com.
+            maximum_speed: Skip slower enrichment for a faster response.
+            max_age_ms: Maximum cache age in milliseconds.
+
+        Returns:
+            JSON string containing the company's brand profile.
+        """
+        return await self.client.apost(
+            "/brand/retrieve",
+            _brand_payload(
+                domain=domain,
+                maximum_speed=maximum_speed,
+                max_age_ms=max_age_ms,
+            ),
+        )
+
+
+def _search_payload(
+    query: str,
+    num_results: int,
+    include_domains: Optional[List[str]],
+    exclude_domains: Optional[List[str]],
+    freshness: Optional[str],
+    country: Optional[str],
+    include_markdown: bool,
+) -> Dict[str, Any]:
+    return _without_none(
+        {
+            "query": query,
+            "numResults": num_results,
+            "includeDomains": include_domains,
+            "excludeDomains": exclude_domains,
+            "freshness": freshness,
+            "country": country,
+            "markdownOptions": {
+                "enabled": include_markdown,
+                "useMainContentOnly": True,
+                "includeLinks": True,
+                "includeImages": False,
+            },
+        }
+    )
+
+
+def _scrape_params(
+    url: str,
+    use_main_content_only: bool,
+    include_links: bool,
+    include_images: bool,
+    max_age_ms: int,
+) -> Dict[str, Any]:
+    return {
+        "url": url,
+        "useMainContentOnly": use_main_content_only,
+        "includeLinks": include_links,
+        "includeImages": include_images,
+        "maxAgeMs": max_age_ms,
+    }
+
+
+def _crawl_payload(
+    url: str,
+    max_pages: int,
+    max_depth: Optional[int],
+    url_regex: Optional[str],
+    follow_subdomains: bool,
+) -> Dict[str, Any]:
+    return _without_none(
+        {
+            "url": url,
+            "maxPages": max_pages,
+            "maxDepth": max_depth,
+            "urlRegex": url_regex,
+            "followSubdomains": follow_subdomains,
+            "useMainContentOnly": True,
+            "includeLinks": True,
+            "includeImages": False,
+        }
+    )
+
+
+def _sitemap_params(
+    domain: str,
+    search: Optional[str],
+    max_links: int,
+    sitemap_url: Optional[str],
+    url_regex: Optional[str],
+) -> Dict[str, Any]:
+    return _without_none(
+        {
+            "domain": domain,
+            "search": search,
+            "maxLinks": max_links,
+            "sitemapUrl": sitemap_url,
+            "urlRegex": url_regex,
+        }
+    )
+
+
+def _extract_payload(
+    url: str,
+    schema: Dict[str, Any],
+    instructions: Optional[str],
+    max_pages: int,
+    max_depth: Optional[int],
+    follow_subdomains: bool,
+    fact_check: bool,
+) -> Dict[str, Any]:
+    return _without_none(
+        {
+            "url": url,
+            "schema": schema,
+            "instructions": instructions,
+            "maxPages": max_pages,
+            "maxDepth": max_depth,
+            "followSubdomains": follow_subdomains,
+            "factCheck": fact_check,
+        }
+    )
+
+
+def _brand_payload(domain: str, maximum_speed: bool, max_age_ms: int) -> Dict[str, Any]:
+    return {
+        "type": "by_domain",
+        "domain": domain,
+        "maxSpeed": maximum_speed,
+        "maxAgeMs": max_age_ms,
+    }
+
+
+def _without_none(values: Dict[str, Any]) -> Dict[str, Any]:
+    return {key: value for key, value in values.items() if value is not None}

--- a/libs/agno/agno/tools/context_client.py
+++ b/libs/agno/agno/tools/context_client.py
@@ -1,0 +1,102 @@
+import json
+from typing import Any, Dict, Optional
+
+import httpx
+
+
+class ContextClient:
+    def __init__(
+        self,
+        api_key: Optional[str],
+        base_url: str,
+        timeout: int,
+    ) -> None:
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+
+    def get(self, path: str, params: Dict[str, Any]) -> str:
+        try:
+            response = httpx.get(
+                f"{self.base_url}{path}",
+                headers=self._headers(),
+                params=params,
+                timeout=self.timeout,
+            )
+            return self._serialize_response(response)
+        except httpx.RequestError as error:
+            return self._serialize_connection_error(error)
+
+    async def aget(self, path: str, params: Dict[str, Any]) -> str:
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.get(
+                    f"{self.base_url}{path}",
+                    headers=self._headers(),
+                    params=params,
+                )
+            return self._serialize_response(response)
+        except httpx.RequestError as error:
+            return self._serialize_connection_error(error)
+
+    def post(self, path: str, payload: Dict[str, Any]) -> str:
+        try:
+            response = httpx.post(
+                f"{self.base_url}{path}",
+                headers=self._headers(),
+                json=payload,
+                timeout=self.timeout,
+            )
+            return self._serialize_response(response)
+        except httpx.RequestError as error:
+            return self._serialize_connection_error(error)
+
+    async def apost(self, path: str, payload: Dict[str, Any]) -> str:
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.post(
+                    f"{self.base_url}{path}",
+                    headers=self._headers(),
+                    json=payload,
+                )
+            return self._serialize_response(response)
+        except httpx.RequestError as error:
+            return self._serialize_connection_error(error)
+
+    def _headers(self) -> Dict[str, str]:
+        if not self.api_key:
+            raise ValueError("CONTEXT_API_KEY is required to use Context.dev tools")
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+    @staticmethod
+    def _serialize_response(response: httpx.Response) -> str:
+        try:
+            data = response.json()
+        except ValueError:
+            data = {"message": response.text or "Context.dev returned a non-JSON response"}
+
+        if response.is_success:
+            return json.dumps(data, ensure_ascii=False, default=str)
+
+        return json.dumps(
+            {
+                "error": "Context.dev API request failed",
+                "status_code": response.status_code,
+                "details": data,
+            },
+            ensure_ascii=False,
+            default=str,
+        )
+
+    @staticmethod
+    def _serialize_connection_error(error: httpx.RequestError) -> str:
+        return json.dumps(
+            {
+                "error": "Could not connect to Context.dev",
+                "details": str(error),
+            },
+            ensure_ascii=False,
+        )

--- a/libs/agno/tests/unit/tools/test_context.py
+++ b/libs/agno/tests/unit/tools/test_context.py
@@ -1,0 +1,225 @@
+import json
+from unittest.mock import AsyncMock, Mock, patch
+
+import httpx
+import pytest
+
+from agno.tools.context import ContextTools
+from agno.tools.context_client import ContextClient
+
+
+@pytest.fixture
+def context_tools() -> ContextTools:
+    tools = ContextTools(api_key="test-key", all=True)
+    tools.client = Mock(spec=ContextClient)
+    tools.client.aget = AsyncMock()
+    tools.client.apost = AsyncMock()
+    return tools
+
+
+def test_default_tools_are_search_and_scrape() -> None:
+    tools = ContextTools(api_key="test-key")
+
+    assert set(tools.functions) == {"search_web", "scrape_url"}
+    assert set(tools.async_functions) == {"search_web", "scrape_url"}
+
+
+def test_all_registers_every_supported_tool() -> None:
+    tools = ContextTools(api_key="test-key", all=True)
+    expected = {
+        "search_web",
+        "scrape_url",
+        "crawl_website",
+        "find_website_pages",
+        "extract_structured_data",
+        "get_brand_profile",
+    }
+
+    assert set(tools.functions) == expected
+    assert set(tools.async_functions) == expected
+    assert all("answer" not in name for name in expected)
+
+
+def test_search_web_sends_production_request_shape(context_tools: ContextTools) -> None:
+    context_tools.client.post.return_value = '{"results": []}'
+
+    result = context_tools.search_web(
+        "latest Context.dev updates",
+        num_results=20,
+        include_domains=["context.dev"],
+        exclude_domains=["example.com"],
+        freshness="last_week",
+        country="us",
+        include_markdown=True,
+    )
+
+    assert json.loads(result) == {"results": []}
+    context_tools.client.post.assert_called_once_with(
+        "/web/search",
+        {
+            "query": "latest Context.dev updates",
+            "numResults": 20,
+            "includeDomains": ["context.dev"],
+            "excludeDomains": ["example.com"],
+            "freshness": "last_week",
+            "country": "us",
+            "markdownOptions": {
+                "enabled": True,
+                "useMainContentOnly": True,
+                "includeLinks": True,
+                "includeImages": False,
+            },
+        },
+    )
+
+
+def test_scrape_url_uses_markdown_endpoint(context_tools: ContextTools) -> None:
+    context_tools.client.get.return_value = '{"markdown": "page"}'
+
+    context_tools.scrape_url("https://example.com", max_age_ms=0)
+
+    context_tools.client.get.assert_called_once_with(
+        "/web/scrape/markdown",
+        {
+            "url": "https://example.com",
+            "useMainContentOnly": True,
+            "includeLinks": True,
+            "includeImages": False,
+            "maxAgeMs": 0,
+        },
+    )
+
+
+def test_crawl_website_omits_unset_optional_fields(context_tools: ContextTools) -> None:
+    context_tools.client.post.return_value = '{"results": []}'
+
+    context_tools.crawl_website("https://example.com", max_pages=12)
+
+    context_tools.client.post.assert_called_once_with(
+        "/web/crawl",
+        {
+            "url": "https://example.com",
+            "maxPages": 12,
+            "followSubdomains": False,
+            "useMainContentOnly": True,
+            "includeLinks": True,
+            "includeImages": False,
+        },
+    )
+
+
+def test_find_website_pages_uses_sitemap_query(context_tools: ContextTools) -> None:
+    context_tools.client.get.return_value = '{"urls": []}'
+
+    context_tools.find_website_pages(
+        "context.dev",
+        search="pricing",
+        max_links=25,
+        sitemap_url="https://context.dev/sitemap.xml",
+        url_regex="/docs/.*",
+    )
+
+    context_tools.client.get.assert_called_once_with(
+        "/web/scrape/sitemap",
+        {
+            "domain": "context.dev",
+            "search": "pricing",
+            "maxLinks": 25,
+            "sitemapUrl": "https://context.dev/sitemap.xml",
+            "urlRegex": "/docs/.*",
+        },
+    )
+
+
+def test_extract_structured_data_preserves_false_values(context_tools: ContextTools) -> None:
+    context_tools.client.post.return_value = '{"data": {}}'
+    schema = {"type": "object", "properties": {"price": {"type": "string"}}}
+
+    context_tools.extract_structured_data(
+        "https://context.dev/pricing",
+        schema,
+        instructions="Return displayed prices",
+        max_pages=3,
+        max_depth=0,
+    )
+
+    context_tools.client.post.assert_called_once_with(
+        "/web/extract",
+        {
+            "url": "https://context.dev/pricing",
+            "schema": schema,
+            "instructions": "Return displayed prices",
+            "maxPages": 3,
+            "maxDepth": 0,
+            "followSubdomains": False,
+            "factCheck": False,
+        },
+    )
+
+
+def test_get_brand_profile_uses_typed_domain_lookup(context_tools: ContextTools) -> None:
+    context_tools.client.post.return_value = '{"domain": "stripe.com"}'
+
+    context_tools.get_brand_profile("stripe.com", maximum_speed=True)
+
+    context_tools.client.post.assert_called_once_with(
+        "/brand/retrieve",
+        {
+            "type": "by_domain",
+            "domain": "stripe.com",
+            "maxSpeed": True,
+            "maxAgeMs": 7776000000,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_tool_uses_async_client(context_tools: ContextTools) -> None:
+    context_tools.client.apost.return_value = '{"results": []}'
+
+    result = await context_tools.asearch_web("Context.dev")
+
+    assert json.loads(result) == {"results": []}
+    context_tools.client.apost.assert_awaited_once()
+    context_tools.client.post.assert_not_called()
+
+
+def test_client_sends_bearer_auth_and_serializes_success() -> None:
+    response = httpx.Response(
+        200,
+        json={"results": [{"url": "https://example.com"}]},
+        request=httpx.Request("POST", "https://api.context.dev/v1/web/search"),
+    )
+    client = ContextClient("test-key", "https://api.context.dev/v1/", 30)
+
+    with patch("agno.tools.context_client.httpx.post", return_value=response) as request:
+        result = client.post("/web/search", {"query": "test"})
+
+    assert json.loads(result)["results"][0]["url"] == "https://example.com"
+    assert request.call_args.kwargs["headers"]["Authorization"] == "Bearer test-key"
+    assert request.call_args.args[0] == "https://api.context.dev/v1/web/search"
+
+
+def test_client_returns_structured_api_error() -> None:
+    response = httpx.Response(
+        400,
+        json={"message": "Invalid query", "error_code": "INPUT_VALIDATION_ERROR"},
+        request=httpx.Request("POST", "https://api.context.dev/v1/web/search"),
+    )
+    client = ContextClient("test-key", "https://api.context.dev/v1", 30)
+
+    with patch("agno.tools.context_client.httpx.post", return_value=response):
+        result = json.loads(client.post("/web/search", {"query": ""}))
+
+    assert result == {
+        "error": "Context.dev API request failed",
+        "status_code": 400,
+        "details": {"message": "Invalid query", "error_code": "INPUT_VALIDATION_ERROR"},
+    }
+
+
+def test_client_requires_api_key_before_request() -> None:
+    client = ContextClient(None, "https://api.context.dev/v1", 30)
+
+    with pytest.raises(ValueError, match="CONTEXT_API_KEY"):
+        client.get("/web/scrape/markdown", {"url": "https://example.com"})


### PR DESCRIPTION
Closes #9836

## Summary

Adds a native Context.dev toolkit for live web search, Markdown scraping, website crawling, sitemap discovery, structured extraction, and brand profile retrieval.

The toolkit uses the production Context.dev API directly through httpx, supports synchronous and asynchronous execution, defaults to the focused search and scrape pair, and allows the remaining capabilities to be enabled individually or together with all=True. No additional runtime dependency is required.

The unreleased Answers endpoint is intentionally excluded.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (./scripts/format.sh and ./scripts/validate.sh)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Validation completed:

- ./scripts/format.sh
- ./scripts/validate.sh: Ruff passed, mypy passed for 1,023 source files, and cookbook checks passed
- .venv/bin/pytest libs/agno/tests/unit/tools/test_context.py -q: 12 passed
- Live production smoke tests passed for synchronous search, synchronous scrape, and asynchronous scrape against https://api.context.dev/v1

The implementation does not expose jobs, monitors, batch operations, or any endpoint that is not currently released in production.
