### PR TITLE
[fix] reject duplicate team member ids

### DIFF
--- a/libs/agno/agno/team/_init.py
+++ b/libs/agno/agno/team/_init.py
@@ -437,6 +437,12 @@ def __init__(
         team,
     )
 
+    # Fail closed before any run can persist a HITL pause under an ambiguous id.
+    if isinstance(team.members, list):
+        from agno.utils.team import validate_unique_member_ids
+
+        validate_unique_member_ids(team.members, team_id=team.id, team_name=team.name)
+
 
 def background_executor(team: "Team") -> Any:
     """Lazy initialization of shared thread pool executor for background tasks.
@@ -527,6 +533,9 @@ def _initialize_member(team: "Team", member: Union["Team", Agent], debug_mode: O
         if isinstance(member.members, list):
             for sub_member in member.members:
                 member._initialize_member(sub_member, debug_mode=debug_mode)
+            from agno.utils.team import validate_unique_member_ids
+
+            validate_unique_member_ids(member.members, team_id=member.id, team_name=member.name)
 
 
 def propagate_run_hooks_in_background(team: "Team", run_in_background: bool = True) -> None:
@@ -901,6 +910,11 @@ def initialize_team(team: "Team", debug_mode: Optional[bool] = None) -> None:
     if isinstance(team.members, list):
         for member in team.members:
             _initialize_member(team, member, debug_mode=team.debug_mode)
+        # Re-check after set_id: assigned ids can collide even when construction
+        # saw distinct get_member_id values (e.g. name="RightTeam" vs id="rightteam").
+        from agno.utils.team import validate_unique_member_ids
+
+        validate_unique_member_ids(team.members, team_id=team.id, team_name=team.name)
 
 
 def add_tool(team: "Team", tool: Union[Toolkit, Callable, Function, Dict]) -> None:

--- a/libs/agno/agno/utils/callables.py
+++ b/libs/agno/agno/utils/callables.py
@@ -400,6 +400,10 @@ def resolve_callable_members(entity: Any, run_context: "RunContext") -> None:
     else:
         result = list(result)
 
+    from agno.utils.team import validate_unique_member_ids
+
+    validate_unique_member_ids(result, team_id=getattr(entity, "id", None), team_name=getattr(entity, "name", None))
+
     # Store in cache
     if cache_enabled and cache_key is not None:
         cache[cache_key] = result
@@ -436,6 +440,10 @@ async def aresolve_callable_members(entity: Any, run_context: "RunContext") -> N
         raise TypeError(f"Callable members factory must return a list or tuple, got {type(result).__name__}")
     else:
         result = list(result)
+
+    from agno.utils.team import validate_unique_member_ids
+
+    validate_unique_member_ids(result, team_id=getattr(entity, "id", None), team_name=getattr(entity, "name", None))
 
     # Store in cache
     if cache_enabled and cache_key is not None:

--- a/libs/agno/agno/utils/team.py
+++ b/libs/agno/agno/utils/team.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
 
 from agno.agent import Agent
 from agno.media import Audio, File, Image, Video
@@ -53,6 +53,58 @@ def get_member_id(member: Union[Agent, "Team"]) -> Optional[str]:
         return url_safe_string(member.name)
     else:
         return None
+
+
+def _member_identity_label(member: Union[Agent, "Team"]) -> str:
+    """Describe a member for duplicate-id errors: originals plus the resolved key."""
+    member_id = getattr(member, "id", None)
+    member_name = getattr(member, "name", None)
+    if member_id is not None:
+        if member_name:
+            return f"id={member_id!r} name={member_name!r}"
+        return f"id={member_id!r}"
+    if member_name is not None:
+        return f"name={member_name!r} (normalized {url_safe_string(member_name)!r})"
+    return "<unnamed member>"
+
+
+def validate_unique_member_ids(
+    members: Sequence[Union[Agent, "Team"]],
+    *,
+    team_id: Optional[str] = None,
+    team_name: Optional[str] = None,
+) -> None:
+    """Reject duplicate resolved ids among a team's direct members.
+
+    Member identity is a namespace-local primary key: ``(team, member_id)``
+    must be unique. Resolution uses ``get_member_id`` (explicit id, else
+    ``url_safe_string(name)``), so name-fallback collisions such as
+    ``Right Team`` / ``right_team`` / ``RightTeam`` fail closed instead of
+    first-match. Same id under different parent teams is allowed.
+
+    Members with no resolvable id are skipped: they receive a unique id at
+    ``set_id`` time and are not addressable for delegation until then.
+    """
+    seen: Dict[str, List[str]] = {}
+    for member in members:
+        resolved_id = get_member_id(member)
+        if not resolved_id:
+            continue
+        seen.setdefault(resolved_id, []).append(_member_identity_label(member))
+
+    collisions = {mid: labels for mid, labels in seen.items() if len(labels) > 1}
+    if not collisions:
+        return
+
+    team_label = team_name or team_id or "this team"
+    collision_parts = [f"{mid!r} <- {'; '.join(labels)}" for mid, labels in collisions.items()]
+    raise ValueError(
+        f"Duplicate member id(s) among direct members of team {team_label!r}: "
+        f"{'; '.join(collision_parts)}. "
+        "Member ids are a namespace-local primary key used for delegation and "
+        "HITL continue and must be unique within a team. "
+        "Assign each member an explicit unique id."
+    )
 
 
 def add_interaction_to_team_run_context(

--- a/libs/agno/tests/unit/team/test_duplicate_member_ids.py
+++ b/libs/agno/tests/unit/team/test_duplicate_member_ids.py
@@ -1,0 +1,153 @@
+"""Direct-member ids are a namespace-local primary key.
+
+Duplicate ids — explicit or via get_member_id name fallback — must fail
+closed at construction or factory resolution so HITL continue cannot
+first-match approved args onto the wrong sibling.
+"""
+
+import pytest
+
+from agno.agent import Agent
+from agno.run import RunContext
+from agno.team.team import Team
+from agno.utils.callables import aresolve_callable_members, resolve_callable_members
+from agno.utils.string import url_safe_string
+from agno.utils.team import get_member_id, validate_unique_member_ids
+
+
+def _run_context() -> RunContext:
+    return RunContext(run_id="test-run", session_id="test-session")
+
+
+def test_explicit_duplicate_ids_rejected_at_construction():
+    with pytest.raises(ValueError, match="Duplicate member id") as exc_info:
+        Team(
+            name="Crew",
+            members=[
+                Agent(id="shared", name="Left"),
+                Agent(id="shared", name="Right"),
+            ],
+        )
+
+    message = str(exc_info.value)
+    assert "shared" in message
+    assert "Left" in message
+    assert "Right" in message
+    assert "Crew" in message
+
+
+def test_name_fallback_collisions_rejected_at_construction():
+    """url_safe_string maps Right Team / right_team / RightTeam to right-team."""
+    assert url_safe_string("Right Team") == "right-team"
+    assert url_safe_string("right_team") == "right-team"
+    assert url_safe_string("RightTeam") == "right-team"
+    assert get_member_id(Agent(name="Right Team")) == "right-team"
+    assert get_member_id(Agent(name="right_team")) == "right-team"
+    assert get_member_id(Agent(name="RightTeam")) == "right-team"
+
+    with pytest.raises(ValueError, match="Duplicate member id") as exc_info:
+        Team(
+            name="Router Team",
+            members=[
+                Agent(name="Right Team"),
+                Agent(name="right_team"),
+            ],
+        )
+
+    message = str(exc_info.value)
+    assert "right-team" in message
+    assert "Right Team" in message
+    assert "right_team" in message
+    assert "normalized 'right-team'" in message
+
+    with pytest.raises(ValueError, match="right-team"):
+        Team(
+            name="Router Team",
+            members=[
+                Agent(name="Right Team"),
+                Agent(name="RightTeam"),
+            ],
+        )
+
+
+def test_explicit_id_collides_with_name_fallback():
+    with pytest.raises(ValueError, match="right-team"):
+        Team(
+            name="Crew",
+            members=[
+                Agent(id="right-team", name="Left"),
+                Agent(name="Right Team"),
+            ],
+        )
+
+
+def test_unique_member_ids_accepted():
+    team = Team(
+        name="Crew",
+        members=[
+            Agent(id="left", name="Left"),
+            Agent(id="right", name="Right"),
+        ],
+    )
+    assert [get_member_id(m) for m in team.members] == ["left", "right"]
+
+
+def test_same_member_id_under_different_subteams_allowed():
+    """Path identity disambiguates; uniqueness is per parent team."""
+    left = Team(id="left-team", name="Left Team", members=[Agent(id="leaf", name="Left Leaf")])
+    right = Team(id="right-team", name="Right Team", members=[Agent(id="leaf", name="Right Leaf")])
+    root = Team(id="root", name="Root", members=[left, right])
+    assert [get_member_id(m) for m in root.members] == ["left-team", "right-team"]
+    assert get_member_id(left.members[0]) == "leaf"
+    assert get_member_id(right.members[0]) == "leaf"
+
+
+def test_callable_factory_duplicate_ids_rejected_before_delegation():
+    def factory():
+        return [Agent(id="dup", name="A"), Agent(id="dup", name="B")]
+
+    team = Team(name="Dynamic", members=factory)
+    with pytest.raises(ValueError, match="Duplicate member id") as exc_info:
+        resolve_callable_members(team, _run_context())
+
+    assert "dup" in str(exc_info.value)
+
+
+def test_callable_factory_name_fallback_collision_rejected():
+    def factory():
+        return [Agent(name="Right Team"), Agent(name="right_team")]
+
+    team = Team(name="Dynamic", members=factory)
+    with pytest.raises(ValueError, match="right-team"):
+        resolve_callable_members(team, _run_context())
+
+
+@pytest.mark.asyncio
+async def test_async_callable_factory_duplicate_ids_rejected():
+    async def factory():
+        return [Agent(id="dup", name="A"), Agent(id="dup", name="B")]
+
+    team = Team(name="Dynamic", members=factory)
+    with pytest.raises(ValueError, match="Duplicate member id"):
+        await aresolve_callable_members(team, _run_context())
+
+
+def test_set_id_collision_is_rejected():
+    """name='RightTeam' becomes id 'rightteam' after set_id, colliding with an explicit id."""
+    explicit = Agent(id="rightteam", name="Explicit")
+    named = Agent(name="RightTeam")
+    # Distinct at construction: explicit id vs url_safe_string("RightTeam") == "right-team"
+    team = Team(name="Crew", members=[explicit, named])
+    named.set_id()
+    assert named.id == "rightteam"
+    with pytest.raises(ValueError, match="rightteam"):
+        validate_unique_member_ids(team.members, team_name=team.name)
+
+
+def test_validate_unique_member_ids_reports_normalized_value():
+    with pytest.raises(ValueError, match="normalized 'right-team'") as exc_info:
+        validate_unique_member_ids(
+            [Agent(name="Right Team"), Agent(name="right_team")],
+            team_name="Router Team",
+        )
+    assert "Router Team" in str(exc_info.value)


### PR DESCRIPTION
fixes #9422

Two direct members of one team could share an id (explicitly, or via `get_member_id` name fallback: `"Right Team"` / `"right_team"` / `"RightTeam"` → `right-team`). Resolution was first-match, but `delegate_to_all_members=True` still paused both. After restart, approved HITL args could run on the wrong sibling with COMPLETED and no error.

This fails closed at construction (and after callable-member resolve / `set_id`): duplicate resolved ids among a team's direct members raise `ValueError`. Same id under different parent teams is still allowed.

## Tests

`libs/agno/tests/unit/team/test_duplicate_member_ids.py` — 10 tests, all passing (explicit dupes, name-fallback collisions, callable factory sync/async, `set_id` collision).

## AI disclosure

Cursor Cloud Agent wrote most of the diff; I reviewed the approach and the tests.