### PR TITLE
feat: folder and file ingestion with per-file rows, PDF pages, and ingest_path

### DIFF
--- a/cookbook/91_tools/knowledge_management_tools.py
+++ b/cookbook/91_tools/knowledge_management_tools.py
@@ -57,6 +57,8 @@ async def main() -> None:
     await operator.aprint_response(
         "Load https://docs.agno.com into the knowledge base."
     )
+    # Folders work the same way: one row per file, refreshed by content digest
+    # await operator.aprint_response("Load the folder ./product-docs into the knowledge base.")
     await operator.aprint_response("What do we have loaded now?")
 
 

--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -1738,24 +1738,7 @@ class Knowledge(RemoteKnowledge):
                 await self._ahandle_vector_db_insert(content, read_documents, upsert)
 
         elif path.is_dir():
-            for file_path in path.iterdir():
-                # Apply include/exclude filtering
-                if not self._should_include_file(str(file_path), include, exclude):
-                    log_debug(f"Skipping file {file_path} due to include/exclude filters")
-                    continue
-
-                file_content = Content(
-                    name=content.name,
-                    path=str(file_path),
-                    metadata=content.metadata,
-                    description=content.description,
-                    reader=content.reader,
-                    user_id=content.user_id,
-                )
-                file_content.content_hash = self._build_content_hash(file_content)
-                file_content.id = generate_id(file_content.content_hash)
-
-                await self._aload_from_path(file_content, upsert, skip_if_exists, include, exclude)
+            await self._aload_dir_as_folder(content, path, upsert, skip_if_exists, include, exclude)
         else:
             log_warning(f"Invalid path: {path}")
 
@@ -1824,24 +1807,7 @@ class Knowledge(RemoteKnowledge):
                 self._handle_vector_db_insert(content, read_documents, upsert)
 
         elif path.is_dir():
-            for file_path in path.iterdir():
-                # Apply include/exclude filtering
-                if not self._should_include_file(str(file_path), include, exclude):
-                    log_debug(f"Skipping file {file_path} due to include/exclude filters")
-                    continue
-
-                file_content = Content(
-                    name=content.name,
-                    path=str(file_path),
-                    metadata=content.metadata,
-                    description=content.description,
-                    reader=content.reader,
-                    user_id=content.user_id,
-                )
-                file_content.content_hash = self._build_content_hash(file_content)
-                file_content.id = generate_id(file_content.content_hash)
-
-                self._load_from_path(file_content, upsert, skip_if_exists, include, exclude)
+            self._load_dir_as_folder(content, path, upsert, skip_if_exists, include, exclude)
         else:
             log_warning(f"Invalid path: {path}")
 
@@ -1887,7 +1853,10 @@ class Knowledge(RemoteKnowledge):
         previous_children, previous_row_owned_vectors = await self._aget_previous_children(content)
 
         # 1. Add content to contents database
-        await self._ainsert_contents_db(content)
+        if previous_row_owned_vectors:
+            await self._ainsert_contents_db(content, vectors_indexed=True)
+        else:
+            await self._ainsert_contents_db(content)
         if previous_children:
             # The upsert above replaced the row's metadata wholesale. Until this read
             # finalizes, the row must keep its cascade record: a failed read that lost
@@ -1902,6 +1871,7 @@ class Knowledge(RemoteKnowledge):
             marker.metadata = set_agno_metadata(None, "vectors_indexed", True)
             await self._aupdate_content(marker)
         if self._should_skip(content.content_hash, skip_if_exists, user_id=content.user_id):  # type: ignore[arg-type]
+            content.metadata = set_agno_metadata(content.metadata, "vectors_indexed", True)
             content.status = ContentStatus.COMPLETED
             await self._aupdate_content(content)
             return
@@ -2068,7 +2038,10 @@ class Knowledge(RemoteKnowledge):
         previous_children, previous_row_owned_vectors = self._get_previous_children(content)
 
         # 1. Add content to contents database
-        self._insert_contents_db(content)
+        if previous_row_owned_vectors:
+            self._insert_contents_db(content, vectors_indexed=True)
+        else:
+            self._insert_contents_db(content)
         if previous_children:
             # See the matching re-stamp in _aload_from_url.
             self._stamp_row_children(content, previous_children)
@@ -2078,6 +2051,7 @@ class Knowledge(RemoteKnowledge):
             marker.metadata = set_agno_metadata(None, "vectors_indexed", True)
             self._update_content(marker)
         if self._should_skip(content.content_hash, skip_if_exists, user_id=content.user_id):  # type: ignore[arg-type]
+            content.metadata = set_agno_metadata(content.metadata, "vectors_indexed", True)
             content.status = ContentStatus.COMPLETED
             self._update_content(content)
             return
@@ -2196,6 +2170,295 @@ class Knowledge(RemoteKnowledge):
             content.id = generate_id(content.content_hash or "")
         self._prepare_documents_for_insert(read_documents, content.id, calculate_sizes=True)
         self._handle_vector_db_insert(content, read_documents, upsert)
+
+    # --- Per-file rows for folder loads ---
+
+    @staticmethod
+    def _file_digest(file_path) -> Optional[str]:
+        """sha256 of a file's bytes, streamed; None when the file cannot be read."""
+        digest = hashlib.sha256()
+        try:
+            with open(file_path, "rb") as handle:
+                for block in iter(lambda: handle.read(1 << 20), b""):
+                    digest.update(block)
+        except OSError:
+            return None
+        return digest.hexdigest()
+
+    def _prepare_folder_file_content(self, content: Content, file_path) -> Content:
+        """The child Content for one file of a folder load.
+
+        Hash inputs are exactly what the per-file recursion has always used (the
+        caller's name/metadata and the file path), so ids match rows written by
+        earlier releases; display name and ``_agno`` bookkeeping land after the id
+        is fixed, mirroring the page-row ordering rule.
+        """
+        file_content = Content(
+            name=content.name,
+            path=str(file_path),
+            metadata=dict(strip_agno_metadata(content.metadata) or {}) or None,
+            description=content.description,
+            reader=content.reader,
+            user_id=content.user_id,
+        )
+        file_content.content_hash = self._build_content_hash(file_content)
+        file_content.id = generate_id(file_content.content_hash)
+        file_content.name = file_path.name
+        file_content.metadata = set_agno_metadata(file_content.metadata, "source_type", "folder")
+        file_content.metadata = set_agno_metadata(file_content.metadata, "source_path", str(file_path))
+        file_content.metadata = set_agno_metadata(file_content.metadata, "parent_id", content.id)
+        digest = self._file_digest(file_path)
+        if digest:
+            file_content.metadata = set_agno_metadata(file_content.metadata, "content_digest", digest)
+        return file_content
+
+    def _folder_files(self, path, include, exclude) -> Tuple[List, bool]:
+        """``(files, enumeration_failed)`` — every readable file under ``path``, sorted.
+
+        An enumeration failure is indistinguishable from an empty folder, so it is
+        reported and the caller must not prune previously loaded files.
+        """
+        try:
+            files = sorted(entry for entry in Path(path).rglob("*") if entry.is_file())
+        except OSError as e:
+            log_debug(f"Could not enumerate folder {path}: {e}")
+            return [], True
+        return [entry for entry in files if self._should_include_file(str(entry), include, exclude)], False
+
+    async def _aload_dir_as_folder(
+        self,
+        content: Content,
+        path,
+        upsert: bool,
+        skip_if_exists: bool,
+        include: Optional[List[str]],
+        exclude: Optional[List[str]],
+    ) -> None:
+        """Land a directory as a folder row owning one child row per file.
+
+        The file twin of ``_aload_url_page_groups``: unchanged files (by byte digest)
+        refresh their row without re-reading or re-embedding, a file that fails to
+        read gets a FAILED child row without aborting the folder, files that left
+        the folder are pruned under the same bool-honoring rules, and deleting the
+        folder row cascades. The folder row owns no vectors.
+        """
+        from agno.vectordb import VectorDb
+
+        self.vector_db = cast(VectorDb, self.vector_db)
+        content.file_type = "folder"
+        content.metadata = set_agno_metadata(content.metadata, "source_type", "folder")
+        content.metadata = set_agno_metadata(content.metadata, "source_path", str(path))
+        if not content.name:
+            content.name = Path(path).name or str(path)
+
+        previous_children, _ = await self._aget_previous_children(content)
+        await self._ainsert_contents_db(content)
+        if previous_children:
+            # See the matching re-stamp in _aload_from_url.
+            await self._astamp_row_children(content, previous_children)
+
+        files, enumeration_failed = self._folder_files(path, include, exclude)
+        if enumeration_failed or (not files and previous_children):
+            # An unreadable or suddenly empty folder must not read as "all files removed"
+            content.status = ContentStatus.FAILED
+            content.status_message = (
+                "Could not enumerate folder" if enumeration_failed else "Folder is empty; previous files kept"
+            )
+            await self._aupdate_content(content)
+            return
+
+        child_ids: List[str] = []
+        failed: List[Dict[str, str]] = []
+        files_loaded = 0
+        for file_path in files:
+            file_content = self._prepare_folder_file_content(content, file_path)
+            child_ids.append(file_content.id)  # type: ignore[arg-type]
+
+            digest = get_agno_metadata(file_content.metadata, "content_digest")
+            if digest is None:
+                # The bytes could not be read; ingesting nothing as COMPLETED would hide it
+                file_content.status = ContentStatus.FAILED
+                file_content.status_message = "File could not be read"
+                await self._ainsert_contents_db(file_content)
+                failed.append({"path": str(file_path), "error": "File could not be read"})
+                continue
+            if self.contents_db is not None:
+                previous_digest = await self._aget_child_digest(file_content.id, content.user_id)
+                if previous_digest is not None and previous_digest == digest:
+                    file_content.status = ContentStatus.COMPLETED
+                    file_content.metadata = set_agno_metadata(file_content.metadata, "vectors_indexed", True)
+                    await self._ainsert_contents_db(file_content)
+                    files_loaded += 1
+                    log_debug(f"File unchanged, embedding skipped: {file_path}")
+                    continue
+                if previous_digest is not None:
+                    # Changed file: replace its chunks wholesale, as the page path does,
+                    # so refresh works without adapter upsert support and never stacks
+                    try:
+                        clear_kwargs = strict_user_id_kwarg(self.vector_db.delete_by_content_id, content.user_id)
+                        self.vector_db.delete_by_content_id(file_content.id, **clear_kwargs)  # type: ignore[arg-type, union-attr]
+                    except Exception as e:
+                        log_debug(f"Could not clear previous chunks for {file_path}: {e}")
+
+            try:
+                await self._aload_from_path(file_content, upsert, skip_if_exists, include, exclude)
+            except Exception as e:
+                log_error(f"Error reading file {file_path}: {str(e)}")
+                file_content.status = ContentStatus.FAILED
+                file_content.status_message = f"{type(e).__name__}: {e}"[:300]
+                if file_content.metadata and isinstance(file_content.metadata.get("_agno"), dict):
+                    # A digest asserts indexed content; a failed read must not leave one
+                    file_content.metadata["_agno"].pop("content_digest", None)
+                await self._ainsert_contents_db(file_content)
+                failed.append({"path": str(file_path), "error": f"{type(e).__name__}: {e}"[:200]})
+                continue
+            if self.contents_db is None:
+                # Vector-only base: no row to read back; the load not raising is the signal
+                files_loaded += 1
+                continue
+            row = await self.aget_content_by_id(file_content.id, user_id=content.user_id)  # type: ignore[arg-type]
+            if row is not None and self._parse_content_status(row.status) == ContentStatus.COMPLETED:
+                files_loaded += 1
+            else:
+                failed.append({"path": str(file_path), "error": (row.status_message if row else None) or "failed"})
+
+        current_ids = set(child_ids)
+        if content.id:
+            current_ids.add(content.id)
+        for stale_id in previous_children:
+            if stale_id not in current_ids:
+                try:
+                    removed = await self.aremove_content_by_id(stale_id, user_id=content.user_id)
+                except Exception as e:
+                    log_debug(f"Could not remove departed file row {stale_id}: {e}")
+                    removed = False
+                if not removed:
+                    child_ids.append(stale_id)
+
+        self._finalize_site_row_content(
+            content,
+            len(files),
+            files_loaded,
+            child_ids,
+            failed,
+            {},
+            "folder",
+            name_was_auto=False,
+            unit="files",
+        )
+        await self._aupdate_content(content)
+
+    def _load_dir_as_folder(
+        self,
+        content: Content,
+        path,
+        upsert: bool,
+        skip_if_exists: bool,
+        include: Optional[List[str]],
+        exclude: Optional[List[str]],
+    ) -> None:
+        """Synchronous version of _aload_dir_as_folder."""
+        from agno.vectordb import VectorDb
+
+        self.vector_db = cast(VectorDb, self.vector_db)
+        content.file_type = "folder"
+        content.metadata = set_agno_metadata(content.metadata, "source_type", "folder")
+        content.metadata = set_agno_metadata(content.metadata, "source_path", str(path))
+        if not content.name:
+            content.name = Path(path).name or str(path)
+
+        previous_children, _ = self._get_previous_children(content)
+        self._insert_contents_db(content)
+        if previous_children:
+            self._stamp_row_children(content, previous_children)
+
+        files, enumeration_failed = self._folder_files(path, include, exclude)
+        if enumeration_failed or (not files and previous_children):
+            content.status = ContentStatus.FAILED
+            content.status_message = (
+                "Could not enumerate folder" if enumeration_failed else "Folder is empty; previous files kept"
+            )
+            self._update_content(content)
+            return
+
+        child_ids: List[str] = []
+        failed: List[Dict[str, str]] = []
+        files_loaded = 0
+        for file_path in files:
+            file_content = self._prepare_folder_file_content(content, file_path)
+            child_ids.append(file_content.id)  # type: ignore[arg-type]
+
+            digest = get_agno_metadata(file_content.metadata, "content_digest")
+            if digest is None:
+                # See the matching guard in _aload_dir_as_folder
+                file_content.status = ContentStatus.FAILED
+                file_content.status_message = "File could not be read"
+                self._insert_contents_db(file_content)
+                failed.append({"path": str(file_path), "error": "File could not be read"})
+                continue
+            if self.contents_db is not None:
+                previous_digest = self._get_child_digest(file_content.id, content.user_id)
+                if previous_digest is not None and previous_digest == digest:
+                    file_content.status = ContentStatus.COMPLETED
+                    file_content.metadata = set_agno_metadata(file_content.metadata, "vectors_indexed", True)
+                    self._insert_contents_db(file_content)
+                    files_loaded += 1
+                    log_debug(f"File unchanged, embedding skipped: {file_path}")
+                    continue
+                if previous_digest is not None:
+                    # See the matching clear in _aload_dir_as_folder
+                    try:
+                        clear_kwargs = strict_user_id_kwarg(self.vector_db.delete_by_content_id, content.user_id)
+                        self.vector_db.delete_by_content_id(file_content.id, **clear_kwargs)  # type: ignore[arg-type, union-attr]
+                    except Exception as e:
+                        log_debug(f"Could not clear previous chunks for {file_path}: {e}")
+
+            try:
+                self._load_from_path(file_content, upsert, skip_if_exists, include, exclude)
+            except Exception as e:
+                log_error(f"Error reading file {file_path}: {str(e)}")
+                file_content.status = ContentStatus.FAILED
+                file_content.status_message = f"{type(e).__name__}: {e}"[:300]
+                if file_content.metadata and isinstance(file_content.metadata.get("_agno"), dict):
+                    file_content.metadata["_agno"].pop("content_digest", None)
+                self._insert_contents_db(file_content)
+                failed.append({"path": str(file_path), "error": f"{type(e).__name__}: {e}"[:200]})
+                continue
+            if self.contents_db is None:
+                # See the matching guard in _aload_dir_as_folder
+                files_loaded += 1
+                continue
+            row = self.get_content_by_id(file_content.id, user_id=content.user_id)  # type: ignore[arg-type]
+            if row is not None and self._parse_content_status(row.status) == ContentStatus.COMPLETED:
+                files_loaded += 1
+            else:
+                failed.append({"path": str(file_path), "error": (row.status_message if row else None) or "failed"})
+
+        current_ids = set(child_ids)
+        if content.id:
+            current_ids.add(content.id)
+        for stale_id in previous_children:
+            if stale_id not in current_ids:
+                try:
+                    removed = self.remove_content_by_id(stale_id, user_id=content.user_id)
+                except Exception as e:
+                    log_debug(f"Could not remove departed file row {stale_id}: {e}")
+                    removed = False
+                if not removed:
+                    child_ids.append(stale_id)
+
+        self._finalize_site_row_content(
+            content,
+            len(files),
+            files_loaded,
+            child_ids,
+            failed,
+            {},
+            "folder",
+            name_was_auto=False,
+            unit="files",
+        )
+        self._update_content(content)
 
     # --- Per-page rows for multi-page URL reads ---
 
@@ -2340,6 +2603,7 @@ class Knowledge(RemoteKnowledge):
         reader_id: Optional[str] = None,
         discovery_incomplete: bool = False,
         site_owns_vectors: bool = False,
+        unit: str = "pages",
     ) -> None:
         """Turn the parent row into the site row: aggregate status, children, provenance."""
         if name_was_auto and content.url:
@@ -2362,11 +2626,11 @@ class Knowledge(RemoteKnowledge):
         if failed:
             content.metadata = set_agno_metadata(content.metadata, "failed", failed[:25])
 
-        message = f"{pages_loaded} of {total_pages} pages loaded"
+        message = f"{pages_loaded} of {total_pages} {unit} loaded"
         if discovery_incomplete:
             message += "; sitemap discovery incomplete, previous pages kept"
         if failed:
-            sample = ", ".join(entry["url"] for entry in failed[:5])
+            sample = ", ".join(str(entry.get("url") or entry.get("path")) for entry in failed[:5])
             message += f"; failed: {sample}"
             if len(failed) > 5:
                 message += f" and {len(failed) - 5} more"
@@ -2416,6 +2680,10 @@ class Knowledge(RemoteKnowledge):
             content.status_message = "Could not clear the row's previous vectors; re-run to retry"
             await self._aupdate_content(content)
             return
+        if legacy_promotion:
+            ownership = Content(id=content.id, user_id=content.user_id)
+            ownership.metadata = set_agno_metadata(None, "vectors_indexed", False)
+            await self._aupdate_content(ownership)
 
         reader_id = self._MULTI_PAGE_READER_IDS.get(type(content.reader).__name__) if content.reader else None
 
@@ -2450,16 +2718,18 @@ class Knowledge(RemoteKnowledge):
             if source_kind is None and doc_source:
                 source_kind = doc_source
 
+            previous_digest: Optional[str] = None
+            if self.contents_db is not None:
+                previous_digest = await self._aget_child_digest(child.id, content.user_id)
+
             if error is not None:
                 # A page that was loaded before keeps its row and vectors: a transient
                 # fetch failure must not demote good, searchable content. The failure is
                 # still surfaced on the site row.
-                if self.contents_db is not None:
-                    previous_digest = await self._aget_child_digest(child.id, content.user_id)
-                    if previous_digest is not None:
-                        failed.append({"url": source_url, "error": error, "stale_kept": "true"})
-                        pages_loaded += 1
-                        continue
+                if previous_digest is not None:
+                    failed.append({"url": source_url, "error": error, "stale_kept": "true"})
+                    pages_loaded += 1
+                    continue
                 child.status = ContentStatus.FAILED
                 child.status_message = error
                 await self._ainsert_contents_db(child)
@@ -2467,7 +2737,6 @@ class Knowledge(RemoteKnowledge):
                 continue
 
             if self.contents_db is not None:
-                previous_digest = await self._aget_child_digest(child.id, content.user_id)
                 if previous_digest is not None and previous_digest == digest:
                     child.status = ContentStatus.COMPLETED
                     child.metadata = set_agno_metadata(child.metadata, "vectors_indexed", True)
@@ -2503,11 +2772,23 @@ class Knowledge(RemoteKnowledge):
                     # Replace wholesale: a changed page refreshes without adapter upsert
                     # support, and a row-less vector group (pre-existing orphans) is
                     # adopted without duplicating its chunks.
+                    deleted = None
                     try:
                         delete_kwargs = strict_user_id_kwarg(self.vector_db.delete_by_content_id, content.user_id)
-                        self.vector_db.delete_by_content_id(child.id, **delete_kwargs)  # type: ignore[arg-type]
+                        deleted = self.vector_db.delete_by_content_id(child.id, **delete_kwargs)  # type: ignore[arg-type]
                     except NotImplementedError:
                         log_debug(f"Vector db cannot clear previous chunks for {source_url}")
+                    if deleted is False and previous_digest is not None:
+                        failed.append(
+                            {
+                                "url": source_url,
+                                "error": "Could not replace previous page vectors",
+                                "stale_kept": "true",
+                            }
+                        )
+                        pages_loaded += 1
+                        log_debug(f"Keeping previous page vectors for retry: {source_url}")
+                        continue
                     await self.vector_db.async_insert(
                         child.content_hash,  # type: ignore[arg-type]
                         documents=source_docs,
@@ -2598,6 +2879,10 @@ class Knowledge(RemoteKnowledge):
             content.status_message = "Could not clear the row's previous vectors; re-run to retry"
             self._update_content(content)
             return
+        if legacy_promotion:
+            ownership = Content(id=content.id, user_id=content.user_id)
+            ownership.metadata = set_agno_metadata(None, "vectors_indexed", False)
+            self._update_content(ownership)
 
         reader_id = self._MULTI_PAGE_READER_IDS.get(type(content.reader).__name__) if content.reader else None
 
@@ -2630,14 +2915,16 @@ class Knowledge(RemoteKnowledge):
             if source_kind is None and doc_source:
                 source_kind = doc_source
 
+            previous_digest: Optional[str] = None
+            if self.contents_db is not None:
+                previous_digest = self._get_child_digest(child.id, content.user_id)
+
             if error is not None:
                 # See the matching last-known-good branch in _aload_url_page_groups.
-                if self.contents_db is not None:
-                    previous_digest = self._get_child_digest(child.id, content.user_id)
-                    if previous_digest is not None:
-                        failed.append({"url": source_url, "error": error, "stale_kept": "true"})
-                        pages_loaded += 1
-                        continue
+                if previous_digest is not None:
+                    failed.append({"url": source_url, "error": error, "stale_kept": "true"})
+                    pages_loaded += 1
+                    continue
                 child.status = ContentStatus.FAILED
                 child.status_message = error
                 self._insert_contents_db(child)
@@ -2645,7 +2932,6 @@ class Knowledge(RemoteKnowledge):
                 continue
 
             if self.contents_db is not None:
-                previous_digest = self._get_child_digest(child.id, content.user_id)
                 if previous_digest is not None and previous_digest == digest:
                     child.status = ContentStatus.COMPLETED
                     child.metadata = set_agno_metadata(child.metadata, "vectors_indexed", True)
@@ -2681,11 +2967,23 @@ class Knowledge(RemoteKnowledge):
                     # Replace wholesale: a changed page refreshes without adapter upsert
                     # support, and a row-less vector group (pre-existing orphans) is
                     # adopted without duplicating its chunks.
+                    deleted = None
                     try:
                         delete_kwargs = strict_user_id_kwarg(self.vector_db.delete_by_content_id, content.user_id)
-                        self.vector_db.delete_by_content_id(child.id, **delete_kwargs)  # type: ignore[arg-type]
+                        deleted = self.vector_db.delete_by_content_id(child.id, **delete_kwargs)  # type: ignore[arg-type]
                     except NotImplementedError:
                         log_debug(f"Vector db cannot clear previous chunks for {source_url}")
+                    if deleted is False and previous_digest is not None:
+                        failed.append(
+                            {
+                                "url": source_url,
+                                "error": "Could not replace previous page vectors",
+                                "stale_kept": "true",
+                            }
+                        )
+                        pages_loaded += 1
+                        log_debug(f"Keeping previous page vectors for retry: {source_url}")
+                        continue
                     self.vector_db.insert(
                         child.content_hash,  # type: ignore[arg-type]
                         documents=source_docs,
@@ -3353,15 +3651,19 @@ class Knowledge(RemoteKnowledge):
     # PRIVATE - DATABASE METHODS
     # ==========================================
 
-    async def _ainsert_contents_db(self, content: Content):
+    async def _ainsert_contents_db(self, content: Content, vectors_indexed: Optional[bool] = None):
         if self.contents_db:
             content_row = self._build_knowledge_row(content)
+            if vectors_indexed is not None:
+                content_row.metadata = merge_user_metadata(
+                    content_row.metadata, set_agno_metadata(None, "vectors_indexed", vectors_indexed)
+                )
             if isinstance(self.contents_db, AsyncBaseDb):
                 await self.contents_db.upsert_knowledge_content(knowledge_row=content_row)
             else:
                 self.contents_db.upsert_knowledge_content(knowledge_row=content_row)
 
-    def _insert_contents_db(self, content: Content):
+    def _insert_contents_db(self, content: Content, vectors_indexed: Optional[bool] = None):
         """Synchronously add content to contents database."""
         if self.contents_db:
             if isinstance(self.contents_db, AsyncBaseDb):
@@ -3369,6 +3671,10 @@ class Knowledge(RemoteKnowledge):
                     "_insert_contents_db() is not supported with an async DB. Please use ainsert() with AsyncDb."
                 )
             content_row = self._build_knowledge_row(content)
+            if vectors_indexed is not None:
+                content_row.metadata = merge_user_metadata(
+                    content_row.metadata, set_agno_metadata(None, "vectors_indexed", vectors_indexed)
+                )
             self.contents_db.upsert_knowledge_content(knowledge_row=content_row)
 
     # --- Vector DB Insert Helpers ---

--- a/libs/agno/agno/knowledge/reader/page_fetcher.py
+++ b/libs/agno/agno/knowledge/reader/page_fetcher.py
@@ -104,15 +104,41 @@ def extract_page_title(html: str) -> Optional[str]:
     return None
 
 
+def _pdf_page_text(url: str, raw: bytes) -> FetchedPage:
+    """Extract a PDF's text as one page. Needs the ``pdf`` extra; absence is a page
+    error naming the install, never an exception through the read."""
+    import io
+
+    try:
+        from agno.knowledge.reader.pdf_reader import PDFReader
+    except ImportError:
+        return FetchedPage(url=url, error="pdf support requires the `agno[pdf]` extra (pypdf)", extractor="httpx")
+    try:
+        documents = PDFReader(chunk=False).read(io.BytesIO(raw), name=url)
+    except Exception as e:
+        return FetchedPage(url=url, error=f"pdf: {type(e).__name__}: {e}"[:300], extractor="httpx")
+    text = "\n\n".join(doc.content for doc in documents if doc.content)
+    if not text:
+        return FetchedPage(url=url, error="empty", extractor="httpx")
+    return FetchedPage(url=url, content=text, extractor="httpx")
+
+
 def _page_from_response(url: str, response: httpx.Response) -> FetchedPage:
     content_type = response.headers.get("content-type", "").split(";")[0].strip().lower()
-    body = response.text
-    if content_type in _TEXT_CONTENT_TYPES:
-        page = FetchedPage(url=url, content=body, extractor="httpx")
-    elif content_type == "text/html" or body.lstrip()[:15].lower().startswith(("<!doctype", "<html")):
-        page = FetchedPage(url=url, content=extract_page_text(body), title=extract_page_title(body), extractor="httpx")
+    if content_type == "application/pdf" or response.content[:5] == b"%PDF-":
+        page = _pdf_page_text(url, response.content)
+        if page.error:
+            return page
     else:
-        return FetchedPage(url=url, error=f"not-html ({content_type or 'unknown content type'})", extractor="httpx")
+        body = response.text
+        if content_type in _TEXT_CONTENT_TYPES:
+            page = FetchedPage(url=url, content=body, extractor="httpx")
+        elif content_type == "text/html" or body.lstrip()[:15].lower().startswith(("<!doctype", "<html")):
+            page = FetchedPage(
+                url=url, content=extract_page_text(body), title=extract_page_title(body), extractor="httpx"
+            )
+        else:
+            return FetchedPage(url=url, error=f"not-html ({content_type or 'unknown content type'})", extractor="httpx")
     if not page.content:
         return FetchedPage(url=url, title=page.title, error="empty", extractor="httpx")
     return page

--- a/libs/agno/agno/os/routers/knowledge/knowledge.py
+++ b/libs/agno/agno/os/routers/knowledge/knowledge.py
@@ -802,6 +802,26 @@ def attach_routes(router: APIRouter, knowledge_instances: List[Union[Knowledge, 
             raise HTTPException(status_code=403, detail="Cannot refresh shared content")
 
         source_url = get_agno_metadata(existing.metadata, "source_url")
+        source_path = get_agno_metadata(existing.metadata, "source_path")
+        if (not isinstance(source_url, str) or not source_url) and isinstance(source_path, str) and source_path:
+            # A folder (or folder-file) row: re-ingest from its recorded path. The row id
+            # is reproducible from the same Content shape the original insert hashed.
+            for candidate_name in (None, existing.name):
+                candidate = Content(
+                    name=candidate_name,
+                    description=existing.description or None,
+                    path=source_path,
+                    metadata=dict(strip_agno_metadata(existing.metadata) or {}) or None,
+                    user_id=existing.user_id,
+                )
+                candidate.content_hash = knowledge._build_content_hash(candidate)
+                candidate.id = generate_id(candidate.content_hash)
+                if candidate.id == content_id:
+                    background_tasks.add_task(process_content, knowledge, candidate, None, None, None, None)
+                    return ContentResponseSchema(id=content_id, name=existing.name, status=ContentStatus.PROCESSING)
+            raise HTTPException(
+                status_code=400, detail="Content row cannot be matched back to its source; re-ingest the path instead"
+            )
         if not isinstance(source_url, str) or not source_url:
             raise HTTPException(status_code=400, detail="Content has no source URL to refresh from")
 

--- a/libs/agno/agno/tools/knowledge_management.py
+++ b/libs/agno/agno/tools/knowledge_management.py
@@ -6,6 +6,7 @@ capability into product agents. Everything goes through the Knowledge API — no
 """
 
 import json
+import os
 import time
 from typing import Any, Dict, List, Literal, Optional
 
@@ -80,6 +81,8 @@ class KnowledgeManagementTools(Toolkit):
         if enable_ingest:
             tools.append(self.ingest_url)
             async_tools.append((self.aingest_url, "ingest_url"))
+            tools.append(self.ingest_path)
+            async_tools.append((self.aingest_path, "ingest_path"))
             tools.append(self.ingest_text)
             async_tools.append((self.aingest_text, "ingest_text"))
         tools.append(self.list_content)
@@ -223,6 +226,65 @@ class KnowledgeManagementTools(Toolkit):
             return self._site_report(row, site_id, seconds=time.monotonic() - started)
         except Exception as e:
             log_error(f"ingest_url failed for {url}: {e}")
+            return self._error(str(e))
+
+    def _predict_path_row_id(self, path: str, owner: Optional[str]) -> str:
+        # The same Content shape insert(path=...) builds, so the returned id is the row's
+        content = Content(path=path, user_id=owner)
+        return generate_id(self.knowledge._build_content_hash(content))
+
+    def ingest_path(self, run_context: RunContext, path: str) -> str:
+        """Ingest a local file or folder into the knowledge base.
+
+        A folder lands one row per file (nested folders included) under a folder row;
+        re-running refreshes files whose content changed, retries failed ones, and
+        removes rows for files deleted from the folder. A single file lands as one row.
+
+        Args:
+            path: A file or directory path readable by the server, e.g. /data/product-docs.
+
+        Returns:
+            JSON: ok, site_id (the row to use with ingest_status/remove_content), name,
+            status, status_message, and for folders pages (files loaded) and failed.
+        """
+        started = time.monotonic()
+        try:
+            if not os.path.exists(path):
+                return self._error(f"path does not exist: {path}")
+            owner = self._owner_id(run_context)
+            row_id = self._predict_path_row_id(path, owner)
+            self.knowledge.insert(path=path, user_id=owner)
+            row = self.knowledge.get_content_by_id(row_id, user_id=owner)
+            return self._site_report(row, row_id, seconds=time.monotonic() - started)
+        except Exception as e:
+            log_error(f"ingest_path failed for {path}: {e}")
+            return self._error(str(e))
+
+    async def aingest_path(self, run_context: RunContext, path: str) -> str:
+        """Ingest a local file or folder into the knowledge base.
+
+        A folder lands one row per file (nested folders included) under a folder row;
+        re-running refreshes files whose content changed, retries failed ones, and
+        removes rows for files deleted from the folder. A single file lands as one row.
+
+        Args:
+            path: A file or directory path readable by the server, e.g. /data/product-docs.
+
+        Returns:
+            JSON: ok, site_id (the row to use with ingest_status/remove_content), name,
+            status, status_message, and for folders pages (files loaded) and failed.
+        """
+        started = time.monotonic()
+        try:
+            if not os.path.exists(path):
+                return self._error(f"path does not exist: {path}")
+            owner = self._owner_id(run_context)
+            row_id = self._predict_path_row_id(path, owner)
+            await self.knowledge.ainsert(path=path, user_id=owner)
+            row = await self.knowledge.aget_content_by_id(row_id, user_id=owner)
+            return self._site_report(row, row_id, seconds=time.monotonic() - started)
+        except Exception as e:
+            log_error(f"ingest_path failed for {path}: {e}")
             return self._error(str(e))
 
     def ingest_text(

--- a/libs/agno/tests/unit/knowledge/test_folder_content_rows.py
+++ b/libs/agno/tests/unit/knowledge/test_folder_content_rows.py
@@ -1,0 +1,549 @@
+"""Folder loads land one contents-db row per file, owned by a folder row.
+
+Each file row's id equals the ``content_id`` its vectors carry, a file whose byte
+digest is unchanged refreshes its row without re-reading or re-embedding, a changed
+file re-embeds alone, a file that left the folder is deleted, an emptied or
+unreadable folder keeps the previously loaded rows, and deleting the folder row
+cascades to its file rows and their vectors.
+
+Folders are real temp directories: ``.txt`` and ``.md`` files go through the stock
+TextReader/MarkdownReader with no extra dependencies.
+"""
+
+import hashlib
+import time
+from pathlib import Path
+from typing import List, Optional, Tuple
+from unittest import mock
+
+from agno.db.sqlite import SqliteDb
+from agno.knowledge.knowledge import Knowledge
+from agno.knowledge.reader.text_reader import TextReader
+from agno.knowledge.utils import get_agno_metadata
+
+ALPHA_TEXT = "alpha text"
+BETA_TEXT = "beta text"
+GAMMA_TEXT = "gamma text"
+
+READ_ERROR = "RuntimeError: disk error"
+
+
+def _kb(tmp_path, vector_db, filename: str = "contents.db") -> Knowledge:
+    return Knowledge(name="t", vector_db=vector_db, contents_db=SqliteDb(db_file=str(tmp_path / filename)))
+
+
+def _make_folder(tmp_path) -> Path:
+    """A folder with two top-level files and one nested file."""
+    folder = tmp_path / "docs"
+    (folder / "sub").mkdir(parents=True)
+    (folder / "a.txt").write_text(ALPHA_TEXT)
+    (folder / "b.md").write_text(BETA_TEXT)
+    (folder / "sub" / "c.txt").write_text(GAMMA_TEXT)
+    return folder
+
+
+def _make_two_file_folder(tmp_path) -> Path:
+    folder = tmp_path / "docs"
+    folder.mkdir()
+    (folder / "a.txt").write_text(ALPHA_TEXT)
+    (folder / "b.md").write_text(BETA_TEXT)
+    return folder
+
+
+def _rows(kb: Knowledge):
+    rows, _ = kb.contents_db.get_knowledge_contents()
+    return rows
+
+
+def _folder_row(rows):
+    folders = [row for row in rows if get_agno_metadata(row.metadata, "children") is not None]
+    assert len(folders) == 1, f"expected exactly one folder row, got {len(folders)}"
+    return folders[0]
+
+
+def _child_rows(rows):
+    return {row.id: row for row in rows if get_agno_metadata(row.metadata, "parent_id") is not None}
+
+
+def _child_by_name(rows, name: str):
+    children = [row for row in _child_rows(rows).values() if row.name == name]
+    assert len(children) == 1, f"expected exactly one child row named {name}, got {len(children)}"
+    return children[0]
+
+
+def _record_deletes(vector_db) -> List[Tuple[str, Optional[str]]]:
+    """Shadow ``delete_by_content_id`` with a recording twin that still declares user_id."""
+    deleted: List[Tuple[str, Optional[str]]] = []
+
+    def delete_by_content_id(content_id: str, user_id: Optional[str] = None) -> bool:
+        deleted.append((content_id, user_id))
+        return True
+
+    vector_db.delete_by_content_id = delete_by_content_id
+    return deleted
+
+
+def _clear_writes(vector_db) -> None:
+    vector_db.writes.clear()
+    vector_db.inserted_documents.clear()
+    vector_db.upserted_documents.clear()
+
+
+async def _raising_async_read(self, source, name=None, password=None):
+    raise RuntimeError("disk error")
+
+
+def _raising_read(self, source, name=None, password=None):
+    raise RuntimeError("disk error")
+
+
+def _assert_folder_and_children_shape(vector_db, rows, folder: Path) -> None:
+    assert len(rows) == 4
+    folder_row = _folder_row(rows)
+    assert folder_row.name == "docs"
+    assert folder_row.status == "completed"
+    assert folder_row.status_message == "3 of 3 files loaded"
+    assert get_agno_metadata(folder_row.metadata, "source_type") == "folder"
+    assert get_agno_metadata(folder_row.metadata, "source_path") == str(folder)
+
+    children = _child_rows(rows)
+    child_ids = get_agno_metadata(folder_row.metadata, "children")
+    assert sorted(child_ids) == sorted(children.keys())
+    assert {child.name for child in children.values()} == {"a.txt", "b.md", "c.txt"}
+
+    # Each file row's id equals the content_id its vectors carry, nested files included
+    assert len(vector_db.writes) == 3
+    content_id_by_name = {doc.name: doc.content_id for doc in vector_db.inserted_documents}
+    for child in children.values():
+        assert content_id_by_name[child.name] == child.id
+        assert child.status == "completed"
+        assert child.metadata["team"] == "docs"
+        assert get_agno_metadata(child.metadata, "parent_id") == folder_row.id
+        assert get_agno_metadata(child.metadata, "source_type") == "folder"
+        assert get_agno_metadata(child.metadata, "content_digest")
+        assert get_agno_metadata(child.metadata, "vectors_indexed") is True
+
+    # The digest is the sha256 of the file's bytes and the nested file keeps its full path
+    alpha = _child_by_name(rows, "a.txt")
+    assert get_agno_metadata(alpha.metadata, "content_digest") == hashlib.sha256(ALPHA_TEXT.encode()).hexdigest()
+    nested = _child_by_name(rows, "c.txt")
+    assert get_agno_metadata(nested.metadata, "source_path") == str(folder / "sub" / "c.txt")
+
+
+async def test_folder_ainsert_lands_folder_row_and_file_rows(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    folder = _make_folder(tmp_path)
+
+    await kb.ainsert(path=str(folder), metadata={"team": "docs"})
+
+    _assert_folder_and_children_shape(vector_db, _rows(kb), folder)
+    folder_content = await kb.aget_content_by_id(_folder_row(_rows(kb)).id)
+    assert folder_content.file_type == "folder"
+
+
+def test_folder_insert_lands_folder_row_and_file_rows(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    folder = _make_folder(tmp_path)
+
+    kb.insert(path=str(folder), metadata={"team": "docs"})
+
+    _assert_folder_and_children_shape(vector_db, _rows(kb), folder)
+    folder_content = kb.get_content_by_id(_folder_row(_rows(kb)).id)
+    assert folder_content.file_type == "folder"
+
+
+async def test_ainsert_unchanged_files_skip_embedding_and_refresh_rows(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    folder = _make_folder(tmp_path)
+    await kb.ainsert(path=str(folder))
+    first_ids = {row.id for row in _rows(kb)}
+    _clear_writes(vector_db)
+
+    future = int(time.time()) + 1000
+    with mock.patch("time.time", return_value=float(future)):
+        await kb.ainsert(path=str(folder))
+
+    assert vector_db.writes == []
+    rows = _rows(kb)
+    assert {row.id for row in rows} == first_ids
+    assert _folder_row(rows).status_message == "3 of 3 files loaded"
+    for child in _child_rows(rows).values():
+        assert child.status == "completed"
+        assert child.updated_at == future, "unchanged file row did not refresh updated_at"
+
+
+def test_insert_unchanged_files_skip_embedding(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    folder = _make_folder(tmp_path)
+    kb.insert(path=str(folder))
+    first_ids = {row.id for row in _rows(kb)}
+    _clear_writes(vector_db)
+
+    kb.insert(path=str(folder))
+
+    assert vector_db.writes == []
+    assert {row.id for row in _rows(kb)} == first_ids
+
+
+async def test_ainsert_changed_file_reembeds_only_that_file(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    folder = _make_folder(tmp_path)
+    await kb.ainsert(path=str(folder))
+    previous = _child_by_name(_rows(kb), "a.txt")
+    deleted = _record_deletes(vector_db)
+    _clear_writes(vector_db)
+
+    (folder / "a.txt").write_text("alpha text v2")
+    await kb.ainsert(path=str(folder))
+
+    assert len(vector_db.writes) == 1
+    assert [doc.content_id for doc in vector_db.inserted_documents] == [previous.id]
+    changed = _child_by_name(_rows(kb), "a.txt")
+    assert changed.id == previous.id, "a changed file keeps its row id"
+    assert get_agno_metadata(changed.metadata, "content_digest") == hashlib.sha256(b"alpha text v2").hexdigest()
+    # A changed file replaces its chunks wholesale, mirroring the page path
+    assert [cid for cid, _ in deleted] == [previous.id]
+
+
+def test_insert_changed_file_reembeds_only_that_file(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    folder = _make_folder(tmp_path)
+    kb.insert(path=str(folder))
+    previous = _child_by_name(_rows(kb), "a.txt")
+    _clear_writes(vector_db)
+
+    (folder / "a.txt").write_text("alpha text v2")
+    kb.insert(path=str(folder))
+
+    assert len(vector_db.writes) == 1
+    assert [doc.content_id for doc in vector_db.inserted_documents] == [previous.id]
+
+
+async def test_ainsert_removed_file_prunes_row_and_new_file_lands(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    folder = _make_two_file_folder(tmp_path)
+    await kb.ainsert(path=str(folder))
+    removed_id = _child_by_name(_rows(kb), "b.md").id
+    deleted = _record_deletes(vector_db)
+    _clear_writes(vector_db)
+
+    (folder / "b.md").unlink()
+    (folder / "c.txt").write_text(GAMMA_TEXT)
+    await kb.ainsert(path=str(folder))
+
+    assert (removed_id, None) in deleted
+    rows = _rows(kb)
+    assert removed_id not in {row.id for row in rows}
+    added = _child_by_name(rows, "c.txt")
+    assert added.status == "completed"
+    assert [doc.name for doc in vector_db.inserted_documents] == ["c.txt"]
+    folder_row = _folder_row(rows)
+    children = get_agno_metadata(folder_row.metadata, "children")
+    assert removed_id not in children
+    assert sorted(children) == sorted(_child_rows(rows).keys())
+    assert folder_row.status_message == "2 of 2 files loaded"
+
+
+def test_insert_removed_file_prunes_row_and_new_file_lands(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    folder = _make_two_file_folder(tmp_path)
+    kb.insert(path=str(folder))
+    removed_id = _child_by_name(_rows(kb), "b.md").id
+    deleted = _record_deletes(vector_db)
+    _clear_writes(vector_db)
+
+    (folder / "b.md").unlink()
+    (folder / "c.txt").write_text(GAMMA_TEXT)
+    kb.insert(path=str(folder))
+
+    assert (removed_id, None) in deleted
+    rows = _rows(kb)
+    assert removed_id not in {row.id for row in rows}
+    assert _child_by_name(rows, "c.txt").status == "completed"
+    assert _folder_row(rows).status_message == "2 of 2 files loaded"
+
+
+async def test_ainsert_failing_file_gets_failed_row_without_aborting_folder(vector_db, tmp_path):
+    """A file whose read raises lands a FAILED child row and a failure entry on the
+    folder row; the folder itself completes with the failure surfaced."""
+    kb = _kb(tmp_path, vector_db)
+    folder = _make_two_file_folder(tmp_path)
+
+    with mock.patch.object(TextReader, "async_read", _raising_async_read):
+        await kb.ainsert(path=str(folder))
+
+    rows = _rows(kb)
+    failed_child = _child_by_name(rows, "a.txt")
+    assert failed_child.status == "failed"
+    assert failed_child.status_message == READ_ERROR
+    assert get_agno_metadata(failed_child.metadata, "content_digest") is None, "a failed read must not leave a digest"
+    healthy_child = _child_by_name(rows, "b.md")
+    assert healthy_child.status == "completed"
+    assert len(vector_db.writes) == 1, "the failed file must not reach the vector db"
+    folder_row = _folder_row(rows)
+    assert folder_row.status == "completed"
+    assert "1 of 2 files loaded" in folder_row.status_message
+    assert str(folder / "a.txt") in folder_row.status_message
+    assert get_agno_metadata(folder_row.metadata, "failed") == [{"path": str(folder / "a.txt"), "error": READ_ERROR}]
+
+    # The file comes back on the next run with a healthy reader: FAILED rows retry
+    _clear_writes(vector_db)
+    await kb.ainsert(path=str(folder))
+
+    rows = _rows(kb)
+    retried = _child_by_name(rows, "a.txt")
+    assert retried.status == "completed"
+    assert [doc.name for doc in vector_db.inserted_documents] == ["a.txt"]
+    folder_row = _folder_row(rows)
+    assert folder_row.status == "completed"
+    assert folder_row.status_message == "2 of 2 files loaded"
+    assert get_agno_metadata(folder_row.metadata, "failed") is None
+
+
+def test_insert_failing_file_gets_failed_row_without_aborting_folder(vector_db, tmp_path):
+    """Synchronous twin of the failing-file test above."""
+    kb = _kb(tmp_path, vector_db)
+    folder = _make_two_file_folder(tmp_path)
+
+    with mock.patch.object(TextReader, "read", _raising_read):
+        kb.insert(path=str(folder))
+
+    rows = _rows(kb)
+    failed_child = _child_by_name(rows, "a.txt")
+    assert failed_child.status == "failed"
+    assert failed_child.status_message == READ_ERROR
+    assert _child_by_name(rows, "b.md").status == "completed"
+    assert len(vector_db.writes) == 1
+    folder_row = _folder_row(rows)
+    assert folder_row.status == "completed"
+    assert "1 of 2 files loaded" in folder_row.status_message
+
+    _clear_writes(vector_db)
+    kb.insert(path=str(folder))
+
+    rows = _rows(kb)
+    assert _child_by_name(rows, "a.txt").status == "completed"
+    assert [doc.name for doc in vector_db.inserted_documents] == ["a.txt"]
+    assert _folder_row(rows).status == "completed"
+
+
+async def test_ainsert_emptied_folder_keeps_previous_rows(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    folder = _make_two_file_folder(tmp_path)
+    await kb.ainsert(path=str(folder))
+    first_ids = {row.id for row in _rows(kb)}
+    deleted = _record_deletes(vector_db)
+    _clear_writes(vector_db)
+
+    (folder / "a.txt").unlink()
+    (folder / "b.md").unlink()
+    await kb.ainsert(path=str(folder))
+
+    rows = _rows(kb)
+    folder_row = _folder_row(rows)
+    assert folder_row.status == "failed"
+    assert folder_row.status_message == "Folder is empty; previous files kept"
+    assert {row.id for row in rows} == first_ids
+    assert sorted(get_agno_metadata(folder_row.metadata, "children")) == sorted(_child_rows(rows).keys())
+    for child in _child_rows(rows).values():
+        assert child.status == "completed"
+    assert deleted == [], "an emptied folder must not delete the previous files' vectors"
+    assert vector_db.writes == []
+
+    # Restoring the files with the same bytes reconciles without re-embedding
+    (folder / "a.txt").write_text(ALPHA_TEXT)
+    (folder / "b.md").write_text(BETA_TEXT)
+    await kb.ainsert(path=str(folder))
+
+    rows = _rows(kb)
+    folder_row = _folder_row(rows)
+    assert folder_row.status == "completed"
+    assert folder_row.status_message == "2 of 2 files loaded"
+    assert {row.id for row in rows} == first_ids
+    assert vector_db.writes == []
+
+
+def test_insert_emptied_folder_keeps_previous_rows(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    folder = _make_two_file_folder(tmp_path)
+    kb.insert(path=str(folder))
+    first_ids = {row.id for row in _rows(kb)}
+    deleted = _record_deletes(vector_db)
+    _clear_writes(vector_db)
+
+    (folder / "a.txt").unlink()
+    (folder / "b.md").unlink()
+    kb.insert(path=str(folder))
+
+    rows = _rows(kb)
+    folder_row = _folder_row(rows)
+    assert folder_row.status == "failed"
+    assert folder_row.status_message == "Folder is empty; previous files kept"
+    assert {row.id for row in rows} == first_ids
+    assert deleted == []
+    assert vector_db.writes == []
+
+    (folder / "a.txt").write_text(ALPHA_TEXT)
+    (folder / "b.md").write_text(BETA_TEXT)
+    kb.insert(path=str(folder))
+
+    assert _folder_row(_rows(kb)).status == "completed"
+    assert vector_db.writes == []
+
+
+async def test_aremove_folder_row_cascades_to_file_rows(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    folder = _make_two_file_folder(tmp_path)
+    await kb.ainsert(path=str(folder))
+    rows = _rows(kb)
+    folder_id = _folder_row(rows).id
+    child_ids = set(_child_rows(rows).keys())
+    deleted = _record_deletes(vector_db)
+
+    await kb.aremove_content_by_id(folder_id)
+
+    assert _rows(kb) == []
+    deleted_ids = [content_id for content_id, _ in deleted]
+    for child_id in child_ids:
+        assert deleted_ids.count(child_id) == 1
+    assert deleted_ids.count(folder_id) == 1
+
+
+def test_remove_folder_row_cascades_to_file_rows(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    folder = _make_two_file_folder(tmp_path)
+    kb.insert(path=str(folder))
+    rows = _rows(kb)
+    folder_id = _folder_row(rows).id
+    child_ids = set(_child_rows(rows).keys())
+    deleted = _record_deletes(vector_db)
+
+    kb.remove_content_by_id(folder_id)
+
+    assert _rows(kb) == []
+    deleted_ids = [content_id for content_id, _ in deleted]
+    for child_id in child_ids:
+        assert deleted_ids.count(child_id) == 1
+    assert deleted_ids.count(folder_id) == 1
+
+
+async def test_aremove_file_row_drops_it_from_parent_children(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    folder = _make_two_file_folder(tmp_path)
+    await kb.ainsert(path=str(folder))
+    rows = _rows(kb)
+    removed_id = _child_by_name(rows, "b.md").id
+    kept_id = _child_by_name(rows, "a.txt").id
+
+    await kb.aremove_content_by_id(removed_id)
+
+    rows = _rows(kb)
+    assert set(_child_rows(rows).keys()) == {kept_id}
+    assert removed_id not in {row.id for row in rows}
+    assert get_agno_metadata(_folder_row(rows).metadata, "children") == [kept_id]
+
+
+async def test_vector_delete_false_keeps_file_row_async(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    folder = _make_two_file_folder(tmp_path)
+    await kb.ainsert(path=str(folder))
+    child_id = _child_by_name(_rows(kb), "a.txt").id
+
+    vector_db.delete_by_content_id = lambda content_id, user_id=None: False
+    removed = await kb.aremove_content_by_id(child_id)
+
+    assert removed is False
+    assert await kb.aget_content_by_id(child_id) is not None, "the row must stay while its vectors exist"
+    assert child_id in get_agno_metadata(_folder_row(_rows(kb)).metadata, "children")
+
+
+def test_vector_delete_false_keeps_file_row_sync(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    folder = _make_two_file_folder(tmp_path)
+    kb.insert(path=str(folder))
+    child_id = _child_by_name(_rows(kb), "a.txt").id
+
+    vector_db.delete_by_content_id = lambda content_id, user_id=None: False
+    removed = kb.remove_content_by_id(child_id)
+
+    assert removed is False
+    assert kb.get_content_by_id(child_id) is not None
+
+
+async def test_ainsert_single_file_keeps_single_row(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    single = tmp_path / "solo.txt"
+    single.write_text("solo text")
+
+    await kb.ainsert(path=str(single))
+
+    rows = _rows(kb)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.name == "solo.txt"
+    assert row.status == "completed"
+    assert get_agno_metadata(row.metadata, "children") is None
+    assert get_agno_metadata(row.metadata, "parent_id") is None
+    assert get_agno_metadata(row.metadata, "vectors_indexed") is True
+    assert len(vector_db.writes) == 1
+    assert all(doc.content_id == row.id for doc in vector_db.inserted_documents)
+
+
+def test_insert_single_file_keeps_single_row(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    single = tmp_path / "solo.txt"
+    single.write_text("solo text")
+
+    kb.insert(path=str(single))
+
+    rows = _rows(kb)
+    assert len(rows) == 1
+    assert rows[0].status == "completed"
+    assert get_agno_metadata(rows[0].metadata, "children") is None
+    assert get_agno_metadata(rows[0].metadata, "vectors_indexed") is True
+    assert len(vector_db.writes) == 1
+
+
+async def test_ainsert_scoped_owner_owns_rows_and_vectors(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    folder = _make_two_file_folder(tmp_path)
+
+    await kb.ainsert(path=str(folder), user_id="u1")
+
+    rows = _rows(kb)
+    assert len(rows) == 3
+    assert all(row.user_id == "u1" for row in rows)
+    assert vector_db.owners == ["u1", "u1"]
+
+    # The owner's scoped delete of the folder row removes everything
+    await kb.aremove_content_by_id(_folder_row(rows).id, user_id="u1")
+    assert _rows(kb) == []
+
+
+async def test_ainsert_exclude_pattern_skips_matching_files(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    folder = _make_two_file_folder(tmp_path)
+    (folder / "noise.log").write_text("log line")
+
+    await kb.ainsert(path=str(folder), exclude=["*.log"])
+
+    rows = _rows(kb)
+    assert {row.name for row in rows} == {"docs", "a.txt", "b.md"}
+    folder_row = _folder_row(rows)
+    assert folder_row.status_message == "2 of 2 files loaded"
+    assert len(get_agno_metadata(folder_row.metadata, "children")) == 2
+    assert len(vector_db.writes) == 2
+
+
+def test_insert_include_pattern_limits_to_matching_files(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    folder = _make_folder(tmp_path)
+
+    kb.insert(path=str(folder), include=["*.txt"])
+
+    rows = _rows(kb)
+    # Basename matching: nested sub/c.txt matches *.txt too
+    assert {row.name for row in rows} == {"docs", "a.txt", "c.txt"}
+    folder_row = _folder_row(rows)
+    assert folder_row.status_message == "2 of 2 files loaded"
+    assert len(vector_db.writes) == 2

--- a/libs/agno/tests/unit/knowledge/test_per_page_content_rows.py
+++ b/libs/agno/tests/unit/knowledge/test_per_page_content_rows.py
@@ -602,6 +602,7 @@ async def test_single_row_site_growing_to_pages_clears_legacy_vectors(vector_db,
     await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "only page", PAGE_TWO: "second"}))
 
     assert parent_id in deleted, "the legacy single-row vectors must not stay searchable under the site row"
+    assert get_agno_metadata(_site_row(_rows(kb)).metadata, "vectors_indexed") is False
 
 
 async def test_prune_failure_keeps_stale_child_in_children(vector_db, tmp_path):
@@ -1096,3 +1097,122 @@ def test_aborted_promotion_keeps_ownership_marker_sync(vector_db, tmp_path):
     row = kb.get_content_by_id(legacy_id)
     assert row.status == "failed"
     assert get_agno_metadata(row.metadata, "vectors_indexed") is True
+
+
+# Review round 5: durable vector state and last-known-good page replacement
+# ---------------------------------------------------------------------------
+
+
+async def test_failed_refresh_preserves_vector_ownership_async(tmp_path):
+    vector_db = ZeroMatchFalseVectorDb()
+    kb = _kb(tmp_path, vector_db)
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "only page"}))
+    content_id = _rows(kb)[0].id
+
+    await kb.ainsert(url=SITE_URL, reader=EmptyReader({}))
+
+    row = await kb.aget_content_by_id(content_id)
+    assert row is not None and row.status == "failed"
+    assert get_agno_metadata(row.metadata, "vectors_indexed") is True
+    vector_db.delete_by_content_id = lambda cid, user_id=None: False
+    assert await kb.aremove_content_by_id(content_id) is False
+    assert await kb.aget_content_by_id(content_id) is not None
+
+
+def test_failed_refresh_preserves_vector_ownership_sync(tmp_path):
+    vector_db = ZeroMatchFalseVectorDb()
+    kb = _kb(tmp_path, vector_db)
+    kb.insert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "only page"}))
+    content_id = _rows(kb)[0].id
+
+    kb.insert(url=SITE_URL, reader=EmptyReader({}))
+
+    row = kb.get_content_by_id(content_id)
+    assert row is not None and row.status == "failed"
+    assert get_agno_metadata(row.metadata, "vectors_indexed") is True
+    vector_db.delete_by_content_id = lambda cid, user_id=None: False
+    assert kb.remove_content_by_id(content_id) is False
+    assert kb.get_content_by_id(content_id) is not None
+
+
+async def test_changed_page_false_delete_keeps_last_known_good_async(tmp_path):
+    vector_db = ZeroMatchFalseVectorDb()
+    kb = _kb(tmp_path, vector_db)
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}))
+    previous_child = _child_by_url(_rows(kb), PAGE_TWO)
+    previous_digest = get_agno_metadata(previous_child.metadata, "content_digest")
+    original_delete = vector_db.delete_by_content_id
+
+    def fail_page_replacement(content_id, user_id=None):
+        if content_id == previous_child.id:
+            return False
+        return original_delete(content_id, user_id=user_id)
+
+    vector_db.delete_by_content_id = fail_page_replacement
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text v2"}))
+
+    kept = _child_by_url(_rows(kb), PAGE_TWO)
+    assert kept.status == "completed"
+    assert get_agno_metadata(kept.metadata, "content_digest") == previous_digest
+    assert get_agno_metadata(kept.metadata, "vectors_indexed") is True
+    assert [doc.content for doc in vector_db.inserted_documents if doc.meta_data["url"] == PAGE_TWO] == ["api text"]
+    failure = get_agno_metadata(_site_row(_rows(kb)).metadata, "failed")
+    assert failure == [{"url": PAGE_TWO, "error": "Could not replace previous page vectors", "stale_kept": "true"}]
+
+    vector_db.delete_by_content_id = original_delete
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text v2"}))
+    assert [doc.content for doc in vector_db.inserted_documents if doc.meta_data["url"] == PAGE_TWO] == ["api text v2"]
+    assert _site_row(_rows(kb)).status_message == "2 of 2 pages loaded"
+
+
+def test_changed_page_false_delete_keeps_last_known_good_sync(tmp_path):
+    vector_db = ZeroMatchFalseVectorDb()
+    kb = _kb(tmp_path, vector_db)
+    kb.insert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text"}))
+    previous_child = _child_by_url(_rows(kb), PAGE_TWO)
+    previous_digest = get_agno_metadata(previous_child.metadata, "content_digest")
+    original_delete = vector_db.delete_by_content_id
+
+    def fail_page_replacement(content_id, user_id=None):
+        if content_id == previous_child.id:
+            return False
+        return original_delete(content_id, user_id=user_id)
+
+    vector_db.delete_by_content_id = fail_page_replacement
+    kb.insert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text v2"}))
+
+    kept = _child_by_url(_rows(kb), PAGE_TWO)
+    assert kept.status == "completed"
+    assert get_agno_metadata(kept.metadata, "content_digest") == previous_digest
+    assert get_agno_metadata(kept.metadata, "vectors_indexed") is True
+    assert [doc.content for doc in vector_db.inserted_documents if doc.meta_data["url"] == PAGE_TWO] == ["api text"]
+
+    vector_db.delete_by_content_id = original_delete
+    kb.insert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "guide text", PAGE_TWO: "api text v2"}))
+    assert [doc.content for doc in vector_db.inserted_documents if doc.meta_data["url"] == PAGE_TWO] == ["api text v2"]
+
+
+async def test_skip_if_exists_records_vector_ownership_async(tmp_path):
+    vector_db = ZeroMatchFalseVectorDb(content_exists=True)
+    kb = _kb(tmp_path, vector_db)
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "already indexed"}), skip_if_exists=True)
+    row = _rows(kb)[0]
+
+    assert row.status == "completed"
+    assert get_agno_metadata(row.metadata, "vectors_indexed") is True
+    assert vector_db.writes == []
+    vector_db.delete_by_content_id = lambda cid, user_id=None: False
+    assert await kb.aremove_content_by_id(row.id) is False
+
+
+def test_skip_if_exists_records_vector_ownership_sync(tmp_path):
+    vector_db = ZeroMatchFalseVectorDb(content_exists=True)
+    kb = _kb(tmp_path, vector_db)
+    kb.insert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "already indexed"}), skip_if_exists=True)
+    row = _rows(kb)[0]
+
+    assert row.status == "completed"
+    assert get_agno_metadata(row.metadata, "vectors_indexed") is True
+    assert vector_db.writes == []
+    vector_db.delete_by_content_id = lambda cid, user_id=None: False
+    assert kb.remove_content_by_id(row.id) is False

--- a/libs/agno/tests/unit/reader/test_page_fetcher.py
+++ b/libs/agno/tests/unit/reader/test_page_fetcher.py
@@ -481,3 +481,123 @@ def test_rate_limit_from_text():
     assert rate_limit_from_text("HTTP 429 Too Many Requests")
     assert rate_limit_from_text("Rate Limit hit")
     assert not rate_limit_from_text("ok")
+
+
+# --- application/pdf branch ---
+
+
+PDF_TEXT = "Hello PDF"
+
+
+def _build_pdf(text: str) -> bytes:
+    """A minimal one-page PDF with a single Tj text operator; parses with pypdf."""
+    import io
+
+    stream = f"BT /F1 12 Tf 72 720 Td ({text}) Tj ET".encode()
+    objects = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R "
+        b"/Resources << /Font << /F1 5 0 R >> >> >>",
+        b"<< /Length " + str(len(stream)).encode() + b" >>\nstream\n" + stream + b"\nendstream",
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    ]
+    out = io.BytesIO()
+    out.write(b"%PDF-1.4\n")
+    offsets = []
+    for index, body in enumerate(objects, start=1):
+        offsets.append(out.tell())
+        out.write(f"{index} 0 obj\n".encode() + body + b"\nendobj\n")
+    xref_at = out.tell()
+    out.write(f"xref\n0 {len(objects) + 1}\n".encode())
+    out.write(b"0000000000 65535 f \n")
+    for offset in offsets:
+        out.write(f"{offset:010d} 00000 n \n".encode())
+    out.write(f"trailer\n<< /Size {len(objects) + 1} /Root 1 0 R >>\nstartxref\n{xref_at}\n%%EOF\n".encode())
+    return out.getvalue()
+
+
+def _pdf_site_handler(request: httpx.Request) -> httpx.Response:
+    path = request.url.path
+    if path == "/doc.pdf":
+        return httpx.Response(200, content=_build_pdf(PDF_TEXT), headers={"content-type": "application/pdf"})
+    if path == "/blob":
+        # A real PDF body served without a PDF content type: only the %PDF- magic identifies it.
+        return httpx.Response(200, content=_build_pdf(PDF_TEXT), headers={"content-type": "application/octet-stream"})
+    if path == "/corrupt.pdf":
+        # No %PDF- magic either: only the content type routes this to the PDF branch.
+        return httpx.Response(200, content=b"not really a pdf at all", headers={"content-type": "application/pdf"})
+    return httpx.Response(404, content=b"gone")
+
+
+def test_pdf_response_extracts_text(monkeypatch):
+    _install_transport(monkeypatch, _pdf_site_handler)
+    page = HttpxPageFetcher().fetch_many(["https://example.com/doc.pdf"])[0]
+
+    assert page.ok
+    assert page.error is None
+    assert page.content == PDF_TEXT
+    assert page.title is None
+    assert page.extractor == "httpx"
+    assert page.attempts == [{"extractor": "httpx", "outcome": "ok"}]
+
+
+@pytest.mark.asyncio
+async def test_async_pdf_response_extracts_text(monkeypatch):
+    _install_transport(monkeypatch, _pdf_site_handler)
+    page = (await HttpxPageFetcher().afetch_many(["https://example.com/doc.pdf"]))[0]
+
+    assert page.ok
+    assert page.content == PDF_TEXT
+    assert page.attempts == [{"extractor": "httpx", "outcome": "ok"}]
+
+
+def test_pdf_magic_under_octet_stream_routes_to_pdf_branch(monkeypatch):
+    _install_transport(monkeypatch, _pdf_site_handler)
+    page = HttpxPageFetcher().fetch_many(["https://example.com/blob"])[0]
+
+    assert page.ok
+    assert page.error is None
+    assert page.content == PDF_TEXT
+
+
+def test_corrupt_pdf_body_is_an_error(monkeypatch):
+    _install_transport(monkeypatch, _pdf_site_handler)
+    page = HttpxPageFetcher().fetch_many(["https://example.com/corrupt.pdf"])[0]
+
+    # PDFReader swallows parse errors internally and returns no documents, so a corrupt
+    # body surfaces as "empty" rather than a pdf-prefixed parse error.
+    assert not page.ok
+    assert page.content is None
+    assert page.error == "empty"
+    assert page.attempts == [{"extractor": "httpx", "outcome": "empty"}]
+
+
+def test_pdf_reader_exception_is_a_pdf_error(monkeypatch):
+    class ExplodingReader:
+        def __init__(self, chunk: bool = True):
+            pass
+
+        def read(self, obj, name=None):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr("agno.knowledge.reader.pdf_reader.PDFReader", ExplodingReader)
+    _install_transport(monkeypatch, _pdf_site_handler)
+    page = HttpxPageFetcher().fetch_many(["https://example.com/doc.pdf"])[0]
+
+    assert not page.ok
+    assert page.content is None
+    assert page.error == "pdf: RuntimeError: boom"
+    assert page.attempts == [{"extractor": "httpx", "outcome": "pdf: RuntimeError: boom"}]
+
+
+def test_missing_pypdf_names_the_extra(monkeypatch):
+    # A None entry in sys.modules makes the lazy import raise ImportError, simulating an
+    # environment without the pdf extra; the read gets a page error, never an exception.
+    monkeypatch.setitem(sys.modules, "agno.knowledge.reader.pdf_reader", None)
+    _install_transport(monkeypatch, _pdf_site_handler)
+    page = HttpxPageFetcher().fetch_many(["https://example.com/doc.pdf"])[0]
+
+    assert not page.ok
+    assert page.error == "pdf support requires the `agno[pdf]` extra (pypdf)"
+    assert page.attempts == [{"extractor": "httpx", "outcome": page.error}]

--- a/libs/agno/tests/unit/tools/test_knowledge_management_tools.py
+++ b/libs/agno/tests/unit/tools/test_knowledge_management_tools.py
@@ -175,7 +175,7 @@ def test_registration_default_exposes_all_tools_sync_and_async():
     kb, _ = _make_kb()
     toolkit = KnowledgeManagementTools(knowledge=kb)
 
-    expected = ["ingest_url", "ingest_text", "list_content", "ingest_status", "remove_content"]
+    expected = ["ingest_url", "ingest_path", "ingest_text", "list_content", "ingest_status", "remove_content"]
     assert list(toolkit.functions.keys()) == expected
     assert list(toolkit.async_functions.keys()) == expected
 
@@ -877,3 +877,218 @@ class TestRemoteParentIdFilter:
 
         assert response.status_code == 501
         assert "parent_id" in response.json()["detail"]
+
+
+# ===========================================================================
+# ingest_path (files and folders) and refresh-by-path
+# ===========================================================================
+
+
+def _make_folder() -> str:
+    folder = tempfile.mkdtemp()
+    with open(os.path.join(folder, "a.txt"), "w") as handle:
+        handle.write("alpha file text")
+    with open(os.path.join(folder, "b.txt"), "w") as handle:
+        handle.write("beta file text")
+    return folder
+
+
+def test_ingest_path_folder_sync_reports_and_writes_rows():
+    kb, db_file = _make_kb()
+    toolkit = _make_toolkit(kb)
+    folder = _make_folder()
+
+    report = json.loads(toolkit.ingest_path(_ctx(), folder))
+
+    assert report["ok"] is True
+    assert report["status"] == "completed"
+    assert report["status_message"] == "2 of 2 files loaded"
+    assert report["pages"] == 2
+    assert report["page_rows"] == 2
+    assert report["failed"] == []
+    assert isinstance(report["seconds"], (int, float))
+
+    rows = _rows(db_file)
+    assert len(rows) == 3  # one folder row + two file rows
+    assert report["site_id"] in {row[0] for row in rows}
+    folder_row = kb.get_content_by_id(report["site_id"])
+    assert folder_row is not None
+    assert folder_row.name == os.path.basename(folder)
+    assert {row[1] for row in rows} == {os.path.basename(folder), "a.txt", "b.txt"}
+
+
+def test_aingest_path_folder_reports_and_writes_rows():
+    kb, db_file = _make_kb()
+    toolkit = _make_toolkit(kb)
+    folder = _make_folder()
+
+    report = json.loads(asyncio.run(toolkit.aingest_path(_ctx(), folder)))
+
+    assert report["ok"] is True
+    assert report["status_message"] == "2 of 2 files loaded"
+    assert report["pages"] == 2
+    assert report["page_rows"] == 2
+    assert "seconds" in report
+    rows = _rows(db_file)
+    assert len(rows) == 3
+    assert report["site_id"] in {row[0] for row in rows}
+
+
+def test_ingest_path_single_file_reports_matching_row():
+    kb, db_file = _make_kb()
+    toolkit = _make_toolkit(kb)
+    file_path = os.path.join(tempfile.mkdtemp(), "solo.txt")
+    with open(file_path, "w") as handle:
+        handle.write("solo file text")
+
+    report = json.loads(toolkit.ingest_path(_ctx(), file_path))
+
+    assert report["ok"] is True
+    assert report["status"] == "completed"
+    # A single file has no children, so the folder-only fields stay unset.
+    assert report["pages"] is None
+    assert "page_rows" not in report
+    rows = _rows(db_file)
+    assert len(rows) == 1
+    assert report["site_id"] == rows[0][0]
+    assert report["name"] == rows[0][1] == "solo.txt"
+
+
+def test_aingest_path_single_file_reports_matching_row():
+    kb, db_file = _make_kb()
+    toolkit = _make_toolkit(kb)
+    file_path = os.path.join(tempfile.mkdtemp(), "solo.txt")
+    with open(file_path, "w") as handle:
+        handle.write("solo file text")
+
+    report = json.loads(asyncio.run(toolkit.aingest_path(_ctx(), file_path)))
+
+    assert report["ok"] is True
+    rows = _rows(db_file)
+    assert len(rows) == 1
+    assert report["site_id"] == rows[0][0]
+
+
+def test_ingest_path_user_scope_writes_run_user_id():
+    kb, db_file = _make_kb()
+    toolkit = _make_toolkit(kb, scope="user")
+    folder = _make_folder()
+
+    report = json.loads(toolkit.ingest_path(_ctx(user_id="alice"), folder))
+
+    assert report["ok"] is True
+    rows = _rows(db_file)
+    assert len(rows) == 3
+    assert all(row[2] == "alice" for row in rows)
+    folder_row = kb.get_content_by_id(report["site_id"], user_id="alice")
+    assert folder_row is not None and folder_row.user_id == "alice"
+
+
+def test_ingest_path_missing_path_returns_error_envelope():
+    kb, db_file = _make_kb()
+    toolkit = _make_toolkit(kb)
+    missing = os.path.join(tempfile.mkdtemp(), "gone")
+    predicted = toolkit._predict_path_row_id(missing, None)
+
+    def rows_or_empty():
+        try:
+            return _rows(db_file)
+        except sqlite3.OperationalError:
+            return []  # nothing was ever written, so the table does not exist
+
+    # The toolkit pre-checks existence and names the real problem, writing nothing
+    report = json.loads(toolkit.ingest_path(_ctx(), missing))
+    assert report == {"ok": False, "error": f"path does not exist: {missing}"}
+    assert rows_or_empty() == []
+
+    areport = json.loads(asyncio.run(toolkit.aingest_path(_ctx(), missing)))
+    assert areport == {"ok": False, "error": f"path does not exist: {missing}"}
+    assert rows_or_empty() == []
+    assert predicted  # id prediction stays stable for callers that stored it
+
+
+def test_ingest_path_error_returns_envelope():
+    kb, _ = _make_kb()
+    toolkit = _make_toolkit(kb)
+
+    def boom(**kwargs):
+        raise RuntimeError("disk exploded")
+
+    kb.insert = boom  # type: ignore[method-assign]
+    real_dir = tempfile.mkdtemp()
+    result = json.loads(toolkit.ingest_path(_ctx(), real_dir))
+    assert result == {"ok": False, "error": "disk exploded"}
+
+
+def test_list_content_groups_folder_like_site():
+    kb, _ = _make_kb()
+    toolkit = _make_toolkit(kb)
+    folder = _make_folder()
+    report = json.loads(toolkit.ingest_path(_ctx(), folder))
+
+    listing = json.loads(toolkit.list_content(_ctx()))
+
+    assert listing["total_rows"] == 3
+    assert listing["other"] == []  # file rows are grouped away, never listed as other
+    assert len(listing["sites"]) == 1
+    site = listing["sites"][0]
+    assert site["site_id"] == report["site_id"]
+    assert site["name"] == os.path.basename(folder)
+    assert site["pages"] == 2
+    assert site["failed"] == 0
+    assert site["status"] == "completed"
+
+
+class TestRefreshByPathRoute:
+    def test_refresh_path_row_schedules_background_ingest(self):
+        content_hash = "stable-hash"
+        content_id = generate_id(content_hash)
+        knowledge = _mock_router_knowledge()
+        knowledge._build_content_hash = MagicMock(return_value=content_hash)
+        existing = _content(
+            content_id,
+            "product-docs",
+            metadata={"_agno": {"source_path": "/data/product-docs", "source_type": "folder"}},
+        )
+        knowledge.aget_content_by_id = AsyncMock(return_value=existing)
+        client = _build_client(knowledge)
+
+        with patch("agno.os.routers.knowledge.knowledge.process_content", new=AsyncMock()) as process_content:
+            response = client.post(f"/knowledge/content/{content_id}/refresh")
+
+        assert response.status_code == 202
+        body = response.json()
+        assert body["id"] == content_id
+        assert body["status"] == "processing"
+
+        # The background task re-ingests the reconstructed Content from its recorded path
+        process_content.assert_awaited_once()
+        args = process_content.await_args.args
+        assert args[0] is knowledge
+        reconstructed = args[1]
+        assert reconstructed.path == "/data/product-docs"
+        assert reconstructed.url is None
+        assert reconstructed.id == content_id
+        assert reconstructed.user_id is None
+        assert reconstructed.metadata is None  # only _agno bookkeeping was stored
+        # Path refreshes pick readers by file extension, never a recorded URL reader
+        assert args[2] is None
+
+    def test_refresh_unmatchable_path_row_returns_400(self):
+        # The stored id cannot be reproduced from the row's fields -> explicit 400, no task
+        knowledge = _mock_router_knowledge()
+        knowledge._build_content_hash = MagicMock(return_value="different-hash")
+        existing = _content(
+            "path-id-that-wont-match",
+            "product-docs",
+            metadata={"_agno": {"source_path": "/data/product-docs"}},
+        )
+        knowledge.aget_content_by_id = AsyncMock(return_value=existing)
+        client = _build_client(knowledge)
+
+        with patch("agno.os.routers.knowledge.knowledge.process_content", new=AsyncMock()) as process_content:
+            response = client.post("/knowledge/content/path-id-that-wont-match/refresh")
+
+        assert response.status_code == 400
+        assert "re-ingest the path" in response.json()["detail"]
+        process_content.assert_not_awaited()


### PR DESCRIPTION
## Summary

Part F of the knowledge-management spec (`specs/agno/knowledge-management-tools/spec-v0.md`), stacked on #9856 and rebased onto its merge: files and folders get the same product surface websites got — per-unit rows, digest-driven refresh, failure isolation, cascade delete, and chat-side ingestion. Requested by the owner as the piece that "completes the product" alongside the AgentOS UI's existing file upload.

### Folder rows (`_aload_dir_as_folder` + sync twin)

A directory insert lands as a **folder row owning one child row per file** (nested folders flattened), the file twin of the per-page loaders:

- **Byte-digest refresh**: unchanged files skip the read *and* the embed; a changed file replaces its chunks wholesale (works without adapter upsert support, mirroring pages); a re-run of an unchanged folder does zero vector writes.
- **Failure isolation**: a file whose reader raises — or whose bytes cannot be read at all — lands a FAILED child row with the reason and never aborts the folder; the folder row aggregates ("1 of 2 files loaded; failed: …") and FAILED children retry next run.
- **Prune with the #9856 deletion contract**: files deleted from the folder lose their rows (bool-honoring, ownership retained on failure); an **emptied or unenumerable folder keeps every previous row** ("previous files kept") instead of reading as mass removal.
- Child rows carry `_agno.parent_id/source_path/content_digest/vectors_indexed`; cascade delete and the `?parent_id=` listing work with no new code. Single-file inserts are byte-for-byte unchanged (pinned).

### PDFs as pages

`HttpxPageFetcher` routes `application/pdf` responses (and `%PDF-` magic under wrong content types) through `PDFReader`, so PDF sitemap entries become citable page rows; a missing `pypdf` is a per-page error naming `agno[pdf]`, never an exception through the read. The keyed Parallel route already extracts PDFs server-side.

### Toolkit + REST

`KnowledgeManagementTools.ingest_path` (sync + async): file or folder, existence pre-checked with a clear envelope, same `site_id`-keyed report as `ingest_url`; `list_content` groups folders like sites. `POST /knowledge/content/{id}/refresh` handles path-sourced rows via the recorded `_agno.source_path`.

## Type of change

- [x] New feature

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings; docs-repo pages extended separately)
- [x] Examples and guides: folder note added to `cookbook/91_tools/knowledge_management_tools.py`
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

- **61 new tests** (`test_folder_content_rows.py` 22, PDF fetcher section 7, toolkit/refresh sections 10, plus updated registration/regression pins); knowledge+reader+toolkit sweep 1,134 green locally; mutation checks run and killed by the writing agents.
- The adversarial test round caught **five defects before push** (folder-failure `KeyError('url')` aborting finalize, changed-file chunk stacking on non-upsert adapters, unreadable files landing COMPLETED-empty, missing-path envelopes, docstring/envelope key drift) — all fixed and pinned.
- Verified live end-to-end: 3-file nested folder → folder row + 3 children in one call; unchanged re-run 0 embeds; changed file 1 embed; deleted file pruned; cascade to zero rows; sync twin equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Rebase note (post #9860):** rebased onto `541f37fe2`; the two test-file conflicts were union-merged (both sides kept, all green together). **Disclosure:** this branch also carries a small "round 5" set of changes authored by the owner's other review session working in the same checkout, swept into the original commit: a `vectors_indexed` parameter on the contents-db insert helpers, a post-clear ownership=False stamp after successful 1→N promotion, and last-known-good retention when a changed page's vector replacement is refused ("Could not replace previous page vectors", `stale_kept`). I audited all three hunks and their tests; they compose with #9860's promotion guard (verified by the combined suite: 1,138 green including both change-sets' regressions).