### PR TITLE
[fix] avoid duplicating paused sub-team run trees

### DIFF
--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -4701,38 +4701,44 @@ async def _amember_run_for_storage(team: "Team", session: TeamSession, member_ru
 
 def _persist_member_runs_for_team_run(
     team: "Team", session: TeamSession, team_run_id: Optional[str], team_run: Optional[TeamRunOutput] = None
-) -> None:
+) -> Set[str]:
     from agno.team._session import save_run
     from agno.utils.media_offload import offload_cache_for
 
     cache = offload_cache_for(team_run) if team_run is not None else None
+    persisted_member_run_ids: Set[str] = set()
 
     for idx, member_run in _iter_member_runs_for_team_run(session, team_run_id):
         try:
             # The team owns this write, so the team's media_storage offloads the member rows too;
             # sharing the team run's cache keeps the same bytes from being uploaded twice.
-            save_run(
+            persisted = save_run(
                 team,
                 run=_media_offloaded(team, session, _member_run_for_storage(team, session, member_run), cache),
                 session_id=session.session_id,
                 user_id=session.user_id,
                 run_index=idx,
             )
+            if persisted and getattr(member_run, "run_id", None) is not None:
+                persisted_member_run_ids.add(member_run.run_id)
         except Exception as e:
             log_debug(f"Failed to persist member run {getattr(member_run, 'run_id', None)}: {e}")
+
+    return persisted_member_run_ids
 
 
 async def _apersist_member_runs_for_team_run(
     team: "Team", session: TeamSession, team_run_id: Optional[str], team_run: Optional[TeamRunOutput] = None
-) -> None:
+) -> Set[str]:
     from agno.team._session import asave_run
     from agno.utils.media_offload import offload_cache_for
 
     cache = offload_cache_for(team_run) if team_run is not None else None
+    persisted_member_run_ids: Set[str] = set()
 
     for idx, member_run in _iter_member_runs_for_team_run(session, team_run_id):
         try:
-            await asave_run(
+            persisted = await asave_run(
                 team,
                 run=await _amedia_offloaded(
                     team, session, await _amember_run_for_storage(team, session, member_run), cache
@@ -4741,8 +4747,12 @@ async def _apersist_member_runs_for_team_run(
                 user_id=session.user_id,
                 run_index=idx,
             )
+            if persisted and getattr(member_run, "run_id", None) is not None:
+                persisted_member_run_ids.add(member_run.run_id)
         except Exception as e:
             log_debug(f"Failed to persist member run {getattr(member_run, 'run_id', None)}: {e}")
+
+    return persisted_member_run_ids
 
 
 def _cleanup_and_store(
@@ -4802,23 +4812,36 @@ def _cleanup_and_store(
         else:
             session.session_data = {"session_state": run_context.session_state}
 
-    # Persist the session row and this single run (both O(1))
-    from agno.team._session import save_run
+    # Write the complete root first so child rows can satisfy their parent
+    # foreign key. This is also the fallback if a child write fails.
+    from agno.team._session import save_run, save_session
 
     team.save_session(session=session)
-    # v3: member runs are always persisted as separate rows in the runs table
-    # (source of truth for member history after reload). The store_member_responses
-    # flag only controls whether the team row ALSO carries an embedded nested
-    # copy in run_data.member_responses.
-    _persist_member_runs_for_team_run(
-        team=team, session=session, team_run_id=storage_copy.run_id, team_run=run_response
-    )
     save_run(
         team,
         run=storage_copy,
         session_id=session.session_id,
         user_id=session.user_id,
         run_index=run_index,
+    )
+
+    # v3: member runs are always persisted as separate rows in the runs table
+    # (source of truth for member history after reload). The store_member_responses
+    # flag only controls whether the team row ALSO carries an embedded nested
+    # copy in run_data.member_responses.
+    persisted_member_run_ids = _persist_member_runs_for_team_run(
+        team=team, session=session, team_run_id=storage_copy.run_id, team_run=run_response
+    )
+    # Rewrite the root only after successful child writes; unconfirmed child
+    # rows remain embedded and therefore resumable.
+    save_session(team, session=session, _persisted_member_run_ids=persisted_member_run_ids)
+    save_run(
+        team,
+        run=storage_copy,
+        session_id=session.session_id,
+        user_id=session.user_id,
+        run_index=run_index,
+        _persisted_member_run_ids=persisted_member_run_ids,
     )
 
     # Update approval run_status if this run has an associated approval.
@@ -4885,23 +4908,36 @@ async def _acleanup_and_store(
         else:
             session.session_data = {"session_state": run_context.session_state}
 
-    # Persist the session row and this single run (both O(1))
-    from agno.team._session import asave_run
+    # Write the complete root first so child rows can satisfy their parent
+    # foreign key. This is also the fallback if a child write fails.
+    from agno.team._session import asave_run, asave_session
 
     await team.asave_session(session=session)
-    # v3: member runs are always persisted as separate rows in the runs table
-    # (source of truth for member history after reload). The store_member_responses
-    # flag only controls whether the team row ALSO carries an embedded nested
-    # copy in run_data.member_responses.
-    await _apersist_member_runs_for_team_run(
-        team=team, session=session, team_run_id=storage_copy.run_id, team_run=run_response
-    )
     await asave_run(
         team,
         run=storage_copy,
         session_id=session.session_id,
         user_id=session.user_id,
         run_index=run_index,
+    )
+
+    # v3: member runs are always persisted as separate rows in the runs table
+    # (source of truth for member history after reload). The store_member_responses
+    # flag only controls whether the team row ALSO carries an embedded nested
+    # copy in run_data.member_responses.
+    persisted_member_run_ids = await _apersist_member_runs_for_team_run(
+        team=team, session=session, team_run_id=storage_copy.run_id, team_run=run_response
+    )
+    # Rewrite the root only after successful child writes; unconfirmed child
+    # rows remain embedded and therefore resumable.
+    await asave_session(team, session=session, _persisted_member_run_ids=persisted_member_run_ids)
+    await asave_run(
+        team,
+        run=storage_copy,
+        session_id=session.session_id,
+        user_id=session.user_id,
+        run_index=run_index,
+        _persisted_member_run_ids=persisted_member_run_ids,
     )
 
     # Update approval run_status if this run has an associated approval.
@@ -5028,19 +5064,32 @@ def _persist_team_run_in_session(
         else:
             session.session_data = {"session_state": run_context.session_state}
 
-    # Persist the session row and this single run (both O(1))
-    from agno.team._session import save_run
+    # Write the complete root first so child rows can satisfy their parent
+    # foreign key. This is also the fallback if a child write fails.
+    from agno.team._session import save_run, save_session
 
     team.save_session(session=session)
-    _persist_member_runs_for_team_run(
-        team=team, session=session, team_run_id=storage_copy.run_id, team_run=run_response
-    )
     save_run(
         team,
         run=storage_copy,
         session_id=session.session_id,
         user_id=session.user_id,
         run_index=run_index,
+    )
+
+    persisted_member_run_ids = _persist_member_runs_for_team_run(
+        team=team, session=session, team_run_id=storage_copy.run_id, team_run=run_response
+    )
+    # Rewrite the root only after successful child writes; unconfirmed child
+    # rows remain embedded and therefore resumable.
+    save_session(team, session=session, _persisted_member_run_ids=persisted_member_run_ids)
+    save_run(
+        team,
+        run=storage_copy,
+        session_id=session.session_id,
+        user_id=session.user_id,
+        run_index=run_index,
+        _persisted_member_run_ids=persisted_member_run_ids,
     )
 
 
@@ -5088,19 +5137,32 @@ async def _apersist_team_run_in_session(
         else:
             session.session_data = {"session_state": run_context.session_state}
 
-    # Persist the session row and this single run (both O(1))
-    from agno.team._session import asave_run
+    # Write the complete root first so child rows can satisfy their parent
+    # foreign key. This is also the fallback if a child write fails.
+    from agno.team._session import asave_run, asave_session
 
     await team.asave_session(session=session)
-    await _apersist_member_runs_for_team_run(
-        team=team, session=session, team_run_id=storage_copy.run_id, team_run=run_response
-    )
     await asave_run(
         team,
         run=storage_copy,
         session_id=session.session_id,
         user_id=session.user_id,
         run_index=run_index,
+    )
+
+    persisted_member_run_ids = await _apersist_member_runs_for_team_run(
+        team=team, session=session, team_run_id=storage_copy.run_id, team_run=run_response
+    )
+    # Rewrite the root only after successful child writes; unconfirmed child
+    # rows remain embedded and therefore resumable.
+    await asave_session(team, session=session, _persisted_member_run_ids=persisted_member_run_ids)
+    await asave_run(
+        team,
+        run=storage_copy,
+        session_id=session.session_id,
+        user_id=session.user_id,
+        run_index=run_index,
+        _persisted_member_run_ids=persisted_member_run_ids,
     )
 
 

--- a/libs/agno/agno/team/_session.py
+++ b/libs/agno/agno/team/_session.py
@@ -8,6 +8,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Set,
     Union,
     cast,
 )
@@ -300,6 +301,7 @@ def _storage_view_of_spared_run(
 def _scrub_member_responses_keeping_paused(
     team: "Team",
     run: Union[TeamRunOutput, "RunOutput"],
+    persisted_member_run_ids: Optional[Set[str]] = None,
 ) -> Union[TeamRunOutput, "RunOutput"]:
     """Return a storage view of the run with member responses removed at every
     nesting level, sparing paused ones: a paused member run is the resume
@@ -316,6 +318,20 @@ def _scrub_member_responses_keeping_paused(
 
     spared = []
     for member_response in getattr(run, "member_responses", None) or []:
+        # A successfully persisted direct sub-team row is the source of truth
+        # for its paused subtree. Do not retain the same subtree in the root
+        # row, but keep the fallback copy when the child write was not
+        # confirmed. Paused agents still need the embedded response because
+        # they are not persisted as separate team-run rows.
+        if (
+            persisted_member_run_ids is not None
+            and getattr(run, "parent_run_id", None) is None
+            and isinstance(member_response, TeamRunOutput)
+            and getattr(member_response, "is_paused", False)
+            and getattr(member_response, "parent_run_id", None) == getattr(run, "run_id", None)
+            and getattr(member_response, "run_id", None) in persisted_member_run_ids
+        ):
+            continue
         if not getattr(member_response, "is_paused", False):
             continue
         # Resolve the owner at THIS level before recursing: the response tree
@@ -326,14 +342,16 @@ def _scrub_member_responses_keeping_paused(
         member_response = _storage_view_of_spared_run(team, member_response, member=member)
         if getattr(member_response, "member_responses", None):
             owning_team = member if isinstance(member, Team) else team
-            member_response = _scrub_member_responses_keeping_paused(owning_team, member_response)
+            member_response = _scrub_member_responses_keeping_paused(
+                owning_team, member_response, persisted_member_run_ids=persisted_member_run_ids
+            )
         spared.append(member_response)
     run = copy(run)
     run.member_responses = spared  # type: ignore[union-attr]
     return run
 
 
-def save_session(team: "Team", session: TeamSession) -> None:
+def save_session(team: "Team", session: TeamSession, _persisted_member_run_ids: Optional[Set[str]] = None) -> None:
     """
     Save the TeamSession to storage
 
@@ -371,7 +389,13 @@ def save_session(team: "Team", session: TeamSession) -> None:
                 # a pending approval on a finished run for good.
                 storage_session = copy(session)
                 storage_session.runs = [
-                    _scrub_member_responses_keeping_paused(team, run) if hasattr(run, "member_responses") else run
+                    (
+                        _scrub_member_responses_keeping_paused(
+                            team, run, persisted_member_run_ids=_persisted_member_run_ids
+                        )
+                        if hasattr(run, "member_responses")
+                        else run
+                    )
                     for run in session.runs
                 ]
             else:
@@ -383,7 +407,9 @@ def save_session(team: "Team", session: TeamSession) -> None:
         log_debug(f"Created or updated TeamSession record: {session.session_id}")
 
 
-async def asave_session(team: "Team", session: TeamSession) -> None:
+async def asave_session(
+    team: "Team", session: TeamSession, _persisted_member_run_ids: Optional[Set[str]] = None
+) -> None:
     """
     Save the TeamSession to storage
 
@@ -413,7 +439,13 @@ async def asave_session(team: "Team", session: TeamSession) -> None:
                 # the scrubbed list live.
                 storage_session = copy(session)
                 storage_session.runs = [
-                    _scrub_member_responses_keeping_paused(team, run) if hasattr(run, "member_responses") else run
+                    (
+                        _scrub_member_responses_keeping_paused(
+                            team, run, persisted_member_run_ids=_persisted_member_run_ids
+                        )
+                        if hasattr(run, "member_responses")
+                        else run
+                    )
                     for run in session.runs
                 ]
             else:
@@ -435,7 +467,8 @@ def save_run(
     session_id: str,
     user_id: Optional[str] = None,
     run_index: Optional[int] = None,
-) -> None:
+    _persisted_member_run_ids: Optional[Set[str]] = None,
+) -> bool:
     """Persist a single run to the database (O(1) operation).
 
     Use this instead of save_session() when only a single run has changed.
@@ -451,11 +484,15 @@ def save_run(
         storage_run = run
         if hasattr(run, "member_responses"):
             if not team.store_member_responses:
-                storage_run = _scrub_member_responses_keeping_paused(team, run)
+                storage_run = _scrub_member_responses_keeping_paused(
+                    team, run, persisted_member_run_ids=_persisted_member_run_ids
+                )
             else:
                 _scrub_member_responses(team, run.member_responses)  # type: ignore[union-attr]
-        _upsert_run(team, run=storage_run, session_id=session_id, user_id=user_id, run_index=run_index)
+        persisted = _upsert_run(team, run=storage_run, session_id=session_id, user_id=user_id, run_index=run_index)
         log_debug(f"Saved run {getattr(run, 'run_id', '?')} to session {session_id}")
+        return persisted
+    return False
 
 
 async def asave_run(
@@ -464,7 +501,8 @@ async def asave_run(
     session_id: str,
     user_id: Optional[str] = None,
     run_index: Optional[int] = None,
-) -> None:
+    _persisted_member_run_ids: Optional[Set[str]] = None,
+) -> bool:
     """Async version of ``save_run``."""
     from agno.team._run import _scrub_member_responses
     from agno.team._storage import _aupsert_run
@@ -473,11 +511,17 @@ async def asave_run(
         storage_run = run
         if hasattr(run, "member_responses"):
             if not team.store_member_responses:
-                storage_run = _scrub_member_responses_keeping_paused(team, run)
+                storage_run = _scrub_member_responses_keeping_paused(
+                    team, run, persisted_member_run_ids=_persisted_member_run_ids
+                )
             else:
                 _scrub_member_responses(team, run.member_responses)  # type: ignore[union-attr]
-        await _aupsert_run(team, run=storage_run, session_id=session_id, user_id=user_id, run_index=run_index)
+        persisted = await _aupsert_run(
+            team, run=storage_run, session_id=session_id, user_id=user_id, run_index=run_index
+        )
         log_debug(f"Saved run {getattr(run, 'run_id', '?')} to session {session_id}")
+        return persisted
+    return False
 
 
 # ---------------------------------------------------------------------------

--- a/libs/agno/agno/team/_storage.py
+++ b/libs/agno/agno/team/_storage.py
@@ -262,26 +262,28 @@ def _upsert_run(
     session_id: str,
     user_id: Optional[str] = None,
     run_index: Optional[int] = None,
-) -> None:
+) -> bool:
     """Persist a single run to the runs storage (O(1) write).
 
     Silently no-ops on adapters that have not implemented ``upsert_run`` yet.
     """
     try:
         if not team.db:
-            return
+            return False
         from agno.run.status_persist import persist_worker_owned_run
 
         # Queue-worker-owned runs save through the attempt-fenced primitive;
         # member-run saves pass through untouched (their run_ids are never
         # registered - a zombie leg's member writes orphan, not clobber)
         if persist_worker_owned_run(team.db, run, session_id=session_id, user_id=user_id):
-            return
+            return True
         team.db.upsert_run(run=run, session_id=session_id, user_id=user_id, run_index=run_index)  # type: ignore[union-attr]
+        return True
     except NotImplementedError:
         log_debug(f"{type(team.db).__name__} does not implement upsert_run; skipping per-run write")
     except Exception as e:
         log_warning(f"Error upserting run into db: {str(e)}")
+    return False
 
 
 async def _aupsert_run(
@@ -290,27 +292,29 @@ async def _aupsert_run(
     session_id: str,
     user_id: Optional[str] = None,
     run_index: Optional[int] = None,
-) -> None:
+) -> bool:
     """Async version of ``_upsert_run``."""
     from agno.team._init import _has_async_db
 
     try:
         if not team.db:
-            return
+            return False
         from agno.run.status_persist import apersist_worker_owned_run
 
         # Queue-worker-owned runs save through the attempt-fenced primitive;
         # member-run saves pass through untouched (see _upsert_run)
         if await apersist_worker_owned_run(team.db, run, session_id=session_id, user_id=user_id):
-            return
+            return True
         if _has_async_db(team):
             await team.db.upsert_run(run=run, session_id=session_id, user_id=user_id, run_index=run_index)  # type: ignore[union-attr,misc]
         else:
             team.db.upsert_run(run=run, session_id=session_id, user_id=user_id, run_index=run_index)  # type: ignore[union-attr]
+        return True
     except NotImplementedError:
         log_debug(f"{type(team.db).__name__} does not implement upsert_run; skipping per-run write")
     except Exception as e:
         log_warning(f"Error upserting run into db: {str(e)}")
+    return False
 
 
 def _read_or_create_session(team: "Team", session_id: str, user_id: Optional[str] = None) -> TeamSession:

--- a/libs/agno/tests/unit/team/test_paused_member_persistence.py
+++ b/libs/agno/tests/unit/team/test_paused_member_persistence.py
@@ -1,7 +1,9 @@
 """
 Unit tests for paused member run persistence in team routing helpers.
 
-Regression test for: https://github.com/agno-agi/agno/issues/8925
+Regression tests for:
+- https://github.com/agno-agi/agno/issues/8925
+- https://github.com/agno-agi/agno/issues/9402
 
 When a member pauses during team.continue_run() routing, its RunOutput must be
 persisted to session.runs so subsequent continue_run calls can find it after
@@ -565,6 +567,118 @@ def test_nested_member_pause_survives_fresh_process_continue(tmp_path):
 
     team_runs = [r for r in _reload_runs(db_file, session_id) if isinstance(r, TeamRunOutput)]
     assert all(r.member_responses == [] for r in team_runs)
+
+
+def test_nested_member_pause_is_not_embedded_in_top_level_team_run(tmp_path):
+    """Persist a paused nested subtree on its direct member row only.
+
+    v3 persists member runs separately. The top-level team row must not also
+    carry the same paused member tree, otherwise each nested pause is stored
+    once per ancestor and can push run payloads toward database item limits.
+    """
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "nested_storage_shape.db")
+    session_id = "s-nested-storage-shape"
+
+    outer = _build_three_level_team(SqliteDb(db_file=db_file), resuming=False)
+    run = outer.run("Email a@example.com", session_id=session_id)
+    assert run.is_paused
+
+    stored_runs = _reload_runs(db_file, session_id)
+    root_run = next(r for r in stored_runs if r.parent_run_id is None)
+    child_run = next(r for r in stored_runs if r.parent_run_id == root_run.run_id)
+
+    assert root_run.member_responses == []
+    assert len(child_run.member_responses) == 1
+    assert len(child_run.member_responses[0].member_responses) == 1
+
+
+def test_paused_subteam_scrub_does_not_bypass_other_member_responses():
+    from agno.team._session import _scrub_member_responses_keeping_paused
+
+    paused_agent = Agent(id="paused-agent", name="Paused Agent")
+    nested_member = Agent(id="nested-member", name="Nested Member")
+    nested_team = Team(id="nested-team", name="Nested Team", members=[nested_member], telemetry=False)
+    root_team = Team(id="root-team", name="Root Team", members=[paused_agent, nested_team], telemetry=False)
+
+    root_run = TeamRunOutput(
+        run_id="root-run",
+        team_id="root-team",
+        member_responses=[
+            RunOutput(run_id="paused-agent-run", agent_id="paused-agent", status=RunStatus.paused),
+            TeamRunOutput(
+                run_id="nested-run",
+                team_id="nested-team",
+                parent_run_id="root-run",
+                status=RunStatus.paused,
+                member_responses=[
+                    RunOutput(run_id="nested-member-run", agent_id="nested-member", status=RunStatus.paused)
+                ],
+            ),
+            RunOutput(run_id="completed-agent-run", agent_id="paused-agent", status=RunStatus.completed),
+        ],
+    )
+
+    storage_view = _scrub_member_responses_keeping_paused(root_team, root_run, persisted_member_run_ids={"nested-run"})
+
+    assert [response.run_id for response in storage_view.member_responses] == ["paused-agent-run"]
+
+
+def test_failed_member_row_write_keeps_nested_fallback(tmp_path, monkeypatch):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "nested-write-failure.db")
+    session_id = "s-nested-write-failure"
+
+    db = SqliteDb(db_file=db_file)
+    original_upsert_run = db.upsert_run
+
+    def fail_nested_member_row(*args, **kwargs):
+        run = kwargs.get("run")
+        if getattr(run, "parent_run_id", None) is not None:
+            raise RuntimeError("simulated member row write failure")
+        return original_upsert_run(*args, **kwargs)
+
+    monkeypatch.setattr(db, "upsert_run", fail_nested_member_row)
+
+    outer = _build_three_level_team(db, resuming=False)
+    run = outer.run("Email a@example.com", session_id=session_id)
+    assert run.is_paused
+
+    stored_runs = _reload_runs(db_file, session_id)
+    assert len(stored_runs) == 1
+    root_run = stored_runs[0]
+    assert root_run.parent_run_id is None
+    assert len(root_run.member_responses) == 1
+    assert len(root_run.member_responses[0].member_responses) == 1
+
+
+@pytest.mark.asyncio
+async def test_failed_member_row_write_keeps_nested_fallback_async(tmp_path, monkeypatch):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "nested-write-failure-async.db")
+    session_id = "s-nested-write-failure-async"
+
+    db = SqliteDb(db_file=db_file)
+    original_upsert_run = db.upsert_run
+
+    def fail_nested_member_row(*args, **kwargs):
+        run = kwargs.get("run")
+        if getattr(run, "parent_run_id", None) is not None:
+            raise RuntimeError("simulated member row write failure")
+        return original_upsert_run(*args, **kwargs)
+
+    monkeypatch.setattr(db, "upsert_run", fail_nested_member_row)
+
+    outer = _build_three_level_team(db, resuming=False)
+    run = await outer.arun("Email a@example.com", session_id=session_id)
+    assert run.is_paused
+
+    stored_runs = _reload_runs(db_file, session_id)
+    assert len(stored_runs) == 1
+    root_run = stored_runs[0]
+    assert root_run.parent_run_id is None
+    assert len(root_run.member_responses) == 1
+    assert len(root_run.member_responses[0].member_responses) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #9402.

When store_member_responses is disabled, a paused nested sub-team was stored both in its dedicated v3 run row and recursively in the top-level team row. This change keeps the resumable subtree on the direct child row and removes the redundant ancestor copy only after the child write is confirmed. If a storage adapter reports a failed child write, the root keeps the embedded subtree as a fallback.

The existing flat paused-agent behavior, mixed-member scrubbing, sync and async paths, and checkpoint persistence remain covered.

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran ./scripts/format.sh and ./scripts/validate.sh
- [x] Self-review completed
- [x] Documentation updated through comments and docstrings
- [x] Tests added/updated
- [x] Searched open pull requests and confirmed no duplicate for #9402

### AI-Generated PR Check

AI assistance was used during implementation and review. The final scope, code paths, tests, and repository gates were manually verified.

## Additional Notes

No migration or deployment steps are required. The change is limited to the existing v3 team-run persistence flow.