### PR TITLE
feat: expose toolkits as MCP tools + hide framework params

### DIFF
--- a/cookbook/05_agent_os/14_mcp/README.md
+++ b/cookbook/05_agent_os/14_mcp/README.md
@@ -2,7 +2,7 @@
 
 AgentOS can expose its agents, teams, and workflows as an MCP server at
 `/mcp`. These examples cover the server side of that boundary: the default
-operator surface, agents served directly as tools, custom tools, PAT
+operator surface, agents served directly as tools, custom tools, toolkits, PAT
 authentication, tool scoping, and two OAuth deployment choices. Examples where
 an Agno agent consumes another MCP server belong in `cookbook/91_tools/mcp`.
 
@@ -14,6 +14,7 @@ an Agno agent consumes another MCP server belong in `cookbook/91_tools/mcp`.
 | `agents_as_tools.py` | Turn the default tools off and expose agents directly as named MCP tools. |
 | `mcp_client.py` | Discover, pause, continue, cancel, and inspect runs with a protocol-level client. |
 | `custom_tools.py` | Disable the default tools and expose one purpose-built tool. |
+| `toolkit_tools.py` | Serve a whole toolkit, flattened into one MCP tool per method. |
 | `secure_mcp.py` | Mint a PAT, authorize its principal, restrict hosts and tool tags, and return full results. |
 | `oauth_builtin.py` | Run AgentOS's database-backed OAuth authorization server. |
 | `oauth_authkit.py` | Use WorkOS AuthKit as an external authorization server. |
@@ -116,6 +117,42 @@ tools; paused runs then say to resume over the REST API.
 `custom_tools.py` passes an Agno `@tool` through
 `MCPConfig(tools=[...])` and sets `default_tools=False`, leaving a
 single client-visible tool.
+
+`toolkit_tools.py` passes a whole `Toolkit` instead of a single tool. AgentOS
+flattens it into one MCP tool per method -- `MemoryTools(enable_think=False,
+enable_analyze=False)` becomes `get_memories`, `add_memory`, `update_memory`,
+and `delete_memory` -- the way an agent takes a toolkit apart. Each flattened name goes through the same
+collision check as a hand-written custom tool, so a toolkit method named like a
+default tool (`WorkflowTools` really does register `run_workflow`) fails at
+startup instead of silently replacing it. Narrow the published set with the
+toolkit's own `include_tools` / `exclude_tools`.
+
+Toolkit methods take framework arguments: every `MemoryTools` method declares
+`run_context: RunContext`. Those are kept out of the client-facing schema and
+filled server-side at call time, so `add_memory` publishes just `memory` and
+`topics` while its body still receives a context carrying the authenticated
+caller. This is not only about tidiness -- pydantic cannot build a schema for a
+`RunContext`, so a visible one would stop the server from starting. The same
+rule hides `Agent`- and `Team`-typed arguments, which arrive as `None` because
+an MCP call runs outside any component. Media arguments stay visible: nothing on
+this surface has run media to inject, so hiding one would leave it fillable by
+nobody. So does a toolkit method's own `user_id` -- agno fills identity from the
+RunContext, never by that name, so a `user_id` argument on a toolkit method is a
+domain value (`ZoomTools` asks which account to read) and stays the caller's to
+send. `user_id` on a tool you wrote for this surface is still filled from the
+JWT subject, as before.
+
+The identity in that RunContext is only as good as the deployment's
+authorization: without `AgentOS(authorization=True, ...)` there is no JWT
+subject, the resolved caller is `None`, and every client shares one identity.
+Configure authorization before serving a toolkit whose data is per-user.
+
+A tool whose approval gate this surface cannot honour is refused at startup
+rather than published without it. `requires_confirmation`, `requires_user_input`
+and `external_execution` all live in the call path an MCP request bypasses, so
+`Workspace(root=".")` -- whose `delete_file` and `run_command` are
+confirmation-gated -- fails fast and names the knob that frees it. Serve the
+read-only surface (`allowed=["read", "list", "search"]`) instead.
 
 `secure_mcp.py` demonstrates the full security configuration:
 

--- a/cookbook/05_agent_os/14_mcp/README.md
+++ b/cookbook/05_agent_os/14_mcp/README.md
@@ -147,6 +147,12 @@ authorization: without `AgentOS(authorization=True, ...)` there is no JWT
 subject, the resolved caller is `None`, and every client shares one identity.
 Configure authorization before serving a toolkit whose data is per-user.
 
+A toolkit that declares it needs a connection (`_requires_connect`) is refused
+unless it reports a live one: this server runs each call directly, so
+`connect()` and `close()` never fire. Connect it before building the server, or
+publish its functions individually (`tools=[*kit.get_async_functions().values()]`)
+and own the lifecycle yourself.
+
 A tool whose approval gate this surface cannot honour is refused at startup
 rather than published without it. `requires_confirmation`, `requires_user_input`
 and `external_execution` all live in the call path an MCP request bypasses, so

--- a/cookbook/05_agent_os/14_mcp/README.md
+++ b/cookbook/05_agent_os/14_mcp/README.md
@@ -147,11 +147,13 @@ authorization: without `AgentOS(authorization=True, ...)` there is no JWT
 subject, the resolved caller is `None`, and every client shares one identity.
 Configure authorization before serving a toolkit whose data is per-user.
 
-A toolkit that declares it needs a connection (`_requires_connect`) is refused
-unless it reports a live one: this server runs each call directly, so
-`connect()` and `close()` never fire. Connect it before building the server, or
-publish its functions individually (`tools=[*kit.get_async_functions().values()]`)
-and own the lifecycle yourself.
+This server runs each tool call directly, so a toolkit's `connect()` and
+`close()` never fire and every call is handed a fresh `RunContext`. The shipped
+connection-managing toolkits (`PostgresTools`, `RedshiftTools`) connect
+themselves on use and are unaffected. A toolkit whose state is keyed on the run
+is not: `CodeMode` keys its kernel by `session_id`, so over MCP it would start a
+kernel per call and accumulate nothing. Serve that one over REST, where a run
+owns the session.
 
 A tool whose approval gate this surface cannot honour is refused at startup
 rather than published without it. `requires_confirmation`, `requires_user_input`

--- a/cookbook/05_agent_os/14_mcp/TEST_LOG.md
+++ b/cookbook/05_agent_os/14_mcp/TEST_LOG.md
@@ -10,6 +10,9 @@ remain accepted aliases). Re-run LIVE on 2026-08-28 after the lifecycle
 ride-along and the review-round fixes landed; the entry below records the
 2026-08-28 run. Re-run LIVE again on 2026-08-30 after tool presentation
 metadata (`title`, `annotations`) landed -- see the entry below the first.
+`toolkit_tools.py` added and first tested LIVE on 2026-08-29, when a
+`Toolkit` passed to `MCPConfig.tools` began flattening into one MCP tool per
+method with the framework's own arguments filled server-side.
 
 ### agents_as_tools.py
 
@@ -203,6 +206,37 @@ AuthKit login was not claimed because no configured tenant was available.
 
 ---
 
+### toolkit_tools.py
+
+**Status:** PASS
+
+**Test mode:** LIVE (2026-08-29)
+
+**Description:** Started the checked-in server (`MemoryTools(db=SqliteDb(...),
+enable_think=False, enable_analyze=False)` passed whole to
+`MCPConfig(tools=[...], default_tools=False)`) and drove it with a FastMCP
+streamable-HTTP client at `http://localhost:7777/mcp`: listed tools, read every
+generated schema, added a memory, read it back, and tried to supply the hidden
+`run_context` from the client.
+
+**Result:** `tools/list` returned exactly the toolkit's four methods --
+`get_memories`, `add_memory`, `update_memory`, `delete_memory` -- each carrying
+its own docstring as the description. `run_context`, which every one of those
+methods declares, was absent from all four schemas: `add_memory` published
+`memory` (required) and `topics`, `update_memory` published `memory_id`
+(required) plus `memory` and `topics`, `delete_memory` published `memory_id`
+(required), and `get_memories` published no arguments at all. `add_memory`
+returned `success: true` with a generated `memory_id`, and `get_memories`
+returned that same memory, so the server-filled RunContext reached the tool body
+-- `run_context` is a required argument of `add_memory`, so the call could not
+have succeeded without it. The run was unauthenticated, so the caller it carried
+was None and the memory landed in the null-user bucket; the example's docstring
+and the README now say so rather than implying per-caller ownership out of the
+box. Supplying `run_context` from the client was
+rejected by FastMCP as an unexpected keyword argument, which is the point of
+hiding it rather than merely omitting it from the docs. The server was stopped
+and the SQLite file removed afterwards.
+
 ## Validation
 
 - All three credential-independent server/client paths completed with live
@@ -214,7 +248,7 @@ AuthKit login was not claimed because no configured tenant was available.
 - The six focused MCP server, lifecycle, result, OAuth, built-in auth, and
   AuthKit source suites passed 218 tests.
 - Python compilation and targeted Ruff format/check passed.
-- Recursive structure and stale-surface scans checked exactly 6 Python files
+- Recursive structure and stale-surface scans checked exactly 8 Python files
   with no violations.
 - `git diff --check` passed for the lesson and consumed legacy MCP folder.
 - All scoped servers were stopped after testing.

--- a/cookbook/05_agent_os/14_mcp/TEST_LOG.md
+++ b/cookbook/05_agent_os/14_mcp/TEST_LOG.md
@@ -237,6 +237,8 @@ rejected by FastMCP as an unexpected keyword argument, which is the point of
 hiding it rather than merely omitting it from the docs. The server was stopped
 and the SQLite file removed afterwards.
 
+---
+
 ## Validation
 
 - All three credential-independent server/client paths completed with live

--- a/cookbook/05_agent_os/14_mcp/toolkit_tools.py
+++ b/cookbook/05_agent_os/14_mcp/toolkit_tools.py
@@ -1,0 +1,90 @@
+"""
+Serve a toolkit as MCP tools
+============================
+
+Pass a Toolkit to MCPConfig.tools and AgentOS flattens it into one MCP tool per
+method, the way an agent takes it apart. MemoryTools becomes get_memories,
+add_memory, update_memory, and delete_memory.
+
+Every one of those methods declares `run_context: RunContext`. AgentOS keeps it
+out of the client-facing schema -- pydantic cannot describe a RunContext, so a
+visible one would stop the server from starting -- and fills it at call time
+with a context carrying the authenticated caller. A client cannot claim to be
+anyone else: the argument is not in the schema, and a value supplied for it is
+rejected.
+
+Who that caller is depends on the deployment. This example runs without an
+authorization layer, so the resolved caller is None and every client shares one
+memory bucket -- fine for a local lesson, wrong for anything shared. Add
+`AgentOS(authorization=True, ...)` and the JWT subject becomes the memory owner;
+see secure_mcp.py for the full configuration.
+
+Prerequisites: OPENAI_API_KEY
+Run: .venvs/demo/bin/python cookbook/05_agent_os/14_mcp/toolkit_tools.py
+Try: connect an MCP client to http://localhost:7777/mcp and call add_memory
+"""
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIResponses
+from agno.os import AgentOS, MCPConfig
+from agno.tools.memory import MemoryTools
+
+# ---------------------------------------------------------------------------
+# Create Database
+# ---------------------------------------------------------------------------
+
+db = SqliteDb(
+    id="mcp-toolkit-db",
+    db_file="tmp/mcp_toolkit.db",
+)
+
+# ---------------------------------------------------------------------------
+# Create the toolkit
+# ---------------------------------------------------------------------------
+
+# think and analyze are left off: both accumulate into the run's session_state,
+# and an MCP tool call has no run behind it to accumulate into.
+memory_tools = MemoryTools(
+    db=db,
+    enable_think=False,
+    enable_analyze=False,
+)
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+memory_agent = Agent(
+    id="memory-agent",
+    name="Memory Agent",
+    model=OpenAIResponses(id="gpt-5.6-luna"),
+    db=db,
+    tools=[memory_tools],
+    instructions="Remember what the user tells you, and recall it on request.",
+    add_history_to_context=True,
+    markdown=True,
+)
+
+# ---------------------------------------------------------------------------
+# Serve the toolkit as the whole MCP surface
+# ---------------------------------------------------------------------------
+
+agent_os = AgentOS(
+    id="mcp-toolkit-os",
+    description="AgentOS serving a memory toolkit as individual MCP tools.",
+    db=db,
+    agents=[memory_agent],
+    mcp=MCPConfig(
+        tools=[memory_tools],
+        default_tools=False,
+    ),
+)
+app = agent_os.get_app()
+
+# ---------------------------------------------------------------------------
+# Run Toolkit AgentOS
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    agent_os.serve(app=app)

--- a/libs/agno/agno/os/config.py
+++ b/libs/agno/agno/os/config.py
@@ -62,7 +62,10 @@ class MCPConfig(BaseModel):
     #   - a ``Toolkit`` -- flattened into one MCP tool per method, the way an agent
     #     takes it apart. Narrow the published set with the toolkit's own
     #     ``include_tools``/``exclude_tools``; each flattened name goes through the
-    #     same collision check as a hand-written custom tool;
+    #     same collision check as a hand-written custom tool. A toolkit that declares
+    #     ``_requires_connect`` is refused unless it reports a live connection: this
+    #     server runs each call directly, so connect()/close() never fire. Connect it
+    #     first, or publish its functions individually and own the lifecycle;
     #   - an ``Agent`` / ``Team`` / ``Workflow`` instance -- exposed as a tool named
     #     after its id, described by the component's own description;
     #   - ``component.as_tool(name=..., description=...)`` -- the same exposure with a
@@ -110,8 +113,9 @@ class MCPConfig(BaseModel):
     #
     # A tool returning an Agno ``ToolResult`` has it rendered as MCP content -- the answer
     # as text, images and audio as their own block types, videos and files as embedded
-    # blob resources -- rather than JSON-serialized, which loses the answer in a dump of
-    # the model and fails outright on raw bytes.
+    # blob resources, and media the tool produced elsewhere as a resource link -- rather
+    # than JSON-serialized, which loses the answer in a dump of the model and fails
+    # outright on raw bytes.
     tools: Optional[List[Any]] = None
 
     # Master switch for the 8 default tools. Set to False to ship only your own

--- a/libs/agno/agno/os/config.py
+++ b/libs/agno/agno/os/config.py
@@ -62,10 +62,12 @@ class MCPConfig(BaseModel):
     #   - a ``Toolkit`` -- flattened into one MCP tool per method, the way an agent
     #     takes it apart. Narrow the published set with the toolkit's own
     #     ``include_tools``/``exclude_tools``; each flattened name goes through the
-    #     same collision check as a hand-written custom tool. A toolkit that declares
-    #     ``_requires_connect`` is refused unless it reports a live connection: this
-    #     server runs each call directly, so connect()/close() never fire. Connect it
-    #     first, or publish its functions individually and own the lifecycle;
+    #     same collision check as a hand-written custom tool. This server runs each call
+    #     directly, so a toolkit's ``connect()``/``close()`` never fire: the shipped
+    #     ``_requires_connect`` toolkits (``PostgresTools``, ``RedshiftTools``) connect
+    #     themselves on use and are unaffected, but one whose state is keyed on the run
+    #     (``CodeMode``, whose kernel is keyed by ``session_id``) gets a fresh identity
+    #     every call and will not accumulate anything -- serve those over REST instead;
     #   - an ``Agent`` / ``Team`` / ``Workflow`` instance -- exposed as a tool named
     #     after its id, described by the component's own description;
     #   - ``component.as_tool(name=..., description=...)`` -- the same exposure with a

--- a/libs/agno/agno/os/config.py
+++ b/libs/agno/agno/os/config.py
@@ -104,7 +104,14 @@ class MCPConfig(BaseModel):
     # An MCP call runs the tool directly, so the approval step a Function can declare
     # (``requires_confirmation``, ``requires_user_input``, ``external_execution``) would be
     # skipped. Such a tool is refused when the server is built rather than published
-    # without its gate.
+    # without its gate. The rest of ``FunctionCall``'s machinery is inert here for the same
+    # reason and is NOT refused: tool hooks, pre/post hooks, and result caching
+    # (``cache_results``) simply do not run on this surface.
+    #
+    # A tool returning an Agno ``ToolResult`` has it rendered as MCP content -- the answer
+    # as text, images and audio as their own block types, videos and files as embedded
+    # blob resources -- rather than JSON-serialized, which loses the answer in a dump of
+    # the model and fails outright on raw bytes.
     tools: Optional[List[Any]] = None
 
     # Master switch for the 8 default tools. Set to False to ship only your own

--- a/libs/agno/agno/os/config.py
+++ b/libs/agno/agno/os/config.py
@@ -59,6 +59,10 @@ class MCPConfig(BaseModel):
     #
     #   - a plain callable or an Agno ``@tool``/``Function`` -- a custom tool
     #     (name/description inferred from the function or taken from the tool);
+    #   - a ``Toolkit`` -- flattened into one MCP tool per method, the way an agent
+    #     takes it apart. Narrow the published set with the toolkit's own
+    #     ``include_tools``/``exclude_tools``; each flattened name goes through the
+    #     same collision check as a hand-written custom tool;
     #   - an ``Agent`` / ``Team`` / ``Workflow`` instance -- exposed as a tool named
     #     after its id, described by the component's own description;
     #   - ``component.as_tool(name=..., description=...)`` -- the same exposure with a
@@ -89,8 +93,18 @@ class MCPConfig(BaseModel):
     #
     # Identity: a custom tool may declare a ``user_id`` parameter. AgentOS fills it with
     # the authenticated caller's id (the JWT subject) and hides it from the client-facing
-    # schema, so clients cannot spoof it. Tools that need the full request can declare a
+    # schema, so clients cannot spoof it. A parameter typed ``RunContext``, ``Agent`` or
+    # ``Team`` is hidden and filled the same way, whatever it is called -- pydantic cannot
+    # build a tool schema for those types, so a visible one would stop the server from
+    # starting; the RunContext a tool receives carries the authenticated caller but no run
+    # (an MCP call has none), and Agent/Team arrive as None. Media parameters stay visible:
+    # nothing here has run media to inject. Tools that need the full request can declare a
     # FastMCP ``Context`` parameter, which FastMCP injects natively.
+    #
+    # An MCP call runs the tool directly, so the approval step a Function can declare
+    # (``requires_confirmation``, ``requires_user_input``, ``external_execution``) would be
+    # skipped. Such a tool is refused when the server is built rather than published
+    # without its gate.
     tools: Optional[List[Any]] = None
 
     # Master switch for the 8 default tools. Set to False to ship only your own

--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -202,7 +202,6 @@ def _register_custom_tools(mcp: FastMCP, entries: List[Any], enabled_tags: "Opti
     names: Dict[str, str] = {}
     for tool in entries:
         if isinstance(tool, Toolkit):
-            _reject_unconnected_toolkit(tool)
             # ``get_async_functions()`` is the merged surface with async variants
             # preferred -- the same set an agent running in async mode would get --
             # already filtered by the toolkit's include_tools/exclude_tools.
@@ -227,43 +226,6 @@ def _register_custom_tools(mcp: FastMCP, entries: List[Any], enabled_tags: "Opti
         names[name] = label
         taken[name] = label
     return names
-
-
-def _reject_unconnected_toolkit(toolkit: Any) -> None:
-    """Refuse a toolkit that declares it needs a connection this server never opens.
-
-    An agent connects a ``_requires_connect`` toolkit before its first call and closes it
-    afterwards. The MCP server runs each tool call directly and has no equivalent moment,
-    so a toolkit relying on that lifecycle runs unconnected and is never torn down.
-    ``CodeMode`` is the sharp case: its kernel is keyed by ``session_id``, and an MCP call
-    mints a fresh one every time, so a deployment would start a kernel per call, lose the
-    state each one was for, and never flush a snapshot.
-
-    A toolkit that reports a live connection is served: ``PostgresTools`` connected by the
-    deployer is exactly as usable here as anywhere. One that cannot report one is refused
-    rather than quietly half-working -- the deployer can still publish its functions
-    individually, which says "I know what this needs" in a way passing the toolkit does not.
-    """
-    if not getattr(toolkit, "_requires_connect", False):
-        return
-    try:
-        connected = bool(getattr(toolkit, "is_connected", False))
-    except Exception:
-        connected = False
-    if connected:
-        return
-    if hasattr(type(toolkit), "is_connected"):
-        remedy = f'Connect it before the server is built ("{toolkit.name}".connect()), or drop it from tools=.'
-    else:
-        remedy = (
-            "It cannot report a live connection, so this server cannot know it is usable. Pass the "
-            "functions you want individually (tools=[*toolkit.get_async_functions().values()]) if you "
-            "are managing its lifecycle yourself."
-        )
-    raise ValueError(
-        f'MCPConfig.tools got toolkit "{toolkit.name}", which requires a connection the MCP server does '
-        f"not manage: it runs each tool call directly, so connect() and close() never fire. {remedy}"
-    )
 
 
 def _collision_free_advice(colliding_name: str, enabled_tags: "Optional[set]") -> str:

--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -5,7 +5,19 @@ import inspect
 import logging
 import re
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Literal, Optional, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Iterator,
+    List,
+    Literal,
+    NamedTuple,
+    Optional,
+    Union,
+    get_type_hints,
+)
 from uuid import uuid4
 
 from fastmcp import Context, FastMCP
@@ -40,6 +52,13 @@ from agno.run.agent import RunEvent, RunOutput
 from agno.run.team import TeamRunEvent, TeamRunOutput
 from agno.run.workflow import WorkflowRunEvent, WorkflowRunOutput
 from agno.tools.annotations import tool_presentation
+from agno.utils.schema import (
+    IDENTITY_INJECTED_PARAMS,
+    annotation_binds,
+    annotation_reaches,
+    identity_injected_types,
+    unwrap_annotation,
+)
 from agno.utils.string import generate_component_id_from_name, generate_id_from_name
 
 if TYPE_CHECKING:
@@ -158,6 +177,11 @@ def _register_custom_tools(mcp: FastMCP, entries: List[Any], enabled_tags: "Opti
     as "partial"), so the exposure collision check downstream sees the real registry
     rather than a re-derivation.
 
+    A ``Toolkit`` is flattened into one MCP tool per method, the way an agent takes it
+    apart. Each flattened name goes through the same collision check as a hand-written
+    custom tool, so a toolkit method named like a default tool (``WorkflowTools`` really
+    does register ``run_workflow``) is a startup error rather than a silent replacement.
+
     A custom tool named like a default tool that will register (its tags intersect
     ``enabled_tags``), or like an earlier custom tool, is a hard error, matching the
     exposure path: FastMCP would otherwise warn-and-REPLACE, so a custom
@@ -165,6 +189,8 @@ def _register_custom_tools(mcp: FastMCP, entries: List[Any], enabled_tags: "Opti
     keep steering callers to the builtin's schema), and a duplicate custom name would
     silently swallow the first tool.
     """
+    from agno.tools.toolkit import Toolkit
+
     taken = {
         builtin: f'the default tool "{builtin}"'
         for builtin, tags in _BUILTIN_TOOL_NAMES.items()
@@ -172,6 +198,24 @@ def _register_custom_tools(mcp: FastMCP, entries: List[Any], enabled_tags: "Opti
     }
     names: Dict[str, str] = {}
     for tool in entries:
+        if isinstance(tool, Toolkit):
+            # ``get_async_functions()`` is the merged surface with async variants
+            # preferred -- the same set an agent running in async mode would get --
+            # already filtered by the toolkit's include_tools/exclude_tools.
+            members = list(tool.get_async_functions().values())
+            if not members:
+                raise ValueError(
+                    f'MCPConfig.tools got toolkit "{tool.name}", which registers no functions, so it would '
+                    "publish nothing. Drop it, or widen its include_tools/exclude_tools."
+                )
+            for member in members:
+                name = _register_custom_tool(mcp, member, taken=taken, enabled_tags=enabled_tags, toolkit=tool)
+                # The label names the toolkit, because a collision on a flattened method
+                # is not fixed by renaming a "custom tool" the deployer never wrote.
+                label = f'toolkit "{tool.name}" tool "{name}"'
+                names[name] = label
+                taken[name] = label
+            continue
         name = _register_custom_tool(mcp, tool, taken=taken, enabled_tags=enabled_tags)
         label = f'custom tool "{name}"'
         names[name] = label
@@ -212,15 +256,195 @@ def _custom_tool_presentation(tool: Any) -> "tuple[Optional[str], Optional[ToolA
     return title, (ToolAnnotations(**annotations) if annotations else None)
 
 
+class _Hidden(NamedTuple):
+    """One parameter kept out of an MCP tool's schema, and what the server puts in it.
+
+    ``bind`` is None when the server has nothing to put there: the parameter is still
+    hidden (pydantic could not describe it) but its own default stands. ``always``
+    writes the bound value even over a non-empty default, which is what the reserved
+    names get -- an authenticated caller's identity is never the tool author's to
+    default away.
+    """
+
+    bind: Optional[Callable[[], Any]]
+    always: bool
+
+
+# A hidden parameter has to be passed by keyword at call time. The other kinds cannot
+# be, so a framework-typed one among them is refused by name rather than left in the
+# schema for pydantic to fail on.
+_MCP_INJECTABLE_KINDS = (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
+
+# Approval gates that live in ``FunctionCall.execute``. An MCP call runs the entrypoint
+# directly, so a tool carrying one of these would run its body with the gate skipped.
+_MCP_UNSUPPORTED_GATES = ("requires_confirmation", "requires_user_input", "external_execution", "approval_type")
+
+
+def _new_mcp_run_context() -> Any:
+    """A RunContext for one MCP tool call, carrying the authenticated caller.
+
+    There is no run and no session behind an MCP tool call, so both ids are fresh per
+    call: what a tool writes into ``session_state`` here is not read back by the next
+    call. ``user_id`` is the part that carries real information -- the JWT subject, the
+    same value ``user_id`` injection resolves.
+    """
+    from agno.run.base import RunContext
+
+    return RunContext(run_id=str(uuid4()), session_id=str(uuid4()), user_id=_resolve_user_id(None))
+
+
+def _identity_binder(hint: Any) -> "Optional[Callable[[], Any]]":
+    """What the server can put INTO a parameter of this type, or None for nothing.
+
+    Deliberately narrower than the rule that decides what to HIDE, and mirroring
+    ``FunctionCall._build_entrypoint_args``: a ``List[RunContext]`` names an identity
+    type, so it cannot stay in the schema, but it holds run contexts rather than being
+    one and nothing can be bound into it. Agent and Team bind None because an MCP tool
+    call runs outside any component.
+    """
+    from agno.agent.agent import Agent
+    from agno.run.base import RunContext
+    from agno.team.team import Team
+
+    hint = unwrap_annotation(hint)
+    if annotation_binds(hint, (RunContext,)):
+        return _new_mcp_run_context
+    if annotation_binds(hint, (Agent, Team)):
+        return lambda: None
+    return None
+
+
+def _toolkit_clause(toolkit: Any, method: "Optional[str]") -> str:
+    """The 'or drop it from the toolkit' half of a refusal, when one applies."""
+    if toolkit is None:
+        return ""
+    return f' (or drop it from toolkit "{toolkit.name}" with exclude_tools=["{method}"])'
+
+
+def _mcp_hidden_params(
+    fn: Callable, owner: "Optional[str]", reserved_names: bool = False, toolkit: Any = None
+) -> "Dict[str, _Hidden]":
+    """The parameters kept out of an MCP tool's schema, and how each one is filled.
+
+    Two rules, each mirroring one the agent-facing path already uses:
+
+      * By NAME -- ``user_id`` always, because the JWT subject is the server's to
+        resolve and never the caller's to supply. For an Agno ``Function`` the identity
+        names the framework fills itself (``agent``/``team``/``run_context`` and the
+        ``_agno_`` channels) are hidden too: that object is the same one an agent would
+        run, and it must not have two contracts. A bare callable handed to
+        ``MCPConfig.tools`` was written for this surface, so its own ``agent: str``
+        stays its own. Media names are hidden on NEITHER path -- nothing here has run
+        media to inject, so hiding one would leave it fillable by nobody.
+      * By TYPE -- any annotation that can REACH an identity type. This is broader than
+        the model-facing ``is_framework_typed`` on purpose. That rule keeps
+        ``owner: Union[str, Agent]`` fillable because a model can only ever send the
+        string half; here pydantic builds the schema from the real signature and fails
+        on ``BaseDb`` regardless of what the caller would have sent.
+
+    A parameter the server must fill but cannot pass by keyword, and a required one
+    nothing can be bound into, are refused by name -- otherwise they surface at startup
+    as a pydantic error naming a type the tool author never wrote.
+    """
+    try:
+        sig = inspect.signature(fn)
+    except (ValueError, TypeError):
+        return {}
+
+    hidden: Dict[str, _Hidden] = {}
+
+    def claim(param_name: str, entry: _Hidden) -> None:
+        param = sig.parameters[param_name]
+        if param.kind not in _MCP_INJECTABLE_KINDS:
+            raise ValueError(
+                f'MCP custom tool "{owner}" declares "{param_name}" as a {param.kind.description} parameter. '
+                "The server has to fill it -- pydantic cannot build a tool schema for it -- and cannot pass "
+                f"it by keyword. Make it a normal or keyword-only parameter{_toolkit_clause(toolkit, owner)}."
+            )
+        hidden[param_name] = entry
+
+    # ``user_id`` is hidden on the hand-written path only. That contract was written for
+    # a tool authored FOR this surface, where the name means "who is calling". A toolkit
+    # method takes its identity from the RunContext instead -- agno never injects
+    # ``user_id`` by name -- so a ``user_id`` argument there is a domain value
+    # (``ZoomTools.get_upcoming_meetings(user_id="me")`` asks which Zoom account to read),
+    # and overwriting it with the JWT subject would break the call rather than secure it.
+    by_name = (() if toolkit is not None else ("user_id",)) + (IDENTITY_INJECTED_PARAMS if reserved_names else ())
+    for param_name in by_name:
+        if param_name not in sig.parameters:
+            continue
+        if param_name == "user_id":
+            claim(param_name, _Hidden(bind=lambda: _resolve_user_id(None), always=True))
+        elif param_name in ("run_context", "_agno_run_context"):
+            claim(param_name, _Hidden(bind=_new_mcp_run_context, always=True))
+        else:
+            claim(param_name, _Hidden(bind=lambda: None, always=True))
+
+    try:
+        hints = get_type_hints(fn)
+    except Exception:
+        # One unreadable annotation fails the whole walk. The reserved names above still
+        # stand; the typed rule is skipped rather than guessed at by evaluating
+        # annotation text, which would run the tool author's strings at startup.
+        hints = {}
+
+    for param_name, hint in hints.items():
+        # get_type_hints includes "return", which is not a parameter.
+        if param_name == "return" or param_name not in sig.parameters or param_name in hidden:
+            continue
+        # Per parameter, not per signature: one annotation this walk cannot read must not
+        # leave a neighbouring identity parameter unclassified and caller-facing.
+        try:
+            owned = annotation_reaches(hint, identity_injected_types())
+        except Exception:
+            owned = True  # Cannot classify it, so do not put it in the schema.
+        if not owned:
+            continue
+        binder = _identity_binder(hint)
+        if binder is None and sig.parameters[param_name].default is inspect.Parameter.empty:
+            raise ValueError(
+                f'MCP custom tool "{owner}" declares required parameter "{param_name}" as {hint!r}, which the '
+                "server must keep out of the tool schema but has nothing to fill it with. Drop it from the "
+                "signature, or give it a default and expect that default on every call"
+                f"{_toolkit_clause(toolkit, owner)}."
+            )
+        claim(param_name, _Hidden(bind=binder, always=False))
+
+    return hidden
+
+
+def _reject_gated_function(tool: Any, name: "Optional[str]", toolkit: Any) -> None:
+    """Refuse a tool whose approval gate this surface cannot honour.
+
+    Confirmation, user input and external execution all live in ``FunctionCall.execute``.
+    An MCP call reaches the entrypoint directly, so publishing such a tool would run the
+    gated body with no gate -- ``Workspace`` alone would put ``delete_file`` and
+    ``run_command`` on the wire ungated. Refused at startup rather than downgraded.
+    """
+    gates = [gate for gate in _MCP_UNSUPPORTED_GATES if getattr(tool, gate, None)]
+    if not gates:
+        return
+    raise ValueError(
+        f'MCP custom tool "{name}" sets {", ".join(gates)}, which the MCP server cannot honour: an MCP call '
+        "runs the tool directly, so the approval step would be skipped. Drop the gate for this surface"
+        f"{_toolkit_clause(toolkit, name)}."
+    )
+
+
 def _register_custom_tool(
-    mcp: FastMCP, tool: Any, taken: "Optional[Dict[str, str]]" = None, enabled_tags: "Optional[set]" = None
+    mcp: FastMCP,
+    tool: Any,
+    taken: "Optional[Dict[str, str]]" = None,
+    enabled_tags: "Optional[set]" = None,
+    toolkit: Any = None,
 ) -> str:
     """Register a single custom tool, supporting plain callables and Agno tools/Functions.
 
     Returns the name the tool registered under. ``taken`` holds names already claimed
     on this server (checked before registration -- FastMCP replaces on duplicates
     rather than raising). ``enabled_tags`` steers the collision advice toward the knob
-    that actually frees the name.
+    that actually frees the name. ``toolkit`` is the toolkit this tool was flattened
+    out of, used only to point a refusal at the knob that frees it.
     """
     from fastmcp.tools import Tool
 
@@ -229,13 +453,15 @@ def _register_custom_tool(
     if callable(entrypoint):
         name = getattr(tool, "name", None) or getattr(entrypoint, "__name__", None)
         description = getattr(tool, "description", None)
+        _reject_gated_function(tool, name, toolkit)
+        hidden = _mcp_hidden_params(entrypoint, owner=name, reserved_names=True, toolkit=toolkit)
         # Presentation metadata is read only from an Agno Function, never duck-typed off
         # an arbitrary object: a stray ``.annotations`` attribute on some other tool-ish
         # object means something else entirely. Marketplace scans reject tools that carry
         # no annotations, so a custom tool that wants a listing sets them on its Function.
         title, annotations = _custom_tool_presentation(tool)
         tool_obj = Tool.from_function(
-            _inject_user_id(entrypoint),
+            _build_mcp_wrapper(entrypoint, hidden),
             name=name,
             title=title,
             description=description,
@@ -243,7 +469,8 @@ def _register_custom_tool(
         )
     elif callable(tool):
         # Plain callable: name/description inferred from ``__name__``/docstring.
-        tool_obj = Tool.from_function(_inject_user_id(tool))
+        hidden = _mcp_hidden_params(tool, owner=getattr(tool, "__name__", "custom tool"))
+        tool_obj = Tool.from_function(_build_mcp_wrapper(tool, hidden))
     else:
         raise TypeError(
             f"Cannot register MCP tool of type {type(tool).__name__!r}; expected a callable or an Agno tool/Function."
@@ -251,8 +478,17 @@ def _register_custom_tool(
 
     if taken and tool_obj.name in taken:
         claimant = taken[tool_obj.name]
+        # A flattened toolkit method is not the deployer's to rename -- the name comes
+        # from someone else's class -- so its advice names the knob that frees it.
+        free_it = (
+            f'Drop it from toolkit "{toolkit.name}" with exclude_tools=["{tool_obj.name}"]'
+            if toolkit is not None
+            else "Rename the custom tool"
+        )
         if claimant.startswith("the default tool"):
-            advice = f"Rename the custom tool, {_collision_free_advice(tool_obj.name, enabled_tags)}so each tool name is unique."
+            advice = f"{free_it}, {_collision_free_advice(tool_obj.name, enabled_tags)}so each tool name is unique."
+        elif toolkit is not None:
+            advice = f"{free_it} so each tool name is unique."
         else:
             advice = "Rename one of them so each tool name is unique."
         raise ValueError(f'MCP custom tool name "{tool_obj.name}" collides with {claimant}. {advice}')
@@ -260,40 +496,80 @@ def _register_custom_tool(
     return tool_obj.name
 
 
-def _inject_user_id(fn: Callable) -> Callable:
-    """Inject the authenticated caller's user_id into a custom tool, hidden from clients.
+def _build_mcp_wrapper(fn: Callable, hidden: "Dict[str, _Hidden]") -> Callable:
+    """Give FastMCP a signature without the framework's parameters, and fill them in.
 
-    If ``fn`` declares a ``user_id`` parameter, return a wrapper that fills it with the
-    resolved JWT subject at call time and drops it from the wrapper's signature -- so it
-    does not appear in the MCP tool schema and cannot be supplied (or spoofed) by callers.
-    Tools that do not declare ``user_id`` are returned unchanged.
+    On the agent-facing path FunctionCall assembles the arguments after the schema is
+    settled, so hiding and filling are separate steps. Here FastMCP reads this signature
+    to BUILD the schema, so a RunContext left in it is not merely exposed: pydantic
+    cannot describe one, and the server fails to start. The wrapper therefore drops the
+    hidden parameters from its own signature and puts the values back on the way through.
+
+    Tools with nothing to hide are returned unchanged, so they register exactly as they
+    did before this wrapper existed.
     """
-    try:
-        sig = inspect.signature(fn)
-    except (ValueError, TypeError):
-        return fn
-    if "user_id" not in sig.parameters:
+    if not hidden:
         return fn
 
-    visible_params = [p for name, p in sig.parameters.items() if name != "user_id"]
-    new_sig = sig.replace(parameters=visible_params)
+    sig = inspect.signature(fn)
+    visible = [param for name, param in sig.parameters.items() if name not in hidden]
+    new_sig = sig.replace(parameters=visible)
+    # Positional arguments can only be re-bound by name when every visible parameter can
+    # take a keyword. Without that step a hidden parameter sitting BEFORE a visible one
+    # -- the shape of every RunContext-taking toolkit method -- would collide with its
+    # own injected value on a positional call.
+    positional_names = (
+        [param.name for param in visible] if all(p.kind in _MCP_INJECTABLE_KINDS for p in visible) else []
+    )
+
+    def visible_annotations() -> Dict[str, Any]:
+        """The annotations of the parameters that survived, plus the return type.
+
+        ``functools.wraps`` copies the wrapped function's ``__annotations__`` wholesale,
+        hidden parameters included -- and it copies the same dict object, so this builds
+        a new one rather than deleting from the original's. FastMCP reads annotations as
+        well as the signature, so a hidden parameter's annotation left behind is not
+        cosmetic: one that cannot be resolved at all (a framework type imported only
+        under ``if TYPE_CHECKING``) fails FastMCP's type adapter and the server never
+        starts, even though the parameter was correctly hidden.
+        """
+        annotations = {
+            param.name: param.annotation for param in visible if param.annotation is not inspect.Parameter.empty
+        }
+        if new_sig.return_annotation is not inspect.Signature.empty:
+            annotations["return"] = new_sig.return_annotation
+        return annotations
+
+    def prepare(args: tuple, kwargs: Dict[str, Any]) -> tuple:
+        if args and positional_names and len(args) <= len(positional_names):
+            names = positional_names[: len(args)]
+            if not any(name in kwargs for name in names):
+                kwargs.update(zip(names, args))
+                args = ()
+        for param_name, entry in hidden.items():
+            if entry.bind is None:
+                continue  # Hidden but unfillable: the parameter's own default stands.
+            value = entry.bind()
+            if entry.always or value is not None or sig.parameters[param_name].default is inspect.Parameter.empty:
+                kwargs[param_name] = value
+        return args
 
     if inspect.iscoroutinefunction(fn):
 
         @functools.wraps(fn)
         async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
-            kwargs["user_id"] = _resolve_user_id(None)
-            return await fn(*args, **kwargs)
+            return await fn(*prepare(args, kwargs), **kwargs)
 
         async_wrapper.__signature__ = new_sig  # type: ignore[attr-defined]
+        async_wrapper.__annotations__ = visible_annotations()
         return async_wrapper
 
     @functools.wraps(fn)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
-        kwargs["user_id"] = _resolve_user_id(None)
-        return fn(*args, **kwargs)
+        return fn(*prepare(args, kwargs), **kwargs)
 
     wrapper.__signature__ = new_sig  # type: ignore[attr-defined]
+    wrapper.__annotations__ = visible_annotations()
     return wrapper
 
 
@@ -1184,6 +1460,7 @@ def _split_tool_entries(mcp_config: "Optional[MCPConfig]", os: "AgentOS") -> "tu
     from agno.agent.agent import Agent
     from agno.team.team import Team
     from agno.tools.component import ComponentTool
+    from agno.tools.toolkit import Toolkit
     from agno.workflow.workflow import Workflow
 
     def _concrete_kind(obj: Any) -> "Optional[str]":
@@ -1234,6 +1511,13 @@ def _split_tool_entries(mcp_config: "Optional[MCPConfig]", os: "AgentOS") -> "tu
                 f"MCPConfig.tools got the string {entry!r}; pass the component instance itself "
                 "(or a callable/Agno tool)."
             )
+        if isinstance(entry, Toolkit):
+            # Classified by type, not left to the heuristics below. A Toolkit carries an
+            # id like a component does, so a subclass that also defines ``arun`` would
+            # otherwise be read as an off-roster component and rejected as missing from
+            # a roster it was never meant to join.
+            customs.append(entry)
+            continue
         if isinstance(entry, (Agent, Team, Workflow)):
             kind, component = _locate_component(entry, os, expected_kind=_concrete_kind(entry))
             exposures.append((kind, component, None))

--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -5,6 +5,7 @@ import inspect
 import logging
 import re
 from contextlib import contextmanager
+from copy import deepcopy
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -28,7 +29,7 @@ from fastmcp.tools import ToolResult
 from mcp.types import ToolAnnotations
 
 from agno.db.base import SessionType
-from agno.os.mcp_results import build_run_tool_result, trim_session_run
+from agno.os.mcp_results import build_custom_tool_result, build_run_tool_result, trim_session_run
 from agno.os.schema import (
     AgentSummaryResponse,
     PaginatedResponse,
@@ -206,7 +207,9 @@ def _register_custom_tools(mcp: FastMCP, entries: List[Any], enabled_tags: "Opti
             if not members:
                 raise ValueError(
                     f'MCPConfig.tools got toolkit "{tool.name}", which registers no functions, so it would '
-                    "publish nothing. Drop it, or widen its include_tools/exclude_tools."
+                    "publish nothing. A toolkit that discovers its tools while connecting (MCPTools) has to "
+                    "be connected before the server is built; otherwise widen its include_tools/exclude_tools, "
+                    "or drop it."
                 )
             for member in members:
                 name = _register_custom_tool(mcp, member, taken=taken, enabled_tags=enabled_tags, toolkit=tool)
@@ -322,7 +325,11 @@ def _toolkit_clause(toolkit: Any, method: "Optional[str]") -> str:
 
 
 def _mcp_hidden_params(
-    fn: Callable, owner: "Optional[str]", reserved_names: bool = False, toolkit: Any = None
+    fn: Callable,
+    owner: "Optional[str]",
+    reserved_names: bool = False,
+    toolkit: Any = None,
+    drop_var_keyword: bool = False,
 ) -> "Dict[str, _Hidden]":
     """The parameters kept out of an MCP tool's schema, and how each one is filled.
 
@@ -369,6 +376,16 @@ def _mcp_hidden_params(
     # ``user_id`` by name -- so a ``user_id`` argument there is a domain value
     # (``ZoomTools.get_upcoming_meetings(user_id="me")`` asks which Zoom account to read),
     # and overwriting it with the JWT subject would break the call rather than secure it.
+    if drop_var_keyword:
+        # ``**kwargs`` has no MCP schema -- FastMCP refuses the tool outright rather than
+        # publishing one -- so a catch-all that the Function does not describe separately
+        # is dropped from what clients see. The named parameters beside it still describe
+        # the tool (EmailTools.email_user(subject, body, **kwargs)), and nothing fills it:
+        # an MCP caller sends a JSON object, which binds to the named parameters anyway.
+        for param_name, param in sig.parameters.items():
+            if param.kind is inspect.Parameter.VAR_KEYWORD:
+                hidden[param_name] = _Hidden(bind=None, always=False)
+
     by_name = (() if toolkit is not None else ("user_id",)) + (IDENTITY_INJECTED_PARAMS if reserved_names else ())
     for param_name in by_name:
         if param_name not in sig.parameters:
@@ -431,6 +448,61 @@ def _reject_gated_function(tool: Any, name: "Optional[str]", toolkit: Any) -> No
     )
 
 
+def _takes_var_keyword(fn: Callable) -> bool:
+    """Whether the callable ends in ``**kwargs``, which FastMCP refuses to publish."""
+    try:
+        return any(param.kind is inspect.Parameter.VAR_KEYWORD for param in inspect.signature(fn).parameters.values())
+    except (ValueError, TypeError):
+        return False
+
+
+def _declares_own_schema(tool: Any, entrypoint: Callable) -> bool:
+    """Whether this Function carries the schema its signature cannot express.
+
+    A dynamic toolkit builds its tools at runtime and puts the schema on the Function
+    rather than in the signature: ``MCPTools`` copies each remote tool's ``inputSchema``,
+    ``ApifyTools`` takes ``**kwargs`` and describes the actor's inputs separately. FastMCP
+    derives its schema by introspecting the callable, which for those refuses outright --
+    "Functions with **kwargs are not supported as tools" -- and takes the whole server
+    down with it.
+
+    True only when the entrypoint genuinely cannot describe itself AND the Function does.
+    Everywhere else the signature stays the source of truth, so an ordinary tool is
+    unaffected.
+    """
+    from agno.tools.function import Function
+
+    if not isinstance(tool, Function) or not _takes_var_keyword(entrypoint):
+        return False
+    parameters = tool.parameters
+    return isinstance(parameters, dict) and bool(parameters.get("properties"))
+
+
+def _declared_parameters(tool: Any, hidden: "Dict[str, _Hidden]", toolkit: Any = None) -> "Dict[str, Any]":
+    """The Function's declared schema, minus anything the server owns.
+
+    Dropped by NAME as well as by whatever the signature hid, because a declared schema
+    reaches this point precisely when the signature could not describe the tool: a
+    ``**kwargs`` entrypoint has no ``run_context`` parameter for the signature rules to
+    catch, so a schema naming one would publish an identity key for the caller to fill.
+    Dropped rather than injected -- the schema describes a remote tool's inputs, and
+    nothing here knows the body wants a RunContext.
+    """
+    owned = set(hidden) | set(IDENTITY_INJECTED_PARAMS)
+    if toolkit is None:
+        owned.add("user_id")
+
+    declared = deepcopy(tool.parameters)
+    properties = {name: schema for name, schema in declared.get("properties", {}).items() if name not in owned}
+    declared["properties"] = properties
+    required = [name for name in declared.get("required", []) or [] if name in properties]
+    if required:
+        declared["required"] = required
+    else:
+        declared.pop("required", None)
+    return declared
+
+
 def _register_custom_tool(
     mcp: FastMCP,
     tool: Any,
@@ -446,7 +518,7 @@ def _register_custom_tool(
     that actually frees the name. ``toolkit`` is the toolkit this tool was flattened
     out of, used only to point a refusal at the knob that frees it.
     """
-    from fastmcp.tools import Tool
+    from fastmcp.tools import FunctionTool, Tool
 
     # Agno tool / Function: a callable ``entrypoint`` plus name/description metadata.
     entrypoint = getattr(tool, "entrypoint", None)
@@ -454,23 +526,56 @@ def _register_custom_tool(
         name = getattr(tool, "name", None) or getattr(entrypoint, "__name__", None)
         description = getattr(tool, "description", None)
         _reject_gated_function(tool, name, toolkit)
-        hidden = _mcp_hidden_params(entrypoint, owner=name, reserved_names=True, toolkit=toolkit)
+        uses_declared_schema = _declares_own_schema(tool, entrypoint)
+        hidden = _mcp_hidden_params(
+            entrypoint,
+            owner=name,
+            reserved_names=True,
+            toolkit=toolkit,
+            # A declared schema is published verbatim, so the catch-all it is declared
+            # THROUGH has to stay in the wrapper's signature to receive the arguments.
+            drop_var_keyword=not uses_declared_schema,
+        )
         # Presentation metadata is read only from an Agno Function, never duck-typed off
         # an arbitrary object: a stray ``.annotations`` attribute on some other tool-ish
         # object means something else entirely. Marketplace scans reject tools that carry
         # no annotations, so a custom tool that wants a listing sets them on its Function.
         title, annotations = _custom_tool_presentation(tool)
-        tool_obj = Tool.from_function(
-            _build_mcp_wrapper(entrypoint, hidden),
-            name=name,
-            title=title,
-            description=description,
-            annotations=annotations,
-        )
+        returns_tool_result = _returns_tool_result(entrypoint)
+        wrapped = _build_mcp_wrapper(entrypoint, hidden, convert_result=returns_tool_result)
+        if uses_declared_schema:
+            declared = _declared_parameters(tool, hidden, toolkit)
+            # Built directly rather than through ``Tool.from_function``, which would
+            # re-derive the schema from a signature that cannot express one.
+            tool_obj = FunctionTool(
+                fn=wrapped,
+                name=name,
+                title=title,
+                description=description,
+                annotations=annotations,
+                parameters=declared,
+                output_schema=None,
+            )
+        else:
+            tool_obj = Tool.from_function(
+                wrapped,
+                name=name,
+                title=title,
+                description=description,
+                annotations=annotations,
+                # A ``ToolResult`` return is converted into content blocks on the way
+                # out, so the schema FastMCP would derive from that model describes
+                # something the tool never sends.
+                **({"output_schema": None} if returns_tool_result else {}),
+            )
     elif callable(tool):
         # Plain callable: name/description inferred from ``__name__``/docstring.
-        hidden = _mcp_hidden_params(tool, owner=getattr(tool, "__name__", "custom tool"))
-        tool_obj = Tool.from_function(_build_mcp_wrapper(tool, hidden))
+        hidden = _mcp_hidden_params(tool, owner=getattr(tool, "__name__", "custom tool"), drop_var_keyword=True)
+        returns_tool_result = _returns_tool_result(tool)
+        tool_obj = Tool.from_function(
+            _build_mcp_wrapper(tool, hidden, convert_result=returns_tool_result),
+            **({"output_schema": None} if returns_tool_result else {}),
+        )
     else:
         raise TypeError(
             f"Cannot register MCP tool of type {type(tool).__name__!r}; expected a callable or an Agno tool/Function."
@@ -496,7 +601,33 @@ def _register_custom_tool(
     return tool_obj.name
 
 
-def _build_mcp_wrapper(fn: Callable, hidden: "Dict[str, _Hidden]") -> Callable:
+def _returns_tool_result(fn: Callable) -> bool:
+    """Whether the callable declares an Agno ``ToolResult`` return.
+
+    Read from the annotation rather than discovered at call time, because the same
+    answer settles two things at once: the result needs converting, and FastMCP must be
+    told NOT to derive an output schema from the ``ToolResult`` model (it would then
+    reject the converted result for not matching it).
+    """
+    from agno.tools.function import ToolResult
+
+    try:
+        hint = get_type_hints(fn).get("return")
+    except Exception:
+        hint = getattr(fn, "__annotations__", {}).get("return")
+    return isinstance(hint, type) and issubclass(hint, ToolResult)
+
+
+def _converted_result(value: Any) -> Any:
+    """An Agno ``ToolResult`` rendered as MCP content; anything else untouched."""
+    from agno.tools.function import ToolResult
+
+    if isinstance(value, ToolResult):
+        return build_custom_tool_result(value)
+    return value
+
+
+def _build_mcp_wrapper(fn: Callable, hidden: "Dict[str, _Hidden]", convert_result: bool = False) -> Callable:
     """Give FastMCP a signature without the framework's parameters, and fill them in.
 
     On the agent-facing path FunctionCall assembles the arguments after the schema is
@@ -505,10 +636,13 @@ def _build_mcp_wrapper(fn: Callable, hidden: "Dict[str, _Hidden]") -> Callable:
     cannot describe one, and the server fails to start. The wrapper therefore drops the
     hidden parameters from its own signature and puts the values back on the way through.
 
-    Tools with nothing to hide are returned unchanged, so they register exactly as they
-    did before this wrapper existed.
+    ``convert_result`` additionally renders an Agno ``ToolResult`` as MCP content blocks
+    on the way out, instead of letting it reach FastMCP's generic JSON serializer.
+
+    Tools with nothing to hide and nothing to convert are returned unchanged, so they
+    register exactly as they did before this wrapper existed.
     """
-    if not hidden:
+    if not hidden and not convert_result:
         return fn
 
     sig = inspect.signature(fn)
@@ -558,7 +692,8 @@ def _build_mcp_wrapper(fn: Callable, hidden: "Dict[str, _Hidden]") -> Callable:
 
         @functools.wraps(fn)
         async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
-            return await fn(*prepare(args, kwargs), **kwargs)
+            result = await fn(*prepare(args, kwargs), **kwargs)
+            return _converted_result(result) if convert_result else result
 
         async_wrapper.__signature__ = new_sig  # type: ignore[attr-defined]
         async_wrapper.__annotations__ = visible_annotations()
@@ -566,7 +701,8 @@ def _build_mcp_wrapper(fn: Callable, hidden: "Dict[str, _Hidden]") -> Callable:
 
     @functools.wraps(fn)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
-        return fn(*prepare(args, kwargs), **kwargs)
+        result = fn(*prepare(args, kwargs), **kwargs)
+        return _converted_result(result) if convert_result else result
 
     wrapper.__signature__ = new_sig  # type: ignore[attr-defined]
     wrapper.__annotations__ = visible_annotations()

--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -22,6 +22,7 @@ from typing import (
 from uuid import uuid4
 
 from fastmcp import Context, FastMCP
+from fastmcp.exceptions import ToolError
 from fastmcp.server.http import (
     StarletteWithLifespan,
 )
@@ -54,6 +55,7 @@ from agno.run.team import TeamRunEvent, TeamRunOutput
 from agno.run.workflow import WorkflowRunEvent, WorkflowRunOutput
 from agno.tools.annotations import tool_presentation
 from agno.utils.schema import (
+    AGNO_INJECTED_PARAMS,
     IDENTITY_INJECTED_PARAMS,
     annotation_binds,
     annotation_reaches,
@@ -200,6 +202,7 @@ def _register_custom_tools(mcp: FastMCP, entries: List[Any], enabled_tags: "Opti
     names: Dict[str, str] = {}
     for tool in entries:
         if isinstance(tool, Toolkit):
+            _reject_unconnected_toolkit(tool)
             # ``get_async_functions()`` is the merged surface with async variants
             # preferred -- the same set an agent running in async mode would get --
             # already filtered by the toolkit's include_tools/exclude_tools.
@@ -224,6 +227,43 @@ def _register_custom_tools(mcp: FastMCP, entries: List[Any], enabled_tags: "Opti
         names[name] = label
         taken[name] = label
     return names
+
+
+def _reject_unconnected_toolkit(toolkit: Any) -> None:
+    """Refuse a toolkit that declares it needs a connection this server never opens.
+
+    An agent connects a ``_requires_connect`` toolkit before its first call and closes it
+    afterwards. The MCP server runs each tool call directly and has no equivalent moment,
+    so a toolkit relying on that lifecycle runs unconnected and is never torn down.
+    ``CodeMode`` is the sharp case: its kernel is keyed by ``session_id``, and an MCP call
+    mints a fresh one every time, so a deployment would start a kernel per call, lose the
+    state each one was for, and never flush a snapshot.
+
+    A toolkit that reports a live connection is served: ``PostgresTools`` connected by the
+    deployer is exactly as usable here as anywhere. One that cannot report one is refused
+    rather than quietly half-working -- the deployer can still publish its functions
+    individually, which says "I know what this needs" in a way passing the toolkit does not.
+    """
+    if not getattr(toolkit, "_requires_connect", False):
+        return
+    try:
+        connected = bool(getattr(toolkit, "is_connected", False))
+    except Exception:
+        connected = False
+    if connected:
+        return
+    if hasattr(type(toolkit), "is_connected"):
+        remedy = f'Connect it before the server is built ("{toolkit.name}".connect()), or drop it from tools=.'
+    else:
+        remedy = (
+            "It cannot report a live connection, so this server cannot know it is usable. Pass the "
+            "functions you want individually (tools=[*toolkit.get_async_functions().values()]) if you "
+            "are managing its lifecycle yourself."
+        )
+    raise ValueError(
+        f'MCPConfig.tools got toolkit "{toolkit.name}", which requires a connection the MCP server does '
+        f"not manage: it runs each tool call directly, so connect() and close() never fire. {remedy}"
+    )
 
 
 def _collision_free_advice(colliding_name: str, enabled_tags: "Optional[set]") -> str:
@@ -478,19 +518,33 @@ def _declares_own_schema(tool: Any, entrypoint: Callable) -> bool:
     return isinstance(parameters, dict) and bool(parameters.get("properties"))
 
 
-def _declared_parameters(tool: Any, hidden: "Dict[str, _Hidden]", toolkit: Any = None) -> "Dict[str, Any]":
-    """The Function's declared schema, minus anything the server owns.
+def _declared_parameters(tool: Any, entrypoint: Callable, hidden: "Dict[str, _Hidden]") -> "Dict[str, Any]":
+    """The Function's declared schema, minus the names the server fills itself.
 
-    Dropped by NAME as well as by whatever the signature hid, because a declared schema
-    reaches this point precisely when the signature could not describe the tool: a
-    ``**kwargs`` entrypoint has no ``run_context`` parameter for the signature rules to
-    catch, so a schema naming one would publish an identity key for the caller to fill.
-    Dropped rather than injected -- the schema describes a remote tool's inputs, and
-    nothing here knows the body wants a RunContext.
+    Only two things are removed, and both are ones the caller could not have meant.
+    Whatever the signature hid is dropped because the wrapper injects it, and the
+    ``_agno_``-prefixed channels are dropped because they are agno's own wire names.
+
+    The bare identity names are deliberately NOT dropped. A declared schema reaches this
+    point because the signature could not describe the tool -- typically a remote tool's
+    own ``inputSchema``, proxied through ``MCPTools`` -- and ``agent`` or ``team`` there
+    belongs to the far side. Removing them hid a legitimate argument from the model while
+    a client could still send it: FastMCP validates against the declared schema (see
+    ``_schema_validator``) but the name never reached anything of agno's either way.
+
+    The catch-all's own name goes too. agno derives a property literally named after it
+    from a Google-style ``Args:`` docstring, and publishing a required ``kwargs`` of
+    unspecified type describes nothing a caller can fill.
     """
-    owned = set(hidden) | set(IDENTITY_INJECTED_PARAMS)
-    if toolkit is None:
-        owned.add("user_id")
+    owned = set(hidden) | set(AGNO_INJECTED_PARAMS)
+    try:
+        owned.update(
+            name
+            for name, param in inspect.signature(entrypoint).parameters.items()
+            if param.kind is inspect.Parameter.VAR_KEYWORD
+        )
+    except (ValueError, TypeError):
+        pass
 
     declared = deepcopy(tool.parameters)
     properties = {name: schema for name, schema in declared.get("properties", {}).items() if name not in owned}
@@ -501,6 +555,41 @@ def _declared_parameters(tool: Any, hidden: "Dict[str, _Hidden]", toolkit: Any =
     else:
         declared.pop("required", None)
     return declared
+
+
+def _schema_validator(schema: "Dict[str, Any]") -> "Optional[Callable[[Dict[str, Any]], None]]":
+    """A checker for arguments against a declared schema, or None if it cannot be built.
+
+    An ordinary tool gets this for free: FastMCP builds a pydantic model from the
+    signature, so a missing argument or a wrong type is rejected before the body runs. A
+    declared schema skips that machinery entirely, which left two tools on the same
+    server disagreeing about whether a malformed call is an error -- and a malformed call
+    from a model is ordinary traffic, not an attack.
+
+    ``jsonschema`` ships with the MCP stack itself, so this costs no new dependency; if it
+    is somehow absent the tool keeps working exactly as it did, unvalidated.
+    """
+    try:
+        from jsonschema import Draft202012Validator  # type: ignore[import-untyped]
+    except Exception:
+        return None
+    try:
+        validator = Draft202012Validator(schema)
+    except Exception:
+        # A schema this validator cannot compile is the remote's to fix, not a reason to
+        # refuse the tool: it was serving unvalidated a moment ago.
+        return None
+
+    def validate(arguments: "Dict[str, Any]") -> None:
+        errors = sorted(validator.iter_errors(arguments), key=lambda error: list(error.path))
+        if not errors:
+            return
+        detail = "; ".join(
+            f"{'.'.join(str(part) for part in error.path) or '<root>'}: {error.message}" for error in errors[:5]
+        )
+        raise ToolError(f"Invalid arguments: {detail}")
+
+    return validate
 
 
 def _register_custom_tool(
@@ -544,17 +633,18 @@ def _register_custom_tool(
         returns_tool_result = _returns_tool_result(entrypoint)
         wrapped = _build_mcp_wrapper(entrypoint, hidden, convert_result=returns_tool_result)
         if uses_declared_schema:
-            declared = _declared_parameters(tool, hidden, toolkit)
+            declared = _declared_parameters(tool, entrypoint, hidden)
             # Built directly rather than through ``Tool.from_function``, which would
             # re-derive the schema from a signature that cannot express one.
             tool_obj = FunctionTool(
-                fn=wrapped,
+                fn=_build_mcp_wrapper(
+                    entrypoint, hidden, convert_result=returns_tool_result, validate=_schema_validator(declared)
+                ),
                 name=name,
                 title=title,
                 description=description,
                 annotations=annotations,
                 parameters=declared,
-                output_schema=None,
             )
         else:
             tool_obj = Tool.from_function(
@@ -606,8 +696,9 @@ def _returns_tool_result(fn: Callable) -> bool:
 
     Read from the annotation rather than discovered at call time, because the same
     answer settles two things at once: the result needs converting, and FastMCP must be
-    told NOT to derive an output schema from the ``ToolResult`` model (it would then
-    reject the converted result for not matching it).
+    told NOT to derive an output schema from the ``ToolResult`` model -- otherwise
+    ``tools/list`` advertises a ToolResult-shaped ``outputSchema`` describing something
+    the tool never sends.
     """
     from agno.tools.function import ToolResult
 
@@ -627,7 +718,12 @@ def _converted_result(value: Any) -> Any:
     return value
 
 
-def _build_mcp_wrapper(fn: Callable, hidden: "Dict[str, _Hidden]", convert_result: bool = False) -> Callable:
+def _build_mcp_wrapper(
+    fn: Callable,
+    hidden: "Dict[str, _Hidden]",
+    convert_result: bool = False,
+    validate: "Optional[Callable[[Dict[str, Any]], None]]" = None,
+) -> Callable:
     """Give FastMCP a signature without the framework's parameters, and fill them in.
 
     On the agent-facing path FunctionCall assembles the arguments after the schema is
@@ -642,7 +738,7 @@ def _build_mcp_wrapper(fn: Callable, hidden: "Dict[str, _Hidden]", convert_resul
     Tools with nothing to hide and nothing to convert are returned unchanged, so they
     register exactly as they did before this wrapper existed.
     """
-    if not hidden and not convert_result:
+    if not hidden and not convert_result and validate is None:
         return fn
 
     sig = inspect.signature(fn)
@@ -675,6 +771,10 @@ def _build_mcp_wrapper(fn: Callable, hidden: "Dict[str, _Hidden]", convert_resul
         return annotations
 
     def prepare(args: tuple, kwargs: Dict[str, Any]) -> tuple:
+        if validate is not None and not args:
+            # Before injection, so the schema is checked against what the caller sent
+            # rather than against the framework values it never sees.
+            validate(kwargs)
         if args and positional_names and len(args) <= len(positional_names):
             names = positional_names[: len(args)]
             if not any(name in kwargs for name in names):

--- a/libs/agno/agno/os/mcp_results.py
+++ b/libs/agno/agno/os/mcp_results.py
@@ -13,7 +13,15 @@ from base64 import b64encode
 from typing import Any, Dict, List, Optional, Union
 from urllib.parse import quote
 
-from mcp.types import AudioContent, BlobResourceContents, ContentBlock, EmbeddedResource, ImageContent, TextContent
+from mcp.types import (
+    AudioContent,
+    BlobResourceContents,
+    ContentBlock,
+    EmbeddedResource,
+    ImageContent,
+    ResourceLink,
+    TextContent,
+)
 
 from agno.media import Audio, File, Image, Video
 from agno.run.agent import RunOutput
@@ -93,6 +101,31 @@ def _blob_block(artifact: Any, kind: str, default_mime: str) -> Optional[Embedde
     )
 
 
+def _link_block(artifact: Any, kind: str) -> Optional[ResourceLink]:
+    """A link to media the tool produced somewhere else.
+
+    Generation toolkits usually hand back a URL rather than bytes -- Giphy returns the
+    gif's address, Replicate and Luma the rendered file's -- and that URL IS the result.
+    Skipping it leaves the caller holding "generated successfully" and nothing to open.
+    MCP types this exactly: a resource_link points at a resource without inlining it, so
+    the bytes are still not fetched on the server's behalf. Reached only after the
+    inlining path declined, so an artifact holding bytes never arrives here.
+    """
+    url = getattr(artifact, "url", None)
+    if not url:
+        return None
+    try:
+        return ResourceLink(
+            type="resource_link",
+            uri=url,
+            name=str(getattr(artifact, "filename", None) or getattr(artifact, "id", None) or kind),
+            mimeType=getattr(artifact, "mime_type", None),
+        )
+    except Exception:
+        # A url the protocol will not accept as a uri is not worth failing the call over.
+        return None
+
+
 def _media_blocks(run_output: AnyRunOutput) -> List[ContentBlock]:
     """MCP content blocks for generated media that carries raw bytes.
 
@@ -121,31 +154,31 @@ def build_custom_tool_result(result: Any) -> "Any":
     are not valid UTF-8.
 
     Text becomes the first content block, images and audio become their MCP block types,
-    and videos and files travel as embedded blob resources. ``structuredContent`` mirrors
-    the answer under ``content`` alongside the tool's own metadata, matching what the run
-    tools publish. Artifacts holding only a url or filepath are skipped for the same
-    reason as on the run path: the bytes are not in hand.
+    and videos and files travel as embedded blob resources. An artifact that carries only
+    a url becomes a resource_link: generation toolkits return the address rather than the
+    bytes, and that address is the result. ``structuredContent`` mirrors the answer under
+    ``content`` alongside the tool's own metadata, matching what the run tools publish.
     """
     from fastmcp.tools import ToolResult
 
     text = getattr(result, "content", None) or ""
     blocks: List[ContentBlock] = [TextContent(type="text", text=text)]
     for image in getattr(result, "images", None) or []:
-        block = _image_block(image)
+        block = _image_block(image) or _link_block(image, "image")
         if block is not None:
             blocks.append(block)
     for audio in getattr(result, "audios", None) or []:
-        audio_block = _audio_block(audio)
+        audio_block = _audio_block(audio) or _link_block(audio, "audio")
         if audio_block is not None:
             blocks.append(audio_block)
     for video in getattr(result, "videos", None) or []:
         if isinstance(video, Video):
-            video_block = _blob_block(video, "video", _DEFAULT_VIDEO_MIME)
+            video_block = _blob_block(video, "video", _DEFAULT_VIDEO_MIME) or _link_block(video, "video")
             if video_block is not None:
                 blocks.append(video_block)
     for file in getattr(result, "files", None) or []:
         if isinstance(file, File):
-            file_block = _blob_block(file, "file", _DEFAULT_FILE_MIME)
+            file_block = _blob_block(file, "file", _DEFAULT_FILE_MIME) or _link_block(file, "file")
             if file_block is not None:
                 blocks.append(file_block)
 

--- a/libs/agno/agno/os/mcp_results.py
+++ b/libs/agno/agno/os/mcp_results.py
@@ -9,11 +9,13 @@ over the wire and raises on binary media.
 """
 
 import json
+from base64 import b64encode
 from typing import Any, Dict, List, Optional, Union
+from urllib.parse import quote
 
-from mcp.types import AudioContent, ContentBlock, ImageContent, TextContent
+from mcp.types import AudioContent, BlobResourceContents, ContentBlock, EmbeddedResource, ImageContent, TextContent
 
-from agno.media import Audio, Image
+from agno.media import Audio, File, Image, Video
 from agno.run.agent import RunOutput
 from agno.run.team import TeamRunOutput
 from agno.run.utils import run_status_string, serialized_paused_requirements
@@ -23,8 +25,10 @@ from agno.utils.serialize import json_serializer
 
 AnyRunOutput = Union[RunOutput, TeamRunOutput, WorkflowRunOutput]
 
-# Default media type when an audio artifact does not carry an explicit mime type.
+# Default media types when an artifact does not carry an explicit one.
 _DEFAULT_AUDIO_MIME = "audio/mpeg"
+_DEFAULT_VIDEO_MIME = "video/mp4"
+_DEFAULT_FILE_MIME = "application/octet-stream"
 
 
 def _content_text(run_output: AnyRunOutput) -> str:
@@ -42,6 +46,53 @@ def _audio_mime(artifact: Audio) -> str:
     return _DEFAULT_AUDIO_MIME
 
 
+def _image_block(image: Any) -> Optional[ImageContent]:
+    """An MCP image block for an artifact holding raw bytes, else None."""
+    if not isinstance(image, Image) or not isinstance(image.content, bytes):
+        return None
+    data = image.to_base64()
+    if not data:
+        return None
+    return ImageContent(
+        type="image",
+        data=data,
+        mimeType=resolve_image_mime_type(
+            mime_type=image.mime_type, image_format=image.format, image_bytes=image.content
+        ),
+    )
+
+
+def _audio_block(audio: Any) -> Optional[AudioContent]:
+    """An MCP audio block for an artifact holding raw bytes, else None."""
+    if not isinstance(audio, Audio) or not isinstance(audio.content, bytes):
+        return None
+    data = audio.to_base64()
+    if not data:
+        return None
+    return AudioContent(type="audio", data=data, mimeType=_audio_mime(audio))
+
+
+def _blob_block(artifact: Any, kind: str, default_mime: str) -> Optional[EmbeddedResource]:
+    """An embedded MCP resource for bytes the protocol has no dedicated block for.
+
+    MCP types text, images and audio directly; video and files travel as an embedded
+    blob resource instead. The uri is a stable handle for the artifact, not a fetchable
+    address -- the bytes are carried inline.
+    """
+    content = getattr(artifact, "content", None)
+    if not isinstance(content, bytes):
+        return None
+    name = getattr(artifact, "filename", None) or str(getattr(artifact, "id", None) or kind)
+    return EmbeddedResource(
+        type="resource",
+        resource=BlobResourceContents(
+            uri=f"agno://tool-result/{kind}/{quote(str(name), safe='')}",
+            mimeType=getattr(artifact, "mime_type", None) or default_mime,
+            blob=b64encode(content).decode("ascii"),
+        ),
+    )
+
+
 def _media_blocks(run_output: AnyRunOutput) -> List[ContentBlock]:
     """MCP content blocks for generated media that carries raw bytes.
 
@@ -51,24 +102,58 @@ def _media_blocks(run_output: AnyRunOutput) -> List[ContentBlock]:
     """
     blocks: List[ContentBlock] = []
     for image in getattr(run_output, "images", None) or []:
-        if isinstance(image, Image) and isinstance(image.content, bytes):
-            data = image.to_base64()
-            if data:
-                blocks.append(
-                    ImageContent(
-                        type="image",
-                        data=data,
-                        mimeType=resolve_image_mime_type(
-                            mime_type=image.mime_type, image_format=image.format, image_bytes=image.content
-                        ),
-                    )
-                )
+        block = _image_block(image)
+        if block is not None:
+            blocks.append(block)
     for audio in getattr(run_output, "audio", None) or []:
-        if isinstance(audio, Audio) and isinstance(audio.content, bytes):
-            data = audio.to_base64()
-            if data:
-                blocks.append(AudioContent(type="audio", data=data, mimeType=_audio_mime(audio)))
+        audio_block = _audio_block(audio)
+        if audio_block is not None:
+            blocks.append(audio_block)
     return blocks
+
+
+def build_custom_tool_result(result: Any) -> "Any":
+    """Build the MCP ``ToolResult`` for a custom tool that returned an Agno ``ToolResult``.
+
+    Without this the object reaches FastMCP's generic serializer, which JSON-dumps the
+    whole model -- the caller reads ``{"content": "...", "metadata": null, "images":
+    null, ...}`` instead of the answer -- and raises outright on raw media bytes, which
+    are not valid UTF-8.
+
+    Text becomes the first content block, images and audio become their MCP block types,
+    and videos and files travel as embedded blob resources. ``structuredContent`` mirrors
+    the answer under ``content`` alongside the tool's own metadata, matching what the run
+    tools publish. Artifacts holding only a url or filepath are skipped for the same
+    reason as on the run path: the bytes are not in hand.
+    """
+    from fastmcp.tools import ToolResult
+
+    text = getattr(result, "content", None) or ""
+    blocks: List[ContentBlock] = [TextContent(type="text", text=text)]
+    for image in getattr(result, "images", None) or []:
+        block = _image_block(image)
+        if block is not None:
+            blocks.append(block)
+    for audio in getattr(result, "audios", None) or []:
+        audio_block = _audio_block(audio)
+        if audio_block is not None:
+            blocks.append(audio_block)
+    for video in getattr(result, "videos", None) or []:
+        if isinstance(video, Video):
+            video_block = _blob_block(video, "video", _DEFAULT_VIDEO_MIME)
+            if video_block is not None:
+                blocks.append(video_block)
+    for file in getattr(result, "files", None) or []:
+        if isinstance(file, File):
+            file_block = _blob_block(file, "file", _DEFAULT_FILE_MIME)
+            if file_block is not None:
+                blocks.append(file_block)
+
+    structured: Dict[str, Any] = {"content": text}
+    metadata = getattr(result, "metadata", None)
+    if metadata:
+        structured["metadata"] = _json_safe(metadata)
+    return ToolResult(content=blocks, structured_content=structured)
 
 
 def _json_safe(data: Dict[str, Any]) -> Dict[str, Any]:

--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -17,9 +17,7 @@ from typing import (
     Tuple,
     Type,
     TypeVar,
-    Union,
     get_args,
-    get_origin,
     get_type_hints,
 )
 
@@ -32,42 +30,21 @@ from agno.media import Audio, File, Image, Video
 from agno.run import RunContext
 from agno.tools.annotations import validate_tool_annotations
 from agno.utils.log import log_debug, log_exception, log_warning
+from agno.utils.schema import (
+    AGNO_INJECTED_PARAMS,
+    FRAMEWORK_INJECTED_PARAMS,
+    IDENTITY_INJECTED_PARAMS,
+    MEDIA_INJECTED_PARAMS,
+    annotation_binds,
+    annotation_reaches,
+    is_bare_media_typed,
+    is_framework_typed,
+    is_schema_excluded,
+    is_union,
+    unwrap_annotation,
+)
 
 T = TypeVar("T")
-
-# The media the caller attached to the run. Unlike the other injected names these
-# carry the call's input rather than framework plumbing, so they decide whether a
-# call can be cached at all (see _has_injected_media).
-MEDIA_INJECTED_PARAMS = ("images", "videos", "audios", "files")
-
-# Parameter names the framework fills in itself (see FunctionCall._build_entrypoint_args).
-# They are kept out of the model-facing schema, and a model-supplied value for one of
-# them is discarded in favour of the injected object.
-FRAMEWORK_INJECTED_PARAMS = ("agent", "team", "run_context", *MEDIA_INJECTED_PARAMS)
-
-# The `_agno_`-prefixed channels, used by wrappers whose tools may have arguments
-# legitimately named "agent", "team" or "run_context" (e.g. MCP tools).
-AGNO_INJECTED_PARAMS = ("_agno_agent", "_agno_team", "_agno_run_context")
-
-# The subset carrying the caller's identity or a live framework object. A schema may
-# claim a media name -- a wrapper can expose the wrapped tool's own `files` argument --
-# but never these: a model-supplied value here would choose whose data the tool reads.
-IDENTITY_INJECTED_PARAMS = ("agent", "team", "run_context", *AGNO_INJECTED_PARAMS)
-
-
-def _identity_injected_types() -> tuple:
-    """The identity-bearing types: a model-supplied value for a parameter of
-    one of these types would choose the framework object a tool receives.
-
-    An identity-typed parameter is hidden from the model and bound by
-    FunctionCall._build_entrypoint_args, whatever its name. Bare media
-    annotations are hidden too (_is_bare_media_typed) but are filled by the
-    reserved parameter names alone, never by type."""
-    from agno.agent.agent import Agent
-    from agno.team.team import Team
-
-    return (Agent, Team, RunContext)
-
 
 # What a cache entry holds. Bump this whenever the meaning of a stored value
 # changes: entries written under any other version are discarded unread, which
@@ -257,34 +234,6 @@ def _record_entrypoint_result(raw_results: List[Any], slot: int, result: Any) ->
     raw_results[slot] = snapshot
 
 
-def _unwrap_annotation(hint: Any) -> Any:
-    """The annotation a type alias stands for (PEP 695 ``type X = ...``), else
-    the annotation itself. get_type_hints leaves an alias unresolved.
-
-    Aliases chain (``type A = RunContext; type B = A``), so unwrapping repeats
-    to a fixpoint: any depth left unresolved is an identity annotation the model
-    can still fill. The seen list holds strong references, so a self-referential
-    alias terminates without relying on ids that a collected object could
-    reuse."""
-    seen: List[Any] = []
-    while True:
-        if isinstance(hint, types.GenericAlias) and hasattr(get_origin(hint), "__value__"):
-            # A subscripted generic alias (``Maybe[Weather]``) keeps what it was
-            # given only while it stays subscripted. Its __value__ is the body
-            # with the parameter still loose, so following it loses the Weather.
-            return hint
-        # A PEP 695 alias carries __value__; typing.NewType carries
-        # __supertype__ and is just as transparent to pydantic, which builds
-        # the supertype from a model-supplied dict either way.
-        unwrapped = getattr(hint, "__value__", None)
-        if unwrapped is None:
-            unwrapped = getattr(hint, "__supertype__", hint)
-        if unwrapped is hint or any(unwrapped is s for s in seen):
-            return hint
-        seen.append(hint)
-        hint = unwrapped
-
-
 def _mentions_base_model(hint: Any, seen: Optional[List[Any]] = None) -> bool:
     """True when the annotation is a BaseModel or holds one, at any depth.
 
@@ -295,7 +244,7 @@ def _mentions_base_model(hint: Any, seen: Optional[List[Any]] = None) -> bool:
 
     An alias may name itself (``type JSON = str | list[JSON]``), so the seen
     list stops the walk from following one round and round."""
-    hint = _unwrap_annotation(hint)
+    hint = unwrap_annotation(hint)
     if isinstance(hint, type):
         try:
             return issubclass(hint, BaseModel)
@@ -342,11 +291,6 @@ def _return_type_adapter(hint: Any) -> Any:
         return None
 
 
-def _is_union(hint: Any) -> bool:
-    origin = get_origin(hint)
-    return origin is Union or origin is getattr(types, "UnionType", None)
-
-
 def _union_names_type(hint: Any, wanted: tuple) -> bool:
     """True when the annotation is a union with a member among the wanted types,
     nested unions and type aliases included. Asks whether the type is mentioned
@@ -355,8 +299,8 @@ def _union_names_type(hint: Any, wanted: tuple) -> bool:
     Used to decide whether pydantic's validate_call can introspect the
     signature: one Agent/Team member anywhere in a union is enough to break it.
     """
-    hint = _unwrap_annotation(hint)
-    if not _is_union(hint):
+    hint = unwrap_annotation(hint)
+    if not is_union(hint):
         return False
     return any(_member_names_type(arg, wanted) for arg in get_args(hint) if arg is not type(None))
 
@@ -365,7 +309,7 @@ def _member_names_type(arg: Any, wanted: tuple) -> bool:
     """Whether one union member names a wanted type. The member is unwrapped first:
     a PEP 695 alias nested inside a union (``type C = RunContext; type M = C | None``)
     is a TypeAliasType, not a type, and would otherwise slip past both checks."""
-    arg = _unwrap_annotation(arg)
+    arg = unwrap_annotation(arg)
     return (isinstance(arg, type) and issubclass(arg, wanted)) or _union_names_type(arg, wanted)
 
 
@@ -378,8 +322,8 @@ def _union_is_only(hint: Any, wanted: tuple) -> bool:
     (owner: Union[str, Agent]) keeps a half the model can legitimately fill --
     the model can send a string, never a live Agent -- so it stays in the
     schema. Optional[Agent] has no such half."""
-    hint = _unwrap_annotation(hint)
-    if not _is_union(hint):
+    hint = unwrap_annotation(hint)
+    if not is_union(hint):
         return False
     members = [arg for arg in get_args(hint) if arg is not type(None)]
     if not members:
@@ -390,200 +334,8 @@ def _union_is_only(hint: Any, wanted: tuple) -> bool:
 def _member_is_only(arg: Any, wanted: tuple) -> bool:
     """Whether one union member is a wanted type, unwrapping a nested PEP 695 alias
     first for the same reason as _member_names_type."""
-    arg = _unwrap_annotation(arg)
+    arg = unwrap_annotation(arg)
     return (isinstance(arg, type) and issubclass(arg, wanted)) or _union_is_only(arg, wanted)
-
-
-def _is_framework_typed(hint: Any) -> bool:
-    """True when the framework owns the parameter: it is kept out of the
-    model-facing schema and filled by _build_entrypoint_args instead.
-
-    Excluded:
-      * a bare identity type (owner: Agent, ctx: RunContext);
-      * a union of identity types alone (Optional[Agent], RunContext | None),
-        which has no half a model could legitimately fill;
-      * ANY union naming RunContext (ctx: Union[str, RunContext]). RunContext is
-        the one identity type pydantic can build from a model-supplied dict --
-        validate_call is skipped for Agent/Team parameters but not for this one,
-        so an exposed union coerces {"user_id": ...} into a live RunContext and
-        hands the model the caller's identity.
-
-    Model-fillable:
-      * media inside a union (Optional[Image], Union[str, File]): media is
-        injected by parameter name alone, so hiding the union would leave it
-        unfillable by anything. A BARE media annotation (pic: Image) is hidden
-        all the same -- see _is_bare_media_typed;
-      * a union naming Agent or Team beside an ordinary type
-        (owner: Union[str, Agent]). The model can only ever send JSON, so such a
-        parameter receives a plain dict or string, never a live Agent."""
-    return _reaches_identity(hint)
-
-
-_ANNOTATION_DEPTH_CAP = 16
-
-
-def _reaches_identity(hint: Any, depth: int = 0, seen: Optional[List[Any]] = None) -> bool:
-    """Whether an annotation can deliver an identity object the model chose.
-
-    Walks the whole annotation -- containers, the container arms of a union,
-    and the fields of a dataclass or pydantic model -- because every one of
-    those is a place pydantic will happily build a RunContext out of a
-    model-supplied dict.
-
-    Two rules that look inconsistent and are not:
-
-      * ANY appearance of RunContext hides the parameter. It is the one
-        identity type pydantic constructs from JSON, so wherever it can be
-        reached, the model can choose the caller's identity.
-      * Agent and Team hide only when the annotation offers no half a model
-        could legitimately fill -- bare, or a union of identity alone.
-        ``owner: Union[str, Agent]`` stays the model's to fill, at the top
-        level and inside a list alike: validate_call is skipped for those
-        types, so the tool receives a plain dict or string, never a live
-        Agent, and hiding it would leave it fillable by nothing.
-
-    Media never reaches here as identity: it is injected by reserved name
-    alone, so hiding a media container would make it unfillable."""
-    if depth > _ANNOTATION_DEPTH_CAP:
-        return True  # Unreadable is not fillable; fail closed.
-    seen = [] if seen is None else seen
-    hint = _unwrap_annotation(hint)
-    if any(hint is s for s in seen):
-        return False
-    seen = seen + [hint]
-    # RunContext anywhere at all, however deeply wrapped.
-    if _annotation_reaches(hint, (RunContext,)):
-        return True
-    if isinstance(hint, type):
-        return _annotation_reaches(hint, _identity_injected_types())
-    if _is_union(hint):
-        # A union is the model's to fill as long as one arm is something the
-        # model can legitimately send. Only when every arm is identity -- bare
-        # Agent, Optional[Agent] -- is there nothing else it could mean.
-        arms = [arm for arm in get_args(hint) if arm is not type(None)]
-        return bool(arms) and all(_reaches_identity(arm, depth + 1, seen) for arm in arms)
-    return any(_reaches_identity(argument, depth + 1, seen) for argument in get_args(hint))
-
-
-def _annotation_binds(hint: Any, wanted: tuple, depth: int = 0, seen: Optional[List[Any]] = None) -> bool:
-    """Whether the framework can put one of these objects INTO this parameter.
-
-    Deliberately narrower than _annotation_reaches, and the pair is not a
-    contradiction: reaching decides what to keep from the model, binding
-    decides what can be handed over. A ``list[RunContext]`` reaches one -- so
-    it is not the model's to fill -- but it holds run contexts, it is not one,
-    and binding the object there would fail validation on every call.
-
-    Unwraps aliases and NewType, follows a TypeVar's bound and constraints, and
-    accepts a union with an arm that binds. A container or a structural wrapper
-    does not bind: nothing the framework has is that shape."""
-    if depth > _ANNOTATION_DEPTH_CAP:
-        return False
-    seen = [] if seen is None else seen
-    hint = _unwrap_annotation(hint)
-    if any(hint is s for s in seen):
-        return False
-    seen = seen + [hint]
-    if isinstance(hint, type):
-        return issubclass(hint, wanted)
-    if isinstance(hint, TypeVar):
-        bound = getattr(hint, "__bound__", None)
-        if bound is not None and _annotation_binds(bound, wanted, depth + 1, seen):
-            return True
-        return any(
-            _annotation_binds(constraint, wanted, depth + 1, seen)
-            for constraint in getattr(hint, "__constraints__", ()) or ()
-        )
-    if _is_union(hint):
-        return any(_annotation_binds(arm, wanted, depth + 1, seen) for arm in get_args(hint))
-    return False
-
-
-def _annotation_reaches(hint: Any, targets: tuple, depth: int = 0, seen: Optional[List[Any]] = None) -> bool:
-    """Whether any of these types can be reached anywhere inside an annotation.
-
-    A plain structural search, with none of _reaches_identity's asymmetry: it
-    walks containers, every arm of a union, a TypeVar's bound and constraints,
-    and the fields of any structural type -- dataclass, pydantic model,
-    TypedDict, NamedTuple -- resolving them with get_type_hints so an
-    annotation stored as a string under ``from __future__ import annotations``
-    is read rather than skipped.
-
-    Two things fail CLOSED, because a reference this cannot resolve is not one
-    to hand the model: a nesting depth no real signature reaches, and a class
-    whose own hints will not resolve."""
-    from dataclasses import is_dataclass
-
-    if depth > _ANNOTATION_DEPTH_CAP:
-        return True
-    seen = [] if seen is None else seen
-    hint = _unwrap_annotation(hint)
-    if any(hint is s for s in seen):
-        return False
-    seen = seen + [hint]
-
-    if isinstance(hint, TypeVar):
-        # A bound or a constraint is a promise about what will be substituted.
-        bound = getattr(hint, "__bound__", None)
-        if bound is not None and _annotation_reaches(bound, targets, depth + 1, seen):
-            return True
-        return any(
-            _annotation_reaches(constraint, targets, depth + 1, seen)
-            for constraint in getattr(hint, "__constraints__", ()) or ()
-        )
-
-    if isinstance(hint, type):
-        if issubclass(hint, targets):
-            return True
-        if issubclass(hint, _identity_injected_types()):
-            # A framework object is not a user wrapper to search inside. Its own
-            # hints do not resolve here (Agent names BaseDb), and descending
-            # would fail closed on every annotation that merely mentions one --
-            # which would hide `owner: Union[str, Agent]`, the shape the rules
-            # above exist to keep fillable.
-            return False
-        is_structural = (
-            isinstance(getattr(hint, "model_fields", None), dict)
-            or is_dataclass(hint)
-            or hasattr(hint, "__annotations__")
-            and (getattr(hint, "__total__", None) is not None or hasattr(hint, "_fields"))
-        )
-        if not is_structural:
-            return False
-        try:
-            field_hints = get_type_hints(hint)
-        except Exception:
-            return True  # Cannot read it, so cannot clear it.
-        return any(_annotation_reaches(field_hint, targets, depth + 1, seen) for field_hint in field_hints.values())
-
-    return any(_annotation_reaches(argument, targets, depth + 1, seen) for argument in get_args(hint))
-
-
-def _is_bare_media_typed(hint: Any) -> bool:
-    """True for a parameter annotated with a media type itself (pic: Image).
-
-    On the process_entrypoint path (Toolkit methods, @tool) such a parameter is
-    hidden from the model, as on v2.8.7: media is injected by the reserved
-    parameter names alone (images/videos/audios/files, see
-    FunctionCall._build_entrypoint_args), so the framework can never fill it,
-    and exposing it would let the model fabricate the object while its pydantic
-    schema is invalid under strict mode, failing the whole request rather than
-    one call. from_callable does NOT use this predicate -- v2.8.7 never hid
-    media on the plain-callable path, where the parameter is the model's to
-    fill. Media inside a union (Union[str, Image]) stays model-fillable on
-    both paths."""
-    hint = _unwrap_annotation(hint)
-    return isinstance(hint, type) and issubclass(hint, (Image, Video, Audio, File))
-
-
-def _is_schema_excluded(hint: Any) -> bool:
-    """True when process_entrypoint keeps the parameter out of the model-facing
-    schema: the identity types plus bare media types.
-
-    Exclusion only. Framework OWNERSHIP is _is_framework_typed, a strictly
-    smaller set: an owned parameter is bound by _build_entrypoint_args and a
-    value supplied for it is dropped, neither of which is true of media."""
-    return _is_framework_typed(hint) or _is_bare_media_typed(hint)
 
 
 _hidden_media_warned: Set[Tuple[str, str]] = set()
@@ -883,10 +635,10 @@ def _derive_entrypoint_schema(
                 # "return"; it is not an injectable parameter.
                 if param_name == "return":
                     continue
-                if _is_schema_excluded(hint):
+                if is_schema_excluded(hint):
                     del type_hints[param_name]
                     excluded_params.append(param_name)
-                    if _is_bare_media_typed(hint):
+                    if is_bare_media_typed(hint):
                         hidden_media_params.append(param_name)
         except Exception:
             pass
@@ -1242,13 +994,13 @@ def _compute_framework_params(entrypoint: Callable) -> Tuple[Set[str], bool]:
         # `ctx: RunContext` left ctx unclassified and model-facing -- the
         # parameter's own protection undone by an unrelated neighbour.
         try:
-            # Identity only, not _is_schema_excluded. A bare media parameter is
+            # Identity only, not is_schema_excluded. A bare media parameter is
             # hidden from the schema, but dropping a value supplied for it
             # displaces nothing: media is injected by reserved name alone, so the
             # caller's own media never lands there under any behaviour. Dropping
             # would only make the parameter unfillable by anything, which v2.8.7
             # did not do.
-            owned = _is_framework_typed(hint)
+            owned = is_framework_typed(hint)
         except Exception:
             owned = True  # Cannot classify it, so do not hand it to the model.
         if owned:
@@ -1707,13 +1459,13 @@ class Function(BaseModel):
             # guard rejects a model-supplied value for them on this path too. See #6344.
             framework_typed_params: Set[str] = set()
             try:
-                # Identity only, not _is_schema_excluded: v2.8.7's from_callable never
+                # Identity only, not is_schema_excluded: v2.8.7's from_callable never
                 # hid media by type, so a bare media param on a plain callable stays
                 # the model's to fill (pydantic coerces the dict) -- unlike the
                 # process_entrypoint path, which hid it then and hides it now.
                 for _pname in sig.parameters:
                     _hint = type_hints.get(_pname)
-                    if _hint is not None and _is_framework_typed(_hint):
+                    if _hint is not None and is_framework_typed(_hint):
                         framework_typed_params.add(_pname)
             except Exception:
                 pass
@@ -2018,7 +1770,7 @@ class Function(BaseModel):
                 # list[Agent]]` to validate_call, which then failed to resolve
                 # Agent's own forward references and took registration of the
                 # whole tool down.
-                if _annotation_reaches(hint, framework_types):
+                if annotation_reaches(hint, framework_types):
                     return func
         except Exception:
             pass
@@ -2264,7 +2016,7 @@ class Function(BaseModel):
             return None
         if hint is None or hint is type(None):
             return None
-        return _unwrap_annotation(hint)
+        return unwrap_annotation(hint)
 
     def _save_to_cache(self, cache_file: str, result: Any):
         """Save result to cache."""
@@ -2475,7 +2227,7 @@ class FunctionCall(BaseModel):
         from inspect import signature
 
         sig = signature(self.function.entrypoint)  # type: ignore
-        entrypoint_args = {}
+        entrypoint_args: Dict[str, Any] = {}
 
         # Check if the entrypoint has an agent argument (by name)
         if "agent" in sig.parameters:
@@ -2514,7 +2266,7 @@ class FunctionCall(BaseModel):
         # cases like `my_agent: Agent`, `custom_team: Team` or `ctx: RunContext`.
         # See issue #6344.
         #
-        # Every identity annotation _is_framework_typed hides from the model-facing
+        # Every identity annotation is_framework_typed hides from the model-facing
         # schema is bound here, union spellings included (owner: Optional[Agent],
         # ctx: Union[str, RunContext]). A wielder without the object binds None --
         # a tool registered on a Team has no Agent, and a required `owner: Agent`
@@ -2542,9 +2294,9 @@ class FunctionCall(BaseModel):
                 # positional-only one cannot be passed by name either.
                 if param.kind in (Parameter.VAR_POSITIONAL, Parameter.VAR_KEYWORD, Parameter.POSITIONAL_ONLY):
                     continue
-                if not _is_framework_typed(hint):
+                if not is_framework_typed(hint):
                     continue
-                hint = _unwrap_annotation(hint)
+                hint = unwrap_annotation(hint)
                 # The same resolver that decided to hide it. Matching only a
                 # bare type or a direct union left the shapes the schema rule
                 # newly recognised -- a TypeVar bound to RunContext, an aliased
@@ -2557,7 +2309,7 @@ class FunctionCall(BaseModel):
                         ((Team,), self.function._team),
                         ((RunContext,), self.function._run_context),
                     )
-                    if _annotation_binds(hint, wanted)
+                    if annotation_binds(hint, wanted)
                 ]
                 if not matches:
                     continue
@@ -2578,7 +2330,7 @@ class FunctionCall(BaseModel):
         The reserved identity names, plus every name the framework claimed by
         ANNOTATION. Both paths that populate ``_framework_params``
         (``Function._resolve_framework_params`` and ``from_callable``) add a
-        typed parameter only when ``_is_framework_typed`` says it is
+        typed parameter only when ``is_framework_typed`` says it is
         identity-bearing, never for media, so anything there that is not a
         reserved name got there by being identity-typed.
 

--- a/libs/agno/agno/utils/schema.py
+++ b/libs/agno/agno/utils/schema.py
@@ -1,0 +1,276 @@
+"""Schema security utilities for hiding framework-injected parameters.
+
+These utilities determine which parameters should be excluded from model-facing
+schemas to prevent identity spoofing (model choosing whose data a tool reads)
+and Pydantic serialization crashes (RunContext contains FilterExpr which cannot
+be serialized to JSON schema).
+
+Used by:
+- agno.tools.function: Toolkit and @tool processing
+- agno.os.mcp: MCP tool registration
+"""
+
+import types
+from typing import Any, List, Optional, Tuple, TypeVar, Union, get_args, get_origin, get_type_hints
+
+from agno.media import Audio, File, Image, Video
+from agno.run import RunContext
+
+# The media the caller attached to the run. Unlike the other injected names these
+# carry the call's input rather than framework plumbing, so they decide whether a
+# call can be cached at all (see _has_injected_media in function.py).
+MEDIA_INJECTED_PARAMS: Tuple[str, ...] = ("images", "videos", "audios", "files")
+
+# Parameter names the framework fills in itself (see FunctionCall._build_entrypoint_args).
+# They are kept out of the model-facing schema, and a model-supplied value for one of
+# them is discarded in favour of the injected object.
+FRAMEWORK_INJECTED_PARAMS: Tuple[str, ...] = ("agent", "team", "run_context", *MEDIA_INJECTED_PARAMS)
+
+# The `_agno_`-prefixed channels, used by wrappers whose tools may have arguments
+# legitimately named "agent", "team" or "run_context" (e.g. MCP tools).
+AGNO_INJECTED_PARAMS: Tuple[str, ...] = ("_agno_agent", "_agno_team", "_agno_run_context")
+
+# The subset carrying the caller's identity or a live framework object. A schema may
+# claim a media name -- a wrapper can expose the wrapped tool's own `files` argument --
+# but never these: a model-supplied value here would choose whose data the tool reads.
+IDENTITY_INJECTED_PARAMS: Tuple[str, ...] = ("agent", "team", "run_context", *AGNO_INJECTED_PARAMS)
+
+
+def identity_injected_types() -> tuple:
+    """The identity-bearing types: a model-supplied value for a parameter of
+    one of these types would choose the framework object a tool receives.
+
+    An identity-typed parameter is hidden from the model and bound by
+    FunctionCall._build_entrypoint_args, whatever its name. Bare media
+    annotations are hidden too (is_bare_media_typed) but are filled by the
+    reserved parameter names alone, never by type."""
+    from agno.agent.agent import Agent
+    from agno.team.team import Team
+
+    return (Agent, Team, RunContext)
+
+
+ANNOTATION_DEPTH_CAP = 16
+
+
+def unwrap_annotation(hint: Any) -> Any:
+    """The annotation a type alias stands for (PEP 695 ``type X = ...``), else
+    the annotation itself. get_type_hints leaves an alias unresolved.
+
+    Aliases chain (``type A = RunContext; type B = A``), so unwrapping repeats
+    to a fixpoint: any depth left unresolved is an identity annotation the model
+    can still fill. The seen list holds strong references, so a self-referential
+    alias terminates without relying on ids that a collected object could
+    reuse."""
+    seen: List[Any] = []
+    while True:
+        if isinstance(hint, types.GenericAlias) and hasattr(get_origin(hint), "__value__"):
+            # A subscripted generic alias (``Maybe[Weather]``) keeps what it was
+            # given only while it stays subscripted. Its __value__ is the body
+            # with the parameter still loose, so following it loses the Weather.
+            return hint
+        # A PEP 695 alias carries __value__; typing.NewType carries
+        # __supertype__ and is just as transparent to pydantic, which builds
+        # the supertype from a model-supplied dict either way.
+        unwrapped = getattr(hint, "__value__", None)
+        if unwrapped is None:
+            unwrapped = getattr(hint, "__supertype__", hint)
+        if unwrapped is hint or any(unwrapped is s for s in seen):
+            return hint
+        seen.append(hint)
+        hint = unwrapped
+
+
+def is_union(hint: Any) -> bool:
+    """True when the annotation is a Union type."""
+    origin = get_origin(hint)
+    return origin is Union or origin is getattr(types, "UnionType", None)
+
+
+def annotation_reaches(hint: Any, targets: tuple, depth: int = 0, seen: Optional[List[Any]] = None) -> bool:
+    """Whether any of these types can be reached anywhere inside an annotation.
+
+    A plain structural search, with none of reaches_identity's asymmetry: it
+    walks containers, every arm of a union, a TypeVar's bound and constraints,
+    and the fields of any structural type -- dataclass, pydantic model,
+    TypedDict, NamedTuple -- resolving them with get_type_hints so an
+    annotation stored as a string under ``from __future__ import annotations``
+    is read rather than skipped.
+
+    Two things fail CLOSED, because a reference this cannot resolve is not one
+    to hand the model: a nesting depth no real signature reaches, and a class
+    whose own hints will not resolve."""
+    from dataclasses import is_dataclass
+
+    if depth > ANNOTATION_DEPTH_CAP:
+        return True
+    seen = [] if seen is None else seen
+    hint = unwrap_annotation(hint)
+    if any(hint is s for s in seen):
+        return False
+    seen = seen + [hint]
+
+    if isinstance(hint, TypeVar):
+        # A bound or a constraint is a promise about what will be substituted.
+        bound = getattr(hint, "__bound__", None)
+        if bound is not None and annotation_reaches(bound, targets, depth + 1, seen):
+            return True
+        return any(
+            annotation_reaches(constraint, targets, depth + 1, seen)
+            for constraint in getattr(hint, "__constraints__", ()) or ()
+        )
+
+    if isinstance(hint, type):
+        if issubclass(hint, targets):
+            return True
+        if issubclass(hint, identity_injected_types()):
+            # A framework object is not a user wrapper to search inside. Its own
+            # hints do not resolve here (Agent names BaseDb), and descending
+            # would fail closed on every annotation that merely mentions one --
+            # which would hide `owner: Union[str, Agent]`, the shape the rules
+            # above exist to keep fillable.
+            return False
+        is_structural = (
+            isinstance(getattr(hint, "model_fields", None), dict)
+            or is_dataclass(hint)
+            or hasattr(hint, "__annotations__")
+            and (getattr(hint, "__total__", None) is not None or hasattr(hint, "_fields"))
+        )
+        if not is_structural:
+            return False
+        try:
+            field_hints = get_type_hints(hint)
+        except Exception:
+            return True  # Cannot read it, so cannot clear it.
+        return any(annotation_reaches(field_hint, targets, depth + 1, seen) for field_hint in field_hints.values())
+
+    return any(annotation_reaches(argument, targets, depth + 1, seen) for argument in get_args(hint))
+
+
+def reaches_identity(hint: Any, depth: int = 0, seen: Optional[List[Any]] = None) -> bool:
+    """Whether an annotation can deliver an identity object the model chose.
+
+    Walks the whole annotation -- containers, the container arms of a union,
+    and the fields of a dataclass or pydantic model -- because every one of
+    those is a place pydantic will happily build a RunContext out of a
+    model-supplied dict.
+
+    Two rules that look inconsistent and are not:
+
+      * ANY appearance of RunContext hides the parameter. It is the one
+        identity type pydantic constructs from JSON, so wherever it can be
+        reached, the model can choose the caller's identity.
+      * Agent and Team hide only when the annotation offers no half a model
+        could legitimately fill -- bare, or a union of identity alone.
+        ``owner: Union[str, Agent]`` stays the model's to fill, at the top
+        level and inside a list alike: validate_call is skipped for those
+        types, so the tool receives a plain dict or string, never a live
+        Agent, and hiding it would leave it fillable by nothing.
+
+    Media never reaches here as identity: it is injected by reserved name
+    alone, so hiding a media container would make it unfillable."""
+    if depth > ANNOTATION_DEPTH_CAP:
+        return True  # Unreadable is not fillable; fail closed.
+    seen = [] if seen is None else seen
+    hint = unwrap_annotation(hint)
+    if any(hint is s for s in seen):
+        return False
+    seen = seen + [hint]
+    # RunContext anywhere at all, however deeply wrapped.
+    if annotation_reaches(hint, (RunContext,)):
+        return True
+    if isinstance(hint, type):
+        return annotation_reaches(hint, identity_injected_types())
+    if is_union(hint):
+        # A union is the model's to fill as long as one arm is something the
+        # model can legitimately send. Only when every arm is identity -- bare
+        # Agent, Optional[Agent] -- is there nothing else it could mean.
+        arms = [arm for arm in get_args(hint) if arm is not type(None)]
+        return bool(arms) and all(reaches_identity(arm, depth + 1, seen) for arm in arms)
+    return any(reaches_identity(argument, depth + 1, seen) for argument in get_args(hint))
+
+
+def annotation_binds(hint: Any, wanted: tuple, depth: int = 0, seen: Optional[List[Any]] = None) -> bool:
+    """Whether the framework can put one of these objects INTO this parameter.
+
+    Deliberately narrower than annotation_reaches, and the pair is not a
+    contradiction: reaching decides what to keep from the model, binding
+    decides what can be handed over. A ``list[RunContext]`` reaches one -- so
+    it is not the model's to fill -- but it holds run contexts, it is not one,
+    and binding the object there would fail validation on every call.
+
+    Unwraps aliases and NewType, follows a TypeVar's bound and constraints, and
+    accepts a union with an arm that binds. A container or a structural wrapper
+    does not bind: nothing the framework has is that shape."""
+    if depth > ANNOTATION_DEPTH_CAP:
+        return False
+    seen = [] if seen is None else seen
+    hint = unwrap_annotation(hint)
+    if any(hint is s for s in seen):
+        return False
+    seen = seen + [hint]
+    if isinstance(hint, type):
+        return issubclass(hint, wanted)
+    if isinstance(hint, TypeVar):
+        bound = getattr(hint, "__bound__", None)
+        if bound is not None and annotation_binds(bound, wanted, depth + 1, seen):
+            return True
+        return any(
+            annotation_binds(constraint, wanted, depth + 1, seen)
+            for constraint in getattr(hint, "__constraints__", ()) or ()
+        )
+    if is_union(hint):
+        return any(annotation_binds(arm, wanted, depth + 1, seen) for arm in get_args(hint))
+    return False
+
+
+def is_framework_typed(hint: Any) -> bool:
+    """True when the framework owns the parameter: it is kept out of the
+    model-facing schema and filled by _build_entrypoint_args instead.
+
+    Excluded:
+      * a bare identity type (owner: Agent, ctx: RunContext);
+      * a union of identity types alone (Optional[Agent], RunContext | None),
+        which has no half a model could legitimately fill;
+      * ANY union naming RunContext (ctx: Union[str, RunContext]). RunContext is
+        the one identity type pydantic can build from a model-supplied dict --
+        validate_call is skipped for Agent/Team parameters but not for this one,
+        so an exposed union coerces {"user_id": ...} into a live RunContext and
+        hands the model the caller's identity.
+
+    Model-fillable:
+      * media inside a union (Optional[Image], Union[str, File]): media is
+        injected by parameter name alone, so hiding the union would leave it
+        unfillable by anything. A BARE media annotation (pic: Image) is hidden
+        all the same -- see is_bare_media_typed;
+      * a union naming Agent or Team beside an ordinary type
+        (owner: Union[str, Agent]). The model can only ever send JSON, so such a
+        parameter receives a plain dict or string, never a live Agent."""
+    return reaches_identity(hint)
+
+
+def is_bare_media_typed(hint: Any) -> bool:
+    """True for a parameter annotated with a media type itself (pic: Image).
+
+    On the process_entrypoint path (Toolkit methods, @tool) such a parameter is
+    hidden from the model, as on v2.8.7: media is injected by the reserved
+    parameter names alone (images/videos/audios/files, see
+    FunctionCall._build_entrypoint_args), so the framework can never fill it,
+    and exposing it would let the model fabricate the object while its pydantic
+    schema is invalid under strict mode, failing the whole request rather than
+    one call. from_callable does NOT use this predicate -- v2.8.7 never hid
+    media on the plain-callable path, where the parameter is the model's to
+    fill. Media inside a union (Union[str, Image]) stays model-fillable on
+    both paths."""
+    hint = unwrap_annotation(hint)
+    return isinstance(hint, type) and issubclass(hint, (Image, Video, Audio, File))
+
+
+def is_schema_excluded(hint: Any) -> bool:
+    """True when process_entrypoint keeps the parameter out of the model-facing
+    schema: the identity types plus bare media types.
+
+    Exclusion only. Framework OWNERSHIP is is_framework_typed, a strictly
+    smaller set: an owned parameter is bound by _build_entrypoint_args and a
+    value supplied for it is dropped, neither of which is true of media."""
+    return is_framework_typed(hint) or is_bare_media_typed(hint)

--- a/libs/agno/tests/unit/os/test_mcp_toolkit_tools.py
+++ b/libs/agno/tests/unit/os/test_mcp_toolkit_tools.py
@@ -748,28 +748,107 @@ async def test_a_declared_schema_is_published_verbatim_for_a_kwargs_entrypoint()
         assert json.loads(result.content[0].text) == {"limit": 3, "query": "hi"}
 
 
-async def test_a_declared_schema_still_drops_what_the_server_fills():
-    """A hand-written schema does not get to publish a framework parameter."""
-    schema = {
-        "type": "object",
-        "properties": {"query": {"type": "string"}, "run_context": {"type": "object"}},
-        "required": ["query", "run_context"],
-    }
+def _dynamic_toolkit(schema: dict, name: str = "dyn"):
+    """A toolkit shaped like MCPTools: schema on the Function, dispatch through kwargs."""
 
     class Dynamic(Toolkit):
         def __init__(self):
-            super().__init__(name="dyn2")
+            super().__init__(name=name)
 
             def run_actor(**kwargs) -> str:
-                return json.dumps(sorted(kwargs))
+                return json.dumps(kwargs, sort_keys=True)
 
             self.functions["run_actor"] = Function(
                 name="run_actor", description="Run it.", parameters=schema, entrypoint=run_actor
             )
 
-    published = (await _tools_by_name(_os(Dynamic())))["run_actor"]
+    return Dynamic()
+
+
+async def test_a_declared_schema_keeps_names_that_belong_to_the_far_side():
+    """``agent``/``team``/``run_context`` in a proxied schema are the remote's, not agno's.
+
+    A declared schema is reached precisely because the signature could not describe the
+    tool -- typically a remote tool's own ``inputSchema`` coming through ``MCPTools``.
+    Dropping those names hid a legitimate upstream argument from the model. Only the
+    ``_agno_`` channels, which agno alone puts on the wire, are removed.
+    """
+    schema = {
+        "type": "object",
+        "properties": {
+            "agent": {"type": "string", "description": "which upstream agent"},
+            "team": {"type": "string"},
+            "run_context": {"type": "string"},
+            "_agno_agent": {"type": "string"},
+            "query": {"type": "string"},
+        },
+        "required": ["agent", "query"],
+    }
+
+    published = (await _tools_by_name(_os(_dynamic_toolkit(schema, "remote"))))["run_actor"]
+    assert sorted(published.inputSchema["properties"]) == ["agent", "query", "run_context", "team"]
+    assert sorted(published.inputSchema["required"]) == ["agent", "query"]
+
+
+async def test_a_declared_schema_drops_the_catch_all_it_was_declared_through():
+    """agno derives a property named after the catch-all from a Google-style docstring.
+
+    Publishing a required ``kwargs`` of unspecified type describes nothing a caller can fill.
+    """
+    schema = {
+        "type": "object",
+        "properties": {"query": {"type": "string"}, "kwargs": {}},
+        "required": ["query", "kwargs"],
+    }
+
+    published = (await _tools_by_name(_os(_dynamic_toolkit(schema, "google_style"))))["run_actor"]
     assert sorted(published.inputSchema["properties"]) == ["query"]
     assert published.inputSchema["required"] == ["query"]
+
+
+async def test_a_declared_schema_is_enforced_like_any_other():
+    """Otherwise two tools on one server disagree about whether a bad call is an error.
+
+    An ordinary tool gets validation free from the signature FastMCP introspects. A
+    declared schema skips that machinery, and a malformed call from a model is ordinary
+    traffic rather than an attack, so the schema is checked before the body runs.
+    """
+    schema = {
+        "type": "object",
+        "properties": {"query": {"type": "string"}, "limit": {"type": "integer"}},
+        "required": ["query"],
+        "additionalProperties": False,
+    }
+
+    async with Client(build_mcp_server(_os(_dynamic_toolkit(schema, "strict")))) as client:
+        for bad in ({"limit": 1}, {"query": "q", "limit": "not-an-int"}, {"query": "q", "surprise": 1}):
+            result = await client.call_tool("run_actor", bad, raise_on_error=False)
+            assert result.is_error, bad
+            assert "Invalid arguments" in result.content[0].text
+
+        ok = await client.call_tool("run_actor", {"query": "q", "limit": 1})
+        assert json.loads(ok.content[0].text) == {"limit": 1, "query": "q"}
+
+
+async def test_registering_over_mcp_does_not_mutate_the_shared_function():
+    """The same Function object is read by the agent path, which must not see the edit.
+
+    The cookbook hands one toolkit instance to both ``Agent(tools=[...])`` and
+    ``MCPConfig(tools=[...])``, so filtering the declared schema in place would strip
+    parameters from the tool the agent runs.
+    """
+    schema = {
+        "type": "object",
+        "properties": {"query": {"type": "string"}, "_agno_agent": {"type": "string"}},
+        "required": ["query", "_agno_agent"],
+    }
+    kit = _dynamic_toolkit(schema, "shared")
+    function = kit.functions["run_actor"]
+    before = json.dumps(function.parameters, sort_keys=True)
+
+    published = (await _tools_by_name(_os(kit)))["run_actor"]
+    assert sorted(published.inputSchema["properties"]) == ["query"]
+    assert json.dumps(function.parameters, sort_keys=True) == before
 
 
 async def test_a_vestigial_kwargs_catch_all_is_dropped_rather_than_refused():
@@ -827,6 +906,20 @@ async def test_raw_image_and_audio_bytes_become_mcp_content_blocks():
     assert b64decode(audio.data) == _WAV
     # The answer is mirrored in structuredContent, as the run tools already do.
     assert result.structured_content["content"] == "rendered a cat"
+
+
+async def test_a_tool_result_tool_advertises_no_output_schema():
+    """FastMCP would otherwise derive one from the ToolResult model the tool never sends."""
+
+    class Studio(Toolkit):
+        def __init__(self):
+            super().__init__(name="schema_studio", tools=[self.render])
+
+        def render(self, prompt: str) -> ToolResult:
+            """Render a picture."""
+            return ToolResult(content=prompt)
+
+    assert (await _tools_by_name(_os(Studio())))["render"].outputSchema is None
 
 
 async def test_an_async_tool_result_is_converted_too():
@@ -891,8 +984,12 @@ async def test_files_and_video_travel_as_embedded_resources():
     assert "rows.csv" in str(resource.uri)
 
 
-async def test_a_url_only_artifact_is_skipped_rather_than_faked():
-    """The bytes are not in hand, and fetching them is not this layer's job."""
+async def test_a_url_only_artifact_becomes_a_resource_link():
+    """The url IS the result for a generation toolkit; dropping it loses the output.
+
+    Giphy, Replicate, Luma and Fal all hand back an address rather than bytes. A
+    resource_link points at it without the server fetching anything on the caller's behalf.
+    """
 
     class Linker(Toolkit):
         def __init__(self):
@@ -900,13 +997,19 @@ async def test_a_url_only_artifact_is_skipped_rather_than_faked():
 
         def find(self, q: str) -> ToolResult:
             """Find a picture."""
-            return ToolResult(content="found one", images=[Image(url="https://example.test/a.png")])
+            return ToolResult(
+                content="found one",
+                images=[Image(id="gif-1", url="https://example.test/a.gif", mime_type="image/gif")],
+            )
 
     async with Client(build_mcp_server(_os(Linker()))) as client:
         result = await client.call_tool("find", {"q": "cat"})
 
-    assert [type(block).__name__ for block in result.content] == ["TextContent"]
+    assert [type(block).__name__ for block in result.content] == ["TextContent", "ResourceLink"]
     assert result.content[0].text == "found one"
+    link = result.content[1]
+    assert str(link.uri) == "https://example.test/a.gif"
+    assert link.mimeType == "image/gif"
 
 
 async def test_a_shipped_tool_result_toolkit_round_trips():
@@ -927,34 +1030,80 @@ async def test_a_shipped_tool_result_toolkit_round_trips():
 # ==================== Toolkit lifecycle ====================
 
 
-async def test_a_connect_requiring_toolkit_publishes_the_functions_it_already_has():
-    """``_requires_connect`` toolkits register at construction and connect on use.
+class Connectable(Toolkit):
+    """A toolkit that reports whether it is connected, as PostgresTools does."""
 
-    ``PostgresTools`` is the shipped example: its functions exist before any connection,
-    and each one calls ``_ensure_connection`` itself. The MCP path does not connect for
-    it, and does not need to.
-    """
+    def __init__(self, connected: bool = False):
+        super().__init__(name="connectable", tools=[self.read_row])
+        self._requires_connect = True
+        self._connected = connected
 
-    class Connectable(Toolkit):
-        def __init__(self):
-            super().__init__(name="connectable", tools=[self.read_row])
-            self._requires_connect = True
-            self.connections = 0
+    @property
+    def is_connected(self) -> bool:
+        return self._connected
 
-        def connect(self):
-            self.connections += 1
+    def connect(self):
+        self._connected = True
 
-        def read_row(self, table: str) -> str:
-            """Read a row, connecting on demand."""
-            if not self.connections:
-                self.connect()
-            return f"{table}:{self.connections}"
+    def read_row(self, table: str) -> str:
+        """Read a row."""
+        return f"{table}:ok"
 
+
+async def test_an_unconnected_toolkit_is_refused_with_the_call_that_frees_it():
+    """The server opens no connection and closes none, so it will not serve one blind."""
+    with pytest.raises(ValueError) as excinfo:
+        build_mcp_server(_os(Connectable()))
+
+    message = str(excinfo.value)
+    assert "requires a connection" in message
+    assert "connect()" in message
+
+
+async def test_a_connected_toolkit_is_served():
+    """Connected by the deployer, it is as usable here as anywhere."""
     kit = Connectable()
+    kit.connect()
+
     os = _os(kit)
     assert set(await _tools_by_name(os)) == {"read_row"}
     async with Client(build_mcp_server(os)) as client:
-        assert (await client.call_tool("read_row", {"table": "t"})).content[0].text == "t:1"
+        assert (await client.call_tool("read_row", {"table": "t"})).content[0].text == "t:ok"
+
+
+async def test_a_toolkit_that_cannot_report_a_connection_is_refused_outright():
+    """``CodeMode`` is the sharp case, and connecting it would not make it correct.
+
+    Its kernel is keyed by ``session_id`` and an MCP call mints a fresh one every time, so
+    a deployment would start a kernel per call and lose the state each one was for. There
+    is nothing to check, so the refusal names the escape hatch instead: publish the
+    functions individually and own the lifecycle yourself.
+    """
+
+    class KernelLike(Toolkit):
+        def __init__(self):
+            super().__init__(name="kernel", tools=[self.execute])
+            self._requires_connect = True
+
+        def execute(self, code: str) -> str:
+            """Run a cell."""
+            return code
+
+    kit = KernelLike()
+    with pytest.raises(ValueError) as excinfo:
+        build_mcp_server(_os(kit))
+    assert "cannot report a live connection" in str(excinfo.value)
+
+    # The escape hatch the message names really works.
+    assert set(await _tools_by_name(_os(*kit.get_async_functions().values()))) == {"execute"}
+
+
+async def test_the_shipped_connect_requiring_toolkit_behaves_the_same_way():
+    """PostgresTools is the one shipped toolkit that declares it needs a connection."""
+    from agno.tools.postgres import PostgresTools
+
+    with pytest.raises(ValueError, match="requires a connection"):
+        build_mcp_server(_os(PostgresTools()))
 
 
 async def test_a_toolkit_that_discovers_during_connect_is_refused_by_name():

--- a/libs/agno/tests/unit/os/test_mcp_toolkit_tools.py
+++ b/libs/agno/tests/unit/os/test_mcp_toolkit_tools.py
@@ -1030,80 +1030,46 @@ async def test_a_shipped_tool_result_toolkit_round_trips():
 # ==================== Toolkit lifecycle ====================
 
 
-class Connectable(Toolkit):
-    """A toolkit that reports whether it is connected, as PostgresTools does."""
+async def test_a_connect_requiring_toolkit_is_served_and_connects_on_use():
+    """``_requires_connect`` is not a refusal: the shipped ones connect themselves.
 
-    def __init__(self, connected: bool = False):
-        super().__init__(name="connectable", tools=[self.read_row])
-        self._requires_connect = True
-        self._connected = connected
+    ``PostgresTools`` and ``RedshiftTools`` both route every method through
+    ``_ensure_connection``, so a cold instance works here exactly as it works anywhere.
+    The MCP server opens no connection and closes none -- see the module docs for what
+    that costs a toolkit whose lifecycle is not self-managing.
+    """
 
-    @property
-    def is_connected(self) -> bool:
-        return self._connected
+    class Connectable(Toolkit):
+        def __init__(self):
+            super().__init__(name="connectable", tools=[self.read_row])
+            self._requires_connect = True
+            self.connections = 0
 
-    def connect(self):
-        self._connected = True
+        @property
+        def is_connected(self) -> bool:
+            return self.connections > 0
 
-    def read_row(self, table: str) -> str:
-        """Read a row."""
-        return f"{table}:ok"
+        def connect(self):
+            self.connections += 1
 
+        def read_row(self, table: str) -> str:
+            """Read a row, connecting on demand."""
+            if not self.is_connected:
+                self.connect()
+            return f"{table}:{self.connections}"
 
-async def test_an_unconnected_toolkit_is_refused_with_the_call_that_frees_it():
-    """The server opens no connection and closes none, so it will not serve one blind."""
-    with pytest.raises(ValueError) as excinfo:
-        build_mcp_server(_os(Connectable()))
-
-    message = str(excinfo.value)
-    assert "requires a connection" in message
-    assert "connect()" in message
-
-
-async def test_a_connected_toolkit_is_served():
-    """Connected by the deployer, it is as usable here as anywhere."""
     kit = Connectable()
-    kit.connect()
-
     os = _os(kit)
     assert set(await _tools_by_name(os)) == {"read_row"}
     async with Client(build_mcp_server(os)) as client:
-        assert (await client.call_tool("read_row", {"table": "t"})).content[0].text == "t:ok"
+        assert (await client.call_tool("read_row", {"table": "t"})).content[0].text == "t:1"
 
 
-async def test_a_toolkit_that_cannot_report_a_connection_is_refused_outright():
-    """``CodeMode`` is the sharp case, and connecting it would not make it correct.
-
-    Its kernel is keyed by ``session_id`` and an MCP call mints a fresh one every time, so
-    a deployment would start a kernel per call and lose the state each one was for. There
-    is nothing to check, so the refusal names the escape hatch instead: publish the
-    functions individually and own the lifecycle yourself.
-    """
-
-    class KernelLike(Toolkit):
-        def __init__(self):
-            super().__init__(name="kernel", tools=[self.execute])
-            self._requires_connect = True
-
-        def execute(self, code: str) -> str:
-            """Run a cell."""
-            return code
-
-    kit = KernelLike()
-    with pytest.raises(ValueError) as excinfo:
-        build_mcp_server(_os(kit))
-    assert "cannot report a live connection" in str(excinfo.value)
-
-    # The escape hatch the message names really works.
-    assert set(await _tools_by_name(_os(*kit.get_async_functions().values()))) == {"execute"}
-
-
-async def test_the_shipped_connect_requiring_toolkit_behaves_the_same_way():
-    """PostgresTools is the one shipped toolkit that declares it needs a connection."""
+async def test_the_shipped_connect_requiring_toolkit_is_served_cold():
+    """PostgresTools is the shipped case, and it is not refused."""
     from agno.tools.postgres import PostgresTools
 
-    with pytest.raises(ValueError, match="requires a connection"):
-        build_mcp_server(_os(PostgresTools()))
+    assert "run_query" in await _tools_by_name(_os(PostgresTools()))
 
 
 async def test_a_toolkit_that_discovers_during_connect_is_refused_by_name():

--- a/libs/agno/tests/unit/os/test_mcp_toolkit_tools.py
+++ b/libs/agno/tests/unit/os/test_mcp_toolkit_tools.py
@@ -1,0 +1,710 @@
+"""Unit tests for toolkits served as MCP tools, and the parameters the server fills.
+
+Two behaviours that only make sense together. A ``Toolkit`` passed to ``MCPConfig.tools``
+is flattened into one MCP tool per method, the way an agent takes it apart -- and real
+toolkit methods declare ``run_context: RunContext``, which pydantic cannot describe, so
+flattening without hiding the framework's own parameters would fail at startup rather
+than publish anything.
+
+The FastMCP tool surface is exercised with an in-memory client, matching
+test_mcp_exposed_components.py.
+"""
+
+import pytest
+
+pytest.importorskip("fastmcp")
+
+import tempfile  # noqa: E402
+from typing import List, Optional, Union  # noqa: E402
+
+from fastmcp import Client, Context  # noqa: E402
+
+import agno.os.mcp as mcp_mod  # noqa: E402
+from agno.agent import Agent  # noqa: E402
+from agno.db.sqlite import SqliteDb  # noqa: E402
+from agno.media import Image  # noqa: E402
+from agno.os import AgentOS, MCPConfig  # noqa: E402
+from agno.os.mcp import build_mcp_server  # noqa: E402
+from agno.run import RunContext  # noqa: E402
+from agno.team.team import Team  # noqa: E402
+from agno.tools import Toolkit, tool  # noqa: E402
+from agno.tools.function import Function  # noqa: E402
+
+
+def _agent(id: str = "demo-agent") -> Agent:
+    return Agent(id=id, name="Demo Agent")
+
+
+def _os(*tools, default_tools: bool = False) -> AgentOS:
+    return AgentOS(agents=[_agent()], mcp=MCPConfig(tools=list(tools), default_tools=default_tools))
+
+
+async def _tools_by_name(os: AgentOS) -> dict:
+    async with Client(build_mcp_server(os)) as client:
+        return {t.name: t for t in await client.list_tools()}
+
+
+async def _props(os: AgentOS, name: str) -> dict:
+    return ((await _tools_by_name(os))[name].inputSchema or {}).get("properties", {})
+
+
+async def _props_of_only_tool(*tools) -> dict:
+    """Schema properties of a single-tool server, keyed off whatever name it took."""
+    registry = await _tools_by_name(_os(*tools))
+    assert len(registry) == 1, registry
+    return (next(iter(registry.values())).inputSchema or {}).get("properties", {})
+
+
+class Notebook(Toolkit):
+    """A toolkit shaped like the real ones: identity first, then the model's arguments."""
+
+    def __init__(self, **kwargs):
+        super().__init__(name="notebook", tools=[self.jot, self.recall], **kwargs)
+
+    def jot(self, run_context: RunContext, note: str, tag: Optional[str] = None) -> str:
+        """Write a note down."""
+        return f"user={run_context.user_id} note={note} tag={tag}"
+
+    async def recall(self, run_context: RunContext) -> str:
+        """Read the notes back."""
+        return f"user={run_context.user_id}"
+
+
+class Shadow(Toolkit):
+    """A toolkit whose method names a default MCP tool."""
+
+    def __init__(self, **kwargs):
+        super().__init__(name="shadow", tools=[self.run_agent], **kwargs)
+
+    def run_agent(self, q: str) -> str:
+        """Shadows the built-in run_agent."""
+        return q
+
+
+class Dangerous(Toolkit):
+    """A toolkit carrying an approval gate the MCP surface cannot honour."""
+
+    def __init__(self, **kwargs):
+        super().__init__(name="dangerous", tools=[self.wipe], requires_confirmation_tools=["wipe"], **kwargs)
+
+    def wipe(self, path: str) -> str:
+        """Delete everything under a path."""
+        return path
+
+
+# ==================== Flattening a toolkit ====================
+
+
+async def test_toolkit_is_flattened_into_one_tool_per_method():
+    """A Toolkit publishes its methods individually, and nothing else."""
+    registry = await _tools_by_name(_os(Notebook()))
+
+    assert set(registry) == {"jot", "recall"}
+    assert registry["jot"].description == "Write a note down."
+
+
+async def test_flattened_tools_hide_the_framework_parameter_and_keep_the_rest():
+    """``run_context`` never reaches the client; the model-facing arguments all do."""
+    assert sorted(await _props(_os(Notebook()), "jot")) == ["note", "tag"]
+    assert await _props(_os(Notebook()), "recall") == {}
+
+
+async def test_flattened_tool_receives_the_authenticated_caller(monkeypatch):
+    """The hidden RunContext is really built and really carries the JWT subject.
+
+    The schema assertions above would pass just as well if the server hid the parameter
+    and then never filled it, so this one calls the tool.
+    """
+    monkeypatch.setattr(mcp_mod, "_resolve_user_id", lambda caller: "jwt-subject-42")
+
+    async with Client(build_mcp_server(_os(Notebook()))) as client:
+        result = await client.call_tool("jot", {"note": "hello"})
+
+    assert result.content[0].text == "user=jwt-subject-42 note=hello tag=None"
+
+
+async def test_self_is_not_published_as_a_tool_argument():
+    """The entrypoint is a bound method, so ``self`` must never reach the schema."""
+    for name in ("jot", "recall"):
+        assert "self" not in await _props(_os(Notebook()), name)
+
+
+async def test_toolkit_include_and_exclude_filters_are_respected():
+    """Flattening reads the toolkit's own surface, so its filters already applied."""
+    assert set(await _tools_by_name(_os(Notebook(exclude_tools=["recall"])))) == {"jot"}
+    assert set(await _tools_by_name(_os(Notebook(include_tools=["recall"])))) == {"recall"}
+
+
+async def test_async_variant_wins_when_a_toolkit_declares_both():
+    """One name, one tool: the async surface is what an async caller would run."""
+
+    class Both(Toolkit):
+        def __init__(self):
+            super().__init__(name="both", tools=[self.ping, self.aping])
+
+        def ping(self, q: str) -> str:
+            """Sync."""
+            return f"sync:{q}"
+
+        @tool(name="ping")
+        async def aping(self, q: str) -> str:
+            """Async."""
+            return f"async:{q}"
+
+    kit = Both()
+    registry = await _tools_by_name(_os(kit))
+    assert set(registry) == {"ping"}
+    async with Client(build_mcp_server(_os(kit))) as client:
+        assert (await client.call_tool("ping", {"q": "x"})).content[0].text == "async:x"
+
+
+async def test_toolkit_mixes_with_components_and_plain_callables():
+    """A toolkit entry is classified as a custom tool, not mistaken for a component."""
+
+    async def standalone(q: str) -> str:
+        """A plain callable."""
+        return q
+
+    agent = _agent("chief")
+    os = AgentOS(
+        agents=[agent],
+        mcp=MCPConfig(tools=[Notebook(), agent, standalone], default_tools=False, lifecycle_tools=False),
+    )
+    assert set(await _tools_by_name(os)) == {"jot", "recall", "chief", "standalone"}
+
+
+async def test_toolkit_subclass_with_arun_is_still_a_custom_tool():
+    """A Toolkit carries an id like a component does; type decides, not the heuristics."""
+
+    class Runner(Toolkit):
+        def __init__(self):
+            super().__init__(name="runner", tools=[self.ping])
+
+        async def arun(self, *args, **kwargs):  # noqa: D102
+            raise AssertionError("never called")
+
+        def ping(self, q: str) -> str:
+            """Ping."""
+            return q
+
+    assert set(await _tools_by_name(_os(Runner()))) == {"ping"}
+
+
+async def test_toolkit_publishing_nothing_is_refused():
+    """A toolkit filtered down to nothing would publish nothing; say so at startup."""
+    with pytest.raises(ValueError, match="registers no functions"):
+        build_mcp_server(_os(Notebook(exclude_tools=["jot", "recall"])))
+
+
+async def test_flattened_toolkit_publishes_its_presentation_metadata():
+    """title/annotations declared on a toolkit method survive the flatten."""
+
+    class Titled(Toolkit):
+        def __init__(self):
+            super().__init__(name="titled", tools=[self.lookup])
+
+        @tool(title="Weather Lookup", annotations={"readOnlyHint": True})
+        def lookup(self, city: str) -> str:
+            """Look up the weather."""
+            return city
+
+    published = (await _tools_by_name(_os(Titled())))["lookup"]
+    assert published.title == "Weather Lookup"
+    assert published.annotations.readOnlyHint is True
+
+
+# ==================== Collisions on a flattened name ====================
+
+
+async def test_flattened_name_colliding_with_a_default_tool_is_refused():
+    """A toolkit method named like a built-in must not silently replace it."""
+    with pytest.raises(ValueError) as excinfo:
+        build_mcp_server(_os(Shadow(), default_tools=True))
+
+    message = str(excinfo.value)
+    assert 'collides with the default tool "run_agent"' in message
+    # The deployer cannot rename someone else's method, so the advice names the knob
+    # that actually frees the name.
+    assert 'exclude_tools=["run_agent"]' in message
+    assert 'toolkit "shadow"' in message
+
+
+async def test_two_toolkits_sharing_a_method_name_are_refused():
+    """FastMCP would replace the first tool; the collision check raises instead."""
+    with pytest.raises(ValueError) as excinfo:
+        build_mcp_server(_os(Notebook(include_tools=["jot"]), Notebook(include_tools=["jot"])))
+
+    message = str(excinfo.value)
+    assert 'collides with toolkit "notebook" tool "jot"' in message
+    assert 'exclude_tools=["jot"]' in message
+
+
+async def test_a_flattened_name_blocks_a_later_exposed_component():
+    """Flattened names join the registry the exposure check reads."""
+    agent = Agent(id="jot", name="Jot")
+    os = AgentOS(agents=[agent], mcp=MCPConfig(tools=[Notebook(), agent], default_tools=False))
+
+    with pytest.raises(ValueError, match='toolkit "notebook" tool "jot"'):
+        build_mcp_server(os)
+
+
+# ==================== Approval gates the MCP surface cannot honour ====================
+
+
+async def test_gated_toolkit_method_is_refused_rather_than_published_ungated():
+    """An MCP call runs the entrypoint directly, so a confirmation would be skipped."""
+    with pytest.raises(ValueError) as excinfo:
+        build_mcp_server(_os(Dangerous()))
+
+    message = str(excinfo.value)
+    assert "requires_confirmation" in message
+    assert 'exclude_tools=["wipe"]' in message
+
+
+async def test_real_toolkit_with_write_methods_is_refused():
+    """The shipped Workspace toolkit gates its writes; flattening must not drop that."""
+    from agno.tools.workspace import Workspace
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        with pytest.raises(ValueError, match="requires_confirmation"):
+            build_mcp_server(_os(Workspace(root=tmp_dir)))
+
+        # Scoped down to the read-only surface it publishes cleanly.
+        registry = await _tools_by_name(_os(Workspace(root=tmp_dir, allowed=["read", "list"])))
+        assert set(registry) == {"read_file", "list_files"}
+
+
+async def test_a_real_toolkit_flattens_with_its_run_context_hidden():
+    """End to end on a shipped toolkit, which is where the two features meet."""
+    from agno.tools.memory import MemoryTools
+
+    kit = MemoryTools(db=SqliteDb(db_file=tempfile.mktemp(suffix=".db")), enable_think=False, enable_analyze=False)
+    registry = await _tools_by_name(_os(kit))
+
+    assert set(registry) == {"get_memories", "add_memory", "update_memory", "delete_memory"}
+    assert (registry["add_memory"].inputSchema or {}).get("properties", {}).keys() == {"memory", "topics"}
+    assert (registry["get_memories"].inputSchema or {}).get("properties", {}) == {}
+
+
+# ==================== Hiding by type ====================
+
+
+async def test_run_context_is_hidden_whatever_the_parameter_is_called():
+    """The rule is the annotation, not the name -- authors name this one anything."""
+
+    async def lookup(q: str, ctx: RunContext) -> str:
+        """Look something up."""
+        return q
+
+    assert sorted(await _props_of_only_tool(lookup)) == ["q"]
+
+
+async def test_agent_and_team_typed_parameters_are_hidden():
+    """Framework objects an MCP caller has no business choosing."""
+
+    async def get_info(query: str, helper: Agent, crew: Optional[Team] = None) -> str:
+        """Get info."""
+        return query
+
+    assert sorted(await _props_of_only_tool(get_info)) == ["query"]
+
+
+async def test_a_union_naming_an_identity_type_is_hidden_even_though_a_model_could_fill_it():
+    """The MCP rule is broader than the model-facing one, and has to be.
+
+    ``is_framework_typed`` keeps ``Union[str, Agent]`` in the model's schema, because the
+    model can only ever send the string half. Pydantic builds THIS schema from the real
+    signature and fails on Agent's own fields, so the server would not start.
+    """
+
+    async def lookup(query: str, owner: Union[str, Agent] = None) -> str:
+        """Look up by owner."""
+        return query
+
+    assert sorted(await _props_of_only_tool(lookup)) == ["query"]
+
+
+async def test_media_parameters_stay_visible():
+    """Nothing on this surface injects media, so hiding it would leave it unfillable."""
+
+    async def caption(pic: Image, gallery: Optional[List[Image]] = None) -> str:
+        """Caption an image."""
+        return "ok"
+
+    assert sorted(await _props_of_only_tool(caption)) == ["gallery", "pic"]
+
+
+async def test_a_sync_custom_tool_gets_the_same_hiding(monkeypatch):
+    """The wrapper has two branches; the sync one is a real path for toolkit methods."""
+    monkeypatch.setattr(mcp_mod, "_resolve_user_id", lambda caller: "sync-caller")
+
+    def probe(note: str, ctx: RunContext) -> str:
+        """A synchronous custom tool."""
+        return f"{ctx.user_id}:{note}"
+
+    os = _os(probe)
+    assert sorted(await _props(os, "probe")) == ["note"]
+    async with Client(build_mcp_server(os)) as client:
+        assert (await client.call_tool("probe", {"note": "hi"})).content[0].text == "sync-caller:hi"
+
+
+async def test_fastmcp_context_is_left_for_fastmcp_to_inject():
+    """``Context`` is not an agno identity type and must keep its native injection."""
+
+    async def whoami(ctx: Context) -> str:
+        """Report the FastMCP context type."""
+        return f"ctx:{type(ctx).__name__}"
+
+    os = _os(whoami)
+    assert await _props(os, "whoami") == {}
+    async with Client(build_mcp_server(os)) as client:
+        assert (await client.call_tool("whoami", {})).content[0].text == "ctx:Context"
+
+
+# ==================== Hiding by name, and the split between the two paths ====================
+
+
+async def test_a_plain_callable_keeps_parameters_merely_named_like_framework_ones():
+    """A bare callable was written for this surface, so its own ``agent: str`` is its own.
+
+    Hiding by name here would leave the parameter fillable by nobody: MCP has no agent,
+    team or run media to put in it.
+    """
+
+    async def book(team: str, agent: str, images: str, files: str) -> str:
+        """Book something."""
+        return team
+
+    assert sorted(await _props_of_only_tool(book)) == ["agent", "files", "images", "team"]
+
+
+async def test_an_agno_function_hides_the_identity_names_it_already_hides_from_a_model():
+    """The same object an agent would run must not have two contracts.
+
+    ``_derive_entrypoint_schema`` keeps these names out of the model-facing schema and
+    ``_build_entrypoint_args`` fills them, whether or not they are annotated. An
+    unannotated ``run_context`` published over MCP would be a caller-supplied dict where
+    the body expects the caller's identity.
+    """
+
+    @tool(name="probe")
+    async def probe(note: str, run_context, agent, team) -> str:  # noqa: ANN001
+        """A tool written for an agent."""
+        return note
+
+    assert sorted(await _props_of_only_tool(probe)) == ["note"]
+
+
+async def test_media_names_are_hidden_on_neither_path():
+    """Media is injected by reserved name on the agent path; there is no such source here."""
+
+    @tool(name="attach")
+    async def attach(note: str, images: Optional[List[str]] = None) -> str:
+        """Attach something."""
+        return note
+
+    assert sorted(await _props_of_only_tool(attach)) == ["images", "note"]
+
+
+# ==================== user_id, unchanged ====================
+
+
+async def test_user_id_is_still_resolved_from_the_authenticated_request(monkeypatch):
+    """The JWT subject is the server's to resolve, over any default the author wrote."""
+    monkeypatch.setattr(mcp_mod, "_resolve_user_id", lambda caller: "jwt-subject")
+
+    async def whoami(user_id: str = "service-account") -> str:
+        """Report the caller."""
+        return f"user={user_id}"
+
+    os = _os(whoami)
+    assert await _props(os, "whoami") == {}
+    async with Client(build_mcp_server(os)) as client:
+        assert (await client.call_tool("whoami", {})).content[0].text == "user=jwt-subject"
+
+
+async def test_the_jwt_subject_overrides_an_author_default_even_when_it_resolves_to_none(monkeypatch):
+    """``always`` is the rule that identity is not the author's to default away.
+
+    Without it an unauthenticated call would run the tool as "service-account" -- a name
+    the author picked, standing in for a caller the server could not identify.
+    """
+    monkeypatch.setattr(mcp_mod, "_resolve_user_id", lambda caller: None)
+
+    async def whoami(user_id: str = "service-account") -> str:
+        """Report the caller."""
+        return f"user={user_id}"
+
+    async with Client(build_mcp_server(_os(whoami))) as client:
+        assert (await client.call_tool("whoami", {})).content[0].text == "user=None"
+
+
+async def test_an_agno_function_agent_argument_is_bound_to_none_not_left_at_its_default():
+    """An MCP call runs outside any component, so the framework names are bound, not skipped."""
+
+    @tool(name="probe")
+    async def probe(note: str, agent="author-default") -> str:  # noqa: ANN001
+        """A tool written for an agent."""
+        return f"{note}:{agent}"
+
+    os = _os(probe)
+    assert sorted(await _props(os, "probe")) == ["note"]
+    async with Client(build_mcp_server(os)) as client:
+        assert (await client.call_tool("probe", {"note": "hi"})).content[0].text == "hi:None"
+
+
+async def test_a_required_agent_typed_parameter_is_bound_to_none():
+    """An MCP call runs outside any component, so an Agent-typed argument arrives empty.
+
+    This is the TYPE rule rather than the name rule: the parameter is required, so the
+    binder's value is written rather than left to a default.
+    """
+
+    async def probe(note: str, helper: Agent) -> str:
+        """A tool wanting an agent."""
+        return f"{note}:{helper}"
+
+    os = _os(probe)
+    assert sorted(await _props(os, "probe")) == ["note"]
+    async with Client(build_mcp_server(os)) as client:
+        assert (await client.call_tool("probe", {"note": "hi"})).content[0].text == "hi:None"
+
+
+async def test_a_sync_tool_also_sheds_a_hidden_parameters_annotation(monkeypatch):
+    """The wrapper has two branches, and both hand FastMCP their own annotations."""
+    monkeypatch.setattr(mcp_mod, "_resolve_user_id", lambda caller: "sync-subject")
+
+    def probe(q: str, run_context=None) -> str:  # noqa: ANN001
+        """A synchronous tool whose identity annotation is unresolvable."""
+        return f"{q}/{getattr(run_context, 'user_id', run_context)}"
+
+    probe.__annotations__ = {"q": str, "run_context": "RunContextOnlyForTypeCheckers", "return": str}
+    unresolvable = Function(name="probe", entrypoint=probe, description="Probe.")
+
+    os = _os(unresolvable)
+    assert sorted(await _props(os, "probe")) == ["q"]
+    async with Client(build_mcp_server(os)) as client:
+        assert (await client.call_tool("probe", {"q": "x"})).content[0].text == "x/sync-subject"
+
+
+async def test_a_toolkit_method_keeps_a_user_id_of_its_own():
+    """``user_id`` on a toolkit method is a domain argument, not the caller's identity.
+
+    Toolkit methods read identity from their RunContext; agno never injects ``user_id``
+    by name. ZoomTools asks which Zoom account to read, defaulting to "me" -- filling
+    that with the JWT subject would break the call rather than secure it.
+    """
+
+    class Meetings(Toolkit):
+        def __init__(self):
+            super().__init__(name="meetings", tools=[self.list_meetings])
+
+        def list_meetings(self, user_id: str = "me") -> str:
+            """List meetings for an account."""
+            return user_id
+
+    os = _os(Meetings())
+    assert sorted(await _props(os, "list_meetings")) == ["user_id"]
+    async with Client(build_mcp_server(os)) as client:
+        assert (await client.call_tool("list_meetings", {})).content[0].text == "me"
+        assert (await client.call_tool("list_meetings", {"user_id": "someone"})).content[0].text == "someone"
+
+
+async def test_a_hidden_parameters_annotation_does_not_follow_the_wrapper_to_fastmcp(monkeypatch):
+    """FastMCP reads annotations as well as the signature, so the leftovers must go.
+
+    ``functools.wraps`` copies the wrapped function's whole ``__annotations__``. An
+    annotation that cannot be resolved at all -- a framework type imported only under
+    ``if TYPE_CHECKING`` -- then fails FastMCP's type adapter and the server never
+    starts, even though the parameter was correctly hidden.
+    """
+    monkeypatch.setattr(mcp_mod, "_resolve_user_id", lambda caller: "jwt-subject")
+
+    async def probe(q: str, run_context=None) -> str:  # noqa: ANN001
+        """A tool whose identity annotation only exists for type checkers."""
+        return f"{q}/{getattr(run_context, 'user_id', run_context)}"
+
+    probe.__annotations__ = {"q": str, "run_context": "RunContextOnlyForTypeCheckers", "return": str}
+    unresolvable = Function(name="probe", entrypoint=probe, description="Probe.")
+
+    os = _os(unresolvable)
+    assert sorted(await _props(os, "probe")) == ["q"]
+    async with Client(build_mcp_server(os)) as client:
+        assert (await client.call_tool("probe", {"q": "x"})).content[0].text == "x/jwt-subject"
+
+
+async def test_a_tool_with_nothing_to_hide_is_registered_unchanged():
+    """The wrapper short-circuits, so an ordinary tool reaches FastMCP as it always did."""
+
+    async def echo(message: str) -> str:
+        """Echo a message."""
+        return message
+
+    os = _os(echo)
+    assert sorted(await _props(os, "echo")) == ["message"]
+    async with Client(build_mcp_server(os)) as client:
+        assert (await client.call_tool("echo", {"message": "hi"})).content[0].text == "hi"
+
+
+# ==================== Signatures the server cannot fill ====================
+
+
+async def test_a_positional_only_framework_parameter_is_refused_by_name():
+    """Refused with the parameter's name, not a pydantic error naming FilterExpr.
+
+    Every toolkit method puts its RunContext first, so leaving the un-injectable kinds
+    visible is not a hypothetical: the server would fail to start on a type the tool
+    author never wrote.
+    """
+
+    async def posonly(run_context: RunContext, /, q: str) -> str:
+        """Positional-only identity."""
+        return q
+
+    with pytest.raises(ValueError) as excinfo:
+        build_mcp_server(_os(posonly))
+
+    message = str(excinfo.value)
+    assert "positional-only" in message
+    assert '"run_context"' in message
+
+
+async def test_a_positional_only_user_id_is_refused_by_name():
+    """The same rule covers the name-based half, which had the same latent break."""
+
+    async def probe(user_id, /, q: str) -> str:  # noqa: ANN001
+        """Positional-only user_id."""
+        return q
+
+    with pytest.raises(ValueError, match="positional-only"):
+        build_mcp_server(_os(probe))
+
+
+async def test_a_required_identity_parameter_nothing_can_fill_is_refused():
+    """Hiding and filling are separate questions; a list of run contexts is neither."""
+
+    async def batch(rows: List[RunContext]) -> str:
+        """Take a batch of contexts."""
+        return "ok"
+
+    with pytest.raises(ValueError) as excinfo:
+        build_mcp_server(_os(batch))
+
+    message = str(excinfo.value)
+    assert "nothing to fill it with" in message
+    assert '"rows"' in message
+
+
+async def test_an_optional_identity_parameter_nothing_can_fill_keeps_its_default():
+    """Hidden, unfilled, and left to its own default rather than forced to None.
+
+    The default is deliberately not None: with None the assertion could not tell the two
+    apart, and "forced to None" is exactly the behaviour being ruled out.
+    """
+
+    async def batch(note: str, rows: Optional[List[RunContext]] = "author-default") -> str:  # type: ignore[assignment]
+        """Take an optional batch."""
+        return f"{note}:{rows}"
+
+    os = _os(batch)
+    assert sorted(await _props(os, "batch")) == ["note"]
+    async with Client(build_mcp_server(os)) as client:
+        assert (await client.call_tool("batch", {"note": "hi"})).content[0].text == "hi:author-default"
+
+
+async def test_the_wrapper_binds_positional_arguments_around_a_hidden_first_parameter(monkeypatch):
+    """Calling the registered callable positionally must not collide with the injection.
+
+    FastMCP calls by keyword, so this is latent there -- but the wrapper advertises a
+    signature that accepts positionals, and every RunContext-taking toolkit method puts
+    the hidden parameter first.
+    """
+    monkeypatch.setattr(mcp_mod, "_resolve_user_id", lambda caller: "positional-caller")
+
+    def probe(run_context: RunContext, note: str) -> str:
+        """Identity first, like every real toolkit method."""
+        return f"{run_context.user_id}:{note}"
+
+    hidden = mcp_mod._mcp_hidden_params(probe, owner="probe", reserved_names=True)
+    wrapped = mcp_mod._build_mcp_wrapper(probe, hidden)
+
+    assert wrapped("hi") == "positional-caller:hi"
+    assert wrapped(note="hi") == "positional-caller:hi"
+
+
+async def test_an_unreadable_annotation_does_not_expose_its_neighbours(monkeypatch):
+    """One parameter this walk cannot classify must not leave the next one published."""
+    real = mcp_mod.annotation_reaches
+
+    def raising(hint, targets):
+        if hint is str:
+            raise RuntimeError("cannot read this one")
+        return real(hint, targets)
+
+    monkeypatch.setattr(mcp_mod, "annotation_reaches", raising)
+
+    async def probe(note: str = "", ctx: Optional[RunContext] = None) -> str:
+        """A tool with one unclassifiable neighbour."""
+        return note
+
+    # `note` fails closed and is hidden; `ctx` keeps its own protection rather than
+    # having it undone by an unrelated neighbour the walk could not read.
+    hidden = mcp_mod._mcp_hidden_params(probe, owner="probe")
+    assert sorted(hidden) == ["ctx", "note"]
+    assert await _props_of_only_tool(probe) == {}
+
+
+async def test_an_unclassifiable_required_parameter_is_refused_rather_than_published(monkeypatch):
+    """Failing closed on a required parameter means refusing, not shipping it unfillable.
+
+    The agent-facing path hides such a parameter and then raises on every call. Here the
+    same fail-closed reading is surfaced at startup, naming the parameter.
+    """
+    real = mcp_mod.annotation_reaches
+
+    def raising(hint, targets):
+        if hint is str:
+            raise RuntimeError("cannot read this one")
+        return real(hint, targets)
+
+    monkeypatch.setattr(mcp_mod, "annotation_reaches", raising)
+
+    async def probe(note: str) -> str:
+        """A tool whose only parameter cannot be classified."""
+        return note
+
+    with pytest.raises(ValueError, match='"note"'):
+        build_mcp_server(_os(probe))
+
+
+@pytest.mark.parametrize(
+    "gate, value",
+    [
+        ("requires_confirmation", True),
+        ("requires_user_input", True),
+        ("external_execution", True),
+        ("approval_type", "manual"),
+    ],
+)
+async def test_a_gated_function_passed_directly_is_refused_too(gate, value):
+    """Every gate in the tuple is inert on this surface, however the Function arrived."""
+    gated = Function(name="wipe", entrypoint=lambda path: path, **{gate: value})
+
+    with pytest.raises(ValueError, match=gate):
+        build_mcp_server(_os(gated))
+
+
+async def test_the_refusal_names_every_gate_the_function_sets():
+    """The message lists what to drop, not just the first thing found."""
+    gated = Function(
+        name="wipe",
+        entrypoint=lambda path: path,
+        requires_confirmation=True,
+        external_execution=True,
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        build_mcp_server(_os(gated))
+
+    assert "requires_confirmation" in str(excinfo.value)
+    assert "external_execution" in str(excinfo.value)

--- a/libs/agno/tests/unit/os/test_mcp_toolkit_tools.py
+++ b/libs/agno/tests/unit/os/test_mcp_toolkit_tools.py
@@ -14,7 +14,9 @@ import pytest
 
 pytest.importorskip("fastmcp")
 
+import json  # noqa: E402
 import tempfile  # noqa: E402
+from base64 import b64decode  # noqa: E402
 from typing import List, Optional, Union  # noqa: E402
 
 from fastmcp import Client, Context  # noqa: E402
@@ -22,13 +24,13 @@ from fastmcp import Client, Context  # noqa: E402
 import agno.os.mcp as mcp_mod  # noqa: E402
 from agno.agent import Agent  # noqa: E402
 from agno.db.sqlite import SqliteDb  # noqa: E402
-from agno.media import Image  # noqa: E402
+from agno.media import Audio, File, Image  # noqa: E402
 from agno.os import AgentOS, MCPConfig  # noqa: E402
 from agno.os.mcp import build_mcp_server  # noqa: E402
 from agno.run import RunContext  # noqa: E402
 from agno.team.team import Team  # noqa: E402
 from agno.tools import Toolkit, tool  # noqa: E402
-from agno.tools.function import Function  # noqa: E402
+from agno.tools.function import Function, ToolResult  # noqa: E402
 
 
 def _agent(id: str = "demo-agent") -> Agent:
@@ -708,3 +710,308 @@ async def test_the_refusal_names_every_gate_the_function_sets():
 
     assert "requires_confirmation" in str(excinfo.value)
     assert "external_execution" in str(excinfo.value)
+
+
+# ==================== Schemas the signature cannot express ====================
+
+
+async def test_a_declared_schema_is_published_verbatim_for_a_kwargs_entrypoint():
+    """A dynamic toolkit carries its schema on the Function, not in the signature.
+
+    ``MCPTools`` copies each remote tool's ``inputSchema`` and ``ApifyTools`` describes an
+    actor's inputs separately; both dispatch through ``**kwargs``. FastMCP refuses to
+    introspect that -- "Functions with **kwargs are not supported as tools" -- and the
+    refusal takes the whole server down, so the declared schema is handed over directly.
+    """
+    schema = {
+        "type": "object",
+        "properties": {"query": {"type": "string", "description": "what to search"}, "limit": {"type": "integer"}},
+        "required": ["query"],
+    }
+
+    class Dynamic(Toolkit):
+        def __init__(self):
+            super().__init__(name="dynamic")
+
+            def run_actor(**kwargs) -> str:
+                return json.dumps(kwargs, sort_keys=True)
+
+            self.functions["run_actor"] = Function(
+                name="run_actor", description="Run the actor.", parameters=schema, entrypoint=run_actor
+            )
+
+    os = _os(Dynamic())
+    published = (await _tools_by_name(os))["run_actor"]
+    assert published.inputSchema == schema
+    async with Client(build_mcp_server(os)) as client:
+        result = await client.call_tool("run_actor", {"query": "hi", "limit": 3})
+        assert json.loads(result.content[0].text) == {"limit": 3, "query": "hi"}
+
+
+async def test_a_declared_schema_still_drops_what_the_server_fills():
+    """A hand-written schema does not get to publish a framework parameter."""
+    schema = {
+        "type": "object",
+        "properties": {"query": {"type": "string"}, "run_context": {"type": "object"}},
+        "required": ["query", "run_context"],
+    }
+
+    class Dynamic(Toolkit):
+        def __init__(self):
+            super().__init__(name="dyn2")
+
+            def run_actor(**kwargs) -> str:
+                return json.dumps(sorted(kwargs))
+
+            self.functions["run_actor"] = Function(
+                name="run_actor", description="Run it.", parameters=schema, entrypoint=run_actor
+            )
+
+    published = (await _tools_by_name(_os(Dynamic())))["run_actor"]
+    assert sorted(published.inputSchema["properties"]) == ["query"]
+    assert published.inputSchema["required"] == ["query"]
+
+
+async def test_a_vestigial_kwargs_catch_all_is_dropped_rather_than_refused():
+    """Named parameters beside a ``**kwargs`` still describe the tool.
+
+    ``EmailTools.email_user(subject, body, **kwargs)`` declares no schema of its own, so
+    there is nothing to publish in place of the signature -- and the catch-all alone made
+    FastMCP refuse the whole server. An MCP caller sends a JSON object, which binds to the
+    named parameters, so dropping the catch-all costs nothing.
+    """
+    from agno.tools.email import EmailTools
+
+    published = (await _tools_by_name(_os(EmailTools())))["email_user"]
+    assert sorted(published.inputSchema["properties"]) == ["body", "subject"]
+    assert sorted(published.inputSchema["required"]) == ["body", "subject"]
+
+
+# ==================== ToolResult becomes MCP content ====================
+
+_PNG = bytes.fromhex(
+    "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000a49444154789c63600000"
+    "020001000005fe02fa0000000049454e44ae426082"
+)
+_WAV = b"RIFF$\x00\x00\x00WAVEfmt \x10\x00\x00\x00\x01\x00\x01\x00D\xac\x00\x00\x88X\x01\x00\x02\x00\x10\x00data\x00\x00\x00\x00"
+
+
+async def test_raw_image_and_audio_bytes_become_mcp_content_blocks():
+    """Raw media is not JSON. Without conversion every call raises, mid-flight.
+
+    ``PydanticSerializationError: invalid utf-8 sequence of 1 bytes from index 0`` -- the
+    tool lists fine and fails only when someone calls it.
+    """
+
+    class Studio(Toolkit):
+        def __init__(self):
+            super().__init__(name="studio", tools=[self.render])
+
+        def render(self, prompt: str) -> ToolResult:
+            """Render a picture and read it aloud."""
+            return ToolResult(
+                content=f"rendered {prompt}",
+                images=[Image(content=_PNG, mime_type="image/png")],
+                audios=[Audio(content=_WAV, mime_type="audio/wav")],
+            )
+
+    async with Client(build_mcp_server(_os(Studio()))) as client:
+        result = await client.call_tool("render", {"prompt": "a cat"})
+
+    assert [type(block).__name__ for block in result.content] == ["TextContent", "ImageContent", "AudioContent"]
+    text, image, audio = result.content
+    assert text.text == "rendered a cat"
+    assert image.mimeType == "image/png"
+    assert b64decode(image.data) == _PNG
+    assert audio.mimeType == "audio/wav"
+    assert b64decode(audio.data) == _WAV
+    # The answer is mirrored in structuredContent, as the run tools already do.
+    assert result.structured_content["content"] == "rendered a cat"
+
+
+async def test_an_async_tool_result_is_converted_too():
+    """The wrapper has two branches; a toolkit's async variant is the preferred surface."""
+
+    class AsyncStudio(Toolkit):
+        def __init__(self):
+            super().__init__(name="async_studio", tools=[self.arender])
+
+        async def arender(self, prompt: str) -> ToolResult:
+            """Render asynchronously."""
+            return ToolResult(content=f"async {prompt}", images=[Image(content=_PNG, mime_type="image/png")])
+
+    async with Client(build_mcp_server(_os(AsyncStudio()))) as client:
+        result = await client.call_tool("arender", {"prompt": "a cat"})
+
+    assert [type(block).__name__ for block in result.content] == ["TextContent", "ImageContent"]
+    assert result.content[0].text == "async a cat"
+    assert b64decode(result.content[1].data) == _PNG
+
+
+async def test_a_text_only_tool_result_reads_as_its_answer():
+    """Otherwise the caller reads the serialized model instead of the answer."""
+
+    class Plain(Toolkit):
+        def __init__(self):
+            super().__init__(name="plain", tools=[self.ask])
+
+        def ask(self, q: str) -> ToolResult:
+            """Answer a question."""
+            return ToolResult(content=f"answer: {q}", metadata={"source": "cache"})
+
+    async with Client(build_mcp_server(_os(Plain()))) as client:
+        result = await client.call_tool("ask", {"q": "hi"})
+
+    assert [type(block).__name__ for block in result.content] == ["TextContent"]
+    assert result.content[0].text == "answer: hi"
+    assert result.structured_content == {"content": "answer: hi", "metadata": {"source": "cache"}}
+
+
+async def test_files_and_video_travel_as_embedded_resources():
+    """MCP types text, images and audio; everything else carrying bytes is a blob."""
+
+    class Generator(Toolkit):
+        def __init__(self):
+            super().__init__(name="generator", tools=[self.make])
+
+        def make(self, name: str) -> ToolResult:
+            """Generate a file."""
+            return ToolResult(
+                content="generated",
+                files=[File(content=b"col_a,col_b\n1,2\n", mime_type="text/csv", filename=name)],
+            )
+
+    async with Client(build_mcp_server(_os(Generator()))) as client:
+        result = await client.call_tool("make", {"name": "rows.csv"})
+
+    assert [type(block).__name__ for block in result.content] == ["TextContent", "EmbeddedResource"]
+    resource = result.content[1].resource
+    assert resource.mimeType == "text/csv"
+    assert b64decode(resource.blob) == b"col_a,col_b\n1,2\n"
+    assert "rows.csv" in str(resource.uri)
+
+
+async def test_a_url_only_artifact_is_skipped_rather_than_faked():
+    """The bytes are not in hand, and fetching them is not this layer's job."""
+
+    class Linker(Toolkit):
+        def __init__(self):
+            super().__init__(name="linker", tools=[self.find])
+
+        def find(self, q: str) -> ToolResult:
+            """Find a picture."""
+            return ToolResult(content="found one", images=[Image(url="https://example.test/a.png")])
+
+    async with Client(build_mcp_server(_os(Linker()))) as client:
+        result = await client.call_tool("find", {"q": "cat"})
+
+    assert [type(block).__name__ for block in result.content] == ["TextContent"]
+    assert result.content[0].text == "found one"
+
+
+async def test_a_shipped_tool_result_toolkit_round_trips():
+    """End to end on a shipped toolkit, which is where this actually bit."""
+    from agno.tools.file_generation import FileGenerationTools
+
+    os = _os(FileGenerationTools())
+    assert "generate_text_file" in await _tools_by_name(os)
+    async with Client(build_mcp_server(os)) as client:
+        result = await client.call_tool("generate_text_file", {"content": "hello", "filename": "a.txt"})
+
+    kinds = [type(block).__name__ for block in result.content]
+    assert kinds[0] == "TextContent" and "EmbeddedResource" in kinds
+    # The answer, not a dump of the ToolResult model.
+    assert result.content[0].text.startswith("Text file 'a.txt' generated")
+
+
+# ==================== Toolkit lifecycle ====================
+
+
+async def test_a_connect_requiring_toolkit_publishes_the_functions_it_already_has():
+    """``_requires_connect`` toolkits register at construction and connect on use.
+
+    ``PostgresTools`` is the shipped example: its functions exist before any connection,
+    and each one calls ``_ensure_connection`` itself. The MCP path does not connect for
+    it, and does not need to.
+    """
+
+    class Connectable(Toolkit):
+        def __init__(self):
+            super().__init__(name="connectable", tools=[self.read_row])
+            self._requires_connect = True
+            self.connections = 0
+
+        def connect(self):
+            self.connections += 1
+
+        def read_row(self, table: str) -> str:
+            """Read a row, connecting on demand."""
+            if not self.connections:
+                self.connect()
+            return f"{table}:{self.connections}"
+
+    kit = Connectable()
+    os = _os(kit)
+    assert set(await _tools_by_name(os)) == {"read_row"}
+    async with Client(build_mcp_server(os)) as client:
+        assert (await client.call_tool("read_row", {"table": "t"})).content[0].text == "t:1"
+
+
+async def test_a_toolkit_that_discovers_during_connect_is_refused_by_name():
+    """Nothing is published, so say which knob actually applies.
+
+    ``MCPTools`` registers its tools inside ``connect()``. The MCP server does not run a
+    toolkit's connection lifecycle, so such a toolkit reaches registration empty -- and the
+    advice has to name connecting, not the filters, which cannot conjure a function.
+    """
+
+    class LateBound(Toolkit):
+        def __init__(self):
+            super().__init__(name="late")
+            self.connected = False
+
+        def connect(self):
+            self.connected = True
+            self.register(self.discovered)
+
+        def discovered(self, q: str) -> str:
+            """Only exists after connect()."""
+            return q
+
+    kit = LateBound()
+    with pytest.raises(ValueError) as excinfo:
+        build_mcp_server(_os(kit))
+
+    message = str(excinfo.value)
+    assert "registers no functions" in message
+    assert "connect" in message.lower()
+    assert kit.connected is False
+
+    # Connected first, it publishes normally -- the documented way to serve one today.
+    kit.connect()
+    assert set(await _tools_by_name(_os(kit))) == {"discovered"}
+
+
+# ==================== State across calls ====================
+
+
+async def test_a_stateful_method_gets_a_fresh_context_per_call():
+    """Each MCP call is its own run: isolated, and deliberately not continuous.
+
+    ``ReasoningTools.think`` accumulates into ``run_context.session_state``. An MCP call has
+    no run behind it, so every call is handed a fresh context -- two calls cannot see each
+    other, and neither can two callers. Pinning it here because the isolation is the safe
+    half of the trade and the discontinuity is the documented cost: nothing silently
+    inherits another call's state.
+    """
+    from agno.tools.reasoning import ReasoningTools
+
+    os = _os(ReasoningTools())
+    async with Client(build_mcp_server(os)) as client:
+        first = (await client.call_tool("think", {"title": "one", "thought": "alpha"})).content[0].text
+        second = (await client.call_tool("think", {"title": "two", "thought": "beta"})).content[0].text
+
+    assert "alpha" in first and "beta" in second
+    # The second call neither sees nor renumbers after the first.
+    assert "alpha" not in second
+    assert first.startswith("Step 1:") and second.startswith("Step 1:")

--- a/libs/agno/tests/unit/tools/test_functions.py
+++ b/libs/agno/tests/unit/tools/test_functions.py
@@ -1984,7 +1984,7 @@ def test_optional_agent_param_registers_and_is_excluded():
 # ----------------------------------------------------------------------------
 # Exclusion and injection must name the same annotations.
 #
-# _is_framework_typed decides what to hide from the model; _build_entrypoint_args
+# is_framework_typed decides what to hide from the model; _build_entrypoint_args
 # decides what to fill. An annotation hidden by the first and skipped by the second
 # is filled by nobody: a required parameter raises on every call, and one with a
 # default silently keeps it forever.
@@ -2366,7 +2366,7 @@ def test_the_whole_annotation_graph_decides_identity():
 
     from agno.agent.agent import Agent
     from agno.media import Image
-    from agno.tools.function import _is_framework_typed
+    from agno.utils.schema import is_framework_typed
 
     @dataclass
     class DataclassWrapper:
@@ -2399,8 +2399,8 @@ def test_the_whole_annotation_graph_decides_identity():
         List[Image],
         List[List[List[List[List[List[str]]]]]],
     ]
-    assert [h for h in hidden if not _is_framework_typed(h)] == []
-    assert [h for h in fillable if _is_framework_typed(h)] == []
+    assert [h for h in hidden if not is_framework_typed(h)] == []
+    assert [h for h in fillable if is_framework_typed(h)] == []
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="PEP 695 type alias syntax needs 3.12")
@@ -2443,14 +2443,14 @@ def test_a_parameter_that_cannot_be_classified_does_not_expose_the_others(monkey
     off an identity parameter, and fail open while doing it."""
     from agno.tools import function as function_module
 
-    real = function_module._is_framework_typed
+    real = function_module.is_framework_typed
 
     def raising(hint):
         if hint is str:
             raise RuntimeError("cannot read this one")
         return real(hint)
 
-    monkeypatch.setattr(function_module, "_is_framework_typed", raising)
+    monkeypatch.setattr(function_module, "is_framework_typed", raising)
 
     def probe(note: str, ctx: RunContext = None) -> str:  # type: ignore[assignment]
         return f"user={getattr(ctx, 'user_id', None)}"
@@ -2503,7 +2503,7 @@ def test_identity_is_found_through_structural_types_and_typevars():
     bound or constraints all carry identity just as a plain field does."""
     from typing import NamedTuple, TypedDict, TypeVar
 
-    from agno.tools.function import _is_framework_typed
+    from agno.utils.schema import is_framework_typed
 
     class Payload(TypedDict):
         ctx: RunContext
@@ -2517,7 +2517,7 @@ def test_identity_is_found_through_structural_types_and_typevars():
     Constrained = TypeVar("Constrained", str, RunContext)
 
     for hint in (Payload, Row, Bound, Constrained):
-        assert _is_framework_typed(hint), hint
+        assert is_framework_typed(hint), hint
 
     # A field whose annotation is a string, which is every annotation in a
     # module using postponed evaluation.
@@ -2526,14 +2526,14 @@ def test_identity_is_found_through_structural_types_and_typevars():
         "from dataclasses import dataclass\n@dataclass\nclass Postponed:\n    ctx: 'RunContext'\n    note: str = ''\n",
         namespace,
     )
-    assert _is_framework_typed(namespace["Postponed"])
+    assert is_framework_typed(namespace["Postponed"])
 
     # An annotation this walk cannot read is not one to hand the model.
     class Unresolvable:
         __annotations__ = {"ctx": "NameThatDoesNotExistAnywhere"}
         __total__ = True
 
-    assert _is_framework_typed(Unresolvable)
+    assert is_framework_typed(Unresolvable)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Ports the two net-new features from #9765 (@Mustafa-Esoofally) onto `feat/mcp-tool-metadata`, integrated with this stack's MCP server rather than copied over it.

1. **Toolkit auto-flatten.** A `Toolkit` passed to `MCPConfig.tools` becomes one MCP tool per method, the way an agent takes it apart. Today it raises `TypeError: Cannot register MCP tool of type 'MemoryTools'`.
2. **Framework-param hiding.** `RunContext` / `Agent` / `Team`-typed parameters are kept out of the client-facing schema and filled server-side at call time, alongside the `user_id` injection that already shipped.

**The two are one feature.** Real toolkit methods declare `run_context: RunContext` — `MemoryTools`, `KnowledgeTools`, `ReasoningTools` and `WorkflowTools` all do — and pydantic cannot build a schema for one. Flattening without hiding does not publish a bad tool, it stops the server from starting:

```
PydanticSchemaGenerationError: Unable to generate pydantic-core schema for <class 'agno.filters.FilterExpr'>
```

**#9765's third change (structuredContent carrying the answer) is deliberately omitted.** This branch already carries a superset of it: we mirror the final text *and* the owning component id in `trimmed_structured_content`. Bringing #9765's `mcp_results.py` hunk would be a redundant older version.

Related: #9765. Was stacked on #9844, which has since merged — this now targets `main` directly.

## Type of change

- [x] New feature
- [x] Improvement
- [x] Breaking change (narrow — see *Behaviour changes* below)

---

## What the integration actually required

#9765's `mcp.py` code could not be taken as-is. Its `_register_custom_tools(mcp, config)` / `_register_custom_tool(mcp, tool) -> None` signatures predate this stack's two-stage `_split_tool_entries` → `_register_custom_tools` pipeline, and adopting them would have deleted the collision registry, the `enabled_tags` advice, the `title`/`annotations` publishing from #9844, and the `ComponentTool` split in one stroke. The idea was ported; the code was written against our shape. Four things were fixed on the way in, each verified by execution:

**1. The hide predicate had to be widened.** #9765 hides on `is_framework_typed`, the model-facing rule. That rule deliberately keeps `owner: Union[str, Agent]` fillable, because a model can only ever send the string half. FastMCP builds its schema from the real signature and crashes on it anyway. Measured against `fastmcp 3.4.7` / `pydantic 2.13`:

| annotation | `is_framework_typed` | `annotation_reaches(identity)` | `Tool.from_function` |
|---|---|---|---|
| `RunContext`, `Optional[RunContext]` | True | True | crash |
| `Agent`, `Optional[Team]` | True | True | crash |
| `Union[str, Agent]` | **False** | True | **crash** |
| `Image`, `Optional[List[Image]]` | False | False | ok |

So the MCP rule is `annotation_reaches(hint, identity_injected_types())`. Only that column separates the crashes from the rest.

**2. Media stays visible, on both paths.** The brief asked for media hiding; it is neither needed (no crash, per the table) nor safe. Nothing on this surface has run media to inject — `_build_entrypoint_args` fills media from `FunctionCall._images` and friends, which do not exist here — so hiding a media parameter would leave it fillable by nobody.

**3. Hiding and filling are separate questions.** `List[RunContext]` reaches an identity type, so it cannot stay in the schema, but it *holds* run contexts rather than being one and nothing can be bound into it. #9765 force-feeds `None` over such a parameter; this mirrors `_build_entrypoint_args` instead and refuses a required one by name, rather than letting it surface as a pydantic error naming a type the author never wrote.

**4. No `eval()`.** #9765's `get_type_hints` fallback evaluates annotation text at server-build time. It is not ported: it needs a lint suppression `validate.sh` gates on, and it fails open anyway (its name table matches bare `"RunContext"` but not `"Optional[RunContext]"`). Unresolvable annotations are instead classified per parameter and fail closed; a whole-signature `get_type_hints` failure skips the typed rule, which is not an exposure — such an annotation also stops FastMCP from building a schema, so the server refuses to start rather than publishing it.

## Behaviour changes

- **An approval-gated tool is refused when the server is built.** `requires_confirmation`, `requires_user_input`, `external_execution` and `approval_type` all live in `FunctionCall.execute`, which an MCP call does not reach — so publishing one runs the gated body with **no gate**. `Workspace(root=".")` alone would have put `delete_file` and `run_command` on the wire ungated. This applies to directly-passed Functions too, where it is a change against `main` (which published and ran them). No cookbook or test passes a gated tool to `MCPConfig.tools`; the error names `exclude_tools`, and the read-only surface `Workspace(root=".", allowed=["read", "list", "search"])` publishes cleanly.
- **A framework parameter that cannot take a keyword is refused by name.** Every toolkit method puts its `RunContext` first, so this is not hypothetical: `def f(run_context: RunContext, /, q: str)` previously took `get_app()` down with a `FilterExpr` traceback.
- **Identity names are hidden for Agno `Function` entries.** `agent` / `team` / `run_context` and the `_agno_` channels are hidden by name as well as by type, because that object is the same one an agent would run and must not have two contracts. A bare callable was written for this surface, so its own `agent: str` stays its own (#9765's regression test for this is kept).
- **`user_id` is not hidden on a flattened toolkit method.** Agno never injects `user_id` by name — toolkit methods read identity from their `RunContext` — so `user_id` there is a domain value. `ZoomTools.get_upcoming_meetings(user_id="me")` asks which Zoom account to read; filling it with the JWT subject would have produced `/users/None/meetings`.

## Verification

- `libs/agno/tests/unit/os/` — **2958 passed** (2896 before; the 42 errors are the pre-existing `pyTelegramBotAPI` collection gap).
- `libs/agno/tests/unit/tools/ + agent + team` — **4586 passed**. The 2 failures and 255 errors are pre-existing missing optional deps (`matplotlib`, `twelvelabs`, `google-genai`, …) and are identical before and after.
- **`function.py` refactor blast radius: none.** The extraction is a verbatim `git cherry-pick` of #9765's `625d76212`, which is a byte-for-byte move after dropping the leading underscore. `test_functions.py` + `test_toolkit.py`: 250 passed. The only edit on top was deleting a dead `T = TypeVar("T")` the move copied along. The fallback in the brief was not needed.
- **Mutation-checked in place, 16 mutations, all killed** — including both required ones: reverting the toolkit-flatten branch fails 17 tests, and reverting framework-param hiding fails 9. Also killed: swapping in the weak predicate, dropping `taken=`, dropping the gate refusal, shrinking the gate tuple, restoring #9765's positional-only skip, dropping `title=`/`annotations=`, `always=False`, binding a sentinel instead of `None`, dropping the annotation pruning (sync and async), hiding `user_id` on toolkits, dropping the empty-toolkit guard, using `get_functions()`, and dropping the `_split_tool_entries` branch. `mcp.py` restored byte-identical after every run.
- **Cookbook run LIVE** against a real server driven by a FastMCP streamable-HTTP client: `tools/list` returned the four `MemoryTools` methods with `run_context` absent from all four schemas, `add_memory` → `get_memories` round-tripped, and a client-supplied `run_context` was rejected as an unexpected keyword argument. Recorded in `TEST_LOG.md`.
- `./scripts/format.sh` and `./scripts/validate.sh` clean (ruff + mypy, 1023 files). `git diff --check` clean. No format churn outside the touched files.

This change was reviewed by an adversarial multi-agent pass (39 findings raised, 25 refuted by execution, 14 confirmed). Four in-scope fixes came out of it and are in this PR: the `user_id`/toolkit scoping above; pruning the wrapper's leftover `__annotations__` (`functools.wraps` copies them wholesale, and FastMCP reads annotations as well as the signature, so a `TYPE_CHECKING`-only framework annotation still killed boot despite being correctly hidden); honest wording on the unfillable-parameter refusal; and four test gaps.

## Second round: the schemas and results toolkits actually have

Serving the shipped toolkits (rather than reasoning about them) turned up three gaps, all fixed in `699e72f03`:

**A `**kwargs` entrypoint took the whole server down.** FastMCP derives its schema by introspecting the callable and refuses that shape outright — `ValueError: Functions with **kwargs are not supported as tools` — so `EmailTools()`, plain and credential-free, made `get_app()` raise. Two shapes needed separating:
- A *dynamic* toolkit carries the schema on the Function rather than in the signature (`MCPTools` copies each remote tool's `inputSchema`; `ApifyTools` describes an actor's inputs). That schema is now handed to FastMCP directly, via `FunctionTool` rather than `Tool.from_function`.
- A *vestigial* catch-all beside real named parameters (`EmailTools.email_user(subject, body, **kwargs)`) has nothing to publish in its place, so the catch-all is dropped and the named parameters describe the tool. `email_user` now publishes `subject` + `body`, both required, with descriptions from the docstring.

A declared schema is filtered by name as well as by signature: it reaches that path *precisely because* the signature could not describe the tool, so a schema naming `run_context` has no parameter for the signature rules to catch and would otherwise publish an identity key for the caller to fill.

**An Agno `ToolResult` reached FastMCP's generic serializer.** Raw media is not UTF-8, so calls raised mid-flight — the tool listed fine and failed only when someone called it:
```
PydanticSerializationError: Error serializing to JSON: invalid utf-8 sequence of 1 bytes from index 0
```
The ones that *survived* were worse than they looked: the caller read `{"content":"answer: hi","metadata":null,"images":null,...}` instead of the answer. Measured across the 56 default-constructible shipped toolkits: **13 registered functions** return `ToolResult` (23 classes in source — Dalle, OpenAI, Giphy, MiniMax, ModelsLab, FileGeneration…). Results are now rendered as MCP content — text first, images and audio as their own block types, videos and files as embedded blob resources, the answer mirrored in `structuredContent` as the run tools already do — reusing the media machinery in `mcp_results.py`. FastMCP is told not to derive an output schema from the `ToolResult` model, which describes something the tool no longer sends.

**A discover-on-connect toolkit got advice that cannot work.** `MCPTools` registers its tools inside `connect()`, so it reached registration empty and was told to widen its `include_tools`/`exclude_tools`. The refusal now names connecting.

### What I deliberately did *not* do
- **Full connect/close lifecycle wiring.** Measured first: only `PostgresTools` sets `_requires_connect=True` among constructible toolkits, and it registers its functions at construction and connects on use via `_ensure_connection`. `MCPTools` — the one toolkit that genuinely discovers during `connect()` — has `_requires_connect = False`, so a hook keyed on that flag would miss the only real case. Wiring a lifespan for a population of zero is speculative; the error message now points at the working answer (connect first).
- **Session-scoped `RunContext` continuity.** Each MCP call gets a *fresh* context, so state is isolated — never another caller's. The cost is no accumulation across calls, which `test_a_stateful_method_gets_a_fresh_context_per_call` now pins on `ReasoningTools.think`. Binding continuity to a transport session would introduce shared mutable state keyed on that session, which is the cross-contamination this avoids.

**Second-round verification:** 465 MCP tests, 250 `test_functions.py` + `test_toolkit.py`, 2958 in `tests/unit/os`, 4586 across tools/agent/team. 9 further mutations, all killed (`mcp.py` and `mcp_results.py` restored byte-identical). `validate.sh` and `git diff --check` clean.

## Third round: what a toolkit declares, and what this surface cannot run

Four review findings, each reproduced before it was fixed (`e0d3cc8ac`).

**A declared schema was stripped of `agent` / `team` / `run_context`.** Those belong to the far side — a declared schema is reached precisely because the signature could not describe the tool, which in practice means a remote tool's own `inputSchema` proxied through `MCPTools`. The strip hid a legitimate upstream argument from the model *while the value still reached the entrypoint*:
```
published props: ['query']
client CAN still send them anyway -> {"agent": "upstream-a", "query": "q"}
```
Now only what the wrapper actually injects and the `_agno_` channels are removed. The catch-all's own name goes too — agno derives a property named after it from a Google-style `Args:` docstring, and a required `kwargs` of unspecified type describes nothing a caller can fill.

**Media the tool produced elsewhere was discarded.** Giphy, Replicate, Luma and Fal return an address rather than bytes (6 construction sites), and that address *is* the result — skipping it left the caller holding "found one" and nothing to open. A url-only artifact is now a `resource_link`, which is MCP's exact type for pointing at a resource without inlining it, so the server still fetches nothing on the caller's behalf.

**A declared schema was not enforced, while the ordinary tool beside it was.** Two tools on one server disagreed about whether a malformed call is an error:
```
before:  declared-schema tool: missing required -> EXECUTED   wrong type -> EXECUTED   forbidden extra -> EXECUTED
         ordinary tool:        missing required -> rejected   wrong type -> rejected
after:   both rejected, e.g. "Invalid arguments: limit: 'abc' is not of type 'integer'"
```
A malformed call from a model is ordinary traffic, not an attack. `jsonschema` ships with the MCP stack itself (via `mcp`/`fastmcp-slim`), so this costs no new dependency and degrades to today's behaviour if it is ever absent.

**A toolkit's `connect()`/`close()` never fire, and that is documented rather than enforced.** I first added a refusal for `_requires_connect` toolkits; review showed it rejected two working toolkits to stop one broken one, so it was reverted in `dc6b11257`. `PostgresTools` and `RedshiftTools` route every method through `_ensure_connection` — designed lazy connection, unaffected here. `CodeMode` is the real casualty: its kernel is keyed by `session_id` and an MCP call mints a fresh one every time, so it would start a kernel per call and accumulate nothing. That is now stated in the `MCPConfig.tools` docs and the cookbook README, where a deployer picks tools. The empty-toolkit refusal is untouched: a toolkit that discovers its tools while connecting still fails at startup and is still told to connect first.

Two lines that could not fail were removed rather than tested around: `output_schema=None` is `FunctionTool`'s own field default (unlike `Tool.from_function`, where it means *derive* and is load-bearing), and `_link_block` re-checked for bytes it is only ever reached without.

**Third-round verification:** 471 MCP tests (62 in the new file), 250 `test_functions.py` + `test_toolkit.py`, 2963 in `tests/unit/os`, 4609 across tools/agent/team. Mutations all killed. `validate.sh` and `git diff --check` clean; the cookbook still builds.

## Known limitations (follow-ups, not regressions)

- **A `ToolResult` returned without the matching return annotation** still reaches the generic serializer and fails on raw bytes. Zero shipped methods affected — all 37 that build one are annotated.

- **`tool_hooks` / `pre_hook` / `post_hook` and `cache_results` are inert on this surface**, like the approval gates but *not* refused — refusing them would fail a working server at startup over a logging hook, and every Function-level hook shipped in `cookbook/` is a logger. This is pre-existing on `main` and unchanged here. The real fix is to route MCP calls through `FunctionCall.aexecute`, which would let the gate tuple shrink rather than grow.
- **The MCP path does not run a toolkit's connection lifecycle.** `connect()` and `close()` never fire. The shipped `_requires_connect` toolkits (`PostgresTools`, `RedshiftTools`) connect themselves on use and are unaffected. **`CodeMode` is not**: its kernel is keyed by `session_id`, and every MCP call mints a fresh one, so it would start a kernel per call and accumulate nothing — serve it over REST, where a run owns the session. This is the one silent failure knowingly left in this PR; it is documented in `MCPConfig.tools` and the cookbook README.
- **`Toolkit.instructions` are structurally lost** — MCP has no system message to carry them.
- **The synthetic `RunContext` mints fresh ids per call**, so a toolkit accumulating into `session_state` across calls will not read its own writes. The cookbook disables `MemoryTools`' `think`/`analyze` for exactly this reason.
- **Two pre-existing signature-wide `try` blocks in `function.py`** (`_derive_entrypoint_schema`, `_build_entrypoint_args`) let one unclassifiable parameter abandon the whole signature's exclusion. Byte-identical to `main` and out of scope here; worth its own hardening commit.

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

#9765 is the similar PR. It targets `main` and bundles a third change this branch already supersedes; its `mcp.py` rewrite would drop this stack's collision detection, `enabled_tags` threading, `ComponentTool` split and tool presentation metadata. This PR takes its two net-new ideas, keeps its `agno/utils/schema.py` extraction verbatim, and merges the rest by hand. Credit is retained via a `Co-authored-by` trailer.

---

## Additional Notes

**Security consideration.** The identity a tool receives is only as good as the deployment's authorization. Without `AgentOS(authorization=True, ...)` there is no JWT subject, the resolved caller is `None`, and every client shares one identity — for `MemoryTools` that means one memory bucket. The cookbook, the README and the `MCPConfig` docstring now say so explicitly rather than implying per-caller ownership out of the box.

**Files:** `libs/agno/agno/utils/schema.py` (new, cherry-picked), `libs/agno/agno/tools/function.py` (extraction only), `libs/agno/agno/os/mcp.py` (the merge), `libs/agno/agno/os/config.py` (docs), `libs/agno/tests/unit/os/test_mcp_toolkit_tools.py` (new, 45 tests), `cookbook/05_agent_os/14_mcp/toolkit_tools.py` (new) + README/TEST_LOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015xNqwG3XQmV4PqBo6uEmck