### PR TITLE
feat: publish title and behaviour annotations on MCP tools

### DIFF
--- a/cookbook/05_agent_os/14_mcp/TEST_LOG.md
+++ b/cookbook/05_agent_os/14_mcp/TEST_LOG.md
@@ -65,6 +65,29 @@ question; `chief` ran to COMPLETED.
 
 ---
 
+### agents_as_tools.py (corrected annotations)
+
+**Status:** PASS
+
+**Test mode:** LIVE (2026-08-30, second run)
+
+**Description:** Re-ran after two corrections: the cookbook's `deep_research`
+override no longer claims `readOnlyHint` (a run writes a session row and a run
+row, so the claim was false), and every tool the server composes now states all
+three of `readOnlyHint`, `destructiveHint`, and `openWorldHint` rather than
+leaving the ones that "do not apply" unset.
+
+**Result:** `tools/list` returned `chief`, `deep_research`, `continue_run`,
+`cancel_run`, and every one carried all three hints with no gaps:
+`chief` false/true/true (published-component defaults), `deep_research`
+false/false/true plus `idempotentHint` false (its override now refines the
+default instead of contradicting it -- it appends to its own session and
+destroys nothing), `continue_run` false/true/true, `cancel_run` false/true/false
+(it writes this deployment's own run state and reaches nothing external).
+`deep_research` ran to COMPLETED.
+
+---
+
 ### basic.py
 
 **Status:** PASS

--- a/cookbook/05_agent_os/14_mcp/TEST_LOG.md
+++ b/cookbook/05_agent_os/14_mcp/TEST_LOG.md
@@ -8,7 +8,8 @@ Tested on 2026-07-24 against Agno source commit
 `MCPConfig` / `default_tools` spellings (behavior unchanged; the old spellings
 remain accepted aliases). Re-run LIVE on 2026-08-28 after the lifecycle
 ride-along and the review-round fixes landed; the entry below records the
-2026-08-28 run.
+2026-08-28 run. Re-run LIVE again on 2026-08-30 after tool presentation
+metadata (`title`, `annotations`) landed -- see the entry below the first.
 
 ### agents_as_tools.py
 
@@ -37,6 +38,30 @@ recalled "Earth", proving live session continuity through the exposed tool.
 The same re-run verified the publication bound on the riding pair:
 `cancel_run` acted on the published `researcher` but refused an id outside
 the publication list with the "published components" error.
+
+---
+
+### agents_as_tools.py (tool presentation metadata)
+
+**Status:** PASS
+
+**Test mode:** LIVE (2026-08-30)
+
+**Description:** Re-ran the checked-in server after `title` / `annotations`
+landed on `as_tool`, and drove it with a FastMCP streamable-HTTP client:
+listed tools and read the presentation each one publishes, then called both
+exposed tools.
+
+**Result:** `tools/list` returned `chief`, `deep_research`, `continue_run`,
+`cancel_run`. `chief` (bare) titled itself from the agent name and carried
+the published-component defaults (`readOnlyHint` false, `destructiveHint`
+true, `openWorldHint` true). `deep_research` carried the cookbook's
+`title="Deep Research"` and its annotation override (`readOnlyHint` true,
+`destructiveHint` false) merged over those defaults, with `openWorldHint`
+still true from the default. Every tool's title also appeared in
+`annotations.title`, so a client reading either slot shows the same name.
+`deep_research` then ran to COMPLETED with a minted session and answered the
+question; `chief` ran to COMPLETED.
 
 ---
 

--- a/cookbook/05_agent_os/14_mcp/TEST_LOG.md
+++ b/cookbook/05_agent_os/14_mcp/TEST_LOG.md
@@ -86,6 +86,12 @@ destroys nothing), `continue_run` false/true/true, `cancel_run` false/true/false
 (it writes this deployment's own run state and reaches nothing external).
 `deep_research` ran to COMPLETED.
 
+Re-run again the same day after `cancel_run` was corrected to
+`openWorldHint` true (cancelling a Remote* component's run is an outbound
+call to that deployment, so "reaches nothing external" was wrong): the four
+tools published false/true/true, false/true/true, false/true/true, and
+false/false/true respectively, with no hint left unset.
+
 ---
 
 ### basic.py
@@ -134,6 +140,10 @@ called `ask_workspace` through a FastMCP streamable-HTTP client with a live
 
 **Result:** The server exposed exactly one tool, `ask_workspace`, with no
 built-ins. The call returned the requested exact response, `custom MCP works`.
+Re-run on 2026-08-30 after the example began declaring its presentation: the
+tool published title "Ask the Workspace Agent" and all three hints
+(`readOnlyHint` false -- the run persists a session, `destructiveHint` false,
+`openWorldHint` true -- the agent calls a model over the network).
 
 ---
 

--- a/cookbook/05_agent_os/14_mcp/agents_as_tools.py
+++ b/cookbook/05_agent_os/14_mcp/agents_as_tools.py
@@ -12,6 +12,11 @@ session minting, scope checks, progress). continue_run and cancel_run ride
 along automatically so paused (human-in-the-loop) runs stay resumable; set
 lifecycle_tools=False to serve exactly the configured tools.
 
+as_tool also carries the presentation a client and a marketplace reviewer
+read: title= is the display name, and annotations= are the behaviour hints
+(readOnlyHint, destructiveHint, idempotentHint, openWorldHint) merged over
+the defaults a published component asserts about itself.
+
 Prerequisites: OPENAI_API_KEY
 Run: .venvs/demo/bin/python cookbook/05_agent_os/14_mcp/agents_as_tools.py
 Try: connect an MCP client to http://localhost:7777/mcp and call chief or deep_research
@@ -68,7 +73,15 @@ agent_os = AgentOS(
             chief,
             researcher.as_tool(
                 name="deep_research",
+                title="Deep Research",
                 description="Thorough, sourced research. Send one clear question.",
+                # The researcher only reads and reports, so it can say so. Hints are
+                # published to the client and read by assistant marketplaces during a
+                # listing review -- which test them against what the tool really does,
+                # so claim read-only only when it is true. The default for a published
+                # component is the honest one for a run that persists a session and can
+                # call side-effectful tools: readOnlyHint False, destructiveHint True.
+                annotations={"readOnlyHint": True, "destructiveHint": False},
             ),
         ],
     ),

--- a/cookbook/05_agent_os/14_mcp/agents_as_tools.py
+++ b/cookbook/05_agent_os/14_mcp/agents_as_tools.py
@@ -75,13 +75,14 @@ agent_os = AgentOS(
                 name="deep_research",
                 title="Deep Research",
                 description="Thorough, sourced research. Send one clear question.",
-                # The researcher only reads and reports, so it can say so. Hints are
-                # published to the client and read by assistant marketplaces during a
-                # listing review -- which test them against what the tool really does,
-                # so claim read-only only when it is true. The default for a published
-                # component is the honest one for a run that persists a session and can
-                # call side-effectful tools: readOnlyHint False, destructiveHint True.
-                annotations={"readOnlyHint": True, "destructiveHint": False},
+                # Hints are published to the client and read by assistant marketplaces
+                # during a listing review, which test them against what the tool really
+                # does -- so a wrong hint is worse than a missing one. The researcher
+                # holds no tools and only appends to its own session, so it refines the
+                # default rather than contradicting it: still not read-only (every run
+                # writes a session and a run row), but nothing it writes destroys
+                # anything, and running it twice is not the same as running it once.
+                annotations={"destructiveHint": False, "idempotentHint": False},
             ),
         ],
     ),

--- a/cookbook/05_agent_os/14_mcp/custom_tools.py
+++ b/cookbook/05_agent_os/14_mcp/custom_tools.py
@@ -37,7 +37,18 @@ workspace_agent = Agent(
 
 @tool(
     name="ask_workspace",
+    title="Ask the Workspace Agent",
     description="Ask the workspace agent a question",
+    # A custom tool publishes whatever it declares here and nothing more, so state all
+    # three hints: a client that finds one missing falls back to a protocol default,
+    # and a directory submission is rejected outright for leaving any of them unset.
+    # These are true of this tool: the run persists a session (not read-only), it only
+    # appends (nothing destroyed), and the agent calls a model over the network.
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "openWorldHint": True,
+    },
 )
 async def ask_workspace(question: str) -> str:
     """Route one question through the workspace agent."""

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -769,17 +769,29 @@ class Agent:
     # _init module delegates
     # ---------------------------------------------------------------
 
-    def as_tool(self, name: Optional[str] = None, description: Optional[str] = None) -> "ComponentTool":
-        """Publish this agent as a tool with its own model-facing name and description.
+    def as_tool(
+        self,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        title: Optional[str] = None,
+        annotations: Optional[Dict[str, Any]] = None,
+    ) -> "ComponentTool":
+        """Publish this agent as a tool with its own model-facing name, description,
+        title, and behaviour annotations.
 
         Returns a declarative :class:`~agno.tools.component.ComponentTool` marker
         for surfaces that turn components into tools. The tool name must be a
         valid tool identifier (start with a letter or underscore, then
         letters/digits/hyphens/underscores).
+
+        ``title`` is the human-facing display name; ``annotations`` are MCP behaviour
+        hints (``readOnlyHint``, ``destructiveHint``, ``idempotentHint``,
+        ``openWorldHint``) merged over the publishing surface's defaults -- see
+        :mod:`agno.tools.annotations`.
         """
         from agno.tools.component import ComponentTool
 
-        return ComponentTool(component=self, name=name, description=description)
+        return ComponentTool(component=self, name=name, description=description, title=title, annotations=annotations)
 
     def set_id(self) -> None:
         return _init.set_id(self)

--- a/libs/agno/agno/agents/base.py
+++ b/libs/agno/agno/agents/base.py
@@ -67,16 +67,27 @@ class BaseExternalAgent:
         """Return the agent ID, guaranteed non-None after __post_init__."""
         return self.id or ""
 
-    def as_tool(self, name: Optional[str] = None, description: Optional[str] = None) -> "ComponentTool":
+    def as_tool(
+        self,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        title: Optional[str] = None,
+        annotations: Optional[Dict[str, Any]] = None,
+    ) -> "ComponentTool":
         """Publish this external-framework agent as a tool with its own model-facing
-        name and description, for surfaces that turn components into tools -- today
-        the AgentOS MCP server: ``MCPConfig(tools=[adapter.as_tool(name=...,
-        description=...)])``. Both overrides are optional; the adapter ``id`` remains
+        name, description, title, and behaviour annotations, for surfaces that turn
+        components into tools -- today the AgentOS MCP server: ``MCPConfig(tools=[adapter.as_tool(name=...,
+        description=...)])``. Every override is optional; the adapter ``id`` remains
         the run/scope handle.
+
+        ``title`` is the human-facing display name; ``annotations`` are MCP behaviour
+        hints (``readOnlyHint``, ``destructiveHint``, ``idempotentHint``,
+        ``openWorldHint``) merged over the publishing surface's defaults -- see
+        :mod:`agno.tools.annotations`.
         """
         from agno.tools.component import ComponentTool
 
-        return ComponentTool(component=self, name=name, description=description)
+        return ComponentTool(component=self, name=name, description=description, title=title, annotations=annotations)
 
     # ---------------------------------------------------------------------------
     # Public async API (satisfies AgentProtocol protocol)

--- a/libs/agno/agno/factory/base.py
+++ b/libs/agno/agno/factory/base.py
@@ -3,7 +3,7 @@
 import inspect
 import json
 from dataclasses import replace
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, Generic, Optional, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, Generic, Optional, Type, TypeVar, Union
 
 from pydantic import BaseModel
 
@@ -61,16 +61,27 @@ class BaseFactory(Generic[T]):
         self.description = description
         self.input_schema = input_schema
 
-    def as_tool(self, name: Optional[str] = None, description: Optional[str] = None) -> "ComponentTool":
-        """Publish this factory as a tool with its own model-facing name and
-        description, for surfaces that turn components into tools -- today the AgentOS
+    def as_tool(
+        self,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        title: Optional[str] = None,
+        annotations: Optional[Dict[str, Any]] = None,
+    ) -> "ComponentTool":
+        """Publish this factory as a tool with its own model-facing name,
+        description, title, and behaviour annotations, for surfaces that turn components into tools -- today the AgentOS
         MCP server: ``MCPConfig(tools=[factory.as_tool(name=..., description=...)])``.
-        Both overrides are optional; the factory ``id`` remains the run/scope handle,
+        Every override is optional; the factory ``id`` remains the run/scope handle,
         and the component is built per request as on every other surface.
+
+        ``title`` is the human-facing display name; ``annotations`` are MCP behaviour
+        hints (``readOnlyHint``, ``destructiveHint``, ``idempotentHint``,
+        ``openWorldHint``) merged over the publishing surface's defaults -- see
+        :mod:`agno.tools.annotations`.
         """
         from agno.tools.component import ComponentTool
 
-        return ComponentTool(component=self, name=name, description=description)
+        return ComponentTool(component=self, name=name, description=description, title=title, annotations=annotations)
 
     def validate_input(self, raw_input: Any) -> Any:
         """Validate and parse raw factory_input against input_schema.

--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -72,9 +72,13 @@ _BUILTIN_TOOL_NAMES: Dict[str, frozenset] = {
 
 # What a published component's run tool asserts about itself, before the deployer's own
 # ``as_tool(annotations=...)``. A run is not read-only (it persists a session and may
-# call side-effectful tools) and reaches beyond this server, and ``destructiveHint`` is
-# stated rather than left implicit: an absent hint defaults to true CLIENT-side, so
-# spelling it out is what makes a reviewer see the deployer's own claim.
+# call side-effectful tools) and reaches beyond this server.
+#
+# All three of readOnlyHint/destructiveHint/openWorldHint are stated rather than left
+# implicit, here and on every built-in tool. An omitted hint is not "unknown" to a
+# client -- it falls back to a protocol default -- and a directory submission scan
+# rejects a tool that leaves any of the three unset, so a hint the server declines to
+# state is a hint someone else answers on its behalf.
 _EXPOSED_COMPONENT_ANNOTATIONS: Dict[str, Any] = {
     "readOnlyHint": False,
     "destructiveHint": True,
@@ -1392,12 +1396,14 @@ def _register_exposed_components(
         component_id = getattr(component, "id", None)
         # On Remote* components name/description are network-backed properties (a
         # synchronous config fetch that blocks to the timeout when the remote is
-        # unreachable). Skip the read entirely when both overrides are supplied and
+        # unreachable). Skip the read for those when both overrides are supplied and
         # non-blank -- neither the tool name nor the description needs the component's
         # own metadata then. The bare path (no name override) still needs the name for
         # the auto-derived-id origin hint; a blank description override still needs the
-        # component description as its fallback.
-        if name_override is not None and (description_override or "").strip():
+        # component description as its fallback. A LOCAL component's metadata is a
+        # plain attribute read, so it is never skipped: the display title falls back to
+        # the component's name, which the skip would otherwise throw away.
+        if isinstance(component, BaseRemote) and name_override is not None and (description_override or "").strip():
             component_name, component_description = None, None
         else:
             component_name, component_description = _safe_component_metadata(component)
@@ -1553,7 +1559,7 @@ def build_mcp_server(
             "the REST /config endpoint."
         ),
         tags={"core"},
-        annotations={"readOnlyHint": True, "idempotentHint": True},
+        annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": False},
     )  # type: ignore
     async def config() -> Dict[str, Any]:
         _require_tool_scopes("GET", "/config")
@@ -1824,7 +1830,7 @@ def build_mcp_server(
             "run_id, its session_id, and exactly one of agent_id / team_id / workflow_id."
         ),
         tags={"core", "lifecycle"},
-        annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": True},
+        annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": True, "openWorldHint": False},
     )  # type: ignore
     async def cancel_run(
         run_id: str,
@@ -1874,7 +1880,7 @@ def build_mcp_server(
             "read its history. db_id is only needed when get_agentos_config lists multiple databases."
         ),
         tags={"session"},
-        annotations={"readOnlyHint": True},
+        annotations={"readOnlyHint": True, "destructiveHint": False, "openWorldHint": False},
     )  # type: ignore
     async def get_sessions(
         session_type: Literal["agent", "team", "workflow"] = "agent",
@@ -1937,7 +1943,7 @@ def build_mcp_server(
             "omitted; db_id is only needed when get_agentos_config lists multiple databases."
         ),
         tags={"session"},
-        annotations={"readOnlyHint": True},
+        annotations={"readOnlyHint": True, "destructiveHint": False, "openWorldHint": False},
     )  # type: ignore
     async def get_session_runs(
         session_id: str,

--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -79,6 +79,11 @@ _BUILTIN_TOOL_NAMES: Dict[str, frozenset] = {
 # client -- it falls back to a protocol default -- and a directory submission scan
 # rejects a tool that leaves any of the three unset, so a hint the server declines to
 # state is a hint someone else answers on its behalf.
+#
+# openWorldHint asks whether a tool can reach a system this deployment does not own.
+# The run tools can, because the component they run may call anything, and so can
+# cancel_run: cancelling a Remote* component's run is an outbound HTTP call to that
+# deployment. The config and session tools only read storage this deployment owns.
 _EXPOSED_COMPONENT_ANNOTATIONS: Dict[str, Any] = {
     "readOnlyHint": False,
     "destructiveHint": True,
@@ -129,7 +134,9 @@ def _builtin_tool_registrar(mcp: FastMCP, enabled_tags: set):
     def register(*args: Any, **kwargs: Any):
         tags = kwargs.get("tags") or set()
         if tags & enabled_tags:
-            title, annotations = tool_presentation(kwargs.get("title"), kwargs.get("annotations"))
+            title, annotations = tool_presentation(
+                kwargs.get("title"), kwargs.get("annotations"), source=f"built-in tool {kwargs.get('name')!r}"
+            )
             if annotations is not None:
                 kwargs["annotations"] = annotations
             return mcp.tool(*args, **kwargs)
@@ -199,7 +206,9 @@ def _custom_tool_presentation(tool: Any) -> "tuple[Optional[str], Optional[ToolA
 
     if not isinstance(tool, Function):
         return None, None
-    title, annotations = tool_presentation(tool.title, tool.annotations)
+    title, annotations = tool_presentation(
+        tool.title, tool.annotations, source=f"@tool(annotations=...) on {tool.name!r}"
+    )
     return title, (ToolAnnotations(**annotations) if annotations else None)
 
 
@@ -1478,6 +1487,7 @@ def _register_exposed_components(
             annotations_override,
             defaults=_EXPOSED_COMPONENT_ANNOTATIONS,
             fallback_title=component_name or tool_name,
+            source=f'as_tool(annotations=...) on {singular} "{component_id}"',
         )
         mcp.tool(name=tool_name, title=title, description=description, annotations=annotations)(fn)
 
@@ -1830,7 +1840,7 @@ def build_mcp_server(
             "run_id, its session_id, and exactly one of agent_id / team_id / workflow_id."
         ),
         tags={"core", "lifecycle"},
-        annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": True, "openWorldHint": False},
+        annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": True, "openWorldHint": True},
     )  # type: ignore
     async def cancel_run(
         run_id: str,

--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -1551,7 +1551,7 @@ def build_mcp_server(
 
     @register_builtin_tool(
         name="get_agentos_config",
-        title="Discover AgentOS",
+        title="Get AgentOS Configuration",
         description=(
             "Discover this AgentOS: the agents, teams, and workflows available to run (with their ids "
             "and descriptions), and the database ids used by the session tools. Call this first to learn "

--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -13,6 +13,7 @@ from fastmcp.server.http import (
     StarletteWithLifespan,
 )
 from fastmcp.tools import ToolResult
+from mcp.types import ToolAnnotations
 
 from agno.db.base import SessionType
 from agno.os.mcp_results import build_run_tool_result, trim_session_run
@@ -38,6 +39,7 @@ from agno.remote.base import BaseRemote, RemoteDb
 from agno.run.agent import RunEvent, RunOutput
 from agno.run.team import TeamRunEvent, TeamRunOutput
 from agno.run.workflow import WorkflowRunEvent, WorkflowRunOutput
+from agno.tools.annotations import tool_presentation
 from agno.utils.string import generate_component_id_from_name, generate_id_from_name
 
 if TYPE_CHECKING:
@@ -66,6 +68,17 @@ _BUILTIN_TOOL_NAMES: Dict[str, frozenset] = {
     "cancel_run": frozenset({"core", "lifecycle"}),
     "get_sessions": frozenset({"session"}),
     "get_session_runs": frozenset({"session"}),
+}
+
+# What a published component's run tool asserts about itself, before the deployer's own
+# ``as_tool(annotations=...)``. A run is not read-only (it persists a session and may
+# call side-effectful tools) and reaches beyond this server, and ``destructiveHint`` is
+# stated rather than left implicit: an absent hint defaults to true CLIENT-side, so
+# spelling it out is what makes a reviewer see the deployer's own claim.
+_EXPOSED_COMPONENT_ANNOTATIONS: Dict[str, Any] = {
+    "readOnlyHint": False,
+    "destructiveHint": True,
+    "openWorldHint": True,
 }
 
 
@@ -112,6 +125,9 @@ def _builtin_tool_registrar(mcp: FastMCP, enabled_tags: set):
     def register(*args: Any, **kwargs: Any):
         tags = kwargs.get("tags") or set()
         if tags & enabled_tags:
+            title, annotations = tool_presentation(kwargs.get("title"), kwargs.get("annotations"))
+            if annotations is not None:
+                kwargs["annotations"] = annotations
             return mcp.tool(*args, **kwargs)
 
         def _skip(fn: Any) -> Any:
@@ -169,6 +185,20 @@ def _collision_free_advice(colliding_name: str, enabled_tags: "Optional[set]") -
     return "or scope the default tool out via default_tools/include_tags/exclude_tags "
 
 
+def _custom_tool_presentation(tool: Any) -> "tuple[Optional[str], Optional[ToolAnnotations]]":
+    """The ``title`` / ``annotations`` an Agno ``Function`` publishes, if it is one.
+
+    ``Tool.from_function`` takes a ``ToolAnnotations`` model rather than a dict (the
+    ``mcp.tool`` decorator accepts either), so the Function's dict is converted here.
+    """
+    from agno.tools.function import Function
+
+    if not isinstance(tool, Function):
+        return None, None
+    title, annotations = tool_presentation(tool.title, tool.annotations)
+    return title, (ToolAnnotations(**annotations) if annotations else None)
+
+
 def _register_custom_tool(
     mcp: FastMCP, tool: Any, taken: "Optional[Dict[str, str]]" = None, enabled_tags: "Optional[set]" = None
 ) -> str:
@@ -186,7 +216,18 @@ def _register_custom_tool(
     if callable(entrypoint):
         name = getattr(tool, "name", None) or getattr(entrypoint, "__name__", None)
         description = getattr(tool, "description", None)
-        tool_obj = Tool.from_function(_inject_user_id(entrypoint), name=name, description=description)
+        # Presentation metadata is read only from an Agno Function, never duck-typed off
+        # an arbitrary object: a stray ``.annotations`` attribute on some other tool-ish
+        # object means something else entirely. Marketplace scans reject tools that carry
+        # no annotations, so a custom tool that wants a listing sets them on its Function.
+        title, annotations = _custom_tool_presentation(tool)
+        tool_obj = Tool.from_function(
+            _inject_user_id(entrypoint),
+            name=name,
+            title=title,
+            description=description,
+            annotations=annotations,
+        )
     elif callable(tool):
         # Plain callable: name/description inferred from ``__name__``/docstring.
         tool_obj = Tool.from_function(_inject_user_id(tool))
@@ -1120,7 +1161,9 @@ def _locate_component(entry: Any, os: "AgentOS", expected_kind: "Optional[str]" 
 def _split_tool_entries(mcp_config: "Optional[MCPConfig]", os: "AgentOS") -> "tuple[List[Any], List[tuple]]":
     """Classify ``MCPConfig.tools`` into custom-tool entries and component exposures.
 
-    Exposures come back as ``(kind, component, name_override, description_override)``.
+    Exposures come back as ``(kind, component, marker)``, where ``marker`` is the
+    ``as_tool(...)`` marker carrying the model-facing overrides, or ``None`` for a bare
+    component that takes all of its presentation from itself.
     A bare Agent/Team/Workflow that is not in the roster is a hard error here (it would
     otherwise fall through to the custom-tool TypeError, which names the type but not
     the fix); non-component callables pass through untouched.
@@ -1171,7 +1214,7 @@ def _split_tool_entries(mcp_config: "Optional[MCPConfig]", os: "AgentOS") -> "tu
     for entry in getattr(mcp_config, "tools", None) or []:
         if isinstance(entry, ComponentTool):
             kind, component = _locate_component(entry.component, os, expected_kind=_concrete_kind(entry.component))
-            exposures.append((kind, component, entry.name, entry.description))
+            exposures.append((kind, component, entry))
             continue
         if isinstance(entry, str):
             raise TypeError(
@@ -1180,7 +1223,7 @@ def _split_tool_entries(mcp_config: "Optional[MCPConfig]", os: "AgentOS") -> "tu
             )
         if isinstance(entry, (Agent, Team, Workflow)):
             kind, component = _locate_component(entry, os, expected_kind=_concrete_kind(entry))
-            exposures.append((kind, component, None, None))
+            exposures.append((kind, component, None))
             continue
         # Anything that lives on the roster is a component entry, whatever its shape:
         # Remote* instances, component factories (BaseFactory has no arun and is not
@@ -1189,7 +1232,7 @@ def _split_tool_entries(mcp_config: "Optional[MCPConfig]", os: "AgentOS") -> "tu
         # a tool at all.
         if _roster_member(entry):
             kind, component = _locate_component(entry, os, expected_kind=_concrete_kind(entry))
-            exposures.append((kind, component, None, None))
+            exposures.append((kind, component, None))
             continue
         # Off-roster component-shaped entries (id + arun, not a callable tool) resolve
         # through the roster too -- reaching an equal-id roster component, the
@@ -1197,7 +1240,7 @@ def _split_tool_entries(mcp_config: "Optional[MCPConfig]", os: "AgentOS") -> "tu
         if not callable(getattr(entry, "entrypoint", None)) and not callable(entry):
             if getattr(entry, "id", None) is not None and hasattr(entry, "arun"):
                 kind, component = _locate_component(entry, os, expected_kind=_concrete_kind(entry))
-                exposures.append((kind, component, None, None))
+                exposures.append((kind, component, None))
                 continue
         customs.append(entry)
     return customs, exposures
@@ -1303,10 +1346,11 @@ def _register_exposed_components(
 ) -> None:
     """Register the component entries from ``MCPConfig.tools`` as named tools.
 
-    ``exposure_entries`` come from ``_split_tool_entries``:
-    ``(kind, component, name_override, description_override)`` -- a bare component gets
-    its id as the tool name and its own description; an ``as_tool(...)`` marker carries
-    explicit model-facing overrides. Names are validated verbatim, never sanitized;
+    ``exposure_entries`` come from ``_split_tool_entries``: ``(kind, component,
+    marker)``, where ``marker`` is the ``as_tool(...)`` marker carrying the
+    explicit model-facing overrides, or ``None`` for a bare component -- which gets its
+    id as the tool name and its own description and name. Names are validated verbatim,
+    never sanitized;
     collisions with the enabled default tools, custom tools, or other exposed
     components are a hard error at build. The component id (not the tool name) remains
     the continue_run handle -- carried in the result's structuredContent -- and the
@@ -1336,7 +1380,11 @@ def _register_exposed_components(
     continue_run_available = bool({"core", "lifecycle"} & enabled_tags)
     singulars = {"agents": "agent", "teams": "team", "workflows": "workflow"}
 
-    for kind, component, name_override, description_override in exposure_entries:
+    for kind, component, marker in exposure_entries:
+        name_override = marker.name if marker is not None else None
+        description_override = marker.description if marker is not None else None
+        title_override = marker.title if marker is not None else None
+        annotations_override = marker.annotations if marker is not None else None
         singular = singulars[kind]
         # AgentOS mints ids for roster components at construction (name-derived when
         # named, generated otherwise), so the id is normally always set here; the
@@ -1416,11 +1464,16 @@ def _register_exposed_components(
             fn = _make_exposed_workflow_tool(os, component_id, result_mode, continue_run_available)
         else:
             fn = _make_exposed_run_tool(os, kind, component_id, result_mode, continue_run_available)  # type: ignore[arg-type]
-        mcp.tool(
-            name=tool_name,
-            description=description,
-            annotations={"readOnlyHint": False, "openWorldHint": True},
-        )(fn)
+        # component_name is None on the skipped-metadata path above, so this fallback
+        # never reaches for a Remote* component's network-backed name just to fill a
+        # display title -- the tool name is the last resort instead.
+        title, annotations = tool_presentation(
+            title_override,
+            annotations_override,
+            defaults=_EXPOSED_COMPONENT_ANNOTATIONS,
+            fallback_title=component_name or tool_name,
+        )
+        mcp.tool(name=tool_name, title=title, description=description, annotations=annotations)(fn)
 
 
 def build_mcp_server(
@@ -1466,7 +1519,7 @@ def build_mcp_server(
     tags_without_ride_along = _enabled_builtin_tags(mcp_config, has_exposures=False)
     lifecycle_rides_only = "lifecycle" in enabled_tags and not ({"core", "lifecycle"} & tags_without_ride_along)
     published_lifecycle_targets: "Optional[set]" = (
-        {(kind, getattr(component, "id", None)) for kind, component, _, _ in exposure_entries}
+        {(kind, getattr(component, "id", None)) for kind, component, _ in exposure_entries}
         if lifecycle_rides_only
         else None
     )
@@ -1492,6 +1545,7 @@ def build_mcp_server(
 
     @register_builtin_tool(
         name="get_agentos_config",
+        title="Discover AgentOS",
         description=(
             "Discover this AgentOS: the agents, teams, and workflows available to run (with their ids "
             "and descriptions), and the database ids used by the session tools. Call this first to learn "
@@ -1584,6 +1638,7 @@ def build_mcp_server(
 
     @register_builtin_tool(
         name="run_agent",
+        title="Run Agent",
         description=(
             "Run an agent with a message and get its response. Pass a session_id from get_sessions to "
             "continue that conversation; omit it to start a new one (the session_id comes back in "
@@ -1591,7 +1646,7 @@ def build_mcp_server(
             "call continue_run. Agent ids come from get_agentos_config."
         ),
         tags={"core"},
-        annotations={"readOnlyHint": False, "openWorldHint": True},
+        annotations={"readOnlyHint": False, "destructiveHint": True, "openWorldHint": True},
     )  # type: ignore
     async def run_agent(
         agent_id: str,
@@ -1613,12 +1668,13 @@ def build_mcp_server(
 
     @register_builtin_tool(
         name="run_team",
+        title="Run Team",
         description=(
             "Run a team of agents with a message and get its response. Same session and PAUSED semantics "
             "as run_agent. Team ids come from get_agentos_config."
         ),
         tags={"core"},
-        annotations={"readOnlyHint": False, "openWorldHint": True},
+        annotations={"readOnlyHint": False, "destructiveHint": True, "openWorldHint": True},
     )  # type: ignore
     async def run_team(
         team_id: str,
@@ -1640,13 +1696,14 @@ def build_mcp_server(
 
     @register_builtin_tool(
         name="run_workflow",
+        title="Run Workflow",
         description=(
             "Run a workflow with an input message and get its result. Can be long-running: progress is "
             "reported per step when the client supports it. Same session and PAUSED semantics as "
             "run_agent. Workflow ids come from get_agentos_config."
         ),
         tags={"core"},
-        annotations={"readOnlyHint": False, "openWorldHint": True},
+        annotations={"readOnlyHint": False, "destructiveHint": True, "openWorldHint": True},
     )  # type: ignore
     async def run_workflow(
         workflow_id: str,
@@ -1686,6 +1743,7 @@ def build_mcp_server(
 
     @register_builtin_tool(
         name="continue_run",
+        title="Continue Paused Run",
         description=(
             "Resume a PAUSED run after resolving its requirements (human-in-the-loop). "
             "When a run tool returns status=PAUSED, its structuredContent carries the unresolved "
@@ -1694,7 +1752,7 @@ def build_mcp_server(
             "(the component that owns the run) plus the run_id and session_id from the paused result."
         ),
         tags={"core", "lifecycle"},
-        annotations={"readOnlyHint": False, "destructiveHint": False},
+        annotations={"readOnlyHint": False, "destructiveHint": True, "openWorldHint": True},
     )  # type: ignore
     async def continue_run(
         run_id: str,
@@ -1759,13 +1817,14 @@ def build_mcp_server(
 
     @register_builtin_tool(
         name="cancel_run",
+        title="Cancel Run",
         description=(
             "Request cancellation of a running run. Irreversible: the run stops and is marked CANCELLED "
             "(if it has not started yet, the intent is recorded and applied when it does). Provide the "
             "run_id, its session_id, and exactly one of agent_id / team_id / workflow_id."
         ),
         tags={"core", "lifecycle"},
-        annotations={"destructiveHint": True, "idempotentHint": True},
+        annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": True},
     )  # type: ignore
     async def cancel_run(
         run_id: str,
@@ -1807,6 +1866,7 @@ def build_mcp_server(
 
     @register_builtin_tool(
         name="get_sessions",
+        title="List Sessions",
         description=(
             "List past sessions (conversations), newest first. Filter by session_type, component_id "
             "(an agent/team/workflow id from get_agentos_config), user, or session_name. Use a returned "
@@ -1866,6 +1926,7 @@ def build_mcp_server(
 
     @register_builtin_tool(
         name="get_session_runs",
+        title="Read Session History",
         description=(
             "Read a session's conversation history: each run's input and response content with its "
             "run_id, status, and timestamp, oldest first. Returns the answer content only, not the full "

--- a/libs/agno/agno/remote/base.py
+++ b/libs/agno/agno/remote/base.py
@@ -424,18 +424,29 @@ class BaseRemote:
         else:
             raise ValueError(f"Invalid protocol: {protocol}")
 
-    def as_tool(self, name: Optional[str] = None, description: Optional[str] = None) -> "ComponentTool":
-        """Publish this remote component as a tool with its own model-facing name and
-        description, for surfaces that turn components into tools -- today the AgentOS
+    def as_tool(
+        self,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        title: Optional[str] = None,
+        annotations: Optional[Dict[str, Any]] = None,
+    ) -> "ComponentTool":
+        """Publish this remote component as a tool with its own model-facing name,
+        description, title, and behaviour annotations, for surfaces that turn components into tools -- today the AgentOS
         MCP server: ``MCPConfig(tools=[remote.as_tool(name=..., description=...)])``.
-        Both overrides are optional. A remote component's id comes from the remote
+        Every override is optional. A remote component's id comes from the remote
         deployment, so ``name=`` is how the local deployment renames the published
         tool without touching that id (which remains the continue_run handle and the
         scope segment).
+
+        ``title`` is the human-facing display name; ``annotations`` are MCP behaviour
+        hints (``readOnlyHint``, ``destructiveHint``, ``idempotentHint``,
+        ``openWorldHint``) merged over the publishing surface's defaults -- see
+        :mod:`agno.tools.annotations`.
         """
         from agno.tools.component import ComponentTool
 
-        return ComponentTool(component=self, name=name, description=description)
+        return ComponentTool(component=self, name=name, description=description, title=title, annotations=annotations)
 
     def get_os_client(self) -> "AgentOSClient":
         """Get an AgentOSClient for fetching remote configuration.

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -732,19 +732,31 @@ class Team:
         self._cached_session = session
         self._cached_session_db = self.db
 
-    def as_tool(self, name: Optional[str] = None, description: Optional[str] = None) -> "ComponentTool":
-        """Publish this team as a tool with its own model-facing name and description.
+    def as_tool(
+        self,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        title: Optional[str] = None,
+        annotations: Optional[Dict[str, Any]] = None,
+    ) -> "ComponentTool":
+        """Publish this team as a tool with its own model-facing name, description,
+        title, and behaviour annotations.
 
         Returns a declarative :class:`~agno.tools.component.ComponentTool` marker
         for surfaces that turn components into tools -- today the AgentOS MCP server:
-        ``MCPConfig(tools=[support.as_tool(name="ask_support", description=...)])``. Both
-        overrides are optional; the tool name must be a valid tool identifier (start
+        ``MCPConfig(tools=[support.as_tool(name="ask_support", description=...)])``. Every
+        override is optional; the tool name must be a valid tool identifier (start
         with a letter or underscore, then letters/digits/hyphens/underscores). The
         team id remains the continue_run handle and the scope segment.
+
+        ``title`` is the human-facing display name; ``annotations`` are MCP behaviour
+        hints (``readOnlyHint``, ``destructiveHint``, ``idempotentHint``,
+        ``openWorldHint``) merged over the publishing surface's defaults -- see
+        :mod:`agno.tools.annotations`.
         """
         from agno.tools.component import ComponentTool
 
-        return ComponentTool(component=self, name=name, description=description)
+        return ComponentTool(component=self, name=name, description=description, title=title, annotations=annotations)
 
     def set_id(self) -> None:
         return _init.set_id(self)

--- a/libs/agno/agno/tools/annotations.py
+++ b/libs/agno/agno/tools/annotations.py
@@ -1,0 +1,91 @@
+"""Tool annotation hints (MCP ``ToolAnnotations``) and their validation.
+
+Annotations tell a client what a tool DOES to the world -- whether it only reads,
+whether a call can destroy something, whether it reaches outside the server. Assistant
+marketplaces read them: a submission scan rejects tools that carry none, and reviewers
+test the claim against the tool's real behaviour, so a wrong hint is worse than a
+missing one.
+
+The keys are fixed by the protocol. They are validated where the developer writes them
+(``as_tool(annotations=...)``, ``@tool(annotations=...)``) rather than at registration,
+because a silent typo -- ``readonlyHint`` for ``readOnlyHint`` -- forwards as an unknown
+key, reads as "no annotation" to a reviewing client, and is only discovered when a
+listing is rejected.
+"""
+
+from difflib import get_close_matches
+from typing import Any, Dict, Mapping, Optional
+
+# The MCP ToolAnnotations fields: a display title plus four behaviour hints.
+TOOL_ANNOTATION_HINTS = ("readOnlyHint", "destructiveHint", "idempotentHint", "openWorldHint")
+TOOL_ANNOTATION_KEYS = ("title",) + TOOL_ANNOTATION_HINTS
+
+
+def validate_tool_annotations(annotations: Optional[Mapping[str, Any]], source: str) -> Optional[Dict[str, Any]]:
+    """Return ``annotations`` as a plain dict, rejecting keys the protocol does not define.
+
+    ``source`` names the call the developer wrote, so the error points at their code.
+    A ``None`` VALUE is legal and meaningful: it removes a key the surface would
+    otherwise supply by default. A ``None`` mapping means "no annotations given".
+    """
+    if annotations is None:
+        return None
+    if not isinstance(annotations, Mapping):
+        raise TypeError(f"{source} expects a dict of tool annotations, got {type(annotations).__name__}.")
+
+    validated: Dict[str, Any] = {}
+    for key, value in annotations.items():
+        if key not in TOOL_ANNOTATION_KEYS:
+            suggestion = get_close_matches(str(key), TOOL_ANNOTATION_KEYS, n=1, cutoff=0.6)
+            hint = f" Did you mean {suggestion[0]!r}?" if suggestion else ""
+            raise ValueError(
+                f"{source} got unknown tool annotation {key!r}.{hint} "
+                f"Valid annotations: {', '.join(TOOL_ANNOTATION_KEYS)}."
+            )
+        if value is not None:
+            if key == "title" and not isinstance(value, str):
+                raise TypeError(f"{source} expects annotation 'title' to be a string, got {type(value).__name__}.")
+            if key in TOOL_ANNOTATION_HINTS and not isinstance(value, bool):
+                raise TypeError(f"{source} expects annotation {key!r} to be a bool, got {type(value).__name__}.")
+        validated[key] = value
+    return validated
+
+
+def merge_tool_annotations(defaults: Mapping[str, Any], overrides: Optional[Mapping[str, Any]]) -> Dict[str, Any]:
+    """Merge developer overrides over a surface's defaults, per key.
+
+    A key set to ``None`` in the overrides is REMOVED from the result rather than
+    emitted as null -- the way to publish a tool without a hint the surface would
+    otherwise assert on the developer's behalf.
+    """
+    merged: Dict[str, Any] = dict(defaults)
+    for key, value in (overrides or {}).items():
+        if value is None:
+            merged.pop(key, None)
+        else:
+            merged[key] = value
+    return merged
+
+
+def tool_presentation(
+    title: Optional[str],
+    annotations: Optional[Mapping[str, Any]],
+    defaults: Optional[Mapping[str, Any]] = None,
+    fallback_title: Optional[str] = None,
+) -> "tuple[Optional[str], Optional[Dict[str, Any]]]":
+    """The ``(title, annotations)`` a tool publishes, resolved and merged in one place.
+
+    A tool carries its title in two protocol slots: its own ``title`` field, and the
+    older ``annotations.title`` that pre-2025-06-18 clients read. They are one setting,
+    not two -- whichever the developer wrote fills both, so no client can be shown a
+    different name than another. Every surface that registers a tool goes through here,
+    so the next one added cannot fill only one slot.
+    """
+    from_annotations = (annotations or {}).get("title")
+    resolved_title = (
+        title or (from_annotations if isinstance(from_annotations, str) else None) or fallback_title or None
+    )
+    merged = merge_tool_annotations(defaults or {}, annotations)
+    if resolved_title:
+        merged["title"] = resolved_title
+    return resolved_title, (merged or None)

--- a/libs/agno/agno/tools/annotations.py
+++ b/libs/agno/agno/tools/annotations.py
@@ -80,6 +80,7 @@ def tool_presentation(
     annotations: Optional[Mapping[str, Any]],
     defaults: Optional[Mapping[str, Any]] = None,
     fallback_title: Optional[str] = None,
+    source: str = "annotations",
 ) -> "tuple[Optional[str], Optional[Dict[str, Any]]]":
     """The ``(title, annotations)`` a tool publishes, resolved and merged in one place.
 
@@ -88,7 +89,14 @@ def tool_presentation(
     not two -- whichever the developer wrote fills both, so no client can be shown a
     different name than another. Every surface that registers a tool goes through here,
     so the next one added cannot fill only one slot.
+
+    Annotations are re-validated here, not only where they were first written. A
+    carrier's dict stays mutable after it is validated -- ``Function.from_callable``
+    hands back a Function precisely so callers can adjust it, and a frozen marker's
+    dict is still a dict -- so publication, not construction, is the last point at
+    which an unknown key can still be caught before a client sees it.
     """
+    annotations = validate_tool_annotations(annotations, source)
     from_annotations = (annotations or {}).get("title")
     resolved_title = (
         title or (from_annotations if isinstance(from_annotations, str) else None) or fallback_title or None

--- a/libs/agno/agno/tools/annotations.py
+++ b/libs/agno/agno/tools/annotations.py
@@ -6,6 +6,14 @@ marketplaces read them: a submission scan rejects tools that carry none, and rev
 test the claim against the tool's real behaviour, so a wrong hint is worse than a
 missing one.
 
+Publish all three of ``readOnlyHint``, ``destructiveHint``, and ``openWorldHint`` on
+every tool. A submission scan rejects a tool that leaves any of them unset, and an
+omitted hint is not read as "unknown" by a client -- it falls back to a protocol
+default, which answers for the tool whether or not that answer is true. Components
+published through ``as_tool`` get all three from the serving surface; a plain callable
+carries none, so a tool that is going to be listed should be an agno ``Function``
+(``@tool(annotations=...)``) that states them.
+
 The keys are fixed by the protocol. They are validated where the developer writes them
 (``as_tool(annotations=...)``, ``@tool(annotations=...)``) rather than at registration,
 because a silent typo -- ``readonlyHint`` for ``readOnlyHint`` -- forwards as an unknown

--- a/libs/agno/agno/tools/component.py
+++ b/libs/agno/agno/tools/component.py
@@ -1,18 +1,22 @@
 """Declarative marker for publishing a component (Agent/Team/Workflow) as a tool."""
 
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Dict, Optional
+
+from agno.tools.annotations import validate_tool_annotations
 
 
 @dataclass(frozen=True)
 class ComponentTool:
-    """Publish an Agent, Team, or Workflow as a tool under its own model-facing name
-    and description.
+    """Publish an Agent, Team, or Workflow as a tool under its own model-facing name,
+    description, title, and behaviour annotations.
 
     Built via ``component.as_tool(name=..., description=...)`` and consumed by surfaces
     that turn components into tools -- today the AgentOS MCP server
-    (``MCPConfig(tools=[...])``). Both overrides are optional: an omitted ``name`` falls
-    back to the component id, an omitted ``description`` to the component's own.
+    (``MCPConfig(tools=[...])``). Every override is optional: an omitted ``name`` falls
+    back to the component id, an omitted ``description`` to the component's own, an
+    omitted ``title`` to the component name (never fetched from a remote just for a
+    title), and omitted ``annotations`` to the surface's defaults.
 
     This is a MARKER, not a callable: binding the component into a plain function here
     would bypass the consuming surface's machinery (for MCP: scope checks, session
@@ -21,11 +25,25 @@ class ComponentTool:
 
     The tool ``name`` is model-facing UX; the component id remains the handle for
     continue_run/get_sessions and the per-resource scope segment (``agents:<id>:run``).
+
+    ``title`` is the human-facing display name a client shows in place of the tool name;
+    ``annotations`` are the MCP behaviour hints (``readOnlyHint`` and friends) merged
+    over the publishing surface's defaults, where a ``None`` value drops a default.
     """
 
     component: Any
     name: Optional[str] = None
     description: Optional[str] = None
+    title: Optional[str] = None
+    annotations: Optional[Dict[str, Any]] = None
+
+    def __post_init__(self) -> None:
+        # Validate where the developer typed it: an unknown annotation key reaches a
+        # reviewing client as "no annotation at all", which is a listing rejection.
+        # Store the validated COPY -- the freeze is shallow, so holding the caller's own
+        # dict would let a later edit to it put an unchecked key on a validated marker.
+        validated = validate_tool_annotations(self.annotations, "as_tool(annotations=...)")
+        object.__setattr__(self, "annotations", validated)
 
 
 def raise_if_component_tool(tool: Any, owner: str, delegate_hint: str) -> None:

--- a/libs/agno/agno/tools/decorator.py
+++ b/libs/agno/agno/tools/decorator.py
@@ -62,6 +62,8 @@ def tool(
     *,
     name: Optional[str] = None,
     description: Optional[str] = None,
+    title: Optional[str] = None,
+    annotations: Optional[Dict[str, Any]] = None,
     strict: Optional[bool] = None,
     instructions: Optional[str] = None,
     add_instructions: bool = True,
@@ -91,6 +93,9 @@ def tool(*args, **kwargs) -> Union[Function, Callable[[F], Function]]:
     Args:
         name: Optional[str] - Override for the function name
         description: Optional[str] - Override for the function description
+        title: Optional[str] - Human-facing display name for clients that render tools to people
+        annotations: Optional[Dict[str, Any]] - MCP behaviour hints (readOnlyHint,
+            destructiveHint, idempotentHint, openWorldHint) published alongside the tool
         strict: Optional[bool] - Flag for strict parameter checking
         instructions: Optional[str] - Instructions for using the tool
         add_instructions: bool - If True, add instructions to the system message
@@ -129,6 +134,8 @@ def tool(*args, **kwargs) -> Union[Function, Callable[[F], Function]]:
         {
             "name",
             "description",
+            "title",
+            "annotations",
             "strict",
             "instructions",
             "add_instructions",

--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -1409,16 +1409,21 @@ def isolated_runtime_value(value: Any) -> Any:
     ``UserInputField`` objects, so one run's input would be visible to every
     other component holding that tool, and to the registry itself.
 
-    Lists are rebuilt rather than deep-copied, so callables such as tool hooks
-    stay the same objects; only dataclass elements are copied, because those
-    are the ones written in place. No RUNTIME_ONLY_FIELDS entry holds a dict,
-    so lists are the only containers handled.
+    Containers are rebuilt one level deep rather than deep-copied, so callables
+    such as tool hooks stay the same objects; only dataclass elements are copied,
+    because those are the ones written in place. Both list and dict entries are
+    handled -- ``annotations`` is a dict, and sharing it would let one component's
+    edit change what every other component and the registry itself publish.
     """
     from copy import copy
     from dataclasses import is_dataclass
 
     if isinstance(value, list):
         return [copy(item) if is_dataclass(item) else item for item in value]
+    if isinstance(value, dict):
+        # Shallow is enough: annotation values are bools and strings, enforced by
+        # validate_tool_annotations at construction.
+        return dict(value)
     return value
 
 

--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -25,11 +25,12 @@ from typing import (
 
 from docstring_parser import parse
 from packaging.version import Version
-from pydantic import BaseModel, Field, validate_call
+from pydantic import BaseModel, Field, field_validator, validate_call
 
 from agno.exceptions import AgentRunException, RunCancelledException
 from agno.media import Audio, File, Image, Video
 from agno.run import RunContext
+from agno.tools.annotations import validate_tool_annotations
 from agno.utils.log import log_debug, log_exception, log_warning
 
 T = TypeVar("T")
@@ -1391,6 +1392,11 @@ RUNTIME_ONLY_FIELDS = (
     # A code-declared trait that discovery reports; the live registry Function
     # owns it, not the persisted config.
     "has_side_effects",
+    # Presentation for people and clients, declared in code alongside the tool.
+    # Restored from the live Function so a reloaded component publishes the same
+    # title and behaviour hints a fresh one does.
+    "title",
+    "annotations",
 )
 
 
@@ -1424,6 +1430,17 @@ class Function(BaseModel):
     name: str
     # A description of what the function does, used by the model to choose when and how to call the function.
     description: Optional[str] = None
+    # Human-facing display name, shown by clients that render tools to people (an MCP
+    # server, an assistant marketplace listing). Never sent to the model, which reads
+    # name/description/parameters: to_dict() serializes an explicit allowlist.
+    title: Optional[str] = None
+    # MCP behaviour hints (readOnlyHint, destructiveHint, idempotentHint, openWorldHint)
+    # published alongside the tool. Marketplace submission scans reject tools that carry
+    # none, and reviewers test the hints against what the tool actually does.
+    # readOnlyHint is the published form of has_side_effects below: set one, or keep the
+    # two consistent -- a tool that declares side effects and claims read-only is making
+    # opposite claims to agno's own discovery and to an MCP client.
+    annotations: Optional[Dict[str, Any]] = None
     # The parameters the functions accepts, described as a JSON Schema object.
     # To describe a function that accepts no parameters, provide the value {"type": "object", "properties": {}}.
     parameters: Dict[str, Any] = Field(
@@ -1513,6 +1530,14 @@ class Function(BaseModel):
     _videos: Optional[Sequence[Video]] = None
     _audios: Optional[Sequence[Audio]] = None
     _files: Optional[Sequence[File]] = None
+
+    @field_validator("annotations")
+    @classmethod
+    def _validate_annotations(cls, annotations: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+        # The MCP annotations model accepts unknown keys, so a misspelled hint would
+        # travel all the way to a client as "no such annotation". Reject it here, where
+        # the developer wrote it.
+        return validate_tool_annotations(annotations, "Function(annotations=...)")
 
     def to_dict(self) -> Dict[str, Any]:
         return self.model_dump(exclude_none=True, include=set(SERIALIZED_FIELDS))

--- a/libs/agno/agno/tools/toolkit.py
+++ b/libs/agno/agno/tools/toolkit.py
@@ -409,6 +409,8 @@ class Toolkit:
         f = Function(
             name=tool_name,
             description=function.description,
+            title=function.title,
+            annotations=function.annotations,
             parameters=function.parameters,
             strict=function.strict,
             instructions=function.instructions,

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -734,19 +734,31 @@ class Workflow:
                 "History won't be persisted. Add a database to persist runs across executions. "
             )
 
-    def as_tool(self, name: Optional[str] = None, description: Optional[str] = None) -> "ComponentTool":
-        """Publish this workflow as a tool with its own model-facing name and description.
+    def as_tool(
+        self,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        title: Optional[str] = None,
+        annotations: Optional[Dict[str, Any]] = None,
+    ) -> "ComponentTool":
+        """Publish this workflow as a tool with its own model-facing name, description,
+        title, and behaviour annotations.
 
         Returns a declarative :class:`~agno.tools.component.ComponentTool` marker
         for surfaces that turn components into tools -- today the AgentOS MCP server:
-        ``MCPConfig(tools=[brief.as_tool(name="ask_brief", description=...)])``. Both
-        overrides are optional; the tool name must be a valid tool identifier (start
+        ``MCPConfig(tools=[brief.as_tool(name="ask_brief", description=...)])``. Every
+        override is optional; the tool name must be a valid tool identifier (start
         with a letter or underscore, then letters/digits/hyphens/underscores). The
         workflow id remains the continue_run handle and the scope segment.
+
+        ``title`` is the human-facing display name; ``annotations`` are MCP behaviour
+        hints (``readOnlyHint``, ``destructiveHint``, ``idempotentHint``,
+        ``openWorldHint``) merged over the publishing surface's defaults -- see
+        :mod:`agno.tools.annotations`.
         """
         from agno.tools.component import ComponentTool
 
-        return ComponentTool(component=self, name=name, description=description)
+        return ComponentTool(component=self, name=name, description=description, title=title, annotations=annotations)
 
     def set_id(self) -> None:
         if self.id is None:

--- a/libs/agno/tests/unit/os/test_mcp_tool_metadata.py
+++ b/libs/agno/tests/unit/os/test_mcp_tool_metadata.py
@@ -145,6 +145,22 @@ async def test_the_explicit_title_wins_when_both_slots_are_set():
     assert published.annotations.title == "Ask the Chief"
 
 
+async def test_a_local_component_keeps_its_name_as_the_title_under_both_overrides():
+    """The metadata skip exists so an unreachable REMOTE cannot block the build. A local
+    component's metadata is a plain attribute read, so overriding name and description
+    must not cost it the documented component-name title fallback."""
+    agent = _agent()
+    os = AgentOS(
+        agents=[agent],
+        mcp=MCPConfig(default_tools=False, tools=[agent.as_tool(name="ask_chief", description="Ask.")]),
+    )
+
+    published = await _tool_by_name(os, "ask_chief")
+
+    assert published.title == "Chief of Staff"
+    assert published.annotations.title == "Chief of Staff"
+
+
 async def test_remote_with_overrides_and_no_title_still_skips_the_metadata_fetch(monkeypatch):
     """A remote's name is a network-backed property that blocks to the timeout when the
     remote is unreachable. Filling a DISPLAY TITLE must never be the thing that triggers
@@ -270,6 +286,22 @@ async def test_toolkit_method_publishes_the_metadata_its_decorator_declared():
     assert published.annotations.openWorldHint is True
 
 
+def test_rehydrated_annotations_are_isolated_from_the_registry_source():
+    """Restoring a runtime-only field by reference would let one component's edit change
+    what every other component -- and the registry itself -- publishes."""
+    from agno.tools.function import isolated_runtime_value
+
+    source = {"readOnlyHint": False, "destructiveHint": True}
+
+    first = isolated_runtime_value(source)
+    second = isolated_runtime_value(source)
+    first["destructiveHint"] = False
+
+    assert first is not source and second is not source
+    assert second == {"readOnlyHint": False, "destructiveHint": True}
+    assert source == {"readOnlyHint": False, "destructiveHint": True}
+
+
 def test_presentation_survives_a_registry_reload():
     """to_dict() deliberately omits presentation, so the registry restores it from the
     live Function instead -- a reloaded component must publish the same title and hints
@@ -356,18 +388,20 @@ async def test_presentation_is_never_duck_typed_off_a_non_function_tool():
 # --------------------------------------------------------------------------------------
 
 
-# What each built-in claims about itself, as (readOnlyHint, destructiveHint). A wrong
-# hint is worse than a missing one -- a reviewer tests these against real behaviour --
-# so the values are pinned per tool, not just checked for presence.
+# What each built-in claims about itself, as (readOnlyHint, destructiveHint,
+# openWorldHint). A wrong hint is worse than a missing one -- a reviewer tests these
+# against real behaviour -- so every value is pinned per tool rather than checked for
+# presence. The run tools reach an open world because the component they run may call
+# anything; the config and session tools only read this deployment's own state.
 _BUILTIN_HINTS = {
-    "get_agentos_config": (True, None),
-    "run_agent": (False, True),
-    "run_team": (False, True),
-    "run_workflow": (False, True),
-    "continue_run": (False, True),
-    "cancel_run": (False, True),
-    "get_sessions": (True, None),
-    "get_session_runs": (True, None),
+    "get_agentos_config": (True, False, False),
+    "run_agent": (False, True, True),
+    "run_team": (False, True, True),
+    "run_workflow": (False, True, True),
+    "continue_run": (False, True, True),
+    "cancel_run": (False, True, False),
+    "get_sessions": (True, False, False),
+    "get_session_runs": (True, False, False),
 }
 
 
@@ -379,17 +413,29 @@ async def test_every_builtin_tool_publishes_the_hints_it_claims():
 
     assert set(published) == set(mcp_mod._BUILTIN_TOOL_NAMES) == set(_BUILTIN_HINTS)
     for name, entry in published.items():
-        read_only, destructive = _BUILTIN_HINTS[name]
+        read_only, destructive, open_world = _BUILTIN_HINTS[name]
         assert entry.title, f"{name} has no title"
         assert entry.description, f"{name} has no description"
         assert entry.annotations is not None, f"{name} has no annotations"
         assert entry.annotations.readOnlyHint is read_only, f"{name} readOnlyHint changed"
         assert entry.annotations.destructiveHint is destructive, f"{name} destructiveHint changed"
-        # A tool that is not read-only must say whether its write destroys something,
-        # rather than leaving a client to fall back on the protocol default (true).
-        if entry.annotations.readOnlyHint is False:
-            assert entry.annotations.destructiveHint is not None, f"{name} writes but omits destructiveHint"
+        assert entry.annotations.openWorldHint is open_world, f"{name} openWorldHint changed"
         assert entry.annotations.title == entry.title, f"{name} title not mirrored into annotations"
+
+
+async def test_no_tool_this_server_owns_leaves_a_required_hint_unset():
+    """A submission scan rejects a tool that leaves readOnlyHint, destructiveHint, or
+    openWorldHint unset, and an omitted hint is answered by a protocol default rather
+    than read as "unknown". Every tool the server itself composes states all three."""
+    agent = _agent()
+    os = AgentOS(
+        agents=[agent],
+        mcp=MCPConfig(tools=[agent, agent.as_tool(name="ask_chief", description="Ask.")]),
+    )
+
+    for name, entry in (await _tools_by_name(os)).items():
+        for hint in ("readOnlyHint", "destructiveHint", "openWorldHint"):
+            assert getattr(entry.annotations, hint) is not None, f"{name} leaves {hint} unset"
 
 
 # --------------------------------------------------------------------------------------

--- a/libs/agno/tests/unit/os/test_mcp_tool_metadata.py
+++ b/libs/agno/tests/unit/os/test_mcp_tool_metadata.py
@@ -241,6 +241,43 @@ def test_validation_stores_a_copy_so_a_later_edit_cannot_smuggle_a_key_in():
     assert marker.annotations == {"readOnlyHint": True}
 
 
+async def test_an_annotation_written_after_construction_is_still_caught():
+    """Construction-time validation cannot be the only gate: from_callable hands back a
+    Function precisely so callers can adjust it, and it accepts no annotations, so
+    assignment is the only way to annotate one. Publication is the last point a typo
+    can be caught before a client sees it."""
+
+    def lookup(city: str) -> str:
+        """Look something up."""
+        return "x"
+
+    fn = Function.from_callable(lookup)
+    fn.annotations = {"readonlyHint": True}  # never passed through a validator
+
+    os = AgentOS(agents=[_agent()], mcp=MCPConfig(default_tools=False, tools=[fn]))
+
+    with pytest.raises(ValueError) as excinfo:
+        await _tools_by_name(os)
+
+    assert "readonlyHint" in str(excinfo.value)
+    assert "'readOnlyHint'" in str(excinfo.value)
+
+
+async def test_an_annotation_mutated_in_place_is_still_caught():
+    """The dict a validated carrier holds stays mutable; only re-reading it at publish
+    time sees what it actually says now."""
+    agent = _agent()
+    marker = agent.as_tool(annotations={"readOnlyHint": True})
+    marker.annotations["destructivehint"] = True  # in place, after validation
+
+    os = AgentOS(agents=[agent], mcp=MCPConfig(default_tools=False, tools=[marker]))
+
+    with pytest.raises(ValueError) as excinfo:
+        await _tools_by_name(os)
+
+    assert "destructivehint" in str(excinfo.value)
+
+
 def test_function_validates_its_annotations_too():
     with pytest.raises(ValueError):
         Function(name="f", annotations={"readonlyHint": True})
@@ -392,14 +429,16 @@ async def test_presentation_is_never_duck_typed_off_a_non_function_tool():
 # openWorldHint). A wrong hint is worse than a missing one -- a reviewer tests these
 # against real behaviour -- so every value is pinned per tool rather than checked for
 # presence. The run tools reach an open world because the component they run may call
-# anything; the config and session tools only read this deployment's own state.
+# anything, and cancel_run does because cancelling a REMOTE component's run is an
+# outbound call to that deployment; the config and session tools only read storage
+# this deployment owns.
 _BUILTIN_HINTS = {
     "get_agentos_config": (True, False, False),
     "run_agent": (False, True, True),
     "run_team": (False, True, True),
     "run_workflow": (False, True, True),
     "continue_run": (False, True, True),
-    "cancel_run": (False, True, False),
+    "cancel_run": (False, True, True),
     "get_sessions": (True, False, False),
     "get_session_runs": (True, False, False),
 }

--- a/libs/agno/tests/unit/os/test_mcp_tool_metadata.py
+++ b/libs/agno/tests/unit/os/test_mcp_tool_metadata.py
@@ -1,0 +1,422 @@
+"""Unit tests for the presentation metadata MCP tools publish: ``title`` and ``annotations``.
+
+Assistant marketplaces read this metadata when they review a listing: a submission scan
+rejects tools that carry no annotations, and reviewers test the hints against what the
+tool actually does. These tests cover the three paths that put a tool on the server --
+exposed components, custom tools, and the built-ins -- plus the validation that stops a
+misspelled hint from reaching a client as "no such annotation".
+
+The FastMCP tool surface is exercised with an in-memory client, matching
+test_mcp_exposed_components.py.
+"""
+
+import pytest
+
+pytest.importorskip("fastmcp")
+
+from typing import Optional  # noqa: E402
+
+from fastmcp import Client  # noqa: E402
+
+import agno.os.mcp as mcp_mod  # noqa: E402
+from agno.agent import Agent  # noqa: E402
+from agno.os import AgentOS, MCPConfig  # noqa: E402
+from agno.os.mcp import build_mcp_server  # noqa: E402
+from agno.tools import tool  # noqa: E402
+from agno.tools.function import Function  # noqa: E402
+
+
+def _agent(id: str = "chief", name: Optional[str] = "Chief of Staff") -> Agent:
+    return Agent(id=id, name=name, description="Runs the day.")
+
+
+async def _tools_by_name(os: AgentOS) -> dict:
+    async with Client(build_mcp_server(os)) as client:
+        return {t.name: t for t in await client.list_tools()}
+
+
+async def _tool_by_name(os: AgentOS, name: str):
+    return (await _tools_by_name(os))[name]
+
+
+# --------------------------------------------------------------------------------------
+# Exposed components
+# --------------------------------------------------------------------------------------
+
+
+async def test_bare_component_titles_from_its_name_and_carries_default_annotations():
+    """A published component says what a run does before the deployer says anything:
+    not read-only, potentially destructive, reaching beyond this server."""
+    agent = _agent()
+    os = AgentOS(agents=[agent], mcp=MCPConfig(default_tools=False, tools=[agent]))
+
+    published = await _tool_by_name(os, "chief")
+
+    assert published.title == "Chief of Staff"
+    assert published.annotations.readOnlyHint is False
+    assert published.annotations.destructiveHint is True
+    assert published.annotations.openWorldHint is True
+
+
+async def test_as_tool_overrides_title_and_merges_annotations_per_key():
+    """The override replaces only the keys it names; the rest of the defaults stand."""
+    agent = _agent()
+    os = AgentOS(
+        agents=[agent],
+        mcp=MCPConfig(
+            default_tools=False,
+            tools=[agent.as_tool(name="ask_chief", title="Ask the Chief", annotations={"readOnlyHint": True})],
+        ),
+    )
+
+    published = await _tool_by_name(os, "ask_chief")
+
+    assert published.title == "Ask the Chief"
+    assert published.annotations.readOnlyHint is True
+    # untouched by the override, so still the surface default
+    assert published.annotations.destructiveHint is True
+    assert published.annotations.openWorldHint is True
+
+
+async def test_annotation_set_to_none_removes_the_default_instead_of_publishing_null():
+    """The way to publish a tool WITHOUT a hint the surface would otherwise assert."""
+    agent = _agent()
+    os = AgentOS(
+        agents=[agent],
+        mcp=MCPConfig(default_tools=False, tools=[agent.as_tool(annotations={"destructiveHint": None})]),
+    )
+
+    published = await _tool_by_name(os, "chief")
+
+    assert published.annotations.destructiveHint is None
+    assert published.annotations.openWorldHint is True
+
+
+async def test_title_falls_back_to_the_tool_name_when_the_component_is_unnamed():
+    agent = _agent(id="chief", name=None)
+    os = AgentOS(agents=[agent], mcp=MCPConfig(default_tools=False, tools=[agent]))
+
+    assert (await _tool_by_name(os, "chief")).title == "chief"
+
+
+async def test_title_is_mirrored_into_annotations_for_older_clients():
+    """A client reading either title slot must be shown the same name."""
+    agent = _agent()
+    os = AgentOS(
+        agents=[agent],
+        mcp=MCPConfig(default_tools=False, tools=[agent.as_tool(title="Ask the Chief")]),
+    )
+
+    published = await _tool_by_name(os, "chief")
+
+    assert published.title == "Ask the Chief"
+    assert published.annotations.title == "Ask the Chief"
+
+
+async def test_title_given_only_in_annotations_is_promoted_to_the_tool_title():
+    """One setting, two protocol slots -- whichever the developer wrote fills both."""
+    agent = _agent()
+    os = AgentOS(
+        agents=[agent],
+        mcp=MCPConfig(default_tools=False, tools=[agent.as_tool(annotations={"title": "Legacy Slot"})]),
+    )
+
+    published = await _tool_by_name(os, "chief")
+
+    assert published.title == "Legacy Slot"
+    assert published.annotations.title == "Legacy Slot"
+
+
+async def test_the_explicit_title_wins_when_both_slots_are_set():
+    """Both slots are one setting, so their tie-break is real API surface: the tool's
+    own title field is the one a developer means."""
+    agent = _agent()
+    os = AgentOS(
+        agents=[agent],
+        mcp=MCPConfig(
+            default_tools=False,
+            tools=[agent.as_tool(title="Ask the Chief", annotations={"title": "Legacy Slot"})],
+        ),
+    )
+
+    published = await _tool_by_name(os, "chief")
+
+    assert published.title == "Ask the Chief"
+    assert published.annotations.title == "Ask the Chief"
+
+
+async def test_remote_with_overrides_and_no_title_still_skips_the_metadata_fetch(monkeypatch):
+    """A remote's name is a network-backed property that blocks to the timeout when the
+    remote is unreachable. Filling a DISPLAY TITLE must never be the thing that triggers
+    that read: the tool name is the fallback instead."""
+    from agno.team.remote import RemoteTeam
+
+    def _boom(component):
+        raise AssertionError("metadata was fetched just to fill a title")
+
+    monkeypatch.setattr(mcp_mod, "_safe_component_metadata", _boom)
+    remote = RemoteTeam(base_url="http://127.0.0.1:9", team_id="remote-team")
+    os = AgentOS(
+        teams=[remote],
+        mcp=MCPConfig(
+            default_tools=False,
+            tools=[remote.as_tool(name="ask_remote", description="Ask the remote team.")],
+        ),
+    )
+
+    published = await _tool_by_name(os, "ask_remote")
+
+    assert published.title == "ask_remote"
+
+
+# --------------------------------------------------------------------------------------
+# Validation
+# --------------------------------------------------------------------------------------
+
+
+def test_misspelled_annotation_is_refused_with_a_suggestion():
+    """ToolAnnotations accepts unknown keys, so an unchecked typo reaches a reviewing
+    client as "no such annotation" -- a listing rejection discovered at review time."""
+    with pytest.raises(ValueError) as excinfo:
+        _agent().as_tool(annotations={"readonlyHint": True})
+
+    message = str(excinfo.value)
+    assert "readonlyHint" in message
+    assert "'readOnlyHint'" in message
+
+
+def test_unknown_annotation_without_a_close_match_still_lists_the_valid_keys():
+    with pytest.raises(ValueError) as excinfo:
+        _agent().as_tool(annotations={"totallyMadeUp": True})
+
+    assert "readOnlyHint" in str(excinfo.value)
+
+
+def test_non_bool_hint_is_refused():
+    with pytest.raises(TypeError) as excinfo:
+        _agent().as_tool(annotations={"readOnlyHint": "yes"})
+
+    assert "readOnlyHint" in str(excinfo.value)
+
+
+def test_non_string_title_annotation_is_refused():
+    with pytest.raises(TypeError):
+        _agent().as_tool(annotations={"title": 42})
+
+
+def test_the_valid_key_list_matches_the_installed_protocol_model():
+    """The allowlist is a copy of the protocol's own field set. If an SDK bump adds a
+    hint, this fails here rather than rejecting a developer's valid annotation."""
+    from mcp.types import ToolAnnotations
+
+    from agno.tools.annotations import TOOL_ANNOTATION_KEYS
+
+    assert set(TOOL_ANNOTATION_KEYS) == set(ToolAnnotations.model_fields)
+
+
+def test_validation_stores_a_copy_so_a_later_edit_cannot_smuggle_a_key_in():
+    """The marker is frozen, but a dict field is not: keeping the caller's own dict
+    would let an edit after construction put an unchecked key on a validated marker."""
+    developer_dict = {"readOnlyHint": True}
+    marker = _agent().as_tool(annotations=developer_dict)
+
+    developer_dict["readonlyHint"] = True
+
+    assert marker.annotations == {"readOnlyHint": True}
+
+
+def test_function_validates_its_annotations_too():
+    with pytest.raises(ValueError):
+        Function(name="f", annotations={"readonlyHint": True})
+
+
+def test_tool_decorator_accepts_title_and_annotations():
+    @tool(title="Weather Lookup", annotations={"readOnlyHint": True})
+    def get_weather(city: str) -> str:
+        """Look up the weather."""
+        return "sunny"
+
+    assert get_weather.title == "Weather Lookup"
+    assert get_weather.annotations == {"readOnlyHint": True}
+
+
+# --------------------------------------------------------------------------------------
+# Custom tools
+# --------------------------------------------------------------------------------------
+
+
+async def test_toolkit_method_publishes_the_metadata_its_decorator_declared():
+    """A Toolkit rebuilds each decorated method into a fresh Function, so presentation
+    has to survive that rebuild -- otherwise the same @tool arguments publish annotations
+    from a module-level function and nothing from a toolkit method."""
+    from agno.tools.toolkit import Toolkit
+
+    class WeatherKit(Toolkit):
+        def __init__(self):
+            super().__init__(name="weather", tools=[self.get_weather])
+
+        @tool(title="Weather Lookup", annotations={"readOnlyHint": True, "openWorldHint": True})
+        def get_weather(self, city: str) -> str:
+            """Look up the weather."""
+            return "sunny"
+
+    kit = WeatherKit()
+    os = AgentOS(agents=[_agent()], mcp=MCPConfig(default_tools=False, tools=[kit.functions["get_weather"]]))
+
+    published = await _tool_by_name(os, "get_weather")
+
+    assert published.title == "Weather Lookup"
+    assert published.annotations.readOnlyHint is True
+    assert published.annotations.openWorldHint is True
+
+
+def test_presentation_survives_a_registry_reload():
+    """to_dict() deliberately omits presentation, so the registry restores it from the
+    live Function instead -- a reloaded component must publish the same title and hints
+    a fresh one does."""
+    from agno.tools.function import RUNTIME_ONLY_FIELDS, SERIALIZED_FIELDS
+
+    unaccounted = set(Function.model_fields) - set(SERIALIZED_FIELDS) - set(RUNTIME_ONLY_FIELDS)
+
+    assert "title" not in unaccounted
+    assert "annotations" not in unaccounted
+
+
+async def test_custom_tool_publishes_its_title_and_annotations():
+    @tool(title="Weather Lookup", annotations={"readOnlyHint": True, "openWorldHint": True})
+    def get_weather(city: str) -> str:
+        """Look up the weather."""
+        return "sunny"
+
+    os = AgentOS(agents=[_agent()], mcp=MCPConfig(default_tools=False, tools=[get_weather]))
+
+    published = await _tool_by_name(os, "get_weather")
+
+    assert published.title == "Weather Lookup"
+    assert published.annotations.title == "Weather Lookup"
+    assert published.annotations.readOnlyHint is True
+    assert published.annotations.openWorldHint is True
+
+
+async def test_custom_tool_title_given_only_in_annotations_is_promoted():
+    """The same one-setting-two-slots rule the exposed path follows."""
+
+    @tool(annotations={"title": "Legacy Slot", "readOnlyHint": True})
+    def legacy(city: str) -> str:
+        """Title set via annotations only."""
+        return "x"
+
+    os = AgentOS(agents=[_agent()], mcp=MCPConfig(default_tools=False, tools=[legacy]))
+
+    published = await _tool_by_name(os, "legacy")
+
+    assert published.title == "Legacy Slot"
+    assert published.annotations.title == "Legacy Slot"
+
+
+async def test_plain_callable_registers_without_annotations():
+    """No metadata is invented for a bare callable, and nothing crashes for the lack
+    of it."""
+
+    def ping() -> str:
+        """Ping."""
+        return "pong"
+
+    os = AgentOS(agents=[_agent()], mcp=MCPConfig(default_tools=False, tools=[ping]))
+
+    published = await _tool_by_name(os, "ping")
+
+    assert published.annotations is None
+
+
+async def test_presentation_is_never_duck_typed_off_a_non_function_tool():
+    """A stray ``.annotations`` attribute on some other tool-shaped object means
+    something else entirely; only an Agno Function publishes annotations."""
+
+    class ToolLike:
+        name = "look_alike"
+        description = "Not an Agno Function."
+        title = "Should Not Be Used"
+        annotations = {"readOnlyHint": True}
+
+        @staticmethod
+        def entrypoint() -> str:
+            return "x"
+
+    os = AgentOS(agents=[_agent()], mcp=MCPConfig(default_tools=False, tools=[ToolLike()]))
+
+    published = await _tool_by_name(os, "look_alike")
+
+    assert published.title is None
+    assert published.annotations is None
+
+
+# --------------------------------------------------------------------------------------
+# Built-ins
+# --------------------------------------------------------------------------------------
+
+
+# What each built-in claims about itself, as (readOnlyHint, destructiveHint). A wrong
+# hint is worse than a missing one -- a reviewer tests these against real behaviour --
+# so the values are pinned per tool, not just checked for presence.
+_BUILTIN_HINTS = {
+    "get_agentos_config": (True, None),
+    "run_agent": (False, True),
+    "run_team": (False, True),
+    "run_workflow": (False, True),
+    "continue_run": (False, True),
+    "cancel_run": (False, True),
+    "get_sessions": (True, None),
+    "get_session_runs": (True, None),
+}
+
+
+async def test_every_builtin_tool_publishes_the_hints_it_claims():
+    """The bar a listing review applies to a customer's tools, applied to our own."""
+    os = AgentOS(agents=[_agent()], mcp=MCPConfig())
+
+    published = await _tools_by_name(os)
+
+    assert set(published) == set(mcp_mod._BUILTIN_TOOL_NAMES) == set(_BUILTIN_HINTS)
+    for name, entry in published.items():
+        read_only, destructive = _BUILTIN_HINTS[name]
+        assert entry.title, f"{name} has no title"
+        assert entry.description, f"{name} has no description"
+        assert entry.annotations is not None, f"{name} has no annotations"
+        assert entry.annotations.readOnlyHint is read_only, f"{name} readOnlyHint changed"
+        assert entry.annotations.destructiveHint is destructive, f"{name} destructiveHint changed"
+        # A tool that is not read-only must say whether its write destroys something,
+        # rather than leaving a client to fall back on the protocol default (true).
+        if entry.annotations.readOnlyHint is False:
+            assert entry.annotations.destructiveHint is not None, f"{name} writes but omits destructiveHint"
+        assert entry.annotations.title == entry.title, f"{name} title not mirrored into annotations"
+
+
+# --------------------------------------------------------------------------------------
+# The marker, and what the model sees
+# --------------------------------------------------------------------------------------
+
+
+def test_component_tool_carries_the_new_fields_and_stays_frozen():
+    from dataclasses import FrozenInstanceError
+
+    from agno.tools import ComponentTool
+
+    marker = _agent().as_tool(name="ask", description="d", title="Ask", annotations={"readOnlyHint": True})
+
+    assert isinstance(marker, ComponentTool)
+    assert (marker.name, marker.description, marker.title) == ("ask", "d", "Ask")
+    assert marker.annotations == {"readOnlyHint": True}
+    with pytest.raises(FrozenInstanceError):
+        marker.title = "Renamed"  # type: ignore[misc]
+
+
+def test_presentation_fields_never_reach_the_model_facing_schema():
+    """title/annotations are for people and clients, not for the model: to_dict() feeds
+    the tool definition sent to the provider and serializes an explicit allowlist."""
+    fn = Function(name="f", description="d", title="Display Name", annotations={"readOnlyHint": True})
+
+    serialized = fn.to_dict()
+
+    assert "title" not in serialized
+    assert "annotations" not in serialized


### PR DESCRIPTION
## Summary

Publishes the tool metadata that assistant marketplaces read when they review a listing: a display `title` and MCP behaviour `annotations` (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`).

This is the first slice of the connector-readiness work on top of #9819. OpenAI's plugin submission scan **hard-fails tools that carry no annotations** and makes you justify each boolean against observed behaviour; Claude's connector review flags tools missing titles and applicable hints. Before this PR AgentOS published no titles anywhere, and custom tools (`MCPConfig(tools=[callable])`) carried no annotations at all — so a deployment whose MCP surface included them could not pass that scan.

```python
researcher.as_tool(
    name="deep_research",
    title="Deep Research",
    description="Thorough, sourced research.",
    annotations={"readOnlyHint": True, "destructiveHint": False},
)

@tool(title="Weather Lookup", annotations={"readOnlyHint": True})
def get_weather(city: str) -> str: ...
```

**What ships**

- `title` / `annotations` on all six `as_tool()` methods (agent, team, workflow, external-agent adapter, factory, remote) via `ComponentTool`, and on the agno `Function` / `@tool` decorator.
- All three registration paths carry them: exposed components, custom tools, and the eight built-ins.
- **One title, both protocol slots.** A tool's `title` field and the older `annotations.title` are one setting — whichever the developer writes fills both, so a pre-2025-06-18 client can never show a different name than a current one. All three paths go through a single helper, so a fourth registration path cannot fill only one slot.
- **Honest defaults for a published component**: `readOnlyHint: False`, `destructiveHint: True`, `openWorldHint: True` — a run persists a session and may call side-effectful tools. Overrides merge per key; a `None` value drops a default (`annotations={"destructiveHint": None}` publishes the tool without that hint).
- **Validation where the developer writes it.** The protocol's `ToolAnnotations` model allows unknown keys, so `readonlyHint` would travel to a client as "no such annotation" and surface only when a listing is rejected. Unknown keys now raise with a closest-match suggestion; hint values are type-checked.

**Our own built-ins held to the same bar.** Three findings, each fixed here: `run_agent` / `run_team` / `run_workflow` asserted `readOnlyHint: False` but omitted `destructiveHint`; `cancel_run` stated `destructiveHint` but omitted `readOnlyHint`; and `continue_run` claimed `destructiveHint: False` while resuming exactly the work `run_agent` declares destructive.

**Filling a title never triggers a metadata fetch.** On a `Remote*` component, name is a network-backed property that blocks to the timeout when the remote is unreachable — the fallback chain is `marker.title` → component name *only when metadata was read anyway* → tool name. Pinned by a test that makes the metadata read raise.

## Type of change

- [x] New feature
- [x] Improvement

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Testing.** 25 new tests in `libs/agno/tests/unit/os/test_mcp_tool_metadata.py`; 5447 passed across `tests/unit/{os,registry,tools,agent,team,workflow,agents}` with no failures (the 41 collection errors are a pre-existing missing `pyTelegramBotAPI` extra, identical on the base branch). Live-verified twice against a running server: `cookbook/05_agent_os/14_mcp/agents_as_tools.py` over streamable HTTP, checking every tool's published title and hints and running both exposed tools to COMPLETED. `TEST_LOG.md` records the run.

**Mutation-tested.** An adversarial pass found four surviving mutations — the built-in title mirror, the custom-tool title mirror, the two-slot precedence tie-break, and wrong-vs-missing hint values — all now covered. Built-in hints are pinned per tool in an expectation table rather than checked for presence, because a wrong hint is worse than a missing one.

**No dependency floor bump needed.** `title=` and `annotations=` were verified present at the `fastmcp>=3.4.3` pin floor as well as the installed 3.4.7. One asymmetry respected in code: `Tool.from_function` takes a `ToolAnnotations` model where `mcp.tool()` accepts either that or a dict.

**Two sibling surfaces fixed after review:**
- `Function.title` / `.annotations` are in `RUNTIME_ONLY_FIELDS`, so a component saved and reloaded through the registry republishes its metadata. Without it the registry invariant test (`test_every_unserialized_field_is_restored`) fails and reloaded tools come back annotation-less.
- `Toolkit` rebuilds each decorated method into a fresh `Function`; it now carries the two fields across, so `@tool(title=..., annotations=...)` on a toolkit method behaves like the same decorator on a module-level function.

**Model-facing behaviour is unchanged.** `Function.to_dict()` serializes an explicit allowlist and feeds the provider tool definition, so the new fields never reach the model — pinned by a test.

Rebased onto `main` after #9819 merged (squash), and retargeted from `feat/mcp-agents-as-tools` to
`main`. The rebase was clean — main's squashed tree is byte-identical to the base this branch was
cut from, so no conflicts and no content drift (diffstat unchanged before and after). Re-verified
against the rebased tree: 3355 passed, 0 failed.

**Review round (2026-08-30).** Four findings from an external review, all reproduced before fixing:

- **Every tool now states all three required hints.** A submission scan rejects a tool leaving `readOnlyHint`, `destructiveHint`, or `openWorldHint` unset — an omitted hint isn't "unknown", it falls back to a protocol default that answers for the tool. Four built-ins stated only the hints that "applied": `get_agentos_config` and both session tools omitted two, `cancel_run` omitted one. All eight now state all three, pinned per tool in the test table. (Bare callables still publish none — we can't invent hints for an arbitrary function, and fabricating them risks a rejection for inaccuracy; `@tool(annotations=...)` is the supported way, now documented.)
- **The cookbook no longer claims read-only on a tool that writes.** `deep_research` persists a session row and a run row per call; the override contradicted both the default it replaced and the rule stated three lines above it. It now refines the default instead — not read-only, but non-destructive — which also makes `destructiveHint` meaningful rather than inert.
- **A local component keeps its title under both overrides.** The metadata skip exists so an unreachable remote can't block the build, but it wasn't gated on remoteness, so a named local agent published via `as_tool(name=..., description=...)` fell back to the tool name, contradicting the documented fallback. Now Remote-only.
- **Rehydrated annotations are isolated.** `isolated_runtime_value` copied lists and returned everything else by reference, on the stated grounds that no runtime-only field held a dict — which this PR made false. Every rehydrated component shared one dict with the registry. Fixed, with the docstring corrected.

One further finding (post-construction `fn.annotations = {...}` bypasses the field validator, since `Function` sets no `validate_assignment`) is accurate but unreachable: nothing in the codebase assigns post-construction, and every documented entry point is constructor-validated. Left as-is rather than changing the model config late in review.

Re-verified: 3358 passed, 0 failed; all three code fixes mutation-checked; cookbook re-run live and `TEST_LOG.md` updated.

**Second review round.** Three more findings; two acted on, plus one correction the reviewer was right about.

- **Annotations are now validated at publication, not only at construction.** `Function.from_callable` accepts no annotations and its docstring invites callers to adjust what it returns, so assignment is the only way to annotate a Function built that way — and a validated carrier's dict stays mutable, so an in-place write lands on an already-checked marker. Neither path saw a validator. Every registration path already funnels through `tool_presentation`, so the check moved there: it sees what the dict says *now*, and each caller names its source so the error points at the `as_tool`, `@tool`, or built-in that carries it. This is strictly better than the `validate_assignment` option considered earlier — it also catches in-place mutation, which construction-time validation never can.
- **`cancel_run` no longer underclaims.** It declared `openWorldHint: false` on the grounds that it touches only this deployment's own state, but cancelling a `Remote*` component's run is an outbound HTTP call to that deployment. Both the hint and the comment were wrong.
- **The custom-tool cookbook now declares its presentation.** It's the example for the path we point people at for listable tools, and it declared neither a title nor annotations.

Declined, with reasoning: the bare `chief` example inheriting `destructiveHint: true` is the point of that example — it demonstrates the conservative default the framework must use when it cannot know a component's tools, and overclaiming destructive fails safe (an extra confirmation) unlike the read-only claim that was fixed. The incomplete triples in this description are a description of a change, not shipped code.

Re-verified: 3370 passed, 0 failed; the publish-time validation mutation-checked; both cookbooks re-run live with `TEST_LOG.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)