### PR TITLE
[fix] refuse unfaithful create_fresh registry agent copies

### DIFF
--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -31,6 +31,7 @@ from agno.run.team import TeamRunOutputEvent
 from agno.run.workflow import WorkflowRunOutputEvent
 from agno.team import RemoteTeam, Team, TeamFactory
 from agno.tools import Function, Toolkit
+from agno.utils.copies import copy_divergence
 from agno.utils.log import log_debug, log_warning, logger
 from agno.workflow import RemoteWorkflow, Workflow, WorkflowFactory
 
@@ -1384,6 +1385,64 @@ def allow_draft_preview(
     return bool(isinstance(component, dict) and component.get("user_id") == actor)
 
 
+def _fresh_registry_agent(agent: Agent, *, strict: bool) -> Agent:
+    """Return a faithful fresh copy of a registry agent for request isolation.
+
+    A kwargs-forwarding Agent subclass can inherit deep_copy() but lose its stored
+    fields when reconstructed, yielding a blank shell. AgentOS must refuse that
+    copy in strict mode rather than silently serve the wrong agent.
+    """
+
+    label = f"Registry agent '{agent.id}'"
+    try:
+        fresh_agent = agent.deep_copy()
+    except Exception as e:
+        if strict:
+            raise ComponentRehydrationError(
+                f"{label} could not be copied for create_fresh (deep_copy failed: {e}). "
+                "AgentOS refuses to dispatch the shared registry instance; give the subclass "
+                "a faithful deep_copy or store the agent in the database."
+            ) from e
+        log_warning(f"{label}: create_fresh deep_copy failed ({e}); using the shared registry instance.")
+        return agent
+
+    if fresh_agent is agent:
+        if strict:
+            raise ComponentRehydrationError(
+                f"{label} deep_copy returned the shared registry instance; AgentOS create_fresh "
+                "requires an isolated copy."
+            )
+        log_warning(f"{label}: create_fresh deep_copy returned the shared registry instance.")
+        return agent
+
+    if not isinstance(fresh_agent, Agent):
+        if strict:
+            raise ComponentRehydrationError(
+                f"{label} deep_copy returned a {type(fresh_agent).__name__}, not an Agent; "
+                "AgentOS create_fresh refuses it."
+            )
+        log_warning(
+            f"{label}: create_fresh deep_copy returned a {type(fresh_agent).__name__}; "
+            "using the shared registry instance."
+        )
+        return agent
+
+    divergence = copy_divergence(agent, fresh_agent)
+    if divergence is not None:
+        if strict:
+            raise ComponentRehydrationError(
+                f"{label} deep_copy lost state: {divergence}. AgentOS create_fresh refuses a copy "
+                "that does not serialize like its original; give the subclass a faithful deep_copy "
+                "or store the agent in the database."
+            )
+        log_warning(f"{label}: create_fresh deep_copy lost state ({divergence}); using the shared registry instance.")
+        return agent
+
+    fresh_agent.team_id = None
+    fresh_agent.workflow_id = None
+    return fresh_agent
+
+
 def get_agent_by_id(
     agent_id: str,
     agents: Optional[Sequence[Union[Agent, RemoteAgent, AgentProtocol, AgentFactory]]] = None,
@@ -1431,10 +1490,7 @@ def get_agent_by_id(
                 # Base Agent — most common path, early exit
                 if isinstance(agent, Agent):
                     if create_fresh:
-                        fresh_agent = agent.deep_copy()
-                        fresh_agent.team_id = None
-                        fresh_agent.workflow_id = None
-                        return fresh_agent
+                        return _fresh_registry_agent(agent, strict=strict)
                     return agent
                 # Factory path
                 if isinstance(agent, AgentFactory):
@@ -1491,10 +1547,7 @@ async def get_agent_by_id_async(
                 # Base Agent — most common path, early exit
                 if isinstance(agent, Agent):
                     if create_fresh:
-                        fresh_agent = agent.deep_copy()
-                        fresh_agent.team_id = None
-                        fresh_agent.workflow_id = None
-                        return fresh_agent
+                        return _fresh_registry_agent(agent, strict=strict)
                     return agent
                 # Factory path
                 if isinstance(agent, AgentFactory):

--- a/libs/agno/tests/unit/os/test_per_request_isolation.py
+++ b/libs/agno/tests/unit/os/test_per_request_isolation.py
@@ -8,11 +8,18 @@ This module tests:
 - Edge cases and concurrent request scenarios
 """
 
+from typing import Any, AsyncIterator, Iterator
+
 import pytest
 
 from agno.agent import Agent
+from agno.exceptions import ComponentRehydrationError
+from agno.models.base import Model
+from agno.models.message import MessageMetrics
+from agno.models.response import ModelResponse
 from agno.os.utils import (
     get_agent_by_id,
+    get_agent_by_id_async,
     get_team_by_id,
     get_workflow_by_id,
 )
@@ -25,6 +32,56 @@ from agno.workflow.router import Router
 from agno.workflow.step import Step
 from agno.workflow.steps import Steps
 from agno.workflow.types import StepInput, StepOutput
+
+
+class MockModel(Model):
+    """Minimal offline model for deep-copy and resolver tests."""
+
+    def __init__(self):
+        super().__init__(id="mock-model", name="mock-model", provider="test")
+        self._mock_response = ModelResponse(content="ok", role="assistant", response_usage=MessageMetrics())
+
+    def get_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    def get_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    def parse_args(self, *args, **kwargs):
+        return {}
+
+    def invoke(self, *args, **kwargs) -> ModelResponse:
+        return self._mock_response
+
+    async def ainvoke(self, *args, **kwargs) -> ModelResponse:
+        return self._mock_response
+
+    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+        yield self._mock_response
+
+    async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+        yield self._mock_response
+        return
+
+    def _parse_provider_response(self, response: Any, **kwargs) -> ModelResponse:
+        return self._mock_response
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return self._mock_response
+
+
+class KwargsForwardingAgent(Agent):
+    """Reproduces the subclass shape that loses state under inherited deep_copy()."""
+
+    def __init__(self, **kwargs):
+        super().__init__(name="helper", **kwargs)
+
 
 # ============================================================================
 # Fixtures
@@ -115,6 +172,44 @@ class TestGetAgentForRequest:
 
         # Internal state should be reset to initial values
         assert copy._cached_session is None
+
+    def test_create_fresh_refuses_kwargs_forwarding_subclass_when_copy_loses_state(self):
+        """A blank deep_copy must fail loudly instead of being served as a fresh agent."""
+        agent = KwargsForwardingAgent(
+            id="helper-id",
+            model=MockModel(),
+            instructions="Say hi.",
+            metadata={"role": "helper"},
+        )
+
+        with pytest.raises(ComponentRehydrationError, match="helper-id"):
+            get_agent_by_id("helper-id", [agent], create_fresh=True)
+
+    @pytest.mark.asyncio
+    async def test_create_fresh_refuses_kwargs_forwarding_subclass_in_async_helper(self):
+        """The async resolver must apply the same fidelity guard as the sync helper."""
+        agent = KwargsForwardingAgent(
+            id="helper-id",
+            model=MockModel(),
+            instructions="Say hi.",
+            metadata={"role": "helper"},
+        )
+
+        with pytest.raises(ComponentRehydrationError, match="helper-id"):
+            await get_agent_by_id_async("helper-id", [agent], create_fresh=True)
+
+    def test_create_fresh_lenient_falls_back_to_shared_instance_when_copy_loses_state(self):
+        """strict=False keeps the old shared-instance fallback but must not return a blank copy."""
+        agent = KwargsForwardingAgent(
+            id="helper-id",
+            model=MockModel(),
+            instructions="Say hi.",
+            metadata={"role": "helper"},
+        )
+
+        result = get_agent_by_id("helper-id", [agent], create_fresh=True, strict=False)
+
+        assert result is agent
 
 
 class TestGetTeamForRequest:


### PR DESCRIPTION
## Summary

Fixes #9407.

Guard `AgentOS` registry-agent resolution when `create_fresh=True` so kwargs-forwarding `Agent` subclasses cannot silently return a blank `deep_copy()` result.

This change:
- validates that a `deep_copy()` result is an `Agent`, is not the shared registry instance, and serializes the same as the original before dispatching it;
- raises `ComponentRehydrationError` in strict mode instead of serving a blank fresh agent;
- preserves the old lenient behavior by falling back to the shared registry instance with a warning when `strict=False`;
- adds sync and async regression tests for the broken subclass shape.

(If applicable, issue number: #9407)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Validation run locally on August 30, 2026:
- `pytest libs/agno/tests/unit/os/test_per_request_isolation.py -q`
- `./scripts/format.sh`
- `./scripts/validate.sh`

This PR was produced with AI assistance and reviewed/validated locally before submission.
