### PR TITLE
fix: reject duplicate caller-supplied run_id on AgentOS run creation

### DIFF
--- a/libs/agno/agno/os/middleware/user_scope.py
+++ b/libs/agno/agno/os/middleware/user_scope.py
@@ -475,6 +475,43 @@ async def assert_session_writable(
     raise HTTPException(status_code=404, detail=SESSION_NOT_FOUND)
 
 
+async def assert_run_id_available(
+    db: Union["BaseDb", "AsyncBaseDb", "RemoteDb", None],
+    run_id: Optional[str],
+) -> None:
+    """Raise 409 if a caller-supplied ``run_id`` already exists in storage.
+
+    The create-run routes forward undeclared form fields into the run methods, which
+    honor a caller-provided ``run_id`` (``run_id or str(uuid4())``), and ``upsert_run``
+    applies ``ON CONFLICT (run_id) DO UPDATE`` with no ownership predicate. Without this
+    check, a caller can point a new run at an existing run_id and silently overwrite
+    that run's row — including a row owned by another session and user.
+
+    A caller-supplied run_id is legitimate (pre-allocating an id for tracking or
+    cancellation; idempotent retries after a network failure), so the id is not
+    stripped — only collisions are refused. 409 is the honest answer for a create
+    collision: a retrying client learns the earlier request succeeded and can fetch
+    the existing run.
+
+    Best-effort, mirroring assert_session_writable: allowed when there is no db, no
+    run_id, or a RemoteDb (the downstream AgentOS enforces its own). Adapters not yet
+    ported to v3 run storage return None from get_run and are treated as available.
+    The probe cannot close the TOCTOU race between two concurrent creations sharing a
+    fresh run_id; that requires a strict insert at the storage layer.
+    """
+    if db is None or not run_id:
+        return
+    if isinstance(db, RemoteDb):
+        return
+    if isinstance(db, AsyncBaseDb):
+        existing = await db.get_run(run_id)
+    else:
+        existing = db.get_run(run_id)
+    if existing is not None:
+        log_warning(f"user_scope: refused a create-run with run_id={run_id!r}: a run with that id already exists.")
+        raise HTTPException(status_code=409, detail="A run with this run_id already exists")
+
+
 async def verify_run_in_session(
     entity,
     session_id: str,

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -54,6 +54,7 @@ from agno.os.job_queue import (
 )
 from agno.os.middleware.user_scope import (
     SESSION_ID_REQUIRED,
+    assert_run_id_available,
     assert_session_matches_component,
     assert_session_writable,
     caller_is_admin,
@@ -746,6 +747,11 @@ def get_agent_router(
             session_type=SessionType.AGENT,
             is_admin=caller_is_admin(request),
         )
+
+        # A caller-supplied run_id is honored (pre-allocation, idempotent retry) but must
+        # not collide: upsert_run overwrites ON CONFLICT with no ownership predicate, so
+        # an existing id would silently destroy that run's row.
+        await assert_run_id_available(getattr(agent, "db", None) or os.db, kwargs.get("run_id"))
 
         if session_id is None or session_id == "":
             log_debug("Creating new session")

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -50,6 +50,7 @@ from agno.os.job_queue import (
 )
 from agno.os.middleware.user_scope import (
     SESSION_ID_REQUIRED,
+    assert_run_id_available,
     assert_session_matches_component,
     assert_session_writable,
     caller_is_admin,
@@ -717,6 +718,11 @@ def get_team_router(
             session_type=SessionType.TEAM,
             is_admin=caller_is_admin(request),
         )
+
+        # A caller-supplied run_id is honored (pre-allocation, idempotent retry) but must
+        # not collide: upsert_run overwrites ON CONFLICT with no ownership predicate, so
+        # an existing id would silently destroy that run's row.
+        await assert_run_id_available(getattr(team, "db", None) or os.db, kwargs.get("run_id"))
 
         if session_id is not None and session_id != "":
             logger.debug(f"Continuing session: {session_id}")

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -52,6 +52,7 @@ from agno.os.middleware.user_scope import (
     SESSION_ID_REQUIRED,
     SESSION_ID_REQUIRED_RECONNECT,
     WORKFLOW_ID_REQUIRED_RECONNECT,
+    assert_run_id_available,
     assert_session_matches_component,
     assert_session_writable,
     caller_is_admin,
@@ -1728,6 +1729,11 @@ def get_workflow_router(
             session_type=SessionType.WORKFLOW,
             is_admin=caller_is_admin(request),
         )
+
+        # A caller-supplied run_id is honored (pre-allocation, idempotent retry) but must
+        # not collide: upsert_run overwrites ON CONFLICT with no ownership predicate, so
+        # an existing id would silently destroy that run's row.
+        await assert_run_id_available(getattr(workflow, "db", None) or os.db, kwargs.get("run_id"))
 
         if session_id:
             logger.debug(f"Continuing session: {session_id}")

--- a/libs/agno/tests/unit/os/test_user_scope_helpers.py
+++ b/libs/agno/tests/unit/os/test_user_scope_helpers.py
@@ -17,6 +17,7 @@ from agno.db.schemas.scheduler import SCHEDULE_OWNER_HEADER
 from agno.os.auth import INTERNAL_SCHEDULER_USER_ID
 from agno.os.middleware.user_scope import (
     apply_scope_to_kwargs,
+    assert_run_id_available,
     assert_session_writable,
     enforce_owner_on_entity,
     get_scoped_user_id,
@@ -595,3 +596,59 @@ class TestAssertSessionWritable:
         db = MagicMock(spec=RemoteDb)
         await assert_session_writable(db, "s1", "user-a")
         db.get_session.assert_not_called()
+
+
+class TestAssertRunIdAvailable:
+    """Pins the create-run collision check: a caller-supplied run_id may not exist already."""
+
+    def _db(self, run):
+        db = MagicMock()
+        db.get_run = MagicMock(return_value=run)
+        return db
+
+    @pytest.mark.asyncio
+    async def test_fresh_run_id_is_allowed(self):
+        db = self._db(None)
+        await assert_run_id_available(db, "new-run-id")
+
+    @pytest.mark.asyncio
+    async def test_existing_run_id_raises_409(self):
+        db = self._db({"run_id": "taken"})
+        with pytest.raises(HTTPException) as exc:
+            await assert_run_id_available(db, "taken")
+        assert exc.value.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_existing_run_id_never_raises_404(self):
+        # A create collision is a conflict, not a missing resource.
+        db = self._db({"run_id": "taken"})
+        with pytest.raises(HTTPException) as exc:
+            await assert_run_id_available(db, "taken")
+        assert exc.value.status_code != 404
+
+    @pytest.mark.asyncio
+    async def test_no_db_is_allowed(self):
+        await assert_run_id_available(None, "any-run-id")
+
+    @pytest.mark.asyncio
+    async def test_blank_run_id_is_allowed(self):
+        db = self._db({"run_id": "taken"})
+        await assert_run_id_available(db, "")
+        await assert_run_id_available(db, None)
+        db.get_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_async_db_is_awaited(self):
+        db = MagicMock(spec=AsyncBaseDb)
+        db.get_run = AsyncMock(return_value={"run_id": "taken"})
+        with pytest.raises(HTTPException) as exc:
+            await assert_run_id_available(db, "taken")
+        assert exc.value.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_remote_db_is_skipped(self):
+        from agno.remote.base import RemoteDb
+
+        # RemoteDb exposes no get_run; reaching it would raise AttributeError.
+        db = MagicMock(spec=RemoteDb)
+        await assert_run_id_available(db, "any-run-id")


### PR DESCRIPTION
## Summary

The create-run endpoints (`POST /agents/{agent_id}/runs`, `POST /teams/{team_id}/runs`, `POST /workflows/{workflow_id}/runs`) forward undeclared form fields into the run methods, which honor a caller-provided `run_id` (`run_id or str(uuid4())`). `upsert_run()` then applies `ON CONFLICT (run_id) DO UPDATE` with no ownership predicate, so a caller could point a new run at an existing `run_id` and **silently overwrite that run's row** — including rows owned by other sessions and users.

A caller-supplied `run_id` is legitimate (pre-allocating an id for tracking/cancellation, idempotent retries), so this PR does not strip it. Instead, mirroring the existing `assert_session_writable` precedent for caller-supplied `session_id`, the three create routers now probe the target db before dispatching and answer **409 Conflict** when the id is already taken — so an idempotent retry learns its earlier request succeeded instead of destroying it.

Issue: #9884

### Changes

- `os/middleware/user_scope.py`: new `assert_run_id_available(db, run_id)` helper, best-effort in the same style as `assert_session_writable` (skipped with no db / no run_id / `RemoteDb`; adapters not yet on v3 run storage return `None` from `get_run` and are treated as available).
- `os/routers/{agents,teams,workflows}/router.py`: call it right after the `assert_session_writable` guard, using the same `getattr(component, "db", None) or os.db` resolution.
- `tests/unit/os/test_user_scope_helpers.py`: `TestAssertRunIdAvailable` (7 tests: fresh id allowed, taken id → 409 and never 404, no db / blank id skipped, async db awaited, RemoteDb skipped).

### Known limitation (documented in the docstring)

The probe cannot close the TOCTOU race between two concurrent creations sharing a fresh `run_id`; that requires a strict insert at the storage layer, suggested in the issue as a defense-in-depth follow-up.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach

---

## Additional Notes

- `./scripts/validate.sh`: ruff clean; mypy reports one error in `libs/agno/agno/db/in_memory/in_memory_db.py:401` that already exists on `main` without this change (verified via stash) — untouched here to keep the PR single-purpose.
- `pytest libs/agno/tests/unit/os/`: identical failure count vs. clean `main` (70 failed / 49 errors, all pre-existing — missing optional interface deps like `a2a`/`slack_sdk`/`telebot` and unrelated schedule/stream fixtures); this change adds 7 passing tests and introduces no regressions.
