### PR TITLE
fix: pin tree-sitter-language-pack<1.16 to unblock chonkie code chunker

### DIFF
--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -215,6 +215,7 @@ weaviate = ["weaviate-client"]
 # Dependencies for Knowledge
 chonkie = [
     "chonkie[semantic,code]>=1.6.7",
+    "tree-sitter-language-pack<1.16",  # 1.16.1 process() returns a dict; chonkie reads .chunks. Drop when xberg-io/tree-sitter-language-pack#183 or chonkie fixes that
 ]
 csv = ["aiofiles"]
 docx = ["python-docx"]


### PR DESCRIPTION
## Summary

CI unblock. `main` and every open PR have been red since 2026-09-01 16:52 UTC: 20 of 22 tests in `libs/agno/tests/unit/knowledge/chunking/test_code_chunking.py` fail with `AttributeError: 'dict' object has no attribute 'chunks'` (failing run: https://github.com/agno-agi/agno/actions/runs/33556194573, last green on `main`: https://github.com/agno-agi/agno/actions/runs/33490379047). This should merge ahead of feature work.

This repeats the #7869 / #7904 / #8012 cycle on the same package in the same extra. #7869 pinned `tree-sitter-language-pack<1.8.0` in the `chonkie` extra when tslp 1.8.0 removed a symbol chonkie imported; #7904 dropped the pin once chonkie migrated; #8012 raised the chonkie floor.

## Root cause

`tree-sitter-language-pack` 1.16.1 (PyPI, 2026-09-01) changed `api.py::process()` from returning the native pyo3 `ProcessResult` object to returning `options.ProcessResult`, which is a `TypedDict`, so a plain `dict` at runtime. There is no alias, no `__getattr__`, no deprecation path; `result.chunks` raises and only `result["chunks"]` works. The change arrived in a generator regeneration commit (xberg-io/tree-sitter-language-pack@18e2a6b2c, "chore(alef): bump pin to 0.72.0 and regenerate tree"); the 1.16.x release notes describe only the regeneration and mention no API change, and tslp's own Python README still documents attribute access.

chonkie's `CodeChunker._process_code` (`chonkie/chunker/code.py:172`) does `return result.chunks`, so every code-chunking call fails. With `language="auto"`, chonkie swallows the same error per language and reports `ValueError: Could not auto-detect the language` instead (the other 2 of the 20 failures).

## Why chonkie is not the culprit

chonkie did not change. Its newest release, 1.7.0, is from 2026-07-07. Verified in three clean environments:

| chonkie | tree-sitter-language-pack | `test_code_chunking.py` |
|---|---|---|
| 1.7.0 (newest) | 1.16.1 (newest) | 20 failed, 2 passed |
| 1.6.7 (this repo's pinned minimum) | 1.16.1 | 20 failed, identical traceback |
| 1.7.0 | 1.15.8 (previous PyPI release) | 22 passed |

Pinning or bumping chonkie would change nothing. The variable is the transitive dependency one level below it. `chonkie[code]` floors tslp at `>=1.8.0` with no ceiling, this repo declares tslp nowhere, and CI installs `libs/agno[tests]` fresh on every run with no lock file, which is why the break propagated within hours of the upload.

## The change

```toml
chonkie = [
    "chonkie[semantic,code]>=1.6.7",
    "tree-sitter-language-pack<1.16",  # 1.16.1 process() returns a dict; chonkie reads .chunks. Drop when xberg-io/tree-sitter-language-pack#183 or chonkie fixes that
]
```

No agno code changes: `CodeChunking.chunk()` reads `chunk.text` off the list chonkie returns and never sees the dict. No tests added or modified — the existing 22 are the contract, and they go 20 failed → 22 passed on the dependency line alone.

`<1.16` rather than `!=1.16.1` because chonkie 1.x is frozen for fixes, so an exclusion would need re-editing on every tslp release.

## Removal condition

tslp restoring attribute access (asked in xberg-io/tree-sitter-language-pack#183). If the dict is intentional, the pin stays until a chonkie release reads it, and removal looks like #7904/#8012.

Upstream: xberg-io/tree-sitter-language-pack#183 · feyninc/chonkie#659 (filed for the record; no PR, 1.x is frozen)

## Verification

Clean resolve picks chonkie 1.7.0 + tslp 1.15.8, reproducible across two fresh envs, package set differs by exactly one line. `test_code_chunking.py` 22 passed · knowledge suite 816 passed, 13 skipped · full unit suite 19191 passed, 93 skipped (with `tests/unit/models/xai_model` run separately: 132 passed, 1 skipped, because under the full suite it hits a pre-existing GC-timing deadlock in `models/xai/oauth.py` unrelated to this change) · resolves on Python 3.10 · ruff clean, mypy at pre-existing baseline.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)
