### PR TITLE
fix: surface unexpected component reconstruction failures

### DIFF
--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -1819,7 +1819,8 @@ def get_agent_by_id(
         Agent instance or None.
 
     Raises:
-        ComponentRehydrationError: If strict and a registry reference cannot be resolved.
+        ComponentRehydrationError: If a stored config cannot be reconstructed. In
+            strict mode, this also includes unresolvable registry references.
     """
     from agno.exceptions import ComponentRehydrationError
     from agno.utils.log import log_error
@@ -1846,18 +1847,25 @@ def get_agent_by_id(
 
         cfg = row.get("config") if isinstance(row, dict) else None
         if cfg is None:
-            raise ValueError(f"Invalid config found for agent {id}")
+            raise ComponentRehydrationError(f"Invalid config found for agent '{id}'")
 
-        agent = Agent.from_dict(cfg, registry=registry, strict=strict)
-        agent.id = id
-        # Only fall back to the caller-provided db if the config didn't
-        # reconstruct one, matching Agent.load.
-        if agent.db is None:
-            if strict:
-                from agno.utils.db_fallback import require_db_fallback_matches
+        try:
+            agent = Agent.from_dict(cfg, registry=registry, strict=strict)
+            agent.id = id
+            # Only fall back to the caller-provided db if the config didn't
+            # reconstruct one, matching Agent.load.
+            if agent.db is None:
+                if strict:
+                    from agno.utils.db_fallback import require_db_fallback_matches
 
-                require_db_fallback_matches(cfg, db, "agent", id)
-            agent.db = db
+                    require_db_fallback_matches(cfg, db, "agent", id)
+                agent.db = db
+        except ComponentRehydrationError:
+            raise
+        except Exception as e:
+            raise ComponentRehydrationError(
+                f"Failed to reconstruct agent '{id}' from stored config: {type(e).__name__}: {e}"
+            ) from e
 
         return agent
 

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -1909,7 +1909,8 @@ def get_team_by_id(
         Team instance or None.
 
     Raises:
-        ComponentRehydrationError: If strict and a member or registry reference cannot be resolved.
+        ComponentRehydrationError: If a stored config cannot be reconstructed. In
+            strict mode, this also includes unresolvable members and registry references.
     """
     from agno.exceptions import ComponentRehydrationError
 
@@ -1937,7 +1938,7 @@ def get_team_by_id(
 
         cfg = row.get("config") if isinstance(row, dict) else None
         if cfg is None:
-            raise ValueError(f"Invalid config found for team {id}")
+            raise ComponentRehydrationError(f"Invalid config found for team '{id}'")
 
         # Links for this config version carry the member versions pinned at
         # save time, so members load at those versions like the graph loader.
@@ -1948,19 +1949,26 @@ def get_team_by_id(
         except NotImplementedError:
             links = []
 
-        # Resolve DB-backed members under the same owner scope as the team.
-        with component_owner_scope(user_id):
-            team = Team.from_dict(cfg, db=db, registry=registry, links=links, strict=strict)
-        # Ensure team.id is set to the component_id
-        team.id = id
-        # Only fall back to the caller-provided db if the config didn't
-        # reconstruct one, matching Team.load.
-        if team.db is None:
-            if strict:
-                from agno.utils.db_fallback import require_db_fallback_matches
+        try:
+            # Resolve DB-backed members under the same owner scope as the team.
+            with component_owner_scope(user_id):
+                team = Team.from_dict(cfg, db=db, registry=registry, links=links, strict=strict)
+            # Ensure team.id is set to the component_id
+            team.id = id
+            # Only fall back to the caller-provided db if the config didn't
+            # reconstruct one, matching Team.load.
+            if team.db is None:
+                if strict:
+                    from agno.utils.db_fallback import require_db_fallback_matches
 
-                require_db_fallback_matches(cfg, db, "team", id)
-            team.db = db
+                    require_db_fallback_matches(cfg, db, "team", id)
+                team.db = db
+        except ComponentRehydrationError:
+            raise
+        except Exception as e:
+            raise ComponentRehydrationError(
+                f"Failed to reconstruct team '{id}' from stored config: {type(e).__name__}: {e}"
+            ) from e
 
         return team
 

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -11829,7 +11829,8 @@ def get_workflow_by_id(
         Workflow instance or None.
 
     Raises:
-        ComponentRehydrationError: If strict and a registry reference cannot be resolved.
+        ComponentRehydrationError: If a stored config cannot be reconstructed. In
+            strict mode, this also includes unresolvable registry references.
     """
     from agno.exceptions import ComponentRehydrationError
 
@@ -11857,7 +11858,7 @@ def get_workflow_by_id(
 
         cfg = row.get("config") if isinstance(row, dict) else None
         if cfg is None:
-            raise ValueError(f"Invalid config found for workflow {id}")
+            raise ComponentRehydrationError(f"Invalid config found for workflow '{id}'")
 
         resolved_version = row.get("version")
 
@@ -11867,20 +11868,27 @@ def get_workflow_by_id(
         except NotImplementedError:
             links = []
 
-        # Resolve DB-backed step executors under the same owner scope as the workflow.
-        with component_owner_scope(user_id):
-            workflow = Workflow.from_dict(cfg, db=db, links=links, registry=registry, strict=strict)
+        try:
+            # Resolve DB-backed step executors under the same owner scope as the workflow.
+            with component_owner_scope(user_id):
+                workflow = Workflow.from_dict(cfg, db=db, links=links, registry=registry, strict=strict)
 
-        # Ensure workflow.id is set to the component_id
-        workflow.id = id
-        # Only fall back to the caller-provided db if the config didn't
-        # reconstruct one, matching Workflow.load.
-        if workflow.db is None:
-            if strict:
-                from agno.utils.db_fallback import require_db_fallback_matches
+            # Ensure workflow.id is set to the component_id
+            workflow.id = id
+            # Only fall back to the caller-provided db if the config didn't
+            # reconstruct one, matching Workflow.load.
+            if workflow.db is None:
+                if strict:
+                    from agno.utils.db_fallback import require_db_fallback_matches
 
-                require_db_fallback_matches(cfg, db, "workflow", id)
-            workflow.db = db
+                    require_db_fallback_matches(cfg, db, "workflow", id)
+                workflow.db = db
+        except ComponentRehydrationError:
+            raise
+        except Exception as e:
+            raise ComponentRehydrationError(
+                f"Failed to reconstruct workflow '{id}' from stored config: {type(e).__name__}: {e}"
+            ) from e
 
         return workflow
 

--- a/libs/agno/tests/unit/os/test_rehydration_error_propagation.py
+++ b/libs/agno/tests/unit/os/test_rehydration_error_propagation.py
@@ -1,12 +1,19 @@
-"""The OS helpers must not degrade ComponentRehydrationError to None/404."""
+"""The component loaders must not degrade reconstruction failures to None/404."""
+
+from types import SimpleNamespace
 
 import pytest
 
 from agno.agent.agent import Agent
+from agno.agent.agent import get_agent_by_id as get_agent_by_id_from_db
 from agno.db.sqlite import SqliteDb
 from agno.exceptions import ComponentRehydrationError
 from agno.models.openai import OpenAIChat
 from agno.os.utils import get_agent_by_id
+from agno.team.team import Team
+from agno.team.team import get_team_by_id as get_team_by_id_from_db
+from agno.workflow.workflow import Workflow
+from agno.workflow.workflow import get_workflow_by_id as get_workflow_by_id_from_db
 
 
 def _save_agent_with_tools(db):
@@ -61,3 +68,29 @@ def test_resolve_agent_strict_false_returns_a_degraded_component(tmp_path):
 
     assert agent is not None
     assert agent.id == "broken-agent"
+
+
+@pytest.mark.parametrize(
+    ("component_name", "component_type", "loader"),
+    [
+        ("agent", Agent, get_agent_by_id_from_db),
+        ("team", Team, get_team_by_id_from_db),
+        ("workflow", Workflow, get_workflow_by_id_from_db),
+    ],
+)
+def test_db_loaders_wrap_unexpected_reconstruction_errors(monkeypatch, component_name, component_type, loader):
+    original_error = ImportError("the stored model provider is no longer installed")
+
+    def fail_to_reconstruct(*args, **kwargs):
+        raise original_error
+
+    monkeypatch.setattr(component_type, "from_dict", fail_to_reconstruct)
+    db = SimpleNamespace(get_config=lambda **kwargs: {"config": {}})
+
+    with pytest.raises(
+        ComponentRehydrationError,
+        match=rf"Failed to reconstruct {component_name} 'broken-{component_name}'.*ImportError",
+    ) as exc_info:
+        loader(db=db, id=f"broken-{component_name}", strict=False, published_only=False)
+
+    assert exc_info.value.__cause__ is original_error


### PR DESCRIPTION
## Summary

The module-level agent, team, and workflow loaders currently turn any unexpected `from_dict` failure into `None`, so a stored component with a removed provider or malformed config is reported as a false 404.

This change:

- wraps unexpected reconstruction failures in `ComponentRehydrationError` while preserving the original exception as the cause;
- keeps database lookup failures and genuinely missing rows on the existing `None` path;
- treats a present row with no config as a typed reconstruction failure; and
- documents the widened loader contract and adds one regression matrix across all three component families.

Fixes #9433.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

The regression matrix failed in all three cases before the fix and passes afterward.

Validation run:

- `pytest -q libs/agno/tests/unit/os/test_rehydration_error_propagation.py` — 6 passed
- `pytest -q libs/agno/tests/unit/os/test_rehydration_http_status.py libs/agno/tests/unit/os/test_db_fallback_guard.py` — 22 passed
- `./scripts/format.sh` — passed
- `./scripts/validate.sh` — passed, including mypy over 1,023 Agno source files

The scope is deliberately narrower than wrapping the whole loader: errors while fetching the component/config row retain the existing missing/unavailable behavior, while errors after a stored config has been selected can no longer masquerade as not-found.
