### PR TITLE
fix: coerce `enum` values to strings in `convert_schema` for integer enums

### DIFF
--- a/libs/agno/agno/utils/gemini.py
+++ b/libs/agno/agno/utils/gemini.py
@@ -258,7 +258,11 @@ def convert_schema(
 
     # Handle enum types
     if "enum" in schema_dict:
-        enum_values = schema_dict["enum"]
+        # ``GeminiType.STRING`` is used for enums, so the values must be
+        # coerced to strings as well: a tool parameter typed as ``IntEnum``
+        # or ``Literal[1, 2, 3]`` produces a JSON schema whose ``enum`` holds
+        # integers, and ``Schema.enum`` is typed ``List[str]``.
+        enum_values = [str(v) for v in schema_dict["enum"]]
         return Schema(type=GeminiType.STRING, enum=enum_values, description=description, default=default, title=title)
 
     if schema_type == "object":


### PR DESCRIPTION
## Summary

Fixes #9833: a tool parameter typed as an `IntEnum` or `Literal[1, 2, 3]` produces a JSON schema whose `enum` holds integers. `convert_schema` passes those straight into `Schema(type=STRING, enum=...)`, and since `Schema.enum` is typed `List[str]`, pydantic raises:

```
ValidationError: 1 validation error for Schema
enum.0
  Input should be a valid string
```

## Changes

- `libs/agno/agno/utils/gemini.py`: in `convert_schema`, enum values are now coerced with `str(v)` — the type is already coerced to `GeminiType.STRING` on that line, so the values are coerced with it.

## Verification

- `ast.parse` passes
- Simulated assertions (pydantic `List[str]` behavior emulated):
  - `{"type": "integer", "enum": [1, 2, 3]}` (the issue's exact repro) → enum `["1", "2", "3"]`, no validation error
  - string enums `["a", "b"]` → unchanged (no regression)
  - mixed values `[1, 2.5, True, "x"]` → all coerced to strings
  - `IntEnum` values → `["1", "2", "3"]`
- Full agno test suite not run locally (no agno install in this environment); 1-line coercion change