### PR TITLE
fix(models): keep interleaved tool content streams contiguous in the tool result

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -2843,6 +2843,13 @@ class Model(ABC):
         async def process_async_generator(result, generator_id):
             function_call_success, function_call_timer, function_call, function_execution_result = result
             function_call_output = ""
+            # A tool can fan out to several agents and yield their content
+            # deltas interleaved (e.g. delegate_task_to_members with
+            # delegate_to_all_members). Accumulating in arrival order garbles
+            # the tool result mid-sentence, so each stream's deltas stay
+            # contiguous, keyed by the event's run_id, in first-arrival order.
+            streamed_content_parts: List[str] = []
+            streamed_part_index: Dict[str, int] = {}
 
             try:
                 async for item in function_call.result:
@@ -2851,10 +2858,18 @@ class Model(ABC):
                         # We only capture content events
                         if isinstance(item, RunContentEvent) or isinstance(item, TeamRunContentEvent):
                             if item.content is not None and isinstance(item.content, BaseModel):
-                                function_call_output += item.content.model_dump_json()
+                                chunk = item.content.model_dump_json()
                             else:
                                 # Capture output
-                                function_call_output += item.content or ""
+                                chunk = item.content or ""
+
+                            run_key = item.run_id or ""
+                            part_index = streamed_part_index.get(run_key)
+                            if part_index is None:
+                                streamed_part_index[run_key] = len(streamed_content_parts)
+                                streamed_content_parts.append(chunk)
+                            else:
+                                streamed_content_parts[part_index] += chunk
 
                             if function_call.function.show_result and item.content is not None:
                                 await event_queue.put(ModelResponse(content=item.content))
@@ -2882,6 +2897,14 @@ class Model(ABC):
                         function_call_output += str(item)
                         if function_call.function.show_result and item is not None:
                             await event_queue.put(ModelResponse(content=str(item)))
+
+                # Join the per-stream parts after any directly captured output so
+                # interleaved sibling streams read as separate blocks
+                if streamed_content_parts:
+                    streamed_output = "\n\n".join(streamed_content_parts)
+                    function_call_output = (
+                        f"{function_call_output}\n\n{streamed_output}" if function_call_output else streamed_output
+                    )
 
                 # Store the final output for this generator
                 async_generator_outputs[generator_id] = (result, function_call_output, None)

--- a/libs/agno/tests/unit/models/test_interleaved_tool_stream_result.py
+++ b/libs/agno/tests/unit/models/test_interleaved_tool_stream_result.py
@@ -1,0 +1,90 @@
+"""Tests for tool-result accumulation of interleaved content streams.
+
+The bug: when a generator tool fans out to several agents and yields their
+content deltas interleaved (Team(delegate_to_all_members=True, stream=True) via
+delegate_task_to_members), Model.arun_function_calls accumulated the deltas in
+arrival order. The tool result handed back to the leader interleaved the
+members' sentences mid-word, making broadcast delegation unusable.
+
+Fix: content-event deltas are grouped per run_id so each stream stays
+contiguous, and the per-stream blocks are joined in first-arrival order.
+"""
+
+from typing import Any, AsyncIterator, Iterator, List
+
+import pytest
+
+from agno.models.base import Model
+from agno.run.agent import RunContentEvent
+from agno.tools.function import Function, FunctionCall
+
+
+class _ConcreteModel(Model):
+    """Minimal concrete Model: arun_function_calls never invokes a provider."""
+
+    def invoke(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+    async def ainvoke(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+    def invoke_stream(self, *args: Any, **kwargs: Any) -> Iterator[Any]:
+        raise NotImplementedError
+
+    async def ainvoke_stream(self, *args: Any, **kwargs: Any) -> AsyncIterator[Any]:
+        raise NotImplementedError
+        yield  # pragma: no cover
+
+    def _parse_provider_response(self, response: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+    def _parse_provider_response_delta(self, response: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+
+def _content_event(run_id: str, agent_name: str, content: str) -> RunContentEvent:
+    return RunContentEvent(run_id=run_id, agent_name=agent_name, content=content, content_type="str")
+
+
+async def broadcast_tool() -> AsyncIterator[RunContentEvent]:
+    """Two member streams yielding deltas interleaved by arrival, as the merged
+    event queue in delegate_task_to_members does for delegate_to_all_members."""
+    member_a = ["Alpha part one ", "and part two."]
+    member_b = ["Beta part one ", "and part two."]
+    for a_delta, b_delta in zip(member_a, member_b):
+        yield _content_event("run-member-a", "Member A", a_delta)
+        yield _content_event("run-member-b", "Member B", b_delta)
+
+
+async def single_stream_tool() -> AsyncIterator[RunContentEvent]:
+    """A single stream must accumulate exactly as before the fix."""
+    for delta in ["Hello ", "world."]:
+        yield _content_event("run-single", "Solo", delta)
+
+
+async def _run_tool(tool) -> str:
+    func = Function.from_callable(tool)
+    func.process_entrypoint()
+    fc = FunctionCall(function=func, arguments={})
+    function_call_results: List[Any] = []
+    model = _ConcreteModel(id="test-model")
+    async for _event in model.arun_function_calls([fc], function_call_results):
+        pass
+    tool_messages = [m for m in function_call_results if getattr(m, "role", None) == "tool"]
+    assert tool_messages, f"expected a tool result message, got {function_call_results}"
+    return tool_messages[0].content
+
+
+@pytest.mark.asyncio
+async def test_interleaved_member_streams_stay_contiguous_in_tool_result():
+    result = await _run_tool(broadcast_tool)
+
+    assert "Alpha part one and part two." in result, f"member A garbled in: {result!r}"
+    assert "Beta part one and part two." in result, f"member B garbled in: {result!r}"
+    assert "part one Beta" not in result, f"members still interleaved in: {result!r}"
+
+
+@pytest.mark.asyncio
+async def test_single_stream_tool_result_is_unchanged():
+    result = await _run_tool(single_stream_tool)
+    assert result == "Hello world."


### PR DESCRIPTION
> **AI disclosure (per CONTRIBUTING.md):** this PR was authored with AI assistance. I reviewed and understand every line; tests and verification are below.

## Summary

- Fixed: `Team(delegate_to_all_members=True, stream=True)` produced a garbled tool result — the members' streamed content deltas were merged mid-word in arrival order, so the team leader received corrupted text and broadcast delegation was unusable
- `Model.arun_function_calls` now groups async-generator content-event deltas per `run_id` (each member stream stays contiguous) and joins the per-stream blocks in first-arrival order
- Single-stream generator tools accumulate exactly as before; the sync/sequential paths are untouched

## Problem

`delegate_task_to_members` (streaming branch) runs all members concurrently and yields their events from a merged queue in arrival order. `process_async_generator` in `models/base.py` accumulates every `RunContentEvent` delta into the tool result with `function_call_output += item.content`. With N members streaming at once, that concatenates token-by-token across members: "words are mixed in halfway and sentences don't make any sense" (#9466). The non-streaming path is unaffected because it yields one labeled string per member after everyone finishes.

## Root cause

Arrival-order accumulation assumes a single content stream per tool. When one tool generator multiplexes several member streams (each delta carrying its member's `run_id`), the interleaving destroys per-member contiguity.

## Changes

- `libs/agno/agno/models/base.py` — in `process_async_generator`, content-event chunks go into per-`run_id` parts (created in first-arrival order); at generator completion the parts are joined with `\n\n` and appended after any directly captured output (plain strings / `CustomEvent`s, unchanged)
- `libs/agno/tests/unit/models/test_interleaved_tool_stream_result.py` — regression tests:
  - `test_interleaved_member_streams_stay_contiguous_in_tool_result` — two interleaved member streams produce two contiguous blocks (fails at merge base, passes at PR tip)
  - `test_single_stream_tool_result_is_unchanged` — single-stream accumulation is byte-identical to before

## Testing

- [x] New regression tests: 1 fails at the merge base, both pass at the PR tip
- [x] `pytest tests/unit/models/ -q`: with fix 32 failed / 1195 passed; without fix 33 failed / 1194 passed — i.e. the only delta is the new regression test turning green; all other failures are pre-existing on this Windows machine (xai OAuth mocks, caching fixtures, provider SDK versions)
- [x] `pytest tests/unit/team -q`: 804 passed, 1 pre-existing failure (`test_team_skills.py::test_system_message_contains_skills_snippet`, fails on clean checkout too)
- [x] `ruff check` / `ruff format --check` (0.15.20) on both files — clean

Tests not run: full unit suite and integration suite (need provider credentials; left to CI).

## Related issue

Fixes #9466