### PR TITLE
fix(gemini): coerce non-string enum values in convert_schema

### DIFF
--- a/libs/agno/agno/utils/gemini.py
+++ b/libs/agno/agno/utils/gemini.py
@@ -258,7 +258,13 @@ def convert_schema(
 
     # Handle enum types
     if "enum" in schema_dict:
-        enum_values = schema_dict["enum"]
+        # The type is coerced to STRING, so non-string enum values (e.g. integer
+        # enums from IntEnum or Literal[1, 2, 3] tool parameters) must be coerced
+        # as well, otherwise Schema's List[str] validation rejects them.
+        raw_enum = schema_dict["enum"]
+        enum_values = [str(value) for value in raw_enum]
+        if default is not None and default in raw_enum:
+            default = str(default)
         return Schema(type=GeminiType.STRING, enum=enum_values, description=description, default=default, title=title)
 
     if schema_type == "object":

--- a/libs/agno/tests/unit/utils/test_gemini.py
+++ b/libs/agno/tests/unit/utils/test_gemini.py
@@ -738,3 +738,34 @@ def test_inject_header_overrides_existing_x_goog_api_client():
     params = {"http_options": {"headers": {"x-goog-api-client": "stale/0.0.0"}}}
     result = inject_agno_client_header(params)
     assert result["http_options"]["headers"]["x-goog-api-client"] == f"agno/{agno_version}"
+
+
+def test_convert_schema_integer_enum_coerced_to_strings():
+    """Integer enums (e.g. from IntEnum or Literal[1, 2, 3] parameters) must be
+    coerced to strings instead of failing Schema's List[str] validation."""
+    schema_dict = {
+        "type": "integer",
+        "enum": [1, 2, 3],
+        "description": "A size choice",
+    }
+
+    result = convert_schema(schema_dict)
+
+    assert result is not None
+    assert result.type == "STRING"
+    assert result.enum == ["1", "2", "3"]
+
+
+def test_convert_schema_integer_enum_default_coerced():
+    """A default that points at an enum value is coerced alongside the values."""
+    schema_dict = {
+        "type": "integer",
+        "enum": [1, 2, 3],
+        "default": 2,
+    }
+
+    result = convert_schema(schema_dict)
+
+    assert result is not None
+    assert result.enum == ["1", "2", "3"]
+    assert result.default == "2"


### PR DESCRIPTION
## Summary

Fixes #9833

Tool parameters typed as `IntEnum` or `Literal[1, 2, 3]` produce JSON schemas whose `enum` holds integers. `convert_schema` was already coercing the schema type to `STRING` but passed the enum values through untouched, so pydantic rejected the ints against `Schema.enum`'s `List[str]`:

```
ValidationError: 1 validation error for Schema
enum.0
  Input should be a valid string
```

The conversion now coerces enum values to strings, and coerces a `default` that matches one of the original values so it stays consistent with the coerced list. String enums behave exactly as before.

(If applicable, issue number: #9833)

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`) - format ran clean on the touched files via project tooling; validation script requires the full toolchain
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: not applicable (no cookbook change needed)
- [x] Tested in clean environment (Python 3.12 venv, editable install)
- [x] Tests added/updated: 2 new cases in `libs/agno/tests/unit/utils/test_gemini.py`

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

**AI disclosure:** this fix was developed with AI assistance (Claude Code driving the change). I verified the repro from #9833 fails before the change and passes after, and the two added tests cover the coercion including the `default` case.

## Additional Notes

Verified on Python 3.12 with an editable install: the repro from the issue (`convert_schema({"type": "integer", "enum": [1, 2, 3]})`) raised `ValidationError` before and returns `enum=["1", "2", "3"]` after; string enums are unchanged. Full `test_gemini.py` suite: 45 passed.
