### PR TITLE
fix: coerce `enum` values to strings in `convert_schema` for integer enums

### DIFF
--- a/libs/agno/agno/utils/gemini.py
+++ b/libs/agno/agno/utils/gemini.py
@@ -258,7 +258,11 @@ def convert_schema(
 
     # Handle enum types
     if "enum" in schema_dict:
-        enum_values = schema_dict["enum"]
+        # ``GeminiType.STRING`` is used for enums, so the values must be
+        # coerced to strings as well: a tool parameter typed as ``IntEnum``
+        # or ``Literal[1, 2, 3]`` produces a JSON schema whose ``enum`` holds
+        # integers, and ``Schema.enum`` is typed ``List[str]``.
+        enum_values = [str(v) for v in schema_dict["enum"]]
         return Schema(type=GeminiType.STRING, enum=enum_values, description=description, default=default, title=title)
 
     if schema_type == "object":

--- a/libs/agno/tests/unit/utils/test_gemini_convert_schema.py
+++ b/libs/agno/tests/unit/utils/test_gemini_convert_schema.py
@@ -1,0 +1,47 @@
+"""Unit tests for ``agno.utils.gemini.convert_schema`` enum handling."""
+
+from enum import IntEnum
+
+import pytest
+
+from agno.utils.gemini import convert_schema
+
+
+class Color(IntEnum):
+    RED = 1
+    GREEN = 2
+    BLUE = 3
+
+
+def test_integer_enum_coerced_to_strings():
+    """An integer ``enum`` (IntEnum / Literal[1, 2, 3] shape) must be coerced
+    to strings, matching the ``GeminiType.STRING`` the converter already uses."""
+    schema = convert_schema({"type": "integer", "enum": [1, 2, 3]})
+    assert schema is not None
+    assert schema.type == "STRING"
+    assert schema.enum == ["1", "2", "3"]
+
+
+def test_intenum_values_coerced_to_strings():
+    schema = convert_schema({"type": "integer", "enum": [c.value for c in Color]})
+    assert schema is not None
+    assert schema.enum == ["1", "2", "3"]
+
+
+def test_string_enum_unchanged():
+    schema = convert_schema({"type": "string", "enum": ["a", "b"]})
+    assert schema is not None
+    assert schema.enum == ["a", "b"]
+
+
+def test_mixed_enum_values_all_coerced():
+    schema = convert_schema({"type": "integer", "enum": [1, 2.5, True, "x"]})
+    assert schema is not None
+    assert schema.enum == ["1", "2.5", "True", "x"]
+
+
+@pytest.mark.parametrize("value", [1, 2, 3])
+def test_each_integer_enum_member_is_string(value):
+    schema = convert_schema({"type": "integer", "enum": [value]})
+    assert schema is not None
+    assert all(isinstance(v, str) for v in schema.enum)


### PR DESCRIPTION
## Summary

Fixes #9833: a tool parameter typed as an `IntEnum` or `Literal[1, 2, 3]` produces a JSON schema whose `enum` holds integers. `convert_schema` passes those straight into `Schema(type=STRING, enum=...)`, and since `Schema.enum` is typed `List[str]`, pydantic raises.

## Changes

- `libs/agno/agno/utils/gemini.py`: enum values are coerced with `str(v)` — the type is already coerced to `GeminiType.STRING` on that line, so the values are coerced with it.
- `libs/agno/tests/unit/utils/test_gemini_convert_schema.py` (new): 6 tests covering the issue repro, `IntEnum` values, string enums (no regression), mixed values, and per-member stringness.

## Verification

- `ast.parse` passes on both files
- Simulated assertions mirroring the test file:
  - `{"type": "integer", "enum": [1, 2, 3]}` (issue repro) → `["1", "2", "3"]`
  - `IntEnum` values → `["1", "2", "3"]`
  - string enums → unchanged
  - mixed `[1, 2.5, True, "x"]` → all coerced
- Full agno test suite not run locally (no agno/google-genai install in this environment)