### PR TITLE
fix: resolve reserved agent identity unions

### DIFF
--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -2286,8 +2286,8 @@ class FunctionCall(BaseModel):
             for param_name, hint in hints.items():
                 # get_type_hints reports the return annotation under "return"; it is
                 # not a parameter, and passing it as a keyword would raise.
-                if param_name not in sig.parameters or param_name in entrypoint_args:
-                    continue  # Not a parameter, or already handled by name-based injection
+                if param_name not in sig.parameters:
+                    continue  # Not a parameter
                 param = sig.parameters[param_name]
                 # A variadic parameter can never take a keyword bind (*rest: Agent
                 # binds rest=() by itself; **extra: RunContext binds {}), and a
@@ -2295,6 +2295,12 @@ class FunctionCall(BaseModel):
                 if param.kind in (Parameter.VAR_POSITIONAL, Parameter.VAR_KEYWORD, Parameter.POSITIONAL_ONLY):
                     continue
                 if not is_framework_typed(hint):
+                    continue
+                # A reserved name is filled before annotations are considered. If
+                # its matching object is unavailable, let an identity-only union
+                # select another object the wielder does have (for example,
+                # ``agent: Union[Agent, Team]`` on a Team).
+                if param_name in entrypoint_args and entrypoint_args[param_name] is not None:
                     continue
                 hint = unwrap_annotation(hint)
                 # The same resolver that decided to hide it. Matching only a
@@ -2319,6 +2325,8 @@ class FunctionCall(BaseModel):
                 injected = next((m for m in matches if m is not None), None)
                 if injected is not None or param.default is Parameter.empty:
                     entrypoint_args[param_name] = injected
+                else:
+                    entrypoint_args.pop(param_name, None)
         except Exception:
             pass
 

--- a/libs/agno/tests/unit/tools/test_functions.py
+++ b/libs/agno/tests/unit/tools/test_functions.py
@@ -2267,6 +2267,34 @@ def test_union_of_two_identity_types_falls_through_to_the_one_available():
     assert FunctionCall(function=func, arguments={"task": "x"}).execute().result == "Agent"
 
 
+def test_reserved_agent_name_falls_through_to_an_available_team():
+    """A reserved-name bind with no Agent must not mask the Team arm of the
+    annotation. Toolkits commonly spell their owner ``agent: Union[Agent, Team]``
+    even when the tool is registered on a Team."""
+    from typing import Union as Un
+
+    from agno.agent.agent import Agent
+    from agno.team.team import Team
+
+    def identify(agent: Un[Agent, Team]) -> str:
+        return type(agent).__name__
+
+    func = Function.from_callable(identify)
+    func._team = Team(id="t", name="T", members=[Agent(id="m", name="M")])
+
+    result = FunctionCall(function=func).execute()
+
+    assert result.status == "success"
+    assert result.result == "Team"
+
+    def identify_agent_only(agent: Agent) -> str:
+        return type(agent).__name__
+
+    agent_only = Function.from_callable(identify_agent_only)
+    agent_only._team = func._team
+    assert FunctionCall(function=agent_only).execute().result == "NoneType"
+
+
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="PEP 695 type alias syntax needs 3.12")
 @pytest.mark.parametrize("annotation", ["Two", "Three", "MaybeTwo"])
 def test_chained_type_aliases_are_unwrapped_to_the_end(annotation):


### PR DESCRIPTION
## Summary

Fixes #9410.

When name-based framework injection reserves a parameter but has no matching object, let an identity-only annotation select another available framework object. This allows `agent: Union[Agent, Team]` to receive the owning `Team` instead of being pinned to `None`, while a strict `agent: Agent` parameter still receives `None` when no agent exists.

The regression test covers both the union fallback and the strict-annotation guard.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Validation performed:

- `pytest -q libs/agno/tests/unit/tools/test_functions.py` — 187 passed
- targeted regression selection — 3 passed
- targeted mypy for `agno/tools/function.py` — passed
- Ruff check and format check for both changed files — passed
- `./scripts/format.sh` — passed
- `./scripts/validate.sh` — Ruff, agnoctl, and cookbook checks passed; the repo-wide Agno mypy step reports 23 existing errors in `_genai_compat.py`, `gemini.py`, and `gemini_interactions.py`. The same 23 errors reproduce on an unmodified `main` checkout.

AI disclosure: this contribution was implemented and reviewed with OpenAI Codex. No CLA, DCO, or other legal attestation was signed by the agent.
