### PR TITLE
[fix] Initialize CustomEvent dataclass fields so events can be serialized

### DIFF
--- a/libs/agno/agno/run/agent.py
+++ b/libs/agno/agno/run/agent.py
@@ -11,7 +11,7 @@ from agno.metrics import RunMetrics
 from agno.models.message import Citations, Message
 from agno.models.response import ToolExecution
 from agno.reasoning.step import ReasoningStep
-from agno.run.base import BaseRunOutputEvent, MessageReferences, RunStatus
+from agno.run.base import BaseRunOutputEvent, MessageReferences, RunStatus, init_custom_event
 from agno.run.requirement import RunRequirement
 from agno.utils.log import log_error
 from agno.utils.media import (
@@ -517,9 +517,7 @@ class CustomEvent(BaseAgentRunEvent):
     tool_call_id: Optional[str] = None
 
     def __init__(self, **kwargs):
-        # Store arbitrary attributes directly on the instance
-        for key, value in kwargs.items():
-            setattr(self, key, value)
+        init_custom_event(self, kwargs)
 
 
 RunOutputEvent = Union[

--- a/libs/agno/agno/run/base.py
+++ b/libs/agno/agno/run/base.py
@@ -1,5 +1,5 @@
 from copy import copy
-from dataclasses import asdict, dataclass
+from dataclasses import MISSING, asdict, dataclass, fields
 from enum import Enum
 from typing import Any, Dict, List, Optional, Type, Union
 
@@ -11,6 +11,36 @@ from agno.metrics import RunMetrics
 from agno.models.message import Citations, Message, MessageReferences
 from agno.reasoning.step import ReasoningStep
 from agno.utils.log import log_error
+
+
+def init_custom_event(event: Any, kwargs: Dict[str, Any]) -> None:
+    """Initialize a CustomEvent instance from arbitrary keyword arguments.
+
+    CustomEvent subclasses accept any keyword argument, so they cannot use the
+    dataclass-generated ``__init__``. They still have to end up with every
+    declared field set: ``to_dict`` serializes through ``asdict``, which reads
+    fields by declaration and raises ``AttributeError`` on the first one that
+    was never assigned (``created_at``, in practice).
+
+    Declared fields are filled from their dataclass defaults first, then the
+    caller's keyword arguments are applied on top - both the ones that name a
+    declared field and the arbitrary extras.
+
+    Args:
+        event: The CustomEvent instance being initialized.
+        kwargs: The keyword arguments passed to its ``__init__``.
+    """
+    for f in fields(event):
+        if f.name in kwargs:
+            continue
+        if f.default is not MISSING:
+            setattr(event, f.name, f.default)
+        elif f.default_factory is not MISSING:  # type: ignore[misc]
+            setattr(event, f.name, f.default_factory())  # type: ignore[misc]
+
+    # Store arbitrary attributes directly on the instance
+    for key, value in kwargs.items():
+        setattr(event, key, value)
 
 
 @dataclass

--- a/libs/agno/agno/run/team.py
+++ b/libs/agno/agno/run/team.py
@@ -12,7 +12,7 @@ from agno.models.message import Citations, Message
 from agno.models.response import ToolExecution
 from agno.reasoning.step import ReasoningStep
 from agno.run.agent import RunEvent, RunOutput, RunOutputEvent, run_output_event_from_dict
-from agno.run.base import BaseRunOutputEvent, MessageReferences, RunStatus
+from agno.run.base import BaseRunOutputEvent, MessageReferences, RunStatus, init_custom_event
 from agno.run.requirement import RunRequirement
 from agno.utils.log import log_error
 from agno.utils.media import (
@@ -633,9 +633,7 @@ class CustomEvent(BaseTeamRunEvent):
     event: str = TeamRunEvent.custom_event.value
 
     def __init__(self, **kwargs):
-        # Store arbitrary attributes directly on the instance
-        for key, value in kwargs.items():
-            setattr(self, key, value)
+        init_custom_event(self, kwargs)
 
 
 TeamRunOutputEvent = Union[

--- a/libs/agno/agno/run/workflow.py
+++ b/libs/agno/agno/run/workflow.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 
 from agno.media import Audio, File, Image, Video
 from agno.run.agent import RunEvent, RunOutput, run_output_event_from_dict
-from agno.run.base import BaseRunOutputEvent, RunStatus
+from agno.run.base import BaseRunOutputEvent, RunStatus, init_custom_event
 from agno.run.team import TeamRunEvent, TeamRunOutput, team_run_output_event_from_dict
 from agno.utils.log import log_warning
 from agno.utils.media import (
@@ -622,9 +622,7 @@ class CustomEvent(BaseWorkflowRunOutputEvent):
     event: str = WorkflowRunEvent.custom_event.value
 
     def __init__(self, **kwargs):
-        # Store arbitrary attributes directly on the instance
-        for key, value in kwargs.items():
-            setattr(self, key, value)
+        init_custom_event(self, kwargs)
 
 
 # Union type for all workflow run response events

--- a/libs/agno/tests/unit/run/test_run_events.py
+++ b/libs/agno/tests/unit/run/test_run_events.py
@@ -523,3 +523,43 @@ def test_requirements_in_run_paused_event():
     assert reconstructed.requirements[0].tool_execution.tool_name == "get_the_weather"
     assert reconstructed.requirements[0].tool_execution.requires_confirmation is True
     assert reconstructed.requirements[0].needs_confirmation is True
+
+
+def test_custom_event_direct_instantiation_is_serializable():
+    """CustomEvent built straight from the base class must serialize (issue #9910)."""
+    from agno.run.agent import CustomEvent as AgentCustomEvent
+    from agno.run.team import CustomEvent as TeamCustomEvent
+    from agno.run.workflow import CustomEvent as WorkflowCustomEvent
+
+    for event_cls, expected_event in (
+        (AgentCustomEvent, "CustomEvent"),
+        (TeamCustomEvent, "CustomEvent"),
+        (WorkflowCustomEvent, "CustomEvent"),
+    ):
+        event = event_cls(stage="research", payload={"progress": 1})
+
+        # Declared dataclass fields carry their defaults instead of being missing
+        assert isinstance(event.created_at, int)
+        assert event.event == expected_event
+
+        event_dict = event.to_dict()
+        assert event_dict["created_at"] == event.created_at
+        assert event_dict["event"] == expected_event
+
+        # Arbitrary attributes are still stored on the instance
+        assert event.stage == "research"
+        assert event.payload == {"progress": 1}
+
+        # And the event survives the SSE serialization path
+        assert json.loads(event.to_json(indent=None))["created_at"] == event.created_at
+
+
+def test_custom_event_keyword_overrides_declared_field():
+    """Keyword arguments naming a declared field win over its dataclass default."""
+    from agno.run.agent import CustomEvent
+
+    event = CustomEvent(created_at=1234567890, run_id="run-123", stage="research")
+
+    assert event.created_at == 1234567890
+    assert event.run_id == "run-123"
+    assert event.to_dict()["run_id"] == "run-123"


### PR DESCRIPTION
## Summary

`CustomEvent` — in `agno/run/agent.py`, `agno/run/team.py` and `agno/run/workflow.py` — overrides `__init__` to accept arbitrary keyword arguments and only `setattr`s what it is given, so the declared dataclass fields are never assigned. `to_dict()` serializes through `asdict()`, which reads fields by declaration, and raises on the first one:

```
AttributeError: 'CustomEvent' object has no attribute 'created_at'
```

Custom events built straight from the base class are therefore unserializable. In AgentOS this is fatal to the stream: `agno/os/utils.py::format_sse_event` only catches `json.JSONDecodeError`, so the `AttributeError` escapes the response generator.

This PR fills the declared fields from their dataclass defaults before applying the caller's kwargs, in a shared `init_custom_event` helper so the three classes stay identical. Subclasses declared with `@dataclass` are unaffected — they get a generated `__init__` and never reach this path, which is why the existing `test_custom_event_subclass_serialization` tests pass today.

Fixes #9910

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Tests.** Two tests in `libs/agno/tests/unit/run/test_run_events.py`:

- `test_custom_event_direct_instantiation_is_serializable` — builds `CustomEvent` directly for all three variants, asserts `created_at`/`event` are populated, extras still land on the instance, and `to_json()` (the SSE path) round-trips.
- `test_custom_event_keyword_overrides_declared_field` — a kwarg naming a declared field wins over its default.

Verified they fail on `main` with the `AttributeError` above and pass with the change. `pytest libs/agno/tests/unit/run` is green (235 passed), and `./scripts/validate.sh` reports no ruff or mypy issues.

**Related.** #7075 reports the neighbouring problem — *extra* (setattr) fields being dropped by `asdict()`. This PR does not change that behaviour; it only makes the declared fields present so serialization runs at all.

**Disclosure.** This change was written with Claude Code. I have reviewed the diff, the reasoning behind it and the tests, and reproduced both the failure and the fix locally.
