### PR TITLE
[fix] Resolve string annotations on dataclass tool params

### DIFF
--- a/libs/agno/agno/utils/json_schema.py
+++ b/libs/agno/agno/utils/json_schema.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Dict, Literal, Optional, Union, get_args, get_origin
+from typing import Any, Dict, Literal, Optional, Union, get_args, get_origin, get_type_hints
 
 from pydantic import BaseModel
 
@@ -153,8 +153,16 @@ def get_json_schema_for_arg(type_hint: Any) -> Optional[Dict[str, Any]]:
         properties = {}
         required = []
 
+        # `field.type` is a string when the dataclass module uses
+        # `from __future__ import annotations` (or quotes its annotations);
+        # resolve the real types so those fields are not silently dropped.
+        try:
+            resolved_types = get_type_hints(type_hint)
+        except Exception:
+            resolved_types = {}
+
         for field_name, field in type_hint.__dataclass_fields__.items():
-            field_type = field.type
+            field_type = resolved_types.get(field_name, field.type)
             field_schema = get_json_schema_for_arg(field_type)
 
             if (

--- a/libs/agno/tests/unit/utils/test_json_schema.py
+++ b/libs/agno/tests/unit/utils/test_json_schema.py
@@ -280,6 +280,28 @@ def test_get_json_schema_dataclass_optional_field_without_type():
     assert "cfg" in schema["properties"]
 
 
+def test_get_json_schema_dataclass_string_annotations():
+    """Dataclass fields whose annotations are strings (as produced by
+    `from __future__ import annotations`, or by quoting) must be resolved to
+    their real types instead of crashing and dropping the parameter."""
+
+    @dataclass
+    class StringAnnotatedDataclass:
+        count: "int"
+        name: "str"
+        tags: "Optional[List[str]]" = None
+
+    arg_schema = get_json_schema_for_arg(StringAnnotatedDataclass)
+    assert arg_schema["properties"]["count"]["type"] == "integer"
+    assert arg_schema["properties"]["name"]["type"] == "string"
+    assert arg_schema["properties"]["tags"]["type"] == "array"
+    assert arg_schema["required"] == ["count", "name"]
+
+    # And the parameter must survive instead of being silently dropped
+    schema = get_json_schema({"cfg": StringAnnotatedDataclass})
+    assert "cfg" in schema["properties"]
+
+
 def test_get_json_schema_strict():
     type_hints = {"name": str, "age": int}
     schema = get_json_schema(type_hints, strict=True)


### PR DESCRIPTION
## Summary

`get_json_schema_for_arg` reads dataclass fields via `field.type`, which is a string when the defining module uses `from __future__ import annotations` (or quotes its annotations). The recursive call then raises `AttributeError`, the error is swallowed in `get_json_schema`, and the parameter is silently dropped from the tool schema.

This resolves field annotations with `typing.get_type_hints` (falling back to `field.type` if resolution fails) before recursing. Behaviour for dataclasses with real type annotations is unchanged. Adds a regression test that fails on `main` and passes with this change.

Fixes #9899

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Supersedes #8980, which used the same approach but was closed for a missing issue link; this PR links #9899 and keeps the regression test in the existing `test_json_schema.py`.

Prepared with Claude assistance; the bug was reproduced, and the change reviewed and tested, by me (unit tests, `./scripts/format.sh`, `./scripts/validate.sh`).