### PR TITLE
fix(gemini): detect image MIME type instead of hardcoding image/jpeg

### DIFF
--- a/libs/agno/agno/utils/gemini.py
+++ b/libs/agno/agno/utils/gemini.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 
 from agno.media import Image
 from agno.utils.log import log_error, log_warning
+from agno.utils.media import resolve_image_mime_type
 
 try:
     from google.genai.types import (
@@ -161,8 +162,13 @@ def format_image_for_message(image: Image) -> Optional[Dict[str, Any]]:
             try:
                 import base64
 
+                resolved_mime = resolve_image_mime_type(
+                    mime_type=image.mime_type,
+                    image_format=image.format,
+                    image_bytes=content_bytes,
+                )
                 image_data = {
-                    "mime_type": "image/jpeg",
+                    "mime_type": resolved_mime,
                     "data": base64.b64encode(content_bytes).decode("utf-8"),
                 }
                 return image_data
@@ -183,8 +189,14 @@ def format_image_for_message(image: Image) -> Optional[Dict[str, Any]]:
             else:
                 log_error(f"Image file {image_path} does not exist.")
                 raise
+            resolved_mime = resolve_image_mime_type(
+                mime_type=image.mime_type,
+                image_format=image.format,
+                file_path=image_path,
+                image_bytes=content_bytes,
+            )
             return {
-                "mime_type": "image/jpeg",
+                "mime_type": resolved_mime,
                 "data": content_bytes,
             }
         except Exception as e:
@@ -196,7 +208,12 @@ def format_image_for_message(image: Image) -> Optional[Dict[str, Any]]:
     elif image.content is not None and isinstance(image.content, bytes):
         import base64
 
-        image_data = {"mime_type": "image/jpeg", "data": base64.b64encode(image.content).decode("utf-8")}
+        resolved_mime = resolve_image_mime_type(
+            mime_type=image.mime_type,
+            image_format=image.format,
+            image_bytes=image.content,
+        )
+        image_data = {"mime_type": resolved_mime, "data": base64.b64encode(image.content).decode("utf-8")}
         return image_data
     else:
         log_warning(f"Unknown image type: {type(image)}")

--- a/libs/agno/tests/unit/utils/test_gemini.py
+++ b/libs/agno/tests/unit/utils/test_gemini.py
@@ -738,3 +738,105 @@ def test_inject_header_overrides_existing_x_goog_api_client():
     params = {"http_options": {"headers": {"x-goog-api-client": "stale/0.0.0"}}}
     result = inject_agno_client_header(params)
     assert result["http_options"]["headers"]["x-goog-api-client"] == f"agno/{agno_version}"
+
+
+# --- format_image_for_message tests ---
+
+import base64
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from agno.media import Image
+from agno.utils.gemini import format_image_for_message
+
+# Well-known magic-byte prefixes
+PNG_HEADER = b"\x89PNG\r\n\x1a\n" + b"\x00" * 8
+JPEG_HEADER = b"\xff\xd8\xff\xe0" + b"\x00" * 8
+WEBP_HEADER = b"RIFF\x00\x00\x00\x00WEBPVP8 " + b"\x00" * 4
+GIF_HEADER = b"GIF89a" + b"\x00" * 8
+
+
+def test_format_image_bytes_png():
+    """Raw PNG bytes should produce mime_type image/png, not image/jpeg."""
+    result = format_image_for_message(Image(content=PNG_HEADER))
+    assert result is not None
+    assert result["mime_type"] == "image/png"
+
+
+def test_format_image_bytes_webp():
+    """Raw WebP bytes should produce mime_type image/webp."""
+    result = format_image_for_message(Image(content=WEBP_HEADER))
+    assert result is not None
+    assert result["mime_type"] == "image/webp"
+
+
+def test_format_image_bytes_jpeg():
+    """Raw JPEG bytes should still produce image/jpeg."""
+    result = format_image_for_message(Image(content=JPEG_HEADER))
+    assert result is not None
+    assert result["mime_type"] == "image/jpeg"
+
+
+def test_format_image_bytes_gif():
+    """Raw GIF bytes should produce image/gif."""
+    result = format_image_for_message(Image(content=GIF_HEADER))
+    assert result is not None
+    assert result["mime_type"] == "image/gif"
+
+
+def test_format_image_explicit_mime_type_wins():
+    """An explicitly set mime_type should take priority over magic bytes."""
+    result = format_image_for_message(Image(content=PNG_HEADER, mime_type="image/webp"))
+    assert result is not None
+    assert result["mime_type"] == "image/webp"
+
+
+def test_format_image_format_field_wins():
+    """The format field should be used when mime_type is not set."""
+    result = format_image_for_message(Image(content=PNG_HEADER, format="gif"))
+    assert result is not None
+    assert result["mime_type"] == "image/gif"
+
+
+def test_format_image_filepath_webp(tmp_path: Path):
+    """A WebP file on disk should produce mime_type image/webp."""
+    webp_file = tmp_path / "photo.webp"
+    webp_file.write_bytes(WEBP_HEADER)
+    result = format_image_for_message(Image(filepath=str(webp_file)))
+    assert result is not None
+    assert result["mime_type"] == "image/webp"
+
+
+def test_format_image_filepath_png(tmp_path: Path):
+    """A PNG file on disk should produce mime_type image/png."""
+    png_file = tmp_path / "photo.png"
+    png_file.write_bytes(PNG_HEADER)
+    result = format_image_for_message(Image(filepath=str(png_file)))
+    assert result is not None
+    assert result["mime_type"] == "image/png"
+
+
+def test_format_image_url_webp():
+    """A URL returning WebP bytes should produce mime_type image/webp."""
+    webp_response = webp_header = WEBP_HEADER
+    with patch("agno.media.Image.get_content_bytes", return_value=webp_response):
+        result = format_image_for_message(Image(url="https://example.com/photo.webp"))
+    assert result is not None
+    assert result["mime_type"] == "image/webp"
+
+
+def test_format_image_url_png():
+    """A URL returning PNG bytes should produce mime_type image/png."""
+    with patch("agno.media.Image.get_content_bytes", return_value=PNG_HEADER):
+        result = format_image_for_message(Image(url="https://example.com/photo.png"))
+    assert result is not None
+    assert result["mime_type"] == "image/png"
+
+
+def test_format_image_bytes_base64_encoded():
+    """The data field should be base64-encoded."""
+    result = format_image_for_message(Image(content=PNG_HEADER))
+    assert result is not None
+    decoded = base64.b64decode(result["data"])
+    assert decoded == PNG_HEADER


### PR DESCRIPTION
## Summary

`format_image_for_message()` hardcoded `"image/jpeg"` for all image inputs (URL, filepath, and raw bytes). This broke WebP, PNG, GIF, and any other format because the actual bytes were sent with the wrong MIME type, causing Gemini to reject the request.

## Fix

Use the existing `resolve_image_mime_type()` utility from `agno.utils.media` which already implements the correct priority cascade:

1. Explicit `mime_type` field
2. `format` field (e.g. `"png"` -> `"image/png"`)
3. File extension (for filepath case)
4. Magic byte detection (PNG, JPEG, WebP, GIF, etc.)
5. JPEG fallback

This is the same utility already used by the OpenAI and OpenAI Responses code paths.

## Tests

Added 11 unit tests covering:
- PNG/WebP/JPEG/GIF magic byte detection
- Explicit `mime_type` takes priority over magic bytes
- `format` field fallback
- Filepath-based detection
- URL-based detection (via mocked download)
- Base64 encoding correctness

All 54 tests in `test_gemini.py` pass.

Fixes #9885
