### PR TITLE
[fix] treat empty compression result as success

### DIFF
--- a/libs/agno/agno/compression/manager.py
+++ b/libs/agno/agno/compression/manager.py
@@ -157,7 +157,7 @@ class CompressionManager:
         for tool_msg in uncompressed_tools:
             original_len = len(str(tool_msg.content)) if tool_msg.content else 0
             compressed = self._compress_tool_result(tool_msg, run_metrics=run_metrics)
-            if compressed:
+            if compressed is not None:
                 tool_msg.compressed_content = compressed
                 # Count actual tool results (Gemini combines multiple in one message)
                 tool_results_count = len(tool_msg.tool_calls) if tool_msg.tool_calls else 1
@@ -267,7 +267,7 @@ class CompressionManager:
 
         # Apply results and track stats
         for msg, compressed, original_len in zip(uncompressed_tools, results, original_sizes):
-            if compressed:
+            if compressed is not None:
                 msg.compressed_content = compressed
                 # Count actual tool results (Gemini combines multiple in one message)
                 tool_results_count = len(msg.tool_calls) if msg.tool_calls else 1

--- a/libs/agno/agno/models/message.py
+++ b/libs/agno/agno/models/message.py
@@ -140,8 +140,12 @@ class Message(BaseModel):
         return ""
 
     def get_content(self, use_compressed_content: bool = False) -> Optional[Union[List[Any], str]]:
-        """Return tool result content to send to API"""
-        if use_compressed_content and self.compressed_content is not None:
+        """Return tool result content to send to API.
+
+        Empty compressed_content is an already-attempted marker, not usable
+        compressed text, so fall back to the original content.
+        """
+        if use_compressed_content and self.compressed_content:
             return self.compressed_content
         return self.content
 

--- a/libs/agno/tests/unit/compression/test_compression_manager.py
+++ b/libs/agno/tests/unit/compression/test_compression_manager.py
@@ -217,10 +217,12 @@ def test_compress_empty_string_is_success_and_not_retried():
     cm.compress(messages)
 
     assert msg.compressed_content == ""
+    assert msg.get_content(use_compressed_content=True) == "Result 1"
     assert call_count["n"] == 1
 
     cm.compress(messages)
     assert call_count["n"] == 1
+    assert msg.get_content(use_compressed_content=True) == "Result 1"
 
 
 @pytest.mark.asyncio
@@ -241,7 +243,9 @@ async def test_acompress_empty_string_is_success_and_not_retried():
     await cm.acompress(messages)
 
     assert msg.compressed_content == ""
+    assert msg.get_content(use_compressed_content=True) == "Result 1"
     assert call_count["n"] == 1
 
     await cm.acompress(messages)
     assert call_count["n"] == 1
+    assert msg.get_content(use_compressed_content=True) == "Result 1"

--- a/libs/agno/tests/unit/compression/test_compression_manager.py
+++ b/libs/agno/tests/unit/compression/test_compression_manager.py
@@ -198,3 +198,50 @@ async def test_ashould_compress_count_based_above_limit():
 
     assert sync_result == async_result
     assert sync_result is True
+
+
+def test_compress_empty_string_is_success_and_not_retried():
+    """An empty compression result is success, not a failure that retries forever."""
+    from agno.compression.manager import CompressionManager
+
+    msg = Message(role="tool", content="Result 1", tool_name="test")
+    messages = [msg]
+    cm = CompressionManager(compress_tool_results=True)
+    call_count = {"n": 0}
+
+    def fake_compress(tool_result, run_metrics=None):
+        call_count["n"] += 1
+        return ""
+
+    cm._compress_tool_result = fake_compress  # type: ignore[method-assign]
+    cm.compress(messages)
+
+    assert msg.compressed_content == ""
+    assert call_count["n"] == 1
+
+    cm.compress(messages)
+    assert call_count["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_acompress_empty_string_is_success_and_not_retried():
+    """Async path: empty compression result is success and is not retried."""
+    from agno.compression.manager import CompressionManager
+
+    msg = Message(role="tool", content="Result 1", tool_name="test")
+    messages = [msg]
+    cm = CompressionManager(compress_tool_results=True)
+    call_count = {"n": 0}
+
+    async def fake_acompress(tool_result, run_metrics=None):
+        call_count["n"] += 1
+        return ""
+
+    cm._acompress_tool_result = fake_acompress  # type: ignore[method-assign]
+    await cm.acompress(messages)
+
+    assert msg.compressed_content == ""
+    assert call_count["n"] == 1
+
+    await cm.acompress(messages)
+    assert call_count["n"] == 1

--- a/libs/agno/tests/unit/models/test_message.py
+++ b/libs/agno/tests/unit/models/test_message.py
@@ -58,3 +58,38 @@ class TestGetContentString:
         content = ["item1", "item2"]
         message = Message(role="assistant", content=content)
         assert message.get_content_string() == json.dumps(content)
+
+
+class TestGetContent:
+    """Tests for Message.get_content() compressed-content fallback."""
+
+    def test_none_compressed_content_returns_original(self):
+        """None means compression has not been recorded; return original content."""
+        message = Message(role="tool", content="original tool result")
+        assert message.compressed_content is None
+        assert message.get_content(use_compressed_content=True) == "original tool result"
+        assert message.get_content(use_compressed_content=False) == "original tool result"
+
+    def test_empty_compressed_content_falls_back_to_original(self):
+        """Empty string is an already-attempted marker, not usable compressed content."""
+        message = Message(role="tool", content="original tool result", compressed_content="")
+        assert message.compressed_content == ""
+        assert message.get_content(use_compressed_content=True) == "original tool result"
+        assert message.get_content(use_compressed_content=False) == "original tool result"
+
+    def test_non_empty_compressed_content_is_returned(self):
+        """Successful compression is returned when requested."""
+        message = Message(
+            role="tool",
+            content="original tool result",
+            compressed_content="some compressed result",
+        )
+        assert message.get_content(use_compressed_content=True) == "some compressed result"
+        assert message.get_content(use_compressed_content=False) == "original tool result"
+
+    def test_empty_compressed_content_survives_to_dict_from_dict(self):
+        """Empty-string marker must round-trip so compression is not retried after persist."""
+        message = Message(role="tool", content="original tool result", compressed_content="")
+        restored = Message.from_dict(message.to_dict())
+        assert restored.compressed_content == ""
+        assert restored.get_content(use_compressed_content=True) == "original tool result"


### PR DESCRIPTION
## Summary

`CompressionManager.compress()` and `acompress()` treated an empty-string compression result as failure (`if compressed:`). That left `compressed_content` as `None`, so the same tool message was selected again on every later compress call.

This PR treats only `None` as failure (`if compressed is not None:`), so an empty response is stored as `compressed_content = ""` and is not retried.

`Message.get_content(use_compressed_content=True)` previously treated any non-`None` value as usable compressed text, so providers would receive `""` instead of the original tool result. Empty compressed content is now treated as an already-attempted marker: `get_content` falls back to the original content. Non-empty compressed content is still returned as before. `None` behavior is unchanged.

The original tool result remains on `content`.

Fixes #9877

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`) — sparse checkout; ran `ruff format` and `ruff check` on the touched files, and `mypy` on `libs/agno/agno/models/message.py` (no issues)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

This PR was written with an AI coding agent. I reviewed the change: empty compression results are stored so they are not retried, and `get_content` falls back to the original tool content when the stored value is empty.

---

## Additional Notes

Unit tests:

```
pytest libs/agno/tests/unit/models/test_message.py libs/agno/tests/unit/compression/test_compression_manager.py -v
```

26 passed.

```
pytest libs/agno/tests/unit/compression/ -v
```

14 passed.

Without the `get_content` fallback, the new tests fail because an empty compressed value is returned instead of the original tool content.

Live model / integration compression tests were not run.
