### PR TITLE
[fix] merge HITL requirements on continue instead of replacing

### DIFF
--- a/libs/agno/agno/agent/_tools.py
+++ b/libs/agno/agno/agent/_tools.py
@@ -987,8 +987,13 @@ def handle_tool_call_updates(
     for _t in run_response.tools or []:
         # Case 1: Handle confirmed tools and execute them
         if _t.requires_confirmation is not None and _t.requires_confirmation is True and _functions:
+            # Already-consumed confirmation: keep the stored result, do not
+            # re-execute or treat the leftover gate as a rejection.
+            if _t.result is not None:
+                _t.requires_confirmation = False
+                continue
             # Tool is confirmed and hasn't been run before
-            if _t.confirmed is not None and _t.confirmed is True and _t.result is None:
+            if _t.confirmed is not None and _t.confirmed is True:
                 # Consume the generator without yielding
                 deque(run_tool(agent, run_response, run_messages, _t, functions=_functions), maxlen=0)
             else:
@@ -1039,8 +1044,13 @@ def handle_tool_call_updates_stream(
     for _t in run_response.tools or []:
         # Case 1: Handle confirmed tools and execute them
         if _t.requires_confirmation is not None and _t.requires_confirmation is True and _functions:
+            # Already-consumed confirmation: keep the stored result, do not
+            # re-execute or treat the leftover gate as a rejection.
+            if _t.result is not None:
+                _t.requires_confirmation = False
+                continue
             # Tool is confirmed and hasn't been run before
-            if _t.confirmed is not None and _t.confirmed is True and _t.result is None:
+            if _t.confirmed is not None and _t.confirmed is True:
                 yield from run_tool(
                     agent, run_response, run_messages, _t, functions=_functions, stream_events=stream_events
                 )
@@ -1089,8 +1099,13 @@ async def ahandle_tool_call_updates(
     for _t in run_response.tools or []:
         # Case 1: Handle confirmed tools and execute them
         if _t.requires_confirmation is not None and _t.requires_confirmation is True and _functions:
+            # Already-consumed confirmation: keep the stored result, do not
+            # re-execute or treat the leftover gate as a rejection.
+            if _t.result is not None:
+                _t.requires_confirmation = False
+                continue
             # Tool is confirmed and hasn't been run before
-            if _t.confirmed is not None and _t.confirmed is True and _t.result is None:
+            if _t.confirmed is not None and _t.confirmed is True:
                 async for _ in arun_tool(agent, run_response, run_messages, _t, functions=_functions):
                     pass
             else:
@@ -1149,8 +1164,13 @@ async def ahandle_tool_call_updates_stream(
     for _t in run_response.tools or []:
         # Case 1: Handle confirmed tools and execute them
         if _t.requires_confirmation is not None and _t.requires_confirmation is True and _functions:
+            # Already-consumed confirmation: keep the stored result, do not
+            # re-execute or treat the leftover gate as a rejection.
+            if _t.result is not None:
+                _t.requires_confirmation = False
+                continue
             # Tool is confirmed and hasn't been run before
-            if _t.confirmed is not None and _t.confirmed is True and _t.result is None:
+            if _t.confirmed is not None and _t.confirmed is True:
                 async for event in arun_tool(
                     agent, run_response, run_messages, _t, functions=_functions, stream_events=stream_events
                 ):

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -5859,6 +5859,12 @@ def _merge_tools_preserving_approval(
     for orig in original_tools:
         updated = updated_tools_map.get(orig.tool_call_id)
         if updated is not None:
+            # A tool that already ran keeps its stored object. Replacing it
+            # with a wire copy (confirmed=true, result empty) would make
+            # continue treat the confirmation as new and re-execute.
+            if getattr(orig, "result", None) is not None:
+                merged.append(orig)
+                continue
             for attr in ("approval_type", "approval_id"):
                 if getattr(updated, attr, None) is None and getattr(orig, attr, None) is not None:
                     setattr(updated, attr, getattr(orig, attr))
@@ -6012,6 +6018,10 @@ def _backfill_approval_to_requirements(
     one) and exactly one stored requirement carries that tool call — and
     the STORED requirement becomes the object routing sees, with only the
     client's decision state merged onto it (_merge_requirement_decision).
+    Undelivered stored requirements stay on the run: a subset payload must
+    not replace the pending set, or the dropped pauses complete the run
+    and leave their members paused forever. An already-consumed
+    confirmation (stored tool already has a result) is not merged again.
     Trusting the wire copy instead mis-executes: a swapped or duplicated id
     binds one member's approved arguments to another member's tool.
 
@@ -6112,12 +6122,34 @@ def _backfill_approval_to_requirements(
     # a bare retry of a rejected request would execute the tools that bound
     # before the bad entry.
     for old_req, req in bindings:
-        _merge_requirement_decision(old_req, req)
-    run_response.requirements = [old_req for old_req, _ in bindings]
+        # A confirmation that already produced a result is spent. Merging
+        # the wire copy onto it would look like a fresh approve.
+        if not _requirement_already_consumed(old_req):
+            _merge_requirement_decision(old_req, req)
+    # Keep the full pending set. Replacing with only the bound entries
+    # drops undelivered pauses, so a one-of-N approve completes the run
+    # and leaves the other member paused forever.
+    if old_requirements:
+        run_response.requirements = list(old_requirements)
+    else:
+        run_response.requirements = [old_req for old_req, _ in bindings]
 
 
 _REQUIREMENT_DECISION_FIELDS = ("confirmation", "confirmation_note", "external_execution_result")
 _TOOL_EXECUTION_DECISION_FIELDS = ("confirmed", "confirmation_note", "answered", "result", "tool_call_error")
+
+
+def _requirement_already_consumed(req: Any) -> bool:
+    """True when the gated tool already ran or an external result was recorded.
+
+    Re-delivering that confirmation must be a no-op: the stored result is
+    the consumed mark, and continue must not treat the wire copy as a new
+    approve.
+    """
+    te = getattr(req, "tool_execution", None)
+    if te is not None and getattr(te, "result", None) is not None:
+        return True
+    return getattr(req, "external_execution_result", None) is not None
 
 
 def _requirement_decision_slots(requirements: Optional[List[Any]]) -> Iterator[Tuple[Any, str]]:
@@ -6423,6 +6455,8 @@ def _group_requirements_for_continue(
 
     member_reqs: Dict[Tuple[str, Optional[str]], List["RunRequirement"]] = {}
     for req in run_response.requirements or []:
+        if _requirement_already_consumed(req):
+            continue
         mid = getattr(req, "member_agent_id", None)
         if mid is not None:
             member_reqs.setdefault((mid, getattr(req, "member_run_id", None)), []).append(req)
@@ -6551,8 +6585,8 @@ def _route_requirements_to_members(
             member_run_output.requirements = reqs
             updated_tools = [req.tool_execution for req in reqs if req.tool_execution is not None]
             if updated_tools and member_run_output.tools:
-                updated_map = {t.tool_call_id: t for t in updated_tools}
-                member_run_output.tools = [updated_map.get(t.tool_call_id, t) for t in member_run_output.tools]
+                updated_map = {t.tool_call_id: t for t in updated_tools if t.tool_call_id}
+                member_run_output.tools = _merge_tools_preserving_approval(member_run_output.tools, updated_map)
 
             member_response = member.continue_run(
                 run_response=member_run_output,  # type: ignore[arg-type]
@@ -6632,8 +6666,8 @@ def _route_requirements_to_members_stream(
             member_run_output.requirements = reqs
             updated_tools = [req.tool_execution for req in reqs if req.tool_execution is not None]
             if updated_tools and member_run_output.tools:
-                updated_map = {t.tool_call_id: t for t in updated_tools}
-                member_run_output.tools = [updated_map.get(t.tool_call_id, t) for t in member_run_output.tools]
+                updated_map = {t.tool_call_id: t for t in updated_tools if t.tool_call_id}
+                member_run_output.tools = _merge_tools_preserving_approval(member_run_output.tools, updated_map)
 
             member_response_stream = member.continue_run(  # type: ignore[call-overload]
                 run_response=member_run_output,  # type: ignore[arg-type]
@@ -6735,8 +6769,8 @@ async def _aroute_requirements_to_members(
             member_run_output.requirements = reqs
             updated_tools = [req.tool_execution for req in reqs if req.tool_execution is not None]
             if updated_tools and member_run_output.tools:
-                updated_map = {t.tool_call_id: t for t in updated_tools}
-                member_run_output.tools = [updated_map.get(t.tool_call_id, t) for t in member_run_output.tools]
+                updated_map = {t.tool_call_id: t for t in updated_tools if t.tool_call_id}
+                member_run_output.tools = _merge_tools_preserving_approval(member_run_output.tools, updated_map)
 
             member_response = await member.acontinue_run(  # type: ignore[misc]
                 run_response=member_run_output,  # type: ignore[arg-type]
@@ -6832,8 +6866,8 @@ async def _aroute_requirements_to_members_stream(
             member_run_output.requirements = reqs
             updated_tools = [req.tool_execution for req in reqs if req.tool_execution is not None]
             if updated_tools and member_run_output.tools:
-                updated_map = {t.tool_call_id: t for t in updated_tools}
-                member_run_output.tools = [updated_map.get(t.tool_call_id, t) for t in member_run_output.tools]
+                updated_map = {t.tool_call_id: t for t in updated_tools if t.tool_call_id}
+                member_run_output.tools = _merge_tools_preserving_approval(member_run_output.tools, updated_map)
 
             member_response_stream = member.acontinue_run(  # type: ignore[call-overload]
                 run_response=member_run_output,  # type: ignore[arg-type]

--- a/libs/agno/tests/unit/team/test_paused_member_persistence.py
+++ b/libs/agno/tests/unit/team/test_paused_member_persistence.py
@@ -890,6 +890,137 @@ async def test_two_paused_members_in_one_subteam_both_execute_async(tmp_path):
     assert sorted(_EXECUTED) == ["a@x.com", "sms:b@x.com"]
 
 
+def _build_flat_two_member_team(db: SqliteDb, resuming: bool) -> Team:
+    """Flat team, two members, each pausing on its own gated tool in one turn."""
+    smser = Agent(
+        name="Smser",
+        id="smser",
+        model=_ScriptedModel(
+            "m-smser",
+            [("content", "SMS sent.")]
+            if resuming
+            else [("tool", "send_sms", {"to": "b@x.com"}, "tc-sms"), ("content", "SMS sent.")],
+        ),
+        tools=[send_sms],
+        db=db,
+        telemetry=False,
+    )
+    emailer = Agent(
+        name="Emailer",
+        id="emailer",
+        model=_ScriptedModel(
+            "m-emailer",
+            [("content", "Email sent.")]
+            if resuming
+            else [("tool", "send_email", {"to": "a@x.com"}, "tc-send"), ("content", "Email sent.")],
+        ),
+        tools=[send_email],
+        db=db,
+        telemetry=False,
+    )
+    return Team(
+        name="Comms Team",
+        id="comms-team",
+        model=_ScriptedModel(
+            "m-leader",
+            [("content", "All done.")]
+            if resuming
+            else [
+                (
+                    "tools",
+                    [
+                        ("delegate_task_to_member", {"member_id": "emailer", "task": "email it"}, "tc-d1"),
+                        ("delegate_task_to_member", {"member_id": "smser", "task": "sms it"}, "tc-d2"),
+                    ],
+                ),
+                ("content", "All done."),
+            ],
+        ),
+        members=[emailer, smser],
+        db=db,
+        telemetry=False,
+    )
+
+
+def test_continue_with_subset_of_requirements_does_not_orphan_sibling(tmp_path):
+    """Posting only the first of two member pauses must not complete the run
+    or leave the other member paused forever. The missing requirement stays
+    reachable on a later continue.
+    """
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "subset_orphan.db")
+    session_id = "s-subset-orphan"
+
+    team1 = _build_flat_two_member_team(SqliteDb(db_file=db_file), resuming=False)
+    run1 = team1.run("Notify everyone", session_id=session_id)
+    assert run1.is_paused
+    assert len(run1.requirements or []) == 2
+
+    first = (run1.requirements or [])[0]
+    team2 = _build_flat_two_member_team(SqliteDb(db_file=db_file), resuming=True)
+    run2 = team2.continue_run(run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements([first]))
+    assert run2.status == RunStatus.paused, (
+        f"a one-of-N continue completed the run ({run2.status}); the other pause is orphaned"
+    )
+    unresolved = [r for r in (run2.requirements or []) if not r.is_resolved()]
+    assert len(unresolved) == 1, f"the undelivered pause vanished: {run2.requirements}"
+
+    stored = [r for r in _reload_runs(db_file, session_id) if r.run_id == run1.run_id]
+    assert stored and stored[0].is_paused
+    paused_members = [
+        r
+        for r in _reload_runs(db_file, session_id)
+        if getattr(r, "agent_id", None) in {"emailer", "smser"} and r.is_paused
+    ]
+    assert paused_members, "the undelivered member was left paused in storage with no way back"
+
+    remaining = [r for r in (run2.requirements or []) if not r.is_resolved()]
+    team3 = _build_flat_two_member_team(SqliteDb(db_file=db_file), resuming=True)
+    run3 = team3.continue_run(run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(remaining))
+    assert run3.status == RunStatus.completed, f"the later continue of the missing requirement no-op'd: {run3.status}"
+    assert sorted(_EXECUTED) == ["a@x.com", "sms:b@x.com"], f"both gated tools must still run: {_EXECUTED}"
+
+
+def test_already_consumed_confirmation_does_not_rerun_tool(tmp_path):
+    """After a chained pause, posting the first (already-run) confirmation
+    back must not execute that tool a second time, and must not complete
+    the run out from under the still-pending pause.
+    """
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "consumed_rerun.db")
+    session_id = "s-consumed-rerun"
+
+    outer1 = _build_nested_chained_team(SqliteDb(db_file=db_file), phase="pause")
+    run1 = outer1.run("Email then sms", session_id=session_id)
+    assert run1.is_paused
+    first_reqs = list(run1.requirements or [])
+
+    outer2 = _build_nested_chained_team(SqliteDb(db_file=db_file), phase="chain")
+    run2 = outer2.continue_run(run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(first_reqs))
+    assert run2.is_paused
+    assert _EXECUTED == ["a@example.com"]
+
+    try:
+        outer3 = _build_nested_chained_team(SqliteDb(db_file=db_file), phase="finish")
+        run3 = outer3.continue_run(
+            run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(first_reqs)
+        )
+    except RunNotContinuableError:
+        run3 = None
+
+    assert _EXECUTED == ["a@example.com"], f"the gated tool ran a second time: {_EXECUTED}"
+    if run3 is not None:
+        assert run3.status != RunStatus.completed, (
+            f"re-delivering a consumed confirmation completed the run ({run3.status})"
+        )
+    stored = [r for r in _reload_runs(db_file, session_id) if getattr(r, "team_id", None) == "org-team"]
+    assert stored and stored[0].is_paused
+    unresolved = [r for r in (stored[0].requirements or []) if not r.is_resolved()]
+    assert any(r.tool_execution and r.tool_execution.tool_name == "send_sms" for r in unresolved), (
+        "the chained send_sms pause was dropped when the consumed confirmation was re-posted"
+    )
+
+
 def test_nested_member_pause_fresh_process_continue_streaming(tmp_path):
     _EXECUTED.clear()
     db_file = str(tmp_path / "nested_stream.db")
@@ -3394,11 +3525,54 @@ def test_unknown_requirement_id_still_binds_by_unique_tool_call_id():
     _apply_requirements_payload(run_response, [wire])
 
     # The fallback bound the entry to the STORED requirement object and merged
-    # only the decision onto it.
+    # only the decision onto it. The undelivered sibling stays in the pending set.
     assert run_response.requirements is not None
-    assert run_response.requirements[0] is stored[1]
+    assert stored[1] in run_response.requirements
+    assert stored[0] in run_response.requirements
     assert stored[1].confirmation is True
     assert stored[1].tool_execution.confirmed is True
+    assert stored[0].confirmation is None
+    assert not stored[0].is_resolved()
+
+
+def test_subset_payload_keeps_undelivered_stored_requirements():
+    """A continue payload with one of N stored requirements must merge, not
+    replace: the undelivered pause stays on the run so it can still be posted.
+    """
+    from agno.team._run import _apply_requirements_payload
+
+    stored = _stored_confirmation_requirements()
+    run_response = _run_with(stored)
+    wire = RunRequirement.from_dict(stored[0].to_dict())
+    wire.confirm()
+
+    _apply_requirements_payload(run_response, [wire])
+
+    assert run_response.requirements == stored
+    assert stored[0].confirmation is True
+    assert stored[0].is_resolved()
+    assert stored[1].confirmation is None
+    assert not stored[1].is_resolved()
+
+
+def test_already_consumed_payload_does_not_clear_stored_result():
+    """Re-delivering a confirmation whose tool already has a result must leave
+    that result in place so continue cannot treat it as a fresh approve.
+    """
+    from agno.team._run import _apply_requirements_payload
+
+    stored = _stored_confirmation_requirements()
+    stored[0].confirm()
+    stored[0].tool_execution.result = "already sent"
+    run_response = _run_with(stored)
+    wire = RunRequirement.from_dict(stored[0].to_dict())
+    wire.tool_execution.result = None
+
+    _apply_requirements_payload(run_response, [wire])
+
+    assert stored[0].tool_execution.result == "already sent"
+    assert stored[1] in (run_response.requirements or [])
+    assert not stored[1].is_resolved()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
fixes #9401

`continue_run` was replacing `run_response.requirements` with whatever the client sent. Approving one of N HITL tools completed the run, left the other member PAUSED forever, and a later post of the missing requirement no-op'd. Re-delivering an already-consumed confirmation could also re-execute the tool.

Continue now merges delivered decisions into the stored pending set. If any requirements remain unresolved, the run re-pauses. Confirmations whose tools already have a result are left untouched.

## Tests

Two-member pause, post only the first requirement: run stays paused; later continue of the missing requirement still executes. Re-posting a consumed confirmation does not re-run the tool.

## AI disclosure

Cursor Cloud Agent wrote most of the diff; I reviewed the approach and the tests.