### PR TITLE
chore: release 3.0.4

### DIFF
--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agno"
-version = "3.0.3"
+version = "3.0.4"
 description = "The programming language for agentic software."
 requires-python = ">=3.9,<4"
 readme = "README.md"


### PR DESCRIPTION
# Changelog

## Behavior Changes

- **`KnowledgeManagementTools` constructor flags renamed, `ingest_path` now opt-in**: the 2.x-style `enable_ingest` / `enable_remove` flags are replaced by flags named after the tools they register — `ingest_url`, `ingest_path`, `ingest_text`, `remove_content` (the old names are no longer recognised and are ignored if passed). `ingest_path` defaults to off: it reads any path the server process can read, and under `scope="shared"` what it loads becomes readable by every agent on that knowledge base, so registering it is now an explicit choice. `list_content` and `ingest_status` stay unflagged — they only read. (#9861)
- **`agno.tools.knowledge_management` import path moved**: `KnowledgeManagementTools` (introduced in 3.0.3) now lives at `agno.tools.knowledge`; the old module path is gone. `from agno.tools.file_generation import FileGenerationTools` keeps working through a compatibility shim. (#9861)

## Improvements

- **`agno.tools.file` and `agno.tools.knowledge` are packages**: `FileTools` and `FileGenerationTools` share `agno.tools.file`; `KnowledgeTools` (read side) and `KnowledgeManagementTools` (write side) share `agno.tools.knowledge`, following the `agno.tools.mcp` and `agno.tools.finance` layout. Names resolve on first access, so importing `FileTools` no longer pulls `reportlab` and `python-docx` in behind it — measured at 44.8 ms with both installed, previously paid on every `FilesystemContextProvider` import. (#9861)
- **AtomicMail reuses its auth handshake**: the resolved context (capability JWT, API URL, account and inbox ids) is cached on the instance until the token nears expiry, in both sync and async paths, and keyed to the api_key it was minted from so re-registration is picked up on the next call. Warm tool calls drop from ~35 s to 0.4–3 s. (#9825)
- **AtomicMail proof-of-work parallelised**: the scrypt nonce search splits across a bounded thread pool — new `pow_workers` argument, default `min(4, cpu_count())`, with `pow_workers=1` matching the old sequential search exactly. Measured at difficulty 10: mean solve 25.9 s → 10.4 s on 4 workers. `pow_timeout` still bounds the search, and a worker that finds a solution wins over a concurrent timeout. (#9825)

## Bug Fixes

- **AtomicMail `list_inbox` returned the agent's own sent mail**: `send_email` files the outgoing message in the inbox mailbox with `$draft` set, and `list_inbox` queried that mailbox unfiltered, so an agent could not tell its own outgoing mail from a reply. The query now filters `notKeyword: "$draft"`, the parser drops any `$draft` entry, and a rejected query is reported as an error instead of an empty inbox. (#9825)
- **Caller-supplied `requires_confirmation_tools` dropped the `remove_content` gate**: `KnowledgeManagementTools` set its confirmation list with `setdefault`, so passing your own list silently removed the built-in confirmation requirement on `remove_content` — the one tool in the kit that destroys data. The lists now union. (#9861)
