### PR TITLE
fix: clean up subagent member-run mappings when a run finishes

### DIFF
--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -63,9 +63,11 @@ from agno.run.cancel import (
     acancel_run as acancel_run_global,
 )
 from agno.run.cancel import (
+    acleanup_member_runs,
     acleanup_run,
     araise_if_cancelled,
     aregister_run,
+    cleanup_member_runs,
     cleanup_run,
     raise_if_cancelled,
     register_run,
@@ -745,6 +747,7 @@ def _run(
         disconnect_connectable_tools(agent)
         # Always clean up the run tracking
         cleanup_run(run_response.run_id)  # type: ignore
+        cleanup_member_runs(run_response.run_id)  # type: ignore
 
     return run_response
 
@@ -1278,6 +1281,7 @@ def _run_stream(
         disconnect_connectable_tools(agent)
         # Always clean up the run tracking
         cleanup_run(run_response.run_id)  # type: ignore
+        cleanup_member_runs(run_response.run_id)  # type: ignore
 
 
 def run_dispatch(
@@ -1908,6 +1912,7 @@ async def _arun(
 
         # Always clean up the run tracking
         await acleanup_run(run_response.run_id)  # type: ignore
+        await acleanup_member_runs(run_response.run_id)  # type: ignore
 
     return run_response
 
@@ -1991,6 +1996,7 @@ async def _arun_background(
             except Exception as e:
                 log_error(f"Failed to persist cancelled state for background run {run_response.run_id}: {str(e)}")
             await acleanup_run(run_context.run_id)
+            await acleanup_member_runs(run_context.run_id)
         except asyncio.CancelledError:
             # Task-level shutdown (event loop stopping), not run-cancellation:
             # best-effort persist so pollers are not left with a run stuck at
@@ -2178,6 +2184,7 @@ async def _arun_background_stream(
             except Exception:
                 log_error(f"Failed to persist cancelled state for background stream run {run_id}", exc_info=True)
             await acleanup_run(run_id)
+            await acleanup_member_runs(run_id)
         except Exception:
             log_error(f"Background stream run {run_id} failed", exc_info=True)
             # Persist ERROR status — only persist the changed run (O(1))
@@ -2796,6 +2803,7 @@ async def _arun_stream(
 
         # Always clean up the run tracking
         await acleanup_run(run_response.run_id)  # type: ignore
+        await acleanup_member_runs(run_response.run_id)  # type: ignore
 
 
 def arun_dispatch(  # type: ignore
@@ -3929,6 +3937,7 @@ def _continue_run(
         disconnect_connectable_tools(agent)
         # Always clean up the run tracking
         cleanup_run(run_response.run_id)  # type: ignore
+        cleanup_member_runs(run_response.run_id)  # type: ignore
     return run_response
 
 
@@ -4240,6 +4249,7 @@ def _continue_run_stream(
         disconnect_connectable_tools(agent)
         # Always clean up the run tracking
         cleanup_run(run_response.run_id)  # type: ignore
+        cleanup_member_runs(run_response.run_id)  # type: ignore
 
 
 def acontinue_run_dispatch(  # type: ignore
@@ -4647,6 +4657,7 @@ async def _acontinue_run_background_stream(
                     f"Failed to persist cancelled state for background continue-run stream {_run_id}", exc_info=True
                 )
             await acleanup_run(_run_id)
+            await acleanup_member_runs(_run_id)
         except Exception:
             log_error(f"Background continue-run stream {_run_id} failed", exc_info=True)
             producer_terminal = RunStatus.error
@@ -5228,6 +5239,7 @@ async def _acontinue_run(
         # Always clean up the run tracking
         if run_response is not None and run_response.run_id:
             await acleanup_run(run_response.run_id)
+            await acleanup_member_runs(run_response.run_id)
     return run_response  # type: ignore
 
 
@@ -5858,6 +5870,7 @@ async def _acontinue_run_stream(
         cleanup_run_id = run_response.run_id if run_response and run_response.run_id is not None else run_id
         if cleanup_run_id is not None:
             await acleanup_run(cleanup_run_id)
+            await acleanup_member_runs(cleanup_run_id)
 
 
 # ---------------------------------------------------------------------------
@@ -6283,6 +6296,7 @@ def _persist_cancelled_run_in_background(
             # re-cancelled; clean up here too so the run is never left tracked.
             if run_response.run_id:
                 await acleanup_run(run_response.run_id)
+                await acleanup_member_runs(run_response.run_id)
         except Exception as store_err:
             log_warning(f"Failed to persist cancelled run: {store_err}")
 

--- a/libs/agno/tests/unit/agent/test_member_run_cleanup.py
+++ b/libs/agno/tests/unit/agent/test_member_run_cleanup.py
@@ -1,0 +1,83 @@
+"""Run finalization must clean up member-run mappings.
+
+spawn-style delegation registers child runs via register_member_run; without a
+cleanup_member_runs sibling at run finalization the mappings outlive the run,
+until the cancellation manager's TTL — or forever with ttl_seconds=None. These
+tests drive real run()/arun() calls with an offline model and assert the
+mappings are gone afterwards, mirroring Teams' finalization behaviour.
+"""
+
+from agno.agent.agent import Agent
+from agno.models.base import Model
+from agno.models.message import MessageMetrics
+from agno.models.response import ModelResponse
+from agno.run.cancel import (
+    aget_member_run_ids,
+    aregister_member_run,
+    get_member_run_ids,
+    register_member_run,
+)
+
+
+class _OfflineModel(Model):
+    """Minimal offline model: canned text response, no network call."""
+
+    def __init__(self):
+        super().__init__(id="test-model", name="test-model", provider="test")
+        self._response = ModelResponse(content="ok", role="assistant", response_usage=MessageMetrics())
+
+    def get_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    def get_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    def parse_args(self, *args, **kwargs):
+        return {}
+
+    def invoke(self, *args, **kwargs):
+        return self._response
+
+    async def ainvoke(self, *args, **kwargs):
+        return self._response
+
+    def invoke_stream(self, *args, **kwargs):
+        yield self._response
+
+    async def ainvoke_stream(self, *args, **kwargs):
+        yield self._response
+        return
+
+    def _parse_provider_response(self, response, **kwargs):
+        return self._response
+
+    def _parse_provider_response_delta(self, response):
+        return self._response
+
+
+def test_run_cleans_up_registered_member_runs():
+    agent = Agent(name="Parent", model=_OfflineModel())
+    run_id = "run-member-cleanup-sync"
+    register_member_run(run_id, "child-1")
+    assert get_member_run_ids(run_id) == {"child-1"}
+
+    agent.run("hi", run_id=run_id)
+
+    assert get_member_run_ids(run_id) == set()
+
+
+async def test_arun_cleans_up_registered_member_runs():
+    agent = Agent(name="Parent", model=_OfflineModel())
+    run_id = "run-member-cleanup-async"
+    await aregister_member_run(run_id, "child-1")
+    assert await aget_member_run_ids(run_id) == {"child-1"}
+
+    await agent.arun("hi", run_id=run_id)
+
+    assert await aget_member_run_ids(run_id) == set()


### PR DESCRIPTION
## Summary

Pair every `cleanup_run` with `cleanup_member_runs` in `agent/_run.py`, so member-run mappings die with the run.

- **Bug:** `spawn_agent` (#9122) registers a parent → child mapping in the cancellation manager for every spawned subagent; nothing on the Agent side ever removed them.
- **Effect:** the mappings outlive the run — until the manager's TTL, or forever with `ttl_seconds=None`.
- **Fix:** add the `cleanup_member_runs` / `acleanup_member_runs` sibling at all **12** `cleanup_run` sites (run / stream / continue / background variants), matching each site's guard, sync/async form, and run-id variable. Plus the two imports. Nothing else touched.
- **Precedent:** Teams already pair the two calls in their finalization (`team/_run.py`).
- **Scope:** a no-op on `main` today — only #9122's `spawn_agent` registers these mappings — but it is shared finalization code, so it ships separately instead of inside the feature PR. Merges cleanly before or after #9122.
- **Tests:** `tests/unit/agent/test_member_run_cleanup.py` — real `run()` / `arun()` with an offline model, mapping asserted empty after the run; verified red → green. The background/continue sites are pattern-verified (driving them end-to-end needs db/pause infra).
- **Credit:** @RayST3 identified and fixed this independently in the course of #9122; @Mustafa-Esoofally flagged it in review there.

```mermaid
flowchart LR
    S["spawn_agent<br/>(one call per child)"] -->|"register_member_run(run_id, child_id)"| M[("cancellation manager<br/>run_id → child ids")]
    F["run finalization<br/>(12 cleanup_run sites:<br/>run / stream / continue / background)"] -->|"cleanup_run(run_id)"| M
    F ==>|"cleanup_member_runs(run_id)<br/>this PR"| M
```

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

No behaviour change for plain agent runs on `main`; the cleanup becomes load-bearing the moment #9122's `spawn_agent` lands.
