### PR TITLE
chore: Release v3.0.5

### DIFF
--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agno"
-version = "3.0.4"
+version = "3.0.5"
 description = "The programming language for agentic software."
 requires-python = ">=3.9,<4"
 readme = "README.md"


### PR DESCRIPTION
# Changelog

## **Breaking Changes**

- **Embedding failures are surfaced, not masked.** Ingestion now reports embedding failures instead of returning success. Content that previously showed `completed` may now show `failed` or `partial` — those ingests were always incomplete, they were only *reported* as successful. The `ContentStatus` enum in the API (`/openapi.json`) gains `partial`, changing from `["processing","completed","failed"]` to `["processing","completed","partial","failed"]`. No schema migration is required (the status column is already `varchar`).
- **Embedders raise `EmbeddingError` instead of returning an empty vector on failure.** Calling a vector DB's `search()` directly now raises where it previously returned `[]`; `Knowledge.search()` is unaffected and still returns no results.
- **AWS Bedrock embedding failures raise `EmbeddingError`, not `ModelProviderError`.** Existing `except ModelProviderError` handlers around Bedrock embedding will stop catching — switch to `except EmbeddingError`.
- **`GET /knowledge/content/{id}/status` returns 404 for missing/non-owned content** instead of 200 with `status: "failed"`.
- **`skip_if_exists=True` no longer skips content recorded as `failed` or `partial`,** so incomplete content is re-embedded rather than silently marked complete.

## **New Features**

- **`partial` content status**: new `ContentStatus.PARTIAL` for files where some chunks embedded and others did not — searchable but incomplete, so neither `completed` nor `failed`. (**#9814**)
- **Optional embedding retry during ingestion** (off by default): enable with `Knowledge(max_embedding_retries=3, embedding_retry_backoff=1.0)`. Authentication failures ignore both settings and fail on the first attempt (the same credential is rejected every time). Note: each retry re-embeds the whole document.
- **GandrTools**: new text-to-speech toolkit for the Gandr TTS API.
- **llmman model provider**: new model provider.

## **Improvements**

- **Actionable embedding failure messages**: failure messages now name the chunk count, embedder, reason and recovery step, instead of "Could not insert embedding".
- **Re-ingest no longer destroys searchable chunks**: an `embed_before_replace` guard embeds documents before deleting existing ones, so a failing re-ingest aborts before anything is removed (previously a failed re-embed could leave a document with zero chunks).
- **`MCPTools` accepts static `headers=`**: connect-time auth headers can be passed directly on the `url=` path for Streamable HTTP and SSE, without constructing `StreamableHTTPClientParams`.