### PR TITLE
[fix] Migrate the Perplexity integration to Agent API

### DIFF
--- a/cookbook/90_models/perplexity/README.md
+++ b/cookbook/90_models/perplexity/README.md
@@ -1,5 +1,9 @@
 # Perplexity Cookbook
 
+> [!WARNING]
+> These examples use Sonar Chat Completions, which is deprecated and supported only until September 27, 2026.
+> For new projects, use the [Perplexity Agent API with Agno's `OpenAIResponses`](https://docs.perplexity.ai/docs/getting-started/integrations/agno).
+
 > Note: Fork and clone this repository if needed
 
 ### 1. Create and activate a virtual environment
@@ -40,4 +44,3 @@ python cookbook/90_models/perplexity/web_search.py
 ```shell
 python cookbook/90_models/perplexity/knowledge.py
 ```
-

--- a/cookbook/90_models/perplexity/README.md
+++ b/cookbook/90_models/perplexity/README.md
@@ -1,8 +1,7 @@
 # Perplexity Cookbook
 
-> [!WARNING]
-> These examples use Sonar Chat Completions, which is deprecated and supported only until September 27, 2026.
-> For new projects, use the [Perplexity Agent API with Agno's `OpenAIResponses`](https://docs.perplexity.ai/docs/getting-started/integrations/agno).
+These examples use the [Perplexity Agent API with Agno's `OpenAIResponses`](https://docs.perplexity.ai/docs/getting-started/integrations/agno).
+They do not use the legacy `agno.models.perplexity.Perplexity` integration, which calls the deprecated Sonar Chat Completions API.
 
 > Note: Fork and clone this repository if needed
 
@@ -22,7 +21,7 @@ export PERPLEXITY_API_KEY=***
 ### 3. Install libraries
 
 ```shell
-uv pip install -U ddgs duckdb agno
+uv pip install -U ddgs duckdb agno openai
 ```
 
 ### 4. Run basic Agent

--- a/cookbook/90_models/perplexity/basic.py
+++ b/cookbook/90_models/perplexity/basic.py
@@ -5,15 +5,24 @@ Perplexity Basic
 Cookbook example for `perplexity/basic.py`.
 """
 
-from agno.agent import Agent, RunOutput  # noqa
-from agno.models.perplexity import Perplexity
 import asyncio
+import os
+
+from agno.agent import Agent, RunOutput  # noqa
+from agno.models.openai import OpenAIResponses
 
 # ---------------------------------------------------------------------------
 # Create Agent
 # ---------------------------------------------------------------------------
 
-agent = Agent(model=Perplexity(id="sonar-pro"), markdown=True)
+agent = Agent(
+    model=OpenAIResponses(
+        id="openai/gpt-5.6-luna",
+        base_url="https://api.perplexity.ai/v1",
+        api_key=os.environ["PERPLEXITY_API_KEY"],
+    ),
+    markdown=True,
+)
 
 # Get the response in a variable
 # run: RunOutput = agent.run("Share a 2 sentence horror story")

--- a/cookbook/90_models/perplexity/knowledge.py
+++ b/cookbook/90_models/perplexity/knowledge.py
@@ -1,9 +1,11 @@
 """Run `uv pip install ddgs sqlalchemy pgvector pypdf openai google.generativeai` to install dependencies."""
 
+import os
+
 from agno.agent import Agent
 from agno.knowledge.embedder.openai import OpenAIEmbedder
 from agno.knowledge.knowledge import Knowledge
-from agno.models.perplexity import Perplexity
+from agno.models.openai import OpenAIResponses
 from agno.vectordb.pgvector import PgVector
 
 # ---------------------------------------------------------------------------
@@ -22,7 +24,14 @@ knowledge = Knowledge(
 # Add content to the knowledge
 knowledge.insert(url="https://agno-public.s3.amazonaws.com/recipes/ThaiRecipes.pdf")
 
-agent = Agent(model=Perplexity(id="sonar-pro"), knowledge=knowledge)
+agent = Agent(
+    model=OpenAIResponses(
+        id="openai/gpt-5.6-luna",
+        base_url="https://api.perplexity.ai/v1",
+        api_key=os.environ["PERPLEXITY_API_KEY"],
+    ),
+    knowledge=knowledge,
+)
 agent.print_response("How to make Thai curry?", markdown=True)
 
 # ---------------------------------------------------------------------------

--- a/cookbook/90_models/perplexity/memory.py
+++ b/cookbook/90_models/perplexity/memory.py
@@ -6,9 +6,11 @@ Steps:
 3. Run: `python cookbook/agents/personalized_memories_and_summaries.py` to run the agent
 """
 
+import os
+
 from agno.agent import Agent
 from agno.db.postgres import PostgresDb
-from agno.models.perplexity import Perplexity
+from agno.models.openai import OpenAIResponses
 from rich.pretty import pprint
 
 # ---------------------------------------------------------------------------
@@ -17,7 +19,11 @@ from rich.pretty import pprint
 
 db_url = "postgresql+psycopg://ai:ai@localhost:5532/ai"
 agent = Agent(
-    model=Perplexity(id="sonar-pro"),
+    model=OpenAIResponses(
+        id="openai/gpt-5.6-luna",
+        base_url="https://api.perplexity.ai/v1",
+        api_key=os.environ["PERPLEXITY_API_KEY"],
+    ),
     # Store the memories and summary in a database
     db=PostgresDb(db_url=db_url),
     update_memory_on_run=True,

--- a/cookbook/90_models/perplexity/retry.py
+++ b/cookbook/90_models/perplexity/retry.py
@@ -1,18 +1,22 @@
 """Example demonstrating how to set up retries with Perplexity."""
 
+import os
+
 from agno.agent import Agent
-from agno.models.perplexity import Perplexity
+from agno.models.openai import OpenAIResponses
 
 # ---------------------------------------------------------------------------
 # Create Agent
 # ---------------------------------------------------------------------------
 
 # We will use a deliberately wrong model ID, to trigger retries.
-wrong_model_id = "perplexity-wrong-id"
+wrong_model_id = "openai/perplexity-wrong-id"
 
 agent = Agent(
-    model=Perplexity(
+    model=OpenAIResponses(
         id=wrong_model_id,
+        base_url="https://api.perplexity.ai/v1",
+        api_key=os.environ["PERPLEXITY_API_KEY"],
         retries=3,  # Number of times to retry the request.
         delay_between_retries=1,  # Delay between retries in seconds.
         exponential_backoff=True,  # If True, the delay between retries is doubled each time.

--- a/cookbook/90_models/perplexity/structured_output.py
+++ b/cookbook/90_models/perplexity/structured_output.py
@@ -5,10 +5,10 @@ Perplexity Structured Output
 Cookbook example for `perplexity/structured_output.py`.
 """
 
-from typing import List
+import os
 
 from agno.agent import Agent, RunOutput  # noqa
-from agno.models.perplexity import Perplexity
+from agno.models.openai import OpenAIResponses
 from pydantic import BaseModel, Field
 
 # ---------------------------------------------------------------------------
@@ -29,7 +29,7 @@ class MovieScript(BaseModel):
         description="Genre of the movie. If not available, select action, thriller or romantic comedy.",
     )
     name: str = Field(..., description="Give a name to this movie")
-    characters: List[str] = Field(..., description="Name of characters for this movie.")
+    characters: list[str] = Field(..., description="Name of characters for this movie.")
     storyline: str = Field(
         ..., description="3 sentence storyline for the movie. Make it exciting!"
     )
@@ -37,7 +37,11 @@ class MovieScript(BaseModel):
 
 # Agent that uses JSON mode
 json_mode_agent = Agent(
-    model=Perplexity(id="sonar-pro"),
+    model=OpenAIResponses(
+        id="openai/gpt-5.6-luna",
+        base_url="https://api.perplexity.ai/v1",
+        api_key=os.environ["PERPLEXITY_API_KEY"],
+    ),
     description="You write movie scripts.",
     output_schema=MovieScript,
     markdown=True,

--- a/cookbook/90_models/perplexity/web_search.py
+++ b/cookbook/90_models/perplexity/web_search.py
@@ -5,14 +5,24 @@ Perplexity Web Search
 Cookbook example for `perplexity/web_search.py`.
 """
 
+import os
+
 from agno.agent import Agent, RunOutput  # noqa
-from agno.models.perplexity import Perplexity
+from agno.models.openai import OpenAIResponses
 
 # ---------------------------------------------------------------------------
 # Create Agent
 # ---------------------------------------------------------------------------
 
-agent = Agent(model=Perplexity(id="sonar-pro"), markdown=True)
+agent = Agent(
+    model=OpenAIResponses(
+        id="openai/gpt-5.6-luna",
+        base_url="https://api.perplexity.ai/v1",
+        api_key=os.environ["PERPLEXITY_API_KEY"],
+        extra_body={"preset": "medium"},
+    ),
+    markdown=True,
+)
 
 # Print the response in the terminal
 agent.print_response("Show me top 2 news stories from USA?")

--- a/libs/agno/agno/models/perplexity/perplexity.py
+++ b/libs/agno/agno/models/perplexity/perplexity.py
@@ -35,7 +35,7 @@ class Perplexity(OpenAILike):
     ``OpenAIResponses`` with Perplexity's Agent API.
 
     Attributes:
-        id (str): The model id. Defaults to "not-provided".
+        id (str): The model id. Defaults to "sonar".
         name (str): The model name. Defaults to "Perplexity".
         provider (str): The provider name. Defaults to "Perplexity".
         api_key (Optional[str]): The API key.
@@ -43,7 +43,7 @@ class Perplexity(OpenAILike):
         max_tokens (int): The maximum number of tokens. Defaults to 1024.
     """
 
-    id: str = "not-provided"
+    id: str = "sonar"
     name: str = "Perplexity"
     provider: str = "Perplexity"
     # Perplexity returns cumulative token counts in each streaming chunk, so only collect on final chunk

--- a/libs/agno/agno/models/perplexity/perplexity.py
+++ b/libs/agno/agno/models/perplexity/perplexity.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from os import getenv
 from typing import Any, Dict, Optional, Type, Union
+from warnings import warn
 
 from pydantic import BaseModel
 
@@ -29,8 +30,12 @@ class Perplexity(OpenAILike):
     """
     A class for using models hosted on Perplexity.
 
+    This class uses Perplexity's deprecated Sonar Chat Completions API, which is
+    supported until September 27, 2026. For new integrations, use
+    ``OpenAIResponses`` with Perplexity's Agent API.
+
     Attributes:
-        id (str): The model id. Defaults to "sonar".
+        id (str): The model id. Defaults to "not-provided".
         name (str): The model name. Defaults to "Perplexity".
         provider (str): The provider name. Defaults to "Perplexity".
         api_key (Optional[str]): The API key.
@@ -38,7 +43,7 @@ class Perplexity(OpenAILike):
         max_tokens (int): The maximum number of tokens. Defaults to 1024.
     """
 
-    id: str = "sonar"
+    id: str = "not-provided"
     name: str = "Perplexity"
     provider: str = "Perplexity"
     # Perplexity returns cumulative token counts in each streaming chunk, so only collect on final chunk
@@ -51,6 +56,16 @@ class Perplexity(OpenAILike):
 
     supports_native_structured_outputs: bool = False
     supports_json_schema_outputs: bool = True
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        warn(
+            "Perplexity Sonar Chat Completions is deprecated and will be supported until September 27, 2026. "
+            "Use agno.models.openai.OpenAIResponses with base_url='https://api.perplexity.ai/v1' for "
+            "Perplexity's Agent API. See https://docs.perplexity.ai/docs/agent-api/migrate-from-sonar",
+            DeprecationWarning,
+            stacklevel=3,
+        )
 
     def _get_client_params(self) -> Dict[str, Any]:
         """

--- a/libs/agno/agno/models/perplexity/perplexity.py
+++ b/libs/agno/agno/models/perplexity/perplexity.py
@@ -35,7 +35,8 @@ class Perplexity(OpenAILike):
     ``OpenAIResponses`` with Perplexity's Agent API.
 
     Attributes:
-        id (str): The model id. Defaults to "sonar".
+        id (str): The model id. Defaults to "not-provided"; callers must select
+            a Sonar model explicitly.
         name (str): The model name. Defaults to "Perplexity".
         provider (str): The provider name. Defaults to "Perplexity".
         api_key (Optional[str]): The API key.
@@ -43,7 +44,7 @@ class Perplexity(OpenAILike):
         max_tokens (int): The maximum number of tokens. Defaults to 1024.
     """
 
-    id: str = "sonar"
+    id: str = "not-provided"
     name: str = "Perplexity"
     provider: str = "Perplexity"
     # Perplexity returns cumulative token counts in each streaming chunk, so only collect on final chunk

--- a/libs/agno/agno/models/perplexity/perplexity.py
+++ b/libs/agno/agno/models/perplexity/perplexity.py
@@ -39,7 +39,7 @@ class Perplexity(OpenAILike):
         name (str): The model name. Defaults to "Perplexity".
         provider (str): The provider name. Defaults to "Perplexity".
         api_key (Optional[str]): The API key.
-        base_url (str): The base URL. Defaults to "https://api.perplexity.ai/chat/completions".
+        base_url (str): The base URL. Defaults to "https://api.perplexity.ai/".
         max_tokens (int): The maximum number of tokens. Defaults to 1024.
     """
 
@@ -60,9 +60,9 @@ class Perplexity(OpenAILike):
     def __post_init__(self) -> None:
         super().__post_init__()
         warn(
-            "Perplexity Sonar Chat Completions is deprecated and will be supported until September 27, 2026. "
-            "Use agno.models.openai.OpenAIResponses with base_url='https://api.perplexity.ai/v1' for "
-            "Perplexity's Agent API. See https://docs.perplexity.ai/docs/agent-api/migrate-from-sonar",
+            "agno.models.perplexity.Perplexity uses Sonar Chat Completions, which is deprecated and supported only "
+            "until September 27, 2026. Migrate to agno.models.openai.OpenAIResponses with Perplexity's Agent API: "
+            "https://docs.perplexity.ai/docs/getting-started/integrations/agno",
             DeprecationWarning,
             stacklevel=3,
         )

--- a/libs/agno/tests/unit/models/perplexity/test_perplexity_model.py
+++ b/libs/agno/tests/unit/models/perplexity/test_perplexity_model.py
@@ -2,27 +2,19 @@ import pytest
 
 from agno.models.perplexity import Perplexity
 
-DEFAULT_MODEL_ID = "not-provided"
+DEFAULT_MODEL_ID = "sonar"
 EXPLICIT_MODEL_ID = "sonar-pro"
-MIGRATION_GUIDE_URL = "https://docs.perplexity.ai/docs/getting-started/integrations/agno"
 
 
-def test_perplexity_does_not_select_a_default_model():
-    with pytest.warns(DeprecationWarning):
-        model = Perplexity(api_key="test-key")
+@pytest.mark.parametrize("model_id", [None, EXPLICIT_MODEL_ID])
+def test_perplexity_warns_about_deprecation_without_changing_model_selection(model_id):
+    model_kwargs = {"api_key": "test-key"}
+    if model_id is not None:
+        model_kwargs["id"] = model_id
 
-    assert model.id == DEFAULT_MODEL_ID
-
-
-def test_perplexity_warns_about_chat_completions_deprecation_with_explicit_model():
     with pytest.warns(DeprecationWarning) as warning_records:
-        model = Perplexity(id=EXPLICIT_MODEL_ID, api_key="test-key")
+        model = Perplexity(**model_kwargs)
 
-    assert model.id == EXPLICIT_MODEL_ID
+    assert model.id == (model_id or DEFAULT_MODEL_ID)
     assert len(warning_records) == 1
-    warning_message = str(warning_records[0].message)
-    assert "Sonar Chat Completions" in warning_message
-    assert "September 27, 2026" in warning_message
-    assert "OpenAIResponses" in warning_message
-    assert MIGRATION_GUIDE_URL in warning_message
     assert warning_records[0].filename == __file__

--- a/libs/agno/tests/unit/models/perplexity/test_perplexity_model.py
+++ b/libs/agno/tests/unit/models/perplexity/test_perplexity_model.py
@@ -2,7 +2,7 @@ import pytest
 
 from agno.models.perplexity import Perplexity
 
-DEFAULT_MODEL_ID = "sonar"
+DEFAULT_MODEL_ID = "not-provided"
 EXPLICIT_MODEL_ID = "sonar-pro"
 
 
@@ -12,7 +12,10 @@ def test_perplexity_warns_about_deprecation_without_changing_model_selection(mod
     if model_id is not None:
         model_kwargs["id"] = model_id
 
-    with pytest.warns(DeprecationWarning) as warning_records:
+    with pytest.warns(
+        DeprecationWarning,
+        match="Sonar Chat Completions.*OpenAIResponses.*Agent API",
+    ) as warning_records:
         model = Perplexity(**model_kwargs)
 
     assert model.id == (model_id or DEFAULT_MODEL_ID)

--- a/libs/agno/tests/unit/models/perplexity/test_perplexity_model.py
+++ b/libs/agno/tests/unit/models/perplexity/test_perplexity_model.py
@@ -2,11 +2,27 @@ import pytest
 
 from agno.models.perplexity import Perplexity
 
+DEFAULT_MODEL_ID = "not-provided"
+EXPLICIT_MODEL_ID = "sonar-pro"
+MIGRATION_GUIDE_URL = "https://docs.perplexity.ai/docs/getting-started/integrations/agno"
 
-def test_perplexity_does_not_select_a_model_and_warns_about_chat_completions_deprecation():
-    with pytest.warns(DeprecationWarning) as warning_records:
+
+def test_perplexity_does_not_select_a_default_model():
+    with pytest.warns(DeprecationWarning):
         model = Perplexity(api_key="test-key")
 
-    assert model.id == "not-provided"
+    assert model.id == DEFAULT_MODEL_ID
+
+
+def test_perplexity_warns_about_chat_completions_deprecation_with_explicit_model():
+    with pytest.warns(DeprecationWarning) as warning_records:
+        model = Perplexity(id=EXPLICIT_MODEL_ID, api_key="test-key")
+
+    assert model.id == EXPLICIT_MODEL_ID
     assert len(warning_records) == 1
+    warning_message = str(warning_records[0].message)
+    assert "Sonar Chat Completions" in warning_message
+    assert "September 27, 2026" in warning_message
+    assert "OpenAIResponses" in warning_message
+    assert MIGRATION_GUIDE_URL in warning_message
     assert warning_records[0].filename == __file__

--- a/libs/agno/tests/unit/models/perplexity/test_perplexity_model.py
+++ b/libs/agno/tests/unit/models/perplexity/test_perplexity_model.py
@@ -1,0 +1,17 @@
+import pytest
+
+from agno.models.perplexity.perplexity import Perplexity
+
+
+def test_perplexity_requires_explicit_model_and_warns_about_chat_completions_deprecation():
+    with pytest.warns(DeprecationWarning) as warning_records:
+        model = Perplexity(api_key="test-key")
+
+    assert model.id == "not-provided"
+    assert len(warning_records) == 1
+
+    warning_message = str(warning_records[0].message)
+    assert "September 27, 2026" in warning_message
+    assert "OpenAIResponses" in warning_message
+    assert "https://docs.perplexity.ai/docs/agent-api/migrate-from-sonar" in warning_message
+    assert warning_records[0].filename == __file__

--- a/libs/agno/tests/unit/models/perplexity/test_perplexity_model.py
+++ b/libs/agno/tests/unit/models/perplexity/test_perplexity_model.py
@@ -1,17 +1,12 @@
 import pytest
 
-from agno.models.perplexity.perplexity import Perplexity
+from agno.models.perplexity import Perplexity
 
 
-def test_perplexity_requires_explicit_model_and_warns_about_chat_completions_deprecation():
+def test_perplexity_does_not_select_a_model_and_warns_about_chat_completions_deprecation():
     with pytest.warns(DeprecationWarning) as warning_records:
         model = Perplexity(api_key="test-key")
 
     assert model.id == "not-provided"
     assert len(warning_records) == 1
-
-    warning_message = str(warning_records[0].message)
-    assert "September 27, 2026" in warning_message
-    assert "OpenAIResponses" in warning_message
-    assert "https://docs.perplexity.ai/docs/agent-api/migrate-from-sonar" in warning_message
     assert warning_records[0].filename == __file__


### PR DESCRIPTION
## Summary

Sonar Chat Completions is retiring on September 27, 2026, but Agno's Perplexity cookbook still directs users to `sonar-pro`, and `Perplexity()` silently selects `sonar`. Perplexity's native Python SDK requires Chat Completions callers to choose a model explicitly, while new integrations should use Agent API.

This change:

- changes the legacy `agno.models.perplexity.Perplexity` default from `sonar` to the existing `not-provided` sentinel, matching the native SDK's explicit Chat Completions model selection
- emits a caller-attributed `DeprecationWarning` with the Sonar support deadline and Agent API migration guidance
- preserves explicitly supplied legacy model IDs during the migration window
- migrates every public Perplexity cookbook example to Agent API through `OpenAIResponses`, using a current non-Sonar model
- uses the Agent API `medium` research preset in the web-search example
- corrects the wrapper's documented default base URL

Related tracking: [API-3605](https://linear.app/perplexity/issue/API-3605), [API-3384](https://linear.app/perplexity/issue/API-3384).

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

`Perplexity()` no longer silently selects Sonar. Existing callers must pass an explicit legacy model ID or migrate to `OpenAIResponses` with Perplexity's Agent API. Explicit `Perplexity(id=...)` usage remains available during the Sonar support window and emits the deprecation warning.
