### PR TITLE
feat: add grep_content for regex search with line numbers

### DIFF
--- a/cookbook/12_context/13_workspace.py
+++ b/cookbook/12_context/13_workspace.py
@@ -5,7 +5,8 @@ Workspace Context Provider
 WorkspaceContextProvider wraps a project directory and gives the agent
 a single `query_<id>` tool. The tool routes through a read-only sub-agent
 that has the `Workspace` toolkit scoped to the root: list files, search
-content, and read files with line numbers.
+content (substring), grep content (regex with line numbers), and read
+files with line numbers.
 
 Use this for repository roots and active project workspaces. It skips
 common dependency directories, build outputs, caches, virtualenvs, and

--- a/cookbook/91_tools/workspace_tools/README.md
+++ b/cookbook/91_tools/workspace_tools/README.md
@@ -45,7 +45,8 @@ raises `ValueError`. The full alias mapping:
 | -------- | -------------------- | --------------------------------------- |
 | `read`   | `read_file`          | Read a file (line-numbered, optional range) |
 | `list`   | `list_files`         | List a directory (optional glob, optional recursive with `max_depth`) |
-| `search` | `search_content`     | Recursive content grep                  |
+| `search` | `search_content`     | Recursive content search (substring)    |
+| `grep`   | `grep_content`       | Regex search with line numbers          |
 | `write`  | `write_file`         | Create or overwrite a file (atomic)     |
 | `edit`   | `edit_file`          | Replace a substring (with `replace_all`)|
 | `move`   | `move_file`          | Move or rename a file                   |
@@ -95,6 +96,8 @@ tools = [Workspace(".", allow_paths=[".env.example"])]
   confirmations disabled so the demo runs end-to-end.
 - `with_confirmation.py` — same agent with the default safety on; you
   approve each write at the console.
+- `grep_content.py` — demonstrates regex search with line numbers, context
+  lines, and files-only mode for code navigation.
 
 ## Running
 

--- a/cookbook/91_tools/workspace_tools/grep_content.py
+++ b/cookbook/91_tools/workspace_tools/grep_content.py
@@ -1,0 +1,61 @@
+"""
+Workspace — grep_content (regex search with line numbers)
+
+grep_content is for precise code search: regex patterns, every matching line
+with its line number, and optional context lines. Returns JSON with file:line
+citations for direct navigation.
+
+This example demonstrates a rename pre-flight sweep — finding all occurrences
+of a method name before refactoring.
+"""
+
+from pathlib import Path
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.tools.workspace import Workspace
+
+project_root = Path(__file__).resolve().parents[3]
+libs_dir = project_root / "libs" / "agno" / "agno"
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.5"),
+    tools=[
+        Workspace(
+            libs_dir,
+            allowed=["read", "list", "search", "grep"],
+            confirm=[],
+        )
+    ],
+    instructions="""\
+You are a refactoring assistant helping prepare a method rename.
+
+Workflow:
+1. Use grep_content to find all occurrences with line numbers
+2. Use context_lines if you need surrounding code to classify matches
+3. Use read_file with a line range when you need more context
+
+Use word-boundary regex (\\b) to avoid false positives. For example,
+`\\bsearch_content\\b` matches the sync method but not `asearch_content`.
+
+Cite every finding as file:line so the developer can navigate directly.
+""",
+    markdown=True,
+)
+
+
+if __name__ == "__main__":
+    prompt = """\
+We're planning to rename the sync method `search_content` (the async variant
+`asearch_content` keeps its name).
+
+1. Search with the word-boundary pattern `\\bsearch_content\\b` and 1 context line
+2. Classify each occurrence as: definition, call site, docstring/comment, or test
+
+Note: A plain substring search would falsely include `asearch_content` — that's
+why we need the regex word boundary.
+
+Produce a rename checklist with file:line citations.
+"""
+    print(f"> {prompt}\n")
+    agent.print_response(prompt)

--- a/libs/agno/agno/context/workspace/provider.py
+++ b/libs/agno/agno/context/workspace/provider.py
@@ -81,11 +81,9 @@ class WorkspaceContextProvider(ContextProvider):
 
     def instructions(self) -> str:
         if self.mode == ContextMode.tools:
-            # Tool names are prefixed with provider id when mode=tools
-            prefix = f"{self.id}_"
             return (
                 f"`{self.name}`: inspect project files under {self.root}. Use read-only "
-                f"`{prefix}list_files`, `{prefix}search_content`, `{prefix}grep_content`, and `{prefix}read_file`. "
+                "`list_files`, `search_content`, `grep_content`, and `read_file`. "
                 f"Paths are relative to the workspace root. {self._exclusion_sentence()}"
             )
         return (
@@ -112,6 +110,14 @@ class WorkspaceContextProvider(ContextProvider):
 
     def _default_tools(self) -> list:
         return [self._query_tool()]
+
+    def _query_tool(self):
+        query_tool = super()._query_tool()
+        query_tool.description = (
+            f"Explore project files under {self.root} with a natural-language question. "
+            "Read-only: lists directories, searches/greps code, and reads file contents."
+        )
+        return query_tool
 
     def _all_tools(self) -> list:
         return [self._build_workspace_tools()]
@@ -148,7 +154,6 @@ class WorkspaceContextProvider(ContextProvider):
             allow_paths=list(self.allow_paths),
             max_file_lines=self.max_file_lines,
             max_file_length=self.max_file_length,
-            **self._toolkit_prefix_kwargs(),
         )
 
 

--- a/libs/agno/agno/context/workspace/provider.py
+++ b/libs/agno/agno/context/workspace/provider.py
@@ -81,10 +81,12 @@ class WorkspaceContextProvider(ContextProvider):
 
     def instructions(self) -> str:
         if self.mode == ContextMode.tools:
+            # Tool names are prefixed with provider id when mode=tools
+            prefix = f"{self.id}_"
             return (
                 f"`{self.name}`: inspect project files under {self.root}. Use read-only "
-                "`list_files`, `search_content`, and `read_file`. Paths are relative to "
-                f"the workspace root. {self._exclusion_sentence()}"
+                f"`{prefix}list_files`, `{prefix}search_content`, `{prefix}grep_content`, and `{prefix}read_file`. "
+                f"Paths are relative to the workspace root. {self._exclusion_sentence()}"
             )
         return (
             f"`{self.name}`: call `{self.query_tool_name}(question)` to inspect project "
@@ -146,6 +148,7 @@ class WorkspaceContextProvider(ContextProvider):
             allow_paths=list(self.allow_paths),
             max_file_lines=self.max_file_lines,
             max_file_length=self.max_file_length,
+            **self._toolkit_prefix_kwargs(),
         )
 
 
@@ -155,9 +158,9 @@ You answer questions by inspecting project files under {root}.
 Workflow:
 1. **Map the workspace first.** Use `list_files(recursive=True)` with a
    modest `max_depth` to identify likely source, docs, and cookbook paths.
-2. **Search narrowly.** Use `search_content(query, directory=...)` once you
-   know the relevant subtree. Avoid whole-workspace searches unless the user
-   asks for a broad audit.
+2. **Search narrowly.** Use `search_content(query, directory=...)` for substring
+   search, or `grep_content(pattern, directory=...)` for regex search with line
+   numbers. Scope to the relevant subtree once you know it.
 3. **Read before citing.** Use `read_file(path)` or a line range for the
    files you rely on. Cite paths relative to the workspace root.
 4. **Ignore generated noise.** {exclusion}

--- a/libs/agno/agno/tools/workspace.py
+++ b/libs/agno/agno/tools/workspace.py
@@ -382,6 +382,99 @@ class Workspace(Toolkit):
         "shell": "run_command",
     }
 
+    @classmethod
+    def _build_instructions(cls, tool_names: List[str]) -> str:
+        """Build instructions based on which tools are actually enabled.
+
+        Only references tools the LLM can call — never mentions disabled tools.
+        """
+        enabled = set(tool_names)
+        sections: List[str] = []
+
+        # Read tools
+        if "read_file" in enabled:
+            sections.append(
+                "**read_file** — read a file with line numbers.\n"
+                "When to use: examining file contents, checking code, getting context.\n"
+                "Always read before editing or citing."
+            )
+
+        if "list_files" in enabled:
+            sections.append(
+                "**list_files** — list directory contents.\n"
+                "When to use: discovering project structure, finding files.\n"
+                "Use `recursive=True` with `max_depth` for broad exploration."
+            )
+
+        if "search_content" in enabled:
+            text = (
+                "**search_content** — substring search across files.\n"
+                "When to use: finding text, locating usages, discovering code."
+            )
+            if "grep_content" in enabled:
+                text += "\nFor regex patterns or line numbers, use grep_content instead."
+            sections.append(text)
+
+        if "grep_content" in enabled:
+            text = (
+                "**grep_content** — regex search with line numbers and context.\n"
+                "When to use: pattern matching, finding code with surrounding context."
+            )
+            if "search_content" in enabled:
+                text += "\nFor simple substring search, use search_content instead."
+            sections.append(text)
+
+        # Write tools
+        if "write_file" in enabled:
+            sections.append(
+                "**write_file** — create or overwrite a file.\n"
+                "When to use: creating new files, replacing entire file contents."
+            )
+
+        if "edit_file" in enabled:
+            text = (
+                "**edit_file** — replace a substring in a file.\n"
+                "When to use: modifying existing code.\n"
+                "IMPORTANT: Always read_file first — use the exact substring from the output."
+            )
+            if "write_file" in enabled:
+                text += "\nUse write_file for new files; edit_file for modifications."
+            sections.append(text)
+
+        if "move_file" in enabled:
+            sections.append("**move_file** — move or rename a file.\nWhen to use: reorganizing, renaming.")
+
+        if "delete_file" in enabled:
+            sections.append("**delete_file** — delete a file.\nWhen to use: removing files. Use with caution.")
+
+        if "run_command" in enabled:
+            sections.append(
+                "**run_command** — run a shell command in the workspace.\n"
+                "When to use: running tests, builds, or other commands.\n"
+                "Note: runs with cwd=workspace root."
+            )
+
+        if len(sections) < 2:
+            return ""
+
+        result = "## Workspace Tools\n\n" + "\n\n".join(sections)
+
+        # Routing guidance
+        routing: List[str] = []
+        if "list_files" in enabled:
+            routing.append("- Discover structure → list_files")
+        if "search_content" in enabled or "grep_content" in enabled:
+            routing.append("- Find code/text → search_content or grep_content")
+        if "read_file" in enabled:
+            routing.append("- Examine contents → read_file")
+        if "edit_file" in enabled:
+            routing.append("- Modify code → read_file first, then edit_file")
+
+        if routing:
+            result += "\n\n## Workflow\n" + "\n".join(routing)
+
+        return result
+
     def __init__(
         self,
         root: Optional[Union[str, Path]] = None,
@@ -429,23 +522,16 @@ class Workspace(Toolkit):
         sync_tools = [getattr(self, name) for name in registered]
         async_tools = [(getattr(self, "a" + name), name) for name in registered]
 
-        # Only nudge the agent about edit_file when edit_file is actually
-        # available — read-only surfaces (e.g. WikiContextProvider's read
-        # sub-agent) shouldn't be told how to use a tool they don't have.
-        edit_registered = "edit" in resolved_allowed_aliases or "edit" in resolved_confirm_aliases
+        # Build instructions dynamically based on enabled tools
         toolkit_kwargs: dict = {}
-        if edit_registered:
-            toolkit_kwargs["instructions"] = (
-                "Always read_file before editing — the line-numbered output gives you "
-                "the exact substring to pass to edit_file's old_str parameter. "
-                "Do not guess file contents or pass line numbers to edit_file."
-            )
-            toolkit_kwargs["add_instructions"] = True
+        if kwargs.get("instructions") is None:
+            built = self._build_instructions(registered)
+            if built:
+                toolkit_kwargs["instructions"] = built
+                toolkit_kwargs.setdefault("add_instructions", True)
 
-        # Allow name override via kwargs (for prefixed tools in context providers)
-        toolkit_name = kwargs.pop("name", "workspace")
         super().__init__(
-            name=toolkit_name,
+            name="workspace",
             tools=sync_tools,
             async_tools=async_tools,
             requires_confirmation_tools=resolved_confirm_methods,
@@ -682,18 +768,20 @@ class Workspace(Toolkit):
             contents = file_path.read_text(encoding=encoding)
             self._read_paths.add(file_path)
             if start_line is None and end_line is None:
+                # Only suggest search_content if it's actually enabled
+                search_hint = (
+                    ", or use search_content to find specific text first" if "search_content" in self.functions else ""
+                )
                 if len(contents) > self.max_file_length:
                     return (
                         f"Error: file too long ({len(contents)} chars > {self.max_file_length}). "
-                        "Use start_line/end_line to read a chunk, "
-                        "or use search_content to find specific text first."
+                        f"Use start_line/end_line to read a chunk{search_hint}."
                     )
                 line_count = contents.count("\n") + 1
                 if line_count > self.max_file_lines:
                     return (
                         f"Error: file too long ({line_count} lines > {self.max_file_lines}). "
-                        "Use start_line/end_line to read a chunk, "
-                        "or use search_content to find specific text first."
+                        f"Use start_line/end_line to read a chunk{search_hint}."
                     )
                 return _format_with_line_numbers(contents, start_line=1)
             lines = contents.split("\n")

--- a/libs/agno/agno/tools/workspace.py
+++ b/libs/agno/agno/tools/workspace.py
@@ -41,6 +41,7 @@ from agno.utils.path_safety import safe_join_relative_path
 TEXT_EXTENSIONS = {
     # Markup and data
     ".md",
+    ".mdx",
     ".txt",
     ".csv",
     ".json",
@@ -302,7 +303,8 @@ class Workspace(Toolkit):
     | -------- | -------------------- | --------------------------------------- |
     | ``read``   | ``read_file``        | Read a file (line-numbered)             |
     | ``list``   | ``list_files``       | List a directory (recursive option)     |
-    | ``search`` | ``search_content``   | Recursive content grep                  |
+    | ``search`` | ``search_content``   | Recursive content search (substring)    |
+    | ``grep``   | ``grep_content``     | Regex search with line numbers          |
     | ``write``  | ``write_file``       | Create or overwrite a file (atomic)     |
     | ``edit``   | ``edit_file``        | Replace a substring (with ``replace_all``)|
     | ``move``   | ``move_file``        | Move or rename a file                   |
@@ -363,7 +365,7 @@ class Workspace(Toolkit):
     this session. Catches the "agent hallucinated the file's contents" bug class.
     """
 
-    READ_TOOLS: List[str] = ["read", "list", "search"]
+    READ_TOOLS: List[str] = ["read", "list", "search", "grep"]
     WRITE_TOOLS: List[str] = ["write", "edit", "move", "delete", "shell"]
     ALL_TOOLS: List[str] = READ_TOOLS + WRITE_TOOLS
 
@@ -372,6 +374,7 @@ class Workspace(Toolkit):
         "read": "read_file",
         "list": "list_files",
         "search": "search_content",
+        "grep": "grep_content",
         "write": "write_file",
         "edit": "edit_file",
         "move": "move_file",
@@ -387,6 +390,8 @@ class Workspace(Toolkit):
         require_read_before_write: bool = False,
         max_file_lines: int = 100_000,
         max_file_length: int = 10_000_000,
+        max_grep_matches: int = 500,
+        max_search_file_size: int = 500 * 1024,
         exclude_patterns: Optional[List[str]] = None,
         allow_paths: Optional[List[str]] = None,
         **kwargs,
@@ -399,6 +404,8 @@ class Workspace(Toolkit):
 
         self.max_file_lines = max_file_lines
         self.max_file_length = max_file_length
+        self.max_grep_matches = max_grep_matches
+        self.max_search_file_size = max_search_file_size
         self.require_read_before_write = require_read_before_write
         self.exclude_patterns: List[str] = _validate_exclude_patterns(exclude_patterns)
         _resolve_allow_paths(self.root, allow_paths)
@@ -435,8 +442,10 @@ class Workspace(Toolkit):
             )
             toolkit_kwargs["add_instructions"] = True
 
+        # Allow name override via kwargs (for prefixed tools in context providers)
+        toolkit_name = kwargs.pop("name", "workspace")
         super().__init__(
-            name="workspace",
+            name=toolkit_name,
             tools=sync_tools,
             async_tools=async_tools,
             requires_confirmation_tools=resolved_confirm_methods,
@@ -811,7 +820,7 @@ class Workspace(Toolkit):
 
             lower_query = query.lower()
             matches: List[dict] = []
-            max_file_size = 500 * 1024
+            max_file_size = self.max_search_file_size
             walk_done = False
 
             for dirpath, dirnames, filenames in os.walk(search_dir):
@@ -849,6 +858,115 @@ class Workspace(Toolkit):
         except Exception as e:
             log_error(f"search_content failed: {e}")
             return f"Error searching content: {e}"
+
+    def grep_content(
+        self,
+        pattern: str,
+        directory: str = ".",
+        context_lines: int = 0,
+        limit: int = 100,
+    ) -> str:
+        """Regex search with line numbers across text files in the workspace.
+
+        Matching is always case-insensitive.
+
+        :param pattern: Regex pattern to search for.
+        :param directory: Subdirectory to scope the search to (default ".").
+        :param context_lines: Lines of context before and after each match (default 0).
+        :param limit: Maximum number of matches to return (default 100, capped by max_grep_matches).
+        :return: JSON with keys ``pattern``, ``total_matches``, ``truncated``, and ``matches``
+            (list of ``{"file", "line", "text"}``).
+        """
+        try:
+            if not pattern or not pattern.strip():
+                return "Error: pattern cannot be empty"
+
+            # Clamp limit to constructor-defined max
+            limit = min(limit, self.max_grep_matches)
+
+            # 1. Compile regex (always case-insensitive)
+            try:
+                rx = re.compile(pattern, re.IGNORECASE)
+            except re.error as exc:
+                return f"Error: invalid regex pattern: {exc}"
+
+            # 2. Resolve directory
+            err, search_dir = self._resolve(directory, what="directory")
+            if err:
+                return err
+            if not search_dir.is_dir():
+                return f"Error: not a directory: {directory}"
+
+            max_file_size = self.max_search_file_size
+            matches: List[dict] = []
+            total_matches = 0
+
+            # 3. Walk the directory tree
+            for dirpath, dirnames, filenames in os.walk(search_dir):
+                if total_matches >= limit:
+                    break
+                # Prune excluded directories
+                dirnames[:] = [name for name in dirnames if not self._is_excluded(Path(dirpath) / name)]
+
+                for filename in filenames:
+                    if total_matches >= limit:
+                        break
+                    file_path = Path(dirpath) / filename
+
+                    # Skip hidden/excluded files
+                    if self._hidden(file_path):
+                        continue
+                    if file_path.suffix.lower() not in TEXT_EXTENSIONS:
+                        continue
+                    try:
+                        if file_path.stat().st_size > max_file_size:
+                            continue
+                    except OSError:
+                        continue
+
+                    # Read and search
+                    try:
+                        content = file_path.read_text(encoding="utf-8", errors="ignore")
+                    except Exception:
+                        continue
+
+                    file_lines = content.splitlines()
+                    hits = [idx for idx, line in enumerate(file_lines) if rx.search(line)]
+
+                    if not hits:
+                        continue
+
+                    rel_path = file_path.relative_to(self.root).as_posix()
+
+                    # Collect matches with context
+                    shown: Set[int] = set()
+
+                    for hit in hits:
+                        if total_matches >= limit:
+                            break
+                        # Calculate context range
+                        start = max(0, hit - context_lines)
+                        end = min(len(file_lines), hit + context_lines + 1)
+
+                        for j in range(start, end):
+                            if j not in shown:
+                                shown.add(j)
+                                matches.append({"file": rel_path, "line": j + 1, "text": file_lines[j]})
+
+                        total_matches += 1
+
+            # 4. Format output as JSON
+            result = {
+                "pattern": pattern,
+                "total_matches": total_matches,
+                "truncated": total_matches >= limit,
+                "matches": matches,
+            }
+            return json.dumps(result, indent=2)
+
+        except Exception as e:
+            log_error(f"grep_content failed: {e}")
+            return f"Error in grep: {e}"
 
     # ------------------------------------------------------------------
     # Write operations (require confirmation by default)
@@ -1075,6 +1193,16 @@ class Workspace(Toolkit):
     async def asearch_content(self, query: str, directory: str = ".", limit: int = 10) -> str:
         """Async variant of ``search_content``."""
         return await asyncio.to_thread(self.search_content, query, directory, limit)
+
+    async def agrep_content(
+        self,
+        pattern: str,
+        directory: str = ".",
+        context_lines: int = 0,
+        limit: int = 100,
+    ) -> str:
+        """Async variant of ``grep_content``."""
+        return await asyncio.to_thread(self.grep_content, pattern, directory, context_lines, limit)
 
     async def awrite_file(self, path: str, content: str, overwrite: bool = True, encoding: str = "utf-8") -> str:
         """Async variant of ``write_file``."""

--- a/libs/agno/tests/unit/context/test_providers.py
+++ b/libs/agno/tests/unit/context/test_providers.py
@@ -112,7 +112,7 @@ def test_workspace_default_surface_is_single_query_tool(tmp_path: Path):
 def test_workspace_tools_mode_is_read_only(tmp_path: Path):
     p = WorkspaceContextProvider(root=tmp_path, mode=ContextMode.tools)
     workspace = p.get_tools()[0]
-    assert sorted(workspace.functions.keys()) == ["list_files", "read_file", "search_content"]
+    assert sorted(workspace.functions.keys()) == ["grep_content", "list_files", "read_file", "search_content"]
 
 
 def test_workspace_context_excludes_agent_scratch_and_plural_venvs(tmp_path: Path):

--- a/libs/agno/tests/unit/context/test_wiki_provider.py
+++ b/libs/agno/tests/unit/context/test_wiki_provider.py
@@ -245,7 +245,7 @@ def test_provider_tools_mode_is_read_only(tmp_path: Path):
     p = WikiContextProvider(backend=FileSystemBackend(path=tmp_path), mode=ContextMode.tools)
     workspace = p.get_tools()[0]
     # Only the read aliases should be registered — no write/edit/delete.
-    assert sorted(workspace.functions.keys()) == ["list_files", "read_file", "search_content"]
+    assert sorted(workspace.functions.keys()) == ["grep_content", "list_files", "read_file", "search_content"]
 
 
 def test_provider_tools_mode_instructions_call_out_read_only(tmp_path: Path):

--- a/libs/agno/tests/unit/tools/test_workspace.py
+++ b/libs/agno/tests/unit/tools/test_workspace.py
@@ -13,13 +13,14 @@ ALL_METHODS = [
     "read_file",
     "list_files",
     "search_content",
+    "grep_content",
     "write_file",
     "edit_file",
     "move_file",
     "delete_file",
     "run_command",
 ]
-READ_METHODS = ["read_file", "list_files", "search_content"]
+READ_METHODS = ["read_file", "list_files", "search_content", "grep_content"]
 WRITE_METHODS = ["write_file", "edit_file", "move_file", "delete_file", "run_command"]
 
 
@@ -474,6 +475,157 @@ def test_search_content_empty_query():
     with tempfile.TemporaryDirectory() as tmp_dir:
         ws = Workspace(tmp_dir)
         assert ws.search_content(query="").startswith("Error")
+
+
+# ------------------------------------------------------------------
+# grep_content (regex with line numbers, JSON output)
+# ------------------------------------------------------------------
+
+
+def test_grep_content_basic():
+    """grep_content returns JSON with matches."""
+    import json
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ws = Workspace(tmp_dir)
+        base = Path(tmp_dir)
+        (base / "code.py").write_text("def foo():\n    pass\n\ndef bar():\n    return 1")
+
+        result = json.loads(ws.grep_content(pattern="def "))
+        assert result["pattern"] == "def "
+        assert result["total_matches"] == 2
+        files = [m["file"] for m in result["matches"]]
+        lines = [m["line"] for m in result["matches"]]
+        assert "code.py" in files[0]
+        assert 1 in lines
+        assert 4 in lines
+
+
+def test_grep_content_regex():
+    """grep_content supports regex patterns."""
+    import json
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ws = Workspace(tmp_dir)
+        base = Path(tmp_dir)
+        (base / "code.py").write_text("async def run():\n    pass\ndef sync_run():\n    pass")
+
+        result = json.loads(ws.grep_content(pattern=r"async\s+def"))
+        assert result["total_matches"] == 1
+        assert result["matches"][0]["line"] == 1
+        assert "async def run" in result["matches"][0]["text"]
+
+
+def test_grep_content_case_insensitive():
+    """grep_content is always case-insensitive."""
+    import json
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ws = Workspace(tmp_dir)
+        base = Path(tmp_dir)
+        (base / "doc.md").write_text("TODO: fix this\nTodo: later\ntodo: now")
+
+        result = json.loads(ws.grep_content(pattern="TODO"))
+        assert result["total_matches"] == 3
+
+
+def test_grep_content_context_lines():
+    """grep_content context_lines shows surrounding lines."""
+    import json
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ws = Workspace(tmp_dir)
+        base = Path(tmp_dir)
+        (base / "code.py").write_text("# header\ndef target():\n    pass\n# footer")
+
+        result = json.loads(ws.grep_content(pattern="def target", context_lines=1))
+        lines = [m["line"] for m in result["matches"]]
+        assert 1 in lines  # header (context)
+        assert 2 in lines  # target (match)
+        assert 3 in lines  # pass (context)
+
+
+def test_grep_content_respects_limit():
+    """grep_content respects the limit parameter."""
+    import json
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ws = Workspace(tmp_dir)
+        base = Path(tmp_dir)
+        (base / "code.py").write_text("\n".join(f"line{i}" for i in range(100)))
+
+        result = json.loads(ws.grep_content(pattern="line", limit=5))
+        assert result["total_matches"] == 5
+        assert result["truncated"] is True
+
+
+def test_grep_content_max_grep_matches_clamps_limit():
+    """grep_content clamps limit to max_grep_matches from constructor."""
+    import json
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        # Constructor sets max_grep_matches=10, LLM requests limit=50
+        ws = Workspace(tmp_dir, max_grep_matches=10)
+        base = Path(tmp_dir)
+        (base / "code.py").write_text("\n".join(f"match{i}" for i in range(100)))
+
+        # Even though limit=50 is requested, max_grep_matches=10 wins
+        result = json.loads(ws.grep_content(pattern="match", limit=50))
+        assert result["total_matches"] == 10
+        assert result["truncated"] is True
+
+
+def test_grep_content_invalid_regex():
+    """grep_content returns error for invalid regex."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ws = Workspace(tmp_dir)
+        result = ws.grep_content(pattern="[invalid")
+        assert result.startswith("Error: invalid regex")
+
+
+def test_grep_content_no_matches():
+    """grep_content returns empty matches when no matches."""
+    import json
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ws = Workspace(tmp_dir)
+        base = Path(tmp_dir)
+        (base / "file.py").write_text("nothing here")
+
+        result = json.loads(ws.grep_content(pattern="NOTFOUND"))
+        assert result["total_matches"] == 0
+        assert result["matches"] == []
+
+
+def test_grep_content_skips_excluded():
+    """grep_content skips excluded directories."""
+    import json
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ws = Workspace(tmp_dir)
+        base = Path(tmp_dir)
+        (base / "real.py").write_text("def real(): pass")
+        (base / ".venv").mkdir()
+        (base / ".venv" / "hidden.py").write_text("def hidden(): pass")
+
+        result = json.loads(ws.grep_content(pattern="def "))
+        files = [m["file"] for m in result["matches"]]
+        assert any("real.py" in f for f in files)
+        assert not any(".venv" in f for f in files)
+
+
+def test_agrep_content_async():
+    """agrep_content async variant works."""
+    import json
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ws = Workspace(tmp_dir)
+        base = Path(tmp_dir)
+        (base / "code.py").write_text("def foo(): pass")
+
+        result = json.loads(asyncio.run(ws.agrep_content(pattern="def ")))
+        assert result["total_matches"] == 1
+        assert result["matches"][0]["file"] == "code.py"
 
 
 # ------------------------------------------------------------------

--- a/libs/agno/tests/unit/tools/test_workspace.py
+++ b/libs/agno/tests/unit/tools/test_workspace.py
@@ -122,24 +122,31 @@ def test_custom_partition_works():
         assert ws.functions["delete_file"].requires_confirmation is True
 
 
-def test_edit_instruction_only_added_when_edit_registered():
-    """The 'always read_file before editing' nudge is gated on edit_file actually being available."""
+def test_instructions_built_dynamically_from_enabled_tools():
+    """Instructions are built dynamically based on which tools are enabled."""
     with tempfile.TemporaryDirectory() as tmp_dir:
+        # Read-only tools get instructions about read/search/grep workflow
         read_only = Workspace(tmp_dir, allowed=Workspace.READ_TOOLS, confirm=[])
         assert "edit_file" not in read_only.functions
-        assert read_only.instructions is None
-        assert read_only.add_instructions is False
+        assert read_only.instructions is not None
+        assert "read_file" in read_only.instructions
+        assert "search_content" in read_only.instructions
+        assert "grep_content" in read_only.instructions
+        assert "edit_file" not in read_only.instructions
+        assert read_only.add_instructions is True
 
+        # With edit, instructions include edit guidance
         with_edit_allowed = Workspace(tmp_dir, allowed=["read", "edit"], confirm=[])
         assert "edit_file" in with_edit_allowed.functions
         assert with_edit_allowed.instructions is not None
         assert "edit_file" in with_edit_allowed.instructions
+        assert "Always read_file first" in with_edit_allowed.instructions
         assert with_edit_allowed.add_instructions is True
 
-        with_edit_confirm = Workspace(tmp_dir, allowed=["read"], confirm=["edit"])
-        assert "edit_file" in with_edit_confirm.functions
-        assert with_edit_confirm.instructions is not None
-        assert with_edit_confirm.add_instructions is True
+        # Single tool = no instructions (no routing needed)
+        single_tool = Workspace(tmp_dir, allowed=["read"], confirm=[])
+        assert single_tool.instructions is None
+        assert single_tool.add_instructions is False
 
 
 def test_root_kwarg_is_optional_positional():


### PR DESCRIPTION
## Summary

Adds `grep_content` to the Workspace toolkit for regex-based file search with line numbers and context. Also fixes instruction hierarchy bugs in WorkspaceContextProvider.

### Changes

**New tool: `grep_content`**
- Regex search across files with line numbers
- Configurable context lines (before/after matches)
- Respects exclude patterns and allow_paths
- Useful for code navigation and refactoring workflows

**Instruction hierarchy fixes**
- Add `_build_instructions()` to Workspace toolkit (follows Slack pattern)
- Instructions dynamically reference only enabled tools
- Fix broken `_toolkit_prefix_kwargs()` call in provider
- Remove false prefix claims in `instructions()` 
- Add `_query_tool()` override with helpful description

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Formatted and validated (`./scripts/format.sh`, `./scripts/validate.sh`)
- [x] Tests added/updated (249 workspace tests pass)
- [x] Cookbook example added (`cookbook/91_tools/workspace_tools/grep_content.py`)
