### PR TITLE
[fix] add followup_use_json_mode to force json_object for followup_model

### DIFF
--- a/libs/agno/agno/agent/_response.py
+++ b/libs/agno/agno/agent/_response.py
@@ -1711,8 +1711,10 @@ def handle_model_response_chunk(
 # ---------------------------------------------------------------------------
 
 
-def _get_followups_response_format(model: Model) -> Optional[Union[Dict, Type[BaseModel]]]:
+def _get_followups_response_format(model: Model, use_json_mode: bool = False) -> Optional[Union[Dict, Type[BaseModel]]]:
     """Get the response format for Followups based on model capabilities."""
+    if use_json_mode:
+        return {"type": "json_object"}
     if model.supports_native_structured_outputs:
         return Followups
     elif model.supports_json_schema_outputs:
@@ -1821,7 +1823,7 @@ def generate_followups(
     if model is None:
         return
 
-    response_format = _get_followups_response_format(model)
+    response_format = _get_followups_response_format(model, agent.followup_use_json_mode)
     user_message = run_response.input.input_content_string() if run_response.input else None
     messages = _build_followup_messages(
         run_response.content, agent.num_followups, user_message=user_message, response_format=response_format
@@ -1852,7 +1854,7 @@ async def agenerate_followups(
     if model is None:
         return
 
-    response_format = _get_followups_response_format(model)
+    response_format = _get_followups_response_format(model, agent.followup_use_json_mode)
     user_message = run_response.input.input_content_string() if run_response.input else None
     messages = _build_followup_messages(
         run_response.content, agent.num_followups, user_message=user_message, response_format=response_format
@@ -1892,7 +1894,7 @@ def generate_followups_stream(
             store_events=agent.store_events,
         )
 
-    response_format = _get_followups_response_format(model)
+    response_format = _get_followups_response_format(model, agent.followup_use_json_mode)
     user_message = run_response.input.input_content_string() if run_response.input else None
     messages = _build_followup_messages(
         run_response.content, agent.num_followups, user_message=user_message, response_format=response_format
@@ -1940,7 +1942,7 @@ async def agenerate_followups_stream(
             store_events=agent.store_events,
         )
 
-    response_format = _get_followups_response_format(model)
+    response_format = _get_followups_response_format(model, agent.followup_use_json_mode)
     user_message = run_response.input.input_content_string() if run_response.input else None
     messages = _build_followup_messages(
         run_response.content, agent.num_followups, user_message=user_message, response_format=response_format

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -327,6 +327,8 @@ class Agent:
     num_followups: int = 3
     # Optional model to use for generating followups (defaults to agent's model)
     followup_model: Optional[Model] = None
+    # Force JSON mode for followup generation (issue #9870)
+    followup_use_json_mode: bool = False
 
     # --- Agent Streaming ---
     # Stream the response from the Agent
@@ -482,6 +484,7 @@ class Agent:
         followups: bool = False,
         num_followups: int = 3,
         followup_model: Optional[Union[Model, str]] = None,
+        followup_use_json_mode: bool = False,
         stream: Optional[bool] = None,
         stream_events: Optional[bool] = None,
         store_events: bool = False,
@@ -657,6 +660,7 @@ class Agent:
             raise ValueError("num_followups must be at least 1")
         self.num_followups = num_followups
         self.followup_model = followup_model  # type: ignore[assignment]
+        self.followup_use_json_mode = followup_use_json_mode
 
         self.stream = stream
         self.stream_events = stream_events

--- a/libs/agno/agno/team/_init.py
+++ b/libs/agno/agno/team/_init.py
@@ -164,6 +164,7 @@ def __init__(
     followups: bool = False,
     num_followups: int = 3,
     followup_model: Optional[Union[Model, str]] = None,
+    followup_use_json_mode: bool = False,
     stream: Optional[bool] = None,
     stream_events: Optional[bool] = None,
     store_events: bool = False,
@@ -364,6 +365,7 @@ def __init__(
         raise ValueError("num_followups must be at least 1")
     team.num_followups = num_followups
     team.followup_model = followup_model  # type: ignore[assignment]
+    team.followup_use_json_mode = followup_use_json_mode
 
     team.stream = stream
     team.stream_events = stream_events

--- a/libs/agno/agno/team/_response.py
+++ b/libs/agno/agno/team/_response.py
@@ -1762,7 +1762,7 @@ def generate_team_followups(
     if model is None:
         return
 
-    response_format = _get_followups_response_format(model)
+    response_format = _get_followups_response_format(model, team.followup_use_json_mode)
     user_message = run_response.input.input_content_string() if run_response.input else None
     messages = _build_followup_messages(
         run_response.content, team.num_followups, user_message=user_message, response_format=response_format
@@ -1796,7 +1796,7 @@ async def agenerate_team_followups(
     if model is None:
         return
 
-    response_format = _get_followups_response_format(model)
+    response_format = _get_followups_response_format(model, team.followup_use_json_mode)
     user_message = run_response.input.input_content_string() if run_response.input else None
     messages = _build_followup_messages(
         run_response.content, team.num_followups, user_message=user_message, response_format=response_format
@@ -1839,7 +1839,7 @@ def generate_team_followups_stream(
             store_events=team.store_events,
         )
 
-    response_format = _get_followups_response_format(model)
+    response_format = _get_followups_response_format(model, team.followup_use_json_mode)
     user_message = run_response.input.input_content_string() if run_response.input else None
     messages = _build_followup_messages(
         run_response.content, team.num_followups, user_message=user_message, response_format=response_format
@@ -1890,7 +1890,7 @@ async def agenerate_team_followups_stream(
             store_events=team.store_events,
         )
 
-    response_format = _get_followups_response_format(model)
+    response_format = _get_followups_response_format(model, team.followup_use_json_mode)
     user_message = run_response.input.input_content_string() if run_response.input else None
     messages = _build_followup_messages(
         run_response.content, team.num_followups, user_message=user_message, response_format=response_format

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -374,6 +374,8 @@ class Team:
     num_followups: int = 3
     # Optional model to use for generating followups (defaults to team's model)
     followup_model: Optional[Model] = None
+    # Force JSON mode for followup generation (issue #9870)
+    followup_use_json_mode: bool = False
 
     # --- Team Streaming ---
     # Stream the response from the Team
@@ -561,6 +563,7 @@ class Team:
         followups: bool = False,
         num_followups: int = 3,
         followup_model: Optional[Union[Model, str]] = None,
+        followup_use_json_mode: bool = False,
         stream: Optional[bool] = None,
         stream_events: Optional[bool] = None,
         store_events: bool = False,
@@ -680,6 +683,7 @@ class Team:
             followups=followups,
             num_followups=num_followups,
             followup_model=followup_model,
+            followup_use_json_mode=followup_use_json_mode,
             stream=stream,
             stream_events=stream_events,
             store_events=store_events,

--- a/libs/agno/tests/unit/agent/test_followup_messages.py
+++ b/libs/agno/tests/unit/agent/test_followup_messages.py
@@ -68,3 +68,24 @@ def test_get_followups_response_format_fallback_to_json_object():
     assert _get_followups_response_format(_FakeModel()) == {"type": "json_object"}
     assert _get_followups_response_format(_FakeModel(native=True)) is Followups
     assert _get_followups_response_format(_FakeModel(json_schema=True))["type"] == "json_schema"
+
+
+def test_get_followups_response_format_use_json_mode_force_json_object():
+    """use_json_mode=True forces json_object regardless of model capabilities.
+
+    Regression test for https://github.com/agno-agi/agno/issues/9870:
+    json_object-only providers (e.g. DeepSeek) have no way to opt into
+    JSON mode for followup generation.
+    """
+    for model in (
+        _FakeModel(),
+        _FakeModel(native=True),
+        _FakeModel(json_schema=True),
+    ):
+        assert _get_followups_response_format(model, use_json_mode=True) == {"type": "json_object"}
+
+
+def test_get_followups_response_format_use_json_mode_default_off():
+    """use_json_mode defaults to False, preserving capability-based selection."""
+    assert _get_followups_response_format(_FakeModel(native=True)) is Followups
+    assert _get_followups_response_format(_FakeModel(json_schema=True))["type"] == "json_schema"


### PR DESCRIPTION
## Summary

Add a `followup_use_json_mode` flag to both `Agent` and `Team` so followup generation can force `response_format={"type": "json_object"}` even when the followup model advertises native structured output support. Some json_object-only providers (e.g. DeepSeek) reject structured/schema outputs and require JSON mode plus the word "json" in the prompt.

The flag is threaded through all four followup generation paths in both `agent/_response.py` (4 places) and `team/_response.py` (4 places), so the behavior is consistent whether followups are generated by an agent or a team. Defaults to `False` for backward compatibility.

**Issue:** #9870

**Changes:**
- `Agent`: new `followup_use_json_mode: bool = False` attribute + `__init__` param
- `Team`: same `followup_use_json_mode: bool = False` attribute + `__init__` param
- `_get_followups_response_format()`: new `use_json_mode` kwarg — when True, always return `{"type": "json_object"}` before consulting model capabilities

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts — ruff format + ruff check pass on all changed files
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

This PR was AI-assisted (drafted by an AI coding agent, reviewed and validated by a human before opening). The fix, regression tests, and verification steps were all exercised locally before submission.

---

## Additional Notes

Two regression tests added:
- `test_get_followups_response_format_use_json_mode_force_json_object` — verifies `use_json_mode=True` forces `json_object` for native, json-schema, and fallback models
- `test_get_followups_response_format_use_json_mode_default_off` — verifies the default `False` preserves existing behavior

Full `test_followup_messages.py` suite: 6 passed. `ruff check` clean.