### PR TITLE
fix: persist registry MCP toolkits from standalone Studio processes

### DIFF
--- a/libs/agno/agno/eval/suite.py
+++ b/libs/agno/agno/eval/suite.py
@@ -876,12 +876,48 @@ async def acli(
     # Connected here, after the --list and no-match early returns, so only an
     # actual run pays for (and has to tear down) live MCP sessions.
     connected_mcp_tools: List[Any] = []
-    for tool in mcp_tools or []:
-        try:
-            await tool.connect()
-            connected_mcp_tools.append(tool)
-        except Exception as exc:
-            console.print(f"[yellow]warning:[/yellow] failed to connect MCP tool: {escape(str(exc))}")
+
+    async def _close_connected_mcp_tools() -> None:
+        for tool in connected_mcp_tools:
+            try:
+                await tool.close()
+            except BaseException:
+                pass
+
+    try:
+        for tool in mcp_tools or []:
+            try:
+                await tool.connect()
+            except BaseException as exc:
+                # BaseException: the mcp client surfaces an unreachable server
+                # as CancelledError out of its cancel scopes, bypassing
+                # connect()'s own fail-soft handler. Unlike a private loop,
+                # this coroutine runs on the caller's loop where cancellation
+                # can also be genuine -- re-raise that so the host's cancel
+                # still lands (detectable on Python 3.11+; below that a
+                # genuine cancel during connect is absorbed like a failure).
+                if isinstance(exc, asyncio.CancelledError):
+                    task = asyncio.current_task()
+                    cancelling = getattr(task, "cancelling", None)
+                    if cancelling is not None and cancelling() > 0:
+                        raise
+                # A failed connect can leave partially-entered transport
+                # contexts that poison a later reconnect; connect()'s own
+                # cleanup was bypassed along with its handler.
+                safe_cleanup = getattr(tool, "_safe_cleanup", None)
+                if safe_cleanup is not None:
+                    try:
+                        maybe = safe_cleanup()
+                        if isawaitable(maybe):
+                            await maybe
+                    except BaseException:
+                        pass
+                console.print(f"[yellow]warning:[/yellow] failed to connect MCP tool: {escape(repr(exc))}")
+            else:
+                connected_mcp_tools.append(tool)
+    except BaseException:
+        await _close_connected_mcp_tools()
+        raise
 
     renderer = _CliRenderer(console=console, total=len(selected), verbose=args.verbose)
     try:
@@ -897,11 +933,7 @@ async def acli(
     finally:
         # Restore the terminal (stop the spinner) even on error or Ctrl-C.
         renderer.close()
-        for tool in connected_mcp_tools:
-            try:
-                await tool.close()
-            except Exception:
-                pass
+        await _close_connected_mcp_tools()
 
     _print_summary(console, suite)
 

--- a/libs/agno/agno/eval/suite.py
+++ b/libs/agno/agno/eval/suite.py
@@ -877,15 +877,50 @@ async def acli(
     # actual run pays for (and has to tear down) live MCP sessions.
     connected_mcp_tools: List[Any] = []
 
+    def _genuinely_cancelled() -> bool:
+        # Detectable on Python 3.11+; below that a genuine cancel during this
+        # bookkeeping is absorbed like a connect failure.
+        cancelling = getattr(asyncio.current_task(), "cancelling", None)
+        return cancelling is not None and cancelling() > 0
+
+    async def _drop_partial_mcp_state(tool: Any) -> None:
+        # A failed connect can leave partially-entered transport contexts that
+        # poison a later reconnect; connect()'s own cleanup does not always
+        # run (a CancelledError bypasses it, and initialize() failures return
+        # with the dead session still attached).
+        safe_cleanup = getattr(tool, "_safe_cleanup", None)
+        if safe_cleanup is None:
+            return
+        try:
+            maybe = safe_cleanup()
+            if isawaitable(maybe):
+                await maybe
+        except BaseException:
+            pass
+
     async def _close_connected_mcp_tools() -> None:
+        cancelled: Optional[BaseException] = None
         for tool in connected_mcp_tools:
             try:
                 await tool.close()
+            except asyncio.CancelledError as exc:
+                # Keep releasing the remaining tools, then let the host's
+                # cancel land instead of reporting a normal exit.
+                if _genuinely_cancelled():
+                    cancelled = exc
             except BaseException:
                 pass
+        if cancelled is not None:
+            raise cancelled
 
     try:
         for tool in mcp_tools or []:
+            if getattr(tool, "initialized", False):
+                # Connected by someone else (a server lifespan, the caller
+                # itself); not ours to manage -- connect() would no-op and
+                # closing it afterwards would tear down a session we never
+                # opened.
+                continue
             try:
                 await tool.connect()
             except BaseException as exc:
@@ -894,27 +929,26 @@ async def acli(
                 # connect()'s own fail-soft handler. Unlike a private loop,
                 # this coroutine runs on the caller's loop where cancellation
                 # can also be genuine -- re-raise that so the host's cancel
-                # still lands (detectable on Python 3.11+; below that a
-                # genuine cancel during connect is absorbed like a failure).
-                if isinstance(exc, asyncio.CancelledError):
-                    task = asyncio.current_task()
-                    cancelling = getattr(task, "cancelling", None)
-                    if cancelling is not None and cancelling() > 0:
-                        raise
-                # A failed connect can leave partially-entered transport
-                # contexts that poison a later reconnect; connect()'s own
-                # cleanup was bypassed along with its handler.
-                safe_cleanup = getattr(tool, "_safe_cleanup", None)
-                if safe_cleanup is not None:
-                    try:
-                        maybe = safe_cleanup()
-                        if isawaitable(maybe):
-                            await maybe
-                    except BaseException:
-                        pass
+                # still lands.
+                if isinstance(exc, asyncio.CancelledError) and _genuinely_cancelled():
+                    await _drop_partial_mcp_state(tool)
+                    raise
+                await _drop_partial_mcp_state(tool)
                 console.print(f"[yellow]warning:[/yellow] failed to connect MCP tool: {escape(repr(exc))}")
             else:
-                connected_mcp_tools.append(tool)
+                if getattr(tool, "initialized", True):
+                    connected_mcp_tools.append(tool)
+                else:
+                    # connect() is fail-soft and can return without a usable
+                    # session (initialize() failures leave the toolkit
+                    # uninitialized); close() would no-op on it, so it is not
+                    # connected for our purposes.
+                    await _drop_partial_mcp_state(tool)
+                    tool_name = getattr(tool, "name", type(tool).__name__)
+                    console.print(
+                        f"[yellow]warning:[/yellow] failed to connect MCP tool: "
+                        f"{escape(str(tool_name))} did not yield a usable session"
+                    )
     except BaseException:
         await _close_connected_mcp_tools()
         raise

--- a/libs/agno/agno/eval/suite.py
+++ b/libs/agno/agno/eval/suite.py
@@ -910,6 +910,11 @@ async def acli(
                     cancelled = exc
             except BaseException:
                 pass
+            if cancelled is None and _genuinely_cancelled():
+                # The real MCPTools.close() swallows everything it is handed,
+                # a delivered cancel included -- the task-level counter is the
+                # only trace left of it.
+                cancelled = asyncio.CancelledError()
         if cancelled is not None:
             raise cancelled
 

--- a/libs/agno/agno/eval/suite.py
+++ b/libs/agno/agno/eval/suite.py
@@ -811,8 +811,16 @@ async def acli(
     judge_model: Optional[Model] = None,
     default_timeout: int = 120,
     argv: Optional[Sequence[str]] = None,
+    mcp_tools: Optional[Sequence[Any]] = None,
 ) -> int:
-    """Async variant of cli() for callers already inside an event loop."""
+    """Async variant of cli() for callers already inside an event loop.
+
+    mcp_tools: MCP toolkits (e.g. the case components' registry tools) to
+    connect in this loop before the cases run and close again afterwards --
+    what the AgentOS lifespan does for a server, for an eval process. Connect
+    failures are logged per tool and the cases still run; a tool that never
+    connected is not closed.
+    """
     import argparse
 
     from rich.console import Console
@@ -865,6 +873,16 @@ async def acli(
                 return 1
         return 0
 
+    # Connected here, after the --list and no-match early returns, so only an
+    # actual run pays for (and has to tear down) live MCP sessions.
+    connected_mcp_tools: List[Any] = []
+    for tool in mcp_tools or []:
+        try:
+            await tool.connect()
+            connected_mcp_tools.append(tool)
+        except Exception as exc:
+            console.print(f"[yellow]warning:[/yellow] failed to connect MCP tool: {escape(str(exc))}")
+
     renderer = _CliRenderer(console=console, total=len(selected), verbose=args.verbose)
     try:
         suite = await arun_cases(
@@ -879,6 +897,11 @@ async def acli(
     finally:
         # Restore the terminal (stop the spinner) even on error or Ctrl-C.
         renderer.close()
+        for tool in connected_mcp_tools:
+            try:
+                await tool.close()
+            except Exception:
+                pass
 
     _print_summary(console, suite)
 
@@ -895,6 +918,7 @@ def cli(
     judge_model: Optional[Model] = None,
     default_timeout: int = 120,
     argv: Optional[Sequence[str]] = None,
+    mcp_tools: Optional[Sequence[Any]] = None,
 ) -> int:
     """Run an argparse CLI over the given cases and return the exit code.
 
@@ -902,6 +926,16 @@ def cli(
     --json-output write), 2 no cases matched the selector. Built purely on the
     public runner API - call it from a template's __main__.py with
     `sys.exit(cli(CASES, db=my_db))`. Inside an already-running event loop, use
-    `await acli(...)` instead.
+    `await acli(...)` instead. mcp_tools are connected in the run's loop before
+    the cases and closed afterwards (see acli).
     """
-    return asyncio.run(acli(cases, db=db, judge_model=judge_model, default_timeout=default_timeout, argv=argv))
+    return asyncio.run(
+        acli(
+            cases,
+            db=db,
+            judge_model=judge_model,
+            default_timeout=default_timeout,
+            argv=argv,
+            mcp_tools=mcp_tools,
+        )
+    )

--- a/libs/agno/agno/tools/mcp_toolbox.py
+++ b/libs/agno/agno/tools/mcp_toolbox.py
@@ -86,7 +86,6 @@ class MCPToolbox(MCPTools, metaclass=MCPToolsMeta):
                     url=self.toolbox_url,
                     client_headers=self.headers,
                 )
-                self._core_client_initialized = True
 
                 if self.toolsets is not None:
                     # Load multiple toolsets
@@ -98,8 +97,26 @@ class MCPToolbox(MCPTools, metaclass=MCPToolsMeta):
                     tool = await self.load_tool(tool_name=self.tool_name)
                     # Replace functions dict with just this single tool
                     self.functions = {tool.name: tool}
+                # Latched only after filtering succeeds: connect() early-returns
+                # on this flag, so latching before a failed filter would let a
+                # reconnect skip filtering and serve the unfiltered superset the
+                # base connect just registered.
+                self._core_client_initialized = True
         except Exception as e:
+            await self._close_core_client()
             raise RuntimeError(f"Failed to connect to ToolboxClient: {e}") from e
+
+    async def _close_core_client(self):
+        """Close and forget the core client so a reconnect rebuilds and
+        re-filters; a client or flag surviving teardown would make the next
+        connect() skip filtering."""
+        if hasattr(self, "_MCPToolbox__core_client"):
+            try:
+                await self.__core_client.close()
+            except Exception:
+                pass
+            del self.__core_client
+        self._core_client_initialized = False
 
     async def load_tool(
         self,
@@ -199,8 +216,7 @@ class MCPToolbox(MCPTools, metaclass=MCPToolsMeta):
 
     async def close(self):
         """Close the underlying asynchronous client."""
-        if self._core_client_initialized and hasattr(self, "_MCPToolbox__core_client"):
-            await self.__core_client.close()
+        await self._close_core_client()
         await super().close()
 
     async def load_toolset_safe(self, toolset_name: str) -> List[str]:
@@ -226,6 +242,5 @@ class MCPToolbox(MCPTools, metaclass=MCPToolsMeta):
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         """Clean up the toolbox client."""
         # Close ToolboxClient first, then MCP client
-        if self._core_client_initialized and hasattr(self, "_MCPToolbox__core_client"):
-            await self.__core_client.close()
+        await self._close_core_client()
         await super().__aexit__(exc_type, exc_val, exc_tb)

--- a/libs/agno/agno/tools/studio.py
+++ b/libs/agno/agno/tools/studio.py
@@ -72,8 +72,10 @@ Persistence:
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 import json
+import threading
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, Sequence, Set, Union
 
 from agno.exceptions import SchemaMismatchError
@@ -107,6 +109,11 @@ _SCHEDULE_TARGET_TYPES = ("agent", "team", "workflow")
 _NAME_MATCH_LIMIT = 20
 
 _NAME_MATCH_PAGES = 10
+
+
+def _is_mcp_toolkit(tool: Any) -> bool:
+    """Checked by class name so the optional mcp extra is never imported here."""
+    return any(c.__name__ == "MCPTools" for c in type(tool).__mro__)
 
 
 def _version_or_latest(version: Optional[int]) -> Optional[int]:
@@ -677,18 +684,89 @@ class StudioTools(Toolkit):
                 resolved.append(found)
         if missing:
             raise _ToolsNotFoundError(f"Tools not found in registry: {missing}")
+        self._connect_unconnected_mcp_toolkits(resolved)
         # Persisting a component serializes each toolkit's functions; a toolkit
-        # with none (e.g. an MCP toolkit that never connected) would be silently
-        # dropped from the config, permanently. Refuse instead.
+        # with none (e.g. an MCP toolkit whose on-demand connection failed)
+        # would be silently dropped from the config, permanently. Refuse instead.
         empty_toolkits = [t.name for t in resolved if isinstance(t, Toolkit) and not t.functions]
         if empty_toolkits:
             raise ValueError(
                 f"Toolkits have no functions and cannot be persisted: {empty_toolkits}. "
-                "An MCP toolkit has no functions until it is connected. Connect it before "
-                "creating or editing components with it (AgentOS connects MCP tools found in "
-                "the registry and on agents/teams/workflows at startup)."
+                "An MCP toolkit has no functions until it is connected; Studio connects "
+                "unconnected registry MCP toolkits on demand, so an MCP toolkit named here "
+                "failed to connect or its server exposes no tools. Any other toolkit named "
+                "here was registered without functions."
             )
         return resolved
+
+    def _connect_unconnected_mcp_toolkits(self, resolved: List[Any]) -> None:
+        """Fetch the function list of registry MCP toolkits nothing has connected.
+
+        A registry MCP toolkit has no functions until something connects it. Under
+        AgentOS the server lifespan does that at startup, but a standalone process
+        (script, notebook, eval run) has no lifespan, so the toolkit reaches
+        persist time empty and the guard in _resolve_tools would refuse a build
+        that succeeds against the running server. Persisting needs the toolkit's
+        function list, not a live session, so each such toolkit is connected on a
+        short-lived private event loop and released again before that loop goes
+        away: close() keeps the registered functions, and a released toolkit
+        reconnects per run, while a session left bound to the dead private loop
+        would break the toolkit's later tool calls in this process.
+
+        The dedicated thread serves every caller shape at once: a sync Studio
+        tool on a worker thread (no loop in this thread, but one running
+        elsewhere), a plain sync call (no loop anywhere), and a direct call from
+        a coroutine (a loop running in THIS thread, which must not be blocked by
+        or re-entered for the connect).
+
+        Fail-soft: connect errors are logged and swallowed, and a toolkit that
+        still has no functions afterwards is refused by the guard in
+        _resolve_tools -- never silently persisted empty.
+        """
+        pending: List[Toolkit] = []
+        seen: Set[int] = set()
+        for tool in resolved:
+            if (
+                isinstance(tool, Toolkit)
+                and not tool.functions
+                and id(tool) not in seen
+                and _is_mcp_toolkit(tool)
+            ):
+                seen.add(id(tool))
+                pending.append(tool)
+        if not pending:
+            return
+
+        async def _call(method: Callable[[], Any]) -> None:
+            result = method()
+            if inspect.isawaitable(result):
+                await result
+
+        async def _connect_and_release() -> None:
+            for toolkit in pending:
+                try:
+                    await _call(toolkit.connect)
+                except Exception as exc:
+                    log_warning(f"Error connecting MCP toolkit '{toolkit.name}': {exc}")
+                finally:
+                    try:
+                        await _call(toolkit.close)
+                    except Exception:
+                        pass
+
+        def _run() -> None:
+            try:
+                asyncio.run(_connect_and_release())
+            except Exception as exc:
+                log_warning(f"Error connecting MCP toolkits: {exc}")
+
+        # If the join times out, the guard in _resolve_tools reports the still-empty
+        # toolkits; a connect that completes late cleans itself up via the close()
+        # in _connect_and_release before its loop exits.
+        timeout = sum(float(getattr(toolkit, "timeout_seconds", None) or 10) for toolkit in pending) + 5.0
+        thread = threading.Thread(target=_run, name="studio-mcp-connect", daemon=True)
+        thread.start()
+        thread.join(timeout=timeout)
 
     def _normalize_tool_names(self, names: List[str]) -> List[str]:
         """Collapse toolkit function names back to their toolkit name."""

--- a/libs/agno/agno/tools/studio.py
+++ b/libs/agno/agno/tools/studio.py
@@ -738,22 +738,49 @@ class StudioTools(Toolkit):
                 await result
 
         async def _connect_and_release() -> None:
+            # BaseException, not Exception: the mcp client surfaces an
+            # unreachable server as CancelledError out of its cancel scopes,
+            # which would otherwise escape connect()'s own fail-soft handler,
+            # skip its cleanup, and kill this thread mid-list. Cancellation
+            # cannot mean anything else here -- this coroutine is the only
+            # thing this private loop ever runs.
             for toolkit in pending:
                 try:
                     await _call(toolkit.connect)
-                except Exception as exc:
-                    log_warning(f"Error connecting MCP toolkit '{toolkit.name}': {exc}")
+                except BaseException as exc:
+                    log_warning(f"Error connecting MCP toolkit '{toolkit.name}': {exc!r}")
                 finally:
                     try:
-                        await _call(toolkit.close)
-                    except Exception:
+                        if getattr(toolkit, "initialized", False):
+                            await _call(toolkit.close)
+                        else:
+                            # A failed connect can leave partially-entered
+                            # transport contexts on the toolkit (close() skips
+                            # uninitialized toolkits); left in place they poison
+                            # the next connect() attempt on a live loop.
+                            safe_cleanup = getattr(toolkit, "_safe_cleanup", None)
+                            if safe_cleanup is not None:
+                                await _call(safe_cleanup)
+                    except BaseException:
                         pass
 
         def _run() -> None:
+            loop = asyncio.new_event_loop()
+            # A failed connect can leave the mcp client's transport async
+            # generators mid-run; their aclose() errors during loop shutdown
+            # are unactionable stderr noise on this throwaway loop -- the
+            # failure itself is already logged per toolkit above.
+            loop.set_exception_handler(lambda _loop, context: log_debug(f"MCP connect loop cleanup: {context}"))
             try:
-                asyncio.run(_connect_and_release())
-            except Exception as exc:
-                log_warning(f"Error connecting MCP toolkits: {exc}")
+                loop.run_until_complete(_connect_and_release())
+            except BaseException as exc:
+                log_warning(f"Error connecting MCP toolkits: {exc!r}")
+            finally:
+                try:
+                    loop.run_until_complete(loop.shutdown_asyncgens())
+                except BaseException:
+                    pass
+                loop.close()
 
         # If the join times out, the guard in _resolve_tools reports the still-empty
         # toolkits; a connect that completes late cleans itself up via the close()

--- a/libs/agno/agno/tools/studio.py
+++ b/libs/agno/agno/tools/studio.py
@@ -116,6 +116,16 @@ def _is_mcp_toolkit(tool: Any) -> bool:
     return any(c.__name__ == "MCPTools" for c in type(tool).__mro__)
 
 
+# Extra headroom on top of a toolkit's own timeout_seconds for the on-demand
+# connect: covers transport setup/teardown around the timed client calls.
+_MCP_CONNECT_SLACK_SECONDS = 5.0
+
+# One connect pass at a time, process-wide: MCPTools instances stage transport
+# state on unlocked attributes, and a registry (and its toolkits) can be shared
+# across StudioTools instances, so this cannot be per-instance state.
+_MCP_CONNECT_LOCK = threading.Lock()
+
+
 def _version_or_latest(version: Optional[int]) -> Optional[int]:
     """Read a "which version" argument, treating 0 as omitted.
 
@@ -684,11 +694,15 @@ class StudioTools(Toolkit):
                 resolved.append(found)
         if missing:
             raise _ToolsNotFoundError(f"Tools not found in registry: {missing}")
-        self._connect_unconnected_mcp_toolkits(resolved)
+        failed_toolkit_ids = self._connect_unconnected_mcp_toolkits(resolved)
         # Persisting a component serializes each toolkit's functions; a toolkit
         # with none (e.g. an MCP toolkit whose on-demand connection failed)
-        # would be silently dropped from the config, permanently. Refuse instead.
-        empty_toolkits = [t.name for t in resolved if isinstance(t, Toolkit) and not t.functions]
+        # would be silently dropped from the config, permanently -- and a
+        # toolkit whose connect attempt failed or was abandoned may hold a
+        # PARTIAL function list. Refuse both instead.
+        empty_toolkits = [
+            t.name for t in resolved if isinstance(t, Toolkit) and (not t.functions or id(t) in failed_toolkit_ids)
+        ]
         if empty_toolkits:
             raise ValueError(
                 f"Toolkits have no functions and cannot be persisted: {empty_toolkits}. "
@@ -699,7 +713,7 @@ class StudioTools(Toolkit):
             )
         return resolved
 
-    def _connect_unconnected_mcp_toolkits(self, resolved: List[Any]) -> None:
+    def _connect_unconnected_mcp_toolkits(self, resolved: List[Any]) -> Set[int]:
         """Fetch the function list of registry MCP toolkits nothing has connected.
 
         A registry MCP toolkit has no functions until something connects it. Under
@@ -716,79 +730,123 @@ class StudioTools(Toolkit):
         The dedicated thread serves every caller shape at once: a sync Studio
         tool on a worker thread (no loop in this thread, but one running
         elsewhere), a plain sync call (no loop anywhere), and a direct call from
-        a coroutine (a loop running in THIS thread, which must not be blocked by
-        or re-entered for the connect).
+        a coroutine -- the caller's loop is never re-entered, though the join
+        below still blocks the calling thread for up to the summed connect
+        budget.
 
-        Fail-soft: connect errors are logged and swallowed, and a toolkit that
-        still has no functions afterwards is refused by the guard in
-        _resolve_tools -- never silently persisted empty.
+        Fail-soft: connect errors are logged and swallowed. Returns the ids of
+        toolkits whose connect attempt raised, timed out, or was abandoned at
+        the join deadline -- an interrupted connect may have registered only
+        part of the server's tools (or still be registering them), so the
+        guard in _resolve_tools must refuse those even when their functions
+        dict is non-empty. Toolkits that merely stay empty are refused by the
+        guard's own emptiness check -- never silently persisted empty.
         """
-        pending: List[Toolkit] = []
-        seen: Set[int] = set()
-        for tool in resolved:
-            if isinstance(tool, Toolkit) and not tool.functions and id(tool) not in seen and _is_mcp_toolkit(tool):
-                seen.add(id(tool))
-                pending.append(tool)
-        if not pending:
-            return
 
-        async def _call(method: Callable[[], Any]) -> None:
-            result = method()
-            if inspect.isawaitable(result):
-                await result
+        def _candidates() -> List[Toolkit]:
+            out: List[Toolkit] = []
+            seen: Set[int] = set()
+            for tool in resolved:
+                if (
+                    isinstance(tool, Toolkit)
+                    and not tool.functions
+                    # A connected toolkit with no functions (its server lists
+                    # zero tools) must not be touched: connect() would no-op
+                    # and the release below would close a LIVE session bound
+                    # to another loop. The guard refuses it on emptiness.
+                    and not getattr(tool, "initialized", False)
+                    and id(tool) not in seen
+                    and _is_mcp_toolkit(tool)
+                ):
+                    seen.add(id(tool))
+                    out.append(tool)
+            return out
 
-        async def _connect_and_release() -> None:
-            # BaseException, not Exception: the mcp client surfaces an
-            # unreachable server as CancelledError out of its cancel scopes,
-            # which would otherwise escape connect()'s own fail-soft handler,
-            # skip its cleanup, and kill this thread mid-list. Cancellation
-            # cannot mean anything else here -- this coroutine is the only
-            # thing this private loop ever runs.
-            for toolkit in pending:
+        if not _candidates():
+            return set()
+
+        # MCPTools stages its transport state on unlocked instance attributes,
+        # so two Studio calls (parallel tool calls each run sync entrypoints in
+        # their own worker thread) connecting the same registry toolkit from
+        # two private loops corrupt each other roughly half the time. Serialize
+        # the whole connect pass; the loser re-checks and finds the work done.
+        with _MCP_CONNECT_LOCK:
+            pending = _candidates()
+            if not pending:
+                return set()
+
+            budgets = {
+                id(toolkit): float(getattr(toolkit, "timeout_seconds", None) or 10) + _MCP_CONNECT_SLACK_SECONDS
+                for toolkit in pending
+            }
+            failed: Set[int] = set()
+            completed: Set[int] = set()
+
+            async def _call(method: Callable[[], Any]) -> None:
+                result = method()
+                if inspect.isawaitable(result):
+                    await result
+
+            async def _connect_and_release() -> None:
+                # BaseException, not Exception: the mcp client surfaces an
+                # unreachable server as CancelledError out of its cancel
+                # scopes, which would otherwise escape connect()'s own
+                # fail-soft handler, skip its cleanup, and kill this thread
+                # mid-list. Cancellation cannot mean anything else here --
+                # this coroutine is the only thing this private loop ever runs.
+                for toolkit in pending:
+                    try:
+                        # wait_for bounds a hung transport in-loop (some hangs,
+                        # e.g. an SSE stream that never sends its endpoint
+                        # event, are otherwise bounded only by the mcp SDK's
+                        # 300s read default), so cleanup runs on this same
+                        # loop and the thread reliably exits.
+                        await asyncio.wait_for(_call(toolkit.connect), timeout=budgets[id(toolkit)])
+                    except BaseException as exc:
+                        failed.add(id(toolkit))
+                        log_warning(f"Error connecting MCP toolkit '{toolkit.name}': {exc!r}")
+                    finally:
+                        try:
+                            if getattr(toolkit, "initialized", False):
+                                await _call(toolkit.close)
+                            else:
+                                # A failed connect can leave partially-entered
+                                # transport contexts on the toolkit (close()
+                                # skips uninitialized toolkits); left in place
+                                # they poison the next connect() attempt on a
+                                # live loop.
+                                safe_cleanup = getattr(toolkit, "_safe_cleanup", None)
+                                if safe_cleanup is not None:
+                                    await _call(safe_cleanup)
+                        except BaseException:
+                            pass
+                        completed.add(id(toolkit))
+
+            def _run() -> None:
+                loop = asyncio.new_event_loop()
+                # A failed connect can leave the mcp client's transport async
+                # generators mid-run; their aclose() errors during loop
+                # shutdown are unactionable stderr noise on this throwaway
+                # loop -- the failure itself is already logged per toolkit.
+                loop.set_exception_handler(lambda _loop, context: log_debug(f"MCP connect loop cleanup: {context}"))
                 try:
-                    await _call(toolkit.connect)
+                    loop.run_until_complete(_connect_and_release())
                 except BaseException as exc:
-                    log_warning(f"Error connecting MCP toolkit '{toolkit.name}': {exc!r}")
+                    log_warning(f"Error connecting MCP toolkits: {exc!r}")
                 finally:
                     try:
-                        if getattr(toolkit, "initialized", False):
-                            await _call(toolkit.close)
-                        else:
-                            # A failed connect can leave partially-entered
-                            # transport contexts on the toolkit (close() skips
-                            # uninitialized toolkits); left in place they poison
-                            # the next connect() attempt on a live loop.
-                            safe_cleanup = getattr(toolkit, "_safe_cleanup", None)
-                            if safe_cleanup is not None:
-                                await _call(safe_cleanup)
+                        loop.run_until_complete(loop.shutdown_asyncgens())
                     except BaseException:
                         pass
+                    loop.close()
 
-        def _run() -> None:
-            loop = asyncio.new_event_loop()
-            # A failed connect can leave the mcp client's transport async
-            # generators mid-run; their aclose() errors during loop shutdown
-            # are unactionable stderr noise on this throwaway loop -- the
-            # failure itself is already logged per toolkit above.
-            loop.set_exception_handler(lambda _loop, context: log_debug(f"MCP connect loop cleanup: {context}"))
-            try:
-                loop.run_until_complete(_connect_and_release())
-            except BaseException as exc:
-                log_warning(f"Error connecting MCP toolkits: {exc!r}")
-            finally:
-                try:
-                    loop.run_until_complete(loop.shutdown_asyncgens())
-                except BaseException:
-                    pass
-                loop.close()
-
-        # If the join times out, the guard in _resolve_tools reports the still-empty
-        # toolkits; a connect that completes late cleans itself up via the close()
-        # in _connect_and_release before its loop exits.
-        timeout = sum(float(getattr(toolkit, "timeout_seconds", None) or 10) for toolkit in pending) + 5.0
-        thread = threading.Thread(target=_run, name="studio-mcp-connect", daemon=True)
-        thread.start()
-        thread.join(timeout=timeout)
+            timeout = sum(budgets.values()) + _MCP_CONNECT_SLACK_SECONDS
+            thread = threading.Thread(target=_run, name="studio-mcp-connect", daemon=True)
+            thread.start()
+            thread.join(timeout=timeout)
+            # A toolkit the abandoned thread never finished counts as failed:
+            # its functions dict may still be mutating under the zombie loop.
+            return failed | {id(toolkit) for toolkit in pending if id(toolkit) not in completed}
 
     def _normalize_tool_names(self, names: List[str]) -> List[str]:
         """Collapse toolkit function names back to their toolkit name."""

--- a/libs/agno/agno/tools/studio.py
+++ b/libs/agno/agno/tools/studio.py
@@ -726,12 +726,7 @@ class StudioTools(Toolkit):
         pending: List[Toolkit] = []
         seen: Set[int] = set()
         for tool in resolved:
-            if (
-                isinstance(tool, Toolkit)
-                and not tool.functions
-                and id(tool) not in seen
-                and _is_mcp_toolkit(tool)
-            ):
+            if isinstance(tool, Toolkit) and not tool.functions and id(tool) not in seen and _is_mcp_toolkit(tool):
                 seen.add(id(tool))
                 pending.append(tool)
         if not pending:

--- a/libs/agno/agno/tools/studio.py
+++ b/libs/agno/agno/tools/studio.py
@@ -125,6 +125,13 @@ _MCP_CONNECT_SLACK_SECONDS = 5.0
 # across StudioTools instances, so this cannot be per-instance state.
 _MCP_CONNECT_LOCK = threading.Lock()
 
+# Connect threads abandoned at their join deadline, by toolkit id. A toolkit
+# held by a live abandoned thread cannot be safely reconnected -- a second
+# connect would interleave with the first on the toolkit's unlocked transport
+# state -- so it stays refused until that thread dies. Guarded by
+# _MCP_CONNECT_LOCK; entries are pruned once their thread has exited.
+_MCP_CONNECT_ZOMBIES: Dict[int, threading.Thread] = {}
+
 
 def _version_or_latest(version: Optional[int]) -> Optional[int]:
     """Read a "which version" argument, treating 0 as omitted.
@@ -736,8 +743,9 @@ class StudioTools(Toolkit):
 
         Fail-soft: connect errors are logged and swallowed. Returns the ids of
         toolkits whose connect attempt raised, timed out, or was abandoned at
-        the join deadline -- an interrupted connect may have registered only
-        part of the server's tools (or still be registering them), so the
+        the join deadline (or that are still held by a connect thread a
+        previous call abandoned) -- an interrupted connect may have registered
+        only part of the server's tools (or still be registering them), so the
         guard in _resolve_tools must refuse those even when their functions
         dict is non-empty. Toolkits that merely stay empty are refused by the
         guard's own emptiness check -- never silently persisted empty.
@@ -762,7 +770,7 @@ class StudioTools(Toolkit):
                     out.append(tool)
             return out
 
-        if not _candidates():
+        if not any(isinstance(tool, Toolkit) and _is_mcp_toolkit(tool) for tool in resolved):
             return set()
 
         # MCPTools stages its transport state on unlocked instance attributes,
@@ -771,9 +779,21 @@ class StudioTools(Toolkit):
         # two private loops corrupt each other roughly half the time. Serialize
         # the whole connect pass; the loser re-checks and finds the work done.
         with _MCP_CONNECT_LOCK:
-            pending = _candidates()
+            for key, zombie in list(_MCP_CONNECT_ZOMBIES.items()):
+                if not zombie.is_alive():
+                    del _MCP_CONNECT_ZOMBIES[key]
+            # Checked against every resolved MCP toolkit, not just the
+            # connect candidates: a zombie's partial registrations make its
+            # toolkit look connected enough to skip candidacy, but they are
+            # still mutating and must not be persisted.
+            blocked = {
+                id(tool)
+                for tool in resolved
+                if isinstance(tool, Toolkit) and id(tool) in _MCP_CONNECT_ZOMBIES and _is_mcp_toolkit(tool)
+            }
+            pending = [toolkit for toolkit in _candidates() if id(toolkit) not in blocked]
             if not pending:
-                return set()
+                return blocked
 
             budgets = {
                 id(toolkit): float(getattr(toolkit, "timeout_seconds", None) or 10) + _MCP_CONNECT_SLACK_SECONDS
@@ -795,6 +815,7 @@ class StudioTools(Toolkit):
                 # mid-list. Cancellation cannot mean anything else here --
                 # this coroutine is the only thing this private loop ever runs.
                 for toolkit in pending:
+                    succeeded = False
                     try:
                         # wait_for bounds a hung transport in-loop (some hangs,
                         # e.g. an SSE stream that never sends its endpoint
@@ -802,6 +823,7 @@ class StudioTools(Toolkit):
                         # 300s read default), so cleanup runs on this same
                         # loop and the thread reliably exits.
                         await asyncio.wait_for(_call(toolkit.connect), timeout=budgets[id(toolkit)])
+                        succeeded = True
                     except BaseException as exc:
                         failed.add(id(toolkit))
                         log_warning(f"Error connecting MCP toolkit '{toolkit.name}': {exc!r}")
@@ -820,6 +842,15 @@ class StudioTools(Toolkit):
                                     await _call(safe_cleanup)
                         except BaseException:
                             pass
+                        if not succeeded:
+                            # An interrupted connect may have registered part
+                            # of the server's tools (MCPToolbox even registers
+                            # the unfiltered superset before filtering, and
+                            # raises with it in place). The failed-ids refusal
+                            # only protects THIS call; restore the unconnected
+                            # invariant -- empty functions -- so a retry
+                            # reconnects instead of persisting the leftovers.
+                            toolkit.functions.clear()
                         completed.add(id(toolkit))
 
             def _run() -> None:
@@ -844,9 +875,13 @@ class StudioTools(Toolkit):
             thread = threading.Thread(target=_run, name="studio-mcp-connect", daemon=True)
             thread.start()
             thread.join(timeout=timeout)
-            # A toolkit the abandoned thread never finished counts as failed:
-            # its functions dict may still be mutating under the zombie loop.
-            return failed | {id(toolkit) for toolkit in pending if id(toolkit) not in completed}
+            # A toolkit the abandoned thread never finished counts as failed
+            # (its functions dict may still be mutating under the zombie loop)
+            # and stays blocked from reconnecting until that thread dies.
+            abandoned = {id(toolkit) for toolkit in pending if id(toolkit) not in completed}
+            for toolkit_id in abandoned:
+                _MCP_CONNECT_ZOMBIES[toolkit_id] = thread
+            return failed | blocked | abandoned
 
     def _normalize_tool_names(self, names: List[str]) -> List[str]:
         """Collapse toolkit function names back to their toolkit name."""

--- a/libs/agno/agno/tools/studio.py
+++ b/libs/agno/agno/tools/studio.py
@@ -731,8 +731,12 @@ class StudioTools(Toolkit):
         function list, not a live session, so each such toolkit is connected on a
         short-lived private event loop and released again before that loop goes
         away: close() keeps the registered functions, and a released toolkit
-        reconnects per run, while a session left bound to the dead private loop
-        would break the toolkit's later tool calls in this process.
+        attached to a component as an MCPTools instance reconnects per run,
+        while a session left bound to the dead private loop would break the
+        toolkit's later tool calls in this process. (A component rehydrated
+        from the DB carries bare Functions, which no run path reconnects:
+        standalone dispatch of the built component still needs the registry
+        toolkit connected by a server lifespan or the eval runner's mcp_tools.)
 
         The dedicated thread serves every caller shape at once: a sync Studio
         tool on a worker thread (no loop in this thread, but one running

--- a/libs/agno/tests/unit/eval/test_suite.py
+++ b/libs/agno/tests/unit/eval/test_suite.py
@@ -1292,6 +1292,95 @@ def test_acli_help_returns_0(monkeypatch, capsys):
     assert "--tag" in capsys.readouterr().out
 
 
+class StubMCPTool:
+    """Connectable stub for the mcp_tools runner affordance: records the
+    connect/close order and the loop each landed on."""
+
+    def __init__(self, connect_error=None):
+        self.events = []
+        self.loops = []
+        self._connect_error = connect_error
+
+    async def connect(self):
+        self.loops.append(asyncio.get_running_loop())
+        if self._connect_error is not None:
+            raise self._connect_error
+        self.events.append("connect")
+
+    async def close(self):
+        self.loops.append(asyncio.get_running_loop())
+        self.events.append("close")
+
+
+def test_acli_connects_and_closes_mcp_tools_in_its_own_loop(monkeypatch):
+    _install_fake_evals(monkeypatch)
+    tool = StubMCPTool()
+    agent = StubAgent()
+
+    async def main():
+        return await acli([_make_case(agent=agent)], argv=[], mcp_tools=[tool])
+
+    exit_code = asyncio.run(main())
+
+    assert exit_code == 0
+    assert tool.events == ["connect", "close"]
+    # Both calls must land on the loop the cases run in - a session connected
+    # on another loop is unusable from this one.
+    assert tool.loops[0] is agent.loops[0]
+    assert tool.loops[1] is agent.loops[0]
+
+
+def test_acli_mcp_tool_connect_failure_is_fail_soft(monkeypatch, capsys):
+    _install_fake_evals(monkeypatch)
+    failing = StubMCPTool(connect_error=RuntimeError("server unreachable"))
+    working = StubMCPTool()
+
+    exit_code = asyncio.run(acli([_make_case()], argv=[], mcp_tools=[failing, working]))
+
+    # The cases still run and decide the exit code; the tool that never
+    # connected is not closed.
+    assert exit_code == 0
+    assert failing.events == []
+    assert working.events == ["connect", "close"]
+    assert "server unreachable" in capsys.readouterr().out
+
+
+def test_acli_closes_mcp_tools_when_the_run_raises(monkeypatch):
+    _install_fake_evals(monkeypatch)
+    tool = StubMCPTool()
+
+    async def boom(*args, **kwargs):
+        raise RuntimeError("runner exploded")
+
+    monkeypatch.setattr(suite, "arun_cases", boom)
+
+    with pytest.raises(RuntimeError, match="runner exploded"):
+        asyncio.run(acli([_make_case()], argv=[], mcp_tools=[tool]))
+
+    assert tool.events == ["connect", "close"]
+
+
+def test_acli_list_does_not_connect_mcp_tools(monkeypatch, capsys):
+    _install_fake_evals(monkeypatch)
+    tool = StubMCPTool()
+
+    exit_code = asyncio.run(acli([_make_case(name="listed_case")], argv=["--list"], mcp_tools=[tool]))
+
+    assert exit_code == 0
+    assert "listed_case" in capsys.readouterr().out
+    assert tool.events == []
+
+
+def test_cli_forwards_mcp_tools(monkeypatch, capsys):
+    _install_fake_evals(monkeypatch)
+    tool = StubMCPTool()
+
+    exit_code = cli([_make_case()], argv=[], mcp_tools=[tool])
+
+    assert exit_code == 0
+    assert tool.events == ["connect", "close"]
+
+
 def test_cli_default_timeout_parameter(monkeypatch, capsys):
     _install_fake_evals(monkeypatch)
 

--- a/libs/agno/tests/unit/eval/test_suite.py
+++ b/libs/agno/tests/unit/eval/test_suite.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -1294,22 +1295,30 @@ def test_acli_help_returns_0(monkeypatch, capsys):
 
 class StubMCPTool:
     """Connectable stub for the mcp_tools runner affordance: records the
-    connect/close order and the loop each landed on."""
+    connect/close/cleanup order and the loop each landed on."""
 
-    def __init__(self, connect_error=None):
+    def __init__(self, connect_error=None, hang=False):
         self.events = []
         self.loops = []
+        self.started = asyncio.Event()
         self._connect_error = connect_error
+        self._hang = hang
 
     async def connect(self):
         self.loops.append(asyncio.get_running_loop())
+        self.started.set()
         if self._connect_error is not None:
             raise self._connect_error
+        if self._hang:
+            await asyncio.Event().wait()
         self.events.append("connect")
 
     async def close(self):
         self.loops.append(asyncio.get_running_loop())
         self.events.append("close")
+
+    async def _safe_cleanup(self):
+        self.events.append("safe_cleanup")
 
 
 def test_acli_connects_and_closes_mcp_tools_in_its_own_loop(monkeypatch):
@@ -1338,11 +1347,48 @@ def test_acli_mcp_tool_connect_failure_is_fail_soft(monkeypatch, capsys):
     exit_code = asyncio.run(acli([_make_case()], argv=[], mcp_tools=[failing, working]))
 
     # The cases still run and decide the exit code; the tool that never
-    # connected is not closed.
+    # connected is not closed, but its partial transport state is cleaned so
+    # a later reconnect is not poisoned.
     assert exit_code == 0
-    assert failing.events == []
+    assert failing.events == ["safe_cleanup"]
     assert working.events == ["connect", "close"]
     assert "server unreachable" in capsys.readouterr().out
+
+
+def test_acli_cancelled_error_from_connect_is_fail_soft(monkeypatch, capsys):
+    # An unreachable server surfaces as CancelledError out of the mcp client's
+    # cancel scopes -- not an Exception. It must be contained like any other
+    # connect failure, not crash the whole eval run.
+    _install_fake_evals(monkeypatch)
+    failing = StubMCPTool(connect_error=asyncio.CancelledError())
+    working = StubMCPTool()
+
+    exit_code = asyncio.run(acli([_make_case()], argv=[], mcp_tools=[failing, working]))
+
+    assert exit_code == 0
+    assert failing.events == ["safe_cleanup"]
+    assert working.events == ["connect", "close"]
+    assert "CancelledError" in capsys.readouterr().out
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="Task.cancelling() needed to tell a real cancel apart")
+def test_acli_genuine_cancellation_still_propagates(monkeypatch):
+    # A host cancelling the acli task mid-connect must not be swallowed by the
+    # connect fail-soft; already-connected tools are still released.
+    _install_fake_evals(monkeypatch)
+    connected = StubMCPTool()
+    hanging = StubMCPTool(hang=True)
+
+    async def main():
+        task = asyncio.ensure_future(acli([_make_case()], argv=[], mcp_tools=[connected, hanging]))
+        await hanging.started.wait()
+        task.cancel()
+        await task
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(main())
+
+    assert connected.events == ["connect", "close"]
 
 
 def test_acli_closes_mcp_tools_when_the_run_raises(monkeypatch):

--- a/libs/agno/tests/unit/eval/test_suite.py
+++ b/libs/agno/tests/unit/eval/test_suite.py
@@ -1295,14 +1295,21 @@ def test_acli_help_returns_0(monkeypatch, capsys):
 
 class StubMCPTool:
     """Connectable stub for the mcp_tools runner affordance: records the
-    connect/close/cleanup order and the loop each landed on."""
+    connect/close/cleanup order and the loop each landed on. `initialized`
+    mirrors the real MCPTools flag acli uses to decide ownership."""
 
-    def __init__(self, connect_error=None, hang=False):
+    def __init__(
+        self, connect_error=None, hang=False, pre_initialized=False, leaves_uninitialized=False, close_hang=False
+    ):
         self.events = []
         self.loops = []
         self.started = asyncio.Event()
+        self.close_started = asyncio.Event()
+        self.initialized = pre_initialized
         self._connect_error = connect_error
         self._hang = hang
+        self._leaves_uninitialized = leaves_uninitialized
+        self._close_hang = close_hang
 
     async def connect(self):
         self.loops.append(asyncio.get_running_loop())
@@ -1311,10 +1318,15 @@ class StubMCPTool:
             raise self._connect_error
         if self._hang:
             await asyncio.Event().wait()
+        if not self._leaves_uninitialized:
+            self.initialized = True
         self.events.append("connect")
 
     async def close(self):
         self.loops.append(asyncio.get_running_loop())
+        self.close_started.set()
+        if self._close_hang:
+            await asyncio.Event().wait()
         self.events.append("close")
 
     async def _safe_cleanup(self):
@@ -1369,6 +1381,55 @@ def test_acli_cancelled_error_from_connect_is_fail_soft(monkeypatch, capsys):
     assert failing.events == ["safe_cleanup"]
     assert working.events == ["connect", "close"]
     assert "CancelledError" in capsys.readouterr().out
+
+
+def test_acli_skips_tools_connected_elsewhere(monkeypatch):
+    # A toolkit something else already connected (a server lifespan, the
+    # caller itself) is not acli's to manage: no connect, and above all no
+    # close tearing down a session acli never opened.
+    _install_fake_evals(monkeypatch)
+    shared = StubMCPTool(pre_initialized=True)
+
+    exit_code = asyncio.run(acli([_make_case()], argv=[], mcp_tools=[shared]))
+
+    assert exit_code == 0
+    assert shared.events == []
+
+
+def test_acli_uninitialized_connect_is_not_treated_as_connected(monkeypatch, capsys):
+    # The real connect() can fail-soft and return with initialized=False and a
+    # dead session still attached (initialize() failures). acli must not count
+    # it as connected -- close() would no-op -- and must drop the partial state.
+    _install_fake_evals(monkeypatch)
+    broken = StubMCPTool(leaves_uninitialized=True)
+    working = StubMCPTool()
+
+    exit_code = asyncio.run(acli([_make_case()], argv=[], mcp_tools=[broken, working]))
+
+    assert exit_code == 0
+    assert broken.events == ["connect", "safe_cleanup"]
+    assert working.events == ["connect", "close"]
+    assert "usable session" in capsys.readouterr().out
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="Task.cancelling() needed to tell a real cancel apart")
+def test_acli_cancel_during_close_still_propagates(monkeypatch):
+    # A host cancel landing while acli releases its tools must not be reported
+    # as a normal exit -- and the remaining tools are still released first.
+    _install_fake_evals(monkeypatch)
+    slow = StubMCPTool(close_hang=True)
+    after = StubMCPTool()
+
+    async def main():
+        task = asyncio.ensure_future(acli([_make_case()], argv=[], mcp_tools=[slow, after]))
+        await slow.close_started.wait()
+        task.cancel()
+        await task
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(main())
+
+    assert after.events == ["connect", "close"]
 
 
 @pytest.mark.skipif(sys.version_info < (3, 11), reason="Task.cancelling() needed to tell a real cancel apart")

--- a/libs/agno/tests/unit/eval/test_suite.py
+++ b/libs/agno/tests/unit/eval/test_suite.py
@@ -1299,7 +1299,13 @@ class StubMCPTool:
     mirrors the real MCPTools flag acli uses to decide ownership."""
 
     def __init__(
-        self, connect_error=None, hang=False, pre_initialized=False, leaves_uninitialized=False, close_hang=False
+        self,
+        connect_error=None,
+        hang=False,
+        pre_initialized=False,
+        leaves_uninitialized=False,
+        close_hang=False,
+        close_swallows_cancel=False,
     ):
         self.events = []
         self.loops = []
@@ -1310,6 +1316,7 @@ class StubMCPTool:
         self._hang = hang
         self._leaves_uninitialized = leaves_uninitialized
         self._close_hang = close_hang
+        self._close_swallows_cancel = close_swallows_cancel
 
     async def connect(self):
         self.loops.append(asyncio.get_running_loop())
@@ -1327,6 +1334,13 @@ class StubMCPTool:
         self.close_started.set()
         if self._close_hang:
             await asyncio.Event().wait()
+        if self._close_swallows_cancel:
+            # The real MCPTools.close() ends in `except BaseException: pass`,
+            # so a cancel delivered mid-teardown vanishes inside it.
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                pass
         self.events.append("close")
 
     async def _safe_cleanup(self):
@@ -1430,6 +1444,48 @@ def test_acli_cancel_during_close_still_propagates(monkeypatch):
         asyncio.run(main())
 
     assert after.events == ["connect", "close"]
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="Task.cancelling() needed to tell a real cancel apart")
+def test_acli_cancel_swallowed_by_close_still_propagates(monkeypatch):
+    # The real MCPTools.close() swallows a delivered cancel entirely, so the
+    # teardown loop never sees a CancelledError -- acli must notice via the
+    # task's cancelling counter, finish releasing, and still exit cancelled.
+    _install_fake_evals(monkeypatch)
+    swallowing = StubMCPTool(close_swallows_cancel=True)
+    after = StubMCPTool()
+
+    async def main():
+        task = asyncio.ensure_future(acli([_make_case()], argv=[], mcp_tools=[swallowing, after]))
+        await swallowing.close_started.wait()
+        task.cancel()
+        await task
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(main())
+
+    assert swallowing.events == ["connect", "close"]  # its close ran to completion
+    assert after.events == ["connect", "close"]  # the rest were still released
+
+
+def test_real_mcp_close_swallows_a_delivered_cancel():
+    # Pins the contract the teardown loop compensates for: close() eats even a
+    # CancelledError raised from its teardown internals and returns normally.
+    pytest.importorskip("mcp")
+    from agno.tools.mcp import MCPTools as RealMCPTools
+
+    tool = RealMCPTools(url="https://docs.example.com/mcp")
+    tool._initialized = True
+
+    class CancellingContext:
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            raise asyncio.CancelledError()
+
+    tool._session_context = CancellingContext()
+
+    asyncio.run(tool.close())  # must not raise
+
+    assert tool.initialized is False
 
 
 @pytest.mark.skipif(sys.version_info < (3, 11), reason="Task.cancelling() needed to tell a real cancel apart")

--- a/libs/agno/tests/unit/tools/test_mcp_toolbox_lifecycle.py
+++ b/libs/agno/tests/unit/tools/test_mcp_toolbox_lifecycle.py
@@ -116,6 +116,31 @@ def test_failed_filter_does_not_latch_and_reconnect_refilters(toolbox_env, monke
     assert list(toolbox.functions) == ["allowed_tool"]  # not the superset
 
 
+def test_cancelled_filter_does_not_latch(toolbox_env, monkeypatch):
+    """A hung filter cancelled from outside (Studio bounds each connect with
+    wait_for) surfaces as CancelledError, which the toolbox's own error
+    handling does not catch -- so no cleanup path runs. Only latching the flag
+    AFTER a successful filter keeps a later reconnect from skipping filtering."""
+    module, created = toolbox_env
+    from agno.tools.mcp import MCPTools
+
+    monkeypatch.setattr(MCPTools, "connect", _fake_base_connect(["allowed_tool", "admin_tool"]))
+
+    async def load_multiple_toolsets(self, toolset_names):
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(module.MCPToolbox, "load_multiple_toolsets", load_multiple_toolsets)
+    toolbox = module.MCPToolbox(url="http://toolbox.local", toolsets=["allowed"])
+
+    async def scenario():
+        with pytest.raises(asyncio.CancelledError):
+            await toolbox.connect()
+
+    asyncio.run(scenario())
+
+    assert toolbox._core_client_initialized is False
+
+
 def test_close_resets_filter_state_so_reconnect_refilters(toolbox_env, monkeypatch):
     module, created = toolbox_env
     from agno.tools.mcp import MCPTools

--- a/libs/agno/tests/unit/tools/test_mcp_toolbox_lifecycle.py
+++ b/libs/agno/tests/unit/tools/test_mcp_toolbox_lifecycle.py
@@ -1,0 +1,164 @@
+"""Lifecycle tests for MCPToolbox's core-client filter state.
+
+MCPToolbox registers the full unfiltered tool set through the base MCP
+connect, then filters it through toolbox-core -- and connect() early-returns
+on _core_client_initialized. These tests pin that the flag can never outlive
+the filtering it certifies: a failed filter must not latch it, and close()
+must reset it, or a reconnect would skip filtering and serve (and let Studio
+persist) the unfiltered superset.
+
+toolbox_core is an optional dependency imported at module level, so the REAL
+MCPToolbox class is exercised against a stub toolbox_core injected into
+sys.modules; every code path under test (connect's early return, the filter
+latch, teardown) is agno's own.
+"""
+
+import asyncio
+import importlib
+import sys
+import types
+
+import pytest
+
+from agno.tools.function import Function
+
+
+@pytest.fixture
+def toolbox_env(monkeypatch):
+    pytest.importorskip("mcp")
+
+    created = []
+
+    class StubToolboxClient:
+        def __init__(self, url=None, client_headers=None):
+            self.closed = False
+            created.append(self)
+
+        async def close(self):
+            self.closed = True
+
+    stub_module = types.ModuleType("toolbox_core")
+    stub_module.ToolboxClient = StubToolboxClient  # type: ignore[attr-defined]
+
+    previous_core = sys.modules.get("toolbox_core")
+    previous_toolbox = sys.modules.get("agno.tools.mcp_toolbox")
+    sys.modules["toolbox_core"] = stub_module
+    sys.modules.pop("agno.tools.mcp_toolbox", None)
+    module = importlib.import_module("agno.tools.mcp_toolbox")
+
+    yield module, created
+
+    sys.modules.pop("agno.tools.mcp_toolbox", None)
+    if previous_toolbox is not None:
+        sys.modules["agno.tools.mcp_toolbox"] = previous_toolbox
+    if previous_core is not None:
+        sys.modules["toolbox_core"] = previous_core
+    else:
+        sys.modules.pop("toolbox_core", None)
+
+
+def _fake_base_connect(tool_names):
+    """Stand in for MCPTools.connect: register the unfiltered superset the
+    way the real base connect does, without any network."""
+
+    async def fake_connect(self, force=False):
+        for name in tool_names:
+            self.functions[name] = Function(
+                name=name,
+                parameters={"type": "object", "properties": {}},
+                skip_entrypoint_processing=True,
+            )
+        self._initialized = True
+
+    return fake_connect
+
+
+def _install_filter(monkeypatch, module, fail_first=False):
+    """Replace the toolbox-core load with one that filters to allowed_tool,
+    optionally failing on the first pass. Returns the call counter."""
+    calls = {"count": 0}
+
+    async def load_multiple_toolsets(self, toolset_names):
+        calls["count"] += 1
+        if fail_first and calls["count"] == 1:
+            raise RuntimeError("transient filter failure")
+        return [self.functions["allowed_tool"]]
+
+    monkeypatch.setattr(module.MCPToolbox, "load_multiple_toolsets", load_multiple_toolsets)
+    return calls
+
+
+def test_failed_filter_does_not_latch_and_reconnect_refilters(toolbox_env, monkeypatch):
+    module, created = toolbox_env
+    from agno.tools.mcp import MCPTools
+
+    monkeypatch.setattr(MCPTools, "connect", _fake_base_connect(["allowed_tool", "admin_tool"]))
+    calls = _install_filter(monkeypatch, module, fail_first=True)
+    toolbox = module.MCPToolbox(url="http://toolbox.local", toolsets=["allowed"])
+
+    async def scenario():
+        with pytest.raises(RuntimeError, match="ToolboxClient"):
+            await toolbox.connect()
+        # The failure must not certify filtering, and the failed pass's core
+        # client must not leak.
+        assert toolbox._core_client_initialized is False
+        assert created and created[0].closed
+
+        # Studio's on-demand release after a failed connect.
+        await toolbox.close()
+        toolbox.functions.clear()
+
+        await toolbox.connect()
+
+    asyncio.run(scenario())
+
+    assert calls["count"] == 2  # the reconnect re-filtered
+    assert list(toolbox.functions) == ["allowed_tool"]  # not the superset
+
+
+def test_close_resets_filter_state_so_reconnect_refilters(toolbox_env, monkeypatch):
+    module, created = toolbox_env
+    from agno.tools.mcp import MCPTools
+
+    monkeypatch.setattr(MCPTools, "connect", _fake_base_connect(["allowed_tool", "admin_tool"]))
+    calls = _install_filter(monkeypatch, module)
+    toolbox = module.MCPToolbox(url="http://toolbox.local", toolsets=["allowed"])
+
+    async def scenario():
+        await toolbox.connect()
+        assert toolbox._core_client_initialized is True
+        assert list(toolbox.functions) == ["allowed_tool"]
+
+        await toolbox.close()
+        assert toolbox._core_client_initialized is False
+        assert created[0].closed
+        toolbox.functions.clear()
+
+        # The base connect re-registers the unfiltered superset; a latched
+        # flag would early-return past filtering and keep it.
+        await toolbox.connect()
+
+    asyncio.run(scenario())
+
+    assert calls["count"] == 2
+    assert list(toolbox.functions) == ["allowed_tool"]
+    assert len(created) == 2  # a fresh core client per filtering pass
+
+
+def test_get_client_refuses_after_close(toolbox_env, monkeypatch):
+    module, created = toolbox_env
+    from agno.tools.mcp import MCPTools
+
+    monkeypatch.setattr(MCPTools, "connect", _fake_base_connect(["allowed_tool"]))
+    _install_filter(monkeypatch, module)
+    toolbox = module.MCPToolbox(url="http://toolbox.local", toolsets=["allowed"])
+
+    async def scenario():
+        await toolbox.connect()
+        assert toolbox.get_client() is created[0]
+        await toolbox.close()
+
+    asyncio.run(scenario())
+
+    with pytest.raises(RuntimeError, match="not initialized"):
+        toolbox.get_client()

--- a/libs/agno/tests/unit/tools/test_studio.py
+++ b/libs/agno/tests/unit/tools/test_studio.py
@@ -8,6 +8,7 @@ error: {code, message, details, retryable}, warnings}. Tests branch on the
 stable error codes, not on message prose.
 """
 
+import asyncio
 import json
 import time
 from datetime import datetime
@@ -803,6 +804,172 @@ class TestMCPToolkitPersistence:
         assert "search_docs" in rehydrated
         assert rehydrated["search_docs"].entrypoint is func.entrypoint
         assert rehydrated["search_docs"].skip_entrypoint_processing is True
+
+
+class MCPTools(Toolkit):
+    """Stub carrying the contract Studio's on-demand connect depends on:
+    functions appear at connect() and survive close(), initialized flips with
+    the session, and a failed connect logs and returns instead of raising.
+    Named MCPTools on purpose -- Studio detects MCP toolkits by class name so
+    the optional mcp extra is never imported."""
+
+    def __init__(self, name="agno_docs", connect_succeeds=True, tool_count=1, **kwargs):
+        super().__init__(name=name, **kwargs)
+        self.timeout_seconds = 5
+        self._initialized = False
+        self._connect_succeeds = connect_succeeds
+        self._tool_count = tool_count
+        self.connect_count = 0
+        self.close_count = 0
+
+    @property
+    def initialized(self) -> bool:
+        return self._initialized
+
+    async def connect(self, force: bool = False) -> None:
+        self.connect_count += 1
+        if not self._connect_succeeds:
+            # The real connect() is fail-soft: it logs the error and returns,
+            # leaving the toolkit empty.
+            return
+        for index in range(self._tool_count):
+            suffix = "" if index == 0 else f"_{index}"
+
+            async def call_proxy(**kwargs) -> str:
+                return "docs result"
+
+            func = Function(
+                name=f"search_docs{suffix}",
+                description="Search the docs.",
+                parameters={"type": "object", "properties": {"query": {"type": "string"}}, "required": ["query"]},
+                entrypoint=call_proxy,
+                skip_entrypoint_processing=True,
+            )
+            self.functions[func.name] = func
+        self._initialized = True
+
+    async def close(self) -> None:
+        self.close_count += 1
+        self._initialized = False
+
+
+class TestMCPToolkitOnDemandConnect:
+    """A standalone process (no AgentOS lifespan) persists a registry MCP
+    toolkit: _resolve_tools connects an unconnected MCP toolkit on demand,
+    keeps the harvested functions, and releases the session so later runs
+    reconnect on their own loop."""
+
+    def _studio(self, db, toolkit):
+        registry = Registry(
+            name="MCP OnDemand Registry",
+            tools=[toolkit],
+            models=[OpenAIResponses(id="gpt-5.5")],
+            dbs=[db],
+        )
+        return StudioTools(registry=registry, db=db)
+
+    def test_create_agent_connects_unconnected_mcp_toolkit(self, db):
+        toolkit = MCPTools()
+        studio = self._studio(db, toolkit)
+
+        out = _loads(studio.create_agent(name="docs-agent", instructions="i", tool_names=["agno_docs"], publish=True))
+
+        assert out["status"] == "created"
+        persisted_tools = db.get_config("docs-agent")["config"]["tools"]
+        assert [t["name"] for t in persisted_tools] == ["search_docs"]
+        assert toolkit.connect_count == 1
+
+    def test_toolkit_is_released_after_harvest(self, db):
+        toolkit = MCPTools()
+        studio = self._studio(db, toolkit)
+
+        _data(studio.create_agent(name="docs-agent", instructions="i", tool_names=["agno_docs"]))
+
+        # The session must not stay bound to the private connect loop; the
+        # registered functions must survive the release so the persisted
+        # config and later per-run reconnects both have them.
+        assert toolkit.close_count == 1
+        assert not toolkit.initialized
+        assert "search_docs" in toolkit.functions
+
+    def test_persists_from_worker_thread_with_running_loop(self, db):
+        """The standalone-arun shape that used to fail: a sync Studio tool
+        executes via asyncio.to_thread while the agent's loop keeps running."""
+        toolkit = MCPTools()
+        studio = self._studio(db, toolkit)
+
+        async def main():
+            return await asyncio.to_thread(
+                studio.create_agent,
+                name="docs-agent",
+                instructions="i",
+                tool_names=["agno_docs"],
+                publish=True,
+            )
+
+        out = _loads(asyncio.run(main()))
+
+        assert out["ok"] is True, out
+        persisted_tools = db.get_config("docs-agent")["config"]["tools"]
+        assert [t["name"] for t in persisted_tools] == ["search_docs"]
+        assert not toolkit.initialized
+
+    def test_direct_call_on_running_loop_does_not_deadlock(self, db):
+        toolkit = MCPTools()
+        studio = self._studio(db, toolkit)
+
+        async def main():
+            return studio.create_agent(name="docs-agent", instructions="i", tool_names=["agno_docs"])
+
+        out = _loads(asyncio.run(main()))
+
+        assert out["ok"] is True, out
+        assert toolkit.connect_count == 1
+
+    def test_failed_connect_still_refuses(self, db):
+        toolkit = MCPTools(connect_succeeds=False)
+        studio = self._studio(db, toolkit)
+
+        error = _error(studio.create_agent(name="docs-agent", instructions="i", tool_names=["agno_docs"]))
+
+        assert error["code"] == "invalid_request"
+        assert "agno_docs" in error["message"]
+        assert db.get_component("docs-agent") is None
+        assert toolkit.connect_count == 1
+
+    def test_connect_that_finds_no_tools_refuses_and_releases(self, db):
+        toolkit = MCPTools(tool_count=0)
+        studio = self._studio(db, toolkit)
+
+        error = _error(studio.create_agent(name="docs-agent", instructions="i", tool_names=["agno_docs"]))
+
+        assert error["code"] == "invalid_request"
+        # A successfully connected but toolless session must not stay bound to
+        # the private connect loop.
+        assert toolkit.close_count == 1
+        assert not toolkit.initialized
+
+    def test_already_connected_toolkit_is_left_alone(self, db):
+        toolkit = MCPTools()
+        asyncio.run(toolkit.connect())
+        studio = self._studio(db, toolkit)
+
+        _data(studio.create_agent(name="docs-agent", instructions="i", tool_names=["agno_docs"]))
+
+        assert toolkit.connect_count == 1  # only the explicit connect above
+        assert toolkit.close_count == 0
+        assert toolkit.initialized
+
+    def test_edit_agent_connects_on_demand(self, db):
+        toolkit = MCPTools()
+        studio = self._studio(db, toolkit)
+        studio.create_agent(name="docs-agent", instructions="i")
+
+        _data(studio.edit_agent(agent_id="docs-agent", tool_names=["agno_docs"]))
+
+        persisted_tools = db.get_latest_config("docs-agent")["config"]["tools"]
+        assert [t["name"] for t in persisted_tools] == ["search_docs"]
+        assert toolkit.connect_count == 1
 
 
 class TestCreateTeam:

--- a/libs/agno/tests/unit/tools/test_studio.py
+++ b/libs/agno/tests/unit/tools/test_studio.py
@@ -10,6 +10,7 @@ stable error codes, not on message prose.
 
 import asyncio
 import json
+import threading
 import time
 from datetime import datetime
 from importlib.util import find_spec
@@ -815,13 +816,24 @@ class MCPTools(Toolkit):
     on purpose -- Studio detects MCP toolkits by class name so the optional
     mcp extra is never imported."""
 
-    def __init__(self, name="agno_docs", connect_succeeds=True, tool_count=1, connect_error=None, **kwargs):
+    def __init__(
+        self,
+        name="agno_docs",
+        connect_succeeds=True,
+        tool_count=1,
+        connect_error=None,
+        connect_delay=0.0,
+        hang_after=None,
+        **kwargs,
+    ):
         super().__init__(name=name, **kwargs)
         self.timeout_seconds = 5
         self._initialized = False
         self._connect_succeeds = connect_succeeds
         self._tool_count = tool_count
         self._connect_error = connect_error
+        self._connect_delay = connect_delay
+        self._hang_after = hang_after
         self.connect_count = 0
         self.close_count = 0
         self.safe_cleanup_count = 0
@@ -834,11 +846,14 @@ class MCPTools(Toolkit):
         self.connect_count += 1
         if self._connect_error is not None:
             raise self._connect_error
+        if self._connect_delay:
+            await asyncio.sleep(self._connect_delay)
         if not self._connect_succeeds:
             # The real connect() is fail-soft for ordinary errors: it logs and
             # returns, leaving the toolkit empty.
             return
-        for index in range(self._tool_count):
+        register_count = self._tool_count if self._hang_after is None else self._hang_after
+        for index in range(register_count):
             suffix = "" if index == 0 else f"_{index}"
 
             async def call_proxy(**kwargs) -> str:
@@ -852,6 +867,10 @@ class MCPTools(Toolkit):
                 skip_entrypoint_processing=True,
             )
             self.functions[func.name] = func
+        if self._hang_after is not None:
+            # Models a transport that stops responding mid-handshake; only
+            # cancellation ends it.
+            await asyncio.Event().wait()
         self._initialized = True
 
     async def close(self) -> None:
@@ -1001,6 +1020,73 @@ class TestMCPToolkitOnDemandConnect:
         assert toolkit.close_count == 0
         assert toolkit.initialized
 
+    def test_hung_connect_is_bounded_and_refused(self, db, monkeypatch):
+        monkeypatch.setattr("agno.tools.studio._MCP_CONNECT_SLACK_SECONDS", 0.2)
+        toolkit = MCPTools(hang_after=0)
+        toolkit.timeout_seconds = 0.1
+        studio = self._studio(db, toolkit)
+
+        start = time.monotonic()
+        error = _error(studio.create_agent(name="docs-agent", instructions="i", tool_names=["agno_docs"]))
+        elapsed = time.monotonic() - start
+
+        assert error["code"] == "invalid_request"
+        assert elapsed < 5
+        assert toolkit.safe_cleanup_count == 1
+        assert db.get_component("docs-agent") is None
+
+    def test_partially_registered_hung_connect_is_refused(self, db, monkeypatch):
+        """A connect interrupted mid-registration may hold a partial function
+        list; it must be refused even though functions is non-empty."""
+        monkeypatch.setattr("agno.tools.studio._MCP_CONNECT_SLACK_SECONDS", 0.2)
+        toolkit = MCPTools(tool_count=2, hang_after=1)
+        toolkit.timeout_seconds = 0.1
+        studio = self._studio(db, toolkit)
+
+        error = _error(studio.create_agent(name="docs-agent", instructions="i", tool_names=["agno_docs"]))
+
+        assert error["code"] == "invalid_request"
+        assert "agno_docs" in error["message"]
+        assert toolkit.functions  # the partial registration happened...
+        assert db.get_component("docs-agent") is None  # ...and was not persisted
+
+    def test_toolkit_connected_elsewhere_with_no_tools_is_not_touched(self, db):
+        toolkit = MCPTools(tool_count=0)
+        asyncio.run(toolkit.connect())  # e.g. the AgentOS lifespan connected it
+        studio = self._studio(db, toolkit)
+
+        error = _error(studio.create_agent(name="docs-agent", instructions="i", tool_names=["agno_docs"]))
+
+        assert error["code"] == "invalid_request"
+        assert toolkit.connect_count == 1  # only the explicit connect above
+        # Its LIVE session, bound to another loop, must not be closed here.
+        assert toolkit.close_count == 0
+        assert toolkit.initialized
+
+    def test_concurrent_creates_connect_once(self, db):
+        """Parallel Studio tool calls each run in their own worker thread; the
+        shared toolkit must be connected by exactly one of them -- MCPTools
+        stages transport state on unlocked instance attributes, so concurrent
+        connects corrupt each other."""
+        toolkit = MCPTools(connect_delay=0.2)
+        studio = self._studio(db, toolkit)
+        barrier = threading.Barrier(2)
+        results: Dict[str, str] = {}
+
+        def create(name: str) -> None:
+            barrier.wait()
+            results[name] = studio.create_agent(name=name, instructions="i", tool_names=["agno_docs"])
+
+        threads = [threading.Thread(target=create, args=(f"racer-{i}",)) for i in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+
+        assert toolkit.connect_count == 1
+        for payload in results.values():
+            assert _loads(payload)["ok"] is True, payload
+
     def test_non_mcp_empty_toolkit_gets_no_connect_attempt(self, db):
         """The on-demand connect is scoped to MCP-shaped toolkits: a plain
         empty toolkit is refused as before, without Studio poking its
@@ -1033,6 +1119,31 @@ class TestMCPToolkitOnDemandConnect:
         persisted_tools = db.get_latest_config("docs-agent")["config"]["tools"]
         assert [t["name"] for t in persisted_tools] == ["search_docs"]
         assert toolkit.connect_count == 1
+
+
+class TestRealMCPToolsContract:
+    """Studio's on-demand connect duck-types the real MCPTools (by class name,
+    so the optional mcp extra is never imported). Pin the pieces it relies on
+    so drift in agno.tools.mcp surfaces here, not in a standalone process at
+    persist time."""
+
+    def test_real_mcp_tools_satisfies_the_on_demand_contract(self):
+        pytest.importorskip("mcp")
+        import inspect
+
+        from agno.tools.mcp import MCPTools as RealMCPTools
+        from agno.tools.studio import _is_mcp_toolkit
+
+        assert isinstance(inspect.getattr_static(RealMCPTools, "initialized"), property)
+        assert inspect.iscoroutinefunction(RealMCPTools.connect)
+        assert inspect.iscoroutinefunction(RealMCPTools.close)
+        assert inspect.iscoroutinefunction(RealMCPTools._safe_cleanup)
+
+        toolkit = RealMCPTools(url="https://docs.example.com/mcp")
+        assert _is_mcp_toolkit(toolkit)
+        assert isinstance(toolkit.timeout_seconds, (int, float)) and toolkit.timeout_seconds > 0
+        assert toolkit.initialized is False
+        assert not toolkit.functions
 
 
 class TestCreateTeam:

--- a/libs/agno/tests/unit/tools/test_studio.py
+++ b/libs/agno/tests/unit/tools/test_studio.py
@@ -960,6 +960,28 @@ class TestMCPToolkitOnDemandConnect:
         assert toolkit.close_count == 0
         assert toolkit.initialized
 
+    def test_non_mcp_empty_toolkit_gets_no_connect_attempt(self, db):
+        """The on-demand connect is scoped to MCP-shaped toolkits: a plain
+        empty toolkit is refused as before, without Studio poking its
+        connect() (which on connectable toolkits opens real resources)."""
+
+        class RecordingToolkit(Toolkit):
+            def __init__(self):
+                super().__init__(name="agno_docs")
+                self.connect_count = 0
+
+            def connect(self) -> None:
+                self.connect_count += 1
+
+        toolkit = RecordingToolkit()
+        studio = self._studio(db, toolkit)
+
+        error = _error(studio.create_agent(name="docs-agent", instructions="i", tool_names=["agno_docs"]))
+
+        assert error["code"] == "invalid_request"
+        assert "agno_docs" in error["message"]
+        assert toolkit.connect_count == 0
+
     def test_edit_agent_connects_on_demand(self, db):
         toolkit = MCPTools()
         studio = self._studio(db, toolkit)

--- a/libs/agno/tests/unit/tools/test_studio.py
+++ b/libs/agno/tests/unit/tools/test_studio.py
@@ -809,18 +809,22 @@ class TestMCPToolkitPersistence:
 class MCPTools(Toolkit):
     """Stub carrying the contract Studio's on-demand connect depends on:
     functions appear at connect() and survive close(), initialized flips with
-    the session, and a failed connect logs and returns instead of raising.
-    Named MCPTools on purpose -- Studio detects MCP toolkits by class name so
-    the optional mcp extra is never imported."""
+    the session, close() skips uninitialized toolkits (so a failed connect
+    needs _safe_cleanup), and an unreachable server can surface as a raised
+    CancelledError escaping connect()'s own fail-soft handler. Named MCPTools
+    on purpose -- Studio detects MCP toolkits by class name so the optional
+    mcp extra is never imported."""
 
-    def __init__(self, name="agno_docs", connect_succeeds=True, tool_count=1, **kwargs):
+    def __init__(self, name="agno_docs", connect_succeeds=True, tool_count=1, connect_error=None, **kwargs):
         super().__init__(name=name, **kwargs)
         self.timeout_seconds = 5
         self._initialized = False
         self._connect_succeeds = connect_succeeds
         self._tool_count = tool_count
+        self._connect_error = connect_error
         self.connect_count = 0
         self.close_count = 0
+        self.safe_cleanup_count = 0
 
     @property
     def initialized(self) -> bool:
@@ -828,9 +832,11 @@ class MCPTools(Toolkit):
 
     async def connect(self, force: bool = False) -> None:
         self.connect_count += 1
+        if self._connect_error is not None:
+            raise self._connect_error
         if not self._connect_succeeds:
-            # The real connect() is fail-soft: it logs the error and returns,
-            # leaving the toolkit empty.
+            # The real connect() is fail-soft for ordinary errors: it logs and
+            # returns, leaving the toolkit empty.
             return
         for index in range(self._tool_count):
             suffix = "" if index == 0 else f"_{index}"
@@ -851,6 +857,9 @@ class MCPTools(Toolkit):
     async def close(self) -> None:
         self.close_count += 1
         self._initialized = False
+
+    async def _safe_cleanup(self) -> None:
+        self.safe_cleanup_count += 1
 
 
 class TestMCPToolkitOnDemandConnect:
@@ -936,6 +945,38 @@ class TestMCPToolkitOnDemandConnect:
         assert "agno_docs" in error["message"]
         assert db.get_component("docs-agent") is None
         assert toolkit.connect_count == 1
+        # close() skips uninitialized toolkits, so a failed connect is cleaned
+        # up through _safe_cleanup -- otherwise partially-entered transport
+        # contexts would poison the next connect() attempt.
+        assert toolkit.safe_cleanup_count == 1
+        assert toolkit.close_count == 0
+
+    def test_cancelled_error_from_connect_is_contained(self, db):
+        """The mcp client surfaces an unreachable server as CancelledError,
+        which escapes connect()'s own fail-soft handler. Studio must clean the
+        toolkit up, keep connecting the rest of the list, and still refuse."""
+        broken = MCPTools(name="agno_docs", connect_error=asyncio.CancelledError())
+        working = MCPTools(name="agno_search")
+        registry = Registry(
+            name="MCP OnDemand Registry",
+            tools=[broken, working],
+            models=[OpenAIResponses(id="gpt-5.5")],
+            dbs=[db],
+        )
+        studio = StudioTools(registry=registry, db=db)
+
+        error = _error(
+            studio.create_agent(name="docs-agent", instructions="i", tool_names=["agno_docs", "agno_search"])
+        )
+
+        assert error["code"] == "invalid_request"
+        assert "agno_docs" in error["message"]
+        assert "agno_search" not in error["message"]
+        assert broken.safe_cleanup_count == 1
+        assert broken.close_count == 0
+        # The failure did not kill the connect pass mid-list.
+        assert working.connect_count == 1
+        assert not working.initialized
 
     def test_connect_that_finds_no_tools_refuses_and_releases(self, db):
         toolkit = MCPTools(tool_count=0)

--- a/libs/agno/tests/unit/tools/test_studio.py
+++ b/libs/agno/tests/unit/tools/test_studio.py
@@ -824,6 +824,10 @@ class MCPTools(Toolkit):
         connect_error=None,
         connect_delay=0.0,
         hang_after=None,
+        fail_times=0,
+        register_before_error=0,
+        error_leaves_initialized=False,
+        swallow_cancel=False,
         **kwargs,
     ):
         super().__init__(name=name, **kwargs)
@@ -834,6 +838,10 @@ class MCPTools(Toolkit):
         self._connect_error = connect_error
         self._connect_delay = connect_delay
         self._hang_after = hang_after
+        self._fail_times = fail_times
+        self._register_before_error = register_before_error
+        self._error_leaves_initialized = error_leaves_initialized
+        self._swallow_cancel = swallow_cancel
         self.connect_count = 0
         self.close_count = 0
         self.safe_cleanup_count = 0
@@ -842,18 +850,8 @@ class MCPTools(Toolkit):
     def initialized(self) -> bool:
         return self._initialized
 
-    async def connect(self, force: bool = False) -> None:
-        self.connect_count += 1
-        if self._connect_error is not None:
-            raise self._connect_error
-        if self._connect_delay:
-            await asyncio.sleep(self._connect_delay)
-        if not self._connect_succeeds:
-            # The real connect() is fail-soft for ordinary errors: it logs and
-            # returns, leaving the toolkit empty.
-            return
-        register_count = self._tool_count if self._hang_after is None else self._hang_after
-        for index in range(register_count):
+    def _register(self, count: int) -> None:
+        for index in range(count):
             suffix = "" if index == 0 else f"_{index}"
 
             async def call_proxy(**kwargs) -> str:
@@ -867,10 +865,39 @@ class MCPTools(Toolkit):
                 skip_entrypoint_processing=True,
             )
             self.functions[func.name] = func
+
+    async def connect(self, force: bool = False) -> None:
+        self.connect_count += 1
+        if self._connect_error is not None:
+            raise self._connect_error
+        if self._connect_delay:
+            await asyncio.sleep(self._connect_delay)
+        if self.connect_count <= self._fail_times:
+            # A transient failure with tools already registered -- the
+            # MCPToolbox shape: it registers the unfiltered superset first and
+            # a filtering failure raises with that superset (and initialized)
+            # in place.
+            self._register(self._register_before_error)
+            self._initialized = self._error_leaves_initialized
+            raise RuntimeError("transient connect failure")
+        if not self._connect_succeeds:
+            # The real connect() is fail-soft for ordinary errors: it logs and
+            # returns, leaving the toolkit empty.
+            return
+        self._register(self._tool_count if self._hang_after is None else self._hang_after)
         if self._hang_after is not None:
-            # Models a transport that stops responding mid-handshake; only
-            # cancellation ends it.
-            await asyncio.Event().wait()
+            if self._swallow_cancel:
+                # A transport whose teardown never completes: the bounding
+                # cancellation is absorbed, so the connect thread outlives its
+                # join deadline.
+                try:
+                    await asyncio.Event().wait()
+                except asyncio.CancelledError:
+                    await asyncio.Event().wait()
+            else:
+                # Models a transport that stops responding mid-handshake; only
+                # cancellation ends it.
+                await asyncio.Event().wait()
         self._initialized = True
 
     async def close(self) -> None:
@@ -1035,9 +1062,11 @@ class TestMCPToolkitOnDemandConnect:
         assert toolkit.safe_cleanup_count == 1
         assert db.get_component("docs-agent") is None
 
-    def test_partially_registered_hung_connect_is_refused(self, db, monkeypatch):
-        """A connect interrupted mid-registration may hold a partial function
-        list; it must be refused even though functions is non-empty."""
+    def test_partially_registered_hung_connect_is_refused_and_cleared(self, db, monkeypatch):
+        """A connect interrupted mid-registration holds a partial function
+        list; the create must be refused and the leftovers cleared -- an
+        unconnected toolkit with functions would be persisted as-is by any
+        LATER call."""
         monkeypatch.setattr("agno.tools.studio._MCP_CONNECT_SLACK_SECONDS", 0.2)
         toolkit = MCPTools(tool_count=2, hang_after=1)
         toolkit.timeout_seconds = 0.1
@@ -1047,8 +1076,58 @@ class TestMCPToolkitOnDemandConnect:
 
         assert error["code"] == "invalid_request"
         assert "agno_docs" in error["message"]
-        assert toolkit.functions  # the partial registration happened...
-        assert db.get_component("docs-agent") is None  # ...and was not persisted
+        assert not toolkit.functions  # the partial registration was cleared
+        assert db.get_component("docs-agent") is None
+
+    def test_retry_after_transient_failure_reconnects_and_persists_fully(self, db):
+        """The first create fails mid-connect with one of two tools already
+        registered; the retry must reconnect (not persist the leftover)."""
+        toolkit = MCPTools(tool_count=2, fail_times=1, register_before_error=1)
+        studio = self._studio(db, toolkit)
+
+        error = _error(studio.create_agent(name="docs-agent", instructions="i", tool_names=["agno_docs"]))
+        assert error["code"] == "invalid_request"
+
+        data = _data(studio.create_agent(name="docs-agent", instructions="i", tool_names=["agno_docs"]))
+        assert data["id"] == "docs-agent"
+        persisted_tools = db.get_latest_config("docs-agent")["config"]["tools"]
+        assert sorted(t["name"] for t in persisted_tools) == ["search_docs", "search_docs_1"]
+        assert toolkit.connect_count == 2
+
+    def test_failed_filter_superset_is_not_persisted_on_retry(self, db):
+        """MCPToolbox registers the unfiltered superset before filtering and a
+        filter failure raises with that superset (and initialized) in place.
+        The retry must reconnect and persist only the filtered set."""
+        toolkit = MCPTools(tool_count=1, fail_times=1, register_before_error=2, error_leaves_initialized=True)
+        studio = self._studio(db, toolkit)
+
+        error = _error(studio.create_agent(name="docs-agent", instructions="i", tool_names=["agno_docs"]))
+        assert error["code"] == "invalid_request"
+        assert toolkit.close_count == 1  # the initialized-but-failed toolkit was released
+        assert not toolkit.functions  # the unfiltered superset was cleared
+
+        data = _data(studio.create_agent(name="docs-agent", instructions="i", tool_names=["agno_docs"]))
+        assert data["id"] == "docs-agent"
+        persisted_tools = db.get_latest_config("docs-agent")["config"]["tools"]
+        assert [t["name"] for t in persisted_tools] == ["search_docs"]
+
+    def test_abandoned_connect_blocks_retry_until_its_thread_dies(self, db, monkeypatch):
+        """A connect that absorbs its bounding cancellation outlives the join
+        deadline. Its partial functions are still live under the zombie loop,
+        so the first call must refuse them via the failed-ids channel, and a
+        retry must not start a second connect against the same toolkit."""
+        monkeypatch.setattr("agno.tools.studio._MCP_CONNECT_SLACK_SECONDS", 0.2)
+        toolkit = MCPTools(hang_after=1, swallow_cancel=True)
+        toolkit.timeout_seconds = 0.1
+        studio = self._studio(db, toolkit)
+
+        error = _error(studio.create_agent(name="docs-agent", instructions="i", tool_names=["agno_docs"]))
+        assert error["code"] == "invalid_request"
+        assert toolkit.functions  # zombie still holds its partial registration
+
+        error = _error(studio.create_agent(name="docs-agent2", instructions="i", tool_names=["agno_docs"]))
+        assert error["code"] == "invalid_request"
+        assert toolkit.connect_count == 1  # no second connect raced the zombie
 
     def test_toolkit_connected_elsewhere_with_no_tools_is_not_touched(self, db):
         toolkit = MCPTools(tool_count=0)
@@ -1144,6 +1223,27 @@ class TestRealMCPToolsContract:
         assert isinstance(toolkit.timeout_seconds, (int, float)) and toolkit.timeout_seconds > 0
         assert toolkit.initialized is False
         assert not toolkit.functions
+
+    def test_real_close_keeps_the_harvested_functions(self):
+        """The single most load-bearing property of the release design: the
+        real close() tears down sessions but never touches functions. If a
+        hygiene refactor ever clears them, the on-demand connect silently
+        regresses into always-refuse in standalone processes."""
+        pytest.importorskip("mcp")
+        from agno.tools.mcp import MCPTools as RealMCPTools
+
+        toolkit = RealMCPTools(url="https://docs.example.com/mcp")
+        toolkit.functions["search_docs"] = Function(
+            name="search_docs",
+            parameters={"type": "object", "properties": {}},
+            skip_entrypoint_processing=True,
+        )
+        toolkit._initialized = True
+        # All teardown contexts are None, so close() no-ops through them.
+        asyncio.run(toolkit.close())
+
+        assert toolkit.initialized is False
+        assert "search_docs" in toolkit.functions
 
 
 class TestCreateTeam:


### PR DESCRIPTION
## Summary

Any standalone process — a script, notebook, or eval run with no AgentOS server lifespan — could not persist a Studio component that wires a **registry MCP toolkit**: nothing ever `connect()`ed the toolkit, so it reached persist time with no functions and `_resolve_tools` refused with *"Toolkits have no functions and cannot be persisted"*. The identical build succeeds against a running server because `AgentOS.mcp_lifespan` connects registry MCP tools at startup. First observed as `python -m evals --tag smoke` red on a fresh agentos-railway clone; only registry-declared MCP toolkits are affected (agent/team-attached MCP tools already auto-connect per run).

Two changes:

**(a) Root fix — Studio connects unconnected registry MCP toolkits on demand.** `StudioTools._resolve_tools` now connects any resolved MCP-shaped toolkit (class name `MCPTools` in the mro, so the optional `mcp` extra is never imported) that has no functions and was never connected, then **releases** it again: connect + `close()` run on a short-lived private event loop in a dedicated thread. This works because persisting needs the toolkit's *function list*, not a live session — `MCPTools.close()` keeps the registered functions — and a released toolkit reconnects per run on whatever loop later uses it, while a session left bound to the dead private loop would break the toolkit's later tool calls in the same process. The dedicated thread serves every caller shape: a sync Studio tool running in an `asyncio.to_thread` worker (the normal `arun` shape), a plain sync call with no loop anywhere, and a direct call from a coroutine — the caller's loop is never re-entered.

Fail-soft in wording, not in effect: connect errors are logged and swallowed, and a toolkit that still has no functions afterwards hits the existing refusal (message updated) — an empty toolkit is never silently persisted. Non-MCP empty toolkits are refused exactly as before, without Studio poking their `connect()`, and the on-demand connect never fires under a running AgentOS (the lifespan already populated the functions).

**(b) Eval-runner affordance — `acli(cases, ..., mcp_tools=[...])`.** `acli` connects the given tools fail-soft in its own loop before the cases run (after the `--list`/no-match early returns, so listing never opens sessions) and closes them around `arun_cases` — what the AgentOS lifespan does for a server, for an eval process. `cli` forwards the param. This lets the agentos-railway template collapse its `evals/__main__.py` workaround back to `sys.exit(cli(CASES, db=eval_db, mcp_tools=...))`.

## Hardening beyond the happy path

Live probes against real MCP servers/transports (a FastMCP stdio server, a real unreachable streamable-http endpoint) plus an adversarial multi-agent review surfaced and fixed five failure modes in the naive version of (a)/(b), each pinned by a test and verified by mutation:

- **`CancelledError` containment.** The mcp client surfaces an unreachable server as `CancelledError` out of its cancel scopes — a `BaseException` that bypasses `MCPTools.connect()`'s own fail-soft `except Exception`, skips its cleanup, and leaves partially-entered transport contexts that poison the next `connect()` attempt. Both the Studio helper and the acli loop catch `BaseException`, restore unconnected toolkits via `_safe_cleanup`, and reduce the failure to one warning line plus the refusal (verified end-to-end against `http://127.0.0.1:9`). acli additionally re-raises *genuine* task cancellation (`Task.cancelling()`, 3.11+) so a host's cancel still lands, and always releases already-connected tools.
- **Concurrent-connect race.** Parallel Studio tool calls each run in their own worker thread; `MCPTools` stages transport state on unlocked instance attributes, so two concurrent connect passes on the same registry toolkit corrupted each other ~50% of the time (probe-confirmed against a real stdio server: 4–5 of 8 barrier-synchronized rounds ended with an empty toolkit and a spurious refusal). The connect pass is now serialized process-wide; the loser re-checks under the lock and finds the work done. Probe after fix: 0 of 8 bad rounds.
- **Hung transports are bounded in-loop.** Some hangs (e.g. an SSE stream that never sends its endpoint event) are otherwise bounded only by the mcp SDK's 300s read default. Each connect now runs under `asyncio.wait_for` with the toolkit's own `timeout_seconds` plus slack, so cleanup runs on the same loop and the thread reliably exits.
- **Interrupted connects are refused even with functions present.** A connect that raised, timed out, or was abandoned at the join deadline may have registered only part of the server's tools (or still be registering them); those toolkits are refused regardless of their functions dict — never persisted partial.
- **Live toolkits are never touched.** A toolkit another loop already connected whose server lists zero tools (`initialized=True`, empty functions) is refused on emptiness without Studio closing its live session cross-loop.

## Review round 2 (Claude + GPT reviews, findings validated by probe)

Every claimed finding was re-verified against the branch before acting; the valid ones are fixed here, each probe-confirmed before and after:

- **Interrupted connects no longer leak their partial function list into a later call.** The failed-ids refusal only protected the call that attempted the connect; the leftovers survived on the toolkit, and a retry — seeing non-empty functions — skipped reconnection and persisted them (probe: retry persisted 1 of 2 tools). Worse, `MCPToolbox` registers the *unfiltered superset* before applying `toolsets` filtering and raises with that superset (and `initialized=True`) in place, so a filter failure could persist capability-filtered tools on retry. A connect attempt that does not fully succeed now clears the toolkit back to the unconnected invariant — empty functions — so a retry reconnects instead of persisting leftovers.
- **A connect thread abandoned at its join deadline now blocks its toolkit until the thread dies.** Previously the lock was released at join timeout while the daemon thread lived on; a retry started a second connect against the same toolkit (probe: `connect_count=2`, two connects active at once) — recreating the corruption the lock exists to prevent. Abandoned threads are registered per toolkit id; the check runs against every resolved MCP toolkit (a zombie's partial registrations make its toolkit look connected enough to skip candidacy), so retries are refused, not raced (probe after: one connect ever).
- **acli owns exactly the sessions it opens.** It now skips toolkits something else already connected (`connect()` would no-op and the close would tear down a session it never opened), refuses to count a connect that returned with the toolkit still uninitialized (`initialize()` failures return fail-soft with a dead session attached — dropped via `_safe_cleanup` instead of leaking to process exit), and a genuine cancel landing during teardown re-raises after the remaining tools are released instead of reporting a normal exit.
- **Contract pin added for the design's most load-bearing assumption:** the real `MCPTools.close()` keeps the harvested functions. If a hygiene refactor upstream ever clears them, CI catches it instead of a standalone process at persist time.

## Review round 3

Two follow-on findings, both verified by reading the real classes before fixing:

- **`MCPToolbox` filter state no longer survives teardown.** The toolbox latched `_core_client_initialized` *before* filtering and never reset it on `close()`, so after a transient filter failure the retry's base connect re-registered the unfiltered superset and `connect()` early-returned past filtering — Studio's retry would persist tools outside the configured `toolsets`, through the *success* path, defeating the round-2 clear-on-failure protection. The flag is now latched only after a successful filter (pinned via the cancelled-filter path, which no `except` in the toolbox catches) and reset by every teardown path (`close()`, `__aexit__`, and the failure branch, which also closes the leaked core client). Tests exercise the real `MCPToolbox` class against a stubbed `toolbox_core` boundary — the optional dependency is injected into `sys.modules`, so the lifecycle logic under test is entirely this repo's own and the tests run without the extra installed.
- **A cancel swallowed by `MCPTools.close()` no longer reads as success.** Real `close()` ends in `except BaseException: pass`, so a cancel delivered mid-teardown vanishes inside it and the eval runner's teardown loop never saw a `CancelledError`. After each close the loop now also checks the task's cancelling counter, finishes releasing the remaining tools, and exits cancelled. The swallow itself is pinned as a real-`MCPTools` contract test, so if upstream ever stops eating the cancel, the compensation is re-examined rather than silently doubled.

The helper's "released toolkit reconnects per run" docstring is also qualified: that holds for MCPTools instances attached to components; rehydrated bare Functions are not reconnected by any run path (the standalone-dispatch gap tracked as issue 0008).

Validated-but-deferred (pre-existing, filed as issue 0008 in the private tracker): standalone dispatch of a freshly built MCP-wired component fails at tool-call time because the run path connects only `MCPTools` *instances*, never the `source_toolkit` of rehydrated bare Functions. The flow only became reachable with this PR (create used to be refused outright); it works under AgentOS and under `acli mcp_tools=`, and the fix belongs on the run path (agent + team + workflow surfaces). Also considered and declined: bounding acli's connect with `wait_for` (parity with the AgentOS lifespan, which is likewise unbounded).

Implements `specs/agno/issues/0007` (issue-tracker doc, private repo).

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Design note — private loop + release instead of `run_coroutine_threadsafe` onto the run loop.** The alternative (connect on the agent's running loop, captured at run start) keeps a live session nobody owns or closes in a standalone process. Since `close()` keeps the harvested functions and both agent and team runs auto-connect their MCP tools per run, connect-harvest-release yields the same persisted config with no session lifetime to manage, no loop-affinity landmine, and no new run-start hook — and behaves identically across the create/edit surfaces that share `_resolve_tools`.

**Tests: 34 new, all mutation-checked** — each fails on unfixed code or on a targeted mutation of the fix (release removed, MCP filter removed, guard removed, failed-ids check removed, initialized gate removed, lock removed, `BaseException` narrowed to `Exception`, partial-clear removed, zombie block removed, acli ownership gates removed):

- `TestMCPToolkitOnDemandConnect` (16): standalone persist from a plain sync call, from the `asyncio.to_thread` worker shape a real `arun` uses, and from a direct call on a running loop (no deadlock); toolkit released after harvest with functions intact; refusal preserved on failed connect, on `CancelledError` (containment mid-list proven with a second toolkit), on a zero-tool server, on a hung connect (bounded, sub-second with shrunk budgets), and on a partially-registered hung connect (with the partial cleared); retry after a transient failure reconnects and persists the full list; a failed-filter superset (the MCPToolbox shape) is never persisted on retry; an abandoned connect blocks retries until its thread dies; connected-elsewhere and already-connected toolkits untouched; concurrent creates connect exactly once; non-MCP empty toolkits get no connect attempt; edit path covered.
- `TestRealMCPToolsContract` (2): pins the real `MCPTools` surface the duck-typed helper relies on (`initialized` property, async `connect`/`close`/`_safe_cleanup`, `timeout_seconds`) and the design's key assumption — real `close()` keeps the harvested functions.
- Eval runner (12): connect/close land on the case-running loop; per-tool fail-soft for ordinary errors and for `CancelledError` (with `_safe_cleanup`); tools connected elsewhere are skipped, not closed; an uninitialized connect is not counted as connected and its dead session is dropped; genuine task cancellation propagates mid-connect, mid-teardown, and even when `close()` swallows the cancel (with the swallow pinned against the real `MCPTools`); close still happens when the runner raises; `--list` never connects; `cli` forwards.
- `test_mcp_toolbox_lifecycle.py` (4): real `MCPToolbox` against a stubbed `toolbox_core` — a failed filter neither latches the filter flag nor leaks the core client; a cancelled filter (no toolbox `except` catches it) doesn't latch; `close()` resets the state so a reconnect re-filters instead of keeping the superset; `get_client()` refuses after close.

Full `libs/agno/tests/unit` sweep: failure set identical to origin/main in the same environment (zero delta both directions); `./scripts/format.sh` and `./scripts/validate.sh` clean.

**Follow-up candidates (pre-existing, out of scope):** `MCPTools.connect()` raising `CancelledError` through the per-run auto-connect path (`agent/_init.py connect_mcp_tools` catches only `Exception`) affects any run against an unreachable server, independent of this change; and `MCPTools`' unlocked transport state remains racy for non-Studio concurrent connects.

**Downstream cleanup once released:** agentos-railway (and the Starter family via core sync) deletes the workaround block in `evals/__main__.py` at the next agno pin bump containing this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017M5r3NrWqjnEaA7T9jpp2m
