### PR TITLE
feat: support background execution and reattach in the AG-UI interface

### DIFF
--- a/cookbook/05_agent_os/16_agui/README.md
+++ b/cookbook/05_agent_os/16_agui/README.md
@@ -23,6 +23,7 @@ default empty prefix those routes are `POST /agui` and `GET /status`.
 | `human_in_the_loop.py` | Pause and resume a real backend tool that uses `requires_confirmation`. |
 | `research_team.py` | Stream a coordinated Team and its member activity over AG-UI. |
 | `multiple_instances.py` | Mount two independent AG-UI interfaces on one AgentOS. |
+| `background_runs.py` | Run detached with `forwarded_props: {"background": true}` and reattach after disconnect with `{"reattach": true}`. |
 | `openui/` | Render an Agent as streaming charts, follow-ups, and validated forms with OpenUI. |
 
 ## Prerequisites
@@ -51,6 +52,7 @@ Start one example at a time; every standalone server uses port 7777:
 .venvs/demo/bin/python cookbook/05_agent_os/16_agui/human_in_the_loop.py
 .venvs/demo/bin/python cookbook/05_agent_os/16_agui/research_team.py
 .venvs/demo/bin/python cookbook/05_agent_os/16_agui/multiple_instances.py
+.venvs/demo/bin/python cookbook/05_agent_os/16_agui/background_runs.py
 ```
 
 The [`openui/`](openui/) example includes its own React client. Follow its

--- a/cookbook/05_agent_os/16_agui/README.md
+++ b/cookbook/05_agent_os/16_agui/README.md
@@ -105,6 +105,54 @@ uses `REASONING_*`; shared state uses `STATE_SNAPSHOT` and `STATE_DELTA`.
 `threadId` becomes the Agno session ID, so later requests can continue the same
 conversation.
 
+## Background runs and reattach
+
+With `forwarded_props: {"background": true}` the run executes in a detached server task: closing the SSE connection does not cancel it, and its events are buffered server-side so any client can reattach later. This powers refresh-proof chats — a user can reload the page, switch devices, or open a second tab while an answer is still generating. Background execution requires a database on the agent or team, and is not available for remote entities.
+
+The recovery contract is a single call. Whenever a thread view mounts — page load, refresh, new window, SPA reconnect — the client reattaches before loading history:
+
+```typescript
+// threadId is known from the route; runId is "" when the client never stored one
+const response = await fetch(`${AGUI_BASE}/agui`, {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    thread_id: threadId,
+    run_id: storedRunId ?? "",  // "" = server resolves the thread's active run
+    messages: [],               // reattach never appends input
+    tools: [],
+    context: [],
+    state: {},
+    forwarded_props: { reattach: true },
+  }),
+});
+
+if (response.status === 404) {
+  // No in-progress run: load history from the session API as usual.
+  await loadHistory(threadId);
+} else {
+  // 200: the stream opens with RUN_STARTED carrying the real run_id,
+  // then a MESSAGES_SNAPSHOT with everything produced so far, then live
+  // deltas (or RUN_FINISHED immediately if the run already ended).
+  await consumeStream(response.body);
+}
+```
+
+How the server answers a reattach:
+
+| Client sends | Server state | Response |
+|---|---|---|
+| `run_id` of a live run | Run active | `RUN_STARTED` → `MESSAGES_SNAPSHOT` of the missed prefix → live events |
+| `run_id` of a finished run | Buffer still holds it (1h) | `RUN_STARTED` → `MESSAGES_SNAPSHOT` → `RUN_FINISHED` |
+| `run_id` of a finished run | Buffer expired | Same, rebuilt from the stored run in the database |
+| `run_id: ""` | Thread has a PENDING/RUNNING run | Resolves it, then behaves like a named reattach |
+| `run_id: ""` | Nothing in progress | `404` — the client loads history |
+| `run_id` that never existed | — | `404`; an explicit id is never silently swapped for another run |
+
+Rendering notes: the replayed prefix arrives as one idempotent `MESSAGES_SNAPSHOT`, not append-only deltas, so a fresh page renders correctly with no special handling. On an in-place SPA reconnect, clear the run's rendered messages first and let the snapshot rebuild them. Multiple tabs may subscribe to the same run concurrently; each gets its own event copy.
+
+Operational notes: only PENDING/RUNNING runs resolve — a PAUSED run waits on human input and follows the HITL resume flow instead. Runs keep executing after disconnect, so a "stop generating" button must call `POST /agents/{agent_id}/runs/{run_id}/cancel`; closing the connection no longer stops anything. Run state lives in memory (or Redis, with the Redis event-stream backend), so after a server restart auto-resolution finds nothing and the client falls back to history, which is unaffected.
+
 ## Frontend tools and backend HITL are different
 
 These two pause patterns look similar in a UI but have different ownership:

--- a/cookbook/05_agent_os/16_agui/README.md
+++ b/cookbook/05_agent_os/16_agui/README.md
@@ -107,51 +107,43 @@ conversation.
 
 ## Background runs and reattach
 
-With `forwarded_props: {"background": true}` the run executes in a detached server task: closing the SSE connection does not cancel it, and its events are buffered server-side so any client can reattach later. This powers refresh-proof chats — a user can reload the page, switch devices, or open a second tab while an answer is still generating. Background execution requires a database on the agent or team, and is not available for remote entities.
+With `forwarded_props: {"background": true}` the run executes in a detached server task: closing the SSE connection does not cancel it, and its events are buffered server-side so any client can reattach later. This powers refresh-proof chats — a user can reload the page, switch devices, or open a second tab while an answer is still generating. Background execution requires a database on the agent or team, is not available for remote entities, and mirrors the per-request opt-in of the REST run endpoints.
 
-The recovery contract is a single call. Whenever a thread view mounts — page load, refresh, new window, SPA reconnect — the client reattaches before loading history:
+The recovery flow builds on the session APIs the frontend already calls. `GET /sessions/{session_id}` reports an `active_run` field (`run_id` + `status`) whenever the thread has a PENDING/RUNNING run whose event stream is still live, and `POST /agui/reattach` subscribes to that run's AG-UI events without starting a new run:
 
 ```typescript
-// threadId is known from the route; runId is "" when the client never stored one
-const response = await fetch(`${AGUI_BASE}/agui`, {
-  method: "POST",
-  headers: { "Content-Type": "application/json" },
-  body: JSON.stringify({
-    thread_id: threadId,
-    run_id: storedRunId ?? "",  // "" = server resolves the thread's active run
-    messages: [],               // reattach never appends input
-    tools: [],
-    context: [],
-    state: {},
-    forwarded_props: { reattach: true },
-  }),
-});
+// 1. Open the conversation — the same call that loads history also answers
+//    "is this thread still generating?"
+const session = await fetch(`${AGENTOS_BASE}/sessions/${threadId}?type=agent`).then(r => r.json());
+renderHistory(session.chat_history);
 
-if (response.status === 404) {
-  // No in-progress run: load history from the session API as usual.
-  await loadHistory(threadId);
-} else {
-  // 200: the stream opens with RUN_STARTED carrying the real run_id,
-  // then a MESSAGES_SNAPSHOT with everything produced so far, then live
-  // deltas (or RUN_FINISHED immediately if the run already ended).
+// 2. If a run is in progress, reattach to its event stream
+if (session.active_run) {
+  const response = await fetch(`${AGENTOS_BASE}/agui/reattach`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ thread_id: threadId, run_id: session.active_run.run_id }),
+  });
+  // RUN_STARTED → MESSAGES_SNAPSHOT (everything produced so far) → live deltas
+  // (or RUN_FINISHED immediately if the run already ended)
   await consumeStream(response.body);
 }
 ```
 
-How the server answers a reattach:
+`run_id` is optional on `POST /agui/reattach`: omit it and the server resolves the thread's in-progress run itself (404 when nothing is running — the client renders history alone). An explicit but unknown `run_id` also 404s; it is never silently swapped for another run. Reattach is also available in flag form on the run endpoint (`POST /agui` with `forwarded_props: {"reattach": true}` and an empty-string `run_id` as the auto-resolve sentinel, since the AG-UI protocol requires the field) for clients built on `@ag-ui/client`'s `HttpAgent`; the dedicated route is preferred for new integrations.
 
-| Client sends | Server state | Response |
-|---|---|---|
-| `run_id` of a live run | Run active | `RUN_STARTED` → `MESSAGES_SNAPSHOT` of the missed prefix → live events |
-| `run_id` of a finished run | Buffer still holds it (1h) | `RUN_STARTED` → `MESSAGES_SNAPSHOT` → `RUN_FINISHED` |
-| `run_id` of a finished run | Buffer expired | Same, rebuilt from the stored run in the database |
-| `run_id: ""` | Thread has a PENDING/RUNNING run | Resolves it, then behaves like a named reattach |
-| `run_id: ""` | Nothing in progress | `404` — the client loads history |
-| `run_id` that never existed | — | `404`; an explicit id is never silently swapped for another run |
+Server behavior on reattach:
 
-Rendering notes: the replayed prefix arrives as one idempotent `MESSAGES_SNAPSHOT`, not append-only deltas, so a fresh page renders correctly with no special handling. On an in-place SPA reconnect, clear the run's rendered messages first and let the snapshot rebuild them. Multiple tabs may subscribe to the same run concurrently; each gets its own event copy.
+| Run state | Response |
+|---|---|
+| Active (PENDING/RUNNING) | `RUN_STARTED` → `MESSAGES_SNAPSHOT` of the missed prefix → live events |
+| Finished, buffer retained (1h) | `RUN_STARTED` → `MESSAGES_SNAPSHOT` → `RUN_FINISHED` |
+| Finished, buffer expired | Same, rebuilt from the stored run in the database |
+| Errored | Prefix replay, then a terminal `RUN_ERROR` |
 
-Operational notes: only PENDING/RUNNING runs resolve — a PAUSED run waits on human input and follows the HITL resume flow instead. Runs keep executing after disconnect, so a "stop generating" button must call `POST /agents/{agent_id}/runs/{run_id}/cancel`; closing the connection no longer stops anything. Run state lives in memory (or Redis, with the Redis event-stream backend), so after a server restart auto-resolution finds nothing and the client falls back to history, which is unaffected.
+Rendering notes: history comes from `chat_history`; the in-progress run's content comes only from the reattach stream, so there is no overlap. The replayed prefix arrives as one idempotent `MESSAGES_SNAPSHOT` (AG-UI events carry no sequence numbers, so replace-semantics snapshot replay is used instead of a cursor), then live deltas continue on the same message IDs. A fresh page renders correctly with no special handling; on an in-place SPA reconnect, clear the run's rendered messages first and let the snapshot rebuild them. Multiple tabs may subscribe to the same run concurrently.
+
+Operational notes: `active_run` and auto-resolution report only PENDING/RUNNING runs whose event stream is still live — a PAUSED run waits on human input and follows the HITL resume flow, and stale RUNNING rows left by a server restart are filtered out, so the field's absence reliably means "settled history". Runs keep executing after disconnect, so a "stop generating" button must call `POST /agents/{agent_id}/runs/{run_id}/cancel`. Run state lives in memory (or Redis, with the Redis event-stream backend, which also makes reattach work across replicas).
 
 ## Frontend tools and backend HITL are different
 

--- a/cookbook/05_agent_os/16_agui/TEST_LOG.md
+++ b/cookbook/05_agent_os/16_agui/TEST_LOG.md
@@ -206,3 +206,13 @@ TypeScript compilation, and the Vite production build passed.
 - Repository-wide Ruff, agnoctl mypy, and cookbook pattern checks passed. The
   core Agno mypy step reported 27 existing errors in six files outside this
   integration's diff.
+
+### background_runs.py
+
+**Status:** PASS
+
+**Description:** Starts a detached run with `forwarded_props: {"background": true}` and reattaches after reconnect with `{"reattach": true}` (same thread_id/run_id, empty messages). Verified server boot, `GET /status`, and the validation contract without a provider key: `reattach` to an unknown run returned 404, `reattach` with a non-empty messages array returned 400, and `background` + `reattach` together returned 400. A background run submitted without `OPENAI_API_KEY` streamed RUN_STARTED/STATE_SNAPSHOT over AG-UI, ended ERROR, and was persisted (visible via `GET /agents/{id}/runs/{run_id}`); reattaching to it returned RUN_STARTED followed by an honest RUN_ERROR. Unit tests cover the snapshot-replay and live-reattach paths.
+
+**Result:** Server booted cleanly; all four request shapes behaved as specified.
+
+---

--- a/cookbook/05_agent_os/16_agui/background_runs.py
+++ b/cookbook/05_agent_os/16_agui/background_runs.py
@@ -41,20 +41,18 @@ then keeps streaming live events (or RUN_FINISHED if the run already ended):
       }'
 
 Reattach WITHOUT the run_id (fresh window, new device, incognito — the client
-never stored it): send an empty run_id and the server resolves the thread's
-in-progress run itself. A 404 means nothing is running — load history instead:
+Reattach WITHOUT the run_id (fresh window, new device, incognito — the client
+never stored it): the dedicated reattach route makes run_id optional and
+resolves the thread's in-progress run. A 404 means nothing is running:
 
-    curl -N -X POST http://localhost:7777/agui \
+    curl -N -X POST http://localhost:7777/agui/reattach \
       -H "Content-Type: application/json" \
-      -d '{
-        "thread_id": "demo-thread",
-        "run_id": "",
-        "messages": [],
-        "tools": [],
-        "context": [],
-        "state": {},
-        "forwarded_props": {"reattach": true}
-      }'
+      -d '{"thread_id": "demo-thread"}'
+
+For the fuller recovery flow, GET /sessions/{session_id} reports an
+"active_run" field whenever the thread has a run in progress; feed its run_id
+into the reattach call above (or omit run_id and let the server resolve it).
+See the README's "Background runs and reattach" section.
 """
 
 from agno.agent import Agent

--- a/cookbook/05_agent_os/16_agui/background_runs.py
+++ b/cookbook/05_agent_os/16_agui/background_runs.py
@@ -1,0 +1,81 @@
+"""
+Background Runs over AG-UI
+==========================
+
+Run an agent in the background through the AG-UI interface: the run survives
+client disconnection, and a reconnecting client reattaches with a snapshot
+replay followed by live events. No new endpoints — both behaviors ride the
+existing POST /agui route via forwarded_props.
+
+Prerequisites: OPENAI_API_KEY
+Run: .venvs/demo/bin/python cookbook/05_agent_os/16_agui/background_runs.py
+
+Start a background run (close the connection any time — the run continues):
+
+    curl -N -X POST http://localhost:7777/agui \
+      -H "Content-Type: application/json" \
+      -d '{
+        "thread_id": "demo-thread",
+        "run_id": "demo-run-1",
+        "messages": [{"id": "m1", "role": "user", "content": "Give me a detailed tour of the solar system."}],
+        "tools": [],
+        "context": [],
+        "state": {},
+        "forwarded_props": {"background": true}
+      }'
+
+Reattach after reconnecting (same thread_id/run_id, empty messages): the
+server replies with RUN_STARTED, a MESSAGES_SNAPSHOT of everything missed,
+then keeps streaming live events (or RUN_FINISHED if the run already ended):
+
+    curl -N -X POST http://localhost:7777/agui \
+      -H "Content-Type: application/json" \
+      -d '{
+        "thread_id": "demo-thread",
+        "run_id": "demo-run-1",
+        "messages": [],
+        "tools": [],
+        "context": [],
+        "state": {},
+        "forwarded_props": {"reattach": true}
+      }'
+"""
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIResponses
+from agno.os import AgentOS
+from agno.os.interfaces.agui import AGUI
+
+# ---------------------------------------------------------------------------
+# Create AG-UI AgentOS
+# ---------------------------------------------------------------------------
+
+# Background execution persists run state, so a database is required
+db = SqliteDb(
+    id="agui-background-db",
+    db_file="tmp/agui_background.db",
+)
+
+assistant = Agent(
+    id="agui-background-assistant",
+    name="AG-UI Background Assistant",
+    model=OpenAIResponses(id="gpt-5.6-luna"),
+    db=db,
+    instructions="Answer thoroughly and at length.",
+)
+
+agent_os = AgentOS(
+    id="agui-background-os",
+    description="AG-UI interface whose runs survive client disconnection.",
+    agents=[assistant],
+    interfaces=[AGUI(agent=assistant)],
+)
+app = agent_os.get_app()
+
+# ---------------------------------------------------------------------------
+# Run AG-UI Server
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    agent_os.serve(app=app)

--- a/cookbook/05_agent_os/16_agui/background_runs.py
+++ b/cookbook/05_agent_os/16_agui/background_runs.py
@@ -39,6 +39,22 @@ then keeps streaming live events (or RUN_FINISHED if the run already ended):
         "state": {},
         "forwarded_props": {"reattach": true}
       }'
+
+Reattach WITHOUT the run_id (fresh window, new device, incognito — the client
+never stored it): send an empty run_id and the server resolves the thread's
+in-progress run itself. A 404 means nothing is running — load history instead:
+
+    curl -N -X POST http://localhost:7777/agui \
+      -H "Content-Type: application/json" \
+      -d '{
+        "thread_id": "demo-thread",
+        "run_id": "",
+        "messages": [],
+        "tools": [],
+        "context": [],
+        "state": {},
+        "forwarded_props": {"reattach": true}
+      }'
 """
 
 from agno.agent import Agent

--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -2045,8 +2045,9 @@ async def _arun_background_stream(
     yield_run_output: Optional[bool] = None,
     debug_mode: Optional[bool] = None,
     background_tasks: Optional[Any] = None,
+    raw_events: bool = False,
     **kwargs: Any,
-) -> AsyncIterator[str]:
+) -> AsyncIterator[Any]:
     """Background streaming agent run that survives client disconnections.
 
     1. Persists RUNNING status in DB
@@ -2059,6 +2060,10 @@ async def _arun_background_stream(
 
     Similar to how Workflow._arun_background_stream handles WebSocket streaming,
     but uses SSE transport backed by the pluggable event stream.
+
+    When ``raw_events`` is True, the queue carries raw RunOutputEvent objects
+    instead of SSE strings (and no keepalive comments are emitted), so
+    non-SSE transports such as AG-UI can convert the events themselves.
     """
     from agno.agent._session import asave_run, asave_session
     from agno.agent._storage import aread_or_create_session, update_metadata
@@ -2141,12 +2146,15 @@ async def _arun_background_stream(
                 except Exception:
                     log_warning(f"Failed to buffer event for run {run_id}")
 
-                # Format as SSE for the primary queue (original client)
-                sse_data = format_sse_event_with_index(event, event_index=event_index, run_id=run_id)
+                # Format as SSE for the primary queue (original client); raw
+                # mode hands the event object to the caller for its own framing
+                queue_item: Any = event
+                if not raw_events:
+                    queue_item = format_sse_event_with_index(event, event_index=event_index, run_id=run_id)
                 try:
-                    await sse_queue.put(sse_data)
+                    await sse_queue.put(queue_item)
                 except Exception:
-                    log_warning(f"Failed to push SSE data to queue for run {run_id}")
+                    log_warning(f"Failed to push event to queue for run {run_id}")
 
         except asyncio.CancelledError:
             # Task-level shutdown (event loop stopping), not run-cancellation:
@@ -2211,12 +2219,14 @@ async def _arun_background_stream(
 
     # 4. Yield SSE strings from the queue. Emit SSE keepalive comments on idle
     # so proxies do not kill the connection while the run waits for a slot (or
-    # during long silent stretches of execution).
+    # during long silent stretches of execution). Raw mode yields event objects
+    # and no keepalives — comment frames would corrupt the caller's conversion.
     while True:
         try:
             sse_data = await asyncio.wait_for(sse_queue.get(), timeout=SSE_KEEPALIVE_INTERVAL_SECONDS)
         except asyncio.TimeoutError:
-            yield ": keepalive\n\n"
+            if not raw_events:
+                yield ": keepalive\n\n"
             continue
         if sse_data is None:
             break
@@ -2838,6 +2848,9 @@ def arun_dispatch(  # type: ignore
         )
 
     background_tasks = kwargs.pop("background_tasks", None)
+    # Raw-event output for non-SSE transports (e.g. AG-UI); only meaningful
+    # for background streaming, popped here so it never leaks into model kwargs
+    raw_events = bool(kwargs.pop("raw_events", False))
     if background_tasks is not None:
         from fastapi import BackgroundTasks
 
@@ -2976,6 +2989,7 @@ def arun_dispatch(  # type: ignore
                 add_session_state_to_context=opts.add_session_state_to_context,
                 debug_mode=debug_mode,
                 background_tasks=background_tasks,
+                raw_events=raw_events,
                 **kwargs,
             )
         return _arun_background(  # type: ignore[return-value]

--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -4316,6 +4316,9 @@ def acontinue_run_dispatch(  # type: ignore
         raise ValueError("Session ID is required to continue a run from a run_id.")
 
     background_tasks = kwargs.pop("background_tasks", None)
+    # Raw-event output for non-SSE transports (e.g. AG-UI); only meaningful
+    # for background streaming, popped here so it never leaks into model kwargs
+    raw_events = bool(kwargs.pop("raw_events", False))
     if background_tasks is not None:
         from fastapi import BackgroundTasks
 
@@ -4420,6 +4423,7 @@ def acontinue_run_dispatch(  # type: ignore
                 yield_run_output=opts.yield_run_output,
                 debug_mode=debug_mode,
                 background_tasks=background_tasks,
+                raw_events=raw_events,
                 **kwargs,
             )
 
@@ -4486,8 +4490,9 @@ async def _acontinue_run_background_stream(
     yield_run_output: Optional[bool] = None,
     debug_mode: Optional[bool] = None,
     background_tasks: Optional[Any] = None,
+    raw_events: bool = False,
     **kwargs: Any,
-) -> AsyncIterator[str]:
+) -> AsyncIterator[Any]:
     """Background streaming continue-run that survives client disconnections.
 
     Same pattern as _arun_background_stream but delegates to _acontinue_run_stream
@@ -4498,6 +4503,10 @@ async def _acontinue_run_background_stream(
     2. Spawns a detached asyncio.Task that runs _acontinue_run_stream
     3. Buffers events and publishes to live tails (via the event stream)
     4. Yields SSE-formatted strings via an asyncio.Queue
+
+    When ``raw_events`` is True, the queue carries raw RunOutputEvent objects
+    instead of SSE strings (and no keepalive comments are emitted), so
+    non-SSE transports such as AG-UI can convert the events themselves.
     """
     from agno.agent._session import asave_run, asave_session
     from agno.agent._storage import aread_or_create_session, update_metadata
@@ -4604,12 +4613,15 @@ async def _acontinue_run_background_stream(
                 except Exception:
                     log_warning(f"Failed to buffer event for continue-run {_run_id}")
 
-                # Format as SSE for the primary queue (original client)
-                sse_data = format_sse_event_with_index(event, event_index=event_index, run_id=_run_id)
+                # Format as SSE for the primary queue (original client); raw
+                # mode hands the event object to the caller for its own framing
+                queue_item: Any = event
+                if not raw_events:
+                    queue_item = format_sse_event_with_index(event, event_index=event_index, run_id=_run_id)
                 try:
-                    await sse_queue.put(sse_data)
+                    await sse_queue.put(queue_item)
                 except Exception:
-                    log_warning(f"Failed to push SSE data to queue for continue-run {_run_id}")
+                    log_warning(f"Failed to push event to queue for continue-run {_run_id}")
 
         except asyncio.CancelledError:
             # Task-level shutdown (event loop stopping), not run-cancellation:
@@ -4720,12 +4732,14 @@ async def _acontinue_run_background_stream(
 
     # 4. Yield SSE strings from the queue. Emit SSE keepalive comments on idle
     # so proxies do not kill the connection while the run waits for a slot (or
-    # during long silent stretches of execution).
+    # during long silent stretches of execution). Raw mode yields event objects
+    # and no keepalives — comment frames would corrupt the caller's conversion.
     while True:
         try:
             sse_data = await asyncio.wait_for(sse_queue.get(), timeout=SSE_KEEPALIVE_INTERVAL_SECONDS)
         except asyncio.TimeoutError:
-            yield ": keepalive\n\n"
+            if not raw_events:
+                yield ": keepalive\n\n"
             continue
         if sse_data is None:
             break

--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -2833,6 +2833,9 @@ def arun_dispatch(  # type: ignore
     yield_run_output: Optional[bool] = None,
     debug_mode: Optional[bool] = None,
     background: bool = False,
+    # Raw RunOutputEvent objects on the queue instead of SSE strings; only
+    # meaningful for background streaming (non-SSE transports such as AG-UI)
+    raw_events: bool = False,
     **kwargs: Any,
 ) -> Union[RunOutput, AsyncIterator[RunOutputEvent]]:
     """Async Run the Agent and return the response."""
@@ -2848,9 +2851,6 @@ def arun_dispatch(  # type: ignore
         )
 
     background_tasks = kwargs.pop("background_tasks", None)
-    # Raw-event output for non-SSE transports (e.g. AG-UI); only meaningful
-    # for background streaming, popped here so it never leaks into model kwargs
-    raw_events = bool(kwargs.pop("raw_events", False))
     if background_tasks is not None:
         from fastapi import BackgroundTasks
 
@@ -4279,6 +4279,9 @@ def acontinue_run_dispatch(  # type: ignore
     debug_mode: Optional[bool] = None,
     yield_run_output: bool = False,
     background: bool = False,
+    # Raw RunOutputEvent objects on the queue instead of SSE strings; only
+    # meaningful for background streaming (non-SSE transports such as AG-UI)
+    raw_events: bool = False,
     **kwargs,
 ) -> Union[RunOutput, AsyncIterator[Union[RunOutputEvent, RunOutput]]]:
     """Continue a previous run.
@@ -4316,9 +4319,6 @@ def acontinue_run_dispatch(  # type: ignore
         raise ValueError("Session ID is required to continue a run from a run_id.")
 
     background_tasks = kwargs.pop("background_tasks", None)
-    # Raw-event output for non-SSE transports (e.g. AG-UI); only meaningful
-    # for background streaming, popped here so it never leaks into model kwargs
-    raw_events = bool(kwargs.pop("raw_events", False))
     if background_tasks is not None:
         from fastapi import BackgroundTasks
 

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -1584,6 +1584,9 @@ class Agent:
         yield_run_output: Optional[bool] = None,
         debug_mode: Optional[bool] = None,
         background: bool = False,
+        # Raw event objects instead of SSE strings on the background stream;
+        # transport-internal (AG-UI), only meaningful with background + stream
+        raw_events: bool = False,
         **kwargs: Any,
     ) -> Union[RunOutput, AsyncIterator[RunOutputEvent]]:
         return _run.arun_dispatch(
@@ -1610,6 +1613,7 @@ class Agent:
             yield_run_output=yield_run_output,
             debug_mode=debug_mode,
             background=background,
+            raw_events=raw_events,
             **kwargs,
         )
 
@@ -1756,6 +1760,9 @@ class Agent:
         debug_mode: Optional[bool] = None,
         yield_run_output: bool = False,
         background: bool = False,
+        # Raw event objects instead of SSE strings on the background stream;
+        # transport-internal (AG-UI), only meaningful with background + stream
+        raw_events: bool = False,
         **kwargs,
     ) -> Union[RunOutput, AsyncIterator[Union[RunOutputEvent, RunOutput]]]:
         return _run.acontinue_run_dispatch(
@@ -1780,6 +1787,7 @@ class Agent:
             debug_mode=debug_mode,
             yield_run_output=yield_run_output,
             background=background,
+            raw_events=raw_events,
             **kwargs,
         )
 

--- a/libs/agno/agno/os/event_streams/__init__.py
+++ b/libs/agno/agno/os/event_streams/__init__.py
@@ -6,11 +6,12 @@ via ``set_event_stream()`` so multi-container deployments can resume streams
 from any replica.
 """
 
-from typing import Optional
+from typing import Any, Optional, Sequence
 
 from agno.os.event_streams.base import BaseEventStream
 from agno.os.event_streams.in_memory import InMemoryEventStream
 from agno.os.event_streams.redis import RedisEventStream
+from agno.run.base import RunStatus
 
 _event_stream: Optional[BaseEventStream] = None
 # True once set_event_stream() has been called. The lazily-created in-memory
@@ -54,10 +55,31 @@ def event_stream_explicitly_set() -> bool:
     return _event_stream_explicitly_set
 
 
+async def find_active_run(runs: Sequence[Any]) -> Optional[Any]:
+    """Return the newest PENDING/RUNNING run whose event stream is still live, or None.
+
+    Candidates come from ``runs`` (stored oldest-first, so scanned newest-first); PAUSED
+    runs wait on human input, not execution, and never qualify. A stored PENDING/RUNNING
+    row is not proof of life: after a server restart or a producer that died without a
+    terminal write, the DB row still says RUNNING while the stream no longer knows the
+    run, so each candidate is probed against the event stream. Callers can therefore
+    treat a None answer as "no recoverable run" and fall back to settled history.
+    """
+    event_stream = get_event_stream()
+    for run in reversed(runs):
+        if getattr(run, "status", None) not in (RunStatus.pending, RunStatus.running):
+            continue
+        run_id = getattr(run, "run_id", None)
+        if run_id and await event_stream.get_run_status(run_id) is not None:
+            return run
+    return None
+
+
 __all__ = [
     "BaseEventStream",
     "InMemoryEventStream",
     "event_stream_explicitly_set",
+    "find_active_run",
     "get_event_stream",
     "set_event_stream",
 ]

--- a/libs/agno/agno/os/event_streams/__init__.py
+++ b/libs/agno/agno/os/event_streams/__init__.py
@@ -12,6 +12,7 @@ from agno.os.event_streams.base import BaseEventStream
 from agno.os.event_streams.in_memory import InMemoryEventStream
 from agno.os.event_streams.redis import RedisEventStream
 from agno.run.base import RunStatus
+from agno.utils.log import log_debug
 
 _event_stream: Optional[BaseEventStream] = None
 # True once set_event_stream() has been called. The lazily-created in-memory
@@ -70,8 +71,12 @@ async def find_active_run(runs: Sequence[Any]) -> Optional[Any]:
         if getattr(run, "status", None) not in (RunStatus.pending, RunStatus.running):
             continue
         run_id = getattr(run, "run_id", None)
-        if run_id and await event_stream.get_run_status(run_id) is not None:
+        if not run_id:
+            continue
+        if await event_stream.get_run_status(run_id) is not None:
             return run
+        # The row outlived its producer (server restart, crashed run) — skip it
+        log_debug(f"Run {run_id} is {getattr(run, 'status', None)} in storage but unknown to the event stream")
     return None
 
 

--- a/libs/agno/agno/os/interfaces/agui/agui.py
+++ b/libs/agno/agno/os/interfaces/agui/agui.py
@@ -51,4 +51,7 @@ class AGUI(BaseInterface):
     def get_scope_mappings(self) -> dict:
         # Agent-wins precedence must match router dispatch (entity = agent or team)
         family = "agents" if self.agent is not None else "teams"
-        return {f"POST {self.prefix}/agui": [f"{family}:run"]}
+        return {
+            f"POST {self.prefix}/agui": [f"{family}:run"],
+            f"POST {self.prefix}/agui/reattach": [f"{family}:run"],
+        }

--- a/libs/agno/agno/os/interfaces/agui/reattach.py
+++ b/libs/agno/agno/os/interfaces/agui/reattach.py
@@ -1,0 +1,263 @@
+"""Reattach support for background AG-UI runs.
+
+A background run (started with ``forwarded_props: {"background": true}``)
+keeps executing server-side after the client disconnects. A client that
+reconnects can reattach with ``forwarded_props: {"reattach": true}`` on the
+same thread_id/run_id: the buffered Agno events are replayed through the
+AG-UI converter and collapsed into an idempotent MESSAGES_SNAPSHOT (AG-UI
+events carry no sequence numbers, so replaying append-only text deltas would
+double-render on clients that still hold partial content), then live events
+continue streaming from the same converter state so message IDs stay
+consistent. Runs whose buffer already expired are replayed from the database.
+"""
+
+import copy
+import json
+from typing import Any, AsyncIterator, Dict, List, Optional, Tuple, Union
+
+from ag_ui.core import (
+    BaseEvent,
+    EventType,
+    MessagesSnapshotEvent,
+    RunErrorEvent,
+    RunFinishedEvent,
+    RunStartedEvent,
+    StateSnapshotEvent,
+    TextMessageContentEvent,
+    TextMessageStartEvent,
+    ToolCallArgsEvent,
+    ToolCallResultEvent,
+    ToolCallStartEvent,
+)
+from ag_ui.core.types import AssistantMessage, FunctionCall, ToolCall, ToolMessage
+from ag_ui.core.types import Message as AGUIMessage
+
+from agno.agent import Agent
+from agno.agent.remote import RemoteAgent
+from agno.os.event_streams import get_event_stream
+from agno.os.interfaces.agui.handlers import is_completion_event, process_completion, process_event
+from agno.os.interfaces.agui.state import StreamState
+from agno.run.agent import run_output_event_from_dict
+from agno.run.base import BaseRunOutputEvent, RunStatus
+from agno.run.team import team_run_output_event_from_dict
+from agno.team.remote import RemoteTeam
+from agno.team.team import Team
+from agno.utils.log import log_debug, log_error
+
+# Statuses where the run will produce no further events
+_TERMINAL_STATUSES = (RunStatus.completed, RunStatus.error, RunStatus.cancelled, RunStatus.paused)
+
+
+class _SnapshotBuilder:
+    """Accumulates a replayed event prefix into a MESSAGES_SNAPSHOT.
+
+    Runs replayed Agno events through the regular converter (so tool calls,
+    reasoning lifecycle, and state deltas mutate StreamState exactly as they
+    did live) and watches the converter's output to build full messages.
+    """
+
+    def __init__(self, thread_id: str, run_id: str, run_state: Optional[Dict[str, Any]] = None):
+        self.state = StreamState(thread_id=thread_id, run_id=run_id, run_state=run_state)
+        self.messages: List[AGUIMessage] = []
+        self._assistant_by_id: Dict[str, AssistantMessage] = {}
+        # tool_call_id -> [name, parent_message_id, args parts]
+        self._tool_calls: Dict[str, Tuple[str, str, List[str]]] = {}
+        self.finished = False
+        self.last_event_index = -1
+        self.latest_session_state: Optional[Dict[str, Any]] = copy.deepcopy(run_state) if run_state else None
+
+    def consume(self, event: BaseRunOutputEvent, event_index: Optional[int] = None) -> None:
+        if event_index is not None and event_index >= 0:
+            self.last_event_index = max(self.last_event_index, event_index)
+        if is_completion_event(event):
+            output_events = process_completion(event, self.state)
+        else:
+            output_events = process_event(event, self.state)
+        for out in output_events:
+            self._watch(out)
+
+    def _watch(self, event: BaseEvent) -> None:
+        if isinstance(event, TextMessageStartEvent):
+            message = AssistantMessage(id=event.message_id, content="")
+            self._assistant_by_id[message.id] = message
+            self.messages.append(message)
+        elif isinstance(event, TextMessageContentEvent):
+            existing = self._assistant_by_id.get(event.message_id)
+            if existing is not None:
+                existing.content = (existing.content or "") + event.delta
+        elif isinstance(event, ToolCallStartEvent):
+            self._tool_calls[event.tool_call_id] = (
+                event.tool_call_name or "",
+                event.parent_message_id or "",
+                [],
+            )
+        elif isinstance(event, ToolCallArgsEvent):
+            record = self._tool_calls.get(event.tool_call_id)
+            if record is not None:
+                record[2].append(event.delta or "")
+        elif isinstance(event, ToolCallResultEvent):
+            self.messages.append(
+                ToolMessage(
+                    id=event.message_id or event.tool_call_id,
+                    content=event.content if isinstance(event.content, str) else json.dumps(event.content),
+                    tool_call_id=event.tool_call_id,
+                )
+            )
+        elif isinstance(event, StateSnapshotEvent):
+            if isinstance(event.snapshot, dict):
+                self.latest_session_state = copy.deepcopy(event.snapshot)
+        elif isinstance(event, RunFinishedEvent):
+            self.finished = True
+
+    def snapshot_events(self) -> List[BaseEvent]:
+        """Build the idempotent snapshot events for the replayed prefix."""
+        # Attach accumulated tool calls to their parent assistant messages
+        for tool_call_id, (name, parent_id, arg_parts) in self._tool_calls.items():
+            parent = self._assistant_by_id.get(parent_id)
+            if parent is None:
+                continue
+            call = ToolCall(id=tool_call_id, function=FunctionCall(name=name, arguments="".join(arg_parts)))
+            parent.tool_calls = [*(parent.tool_calls or []), call]
+
+        events: List[BaseEvent] = []
+        if self.messages:
+            events.append(MessagesSnapshotEvent(type=EventType.MESSAGES_SNAPSHOT, messages=self.messages))
+        # Prefer the converter's live-tracked state (shared reference mutated
+        # by the run) over snapshots captured along the way
+        session_state = self.state.run_state if self.state.run_state is not None else self.latest_session_state
+        if session_state is not None:
+            events.append(StateSnapshotEvent(type=EventType.STATE_SNAPSHOT, snapshot=copy.deepcopy(session_state)))
+        return events
+
+
+def _sse_payload_to_event(payload: str, is_team: bool) -> Optional[BaseRunOutputEvent]:
+    """Recover an event object from a serialized SSE frame.
+
+    The in-memory event stream replays raw event objects, but the Redis
+    backend and all live tails carry SSE-formatted strings; the frame's data
+    line is the event's own ``to_dict()`` JSON, so parsing it back is lossless
+    for converter purposes. Unknown event types are skipped, never fatal.
+    """
+    data: Optional[Dict[str, Any]] = None
+    for line in payload.splitlines():
+        if line.startswith("data:"):
+            try:
+                data = json.loads(line[len("data:") :].strip())
+            except json.JSONDecodeError:
+                return None
+            break
+    if not isinstance(data, dict):
+        return None
+    try:
+        if is_team:
+            return team_run_output_event_from_dict(data)  # type: ignore[return-value]
+        return run_output_event_from_dict(data)
+    except Exception:
+        log_debug(f"Reattach: skipping unserializable event of type '{data.get('event')}'")
+        return None
+
+
+def _normalize_payload(payload: Any, is_team: bool) -> Optional[BaseRunOutputEvent]:
+    """Normalize an event-stream payload (raw object or SSE string) to an event."""
+    if isinstance(payload, str):
+        return _sse_payload_to_event(payload, is_team)
+    return payload
+
+
+async def find_reattach_target(
+    entity: Union[Agent, Team],
+    run_id: str,
+    session_id: str,
+    user_id: Optional[str] = None,
+) -> Tuple[Optional[RunStatus], Optional[Any]]:
+    """Locate a reattachable run. Returns (buffer_status, stored_run_output).
+
+    (None, None) means the run exists in neither the event buffer nor the
+    database — the caller answers 404 before any streaming starts.
+    """
+    event_stream = get_event_stream()
+    buffer_status = await event_stream.get_run_status(run_id)
+    if buffer_status is not None:
+        return buffer_status, None
+    if isinstance(entity, (RemoteAgent, RemoteTeam)) or getattr(entity, "db", None) is None:
+        return None, None
+    run_output = await entity.aget_run_output(run_id=run_id, session_id=session_id, user_id=user_id)
+    return None, run_output
+
+
+async def reattach_run_events(
+    entity: Union[Agent, Team],
+    thread_id: str,
+    run_id: str,
+    user_id: Optional[str] = None,
+    buffer_status: Optional[RunStatus] = None,
+    stored_run: Optional[Any] = None,
+) -> AsyncIterator[BaseEvent]:
+    """Reattach to a background run: snapshot the missed prefix, then go live.
+
+    ``buffer_status``/``stored_run`` come pre-fetched from
+    ``find_reattach_target`` so the route handler could 404 before streaming.
+    """
+    is_team = isinstance(entity, Team)
+    yield RunStartedEvent(type=EventType.RUN_STARTED, thread_id=thread_id, run_id=run_id)
+
+    event_stream = get_event_stream()
+
+    # Path 1: run not in the buffer — replay the stored terminal run from the DB
+    if buffer_status is None:
+        if stored_run is None:
+            yield RunErrorEvent(type=EventType.RUN_ERROR, message=f"Run {run_id} not found")
+            return
+        builder = _SnapshotBuilder(
+            thread_id=thread_id, run_id=run_id, run_state=getattr(stored_run, "session_state", None)
+        )
+        for position, event in enumerate(getattr(stored_run, "events", None) or []):
+            builder.consume(event, event_index=position)
+        for event in builder.snapshot_events():
+            yield event
+        status = getattr(stored_run, "status", None)
+        status_value = status.value if status is not None and hasattr(status, "value") else status
+        if builder.finished or status_value == "completed":
+            yield RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id=thread_id, run_id=run_id)
+        else:
+            yield RunErrorEvent(type=EventType.RUN_ERROR, message=f"Run ended with status: {status_value or 'unknown'}")
+        return
+
+    # Path 2: run in the buffer — replay the buffered prefix into a snapshot
+    builder = _SnapshotBuilder(thread_id=thread_id, run_id=run_id)
+    try:
+        replayed = await event_stream.replay(run_id, last_event_index=None)
+    except Exception as e:
+        log_error(f"Reattach: event stream replay failed for run {run_id}: {e}")
+        yield RunErrorEvent(type=EventType.RUN_ERROR, message="event stream unavailable")
+        return
+    for event_index, payload in replayed:
+        event = _normalize_payload(payload, is_team)
+        if event is not None:
+            builder.consume(event, event_index=event_index)
+
+    # Terminal runs end right after the snapshot
+    if buffer_status in _TERMINAL_STATUSES:
+        for event in builder.snapshot_events():
+            yield event
+        if builder.finished or buffer_status in (RunStatus.completed, RunStatus.paused):
+            yield RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id=thread_id, run_id=run_id)
+        else:
+            yield RunErrorEvent(type=EventType.RUN_ERROR, message=f"Run ended with status: {buffer_status.value}")
+        return
+
+    # Path 3: run still active — snapshot, then stream live events through the
+    # same converter state so message IDs continue consistently
+    for event in builder.snapshot_events():
+        yield event
+
+    async for event_index, payload in event_stream.tail(run_id, last_event_index=builder.last_event_index):
+        event = _normalize_payload(payload, is_team)
+        if event is None:
+            continue
+        if is_completion_event(event):
+            for out in process_completion(event, builder.state):
+                yield out
+        else:
+            for out in process_event(event, builder.state):
+                yield out

--- a/libs/agno/agno/os/interfaces/agui/reattach.py
+++ b/libs/agno/agno/os/interfaces/agui/reattach.py
@@ -164,6 +164,40 @@ def _normalize_payload(payload: Any, is_team: bool) -> Optional[BaseRunOutputEve
     return payload
 
 
+async def find_active_run_id(
+    entity: Union[Agent, Team],
+    thread_id: str,
+    user_id: Optional[str] = None,
+) -> Optional[str]:
+    """Resolve the thread's in-progress run for sentinel reattach (run_id="").
+
+    A client that never held the original run_id (fresh window, new device,
+    incognito) can reattach with an empty run_id; the server finds the run
+    itself. Only PENDING/RUNNING runs qualify — PAUSED runs wait on HITL
+    input and follow the resume flow instead.
+
+    Candidates come from the stored session (already scoped to session_id +
+    user_id, so the lookup doubles as the run-thread binding check), then
+    each is probed against the event stream: a PENDING/RUNNING row the buffer
+    no longer knows (e.g. the server restarted, or the run died without a
+    terminal write) is skipped, so callers get None and the client falls back
+    to loading history. Runs are stored oldest-first, so scan in reverse.
+    """
+    if getattr(entity, "db", None) is None:
+        return None
+    session = await entity.aget_session(session_id=thread_id, user_id=user_id)
+    if session is None or not session.runs:
+        return None
+    event_stream = get_event_stream()
+    for run in reversed(session.runs):
+        if getattr(run, "status", None) not in (RunStatus.pending, RunStatus.running):
+            continue
+        run_id = getattr(run, "run_id", None)
+        if run_id and await event_stream.get_run_status(run_id) is not None:
+            return run_id
+    return None
+
+
 async def find_reattach_target(
     entity: Union[Agent, Team],
     run_id: str,

--- a/libs/agno/agno/os/interfaces/agui/reattach.py
+++ b/libs/agno/agno/os/interfaces/agui/reattach.py
@@ -34,7 +34,7 @@ from ag_ui.core.types import Message as AGUIMessage
 
 from agno.agent import Agent
 from agno.agent.remote import RemoteAgent
-from agno.os.event_streams import get_event_stream
+from agno.os.event_streams import find_active_run, get_event_stream
 from agno.os.interfaces.agui.handlers import is_completion_event, process_completion, process_event
 from agno.os.interfaces.agui.state import StreamState
 from agno.run.agent import run_output_event_from_dict
@@ -173,29 +173,19 @@ async def find_active_run_id(
 
     A client that never held the original run_id (fresh window, new device,
     incognito) can reattach with an empty run_id; the server finds the run
-    itself. Only PENDING/RUNNING runs qualify — PAUSED runs wait on HITL
-    input and follow the resume flow instead.
-
-    Candidates come from the stored session (already scoped to session_id +
-    user_id, so the lookup doubles as the run-thread binding check), then
-    each is probed against the event stream: a PENDING/RUNNING row the buffer
-    no longer knows (e.g. the server restarted, or the run died without a
-    terminal write) is skipped, so callers get None and the client falls back
-    to loading history. Runs are stored oldest-first, so scan in reverse.
+    itself. The stored session is already scoped to session_id + user_id, so
+    this lookup doubles as the run-thread binding check, and the event-stream
+    liveness probe inside ``find_active_run`` filters rows that outlived
+    their producer (server restart, crashed run). A None answer means "no
+    recoverable run" — the client falls back to loading history.
     """
     if getattr(entity, "db", None) is None:
         return None
     session = await entity.aget_session(session_id=thread_id, user_id=user_id)
     if session is None or not session.runs:
         return None
-    event_stream = get_event_stream()
-    for run in reversed(session.runs):
-        if getattr(run, "status", None) not in (RunStatus.pending, RunStatus.running):
-            continue
-        run_id = getattr(run, "run_id", None)
-        if run_id and await event_stream.get_run_status(run_id) is not None:
-            return run_id
-    return None
+    run = await find_active_run(session.runs)
+    return run.run_id if run is not None else None
 
 
 async def find_reattach_target(

--- a/libs/agno/agno/os/interfaces/agui/resume.py
+++ b/libs/agno/agno/os/interfaces/agui/resume.py
@@ -119,6 +119,7 @@ async def resume_paused_run(
     tool_messages: List[AGUIToolMessage],
     run_context: RunContext,
     run_kwargs: dict,
+    background: bool = False,
 ):
     if not isinstance(entity, (Agent, Team)):
         raise ValueError("Frontend tool resume requires a local Agent or Team")
@@ -162,6 +163,9 @@ async def resume_paused_run(
         stream=True,
         stream_events=True,
         run_context=run_context,
+        # raw_events: the background stream hands raw event objects to the
+        # AG-UI converter instead of pre-formatted SSE strings
+        **({"background": True, "raw_events": True} if background else {}),
         **run_kwargs,
     )
 
@@ -184,7 +188,12 @@ async def resume_paused_run(
             async for chunk in inner:
                 yield chunk
         finally:
-            with contextlib.suppress(Exception):
-                await acomplete_continue_stream(entity, run_id, session_id, only_if_tracked=True)
+            if not background:
+                # Background continues own their terminal sentinel via the
+                # detached producer. Syncing here would read the row mid-run
+                # (RUNNING) on a client disconnect and falsely complete the
+                # stream while the producer is still writing to it.
+                with contextlib.suppress(Exception):
+                    await acomplete_continue_stream(entity, run_id, session_id, only_if_tracked=True)
 
     return _stream_then_sync()

--- a/libs/agno/agno/os/interfaces/agui/router.py
+++ b/libs/agno/agno/os/interfaces/agui/router.py
@@ -31,7 +31,7 @@ from agno.os.interfaces.agui.input import (
     parse_client_tools,
     validate_state,
 )
-from agno.os.interfaces.agui.reattach import find_reattach_target, reattach_run_events
+from agno.os.interfaces.agui.reattach import find_active_run_id, find_reattach_target, reattach_run_events
 from agno.os.interfaces.agui.resume import resume_paused_run
 from agno.os.interfaces.agui.stream import async_stream_agno_response_as_agui_events
 from agno.os.middleware.user_scope import assert_session_writable, caller_is_admin, resolve_run_user_id
@@ -267,27 +267,53 @@ def attach_routes(
                 )
             if run_input.resume:
                 raise HTTPException(status_code=400, detail="reattach cannot be combined with HITL resume entries")
-            await _verify_reattach_binding(
-                entity,  # type: ignore[arg-type]
-                run_id=run_input.run_id,
-                thread_id=run_input.thread_id,
-                user_id=user_id,
-            )
+
+            # Empty run_id is the auto-resolve sentinel: the protocol requires a
+            # run_id, so a client that never held one (fresh window, new device)
+            # sends "" and the server finds the thread's in-progress run itself.
+            run_id = run_input.run_id
+            resolved = False
+            if not run_id:
+                if getattr(entity, "db", None) is None:
+                    raise HTTPException(
+                        status_code=400,
+                        detail="reattach with an empty run_id requires a database to resolve the active run; "
+                        "pass an explicit run_id",
+                    )
+                resolved_run_id = await find_active_run_id(
+                    entity,  # type: ignore[arg-type]
+                    thread_id=run_input.thread_id,
+                    user_id=user_id,
+                )
+                if resolved_run_id is None:
+                    raise HTTPException(status_code=404, detail=f"No active run for thread {run_input.thread_id}")
+                run_id = resolved_run_id
+                resolved = True
+
+            if not resolved:
+                # Auto-resolved runs came from a session read already scoped to
+                # this thread and caller, so the binding check is redundant.
+                await _verify_reattach_binding(
+                    entity,  # type: ignore[arg-type]
+                    run_id=run_id,
+                    thread_id=run_input.thread_id,
+                    user_id=user_id,
+                )
             buffer_status, stored_run = await find_reattach_target(
                 entity,  # type: ignore[arg-type]
-                run_id=run_input.run_id,
+                run_id=run_id,
                 session_id=run_input.thread_id,
                 user_id=user_id,
             )
             if buffer_status is None and stored_run is None:
-                raise HTTPException(status_code=404, detail=f"Run {run_input.run_id} not found")
+                raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
 
             return StreamingResponse(
                 _encode_with_keepalive(
                     reattach_run_events(
                         entity,  # type: ignore[arg-type]
                         thread_id=run_input.thread_id,
-                        run_id=run_input.run_id,
+                        run_id=run_id,
                         user_id=user_id,
                         buffer_status=buffer_status,
                         stored_run=stored_run,

--- a/libs/agno/agno/os/interfaces/agui/router.py
+++ b/libs/agno/agno/os/interfaces/agui/router.py
@@ -1,6 +1,6 @@
 import copy
 import uuid
-from typing import AsyncIterator, Optional, Union
+from typing import Any, AsyncIterator, Dict, Optional, Union
 
 from agno.utils.log import log_error
 
@@ -17,7 +17,7 @@ try:
 except ImportError as e:
     raise ImportError("`ag_ui` not installed. Please install it with `pip install -U ag-ui-protocol`") from e
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
 from agno.agent import Agent, RemoteAgent
@@ -29,6 +29,7 @@ from agno.os.interfaces.agui.input import (
     parse_client_tools,
     validate_state,
 )
+from agno.os.interfaces.agui.reattach import find_reattach_target, reattach_run_events
 from agno.os.interfaces.agui.resume import resume_paused_run
 from agno.os.interfaces.agui.stream import async_stream_agno_response_as_agui_events
 from agno.os.middleware.user_scope import assert_session_writable, caller_is_admin, resolve_run_user_id
@@ -37,16 +38,27 @@ from agno.team.remote import RemoteTeam
 from agno.team.team import Team
 
 
+def _extract_forwarded_flags(run_input: RunAgentInput) -> Dict[str, Any]:
+    """Read Agno extension flags from forwarded_props (the AG-UI extension point)."""
+    props = run_input.forwarded_props
+    return props if isinstance(props, dict) else {}
+
+
 async def run_entity(
     entity: Union[Agent, RemoteAgent, Team, RemoteTeam],
     run_input: RunAgentInput,
     user_id: Optional[str] = None,
+    background: bool = False,
 ) -> AsyncIterator[BaseEvent]:
     """Shared handler for running an Agent or Team with AG-UI input/output mapping.
 
     ``user_id`` is the server-resolved identity (see the route handler). It is
     deliberately NOT read from ``run_input.forwarded_props`` here: an authenticated
     caller must not attribute runs, sessions, or memory writes to an arbitrary user.
+
+    With ``background=True`` the run executes in a detached task that survives
+    client disconnection (events are buffered for later reattach); the live
+    stream to the connected client is unchanged.
     """
     run_id = run_input.run_id or str(uuid.uuid4())
 
@@ -108,6 +120,9 @@ async def run_entity(
                 videos=videos or None,
                 files=files or None,
                 run_context=run_context,
+                # raw_events: the background stream hands raw RunOutputEvent
+                # objects to the converter instead of pre-formatted SSE strings
+                **({"background": True, "raw_events": True} if background else {}),
                 **run_kwargs,
             )
 
@@ -149,8 +164,68 @@ def attach_routes(
             is_admin=caller_is_admin(request),
         )
 
+        # Agno extension flags ride forwarded_props (the AG-UI extension point)
+        flags = _extract_forwarded_flags(run_input)
+        background = bool(flags.get("background"))
+        reattach = bool(flags.get("reattach"))
+
+        # Validate BEFORE streaming starts: a misconfiguration must answer an
+        # honest HTTP error, not a 200 whose SSE stream opens with an error frame
+        if background and reattach:
+            raise HTTPException(
+                status_code=400, detail="background and reattach are mutually exclusive forwarded_props"
+            )
+        if background or reattach:
+            if isinstance(entity, (RemoteAgent, RemoteTeam)):
+                raise HTTPException(
+                    status_code=400, detail="Background execution is not supported for remote agents or teams"
+                )
+        if background and getattr(entity, "db", None) is None:
+            raise HTTPException(
+                status_code=400, detail="Background execution requires a database to be configured on the entity"
+            )
+
+        if reattach:
+            if run_input.messages:
+                raise HTTPException(
+                    status_code=400, detail="reattach requires an empty messages array; input cannot be appended"
+                )
+            if run_input.resume:
+                raise HTTPException(status_code=400, detail="reattach cannot be combined with HITL resume entries")
+            buffer_status, stored_run = await find_reattach_target(
+                entity,  # type: ignore[arg-type]
+                run_id=run_input.run_id,
+                session_id=run_input.thread_id,
+                user_id=user_id,
+            )
+            if buffer_status is None and stored_run is None:
+                raise HTTPException(status_code=404, detail=f"Run {run_input.run_id} not found")
+
+            async def reattach_event_generator():
+                async for event in reattach_run_events(
+                    entity,  # type: ignore[arg-type]
+                    thread_id=run_input.thread_id,
+                    run_id=run_input.run_id,
+                    user_id=user_id,
+                    buffer_status=buffer_status,
+                    stored_run=stored_run,
+                ):
+                    yield encoder.encode(event)
+
+            return StreamingResponse(
+                reattach_event_generator(),
+                media_type="text/event-stream",
+                headers={
+                    "Cache-Control": "no-cache",
+                    "Connection": "keep-alive",
+                    "Access-Control-Allow-Origin": "*",
+                    "Access-Control-Allow-Methods": "POST, GET, OPTIONS",
+                    "Access-Control-Allow-Headers": "*",
+                },
+            )
+
         async def event_generator():
-            async for event in run_entity(entity, run_input, user_id=user_id):  # type: ignore
+            async for event in run_entity(entity, run_input, user_id=user_id, background=background):  # type: ignore
                 yield encoder.encode(event)
 
         return StreamingResponse(

--- a/libs/agno/agno/os/interfaces/agui/router.py
+++ b/libs/agno/agno/os/interfaces/agui/router.py
@@ -21,6 +21,7 @@ except ImportError as e:
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
 
 from agno.agent import Agent, RemoteAgent
 from agno.os.interfaces.agui.input import (
@@ -93,6 +94,74 @@ async def _encode_with_keepalive(events: AsyncIterator[BaseEvent], encoder: Even
         pump_task.cancel()
         with contextlib.suppress(BaseException):
             await pump_task
+
+
+class ReattachRequest(BaseModel):
+    """Body for POST /agui/reattach: subscribe to an existing run's event stream without starting a new run."""
+
+    thread_id: str
+    # Omitted = resolve the thread's in-progress run (a client that never held the run_id)
+    run_id: Optional[str] = None
+    # Anonymous attribution only; authenticated callers are pinned to their server-resolved identity
+    user_id: Optional[str] = None
+
+
+async def _build_reattach_response(
+    entity: Union[Agent, Team],
+    thread_id: str,
+    run_id: Optional[str],
+    user_id: Optional[str],
+    encoder: EventEncoder,
+) -> StreamingResponse:
+    """Shared reattach pipeline for POST /agui (flag form) and POST /agui/reattach.
+
+    An explicit run_id stays strict: unknown ids 404 and are never swapped for
+    the thread's active run. A falsy run_id ("" from the AG-UI flag form, where
+    the protocol requires the field; omitted on the dedicated route) resolves
+    the thread's in-progress run instead — and since the resolving session read
+    is already scoped to thread and caller, the binding re-check is redundant.
+    """
+    resolved = False
+    if not run_id:
+        if getattr(entity, "db", None) is None:
+            raise HTTPException(
+                status_code=400,
+                detail="reattach without a run_id requires a database to resolve the active run; "
+                "pass an explicit run_id",
+            )
+        resolved_run_id = await find_active_run_id(entity, thread_id=thread_id, user_id=user_id)
+        if resolved_run_id is None:
+            raise HTTPException(status_code=404, detail=f"No active run for thread {thread_id}")
+        run_id = resolved_run_id
+        resolved = True
+
+    if not resolved:
+        await _verify_reattach_binding(entity, run_id, thread_id, user_id)
+
+    buffer_status, stored_run = await find_reattach_target(
+        entity,
+        run_id=run_id,
+        session_id=thread_id,
+        user_id=user_id,
+    )
+    if buffer_status is None and stored_run is None:
+        raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
+
+    return StreamingResponse(
+        _encode_with_keepalive(
+            reattach_run_events(
+                entity,
+                thread_id=thread_id,
+                run_id=run_id,
+                user_id=user_id,
+                buffer_status=buffer_status,
+                stored_run=stored_run,
+            ),
+            encoder,
+        ),
+        media_type="text/event-stream",
+        headers=_SSE_HEADERS,
+    )
 
 
 async def _verify_reattach_binding(
@@ -279,61 +348,15 @@ def attach_routes(
                 )
             if run_input.resume:
                 raise HTTPException(status_code=400, detail="reattach cannot be combined with HITL resume entries")
-
-            # Empty run_id is the auto-resolve sentinel: the protocol requires a
-            # run_id, so a client that never held one (fresh window, new device)
-            # sends "" and the server finds the thread's in-progress run itself.
-            run_id = run_input.run_id
-            resolved = False
-            if not run_id:
-                if getattr(entity, "db", None) is None:
-                    raise HTTPException(
-                        status_code=400,
-                        detail="reattach with an empty run_id requires a database to resolve the active run; "
-                        "pass an explicit run_id",
-                    )
-                resolved_run_id = await find_active_run_id(
-                    entity,  # type: ignore[arg-type]
-                    thread_id=run_input.thread_id,
-                    user_id=user_id,
-                )
-                if resolved_run_id is None:
-                    raise HTTPException(status_code=404, detail=f"No active run for thread {run_input.thread_id}")
-                run_id = resolved_run_id
-                resolved = True
-
-            if not resolved:
-                # Auto-resolved runs came from a session read already scoped to
-                # this thread and caller, so the binding check is redundant.
-                await _verify_reattach_binding(
-                    entity,  # type: ignore[arg-type]
-                    run_id=run_id,
-                    thread_id=run_input.thread_id,
-                    user_id=user_id,
-                )
-            buffer_status, stored_run = await find_reattach_target(
+            # Empty run_id is the auto-resolve sentinel: the protocol requires the
+            # field, so a client that never held one sends "". The dedicated
+            # POST /agui/reattach route makes run_id truly optional instead.
+            return await _build_reattach_response(
                 entity,  # type: ignore[arg-type]
-                run_id=run_id,
-                session_id=run_input.thread_id,
+                thread_id=run_input.thread_id,
+                run_id=run_input.run_id,
                 user_id=user_id,
-            )
-            if buffer_status is None and stored_run is None:
-                raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
-
-            return StreamingResponse(
-                _encode_with_keepalive(
-                    reattach_run_events(
-                        entity,  # type: ignore[arg-type]
-                        thread_id=run_input.thread_id,
-                        run_id=run_id,
-                        user_id=user_id,
-                        buffer_status=buffer_status,
-                        stored_run=stored_run,
-                    ),
-                    encoder,
-                ),
-                media_type="text/event-stream",
-                headers=_SSE_HEADERS,
+                encoder=encoder,
             )
 
         return StreamingResponse(
@@ -343,6 +366,34 @@ def attach_routes(
             ),
             media_type="text/event-stream",
             headers=_SSE_HEADERS,
+        )
+
+    @router.post("/agui/reattach", name="reattach_run")
+    async def reattach_run_agui(request: Request, body: ReattachRequest):
+        """Subscribe to an existing run's event stream without starting a new run.
+
+        Dedicated sibling of the REST ``/runs/{run_id}/resume`` route, with the
+        same ownership posture — but speaking AG-UI events: the missed prefix is
+        collapsed into an idempotent MESSAGES_SNAPSHOT (AG-UI events carry no
+        sequence numbers for a cursor), then live events follow. Omitting
+        ``run_id`` resolves the thread's in-progress run.
+        """
+        if isinstance(entity, (RemoteAgent, RemoteTeam)):
+            raise HTTPException(status_code=400, detail="Reattach is not supported for remote agents or teams")
+
+        user_id = resolve_run_user_id(request, body.user_id)
+        await assert_session_writable(
+            getattr(entity, "db", None),
+            body.thread_id,
+            user_id or getattr(entity, "user_id", None),
+            is_admin=caller_is_admin(request),
+        )
+        return await _build_reattach_response(
+            entity,  # type: ignore[arg-type]
+            thread_id=body.thread_id,
+            run_id=body.run_id,
+            user_id=user_id,
+            encoder=encoder,
         )
 
     @router.get("/status")

--- a/libs/agno/agno/os/interfaces/agui/router.py
+++ b/libs/agno/agno/os/interfaces/agui/router.py
@@ -1,3 +1,5 @@
+import asyncio
+import contextlib
 import copy
 import uuid
 from typing import Any, AsyncIterator, Dict, Optional, Union
@@ -34,14 +36,85 @@ from agno.os.interfaces.agui.resume import resume_paused_run
 from agno.os.interfaces.agui.stream import async_stream_agno_response_as_agui_events
 from agno.os.middleware.user_scope import assert_session_writable, caller_is_admin, resolve_run_user_id
 from agno.run.base import RunContext
+from agno.run.concurrency import SSE_KEEPALIVE_INTERVAL_SECONDS
 from agno.team.remote import RemoteTeam
 from agno.team.team import Team
+
+_SSE_HEADERS = {
+    "Cache-Control": "no-cache",
+    "Connection": "keep-alive",
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "POST, GET, OPTIONS",
+    "Access-Control-Allow-Headers": "*",
+}
 
 
 def _extract_forwarded_flags(run_input: RunAgentInput) -> Dict[str, Any]:
     """Read Agno extension flags from forwarded_props (the AG-UI extension point)."""
     props = run_input.forwarded_props
     return props if isinstance(props, dict) else {}
+
+
+async def _encode_with_keepalive(events: AsyncIterator[BaseEvent], encoder: EventEncoder) -> AsyncIterator[str]:
+    """Encode AG-UI events as SSE, emitting keepalive comments on idle.
+
+    Background runs can sit silent while queued for a concurrency slot or
+    during long model stretches; without keepalives, proxies kill the
+    connection. Events are pumped through a queue so the idle timeout never
+    cancels an in-flight __anext__ (cancelling it would kill the source
+    generator).
+    """
+    queue: asyncio.Queue = asyncio.Queue()
+
+    async def _pump() -> None:
+        try:
+            async for event in events:
+                await queue.put(event)
+        except Exception as e:
+            await queue.put(e)
+        finally:
+            await queue.put(None)
+
+    pump_task = asyncio.create_task(_pump())
+    try:
+        while True:
+            try:
+                item = await asyncio.wait_for(queue.get(), timeout=SSE_KEEPALIVE_INTERVAL_SECONDS)
+            except asyncio.TimeoutError:
+                yield ": keepalive\n\n"
+                continue
+            if item is None:
+                break
+            if isinstance(item, Exception):
+                yield encoder.encode(RunErrorEvent(type=EventType.RUN_ERROR, message=str(item)))
+                continue  # the None sentinel follows right after
+            yield encoder.encode(item)
+    finally:
+        pump_task.cancel()
+        with contextlib.suppress(BaseException):
+            await pump_task
+
+
+async def _verify_reattach_binding(
+    entity: Union[Agent, Team],
+    run_id: str,
+    thread_id: str,
+    user_id: Optional[str],
+) -> None:
+    """Verify the run belongs to this thread before replaying its events.
+
+    The event buffer is keyed on run_id alone, so a scoped caller could
+    otherwise attach to another user's run by naming a thread of their own.
+    Background runs persist a PENDING row before execution starts, so the DB
+    binding check holds for queued, active, and terminal runs alike. Unscoped
+    deployments (and db-less entities, where reattach serves only the live
+    buffer) skip this, mirroring the REST /resume ownership posture.
+    """
+    if user_id is None or getattr(entity, "db", None) is None:
+        return
+    bound_run = await entity.aget_run_output(run_id=run_id, session_id=thread_id, user_id=user_id)
+    if bound_run is None:
+        raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
 
 
 async def run_entity(
@@ -194,6 +267,12 @@ def attach_routes(
                 )
             if run_input.resume:
                 raise HTTPException(status_code=400, detail="reattach cannot be combined with HITL resume entries")
+            await _verify_reattach_binding(
+                entity,  # type: ignore[arg-type]
+                run_id=run_input.run_id,
+                thread_id=run_input.thread_id,
+                user_id=user_id,
+            )
             buffer_status, stored_run = await find_reattach_target(
                 entity,  # type: ignore[arg-type]
                 run_id=run_input.run_id,
@@ -203,43 +282,29 @@ def attach_routes(
             if buffer_status is None and stored_run is None:
                 raise HTTPException(status_code=404, detail=f"Run {run_input.run_id} not found")
 
-            async def reattach_event_generator():
-                async for event in reattach_run_events(
-                    entity,  # type: ignore[arg-type]
-                    thread_id=run_input.thread_id,
-                    run_id=run_input.run_id,
-                    user_id=user_id,
-                    buffer_status=buffer_status,
-                    stored_run=stored_run,
-                ):
-                    yield encoder.encode(event)
-
             return StreamingResponse(
-                reattach_event_generator(),
+                _encode_with_keepalive(
+                    reattach_run_events(
+                        entity,  # type: ignore[arg-type]
+                        thread_id=run_input.thread_id,
+                        run_id=run_input.run_id,
+                        user_id=user_id,
+                        buffer_status=buffer_status,
+                        stored_run=stored_run,
+                    ),
+                    encoder,
+                ),
                 media_type="text/event-stream",
-                headers={
-                    "Cache-Control": "no-cache",
-                    "Connection": "keep-alive",
-                    "Access-Control-Allow-Origin": "*",
-                    "Access-Control-Allow-Methods": "POST, GET, OPTIONS",
-                    "Access-Control-Allow-Headers": "*",
-                },
+                headers=_SSE_HEADERS,
             )
 
-        async def event_generator():
-            async for event in run_entity(entity, run_input, user_id=user_id, background=background):  # type: ignore
-                yield encoder.encode(event)
-
         return StreamingResponse(
-            event_generator(),
+            _encode_with_keepalive(
+                run_entity(entity, run_input, user_id=user_id, background=background),  # type: ignore
+                encoder,
+            ),
             media_type="text/event-stream",
-            headers={
-                "Cache-Control": "no-cache",
-                "Connection": "keep-alive",
-                "Access-Control-Allow-Origin": "*",
-                "Access-Control-Allow-Methods": "POST, GET, OPTIONS",
-                "Access-Control-Allow-Headers": "*",
-            },
+            headers=_SSE_HEADERS,
         )
 
     @router.get("/status")

--- a/libs/agno/agno/os/interfaces/agui/router.py
+++ b/libs/agno/agno/os/interfaces/agui/router.py
@@ -98,13 +98,15 @@ async def run_entity(
 
         # 4. Determine if this is a resume (trailing ToolMessages) or fresh run
         if tool_messages:
-            # Resume: frontend executed external tools and sent results back
+            # Resume: frontend executed external tools and sent results back.
+            # background carries over so the resumed leg also survives disconnect.
             response_stream = await resume_paused_run(
                 entity=entity,  # type: ignore[arg-type]
                 session_id=run_input.thread_id,
                 tool_messages=tool_messages,
                 run_context=run_context,
                 run_kwargs=run_kwargs,
+                background=background,
             )
         else:
             # Fresh run: new user input

--- a/libs/agno/agno/os/interfaces/agui/router.py
+++ b/libs/agno/agno/os/interfaces/agui/router.py
@@ -4,7 +4,7 @@ import copy
 import uuid
 from typing import Any, AsyncIterator, Dict, Optional, Union
 
-from agno.utils.log import log_error, log_warning
+from agno.utils.log import log_debug, log_error, log_warning
 
 try:
     from ag_ui.core import (
@@ -132,6 +132,7 @@ async def _build_reattach_response(
         resolved_run_id = await find_active_run_id(entity, thread_id=thread_id, user_id=user_id)
         if resolved_run_id is None:
             raise HTTPException(status_code=404, detail=f"No active run for thread {thread_id}")
+        log_debug(f"Reattach auto-resolved thread {thread_id} to run {resolved_run_id}")
         run_id = resolved_run_id
         resolved = True
 

--- a/libs/agno/agno/os/routers/session/session.py
+++ b/libs/agno/agno/os/routers/session/session.py
@@ -11,6 +11,7 @@ from agno.db.utils import deserialize_session_by_type, resolve_session_type
 from agno.exceptions import AgnoError
 from agno.media.storage.base import AsyncMediaStorage, MediaStorage
 from agno.os.auth import get_auth_token_from_request, get_authentication_dependency
+from agno.os.event_streams import find_active_run
 from agno.os.middleware.user_scope import (
     enforce_owner_on_entity,
     get_scoped_user_id,
@@ -46,6 +47,26 @@ from agno.utils.log import log_debug
 from agno.utils.media_offload import adelete_media_keys, session_media_keys
 
 logger = logging.getLogger(__name__)
+
+
+async def _active_run_payload(session: Session) -> Optional[Dict[str, Any]]:
+    """Build the active_run field for a session detail response: the thread's in-progress run, if any.
+
+    Only PENDING/RUNNING runs whose event stream is still live qualify — the probe inside
+    find_active_run skips rows that outlived their producer (server restart, crashed run), so a
+    client can treat the field's absence as "settled history, nothing to reattach to". PAUSED
+    runs wait on human input and follow the HITL resume flow, not reattach.
+    """
+    runs = getattr(session, "runs", None)
+    if not runs:
+        return None
+    run = await find_active_run(runs)
+    if run is None:
+        return None
+    return {
+        "run_id": run.run_id,
+        "status": run.status.value if hasattr(run.status, "value") else run.status,
+    }
 
 
 def get_session_router(
@@ -555,9 +576,13 @@ def attach_routes(
             )
 
         if session_type == SessionType.AGENT:
-            return AgentSessionDetailSchema.from_session(session)  # type: ignore
+            detail = AgentSessionDetailSchema.from_session(session)  # type: ignore
+            detail.active_run = await _active_run_payload(session)
+            return detail
         elif session_type == SessionType.TEAM:
-            return TeamSessionDetailSchema.from_session(session)  # type: ignore
+            detail = TeamSessionDetailSchema.from_session(session)  # type: ignore
+            detail.active_run = await _active_run_payload(session)
+            return detail
         else:
             return WorkflowSessionDetailSchema.from_session(session)  # type: ignore
 

--- a/libs/agno/agno/os/routers/session/session.py
+++ b/libs/agno/agno/os/routers/session/session.py
@@ -66,6 +66,7 @@ async def _active_run_payload(session: Session) -> Optional[Dict[str, Any]]:
     return {
         "run_id": run.run_id,
         "status": run.status.value if hasattr(run.status, "value") else run.status,
+        "created_at": run.created_at,
     }
 
 

--- a/libs/agno/agno/os/schema.py
+++ b/libs/agno/agno/os/schema.py
@@ -470,6 +470,11 @@ class AgentSessionDetailSchema(BaseModel):
     metrics: Optional[dict] = Field(None, description="Session metrics")
     metadata: Optional[dict] = Field(None, description="Additional metadata")
     chat_history: Optional[List[dict]] = Field(None, description="Complete chat history")
+    active_run: Optional[dict] = Field(
+        None,
+        description="In-progress run (run_id, status) whose event stream is still live — reattach to keep watching; "
+        "absent when nothing is running",
+    )
     created_at: Optional[datetime] = Field(None, description="Session creation timestamp")
     updated_at: Optional[datetime] = Field(None, description="Last update timestamp")
 
@@ -509,6 +514,11 @@ class TeamSessionDetailSchema(BaseModel):
     team_data: Optional[dict] = Field(None, description="Team-specific data")
     metadata: Optional[dict] = Field(None, description="Additional metadata")
     chat_history: Optional[List[dict]] = Field(None, description="Complete chat history")
+    active_run: Optional[dict] = Field(
+        None,
+        description="In-progress run (run_id, status) whose event stream is still live — reattach to keep watching; "
+        "absent when nothing is running",
+    )
     created_at: Optional[datetime] = Field(None, description="Session creation timestamp")
     updated_at: Optional[datetime] = Field(None, description="Last update timestamp")
     total_tokens: Optional[int] = Field(None, description="Total tokens used in this session")

--- a/libs/agno/agno/os/schema.py
+++ b/libs/agno/agno/os/schema.py
@@ -472,8 +472,8 @@ class AgentSessionDetailSchema(BaseModel):
     chat_history: Optional[List[dict]] = Field(None, description="Complete chat history")
     active_run: Optional[dict] = Field(
         None,
-        description="In-progress run (run_id, status) whose event stream is still live — reattach to keep watching; "
-        "absent when nothing is running",
+        description="In-progress run (run_id, status, created_at) whose event stream is still live — reattach to "
+        "keep watching; absent when nothing is running",
     )
     created_at: Optional[datetime] = Field(None, description="Session creation timestamp")
     updated_at: Optional[datetime] = Field(None, description="Last update timestamp")
@@ -516,8 +516,8 @@ class TeamSessionDetailSchema(BaseModel):
     chat_history: Optional[List[dict]] = Field(None, description="Complete chat history")
     active_run: Optional[dict] = Field(
         None,
-        description="In-progress run (run_id, status) whose event stream is still live — reattach to keep watching; "
-        "absent when nothing is running",
+        description="In-progress run (run_id, status, created_at) whose event stream is still live — reattach to "
+        "keep watching; absent when nothing is running",
     )
     created_at: Optional[datetime] = Field(None, description="Session creation timestamp")
     updated_at: Optional[datetime] = Field(None, description="Last update timestamp")

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -8808,13 +8808,18 @@ async def _acontinue_run_background_stream(
     yield_run_output: Optional[bool] = None,
     debug_mode: Optional[bool] = None,
     background_tasks: Optional[Any] = None,
+    raw_events: bool = False,
     **kwargs: Any,
-) -> AsyncIterator[str]:
+) -> AsyncIterator[Any]:
     """Background streaming continue-run that survives client disconnections.
 
     Mirrors _arun_background_stream but drives _acontinue_run_stream instead of
     _arun_stream. Used for HITL scenarios where a paused run resumes and the
     client needs reconnection support.
+
+    When ``raw_events`` is True, the queue carries raw TeamRunOutputEvent
+    objects instead of SSE strings (and no keepalive comments are emitted),
+    so non-SSE transports such as AG-UI can convert the events themselves.
 
     Without this, team.acontinue_run(background=True, stream=True) would route
     to _acontinue_run_stream and yield raw TeamRunOutputEvent objects directly
@@ -8947,12 +8952,15 @@ async def _acontinue_run_background_stream(
             except Exception:
                 log_warning(f"Failed to buffer event for continue-run {_run_id}")
 
-            sse_data = format_sse_event_with_index(event, event_index=event_index, run_id=_run_id)
+            # Raw mode hands the event object to the caller for its own framing
+            queue_item: Any = event
+            if not raw_events:
+                queue_item = format_sse_event_with_index(event, event_index=event_index, run_id=_run_id)
 
             try:
-                await sse_queue.put(sse_data)
+                await sse_queue.put(queue_item)
             except Exception:
-                log_warning(f"Failed to push SSE data to queue for continue-run {_run_id}")
+                log_warning(f"Failed to push event to queue for continue-run {_run_id}")
 
         try:
             await slot_cm.__aenter__()
@@ -9241,12 +9249,14 @@ async def _acontinue_run_background_stream(
 
     # 4. Yield SSE strings from the queue. Emit SSE keepalive comments on idle
     # so proxies do not kill the connection while the run waits for a slot (or
-    # during long silent stretches of execution).
+    # during long silent stretches of execution). Raw mode yields event objects
+    # and no keepalives — comment frames would corrupt the caller's conversion.
     while True:
         try:
             sse_data = await asyncio.wait_for(sse_queue.get(), timeout=SSE_KEEPALIVE_INTERVAL_SECONDS)
         except asyncio.TimeoutError:
-            yield ": keepalive\n\n"
+            if not raw_events:
+                yield ": keepalive\n\n"
             continue
         if sse_data is None:
             break
@@ -9299,6 +9309,9 @@ def acontinue_run_dispatch(  # type: ignore
         raise ValueError("Session ID is required to continue a run from a run_id.")
 
     background_tasks = kwargs.pop("background_tasks", None)
+    # Raw-event output for non-SSE transports (e.g. AG-UI); only meaningful
+    # for background streaming, popped here so it never leaks into model kwargs
+    raw_events = bool(kwargs.pop("raw_events", False))
     if background_tasks is not None:
         from fastapi import BackgroundTasks
 
@@ -9400,6 +9413,7 @@ def acontinue_run_dispatch(  # type: ignore
                 yield_run_output=opts.yield_run_output,
                 debug_mode=debug_mode,
                 background_tasks=background_tasks,
+                raw_events=raw_events,
                 **kwargs,
             )
         # background=True, stream=False is not supported for continue_run yet —

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -3581,8 +3581,9 @@ async def _arun_background_stream(
     yield_run_output: Optional[bool] = None,
     debug_mode: Optional[bool] = None,
     background_tasks: Optional[Any] = None,
+    raw_events: bool = False,
     **kwargs: Any,
-) -> AsyncIterator[str]:
+) -> AsyncIterator[Any]:
     """Background streaming team run that survives client disconnections.
 
     1. Persists RUNNING status in DB
@@ -3592,6 +3593,10 @@ async def _arun_background_stream(
 
     The detached task keeps running even if the client disconnects.
     The caller (router) just yields the SSE strings to the client.
+
+    When ``raw_events`` is True, the queue carries raw TeamRunOutputEvent
+    objects instead of SSE strings (and no keepalive comments are emitted),
+    so non-SSE transports such as AG-UI can convert the events themselves.
     """
     from agno.os.event_streams import get_event_stream
     from agno.team._session import asave_run, asave_session
@@ -3671,12 +3676,15 @@ async def _arun_background_stream(
                 except Exception:
                     log_warning(f"Failed to buffer event for run {run_id}")
 
-                # Format as SSE for the primary queue (original client)
-                sse_data = format_sse_event_with_index(event, event_index=event_index, run_id=run_id)
+                # Format as SSE for the primary queue (original client); raw
+                # mode hands the event object to the caller for its own framing
+                queue_item: Any = event
+                if not raw_events:
+                    queue_item = format_sse_event_with_index(event, event_index=event_index, run_id=run_id)
                 try:
-                    await sse_queue.put(sse_data)
+                    await sse_queue.put(queue_item)
                 except Exception:
-                    log_warning(f"Failed to push SSE data to queue for run {run_id}")
+                    log_warning(f"Failed to push event to queue for run {run_id}")
 
         except asyncio.CancelledError:
             # Task-level shutdown (event loop stopping), not run-cancellation:
@@ -3741,12 +3749,14 @@ async def _arun_background_stream(
 
     # 4. Yield SSE strings from the queue. Emit SSE keepalive comments on idle
     # so proxies do not kill the connection while the run waits for a slot (or
-    # during long silent stretches of execution).
+    # during long silent stretches of execution). Raw mode yields event objects
+    # and no keepalives — comment frames would corrupt the caller's conversion.
     while True:
         try:
             sse_data = await asyncio.wait_for(sse_queue.get(), timeout=SSE_KEEPALIVE_INTERVAL_SECONDS)
         except asyncio.TimeoutError:
-            yield ": keepalive\n\n"
+            if not raw_events:
+                yield ": keepalive\n\n"
             continue
         if sse_data is None:
             break
@@ -4330,6 +4340,9 @@ def arun_dispatch(  # type: ignore
         )
 
     background_tasks = kwargs.pop("background_tasks", None)
+    # Raw-event output for non-SSE transports (e.g. AG-UI); only meaningful
+    # for background streaming, popped here so it never leaks into model kwargs
+    raw_events = bool(kwargs.pop("raw_events", False))
     if background_tasks is not None:
         from fastapi import BackgroundTasks
 
@@ -4434,6 +4447,7 @@ def arun_dispatch(  # type: ignore
                 yield_run_output=opts.yield_run_output,
                 debug_mode=debug_mode,
                 background_tasks=background_tasks,
+                raw_events=raw_events,
                 **kwargs,
             )
         return _arun_background(  # type: ignore[return-value]

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -4303,6 +4303,9 @@ def arun_dispatch(  # type: ignore
     yield_run_output: bool = False,
     output_schema: Optional[Union[Type[BaseModel], Dict[str, Any]]] = None,
     background: bool = False,
+    # Raw TeamRunOutputEvent objects on the queue instead of SSE strings; only
+    # meaningful for background streaming (non-SSE transports such as AG-UI)
+    raw_events: bool = False,
     **kwargs: Any,
 ) -> Union[TeamRunOutput, AsyncIterator[Union[RunOutputEvent, TeamRunOutputEvent]]]:
     """Run the Team asynchronously and return the response."""
@@ -4340,9 +4343,6 @@ def arun_dispatch(  # type: ignore
         )
 
     background_tasks = kwargs.pop("background_tasks", None)
-    # Raw-event output for non-SSE transports (e.g. AG-UI); only meaningful
-    # for background streaming, popped here so it never leaks into model kwargs
-    raw_events = bool(kwargs.pop("raw_events", False))
     if background_tasks is not None:
         from fastapi import BackgroundTasks
 
@@ -9288,6 +9288,9 @@ def acontinue_run_dispatch(  # type: ignore
     debug_mode: Optional[bool] = None,
     yield_run_output: bool = False,
     background: bool = False,
+    # Raw event objects on the queue instead of SSE strings; only
+    # meaningful for background streaming (non-SSE transports such as AG-UI)
+    raw_events: bool = False,
     **kwargs: Any,
 ) -> Union[TeamRunOutput, AsyncIterator[Union[TeamRunOutputEvent, RunOutputEvent, TeamRunOutput]]]:
     """Continue a paused team run (async entry point).
@@ -9309,9 +9312,6 @@ def acontinue_run_dispatch(  # type: ignore
         raise ValueError("Session ID is required to continue a run from a run_id.")
 
     background_tasks = kwargs.pop("background_tasks", None)
-    # Raw-event output for non-SSE transports (e.g. AG-UI); only meaningful
-    # for background streaming, popped here so it never leaks into model kwargs
-    raw_events = bool(kwargs.pop("raw_events", False))
     if background_tasks is not None:
         from fastapi import BackgroundTasks
 

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -1041,6 +1041,9 @@ class Team:
         yield_run_output: bool = False,
         output_schema: Optional[Union[Type[BaseModel], Dict[str, Any]]] = None,
         background: bool = False,
+        # Raw event objects instead of SSE strings on the background stream;
+        # transport-internal (AG-UI), only meaningful with background + stream
+        raw_events: bool = False,
         **kwargs: Any,
     ) -> Union[TeamRunOutput, AsyncIterator[Union[RunOutputEvent, TeamRunOutputEvent]]]:
         return _run.arun_dispatch(
@@ -1067,6 +1070,7 @@ class Team:
             yield_run_output=yield_run_output,
             output_schema=output_schema,
             background=background,
+            raw_events=raw_events,
             **kwargs,
         )
 
@@ -1219,6 +1223,9 @@ class Team:
         debug_mode: Optional[bool] = None,
         yield_run_output: bool = False,
         background: bool = False,
+        # Raw event objects instead of SSE strings on the background stream;
+        # transport-internal (AG-UI), only meaningful with background + stream
+        raw_events: bool = False,
         **kwargs: Any,
     ) -> Union[TeamRunOutput, AsyncIterator[Union[TeamRunOutputEvent, RunOutputEvent, TeamRunOutput]]]:
         return _run.acontinue_run_dispatch(
@@ -1243,6 +1250,7 @@ class Team:
             debug_mode=debug_mode,
             yield_run_output=yield_run_output,
             background=background,
+            raw_events=raw_events,
             **kwargs,
         )
 

--- a/libs/agno/tests/unit/os/interfaces/test_agui_background.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_background.py
@@ -182,6 +182,108 @@ def test_normalize_payload_garbage_returns_none():
 
 
 # ----------------------------------------------------------------------
+# find_active_run_id
+# ----------------------------------------------------------------------
+
+
+class _ProbeStream:
+    """Event stream stub whose liveness answer varies per run_id."""
+
+    def __init__(self, statuses):
+        self.statuses = statuses
+
+    async def get_run_status(self, run_id):
+        return self.statuses.get(run_id)
+
+
+def _run_stub(run_id, status):
+    run = MagicMock()
+    run.run_id = run_id
+    run.status = status
+    return run
+
+
+def _entity_with_session_runs(runs):
+    from unittest.mock import AsyncMock
+
+    session = MagicMock()
+    session.runs = runs
+    entity = MagicMock()
+    entity.db = MagicMock()
+    entity.aget_session = AsyncMock(return_value=session)
+    return entity
+
+
+@pytest.mark.asyncio
+async def test_find_active_run_id_picks_newest_live_run(monkeypatch):
+    stream = _ProbeStream({"r1": RunStatus.running, "r2": RunStatus.running})
+    monkeypatch.setattr("agno.os.interfaces.agui.reattach.get_event_stream", lambda: stream)
+    entity = _entity_with_session_runs(
+        [_run_stub("r0", RunStatus.completed), _run_stub("r1", RunStatus.running), _run_stub("r2", RunStatus.pending)]
+    )
+
+    from agno.os.interfaces.agui.reattach import find_active_run_id
+
+    assert await find_active_run_id(entity, thread_id="t", user_id=None) == "r2"
+
+
+@pytest.mark.asyncio
+async def test_find_active_run_id_skips_runs_the_buffer_no_longer_knows(monkeypatch):
+    # Server restarted: r2's row still says RUNNING but its buffer is gone
+    stream = _ProbeStream({"r1": RunStatus.running})
+    monkeypatch.setattr("agno.os.interfaces.agui.reattach.get_event_stream", lambda: stream)
+    entity = _entity_with_session_runs([_run_stub("r1", RunStatus.running), _run_stub("r2", RunStatus.running)])
+
+    from agno.os.interfaces.agui.reattach import find_active_run_id
+
+    assert await find_active_run_id(entity, thread_id="t", user_id=None) == "r1"
+
+
+@pytest.mark.asyncio
+async def test_find_active_run_id_returns_none_when_nothing_is_live(monkeypatch):
+    stream = _ProbeStream({})
+    monkeypatch.setattr("agno.os.interfaces.agui.reattach.get_event_stream", lambda: stream)
+    entity = _entity_with_session_runs([_run_stub("r1", RunStatus.running)])
+
+    from agno.os.interfaces.agui.reattach import find_active_run_id
+
+    assert await find_active_run_id(entity, thread_id="t", user_id=None) is None
+
+
+@pytest.mark.asyncio
+async def test_find_active_run_id_ignores_paused_runs(monkeypatch):
+    # PAUSED runs wait on HITL input and follow the resume flow, not reattach
+    stream = _ProbeStream({"r1": RunStatus.paused})
+    monkeypatch.setattr("agno.os.interfaces.agui.reattach.get_event_stream", lambda: stream)
+    entity = _entity_with_session_runs([_run_stub("r1", RunStatus.paused)])
+
+    from agno.os.interfaces.agui.reattach import find_active_run_id
+
+    assert await find_active_run_id(entity, thread_id="t", user_id=None) is None
+
+
+@pytest.mark.asyncio
+async def test_find_active_run_id_without_db_returns_none():
+    from agno.os.interfaces.agui.reattach import find_active_run_id
+
+    entity = MagicMock()
+    entity.db = None
+    assert await find_active_run_id(entity, thread_id="t", user_id=None) is None
+
+
+@pytest.mark.asyncio
+async def test_find_active_run_id_without_session_returns_none():
+    from unittest.mock import AsyncMock
+
+    from agno.os.interfaces.agui.reattach import find_active_run_id
+
+    entity = MagicMock()
+    entity.db = MagicMock()
+    entity.aget_session = AsyncMock(return_value=None)
+    assert await find_active_run_id(entity, thread_id="t", user_id=None) is None
+
+
+# ----------------------------------------------------------------------
 # find_reattach_target
 # ----------------------------------------------------------------------
 
@@ -432,6 +534,74 @@ def test_route_reattach_unknown_run_is_404():
 
     response = client.post("/agui", json=_agui_payload(forwarded_props={"reattach": True}))
     assert response.status_code == 404
+
+
+def _make_reattach_route_entity(runs):
+    """Entity whose session carries `runs`; db.get_session returns None so the
+    session-writable probe treats the thread as not yet owned."""
+    from unittest.mock import AsyncMock
+
+    session = MagicMock()
+    session.runs = runs
+    entity = MagicMock()
+    entity.db = MagicMock()
+    entity.db.get_session = MagicMock(return_value=None)
+    entity.aget_session = AsyncMock(return_value=session)
+    return entity
+
+
+def test_route_reattach_empty_run_id_resolves_active_run(monkeypatch):
+    stream = FakeEventStream(
+        status=RunStatus.completed,
+        replay=[(0, _content_event("done")), (1, _completed_event())],
+    )
+    monkeypatch.setattr("agno.os.interfaces.agui.reattach.get_event_stream", lambda: stream)
+    entity = _make_reattach_route_entity([_run_stub("r-active", RunStatus.running)])
+    client = _make_client(entity)
+
+    response = client.post("/agui", json=_agui_payload(run_id="", forwarded_props={"reattach": True}))
+
+    assert response.status_code == 200
+    # The stream opens with RUN_STARTED carrying the RESOLVED run_id, so the
+    # client learns which run it was attached to
+    first_frame = response.text.split("\n\n")[0]
+    assert "RUN_STARTED" in first_frame
+    assert "r-active" in first_frame
+
+
+def test_route_reattach_empty_run_id_without_active_run_is_404(monkeypatch):
+    stream = FakeEventStream(status=None)
+    monkeypatch.setattr("agno.os.interfaces.agui.reattach.get_event_stream", lambda: stream)
+    entity = _make_reattach_route_entity([_run_stub("r0", RunStatus.completed)])
+    client = _make_client(entity)
+
+    response = client.post("/agui", json=_agui_payload(run_id="", forwarded_props={"reattach": True}))
+    assert response.status_code == 404
+    assert "No active run" in response.json()["detail"]
+
+
+def test_route_reattach_empty_run_id_without_db_is_400():
+    entity = MagicMock()
+    entity.db = None
+    client = _make_client(entity)
+
+    response = client.post("/agui", json=_agui_payload(run_id="", forwarded_props={"reattach": True}))
+    assert response.status_code == 400
+    assert "database" in response.json()["detail"]
+
+
+def test_route_reattach_explicit_unknown_run_id_never_auto_resolves(monkeypatch):
+    # Strictness guard: a named-but-unknown run 404s even when the thread HAS
+    # an active run — auto-resolution only triggers on the empty-string sentinel
+    stream = _ProbeStream({"r-active": RunStatus.running})
+    monkeypatch.setattr("agno.os.interfaces.agui.reattach.get_event_stream", lambda: stream)
+    entity = _make_reattach_route_entity([_run_stub("r-active", RunStatus.running)])
+    entity.aget_run_output = MagicMock(return_value=_coro(None))
+    client = _make_client(entity)
+
+    response = client.post("/agui", json=_agui_payload(run_id="r-typo", forwarded_props={"reattach": True}))
+    assert response.status_code == 404
+    assert "r-typo" in response.json()["detail"]
 
 
 # ----------------------------------------------------------------------

--- a/libs/agno/tests/unit/os/interfaces/test_agui_background.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_background.py
@@ -1,0 +1,434 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("ag_ui", reason="ag_ui not installed")
+
+from ag_ui.core import EventType
+
+from agno.models.response import ToolExecution
+from agno.os.interfaces.agui.reattach import (
+    _normalize_payload,
+    _SnapshotBuilder,
+    find_reattach_target,
+    reattach_run_events,
+)
+from agno.os.interfaces.agui.router import run_entity
+from agno.os.utils import format_sse_event_with_index
+from agno.run.agent import RunCompletedEvent, RunContentEvent, RunEvent, ToolCallCompletedEvent, ToolCallStartedEvent
+from agno.run.base import RunStatus
+
+
+class FakeRunInput:
+    def __init__(self, *, messages=None, forwarded_props=None, resume=None):
+        self.messages = messages if messages is not None else [MagicMock(role="user", content="test")]
+        self.thread_id = "test-thread"
+        self.run_id = "test-run"
+        self.forwarded_props = forwarded_props
+        self.state = None
+        self.context = None
+        self.tools = None
+        self.resume = resume
+
+
+class CaptureKwargsEntity:
+    def __init__(self):
+        self.captured_kwargs = {}
+
+    async def arun(self, **kwargs):
+        self.captured_kwargs = kwargs
+        return
+        yield
+
+
+def _content_event(text: str) -> RunContentEvent:
+    event = RunContentEvent()
+    event.event = RunEvent.run_content
+    event.content = text
+    return event
+
+
+def _completed_event() -> RunCompletedEvent:
+    event = RunCompletedEvent()
+    event.event = RunEvent.run_completed
+    event.content = ""
+    return event
+
+
+def _tool_started_event() -> ToolCallStartedEvent:
+    event = ToolCallStartedEvent()
+    event.event = RunEvent.tool_call_started
+    event.tool = ToolExecution(tool_call_id="call_1", tool_name="get_weather", tool_args={"city": "NYC"})
+    return event
+
+
+def _tool_completed_event() -> ToolCallCompletedEvent:
+    event = ToolCallCompletedEvent()
+    event.event = RunEvent.tool_call_completed
+    event.tool = ToolExecution(
+        tool_call_id="call_1", tool_name="get_weather", tool_args={"city": "NYC"}, result="sunny"
+    )
+    return event
+
+
+# ----------------------------------------------------------------------
+# run_entity background flag passthrough
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_entity_background_passes_raw_events_flag():
+    entity = CaptureKwargsEntity()
+
+    async for _ in run_entity(entity, FakeRunInput(), background=True):
+        pass
+
+    assert entity.captured_kwargs.get("background") is True
+    assert entity.captured_kwargs.get("raw_events") is True
+    assert entity.captured_kwargs.get("stream") is True
+
+
+@pytest.mark.asyncio
+async def test_run_entity_inline_omits_background_flags():
+    entity = CaptureKwargsEntity()
+
+    async for _ in run_entity(entity, FakeRunInput()):
+        pass
+
+    assert "background" not in entity.captured_kwargs
+    assert "raw_events" not in entity.captured_kwargs
+
+
+# ----------------------------------------------------------------------
+# _SnapshotBuilder
+# ----------------------------------------------------------------------
+
+
+def test_snapshot_builder_text_and_completion():
+    builder = _SnapshotBuilder(thread_id="t", run_id="r")
+    builder.consume(_content_event("Hello "))
+    builder.consume(_content_event("world"))
+    builder.consume(_completed_event())
+
+    assert builder.finished is True
+    snapshot = builder.snapshot_events()
+    assert snapshot[0].type == EventType.MESSAGES_SNAPSHOT
+    messages = snapshot[0].messages
+    assert len(messages) == 1
+    assert messages[0].role == "assistant"
+    assert messages[0].content == "Hello world"
+
+
+def test_snapshot_builder_tool_calls_attached_to_parent_message():
+    builder = _SnapshotBuilder(thread_id="t", run_id="r")
+    builder.consume(_content_event("Checking weather"))
+    builder.consume(_tool_started_event())
+    builder.consume(_tool_completed_event())
+    builder.consume(_completed_event())
+
+    snapshot = builder.snapshot_events()
+    messages = snapshot[0].messages
+
+    assistant_messages = [m for m in messages if m.role == "assistant"]
+    tool_messages = [m for m in messages if m.role == "tool"]
+
+    # The tool call is attached to its parent assistant message
+    parent = next(m for m in assistant_messages if m.tool_calls)
+    assert parent.tool_calls[0].id == "call_1"
+    assert parent.tool_calls[0].function.name == "get_weather"
+    assert '"city": "NYC"' in parent.tool_calls[0].function.arguments
+
+    # The tool result becomes a tool message linked by tool_call_id
+    assert len(tool_messages) == 1
+    assert tool_messages[0].tool_call_id == "call_1"
+    assert "sunny" in tool_messages[0].content
+
+
+def test_snapshot_builder_empty_prefix_emits_no_snapshot():
+    builder = _SnapshotBuilder(thread_id="t", run_id="r")
+    assert builder.snapshot_events() == []
+
+
+def test_snapshot_builder_state_snapshot_tracked():
+    builder = _SnapshotBuilder(thread_id="t", run_id="r", run_state={"count": 1})
+    snapshot = builder.snapshot_events()
+    assert len(snapshot) == 1
+    assert snapshot[0].type == EventType.STATE_SNAPSHOT
+    assert snapshot[0].snapshot == {"count": 1}
+
+
+# ----------------------------------------------------------------------
+# _normalize_payload
+# ----------------------------------------------------------------------
+
+
+def test_normalize_payload_passthrough_raw_object():
+    event = _content_event("hi")
+    assert _normalize_payload(event, is_team=False) is event
+
+
+def test_normalize_payload_parses_sse_string():
+    event = _content_event("hi")
+    sse = format_sse_event_with_index(event, event_index=3, run_id="r")
+    recovered = _normalize_payload(sse, is_team=False)
+    assert recovered is not None
+    assert recovered.event == RunEvent.run_content
+    assert recovered.content == "hi"
+
+
+def test_normalize_payload_garbage_returns_none():
+    assert _normalize_payload("not an sse frame", is_team=False) is None
+    assert _normalize_payload('data: {"event": "unknown_thing"}\n\n', is_team=False) is None
+
+
+# ----------------------------------------------------------------------
+# find_reattach_target
+# ----------------------------------------------------------------------
+
+
+class FakeEventStream:
+    def __init__(self, status=None, replay=None, tail_items=None):
+        self.status = status
+        self.replay_items = replay or []
+        self.tail_items = tail_items or []
+
+    async def get_run_status(self, run_id):
+        return self.status
+
+    async def replay(self, run_id, last_event_index=None):
+        return list(self.replay_items)
+
+    async def tail(self, run_id, last_event_index=None):
+        for item in self.tail_items:
+            yield item
+
+
+@pytest.mark.asyncio
+async def test_find_reattach_target_in_buffer(monkeypatch):
+    stream = FakeEventStream(status=RunStatus.running)
+    monkeypatch.setattr("agno.os.interfaces.agui.reattach.get_event_stream", lambda: stream)
+
+    status, stored = await find_reattach_target(MagicMock(), run_id="r", session_id="s")
+    assert status == RunStatus.running
+    assert stored is None
+
+
+@pytest.mark.asyncio
+async def test_find_reattach_target_db_fallback(monkeypatch):
+    stream = FakeEventStream(status=None)
+    monkeypatch.setattr("agno.os.interfaces.agui.reattach.get_event_stream", lambda: stream)
+
+    run_output = MagicMock()
+    entity = MagicMock()
+    entity.db = MagicMock()
+    entity.aget_run_output = MagicMock(return_value=_coro(run_output))
+
+    # isinstance guards exclude remotes; a plain MagicMock entity is local
+    status, stored = await find_reattach_target(entity, run_id="r", session_id="s")
+    assert status is None
+    assert stored is run_output
+
+
+@pytest.mark.asyncio
+async def test_find_reattach_target_not_found_without_db(monkeypatch):
+    stream = FakeEventStream(status=None)
+    monkeypatch.setattr("agno.os.interfaces.agui.reattach.get_event_stream", lambda: stream)
+
+    entity = MagicMock()
+    entity.db = None
+    status, stored = await find_reattach_target(entity, run_id="r", session_id="s")
+    assert status is None
+    assert stored is None
+
+
+async def _coro(value):
+    return value
+
+
+# ----------------------------------------------------------------------
+# reattach_run_events
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reattach_from_database_replay():
+    stored_run = MagicMock()
+    stored_run.session_state = None
+    stored_run.events = [_content_event("Hello "), _content_event("world"), _completed_event()]
+    stored_run.status = RunStatus.completed
+
+    events = []
+    async for event in reattach_run_events(
+        MagicMock(), thread_id="t", run_id="r", buffer_status=None, stored_run=stored_run
+    ):
+        events.append(event)
+
+    types = [e.type for e in events]
+    assert types == [EventType.RUN_STARTED, EventType.MESSAGES_SNAPSHOT, EventType.RUN_FINISHED]
+    assert events[1].messages[0].content == "Hello world"
+
+
+@pytest.mark.asyncio
+async def test_reattach_terminal_from_buffer(monkeypatch):
+    stream = FakeEventStream(
+        status=RunStatus.completed,
+        replay=[(0, _content_event("done")), (1, _completed_event())],
+    )
+    monkeypatch.setattr("agno.os.interfaces.agui.reattach.get_event_stream", lambda: stream)
+
+    events = []
+    async for event in reattach_run_events(
+        MagicMock(), thread_id="t", run_id="r", buffer_status=stream.status, stored_run=None
+    ):
+        events.append(event)
+
+    types = [e.type for e in events]
+    assert types == [EventType.RUN_STARTED, EventType.MESSAGES_SNAPSHOT, EventType.RUN_FINISHED]
+
+
+@pytest.mark.asyncio
+async def test_reattach_error_run_from_buffer(monkeypatch):
+    stream = FakeEventStream(status=RunStatus.error, replay=[(0, _content_event("partial"))])
+    monkeypatch.setattr("agno.os.interfaces.agui.reattach.get_event_stream", lambda: stream)
+
+    events = []
+    async for event in reattach_run_events(MagicMock(), thread_id="t", run_id="r", buffer_status=stream.status):
+        events.append(event)
+
+    assert events[0].type == EventType.RUN_STARTED
+    assert events[-1].type == EventType.RUN_ERROR
+
+
+@pytest.mark.asyncio
+async def test_reattach_active_run_snapshots_then_streams_live(monkeypatch):
+    # Buffer holds the prefix as raw objects; the tail carries SSE strings
+    # (as both backends do), exercising the parse-back path
+    live_content = _content_event(" live")
+    live_done = _completed_event()
+    stream = FakeEventStream(
+        status=RunStatus.running,
+        replay=[(0, _content_event("buffered"))],
+        tail_items=[
+            (1, format_sse_event_with_index(live_content, event_index=1, run_id="r")),
+            (2, format_sse_event_with_index(live_done, event_index=2, run_id="r")),
+        ],
+    )
+
+    monkeypatch.setattr("agno.os.interfaces.agui.reattach.get_event_stream", lambda: stream)
+
+    events = []
+    async for event in reattach_run_events(MagicMock(), thread_id="t", run_id="r", buffer_status=stream.status):
+        events.append(event)
+
+    types = [e.type for e in events]
+    assert types[0] == EventType.RUN_STARTED
+    assert EventType.MESSAGES_SNAPSHOT in types
+    # Live deltas continue on the SAME message id the snapshot established
+    snapshot = next(e for e in events if e.type == EventType.MESSAGES_SNAPSHOT)
+    live_delta = next(e for e in events if e.type == EventType.TEXT_MESSAGE_CONTENT)
+    assert snapshot.messages[0].content == "buffered"
+    assert live_delta.message_id == snapshot.messages[0].id
+    assert live_delta.delta == " live"
+    assert types[-1] == EventType.RUN_FINISHED
+
+
+# ----------------------------------------------------------------------
+# Route-level validation (errors before streaming starts)
+# ----------------------------------------------------------------------
+
+
+def _make_client(entity):
+    from fastapi import FastAPI
+    from fastapi.routing import APIRouter
+    from fastapi.testclient import TestClient
+
+    from agno.os.interfaces.agui.router import attach_routes
+
+    app = FastAPI()
+    router = attach_routes(router=APIRouter(), agent=entity)
+    app.include_router(router)
+    return TestClient(app)
+
+
+def _agui_payload(**overrides):
+    payload = {
+        "thread_id": "t",
+        "run_id": "r",
+        "state": None,
+        "messages": [],
+        "tools": [],
+        "context": [],
+        "forwarded_props": {},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_route_background_without_db_is_400():
+    entity = MagicMock()
+    entity.db = None
+    client = _make_client(entity)
+
+    response = client.post("/agui", json=_agui_payload(forwarded_props={"background": True}))
+    assert response.status_code == 400
+    assert "database" in response.json()["detail"]
+
+
+def test_route_background_on_remote_entity_is_400():
+    from agno.agent.remote import RemoteAgent
+
+    entity = MagicMock(spec=RemoteAgent)
+    entity.db = None
+    client = _make_client(entity)
+
+    response = client.post("/agui", json=_agui_payload(forwarded_props={"background": True}))
+    assert response.status_code == 400
+
+
+def test_route_background_and_reattach_together_is_400():
+    entity = MagicMock()
+    entity.db = None
+    client = _make_client(entity)
+
+    response = client.post("/agui", json=_agui_payload(forwarded_props={"background": True, "reattach": True}))
+    assert response.status_code == 400
+
+
+def test_route_reattach_with_messages_is_400():
+    entity = MagicMock()
+    entity.db = None
+    client = _make_client(entity)
+
+    response = client.post(
+        "/agui",
+        json=_agui_payload(
+            messages=[{"id": "m1", "role": "user", "content": "hello"}],
+            forwarded_props={"reattach": True},
+        ),
+    )
+    assert response.status_code == 400
+    assert "messages" in response.json()["detail"]
+
+
+def test_route_reattach_with_resume_entries_is_400():
+    entity = MagicMock()
+    entity.db = None
+    client = _make_client(entity)
+
+    response = client.post(
+        "/agui",
+        json=_agui_payload(
+            forwarded_props={"reattach": True},
+            resume=[{"interrupt_id": "i1", "status": "resolved"}],
+        ),
+    )
+    assert response.status_code == 400
+
+
+def test_route_reattach_unknown_run_is_404():
+    entity = MagicMock()
+    entity.db = None
+    client = _make_client(entity)
+
+    response = client.post("/agui", json=_agui_payload(forwarded_props={"reattach": True}))
+    assert response.status_code == 404

--- a/libs/agno/tests/unit/os/interfaces/test_agui_background.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_background.py
@@ -432,3 +432,112 @@ def test_route_reattach_unknown_run_is_404():
 
     response = client.post("/agui", json=_agui_payload(forwarded_props={"reattach": True}))
     assert response.status_code == 404
+
+
+# ----------------------------------------------------------------------
+# resume_paused_run background passthrough
+# ----------------------------------------------------------------------
+
+
+def _make_paused_run():
+    from agno.run.agent import RunOutput
+    from agno.run.requirement import RunRequirement
+
+    return RunOutput(
+        run_id="paused-run-123",
+        session_id="test-session",
+        status=RunStatus.paused,
+        requirements=[
+            RunRequirement(
+                tool_execution=ToolExecution(
+                    tool_call_id="call_1",
+                    tool_name="change_background",
+                    tool_args={"color": "blue"},
+                    external_execution_required=True,
+                )
+            )
+        ],
+    )
+
+
+def _make_resume_entity():
+    from unittest.mock import AsyncMock
+
+    from agno.agent import Agent
+    from agno.session.agent import AgentSession
+
+    async def _empty_stream():
+        return
+        yield
+
+    session = AgentSession(session_id="test-session")
+    session.runs = [_make_paused_run()]
+
+    entity = MagicMock(spec=Agent)
+    entity.db = MagicMock()
+    entity.aget_session = AsyncMock(return_value=session)
+    entity.acontinue_run = MagicMock(return_value=_empty_stream())
+    return entity
+
+
+class _FakeToolMessage:
+    tool_call_id = "call_1"
+    content = "Background changed"
+    error = None
+
+
+@pytest.mark.asyncio
+async def test_resume_background_passes_raw_events_and_skips_stream_sync(monkeypatch):
+    from unittest.mock import AsyncMock
+
+    from agno.os.interfaces.agui.resume import resume_paused_run
+    from agno.run.base import RunContext
+
+    sync_mock = AsyncMock()
+    monkeypatch.setattr("agno.os.utils.acomplete_continue_stream", sync_mock)
+
+    entity = _make_resume_entity()
+    stream = await resume_paused_run(
+        entity=entity,
+        session_id="test-session",
+        tool_messages=[_FakeToolMessage()],
+        run_context=RunContext(run_id="new-run", session_id="test-session"),
+        run_kwargs={},
+        background=True,
+    )
+    async for _ in stream:
+        pass
+
+    call_kwargs = entity.acontinue_run.call_args.kwargs
+    assert call_kwargs["background"] is True
+    assert call_kwargs["raw_events"] is True
+    # The detached producer owns the terminal sentinel; the consumer-side
+    # stream sync must NOT run (it would falsely complete a live stream)
+    sync_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_resume_inline_runs_stream_sync(monkeypatch):
+    from unittest.mock import AsyncMock
+
+    from agno.os.interfaces.agui.resume import resume_paused_run
+    from agno.run.base import RunContext
+
+    sync_mock = AsyncMock()
+    monkeypatch.setattr("agno.os.utils.acomplete_continue_stream", sync_mock)
+
+    entity = _make_resume_entity()
+    stream = await resume_paused_run(
+        entity=entity,
+        session_id="test-session",
+        tool_messages=[_FakeToolMessage()],
+        run_context=RunContext(run_id="new-run", session_id="test-session"),
+        run_kwargs={},
+    )
+    async for _ in stream:
+        pass
+
+    call_kwargs = entity.acontinue_run.call_args.kwargs
+    assert "background" not in call_kwargs
+    assert "raw_events" not in call_kwargs
+    sync_mock.assert_awaited_once()

--- a/libs/agno/tests/unit/os/interfaces/test_agui_background.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_background.py
@@ -217,7 +217,8 @@ def _entity_with_session_runs(runs):
 @pytest.mark.asyncio
 async def test_find_active_run_id_picks_newest_live_run(monkeypatch):
     stream = _ProbeStream({"r1": RunStatus.running, "r2": RunStatus.running})
-    monkeypatch.setattr("agno.os.interfaces.agui.reattach.get_event_stream", lambda: stream)
+    # The probe now lives in the shared event_streams helper, so patch its registry rather than the reattach module
+    monkeypatch.setattr("agno.os.event_streams.get_event_stream", lambda: stream)
     entity = _entity_with_session_runs(
         [_run_stub("r0", RunStatus.completed), _run_stub("r1", RunStatus.running), _run_stub("r2", RunStatus.pending)]
     )
@@ -231,7 +232,7 @@ async def test_find_active_run_id_picks_newest_live_run(monkeypatch):
 async def test_find_active_run_id_skips_runs_the_buffer_no_longer_knows(monkeypatch):
     # Server restarted: r2's row still says RUNNING but its buffer is gone
     stream = _ProbeStream({"r1": RunStatus.running})
-    monkeypatch.setattr("agno.os.interfaces.agui.reattach.get_event_stream", lambda: stream)
+    monkeypatch.setattr("agno.os.event_streams.get_event_stream", lambda: stream)
     entity = _entity_with_session_runs([_run_stub("r1", RunStatus.running), _run_stub("r2", RunStatus.running)])
 
     from agno.os.interfaces.agui.reattach import find_active_run_id
@@ -242,7 +243,7 @@ async def test_find_active_run_id_skips_runs_the_buffer_no_longer_knows(monkeypa
 @pytest.mark.asyncio
 async def test_find_active_run_id_returns_none_when_nothing_is_live(monkeypatch):
     stream = _ProbeStream({})
-    monkeypatch.setattr("agno.os.interfaces.agui.reattach.get_event_stream", lambda: stream)
+    monkeypatch.setattr("agno.os.event_streams.get_event_stream", lambda: stream)
     entity = _entity_with_session_runs([_run_stub("r1", RunStatus.running)])
 
     from agno.os.interfaces.agui.reattach import find_active_run_id
@@ -254,7 +255,7 @@ async def test_find_active_run_id_returns_none_when_nothing_is_live(monkeypatch)
 async def test_find_active_run_id_ignores_paused_runs(monkeypatch):
     # PAUSED runs wait on HITL input and follow the resume flow, not reattach
     stream = _ProbeStream({"r1": RunStatus.paused})
-    monkeypatch.setattr("agno.os.interfaces.agui.reattach.get_event_stream", lambda: stream)
+    monkeypatch.setattr("agno.os.event_streams.get_event_stream", lambda: stream)
     entity = _entity_with_session_runs([_run_stub("r1", RunStatus.paused)])
 
     from agno.os.interfaces.agui.reattach import find_active_run_id
@@ -555,6 +556,8 @@ def test_route_reattach_empty_run_id_resolves_active_run(monkeypatch):
         status=RunStatus.completed,
         replay=[(0, _content_event("done")), (1, _completed_event())],
     )
+    # Probe (event_streams registry) and replay/tail (reattach module) read the stream from different module globals — patch both with the same double
+    monkeypatch.setattr("agno.os.event_streams.get_event_stream", lambda: stream)
     monkeypatch.setattr("agno.os.interfaces.agui.reattach.get_event_stream", lambda: stream)
     entity = _make_reattach_route_entity([_run_stub("r-active", RunStatus.running)])
     client = _make_client(entity)
@@ -602,6 +605,109 @@ def test_route_reattach_explicit_unknown_run_id_never_auto_resolves(monkeypatch)
     response = client.post("/agui", json=_agui_payload(run_id="r-typo", forwarded_props={"reattach": True}))
     assert response.status_code == 404
     assert "r-typo" in response.json()["detail"]
+
+
+# ----------------------------------------------------------------------
+# POST /agui/reattach (dedicated route)
+# ----------------------------------------------------------------------
+
+
+def test_reattach_route_named_run_streams(monkeypatch):
+    stream = FakeEventStream(
+        status=RunStatus.completed,
+        replay=[(0, _content_event("done")), (1, _completed_event())],
+    )
+    monkeypatch.setattr("agno.os.interfaces.agui.reattach.get_event_stream", lambda: stream)
+    entity = _make_reattach_route_entity([_run_stub("r1", RunStatus.completed)])
+    client = _make_client(entity)
+
+    response = client.post("/agui/reattach", json={"thread_id": "t", "run_id": "r1"})
+
+    assert response.status_code == 200
+    assert "RUN_STARTED" in response.text
+    assert "RUN_FINISHED" in response.text
+
+
+def test_reattach_route_omitted_run_id_resolves_active_run(monkeypatch):
+    stream = FakeEventStream(
+        status=RunStatus.completed,
+        replay=[(0, _content_event("done")), (1, _completed_event())],
+    )
+    # Probe (event_streams registry) and replay/tail (reattach module) read the
+    # stream from different module globals — patch both with the same double
+    monkeypatch.setattr("agno.os.event_streams.get_event_stream", lambda: stream)
+    monkeypatch.setattr("agno.os.interfaces.agui.reattach.get_event_stream", lambda: stream)
+    entity = _make_reattach_route_entity([_run_stub("r-active", RunStatus.running)])
+    client = _make_client(entity)
+
+    # run_id omitted entirely — the dedicated route makes it truly optional
+    response = client.post("/agui/reattach", json={"thread_id": "t"})
+
+    assert response.status_code == 200
+    first_frame = response.text.split("\n\n")[0]
+    assert "RUN_STARTED" in first_frame
+    assert "r-active" in first_frame
+
+
+def test_reattach_route_omitted_run_id_without_active_run_is_404(monkeypatch):
+    stream = _ProbeStream({})
+    monkeypatch.setattr("agno.os.event_streams.get_event_stream", lambda: stream)
+    entity = _make_reattach_route_entity([_run_stub("r0", RunStatus.completed)])
+    client = _make_client(entity)
+
+    response = client.post("/agui/reattach", json={"thread_id": "t"})
+    assert response.status_code == 404
+    assert "No active run" in response.json()["detail"]
+
+
+def test_reattach_route_named_unknown_run_id_never_auto_resolves(monkeypatch):
+    stream = _ProbeStream({"r-active": RunStatus.running})
+    monkeypatch.setattr("agno.os.event_streams.get_event_stream", lambda: stream)
+    monkeypatch.setattr("agno.os.interfaces.agui.reattach.get_event_stream", lambda: stream)
+    entity = _make_reattach_route_entity([_run_stub("r-active", RunStatus.running)])
+    entity.aget_run_output = MagicMock(return_value=_coro(None))
+    client = _make_client(entity)
+
+    response = client.post("/agui/reattach", json={"thread_id": "t", "run_id": "r-typo"})
+    assert response.status_code == 404
+    assert "r-typo" in response.json()["detail"]
+
+
+def test_reattach_route_on_remote_entity_is_400():
+    from agno.agent.remote import RemoteAgent
+
+    entity = MagicMock(spec=RemoteAgent)
+    entity.db = None
+    client = _make_client(entity)
+
+    response = client.post("/agui/reattach", json={"thread_id": "t", "run_id": "r1"})
+    assert response.status_code == 400
+
+
+def test_reattach_route_db_less_entity_with_named_run_uses_buffer(monkeypatch):
+    # No database: auto-resolution is impossible, but an explicit run_id can
+    # still reattach to the live buffer
+    stream = FakeEventStream(
+        status=RunStatus.completed,
+        replay=[(0, _content_event("done")), (1, _completed_event())],
+    )
+    monkeypatch.setattr("agno.os.interfaces.agui.reattach.get_event_stream", lambda: stream)
+    entity = MagicMock()
+    entity.db = None
+    client = _make_client(entity)
+
+    response = client.post("/agui/reattach", json={"thread_id": "t", "run_id": "r1"})
+    assert response.status_code == 200
+
+
+def test_reattach_route_db_less_entity_without_run_id_is_400():
+    entity = MagicMock()
+    entity.db = None
+    client = _make_client(entity)
+
+    response = client.post("/agui/reattach", json={"thread_id": "t"})
+    assert response.status_code == 400
+    assert "database" in response.json()["detail"]
 
 
 # ----------------------------------------------------------------------

--- a/libs/agno/tests/unit/os/interfaces/test_agui_background.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_background.py
@@ -541,3 +541,124 @@ async def test_resume_inline_runs_stream_sync(monkeypatch):
     assert "background" not in call_kwargs
     assert "raw_events" not in call_kwargs
     sync_mock.assert_awaited_once()
+
+
+# ----------------------------------------------------------------------
+# _encode_with_keepalive
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_keepalive_emitted_on_idle(monkeypatch):
+    import asyncio
+
+    from ag_ui.core import RunFinishedEvent
+
+    from agno.os.interfaces.agui import router as router_module
+
+    monkeypatch.setattr(router_module, "SSE_KEEPALIVE_INTERVAL_SECONDS", 0.05)
+
+    async def slow_events():
+        await asyncio.sleep(0.2)
+        yield RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id="t", run_id="r")
+
+    encoder = router_module.EventEncoder()
+    lines = []
+    async for line in router_module._encode_with_keepalive(slow_events(), encoder):
+        lines.append(line)
+
+    assert ": keepalive\n\n" in lines
+    # Keepalives precede the real event; the stream ends with the encoded event
+    assert lines[-1].startswith("data:")
+    assert "RUN_FINISHED" in lines[-1]
+
+
+@pytest.mark.asyncio
+async def test_keepalive_not_emitted_when_events_flow_quickly(monkeypatch):
+    from ag_ui.core import RunFinishedEvent
+
+    from agno.os.interfaces.agui import router as router_module
+
+    async def fast_events():
+        yield RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id="t", run_id="r")
+
+    encoder = router_module.EventEncoder()
+    lines = []
+    async for line in router_module._encode_with_keepalive(fast_events(), encoder):
+        lines.append(line)
+
+    assert lines == [encoder.encode(RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id="t", run_id="r"))]
+
+
+@pytest.mark.asyncio
+async def test_keepalive_encoder_surfaces_source_exception_as_run_error():
+    from agno.os.interfaces.agui import router as router_module
+
+    async def failing_events():
+        raise RuntimeError("boom")
+        yield
+
+    encoder = router_module.EventEncoder()
+    lines = []
+    async for line in router_module._encode_with_keepalive(failing_events(), encoder):
+        lines.append(line)
+
+    assert len(lines) == 1
+    assert "RUN_ERROR" in lines[0]
+    assert "boom" in lines[0]
+
+
+# ----------------------------------------------------------------------
+# _verify_reattach_binding
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_verify_reattach_binding_skips_unscoped_callers():
+    from agno.os.interfaces.agui.router import _verify_reattach_binding
+
+    entity = MagicMock()
+    entity.db = MagicMock()
+    await _verify_reattach_binding(entity, run_id="r", thread_id="t", user_id=None)
+    entity.aget_run_output.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_verify_reattach_binding_skips_dbless_entities():
+    from agno.os.interfaces.agui.router import _verify_reattach_binding
+
+    entity = MagicMock()
+    entity.db = None
+    await _verify_reattach_binding(entity, run_id="r", thread_id="t", user_id="u1")
+    entity.aget_run_output.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_verify_reattach_binding_404_on_cross_thread_run():
+    from unittest.mock import AsyncMock
+
+    from fastapi import HTTPException
+
+    from agno.os.interfaces.agui.router import _verify_reattach_binding
+
+    entity = MagicMock()
+    entity.db = MagicMock()
+    entity.aget_run_output = AsyncMock(return_value=None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _verify_reattach_binding(entity, run_id="r", thread_id="other-thread", user_id="u1")
+    assert exc_info.value.status_code == 404
+    entity.aget_run_output.assert_awaited_once_with(run_id="r", session_id="other-thread", user_id="u1")
+
+
+@pytest.mark.asyncio
+async def test_verify_reattach_binding_passes_when_run_bound():
+    from unittest.mock import AsyncMock
+
+    from agno.os.interfaces.agui.router import _verify_reattach_binding
+
+    entity = MagicMock()
+    entity.db = MagicMock()
+    entity.aget_run_output = AsyncMock(return_value=MagicMock())
+
+    await _verify_reattach_binding(entity, run_id="r", thread_id="t", user_id="u1")

--- a/libs/agno/tests/unit/os/routers/test_session_active_run.py
+++ b/libs/agno/tests/unit/os/routers/test_session_active_run.py
@@ -1,0 +1,137 @@
+"""Unit tests for the active_run field on GET /sessions/{session_id}.
+
+The field surfaces the thread's in-progress run (PENDING/RUNNING whose event
+stream is still live) so a client opening a conversation learns — from the
+same response that carries its history — whether an answer is still being
+generated and which run to reattach to.
+"""
+
+import time
+import uuid
+
+from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
+
+from agno.db.in_memory.in_memory_db import InMemoryDb
+from agno.run.agent import RunOutput
+from agno.run.base import RunStatus
+from agno.session.agent import AgentSession
+
+
+class _ProbeStream:
+    """Event stream stub whose liveness answer varies per run_id."""
+
+    def __init__(self, statuses):
+        self.statuses = statuses
+
+    async def get_run_status(self, run_id):
+        return self.statuses.get(run_id)
+
+
+def _build_client(db):
+    from agno.os.routers.session.session import attach_routes
+
+    app = FastAPI()
+    router = APIRouter()
+    attach_routes(router, {"default": [db]})
+    app.include_router(router)
+    return TestClient(app)
+
+
+def _seed_session(db: InMemoryDb, runs) -> str:
+    uid = uuid.uuid4().hex[:8]
+    now = int(time.time())
+    session = AgentSession(
+        session_id=f"agent-{uid}",
+        agent_id="test-agent",
+        user_id="user-1",
+        session_data={"session_name": "Chat"},
+        created_at=now,
+        updated_at=now,
+        runs=runs,
+    )
+    db.upsert_session(session)
+    return session.session_id
+
+
+def _run(run_id: str, status: RunStatus) -> RunOutput:
+    return RunOutput(run_id=run_id, agent_id="test-agent", user_id="user-1", status=status)
+
+
+def test_detail_reports_live_running_run(monkeypatch):
+    monkeypatch.setattr("agno.os.event_streams.get_event_stream", lambda: _ProbeStream({"r1": RunStatus.running}))
+    db = InMemoryDb()
+    session_id = _seed_session(db, [_run("r0", RunStatus.completed), _run("r1", RunStatus.running)])
+    client = _build_client(db)
+
+    response = client.get(f"/sessions/{session_id}?type=agent")
+
+    assert response.status_code == 200
+    active_run = response.json().get("active_run")
+    assert active_run is not None
+    assert active_run["run_id"] == "r1"
+    assert active_run["status"] == "RUNNING"
+
+
+def test_detail_omits_active_run_when_all_completed(monkeypatch):
+    monkeypatch.setattr("agno.os.event_streams.get_event_stream", lambda: _ProbeStream({}))
+    db = InMemoryDb()
+    session_id = _seed_session(db, [_run("r0", RunStatus.completed)])
+    client = _build_client(db)
+
+    response = client.get(f"/sessions/{session_id}?type=agent")
+
+    assert response.status_code == 200
+    assert "active_run" not in response.json()
+
+
+def test_detail_omits_zombie_running_row(monkeypatch):
+    # Server restarted: the row still says RUNNING but the stream no longer knows it
+    monkeypatch.setattr("agno.os.event_streams.get_event_stream", lambda: _ProbeStream({}))
+    db = InMemoryDb()
+    session_id = _seed_session(db, [_run("r1", RunStatus.running)])
+    client = _build_client(db)
+
+    response = client.get(f"/sessions/{session_id}?type=agent")
+
+    assert response.status_code == 200
+    assert "active_run" not in response.json()
+
+
+def test_detail_omits_paused_run(monkeypatch):
+    # PAUSED runs wait on human input and follow the HITL resume flow, not reattach
+    monkeypatch.setattr("agno.os.event_streams.get_event_stream", lambda: _ProbeStream({"r1": RunStatus.paused}))
+    db = InMemoryDb()
+    session_id = _seed_session(db, [_run("r1", RunStatus.paused)])
+    client = _build_client(db)
+
+    response = client.get(f"/sessions/{session_id}?type=agent")
+
+    assert response.status_code == 200
+    assert "active_run" not in response.json()
+
+
+def test_detail_picks_newest_live_run(monkeypatch):
+    monkeypatch.setattr(
+        "agno.os.event_streams.get_event_stream",
+        lambda: _ProbeStream({"r1": RunStatus.running, "r2": RunStatus.running}),
+    )
+    db = InMemoryDb()
+    session_id = _seed_session(db, [_run("r1", RunStatus.running), _run("r2", RunStatus.pending)])
+    client = _build_client(db)
+
+    response = client.get(f"/sessions/{session_id}?type=agent")
+
+    assert response.status_code == 200
+    assert response.json()["active_run"]["run_id"] == "r2"
+
+
+def test_detail_without_runs_omits_active_run():
+    db = InMemoryDb()
+    session_id = _seed_session(db, [])
+    client = _build_client(db)
+
+    response = client.get(f"/sessions/{session_id}?type=agent")
+
+    assert response.status_code == 200
+    assert "active_run" not in response.json()

--- a/libs/agno/tests/unit/os/routers/test_session_active_run.py
+++ b/libs/agno/tests/unit/os/routers/test_session_active_run.py
@@ -71,6 +71,7 @@ def test_detail_reports_live_running_run(monkeypatch):
     assert active_run is not None
     assert active_run["run_id"] == "r1"
     assert active_run["status"] == "RUNNING"
+    assert active_run["created_at"] is not None
 
 
 def test_detail_omits_active_run_when_all_completed(monkeypatch):


### PR DESCRIPTION
## Summary

Expose AgentOS background execution through the AG-UI interface, so agent/team runs started over `POST /agui` survive client disconnection and reconnecting clients can reattach — and surface run liveness where the frontend already looks for it: the session APIs.

Closes #9892

**Three additions:**

1. **Background runs** — `POST /agui` with `forwarded_props: {"background": true}` executes the run detached via `arun(background=True, stream=True)`: AG-UI events stream live to the connected client exactly as today, but a disconnect no longer cancels the run. Per-request opt-in, mirroring the REST run endpoints' `background: Form(False)`.
2. **Reattach** — `POST /agui/reattach` with `{"thread_id", "run_id"?}` subscribes to an existing run's AG-UI events without starting a new run, mirroring the REST side's dedicated `/runs/{run_id}/resume` route. The missed prefix is collapsed into an idempotent `MESSAGES_SNAPSHOT` (AG-UI events carry no sequence numbers, so snapshot replay replaces a cursor contract), then live deltas continue from the same converter state so message IDs stay consistent. Runs whose buffer expired fall back to a database replay. `run_id` is optional: omit it and the server resolves the thread's in-progress run itself (404 when nothing is running).
3. **Run liveness on session detail** — `GET /sessions/{session_id}` now reports `active_run` (`run_id` + `status` + `created_at`) when the thread has a PENDING/RUNNING run whose event stream is still live.

## Frontend flow

Opening a conversation takes two calls and no client-side persistence:

```typescript
// 1. List conversations (unchanged)
const list = await fetch(`${AGENTOS_BASE}/sessions?type=agent&sort_by=updated_at&sort_order=desc`)
  .then((r) => r.json());

// 2. Open a conversation: load history AND learn whether it is still generating, in one call
const session = await fetch(`${AGENTOS_BASE}/sessions/${threadId}?type=agent`)
  .then((r) => r.json());
renderHistory(session.chat_history);

if (session.active_run) {
  // 3. A run is in progress — reattach to its AG-UI event stream
  const response = await fetch(`${AGENTOS_BASE}/agui/reattach`, {
    method: "POST",
    headers: { "Content-Type": "application/json" },
    body: JSON.stringify({ thread_id: threadId, run_id: session.active_run.run_id }),
  });
  await consumeStream(response.body);
  // RUN_STARTED → MESSAGES_SNAPSHOT (everything produced so far) → live deltas → RUN_FINISHED
}

// 4. New questions go through POST /agui as usual, with background opted in
await agent.runAgent({ forwardedProps: { background: true } });
```

Server behavior on reattach:

| Run state | Response |
|---|---|
| Active (PENDING/RUNNING) | `RUN_STARTED` → `MESSAGES_SNAPSHOT` of the missed prefix → live events |
| Finished, buffer retained (1h) | `RUN_STARTED` → `MESSAGES_SNAPSHOT` → `RUN_FINISHED` |
| Finished, buffer expired | Same, rebuilt from the stored run in the database |
| Errored | Prefix replay, then a terminal `RUN_ERROR` |

Semantics the client can rely on:

- The replayed prefix arrives as one idempotent `MESSAGES_SNAPSHOT` — replace-render the run's area, never append (a fresh page needs no handling; SPA reconnects should clear the run's rendered area first).
- History (`chat_history`) and the reattach stream never overlap: the in-progress run's content comes only from the reattach stream.
- Multiple tabs may subscribe to the same run concurrently; each gets its own event copy.
- Disconnecting no longer stops a run — "stop generating" must call `POST /agents/{agent_id}/runs/{run_id}/cancel`.
- Only PENDING/RUNNING runs surface via `active_run` and auto-resolution — a PAUSED run waits on human input and follows the HITL resume flow.

## Server-side design

**Dedicated reattach route.** `POST /agui/reattach` makes `run_id` truly optional — the flag form (`POST /agui` + `{"reattach": true}`, kept working unchanged) needed an empty-string sentinel because the AG-UI protocol requires `run_id`. Both forms delegate to one shared pipeline (`_build_reattach_response`) so validation, auto-resolution, binding checks, and streaming semantics cannot drift apart.

**Liveness is probed, not assumed.** A stored PENDING/RUNNING row is not proof of life — after a server restart or a crashed producer, the DB row still says RUNNING while the stream is long gone. The shared `find_active_run` helper (`agno.os.event_streams`) scans the thread's stored runs newest-first and probes each candidate against the event stream — the same liveness check the REST `/resume` path uses internally — skipping rows the buffer no longer knows, so `active_run` and auto-resolution never point a client at a dead run.

**Validation before streaming starts**, so misconfiguration answers an honest HTTP error instead of a 200 whose SSE stream opens with an error frame:

- `background` without a database, or `background`/`reattach` on a remote agent/team → 400
- `background` + `reattach` flags together → 400; `reattach` with non-empty `messages` or HITL `resume` entries → 400
- reattach without `run_id` on a database-less entity → 400 (auto-resolution needs the DB; an explicit `run_id` can still reattach buffer-only)
- reattach to a run found in neither the event buffer nor the database → 404 — an explicit-but-unknown `run_id` is never swapped for the thread's active run; only omission (dedicated route) or the empty-string sentinel (flag form) triggers auto-resolution
- reattach by a scoped caller to a run not bound to the requested `thread_id` → 404 (the event buffer is keyed on `run_id` alone, so `_verify_reattach_binding` mirrors the REST `/resume` ownership check; background runs persist a PENDING row before execution, so the DB binding holds for queued, active, and terminal runs). Auto-resolved runs skip this re-check: the session read that found them is already scoped to `session_id` + `user_id`.

**Core enabler:** `_arun_background_stream` and `_acontinue_run_background_stream` (agent and team) gain a `raw_events` mode where the producer queue carries raw `RunOutputEvent` objects instead of pre-formatted SSE strings, letting non-SSE transports consume the background stream through their own converters. The kwarg is popped in the dispatch layer so it never leaks into model kwargs.

**Keepalives:** AG-UI responses emit SSE keepalive comments whenever the event source goes idle (parity with the REST background streams — a run queued for a concurrency slot can sit silent long enough for proxies to kill the connection). Events are pumped through a queue so the idle timeout never cancels an in-flight `__anext__`, which would kill the source generator.

**Scope notes:** Agent and Team, streaming shape only. `background` applies to fresh runs and HITL resume legs alike (`resume_paused_run` forwards it, so a resumed leg also survives disconnection; its consumer-side stream sync is skipped because the detached producer owns the terminal sentinel). Background for remote agents/teams remains unsupported (core limitation).

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`) — clean except one pre-existing mypy error in `in_memory_db.py` that reproduces on a clean `main`; not in this diff
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings, cookbook README section "Background runs and reattach" with the full frontend recovery flow)
- [x] Examples and guides: `cookbook/05_agent_os/16_agui/background_runs.py` documents background start, named reattach, dedicated-route reattach, and auto-resolution
- [x] Tested in clean environment
- [x] Tests added/updated: 61 unit tests — flag passthrough, snapshot building, payload normalization, all reattach paths, resume-leg background passthrough, keepalive emission, binding verification, route validation, auto-resolution (newest-live selection, dead-buffer skipping, PAUSED exclusion, strict explicit-id 404), the dedicated `/agui/reattach` route, and `active_run` on session detail (live/zombie/paused/completed/newest-first)

---

## Additional Notes

Server-restart semantics: with the in-memory event stream, a restart empties the buffer — `active_run` disappears (the liveness probe filters the stale DB row) and auto-resolution finds nothing, so clients render settled history; completed runs remain fully recoverable from the database. With the Redis event-stream backend, buffers survive restarts and reattach works across replicas.

Known limitation: on reattach to an active run, session-state deltas during the live tail are best-effort when the original request carried `state` (the reattaching client already holds it, having sent it).

