### PR TITLE
[fix] Fail closed when Team member deepcopy raises

### DIFF
--- a/libs/agno/agno/team/_utils.py
+++ b/libs/agno/agno/team/_utils.py
@@ -140,6 +140,8 @@ def deep_copy(team: Team, *, update: Optional[Dict[str, Any]] = None) -> Team:
             try:
                 fields_for_new_team[f.name] = _deep_copy_field(team, f.name, field_value)
             except Exception as e:
+                if f.name == "members":
+                    raise
                 log_warning(f"Failed to deep copy field '{f.name}'. Using original value.: {str(e)}")
                 fields_for_new_team[f.name] = field_value
 
@@ -171,9 +173,17 @@ def _deep_copy_field(team: Team, field_name: str, field_value: Any) -> Any:
         if is_callable_factory(field_value):
             return field_value
         copied_members = []
-        for member in field_value:
+        for index, member in enumerate(field_value):
             if hasattr(member, "deep_copy"):
-                copied_members.append(member.deep_copy())
+                try:
+                    copied_members.append(member.deep_copy())
+                except Exception as e:
+                    member_identifier = getattr(member, "name", None) or getattr(member, "id", None)
+                    if member_identifier:
+                        member_context = f" ({member_identifier})"
+                    else:
+                        member_context = f" ({type(member).__name__})"
+                    raise RuntimeError(f"Failed to deep copy team member at index {index}{member_context}") from e
             else:
                 copied_members.append(member)
         return copied_members

--- a/libs/agno/tests/unit/team/test_callable_resources.py
+++ b/libs/agno/tests/unit/team/test_callable_resources.py
@@ -515,6 +515,22 @@ class TestTeamDeepCopyCallableFactories:
         copy = team.deep_copy()
         assert isinstance(copy.members, list)
 
+    def test_deep_copy_raises_when_a_member_cannot_be_copied(self):
+        healthy_member = Agent(name="healthy-member")
+
+        class UncopyableAgent(Agent):
+            def __init__(self, required_value: str, **kwargs):
+                super().__init__(**kwargs)
+                self.required_value = required_value
+
+        uncopyable_member = UncopyableAgent(required_value="required", name="uncopyable-member")
+        team = _make_team(members=[healthy_member, uncopyable_member])
+
+        with pytest.raises(RuntimeError, match="Failed to deep copy team member at index 1 .*uncopyable-member"):
+            team.deep_copy()
+
+        assert team.members == [healthy_member, uncopyable_member]
+
     def test_deep_copy_no_warning_on_callable_tools(self):
         """Regression: Team.deep_copy() must not iterate a callable tools factory."""
         import logging

--- a/libs/agno/tests/unit/tools/test_studio_runner.py
+++ b/libs/agno/tests/unit/tools/test_studio_runner.py
@@ -3439,8 +3439,8 @@ class TestMemberIsolation:
         assert fresh.members[1] is remote
 
     def test_shared_member_nested_in_a_team_of_teams_refuses_dispatch(self, db):
-        # An inner team whose own member copy failed comes back as a new object
-        # holding the shared grandchild, so the check has to descend.
+        # A nested member copy failure must stop dispatch before a shared
+        # grandchild can escape through the outer team's copy.
         from agno.agent.agent import Agent as AgentClass
         from agno.team.team import Team as TeamClass
 
@@ -3454,7 +3454,9 @@ class TestMemberIsolation:
         outer = TeamClass(id="outer", name="Outer", model=OpenAIResponses(id="gpt-5.4"), members=[inner])
 
         out = _loads(StudioRunnerTools(db=db, include_teams=[outer]).run_team("outer", "hi"))
-        assert "still shares member 'grandchild'" in out["error"]
+        assert "deep_copy failed" in out["error"]
+        assert "Failed to deep copy team member" in out["error"]
+        assert "Inner" in out["error"]
 
     def test_healthy_nested_team_dispatches(self, db):
         from agno.agent.agent import Agent as AgentClass


### PR DESCRIPTION
## Summary

Fixes #9414.

When one Team member's `deep_copy()` raised, `Team.deep_copy()` caught the
exception for the whole `members` field and installed the original members
list on the new Team. Copies could therefore alias the roster and healthy
members.

This change propagates member-copy failures with the failing member's index
and identifier, while preserving callable-member factories and existing
non-member fallback behavior. Regression coverage includes direct and nested
StudioRunner dispatch.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (not required for this internal failure-mode fix)
- [ ] Examples and guides: Not applicable
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] This PR was developed with AI assistance; the implementation and tests were reviewed by the author

## Additional Notes

Targeted regression tests:
- `3 passed` for the Team deep-copy and nested StudioRunner isolation cases

Full validation:
- `./scripts/format.sh` passed
- `./scripts/validate.sh` passed (Ruff, mypy, and cookbook pattern checks)

Related PR #9555 handles agent-tool deepcopy failures and is out of scope for this Team-member issue.