### PR TITLE
fix: cap Gemini media URL download size to prevent memory exhaustion

### DIFF
--- a/libs/agno/agno/models/google/utils.py
+++ b/libs/agno/agno/models/google/utils.py
@@ -74,9 +74,29 @@ def media_to_content_item(
             import httpx
 
             headers = {"User-Agent": "Mozilla/5.0 (compatible; agno/1.0)"}
-            response = httpx.get(url, follow_redirects=True, headers=headers)
-            response.raise_for_status()
-            item["data"] = base64.b64encode(response.content).decode("utf-8")
+            # Cap the download size: media URLs are attacker-influenceable input
+            # (user input or model tool calls), and `response.content` materializes
+            # the whole body before any size check, allowing an arbitrarily large
+            # body plus a ~1.33x base64 copy in memory.
+            max_bytes = 25 * 1024 * 1024  # 25 MiB
+            with httpx.Client(follow_redirects=True, headers=headers) as client:
+                with client.stream("GET", url) as response:
+                    response.raise_for_status()
+                    content_length = response.headers.get("content-length")
+                    if content_length and int(content_length) > max_bytes:
+                        raise ValueError(
+                            f"media exceeds size limit of {max_bytes} bytes"
+                        )
+                    chunks = []
+                    size = 0
+                    for chunk in response.iter_bytes():
+                        size += len(chunk)
+                        if size > max_bytes:
+                            raise ValueError(
+                                f"media exceeds size limit of {max_bytes} bytes"
+                            )
+                        chunks.append(chunk)
+            item["data"] = base64.b64encode(b"".join(chunks)).decode("utf-8")
             return item
         except Exception as e:
             log_warning(f"Failed to download {content_type} from URL {url}: {e}")


### PR DESCRIPTION
## Summary

Fixes #9823: `media_to_content_item` downloads a remote media URL with no ceiling on the response body, then base64-encodes it in memory. `response.content` materializes the whole body before any size check, so a single URL can force an arbitrarily large body (plus ~1.33x for base64) into the process.

## Changes

- `libs/agno/agno/models/google/utils.py`: the HTTP URL download path now uses `httpx.Client.stream` with a **25 MiB cap**:
  - rejects early when `Content-Length` exceeds the limit
  - aborts mid-stream when accumulated chunks exceed the limit (chunked responses without `Content-Length`)
  - falls back to `item["uri"]` (existing error path) when the limit is hit, mirroring the current exception handling

## Verification

- `ast.parse` passes
- Simulated assertions:
  - normal small body (chunked, no Content-Length) → downloaded OK
  - Content-Length over limit → rejected before body read
  - streamed body over limit (no Content-Length) → aborted mid-stream
  - 20 MiB multi-chunk body → OK (under limit)
  - HTTP error → raises (outer handler falls back to uri)
- Full agno test suite not run locally (no agno install in this environment)