### PR TITLE
fix: share client objects on Model deep copy instead of dropping them

### DIFF
--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -181,6 +181,7 @@ class Claude(Model):
 
     def __post_init__(self):
         """Validate model configuration after initialization"""
+        super().__post_init__()
         # Validate thinking support immediately at model creation
         if self.thinking:
             self._validate_thinking_support()

--- a/libs/agno/agno/models/azure/claude.py
+++ b/libs/agno/agno/models/azure/claude.py
@@ -43,6 +43,7 @@ class Claude(AnthropicClaude):
 
     def __post_init__(self):
         """Validate model configuration after initialization"""
+        super().__post_init__()
         if self.thinking:
             self._validate_thinking_support()
         self.supports_native_structured_outputs = False

--- a/libs/agno/agno/models/azure/openai_chat.py
+++ b/libs/agno/agno/models/azure/openai_chat.py
@@ -1,4 +1,3 @@
-from copy import copy, deepcopy
 from dataclasses import dataclass
 from os import getenv
 from typing import Any, Dict, Optional
@@ -57,36 +56,6 @@ class AzureOpenAI(OpenAILike):
 
     client: Optional[AzureOpenAIClient] = None
     async_client: Optional[AsyncAzureOpenAIClient] = None
-
-    def __deepcopy__(self, memo: dict) -> "AzureOpenAI":
-        """Create a deep copy that preserves client references.
-
-        Azure OpenAI clients may carry authentication state (e.g. AD tokens,
-        token providers) that cannot be reconstructed from the model's own
-        fields alone. Preserving the client references avoids authentication
-        errors when the copied model is used (e.g. in the reasoning flow).
-        """
-
-        cls = self.__class__
-        new_model = cls.__new__(cls)
-        memo[id(self)] = new_model
-
-        for k, v in self.__dict__.items():
-            if k in {"response_format", "_tools", "_functions"}:
-                continue
-            # Preserve client references instead of nullifying them
-            if k in {"client", "async_client", "http_client"}:
-                setattr(new_model, k, v)
-                continue
-            try:
-                setattr(new_model, k, deepcopy(v, memo))
-            except Exception:
-                try:
-                    setattr(new_model, k, copy(v))
-                except Exception:
-                    setattr(new_model, k, v)
-
-        return new_model
 
     def _get_client_params(self) -> Dict[str, Any]:
         _client_params: Dict[str, Any] = {}

--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -130,6 +130,9 @@ def _handle_agent_exception(a_exc: AgentRunException, additional_input: Optional
             m.stop_after_tool_call = True
 
 
+_CLIENT_ATTRS = ("client", "async_client", "http_client", "mistral_client", "model_client")
+
+
 @dataclass
 class Model(ABC):
     # ID of the model to use.
@@ -189,6 +192,9 @@ class Model(ABC):
     def __post_init__(self):
         if self.provider is None and self.name is not None:
             self.provider = f"{self.name} ({self.id})"
+        # A client already set here was supplied by the caller (agno builds its own lazily, later).
+        # Record which ones so a deep copy can keep them while dropping agno-built clients.
+        self._caller_supplied_clients = frozenset(a for a in _CLIENT_ATTRS if getattr(self, a, None) is not None)
 
     def _get_retry_delay(self, attempt: int) -> float:
         """Calculate the delay before the next retry attempt."""
@@ -3213,13 +3219,16 @@ class Model(ABC):
         new_model = cls.__new__(cls)
         memo[id(self)] = new_model
 
-        # Deep copy all attributes except client objects
+        caller_supplied: frozenset = getattr(self, "_caller_supplied_clients", frozenset())
+        # Deep copy all attributes; client objects are handled by ownership below
         for k, v in self.__dict__.items():
             if k in {"response_format", "_tools", "_functions"}:
                 continue
-            # Skip client objects
-            if k in {"client", "async_client", "http_client", "mistral_client", "model_client"}:
-                setattr(new_model, k, None)
+            # Keep a caller-supplied client so custom credentials/transport survive the copy; drop
+            # an agno-built one so the copy rebuilds its own and concurrent copies (the main run and
+            # its memory pass) don't share one connection pool.
+            if k in _CLIENT_ATTRS:
+                setattr(new_model, k, v if k in caller_supplied else None)
                 continue
             try:
                 setattr(new_model, k, deepcopy(v, memo))

--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -1,3 +1,4 @@
+import weakref
 import asyncio
 import collections.abc
 import json
@@ -192,9 +193,20 @@ class Model(ABC):
     def __post_init__(self):
         if self.provider is None and self.name is not None:
             self.provider = f"{self.name} ({self.id})"
-        # A client already set here was supplied by the caller (agno builds its own lazily, later).
-        # Record which ones so a deep copy can keep them while dropping agno-built clients.
-        self._caller_supplied_clients = frozenset(a for a in _CLIENT_ATTRS if getattr(self, a, None) is not None)
+        # Remember the client objects the caller supplied (agno builds its own lazily, later), keyed
+        # by a weak reference so a deep copy keeps a caller-supplied client but drops an agno-built
+        # one. A client a provider rebuilds later is a different object, so its weak reference no
+        # longer matches and it is dropped too.
+        marks: dict = {}
+        for _attr in _CLIENT_ATTRS:
+            _obj = getattr(self, _attr, None)
+            if _obj is None:
+                continue
+            try:
+                marks[_attr] = weakref.ref(_obj)
+            except TypeError:
+                marks[_attr] = _obj  # not weak-referenceable; hold a direct reference
+        self._caller_supplied_clients = marks
 
     def _get_retry_delay(self, attempt: int) -> float:
         """Calculate the delay before the next retry attempt."""
@@ -3219,16 +3231,19 @@ class Model(ABC):
         new_model = cls.__new__(cls)
         memo[id(self)] = new_model
 
-        caller_supplied: frozenset = getattr(self, "_caller_supplied_clients", frozenset())
+        caller_supplied: dict = getattr(self, "_caller_supplied_clients", {})
         # Deep copy all attributes; client objects are handled by ownership below
         for k, v in self.__dict__.items():
             if k in {"response_format", "_tools", "_functions"}:
                 continue
-            # Keep a caller-supplied client so custom credentials/transport survive the copy; drop
-            # an agno-built one so the copy rebuilds its own and concurrent copies (the main run and
-            # its memory pass) don't share one connection pool.
+            # Keep a caller-supplied client so custom credentials/transport survive the copy; drop an
+            # agno-built one (or a client a provider rebuilt over the caller's) so the copy makes its
+            # own and concurrent copies (the main run and its memory pass) don't share one pool. The
+            # mark is by object, so a rebuilt client no longer matches and is dropped.
             if k in _CLIENT_ATTRS:
-                setattr(new_model, k, v if k in caller_supplied else None)
+                mark = caller_supplied.get(k)
+                owned = mark() if isinstance(mark, weakref.ReferenceType) else mark
+                setattr(new_model, k, v if owned is not None and owned is v else None)
                 continue
             try:
                 setattr(new_model, k, deepcopy(v, memo))

--- a/libs/agno/agno/models/cloudflare/cloudflare.py
+++ b/libs/agno/agno/models/cloudflare/cloudflare.py
@@ -69,6 +69,7 @@ class Cloudflare(OpenAILike):
     max_tokens: Optional[int] = None
 
     def __post_init__(self) -> None:
+        super().__post_init__()
         self.id = normalize_cloudflare_gateway_model_id(self.id)
 
     def _get_client_params(self) -> Dict[str, Any]:

--- a/libs/agno/tests/unit/models/test_client_caching.py
+++ b/libs/agno/tests/unit/models/test_client_caching.py
@@ -557,6 +557,20 @@ class TestDeepCopyClientOwnership:
             deepcopy(Cloudflare(id="@cf/meta/llama-3-8b-instruct", api_key="test", client=sentinel)).client is sentinel
         )
 
+    def test_rebuilt_client_not_shared_on_deepcopy(self):
+        # If a provider rebuilds a closed caller-supplied client, the replacement is agno-built and
+        # must not be shared on a copy. Ownership is by object identity, not attribute name.
+        from agno.models.anthropic import Claude
+
+        caller = MagicMock()
+        caller.is_closed.return_value = True
+        model = Claude(id="claude-3-5-sonnet-20241022", api_key="test", client=caller)
+
+        rebuilt = model.get_client()
+        assert model.client is rebuilt and model.client is not caller
+
+        assert deepcopy(model).client is None
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/libs/agno/tests/unit/models/test_client_caching.py
+++ b/libs/agno/tests/unit/models/test_client_caching.py
@@ -9,6 +9,8 @@ This test suite verifies that:
 """
 
 import os
+from copy import deepcopy
+from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
@@ -470,6 +472,90 @@ class TestResourceLeakPrevention:
         # Multiple retrievals return the same instance
         for _ in range(10):
             assert get_default_sync_client() is global_client
+
+
+class TestDeepCopyClientOwnership:
+    """A deep copy keeps a caller-supplied client (custom auth survives) but drops an agno-built one,
+    so each copy rebuilds its own connection (preserving the per-instance-connection design)."""
+
+    def test_caller_supplied_client_survives_deepcopy(self):
+        from agno.models.aws import AwsBedrock
+        from agno.models.message import Message
+
+        spy = MagicMock()
+        spy.converse.return_value = {
+            "output": {"message": {"role": "assistant", "content": [{"text": "hi"}]}},
+            "stopReason": "end_turn",
+        }
+        copied = deepcopy(AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0", client=spy))
+
+        assert copied.client is spy
+        copied.invoke(messages=[Message(role="user", content="hi")], assistant_message=Message(role="assistant"))
+        assert spy.converse.call_count == 1
+
+    async def test_caller_supplied_async_client_survives_deepcopy(self):
+        from agno.models.aws import AwsBedrock
+        from agno.models.message import Message
+
+        spy = MagicMock()
+        spy.converse = AsyncMock(
+            return_value={
+                "output": {"message": {"role": "assistant", "content": [{"text": "hi"}]}},
+                "stopReason": "end_turn",
+            }
+        )
+        copied = deepcopy(AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0", async_client=spy))
+
+        assert copied.async_client is spy
+        await copied.ainvoke(messages=[Message(role="user", content="hi")], assistant_message=Message(role="assistant"))
+        assert spy.converse.await_count == 1
+
+    def test_caller_supplied_http_client_survives_deepcopy(self):
+        with httpx.Client() as http_client:
+            model = OpenAIChat(id="gpt-4o", api_key="test", http_client=http_client)
+
+            assert deepcopy(model).http_client is http_client
+
+    def test_agno_built_client_dropped_on_deepcopy(self):
+        # An agno-built client must NOT survive the copy: each copy rebuilds its own so concurrent
+        # copies (main run + memory pass) do not share one connection pool.
+        model = OpenAIChat(id="gpt-4o", api_key="test")
+        built = model.get_client()
+
+        assert model.client is built
+        assert deepcopy(model).client is None
+
+    def test_fallback_resolve_keeps_supplied_client(self):
+        from agno.models.aws import AwsBedrock
+        from agno.models.fallback import FallbackConfig
+
+        spy = MagicMock()
+        config = FallbackConfig(on_error=[AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0", async_client=spy)])
+        config.resolve_models()
+
+        assert config.on_error[0].async_client is spy
+
+    # Regression guards: these providers define their own __post_init__ and must call super(),
+    # or a caller-supplied client is silently dropped on copy again.
+    def test_anthropic_claude_keeps_caller_client(self):
+        from agno.models.anthropic import Claude
+
+        sentinel = MagicMock()
+        assert deepcopy(Claude(id="claude-3-5-sonnet-20241022", api_key="test", client=sentinel)).client is sentinel
+
+    def test_azure_claude_keeps_caller_client(self):
+        from agno.models.azure.claude import Claude
+
+        sentinel = MagicMock()
+        assert deepcopy(Claude(id="claude-3-5-sonnet", api_key="test", client=sentinel)).client is sentinel
+
+    def test_cloudflare_keeps_caller_client(self):
+        from agno.models.cloudflare import Cloudflare
+
+        sentinel = MagicMock()
+        assert (
+            deepcopy(Cloudflare(id="@cf/meta/llama-3-8b-instruct", api_key="test", client=sentinel)).client is sentinel
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

You can hand an agno model your own AWS/Bedrock client so it talks to the service with your credentials — a proxy, injected credentials, custom TLS. agno copies the model internally for routine work like the memory step. Today the copy throws your client away and quietly builds a new one from the `AWS_*` environment variables. Your main request goes out as you; the copy's request goes out as someone else, and nothing tells you.

**How we know.** With a model set up to use a supplied client, one `arun` makes two calls. The main call is signed with the supplied client's credentials. The memory call is signed with the environment key. Same run, two identities, no error.

**Where it happens.** Every path that deep-copies a model: the memory manager, the learn stores, the evals router, fallback chains (each fallback model is copied), and any `copy.deepcopy(model)` a user does themselves. `Agent.deep_copy()` is not affected — it shares the model by reference.

## The fix

On deep copy, keep a client the caller supplied, and keep dropping a client agno built itself.

- **Your client is kept**, so your credentials survive the copy.
- **agno's own client is still dropped**, so the copy rebuilds its own connection. This is deliberate: each model instance is meant to get its own connection, so a background copy (the memory pass) and the main run don't share one connection pool and saturate it. Sharing everything would break that.

To tell the two apart, the model records at construction which client objects the caller passed in (by a weak reference to each), and a copy keeps a field only if it still holds that same object. If a provider later rebuilds a client — for example anthropic's `get_client()` rebuilds when a supplied client is closed — the replacement is a different object and is correctly treated as agno-built, so it is not shared across copies.

**Why not just share every client.** An earlier version of this PR shared all clients unconditionally. Review flagged that it defeats the per-instance-connection design in `anthropic/claude.py` and the other providers, where each instance intentionally gets its own connection to avoid HTTP/2 stream saturation when the main agent and the memory manager run at once. Keeping only caller-supplied clients fixes the bug without that regression.

**Three providers needed a one-line change.** The ownership mark is recorded in the base `__post_init__`. `anthropic/claude.py`, `azure/claude.py` and `cloudflare` defined their own `__post_init__` without calling `super()`, so they now call it. A per-provider test fails if that call is ever dropped.

**The exception.** `Gemini` overrides `__deepcopy__` to null its client on purpose, with a test asserting it. Left untouched and called out here so it doesn't look missed.

**A redundant override removed.** `AzureOpenAI` had its own `__deepcopy__` that shared clients unconditionally. Under the new rule the base class does the right thing, and that override would have kept agno-built clients too, so it's deleted. Its docstring justified preserving clients for Azure AD auth, but those tokens are model fields the client params rebuild from, so the base ownership handling covers that case.

**Why now.** #9531 just merged, adding exactly this surface for Bedrock (a caller-supplied `async_client` for custom auth). This bug makes that feature half-work: it holds on the main call but not on any copy path.

**Known limitations.** Ownership is recorded at construction, so a client assigned after construction (`model.client = x`) is treated as agno-built and dropped on copy; pass the client to the constructor to have it kept. And because a caller-supplied client is now shared with the copy, if you pass your own client to `AzureAIFoundry` and then call `close()`/`aclose()` on a copy, you close the original's client too. Nothing in agno calls `model.close()` on a Model, so this only arises if you both supply a client and close a copy yourself; it is consistent with the caller owning the client's lifecycle.

**Follow-ups, not here.** `LiteLLM` keeps its own `__deepcopy__` and an `_original_client` field that preserve its client unconditionally (Router reuse); it now differs from the base drop-agno-built policy, an intentional exception like Gemini that can be revisited later. Precedence when both a `session` and a client are set is a separate change.

**Origin.** The nulling came from #5253, which only needed to avoid deep-copying SDK clients (they hold locks and sockets). Recording ownership avoids that just as well and keeps the caller's client.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)
