### PR TITLE
fix: guard aborted promotions, cap-truncated reads, and remote parent_id filtering

### DIFF
--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -1894,6 +1894,13 @@ class Knowledge(RemoteKnowledge):
             # the children list would strand every page row on a later site delete.
             # The ROW is patched, never content.metadata — that is a hash input.
             await self._astamp_row_children(content, previous_children)
+        elif previous_row_owned_vectors:
+            # Same wholesale-upsert hazard for the ownership marker: an aborted legacy
+            # promotion must still be recognized as one on the retry, or the retry runs
+            # unguarded and lands COMPLETED beside stale searchable vectors.
+            marker = Content(id=content.id, user_id=content.user_id)
+            marker.metadata = set_agno_metadata(None, "vectors_indexed", True)
+            await self._aupdate_content(marker)
         if self._should_skip(content.content_hash, skip_if_exists, user_id=content.user_id):  # type: ignore[arg-type]
             content.status = ContentStatus.COMPLETED
             await self._aupdate_content(content)
@@ -2065,6 +2072,11 @@ class Knowledge(RemoteKnowledge):
         if previous_children:
             # See the matching re-stamp in _aload_from_url.
             self._stamp_row_children(content, previous_children)
+        elif previous_row_owned_vectors:
+            # See the matching marker re-stamp in _aload_from_url.
+            marker = Content(id=content.id, user_id=content.user_id)
+            marker.metadata = set_agno_metadata(None, "vectors_indexed", True)
+            self._update_content(marker)
         if self._should_skip(content.content_hash, skip_if_exists, user_id=content.user_id):  # type: ignore[arg-type]
             content.status = ContentStatus.COMPLETED
             self._update_content(content)

--- a/libs/agno/agno/knowledge/reader/sitemap_reader.py
+++ b/libs/agno/agno/knowledge/reader/sitemap_reader.py
@@ -215,9 +215,12 @@ class SitemapReader(Reader):
                 else:
                     page_locs.extend(child_locs)
 
+            if pending:
+                # Shards were never opened because the cap was reached first
+                incomplete = True
             pages: List[str] = []
             seen: set = set()
-            for loc in page_locs:
+            for index, loc in enumerate(page_locs):
                 key = canonical_page_url(loc)
                 if key in seen:
                     continue
@@ -227,6 +230,10 @@ class SitemapReader(Reader):
                     continue
                 pages.append(loc)
                 if len(pages) >= self.max_pages:
+                    if index + 1 < len(page_locs):
+                        # The cap truncated the read: pages beyond it still exist on the
+                        # site, so a reconciling caller must not treat them as removed
+                        incomplete = True
                     break
             return pages, candidate, incomplete
 

--- a/libs/agno/agno/os/routers/knowledge/knowledge.py
+++ b/libs/agno/agno/os/routers/knowledge/knowledge.py
@@ -566,6 +566,9 @@ def attach_routes(router: APIRouter, knowledge_instances: List[Union[Knowledge, 
         knowledge = get_knowledge_instance(knowledge_instances, db_id, knowledge_id)
 
         if isinstance(knowledge, RemoteKnowledge):
+            if parent_id is not None:
+                # Silently returning the unfiltered base would look like a filtered result
+                raise HTTPException(status_code=501, detail="parent_id filtering is not supported for remote knowledge")
             auth_token = get_auth_token_from_request(request)
             headers = {"Authorization": f"Bearer {auth_token}"} if auth_token else None
             return await knowledge.get_content(

--- a/libs/agno/tests/unit/knowledge/test_per_page_content_rows.py
+++ b/libs/agno/tests/unit/knowledge/test_per_page_content_rows.py
@@ -1049,3 +1049,50 @@ async def test_async_lightrag_removal_honors_false(tmp_path):
 
     assert removed is False
     assert await kb.aget_content_by_id(content.id) is not None
+
+
+# ---------------------------------------------------------------------------
+# Post-merge review round: ownership survives aborted promotions
+# ---------------------------------------------------------------------------
+
+
+async def test_aborted_promotion_keeps_ownership_marker_and_guards_retry(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "legacy text"}))
+    legacy_id = _rows(kb)[0].id
+
+    def raising_clear(content_id, user_id=None):
+        raise RuntimeError("adapter down")
+
+    vector_db.delete_by_content_id = raising_clear
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "legacy text", PAGE_TWO: "second"}))
+
+    row = await kb.aget_content_by_id(legacy_id)
+    assert row.status == "failed"
+    # The wholesale upsert must not erase the evidence the retry's promotion guard needs
+    assert get_agno_metadata(row.metadata, "vectors_indexed") is True
+
+    # A retry with the clear still failing stays guarded — no unguarded COMPLETED
+    vector_db.delete_by_content_id = lambda cid, user_id=None: False
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "legacy text", PAGE_TWO: "second"}))
+    assert (await kb.aget_content_by_id(legacy_id)).status == "failed"
+
+    # A healed clear reconciles to a proper site
+    del vector_db.delete_by_content_id
+    await kb.ainsert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "legacy text", PAGE_TWO: "second"}))
+    site = await kb.aget_content_by_id(legacy_id)
+    assert site.status == "completed"
+    assert len(get_agno_metadata(site.metadata, "children")) == 2
+
+
+def test_aborted_promotion_keeps_ownership_marker_sync(vector_db, tmp_path):
+    kb = _kb(tmp_path, vector_db)
+    kb.insert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "legacy text"}))
+    legacy_id = _rows(kb)[0].id
+
+    vector_db.delete_by_content_id = lambda cid, user_id=None: False
+    kb.insert(url=SITE_URL, reader=FakePagesReader({PAGE_ONE: "legacy text", PAGE_TWO: "second"}))
+
+    row = kb.get_content_by_id(legacy_id)
+    assert row.status == "failed"
+    assert get_agno_metadata(row.metadata, "vectors_indexed") is True

--- a/libs/agno/tests/unit/reader/test_sitemap_reader.py
+++ b/libs/agno/tests/unit/reader/test_sitemap_reader.py
@@ -607,3 +607,20 @@ def test_complete_discovery_carries_no_incomplete_flag():
 
     assert documents
     assert all("discovery_incomplete" not in doc.meta_data for doc in documents)
+
+
+def test_cap_truncated_read_marks_discovery_incomplete():
+    locs = [f"https://example.com/p{i}" for i in range(6)]
+    routes = {"https://example.com/sitemap.xml": (urlset_xml(*locs), "application/xml")}
+    for loc in locs:
+        routes[loc.replace("https://example.com", "https://example.com")] = (html_page("P", "page body"), "text/html")
+    with mock_site(routes):
+        capped = make_reader(max_pages=3).read("https://example.com/sitemap.xml")
+        full = make_reader(max_pages=10).read("https://example.com/sitemap.xml")
+
+    assert len(capped) == 3
+    assert all(doc.meta_data.get("discovery_incomplete") is True for doc in capped), (
+        "pages beyond the cap still exist on the site; a reconciling caller must not prune them"
+    )
+    assert len(full) == 6
+    assert all("discovery_incomplete" not in doc.meta_data for doc in full)

--- a/libs/agno/tests/unit/tools/test_knowledge_management_tools.py
+++ b/libs/agno/tests/unit/tools/test_knowledge_management_tools.py
@@ -860,3 +860,20 @@ class TestDeleteAllRouteAggregation:
 
         assert response.status_code == 200
         assert response.json() == "success"
+
+
+class TestRemoteParentIdFilter:
+    def test_parent_id_on_remote_knowledge_returns_501(self):
+        from agno.remote.base import RemoteKnowledge
+
+        knowledge = MagicMock(spec=RemoteKnowledge)
+        knowledge.name = "remote"
+        knowledge.id = "remote-kb"
+        knowledge.db_id = None
+        knowledge.knowledge_id = "remote-kb"
+        client = _build_client(knowledge)
+
+        response = client.get("/knowledge/content", params={"parent_id": "site-1"})
+
+        assert response.status_code == 501
+        assert "parent_id" in response.json()["detail"]


### PR DESCRIPTION
## Summary

Three defects found by the final composed-state review of #9856 (it completed just after the merge; two of four lenses were merge-ready — all 10 acceptance scenarios replayed green, all mutation checks killed — and the diff-reading lenses caught these). Each was reproduced by executed probe on `main` before fixing, and each fix carries a stateful regression.

1. **Aborted 1→N promotion lost its guard.** The wholesale row upsert at ingest start erased `vectors_indexed` on the FAILED promotion row, so the retry the status message demands ran *unguarded* and landed COMPLETED beside stale searchable legacy vectors (probe: `status=completed, legacy vectors present`). The ownership marker is now re-stamped across the attempt — the exact mechanism the children list already uses — so retries stay guarded until the clear succeeds, then reconcile. `test_aborted_promotion_keeps_ownership_marker_and_guards_retry` (+ sync twin).

2. **Cap-truncated reads pruned live pages.** A sitemap read that hit `max_pages` with more entries remaining (the exact shape of `POST /refresh`, which rebuilds the reader with factory defaults) reported complete discovery — reconciliation then deleted every beyond-cap page row and its vectors while reporting COMPLETED (probe: 7 rows → 4). Cap truncation and never-opened index shards now mark the read incomplete, which suppresses pruning and says so in the site status. `test_cap_truncated_read_marks_discovery_incomplete`.

3. **Remote `parent_id` was silently dropped.** `GET /knowledge/content?parent_id=…` on a `RemoteKnowledge` returned the full unfiltered base as a filtered-looking response; it now returns 501, matching remote refresh. `test_parent_id_on_remote_knowledge_returns_501`.

Non-blocking findings from the same review, recorded as follow-ups rather than fixed here: reader *config* (not identity) is still not persisted for refresh — safe now that truncation suppresses pruning, but a capped refresh reads fewer pages than the original ingest; the unreachable llms.txt overview branch; a tripped breaker's fallback fetches escaping the per-read concurrency bound; refresh reverting an operator-renamed auto-named site row.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: not applicable
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Validation: knowledge + reader + toolkit sweep 1,094 passed / 5 skipped (pre-existing extras); ruff clean; scoped mypy clean. #9858 (folder ingestion) is unaffected: folders have no page cap and no promotion path; its prune already rides the shared bool-honoring rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
