### PR TITLE
fix: resolve callable dependencies in Team async continue paths

### DIFF
--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -9507,6 +9507,13 @@ async def _acontinue_run(
                     run_context, run_response=run_response, run_id=run_id, session=team_session
                 )
 
+                # Resolve dependencies — mirrors the sync continue path
+                # (`_continue_run`) and the agent async continue path; without
+                # this, an async continuation runs with the raw callables still
+                # in `run_context.dependencies`.
+                if run_context.dependencies is not None:
+                    await _aresolve_run_dependencies(team, run_context=run_context)
+
                 # Resolve run_response from run_id if needed
                 if run_response is None and run_id is not None:
                     runs = team_session.runs or []
@@ -9987,6 +9994,13 @@ async def _acontinue_run_stream(
                 _restore_continue_context_metadata_team(
                     run_context, run_response=run_response, run_id=run_id, session=team_session
                 )
+
+                # Resolve dependencies — mirrors the sync continue path
+                # (`_continue_run`) and the agent async continue path; without
+                # this, an async continuation runs with the raw callables still
+                # in `run_context.dependencies`.
+                if run_context.dependencies is not None:
+                    await _aresolve_run_dependencies(team, run_context=run_context)
 
                 # Resolve run_response from run_id if needed
                 if run_response is None and run_id is not None:

--- a/libs/agno/tests/unit/team/test_acontinue_dependencies.py
+++ b/libs/agno/tests/unit/team/test_acontinue_dependencies.py
@@ -1,0 +1,114 @@
+"""Team async continue paths must resolve callable dependencies.
+
+``_acontinue_run`` / ``_acontinue_run_stream`` previously never called
+``_aresolve_run_dependencies``, so a callable dependency configured on a Team
+was resolved on ``team.run()``/``team.arun()`` and on the sync continue
+dispatch, but an async continuation ran with the raw callables still in
+``run_context.dependencies``. These tests pin the resolution inside both async
+implementations, right after the continue metadata is restored.
+"""
+
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key-for-testing")
+
+from agno.run import RunContext  # noqa: E402
+
+
+class StopTest(Exception):
+    """Sentinel raised right after the dependency-resolution point."""
+
+
+def _paused_session(run_id="r-1", owner="alice"):
+    session = MagicMock()
+    session.runs = [SimpleNamespace(run_id=run_id, user_id=owner)]
+    return session
+
+
+def _run_context():
+    run_context = RunContext(run_id="r-1", session_id="s-1", user_id=None)
+    run_context.dependencies = {"robot_name": lambda: "Anna"}
+    return run_context
+
+
+@pytest.mark.asyncio
+class TestTeamAsyncContinueDependencies:
+    async def test_acontinue_run_resolves_dependencies(self, monkeypatch):
+        from agno.team import _run as team_run
+
+        monkeypatch.setattr(team_run, "_asetup_session", AsyncMock(return_value=_paused_session()))
+        monkeypatch.setattr(team_run, "_resolve_continue_owner_team", lambda *a, **k: "alice")
+        resolved = AsyncMock()
+        monkeypatch.setattr(team_run, "_aresolve_run_dependencies", resolved)
+
+        def boom(*args, **kwargs):
+            raise StopTest
+
+        monkeypatch.setattr(team_run, "_resolve_continue_from_team", boom)
+
+        team = MagicMock()
+        team.save_response_to_file = None
+        team.retries = 0
+        run_context = _run_context()
+        try:
+            await team_run._acontinue_run(team, session_id="s-1", run_context=run_context, run_id="r-1", user_id=None)
+        except Exception:
+            pass
+
+        resolved.assert_awaited_once_with(team, run_context=run_context)
+
+    async def test_acontinue_run_stream_resolves_dependencies(self, monkeypatch):
+        from agno.team import _run as team_run
+
+        monkeypatch.setattr(team_run, "_asetup_session", AsyncMock(return_value=_paused_session()))
+        monkeypatch.setattr(team_run, "_resolve_continue_owner_team", lambda *a, **k: "alice")
+        resolved = AsyncMock()
+        monkeypatch.setattr(team_run, "_aresolve_run_dependencies", resolved)
+
+        def boom(*args, **kwargs):
+            raise StopTest
+
+        monkeypatch.setattr(team_run, "_resolve_continue_from_team", boom)
+
+        team = MagicMock()
+        team.save_response_to_file = None
+        team.retries = 0
+        run_context = _run_context()
+        try:
+            async for _event in team_run._acontinue_run_stream(
+                team, session_id="s-1", run_context=run_context, run_id="r-1", user_id=None
+            ):
+                pass
+        except Exception:
+            pass
+
+        resolved.assert_awaited_once_with(team, run_context=run_context)
+
+    async def test_acontinue_run_skips_resolution_when_dependencies_none(self, monkeypatch):
+        from agno.team import _run as team_run
+
+        monkeypatch.setattr(team_run, "_asetup_session", AsyncMock(return_value=_paused_session()))
+        monkeypatch.setattr(team_run, "_resolve_continue_owner_team", lambda *a, **k: "alice")
+        resolved = AsyncMock()
+        monkeypatch.setattr(team_run, "_aresolve_run_dependencies", resolved)
+
+        def boom(*args, **kwargs):
+            raise StopTest
+
+        monkeypatch.setattr(team_run, "_resolve_continue_from_team", boom)
+
+        team = MagicMock()
+        team.save_response_to_file = None
+        team.retries = 0
+        run_context = RunContext(run_id="r-1", session_id="s-1", user_id=None)
+        run_context.dependencies = None
+        try:
+            await team_run._acontinue_run(team, session_id="s-1", run_context=run_context, run_id="r-1", user_id=None)
+        except Exception:
+            pass
+
+        resolved.assert_not_awaited()


### PR DESCRIPTION
## Summary

Fixes #9806: the Team ASYNC continue paths (`_acontinue_run`, `_acontinue_run_stream` in `team/_run.py`) never called `_aresolve_run_dependencies`. A callable dependency configured on a Team is resolved on `team.run()`/`team.arun()` and on the sync `continue_run` dispatch, but an async continuation runs with the raw callables still in `run_context.dependencies` (or with nothing when the context is rebuilt).

## Changes

- `libs/agno/agno/team/_run.py`: both `_acontinue_run` and `_acontinue_run_stream` now resolve dependencies after the continue metadata is restored, mirroring the sync continue path (`_continue_run` → `_resolve_run_dependencies`) and the agent async continue path (`aresolve_run_dependencies`).
- `libs/agno/tests/unit/team/test_acontinue_dependencies.py` (new): 3 tests pinning the resolution inside both async implementations (sentinel pattern, mirroring `test_acontinue_owner_recovery.py`):
  - `_acontinue_run` calls `_aresolve_run_dependencies(team, run_context=run_context)`
  - `_acontinue_run_stream` does the same
  - `dependencies=None` skips resolution (no behavior change)

## Verification

- `ast.parse` passes on both files
- Simulated assertions:
  - callable dependency resolved to its return value when `dependencies` is a dict
  - `dependencies=None` → resolution skipped (unchanged)
- Full agno test suite not run locally (no agno install in this environment); the new tests follow the existing `test_acontinue_owner_recovery.py` pattern and will run in CI