### PR TITLE
fix: send wire fields instead of RunContext to remote entities over AG-UI

### DIFF
--- a/libs/agno/agno/os/interfaces/agui/router.py
+++ b/libs/agno/agno/os/interfaces/agui/router.py
@@ -2,7 +2,7 @@ import copy
 import uuid
 from typing import AsyncIterator, Optional, Union
 
-from agno.utils.log import log_error
+from agno.utils.log import log_error, log_warning
 
 try:
     from ag_ui.core import (
@@ -96,6 +96,17 @@ async def run_entity(
             )
         else:
             # Fresh run: new user input
+            if isinstance(entity, (RemoteAgent, RemoteTeam)):
+                # A RunContext is an in-process object: RemoteAgent/RemoteTeam forward every
+                # unknown kwarg as a form field, and the remote AgentOS would hand the
+                # stringified object to Agent.arun. Send the wire fields it carries instead.
+                run_kwargs["session_state"] = session_state
+                run_kwargs["dependencies"] = ui_deps
+                if client_tools:
+                    # Dropped: the remote agent cannot pause back into this process's session.
+                    log_warning("AG-UI client tools are not forwarded to remote agents or teams")
+            else:
+                run_kwargs["run_context"] = run_context
             response_stream = entity.arun(  # type: ignore
                 input=user_input,
                 stream=True,
@@ -107,7 +118,6 @@ async def run_entity(
                 audio=audio or None,
                 videos=videos or None,
                 files=files or None,
-                run_context=run_context,
                 **run_kwargs,
             )
 

--- a/libs/agno/tests/unit/os/interfaces/test_agui_router.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_router.py
@@ -1,12 +1,16 @@
+import logging
 from unittest.mock import MagicMock
 
 import pytest
 
 pytest.importorskip("ag_ui", reason="ag_ui not installed")
 
+from ag_ui.core import EventType
 from ag_ui.core.types import Tool as AGUITool
 
+from agno.agent.remote import RemoteAgent
 from agno.os.interfaces.agui.router import run_entity
+from agno.team.remote import RemoteTeam
 
 
 class FakeRunInput:
@@ -32,6 +36,17 @@ class CaptureKwargsEntity:
         self.arun_called = True
         return
         yield
+
+
+def capturing_wire_stream(captured: dict):
+    """Stand-in for the AgentOS client's stream methods: records the wire kwargs."""
+
+    async def stream(**kwargs):
+        captured.update(kwargs)
+        return
+        yield
+
+    return stream
 
 
 @pytest.mark.asyncio
@@ -150,3 +165,56 @@ async def test_run_entity_fresh_run_calls_arun():
         pass
 
     assert fake_entity.arun_called is True
+
+
+@pytest.mark.asyncio
+async def test_run_entity_remote_agent_sends_wire_fields_instead_of_run_context():
+    """A RunContext cannot cross the wire: the remote proxy would post it as a stringified form field."""
+    remote_agent = RemoteAgent(base_url="http://fake-host", agent_id="remote-agent")
+    captured: dict = {}
+    remote_agent.agentos_client = MagicMock(run_agent_stream=capturing_wire_stream(captured))
+    context = [MagicMock(description="user_name", value="Alice")]
+    run_input = FakeRunInput(context=context, state={"counter": 1})
+
+    events = [event async for event in run_entity(remote_agent, run_input, user_id="test-user-123")]
+
+    assert "run_context" not in captured
+    assert captured["session_state"] == {"counter": 1}
+    assert captured["dependencies"] == {"user_name": "Alice"}
+    assert captured["add_dependencies_to_context"] is True
+    assert captured["session_id"] == "test-thread"
+    assert captured["user_id"] == "test-user-123"
+    assert captured["run_id"] == "test-run"
+    assert events[-1].type == EventType.RUN_FINISHED
+
+
+@pytest.mark.asyncio
+async def test_run_entity_remote_team_sends_wire_fields_instead_of_run_context():
+    remote_team = RemoteTeam(base_url="http://fake-host", team_id="remote-team")
+    captured: dict = {}
+    remote_team.agentos_client = MagicMock(run_team_stream=capturing_wire_stream(captured))
+    run_input = FakeRunInput(state={"counter": 1})
+
+    events = [event async for event in run_entity(remote_team, run_input)]
+
+    assert "run_context" not in captured
+    assert captured["session_state"] == {"counter": 1}
+    assert captured["session_id"] == "test-thread"
+    assert captured["run_id"] == "test-run"
+    assert events[-1].type == EventType.RUN_FINISHED
+
+
+@pytest.mark.asyncio
+async def test_run_entity_remote_agent_warns_and_drops_client_tools(caplog):
+    """Client tools resolve against this process's session, so a remote run proceeds without them."""
+    remote_agent = RemoteAgent(base_url="http://fake-host", agent_id="remote-agent")
+    captured: dict = {}
+    remote_agent.agentos_client = MagicMock(run_agent_stream=capturing_wire_stream(captured))
+    run_input = FakeRunInput(tools=[AGUITool(name="change_background", description="Change page background color")])
+
+    with caplog.at_level(logging.WARNING, logger="agno"):
+        events = [event async for event in run_entity(remote_agent, run_input)]
+
+    assert "run_context" not in captured
+    assert any("client tools are not forwarded" in record.message for record in caplog.records)
+    assert events[-1].type == EventType.RUN_FINISHED


### PR DESCRIPTION
## Summary

`test-agentos-system` fails on `release/v3.0.6` (#9907): the two AG-UI remote streaming tests end in `RUN_ERROR` instead of `RUN_FINISHED`. The failure is on `main`; the release PR only bumps the version.

### Where the value breaks

```
AG-UI client
   │  POST /agui
   ▼
run_entity (agui/router.py)
   │  entity.arun(..., run_id=..., run_context=RunContext(...))
   ▼
RemoteAgent.arun / RemoteTeam.arun          run_context, run_id land in **kwargs
   │  agentos_client.run_*_stream(**kwargs)
   ▼
AgentOSClient                               every kwarg becomes a form field
   │  data["run_context"] = str(RunContext(...))
   ▼
remote AgentOS  /agents/{id}/runs
   │  get_request_kwargs harvests unknown form fields
   ▼
Agent.arun(run_context="RunContext(run_id=...)")
   │  apply_to_context -> run_context.user_id
   ▼
AttributeError: 'str' object has no attribute 'user_id'
   │  agent_response_streamer -> RunErrorEvent on a 200 SSE stream
   ▼
gateway AG-UI mapper -> RUN_ERROR
```

### Timeline

| When | Change | Effect on the remote AG-UI path |
|---|---|---|
| #8565 (Jul 8) | Router builds a `RunContext` for client tools and passes it to every entity | Remote runs start failing on the remote server; the `RunError` chunk is mapped to `RAW` and the stream still ends in a synthesised `RUN_FINISHED`, so the system test keeps passing |
| #9487 (Sep 2) | `RunError` becomes a terminal AG-UI event | The same failure now surfaces as `RUN_ERROR`; `release/v3.0.6` is the first release run since the merge |

### Change

`run_entity`, fresh-run branch only:

```python
# before
response_stream = entity.arun(..., run_context=run_context, **run_kwargs)

# after
if isinstance(entity, (RemoteAgent, RemoteTeam)):
    run_kwargs["session_state"] = session_state
    run_kwargs["dependencies"] = ui_deps
    if client_tools:
        log_warning("AG-UI client tools are not forwarded to remote agents or teams")
else:
    run_kwargs["run_context"] = run_context
response_stream = entity.arun(..., **run_kwargs)
```

`session_state` and `dependencies` are declared on both remote `arun` signatures and decoded by `get_request_kwargs` on the server. `run_id` keeps flowing as a form field the server hands to `Agent.arun`, so the remote run keeps the AG-UI run id like a local run does. The resume path already rejects remote entities and is untouched.

| Path | Change |
|---|---|
| `libs/agno/agno/os/interfaces/agui/router.py` | Remote entities get wire fields instead of `RunContext`; warning for client tools |
| `libs/agno/tests/unit/os/interfaces/test_agui_router.py` | Three regression tests against real `RemoteAgent`/`RemoteTeam` with the AgentOS client stubbed; all three fail without the fix |

### Verification

Against the `libs/agno/tests/system` Docker stack built from this branch:

| Check | Before | After |
|---|---|---|
| `tests/test_agui_routes.py` | 2 failed, 5 passed | 7 passed (run twice) |
| Remote server log | `AttributeError: 'str' object has no attribute 'user_id'` per remote run | no tracebacks |
| AG-UI `context` reaches the remote agent | never | agent answers from the context value |
| AG-UI `state` persists on the remote session | never | persisted |
| Remote run id equals the AG-UI run id | n/a | yes |

Unit: `tests/unit/os/interfaces/`, `tests/unit/app/test_agui_app.py`, `tests/unit/team/test_remote_team.py` green. `ruff check`, `ruff format --check` clean; `./scripts/validate.sh` output on this branch is identical to the `origin/main` baseline (the 32 pre-existing mypy errors in 8 files are unchanged; nothing new).

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Out of scope, noted for follow-up: the `docker-compose.yaml` source volume mount in `tests/system` is shadowed by the pip-installed copy in the image, so "live code updates" never take effect; and `RemoteAgent`/`RemoteTeam` could accept `run_context`/`run_id` explicitly instead of relying on the `**kwargs` passthrough.
