### PR TITLE
[fix] Resolve Gemini image MIME type instead of hard-coding image/jpeg

### DIFF
--- a/libs/agno/agno/utils/gemini.py
+++ b/libs/agno/agno/utils/gemini.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 
 from agno.media import Image
 from agno.utils.log import log_error, log_warning
+from agno.utils.media import resolve_image_mime_type
 
 try:
     from google.genai.types import (
@@ -162,7 +163,11 @@ def format_image_for_message(image: Image) -> Optional[Dict[str, Any]]:
                 import base64
 
                 image_data = {
-                    "mime_type": "image/jpeg",
+                    "mime_type": resolve_image_mime_type(
+                        mime_type=image.mime_type,
+                        image_format=image.format,
+                        image_bytes=content_bytes,
+                    ),
                     "data": base64.b64encode(content_bytes).decode("utf-8"),
                 }
                 return image_data
@@ -184,7 +189,12 @@ def format_image_for_message(image: Image) -> Optional[Dict[str, Any]]:
                 log_error(f"Image file {image_path} does not exist.")
                 raise
             return {
-                "mime_type": "image/jpeg",
+                "mime_type": resolve_image_mime_type(
+                    mime_type=image.mime_type,
+                    image_format=image.format,
+                    file_path=image_path,
+                    image_bytes=content_bytes,
+                ),
                 "data": content_bytes,
             }
         except Exception as e:
@@ -196,7 +206,14 @@ def format_image_for_message(image: Image) -> Optional[Dict[str, Any]]:
     elif image.content is not None and isinstance(image.content, bytes):
         import base64
 
-        image_data = {"mime_type": "image/jpeg", "data": base64.b64encode(image.content).decode("utf-8")}
+        image_data = {
+            "mime_type": resolve_image_mime_type(
+                mime_type=image.mime_type,
+                image_format=image.format,
+                image_bytes=image.content,
+            ),
+            "data": base64.b64encode(image.content).decode("utf-8"),
+        }
         return image_data
     else:
         log_warning(f"Unknown image type: {type(image)}")

--- a/libs/agno/tests/unit/models/google/test_gemini.py
+++ b/libs/agno/tests/unit/models/google/test_gemini.py
@@ -296,7 +296,7 @@ def test_format_messages_nests_tool_result_media_in_function_response():
     assert function_response.response == {"result": "Document prepared"}
     assert function_response.parts is not None
     assert [part.inline_data.mime_type for part in function_response.parts if part.inline_data] == [
-        "image/jpeg",
+        "image/png",
         "application/pdf",
     ]
 

--- a/libs/agno/tests/unit/utils/test_gemini.py
+++ b/libs/agno/tests/unit/utils/test_gemini.py
@@ -1,6 +1,11 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from agno.media import Image
 from agno.utils.gemini import (
     convert_schema,
     format_function_definitions,
+    format_image_for_message,
     inject_agno_client_header,
     needs_conversion,
     prepare_response_schema,
@@ -738,3 +743,64 @@ def test_inject_header_overrides_existing_x_goog_api_client():
     params = {"http_options": {"headers": {"x-goog-api-client": "stale/0.0.0"}}}
     result = inject_agno_client_header(params)
     assert result["http_options"]["headers"]["x-goog-api-client"] == f"agno/{agno_version}"
+
+
+# Magic-byte headers, so the helper can identify the format from the bytes alone.
+WEBP_BYTES = b"RIFF" + (100).to_bytes(4, "little") + b"WEBPVP8 " + b"\x00" * 88
+PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+JPEG_BYTES = b"\xff\xd8\xff" + b"\x00" * 32
+
+
+def test_format_image_for_message_url_uses_downloaded_bytes_format():
+    """A URL serving WebP must not be labelled image/jpeg."""
+    with patch.object(Image, "get_content_bytes", return_value=WEBP_BYTES):
+        result = format_image_for_message(Image(url="https://example.com/photo.webp"))
+
+    assert result is not None
+    assert result["mime_type"] == "image/webp"
+
+
+def test_format_image_for_message_content_uses_detected_format():
+    result = format_image_for_message(Image(content=WEBP_BYTES))
+
+    assert result is not None
+    assert result["mime_type"] == "image/webp"
+
+
+def test_format_image_for_message_filepath_uses_file_extension(tmp_path: Path):
+    image_path = tmp_path / "photo.png"
+    image_path.write_bytes(PNG_BYTES)
+
+    result = format_image_for_message(Image(filepath=str(image_path)))
+
+    assert result is not None
+    assert result["mime_type"] == "image/png"
+
+
+def test_format_image_for_message_prefers_explicit_mime_type():
+    result = format_image_for_message(Image(content=WEBP_BYTES, mime_type="image/webp"))
+
+    assert result is not None
+    assert result["mime_type"] == "image/webp"
+
+
+def test_format_image_for_message_uses_format_field():
+    result = format_image_for_message(Image(content=WEBP_BYTES, format="webp"))
+
+    assert result is not None
+    assert result["mime_type"] == "image/webp"
+
+
+def test_format_image_for_message_keeps_jpeg_for_jpeg_bytes():
+    result = format_image_for_message(Image(content=JPEG_BYTES))
+
+    assert result is not None
+    assert result["mime_type"] == "image/jpeg"
+
+
+def test_format_image_for_message_falls_back_to_jpeg_for_unknown_bytes():
+    """Unidentifiable bytes keep the previous default so existing behaviour is unchanged."""
+    result = format_image_for_message(Image(content=b"not-an-image"))
+
+    assert result is not None
+    assert result["mime_type"] == "image/jpeg"


### PR DESCRIPTION
## Summary

Gemini image inputs were always labelled `image/jpeg`, regardless of the actual image format. `format_image_for_message()` in `libs/agno/agno/utils/gemini.py` hard-coded `"mime_type": "image/jpeg"` in all three branches (URL, filepath, raw bytes), so a PNG/WebP/GIF/HEIC image was sent to the Gemini API declared as a JPEG. This can cause the API to reject or misinterpret the image, and it silently discards an explicitly supplied `Image.mime_type`.

This PR replaces the three hard-coded values with the existing helper `agno.utils.media.resolve_image_mime_type()`, which is already used elsewhere in the codebase and resolves in the documented priority order: explicit `mime_type` > `format` field > file extension > magic bytes > `image/jpeg` fallback. Behaviour for real JPEGs is unchanged, and the fallback keeps the previous value when nothing can be determined, so this is not a breaking change.

Issue number: #9885

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Changes

- `libs/agno/agno/utils/gemini.py`
  - URL branch: resolve from the **downloaded bytes** (`image_bytes=content_bytes`) plus any explicit `mime_type`/`format`. The URL extension is deliberately *not* used here — the downloaded bytes are authoritative, and a `.jpg` URL that actually serves WebP is precisely the case this issue is about.
  - Filepath branch: resolve from explicit `mime_type`/`format`, then the file extension, then the file's magic bytes.
  - Raw-bytes branch: resolve from explicit `mime_type`/`format`, then magic bytes.
- `libs/agno/tests/unit/utils/test_gemini.py`: 7 new regression tests covering URL/bytes/filepath resolution, explicit `mime_type` precedence, the `format` field, JPEG stability, and the unknown-bytes fallback.
- `libs/agno/tests/unit/models/google/test_gemini.py`: **one existing expectation changed.** `test_format_messages_nests_tool_result_media_in_function_response` builds `Image(content=b"image-bytes", mime_type="image/png")` but asserted `"image/jpeg"` — i.e. the assertion encoded the bug being fixed here. It now asserts `"image/png"`, matching the image the fixture declares. Flagging this explicitly since changing an existing assertion deserves a maintainer's eye.

## Testing

Commands actually run, in a clean `uv` venv with `uv pip install -e libs/agno`:

- Reproduction script (no network; WebP/PNG/JPEG byte headers constructed locally) covering URL, raw bytes, filepath, explicit `mime_type`, and real JPEG.
  - Before: all 5 cases returned `image/jpeg`.
  - After: `image/webp`, `image/webp`, `image/png`, `image/webp`, `image/jpeg`.
- Sabotage check: with the fix reverted and the new tests kept, 5 of the 7 new tests fail; restoring the fix makes them pass. The tests genuinely exercise the change.
- `ruff format --check` on the changed files → already formatted.
- `ruff check` on the changed files → all checks passed.
- `mypy --config-file libs/agno/pyproject.toml libs/agno/agno/utils/gemini.py` (same config `./scripts/validate.sh` uses) → 0 errors.
- `pytest libs/agno/tests/unit/utils/` → 488 passed, 1 skipped (excluding `test_path_safety_consistency.py`, which needs the `slack_sdk` extra that is not installed in my environment).
- `pytest libs/agno/tests/unit/models/google/` → 185 passed.

I did **not** run the entire `libs/agno/tests/unit` suite: it aborts during collection on modules requiring optional vectordb/workflow extras that I could not install here. Stating this rather than claiming a green full suite. CI will cover the rest.

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (ruff format/check and mypy with the repo's `pyproject.toml` config, as `./scripts/validate.sh` does)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings) — no public API or docstring change; behaviour is documented by the tests
- [ ] Examples and guides: not applicable, no example changes needed
- [x] Tested in clean environment (fresh `uv` venv, editable install)
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

**Related open PR.** #9827 ("fix(media): standardize MIME normalization…") touches `agno/utils/media.py`. It does not modify `agno/utils/gemini.py`, so it does not fix this issue — the Gemini helper never called into the resolver at all. This PR is the call-site fix and builds on the helper that #9827 refines, so the two are complementary rather than competing. If #9827 lands first I'm happy to rebase.

**AI disclosure.** This PR was generated by an AI agent (Claude), per the CONTRIBUTING requirement to disclose. Everything reported under "Testing" was actually executed and the output observed; nothing is assumed. Please review with the scrutiny that warrants, particularly the changed assertion in `test_format_messages_nests_tool_result_media_in_function_response`. If you'd prefer this issue be handled by a human contributor, close it and I won't reopen.

Fixes #9885
