### PR TITLE
fix: keep image_output and video_output through a Message round trip

### DIFF
--- a/libs/agno/agno/models/message.py
+++ b/libs/agno/agno/models/message.py
@@ -276,6 +276,11 @@ class Message(BaseModel):
                         id=img_data.get("id"),
                         mime_type=img_data.get("mime_type"),
                         format=img_data.get("format"),
+                        detail=img_data.get("detail"),
+                        original_prompt=img_data.get("original_prompt"),
+                        revised_prompt=img_data.get("revised_prompt"),
+                        alt_text=img_data.get("alt_text"),
+                        metadata=img_data.get("metadata"),
                     )
                 else:
                     data["image_output"] = Image(**img_data)
@@ -292,6 +297,14 @@ class Message(BaseModel):
                         id=vid_data.get("id"),
                         mime_type=vid_data.get("mime_type"),
                         format=vid_data.get("format"),
+                        duration=vid_data.get("duration"),
+                        width=vid_data.get("width"),
+                        height=vid_data.get("height"),
+                        fps=vid_data.get("fps"),
+                        eta=vid_data.get("eta"),
+                        original_prompt=vid_data.get("original_prompt"),
+                        revised_prompt=vid_data.get("revised_prompt"),
+                        metadata=vid_data.get("metadata"),
                     )
                 else:
                     data["video_output"] = Video(**vid_data)

--- a/libs/agno/agno/models/message.py
+++ b/libs/agno/agno/models/message.py
@@ -343,6 +343,10 @@ class Message(BaseModel):
             message_dict["files"] = [file.to_dict() for file in self.files]
         if self.audio_output:
             message_dict["audio_output"] = self.audio_output.to_dict()
+        if self.image_output:
+            message_dict["image_output"] = self.image_output.to_dict()
+        if self.video_output:
+            message_dict["video_output"] = self.video_output.to_dict()
 
         if self.references:
             message_dict["references"] = self.references.model_dump()

--- a/libs/agno/tests/unit/models/test_message_media_output_serialization.py
+++ b/libs/agno/tests/unit/models/test_message_media_output_serialization.py
@@ -1,0 +1,43 @@
+"""Tests that Message.to_dict serializes generated media output.
+
+Message declares audio_output, image_output and video_output, and from_dict
+reconstructs all three. to_dict only wrote audio_output, so a generated image
+or video was dropped whenever a message was persisted and read back.
+"""
+
+from agno.media import Audio, Image, Video
+from agno.models.message import Message
+
+
+class TestMessageMediaOutputSerialization:
+    def test_to_dict_includes_image_and_video_output(self):
+        message = Message(
+            role="assistant",
+            content="Here is your media",
+            image_output=Image(url="https://example.com/generated.png", id="img-1"),
+            video_output=Video(url="https://example.com/generated.mp4", id="vid-1"),
+        )
+
+        message_dict = message.to_dict()
+
+        assert "image_output" in message_dict
+        assert "video_output" in message_dict
+        assert message_dict["image_output"]["id"] == "img-1"
+        assert message_dict["video_output"]["id"] == "vid-1"
+
+    def test_media_output_survives_a_round_trip(self):
+        message = Message(
+            role="assistant",
+            content="Here is your media",
+            audio_output=Audio(url="https://example.com/generated.wav", id="aud-1"),
+            image_output=Image(url="https://example.com/generated.png", id="img-1"),
+            video_output=Video(url="https://example.com/generated.mp4", id="vid-1"),
+        )
+
+        restored = Message.from_dict(message.to_dict())
+
+        assert restored.audio_output is not None
+        assert restored.image_output is not None
+        assert restored.video_output is not None
+        assert restored.image_output.id == "img-1"
+        assert restored.video_output.id == "vid-1"

--- a/libs/agno/tests/unit/models/test_message_media_output_serialization.py
+++ b/libs/agno/tests/unit/models/test_message_media_output_serialization.py
@@ -1,8 +1,10 @@
-"""Tests that Message.to_dict serializes generated media output.
+"""Tests that Message round-trips generated media output.
 
 Message declares audio_output, image_output and video_output, and from_dict
 reconstructs all three. to_dict only wrote audio_output, so a generated image
-or video was dropped whenever a message was persisted and read back.
+or video was dropped whenever a message was persisted and read back. A
+byte-backed image or video also came back stripped, because from_dict passed
+only id, mime_type and format to from_base64.
 """
 
 from agno.media import Audio, Image, Video
@@ -41,3 +43,57 @@ class TestMessageMediaOutputSerialization:
         assert restored.video_output is not None
         assert restored.image_output.id == "img-1"
         assert restored.video_output.id == "vid-1"
+
+    def test_byte_backed_media_output_keeps_its_fields(self):
+        message = Message(
+            role="assistant",
+            content="Here is your media",
+            image_output=Image(
+                content=b"fake-png-bytes",
+                id="img-1",
+                format="png",
+                mime_type="image/png",
+                detail="high",
+                original_prompt="a red bicycle",
+                revised_prompt="a red bicycle on a wet street",
+                alt_text="A red bicycle",
+                metadata={"source": "unit-test"},
+            ),
+            video_output=Video(
+                content=b"fake-mp4-bytes",
+                id="vid-1",
+                format="mp4",
+                mime_type="video/mp4",
+                duration=12.5,
+                width=1920,
+                height=1080,
+                fps=24.0,
+                eta="10s",
+                original_prompt="a cat",
+                revised_prompt="a cat on a sofa",
+                metadata={"source": "unit-test"},
+            ),
+        )
+
+        restored = Message.from_dict(message.to_dict())
+
+        image = restored.image_output
+        assert image is not None
+        assert image.content == b"fake-png-bytes"
+        assert image.detail == "high"
+        assert image.original_prompt == "a red bicycle"
+        assert image.revised_prompt == "a red bicycle on a wet street"
+        assert image.alt_text == "A red bicycle"
+        assert image.metadata == {"source": "unit-test"}
+
+        video = restored.video_output
+        assert video is not None
+        assert video.content == b"fake-mp4-bytes"
+        assert video.duration == 12.5
+        assert video.width == 1920
+        assert video.height == 1080
+        assert video.fps == 24.0
+        assert video.eta == "10s"
+        assert video.original_prompt == "a cat"
+        assert video.revised_prompt == "a cat on a sofa"
+        assert video.metadata == {"source": "unit-test"}


### PR DESCRIPTION
## Summary

Fixes #9879.

`Message` declares three generated-media fields, at `libs/agno/agno/models/message.py:84-86`:

```python
audio_output: Optional[Audio] = None
image_output: Optional[Image] = None
video_output: Optional[Video] = None
```

`from_dict` rebuilds all three, at lines 248, 267 and 283. `to_dict` wrote only `audio_output`:

```python
if self.audio_output:
    message_dict["audio_output"] = self.audio_output.to_dict()
```

So a message carrying a generated image or video lost it as soon as it was serialized. `run/agent.py` calls `to_dict()` per message when it builds the stored row, so the loss lands on anything that persists a run and reads it back. The two `from_dict` branches for these keys could never fire on data this method produced.

This adds the two missing branches, mirroring the `audio_output` one.

`from_dict` then turned out to lose data on the same path. Its base64 branches passed only `id`, `mime_type` and `format` into `from_base64`, so a byte-backed image came back without `detail`, `alt_text`, both prompts and `metadata`, and a byte-backed video without `duration`, `width`, `height`, `fps`, `eta`, both prompts and `metadata`. Those branches could not run for `image_output` or `video_output` until `to_dict` started writing the keys, so this PR is what makes the loss reachable. The second commit forwards the remaining fields. Every one of them defaults to `None` on the model, so an absent key behaves exactly as before.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

## Tests

`libs/agno/tests/unit/models/test_message_media_output_serialization.py`, three cases:

- `to_dict` includes both keys with the right ids.
- A message with all three media outputs survives `to_dict` then `from_dict`, which is the asymmetry this fixes.

- A byte-backed image and video keep all thirteen fields across `to_dict` then `from_dict`. The earlier round-trip case used URL-backed media, which takes the branch that already preserved everything.

```
pytest libs/agno/tests/unit/models/test_message_media_output_serialization.py
3 passed
```

Removing the two added branches and keeping the tests fails both, so they hold the behaviour rather than restating it.

I could not run the whole `tests/unit/models` directory: 47 modules fail to collect on a clean checkout because optional provider SDKs are absent (`ModuleNotFoundError: No module named 'anthropic'` and similar), and the 88 downstream failures are all in those provider directories. That is the same on `main` without this branch.

`ruff format` and `ruff check --select I` leave both files unchanged. `ruff check` reports 65 pre-existing findings on `message.py` before this change and 64 after, so this adds none; the new test file is clean.

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`ruff format` and `ruff check --select I`, as `scripts/format.sh` runs)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: not applicable, no public API change
- [x] Tested in clean environment

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue. I listed every open PR and checked each one's changed files; none touches `libs/agno/agno/models/message.py`.
- [ ] If a similar PR exists, I have explained below why this PR is a better approach. Not applicable, no similar PR exists.
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

On the AI checkbox above: Claude Code CLI with Opus 5. I ran the tests, verified they fail with the change reverted, and checked that `ruff check` on `message.py` goes from 65 findings to 64.

No deployment steps and no security considerations. The change is additive: it writes two keys that `from_dict` already knew how to read.