### PR TITLE
[fix] ignore stale paused run_response when stored run is terminal

### DIFF
--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -4516,7 +4516,20 @@ async def _acontinue_run_background_stream(
     # reads PAUSED for the whole execution while the run actually runs. The
     # loaded run is used ONLY for the status persists - the continue dispatch
     # below still receives the caller's run_response untouched.
-    persist_run = run_response or cast(Optional[RunOutput], agent_session.get_run(_run_id))
+    stored_run = cast(Optional[RunOutput], agent_session.get_run(_run_id))
+    if (
+        run_response is not None
+        and stored_run is not None
+        and not (fork or regenerate)
+        and stored_run.status in (RunStatus.completed, RunStatus.cancelled)
+        and run_response.status == RunStatus.paused
+    ):
+        raise RunNotContinuableError(
+            f"Cannot continue run {_run_id}: the stored run has status "
+            f"{getattr(stored_run.status, 'value', stored_run.status)} "
+            "and cannot be continued in place from a paused caller snapshot. The stored run is unchanged."
+        )
+    persist_run = run_response or stored_run
     if persist_run:
         persist_run.status = RunStatus.pending
         storage_run = await abuild_offloaded_storage_copy(agent, persist_run, session_id) or persist_run

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -8840,9 +8840,10 @@ def _raise_if_stale_paused_over_terminal(
     stored_status = _as_run_status(getattr(stored_run, "status", None))
     caller_status = _as_run_status(getattr(run_response, "status", None))
     if stored_status in (RunStatus.completed, RunStatus.cancelled) and caller_status == RunStatus.paused:
+        status_label = stored_status.value if isinstance(stored_status, RunStatus) else stored_status
         raise RunNotContinuableError(
             f"Cannot continue run {run_response.run_id}: the stored run has status "
-            f"{stored_status.value} and cannot be continued in place from a paused "
+            f"{status_label} and cannot be continued in place from a paused "
             "caller snapshot. The stored run is unchanged."
         )
 

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -7646,6 +7646,13 @@ def continue_run_dispatch(
 
     run_response = cast(TeamRunOutput, run_response)
 
+    _raise_if_stale_paused_over_terminal(
+        run_response,
+        _stored_run_for_continue(team, run_response.run_id, team_session),
+        fork=fork,
+        regenerate=regenerate,
+    )
+
     if run_response.status == RunStatus.cancelled:
         raise RunNotContinuableError(f"Cannot continue run {run_response.run_id}: run is cancelled")
 
@@ -8775,6 +8782,71 @@ def _as_run_status(value: Union[RunStatus, str, None]) -> Union[RunStatus, str, 
         return value
 
 
+def _session_run_by_id(session: Any, run_id: Optional[str]) -> Optional[Any]:
+    """Find a run on an already-loaded session without trusting the caller object."""
+    if session is None or not run_id:
+        return None
+    for candidate in getattr(session, "runs", None) or []:
+        if getattr(candidate, "run_id", None) == run_id:
+            return candidate
+    getter = getattr(session, "get_run", None)
+    if callable(getter):
+        return getter(run_id)
+    return None
+
+
+def _stored_run_for_continue(team: "Team", run_id: Optional[str], session: Any = None) -> Optional[Any]:
+    """Load the durable run row. A cached session can still hold a paused snapshot
+    after another continue completed or cancelled the same run."""
+    if run_id and team.db is not None:
+        getter = getattr(team.db, "get_run", None)
+        if callable(getter):
+            stored = getter(run_id)
+            if stored is not None:
+                return stored
+    return _session_run_by_id(session, run_id)
+
+
+async def _astored_run_for_continue(team: "Team", run_id: Optional[str], session: Any = None) -> Optional[Any]:
+    """Async counterpart of ``_stored_run_for_continue``."""
+    from agno.team._init import _has_async_db
+
+    if run_id and team.db is not None:
+        getter = getattr(team.db, "get_run", None)
+        if callable(getter):
+            stored = await getter(run_id) if _has_async_db(team) else getter(run_id)
+            if stored is not None:
+                return stored
+    return _session_run_by_id(session, run_id)
+
+
+def _raise_if_stale_paused_over_terminal(
+    run_response: Optional[TeamRunOutput],
+    stored_run: Optional[Any],
+    *,
+    fork: bool,
+    regenerate: bool,
+) -> None:
+    """Refuse when a paused caller snapshot would reopen a terminal stored run.
+
+    A caller-held ``run_response`` is a snapshot, not authority for lifecycle
+    state. If the durable row is already COMPLETED or CANCELLED while the
+    object still reads PAUSED, an in-place continue would re-execute a gated
+    tool or erase a cancellation. Explicit fork/regenerate branch off the
+    finished run and stay allowed.
+    """
+    if run_response is None or stored_run is None or fork or regenerate:
+        return
+    stored_status = _as_run_status(getattr(stored_run, "status", None))
+    caller_status = _as_run_status(getattr(run_response, "status", None))
+    if stored_status in (RunStatus.completed, RunStatus.cancelled) and caller_status == RunStatus.paused:
+        raise RunNotContinuableError(
+            f"Cannot continue run {run_response.run_id}: the stored run has status "
+            f"{stored_status.value} and cannot be continued in place from a paused "
+            "caller snapshot. The stored run is unchanged."
+        )
+
+
 async def _acontinue_run_background_stream(
     team: Team,
     run_context: RunContext,
@@ -9516,6 +9588,13 @@ async def _acontinue_run(
 
                 run_response = cast(TeamRunOutput, run_response)
 
+                _raise_if_stale_paused_over_terminal(
+                    run_response,
+                    await _astored_run_for_continue(team, run_response.run_id, team_session),
+                    fork=fork,
+                    regenerate=regenerate,
+                )
+
                 if run_response.status == RunStatus.cancelled:
                     raise RunNotContinuableError(f"Cannot continue run {run_response.run_id}: run is cancelled")
 
@@ -9996,6 +10075,13 @@ async def _acontinue_run_stream(
                         raise RunNotFoundError(f"No runs found for run ID {run_id}")
 
                 run_response = cast(TeamRunOutput, run_response)
+
+                _raise_if_stale_paused_over_terminal(
+                    run_response,
+                    await _astored_run_for_continue(team, run_response.run_id, team_session),
+                    fork=fork,
+                    regenerate=regenerate,
+                )
 
                 if run_response.status == RunStatus.cancelled:
                     raise RunNotContinuableError(f"Cannot continue run {run_response.run_id}: run is cancelled")

--- a/libs/agno/tests/unit/agent/test_acontinue_run_background_stream.py
+++ b/libs/agno/tests/unit/agent/test_acontinue_run_background_stream.py
@@ -6,6 +6,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from agno.run import RunStatus
+
 
 def make_mock_event_stream() -> MagicMock:
     """Mock BaseEventStream: async methods, add_event assigns index 0."""
@@ -309,3 +311,53 @@ class TestRunIdOnlyContinuePersistsStatus:
         assert seen_dispatch_kwargs.get("run_response") is None, (
             "the loaded run is for persistence only - the dispatch must still receive run_response=None"
         )
+
+
+class TestStalePausedCallerOverTerminal:
+    """Issue #9447 on the agent background continue: a caller-held paused
+    object must not take over a COMPLETED or CANCELLED stored run."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("stored_status", [RunStatus.completed, RunStatus.cancelled])
+    async def test_stale_paused_object_over_terminal_is_refused(self, stored_status):
+        from agno.agent._run import _acontinue_run_background_stream
+        from agno.exceptions import RunNotContinuableError
+
+        agent = MagicMock()
+        agent.db = None
+        run_context = MagicMock()
+
+        stored = MagicMock()
+        stored.status = stored_status
+        stored.run_id = "r-1"
+        agent_session = MagicMock()
+        agent_session.get_run.return_value = stored
+
+        stale = MagicMock()
+        stale.status = RunStatus.paused
+        stale.run_id = "r-1"
+        stale.session_id = "s-1"
+
+        with (
+            patch(
+                "agno.agent._storage.aread_or_create_session",
+                new_callable=AsyncMock,
+                return_value=agent_session,
+            ),
+            patch("agno.agent._storage.update_metadata"),
+            patch("agno.agent._session.asave_session", new_callable=AsyncMock),
+            patch("agno.agent._run._acontinue_run_stream") as mock_stream,
+        ):
+            with pytest.raises(RunNotContinuableError):
+                async for _ in _acontinue_run_background_stream(
+                    agent,
+                    run_context=run_context,
+                    session_id="s-1",
+                    run_id="r-1",
+                    run_response=stale,
+                ):
+                    pass
+
+        agent_session.upsert_run.assert_not_called()
+        mock_stream.assert_not_called()
+        assert stored.status == stored_status

--- a/libs/agno/tests/unit/team/test_paused_member_persistence.py
+++ b/libs/agno/tests/unit/team/test_paused_member_persistence.py
@@ -6058,3 +6058,233 @@ def test_a_routing_failure_restores_the_callers_team_level_requirements(tmp_path
 
     names = [r.tool_execution.tool_name for r in (run1.requirements or [])]
     assert names.count("publish") == 1, f"the caller's run object carries: {names}"
+
+
+# ---------------------------------------------------------------------------
+# Issue #9447: a caller-held paused run_response is a snapshot, not authority.
+# If the stored run is already COMPLETED or CANCELLED, refuse before the gated
+# tool can run again or a cancellation can be overwritten.
+# ---------------------------------------------------------------------------
+
+
+def _issue_9447_stored_status(db_file: str, session_id: str, run_id: str) -> RunStatus:
+    stored = [r for r in _reload_runs(db_file, session_id) if r.run_id == run_id]
+    assert len(stored) == 1
+    return stored[0].status
+
+
+def test_issue_9447_sync_stale_paused_object_cannot_reexecute_completed_run(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "issue_9447_sync_completed.db")
+    session_id = "s-issue-9447-sync-completed"
+
+    stale = _build_flat_team(SqliteDb(db_file=db_file), resuming=False).run(
+        "Email a@example.com", session_id=session_id
+    )
+    assert stale.status == RunStatus.paused
+    done = _build_flat_team(SqliteDb(db_file=db_file), resuming=True).continue_run(
+        run_id=stale.run_id,
+        session_id=session_id,
+        requirements=_wire_requirements(stale.requirements),
+    )
+    assert done.status == RunStatus.completed
+    assert stale.status == RunStatus.paused
+    assert _EXECUTED == ["a@example.com"]
+
+    with pytest.raises(RunNotContinuableError):
+        _build_flat_team(SqliteDb(db_file=db_file), resuming=True).continue_run(
+            run_response=stale,
+            session_id=session_id,
+            requirements=_wire_requirements(stale.requirements),
+        )
+
+    assert _issue_9447_stored_status(db_file, session_id, stale.run_id) == RunStatus.completed
+    assert _EXECUTED == ["a@example.com"], f"the gated tool ran a second time: {_EXECUTED}"
+
+
+def test_issue_9447_sync_stale_paused_object_cannot_override_cancelled_run(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "issue_9447_sync_cancelled.db")
+    session_id = "s-issue-9447-sync-cancelled"
+
+    stale = _build_flat_team(SqliteDb(db_file=db_file), resuming=False).run(
+        "Email a@example.com", session_id=session_id
+    )
+    assert stale.status == RunStatus.paused
+    _set_stored_team_run_status(SqliteDb(db_file=db_file), session_id, stale.run_id, RunStatus.cancelled)
+
+    with pytest.raises(RunNotContinuableError):
+        _build_flat_team(SqliteDb(db_file=db_file), resuming=True).continue_run(
+            run_response=stale,
+            session_id=session_id,
+            requirements=_wire_requirements(stale.requirements),
+        )
+
+    assert _issue_9447_stored_status(db_file, session_id, stale.run_id) == RunStatus.cancelled
+    assert _EXECUTED == [], f"the gated tool ran on a cancelled run: {_EXECUTED}"
+
+
+def test_issue_9447_sync_stream_stale_paused_object_cannot_reexecute_completed_run(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "issue_9447_sync_stream_completed.db")
+    session_id = "s-issue-9447-sync-stream-completed"
+
+    stale = _build_flat_team(SqliteDb(db_file=db_file), resuming=False).run(
+        "Email a@example.com", session_id=session_id
+    )
+    assert stale.status == RunStatus.paused
+    done = _build_flat_team(SqliteDb(db_file=db_file), resuming=True).continue_run(
+        run_id=stale.run_id,
+        session_id=session_id,
+        requirements=_wire_requirements(stale.requirements),
+    )
+    assert done.status == RunStatus.completed
+    assert _EXECUTED == ["a@example.com"]
+
+    with pytest.raises(RunNotContinuableError):
+        _build_flat_team(SqliteDb(db_file=db_file), resuming=True).continue_run(
+            run_response=stale,
+            session_id=session_id,
+            requirements=_wire_requirements(stale.requirements),
+            stream=True,
+            stream_events=True,
+        )
+
+    assert _issue_9447_stored_status(db_file, session_id, stale.run_id) == RunStatus.completed
+    assert _EXECUTED == ["a@example.com"]
+
+
+def test_issue_9447_sync_stream_stale_paused_object_cannot_override_cancelled_run(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "issue_9447_sync_stream_cancelled.db")
+    session_id = "s-issue-9447-sync-stream-cancelled"
+
+    stale = _build_flat_team(SqliteDb(db_file=db_file), resuming=False).run(
+        "Email a@example.com", session_id=session_id
+    )
+    assert stale.status == RunStatus.paused
+    _set_stored_team_run_status(SqliteDb(db_file=db_file), session_id, stale.run_id, RunStatus.cancelled)
+
+    with pytest.raises(RunNotContinuableError):
+        _build_flat_team(SqliteDb(db_file=db_file), resuming=True).continue_run(
+            run_response=stale,
+            session_id=session_id,
+            requirements=_wire_requirements(stale.requirements),
+            stream=True,
+            stream_events=True,
+        )
+
+    assert _issue_9447_stored_status(db_file, session_id, stale.run_id) == RunStatus.cancelled
+    assert _EXECUTED == []
+
+
+@pytest.mark.asyncio
+async def test_issue_9447_async_stale_paused_object_cannot_reexecute_completed_run(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "issue_9447_async_completed.db")
+    session_id = "s-issue-9447-async-completed"
+
+    stale = await _build_flat_team(SqliteDb(db_file=db_file), resuming=False).arun(
+        "Email a@example.com", session_id=session_id
+    )
+    assert stale.status == RunStatus.paused
+    done = await _build_flat_team(SqliteDb(db_file=db_file), resuming=True).acontinue_run(
+        run_id=stale.run_id,
+        session_id=session_id,
+        requirements=_wire_requirements(stale.requirements),
+    )
+    assert done.status == RunStatus.completed
+    assert stale.status == RunStatus.paused
+    assert _EXECUTED == ["a@example.com"]
+
+    with pytest.raises(RunNotContinuableError):
+        await _build_flat_team(SqliteDb(db_file=db_file), resuming=True).acontinue_run(
+            run_response=stale,
+            session_id=session_id,
+            requirements=_wire_requirements(stale.requirements),
+        )
+
+    assert _issue_9447_stored_status(db_file, session_id, stale.run_id) == RunStatus.completed
+    assert _EXECUTED == ["a@example.com"], f"the gated tool ran a second time: {_EXECUTED}"
+
+
+@pytest.mark.asyncio
+async def test_issue_9447_async_stale_paused_object_cannot_override_cancelled_run(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "issue_9447_async_cancelled.db")
+    session_id = "s-issue-9447-async-cancelled"
+
+    stale = await _build_flat_team(SqliteDb(db_file=db_file), resuming=False).arun(
+        "Email a@example.com", session_id=session_id
+    )
+    assert stale.status == RunStatus.paused
+    _set_stored_team_run_status(SqliteDb(db_file=db_file), session_id, stale.run_id, RunStatus.cancelled)
+
+    with pytest.raises(RunNotContinuableError):
+        await _build_flat_team(SqliteDb(db_file=db_file), resuming=True).acontinue_run(
+            run_response=stale,
+            session_id=session_id,
+            requirements=_wire_requirements(stale.requirements),
+        )
+
+    assert _issue_9447_stored_status(db_file, session_id, stale.run_id) == RunStatus.cancelled
+    assert _EXECUTED == [], f"the gated tool ran on a cancelled run: {_EXECUTED}"
+
+
+@pytest.mark.asyncio
+async def test_issue_9447_async_stream_stale_paused_object_cannot_reexecute_completed_run(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "issue_9447_async_stream_completed.db")
+    session_id = "s-issue-9447-async-stream-completed"
+
+    stale = await _build_flat_team(SqliteDb(db_file=db_file), resuming=False).arun(
+        "Email a@example.com", session_id=session_id
+    )
+    assert stale.status == RunStatus.paused
+    done = await _build_flat_team(SqliteDb(db_file=db_file), resuming=True).acontinue_run(
+        run_id=stale.run_id,
+        session_id=session_id,
+        requirements=_wire_requirements(stale.requirements),
+    )
+    assert done.status == RunStatus.completed
+    assert stale.status == RunStatus.paused
+    assert _EXECUTED == ["a@example.com"]
+
+    with pytest.raises(RunNotContinuableError):
+        async for _ in _build_flat_team(SqliteDb(db_file=db_file), resuming=True).acontinue_run(
+            run_response=stale,
+            session_id=session_id,
+            requirements=_wire_requirements(stale.requirements),
+            stream=True,
+            stream_events=True,
+        ):
+            pass
+
+    assert _issue_9447_stored_status(db_file, session_id, stale.run_id) == RunStatus.completed
+    assert _EXECUTED == ["a@example.com"], f"the gated tool ran a second time: {_EXECUTED}"
+
+
+@pytest.mark.asyncio
+async def test_issue_9447_async_stream_stale_paused_object_cannot_override_cancelled_run(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "issue_9447_async_stream_cancelled.db")
+    session_id = "s-issue-9447-async-stream-cancelled"
+
+    stale = await _build_flat_team(SqliteDb(db_file=db_file), resuming=False).arun(
+        "Email a@example.com", session_id=session_id
+    )
+    assert stale.status == RunStatus.paused
+    _set_stored_team_run_status(SqliteDb(db_file=db_file), session_id, stale.run_id, RunStatus.cancelled)
+
+    with pytest.raises(RunNotContinuableError):
+        async for _ in _build_flat_team(SqliteDb(db_file=db_file), resuming=True).acontinue_run(
+            run_response=stale,
+            session_id=session_id,
+            requirements=_wire_requirements(stale.requirements),
+            stream=True,
+            stream_events=True,
+        ):
+            pass
+
+    assert _issue_9447_stored_status(db_file, session_id, stale.run_id) == RunStatus.cancelled
+    assert _EXECUTED == [], f"the gated tool ran on a cancelled run: {_EXECUTED}"


### PR DESCRIPTION
fixes #9447

Team continue trusted a caller-supplied `run_response.status` over the stored run. Holding a stale `PAUSED` object after the durable row was already `COMPLETED` or `CANCELLED` re-executed the gated tool (or un-cancelled the run).

This refuses an in-place continue when the stored run is terminal and the caller object still reads paused. Applied to the team continue dispatchers and the agent background continue path. Explicit `fork` / `regenerate` stay allowed.

This is not a duplicate of #9594 (overlapping continues of a still-paused run) or of auto-closed #9766.

## Tests

- `libs/agno/tests/unit/team/test_paused_member_persistence.py` — stale paused object after complete/cancel
- `libs/agno/tests/unit/agent/test_acontinue_run_background_stream.py` — same guard on agent background continue

## AI disclosure

Cursor Cloud Agent wrote most of the diff; I reviewed the approach and the tests.