### PR TITLE
feat: per-page website ingestion with SitemapReader and KnowledgeManagementTools

### DIFF
--- a/cookbook/07_knowledge/01_getting_started/05_website_per_page.py
+++ b/cookbook/07_knowledge/01_getting_started/05_website_per_page.py
@@ -1,0 +1,67 @@
+"""
+Website Ingestion: One Row Per Page
+===================================
+Load a website into a knowledge base page by page from its sitemap:
+one content row per page with its source URL kept, so the agent can
+cite the page it answered from and a re-run refreshes only pages
+that changed.
+
+SitemapReader discovers pages from the site's sitemap (robots.txt and
+sitemap indexes are followed) and fetches each page whole. Pages land
+as separate rows on the Knowledge page; deleting the site row removes
+every page and its vectors.
+
+A bare sitemap URL selects this reader automatically:
+    await knowledge.ainsert(url="https://docs.agno.com/sitemap.xml")
+"""
+
+import asyncio
+
+from agno.agent import Agent
+from agno.knowledge.embedder.openai import OpenAIEmbedder
+from agno.knowledge.knowledge import Knowledge
+from agno.knowledge.reader.sitemap_reader import SitemapReader
+from agno.models.openai import OpenAIResponses
+from agno.vectordb.qdrant import Qdrant
+
+# ---------------------------------------------------------------------------
+# Create Knowledge
+# ---------------------------------------------------------------------------
+knowledge = Knowledge(
+    name="Agno Docs",
+    vector_db=Qdrant(
+        collection="website-pages",
+        url="http://localhost:6333",
+        embedder=OpenAIEmbedder(id="text-embedding-3-small"),
+    ),
+)
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.6-luna"),
+    knowledge=knowledge,
+    search_knowledge=True,
+    instructions="Answer from the knowledge base and cite the source URL of the page you used.",
+    markdown=True,
+)
+
+
+# ---------------------------------------------------------------------------
+# Run Demo
+# ---------------------------------------------------------------------------
+async def main() -> None:
+    # One call: sitemap discovery, page-by-page fetch, one row per page.
+    # Uses Parallel's extraction when PARALLEL_API_KEY or the mcp extra is
+    # available, the built-in fetcher otherwise.
+    await knowledge.ainsert(
+        url="https://docs.agno.com",
+        reader=SitemapReader(max_pages=25),
+    )
+
+    await agent.aprint_response("What is an Agent in Agno? Cite the page you used.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/cookbook/07_knowledge/01_getting_started/05_website_per_page.py
+++ b/cookbook/07_knowledge/01_getting_started/05_website_per_page.py
@@ -18,6 +18,7 @@ A bare sitemap URL selects this reader automatically:
 import asyncio
 
 from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
 from agno.knowledge.embedder.openai import OpenAIEmbedder
 from agno.knowledge.knowledge import Knowledge
 from agno.knowledge.reader.sitemap_reader import SitemapReader
@@ -27,8 +28,11 @@ from agno.vectordb.qdrant import Qdrant
 # ---------------------------------------------------------------------------
 # Create Knowledge
 # ---------------------------------------------------------------------------
+# The contents db is what holds the per-page rows (and the digests that make
+# re-ingest refresh only changed pages) — without it, only vectors are stored.
 knowledge = Knowledge(
     name="Agno Docs",
+    contents_db=SqliteDb(db_file="tmp/agno_docs_contents.db"),
     vector_db=Qdrant(
         collection="website-pages",
         url="http://localhost:6333",

--- a/cookbook/07_knowledge/01_getting_started/README.md
+++ b/cookbook/07_knowledge/01_getting_started/README.md
@@ -15,6 +15,7 @@ Start here to learn the basics of RAG (Retrieval-Augmented Generation) with Agno
 | [02_agentic_rag.py](./02_agentic_rag.py) | Agentic RAG where the agent decides when to search |
 | [03_loading_content.py](./03_loading_content.py) | Loading from files, URLs, text, topics, and batches |
 | [04_choosing_components.md](./04_choosing_components.md) | Decision guide for vector DBs, embedders, and chunking |
+| [05_website_per_page.py](./05_website_per_page.py) | Loading a website page by page from its sitemap, with per-page citations |
 
 ## Start Here
 

--- a/cookbook/91_tools/knowledge_management_tools.py
+++ b/cookbook/91_tools/knowledge_management_tools.py
@@ -1,0 +1,62 @@
+"""
+Knowledge Management Tools
+==========================
+
+An operator agent that manages a knowledge base by chat: ingest a
+website page by page, list what is loaded grouped by site, check a
+site's status, and remove content.
+
+This is the write side of knowledge. Hand it to a builder or operator
+agent; end-user-facing agents get search only (search_knowledge=True).
+remove_content requires confirmation by default.
+
+Requirements:
+- Qdrant running locally: ./cookbook/scripts/run_qdrant.sh
+- OPENAI_API_KEY
+- (optional) PARALLEL_API_KEY for higher-quality page extraction
+"""
+
+import asyncio
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.knowledge.embedder.openai import OpenAIEmbedder
+from agno.knowledge.knowledge import Knowledge
+from agno.models.openai import OpenAIResponses
+from agno.tools.knowledge_management import KnowledgeManagementTools
+from agno.vectordb.qdrant import Qdrant
+
+# ---------------------------------------------------------------------------
+# Create Knowledge
+# ---------------------------------------------------------------------------
+knowledge = Knowledge(
+    name="Product Docs",
+    contents_db=SqliteDb(db_file="tmp/knowledge_contents.db"),
+    vector_db=Qdrant(
+        collection="product-docs",
+        url="http://localhost:6333",
+        embedder=OpenAIEmbedder(id="text-embedding-3-small"),
+    ),
+)
+
+# ---------------------------------------------------------------------------
+# Create the operator agent
+# ---------------------------------------------------------------------------
+operator = Agent(
+    name="Knowledge Operator",
+    model=OpenAIResponses(id="gpt-5.6-luna"),
+    tools=[KnowledgeManagementTools(knowledge=knowledge, max_pages=25)],
+    markdown=True,
+)
+
+
+# ---------------------------------------------------------------------------
+# Run Demo
+# ---------------------------------------------------------------------------
+async def main() -> None:
+    await operator.aprint_response("Load https://docs.agno.com into the knowledge base.")
+    await operator.aprint_response("What do we have loaded now?")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/cookbook/91_tools/knowledge_management_tools.py
+++ b/cookbook/91_tools/knowledge_management_tools.py
@@ -54,7 +54,9 @@ operator = Agent(
 # Run Demo
 # ---------------------------------------------------------------------------
 async def main() -> None:
-    await operator.aprint_response("Load https://docs.agno.com into the knowledge base.")
+    await operator.aprint_response(
+        "Load https://docs.agno.com into the knowledge base."
+    )
     await operator.aprint_response("What do we have loaded now?")
 
 

--- a/libs/agno/agno/context/backend.py
+++ b/libs/agno/agno/context/backend.py
@@ -12,12 +12,21 @@ The provider can swap between backends without changing its agent interface.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, ClassVar, List
 
 from agno.context.provider import Status
+
+if TYPE_CHECKING:
+    from agno.knowledge.reader.page_fetcher import FetchedPage
 
 
 class ContextBackend(ABC):
     """Base class for the I/O layer behind a `ContextProvider`."""
+
+    # How many URLs one fetch_many/afetch_many call may take (one provider request per call).
+    fetch_batch_limit: ClassVar[int] = 1
+    # What lands in FetchedPage.extractor and knowledge provenance for pages this backend fetched.
+    extractor_id: ClassVar[str] = "backend"
 
     @abstractmethod
     def status(self) -> Status: ...
@@ -27,6 +36,19 @@ class ContextBackend(ABC):
 
     @abstractmethod
     def get_tools(self) -> list: ...
+
+    def fetch_many(self, urls: List[str], *, max_chars: int = 50_000) -> List[FetchedPage]:
+        """Fetch up to ``fetch_batch_limit`` pages in one provider request.
+
+        Backends that can extract pages override this (and ``afetch_many``) so knowledge
+        readers can fetch through them. Raises ``RateLimited`` when the provider says to slow
+        down; any other per-page problem is reported on the page, not raised.
+        """
+        raise NotImplementedError(f"{type(self).__name__} does not implement page fetching")
+
+    async def afetch_many(self, urls: List[str], *, max_chars: int = 50_000) -> List[FetchedPage]:
+        """Async variant of :meth:`fetch_many`."""
+        raise NotImplementedError(f"{type(self).__name__} does not implement page fetching")
 
     async def asetup(self) -> None:
         """Setup any resources the backend needs. Default: no-op.

--- a/libs/agno/agno/context/web/parallel.py
+++ b/libs/agno/agno/context/web/parallel.py
@@ -31,9 +31,13 @@ class ParallelBackend(ContextBackend):
     in `parallel-web` >= 1.0, not the pre-1.0 `client.beta.*` endpoints.
     """
 
+    extractor_id = "parallel"
+    fetch_batch_limit = 20  # the extract API takes up to 20 URLs per request
+
     def __init__(self, *, api_key: str | None = None) -> None:
         self.api_key: str = api_key if api_key else getenv("PARALLEL_API_KEY", "")
         self._client: Any = None
+        self._sync_client: Any = None
 
     def status(self) -> Status:
         if not self.api_key:
@@ -49,6 +53,82 @@ class ParallelBackend(ContextBackend):
 
             self._client = AsyncParallel(api_key=self.api_key)
         return self._client
+
+    def _get_sync_client(self) -> Any:
+        if self._sync_client is None:
+            from parallel import Parallel  # type: ignore[import-not-found]
+
+            self._sync_client = Parallel(api_key=self.api_key)
+        return self._sync_client
+
+    # ------------------------------------------------------------------
+    # Page fetching (knowledge readers fetch through this)
+    # ------------------------------------------------------------------
+
+    def _pages_from_extract(self, urls: list[str], result: Any) -> list:
+        from agno.knowledge.reader.page_fetcher import FetchedPage
+
+        by_url: dict[str, Any] = {}
+        for entry in getattr(result, "results", None) or []:
+            entry_url = getattr(entry, "url", None)
+            if entry_url:
+                by_url[entry_url] = entry
+        pages = []
+        for url in urls:
+            entry = by_url.get(url)
+            content = None
+            title = None
+            if entry is not None:
+                content = getattr(entry, "full_content", None) or "\n".join(getattr(entry, "excerpts", None) or [])
+                title = getattr(entry, "title", None)
+            if content:
+                pages.append(FetchedPage(url=url, content=content, title=title, extractor=self.extractor_id))
+            else:
+                pages.append(FetchedPage(url=url, error="empty", extractor=self.extractor_id))
+        return pages
+
+    @staticmethod
+    def _raise_if_rate_limited(e: Exception) -> None:
+        from agno.knowledge.reader.page_fetcher import RateLimited, rate_limit_from_text
+
+        status_code = getattr(e, "status_code", None)
+        if status_code == 429 or rate_limit_from_text(str(e)):
+            retry_after: float | None = None
+            headers = getattr(getattr(e, "response", None), "headers", None)
+            if headers is not None:
+                try:
+                    retry_after = float(headers.get("retry-after"))
+                except (TypeError, ValueError):
+                    retry_after = None
+            raise RateLimited(str(e), retry_after=retry_after) from e
+
+    def fetch_many(self, urls: list[str], *, max_chars: int = _MAX_EXTRACT_CHARS) -> list:
+        from agno.knowledge.reader.page_fetcher import FetchedPage
+
+        try:
+            result = self._get_sync_client().extract(
+                urls=urls,
+                advanced_settings={"full_content": {"max_chars_per_result": max_chars}},
+            )
+        except Exception as e:
+            self._raise_if_rate_limited(e)
+            log_error(f"parallel extract failed for {len(urls)} urls: {e}")
+            return [FetchedPage(url=url, error=f"{type(e).__name__}: {e}", extractor=self.extractor_id) for url in urls]
+        return self._pages_from_extract(urls, result)
+
+    async def afetch_many(self, urls: list[str], *, max_chars: int = _MAX_EXTRACT_CHARS) -> list:
+        from agno.knowledge.reader.page_fetcher import FetchedPage
+
+        try:
+            result = await self._get_client().extract(
+                urls=urls,
+                advanced_settings={"full_content": {"max_chars_per_result": max_chars}},
+            )
+        except Exception as e:
+            self._raise_if_rate_limited(e)
+            log_error(f"parallel extract failed for {len(urls)} urls: {e}")
+            return [FetchedPage(url=url, error=f"{type(e).__name__}: {e}", extractor=self.extractor_id) for url in urls]
+        return self._pages_from_extract(urls, result)
 
     def get_tools(self) -> list:
         backend = self

--- a/libs/agno/agno/context/web/parallel_mcp.py
+++ b/libs/agno/agno/context/web/parallel_mcp.py
@@ -144,7 +144,7 @@ class ParallelMCPBackend(ContextBackend):
     extractor_id = "parallel_mcp"
     fetch_batch_limit = 20  # web_fetch takes up to 20 URLs per request
 
-    def _pages_from_fetch_payload(self, urls: list, payload: dict) -> list:
+    def _pages_from_fetch_payload(self, urls: list, payload: dict, max_chars: int = 50_000) -> list:
         from agno.knowledge.reader.page_fetcher import FetchedPage
 
         by_url: dict = {}
@@ -165,7 +165,10 @@ class ParallelMCPBackend(ContextBackend):
                 content = entry.get("full_content") or "\n".join(entry.get("excerpts") or [])
                 title = entry.get("title")
             if content:
-                pages.append(FetchedPage(url=url, content=content, title=title, extractor=self.extractor_id))
+                # The MCP tool has no per-page size parameter, so the cap is applied here
+                pages.append(
+                    FetchedPage(url=url, content=content[:max_chars], title=title, extractor=self.extractor_id)
+                )
             else:
                 pages.append(FetchedPage(url=url, error=errors_by_url.get(url, "empty"), extractor=self.extractor_id))
         return pages
@@ -221,7 +224,7 @@ class ParallelMCPBackend(ContextBackend):
             payload = {}
         if not isinstance(payload, dict):
             payload = {}
-        return self._pages_from_fetch_payload(list(urls), payload)
+        return self._pages_from_fetch_payload(list(urls), payload, max_chars=max_chars)
 
     def fetch_many(self, urls: list, *, max_chars: int = 50_000) -> list:
         """Sync variant: runs :meth:`afetch_many` on a private event loop in a worker thread.

--- a/libs/agno/agno/context/web/parallel_mcp.py
+++ b/libs/agno/agno/context/web/parallel_mcp.py
@@ -167,9 +167,7 @@ class ParallelMCPBackend(ContextBackend):
             if content:
                 pages.append(FetchedPage(url=url, content=content, title=title, extractor=self.extractor_id))
             else:
-                pages.append(
-                    FetchedPage(url=url, error=errors_by_url.get(url, "empty"), extractor=self.extractor_id)
-                )
+                pages.append(FetchedPage(url=url, error=errors_by_url.get(url, "empty"), extractor=self.extractor_id))
         return pages
 
     async def afetch_many(self, urls: list, *, max_chars: int = 50_000) -> list:
@@ -213,7 +211,9 @@ class ParallelMCPBackend(ContextBackend):
         if result.isError:
             if rate_limit_from_text(text):
                 raise RateLimited(text[:300])
-            return [FetchedPage(url=url, error=(text or "tool error")[:300], extractor=self.extractor_id) for url in urls]
+            return [
+                FetchedPage(url=url, error=(text or "tool error")[:300], extractor=self.extractor_id) for url in urls
+            ]
 
         try:
             payload = json.loads(text) if text else {}

--- a/libs/agno/agno/context/web/parallel_mcp.py
+++ b/libs/agno/agno/context/web/parallel_mcp.py
@@ -63,6 +63,11 @@ class ParallelMCPBackend(ContextBackend):
         # regularly exceeds MCPTools' 10s default.
         self.timeout_seconds = timeout_seconds
         self._mcp_tools: Any = None
+        # The keyless tier meters by session_id (per the web_fetch schema); one per backend
+        # keeps this instance's fetches on one meter and correlates them in Parallel's logs.
+        from uuid import uuid4
+
+        self._fetch_session_id = uuid4().hex
 
     def status(self) -> Status:
         endpoint = self.url.rsplit("/", 1)[-1]
@@ -76,15 +81,19 @@ class ParallelMCPBackend(ContextBackend):
             self._mcp_tools = self._build_tools()
         return [self._mcp_tools]
 
+    def _headers(self) -> dict:
+        headers: dict[str, Any] = {"User-Agent": f"agno/{_AGNO_VERSION}"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return headers
+
     def _build_tools(self) -> Any:
         from datetime import timedelta
 
         from agno.tools.mcp import MCPTools
         from agno.tools.mcp.params import StreamableHTTPClientParams
 
-        headers: dict[str, Any] = {"User-Agent": f"agno/{_AGNO_VERSION}"}
-        if self.api_key:
-            headers["Authorization"] = f"Bearer {self.api_key}"
+        headers = self._headers()
 
         server_params = StreamableHTTPClientParams(
             url=self.url,
@@ -127,3 +136,119 @@ class ParallelMCPBackend(ContextBackend):
             await tools.close()
         except Exception as exc:
             log_warning(f"ParallelMCPBackend close raised {type(exc).__name__}: {exc}")
+
+    # ------------------------------------------------------------------
+    # Page fetching (knowledge readers fetch through this)
+    # ------------------------------------------------------------------
+
+    extractor_id = "parallel_mcp"
+    fetch_batch_limit = 20  # web_fetch takes up to 20 URLs per request
+
+    def _pages_from_fetch_payload(self, urls: list, payload: dict) -> list:
+        from agno.knowledge.reader.page_fetcher import FetchedPage
+
+        by_url: dict = {}
+        for entry in payload.get("results") or []:
+            if isinstance(entry, dict) and entry.get("url"):
+                by_url[entry["url"]] = entry
+        errors_by_url: dict = {}
+        for entry in payload.get("errors") or []:
+            if isinstance(entry, dict) and entry.get("url"):
+                errors_by_url[entry["url"]] = str(entry.get("error") or entry.get("message") or "fetch error")
+
+        pages = []
+        for url in urls:
+            entry = by_url.get(url)
+            content = None
+            title = None
+            if entry is not None:
+                content = entry.get("full_content") or "\n".join(entry.get("excerpts") or [])
+                title = entry.get("title")
+            if content:
+                pages.append(FetchedPage(url=url, content=content, title=title, extractor=self.extractor_id))
+            else:
+                pages.append(
+                    FetchedPage(url=url, error=errors_by_url.get(url, "empty"), extractor=self.extractor_id)
+                )
+        return pages
+
+    async def afetch_many(self, urls: list, *, max_chars: int = 50_000) -> list:
+        """Fetch up to ``fetch_batch_limit`` pages with one ``web_fetch`` call.
+
+        Opens and closes its own MCP session on the calling task — the HTTP transport keeps
+        anyio cancel scopes that must be entered and exited on one task, so a fetch never
+        reuses the provider-side session ``get_tools()`` manages.
+        """
+        import json
+        from datetime import timedelta
+
+        from mcp import ClientSession
+        from mcp.client.streamable_http import streamablehttp_client
+
+        from agno.knowledge.reader.page_fetcher import FetchedPage, RateLimited, rate_limit_from_text
+
+        arguments: dict[str, Any] = {"urls": list(urls), "full_content": True}
+        if not self.api_key:
+            arguments["session_id"] = self._fetch_session_id
+
+        try:
+            async with streamablehttp_client(
+                url=self.url, headers=self._headers(), timeout=timedelta(seconds=self.timeout_seconds)
+            ) as (read, write, _):
+                async with ClientSession(
+                    read, write, read_timeout_seconds=timedelta(seconds=self.timeout_seconds)
+                ) as session:
+                    await session.initialize()
+                    result = await session.call_tool("web_fetch", arguments)
+        except Exception as e:
+            message = str(e)
+            if rate_limit_from_text(message):
+                raise RateLimited(message) from e
+            return [
+                FetchedPage(url=url, error=f"{type(e).__name__}: {message}"[:300], extractor=self.extractor_id)
+                for url in urls
+            ]
+
+        text = "".join(getattr(block, "text", "") or "" for block in result.content or [])
+        if result.isError:
+            if rate_limit_from_text(text):
+                raise RateLimited(text[:300])
+            return [FetchedPage(url=url, error=(text or "tool error")[:300], extractor=self.extractor_id) for url in urls]
+
+        try:
+            payload = json.loads(text) if text else {}
+        except ValueError:
+            payload = {}
+        if not isinstance(payload, dict):
+            payload = {}
+        return self._pages_from_fetch_payload(list(urls), payload)
+
+    def fetch_many(self, urls: list, *, max_chars: int = 50_000) -> list:
+        """Sync variant: runs :meth:`afetch_many` on a private event loop in a worker thread.
+
+        The MCP client is async-only, so the sync path pays one thread per call. Works from
+        inside a running event loop too, because the loop lives on its own thread.
+        """
+        import threading
+
+        outcome: dict[str, Any] = {}
+
+        def runner() -> None:
+            loop = asyncio.new_event_loop()
+            try:
+                outcome["pages"] = loop.run_until_complete(self.afetch_many(list(urls), max_chars=max_chars))
+            except BaseException as e:  # noqa: BLE001 - re-raised on the calling thread
+                outcome["error"] = e
+            finally:
+                try:
+                    loop.run_until_complete(loop.shutdown_asyncgens())
+                except Exception:
+                    pass
+                loop.close()
+
+        thread = threading.Thread(target=runner, name="parallel-mcp-fetch", daemon=True)
+        thread.start()
+        thread.join()
+        if "error" in outcome:
+            raise outcome["error"]
+        return outcome["pages"]

--- a/libs/agno/agno/context/web/provider.py
+++ b/libs/agno/agno/context/web/provider.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from agno.agent import Agent
 from agno.context._utils import answer_from_run
 from agno.context.backend import ContextBackend
 from agno.context.mode import ContextMode
@@ -19,6 +18,7 @@ from agno.context.provider import Answer, ContextProvider, Status
 from agno.run import RunContext
 
 if TYPE_CHECKING:
+    from agno.agent import Agent
     from agno.models.base import Model
 
 
@@ -110,6 +110,10 @@ class WebContextProvider(ContextProvider):
         return self._agent
 
     def _build_agent(self) -> Agent:
+        # Imported here, not at module scope: this module rides along with the page-fetch
+        # backends, and importing a fetch backend must not load the agent package.
+        from agno.agent import Agent
+
         return Agent(
             id=self.id,
             name=self.name,

--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -800,10 +800,13 @@ class Knowledge(RemoteKnowledge):
     ) -> bool:
         """Remove one content row and its vectors; cascades through a site row's pages.
 
-        Returns False when nothing was removed (ownership refused it) or when the vector
-        store reported a failed delete — in that case the contents row and its place in
-        the parent's cascade record are kept, so a later attempt can still reach the
-        vectors instead of orphaning them.
+        Returns False when nothing was removed (ownership refused it), when the vector
+        store reported a failed delete for a row that records indexed content, or when
+        part of a site's cascade failed — the affected rows and their place in the
+        parent's cascade record are kept, so a later attempt can still reach the
+        vectors instead of orphaning them. A False from the vector store for a row with
+        no recorded indexed content (site parents, legacy rows) is a zero-match no-op,
+        not a failure — several adapters answer False for both.
         """
         from agno.vectordb import VectorDb
 
@@ -825,13 +828,18 @@ class Knowledge(RemoteKnowledge):
         # parent-list maintenance below.
         seen = _seen if _seen is not None else set()
         seen.add(content_id)
-        all_removed = True
+        surviving_children: List[str] = []
         children = get_agno_metadata(content.metadata, "children") if content else None
         if isinstance(children, list):
             for child_id in children:
                 if isinstance(child_id, str) and child_id not in seen:
                     if not self.remove_content_by_id(child_id, user_id=user_id, _seen=seen):
-                        all_removed = False
+                        surviving_children.append(child_id)
+        if surviving_children and content is not None:
+            # Some pages could not be removed: the parent stays as the retry anchor,
+            # its cascade record narrowed to what actually survives.
+            self._stamp_row_children(content, surviving_children)
+            return False
 
         if self.vector_db is not None:
             if self.vector_db.__class__.__name__ == "LightRag":
@@ -839,24 +847,25 @@ class Knowledge(RemoteKnowledge):
                 if content is None and self.contents_db is not None:
                     content = self.get_content_by_id(content_id, user_id=user_id)
                 if content and content.external_id:
-                    self.vector_db.delete_by_external_id(content.external_id)  # type: ignore
+                    lightrag_deleted = self.vector_db.delete_by_external_id(content.external_id)  # type: ignore
+                    if lightrag_deleted is False:
+                        log_debug(f"LightRAG delete failed for content {content_id}; keeping the row for retry")
+                        return False
                 else:
                     log_warning(f"No external_id found for content {content_id}, cannot delete from LightRAG")
             else:
                 # Backends without per-user isolation accept ``user_id`` as a no-op.
-                # Adapters report operational failures as False — the row must then stay,
-                # or the vectors become permanently orphaned but still searchable.
                 deleted = self.vector_db.delete_by_content_id(
                     content_id, **strict_user_id_kwarg(self.vector_db.delete_by_content_id, user_id)
                 )
-                if deleted is False:
+                if deleted is False and self._false_delete_is_failure(content):
                     log_debug(f"Vector delete failed for content {content_id}; keeping the row for retry")
                     return False
 
         if self.contents_db is not None:
             self.contents_db.delete_knowledge_content(content_id, user_id=user_id)
             self._drop_from_parent_children(content, content_id, user_id, seen)
-        return all_removed
+        return True
 
     def _drop_from_parent_children(
         self, content: Optional[Content], content_id: str, user_id: Optional[str], seen: Set[str]
@@ -914,13 +923,17 @@ class Knowledge(RemoteKnowledge):
         # See the matching cascade in ``remove_content_by_id``.
         seen = _seen if _seen is not None else set()
         seen.add(content_id)
-        all_removed = True
+        surviving_children: List[str] = []
         children = get_agno_metadata(content.metadata, "children") if content else None
         if isinstance(children, list):
             for child_id in children:
                 if isinstance(child_id, str) and child_id not in seen:
                     if not await self.aremove_content_by_id(child_id, user_id=user_id, _seen=seen):
-                        all_removed = False
+                        surviving_children.append(child_id)
+        if surviving_children and content is not None:
+            # See the matching branch in ``remove_content_by_id``.
+            await self._astamp_row_children(content, surviving_children)
+            return False
 
         if self.vector_db is not None:
             if self.vector_db.__class__.__name__ == "LightRag":
@@ -928,7 +941,10 @@ class Knowledge(RemoteKnowledge):
                 if content is None and self.contents_db is not None:
                     content = await self.aget_content_by_id(content_id, user_id=user_id)
                 if content and content.external_id:
-                    self.vector_db.delete_by_external_id(content.external_id)  # type: ignore
+                    lightrag_deleted = self.vector_db.delete_by_external_id(content.external_id)  # type: ignore
+                    if lightrag_deleted is False:
+                        log_debug(f"LightRAG delete failed for content {content_id}; keeping the row for retry")
+                        return False
                 else:
                     log_warning(f"No external_id found for content {content_id}, cannot delete from LightRAG")
             else:
@@ -936,7 +952,7 @@ class Knowledge(RemoteKnowledge):
                 deleted = self.vector_db.delete_by_content_id(
                     content_id, **strict_user_id_kwarg(self.vector_db.delete_by_content_id, user_id)
                 )
-                if deleted is False:
+                if deleted is False and self._false_delete_is_failure(content):
                     log_debug(f"Vector delete failed for content {content_id}; keeping the row for retry")
                     return False
 
@@ -946,19 +962,45 @@ class Knowledge(RemoteKnowledge):
             else:
                 self.contents_db.delete_knowledge_content(content_id, user_id=user_id)
             await self._adrop_from_parent_children(content, content_id, user_id, seen)
+        return True
+
+    def remove_all_content(self, user_id: Optional[str] = None) -> bool:
+        """Remove every deletable row. Returns False when any removal failed (see
+        ``remove_content_by_id``); the failed rows are kept for retry."""
+        contents, _ = self.get_content(user_id=user_id)
+        all_removed = True
+        for content in contents:
+            if content.id is not None and not self._content_is_shared(content, user_id):
+                if self.get_content_by_id(content.id, user_id=user_id) is None:
+                    continue  # already removed by an earlier row's cascade
+                if not self.remove_content_by_id(content.id, user_id=user_id):
+                    all_removed = False
         return all_removed
 
-    def remove_all_content(self, user_id: Optional[str] = None):
-        contents, _ = self.get_content(user_id=user_id)
-        for content in contents:
-            if content.id is not None and not self._content_is_shared(content, user_id):
-                self.remove_content_by_id(content.id, user_id=user_id)
-
-    async def aremove_all_content(self, user_id: Optional[str] = None):
+    async def aremove_all_content(self, user_id: Optional[str] = None) -> bool:
+        """Async version of :meth:`remove_all_content`."""
         contents, _ = await self.aget_content(user_id=user_id)
+        all_removed = True
         for content in contents:
             if content.id is not None and not self._content_is_shared(content, user_id):
-                await self.aremove_content_by_id(content.id, user_id=user_id)
+                if await self.aget_content_by_id(content.id, user_id=user_id) is None:
+                    continue  # already removed by an earlier row's cascade
+                if not await self.aremove_content_by_id(content.id, user_id=user_id):
+                    all_removed = False
+        return all_removed
+
+    @staticmethod
+    def _false_delete_is_failure(content: Optional[Content]) -> bool:
+        """Whether a False from ``delete_by_content_id`` means the delete failed.
+
+        Adapter return semantics are mixed: some return False on operational failure,
+        others (Chroma, LanceDB, Weaviate) on a zero-match no-op. The two are told apart
+        by what this side knows: a row that records indexed content
+        (``_agno.content_digest``) owns vectors, so a False there is a failure and the
+        row is kept for retry. Any other row — a site parent, which owns no page
+        vectors, or a legacy row — treats False as the no-op it usually is.
+        """
+        return content is not None and isinstance(get_agno_metadata(content.metadata, "content_digest"), str)
 
     @staticmethod
     def _content_is_shared(content: Content, user_id: Optional[str]) -> bool:
@@ -1826,7 +1868,7 @@ class Knowledge(RemoteKnowledge):
 
         # A multi-page re-ingest needs the previous run's child-row ids to delete pages that
         # left the site; the upsert below overwrites them, so capture first.
-        previous_children = await self._aget_previous_children(content)
+        previous_children, had_previous_row = await self._aget_previous_children(content)
 
         # 1. Add content to contents database
         await self._ainsert_contents_db(content)
@@ -1942,6 +1984,7 @@ class Knowledge(RemoteKnowledge):
                 previous_children,
                 name_was_auto,
                 discovery_incomplete=discovery_incomplete,
+                legacy_promotion=had_previous_row and not previous_children,
             )
             return
 
@@ -1999,7 +2042,7 @@ class Knowledge(RemoteKnowledge):
 
         # A multi-page re-ingest needs the previous run's child-row ids to delete pages that
         # left the site; the upsert below overwrites them, so capture first.
-        previous_children = self._get_previous_children(content)
+        previous_children, had_previous_row = self._get_previous_children(content)
 
         # 1. Add content to contents database
         self._insert_contents_db(content)
@@ -2110,6 +2153,7 @@ class Knowledge(RemoteKnowledge):
                 previous_children,
                 name_was_auto,
                 discovery_incomplete=discovery_incomplete,
+                legacy_promotion=had_previous_row and not previous_children,
             )
             return
 
@@ -2141,28 +2185,34 @@ class Knowledge(RemoteKnowledge):
 
     _MULTI_PAGE_READER_IDS = {"SitemapReader": "sitemap", "LLMsTxtReader": "llms_txt", "WebsiteReader": "website"}
 
-    async def _aget_previous_children(self, content: Content) -> List[str]:
-        """Child-row ids recorded on the site row by the previous run, if any."""
+    async def _aget_previous_children(self, content: Content) -> Tuple[List[str], bool]:
+        """``(child ids recorded by the previous run, whether a previous row existed)``.
+
+        A row that existed with no children is a legacy single row about to be promoted
+        to a site row — its vectors live under the row's own id and must be cleared.
+        """
         if self.contents_db is None or not content.id:
-            return []
+            return [], False
         if isinstance(self.contents_db, AsyncBaseDb):
             row = await self.contents_db.get_knowledge_content(content.id, user_id=content.user_id)
         else:
             row = self.contents_db.get_knowledge_content(content.id, user_id=content.user_id)
         if row is None:
-            return []
+            return [], False
         children = get_agno_metadata(row.metadata, "children")
-        return [child for child in children if isinstance(child, str)] if isinstance(children, list) else []
+        parsed = [child for child in children if isinstance(child, str)] if isinstance(children, list) else []
+        return parsed, True
 
-    def _get_previous_children(self, content: Content) -> List[str]:
+    def _get_previous_children(self, content: Content) -> Tuple[List[str], bool]:
         """Synchronous version of _aget_previous_children."""
         if self.contents_db is None or not content.id or isinstance(self.contents_db, AsyncBaseDb):
-            return []
+            return [], False
         row = self.contents_db.get_knowledge_content(content.id, user_id=content.user_id)
         if row is None:
-            return []
+            return [], False
         children = get_agno_metadata(row.metadata, "children")
-        return [child for child in children if isinstance(child, str)] if isinstance(children, list) else []
+        parsed = [child for child in children if isinstance(child, str)] if isinstance(children, list) else []
+        return parsed, True
 
     async def _aget_child_digest(self, child_id: Optional[str], user_id: Optional[str]) -> Optional[str]:
         """The stored page-text digest of a child row, or None when the row does not exist."""
@@ -2293,6 +2343,7 @@ class Knowledge(RemoteKnowledge):
         previous_children: List[str],
         name_was_auto: bool,
         discovery_incomplete: bool = False,
+        legacy_promotion: bool = False,
     ) -> None:
         """Land a multi-page read as one content row per page under the site row.
 
@@ -2309,14 +2360,23 @@ class Knowledge(RemoteKnowledge):
 
         # The site row owns no page vectors. Clearing its content_id first makes the
         # 1-to-N transition drop the legacy single-row vectors, and lets the overview
-        # branch below re-insert without stacking chunks run over run.
+        # branch below re-insert without stacking chunks run over run. On an ordinary
+        # re-ingest there is nothing to clear, so a False is a zero-match no-op; during
+        # a promotion (a legacy row growing into a site) the legacy vectors are real,
+        # and inserting page rows beside them would leave stale content searchable —
+        # a failed clear aborts the promotion for a later retry.
         try:
             clear_kwargs = strict_user_id_kwarg(self.vector_db.delete_by_content_id, content.user_id)
             cleared = self.vector_db.delete_by_content_id(content.id, **clear_kwargs)  # type: ignore[arg-type]
-            if cleared is False:
-                log_debug("Vector store reported a failed clear of the site row's legacy vectors")
+            clear_failed = cleared is False and legacy_promotion
         except Exception as e:
             log_debug(f"Could not clear site-row vectors before per-page load: {e}")
+            clear_failed = legacy_promotion
+        if clear_failed:
+            content.status = ContentStatus.FAILED
+            content.status_message = "Could not clear the row's previous vectors; re-run to retry"
+            await self._aupdate_content(content)
+            return
 
         reader_id = self._MULTI_PAGE_READER_IDS.get(type(content.reader).__name__) if content.reader else None
 
@@ -2474,20 +2534,26 @@ class Knowledge(RemoteKnowledge):
         previous_children: List[str],
         name_was_auto: bool,
         discovery_incomplete: bool = False,
+        legacy_promotion: bool = False,
     ) -> None:
         """Synchronous version of _aload_url_page_groups."""
         from agno.vectordb import VectorDb
 
         self.vector_db = cast(VectorDb, self.vector_db)
 
-        # See the matching clear in _aload_url_page_groups.
+        # See the matching clear-and-abort in _aload_url_page_groups.
         try:
             clear_kwargs = strict_user_id_kwarg(self.vector_db.delete_by_content_id, content.user_id)
             cleared = self.vector_db.delete_by_content_id(content.id, **clear_kwargs)  # type: ignore[arg-type]
-            if cleared is False:
-                log_debug("Vector store reported a failed clear of the site row's legacy vectors")
+            clear_failed = cleared is False and legacy_promotion
         except Exception as e:
             log_debug(f"Could not clear site-row vectors before per-page load: {e}")
+            clear_failed = legacy_promotion
+        if clear_failed:
+            content.status = ContentStatus.FAILED
+            content.status_message = "Could not clear the row's previous vectors; re-run to retry"
+            self._update_content(content)
+            return
 
         reader_id = self._MULTI_PAGE_READER_IDS.get(type(content.reader).__name__) if content.reader else None
 

--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -941,7 +941,9 @@ class Knowledge(RemoteKnowledge):
                 if content is None and self.contents_db is not None:
                     content = await self.aget_content_by_id(content_id, user_id=user_id)
                 if content and content.external_id:
-                    lightrag_deleted = self.vector_db.delete_by_external_id(content.external_id)  # type: ignore
+                    # The sync wrapper runs asyncio.run and cannot be called from a
+                    # running event loop (e.g. under the REST server)
+                    lightrag_deleted = await self.vector_db.async_delete_by_external_id(content.external_id)  # type: ignore
                     if lightrag_deleted is False:
                         log_debug(f"LightRAG delete failed for content {content_id}; keeping the row for retry")
                         return False
@@ -990,17 +992,31 @@ class Knowledge(RemoteKnowledge):
         return all_removed
 
     @staticmethod
-    def _false_delete_is_failure(content: Optional[Content]) -> bool:
+    def _row_owns_vectors(content: Optional[Content]) -> bool:
+        """Whether this row is recorded as owning indexed vectors.
+
+        ``_agno.vectors_indexed`` is written at every successful vector insert (text,
+        file, single-page, and per-page rows alike); ``_agno.content_digest`` is the
+        page-row form of the same evidence and is stripped when an embed fails.
+        """
+        if content is None:
+            return False
+        if get_agno_metadata(content.metadata, "vectors_indexed") is True:
+            return True
+        return isinstance(get_agno_metadata(content.metadata, "content_digest"), str)
+
+    @classmethod
+    def _false_delete_is_failure(cls, content: Optional[Content]) -> bool:
         """Whether a False from ``delete_by_content_id`` means the delete failed.
 
         Adapter return semantics are mixed: some return False on operational failure,
-        others (Chroma, LanceDB, Weaviate) on a zero-match no-op. The two are told apart
-        by what this side knows: a row that records indexed content
-        (``_agno.content_digest``) owns vectors, so a False there is a failure and the
-        row is kept for retry. Any other row — a site parent, which owns no page
-        vectors, or a legacy row — treats False as the no-op it usually is.
+        others (Chroma, LanceDB, Weaviate) on a zero-match no-op. The two are told
+        apart by what this side persisted: a row recorded as owning vectors treats
+        False as a failure and is kept for retry; a row with no such record — a site
+        parent, or a row whose indexing never succeeded — treats False as the no-op
+        it usually is.
         """
-        return content is not None and isinstance(get_agno_metadata(content.metadata, "content_digest"), str)
+        return cls._row_owns_vectors(content)
 
     @staticmethod
     def _content_is_shared(content: Content, user_id: Optional[str]) -> bool:
@@ -1868,7 +1884,7 @@ class Knowledge(RemoteKnowledge):
 
         # A multi-page re-ingest needs the previous run's child-row ids to delete pages that
         # left the site; the upsert below overwrites them, so capture first.
-        previous_children, had_previous_row = await self._aget_previous_children(content)
+        previous_children, previous_row_owned_vectors = await self._aget_previous_children(content)
 
         # 1. Add content to contents database
         await self._ainsert_contents_db(content)
@@ -1984,7 +2000,7 @@ class Knowledge(RemoteKnowledge):
                 previous_children,
                 name_was_auto,
                 discovery_incomplete=discovery_incomplete,
-                legacy_promotion=had_previous_row and not previous_children,
+                legacy_promotion=previous_row_owned_vectors and not previous_children,
             )
             return
 
@@ -2042,7 +2058,7 @@ class Knowledge(RemoteKnowledge):
 
         # A multi-page re-ingest needs the previous run's child-row ids to delete pages that
         # left the site; the upsert below overwrites them, so capture first.
-        previous_children, had_previous_row = self._get_previous_children(content)
+        previous_children, previous_row_owned_vectors = self._get_previous_children(content)
 
         # 1. Add content to contents database
         self._insert_contents_db(content)
@@ -2153,7 +2169,7 @@ class Knowledge(RemoteKnowledge):
                 previous_children,
                 name_was_auto,
                 discovery_incomplete=discovery_incomplete,
-                legacy_promotion=had_previous_row and not previous_children,
+                legacy_promotion=previous_row_owned_vectors and not previous_children,
             )
             return
 
@@ -2185,12 +2201,24 @@ class Knowledge(RemoteKnowledge):
 
     _MULTI_PAGE_READER_IDS = {"SitemapReader": "sitemap", "LLMsTxtReader": "llms_txt", "WebsiteReader": "website"}
 
-    async def _aget_previous_children(self, content: Content) -> Tuple[List[str], bool]:
-        """``(child ids recorded by the previous run, whether a previous row existed)``.
+    @staticmethod
+    def _parse_previous_row(row) -> Tuple[List[str], bool]:
+        """``(children, owned_vectors)`` from a previous run's row.
 
-        A row that existed with no children is a legacy single row about to be promoted
-        to a site row — its vectors live under the row's own id and must be cleared.
+        A row that owned vectors and has no children is a legacy single row about to
+        be promoted to a site row — its vectors live under its own id and must be
+        cleared first. A row without that positive evidence (for example a FAILED
+        first ingest) is not a promotion, so a later healthy run can proceed.
         """
+        children = get_agno_metadata(row.metadata, "children")
+        parsed = [child for child in children if isinstance(child, str)] if isinstance(children, list) else []
+        owned = get_agno_metadata(row.metadata, "vectors_indexed") is True or isinstance(
+            get_agno_metadata(row.metadata, "content_digest"), str
+        )
+        return parsed, owned
+
+    async def _aget_previous_children(self, content: Content) -> Tuple[List[str], bool]:
+        """``(previous child ids, previous row owned vectors)`` — see _parse_previous_row."""
         if self.contents_db is None or not content.id:
             return [], False
         if isinstance(self.contents_db, AsyncBaseDb):
@@ -2199,9 +2227,7 @@ class Knowledge(RemoteKnowledge):
             row = self.contents_db.get_knowledge_content(content.id, user_id=content.user_id)
         if row is None:
             return [], False
-        children = get_agno_metadata(row.metadata, "children")
-        parsed = [child for child in children if isinstance(child, str)] if isinstance(children, list) else []
-        return parsed, True
+        return self._parse_previous_row(row)
 
     def _get_previous_children(self, content: Content) -> Tuple[List[str], bool]:
         """Synchronous version of _aget_previous_children."""
@@ -2210,9 +2236,7 @@ class Knowledge(RemoteKnowledge):
         row = self.contents_db.get_knowledge_content(content.id, user_id=content.user_id)
         if row is None:
             return [], False
-        children = get_agno_metadata(row.metadata, "children")
-        parsed = [child for child in children if isinstance(child, str)] if isinstance(children, list) else []
-        return parsed, True
+        return self._parse_previous_row(row)
 
     async def _aget_child_digest(self, child_id: Optional[str], user_id: Optional[str]) -> Optional[str]:
         """The stored page-text digest of a child row, or None when the row does not exist."""
@@ -2303,6 +2327,7 @@ class Knowledge(RemoteKnowledge):
         name_was_auto: bool,
         reader_id: Optional[str] = None,
         discovery_incomplete: bool = False,
+        site_owns_vectors: bool = False,
     ) -> None:
         """Turn the parent row into the site row: aggregate status, children, provenance."""
         if name_was_auto and content.url:
@@ -2315,6 +2340,8 @@ class Knowledge(RemoteKnowledge):
         content.metadata = set_agno_metadata(content.metadata, "children", child_ids)
         content.metadata = set_agno_metadata(content.metadata, "page_count", pages_loaded)
         content.metadata = set_agno_metadata(content.metadata, "auto_named", name_was_auto)
+        if site_owns_vectors:
+            content.metadata = set_agno_metadata(content.metadata, "vectors_indexed", True)
         if reader_id:
             # A refresh must re-run the reader that built this site, never a guessed one
             content.metadata = set_agno_metadata(content.metadata, "reader_id", reader_id)
@@ -2385,6 +2412,7 @@ class Knowledge(RemoteKnowledge):
         extractor_counts: Dict[str, int] = {}
         pages_loaded = 0
         source_kind: Optional[str] = None
+        site_owns_vectors = False
 
         for source_url, source_docs in docs_by_source.items():
             child, digest, error, extractor, doc_source = self._prepare_page_child(content, source_url, source_docs)
@@ -2402,6 +2430,7 @@ class Knowledge(RemoteKnowledge):
                             filters=strip_agno_metadata(content.metadata),
                             **owner_kwargs,
                         )
+                        site_owns_vectors = True
                     except Exception as e:
                         log_error(f"Error inserting overview document from {source_url}: {str(e)}")
                 continue
@@ -2429,6 +2458,7 @@ class Knowledge(RemoteKnowledge):
                 previous_digest = await self._aget_child_digest(child.id, content.user_id)
                 if previous_digest is not None and previous_digest == digest:
                     child.status = ContentStatus.COMPLETED
+                    child.metadata = set_agno_metadata(child.metadata, "vectors_indexed", True)
                     await self._ainsert_contents_db(child)
                     extractor_counts[extractor] = extractor_counts.get(extractor, 0) + 1
                     pages_loaded += 1
@@ -2486,6 +2516,7 @@ class Knowledge(RemoteKnowledge):
                 continue
 
             child.status = ContentStatus.COMPLETED
+            child.metadata = set_agno_metadata(child.metadata, "vectors_indexed", True)
             await self._ainsert_contents_db(child)
             extractor_counts[extractor] = extractor_counts.get(extractor, 0) + 1
             pages_loaded += 1
@@ -2522,6 +2553,7 @@ class Knowledge(RemoteKnowledge):
             name_was_auto,
             reader_id=reader_id,
             discovery_incomplete=discovery_incomplete,
+            site_owns_vectors=site_owns_vectors,
         )
         await self._aupdate_content(content)
 
@@ -2562,6 +2594,7 @@ class Knowledge(RemoteKnowledge):
         extractor_counts: Dict[str, int] = {}
         pages_loaded = 0
         source_kind: Optional[str] = None
+        site_owns_vectors = False
 
         for source_url, source_docs in docs_by_source.items():
             child, digest, error, extractor, doc_source = self._prepare_page_child(content, source_url, source_docs)
@@ -2577,6 +2610,7 @@ class Knowledge(RemoteKnowledge):
                             filters=strip_agno_metadata(content.metadata),
                             **owner_kwargs,
                         )
+                        site_owns_vectors = True
                     except Exception as e:
                         log_error(f"Error inserting overview document from {source_url}: {str(e)}")
                 continue
@@ -2602,6 +2636,7 @@ class Knowledge(RemoteKnowledge):
                 previous_digest = self._get_child_digest(child.id, content.user_id)
                 if previous_digest is not None and previous_digest == digest:
                     child.status = ContentStatus.COMPLETED
+                    child.metadata = set_agno_metadata(child.metadata, "vectors_indexed", True)
                     self._insert_contents_db(child)
                     extractor_counts[extractor] = extractor_counts.get(extractor, 0) + 1
                     pages_loaded += 1
@@ -2657,6 +2692,7 @@ class Knowledge(RemoteKnowledge):
                 continue
 
             child.status = ContentStatus.COMPLETED
+            child.metadata = set_agno_metadata(child.metadata, "vectors_indexed", True)
             self._insert_contents_db(child)
             extractor_counts[extractor] = extractor_counts.get(extractor, 0) + 1
             pages_loaded += 1
@@ -2691,6 +2727,7 @@ class Knowledge(RemoteKnowledge):
             name_was_auto,
             reader_id=reader_id,
             discovery_incomplete=discovery_incomplete,
+            site_owns_vectors=site_owns_vectors,
         )
         self._update_content(content)
 
@@ -3382,6 +3419,9 @@ class Knowledge(RemoteKnowledge):
                 await self._aupdate_content(content)
                 return
 
+        # The row now provably owns vectors; deletion reads this marker to tell an
+        # operational False apart from a zero-match no-op.
+        content.metadata = set_agno_metadata(content.metadata, "vectors_indexed", True)
         content.status = ContentStatus.COMPLETED
         await self._aupdate_content(content)
 
@@ -3440,6 +3480,8 @@ class Knowledge(RemoteKnowledge):
                 self._update_content(content)
                 return
 
+        # See the matching marker in _ahandle_vector_db_insert.
+        content.metadata = set_agno_metadata(content.metadata, "vectors_indexed", True)
         content.status = ContentStatus.COMPLETED
         self._update_content(content)
 

--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -1806,6 +1806,12 @@ class Knowledge(RemoteKnowledge):
 
         # 1. Add content to contents database
         await self._ainsert_contents_db(content)
+        if previous_children:
+            # The upsert above replaced the row's metadata wholesale. Until this read
+            # finalizes, the row must keep its cascade record: a failed read that lost
+            # the children list would strand every page row on a later site delete.
+            # The ROW is patched, never content.metadata — that is a hash input.
+            await self._astamp_row_children(content, previous_children)
         if self._should_skip(content.content_hash, skip_if_exists, user_id=content.user_id):  # type: ignore[arg-type]
             content.status = ContentStatus.COMPLETED
             await self._aupdate_content(content)
@@ -1896,6 +1902,13 @@ class Knowledge(RemoteKnowledge):
             return
 
         # 9. Single source - use existing logic with original content hash
+        if read_documents and all((doc.meta_data or {}).get("error") for doc in read_documents):
+            # The reader reported every document as a failed fetch; embedding empty
+            # text and reporting COMPLETED would hide the failure from status polls.
+            content.status = ContentStatus.FAILED
+            content.status_message = str((read_documents[0].meta_data or {}).get("error"))
+            await self._aupdate_content(content)
+            return
         if not content.id:
             content.id = generate_id(content.content_hash or "")
         self._prepare_documents_for_insert(read_documents, content.id, calculate_sizes=True)
@@ -1946,6 +1959,9 @@ class Knowledge(RemoteKnowledge):
 
         # 1. Add content to contents database
         self._insert_contents_db(content)
+        if previous_children:
+            # See the matching re-stamp in _aload_from_url.
+            self._stamp_row_children(content, previous_children)
         if self._should_skip(content.content_hash, skip_if_exists, user_id=content.user_id):  # type: ignore[arg-type]
             content.status = ContentStatus.COMPLETED
             self._update_content(content)
@@ -2037,12 +2053,32 @@ class Knowledge(RemoteKnowledge):
             return
 
         # 9. Single source - use existing logic with original content hash
+        if read_documents and all((doc.meta_data or {}).get("error") for doc in read_documents):
+            # See the matching guard in _aload_from_url.
+            content.status = ContentStatus.FAILED
+            content.status_message = str((read_documents[0].meta_data or {}).get("error"))
+            self._update_content(content)
+            return
         if not content.id:
             content.id = generate_id(content.content_hash or "")
         self._prepare_documents_for_insert(read_documents, content.id, calculate_sizes=True)
         self._handle_vector_db_insert(content, read_documents, upsert)
 
     # --- Per-page rows for multi-page URL reads ---
+
+    async def _astamp_row_children(self, content: Content, children: List[str]) -> None:
+        """Write a children list onto the site ROW without touching content.metadata."""
+        update = Content(id=content.id, user_id=content.user_id)
+        update.metadata = set_agno_metadata(None, "children", children)
+        await self._aupdate_content(update)
+
+    def _stamp_row_children(self, content: Content, children: List[str]) -> None:
+        """Synchronous version of _astamp_row_children."""
+        update = Content(id=content.id, user_id=content.user_id)
+        update.metadata = set_agno_metadata(None, "children", children)
+        self._update_content(update)
+
+    _MULTI_PAGE_READER_IDS = {"SitemapReader": "sitemap", "LLMsTxtReader": "llms_txt", "WebsiteReader": "website"}
 
     async def _aget_previous_children(self, content: Content) -> List[str]:
         """Child-row ids recorded on the site row by the previous run, if any."""
@@ -2154,6 +2190,8 @@ class Knowledge(RemoteKnowledge):
         extractor_counts: Dict[str, int],
         source_kind: Optional[str],
         name_was_auto: bool,
+        reader_id: Optional[str] = None,
+        discovery_incomplete: bool = False,
     ) -> None:
         """Turn the parent row into the site row: aggregate status, children, provenance."""
         if name_was_auto and content.url:
@@ -2166,12 +2204,17 @@ class Knowledge(RemoteKnowledge):
         content.metadata = set_agno_metadata(content.metadata, "children", child_ids)
         content.metadata = set_agno_metadata(content.metadata, "page_count", pages_loaded)
         content.metadata = set_agno_metadata(content.metadata, "auto_named", name_was_auto)
+        if reader_id:
+            # A refresh must re-run the reader that built this site, never a guessed one
+            content.metadata = set_agno_metadata(content.metadata, "reader_id", reader_id)
         if extractor_counts:
             content.metadata = set_agno_metadata(content.metadata, "extractor_counts", extractor_counts)
         if failed:
             content.metadata = set_agno_metadata(content.metadata, "failed", failed[:25])
 
         message = f"{pages_loaded} of {total_pages} pages loaded"
+        if discovery_incomplete:
+            message += "; sitemap discovery incomplete, previous pages kept"
         if failed:
             sample = ", ".join(entry["url"] for entry in failed[:5])
             message += f"; failed: {sample}"
@@ -2202,6 +2245,22 @@ class Knowledge(RemoteKnowledge):
 
         self.vector_db = cast(VectorDb, self.vector_db)
 
+        # The site row owns no page vectors. Clearing its content_id first makes the
+        # 1-to-N transition drop the legacy single-row vectors, and lets the overview
+        # branch below re-insert without stacking chunks run over run.
+        try:
+            clear_kwargs = strict_user_id_kwarg(self.vector_db.delete_by_content_id, content.user_id)
+            self.vector_db.delete_by_content_id(content.id, **clear_kwargs)  # type: ignore[arg-type]
+        except Exception as e:
+            log_debug(f"Could not clear site-row vectors before per-page load: {e}")
+
+        # A read that could not see every sitemap shard must not treat the missing
+        # shard's pages as removed from the site.
+        discovery_incomplete = any(
+            bool((doc.meta_data or {}).get("discovery_incomplete")) for docs in docs_by_source.values() for doc in docs
+        )
+        reader_id = self._MULTI_PAGE_READER_IDS.get(type(content.reader).__name__) if content.reader else None
+
         child_ids: List[str] = []
         failed: List[Dict[str, str]] = []
         extractor_counts: Dict[str, int] = {}
@@ -2209,6 +2268,9 @@ class Knowledge(RemoteKnowledge):
         source_kind: Optional[str] = None
 
         for source_url, source_docs in docs_by_source.items():
+            for doc in source_docs:
+                if doc.meta_data:
+                    doc.meta_data.pop("discovery_incomplete", None)
             child, digest, error, extractor, doc_source = self._prepare_page_child(content, source_url, source_docs)
             if child.id == content.id:
                 # A document whose URL is the insert URL itself (e.g. an llms.txt overview)
@@ -2232,6 +2294,15 @@ class Knowledge(RemoteKnowledge):
                 source_kind = doc_source
 
             if error is not None:
+                # A page that was loaded before keeps its row and vectors: a transient
+                # fetch failure must not demote good, searchable content. The failure is
+                # still surfaced on the site row.
+                if self.contents_db is not None:
+                    previous_digest = await self._aget_child_digest(child.id, content.user_id)
+                    if previous_digest is not None:
+                        failed.append({"url": source_url, "error": error, "stale_kept": "true"})
+                        pages_loaded += 1
+                        continue
                 child.status = ContentStatus.FAILED
                 child.status_message = error
                 await self._ainsert_contents_db(child)
@@ -2289,6 +2360,11 @@ class Knowledge(RemoteKnowledge):
                 log_error(f"Error inserting document from {source_url}: {str(e)}")
                 child.status = ContentStatus.FAILED
                 child.status_message = "Could not embed page"
+                # The digest asserts "this text is indexed" — it must not survive an
+                # embed failure, or the next identical run would skip the embed and
+                # mark the page COMPLETED with no vectors behind it.
+                if child.metadata and isinstance(child.metadata.get("_agno"), dict):
+                    child.metadata["_agno"].pop("content_digest", None)
                 await self._ainsert_contents_db(child)
                 failed.append({"url": source_url, "error": "Could not embed page"})
                 continue
@@ -2298,19 +2374,36 @@ class Knowledge(RemoteKnowledge):
             extractor_counts[extractor] = extractor_counts.get(extractor, 0) + 1
             pages_loaded += 1
 
-        # Pages that left the site since the previous run disappear with it
+        # Pages that left the site since the previous run disappear with it — but only
+        # when discovery saw the whole site, and a page whose delete failed keeps its
+        # place in the children list so a later run can still reach it.
         current_ids = set(child_ids)
         if content.id:
             current_ids.add(content.id)  # never prune the site row itself
-        for stale_id in previous_children:
-            if stale_id not in current_ids:
-                try:
-                    await self.aremove_content_by_id(stale_id, user_id=content.user_id)
-                except Exception as e:
-                    log_debug(f"Could not remove stale page row {stale_id}: {e}")
+        if not discovery_incomplete:
+            for stale_id in previous_children:
+                if stale_id not in current_ids:
+                    try:
+                        await self.aremove_content_by_id(stale_id, user_id=content.user_id)
+                    except Exception as e:
+                        log_debug(f"Could not remove stale page row {stale_id}: {e}")
+                        child_ids.append(stale_id)
+        else:
+            for stale_id in previous_children:
+                if stale_id not in current_ids:
+                    child_ids.append(stale_id)
 
         self._finalize_site_row_content(
-            content, len(docs_by_source), pages_loaded, child_ids, failed, extractor_counts, source_kind, name_was_auto
+            content,
+            len(docs_by_source),
+            pages_loaded,
+            child_ids,
+            failed,
+            extractor_counts,
+            source_kind,
+            name_was_auto,
+            reader_id=reader_id,
+            discovery_incomplete=discovery_incomplete,
         )
         await self._aupdate_content(content)
 
@@ -2328,6 +2421,18 @@ class Knowledge(RemoteKnowledge):
 
         self.vector_db = cast(VectorDb, self.vector_db)
 
+        # See the matching clear in _aload_url_page_groups.
+        try:
+            clear_kwargs = strict_user_id_kwarg(self.vector_db.delete_by_content_id, content.user_id)
+            self.vector_db.delete_by_content_id(content.id, **clear_kwargs)  # type: ignore[arg-type]
+        except Exception as e:
+            log_debug(f"Could not clear site-row vectors before per-page load: {e}")
+
+        discovery_incomplete = any(
+            bool((doc.meta_data or {}).get("discovery_incomplete")) for docs in docs_by_source.values() for doc in docs
+        )
+        reader_id = self._MULTI_PAGE_READER_IDS.get(type(content.reader).__name__) if content.reader else None
+
         child_ids: List[str] = []
         failed: List[Dict[str, str]] = []
         extractor_counts: Dict[str, int] = {}
@@ -2335,6 +2440,9 @@ class Knowledge(RemoteKnowledge):
         source_kind: Optional[str] = None
 
         for source_url, source_docs in docs_by_source.items():
+            for doc in source_docs:
+                if doc.meta_data:
+                    doc.meta_data.pop("discovery_incomplete", None)
             child, digest, error, extractor, doc_source = self._prepare_page_child(content, source_url, source_docs)
             if child.id == content.id:
                 # See the matching branch in _aload_url_page_groups.
@@ -2356,6 +2464,13 @@ class Knowledge(RemoteKnowledge):
                 source_kind = doc_source
 
             if error is not None:
+                # See the matching last-known-good branch in _aload_url_page_groups.
+                if self.contents_db is not None:
+                    previous_digest = self._get_child_digest(child.id, content.user_id)
+                    if previous_digest is not None:
+                        failed.append({"url": source_url, "error": error, "stale_kept": "true"})
+                        pages_loaded += 1
+                        continue
                 child.status = ContentStatus.FAILED
                 child.status_message = error
                 self._insert_contents_db(child)
@@ -2413,6 +2528,9 @@ class Knowledge(RemoteKnowledge):
                 log_error(f"Error inserting document from {source_url}: {str(e)}")
                 child.status = ContentStatus.FAILED
                 child.status_message = "Could not embed page"
+                # See the matching digest strip in _aload_url_page_groups.
+                if child.metadata and isinstance(child.metadata.get("_agno"), dict):
+                    child.metadata["_agno"].pop("content_digest", None)
                 self._insert_contents_db(child)
                 failed.append({"url": source_url, "error": "Could not embed page"})
                 continue
@@ -2422,19 +2540,34 @@ class Knowledge(RemoteKnowledge):
             extractor_counts[extractor] = extractor_counts.get(extractor, 0) + 1
             pages_loaded += 1
 
-        # Pages that left the site since the previous run disappear with it
+        # See the matching prune guard in _aload_url_page_groups.
         current_ids = set(child_ids)
         if content.id:
             current_ids.add(content.id)  # never prune the site row itself
-        for stale_id in previous_children:
-            if stale_id not in current_ids:
-                try:
-                    self.remove_content_by_id(stale_id, user_id=content.user_id)
-                except Exception as e:
-                    log_debug(f"Could not remove stale page row {stale_id}: {e}")
+        if not discovery_incomplete:
+            for stale_id in previous_children:
+                if stale_id not in current_ids:
+                    try:
+                        self.remove_content_by_id(stale_id, user_id=content.user_id)
+                    except Exception as e:
+                        log_debug(f"Could not remove stale page row {stale_id}: {e}")
+                        child_ids.append(stale_id)
+        else:
+            for stale_id in previous_children:
+                if stale_id not in current_ids:
+                    child_ids.append(stale_id)
 
         self._finalize_site_row_content(
-            content, len(docs_by_source), pages_loaded, child_ids, failed, extractor_counts, source_kind, name_was_auto
+            content,
+            len(docs_by_source),
+            pages_loaded,
+            child_ids,
+            failed,
+            extractor_counts,
+            source_kind,
+            name_was_auto,
+            reader_id=reader_id,
+            discovery_incomplete=discovery_incomplete,
         )
         self._update_content(content)
 

--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -795,7 +795,16 @@ class Knowledge(RemoteKnowledge):
     async def apatch_content(self, content: Content, user_id: Optional[str] = None) -> Optional[Dict[str, Any]]:
         return await self._aupdate_content(content, user_id=user_id)
 
-    def remove_content_by_id(self, content_id: str, user_id: Optional[str] = None, _seen: Optional[Set[str]] = None):
+    def remove_content_by_id(
+        self, content_id: str, user_id: Optional[str] = None, _seen: Optional[Set[str]] = None
+    ) -> bool:
+        """Remove one content row and its vectors; cascades through a site row's pages.
+
+        Returns False when nothing was removed (ownership refused it) or when the vector
+        store reported a failed delete — in that case the contents row and its place in
+        the parent's cascade record are kept, so a later attempt can still reach the
+        vectors instead of orphaning them.
+        """
         from agno.vectordb import VectorDb
 
         self.vector_db = cast(VectorDb, self.vector_db)
@@ -806,7 +815,7 @@ class Knowledge(RemoteKnowledge):
             # ``delete_by_content_id`` takes no owner, so going ahead would strip another
             # owner's vectors and leave their row behind pointing at nothing
             log_debug(f"Skipping delete of content {content_id}: not owned by {user_id}")
-            return
+            return False
 
         if content is None and self.contents_db is not None:
             content = self.get_content_by_id(content_id, user_id=user_id)
@@ -816,11 +825,13 @@ class Knowledge(RemoteKnowledge):
         # parent-list maintenance below.
         seen = _seen if _seen is not None else set()
         seen.add(content_id)
+        all_removed = True
         children = get_agno_metadata(content.metadata, "children") if content else None
         if isinstance(children, list):
             for child_id in children:
                 if isinstance(child_id, str) and child_id not in seen:
-                    self.remove_content_by_id(child_id, user_id=user_id, _seen=seen)
+                    if not self.remove_content_by_id(child_id, user_id=user_id, _seen=seen):
+                        all_removed = False
 
         if self.vector_db is not None:
             if self.vector_db.__class__.__name__ == "LightRag":
@@ -832,14 +843,20 @@ class Knowledge(RemoteKnowledge):
                 else:
                     log_warning(f"No external_id found for content {content_id}, cannot delete from LightRAG")
             else:
-                # Backends without per-user isolation accept ``user_id`` as a no-op
-                self.vector_db.delete_by_content_id(
+                # Backends without per-user isolation accept ``user_id`` as a no-op.
+                # Adapters report operational failures as False — the row must then stay,
+                # or the vectors become permanently orphaned but still searchable.
+                deleted = self.vector_db.delete_by_content_id(
                     content_id, **strict_user_id_kwarg(self.vector_db.delete_by_content_id, user_id)
                 )
+                if deleted is False:
+                    log_debug(f"Vector delete failed for content {content_id}; keeping the row for retry")
+                    return False
 
         if self.contents_db is not None:
             self.contents_db.delete_knowledge_content(content_id, user_id=user_id)
             self._drop_from_parent_children(content, content_id, user_id, seen)
+        return all_removed
 
     def _drop_from_parent_children(
         self, content: Optional[Content], content_id: str, user_id: Optional[str], seen: Set[str]
@@ -882,13 +899,14 @@ class Knowledge(RemoteKnowledge):
 
     async def aremove_content_by_id(
         self, content_id: str, user_id: Optional[str] = None, _seen: Optional[Set[str]] = None
-    ):
+    ) -> bool:
+        """Async version of :meth:`remove_content_by_id` (see there for the return contract)."""
         scoped = user_id is not None and self.contents_db is not None
         content = await self.aget_content_by_id(content_id, user_id=user_id) if scoped else None
         if scoped and (content is None or self._content_is_shared(content, user_id)):
             # See the matching guard in ``remove_content_by_id``.
             log_debug(f"Skipping delete of content {content_id}: not owned by {user_id}")
-            return
+            return False
 
         if content is None and self.contents_db is not None:
             content = await self.aget_content_by_id(content_id, user_id=user_id)
@@ -896,11 +914,13 @@ class Knowledge(RemoteKnowledge):
         # See the matching cascade in ``remove_content_by_id``.
         seen = _seen if _seen is not None else set()
         seen.add(content_id)
+        all_removed = True
         children = get_agno_metadata(content.metadata, "children") if content else None
         if isinstance(children, list):
             for child_id in children:
                 if isinstance(child_id, str) and child_id not in seen:
-                    await self.aremove_content_by_id(child_id, user_id=user_id, _seen=seen)
+                    if not await self.aremove_content_by_id(child_id, user_id=user_id, _seen=seen):
+                        all_removed = False
 
         if self.vector_db is not None:
             if self.vector_db.__class__.__name__ == "LightRag":
@@ -913,9 +933,12 @@ class Knowledge(RemoteKnowledge):
                     log_warning(f"No external_id found for content {content_id}, cannot delete from LightRAG")
             else:
                 # See the matching comment in ``remove_content_by_id``.
-                self.vector_db.delete_by_content_id(
+                deleted = self.vector_db.delete_by_content_id(
                     content_id, **strict_user_id_kwarg(self.vector_db.delete_by_content_id, user_id)
                 )
+                if deleted is False:
+                    log_debug(f"Vector delete failed for content {content_id}; keeping the row for retry")
+                    return False
 
         if self.contents_db is not None:
             if isinstance(self.contents_db, AsyncBaseDb):
@@ -923,6 +946,7 @@ class Knowledge(RemoteKnowledge):
             else:
                 self.contents_db.delete_knowledge_content(content_id, user_id=user_id)
             await self._adrop_from_parent_children(content, content_id, user_id, seen)
+        return all_removed
 
     def remove_all_content(self, user_id: Optional[str] = None):
         contents, _ = self.get_content(user_id=user_id)
@@ -1884,9 +1908,23 @@ class Knowledge(RemoteKnowledge):
             await self._aupdate_content(content)
             return
 
+        # A reader that returned nothing read nothing: report the failure and leave every
+        # previously loaded page (and its row ownership) untouched. Landing this as
+        # COMPLETED-with-no-vectors — or worse, reconciling it against previous children —
+        # would turn an outage into a site wipe.
+        if not read_documents:
+            content.status = ContentStatus.FAILED
+            content.status_message = "Reader returned no documents"
+            await self._aupdate_content(content)
+            return
+
         # 6. Group documents by source URL for multi-page readers (like WebsiteReader)
         docs_by_source: Dict[str, List[Document]] = {}
+        discovery_incomplete = False
         for doc in read_documents:
+            # Transport-level flag from the reader; consumed here, never embedded
+            if doc.meta_data and doc.meta_data.pop("discovery_incomplete", None):
+                discovery_incomplete = True
             source_url = doc.meta_data.get("url", content.url) if doc.meta_data else content.url
             source_url = source_url or "unknown"
             if source_url not in docs_by_source:
@@ -1897,7 +1935,13 @@ class Knowledge(RemoteKnowledge):
         # A row that is already a site row stays one even when the site shrank to one page.
         if len(docs_by_source) > 1 or previous_children:
             await self._aload_url_page_groups(
-                content, docs_by_source, upsert, skip_if_exists, previous_children, name_was_auto
+                content,
+                docs_by_source,
+                upsert,
+                skip_if_exists,
+                previous_children,
+                name_was_auto,
+                discovery_incomplete=discovery_incomplete,
             )
             return
 
@@ -2035,9 +2079,20 @@ class Knowledge(RemoteKnowledge):
             self._update_content(content)
             return
 
+        # See the matching guard in _aload_from_url: an empty read never prunes.
+        if not read_documents:
+            content.status = ContentStatus.FAILED
+            content.status_message = "Reader returned no documents"
+            self._update_content(content)
+            return
+
         # 6. Group documents by source URL for multi-page readers (like WebsiteReader)
         docs_by_source: Dict[str, List[Document]] = {}
+        discovery_incomplete = False
         for doc in read_documents:
+            # Transport-level flag from the reader; consumed here, never embedded
+            if doc.meta_data and doc.meta_data.pop("discovery_incomplete", None):
+                discovery_incomplete = True
             source_url = doc.meta_data.get("url", content.url) if doc.meta_data else content.url
             source_url = source_url or "unknown"
             if source_url not in docs_by_source:
@@ -2048,7 +2103,13 @@ class Knowledge(RemoteKnowledge):
         # A row that is already a site row stays one even when the site shrank to one page.
         if len(docs_by_source) > 1 or previous_children:
             self._load_url_page_groups(
-                content, docs_by_source, upsert, skip_if_exists, previous_children, name_was_auto
+                content,
+                docs_by_source,
+                upsert,
+                skip_if_exists,
+                previous_children,
+                name_was_auto,
+                discovery_incomplete=discovery_incomplete,
             )
             return
 
@@ -2231,6 +2292,7 @@ class Knowledge(RemoteKnowledge):
         skip_if_exists: bool,
         previous_children: List[str],
         name_was_auto: bool,
+        discovery_incomplete: bool = False,
     ) -> None:
         """Land a multi-page read as one content row per page under the site row.
 
@@ -2250,15 +2312,12 @@ class Knowledge(RemoteKnowledge):
         # branch below re-insert without stacking chunks run over run.
         try:
             clear_kwargs = strict_user_id_kwarg(self.vector_db.delete_by_content_id, content.user_id)
-            self.vector_db.delete_by_content_id(content.id, **clear_kwargs)  # type: ignore[arg-type]
+            cleared = self.vector_db.delete_by_content_id(content.id, **clear_kwargs)  # type: ignore[arg-type]
+            if cleared is False:
+                log_debug("Vector store reported a failed clear of the site row's legacy vectors")
         except Exception as e:
             log_debug(f"Could not clear site-row vectors before per-page load: {e}")
 
-        # A read that could not see every sitemap shard must not treat the missing
-        # shard's pages as removed from the site.
-        discovery_incomplete = any(
-            bool((doc.meta_data or {}).get("discovery_incomplete")) for docs in docs_by_source.values() for doc in docs
-        )
         reader_id = self._MULTI_PAGE_READER_IDS.get(type(content.reader).__name__) if content.reader else None
 
         child_ids: List[str] = []
@@ -2268,9 +2327,6 @@ class Knowledge(RemoteKnowledge):
         source_kind: Optional[str] = None
 
         for source_url, source_docs in docs_by_source.items():
-            for doc in source_docs:
-                if doc.meta_data:
-                    doc.meta_data.pop("discovery_incomplete", None)
             child, digest, error, extractor, doc_source = self._prepare_page_child(content, source_url, source_docs)
             if child.id == content.id:
                 # A document whose URL is the insert URL itself (e.g. an llms.txt overview)
@@ -2384,9 +2440,11 @@ class Knowledge(RemoteKnowledge):
             for stale_id in previous_children:
                 if stale_id not in current_ids:
                     try:
-                        await self.aremove_content_by_id(stale_id, user_id=content.user_id)
+                        removed = await self.aremove_content_by_id(stale_id, user_id=content.user_id)
                     except Exception as e:
                         log_debug(f"Could not remove stale page row {stale_id}: {e}")
+                        removed = False
+                    if not removed:
                         child_ids.append(stale_id)
         else:
             for stale_id in previous_children:
@@ -2415,6 +2473,7 @@ class Knowledge(RemoteKnowledge):
         skip_if_exists: bool,
         previous_children: List[str],
         name_was_auto: bool,
+        discovery_incomplete: bool = False,
     ) -> None:
         """Synchronous version of _aload_url_page_groups."""
         from agno.vectordb import VectorDb
@@ -2424,13 +2483,12 @@ class Knowledge(RemoteKnowledge):
         # See the matching clear in _aload_url_page_groups.
         try:
             clear_kwargs = strict_user_id_kwarg(self.vector_db.delete_by_content_id, content.user_id)
-            self.vector_db.delete_by_content_id(content.id, **clear_kwargs)  # type: ignore[arg-type]
+            cleared = self.vector_db.delete_by_content_id(content.id, **clear_kwargs)  # type: ignore[arg-type]
+            if cleared is False:
+                log_debug("Vector store reported a failed clear of the site row's legacy vectors")
         except Exception as e:
             log_debug(f"Could not clear site-row vectors before per-page load: {e}")
 
-        discovery_incomplete = any(
-            bool((doc.meta_data or {}).get("discovery_incomplete")) for docs in docs_by_source.values() for doc in docs
-        )
         reader_id = self._MULTI_PAGE_READER_IDS.get(type(content.reader).__name__) if content.reader else None
 
         child_ids: List[str] = []
@@ -2440,9 +2498,6 @@ class Knowledge(RemoteKnowledge):
         source_kind: Optional[str] = None
 
         for source_url, source_docs in docs_by_source.items():
-            for doc in source_docs:
-                if doc.meta_data:
-                    doc.meta_data.pop("discovery_incomplete", None)
             child, digest, error, extractor, doc_source = self._prepare_page_child(content, source_url, source_docs)
             if child.id == content.id:
                 # See the matching branch in _aload_url_page_groups.
@@ -2548,9 +2603,11 @@ class Knowledge(RemoteKnowledge):
             for stale_id in previous_children:
                 if stale_id not in current_ids:
                     try:
-                        self.remove_content_by_id(stale_id, user_id=content.user_id)
+                        removed = self.remove_content_by_id(stale_id, user_id=content.user_id)
                     except Exception as e:
                         log_debug(f"Could not remove stale page row {stale_id}: {e}")
+                        removed = False
+                    if not removed:
                         child_ids.append(stale_id)
         else:
             for stale_id in previous_children:

--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -2210,6 +2210,23 @@ class Knowledge(RemoteKnowledge):
 
         for source_url, source_docs in docs_by_source.items():
             child, digest, error, extractor, doc_source = self._prepare_page_child(content, source_url, source_docs)
+            if child.id == content.id:
+                # A document whose URL is the insert URL itself (e.g. an llms.txt overview)
+                # hashes to the site row's own id. Its vectors stay under the site hash as
+                # before; it must not become a child row or the prune pass would eat the site.
+                if error is None:
+                    self._prepare_documents_for_insert(source_docs, content.id, calculate_sizes=True)  # type: ignore[arg-type]
+                    try:
+                        owner_kwargs = strict_user_id_kwarg(self.vector_db.async_insert, content.user_id)
+                        await self.vector_db.async_insert(
+                            content.content_hash,  # type: ignore[arg-type]
+                            documents=source_docs,
+                            filters=strip_agno_metadata(content.metadata),
+                            **owner_kwargs,
+                        )
+                    except Exception as e:
+                        log_error(f"Error inserting overview document from {source_url}: {str(e)}")
+                continue
             child_ids.append(child.id)  # type: ignore[arg-type]
             if source_kind is None and doc_source:
                 source_kind = doc_source
@@ -2283,6 +2300,8 @@ class Knowledge(RemoteKnowledge):
 
         # Pages that left the site since the previous run disappear with it
         current_ids = set(child_ids)
+        if content.id:
+            current_ids.add(content.id)  # never prune the site row itself
         for stale_id in previous_children:
             if stale_id not in current_ids:
                 try:
@@ -2317,6 +2336,21 @@ class Knowledge(RemoteKnowledge):
 
         for source_url, source_docs in docs_by_source.items():
             child, digest, error, extractor, doc_source = self._prepare_page_child(content, source_url, source_docs)
+            if child.id == content.id:
+                # See the matching branch in _aload_url_page_groups.
+                if error is None:
+                    self._prepare_documents_for_insert(source_docs, content.id, calculate_sizes=True)  # type: ignore[arg-type]
+                    try:
+                        owner_kwargs = strict_user_id_kwarg(self.vector_db.insert, content.user_id)
+                        self.vector_db.insert(
+                            content.content_hash,  # type: ignore[arg-type]
+                            documents=source_docs,
+                            filters=strip_agno_metadata(content.metadata),
+                            **owner_kwargs,
+                        )
+                    except Exception as e:
+                        log_error(f"Error inserting overview document from {source_url}: {str(e)}")
+                continue
             child_ids.append(child.id)  # type: ignore[arg-type]
             if source_kind is None and doc_source:
                 source_kind = doc_source
@@ -2390,6 +2424,8 @@ class Knowledge(RemoteKnowledge):
 
         # Pages that left the site since the previous run disappear with it
         current_ids = set(child_ids)
+        if content.id:
+            current_ids.add(content.id)  # never prune the site row itself
         for stale_id in previous_children:
             if stale_id not in current_ids:
                 try:

--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -18,13 +18,14 @@ from agno.filters import EQ, FilterExpr
 from agno.knowledge.content import Content, ContentAuth, ContentStatus, FileData
 from agno.knowledge.document import Document
 from agno.knowledge.reader import Reader, ReaderFactory
+from agno.knowledge.reader.utils.urls import canonical_page_name, is_sitemap_url
 from agno.knowledge.remote_content.base import BaseStorageConfig
 from agno.knowledge.remote_content.remote_content import (
     RemoteContent,
 )
 from agno.knowledge.remote_knowledge import RemoteKnowledge
 from agno.knowledge.types import ContentType
-from agno.knowledge.utils import merge_user_metadata, set_agno_metadata, strip_agno_metadata
+from agno.knowledge.utils import get_agno_metadata, merge_user_metadata, set_agno_metadata, strip_agno_metadata
 from agno.utils.http import async_fetch_with_retry
 from agno.utils.knowledge import strict_user_id_kwarg
 from agno.utils.log import log_debug, log_error, log_info, log_warning
@@ -794,7 +795,7 @@ class Knowledge(RemoteKnowledge):
     async def apatch_content(self, content: Content, user_id: Optional[str] = None) -> Optional[Dict[str, Any]]:
         return await self._aupdate_content(content, user_id=user_id)
 
-    def remove_content_by_id(self, content_id: str, user_id: Optional[str] = None):
+    def remove_content_by_id(self, content_id: str, user_id: Optional[str] = None, _seen: Optional[Set[str]] = None):
         from agno.vectordb import VectorDb
 
         self.vector_db = cast(VectorDb, self.vector_db)
@@ -806,6 +807,20 @@ class Knowledge(RemoteKnowledge):
             # owner's vectors and leave their row behind pointing at nothing
             log_debug(f"Skipping delete of content {content_id}: not owned by {user_id}")
             return
+
+        if content is None and self.contents_db is not None:
+            content = self.get_content_by_id(content_id, user_id=user_id)
+
+        # A site row owns its page rows: deleting it deletes them and their vectors.
+        # ``_seen`` guards against a metadata cycle and marks the cascade for the
+        # parent-list maintenance below.
+        seen = _seen if _seen is not None else set()
+        seen.add(content_id)
+        children = get_agno_metadata(content.metadata, "children") if content else None
+        if isinstance(children, list):
+            for child_id in children:
+                if isinstance(child_id, str) and child_id not in seen:
+                    self.remove_content_by_id(child_id, user_id=user_id, _seen=seen)
 
         if self.vector_db is not None:
             if self.vector_db.__class__.__name__ == "LightRag":
@@ -824,14 +839,68 @@ class Knowledge(RemoteKnowledge):
 
         if self.contents_db is not None:
             self.contents_db.delete_knowledge_content(content_id, user_id=user_id)
+            self._drop_from_parent_children(content, content_id, user_id, seen)
 
-    async def aremove_content_by_id(self, content_id: str, user_id: Optional[str] = None):
+    def _drop_from_parent_children(
+        self, content: Optional[Content], content_id: str, user_id: Optional[str], seen: Set[str]
+    ) -> None:
+        """After a page row is deleted on its own, take its id off the site row's list."""
+        parent_id = get_agno_metadata(content.metadata, "parent_id") if content else None
+        if not isinstance(parent_id, str) or parent_id in seen or self.contents_db is None:
+            return
+        if isinstance(self.contents_db, AsyncBaseDb):
+            return
+        parent_row = self.contents_db.get_knowledge_content(parent_id, user_id=user_id)
+        if parent_row is None:
+            return
+        siblings = get_agno_metadata(parent_row.metadata, "children")
+        if not isinstance(siblings, list) or content_id not in siblings:
+            return
+        update = Content(id=parent_id, user_id=parent_row.user_id)
+        update.metadata = set_agno_metadata(None, "children", [child for child in siblings if child != content_id])
+        self._update_content(update)
+
+    async def _adrop_from_parent_children(
+        self, content: Optional[Content], content_id: str, user_id: Optional[str], seen: Set[str]
+    ) -> None:
+        """Async version of _drop_from_parent_children."""
+        parent_id = get_agno_metadata(content.metadata, "parent_id") if content else None
+        if not isinstance(parent_id, str) or parent_id in seen or self.contents_db is None:
+            return
+        if isinstance(self.contents_db, AsyncBaseDb):
+            parent_row = await self.contents_db.get_knowledge_content(parent_id, user_id=user_id)
+        else:
+            parent_row = self.contents_db.get_knowledge_content(parent_id, user_id=user_id)
+        if parent_row is None:
+            return
+        siblings = get_agno_metadata(parent_row.metadata, "children")
+        if not isinstance(siblings, list) or content_id not in siblings:
+            return
+        update = Content(id=parent_id, user_id=parent_row.user_id)
+        update.metadata = set_agno_metadata(None, "children", [child for child in siblings if child != content_id])
+        await self._aupdate_content(update)
+
+    async def aremove_content_by_id(
+        self, content_id: str, user_id: Optional[str] = None, _seen: Optional[Set[str]] = None
+    ):
         scoped = user_id is not None and self.contents_db is not None
         content = await self.aget_content_by_id(content_id, user_id=user_id) if scoped else None
         if scoped and (content is None or self._content_is_shared(content, user_id)):
             # See the matching guard in ``remove_content_by_id``.
             log_debug(f"Skipping delete of content {content_id}: not owned by {user_id}")
             return
+
+        if content is None and self.contents_db is not None:
+            content = await self.aget_content_by_id(content_id, user_id=user_id)
+
+        # See the matching cascade in ``remove_content_by_id``.
+        seen = _seen if _seen is not None else set()
+        seen.add(content_id)
+        children = get_agno_metadata(content.metadata, "children") if content else None
+        if isinstance(children, list):
+            for child_id in children:
+                if isinstance(child_id, str) and child_id not in seen:
+                    await self.aremove_content_by_id(child_id, user_id=user_id, _seen=seen)
 
         if self.vector_db is not None:
             if self.vector_db.__class__.__name__ == "LightRag":
@@ -853,6 +922,7 @@ class Knowledge(RemoteKnowledge):
                 await self.contents_db.delete_knowledge_content(content_id, user_id=user_id)
             else:
                 self.contents_db.delete_knowledge_content(content_id, user_id=user_id)
+            await self._adrop_from_parent_children(content, content_id, user_id, seen)
 
     def remove_all_content(self, user_id: Optional[str] = None):
         contents, _ = self.get_content(user_id=user_id)
@@ -1212,6 +1282,11 @@ class Knowledge(RemoteKnowledge):
     def website_reader(self) -> Optional[Reader]:
         """Website reader - lazy loaded via factory."""
         return self._get_reader("website")
+
+    @property
+    def sitemap_reader(self) -> Optional[Reader]:
+        """Sitemap reader - lazy loaded via factory."""
+        return self._get_reader("sitemap")
 
     @property
     def firecrawl_reader(self) -> Optional[Reader]:
@@ -1715,13 +1790,19 @@ class Knowledge(RemoteKnowledge):
         content.metadata = set_agno_metadata(content.metadata, "source_type", "url")
         content.metadata = set_agno_metadata(content.metadata, "source_url", content.url)
 
-        # Set name from URL if not provided
+        # Set name from URL if not provided. Whether it was caller-provided decides the
+        # site row's display name for multi-page reads (see _aload_url_page_groups).
+        name_was_auto = not content.name
         if not content.name and content.url:
             from urllib.parse import urlparse
 
             parsed = urlparse(content.url)
             url_path = Path(parsed.path)
             content.name = url_path.name if url_path.name else content.url
+
+        # A multi-page re-ingest needs the previous run's child-row ids to delete pages that
+        # left the site; the upsert below overwrites them, so capture first.
+        previous_children = await self._aget_previous_children(content)
 
         # 1. Add content to contents database
         await self._ainsert_contents_db(content)
@@ -1754,9 +1835,11 @@ class Knowledge(RemoteKnowledge):
         file_extension = url_path.suffix.lower()
 
         bytes_content = None
+        # A bare sitemap URL routes to the sitemap reader, which owns the URL end to end
+        auto_sitemap = content.reader is None and is_sitemap_url(content.url)
         # Skip pre-download when a custom URL-based reader is provided —
         # it handles the URL directly (e.g. LLMsTxtReader fetches linked pages)
-        skip_download = (
+        skip_download = auto_sitemap or (
             content.reader is not None
             and hasattr(content.reader, "get_supported_content_types")
             and ContentType.URL in content.reader.get_supported_content_types()
@@ -1768,7 +1851,9 @@ class Knowledge(RemoteKnowledge):
 
         # 4. Select reader
         name = content.name if content.name else content.url
-        if file_extension:
+        if auto_sitemap:
+            reader = self.sitemap_reader
+        elif file_extension:
             reader, default_name = self._select_reader_by_extension(file_extension, content.reader)
             if default_name and file_extension == ".csv":
                 name = basename(parsed_url.path) or default_name
@@ -1802,50 +1887,12 @@ class Knowledge(RemoteKnowledge):
                 docs_by_source[source_url] = []
             docs_by_source[source_url].append(doc)
 
-        # 8. Process each source separately if multiple sources exist
-        if len(docs_by_source) > 1:
-            for source_url, source_docs in docs_by_source.items():
-                # Compute per-document hash based on actual source URL
-                doc_hash = self._build_document_content_hash(source_docs[0], content)
-
-                # Check skip_if_exists for each source individually
-                if self._should_skip(doc_hash, skip_if_exists, user_id=content.user_id):
-                    log_debug(f"Skipping already indexed: {source_url}")
-                    continue
-
-                doc_id = generate_id(doc_hash)
-                self._prepare_documents_for_insert(source_docs, doc_id, calculate_sizes=True)
-
-                # Insert with per-document hash. Resolve the owner scope OUTSIDE the try:
-                # a scoped write against a legacy adapter must fail the ingest (marked FAILED
-                # by _aload_content), not be swallowed per-source and reported COMPLETED.
-                if self.vector_db.upsert_available() and upsert:
-                    owner_kwargs = strict_user_id_kwarg(self.vector_db.async_upsert, content.user_id)
-                    try:
-                        await self.vector_db.async_upsert(
-                            doc_hash,
-                            source_docs,
-                            content.metadata,
-                            **owner_kwargs,
-                        )
-                    except Exception as e:
-                        log_error(f"Error upserting document from {source_url}: {str(e)}")
-                        continue
-                else:
-                    owner_kwargs = strict_user_id_kwarg(self.vector_db.async_insert, content.user_id)
-                    try:
-                        await self.vector_db.async_insert(
-                            doc_hash,
-                            documents=source_docs,
-                            filters=content.metadata,
-                            **owner_kwargs,
-                        )
-                    except Exception as e:
-                        log_error(f"Error inserting document from {source_url}: {str(e)}")
-                        continue
-
-            content.status = ContentStatus.COMPLETED
-            await self._aupdate_content(content)
+        # 8. Multi-page reads land one content row per page, owned by the site row.
+        # A row that is already a site row stays one even when the site shrank to one page.
+        if len(docs_by_source) > 1 or previous_children:
+            await self._aload_url_page_groups(
+                content, docs_by_source, upsert, skip_if_exists, previous_children, name_was_auto
+            )
             return
 
         # 9. Single source - use existing logic with original content hash
@@ -1883,13 +1930,19 @@ class Knowledge(RemoteKnowledge):
         content.metadata = set_agno_metadata(content.metadata, "source_type", "url")
         content.metadata = set_agno_metadata(content.metadata, "source_url", content.url)
 
-        # Set name from URL if not provided
+        # Set name from URL if not provided. Whether it was caller-provided decides the
+        # site row's display name for multi-page reads (see _load_url_page_groups).
+        name_was_auto = not content.name
         if not content.name and content.url:
             from urllib.parse import urlparse
 
             parsed = urlparse(content.url)
             url_path = Path(parsed.path)
             content.name = url_path.name if url_path.name else content.url
+
+        # A multi-page re-ingest needs the previous run's child-row ids to delete pages that
+        # left the site; the upsert below overwrites them, so capture first.
+        previous_children = self._get_previous_children(content)
 
         # 1. Add content to contents database
         self._insert_contents_db(content)
@@ -1923,9 +1976,11 @@ class Knowledge(RemoteKnowledge):
         file_extension = url_path.suffix.lower()
 
         bytes_content = None
+        # A bare sitemap URL routes to the sitemap reader, which owns the URL end to end
+        auto_sitemap = content.reader is None and is_sitemap_url(content.url)
         # Skip pre-download when a custom URL-based reader is provided —
         # it handles the URL directly (e.g. LLMsTxtReader fetches linked pages)
-        skip_download = (
+        skip_download = auto_sitemap or (
             content.reader is not None
             and hasattr(content.reader, "get_supported_content_types")
             and ContentType.URL in content.reader.get_supported_content_types()
@@ -1936,7 +1991,9 @@ class Knowledge(RemoteKnowledge):
 
         # 4. Select reader
         name = content.name if content.name else content.url
-        if file_extension:
+        if auto_sitemap:
+            reader = self.sitemap_reader
+        elif file_extension:
             reader, default_name = self._select_reader_by_extension(file_extension, content.reader)
             if default_name and file_extension == ".csv":
                 name = basename(parsed_url.path) or default_name
@@ -1971,50 +2028,12 @@ class Knowledge(RemoteKnowledge):
                 docs_by_source[source_url] = []
             docs_by_source[source_url].append(doc)
 
-        # 8. Process each source separately if multiple sources exist
-        if len(docs_by_source) > 1:
-            for source_url, source_docs in docs_by_source.items():
-                # Compute per-document hash based on actual source URL
-                doc_hash = self._build_document_content_hash(source_docs[0], content)
-
-                # Check skip_if_exists for each source individually
-                if self._should_skip(doc_hash, skip_if_exists, user_id=content.user_id):
-                    log_debug(f"Skipping already indexed: {source_url}")
-                    continue
-
-                doc_id = generate_id(doc_hash)
-                self._prepare_documents_for_insert(source_docs, doc_id, calculate_sizes=True)
-
-                # Insert with per-document hash. Resolve the owner scope OUTSIDE the try:
-                # a scoped write against a legacy adapter must fail the ingest (marked FAILED
-                # by _load_content), not be swallowed per-source and reported COMPLETED.
-                if self.vector_db.upsert_available() and upsert:
-                    owner_kwargs = strict_user_id_kwarg(self.vector_db.upsert, content.user_id)
-                    try:
-                        self.vector_db.upsert(
-                            doc_hash,
-                            source_docs,
-                            content.metadata,
-                            **owner_kwargs,
-                        )
-                    except Exception as e:
-                        log_error(f"Error upserting document from {source_url}: {str(e)}")
-                        continue
-                else:
-                    owner_kwargs = strict_user_id_kwarg(self.vector_db.insert, content.user_id)
-                    try:
-                        self.vector_db.insert(
-                            doc_hash,
-                            documents=source_docs,
-                            filters=content.metadata,
-                            **owner_kwargs,
-                        )
-                    except Exception as e:
-                        log_error(f"Error inserting document from {source_url}: {str(e)}")
-                        continue
-
-            content.status = ContentStatus.COMPLETED
-            self._update_content(content)
+        # 8. Multi-page reads land one content row per page, owned by the site row.
+        # A row that is already a site row stays one even when the site shrank to one page.
+        if len(docs_by_source) > 1 or previous_children:
+            self._load_url_page_groups(
+                content, docs_by_source, upsert, skip_if_exists, previous_children, name_was_auto
+            )
             return
 
         # 9. Single source - use existing logic with original content hash
@@ -2022,6 +2041,366 @@ class Knowledge(RemoteKnowledge):
             content.id = generate_id(content.content_hash or "")
         self._prepare_documents_for_insert(read_documents, content.id, calculate_sizes=True)
         self._handle_vector_db_insert(content, read_documents, upsert)
+
+    # --- Per-page rows for multi-page URL reads ---
+
+    async def _aget_previous_children(self, content: Content) -> List[str]:
+        """Child-row ids recorded on the site row by the previous run, if any."""
+        if self.contents_db is None or not content.id:
+            return []
+        if isinstance(self.contents_db, AsyncBaseDb):
+            row = await self.contents_db.get_knowledge_content(content.id, user_id=content.user_id)
+        else:
+            row = self.contents_db.get_knowledge_content(content.id, user_id=content.user_id)
+        if row is None:
+            return []
+        children = get_agno_metadata(row.metadata, "children")
+        return [child for child in children if isinstance(child, str)] if isinstance(children, list) else []
+
+    def _get_previous_children(self, content: Content) -> List[str]:
+        """Synchronous version of _aget_previous_children."""
+        if self.contents_db is None or not content.id or isinstance(self.contents_db, AsyncBaseDb):
+            return []
+        row = self.contents_db.get_knowledge_content(content.id, user_id=content.user_id)
+        if row is None:
+            return []
+        children = get_agno_metadata(row.metadata, "children")
+        return [child for child in children if isinstance(child, str)] if isinstance(children, list) else []
+
+    async def _aget_child_digest(self, child_id: Optional[str], user_id: Optional[str]) -> Optional[str]:
+        """The stored page-text digest of a child row, or None when the row does not exist."""
+        if self.contents_db is None or not child_id:
+            return None
+        if isinstance(self.contents_db, AsyncBaseDb):
+            row = await self.contents_db.get_knowledge_content(child_id, user_id=user_id)
+        else:
+            row = self.contents_db.get_knowledge_content(child_id, user_id=user_id)
+        if row is None:
+            return None
+        digest = get_agno_metadata(row.metadata, "content_digest")
+        return digest if isinstance(digest, str) else None
+
+    def _get_child_digest(self, child_id: Optional[str], user_id: Optional[str]) -> Optional[str]:
+        """Synchronous version of _aget_child_digest."""
+        if self.contents_db is None or not child_id or isinstance(self.contents_db, AsyncBaseDb):
+            return None
+        row = self.contents_db.get_knowledge_content(child_id, user_id=user_id)
+        if row is None:
+            return None
+        digest = get_agno_metadata(row.metadata, "content_digest")
+        return digest if isinstance(digest, str) else None
+
+    def _prepare_page_child(
+        self, content: Content, source_url: str, source_docs: List[Document]
+    ) -> Tuple[Content, Optional[str], Optional[str], str, Optional[str]]:
+        """Build the child Content for one page's URL group.
+
+        Returns ``(child, digest, error, extractor, source_kind)``. The child's id equals the
+        ``content_id`` its vectors carry (both derive from the per-URL document hash), which
+        is what makes per-page delete reach the vectors. The digest is over the page text
+        before any header injection, so provenance decoration never forces a re-embed.
+        """
+        doc_hash = self._build_document_content_hash(source_docs[0], content)
+        first = source_docs[0]
+        meta = first.meta_data or {}
+        error = meta.get("error")
+        page_text = "".join(doc.content or "" for doc in source_docs)
+        if not error and not page_text:
+            error = "empty"
+        digest = hashlib.sha256(page_text.encode("utf-8", errors="replace")).hexdigest() if not error else None
+
+        # Readers that name pages per page keep their names; a reader that stamped every
+        # document with the read-level name gets a canonical per-page one instead.
+        if first.name and first.name not in (content.name, content.url):
+            child_name = first.name
+        else:
+            child_name = canonical_page_name(source_url)
+
+        user_metadata = strip_agno_metadata(content.metadata)
+        child = Content(
+            id=generate_id(doc_hash),
+            name=child_name,
+            description=content.description,
+            url=source_url,
+            metadata=dict(user_metadata) if user_metadata else None,
+            user_id=content.user_id,
+            content_hash=doc_hash,
+            file_type="url",
+            size=len(page_text.encode("utf-8", errors="replace")) if page_text else None,
+        )
+        source_kind = meta.get("source")
+        extractor = meta.get("extractor") or "unknown"
+        child.metadata = set_agno_metadata(child.metadata, "source_type", source_kind or "url")
+        child.metadata = set_agno_metadata(child.metadata, "source_url", source_url)
+        child.metadata = set_agno_metadata(child.metadata, "parent_id", content.id)
+        child.metadata = set_agno_metadata(child.metadata, "fetched_at", int(time.time()))
+        if meta.get("title"):
+            child.metadata = set_agno_metadata(child.metadata, "title", meta["title"])
+        if meta.get("extractor"):
+            child.metadata = set_agno_metadata(child.metadata, "extractor", meta["extractor"])
+        if meta.get("attempts"):
+            child.metadata = set_agno_metadata(child.metadata, "attempts", meta["attempts"])
+        if digest:
+            child.metadata = set_agno_metadata(child.metadata, "content_digest", digest)
+        return child, digest, (str(error) if error else None), extractor, source_kind
+
+    def _finalize_site_row_content(
+        self,
+        content: Content,
+        total_pages: int,
+        pages_loaded: int,
+        child_ids: List[str],
+        failed: List[Dict[str, str]],
+        extractor_counts: Dict[str, int],
+        source_kind: Optional[str],
+        name_was_auto: bool,
+    ) -> None:
+        """Turn the parent row into the site row: aggregate status, children, provenance."""
+        if name_was_auto and content.url:
+            from urllib.parse import urlparse
+
+            host = urlparse(content.url).netloc
+            if host:
+                content.name = host
+        content.metadata = set_agno_metadata(content.metadata, "source_type", source_kind or "url")
+        content.metadata = set_agno_metadata(content.metadata, "children", child_ids)
+        content.metadata = set_agno_metadata(content.metadata, "page_count", pages_loaded)
+        content.metadata = set_agno_metadata(content.metadata, "auto_named", name_was_auto)
+        if extractor_counts:
+            content.metadata = set_agno_metadata(content.metadata, "extractor_counts", extractor_counts)
+        if failed:
+            content.metadata = set_agno_metadata(content.metadata, "failed", failed[:25])
+
+        message = f"{pages_loaded} of {total_pages} pages loaded"
+        if failed:
+            sample = ", ".join(entry["url"] for entry in failed[:5])
+            message += f"; failed: {sample}"
+            if len(failed) > 5:
+                message += f" and {len(failed) - 5} more"
+        content.status = ContentStatus.COMPLETED if pages_loaded > 0 else ContentStatus.FAILED
+        content.status_message = message
+
+    async def _aload_url_page_groups(
+        self,
+        content: Content,
+        docs_by_source: Dict[str, List[Document]],
+        upsert: bool,
+        skip_if_exists: bool,
+        previous_children: List[str],
+        name_was_auto: bool,
+    ) -> None:
+        """Land a multi-page read as one content row per page under the site row.
+
+        Each page row's id equals its vectors' ``content_id``. A page whose stored text
+        digest is unchanged refreshes its row without re-embedding; a changed page replaces
+        its vectors wholesale (works without adapter upsert support, so the REST route's
+        ``upsert=False`` still refreshes); a page that left the site since the previous run
+        is deleted; a page that failed to fetch gets a FAILED row and is retried next run.
+        ``skip_if_exists`` for page rows therefore means "same URL and same text".
+        """
+        from agno.vectordb import VectorDb
+
+        self.vector_db = cast(VectorDb, self.vector_db)
+
+        child_ids: List[str] = []
+        failed: List[Dict[str, str]] = []
+        extractor_counts: Dict[str, int] = {}
+        pages_loaded = 0
+        source_kind: Optional[str] = None
+
+        for source_url, source_docs in docs_by_source.items():
+            child, digest, error, extractor, doc_source = self._prepare_page_child(content, source_url, source_docs)
+            child_ids.append(child.id)  # type: ignore[arg-type]
+            if source_kind is None and doc_source:
+                source_kind = doc_source
+
+            if error is not None:
+                child.status = ContentStatus.FAILED
+                child.status_message = error
+                await self._ainsert_contents_db(child)
+                failed.append({"url": source_url, "error": error})
+                continue
+
+            if self.contents_db is not None:
+                previous_digest = await self._aget_child_digest(child.id, content.user_id)
+                if previous_digest is not None and previous_digest == digest:
+                    child.status = ContentStatus.COMPLETED
+                    await self._ainsert_contents_db(child)
+                    extractor_counts[extractor] = extractor_counts.get(extractor, 0) + 1
+                    pages_loaded += 1
+                    log_debug(f"Page unchanged, embedding skipped: {source_url}")
+                    continue
+            elif self._should_skip(child.content_hash, skip_if_exists, user_id=content.user_id):  # type: ignore[arg-type]
+                # Vector-only knowledge base: no digest to compare, keep the legacy check
+                log_debug(f"Skipping already indexed: {source_url}")
+                continue
+
+            self._prepare_documents_for_insert(source_docs, child.id, calculate_sizes=True)  # type: ignore[arg-type]
+            vector_metadata = strip_agno_metadata(content.metadata)
+
+            # Resolve the owner scope OUTSIDE the try: a scoped write against a legacy
+            # adapter must fail the ingest (marked FAILED by _aload_content), not be
+            # swallowed per-page and reported COMPLETED.
+            use_upsert = self.vector_db.upsert_available() and upsert
+            owner_kwargs = strict_user_id_kwarg(
+                self.vector_db.async_upsert if use_upsert else self.vector_db.async_insert, content.user_id
+            )
+            try:
+                if use_upsert:
+                    await self.vector_db.async_upsert(
+                        child.content_hash,  # type: ignore[arg-type]
+                        source_docs,
+                        vector_metadata,
+                        **owner_kwargs,
+                    )
+                else:
+                    # Replace wholesale: a changed page refreshes without adapter upsert
+                    # support, and a row-less vector group (pre-existing orphans) is
+                    # adopted without duplicating its chunks.
+                    try:
+                        delete_kwargs = strict_user_id_kwarg(self.vector_db.delete_by_content_id, content.user_id)
+                        self.vector_db.delete_by_content_id(child.id, **delete_kwargs)  # type: ignore[arg-type]
+                    except NotImplementedError:
+                        log_debug(f"Vector db cannot clear previous chunks for {source_url}")
+                    await self.vector_db.async_insert(
+                        child.content_hash,  # type: ignore[arg-type]
+                        documents=source_docs,
+                        filters=vector_metadata,
+                        **owner_kwargs,
+                    )
+            except Exception as e:
+                log_error(f"Error inserting document from {source_url}: {str(e)}")
+                child.status = ContentStatus.FAILED
+                child.status_message = "Could not embed page"
+                await self._ainsert_contents_db(child)
+                failed.append({"url": source_url, "error": "Could not embed page"})
+                continue
+
+            child.status = ContentStatus.COMPLETED
+            await self._ainsert_contents_db(child)
+            extractor_counts[extractor] = extractor_counts.get(extractor, 0) + 1
+            pages_loaded += 1
+
+        # Pages that left the site since the previous run disappear with it
+        current_ids = set(child_ids)
+        for stale_id in previous_children:
+            if stale_id not in current_ids:
+                try:
+                    await self.aremove_content_by_id(stale_id, user_id=content.user_id)
+                except Exception as e:
+                    log_debug(f"Could not remove stale page row {stale_id}: {e}")
+
+        self._finalize_site_row_content(
+            content, len(docs_by_source), pages_loaded, child_ids, failed, extractor_counts, source_kind, name_was_auto
+        )
+        await self._aupdate_content(content)
+
+    def _load_url_page_groups(
+        self,
+        content: Content,
+        docs_by_source: Dict[str, List[Document]],
+        upsert: bool,
+        skip_if_exists: bool,
+        previous_children: List[str],
+        name_was_auto: bool,
+    ) -> None:
+        """Synchronous version of _aload_url_page_groups."""
+        from agno.vectordb import VectorDb
+
+        self.vector_db = cast(VectorDb, self.vector_db)
+
+        child_ids: List[str] = []
+        failed: List[Dict[str, str]] = []
+        extractor_counts: Dict[str, int] = {}
+        pages_loaded = 0
+        source_kind: Optional[str] = None
+
+        for source_url, source_docs in docs_by_source.items():
+            child, digest, error, extractor, doc_source = self._prepare_page_child(content, source_url, source_docs)
+            child_ids.append(child.id)  # type: ignore[arg-type]
+            if source_kind is None and doc_source:
+                source_kind = doc_source
+
+            if error is not None:
+                child.status = ContentStatus.FAILED
+                child.status_message = error
+                self._insert_contents_db(child)
+                failed.append({"url": source_url, "error": error})
+                continue
+
+            if self.contents_db is not None:
+                previous_digest = self._get_child_digest(child.id, content.user_id)
+                if previous_digest is not None and previous_digest == digest:
+                    child.status = ContentStatus.COMPLETED
+                    self._insert_contents_db(child)
+                    extractor_counts[extractor] = extractor_counts.get(extractor, 0) + 1
+                    pages_loaded += 1
+                    log_debug(f"Page unchanged, embedding skipped: {source_url}")
+                    continue
+            elif self._should_skip(child.content_hash, skip_if_exists, user_id=content.user_id):  # type: ignore[arg-type]
+                # Vector-only knowledge base: no digest to compare, keep the legacy check
+                log_debug(f"Skipping already indexed: {source_url}")
+                continue
+
+            self._prepare_documents_for_insert(source_docs, child.id, calculate_sizes=True)  # type: ignore[arg-type]
+            vector_metadata = strip_agno_metadata(content.metadata)
+
+            # Resolve the owner scope OUTSIDE the try: a scoped write against a legacy
+            # adapter must fail the ingest (marked FAILED by _load_content), not be
+            # swallowed per-page and reported COMPLETED.
+            use_upsert = self.vector_db.upsert_available() and upsert
+            owner_kwargs = strict_user_id_kwarg(
+                self.vector_db.upsert if use_upsert else self.vector_db.insert, content.user_id
+            )
+            try:
+                if use_upsert:
+                    self.vector_db.upsert(
+                        child.content_hash,  # type: ignore[arg-type]
+                        source_docs,
+                        vector_metadata,
+                        **owner_kwargs,
+                    )
+                else:
+                    # Replace wholesale: a changed page refreshes without adapter upsert
+                    # support, and a row-less vector group (pre-existing orphans) is
+                    # adopted without duplicating its chunks.
+                    try:
+                        delete_kwargs = strict_user_id_kwarg(self.vector_db.delete_by_content_id, content.user_id)
+                        self.vector_db.delete_by_content_id(child.id, **delete_kwargs)  # type: ignore[arg-type]
+                    except NotImplementedError:
+                        log_debug(f"Vector db cannot clear previous chunks for {source_url}")
+                    self.vector_db.insert(
+                        child.content_hash,  # type: ignore[arg-type]
+                        documents=source_docs,
+                        filters=vector_metadata,
+                        **owner_kwargs,
+                    )
+            except Exception as e:
+                log_error(f"Error inserting document from {source_url}: {str(e)}")
+                child.status = ContentStatus.FAILED
+                child.status_message = "Could not embed page"
+                self._insert_contents_db(child)
+                failed.append({"url": source_url, "error": "Could not embed page"})
+                continue
+
+            child.status = ContentStatus.COMPLETED
+            self._insert_contents_db(child)
+            extractor_counts[extractor] = extractor_counts.get(extractor, 0) + 1
+            pages_loaded += 1
+
+        # Pages that left the site since the previous run disappear with it
+        current_ids = set(child_ids)
+        for stale_id in previous_children:
+            if stale_id not in current_ids:
+                try:
+                    self.remove_content_by_id(stale_id, user_id=content.user_id)
+                except Exception as e:
+                    log_debug(f"Could not remove stale page row {stale_id}: {e}")
+
+        self._finalize_site_row_content(
+            content, len(docs_by_source), pages_loaded, child_ids, failed, extractor_counts, source_kind, name_was_auto
+        )
+        self._update_content(content)
 
     async def _aload_from_content(
         self,
@@ -2957,8 +3336,14 @@ class Knowledge(RemoteKnowledge):
                     await self._aupdate_content(content)
                     return
 
+                # The reader is a shared instance; restore its chunking preference after the
+                # unchunked read this store needs.
+                previous_chunk = reader.chunk
                 reader.chunk = False
-                read_documents = reader.read(content.url, name=content.name)
+                try:
+                    read_documents = reader.read(content.url, name=content.name)
+                finally:
+                    reader.chunk = previous_chunk
                 if not content.id:
                     content.id = generate_id(content.content_hash or "")
                 self._prepare_documents_for_insert(read_documents, content.id)
@@ -2966,6 +3351,15 @@ class Knowledge(RemoteKnowledge):
                 if not read_documents:
                     log_error("No documents read from URL")
                     content.status = ContentStatus.FAILED
+                    await self._aupdate_content(content)
+                    return
+
+                # Only the first document would land below; refusing beats silently
+                # ingesting one page of a multi-page read.
+                page_urls = {doc.meta_data.get("url") for doc in read_documents if doc.meta_data} - {None}
+                if len(page_urls) > 1:
+                    content.status = ContentStatus.FAILED
+                    content.status_message = "LightRag does not support multi-page readers"
                     await self._aupdate_content(content)
                     return
 
@@ -3117,8 +3511,14 @@ class Knowledge(RemoteKnowledge):
                     self._update_content(content)
                     return
 
+                # The reader is a shared instance; restore its chunking preference after the
+                # unchunked read this store needs.
+                previous_chunk = reader.chunk
                 reader.chunk = False
-                read_documents = reader.read(content.url, name=content.name)
+                try:
+                    read_documents = reader.read(content.url, name=content.name)
+                finally:
+                    reader.chunk = previous_chunk
                 if not content.id:
                     content.id = generate_id(content.content_hash or "")
                 self._prepare_documents_for_insert(read_documents, content.id)
@@ -3126,6 +3526,15 @@ class Knowledge(RemoteKnowledge):
                 if not read_documents:
                     log_error("No documents read from URL")
                     content.status = ContentStatus.FAILED
+                    self._update_content(content)
+                    return
+
+                # Only the first document would land below; refusing beats silently
+                # ingesting one page of a multi-page read.
+                page_urls = {doc.meta_data.get("url") for doc in read_documents if doc.meta_data} - {None}
+                if len(page_urls) > 1:
+                    content.status = ContentStatus.FAILED
+                    content.status_message = "LightRag does not support multi-page readers"
                     self._update_content(content)
                     return
 

--- a/libs/agno/agno/knowledge/reader/page_fetcher.py
+++ b/libs/agno/agno/knowledge/reader/page_fetcher.py
@@ -85,9 +85,7 @@ class PageFetcher(Protocol):
 
     def fetch_many(self, urls: List[str], *, allowed_hosts: Optional[List[str]] = None) -> List[FetchedPage]: ...
 
-    async def afetch_many(
-        self, urls: List[str], *, allowed_hosts: Optional[List[str]] = None
-    ) -> List[FetchedPage]: ...
+    async def afetch_many(self, urls: List[str], *, allowed_hosts: Optional[List[str]] = None) -> List[FetchedPage]: ...
 
 
 def extract_page_text(html: str) -> str:
@@ -160,9 +158,7 @@ class HttpxPageFetcher:
         with httpx.Client(timeout=self.timeout, proxy=self.proxy, event_hooks=event_hooks) as client:  # type: ignore[arg-type]
             return [self._fetch_one(client, url, allowed_hosts) for url in urls]
 
-    async def afetch_many(
-        self, urls: List[str], *, allowed_hosts: Optional[List[str]] = None
-    ) -> List[FetchedPage]:
+    async def afetch_many(self, urls: List[str], *, allowed_hosts: Optional[List[str]] = None) -> List[FetchedPage]:
         guard = make_async_redirect_guard(allowed_hosts)
         event_hooks = {"request": [guard]} if guard else None
         semaphore = asyncio.Semaphore(self.concurrency)
@@ -239,9 +235,7 @@ class ParallelPageFetcher:
 
     # --- async ---
 
-    async def afetch_many(
-        self, urls: List[str], *, allowed_hosts: Optional[List[str]] = None
-    ) -> List[FetchedPage]:
+    async def afetch_many(self, urls: List[str], *, allowed_hosts: Optional[List[str]] = None) -> List[FetchedPage]:
         if self.backend is None:
             return await self.fallback.afetch_many(urls, allowed_hosts=allowed_hosts)
 
@@ -271,9 +265,7 @@ class ParallelPageFetcher:
                         pages = await self.backend.afetch_many(batch, max_chars=self.max_chars)  # type: ignore[union-attr]
                         state["consecutive_rate_limits"] = 0
                         for page in pages:
-                            page.attempts = attempts + [
-                                {"extractor": page.extractor, "outcome": page.error or "ok"}
-                            ]
+                            page.attempts = attempts + [{"extractor": page.extractor, "outcome": page.error or "ok"}]
                         return pages
                     except RateLimited as e:
                         attempts.append({"extractor": self.extractor_id, "outcome": "rate-limited"})
@@ -300,8 +292,10 @@ class ParallelPageFetcher:
             return pages
 
         batches = [fetchable[i : i + self.batch_size] for i in range(0, len(fetchable), self.batch_size)]
+        fallback_extractor = getattr(self.fallback, "extractor_id", "httpx")
         for batch_pages in await asyncio.gather(*[fetch_batch(batch) for batch in batches]):
-            retry_urls = [page.url for page in batch_pages if not page.ok]
+            # Pages the fallback already produced have nowhere further to fall
+            retry_urls = [page.url for page in batch_pages if not page.ok and page.extractor != fallback_extractor]
             retry_pages: Dict[str, FetchedPage] = {}
             if retry_urls:
                 # Pages the provider could not serve fall through to the fallback one level.
@@ -309,7 +303,7 @@ class ParallelPageFetcher:
                     retry_pages[fallback_page.url] = fallback_page
             for page in batch_pages:
                 replacement = retry_pages.get(page.url)
-                if replacement is not None and page.extractor != getattr(self.fallback, "extractor_id", "httpx"):
+                if replacement is not None:
                     replacement.attempts = page.attempts + replacement.attempts
                     results[page.url] = replacement
                 else:
@@ -347,9 +341,7 @@ class ParallelPageFetcher:
                         batch_pages = self.backend.fetch_many(batch, max_chars=self.max_chars)
                         consecutive_rate_limits = 0
                         for page in batch_pages:
-                            page.attempts = attempts + [
-                                {"extractor": page.extractor, "outcome": page.error or "ok"}
-                            ]
+                            page.attempts = attempts + [{"extractor": page.extractor, "outcome": page.error or "ok"}]
                         break
                     except RateLimited as e:
                         attempts.append({"extractor": self.extractor_id, "outcome": "rate-limited"})
@@ -372,14 +364,16 @@ class ParallelPageFetcher:
                 for page in batch_pages:
                     page.attempts = attempts + page.attempts
 
-            retry_urls = [page.url for page in batch_pages if not page.ok]
+            fallback_extractor = getattr(self.fallback, "extractor_id", "httpx")
+            # Pages the fallback already produced have nowhere further to fall
+            retry_urls = [page.url for page in batch_pages if not page.ok and page.extractor != fallback_extractor]
             retry_pages: Dict[str, FetchedPage] = {}
             if retry_urls:
                 for fallback_page in self.fallback.fetch_many(retry_urls, allowed_hosts=allowed_hosts):
                     retry_pages[fallback_page.url] = fallback_page
             for page in batch_pages:
                 replacement = retry_pages.get(page.url)
-                if replacement is not None and page.extractor != getattr(self.fallback, "extractor_id", "httpx"):
+                if replacement is not None:
                     replacement.attempts = page.attempts + replacement.attempts
                     results[page.url] = replacement
                 else:

--- a/libs/agno/agno/knowledge/reader/page_fetcher.py
+++ b/libs/agno/agno/knowledge/reader/page_fetcher.py
@@ -184,6 +184,13 @@ class HttpxPageFetcher:
 class ParallelPageFetcher:
     """Parallel's extraction API with the built-in fetcher as the per-page fallback.
 
+    ``allowed_hosts`` is enforced on the submitted URL; the provider fetches on its own
+    infrastructure and may follow a site's redirects, which this client cannot observe or
+    veto (unlike the built-in fetcher, whose redirect guard blocks off-host hops). A page
+    behind an off-host redirect comes back labeled with the submitted URL. Use
+    ``HttpxPageFetcher`` when redirect-boundary enforcement matters more than extraction
+    quality.
+
     The backend is resolved once, at construction, silently: the keyed SDK when
     ``PARALLEL_API_KEY`` (or ``api_key``) is set and ``parallel`` is importable, else the
     keyless MCP endpoint when ``mcp`` is importable, else this fetcher *is* the built-in

--- a/libs/agno/agno/knowledge/reader/page_fetcher.py
+++ b/libs/agno/agno/knowledge/reader/page_fetcher.py
@@ -1,0 +1,412 @@
+"""Page fetching for URL readers.
+
+One seam below the readers: a ``PageFetcher`` turns a list of page URLs into whole-page text,
+recording per page which extractor produced it and what was tried. ``HttpxPageFetcher`` is the
+built-in fetcher that always works; ``ParallelPageFetcher`` uses Parallel's extraction API when
+a key or the ``mcp`` package is available and falls back to the built-in fetcher per page.
+
+Fetchers hold no per-read state — readers are shared objects and reads run concurrently — so
+every ``fetch_many``/``afetch_many`` call keeps its bookkeeping in locals.
+"""
+
+import asyncio
+import time
+from dataclasses import dataclass, field
+from importlib.util import find_spec
+from os import getenv
+from typing import TYPE_CHECKING, Dict, List, Optional, Protocol, Set, runtime_checkable
+
+import httpx
+
+from agno.knowledge.reader.utils.url_validation import (
+    is_host_allowed,
+    make_async_redirect_guard,
+    make_redirect_guard,
+)
+from agno.utils.log import log_debug, log_info
+
+try:
+    from bs4 import BeautifulSoup  # noqa: F401
+except ImportError:
+    raise ImportError("The `bs4` package is not installed. Please install it via `pip install beautifulsoup4`.")
+
+if TYPE_CHECKING:
+    from agno.context.backend import ContextBackend
+
+
+_TEXT_CONTENT_TYPES = ("text/plain", "text/markdown")
+_DEFAULT_MAX_CHARS = 50_000
+
+
+@dataclass
+class FetchedPage:
+    """One page's fetch result: the whole page as text, unchunked, with provenance."""
+
+    url: str
+    content: Optional[str] = None
+    title: Optional[str] = None
+    extractor: str = "httpx"
+    error: Optional[str] = None
+    attempts: List[Dict[str, str]] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return self.error is None and bool(self.content)
+
+
+class RateLimited(Exception):
+    """A provider said to slow down. ``retry_after`` is seconds when the provider named one."""
+
+    def __init__(self, message: str, retry_after: Optional[float] = None):
+        super().__init__(message)
+        self.retry_after = retry_after
+
+
+@dataclass
+class RateLimitPolicy:
+    """How a provider-backed fetcher behaves when the provider rate-limits.
+
+    A rate-limited request sleeps (``retry_after`` when the provider sent one, else exponential
+    from ``base_delay`` capped at ``max_delay``) and retries up to ``max_retries`` times before
+    that batch falls through to the fallback fetcher. After ``breaker_after`` consecutive
+    rate-limited requests the provider is skipped for the remainder of the read.
+    """
+
+    max_retries: int = 3
+    honor_retry_after: bool = True
+    base_delay: float = 1.0
+    max_delay: float = 30.0
+    breaker_after: int = 5
+
+
+@runtime_checkable
+class PageFetcher(Protocol):
+    """Turns page URLs into ``FetchedPage`` results, in input order, never raising per page."""
+
+    def fetch_many(self, urls: List[str], *, allowed_hosts: Optional[List[str]] = None) -> List[FetchedPage]: ...
+
+    async def afetch_many(
+        self, urls: List[str], *, allowed_hosts: Optional[List[str]] = None
+    ) -> List[FetchedPage]: ...
+
+
+def extract_page_text(html: str) -> str:
+    """Main-content text from an HTML page: chrome removed, block structure kept as newlines."""
+    soup = BeautifulSoup(html, "html.parser")
+    for element in soup(["script", "style", "nav", "header", "footer", "aside"]):
+        element.decompose()
+    main = soup.find("main") or soup.find("article") or soup.find(role="main") or soup.body or soup
+    return main.get_text(separator="\n", strip=True)
+
+
+def extract_page_title(html: str) -> Optional[str]:
+    soup = BeautifulSoup(html, "html.parser")
+    if soup.title and soup.title.string:
+        return soup.title.string.strip() or None
+    return None
+
+
+def _page_from_response(url: str, response: httpx.Response) -> FetchedPage:
+    content_type = response.headers.get("content-type", "").split(";")[0].strip().lower()
+    body = response.text
+    if content_type in _TEXT_CONTENT_TYPES:
+        page = FetchedPage(url=url, content=body, extractor="httpx")
+    elif content_type == "text/html" or body.lstrip()[:15].lower().startswith(("<!doctype", "<html")):
+        page = FetchedPage(url=url, content=extract_page_text(body), title=extract_page_title(body), extractor="httpx")
+    else:
+        return FetchedPage(url=url, error=f"not-html ({content_type or 'unknown content type'})", extractor="httpx")
+    if not page.content:
+        return FetchedPage(url=url, title=page.title, error="empty", extractor="httpx")
+    return page
+
+
+def _failure_reason(exc: Exception) -> str:
+    if isinstance(exc, httpx.HTTPStatusError):
+        return f"HTTP {exc.response.status_code}"
+    if isinstance(exc, httpx.TimeoutException):
+        return "timeout"
+    return f"{type(exc).__name__}: {exc}"
+
+
+class HttpxPageFetcher:
+    """The fetcher that always works: httpx + BeautifulSoup, no key, no crawl delay.
+
+    Fetching a list the caller already chose is not crawling, so there is no politeness sleep;
+    ``concurrency`` bounds how many requests are in flight at once instead.
+    """
+
+    extractor_id = "httpx"
+
+    def __init__(self, *, concurrency: int = 8, timeout: int = 30, proxy: Optional[str] = None):
+        self.concurrency = concurrency
+        self.timeout = timeout
+        self.proxy = proxy
+
+    def _fetch_one(self, client: httpx.Client, url: str, allowed_hosts: Optional[List[str]]) -> FetchedPage:
+        if not is_host_allowed(url, allowed_hosts):
+            return FetchedPage(url=url, error="off-host", extractor=self.extractor_id)
+        try:
+            response = client.get(url, follow_redirects=True)
+            response.raise_for_status()
+            page = _page_from_response(url, response)
+        except Exception as e:
+            page = FetchedPage(url=url, error=_failure_reason(e), extractor=self.extractor_id)
+        page.attempts.append({"extractor": self.extractor_id, "outcome": page.error or "ok"})
+        return page
+
+    def fetch_many(self, urls: List[str], *, allowed_hosts: Optional[List[str]] = None) -> List[FetchedPage]:
+        guard = make_redirect_guard(allowed_hosts)
+        event_hooks = {"request": [guard]} if guard else None
+        with httpx.Client(timeout=self.timeout, proxy=self.proxy, event_hooks=event_hooks) as client:  # type: ignore[arg-type]
+            return [self._fetch_one(client, url, allowed_hosts) for url in urls]
+
+    async def afetch_many(
+        self, urls: List[str], *, allowed_hosts: Optional[List[str]] = None
+    ) -> List[FetchedPage]:
+        guard = make_async_redirect_guard(allowed_hosts)
+        event_hooks = {"request": [guard]} if guard else None
+        semaphore = asyncio.Semaphore(self.concurrency)
+
+        async with httpx.AsyncClient(timeout=self.timeout, proxy=self.proxy, event_hooks=event_hooks) as client:  # type: ignore[arg-type]
+
+            async def fetch_one(url: str) -> FetchedPage:
+                if not is_host_allowed(url, allowed_hosts):
+                    return FetchedPage(url=url, error="off-host", extractor=self.extractor_id)
+                async with semaphore:
+                    try:
+                        response = await client.get(url, follow_redirects=True)
+                        response.raise_for_status()
+                        page = _page_from_response(url, response)
+                    except Exception as e:
+                        page = FetchedPage(url=url, error=_failure_reason(e), extractor=self.extractor_id)
+                page.attempts.append({"extractor": self.extractor_id, "outcome": page.error or "ok"})
+                return page
+
+            return list(await asyncio.gather(*[fetch_one(url) for url in urls]))
+
+
+class ParallelPageFetcher:
+    """Parallel's extraction API with the built-in fetcher as the per-page fallback.
+
+    The backend is resolved once, at construction, silently: the keyed SDK when
+    ``PARALLEL_API_KEY`` (or ``api_key``) is set and ``parallel`` is importable, else the
+    keyless MCP endpoint when ``mcp`` is importable, else this fetcher *is* the built-in
+    fetcher. Provider rate limits are retried per ``RateLimitPolicy`` (a retrying task keeps
+    its concurrency slot, which throttles the whole read while the provider is limiting);
+    after ``breaker_after`` consecutive rate-limited requests the rest of the read goes to
+    the fallback, reported once and recorded per page in ``attempts``.
+    """
+
+    def __init__(
+        self,
+        *,
+        backend: Optional["ContextBackend"] = None,
+        api_key: Optional[str] = None,
+        concurrency: int = 8,
+        batch_size: int = 10,
+        max_chars: int = _DEFAULT_MAX_CHARS,
+        policy: Optional[RateLimitPolicy] = None,
+        fallback: Optional[PageFetcher] = None,
+    ):
+        self.concurrency = concurrency
+        self.max_chars = max_chars
+        self.policy = policy if policy is not None else RateLimitPolicy()
+        self.fallback: PageFetcher = fallback if fallback is not None else HttpxPageFetcher(concurrency=concurrency)
+        self.backend = backend if backend is not None else self._resolve_backend(api_key)
+        limit = getattr(self.backend, "fetch_batch_limit", 1) if self.backend is not None else 1
+        self.batch_size = max(1, min(batch_size, limit))
+
+    @staticmethod
+    def _resolve_backend(api_key: Optional[str]) -> Optional["ContextBackend"]:
+        # Imported lazily: a knowledge import must not load the context package until a
+        # provider-backed fetcher is actually constructed.
+        key = api_key if api_key is not None else (getenv("PARALLEL_API_KEY", "") or None)
+        if key and find_spec("parallel") is not None:
+            from agno.context.web.parallel import ParallelBackend
+
+            return ParallelBackend(api_key=key)
+        if find_spec("mcp") is not None:
+            from agno.context.web.parallel_mcp import ParallelMCPBackend
+
+            return ParallelMCPBackend(api_key=key)
+        return None
+
+    @property
+    def extractor_id(self) -> str:
+        if self.backend is None:
+            return getattr(self.fallback, "extractor_id", "httpx")
+        return getattr(self.backend, "extractor_id", "parallel")
+
+    # --- async ---
+
+    async def afetch_many(
+        self, urls: List[str], *, allowed_hosts: Optional[List[str]] = None
+    ) -> List[FetchedPage]:
+        if self.backend is None:
+            return await self.fallback.afetch_many(urls, allowed_hosts=allowed_hosts)
+
+        results: Dict[str, FetchedPage] = {}
+        fetchable: List[str] = []
+        seen: Set[str] = set()
+        for url in urls:
+            if url in seen:
+                continue
+            seen.add(url)
+            if not is_host_allowed(url, allowed_hosts):
+                results[url] = FetchedPage(url=url, error="off-host", extractor=self.extractor_id)
+            else:
+                fetchable.append(url)
+
+        semaphore = asyncio.Semaphore(self.concurrency)
+        # Per-call state on purpose — the fetcher instance is shared across concurrent reads.
+        state = {"consecutive_rate_limits": 0, "tripped": False}
+
+        async def fetch_batch(batch: List[str]) -> List[FetchedPage]:
+            async with semaphore:
+                attempts: List[Dict[str, str]] = []
+                for attempt in range(self.policy.max_retries + 1):
+                    if state["tripped"]:
+                        break
+                    try:
+                        pages = await self.backend.afetch_many(batch, max_chars=self.max_chars)  # type: ignore[union-attr]
+                        state["consecutive_rate_limits"] = 0
+                        for page in pages:
+                            page.attempts = attempts + [
+                                {"extractor": page.extractor, "outcome": page.error or "ok"}
+                            ]
+                        return pages
+                    except RateLimited as e:
+                        attempts.append({"extractor": self.extractor_id, "outcome": "rate-limited"})
+                        state["consecutive_rate_limits"] += 1
+                        if state["consecutive_rate_limits"] >= self.policy.breaker_after:
+                            if not state["tripped"]:
+                                state["tripped"] = True
+                                log_info(
+                                    f"{self.extractor_id} rate-limited "
+                                    f"{state['consecutive_rate_limits']} times in a row; "
+                                    "fetching the rest of this read with the built-in fetcher"
+                                )
+                            break
+                        if attempt < self.policy.max_retries:
+                            await asyncio.sleep(self._delay(e, attempt))
+                    except Exception as e:
+                        attempts.append({"extractor": self.extractor_id, "outcome": _failure_reason(e)})
+                        log_debug(f"{self.extractor_id} fetch failed for batch of {len(batch)}: {e}")
+                        break
+            # Provider unavailable for this batch: the fallback owns these pages now.
+            pages = await self.fallback.afetch_many(batch, allowed_hosts=allowed_hosts)
+            for page in pages:
+                page.attempts = attempts + page.attempts
+            return pages
+
+        batches = [fetchable[i : i + self.batch_size] for i in range(0, len(fetchable), self.batch_size)]
+        for batch_pages in await asyncio.gather(*[fetch_batch(batch) for batch in batches]):
+            retry_urls = [page.url for page in batch_pages if not page.ok]
+            retry_pages: Dict[str, FetchedPage] = {}
+            if retry_urls:
+                # Pages the provider could not serve fall through to the fallback one level.
+                for fallback_page in await self.fallback.afetch_many(retry_urls, allowed_hosts=allowed_hosts):
+                    retry_pages[fallback_page.url] = fallback_page
+            for page in batch_pages:
+                replacement = retry_pages.get(page.url)
+                if replacement is not None and page.extractor != getattr(self.fallback, "extractor_id", "httpx"):
+                    replacement.attempts = page.attempts + replacement.attempts
+                    results[page.url] = replacement
+                else:
+                    results[page.url] = page
+
+        return [results.get(url, FetchedPage(url=url, error="not fetched")) for url in urls]
+
+    # --- sync ---
+
+    def fetch_many(self, urls: List[str], *, allowed_hosts: Optional[List[str]] = None) -> List[FetchedPage]:
+        if self.backend is None:
+            return self.fallback.fetch_many(urls, allowed_hosts=allowed_hosts)
+
+        results: Dict[str, FetchedPage] = {}
+        fetchable: List[str] = []
+        seen: Set[str] = set()
+        for url in urls:
+            if url in seen:
+                continue
+            seen.add(url)
+            if not is_host_allowed(url, allowed_hosts):
+                results[url] = FetchedPage(url=url, error="off-host", extractor=self.extractor_id)
+            else:
+                fetchable.append(url)
+
+        consecutive_rate_limits = 0
+        tripped = False
+        for start in range(0, len(fetchable), self.batch_size):
+            batch = fetchable[start : start + self.batch_size]
+            attempts: List[Dict[str, str]] = []
+            batch_pages: Optional[List[FetchedPage]] = None
+            if not tripped:
+                for attempt in range(self.policy.max_retries + 1):
+                    try:
+                        batch_pages = self.backend.fetch_many(batch, max_chars=self.max_chars)
+                        consecutive_rate_limits = 0
+                        for page in batch_pages:
+                            page.attempts = attempts + [
+                                {"extractor": page.extractor, "outcome": page.error or "ok"}
+                            ]
+                        break
+                    except RateLimited as e:
+                        attempts.append({"extractor": self.extractor_id, "outcome": "rate-limited"})
+                        consecutive_rate_limits += 1
+                        if consecutive_rate_limits >= self.policy.breaker_after:
+                            tripped = True
+                            log_info(
+                                f"{self.extractor_id} rate-limited {consecutive_rate_limits} times in a row; "
+                                "fetching the rest of this read with the built-in fetcher"
+                            )
+                            break
+                        if attempt < self.policy.max_retries:
+                            time.sleep(self._delay(e, attempt))
+                    except Exception as e:
+                        attempts.append({"extractor": self.extractor_id, "outcome": _failure_reason(e)})
+                        log_debug(f"{self.extractor_id} fetch failed for batch of {len(batch)}: {e}")
+                        break
+            if batch_pages is None:
+                batch_pages = self.fallback.fetch_many(batch, allowed_hosts=allowed_hosts)
+                for page in batch_pages:
+                    page.attempts = attempts + page.attempts
+
+            retry_urls = [page.url for page in batch_pages if not page.ok]
+            retry_pages: Dict[str, FetchedPage] = {}
+            if retry_urls:
+                for fallback_page in self.fallback.fetch_many(retry_urls, allowed_hosts=allowed_hosts):
+                    retry_pages[fallback_page.url] = fallback_page
+            for page in batch_pages:
+                replacement = retry_pages.get(page.url)
+                if replacement is not None and page.extractor != getattr(self.fallback, "extractor_id", "httpx"):
+                    replacement.attempts = page.attempts + replacement.attempts
+                    results[page.url] = replacement
+                else:
+                    results[page.url] = page
+
+        return [results.get(url, FetchedPage(url=url, error="not fetched")) for url in urls]
+
+    def _delay(self, exc: RateLimited, attempt: int) -> float:
+        if self.policy.honor_retry_after and exc.retry_after is not None:
+            return min(max(exc.retry_after, 0.0), self.policy.max_delay)
+        return min(self.policy.base_delay * (2**attempt), self.policy.max_delay)
+
+
+def rate_limit_from_text(message: str) -> bool:
+    """Whether a provider error message names a rate limit."""
+    lowered = message.lower()
+    return "rate limit" in lowered or "429" in lowered
+
+
+__all__ = [
+    "FetchedPage",
+    "HttpxPageFetcher",
+    "PageFetcher",
+    "ParallelPageFetcher",
+    "RateLimitPolicy",
+    "RateLimited",
+    "extract_page_text",
+    "extract_page_title",
+    "rate_limit_from_text",
+]

--- a/libs/agno/agno/knowledge/reader/reader_factory.py
+++ b/libs/agno/agno/knowledge/reader/reader_factory.py
@@ -2,6 +2,7 @@ import os
 from typing import Any, Callable, Dict, List, Optional
 
 from agno.knowledge.reader.base import Reader
+from agno.knowledge.reader.utils.urls import is_sitemap_url
 
 
 class ReaderFactory:
@@ -79,6 +80,10 @@ class ReaderFactory:
         "llms_txt": {
             "name": "LLMsTxtReader",
             "description": "Reads llms.txt files, discovers linked documentation URLs, and fetches their content",
+        },
+        "sitemap": {
+            "name": "SitemapReader",
+            "description": "Discovers a website's sitemap and loads one document per page with its source URL",
         },
         "docling": {
             "name": "DoclingReader",
@@ -296,6 +301,18 @@ class ReaderFactory:
         return LLMsTxtReader(**config)
 
     @classmethod
+    def _get_sitemap_reader(cls, **kwargs) -> Reader:
+        """Get Sitemap reader instance."""
+        from agno.knowledge.reader.sitemap_reader import SitemapReader
+
+        config: Dict[str, Any] = {
+            "name": "Sitemap Reader",
+            "description": "Discovers a website's sitemap and loads one document per page with its source URL",
+        }
+        config.update(kwargs)
+        return SitemapReader(**config)
+
+    @classmethod
     def _get_docling_reader(cls, **kwargs) -> Reader:
         """Get Docling reader instance."""
         from agno.knowledge.reader.docling_reader import DoclingReader
@@ -351,6 +368,7 @@ class ReaderFactory:
             "wikipedia": ("agno.knowledge.reader.wikipedia_reader", "WikipediaReader"),
             "web_search": ("agno.knowledge.reader.web_search_reader", "WebSearchReader"),
             "llms_txt": ("agno.knowledge.reader.llms_txt_reader", "LLMsTxtReader"),
+            "sitemap": ("agno.knowledge.reader.sitemap_reader", "SitemapReader"),
             "docling": ("agno.knowledge.reader.docling_reader", "DoclingReader"),
         }
 
@@ -432,6 +450,10 @@ class ReaderFactory:
         # Check for YouTube URLs
         if any(domain in url_lower for domain in ["youtube.com", "youtu.be"]):
             return cls.create_reader("youtube")
+
+        # A sitemap URL gets the per-page sitemap reader
+        if is_sitemap_url(url):
+            return cls.create_reader("sitemap")
 
         # Default to website reader
         return cls.create_reader("website")

--- a/libs/agno/agno/knowledge/reader/sitemap_reader.py
+++ b/libs/agno/agno/knowledge/reader/sitemap_reader.py
@@ -1,0 +1,315 @@
+"""Reader that loads a website page by page from its sitemap.
+
+Discovery follows the sitemap protocol: the URL itself when it is a sitemap, the ``Sitemap:``
+lines in robots.txt, then the conventional locations. Pages are fetched through a
+``PageFetcher`` (Parallel's extraction API when available, the built-in httpx fetcher
+otherwise) and returned as one whole-page ``Document`` per page, so the insert path lands one
+content row per page with its source URL kept.
+
+The reader holds no per-read state — the factory hands every caller one shared instance and
+reads run concurrently.
+"""
+
+import gzip
+from typing import Generator, List, Optional, Tuple
+from urllib.parse import urlparse
+from xml.etree import ElementTree
+
+import httpx
+
+from agno.knowledge.chunking.fixed import FixedSizeChunking
+from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyType
+from agno.knowledge.document.base import Document
+from agno.knowledge.reader.base import Reader
+from agno.knowledge.reader.page_fetcher import FetchedPage, PageFetcher, ParallelPageFetcher
+from agno.knowledge.reader.utils.url_validation import (
+    is_host_allowed,
+    make_async_redirect_guard,
+    make_redirect_guard,
+    validate_allowed_hosts,
+)
+from agno.knowledge.reader.utils.urls import canonical_page_name, canonical_page_url
+from agno.knowledge.types import ContentType
+from agno.utils.log import log_debug
+
+_SITEMAP_PATH_HINTS = ("sitemap", ".xml")
+_GZIP_MAGIC = b"\x1f\x8b"
+
+# The discovery generator yields URLs to fetch and receives their bodies (or None on
+# failure); it returns (page_urls, sitemap_url). One implementation, driven by both the
+# sync and async transports.
+_DiscoveryGen = Generator[str, Optional[bytes], Tuple[List[str], Optional[str]]]
+
+
+def _default_allowed_hosts(host: str) -> List[str]:
+    """The host plus its www twin — host matching is exact, and sites mix the two freely."""
+    host = host.lower()
+    bare = host[4:] if host.startswith("www.") else host
+    return sorted({host, bare, f"www.{bare}"})
+
+
+class SitemapReader(Reader):
+    """Reads a website's sitemap and returns one whole-page document per page."""
+
+    def __init__(
+        self,
+        max_pages: int = 50,
+        allowed_hosts: Optional[List[str]] = None,
+        follow_index: bool = True,
+        page_fetcher: Optional[PageFetcher] = None,
+        source_header: bool = False,
+        timeout: int = 30,
+        chunking_strategy: Optional[ChunkingStrategy] = None,
+        **kwargs,
+    ):
+        if chunking_strategy is None:
+            chunk_size = kwargs.get("chunk_size", 5000)
+            chunking_strategy = FixedSizeChunking(chunk_size=chunk_size)
+        super().__init__(chunking_strategy=chunking_strategy, **kwargs)
+        self.max_pages = max_pages
+        self.allowed_hosts: Optional[List[str]] = validate_allowed_hosts(allowed_hosts)
+        self.follow_index = follow_index
+        self.page_fetcher: PageFetcher = page_fetcher if page_fetcher is not None else ParallelPageFetcher()
+        self.source_header = source_header
+        self.timeout = timeout
+
+    @classmethod
+    def get_supported_chunking_strategies(cls) -> List[ChunkingStrategyType]:
+        return [
+            ChunkingStrategyType.FIXED_SIZE_CHUNKER,
+            ChunkingStrategyType.AGENTIC_CHUNKER,
+            ChunkingStrategyType.DOCUMENT_CHUNKER,
+            ChunkingStrategyType.RECURSIVE_CHUNKER,
+            ChunkingStrategyType.SEMANTIC_CHUNKER,
+            ChunkingStrategyType.MARKDOWN_CHUNKER,
+        ]
+
+    @classmethod
+    def get_supported_content_types(cls) -> List[ContentType]:
+        # Declaring URL also tells the insert path not to pre-download the .xml for us.
+        return [ContentType.URL]
+
+    canonical_name = staticmethod(canonical_page_name)
+
+    # ------------------------------------------------------------------
+    # Discovery (sans-io: yields URLs, receives bodies)
+    # ------------------------------------------------------------------
+
+    def _hosts_for(self, url: str) -> List[str]:
+        if self.allowed_hosts is not None:
+            return self.allowed_hosts
+        return _default_allowed_hosts(urlparse(url).hostname or "")
+
+    @staticmethod
+    def _decode_sitemap_bytes(raw: bytes) -> bytes:
+        # .xml.gz served without Content-Encoding arrives still gzipped.
+        if raw[:2] == _GZIP_MAGIC:
+            try:
+                return gzip.decompress(raw)
+            except OSError:
+                return raw
+        return raw
+
+    @staticmethod
+    def _parse_sitemap(raw: bytes) -> Optional[Tuple[bool, List[str]]]:
+        """``(is_index, locs)`` for a sitemap document, or None when it is not one.
+
+        Only ``<loc>`` entries that are direct children of ``<url>``/``<sitemap>`` elements
+        count — ``image:loc``/``video:loc`` live one level deeper and are not pages.
+        """
+        try:
+            root = ElementTree.fromstring(SitemapReader._decode_sitemap_bytes(raw))
+        except ElementTree.ParseError:
+            return None
+        tag = root.tag.rsplit("}", 1)[-1]
+        if tag not in ("urlset", "sitemapindex"):
+            return None
+        locs: List[str] = []
+        for entry in root:
+            if entry.tag.rsplit("}", 1)[-1] not in ("url", "sitemap"):
+                continue
+            for child in entry:
+                if child.tag.rsplit("}", 1)[-1] == "loc" and child.text and child.text.strip():
+                    locs.append(child.text.strip())
+                    break
+        return tag == "sitemapindex", locs
+
+    def _sitemap_candidates(self, url: str, robots_sitemaps: List[str]) -> List[str]:
+        """Where a sitemap may live for ``url``, in discovery order, the URL itself first."""
+        parsed = urlparse(url)
+        root = f"{parsed.scheme}://{parsed.netloc}"
+        candidates: List[str] = []
+        last_segment = parsed.path.rsplit("/", 1)[-1].lower()
+        if any(hint in last_segment for hint in _SITEMAP_PATH_HINTS):
+            candidates.append(url)
+        candidates.extend(robots_sitemaps)
+        candidates.append(f"{root}/sitemap.xml")
+        candidates.append(f"{root}/sitemap_index.xml")
+        directory = parsed.path.rsplit("/", 1)[0]
+        if directory:
+            candidates.append(f"{root}{directory}/sitemap.xml")
+        seen: set = set()
+        ordered = []
+        for candidate in candidates:
+            if candidate not in seen:
+                seen.add(candidate)
+                ordered.append(candidate)
+        return ordered
+
+    @staticmethod
+    def _robots_sitemap_lines(robots_txt: str) -> List[str]:
+        lines = []
+        for line in robots_txt.splitlines():
+            key, _, value = line.partition(":")
+            if key.strip().lower() == "sitemap" and value.strip():
+                lines.append(value.strip())
+        return lines
+
+    def _discover(self, url: str, allowed_hosts: List[str]) -> _DiscoveryGen:
+        """Find the sitemap for ``url`` and collect its page URLs.
+
+        Yields each URL it needs fetched and receives the body (None on failure). Returns
+        ``(page_urls, sitemap_url)`` — pages in document order, deduplicated on canonical
+        form, host-filtered, bounded by ``max_pages``; ``sitemap_url`` is None when no
+        sitemap was found and the read falls back to the single page at ``url``.
+        """
+        parsed_url = urlparse(url)
+        robots_body = yield f"{parsed_url.scheme}://{parsed_url.netloc}/robots.txt"
+        robots_sitemaps = self._robots_sitemap_lines(robots_body.decode(errors="replace")) if robots_body else []
+
+        for candidate in self._sitemap_candidates(url, robots_sitemaps):
+            if not is_host_allowed(candidate, allowed_hosts):
+                log_debug(f"Sitemap candidate on another host, skipping: {candidate}")
+                continue
+            raw = yield candidate
+            parsed = self._parse_sitemap(raw) if raw is not None else None
+            if parsed is None:
+                continue
+
+            is_index, locs = parsed
+            pending: List[str] = list(locs) if is_index and self.follow_index else []
+            page_locs: List[str] = [] if is_index else list(locs)
+            visited = {canonical_page_url(candidate)}
+            while pending and len(page_locs) < self.max_pages:
+                child = pending.pop(0)
+                child_key = canonical_page_url(child)
+                if child_key in visited:
+                    continue
+                visited.add(child_key)
+                if not is_host_allowed(child, allowed_hosts):
+                    log_debug(f"Child sitemap on another host, skipping: {child}")
+                    continue
+                child_raw = yield child
+                child_parsed = self._parse_sitemap(child_raw) if child_raw is not None else None
+                if child_parsed is None:
+                    continue
+                child_is_index, child_locs = child_parsed
+                if child_is_index:
+                    pending.extend(child_locs)
+                else:
+                    page_locs.extend(child_locs)
+
+            pages: List[str] = []
+            seen: set = set()
+            for loc in page_locs:
+                key = canonical_page_url(loc)
+                if key in seen:
+                    continue
+                seen.add(key)
+                if not is_host_allowed(loc, allowed_hosts):
+                    log_debug(f"Sitemap entry on another host, skipping: {loc}")
+                    continue
+                pages.append(loc)
+                if len(pages) >= self.max_pages:
+                    break
+            return pages, candidate
+
+        return [url], None
+
+    # ------------------------------------------------------------------
+    # Documents
+    # ------------------------------------------------------------------
+
+    def _build_documents(self, pages: List[FetchedPage], source_kind: str) -> List[Document]:
+        documents: List[Document] = []
+        for page in pages:
+            url_key = canonical_page_url(page.url)
+            name = canonical_page_name(page.url)
+            title = page.title or name
+            meta: dict = {
+                "url": url_key,
+                "title": title,
+                "host": urlparse(page.url).hostname or "",
+                "extractor": page.extractor,
+                "source": source_kind,
+            }
+            if page.attempts:
+                meta["attempts"] = page.attempts
+            if not page.ok:
+                meta["error"] = page.error or "empty"
+                documents.append(Document(name=name, id=url_key, meta_data=meta, content=""))
+                continue
+            content = page.content or ""
+            if self.source_header:
+                # Prepended before chunking, so it lands in the first chunk only.
+                content = f"# {title}\nSource: {url_key}\n\n{content}"
+            document = Document(name=name, id=url_key, meta_data=meta, content=content)
+            if self.chunk:
+                documents.extend(self.chunk_document(document))
+            else:
+                documents.append(document)
+        return documents
+
+    # ------------------------------------------------------------------
+    # Read
+    # ------------------------------------------------------------------
+
+    def read(self, url: str, name: Optional[str] = None) -> List[Document]:
+        allowed_hosts = self._hosts_for(url)
+        guard = make_redirect_guard(allowed_hosts)
+        event_hooks = {"request": [guard]} if guard else None
+
+        discovery = self._discover(url, allowed_hosts)
+        with httpx.Client(timeout=self.timeout, event_hooks=event_hooks) as client:  # type: ignore[arg-type]
+            try:
+                request_url = next(discovery)
+                while True:
+                    body: Optional[bytes]
+                    try:
+                        response = client.get(request_url, follow_redirects=True)
+                        response.raise_for_status()
+                        body = response.content
+                    except Exception:
+                        body = None
+                    request_url = discovery.send(body)
+            except StopIteration as stop:
+                page_urls, sitemap_url = stop.value
+
+        source_kind = "sitemap" if sitemap_url else "page"
+        fetched = self.page_fetcher.fetch_many(page_urls, allowed_hosts=allowed_hosts)
+        return self._build_documents(fetched, source_kind)
+
+    async def async_read(self, url: str, name: Optional[str] = None) -> List[Document]:
+        allowed_hosts = self._hosts_for(url)
+        guard = make_async_redirect_guard(allowed_hosts)
+        event_hooks = {"request": [guard]} if guard else None
+
+        discovery = self._discover(url, allowed_hosts)
+        async with httpx.AsyncClient(timeout=self.timeout, event_hooks=event_hooks) as client:  # type: ignore[arg-type]
+            try:
+                request_url = next(discovery)
+                while True:
+                    body: Optional[bytes]
+                    try:
+                        response = await client.get(request_url, follow_redirects=True)
+                        response.raise_for_status()
+                        body = response.content
+                    except Exception:
+                        body = None
+                    request_url = discovery.send(body)
+            except StopIteration as stop:
+                page_urls, sitemap_url = stop.value
+
+        source_kind = "sitemap" if sitemap_url else "page"
+        fetched = await self.page_fetcher.afetch_many(page_urls, allowed_hosts=allowed_hosts)
+        return self._build_documents(fetched, source_kind)

--- a/libs/agno/agno/knowledge/reader/sitemap_reader.py
+++ b/libs/agno/agno/knowledge/reader/sitemap_reader.py
@@ -36,9 +36,11 @@ _SITEMAP_PATH_HINTS = ("sitemap", ".xml")
 _GZIP_MAGIC = b"\x1f\x8b"
 
 # The discovery generator yields URLs to fetch and receives their bodies (or None on
-# failure); it returns (page_urls, sitemap_url). One implementation, driven by both the
-# sync and async transports.
-_DiscoveryGen = Generator[str, Optional[bytes], Tuple[List[str], Optional[str]]]
+# failure); it returns (page_urls, sitemap_url, incomplete). One implementation, driven
+# by both the sync and async transports. ``incomplete`` is True when a child sitemap of
+# an index could not be fetched or parsed — its pages are silently absent, so a caller
+# reconciling against a previous read must not treat them as removed.
+_DiscoveryGen = Generator[str, Optional[bytes], Tuple[List[str], Optional[str], bool]]
 
 
 def _default_allowed_hosts(host: str) -> List[str]:
@@ -169,9 +171,10 @@ class SitemapReader(Reader):
         """Find the sitemap for ``url`` and collect its page URLs.
 
         Yields each URL it needs fetched and receives the body (None on failure). Returns
-        ``(page_urls, sitemap_url)`` — pages in document order, deduplicated on canonical
-        form, host-filtered, bounded by ``max_pages``; ``sitemap_url`` is None when no
-        sitemap was found and the read falls back to the single page at ``url``.
+        ``(page_urls, sitemap_url, incomplete)`` — pages in document order, deduplicated
+        on canonical form, host-filtered, bounded by ``max_pages``; ``sitemap_url`` is
+        None when no sitemap was found and the read falls back to the single page at
+        ``url``; ``incomplete`` is True when an index child could not be fetched/parsed.
         """
         parsed_url = urlparse(url)
         robots_body = yield f"{parsed_url.scheme}://{parsed_url.netloc}/robots.txt"
@@ -189,6 +192,7 @@ class SitemapReader(Reader):
             is_index, locs = parsed
             pending: List[str] = list(locs) if is_index and self.follow_index else []
             page_locs: List[str] = [] if is_index else list(locs)
+            incomplete = False
             visited = {canonical_page_url(candidate)}
             while pending and len(page_locs) < self.max_pages:
                 child = pending.pop(0)
@@ -202,6 +206,8 @@ class SitemapReader(Reader):
                 child_raw = yield child
                 child_parsed = self._parse_sitemap(child_raw) if child_raw is not None else None
                 if child_parsed is None:
+                    # This shard's pages are absent from the read, not from the site
+                    incomplete = True
                     continue
                 child_is_index, child_locs = child_parsed
                 if child_is_index:
@@ -222,15 +228,17 @@ class SitemapReader(Reader):
                 pages.append(loc)
                 if len(pages) >= self.max_pages:
                     break
-            return pages, candidate
+            return pages, candidate, incomplete
 
-        return [url], None
+        return [url], None, False
 
     # ------------------------------------------------------------------
     # Documents
     # ------------------------------------------------------------------
 
-    def _build_documents(self, pages: List[FetchedPage], source_kind: str) -> List[Document]:
+    def _build_documents(
+        self, pages: List[FetchedPage], source_kind: str, discovery_incomplete: bool = False
+    ) -> List[Document]:
         documents: List[Document] = []
         for page in pages:
             url_key = canonical_page_url(page.url)
@@ -245,6 +253,10 @@ class SitemapReader(Reader):
             }
             if page.attempts:
                 meta["attempts"] = page.attempts
+            if discovery_incomplete:
+                # Read by the insert path (and stripped there): pages missing from this
+                # read may still exist on the site.
+                meta["discovery_incomplete"] = True
             if not page.ok:
                 meta["error"] = page.error or "empty"
                 documents.append(Document(name=name, id=url_key, meta_data=meta, content=""))
@@ -283,11 +295,11 @@ class SitemapReader(Reader):
                         body = None
                     request_url = discovery.send(body)
             except StopIteration as stop:
-                page_urls, sitemap_url = stop.value
+                page_urls, sitemap_url, incomplete = stop.value
 
         source_kind = "sitemap" if sitemap_url else "page"
         fetched = self.page_fetcher.fetch_many(page_urls, allowed_hosts=allowed_hosts)
-        return self._build_documents(fetched, source_kind)
+        return self._build_documents(fetched, source_kind, discovery_incomplete=incomplete)
 
     async def async_read(self, url: str, name: Optional[str] = None) -> List[Document]:
         allowed_hosts = self._hosts_for(url)
@@ -308,8 +320,8 @@ class SitemapReader(Reader):
                         body = None
                     request_url = discovery.send(body)
             except StopIteration as stop:
-                page_urls, sitemap_url = stop.value
+                page_urls, sitemap_url, incomplete = stop.value
 
         source_kind = "sitemap" if sitemap_url else "page"
         fetched = await self.page_fetcher.afetch_many(page_urls, allowed_hosts=allowed_hosts)
-        return self._build_documents(fetched, source_kind)
+        return self._build_documents(fetched, source_kind, discovery_incomplete=incomplete)

--- a/libs/agno/agno/knowledge/reader/sitemap_reader.py
+++ b/libs/agno/agno/knowledge/reader/sitemap_reader.py
@@ -230,7 +230,11 @@ class SitemapReader(Reader):
                     break
             return pages, candidate, incomplete
 
-        return [url], None, False
+        # No sitemap could be fetched and parsed anywhere. For a site that never had one
+        # this is the normal single-page mode; for a site that did, it is an outage. The
+        # two are indistinguishable here, so the read is marked incomplete either way —
+        # the insert path then keeps previously loaded pages instead of pruning them.
+        return [url], None, True
 
     # ------------------------------------------------------------------
     # Documents

--- a/libs/agno/agno/knowledge/reader/utils/urls.py
+++ b/libs/agno/agno/knowledge/reader/utils/urls.py
@@ -1,0 +1,73 @@
+"""URL canonicalization for page-level knowledge rows.
+
+Kept free of heavy imports: ``knowledge.py`` uses it on the per-page insert path,
+which must not require the html-parsing extras.
+"""
+
+import hashlib
+from urllib.parse import unquote, urlparse
+
+# Contents-db row names must fit the narrowest adapter column (MySQL: String(255)).
+MAX_PAGE_NAME_LENGTH = 255
+
+_INDEX_SUFFIXES = ("index.html", "index.htm")
+
+
+def canonical_page_name(url: str) -> str:
+    """A stable, human-readable name for one page: ``<host>/<path>``.
+
+    Two sitemap entries for the same page must produce the same name, so the fragment is
+    dropped, a trailing slash and a trailing ``index.html``/``index.htm`` are stripped, and
+    the path is percent-decoded. The query is kept when present — ``?v=1`` and ``?v=2`` are
+    different pages. The site root is just the host. Names longer than the narrowest
+    contents-db column are truncated with a short hash suffix so they stay unique.
+    """
+    parsed = urlparse(url)
+    host = (parsed.hostname or "").lower()
+    path = unquote(parsed.path or "")
+
+    for suffix in _INDEX_SUFFIXES:
+        if path.endswith(suffix):
+            path = path[: -len(suffix)]
+            break
+    path = path.strip("/")
+
+    name = f"{host}/{path}" if path else host
+    if parsed.query:
+        name = f"{name}?{parsed.query}"
+
+    if len(name) > MAX_PAGE_NAME_LENGTH:
+        digest = hashlib.sha256(name.encode()).hexdigest()[:8]
+        name = f"{name[: MAX_PAGE_NAME_LENGTH - 9]}-{digest}"
+    return name
+
+
+def is_sitemap_url(url: str) -> bool:
+    """Whether a URL names a sitemap file (``sitemap*.xml`` / ``sitemap*.xml.gz``)."""
+    path = urlparse(url).path.lower()
+    segment = path.rsplit("/", 1)[-1]
+    return segment.startswith("sitemap") and (segment.endswith(".xml") or segment.endswith(".xml.gz"))
+
+
+def canonical_page_url(url: str) -> str:
+    """The canonical form of a page URL for identity and de-duplication.
+
+    Same rules as :func:`canonical_page_name` applied to the URL itself: fragment dropped,
+    trailing slash and ``index.html``/``index.htm`` stripped, query kept. The scheme and host
+    are lowercased; the path keeps its original encoding (it is what gets fetched).
+    """
+    parsed = urlparse(url)
+    path = parsed.path or ""
+    for suffix in _INDEX_SUFFIXES:
+        if path.endswith(suffix):
+            path = path[: -len(suffix)]
+            break
+    if path != "/":
+        path = path.rstrip("/")
+
+    scheme = (parsed.scheme or "https").lower()
+    host = (parsed.netloc or "").lower()
+    canonical = f"{scheme}://{host}{path}"
+    if parsed.query:
+        canonical = f"{canonical}?{parsed.query}"
+    return canonical

--- a/libs/agno/agno/knowledge/reader/utils/urls.py
+++ b/libs/agno/agno/knowledge/reader/utils/urls.py
@@ -62,8 +62,8 @@ def canonical_page_url(url: str) -> str:
         if path.endswith(suffix):
             path = path[: -len(suffix)]
             break
-    if path != "/":
-        path = path.rstrip("/")
+    # The site root's two spellings ("" and "/") must canonicalise identically
+    path = path.rstrip("/")
 
     scheme = (parsed.scheme or "https").lower()
     host = (parsed.netloc or "").lower()

--- a/libs/agno/agno/os/routers/knowledge/knowledge.py
+++ b/libs/agno/agno/os/routers/knowledge/knowledge.py
@@ -722,7 +722,11 @@ def attach_routes(router: APIRouter, knowledge_instances: List[Union[Knowledge, 
             # Non-admins can read shared (unowned) content but not delete it.
             if scoped_user_id is not None and existing.user_id is None:
                 raise HTTPException(status_code=403, detail="Cannot delete shared content")
-            await knowledge.aremove_content_by_id(content_id=content_id, user_id=scoped_user_id)
+            removed = await knowledge.aremove_content_by_id(content_id=content_id, user_id=scoped_user_id)
+            if removed is False:
+                # The vector store refused the delete; the row is kept so a retry can
+                # still reach the vectors.
+                raise HTTPException(status_code=500, detail="Content was not fully removed; vector deletion failed")
 
         return ContentResponseSchema(
             id=content_id,

--- a/libs/agno/agno/os/routers/knowledge/knowledge.py
+++ b/libs/agno/agno/os/routers/knowledge/knowledge.py
@@ -13,11 +13,13 @@ from agno.knowledge.reader import ReaderFactory
 from agno.knowledge.reader.base import Reader
 from agno.knowledge.remote_content.s3 import S3Config
 from agno.knowledge.utils import (
+    get_agno_metadata,
     get_all_chunkers_info,
     get_content_types_to_readers_mapping,
     get_read_time_availability,
     get_readers_availability,
     get_unavailable_chunkers_info,
+    strip_agno_metadata,
 )
 from agno.os.auth import get_auth_token_from_request, get_authentication_dependency
 from agno.os.middleware.user_scope import get_scoped_user_id
@@ -559,6 +561,9 @@ def attach_routes(router: APIRouter, knowledge_instances: List[Union[Knowledge, 
         sort_order: Optional[SortOrder] = Query(default=SortOrder.DESC, description="Sort order (asc or desc)"),
         db_id: Optional[str] = Query(default=None, description="Database ID to use"),
         knowledge_id: Optional[str] = Query(default=None, description="Knowledge base ID to use"),
+        parent_id: Optional[str] = Query(
+            default=None, description="Only page rows of this site row (exact id match)"
+        ),
     ) -> PaginatedResponse[ContentResponseSchema]:
         knowledge = get_knowledge_instance(knowledge_instances, db_id, knowledge_id)
 
@@ -575,9 +580,25 @@ def attach_routes(router: APIRouter, knowledge_instances: List[Union[Knowledge, 
 
         # Non-admin callers see their own rows plus shared (NULL) ones.
         scoped_user_id = get_scoped_user_id(request)
-        contents, count = await knowledge.aget_content(
-            limit=limit, page=page, sort_by=sort_by, sort_order=sort_order, user_id=scoped_user_id
-        )
+        if parent_id is not None:
+            # The contents db cannot filter on metadata, so fetch every row for this base
+            # and page in the route. Site sizes are bounded by the reader's page cap.
+            all_contents, _ = await knowledge.aget_content(
+                sort_by=sort_by, sort_order=sort_order, user_id=scoped_user_id
+            )
+            matched = [
+                content
+                for content in all_contents
+                if get_agno_metadata(content.metadata, "parent_id") == parent_id
+            ]
+            count = len(matched)
+            page_number = page or 1
+            page_size = limit or 20
+            contents = matched[(page_number - 1) * page_size : page_number * page_size]
+        else:
+            contents, count = await knowledge.aget_content(
+                limit=limit, page=page, sort_by=sort_by, sort_order=sort_order, user_id=scoped_user_id
+            )
 
         return PaginatedResponse(
             data=[
@@ -740,6 +761,72 @@ def attach_routes(router: APIRouter, knowledge_instances: List[Union[Knowledge, 
         scoped_user_id = get_scoped_user_id(request)
         await knowledge.aremove_all_content(user_id=scoped_user_id)
         return "success"
+
+    @router.post(
+        "/knowledge/content/{content_id}/refresh",
+        response_model=ContentResponseSchema,
+        status_code=202,
+        operation_id="refresh_content",
+        summary="Refresh Content",
+        description=(
+            "Re-ingest a URL-sourced content row from its source. For a site row this refreshes "
+            "changed pages, retries failed ones, and removes pages that left the site."
+        ),
+        responses={
+            202: {"description": "Refresh started"},
+            400: {"description": "Content has no source URL", "model": BadRequestResponse},
+            404: {"description": "Content not found", "model": NotFoundResponse},
+        },
+    )
+    async def refresh_content(
+        request: Request,
+        background_tasks: BackgroundTasks,
+        content_id: str = Path(..., description="Content ID to refresh"),
+        db_id: Optional[str] = Query(default=None, description="Database ID to use"),
+        knowledge_id: Optional[str] = Query(default=None, description="Knowledge base ID to use"),
+    ) -> ContentResponseSchema:
+        knowledge = get_knowledge_instance(knowledge_instances, db_id, knowledge_id)
+        if isinstance(knowledge, RemoteKnowledge):
+            raise HTTPException(status_code=501, detail="Refresh is not supported for remote knowledge")
+
+        scoped_user_id = get_scoped_user_id(request)
+        existing = await knowledge.aget_content_by_id(content_id, user_id=scoped_user_id)
+        if existing is None:
+            raise HTTPException(status_code=404, detail=f"Content not found: {content_id}")
+        if scoped_user_id is not None and existing.user_id is None:
+            raise HTTPException(status_code=403, detail="Cannot refresh shared content")
+
+        source_url = get_agno_metadata(existing.metadata, "source_url")
+        if not isinstance(source_url, str) or not source_url:
+            raise HTTPException(status_code=400, detail="Content has no source URL to refresh from")
+
+        # Rebuild the exact Content the original insert built, so the refresh lands on the
+        # same row. The name is part of the row hash, so try the stored name and the
+        # auto-derived (None) form and keep whichever reproduces this id.
+        user_metadata = strip_agno_metadata(existing.metadata)
+        content: Optional[Content] = None
+        for candidate_name in (None, existing.name):
+            candidate = Content(
+                name=candidate_name,
+                description=existing.description or None,
+                url=source_url,
+                metadata=dict(user_metadata) if user_metadata else None,
+                user_id=existing.user_id,
+            )
+            candidate.content_hash = knowledge._build_content_hash(candidate)
+            candidate.id = generate_id(candidate.content_hash)
+            if candidate.id == content_id:
+                content = candidate
+                break
+        if content is None:
+            raise HTTPException(
+                status_code=400, detail="Content row cannot be matched back to its source; re-ingest the URL instead"
+            )
+
+        source_type = get_agno_metadata(existing.metadata, "source_type")
+        reader_id = "sitemap" if source_type in ("sitemap", "page") else None
+        background_tasks.add_task(process_content, knowledge, content, reader_id, None, None, None)
+        return ContentResponseSchema(id=content_id, name=existing.name, status=ContentStatus.PROCESSING)
 
     @router.get(
         "/knowledge/content/{content_id}/status",

--- a/libs/agno/agno/os/routers/knowledge/knowledge.py
+++ b/libs/agno/agno/os/routers/knowledge/knowledge.py
@@ -759,7 +759,9 @@ def attach_routes(router: APIRouter, knowledge_instances: List[Union[Knowledge, 
 
         # Admins clear everything; a non-admin clears only their own rows, never shared ones.
         scoped_user_id = get_scoped_user_id(request)
-        await knowledge.aremove_all_content(user_id=scoped_user_id)
+        all_removed = await knowledge.aremove_all_content(user_id=scoped_user_id)
+        if all_removed is False:
+            raise HTTPException(status_code=500, detail="Some content was not fully removed; vector deletion failed")
         return "success"
 
     @router.post(

--- a/libs/agno/agno/os/routers/knowledge/knowledge.py
+++ b/libs/agno/agno/os/routers/knowledge/knowledge.py
@@ -819,8 +819,20 @@ def attach_routes(router: APIRouter, knowledge_instances: List[Union[Knowledge, 
                 status_code=400, detail="Content row cannot be matched back to its source; re-ingest the URL instead"
             )
 
-        source_type = get_agno_metadata(existing.metadata, "source_type")
-        reader_id = "sitemap" if source_type in ("sitemap", "page") else None
+        # A refresh must re-run the reader that built this row — refreshing an
+        # llms.txt site with the sitemap (or text) reader would rewrite and prune
+        # its pages. Rows record their reader at finalize; without a record, only
+        # the unambiguous sitemap kinds may be inferred.
+        reader_id = get_agno_metadata(existing.metadata, "reader_id")
+        if not isinstance(reader_id, str) or not reader_id:
+            source_type = get_agno_metadata(existing.metadata, "source_type")
+            if source_type in ("sitemap", "page"):
+                reader_id = "sitemap"
+            else:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Content row does not record which reader built it; re-ingest the URL instead",
+                )
         background_tasks.add_task(process_content, knowledge, content, reader_id, None, None, None)
         return ContentResponseSchema(id=content_id, name=existing.name, status=ContentStatus.PROCESSING)
 

--- a/libs/agno/agno/os/routers/knowledge/knowledge.py
+++ b/libs/agno/agno/os/routers/knowledge/knowledge.py
@@ -561,9 +561,7 @@ def attach_routes(router: APIRouter, knowledge_instances: List[Union[Knowledge, 
         sort_order: Optional[SortOrder] = Query(default=SortOrder.DESC, description="Sort order (asc or desc)"),
         db_id: Optional[str] = Query(default=None, description="Database ID to use"),
         knowledge_id: Optional[str] = Query(default=None, description="Knowledge base ID to use"),
-        parent_id: Optional[str] = Query(
-            default=None, description="Only page rows of this site row (exact id match)"
-        ),
+        parent_id: Optional[str] = Query(default=None, description="Only page rows of this site row (exact id match)"),
     ) -> PaginatedResponse[ContentResponseSchema]:
         knowledge = get_knowledge_instance(knowledge_instances, db_id, knowledge_id)
 
@@ -587,9 +585,7 @@ def attach_routes(router: APIRouter, knowledge_instances: List[Union[Knowledge, 
                 sort_by=sort_by, sort_order=sort_order, user_id=scoped_user_id
             )
             matched = [
-                content
-                for content in all_contents
-                if get_agno_metadata(content.metadata, "parent_id") == parent_id
+                content for content in all_contents if get_agno_metadata(content.metadata, "parent_id") == parent_id
             ]
             count = len(matched)
             page_number = page or 1

--- a/libs/agno/agno/tools/knowledge_management.py
+++ b/libs/agno/agno/tools/knowledge_management.py
@@ -1,0 +1,420 @@
+"""Operator-side toolkit for managing a knowledge base: ingest, list, remove.
+
+The write side of knowledge. `KnowledgeTools` (think/search) is what an end-user-facing agent
+gets; this toolkit is what a builder or operator agent gets, so widening one never leaks write
+capability into product agents. Everything goes through the Knowledge API — no direct SQL.
+"""
+
+import json
+import time
+from typing import Any, Dict, List, Literal, Optional
+
+from agno.knowledge.content import Content, FileData
+from agno.knowledge.knowledge import Knowledge
+from agno.knowledge.utils import get_agno_metadata, strip_agno_metadata
+from agno.run import RunContext
+from agno.tools import Toolkit
+from agno.utils.log import log_error
+from agno.utils.string import generate_id
+
+_HARD_PAGE_CAP = 500
+_LIST_PAGE_SIZE = 100
+_SAMPLE_SIZE = 5
+
+DEFAULT_INSTRUCTIONS = """\
+You manage this platform's knowledge base.
+
+- `ingest_url` loads a website page by page from its sitemap: one row per page, source URL
+  kept. Point it at the docs subdomain rather than a marketing root. Re-running it refreshes
+  pages that changed, retries pages that failed, and drops pages that left the site.
+- `list_content` shows what is loaded, grouped by site. `ingest_status` reports one site.
+- `remove_content` deletes a site row with every page under it, or one page row.
+Report the returned numbers (pages loaded, failures) back to the operator plainly.\
+"""
+
+
+class KnowledgeManagementTools(Toolkit):
+    """Manage a knowledge base: ingest websites and text, list what is loaded, remove it."""
+
+    def __init__(
+        self,
+        knowledge: Knowledge,
+        *,
+        scope: Literal["shared", "user"] = "shared",
+        max_pages: int = 50,
+        page_fetcher: Optional[Any] = None,
+        enable_ingest: bool = True,
+        enable_remove: bool = True,
+        instructions: Optional[str] = None,
+        add_instructions: bool = True,
+        **kwargs,
+    ):
+        """
+        Args:
+            knowledge: The knowledge base to manage.
+            scope: Who owns what this toolkit writes. "shared" (default) writes rows every
+                user can read — right for product docs. "user" writes rows owned by the
+                run's user.
+            max_pages: Default page cap for ingest_url (hard cap 500).
+            page_fetcher: Optional PageFetcher for ingest_url; default resolves Parallel
+                when available, the built-in fetcher otherwise.
+            enable_ingest: Register the ingest tools.
+            enable_remove: Register remove_content (requires confirmation by default).
+        """
+        if knowledge is None:
+            raise ValueError("knowledge must be provided when using KnowledgeManagementTools")
+        self.knowledge = knowledge
+        self.scope = scope
+        self.max_pages = max(1, min(max_pages, _HARD_PAGE_CAP))
+        self.page_fetcher = page_fetcher
+
+        tools: List[Any] = []
+        async_tools: List[Any] = []
+        if enable_ingest:
+            tools.append(self.ingest_url)
+            async_tools.append((self.aingest_url, "ingest_url"))
+            tools.append(self.ingest_text)
+            async_tools.append((self.aingest_text, "ingest_text"))
+        tools.append(self.list_content)
+        async_tools.append((self.alist_content, "list_content"))
+        tools.append(self.ingest_status)
+        async_tools.append((self.aingest_status, "ingest_status"))
+        if enable_remove:
+            tools.append(self.remove_content)
+            async_tools.append((self.aremove_content, "remove_content"))
+            kwargs.setdefault("requires_confirmation_tools", ["remove_content"])
+
+        super().__init__(
+            name="knowledge_management",
+            tools=tools,
+            async_tools=async_tools,
+            instructions=instructions if instructions is not None else DEFAULT_INSTRUCTIONS,
+            add_instructions=add_instructions,
+            **kwargs,
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _owner_id(self, run_context: Optional[RunContext]) -> Optional[str]:
+        if self.scope == "user":
+            return getattr(run_context, "user_id", None)
+        return None
+
+    def _build_reader(self, max_pages: Optional[int]):
+        from agno.knowledge.reader.sitemap_reader import SitemapReader
+
+        cap = max(1, min(int(max_pages), _HARD_PAGE_CAP)) if max_pages else self.max_pages
+        if self.page_fetcher is not None:
+            return SitemapReader(max_pages=cap, page_fetcher=self.page_fetcher)
+        return SitemapReader(max_pages=cap)
+
+    def _predict_url_row_id(self, url: str, owner: Optional[str]) -> str:
+        # The same Content shape ainsert(url=..., user_id=...) builds, so the hash — and the
+        # row id — match what the insert writes.
+        content = Content(url=url, user_id=owner)
+        return generate_id(self.knowledge._build_content_hash(content))
+
+    def _predict_text_row_id(self, name: str, metadata: Optional[Dict[str, Any]], owner: Optional[str]) -> str:
+        content = Content(
+            name=name,
+            file_data=FileData(content="", type="Text"),
+            metadata=strip_agno_metadata(metadata),
+            user_id=owner,
+        )
+        return generate_id(self.knowledge._build_content_hash(content))
+
+    @staticmethod
+    def _error(message: str) -> str:
+        return json.dumps({"ok": False, "error": message})
+
+    @staticmethod
+    def _status_value(status: Any) -> str:
+        return str(getattr(status, "value", status) or "").lower()
+
+    def _site_report(self, row: Optional[Content], site_id: str, seconds: Optional[float] = None) -> str:
+        if row is None:
+            return self._error(f"content {site_id} not found")
+        meta = row.metadata or {}
+        status = self._status_value(row.status)
+        report: Dict[str, Any] = {
+            "ok": status != "failed",
+            "site_id": site_id,
+            "name": row.name,
+            "status": status,
+            "status_message": row.status_message,
+            "pages": get_agno_metadata(meta, "page_count"),
+            "failed": get_agno_metadata(meta, "failed") or [],
+            "extractors": get_agno_metadata(meta, "extractor_counts") or {},
+        }
+        children = get_agno_metadata(meta, "children")
+        if isinstance(children, list):
+            report["page_rows"] = len(children)
+        if seconds is not None:
+            report["seconds"] = round(seconds, 1)
+        return json.dumps(report, default=str)
+
+    # ------------------------------------------------------------------
+    # Ingest
+    # ------------------------------------------------------------------
+
+    def ingest_url(self, run_context: RunContext, url: str, max_pages: Optional[int] = None) -> str:
+        """Ingest a website into the knowledge base, one row per page with its source URL.
+
+        Discovers pages from the site's sitemap (robots.txt and sitemap indexes are
+        followed). A site without a sitemap gets the one page at `url`. Re-running refreshes
+        changed pages, retries failed ones, and removes pages that left the site.
+
+        Args:
+            url: Any page of the site, e.g. https://docs.example.com. Prefer the docs subdomain.
+            max_pages: Maximum pages to ingest (default from the toolkit, hard cap 500).
+
+        Returns:
+            JSON: ok, site_id, name, status, pages, failed (per-URL errors), extractors, seconds.
+        """
+        owner = self._owner_id(run_context)
+        started = time.monotonic()
+        try:
+            site_id = self._predict_url_row_id(url, owner)
+            self.knowledge.insert(url=url, reader=self._build_reader(max_pages), user_id=owner)
+            row = self.knowledge.get_content_by_id(site_id, user_id=owner)
+            return self._site_report(row, site_id, seconds=time.monotonic() - started)
+        except Exception as e:
+            log_error(f"ingest_url failed for {url}: {e}")
+            return self._error(str(e))
+
+    async def aingest_url(self, run_context: RunContext, url: str, max_pages: Optional[int] = None) -> str:
+        """Ingest a website into the knowledge base, one row per page with its source URL.
+
+        Discovers pages from the site's sitemap (robots.txt and sitemap indexes are
+        followed). A site without a sitemap gets the one page at `url`. Re-running refreshes
+        changed pages, retries failed ones, and removes pages that left the site.
+
+        Args:
+            url: Any page of the site, e.g. https://docs.example.com. Prefer the docs subdomain.
+            max_pages: Maximum pages to ingest (default from the toolkit, hard cap 500).
+
+        Returns:
+            JSON: ok, site_id, name, status, pages, failed (per-URL errors), extractors, seconds.
+        """
+        owner = self._owner_id(run_context)
+        started = time.monotonic()
+        try:
+            site_id = self._predict_url_row_id(url, owner)
+            await self.knowledge.ainsert(url=url, reader=self._build_reader(max_pages), user_id=owner)
+            row = await self.knowledge.aget_content_by_id(site_id, user_id=owner)
+            return self._site_report(row, site_id, seconds=time.monotonic() - started)
+        except Exception as e:
+            log_error(f"ingest_url failed for {url}: {e}")
+            return self._error(str(e))
+
+    def ingest_text(
+        self, run_context: RunContext, name: str, text: str, metadata: Optional[Dict[str, str]] = None
+    ) -> str:
+        """Add a piece of text to the knowledge base as one named document.
+
+        Args:
+            name: A short, unique name for the document.
+            text: The document text.
+            metadata: Optional metadata key-value pairs stored with the document.
+
+        Returns:
+            JSON: ok, id, name.
+        """
+        owner = self._owner_id(run_context)
+        try:
+            self.knowledge.insert(name=name, text_content=text, metadata=metadata, user_id=owner)
+            row_id = self._predict_text_row_id(name, metadata, owner)
+            return json.dumps({"ok": True, "id": row_id, "name": name})
+        except Exception as e:
+            log_error(f"ingest_text failed for {name}: {e}")
+            return self._error(str(e))
+
+    async def aingest_text(
+        self, run_context: RunContext, name: str, text: str, metadata: Optional[Dict[str, str]] = None
+    ) -> str:
+        """Add a piece of text to the knowledge base as one named document.
+
+        Args:
+            name: A short, unique name for the document.
+            text: The document text.
+            metadata: Optional metadata key-value pairs stored with the document.
+
+        Returns:
+            JSON: ok, id, name.
+        """
+        owner = self._owner_id(run_context)
+        try:
+            await self.knowledge.ainsert(name=name, text_content=text, metadata=metadata, user_id=owner)
+            row_id = self._predict_text_row_id(name, metadata, owner)
+            return json.dumps({"ok": True, "id": row_id, "name": name})
+        except Exception as e:
+            log_error(f"ingest_text failed for {name}: {e}")
+            return self._error(str(e))
+
+    # ------------------------------------------------------------------
+    # List / status
+    # ------------------------------------------------------------------
+
+    def _group_rows(self, rows: List[Content], host: Optional[str]) -> str:
+        sites: List[Dict[str, Any]] = []
+        pages_by_parent: Dict[str, int] = {}
+        other: List[Dict[str, Any]] = []
+        for row in rows:
+            meta = row.metadata or {}
+            parent_id = get_agno_metadata(meta, "parent_id")
+            if isinstance(parent_id, str):
+                pages_by_parent[parent_id] = pages_by_parent.get(parent_id, 0) + 1
+                continue
+            children = get_agno_metadata(meta, "children")
+            if isinstance(children, list):
+                sites.append(
+                    {
+                        "site_id": row.id,
+                        "name": row.name,
+                        "pages": len(children),
+                        "failed": len(get_agno_metadata(meta, "failed") or []),
+                        "status": self._status_value(row.status),
+                        "updated_at": row.updated_at,
+                    }
+                )
+            else:
+                other.append({"id": row.id, "name": row.name, "type": row.file_type, "status": self._status_value(row.status)})
+        if host:
+            needle = host.lower()
+            sites = [site for site in sites if needle in (site["name"] or "").lower()]
+            other = [entry for entry in other if needle in (entry["name"] or "").lower()]
+        return json.dumps({"sites": sites, "other": other, "total_rows": len(rows)}, default=str)
+
+    def list_content(self, run_context: RunContext, host: Optional[str] = None) -> str:
+        """List what the knowledge base holds, grouped by ingested site.
+
+        Args:
+            host: Optional host filter, e.g. "docs.example.com" — only entries whose name
+                contains it are returned.
+
+        Returns:
+            JSON: sites (site_id, name, pages, failed, status, updated_at), other documents,
+            and the total row count.
+        """
+        owner = self._owner_id(run_context)
+        try:
+            rows: List[Content] = []
+            page = 1
+            while True:
+                batch, count = self.knowledge.get_content(limit=_LIST_PAGE_SIZE, page=page, user_id=owner)
+                rows.extend(batch)
+                if len(rows) >= count or not batch:
+                    break
+                page += 1
+            return self._group_rows(rows, host)
+        except Exception as e:
+            log_error(f"list_content failed: {e}")
+            return self._error(str(e))
+
+    async def alist_content(self, run_context: RunContext, host: Optional[str] = None) -> str:
+        """List what the knowledge base holds, grouped by ingested site.
+
+        Args:
+            host: Optional host filter, e.g. "docs.example.com" — only entries whose name
+                contains it are returned.
+
+        Returns:
+            JSON: sites (site_id, name, pages, failed, status, updated_at), other documents,
+            and the total row count.
+        """
+        owner = self._owner_id(run_context)
+        try:
+            rows = []
+            page = 1
+            while True:
+                batch, count = await self.knowledge.aget_content(limit=_LIST_PAGE_SIZE, page=page, user_id=owner)
+                rows.extend(batch)
+                if len(rows) >= count or not batch:
+                    break
+                page += 1
+            return self._group_rows(rows, host)
+        except Exception as e:
+            log_error(f"list_content failed: {e}")
+            return self._error(str(e))
+
+    def ingest_status(self, run_context: RunContext, site_id: str) -> str:
+        """Report one ingested site: status, pages loaded, and per-page failures.
+
+        Args:
+            site_id: The site row id returned by ingest_url or list_content.
+
+        Returns:
+            JSON: ok, site_id, name, status, status_message, pages, failed, extractors.
+        """
+        owner = self._owner_id(run_context)
+        try:
+            row = self.knowledge.get_content_by_id(site_id, user_id=owner)
+            return self._site_report(row, site_id)
+        except Exception as e:
+            log_error(f"ingest_status failed for {site_id}: {e}")
+            return self._error(str(e))
+
+    async def aingest_status(self, run_context: RunContext, site_id: str) -> str:
+        """Report one ingested site: status, pages loaded, and per-page failures.
+
+        Args:
+            site_id: The site row id returned by ingest_url or list_content.
+
+        Returns:
+            JSON: ok, site_id, name, status, status_message, pages, failed, extractors.
+        """
+        owner = self._owner_id(run_context)
+        try:
+            row = await self.knowledge.aget_content_by_id(site_id, user_id=owner)
+            return self._site_report(row, site_id)
+        except Exception as e:
+            log_error(f"ingest_status failed for {site_id}: {e}")
+            return self._error(str(e))
+
+    # ------------------------------------------------------------------
+    # Remove
+    # ------------------------------------------------------------------
+
+    def remove_content(self, run_context: RunContext, content_id: str) -> str:
+        """Delete content from the knowledge base. Deleting a site removes every page under it.
+
+        Args:
+            content_id: A site row id (removes the site and all its pages) or a single
+                document/page row id.
+
+        Returns:
+            JSON: ok and the id removed.
+        """
+        owner = self._owner_id(run_context)
+        try:
+            row = self.knowledge.get_content_by_id(content_id, user_id=owner)
+            if row is None:
+                return self._error(f"content {content_id} not found")
+            self.knowledge.remove_content_by_id(content_id, user_id=owner)
+            return json.dumps({"ok": True, "removed": content_id, "name": row.name})
+        except Exception as e:
+            log_error(f"remove_content failed for {content_id}: {e}")
+            return self._error(str(e))
+
+    async def aremove_content(self, run_context: RunContext, content_id: str) -> str:
+        """Delete content from the knowledge base. Deleting a site removes every page under it.
+
+        Args:
+            content_id: A site row id (removes the site and all its pages) or a single
+                document/page row id.
+
+        Returns:
+            JSON: ok and the id removed.
+        """
+        owner = self._owner_id(run_context)
+        try:
+            row = await self.knowledge.aget_content_by_id(content_id, user_id=owner)
+            if row is None:
+                return self._error(f"content {content_id} not found")
+            await self.knowledge.aremove_content_by_id(content_id, user_id=owner)
+            return json.dumps({"ok": True, "removed": content_id, "name": row.name})
+        except Exception as e:
+            log_error(f"remove_content failed for {content_id}: {e}")
+            return self._error(str(e))

--- a/libs/agno/agno/tools/knowledge_management.py
+++ b/libs/agno/agno/tools/knowledge_management.py
@@ -99,7 +99,12 @@ class KnowledgeManagementTools(Toolkit):
 
     def _owner_id(self, run_context: Optional[RunContext]) -> Optional[str]:
         if self.scope == "user":
-            return getattr(run_context, "user_id", None)
+            user_id = getattr(run_context, "user_id", None)
+            if not user_id:
+                # Fail closed: scope="user" content silently landing in the shared
+                # bucket would be readable and deletable by everyone.
+                raise ValueError("scope='user' requires the run to have a user_id")
+            return user_id
         return None
 
     def _build_reader(self, max_pages: Optional[int]):
@@ -177,9 +182,9 @@ class KnowledgeManagementTools(Toolkit):
         Returns:
             JSON: ok, site_id, name, status, pages, failed (per-URL errors), extractors, seconds.
         """
-        owner = self._owner_id(run_context)
         started = time.monotonic()
         try:
+            owner = self._owner_id(run_context)
             site_id = self._predict_url_row_id(url, owner)
             self.knowledge.insert(url=url, reader=self._build_reader(max_pages), user_id=owner)
             row = self.knowledge.get_content_by_id(site_id, user_id=owner)
@@ -202,9 +207,9 @@ class KnowledgeManagementTools(Toolkit):
         Returns:
             JSON: ok, site_id, name, status, pages, failed (per-URL errors), extractors, seconds.
         """
-        owner = self._owner_id(run_context)
         started = time.monotonic()
         try:
+            owner = self._owner_id(run_context)
             site_id = self._predict_url_row_id(url, owner)
             await self.knowledge.ainsert(url=url, reader=self._build_reader(max_pages), user_id=owner)
             row = await self.knowledge.aget_content_by_id(site_id, user_id=owner)
@@ -226,10 +231,13 @@ class KnowledgeManagementTools(Toolkit):
         Returns:
             JSON: ok, id, name.
         """
-        owner = self._owner_id(run_context)
         try:
+            owner = self._owner_id(run_context)
             self.knowledge.insert(name=name, text_content=text, metadata=metadata, user_id=owner)
             row_id = self._predict_text_row_id(name, text, metadata, owner)
+            row = self.knowledge.get_content_by_id(row_id, user_id=owner) if self.knowledge.contents_db else None
+            if row is not None and self._status_value(row.status) == "failed":
+                return json.dumps({"ok": False, "id": row_id, "name": name, "error": row.status_message})
             return json.dumps({"ok": True, "id": row_id, "name": name})
         except Exception as e:
             log_error(f"ingest_text failed for {name}: {e}")
@@ -248,10 +256,13 @@ class KnowledgeManagementTools(Toolkit):
         Returns:
             JSON: ok, id, name.
         """
-        owner = self._owner_id(run_context)
         try:
+            owner = self._owner_id(run_context)
             await self.knowledge.ainsert(name=name, text_content=text, metadata=metadata, user_id=owner)
             row_id = self._predict_text_row_id(name, text, metadata, owner)
+            row = await self.knowledge.aget_content_by_id(row_id, user_id=owner) if self.knowledge.contents_db else None
+            if row is not None and self._status_value(row.status) == "failed":
+                return json.dumps({"ok": False, "id": row_id, "name": name, "error": row.status_message})
             return json.dumps({"ok": True, "id": row_id, "name": name})
         except Exception as e:
             log_error(f"ingest_text failed for {name}: {e}")
@@ -304,8 +315,8 @@ class KnowledgeManagementTools(Toolkit):
             JSON: sites (site_id, name, pages, failed, status, updated_at), other documents,
             and the total row count.
         """
-        owner = self._owner_id(run_context)
         try:
+            owner = self._owner_id(run_context)
             rows: List[Content] = []
             page = 1
             while True:
@@ -330,8 +341,8 @@ class KnowledgeManagementTools(Toolkit):
             JSON: sites (site_id, name, pages, failed, status, updated_at), other documents,
             and the total row count.
         """
-        owner = self._owner_id(run_context)
         try:
+            owner = self._owner_id(run_context)
             rows = []
             page = 1
             while True:
@@ -354,8 +365,8 @@ class KnowledgeManagementTools(Toolkit):
         Returns:
             JSON: ok, site_id, name, status, status_message, pages, failed, extractors.
         """
-        owner = self._owner_id(run_context)
         try:
+            owner = self._owner_id(run_context)
             row = self.knowledge.get_content_by_id(site_id, user_id=owner)
             return self._site_report(row, site_id)
         except Exception as e:
@@ -371,8 +382,8 @@ class KnowledgeManagementTools(Toolkit):
         Returns:
             JSON: ok, site_id, name, status, status_message, pages, failed, extractors.
         """
-        owner = self._owner_id(run_context)
         try:
+            owner = self._owner_id(run_context)
             row = await self.knowledge.aget_content_by_id(site_id, user_id=owner)
             return self._site_report(row, site_id)
         except Exception as e:
@@ -393,12 +404,15 @@ class KnowledgeManagementTools(Toolkit):
         Returns:
             JSON: ok and the id removed.
         """
-        owner = self._owner_id(run_context)
         try:
+            owner = self._owner_id(run_context)
             row = self.knowledge.get_content_by_id(content_id, user_id=owner)
             if row is None:
                 return self._error(f"content {content_id} not found")
             self.knowledge.remove_content_by_id(content_id, user_id=owner)
+            if self.knowledge.contents_db and self.knowledge.get_content_by_id(content_id, user_id=owner) is not None:
+                # The core silently refuses some deletes (e.g. shared content under a scoped owner)
+                return self._error(f"content {content_id} was not removed (not permitted for this scope)")
             return json.dumps({"ok": True, "removed": content_id, "name": row.name})
         except Exception as e:
             log_error(f"remove_content failed for {content_id}: {e}")
@@ -414,12 +428,18 @@ class KnowledgeManagementTools(Toolkit):
         Returns:
             JSON: ok and the id removed.
         """
-        owner = self._owner_id(run_context)
         try:
+            owner = self._owner_id(run_context)
             row = await self.knowledge.aget_content_by_id(content_id, user_id=owner)
             if row is None:
                 return self._error(f"content {content_id} not found")
             await self.knowledge.aremove_content_by_id(content_id, user_id=owner)
+            if (
+                self.knowledge.contents_db
+                and await self.knowledge.aget_content_by_id(content_id, user_id=owner) is not None
+            ):
+                # The core silently refuses some deletes (e.g. shared content under a scoped owner)
+                return self._error(f"content {content_id} was not removed (not permitted for this scope)")
             return json.dumps({"ok": True, "removed": content_id, "name": row.name})
         except Exception as e:
             log_error(f"remove_content failed for {content_id}: {e}")

--- a/libs/agno/agno/tools/knowledge_management.py
+++ b/libs/agno/agno/tools/knowledge_management.py
@@ -116,10 +116,14 @@ class KnowledgeManagementTools(Toolkit):
         content = Content(url=url, user_id=owner)
         return generate_id(self.knowledge._build_content_hash(content))
 
-    def _predict_text_row_id(self, name: str, metadata: Optional[Dict[str, Any]], owner: Optional[str]) -> str:
+    def _predict_text_row_id(
+        self, name: str, text: str, metadata: Optional[Dict[str, Any]], owner: Optional[str]
+    ) -> str:
+        # Mirror the Content shape ainsert(text_content=...) builds — the file_data branch of
+        # the hash only engages when content is non-empty, so the real text goes in.
         content = Content(
             name=name,
-            file_data=FileData(content="", type="Text"),
+            file_data=FileData(content=text, type="Text"),
             metadata=strip_agno_metadata(metadata),
             user_id=owner,
         )
@@ -225,7 +229,7 @@ class KnowledgeManagementTools(Toolkit):
         owner = self._owner_id(run_context)
         try:
             self.knowledge.insert(name=name, text_content=text, metadata=metadata, user_id=owner)
-            row_id = self._predict_text_row_id(name, metadata, owner)
+            row_id = self._predict_text_row_id(name, text, metadata, owner)
             return json.dumps({"ok": True, "id": row_id, "name": name})
         except Exception as e:
             log_error(f"ingest_text failed for {name}: {e}")
@@ -247,7 +251,7 @@ class KnowledgeManagementTools(Toolkit):
         owner = self._owner_id(run_context)
         try:
             await self.knowledge.ainsert(name=name, text_content=text, metadata=metadata, user_id=owner)
-            row_id = self._predict_text_row_id(name, metadata, owner)
+            row_id = self._predict_text_row_id(name, text, metadata, owner)
             return json.dumps({"ok": True, "id": row_id, "name": name})
         except Exception as e:
             log_error(f"ingest_text failed for {name}: {e}")
@@ -280,7 +284,9 @@ class KnowledgeManagementTools(Toolkit):
                     }
                 )
             else:
-                other.append({"id": row.id, "name": row.name, "type": row.file_type, "status": self._status_value(row.status)})
+                other.append(
+                    {"id": row.id, "name": row.name, "type": row.file_type, "status": self._status_value(row.status)}
+                )
         if host:
             needle = host.lower()
             sites = [site for site in sites if needle in (site["name"] or "").lower()]

--- a/libs/agno/agno/tools/knowledge_management.py
+++ b/libs/agno/agno/tools/knowledge_management.py
@@ -63,6 +63,13 @@ class KnowledgeManagementTools(Toolkit):
         """
         if knowledge is None:
             raise ValueError("knowledge must be provided when using KnowledgeManagementTools")
+        if getattr(knowledge, "contents_db", None) is None:
+            # Every tool here reads or writes content rows (status, listing, digests,
+            # cascade delete); on a vector-only base they would silently half-work.
+            raise ValueError(
+                "KnowledgeManagementTools requires a Knowledge with a contents_db "
+                "(e.g. Knowledge(vector_db=..., contents_db=SqliteDb(...)))"
+            )
         self.knowledge = knowledge
         self.scope = scope
         self.max_pages = max(1, min(max_pages, _HARD_PAGE_CAP))
@@ -409,10 +416,9 @@ class KnowledgeManagementTools(Toolkit):
             row = self.knowledge.get_content_by_id(content_id, user_id=owner)
             if row is None:
                 return self._error(f"content {content_id} not found")
-            self.knowledge.remove_content_by_id(content_id, user_id=owner)
-            if self.knowledge.contents_db and self.knowledge.get_content_by_id(content_id, user_id=owner) is not None:
-                # The core silently refuses some deletes (e.g. shared content under a scoped owner)
-                return self._error(f"content {content_id} was not removed (not permitted for this scope)")
+            removed = self.knowledge.remove_content_by_id(content_id, user_id=owner)
+            if removed is False:
+                return self._error(f"content {content_id} was not removed (delete refused or vector store failed)")
             return json.dumps({"ok": True, "removed": content_id, "name": row.name})
         except Exception as e:
             log_error(f"remove_content failed for {content_id}: {e}")
@@ -433,13 +439,9 @@ class KnowledgeManagementTools(Toolkit):
             row = await self.knowledge.aget_content_by_id(content_id, user_id=owner)
             if row is None:
                 return self._error(f"content {content_id} not found")
-            await self.knowledge.aremove_content_by_id(content_id, user_id=owner)
-            if (
-                self.knowledge.contents_db
-                and await self.knowledge.aget_content_by_id(content_id, user_id=owner) is not None
-            ):
-                # The core silently refuses some deletes (e.g. shared content under a scoped owner)
-                return self._error(f"content {content_id} was not removed (not permitted for this scope)")
+            removed = await self.knowledge.aremove_content_by_id(content_id, user_id=owner)
+            if removed is False:
+                return self._error(f"content {content_id} was not removed (delete refused or vector store failed)")
             return json.dumps({"ok": True, "removed": content_id, "name": row.name})
         except Exception as e:
             log_error(f"remove_content failed for {content_id}: {e}")

--- a/libs/agno/tests/unit/knowledge/test_per_page_content_rows.py
+++ b/libs/agno/tests/unit/knowledge/test_per_page_content_rows.py
@@ -1,0 +1,468 @@
+"""Multi-page URL reads land one contents-db row per page, owned by a site row.
+
+Each page row's id equals the ``content_id`` its vectors carry, an unchanged page
+refreshes its row without re-embedding, a changed page re-embeds alone, a page that
+left the site is deleted, a failed page gets a FAILED row and is retried next run,
+and deleting the site row cascades to its page rows and their vectors.
+"""
+
+import time
+from typing import Dict, List, Optional, Tuple
+from unittest import mock
+
+from agno.db.sqlite import SqliteDb
+from agno.knowledge.document import Document
+from agno.knowledge.knowledge import Knowledge
+from agno.knowledge.reader.base import Reader
+from agno.knowledge.types import ContentType
+from agno.knowledge.utils import get_agno_metadata
+
+SITE_URL = "https://docs.x.com/sitemap.xml"
+PAGE_ONE = "https://docs.x.com/guide"
+PAGE_TWO = "https://docs.x.com/api"
+PAGE_THREE = "https://docs.x.com/faq"
+
+PAGE_ERROR = "HTTP 500"
+
+
+class FakePagesReader(Reader):
+    """Multi-page reader stub: one document per entry in ``pages``, no network.
+
+    A ``None`` page text marks an error page: empty content plus
+    ``meta_data['error']``, the shape multi-page readers use for a fetch failure.
+    """
+
+    def __init__(self, pages: Dict[str, Optional[str]], **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.pages = dict(pages)
+
+    @classmethod
+    def get_supported_content_types(cls) -> List[ContentType]:
+        return [ContentType.URL]
+
+    def read(self, obj, name: Optional[str] = None, password: Optional[str] = None) -> List[Document]:
+        documents = []
+        for url, text in self.pages.items():
+            meta = {"url": url, "title": "Title", "extractor": "fake", "source": "sitemap"}
+            if text is None:
+                meta["error"] = PAGE_ERROR
+                text = ""
+            documents.append(Document(name=name, meta_data=meta, content=text))
+        return documents
+
+    async def async_read(self, obj, name: Optional[str] = None, password: Optional[str] = None) -> List[Document]:
+        return self.read(obj, name=name, password=password)
+
+
+class LightRag:
+    """Stands in for the real LightRag adapter, which Knowledge matches by class name."""
+
+    def __init__(self) -> None:
+        self.inserted_texts: List[Tuple[str, str]] = []
+
+    def exists(self) -> bool:
+        return True
+
+    def create(self) -> None:
+        pass
+
+    def content_hash_exists(self, content_hash: str, user_id: Optional[str] = None) -> bool:
+        return False
+
+    def update_metadata(self, content_id: str, metadata: Dict) -> None:
+        pass
+
+    async def insert_text(self, file_source: str, text: str) -> str:
+        self.inserted_texts.append((file_source, text))
+        return "ext-1"
+
+
+def _kb(tmp_path, vector_db, filename: str = "contents.db") -> Knowledge:
+    return Knowledge(name="t", vector_db=vector_db, contents_db=SqliteDb(db_file=str(tmp_path / filename)))
+
+
+def _rows(kb: Knowledge):
+    rows, _ = kb.contents_db.get_knowledge_contents()
+    return rows
+
+
+def _site_row(rows):
+    sites = [row for row in rows if get_agno_metadata(row.metadata, "children") is not None]
+    assert len(sites) == 1, f"expected exactly one site row, got {len(sites)}"
+    return sites[0]
+
+
+def _child_rows(rows):
+    return {row.id: row for row in rows if get_agno_metadata(row.metadata, "parent_id") is not None}
+
+
+def _child_by_url(rows, url: str):
+    children = [row for row in _child_rows(rows).values() if get_agno_metadata(row.metadata, "source_url") == url]
+    assert len(children) == 1, f"expected exactly one child row for {url}, got {len(children)}"
+    return children[0]
+
+
+def _record_deletes(vector_db) -> List[Tuple[str, Optional[str]]]:
+    """Shadow ``delete_by_content_id`` with a recording twin that still declares user_id."""
+    deleted: List[Tuple[str, Optional[str]]] = []
+
+    def delete_by_content_id(content_id: str, user_id: Optional[str] = None) -> bool:
+        deleted.append((content_id, user_id))
+        return True
+
+    vector_db.delete_by_content_id = delete_by_content_id
+    return deleted
+
+
+def _clear_writes(vector_db) -> None:
+    vector_db.writes.clear()
+    vector_db.inserted_documents.clear()
+    vector_db.upserted_documents.clear()
+
+
+def _assert_site_and_children_shape(vector_db, rows) -> None:
+    assert len(rows) == 3
+    site = _site_row(rows)
+    assert site.name == "docs.x.com"
+    assert site.status == "completed"
+    assert site.status_message == "2 of 2 pages loaded"
+    assert get_agno_metadata(site.metadata, "extractor_counts") == {"fake": 2}
+
+    children = _child_rows(rows)
+    child_ids = get_agno_metadata(site.metadata, "children")
+    assert sorted(child_ids) == sorted(children.keys())
+
+    # Each page row's id equals the content_id its vectors carry
+    assert len(vector_db.writes) == 2
+    content_id_by_url = {doc.meta_data["url"]: doc.content_id for doc in vector_db.inserted_documents}
+    for child in children.values():
+        source_url = get_agno_metadata(child.metadata, "source_url")
+        assert source_url in (PAGE_ONE, PAGE_TWO)
+        assert content_id_by_url[source_url] == child.id
+        assert child.status == "completed"
+        assert child.metadata["team"] == "docs"
+        assert get_agno_metadata(child.metadata, "parent_id") == site.id
+        assert get_agno_metadata(child.metadata, "content_digest")
+        assert get_agno_metadata(child.metadata, "extractor") == "fake"
+
+
+async def test_multi_page_ainsert_lands_site_row_and_page_rows(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    reader = FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"})
+
+    await kb.ainsert(url=SITE_URL, reader=reader, metadata={"team": "docs"})
+
+    _assert_site_and_children_shape(vector_db, _rows(kb))
+
+
+def test_multi_page_insert_lands_site_row_and_page_rows(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    reader = FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"})
+
+    kb.insert(url=SITE_URL, reader=reader, metadata={"team": "docs"})
+
+    _assert_site_and_children_shape(vector_db, _rows(kb))
+
+
+async def test_ainsert_unchanged_pages_skip_embedding_and_refresh_rows(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    reader = FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"})
+    await kb.ainsert(url=SITE_URL, reader=reader)
+    first_ids = {row.id for row in _rows(kb)}
+    _clear_writes(vector_db)
+
+    future = int(time.time()) + 1000
+    with mock.patch("time.time", return_value=float(future)):
+        await kb.ainsert(url=SITE_URL, reader=reader)
+
+    assert vector_db.writes == []
+    rows = _rows(kb)
+    assert {row.id for row in rows} == first_ids
+    assert _site_row(rows).status_message == "2 of 2 pages loaded"
+    for child in _child_rows(rows).values():
+        assert child.status == "completed"
+        assert child.updated_at == future, "unchanged page row did not refresh updated_at"
+
+
+def test_insert_unchanged_pages_skip_embedding(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    reader = FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"})
+    kb.insert(url=SITE_URL, reader=reader)
+    first_ids = {row.id for row in _rows(kb)}
+    _clear_writes(vector_db)
+
+    kb.insert(url=SITE_URL, reader=reader)
+
+    assert vector_db.writes == []
+    assert {row.id for row in _rows(kb)} == first_ids
+
+
+async def test_ainsert_changed_page_reembeds_only_that_page(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}))
+    _clear_writes(vector_db)
+
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text v2"}))
+
+    assert len(vector_db.writes) == 1
+    assert {doc.meta_data["url"] for doc in vector_db.inserted_documents} == {PAGE_TWO}
+
+
+def test_insert_changed_page_reembeds_only_that_page(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    kb.insert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}))
+    _clear_writes(vector_db)
+
+    kb.insert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text v2"}))
+
+    assert len(vector_db.writes) == 1
+    assert {doc.meta_data["url"] for doc in vector_db.inserted_documents} == {PAGE_TWO}
+
+
+async def test_ainsert_removed_page_deletes_its_row_and_vectors(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    await kb.ainsert(
+        url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text", PAGE_THREE: "faq text"})
+    )
+    removed_id = _child_by_url(_rows(kb), PAGE_THREE).id
+    deleted = _record_deletes(vector_db)
+
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}))
+
+    assert deleted == [(removed_id, None)]
+    rows = _rows(kb)
+    assert removed_id not in {row.id for row in rows}
+    site = _site_row(rows)
+    assert removed_id not in get_agno_metadata(site.metadata, "children")
+    assert len(get_agno_metadata(site.metadata, "children")) == 2
+    assert site.status_message == "2 of 2 pages loaded"
+
+
+async def test_ainsert_failed_page_gets_failed_row_and_is_retried(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: None}))
+
+    rows = _rows(kb)
+    failed_child = _child_by_url(rows, PAGE_TWO)
+    assert failed_child.status == "failed"
+    assert failed_child.status_message == PAGE_ERROR
+    assert len(vector_db.writes) == 1, "the failed page must not reach the vector db"
+    assert {doc.meta_data["url"] for doc in vector_db.inserted_documents} == {PAGE_ONE}
+    site = _site_row(rows)
+    assert site.status == "completed"
+    assert site.status_message == f"1 of 2 pages loaded; failed: {PAGE_TWO}"
+    assert get_agno_metadata(site.metadata, "failed") == [{"url": PAGE_TWO, "error": PAGE_ERROR}]
+
+    # The page comes back on the next run: FAILED rows retry
+    _clear_writes(vector_db)
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}))
+
+    rows = _rows(kb)
+    retried = _child_by_url(rows, PAGE_TWO)
+    assert retried.status == "completed"
+    assert len(vector_db.writes) == 1
+    assert {doc.meta_data["url"] for doc in vector_db.inserted_documents} == {PAGE_TWO}
+    assert _site_row(rows).status_message == "2 of 2 pages loaded"
+
+
+def test_insert_failed_page_gets_failed_row(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    kb.insert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: None}))
+
+    rows = _rows(kb)
+    failed_child = _child_by_url(rows, PAGE_TWO)
+    assert failed_child.status == "failed"
+    assert failed_child.status_message == PAGE_ERROR
+    assert len(vector_db.writes) == 1
+    site = _site_row(rows)
+    assert site.status == "completed"
+    assert site.status_message == f"1 of 2 pages loaded; failed: {PAGE_TWO}"
+
+
+async def test_ainsert_all_pages_failed_marks_site_row_failed(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: None, PAGE_TWO: None}))
+
+    rows = _rows(kb)
+    site = _site_row(rows)
+    assert site.status == "failed"
+    assert site.status_message == f"0 of 2 pages loaded; failed: {PAGE_ONE}, {PAGE_TWO}"
+    assert vector_db.writes == []
+    for child in _child_rows(rows).values():
+        assert child.status == "failed"
+
+
+async def test_ainsert_scoped_owner_owns_rows_and_vectors(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}), user_id="u1")
+
+    rows = _rows(kb)
+    assert len(rows) == 3
+    assert all(row.user_id == "u1" for row in rows)
+    assert vector_db.owners == ["u1", "u1"]
+
+    # Another user's scoped read sees only shared rows -- none here
+    visible_to_u2, count_u2 = await kb.aget_content(user_id="u2")
+    assert visible_to_u2 == []
+    assert count_u2 == 0
+    visible_to_u1, count_u1 = await kb.aget_content(user_id="u1")
+    assert count_u1 == 3
+    assert {content.id for content in visible_to_u1} == {row.id for row in rows}
+
+    # The owner's scoped delete of the site row removes everything
+    await kb.aremove_content_by_id(_site_row(rows).id, user_id="u1")
+    assert _rows(kb) == []
+
+
+async def test_aremove_site_row_cascades_to_page_rows(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}))
+    rows = _rows(kb)
+    site_id = _site_row(rows).id
+    child_ids = set(_child_rows(rows).keys())
+    deleted = _record_deletes(vector_db)
+
+    await kb.aremove_content_by_id(site_id)
+
+    assert _rows(kb) == []
+    deleted_ids = [content_id for content_id, _ in deleted]
+    for child_id in child_ids:
+        assert deleted_ids.count(child_id) == 1
+    assert deleted_ids.count(site_id) == 1
+
+
+def test_remove_site_row_cascades_to_page_rows(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    kb.insert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}))
+    rows = _rows(kb)
+    site_id = _site_row(rows).id
+    child_ids = set(_child_rows(rows).keys())
+    deleted = _record_deletes(vector_db)
+
+    kb.remove_content_by_id(site_id)
+
+    assert _rows(kb) == []
+    deleted_ids = [content_id for content_id, _ in deleted]
+    for child_id in child_ids:
+        assert deleted_ids.count(child_id) == 1
+    assert deleted_ids.count(site_id) == 1
+
+
+async def test_aremove_child_row_drops_it_from_parent_children(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}))
+    rows = _rows(kb)
+    removed_id = _child_by_url(rows, PAGE_TWO).id
+    kept_id = _child_by_url(rows, PAGE_ONE).id
+
+    await kb.aremove_content_by_id(removed_id)
+
+    rows = _rows(kb)
+    assert set(_child_rows(rows).keys()) == {kept_id}
+    remaining_ids = {row.id for row in rows}
+    assert removed_id not in remaining_ids
+    site = _site_row(rows)
+    children = get_agno_metadata(site.metadata, "children")
+    assert removed_id not in children
+    assert children == [kept_id]
+
+
+async def test_single_page_read_keeps_legacy_single_row(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "only page"}))
+
+    rows = _rows(kb)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.name == "sitemap.xml"
+    assert row.status == "completed"
+    assert get_agno_metadata(row.metadata, "children") is None
+    assert get_agno_metadata(row.metadata, "parent_id") is None
+    assert len(vector_db.writes) == 1
+    assert all(doc.content_id == row.id for doc in vector_db.inserted_documents)
+
+
+def test_insert_single_page_read_keeps_legacy_single_row(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    kb.insert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "only page"}))
+
+    rows = _rows(kb)
+    assert len(rows) == 1
+    assert rows[0].status == "completed"
+    assert get_agno_metadata(rows[0].metadata, "children") is None
+    assert len(vector_db.writes) == 1
+
+
+async def test_shrink_to_one_page_keeps_site_row(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}))
+
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text"}))
+
+    rows = _rows(kb)
+    assert len(rows) == 2
+    site = _site_row(rows)
+    assert site.status == "completed"
+    assert site.status_message == "1 of 1 pages loaded"
+    children = get_agno_metadata(site.metadata, "children")
+    assert children == [_child_by_url(rows, PAGE_ONE).id]
+
+
+async def test_lightrag_refuses_multi_page_read_async(tmp_path):
+    lightrag = LightRag()
+    kb = _kb(tmp_path, lightrag)
+    reader = FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"})
+    reader.chunk = True
+
+    await kb.ainsert(url=SITE_URL, reader=reader)
+
+    rows = _rows(kb)
+    assert len(rows) == 1
+    assert rows[0].status == "failed"
+    assert rows[0].status_message == "LightRag does not support multi-page readers"
+    assert lightrag.inserted_texts == []
+    assert reader.chunk is True, "reader.chunk was not restored after the unchunked read"
+
+
+def test_lightrag_refuses_multi_page_read_sync(tmp_path):
+    lightrag = LightRag()
+    kb = _kb(tmp_path, lightrag)
+    reader = FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"})
+    reader.chunk = True
+
+    kb.insert(url=SITE_URL, reader=reader)
+
+    rows = _rows(kb)
+    assert len(rows) == 1
+    assert rows[0].status == "failed"
+    assert rows[0].status_message == "LightRag does not support multi-page readers"
+    assert lightrag.inserted_texts == []
+    assert reader.chunk is True, "reader.chunk was not restored after the unchunked read"
+
+
+async def test_skip_if_exists_still_refreshes_changed_page(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    await kb.ainsert(
+        url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}), skip_if_exists=True
+    )
+    _clear_writes(vector_db)
+
+    await kb.ainsert(
+        url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text v2"}), skip_if_exists=True
+    )
+
+    assert len(vector_db.writes) == 1
+    assert {doc.meta_data["url"] for doc in vector_db.inserted_documents} == {PAGE_TWO}
+
+
+async def test_upsert_false_still_refreshes_changed_page(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}))
+    _clear_writes(vector_db)
+
+    await kb.ainsert(
+        url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text v2"}), upsert=False
+    )
+
+    assert len(vector_db.writes) == 1
+    assert {doc.meta_data["url"] for doc in vector_db.inserted_documents} == {PAGE_TWO}

--- a/libs/agno/tests/unit/knowledge/test_per_page_content_rows.py
+++ b/libs/agno/tests/unit/knowledge/test_per_page_content_rows.py
@@ -764,3 +764,163 @@ async def test_prune_honors_false_returning_adapter(vector_db, tmp_path):
     site = _site_row(_rows(kb))
     children = set(get_agno_metadata(site.metadata, "children"))
     assert stale_ids <= children, "a page whose vector delete failed keeps its place for retry"
+
+
+# ---------------------------------------------------------------------------
+# Review round 3: deletion-contract semantics
+# ---------------------------------------------------------------------------
+
+
+from conftest import StubVectorDb  # noqa: E402 - fixture class shared with the suite
+
+
+class ZeroMatchFalseVectorDb(StubVectorDb):
+    """Chroma/LanceDB/Weaviate-shaped: delete_by_content_id answers False when zero
+    vectors matched, True when something was deleted."""
+
+    def delete_by_content_id(self, content_id, user_id=None):
+        remaining = [doc for doc in self.inserted_documents + self.upserted_documents if doc.content_id != content_id]
+        matched = len(remaining) != len(self.inserted_documents) + len(self.upserted_documents)
+        self.inserted_documents = [doc for doc in self.inserted_documents if doc.content_id != content_id]
+        self.upserted_documents = [doc for doc in self.upserted_documents if doc.content_id != content_id]
+        return matched
+
+
+async def test_vectorless_site_parent_deletes_cleanly_on_zero_match_false_adapter_async(tmp_path):
+    vector_db = ZeroMatchFalseVectorDb()
+    kb = _kb(tmp_path, vector_db)
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}))
+    site = _site_row(_rows(kb))
+
+    removed = await kb.aremove_content_by_id(site.id)
+
+    assert removed is True, "a zero-match False on the vectorless parent is a no-op, not a failure"
+    rows, count = await kb.aget_content()
+    assert count == 0
+    assert vector_db.inserted_documents == []
+
+
+def test_vectorless_site_parent_deletes_cleanly_on_zero_match_false_adapter_sync(tmp_path):
+    vector_db = ZeroMatchFalseVectorDb()
+    kb = _kb(tmp_path, vector_db)
+    kb.insert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}))
+    site = _site_row(_rows(kb))
+
+    removed = kb.remove_content_by_id(site.id)
+
+    assert removed is True
+    rows, count = kb.get_content()
+    assert count == 0
+
+
+async def test_partial_cascade_failure_preserves_parent_async(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}))
+    rows = _rows(kb)
+    site = _site_row(rows)
+    failing_id = next(row.id for row in rows if get_agno_metadata(row.metadata, "source_url") == PAGE_TWO)
+
+    vector_db.delete_by_content_id = lambda cid, user_id=None: False if cid == failing_id else True
+    removed = await kb.aremove_content_by_id(site.id)
+
+    assert removed is False
+    site_row = await kb.aget_content_by_id(site.id)
+    assert site_row is not None, "the parent stays as the retry anchor"
+    assert get_agno_metadata(site_row.metadata, "children") == [failing_id]
+    assert await kb.aget_content_by_id(failing_id) is not None
+
+    # Retry with a healthy adapter reconciles fully
+    vector_db.delete_by_content_id = lambda cid, user_id=None: True
+    assert await kb.aremove_content_by_id(site.id) is True
+    _, count = await kb.aget_content()
+    assert count == 0
+
+
+def test_partial_cascade_failure_preserves_parent_sync(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    kb.insert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}))
+    rows = _rows(kb)
+    site = _site_row(rows)
+    failing_id = next(row.id for row in rows if get_agno_metadata(row.metadata, "source_url") == PAGE_TWO)
+
+    vector_db.delete_by_content_id = lambda cid, user_id=None: False if cid == failing_id else True
+    removed = kb.remove_content_by_id(site.id)
+
+    assert removed is False
+    site_row = kb.get_content_by_id(site.id)
+    assert site_row is not None
+    assert get_agno_metadata(site_row.metadata, "children") == [failing_id]
+
+
+async def test_legacy_promotion_aborts_when_clear_fails_async(tmp_path):
+    vector_db = ZeroMatchFalseVectorDb()
+    kb = _kb(tmp_path, vector_db)
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "only page"}))
+    row = _rows(kb)[0]
+
+    def failing_clear(content_id, user_id=None):
+        raise RuntimeError("adapter down")
+
+    vector_db.delete_by_content_id = failing_clear
+    inserted_before = len(vector_db.inserted_documents)
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "only page", PAGE_TWO: "second"}))
+
+    refreshed = await kb.aget_content_by_id(row.id)
+    assert refreshed.status == "failed"
+    assert "previous vectors" in (refreshed.status_message or "")
+    assert len(vector_db.inserted_documents) == inserted_before, "no child vectors beside uncleared legacy ones"
+
+
+def test_legacy_promotion_aborts_when_clear_fails_sync(tmp_path):
+    vector_db = ZeroMatchFalseVectorDb()
+    kb = _kb(tmp_path, vector_db)
+    kb.insert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "only page"}))
+    row = _rows(kb)[0]
+
+    vector_db.delete_by_content_id = lambda content_id, user_id=None: False  # operational False mid-promotion
+    inserted_before = len(vector_db.inserted_documents)
+    kb.insert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "only page", PAGE_TWO: "second"}))
+
+    refreshed = kb.get_content_by_id(row.id)
+    assert refreshed.status == "failed"
+    assert len(vector_db.inserted_documents) == inserted_before
+
+
+async def test_ordinary_reingest_tolerates_zero_match_false_clear(tmp_path):
+    vector_db = ZeroMatchFalseVectorDb()
+    kb = _kb(tmp_path, vector_db)
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}))
+
+    # The site row owns no vectors: its clear answers False and that must not fail the read
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}))
+
+    assert _site_row(_rows(kb)).status == "completed"
+
+
+async def test_remove_all_content_aggregates_failures_async(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}))
+    rows = _rows(kb)
+    failing_id = next(row.id for row in rows if get_agno_metadata(row.metadata, "source_url") == PAGE_TWO)
+
+    vector_db.delete_by_content_id = lambda cid, user_id=None: False if cid == failing_id else True
+    result = await kb.aremove_all_content()
+
+    assert result is False
+    assert await kb.aget_content_by_id(failing_id) is not None
+
+    vector_db.delete_by_content_id = lambda cid, user_id=None: True
+    assert await kb.aremove_all_content() is True
+    _, count = await kb.aget_content()
+    assert count == 0
+
+
+def test_remove_all_content_aggregates_failures_sync(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    kb.insert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}))
+    rows = _rows(kb)
+    failing_id = next(row.id for row in rows if get_agno_metadata(row.metadata, "source_url") == PAGE_TWO)
+
+    vector_db.delete_by_content_id = lambda cid, user_id=None: False if cid == failing_id else True
+    assert kb.remove_all_content() is False
+    assert kb.get_content_by_id(failing_id) is not None

--- a/libs/agno/tests/unit/knowledge/test_per_page_content_rows.py
+++ b/libs/agno/tests/unit/knowledge/test_per_page_content_rows.py
@@ -10,7 +10,6 @@ import time
 from typing import Dict, List, Optional, Tuple
 from unittest import mock
 
-
 from agno.db.sqlite import SqliteDb
 from agno.knowledge.document import Document
 from agno.knowledge.knowledge import Knowledge
@@ -632,3 +631,136 @@ async def test_site_row_records_reader_id(vector_db, tmp_path):
 
     site = _site_row(_rows(kb))
     assert get_agno_metadata(site.metadata, "reader_id") == "sitemap"
+
+
+# ---------------------------------------------------------------------------
+# Review round 2: total discovery failure never prunes; vector delete False honored
+# ---------------------------------------------------------------------------
+
+
+class EmptyReader(FakePagesReader):
+    """A read that saw nothing — total outage: every shard failed, zero documents."""
+
+    def read(self, obj, name=None, password=None):
+        return []
+
+
+class FallbackOutageReader(FakePagesReader):
+    """The root sitemap is unreachable: the reader falls back to the single page at the
+    URL, fails to fetch it, and flags the read as incomplete discovery — the exact
+    document shape SitemapReader emits in that state."""
+
+    def read(self, obj, name=None, password=None):
+        return [
+            Document(
+                name=str(obj),
+                meta_data={"url": str(obj), "error": "HTTP 503", "source": "page", "discovery_incomplete": True},
+                content="",
+            )
+        ]
+
+
+def _assert_pages_survive(kb, vector_db):
+    rows = _rows(kb)
+    kept_urls = {get_agno_metadata(row.metadata, "source_url") for row in rows} - {None}
+    assert {PAGE_ONE, PAGE_TWO} <= kept_urls, f"pages lost: {kept_urls}"
+    site = _site_row(rows)
+    children = set(get_agno_metadata(site.metadata, "children") or [])
+    page_row_ids = {row.id for row in rows if get_agno_metadata(row.metadata, "parent_id")}
+    assert page_row_ids <= children, "surviving pages must stay owned by the site row"
+    loaded_row_ids = {
+        row.id for row in rows if get_agno_metadata(row.metadata, "parent_id") and row.status == "completed"
+    }
+    vector_ids = {doc.content_id for doc in vector_db.inserted_documents}
+    assert loaded_row_ids <= vector_ids, "surviving loaded rows must keep their vector groups"
+
+
+async def test_all_shards_failed_refresh_preserves_pages_async(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}))
+
+    await kb.ainsert(url=SITE_URL, reader=EmptyReader({}))
+
+    _assert_pages_survive(kb, vector_db)
+    site = _site_row(_rows(kb))
+    assert site.status == "failed"
+    assert "no documents" in (site.status_message or "")
+    # A later healthy refresh reconciles normally
+    _clear_writes(vector_db)
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text v2"}))
+    assert _site_row(_rows(kb)).status == "completed"
+    assert {doc.meta_data["url"] for doc in vector_db.inserted_documents} == {PAGE_TWO}
+
+
+def test_all_shards_failed_refresh_preserves_pages_sync(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    kb.insert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}))
+
+    kb.insert(url=SITE_URL, reader=EmptyReader({}))
+
+    _assert_pages_survive(kb, vector_db)
+    assert _site_row(_rows(kb)).status == "failed"
+
+
+async def test_root_sitemap_outage_refresh_preserves_pages_async(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}))
+
+    await kb.ainsert(url=SITE_URL, reader=FallbackOutageReader({}))
+
+    _assert_pages_survive(kb, vector_db)
+    site = _site_row(_rows(kb))
+    assert "discovery incomplete" in (site.status_message or "")
+
+
+def test_root_sitemap_outage_refresh_preserves_pages_sync(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    kb.insert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}))
+
+    kb.insert(url=SITE_URL, reader=FallbackOutageReader({}))
+
+    _assert_pages_survive(kb, vector_db)
+
+
+async def test_vector_delete_false_keeps_row_and_ownership_async(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}))
+    site = _site_row(_rows(kb))
+    child_id = get_agno_metadata(site.metadata, "children")[0]
+
+    vector_db.delete_by_content_id = lambda content_id, user_id=None: False
+    removed = await kb.aremove_content_by_id(child_id)
+
+    assert removed is False
+    assert await kb.aget_content_by_id(child_id) is not None, "the row must stay while its vectors exist"
+    site = _site_row(_rows(kb))
+    assert child_id in get_agno_metadata(site.metadata, "children"), "ownership must survive a failed delete"
+
+
+def test_vector_delete_false_keeps_row_and_ownership_sync(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    kb.insert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}))
+    site = _site_row(_rows(kb))
+    child_id = get_agno_metadata(site.metadata, "children")[0]
+
+    vector_db.delete_by_content_id = lambda content_id, user_id=None: False
+    removed = kb.remove_content_by_id(child_id)
+
+    assert removed is False
+    assert kb.get_content_by_id(child_id) is not None
+
+
+async def test_prune_honors_false_returning_adapter(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}))
+    site = _site_row(_rows(kb))
+    stale_ids = set(get_agno_metadata(site.metadata, "children"))
+
+    original_delete = vector_db.delete_by_content_id
+    vector_db.delete_by_content_id = lambda content_id, user_id=None: False
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text"}))
+    vector_db.delete_by_content_id = original_delete
+
+    site = _site_row(_rows(kb))
+    children = set(get_agno_metadata(site.metadata, "children"))
+    assert stale_ids <= children, "a page whose vector delete failed keeps its place for retry"

--- a/libs/agno/tests/unit/knowledge/test_per_page_content_rows.py
+++ b/libs/agno/tests/unit/knowledge/test_per_page_content_rows.py
@@ -6,16 +6,19 @@ left the site is deleted, a failed page gets a FAILED row and is retried next ru
 and deleting the site row cascades to its page rows and their vectors.
 """
 
+import asyncio
 import time
 from typing import Dict, List, Optional, Tuple
 from unittest import mock
 
 from agno.db.sqlite import SqliteDb
+from agno.knowledge.content import Content
 from agno.knowledge.document import Document
 from agno.knowledge.knowledge import Knowledge
 from agno.knowledge.reader.base import Reader
 from agno.knowledge.types import ContentType
 from agno.knowledge.utils import get_agno_metadata
+from agno.utils.string import generate_id
 
 SITE_URL = "https://docs.x.com/sitemap.xml"
 PAGE_ONE = "https://docs.x.com/guide"
@@ -924,3 +927,125 @@ def test_remove_all_content_aggregates_failures_sync(vector_db, tmp_path):
     vector_db.delete_by_content_id = lambda cid, user_id=None: False if cid == failing_id else True
     assert kb.remove_all_content() is False
     assert kb.get_content_by_id(failing_id) is not None
+
+
+# ---------------------------------------------------------------------------
+# Review round 4: persisted vector ownership, failed-first-ingest recovery, async LightRAG
+# ---------------------------------------------------------------------------
+
+
+async def test_text_row_operational_false_keeps_row_async(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    await kb.ainsert(name="doc", text_content="important text")
+    row = _rows(kb)[0]
+    assert get_agno_metadata(row.metadata, "vectors_indexed") is True, "successful inserts persist ownership"
+
+    vector_db.delete_by_content_id = lambda cid, user_id=None: False  # operational failure
+    removed = await kb.aremove_content_by_id(row.id)
+
+    assert removed is False
+    assert await kb.aget_content_by_id(row.id) is not None, "the row must stay while its vectors exist"
+    assert await kb.aremove_all_content() is False, "bulk removal reports the failure"
+
+
+def test_text_row_operational_false_keeps_row_sync(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    kb.insert(name="doc", text_content="important text")
+    row = _rows(kb)[0]
+
+    vector_db.delete_by_content_id = lambda cid, user_id=None: False
+    removed = kb.remove_content_by_id(row.id)
+
+    assert removed is False
+    assert kb.get_content_by_id(row.id) is not None
+    assert kb.remove_all_content() is False
+
+
+async def test_failed_first_ingest_recovers_on_zero_match_false_adapter_async(tmp_path):
+    vector_db = ZeroMatchFalseVectorDb()
+    kb = _kb(tmp_path, vector_db)
+    # Outage first ingest: FAILED row, no children, no vectors — not a legacy promotion
+    await kb.ainsert(url=SITE_URL, reader=EmptyReader({}))
+    assert _rows(kb)[0].status == "failed"
+
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}))
+
+    site = _site_row(_rows(kb))
+    assert site.status == "completed", "a healthy retry must not be mistaken for a failed legacy clear"
+    assert len(get_agno_metadata(site.metadata, "children")) == 2
+
+
+def test_failed_first_ingest_recovers_on_zero_match_false_adapter_sync(tmp_path):
+    vector_db = ZeroMatchFalseVectorDb()
+    kb = _kb(tmp_path, vector_db)
+    kb.insert(url=SITE_URL, reader=EmptyReader({}))
+    assert _rows(kb)[0].status == "failed"
+
+    kb.insert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}))
+
+    assert _site_row(_rows(kb)).status == "completed"
+
+
+class AsyncLightRag:
+    """LightRag-shaped adapter: sync delete wrapper uses asyncio.run (fails inside a
+    running loop); the async path must await async_delete_by_external_id instead."""
+
+    def __init__(self) -> None:
+        self.async_deleted: List[str] = []
+        self.delete_result = True
+
+    def exists(self) -> bool:
+        return True
+
+    def create(self) -> None:
+        return None
+
+    def update_metadata(self, content_id: str, metadata: dict) -> None:
+        return None
+
+    def delete_by_external_id(self, external_id: str) -> bool:
+        asyncio.run(self._noop())  # what the real adapter does — raises inside a loop
+        return True
+
+    async def _noop(self) -> None:
+        return None
+
+    async def async_delete_by_external_id(self, external_id: str) -> bool:
+        self.async_deleted.append(external_id)
+        return self.delete_result
+
+
+AsyncLightRag.__name__ = "LightRag"
+
+
+async def test_async_lightrag_removal_awaits_async_delete(tmp_path):
+    lightrag = AsyncLightRag()
+    kb = Knowledge(name="t", vector_db=lightrag, contents_db=SqliteDb(db_file=str(tmp_path / "c.db")))
+    content = Content(name="doc", user_id=None)
+    content.content_hash = kb._build_content_hash(content)
+    content.id = generate_id(content.content_hash)
+    await kb._ainsert_contents_db(content)
+    # external_id lands the way the LightRag load path writes it: through the update
+    await kb.apatch_content(Content(id=content.id, external_id="ext-1"))
+
+    removed = await kb.aremove_content_by_id(content.id)
+
+    assert removed is True
+    assert lightrag.async_deleted == ["ext-1"], "the async path must await async_delete_by_external_id"
+    assert await kb.aget_content_by_id(content.id) is None
+
+
+async def test_async_lightrag_removal_honors_false(tmp_path):
+    lightrag = AsyncLightRag()
+    lightrag.delete_result = False
+    kb = Knowledge(name="t", vector_db=lightrag, contents_db=SqliteDb(db_file=str(tmp_path / "c.db")))
+    content = Content(name="doc", user_id=None)
+    content.content_hash = kb._build_content_hash(content)
+    content.id = generate_id(content.content_hash)
+    await kb._ainsert_contents_db(content)
+    await kb.apatch_content(Content(id=content.id, external_id="ext-1"))
+
+    removed = await kb.aremove_content_by_id(content.id)
+
+    assert removed is False
+    assert await kb.aget_content_by_id(content.id) is not None

--- a/libs/agno/tests/unit/knowledge/test_per_page_content_rows.py
+++ b/libs/agno/tests/unit/knowledge/test_per_page_content_rows.py
@@ -10,6 +10,7 @@ import time
 from typing import Dict, List, Optional, Tuple
 from unittest import mock
 
+
 from agno.db.sqlite import SqliteDb
 from agno.knowledge.document import Document
 from agno.knowledge.knowledge import Knowledge
@@ -229,7 +230,10 @@ async def test_ainsert_removed_page_deletes_its_row_and_vectors(vector_db, tmp_p
 
     await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}))
 
-    assert deleted == [(removed_id, None)]
+    # The multi-page load clears the site row's own content_id first (legacy-vector
+    # hygiene), then removes the departed page.
+    assert deleted[-1] == (removed_id, None)
+    assert (removed_id, None) in deleted
     rows = _rows(kb)
     assert removed_id not in {row.id for row in rows}
     site = _site_row(rows)
@@ -466,3 +470,165 @@ async def test_upsert_false_still_refreshes_changed_page(vector_db, tmp_path):
 
     assert len(vector_db.writes) == 1
     assert {doc.meta_data["url"] for doc in vector_db.inserted_documents} == {PAGE_TWO}
+
+
+# ---------------------------------------------------------------------------
+# Failure-mode hardening (review round: fail closed, keep ownership)
+# ---------------------------------------------------------------------------
+
+
+class RaisingReader(FakePagesReader):
+    """Raises on read, standing in for a transient reader failure mid-refresh."""
+
+    def read(self, obj, name=None, password=None):
+        raise RuntimeError("transient reader failure")
+
+    async def async_read(self, obj, name=None, password=None):
+        raise RuntimeError("transient reader failure")
+
+
+class IncompleteDiscoveryReader(FakePagesReader):
+    """Marks every document as coming from an incomplete sitemap discovery."""
+
+    def read(self, obj, name=None, password=None):
+        documents = super().read(obj, name=name, password=password)
+        for doc in documents:
+            doc.meta_data["discovery_incomplete"] = True
+        return documents
+
+
+async def test_failed_refresh_keeps_children_on_site_row(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}))
+    site = _site_row(_rows(kb))
+    previous_children = get_agno_metadata(site.metadata, "children")
+
+    # Reader failures are caught by the load path: the row lands FAILED, nothing raises
+    await kb.ainsert(url=SITE_URL, reader=RaisingReader({}))
+
+    row = await kb.aget_content_by_id(site.id)
+    assert row.status == "failed"
+    # The cascade record survives the failed read, so a site delete still reaches the pages
+    assert get_agno_metadata(row.metadata, "children") == previous_children
+    await kb.aremove_content_by_id(site.id)
+    rows, count = await kb.aget_content()
+    assert count == 0
+
+
+async def test_embed_failure_does_not_persist_digest(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    original_insert = vector_db.async_insert
+    fail = {"active": True}
+
+    async def failing_insert(content_hash, documents=None, filters=None, **kwargs):
+        if fail["active"] and any(doc.meta_data.get("url") == PAGE_TWO for doc in documents):
+            raise RuntimeError("embed down")
+        return await original_insert(content_hash, documents=documents, filters=filters)
+
+    vector_db.async_insert = failing_insert
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}))
+
+    failed_child = next(row for row in _rows(kb) if get_agno_metadata(row.metadata, "source_url") == PAGE_TWO)
+    assert failed_child.status == "failed"
+    assert get_agno_metadata(failed_child.metadata, "content_digest") is None
+
+    # Same text again with a healthy embedder: the page must re-embed, not flip to
+    # completed on a digest recorded by the failed run
+    fail["active"] = False
+    _clear_writes(vector_db)
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}))
+    healed = next(row for row in _rows(kb) if get_agno_metadata(row.metadata, "source_url") == PAGE_TWO)
+    assert healed.status == "completed"
+    assert any(doc.meta_data.get("url") == PAGE_TWO for doc in vector_db.inserted_documents)
+
+
+async def test_incomplete_discovery_suppresses_prune(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}))
+
+    # A read that lost a sitemap shard reports only page one, flagged incomplete
+    await kb.ainsert(url=SITE_URL, reader=IncompleteDiscoveryReader({PAGE_ONE: "guide text"}))
+
+    rows = _rows(kb)
+    kept = {get_agno_metadata(row.metadata, "source_url") for row in rows} - {None}
+    assert PAGE_TWO in kept, "a missing shard's pages must not be treated as removed"
+    site = _site_row(rows)
+    assert "discovery incomplete" in site.status_message
+    # The transport flag never reaches vector metadata
+    assert not any("discovery_incomplete" in (doc.meta_data or {}) for doc in vector_db.inserted_documents)
+
+
+async def test_fetch_failure_keeps_last_known_good_page(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}))
+
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: None}))
+
+    rows = _rows(kb)
+    kept = next(row for row in rows if get_agno_metadata(row.metadata, "source_url") == PAGE_TWO)
+    assert kept.status == "completed", "a transient fetch failure must not demote a loaded page"
+    site = _site_row(rows)
+    failures = get_agno_metadata(site.metadata, "failed")
+    assert failures and failures[0]["url"] == PAGE_TWO and failures[0].get("stale_kept") == "true"
+
+
+async def test_all_pages_failed_single_group_marks_row_failed(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+
+    await kb.ainsert(url="https://docs.x.com/only", reader=FakePagesReader({PAGE_ONE: None}))
+
+    rows, count = await kb.aget_content()
+    assert count == 1
+    assert rows[0].status == "failed"
+    assert PAGE_ERROR in (rows[0].status_message or "")
+    assert vector_db.writes == []
+
+
+async def test_single_row_site_growing_to_pages_clears_legacy_vectors(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "only page"}))
+    parent_id = _rows(kb)[0].id
+
+    deleted = []
+    original_delete = vector_db.delete_by_content_id
+
+    def recording_delete(content_id, user_id=None):
+        deleted.append(content_id)
+        return original_delete(content_id)
+
+    vector_db.delete_by_content_id = recording_delete
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "only page", PAGE_TWO: "second"}))
+
+    assert parent_id in deleted, "the legacy single-row vectors must not stay searchable under the site row"
+
+
+async def test_prune_failure_keeps_stale_child_in_children(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}))
+    site = _site_row(_rows(kb))
+    stale_ids = set(get_agno_metadata(site.metadata, "children"))
+
+    original_delete = vector_db.delete_by_content_id
+
+    def failing_delete(content_id, user_id=None):
+        raise RuntimeError("adapter down")
+
+    vector_db.delete_by_content_id = failing_delete
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text"}))
+    vector_db.delete_by_content_id = original_delete
+
+    site = _site_row(_rows(kb))
+    children = set(get_agno_metadata(site.metadata, "children"))
+    # The page whose delete failed keeps its place in the cascade record
+    assert stale_ids - children == set(), f"lost ownership of {stale_ids - children}"
+
+
+async def test_site_row_records_reader_id(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    reader = FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"})
+    reader.__class__ = type("SitemapReader", (FakePagesReader,), {})
+
+    await kb.ainsert(url=SITE_URL, reader=reader)
+
+    site = _site_row(_rows(kb))
+    assert get_agno_metadata(site.metadata, "reader_id") == "sitemap"

--- a/libs/agno/tests/unit/reader/test_page_fetcher.py
+++ b/libs/agno/tests/unit/reader/test_page_fetcher.py
@@ -1,0 +1,483 @@
+"""Unit tests for the page-fetcher seam below the URL readers.
+
+HttpxPageFetcher is exercised through httpx.MockTransport (no network); the
+ParallelPageFetcher retry/breaker/fallback plumbing is exercised with stub
+backends and fallbacks so every provider behavior is scripted.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import subprocess
+import sys
+from typing import List, Optional
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from agno.knowledge.reader.page_fetcher import (
+    FetchedPage,
+    HttpxPageFetcher,
+    ParallelPageFetcher,
+    RateLimited,
+    RateLimitPolicy,
+    rate_limit_from_text,
+)
+
+HTML_PAGE = """
+<html>
+  <head><title>Test Page</title></head>
+  <body>
+    <nav>Navigation links here</nav>
+    <main>Main content paragraph.</main>
+    <footer>Footer text here</footer>
+  </body>
+</html>
+"""
+
+PLAIN_TEXT = "just plain text, no markup"
+
+RSS_BODY = '<?xml version="1.0"?><rss><channel><title>Feed</title></channel></rss>'
+
+
+def _site_handler(request: httpx.Request) -> httpx.Response:
+    path = request.url.path
+    if path == "/page":
+        return httpx.Response(200, content=HTML_PAGE.encode(), headers={"content-type": "text/html; charset=utf-8"})
+    if path == "/plain":
+        return httpx.Response(200, content=PLAIN_TEXT.encode(), headers={"content-type": "text/plain"})
+    if path == "/rss":
+        return httpx.Response(200, content=RSS_BODY.encode(), headers={"content-type": "application/rss+xml"})
+    if path == "/missing":
+        return httpx.Response(404, content=b"gone")
+    if path == "/redirect":
+        return httpx.Response(302, headers={"location": "https://evil.com/page"})
+    return httpx.Response(200, content=b"<html><body>other</body></html>", headers={"content-type": "text/html"})
+
+
+def _install_transport(monkeypatch, handler):
+    """Route the fetcher's own httpx clients through a MockTransport; returns the request log."""
+    requests: List[httpx.Request] = []
+
+    def tracking_handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return handler(request)
+
+    transport = httpx.MockTransport(tracking_handler)
+    real_client, real_async_client = httpx.Client, httpx.AsyncClient
+
+    def client(**kwargs):
+        kwargs["transport"] = transport
+        return real_client(**kwargs)
+
+    def async_client(**kwargs):
+        kwargs["transport"] = transport
+        return real_async_client(**kwargs)
+
+    monkeypatch.setattr(httpx, "Client", client)
+    monkeypatch.setattr(httpx, "AsyncClient", async_client)
+    return requests
+
+
+# --- HttpxPageFetcher ---
+
+
+def test_html_page_extracts_main_content(monkeypatch):
+    _install_transport(monkeypatch, _site_handler)
+    page = HttpxPageFetcher().fetch_many(["https://example.com/page"])[0]
+
+    assert page.ok
+    assert page.error is None
+    assert "Main content paragraph." in page.content
+    assert "Navigation links" not in page.content
+    assert "Footer text" not in page.content
+    assert page.title == "Test Page"
+    assert page.extractor == "httpx"
+    assert page.attempts == [{"extractor": "httpx", "outcome": "ok"}]
+
+
+def test_plain_text_passes_through_raw(monkeypatch):
+    _install_transport(monkeypatch, _site_handler)
+    page = HttpxPageFetcher().fetch_many(["https://example.com/plain"])[0]
+
+    assert page.ok
+    assert page.content == PLAIN_TEXT
+    assert page.title is None
+    assert page.attempts == [{"extractor": "httpx", "outcome": "ok"}]
+
+
+def test_non_html_content_type_is_an_error(monkeypatch):
+    _install_transport(monkeypatch, _site_handler)
+    page = HttpxPageFetcher().fetch_many(["https://example.com/rss"])[0]
+
+    assert not page.ok
+    assert page.content is None
+    assert page.error.startswith("not-html")
+    assert "application/rss+xml" in page.error
+    assert page.attempts == [{"extractor": "httpx", "outcome": page.error}]
+
+
+def test_http_404_is_an_error(monkeypatch):
+    _install_transport(monkeypatch, _site_handler)
+    page = HttpxPageFetcher().fetch_many(["https://example.com/missing"])[0]
+
+    assert not page.ok
+    assert page.error == "HTTP 404"
+    assert page.attempts == [{"extractor": "httpx", "outcome": "HTTP 404"}]
+
+
+def test_off_host_url_refused_without_a_request(monkeypatch):
+    requests = _install_transport(monkeypatch, _site_handler)
+    pages = HttpxPageFetcher().fetch_many(
+        ["https://example.com/page", "https://other.com/page"], allowed_hosts=["example.com"]
+    )
+
+    assert pages[0].ok
+    assert pages[1].error == "off-host"
+    assert pages[1].content is None
+    # Refused before any request went out: nothing was tried, so no attempt is recorded.
+    assert pages[1].attempts == []
+    assert [request.url.host for request in requests] == ["example.com"]
+
+
+def test_redirect_to_off_host_is_guarded(monkeypatch):
+    requests = _install_transport(monkeypatch, _site_handler)
+    page = HttpxPageFetcher().fetch_many(["https://example.com/redirect"], allowed_hosts=["example.com"])[0]
+
+    assert not page.ok
+    assert "Host not in allowed_hosts: evil.com" in page.error
+    assert page.attempts == [{"extractor": "httpx", "outcome": page.error}]
+    # The redirect guard fired before the request to evil.com was sent.
+    assert [request.url.host for request in requests] == ["example.com"]
+
+
+@pytest.mark.asyncio
+async def test_async_concurrency_wires_semaphore(monkeypatch):
+    _install_transport(monkeypatch, _site_handler)
+    recorded: List[int] = []
+    real_semaphore = asyncio.Semaphore
+
+    class RecordingSemaphore(real_semaphore):
+        def __init__(self, value: int = 1):
+            recorded.append(value)
+            super().__init__(value)
+
+    monkeypatch.setattr(asyncio, "Semaphore", RecordingSemaphore)
+    fetcher = HttpxPageFetcher(concurrency=2)
+    pages = await fetcher.afetch_many(["https://example.com/page"])
+
+    assert pages[0].ok
+    assert recorded == [2]
+
+
+@pytest.mark.asyncio
+async def test_sync_and_async_return_same_shapes(monkeypatch):
+    _install_transport(monkeypatch, _site_handler)
+    urls = [
+        "https://example.com/page",
+        "https://example.com/plain",
+        "https://example.com/rss",
+        "https://example.com/missing",
+        "https://example.com/redirect",
+        "https://other.com/page",
+    ]
+    fetcher = HttpxPageFetcher()
+    sync_pages = fetcher.fetch_many(urls, allowed_hosts=["example.com"])
+    async_pages = await fetcher.afetch_many(urls, allowed_hosts=["example.com"])
+
+    assert len(sync_pages) == len(async_pages) == len(urls)
+    for sync_page, async_page, url in zip(sync_pages, async_pages, urls):
+        assert sync_page.url == async_page.url == url
+        assert sync_page.content == async_page.content
+        assert sync_page.error == async_page.error
+        assert sync_page.title == async_page.title
+        assert sync_page.extractor == async_page.extractor == "httpx"
+
+
+# --- ParallelPageFetcher stubs ---
+
+
+def _ok_pages(urls: List[str]) -> List[FetchedPage]:
+    return [FetchedPage(url=url, content=f"primary:{url}", extractor="parallel") for url in urls]
+
+
+class StubBackend:
+    """Scripted backend: each call serves the next script entry (exception -> raised,
+    callable -> its pages); the last entry repeats forever."""
+
+    extractor_id = "parallel"
+
+    def __init__(self, script, fetch_batch_limit: int = 20):
+        self.script = list(script)
+        self.fetch_batch_limit = fetch_batch_limit
+        self.calls: List[List[str]] = []
+
+    def _serve(self, urls: List[str]) -> List[FetchedPage]:
+        self.calls.append(list(urls))
+        entry = self.script.pop(0) if len(self.script) > 1 else self.script[0]
+        if isinstance(entry, Exception):
+            raise entry
+        return entry(urls)
+
+    def fetch_many(self, urls: List[str], *, max_chars: int = 50_000) -> List[FetchedPage]:
+        return self._serve(urls)
+
+    async def afetch_many(self, urls: List[str], *, max_chars: int = 50_000) -> List[FetchedPage]:
+        return self._serve(urls)
+
+
+class StubFallback:
+    """Recording fallback fetcher that always succeeds."""
+
+    extractor_id = "stub"
+
+    def __init__(self):
+        self.sync_calls: List[tuple] = []
+        self.async_calls: List[tuple] = []
+
+    def _pages(self, urls: List[str]) -> List[FetchedPage]:
+        return [
+            FetchedPage(
+                url=url,
+                content=f"fallback:{url}",
+                extractor=self.extractor_id,
+                attempts=[{"extractor": self.extractor_id, "outcome": "ok"}],
+            )
+            for url in urls
+        ]
+
+    def fetch_many(self, urls: List[str], *, allowed_hosts: Optional[List[str]] = None) -> List[FetchedPage]:
+        self.sync_calls.append((list(urls), allowed_hosts))
+        return self._pages(urls)
+
+    async def afetch_many(self, urls: List[str], *, allowed_hosts: Optional[List[str]] = None) -> List[FetchedPage]:
+        self.async_calls.append((list(urls), allowed_hosts))
+        return self._pages(urls)
+
+
+# --- ParallelPageFetcher backend resolution ---
+
+
+def test_backend_resolves_to_none_without_key_or_packages(monkeypatch):
+    monkeypatch.delenv("PARALLEL_API_KEY", raising=False)
+    monkeypatch.setattr("agno.knowledge.reader.page_fetcher.find_spec", lambda name: None)
+    fallback = StubFallback()
+    fetcher = ParallelPageFetcher(fallback=fallback)
+
+    assert fetcher.backend is None
+    # With no backend, the fetcher reports the fallback's identity and batches degenerate to 1.
+    assert fetcher.extractor_id == "stub"
+    assert fetcher.batch_size == 1
+
+
+@pytest.mark.asyncio
+async def test_no_backend_delegates_async_to_fallback(monkeypatch):
+    monkeypatch.delenv("PARALLEL_API_KEY", raising=False)
+    monkeypatch.setattr("agno.knowledge.reader.page_fetcher.find_spec", lambda name: None)
+    fallback = StubFallback()
+    fetcher = ParallelPageFetcher(fallback=fallback)
+
+    pages = await fetcher.afetch_many(["https://a.com/x"], allowed_hosts=["a.com"])
+
+    assert fallback.async_calls == [(["https://a.com/x"], ["a.com"])]
+    assert pages[0].content == "fallback:https://a.com/x"
+
+
+def test_no_backend_delegates_sync_to_fallback(monkeypatch):
+    monkeypatch.delenv("PARALLEL_API_KEY", raising=False)
+    monkeypatch.setattr("agno.knowledge.reader.page_fetcher.find_spec", lambda name: None)
+    fallback = StubFallback()
+    fetcher = ParallelPageFetcher(fallback=fallback)
+
+    pages = fetcher.fetch_many(["https://a.com/x"])
+
+    assert fallback.sync_calls == [(["https://a.com/x"], None)]
+    assert pages[0].content == "fallback:https://a.com/x"
+
+
+def test_explicit_backend_reports_backend_extractor_and_batch_limit():
+    backend = StubBackend([_ok_pages], fetch_batch_limit=3)
+    fetcher = ParallelPageFetcher(backend=backend, fallback=StubFallback(), batch_size=10)
+
+    assert fetcher.backend is backend
+    assert fetcher.extractor_id == "parallel"
+    assert fetcher.batch_size == 3
+
+
+# --- ParallelPageFetcher retry / breaker / fallback ---
+
+
+@pytest.mark.asyncio
+async def test_rate_limited_once_then_success_sleeps_retry_after():
+    backend = StubBackend([RateLimited("429", retry_after=0.01), _ok_pages])
+    fetcher = ParallelPageFetcher(backend=backend, fallback=StubFallback())
+
+    with patch("asyncio.sleep") as mock_sleep:
+        pages = await fetcher.afetch_many(["https://a.com/1"])
+
+    mock_sleep.assert_awaited_once_with(0.01)
+    assert len(backend.calls) == 2
+    assert pages[0].content == "primary:https://a.com/1"
+    assert pages[0].attempts == [
+        {"extractor": "parallel", "outcome": "rate-limited"},
+        {"extractor": "parallel", "outcome": "ok"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_retries_exhausted_batch_falls_to_fallback():
+    policy = RateLimitPolicy(max_retries=1, breaker_after=10)
+    backend = StubBackend([RateLimited("429", retry_after=0.0)])
+    fallback = StubFallback()
+    fetcher = ParallelPageFetcher(backend=backend, fallback=fallback, policy=policy)
+    urls = ["https://a.com/1", "https://a.com/2"]
+
+    with patch("asyncio.sleep") as mock_sleep:
+        pages = await fetcher.afetch_many(urls)
+
+    assert len(backend.calls) == 2  # initial attempt + 1 retry
+    assert mock_sleep.await_count == 1
+    assert fallback.async_calls == [(urls, None)]
+    assert [page.url for page in pages] == urls
+    for page in pages:
+        assert page.content == f"fallback:{page.url}"
+        assert page.attempts == [
+            {"extractor": "parallel", "outcome": "rate-limited"},
+            {"extractor": "parallel", "outcome": "rate-limited"},
+            {"extractor": "stub", "outcome": "ok"},
+        ]
+
+
+def test_breaker_trips_and_skips_backend_for_remaining_batches(caplog):
+    policy = RateLimitPolicy(max_retries=0, breaker_after=2)
+    backend = StubBackend([RateLimited("429")], fetch_batch_limit=1)
+    fallback = StubFallback()
+    fetcher = ParallelPageFetcher(backend=backend, fallback=fallback, policy=policy)
+    urls = ["https://a.com/1", "https://a.com/2", "https://a.com/3"]
+
+    # The agno logger does not propagate to root, so attach caplog's handler directly.
+    agno_logger = logging.getLogger("agno")
+    agno_logger.addHandler(caplog.handler)
+    try:
+        with caplog.at_level(logging.INFO, logger="agno"):
+            pages = fetcher.fetch_many(urls)
+    finally:
+        agno_logger.removeHandler(caplog.handler)
+
+    # Two rate-limited batches trip the breaker; the third never reaches the backend.
+    assert backend.calls == [["https://a.com/1"], ["https://a.com/2"]]
+    assert [page.content for page in pages] == [f"fallback:{url}" for url in urls]
+    rate_limited_logs = [record for record in caplog.records if "rate-limited" in record.getMessage()]
+    assert len(rate_limited_logs) == 1
+
+
+@pytest.mark.asyncio
+async def test_per_page_fallback_keeps_ok_pages_and_merges_attempts():
+    def serve(urls: List[str]) -> List[FetchedPage]:
+        return [
+            FetchedPage(url=urls[0], content=f"primary:{urls[0]}", extractor="parallel"),
+            FetchedPage(url=urls[1], error="provider-error", extractor="parallel"),
+        ]
+
+    backend = StubBackend([serve])
+    fallback = StubFallback()
+    fetcher = ParallelPageFetcher(backend=backend, fallback=fallback)
+    urls = ["https://a.com/ok", "https://a.com/bad"]
+
+    pages = await fetcher.afetch_many(urls)
+
+    assert [page.url for page in pages] == urls
+    assert pages[0].content == "primary:https://a.com/ok"
+    assert pages[0].extractor == "parallel"
+    assert pages[0].attempts == [{"extractor": "parallel", "outcome": "ok"}]
+    assert pages[1].content == "fallback:https://a.com/bad"
+    assert pages[1].extractor == "stub"
+    assert pages[1].attempts == [
+        {"extractor": "parallel", "outcome": "provider-error"},
+        {"extractor": "stub", "outcome": "ok"},
+    ]
+    # Only the failed page was refetched.
+    assert fallback.async_calls == [(["https://a.com/bad"], None)]
+
+
+def test_duplicate_urls_fetched_once_result_matches_input_order():
+    backend = StubBackend([_ok_pages])
+    fetcher = ParallelPageFetcher(backend=backend, fallback=StubFallback())
+    urls = ["https://a.com/1", "https://a.com/2", "https://a.com/1"]
+
+    pages = fetcher.fetch_many(urls)
+
+    assert backend.calls == [["https://a.com/1", "https://a.com/2"]]
+    assert [page.url for page in pages] == urls
+    assert pages[0].content == pages[2].content == "primary:https://a.com/1"
+
+
+def test_off_host_urls_never_reach_backend():
+    backend = StubBackend([_ok_pages])
+    fetcher = ParallelPageFetcher(backend=backend, fallback=StubFallback())
+    urls = ["https://a.com/1", "https://evil.com/1"]
+
+    pages = fetcher.fetch_many(urls, allowed_hosts=["a.com"])
+
+    assert backend.calls == [["https://a.com/1"]]
+    assert pages[0].content == "primary:https://a.com/1"
+    assert pages[1].error == "off-host"
+
+
+# --- RateLimitPolicy delay behavior ---
+
+
+def test_exponential_backoff_when_not_honoring_retry_after():
+    policy = RateLimitPolicy(max_retries=3, honor_retry_after=False, base_delay=1.0, max_delay=2.0, breaker_after=99)
+    backend = StubBackend([RateLimited("429", retry_after=50.0)])
+    fallback = StubFallback()
+    fetcher = ParallelPageFetcher(backend=backend, fallback=fallback, policy=policy)
+
+    with patch("time.sleep") as mock_sleep:
+        pages = fetcher.fetch_many(["https://a.com/1"])
+
+    # retry_after is ignored: base_delay * 2**attempt, capped at max_delay.
+    assert [call.args[0] for call in mock_sleep.call_args_list] == [1.0, 2.0, 2.0]
+    assert pages[0].content == "fallback:https://a.com/1"
+
+
+def test_honored_retry_after_is_capped_at_max_delay():
+    policy = RateLimitPolicy(max_retries=1, max_delay=2.0, breaker_after=99)
+    backend = StubBackend([RateLimited("429", retry_after=50.0)])
+    fetcher = ParallelPageFetcher(backend=backend, fallback=StubFallback(), policy=policy)
+
+    with patch("time.sleep") as mock_sleep:
+        fetcher.fetch_many(["https://a.com/1"])
+
+    assert [call.args[0] for call in mock_sleep.call_args_list] == [2.0]
+
+
+# --- import hygiene ---
+
+
+def test_page_fetcher_import_does_not_load_agent_or_context():
+    code = (
+        "import sys\n"
+        "import agno.knowledge.reader.page_fetcher\n"
+        "assert 'agno.agent' not in sys.modules, 'agno.agent loaded'\n"
+        "assert 'agno.context' not in sys.modules, 'agno.context loaded'\n"
+    )
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+
+
+def test_context_web_import_does_not_load_agent():
+    code = "import sys\nimport agno.context.web\nassert 'agno.agent' not in sys.modules, 'agno.agent loaded'\n"
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+
+
+# --- rate_limit_from_text ---
+
+
+def test_rate_limit_from_text():
+    assert rate_limit_from_text("HTTP 429 Too Many Requests")
+    assert rate_limit_from_text("Rate Limit hit")
+    assert not rate_limit_from_text("ok")

--- a/libs/agno/tests/unit/reader/test_sitemap_reader.py
+++ b/libs/agno/tests/unit/reader/test_sitemap_reader.py
@@ -1,0 +1,573 @@
+"""Unit tests for SitemapReader: URL canonicalization, sitemap discovery, document
+construction, reader statelessness, and factory wiring.
+
+All HTTP goes through httpx.MockTransport — no network. Both the reader's discovery
+clients and HttpxPageFetcher's clients are patched to route through the same transport.
+"""
+
+import asyncio
+import gzip
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from agno.knowledge.document.base import Document
+from agno.knowledge.reader.page_fetcher import HttpxPageFetcher
+from agno.knowledge.reader.sitemap_reader import SitemapReader
+from agno.knowledge.reader.utils.urls import (
+    MAX_PAGE_NAME_LENGTH,
+    canonical_page_name,
+    canonical_page_url,
+    is_sitemap_url,
+)
+from agno.knowledge.types import ContentType
+
+_ORIG_CLIENT = httpx.Client
+_ORIG_ASYNC_CLIENT = httpx.AsyncClient
+
+SITEMAP_NS = "http://www.sitemaps.org/schemas/sitemap/0.9"
+IMAGE_NS = "http://www.google.com/schemas/sitemap-image/1.1"
+
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+
+def urlset_xml(*locs: str) -> str:
+    entries = "".join(f"<url><loc>{loc}</loc></url>" for loc in locs)
+    return f'<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="{SITEMAP_NS}">{entries}</urlset>'
+
+
+def sitemapindex_xml(*locs: str) -> str:
+    entries = "".join(f"<sitemap><loc>{loc}</loc></sitemap>" for loc in locs)
+    return f'<?xml version="1.0" encoding="UTF-8"?><sitemapindex xmlns="{SITEMAP_NS}">{entries}</sitemapindex>'
+
+
+def html_page(title: str, body: str) -> str:
+    return f"<html><head><title>{title}</title></head><body><main>{body}</main></body></html>"
+
+
+@contextmanager
+def mock_site(routes):
+    """Serve ``routes`` ({"scheme://host/path": (body, content_type)}) via MockTransport.
+
+    Patches the httpx client constructors used by both the sitemap reader and the page
+    fetcher so every request in a read hits the mock. Yields the list of requested URLs
+    (in request order). Unrouted URLs get a 404.
+    """
+    requested = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requested.append(str(request.url))
+        key = f"{request.url.scheme}://{request.url.host}{request.url.path}"
+        spec = routes.get(key)
+        if spec is None:
+            return httpx.Response(404, text="not found")
+        body, content_type = spec
+        if isinstance(body, bytes):
+            return httpx.Response(200, content=body, headers={"content-type": content_type})
+        return httpx.Response(200, text=body, headers={"content-type": content_type})
+
+    transport = httpx.MockTransport(handler)
+
+    def client_factory(**kwargs):
+        kwargs.pop("proxy", None)
+        return _ORIG_CLIENT(transport=transport, **kwargs)
+
+    def async_client_factory(**kwargs):
+        kwargs.pop("proxy", None)
+        return _ORIG_ASYNC_CLIENT(transport=transport, **kwargs)
+
+    with (
+        patch("agno.knowledge.reader.sitemap_reader.httpx.Client", client_factory),
+        patch("agno.knowledge.reader.sitemap_reader.httpx.AsyncClient", async_client_factory),
+        patch("agno.knowledge.reader.page_fetcher.httpx.Client", client_factory),
+        patch("agno.knowledge.reader.page_fetcher.httpx.AsyncClient", async_client_factory),
+    ):
+        yield requested
+
+
+def make_reader(**kwargs) -> SitemapReader:
+    kwargs.setdefault("page_fetcher", HttpxPageFetcher())
+    return SitemapReader(**kwargs)
+
+
+# ----------------------------------------------------------------------
+# canonical_page_name / canonical_page_url / is_sitemap_url
+# ----------------------------------------------------------------------
+
+
+def test_canonical_page_name_trailing_slash_equivalence():
+    assert canonical_page_name("https://example.com/docs/") == canonical_page_name("https://example.com/docs")
+    assert canonical_page_name("https://example.com/docs") == "example.com/docs"
+
+
+def test_canonical_page_name_index_html_stripped():
+    assert canonical_page_name("https://example.com/docs/index.html") == "example.com/docs"
+    assert canonical_page_name("https://example.com/docs/index.htm") == "example.com/docs"
+    assert canonical_page_name("https://example.com/index.html") == "example.com"
+
+
+def test_canonical_page_name_query_kept():
+    assert canonical_page_name("https://example.com/p?v=1") == "example.com/p?v=1"
+    assert canonical_page_name("https://example.com/p?v=1") != canonical_page_name("https://example.com/p?v=2")
+
+
+def test_canonical_page_name_fragment_dropped():
+    assert canonical_page_name("https://example.com/p#section-2") == "example.com/p"
+
+
+def test_canonical_page_name_percent_decoded():
+    assert canonical_page_name("https://example.com/caf%C3%A9") == "example.com/café"
+
+
+def test_canonical_page_name_root_is_host():
+    assert canonical_page_name("https://example.com/") == "example.com"
+    assert canonical_page_name("https://Example.COM") == "example.com"
+
+
+def test_canonical_page_name_truncated_with_hash_suffix():
+    import hashlib
+
+    long_url = "https://example.com/" + "a" * 300
+    full_name = "example.com/" + "a" * 300
+    name = canonical_page_name(long_url)
+    assert MAX_PAGE_NAME_LENGTH == 255
+    assert len(name) == MAX_PAGE_NAME_LENGTH
+    digest = hashlib.sha256(full_name.encode()).hexdigest()[:8]
+    assert name == f"{full_name[: MAX_PAGE_NAME_LENGTH - 9]}-{digest}"
+
+
+def test_canonical_page_url_rules():
+    # Lowercased scheme and host; path case preserved
+    assert canonical_page_url("HTTPS://Example.COM/Path") == "https://example.com/Path"
+    # Fragment dropped
+    assert canonical_page_url("https://example.com/a#frag") == "https://example.com/a"
+    # Trailing slash stripped
+    assert canonical_page_url("https://example.com/a/") == "https://example.com/a"
+    # index.html stripped
+    assert canonical_page_url("https://example.com/docs/index.html") == "https://example.com/docs"
+    # Query kept
+    assert canonical_page_url("https://example.com/p?v=1") == "https://example.com/p?v=1"
+
+
+def test_is_sitemap_url():
+    assert is_sitemap_url("https://x.com/sitemap.xml") is True
+    assert is_sitemap_url("https://x.com/sitemap-0.xml") is True
+    assert is_sitemap_url("https://x.com/sitemap_index.xml.gz") is True
+    assert is_sitemap_url("https://x.com/page.xml") is False
+    assert is_sitemap_url("https://x.com/sitemap/page") is False
+
+
+# ----------------------------------------------------------------------
+# Discovery
+# ----------------------------------------------------------------------
+
+
+def test_url_is_sitemap_robots_consulted_first():
+    routes = {
+        "https://example.com/robots.txt": ("Sitemap: https://example.com/other.xml\n", "text/plain"),
+        "https://example.com/sitemap.xml": (urlset_xml("https://example.com/a"), "application/xml"),
+        "https://example.com/other.xml": (urlset_xml("https://example.com/b"), "application/xml"),
+        "https://example.com/a": (html_page("Page A", "Main content A"), "text/html"),
+        "https://example.com/b": (html_page("Page B", "Main content B"), "text/html"),
+    }
+    reader = make_reader()
+    with mock_site(routes) as requested:
+        documents = reader.read("https://example.com/sitemap.xml")
+
+    # robots.txt is fetched first, but the URL itself is the first candidate and wins
+    assert requested[0] == "https://example.com/robots.txt"
+    assert requested[1] == "https://example.com/sitemap.xml"
+    assert not any("other.xml" in url for url in requested)
+    assert not any(url.endswith("/b") for url in requested)
+    assert len(documents) == 1
+    assert documents[0].meta_data["url"] == "https://example.com/a"
+    assert documents[0].meta_data["source"] == "sitemap"
+
+
+def test_robots_only_discovery():
+    # No /sitemap.xml anywhere; robots.txt names a custom location
+    routes = {
+        "https://example.com/robots.txt": (
+            "User-agent: *\nSitemap: https://example.com/custom/sitemap.xml\n",
+            "text/plain",
+        ),
+        "https://example.com/custom/sitemap.xml": (urlset_xml("https://example.com/p1"), "application/xml"),
+        "https://example.com/p1": (html_page("P1", "Content one"), "text/html"),
+    }
+    reader = make_reader()
+    with mock_site(routes) as requested:
+        documents = reader.read("https://example.com")
+
+    # The robots-declared sitemap comes before the conventional /sitemap.xml candidate
+    assert "https://example.com/custom/sitemap.xml" in requested
+    assert "https://example.com/sitemap.xml" not in requested
+    assert len(documents) == 1
+    assert documents[0].meta_data["url"] == "https://example.com/p1"
+    assert documents[0].meta_data["source"] == "sitemap"
+
+
+def test_sitemap_index_pages_in_document_order():
+    routes = {
+        "https://example.com/sitemap.xml": (
+            sitemapindex_xml("https://example.com/sm1.xml", "https://example.com/sm2.xml"),
+            "application/xml",
+        ),
+        "https://example.com/sm1.xml": (
+            urlset_xml("https://example.com/p1", "https://example.com/p2"),
+            "application/xml",
+        ),
+        "https://example.com/sm2.xml": (urlset_xml("https://example.com/p3"), "application/xml"),
+        "https://example.com/p1": (html_page("P1", "One"), "text/html"),
+        "https://example.com/p2": (html_page("P2", "Two"), "text/html"),
+        "https://example.com/p3": (html_page("P3", "Three"), "text/html"),
+    }
+    reader = make_reader()
+    with mock_site(routes):
+        documents = reader.read("https://example.com/sitemap.xml")
+
+    assert [doc.meta_data["url"] for doc in documents] == [
+        "https://example.com/p1",
+        "https://example.com/p2",
+        "https://example.com/p3",
+    ]
+    assert all(doc.meta_data["source"] == "sitemap" for doc in documents)
+
+
+def test_gzipped_sitemap_parsed():
+    # No-namespace urlset, gzipped body served without Content-Encoding
+    plain_xml = '<?xml version="1.0"?><urlset><url><loc>https://example.com/p1</loc></url></urlset>'
+    routes = {
+        "https://example.com/sitemap.xml.gz": (gzip.compress(plain_xml.encode()), "application/gzip"),
+        "https://example.com/p1": (html_page("P1", "Unzipped fine"), "text/html"),
+    }
+    reader = make_reader()
+    with mock_site(routes):
+        documents = reader.read("https://example.com/sitemap.xml.gz")
+
+    assert len(documents) == 1
+    assert documents[0].meta_data["url"] == "https://example.com/p1"
+    assert documents[0].meta_data["source"] == "sitemap"
+
+
+def test_nested_index_cycle_terminates():
+    routes = {
+        "https://example.com/sitemap.xml": (sitemapindex_xml("https://example.com/idx2.xml"), "application/xml"),
+        # The child index points back at its parent (cycle) plus a real urlset
+        "https://example.com/idx2.xml": (
+            sitemapindex_xml("https://example.com/sitemap.xml", "https://example.com/pages.xml"),
+            "application/xml",
+        ),
+        "https://example.com/pages.xml": (urlset_xml("https://example.com/p1"), "application/xml"),
+        "https://example.com/p1": (html_page("P1", "Reached through the cycle"), "text/html"),
+    }
+    reader = make_reader()
+    with mock_site(routes) as requested:
+        documents = reader.read("https://example.com/sitemap.xml")
+
+    assert len(documents) == 1
+    assert documents[0].meta_data["url"] == "https://example.com/p1"
+    # The parent sitemap was fetched exactly once — the back-reference was not refetched
+    assert requested.count("https://example.com/sitemap.xml") == 1
+
+
+def test_image_loc_not_collected_as_page():
+    xml = (
+        f'<?xml version="1.0"?><urlset xmlns="{SITEMAP_NS}" xmlns:image="{IMAGE_NS}">'
+        "<url><loc>https://example.com/p1</loc>"
+        "<image:image><image:loc>https://example.com/img.jpg</image:loc></image:image>"
+        "</url></urlset>"
+    )
+    routes = {
+        "https://example.com/sitemap.xml": (xml, "application/xml"),
+        "https://example.com/p1": (html_page("P1", "Page with image"), "text/html"),
+    }
+    reader = make_reader()
+    with mock_site(routes) as requested:
+        documents = reader.read("https://example.com/sitemap.xml")
+
+    assert [doc.meta_data["url"] for doc in documents] == ["https://example.com/p1"]
+    assert not any("img.jpg" in url for url in requested)
+
+
+def test_max_pages_cap_across_children_preserves_order():
+    routes = {
+        "https://example.com/sitemap.xml": (
+            sitemapindex_xml("https://example.com/sm1.xml", "https://example.com/sm2.xml"),
+            "application/xml",
+        ),
+        "https://example.com/sm1.xml": (
+            urlset_xml("https://example.com/a", "https://example.com/b"),
+            "application/xml",
+        ),
+        "https://example.com/sm2.xml": (
+            urlset_xml("https://example.com/c", "https://example.com/d"),
+            "application/xml",
+        ),
+        "https://example.com/a": (html_page("A", "Alpha"), "text/html"),
+        "https://example.com/b": (html_page("B", "Beta"), "text/html"),
+        "https://example.com/c": (html_page("C", "Gamma"), "text/html"),
+        "https://example.com/d": (html_page("D", "Delta"), "text/html"),
+    }
+    reader = make_reader(max_pages=3)
+    with mock_site(routes) as requested:
+        documents = reader.read("https://example.com/sitemap.xml")
+
+    assert [doc.meta_data["url"] for doc in documents] == [
+        "https://example.com/a",
+        "https://example.com/b",
+        "https://example.com/c",
+    ]
+    assert not any(url.endswith("/d") for url in requested)
+
+
+def test_no_sitemap_falls_back_to_single_page():
+    routes = {
+        "https://example.com/about": (html_page("About", "Just this page"), "text/html"),
+    }
+    reader = make_reader()
+    with mock_site(routes) as requested:
+        documents = reader.read("https://example.com/about")
+
+    # Only the URL itself is read as a page
+    page_requests = [url for url in requested if url == "https://example.com/about"]
+    assert page_requests == ["https://example.com/about"]
+    assert len(documents) == 1
+    assert documents[0].meta_data["url"] == "https://example.com/about"
+    assert documents[0].meta_data["source"] == "page"
+
+
+def test_cross_host_loc_skipped():
+    routes = {
+        "https://example.com/sitemap.xml": (
+            urlset_xml("https://example.com/a", "https://evil.com/x"),
+            "application/xml",
+        ),
+        "https://example.com/a": (html_page("A", "Same host"), "text/html"),
+        "https://evil.com/x": (html_page("X", "Other host"), "text/html"),
+    }
+    reader = make_reader()
+    with mock_site(routes) as requested:
+        documents = reader.read("https://example.com/sitemap.xml")
+
+    assert [doc.meta_data["url"] for doc in documents] == ["https://example.com/a"]
+    assert not any("evil.com" in url for url in requested)
+
+
+def test_cross_host_robots_sitemap_skipped():
+    routes = {
+        "https://example.com/robots.txt": ("Sitemap: https://other.com/sitemap.xml\n", "text/plain"),
+        "https://example.com/sitemap.xml": (urlset_xml("https://example.com/a"), "application/xml"),
+        "https://other.com/sitemap.xml": (urlset_xml("https://other.com/x"), "application/xml"),
+        "https://example.com/a": (html_page("A", "Own host wins"), "text/html"),
+    }
+    reader = make_reader()
+    with mock_site(routes) as requested:
+        documents = reader.read("https://example.com")
+
+    assert not any("other.com" in url for url in requested)
+    assert [doc.meta_data["url"] for doc in documents] == ["https://example.com/a"]
+
+
+def test_duplicate_locs_deduplicated_first_kept():
+    routes = {
+        "https://example.com/sitemap.xml": (
+            urlset_xml("https://example.com/a", "https://example.com/a/"),
+            "application/xml",
+        ),
+        "https://example.com/a": (html_page("A", "Deduplicated"), "text/html"),
+    }
+    reader = make_reader()
+    with mock_site(routes) as requested:
+        documents = reader.read("https://example.com/sitemap.xml")
+
+    assert len(documents) == 1
+    assert documents[0].meta_data["url"] == "https://example.com/a"
+    # The first form (no trailing slash) was fetched, exactly once; the twin never was
+    assert requested.count("https://example.com/a") == 1
+    assert "https://example.com/a/" not in requested
+
+
+# ----------------------------------------------------------------------
+# Documents
+# ----------------------------------------------------------------------
+
+
+def test_document_metadata_fields():
+    routes = {
+        "https://example.com/sitemap.xml": (urlset_xml("https://example.com/a/"), "application/xml"),
+        "https://example.com/a/": (html_page("Page A Title", "Body of A"), "text/html"),
+    }
+    reader = make_reader()
+    with mock_site(routes):
+        documents = reader.read("https://example.com/sitemap.xml")
+
+    assert len(documents) == 1
+    doc = documents[0]
+    assert isinstance(doc, Document)
+    assert doc.name == "example.com/a"
+    assert doc.meta_data["url"] == "https://example.com/a"  # canonical: trailing slash stripped
+    assert doc.meta_data["title"] == "Page A Title"
+    assert doc.meta_data["host"] == "example.com"
+    assert doc.meta_data["extractor"] == "httpx"
+    assert doc.meta_data["source"] == "sitemap"
+    assert doc.meta_data["attempts"] == [{"extractor": "httpx", "outcome": "ok"}]
+    assert doc.content == "Body of A"
+
+
+def test_failed_page_yields_error_document():
+    routes = {
+        "https://example.com/sitemap.xml": (
+            urlset_xml("https://example.com/good", "https://example.com/missing"),
+            "application/xml",
+        ),
+        "https://example.com/good": (html_page("Good", "Fetched fine"), "text/html"),
+        # /missing has no route -> 404
+    }
+    reader = make_reader()
+    with mock_site(routes):
+        documents = reader.read("https://example.com/sitemap.xml")
+
+    assert len(documents) == 2
+    good, failed = documents
+    assert good.meta_data["url"] == "https://example.com/good"
+    assert "error" not in good.meta_data
+    assert failed.meta_data["url"] == "https://example.com/missing"
+    assert failed.content == ""
+    assert failed.meta_data["error"] == "HTTP 404"
+    assert failed.meta_data["source"] == "sitemap"
+    # Failed pages are not chunked
+    assert "chunk" not in failed.meta_data
+
+
+def test_page_chunked_exactly_once():
+    body = " ".join(f"word{i}" for i in range(120))  # single-spaced, ~800 chars
+    routes = {
+        "https://example.com/sitemap.xml": (urlset_xml("https://example.com/long"), "application/xml"),
+        "https://example.com/long": (html_page("Long", body), "text/html"),
+    }
+    reader = make_reader(chunk_size=200)
+    with mock_site(routes):
+        documents = reader.read("https://example.com/sitemap.xml")
+
+    assert len(documents) >= 2
+    assert all(len(doc.content) <= 200 for doc in documents)
+    # Chunk numbers run 1..n once — a re-chunked read would restart the numbering
+    assert [doc.meta_data["chunk"] for doc in documents] == list(range(1, len(documents) + 1))
+    # Every chunk carries the same canonical page url
+    assert {doc.meta_data["url"] for doc in documents} == {"https://example.com/long"}
+    # Nothing lost or duplicated across chunks
+    assert "".join(doc.content for doc in documents) == body
+
+
+def test_source_header_default_off():
+    routes = {
+        "https://example.com/sitemap.xml": (urlset_xml("https://example.com/a"), "application/xml"),
+        "https://example.com/a": (html_page("Page A", "Hello content"), "text/html"),
+    }
+    reader = make_reader()
+    assert reader.source_header is False
+    with mock_site(routes):
+        documents = reader.read("https://example.com/sitemap.xml")
+
+    assert len(documents) == 1
+    assert not documents[0].content.startswith("# ")
+    assert "Source:" not in documents[0].content
+
+
+def test_source_header_unchunked_format():
+    routes = {
+        "https://example.com/sitemap.xml": (urlset_xml("https://example.com/a"), "application/xml"),
+        "https://example.com/a": (html_page("Page A", "Hello content"), "text/html"),
+    }
+    reader = make_reader(source_header=True, chunk=False)
+    with mock_site(routes):
+        documents = reader.read("https://example.com/sitemap.xml")
+
+    assert len(documents) == 1
+    assert documents[0].content.startswith("# Page A\nSource: https://example.com/a\n\n")
+    assert documents[0].content.endswith("Hello content")
+
+
+def test_source_header_lands_in_first_chunk_only():
+    body = " ".join(f"word{i}" for i in range(120))
+    routes = {
+        "https://example.com/sitemap.xml": (urlset_xml("https://example.com/a"), "application/xml"),
+        "https://example.com/a": (html_page("Page A", body), "text/html"),
+    }
+    reader = make_reader(source_header=True, chunk_size=200)
+    with mock_site(routes):
+        documents = reader.read("https://example.com/sitemap.xml")
+
+    assert len(documents) >= 2
+    # FixedSizeChunking collapses whitespace, so the header's newlines become spaces
+    assert documents[0].content.startswith("# Page A Source: https://example.com/a ")
+    for later in documents[1:]:
+        assert "# Page A" not in later.content
+        assert "Source:" not in later.content
+
+
+# ----------------------------------------------------------------------
+# Statelessness
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_async_reads_do_not_interleave():
+    routes = {
+        "https://site-a.com/sitemap.xml": (
+            urlset_xml("https://site-a.com/a1", "https://site-a.com/a2"),
+            "application/xml",
+        ),
+        "https://site-a.com/a1": (html_page("A1", "Alpha one"), "text/html"),
+        "https://site-a.com/a2": (html_page("A2", "Alpha two"), "text/html"),
+        "https://site-b.com/sitemap.xml": (
+            urlset_xml("https://site-b.com/b1", "https://site-b.com/b2"),
+            "application/xml",
+        ),
+        "https://site-b.com/b1": (html_page("B1", "Beta one"), "text/html"),
+        "https://site-b.com/b2": (html_page("B2", "Beta two"), "text/html"),
+    }
+    reader = make_reader()
+    with mock_site(routes):
+        docs_a, docs_b = await asyncio.gather(
+            reader.async_read("https://site-a.com/sitemap.xml"),
+            reader.async_read("https://site-b.com/sitemap.xml"),
+        )
+
+    assert [doc.meta_data["url"] for doc in docs_a] == ["https://site-a.com/a1", "https://site-a.com/a2"]
+    assert all(doc.meta_data["host"] == "site-a.com" for doc in docs_a)
+    assert [doc.content for doc in docs_a] == ["Alpha one", "Alpha two"]
+
+    assert [doc.meta_data["url"] for doc in docs_b] == ["https://site-b.com/b1", "https://site-b.com/b2"]
+    assert all(doc.meta_data["host"] == "site-b.com" for doc in docs_b)
+    assert [doc.content for doc in docs_b] == ["Beta one", "Beta two"]
+
+
+# ----------------------------------------------------------------------
+# Content types and factory
+# ----------------------------------------------------------------------
+
+
+def test_get_supported_content_types():
+    assert SitemapReader.get_supported_content_types() == [ContentType.URL]
+
+
+def test_reader_factory_sitemap(monkeypatch):
+    from agno.knowledge.reader.reader_factory import ReaderFactory
+
+    # Keep backend resolution deterministic and keyless for the default ParallelPageFetcher
+    monkeypatch.delenv("PARALLEL_API_KEY", raising=False)
+    ReaderFactory.clear_cache()
+    try:
+        assert "sitemap" in ReaderFactory.get_all_reader_keys()
+        reader = ReaderFactory.create_reader("sitemap")
+        assert isinstance(reader, SitemapReader)
+        url_reader = ReaderFactory.get_reader_for_url("https://x.com/sitemap.xml")
+        assert isinstance(url_reader, SitemapReader)
+    finally:
+        ReaderFactory.clear_cache()

--- a/libs/agno/tests/unit/reader/test_sitemap_reader.py
+++ b/libs/agno/tests/unit/reader/test_sitemap_reader.py
@@ -571,3 +571,39 @@ def test_reader_factory_sitemap(monkeypatch):
         assert isinstance(url_reader, SitemapReader)
     finally:
         ReaderFactory.clear_cache()
+
+
+# ----------------------------------------------------------------------
+# Incomplete discovery (a lost shard must not read as removed content)
+# ----------------------------------------------------------------------
+
+
+def test_failed_index_child_marks_documents_discovery_incomplete():
+    routes = {
+        "https://example.com/sitemap.xml": (
+            sitemapindex_xml("https://example.com/sitemap-a.xml", "https://example.com/sitemap-b.xml"),
+            "application/xml",
+        ),
+        "https://example.com/sitemap-a.xml": (urlset_xml("https://example.com/page-a"), "application/xml"),
+        # sitemap-b.xml is unrouted -> 404: an entire shard is missing from this read
+        "https://example.com/page-a": (html_page("A", "Alpha content"), "text/html"),
+    }
+    with mock_site(routes):
+        documents = make_reader().read("https://example.com/sitemap.xml")
+
+    assert documents, "the reachable shard's pages are still read"
+    assert all(doc.meta_data.get("discovery_incomplete") is True for doc in documents), (
+        "every document must carry the incomplete-discovery flag so the insert path suppresses pruning"
+    )
+
+
+def test_complete_discovery_carries_no_incomplete_flag():
+    routes = {
+        "https://example.com/sitemap.xml": (urlset_xml("https://example.com/page-a"), "application/xml"),
+        "https://example.com/page-a": (html_page("A", "Alpha content"), "text/html"),
+    }
+    with mock_site(routes):
+        documents = make_reader().read("https://example.com/sitemap.xml")
+
+    assert documents
+    assert all("discovery_incomplete" not in doc.meta_data for doc in documents)

--- a/libs/agno/tests/unit/tools/test_knowledge_management_tools.py
+++ b/libs/agno/tests/unit/tools/test_knowledge_management_tools.py
@@ -794,3 +794,47 @@ class TestRefreshReaderIdentity:
 
         assert response.status_code == 400
         assert "re-ingest" in response.json()["detail"]
+
+
+def test_toolkit_rejects_vector_only_knowledge():
+    knowledge = Knowledge(name="vector-only", vector_db=StubVectorDb())
+
+    with pytest.raises(ValueError, match="contents_db"):
+        KnowledgeManagementTools(knowledge=knowledge)
+
+
+def test_remove_content_reports_vector_store_failure():
+    kb, _ = _make_kb()
+    toolkit = _make_toolkit(kb)
+    report = json.loads(toolkit.ingest_url(_ctx(), SITE_URL))
+
+    kb.vector_db.delete_by_content_id = lambda content_id, user_id=None: False
+    result = json.loads(toolkit.remove_content(_ctx(), report["site_id"]))
+
+    assert result["ok"] is False
+    assert "vector store failed" in result["error"]
+
+
+class TestDeleteContentRouteVectorFailure:
+    def test_delete_returns_500_when_vector_delete_fails(self):
+        knowledge = _mock_router_knowledge()
+        existing = _content("row-1", "docs.example.com", metadata={})
+        knowledge.aget_content_by_id = AsyncMock(return_value=existing)
+        knowledge.aremove_content_by_id = AsyncMock(return_value=False)
+        client = _build_client(knowledge)
+
+        response = client.delete("/knowledge/content/row-1")
+
+        assert response.status_code == 500
+        assert "vector deletion failed" in response.json()["detail"]
+
+    def test_delete_succeeds_when_removal_reports_true(self):
+        knowledge = _mock_router_knowledge()
+        existing = _content("row-1", "docs.example.com", metadata={})
+        knowledge.aget_content_by_id = AsyncMock(return_value=existing)
+        knowledge.aremove_content_by_id = AsyncMock(return_value=True)
+        client = _build_client(knowledge)
+
+        response = client.delete("/knowledge/content/row-1")
+
+        assert response.status_code == 200

--- a/libs/agno/tests/unit/tools/test_knowledge_management_tools.py
+++ b/libs/agno/tests/unit/tools/test_knowledge_management_tools.py
@@ -1,0 +1,701 @@
+"""Unit tests for KnowledgeManagementTools and the knowledge REST routes it pairs with.
+
+Section 1 exercises the toolkit against a real Knowledge with a SQLite contents db and a
+local stub vector db - no network: the sitemap reader is replaced by patching the toolkit's
+_build_reader seam with a fake multi-page Reader.
+
+Section 2 exercises the router-level parent_id filter and the refresh route with a mocked
+Knowledge behind FastAPI's TestClient.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sqlite3
+import tempfile
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from agno.db.sqlite import SqliteDb
+from agno.knowledge.content import Content, ContentStatus
+from agno.knowledge.document import Document
+from agno.knowledge.knowledge import Knowledge
+from agno.knowledge.reader.base import Reader
+from agno.knowledge.types import ContentType
+from agno.run import RunContext
+from agno.tools.knowledge_management import KnowledgeManagementTools
+from agno.utils.string import generate_id
+from agno.vectordb.base import VectorDb
+
+SITE_URL = "https://docs.example.com"
+PAGE_A = "https://docs.example.com/a"
+PAGE_B = "https://docs.example.com/b"
+
+
+class StubVectorDb(VectorDb):
+    """Local minimal vector db stub; records writes and content-id deletes."""
+
+    def __init__(self) -> None:
+        self.writes: List[tuple] = []
+        self.deleted_content_ids: List[str] = []
+
+    def create(self) -> None:
+        pass
+
+    async def async_create(self) -> None:
+        pass
+
+    def name_exists(self, name: str) -> bool:
+        return False
+
+    def async_name_exists(self, name: str) -> bool:
+        return False
+
+    def id_exists(self, id: str) -> bool:
+        return False
+
+    def content_hash_exists(self, content_hash: str, user_id: Optional[str] = None) -> bool:
+        return False
+
+    def upsert_available(self) -> bool:
+        return False
+
+    def insert(self, content_hash: str, documents: List[Document], filters=None, user_id: Optional[str] = None) -> None:
+        self.writes.append((content_hash, user_id))
+
+    async def async_insert(
+        self, content_hash: str, documents: List[Document], filters=None, user_id: Optional[str] = None
+    ) -> None:
+        self.insert(content_hash, documents, filters, user_id)
+
+    def upsert(self, content_hash: str, documents: List[Document], filters=None, user_id: Optional[str] = None) -> None:
+        self.writes.append((content_hash, user_id))
+
+    async def async_upsert(
+        self, content_hash: str, documents: List[Document], filters=None, user_id: Optional[str] = None
+    ) -> None:
+        self.upsert(content_hash, documents, filters, user_id)
+
+    def search(self, query: str, limit: int = 5, filters=None, user_id: Optional[str] = None) -> List[Document]:
+        return []
+
+    async def async_search(
+        self, query: str, limit: int = 5, filters=None, user_id: Optional[str] = None
+    ) -> List[Document]:
+        return []
+
+    def drop(self) -> None:
+        pass
+
+    async def async_drop(self) -> None:
+        pass
+
+    def exists(self) -> bool:
+        return True
+
+    async def async_exists(self) -> bool:
+        return True
+
+    def delete(self) -> bool:
+        return True
+
+    def delete_by_id(self, id: str) -> bool:
+        return True
+
+    def delete_by_name(self, name: str) -> bool:
+        return True
+
+    def delete_by_metadata(self, metadata: Dict[str, Any]) -> bool:
+        return True
+
+    def update_metadata(self, content_id: str, metadata: Dict[str, Any]) -> None:
+        pass
+
+    def delete_by_content_id(self, content_id: str, user_id: Optional[str] = None) -> bool:
+        self.deleted_content_ids.append(content_id)
+        return True
+
+    def get_supported_search_types(self) -> List[str]:
+        return ["vector"]
+
+
+class TwoPageReader(Reader):
+    """Fake sitemap-style reader: yields one document per page, no network."""
+
+    @classmethod
+    def get_supported_content_types(cls) -> List[ContentType]:
+        return [ContentType.URL]
+
+    def read(self, obj: Any, name: Optional[str] = None, password: Optional[str] = None) -> List[Document]:
+        return [
+            Document(content="alpha page text", meta_data={"url": PAGE_A, "extractor": "test"}),
+            Document(content="beta page text", meta_data={"url": PAGE_B, "extractor": "test"}),
+        ]
+
+    async def async_read(self, obj: Any, name: Optional[str] = None, password: Optional[str] = None) -> List[Document]:
+        return self.read(obj, name=name, password=password)
+
+
+def _make_kb():
+    db_file = os.path.join(tempfile.mkdtemp(), "contents.db")
+    kb = Knowledge(name="t", vector_db=StubVectorDb(), contents_db=SqliteDb(db_file=db_file))
+    return kb, db_file
+
+
+def _make_toolkit(kb: Knowledge, **kwargs) -> KnowledgeManagementTools:
+    toolkit = KnowledgeManagementTools(knowledge=kb, **kwargs)
+    toolkit._build_reader = lambda max_pages: TwoPageReader()  # type: ignore[method-assign]
+    return toolkit
+
+
+def _ctx(user_id: Optional[str] = "alice") -> RunContext:
+    return RunContext(run_id="r1", session_id="s1", user_id=user_id)
+
+
+def _rows(db_file: str):
+    conn = sqlite3.connect(db_file)
+    try:
+        return conn.execute("SELECT id, name, user_id, status FROM agno_knowledge").fetchall()
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Toolkit: registration
+# ---------------------------------------------------------------------------
+
+
+def test_registration_default_exposes_all_tools_sync_and_async():
+    kb, _ = _make_kb()
+    toolkit = KnowledgeManagementTools(knowledge=kb)
+
+    expected = ["ingest_url", "ingest_text", "list_content", "ingest_status", "remove_content"]
+    assert list(toolkit.functions.keys()) == expected
+    assert list(toolkit.async_functions.keys()) == expected
+
+
+def test_remove_content_requires_confirmation_by_default():
+    kb, _ = _make_kb()
+    toolkit = KnowledgeManagementTools(knowledge=kb)
+
+    assert toolkit.functions["remove_content"].requires_confirmation is True
+    assert toolkit.async_functions["remove_content"].requires_confirmation is True
+    # The other tools stay unguarded
+    assert not toolkit.functions["ingest_url"].requires_confirmation
+    assert not toolkit.functions["list_content"].requires_confirmation
+
+
+def test_enable_remove_false_drops_tool_and_sets_no_confirmation_flag():
+    kb, _ = _make_kb()
+    toolkit = KnowledgeManagementTools(knowledge=kb, enable_remove=False)
+
+    assert "remove_content" not in toolkit.functions
+    assert "remove_content" not in toolkit.async_functions
+    assert toolkit.requires_confirmation_tools == []
+
+
+def test_enable_ingest_false_drops_ingest_tools():
+    kb, _ = _make_kb()
+    toolkit = KnowledgeManagementTools(knowledge=kb, enable_ingest=False)
+
+    assert list(toolkit.functions.keys()) == ["list_content", "ingest_status", "remove_content"]
+    assert list(toolkit.async_functions.keys()) == ["list_content", "ingest_status", "remove_content"]
+
+
+def test_requires_knowledge():
+    with pytest.raises(ValueError, match="knowledge"):
+        KnowledgeManagementTools(knowledge=None)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Toolkit: ingest_url
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_url_sync_reports_site_and_writes_rows():
+    kb, db_file = _make_kb()
+    toolkit = _make_toolkit(kb)
+
+    report = json.loads(toolkit.ingest_url(_ctx(), SITE_URL))
+
+    assert report["ok"] is True
+    assert report["status"] == "completed"
+    assert report["pages"] == 2
+    assert report["failed"] == []
+    assert report["extractors"] == {"test": 2}
+    assert report["page_rows"] == 2
+    assert isinstance(report["seconds"], (int, float))
+
+    rows = _rows(db_file)
+    assert len(rows) == 3  # one site row + two page rows
+    assert report["site_id"] in {row[0] for row in rows}
+    site_row = kb.get_content_by_id(report["site_id"])
+    assert site_row is not None
+    assert site_row.name == "docs.example.com"
+
+
+def test_ingest_url_shared_scope_writes_owner_none_even_with_run_user():
+    kb, db_file = _make_kb()
+    toolkit = _make_toolkit(kb)  # scope defaults to "shared"
+
+    report = json.loads(toolkit.ingest_url(_ctx(user_id="alice"), SITE_URL))
+
+    assert report["ok"] is True
+    assert all(row[2] is None for row in _rows(db_file))
+    site_row = kb.get_content_by_id(report["site_id"])
+    assert site_row is not None and site_row.user_id is None
+
+
+def test_ingest_url_user_scope_writes_run_user_id():
+    kb, db_file = _make_kb()
+    toolkit = _make_toolkit(kb, scope="user")
+
+    report = json.loads(toolkit.ingest_url(_ctx(user_id="alice"), SITE_URL))
+
+    assert report["ok"] is True
+    rows = _rows(db_file)
+    assert len(rows) == 3
+    assert all(row[2] == "alice" for row in rows)
+    site_row = kb.get_content_by_id(report["site_id"], user_id="alice")
+    assert site_row is not None and site_row.user_id == "alice"
+
+
+def test_aingest_url_reports_site_and_writes_rows():
+    kb, db_file = _make_kb()
+    toolkit = _make_toolkit(kb)
+
+    report = json.loads(asyncio.run(toolkit.aingest_url(_ctx(), SITE_URL)))
+
+    assert report["ok"] is True
+    assert report["pages"] == 2
+    assert report["extractors"] == {"test": 2}
+    assert "seconds" in report
+    rows = _rows(db_file)
+    assert len(rows) == 3
+    assert report["site_id"] in {row[0] for row in rows}
+
+
+def test_aingest_url_user_scope_writes_run_user_id():
+    kb, db_file = _make_kb()
+    toolkit = _make_toolkit(kb, scope="user")
+
+    report = json.loads(asyncio.run(toolkit.aingest_url(_ctx(user_id="alice"), SITE_URL)))
+
+    assert report["ok"] is True
+    assert all(row[2] == "alice" for row in _rows(db_file))
+
+
+# ---------------------------------------------------------------------------
+# Toolkit: ingest_text
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_text_sync_lands_named_row():
+    kb, db_file = _make_kb()
+    toolkit = _make_toolkit(kb)
+
+    report = json.loads(toolkit.ingest_text(_ctx(), name="mydoc", text="hello world"))
+
+    assert report["ok"] is True
+    assert report["name"] == "mydoc"
+    rows = _rows(db_file)
+    assert len(rows) == 1
+    assert rows[0][1] == "mydoc"
+    assert rows[0][3] == "completed"
+    assert rows[0][2] is None  # shared scope
+
+
+def test_aingest_text_lands_named_row_with_user_scope():
+    kb, db_file = _make_kb()
+    toolkit = _make_toolkit(kb, scope="user")
+
+    report = json.loads(asyncio.run(toolkit.aingest_text(_ctx(user_id="alice"), name="mydoc", text="hello world")))
+
+    assert report["ok"] is True
+    rows = _rows(db_file)
+    assert len(rows) == 1
+    assert rows[0][1] == "mydoc"
+    assert rows[0][2] == "alice"
+
+
+def test_ingest_text_returned_id_matches_db_row():
+    kb, db_file = _make_kb()
+    toolkit = _make_toolkit(kb)
+
+    sync_report = json.loads(toolkit.ingest_text(_ctx(), name="mydoc", text="hello world"))
+    async_report = json.loads(asyncio.run(toolkit.aingest_text(_ctx(), name="otherdoc", text="hello again")))
+
+    row_ids = {row[0] for row in _rows(db_file)}
+    assert sync_report["id"] in row_ids
+    assert async_report["id"] in row_ids
+
+
+# ---------------------------------------------------------------------------
+# Toolkit: list_content
+# ---------------------------------------------------------------------------
+
+
+def test_list_content_groups_pages_under_site():
+    kb, _ = _make_kb()
+    toolkit = _make_toolkit(kb)
+    report = json.loads(toolkit.ingest_url(_ctx(), SITE_URL))
+
+    listing = json.loads(toolkit.list_content(_ctx()))
+
+    assert listing["total_rows"] == 3
+    assert listing["other"] == []  # page rows are grouped away, never listed as other
+    assert len(listing["sites"]) == 1
+    site = listing["sites"][0]
+    assert site["site_id"] == report["site_id"]
+    assert site["name"] == "docs.example.com"
+    assert site["pages"] == 2
+    assert site["failed"] == 0
+    assert site["status"] == "completed"
+
+
+def test_list_content_host_filter():
+    kb, _ = _make_kb()
+    toolkit = _make_toolkit(kb)
+    toolkit.ingest_url(_ctx(), SITE_URL)
+
+    match = json.loads(toolkit.list_content(_ctx(), host="docs.example.com"))
+    assert len(match["sites"]) == 1
+
+    miss = json.loads(toolkit.list_content(_ctx(), host="nope.example.org"))
+    assert miss["sites"] == []
+
+
+def test_alist_content_groups_pages_under_site():
+    kb, _ = _make_kb()
+    toolkit = _make_toolkit(kb)
+    toolkit.ingest_url(_ctx(), SITE_URL)
+
+    listing = json.loads(asyncio.run(toolkit.alist_content(_ctx())))
+
+    assert listing["total_rows"] == 3
+    assert len(listing["sites"]) == 1
+    assert listing["sites"][0]["pages"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Toolkit: ingest_status
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_status_reports_site():
+    kb, _ = _make_kb()
+    toolkit = _make_toolkit(kb)
+    report = json.loads(toolkit.ingest_url(_ctx(), SITE_URL))
+
+    status = json.loads(toolkit.ingest_status(_ctx(), report["site_id"]))
+
+    assert status["ok"] is True
+    assert status["site_id"] == report["site_id"]
+    assert status["status"] == "completed"
+    assert status["status_message"] == "2 of 2 pages loaded"
+    assert status["pages"] == 2
+    assert status["failed"] == []
+    assert status["extractors"] == {"test": 2}
+
+
+def test_ingest_status_unknown_id_returns_error_envelope():
+    kb, _ = _make_kb()
+    toolkit = _make_toolkit(kb)
+
+    status = json.loads(toolkit.ingest_status(_ctx(), "no-such-id"))
+    assert status == {"ok": False, "error": "content no-such-id not found"}
+
+    astatus = json.loads(asyncio.run(toolkit.aingest_status(_ctx(), "no-such-id")))
+    assert astatus == {"ok": False, "error": "content no-such-id not found"}
+
+
+# ---------------------------------------------------------------------------
+# Toolkit: remove_content
+# ---------------------------------------------------------------------------
+
+
+def test_remove_content_deletes_site_and_children():
+    kb, db_file = _make_kb()
+    toolkit = _make_toolkit(kb)
+    report = json.loads(toolkit.ingest_url(_ctx(), SITE_URL))
+    assert len(_rows(db_file)) == 3
+
+    removed = json.loads(toolkit.remove_content(_ctx(), report["site_id"]))
+
+    assert removed["ok"] is True
+    assert removed["removed"] == report["site_id"]
+    assert removed["name"] == "docs.example.com"
+    assert _rows(db_file) == []
+
+
+def test_aremove_content_deletes_site_and_children():
+    kb, db_file = _make_kb()
+    toolkit = _make_toolkit(kb)
+    report = json.loads(toolkit.ingest_url(_ctx(), SITE_URL))
+
+    removed = json.loads(asyncio.run(toolkit.aremove_content(_ctx(), report["site_id"])))
+
+    assert removed["ok"] is True
+    assert _rows(db_file) == []
+
+
+def test_remove_content_unknown_id_returns_error_envelope():
+    kb, _ = _make_kb()
+    toolkit = _make_toolkit(kb)
+
+    removed = json.loads(toolkit.remove_content(_ctx(), "no-such-id"))
+    assert removed == {"ok": False, "error": "content no-such-id not found"}
+
+    aremoved = json.loads(asyncio.run(toolkit.aremove_content(_ctx(), "no-such-id")))
+    assert aremoved == {"ok": False, "error": "content no-such-id not found"}
+
+
+# ---------------------------------------------------------------------------
+# Toolkit: error envelopes, never raises
+# ---------------------------------------------------------------------------
+
+
+def test_list_content_error_returns_envelope():
+    kb, _ = _make_kb()
+    toolkit = _make_toolkit(kb)
+
+    def boom(**kwargs):
+        raise RuntimeError("db exploded")
+
+    kb.get_content = boom  # type: ignore[method-assign]
+    result = json.loads(toolkit.list_content(_ctx()))
+    assert result == {"ok": False, "error": "db exploded"}
+
+
+def test_alist_content_error_returns_envelope():
+    kb, _ = _make_kb()
+    toolkit = _make_toolkit(kb)
+
+    async def aboom(**kwargs):
+        raise RuntimeError("db exploded")
+
+    kb.aget_content = aboom  # type: ignore[method-assign]
+    result = json.loads(asyncio.run(toolkit.alist_content(_ctx())))
+    assert result == {"ok": False, "error": "db exploded"}
+
+
+def test_ingest_url_error_returns_envelope():
+    kb, _ = _make_kb()
+    toolkit = _make_toolkit(kb)
+
+    def boom(**kwargs):
+        raise RuntimeError("reader blew up")
+
+    kb.insert = boom  # type: ignore[method-assign]
+    result = json.loads(toolkit.ingest_url(_ctx(), SITE_URL))
+    assert result == {"ok": False, "error": "reader blew up"}
+
+
+def test_ingest_text_error_returns_envelope():
+    kb, _ = _make_kb()
+    toolkit = _make_toolkit(kb)
+
+    def boom(**kwargs):
+        raise RuntimeError("insert failed")
+
+    kb.insert = boom  # type: ignore[method-assign]
+    result = json.loads(toolkit.ingest_text(_ctx(), name="mydoc", text="hello"))
+    assert result == {"ok": False, "error": "insert failed"}
+
+
+def test_ingest_status_error_returns_envelope():
+    kb, _ = _make_kb()
+    toolkit = _make_toolkit(kb)
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("lookup failed")
+
+    kb.get_content_by_id = boom  # type: ignore[method-assign]
+    result = json.loads(toolkit.ingest_status(_ctx(), "some-id"))
+    assert result == {"ok": False, "error": "lookup failed"}
+
+
+def test_remove_content_error_returns_envelope():
+    kb, _ = _make_kb()
+    toolkit = _make_toolkit(kb)
+    report = json.loads(toolkit.ingest_url(_ctx(), SITE_URL))
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("delete failed")
+
+    kb.remove_content_by_id = boom  # type: ignore[method-assign]
+    result = json.loads(toolkit.remove_content(_ctx(), report["site_id"]))
+    assert result == {"ok": False, "error": "delete failed"}
+
+
+# ===========================================================================
+# REST routes: parent_id filter and refresh
+# ===========================================================================
+
+
+def _mock_router_knowledge() -> MagicMock:
+    mock = MagicMock(spec=Knowledge)
+    mock.name = "test-kb"
+    mock.id = "test-kb-id"
+    mock.db_id = "test-db"
+    mock.knowledge_id = "test-kb-id"
+    mock.aget_content = AsyncMock(return_value=([], 0))
+    return mock
+
+
+def _build_client(knowledge: MagicMock) -> TestClient:
+    from agno.os.routers.knowledge import get_knowledge_router
+    from agno.os.settings import AgnoAPISettings
+
+    app = FastAPI()
+    router = get_knowledge_router(knowledge_instances=[knowledge], settings=AgnoAPISettings())
+    app.include_router(router)
+    return TestClient(app)
+
+
+def _content(content_id: str, name: str, metadata: Optional[Dict[str, Any]] = None, user_id: Optional[str] = None):
+    return Content(
+        id=content_id,
+        name=name,
+        metadata=metadata,
+        status=ContentStatus.COMPLETED,
+        user_id=user_id,
+        created_at=1700000000,
+        updated_at=1700000000,
+    )
+
+
+class TestGetContentParentIdFilter:
+    def _knowledge_with_rows(self):
+        site = _content("site-1", "docs.example.com", metadata={"_agno": {"children": ["page-a", "page-b"]}})
+        page_a = _content("page-a", "docs.example.com/a", metadata={"_agno": {"parent_id": "site-1"}})
+        page_b = _content("page-b", "docs.example.com/b", metadata={"_agno": {"parent_id": "site-1"}})
+        stray = _content("page-x", "other.example.com/x", metadata={"_agno": {"parent_id": "site-2"}})
+        loose = _content("doc-1", "loose-doc", metadata={"foo": "bar"})
+        rows = [site, page_a, page_b, stray, loose]
+        knowledge = _mock_router_knowledge()
+        knowledge.aget_content = AsyncMock(return_value=(rows, len(rows)))
+        return knowledge
+
+    def test_parent_id_returns_only_matching_page_rows(self):
+        knowledge = self._knowledge_with_rows()
+        client = _build_client(knowledge)
+
+        response = client.get("/knowledge/content?parent_id=site-1")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert [entry["id"] for entry in body["data"]] == ["page-a", "page-b"]
+        assert body["meta"]["total_count"] == 2
+
+        # The route fetches every row for the base and filters in the route
+        call_kwargs = knowledge.aget_content.call_args.kwargs
+        assert "limit" not in call_kwargs
+
+    def test_parent_id_no_match_returns_empty(self):
+        knowledge = self._knowledge_with_rows()
+        client = _build_client(knowledge)
+
+        response = client.get("/knowledge/content?parent_id=site-404")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["data"] == []
+        assert body["meta"]["total_count"] == 0
+
+    def test_parent_id_filter_paginates_but_counts_all_matches(self):
+        knowledge = self._knowledge_with_rows()
+        client = _build_client(knowledge)
+
+        response = client.get("/knowledge/content?parent_id=site-1&limit=1&page=2")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert [entry["id"] for entry in body["data"]] == ["page-b"]
+        assert body["meta"]["total_count"] == 2
+
+    def test_without_parent_id_all_rows_returned(self):
+        knowledge = self._knowledge_with_rows()
+        client = _build_client(knowledge)
+
+        response = client.get("/knowledge/content")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body["data"]) == 5
+        assert body["meta"]["total_count"] == 5
+
+
+class TestRefreshContentRoute:
+    def test_refresh_unknown_content_returns_404(self):
+        knowledge = _mock_router_knowledge()
+        knowledge.aget_content_by_id = AsyncMock(return_value=None)
+        client = _build_client(knowledge)
+
+        response = client.post("/knowledge/content/no-such-id/refresh")
+
+        assert response.status_code == 404
+
+    def test_refresh_row_without_source_url_returns_400(self):
+        knowledge = _mock_router_knowledge()
+        existing = _content("doc-1", "loose-doc", metadata={"foo": "bar"})
+        knowledge.aget_content_by_id = AsyncMock(return_value=existing)
+        client = _build_client(knowledge)
+
+        response = client.post("/knowledge/content/doc-1/refresh")
+
+        assert response.status_code == 400
+
+    def test_refresh_reconstructable_row_schedules_background_ingest(self):
+        content_hash = "stable-hash"
+        content_id = generate_id(content_hash)
+        knowledge = _mock_router_knowledge()
+        knowledge._build_content_hash = MagicMock(return_value=content_hash)
+        existing = _content(
+            content_id,
+            "docs.example.com",
+            metadata={"_agno": {"source_url": SITE_URL, "source_type": "sitemap"}},
+        )
+        knowledge.aget_content_by_id = AsyncMock(return_value=existing)
+        client = _build_client(knowledge)
+
+        with patch("agno.os.routers.knowledge.knowledge.process_content", new=AsyncMock()) as process_content:
+            response = client.post(f"/knowledge/content/{content_id}/refresh")
+
+        assert response.status_code == 202
+        body = response.json()
+        assert body["id"] == content_id
+        assert body["status"] == "processing"
+
+        # The background task re-ingests the reconstructed Content through the sitemap reader
+        process_content.assert_awaited_once()
+        args = process_content.await_args.args
+        assert args[0] is knowledge
+        reconstructed = args[1]
+        assert reconstructed.url == SITE_URL
+        assert reconstructed.id == content_id
+        assert args[2] == "sitemap"
+
+    def test_refresh_unmatchable_row_returns_400(self):
+        # The stored id cannot be reproduced from the row's fields -> explicit 400, no task
+        knowledge = _mock_router_knowledge()
+        knowledge._build_content_hash = MagicMock(return_value="different-hash")
+        existing = _content(
+            "id-that-wont-match",
+            "docs.example.com",
+            metadata={"_agno": {"source_url": SITE_URL}},
+        )
+        knowledge.aget_content_by_id = AsyncMock(return_value=existing)
+        client = _build_client(knowledge)
+
+        with patch("agno.os.routers.knowledge.knowledge.process_content", new=AsyncMock()) as process_content:
+            response = client.post("/knowledge/content/id-that-wont-match/refresh")
+
+        assert response.status_code == 400
+        process_content.assert_not_awaited()

--- a/libs/agno/tests/unit/tools/test_knowledge_management_tools.py
+++ b/libs/agno/tests/unit/tools/test_knowledge_management_tools.py
@@ -838,3 +838,25 @@ class TestDeleteContentRouteVectorFailure:
         response = client.delete("/knowledge/content/row-1")
 
         assert response.status_code == 200
+
+
+class TestDeleteAllRouteAggregation:
+    def test_delete_all_returns_500_when_any_removal_fails(self):
+        knowledge = _mock_router_knowledge()
+        knowledge.aremove_all_content = AsyncMock(return_value=False)
+        client = _build_client(knowledge)
+
+        response = client.delete("/knowledge/content")
+
+        assert response.status_code == 500
+        assert "not fully removed" in response.json()["detail"]
+
+    def test_delete_all_succeeds_when_aggregate_is_true(self):
+        knowledge = _mock_router_knowledge()
+        knowledge.aremove_all_content = AsyncMock(return_value=True)
+        client = _build_client(knowledge)
+
+        response = client.delete("/knowledge/content")
+
+        assert response.status_code == 200
+        assert response.json() == "success"

--- a/libs/agno/tests/unit/tools/test_knowledge_management_tools.py
+++ b/libs/agno/tests/unit/tools/test_knowledge_management_tools.py
@@ -699,3 +699,98 @@ class TestRefreshContentRoute:
 
         assert response.status_code == 400
         process_content.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Review-round hardening: fail-closed scope, honest envelopes, reader identity
+# ---------------------------------------------------------------------------
+
+
+def test_user_scope_without_user_id_fails_closed():
+    kb, db_file = _make_kb()
+    toolkit = _make_toolkit(kb, scope="user")
+
+    report = json.loads(asyncio.run(toolkit.aingest_text(_ctx(user_id=None), name="secret", text="private notes")))
+
+    def rows_or_empty():
+        try:
+            return _rows(db_file)
+        except sqlite3.OperationalError:
+            return []  # nothing was ever written, so the table does not exist
+
+    assert report["ok"] is False
+    assert "user_id" in report["error"]
+    assert rows_or_empty() == [], "nothing may land in the shared bucket when user scope has no user"
+    sync_report = json.loads(toolkit.ingest_text(_ctx(user_id=None), name="secret", text="private notes"))
+    assert sync_report["ok"] is False and rows_or_empty() == []
+
+
+def test_ingest_text_reports_failed_row():
+    kb, db_file = _make_kb()
+    toolkit = _make_toolkit(kb)
+
+    def failing_insert(*args, **kwargs):
+        raise RuntimeError("embed down")
+
+    kb.vector_db.insert = failing_insert
+    kb.vector_db.async_insert = failing_insert
+
+    report = json.loads(toolkit.ingest_text(_ctx(), name="doomed", text="text"))
+
+    assert report["ok"] is False, "a FAILED row must not be reported as ok"
+    rows = _rows(db_file)
+    assert rows and rows[0][1] == "doomed"
+
+
+def test_remove_content_reports_refused_delete():
+    kb, db_file = _make_kb()
+    # A shared row (user_id None): core refuses a scoped delete of shared content
+    kb.insert(name="shared-doc", text_content="for everyone", user_id=None)
+    toolkit = _make_toolkit(kb, scope="user")
+    row_id = _rows(db_file)[0][0]
+
+    report = json.loads(toolkit.remove_content(_ctx(user_id="alice"), row_id))
+
+    assert report["ok"] is False
+    assert "not removed" in report["error"]
+    assert _rows(db_file), "the shared row must still exist"
+
+
+class TestRefreshReaderIdentity:
+    def test_refresh_uses_recorded_reader_id(self):
+        content_hash = "stable-hash"
+        content_id = generate_id(content_hash)
+        knowledge = _mock_router_knowledge()
+        knowledge._build_content_hash = MagicMock(return_value=content_hash)
+        existing = _content(
+            content_id,
+            "x.com",
+            metadata={"_agno": {"source_url": "https://x.com/llms.txt", "source_type": "url", "reader_id": "llms_txt"}},
+        )
+        knowledge.aget_content_by_id = AsyncMock(return_value=existing)
+        client = _build_client(knowledge)
+
+        with patch("agno.os.routers.knowledge.knowledge.process_content", new=AsyncMock()) as process_content:
+            response = client.post(f"/knowledge/content/{content_id}/refresh")
+
+        assert response.status_code == 202
+        assert process_content.await_args.args[2] == "llms_txt"
+
+    def test_refresh_without_reader_record_refuses_to_guess(self):
+        content_hash = "stable-hash"
+        content_id = generate_id(content_hash)
+        knowledge = _mock_router_knowledge()
+        knowledge._build_content_hash = MagicMock(return_value=content_hash)
+        # An llms.txt-shaped row with no reader record: guessing would rewrite the site
+        existing = _content(
+            content_id,
+            "x.com",
+            metadata={"_agno": {"source_url": "https://x.com/llms.txt", "source_type": "url"}},
+        )
+        knowledge.aget_content_by_id = AsyncMock(return_value=existing)
+        client = _build_client(knowledge)
+
+        response = client.post(f"/knowledge/content/{content_id}/refresh")
+
+        assert response.status_code == 400
+        assert "re-ingest" in response.json()["detail"]


### PR DESCRIPTION
## Summary

Makes "load this website into a knowledge base" a one-call primitive that lands **one content row per page with its source URL kept**, and ships the operator toolkit that drives it by chat. Spec: `specs/agno/knowledge-management-tools/spec-v0.md` (supersedes the website-ingestion draft). Origin: agentos-railway's `app/ingest.py`, the template-side workaround this replaces.

**Fixes a live defect on main:** multi-page URL inserts (`WebsiteReader` crawls, `LLMsTxtReader`) already write per-URL vector groups whose `content_id` matches no contents row (#6054 follow-on), so deleting the row from the Knowledge page leaves every page's vectors behind — reproduced with an executed probe (delete removed 0 vectors, 2 orphaned).

### Per-page content rows (`knowledge.py` step 8, sync + async)

- Each URL group lands as a child row whose **id equals the `content_id` its vectors already carry** — existing vector groups become owned without re-embedding, and per-page delete works. Hash inputs are computed exactly as main computes them, and all new `_agno` bookkeeping is written strictly after ids are fixed.
- The parent row becomes the **site row**: named after the host, `status_message` aggregates ("9 of 10 pages loaded; failed: …"), `_agno.children` / `page_count` / `extractor_counts` / `failed` recorded. Deleting it cascades to every page and its vectors; deleting one page updates the parent's list.
- **Re-ingest is digest-driven**: `_agno.content_digest` (sha256 of page text) — unchanged pages skip embedding entirely, changed pages replace only their own vectors (works with `upsert=False`, so the AgentOS upload path refreshes too), failed pages retry, pages that left the sitemap are pruned.
- Child rows inherit `user_id` (owner-scoped deployments keep isolation; the id stays equal to the owner-digested vector ids).
- LightRag URL path now refuses multi-page reads with a clear FAILED message instead of silently ingesting page 1, and no longer permanently mutates the shared reader's `chunk` flag.

### `SitemapReader` + `PageFetcher`

- Discovery per the sitemap protocol: the URL itself, robots.txt `Sitemap:` lines, `/sitemap.xml`, `/sitemap_index.xml`, directory sitemap; gzip, nested/cyclic indexes, `image:`/`video:` entries, document order, canonical dedup, `max_pages` cap. Auto-selected for bare `sitemap*.xml(.gz)` URLs; registered in `ReaderFactory` (UI reader dropdown + `readersForType["url"]`).
- One whole-page `Document` per page, chunked exactly once; canonical `<host>/<path>` names (255-char safe); failed pages return as data and become FAILED child rows.
- `PageFetcher` seam below the readers: `HttpxPageFetcher` (bounded concurrency, redirect guard, no crawl sleep) and `ParallelPageFetcher` — resolves silently to Parallel's keyed SDK → keyless MCP → httpx; honors `retry-after`, exponential backoff, per-read circuit breaker; per-page fallback; per-page `extractor` + `attempts` provenance.
- `ParallelBackend`/`ParallelMCPBackend` gain `fetch_many`/`afetch_many` (batch `urls`, verified against the live API); `context.web` no longer imports `agno.agent` at module scope.

### `KnowledgeManagementTools` (the write side)

Operator toolkit, deliberately separate from `KnowledgeTools` (read side): `ingest_url`, `ingest_text`, `list_content` (grouped by site), `ingest_status`, `remove_content` (requires confirmation by default). Sync + async under the same tool names; JSON envelopes; `scope="shared"|"user"`. Replaces the template's raw-SQL `ProductIngestTools`.

### AgentOS routes

`GET /knowledge/content?parent_id=` lists a site's pages with correct totals; `POST /knowledge/content/{id}/refresh` (the UI already calls it; the server now has it) re-runs a URL row's ingest in the background.

### Measured (live, 2026-08-30)

- Bare `https://docs.railway.com` → 10 page rows in **1.0 s** (keyed SDK); the non-HTML `rss.xml` correctly lands as a FAILED child listed on the site row.
- Immediate re-run: **0 vector writes** (digest skip), 1.0 s.
- Keyless MCP burst earlier in the session: 12/12 concurrent fetches, full markdown with code fences and titles.

## Type of change

- [x] New feature
- [x] Bug fix (multi-page delete orphaned vectors; LightRag silent truncation; shared-reader `chunk` mutation)

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings; docs-repo pages for the reader + toolkit drafted separately)
- [x] Examples and guides: `cookbook/07_knowledge/01_getting_started/05_website_per_page.py`, `cookbook/91_tools/knowledge_management_tools.py`
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

- **108 new unit tests** across 4 files (`test_per_page_content_rows`, `test_sitemap_reader`, `test_page_fetcher`, `test_knowledge_management_tools`), written against pinned behavior and mutation-checked (scripted mutations of the digest comparison, breaker threshold, cascade, and LightRag guard are each killed by a named test). Full local run: knowledge + reader + os + tools suites green (1047 + 3125 + 458 passed).
- **Behavior change (intended, it is the fix):** multi-page inserts now produce per-page rows on the Knowledge page instead of one row. Single-URL inserts are byte-for-byte unchanged (pinned by test).
- Default extractor when unkeyed is Parallel's keyless MCP endpoint (best measured output; no throttling observed at 12 concurrent). Fully local fetching is one argument away (`page_fetcher=HttpxPageFetcher()`); flagged in the docs page and open for review.
- agno-os follow-ups (UI): allow sitemap URLs in the web upload form, render `_agno.children` on site rows, show `_agno.title`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
