### PR TITLE
[fix] Make ExaTools pass the Exa options it accepts, and add the missing ones

### DIFF
--- a/libs/agno/agno/tools/exa.py
+++ b/libs/agno/agno/tools/exa.py
@@ -39,6 +39,14 @@ class ExaTools(Toolkit):
         category (Optional[str]): Filter results by category. Options are "company", "research paper", "news", "pdf", "github", "tweet", "personal site", "linkedin profile", "financial report".
         include_domains (Optional[List[str]]): Restrict results to these domains.
         exclude_domains (Optional[List[str]]): Exclude results from these domains.
+        include_text (Optional[List[str]]): Require this string to be present in the page text
+            (one string, up to 5 words). Applies to search and find-similar.
+        exclude_text (Optional[List[str]]): Exclude pages whose text contains this string
+            (one string, up to 5 words). Applies to search and find-similar.
+        user_location (Optional[str]): Two-letter ISO country code of the user (e.g. "US").
+        moderation (Optional[bool]): Ask Exa to moderate search results for safety.
+        highlights (bool): Retrieve highlights - the relevant sentences of each page. Default is False.
+        subpages (Optional[int]): Number of subpages to crawl per result.
         show_results (bool): Log search results for debugging. Default is False.
         model (Optional[str]): The search model to use. Options are 'exa' or 'exa-pro'.
         timeout (int): Maximum time in seconds to wait for API responses. Default is 30 seconds.
@@ -66,6 +74,12 @@ class ExaTools(Toolkit):
         category: Optional[str] = None,
         include_domains: Optional[List[str]] = None,
         exclude_domains: Optional[List[str]] = None,
+        include_text: Optional[List[str]] = None,
+        exclude_text: Optional[List[str]] = None,
+        user_location: Optional[str] = None,
+        moderation: Optional[bool] = None,
+        highlights: bool = False,
+        subpages: Optional[int] = None,
         show_results: bool = False,
         model: Optional[str] = None,
         timeout: int = 30,
@@ -94,6 +108,12 @@ class ExaTools(Toolkit):
         self.category: Optional[str] = category
         self.include_domains: Optional[List[str]] = include_domains
         self.exclude_domains: Optional[List[str]] = exclude_domains
+        self.include_text: Optional[List[str]] = include_text
+        self.exclude_text: Optional[List[str]] = exclude_text
+        self.user_location: Optional[str] = user_location
+        self.moderation: Optional[bool] = moderation
+        self.highlights: bool = highlights
+        self.subpages: Optional[int] = subpages
         self.model: Optional[str] = model
         self.research_model: Literal["exa-research", "exa-research-pro"] = research_model
 
@@ -142,6 +162,9 @@ class ExaTools(Toolkit):
             summary = getattr(result, "summary", None)
             if summary:
                 result_dict["summary"] = summary
+            highlights = getattr(result, "highlights", None)
+            if highlights:
+                result_dict["highlights"] = highlights
             exa_results_parsed.append(result_dict)
         return json.dumps(exa_results_parsed, indent=4, ensure_ascii=False)
 
@@ -174,6 +197,12 @@ class ExaTools(Toolkit):
                 "category": self.category or category,  # Prefer a user-set category
                 "include_domains": self.include_domains,
                 "exclude_domains": self.exclude_domains,
+                "include_text": self.include_text,
+                "exclude_text": self.exclude_text,
+                "user_location": self.user_location,
+                "moderation": self.moderation,
+                "highlights": self.highlights or None,
+                "subpages": self.subpages,
             }
             # Clean up the kwargs
             search_kwargs = {k: v for k, v in search_kwargs.items() if v is not None}
@@ -208,6 +237,8 @@ class ExaTools(Toolkit):
             "text": self.text,
             "summary": self.summary,
             "livecrawl": self.livecrawl,
+            "highlights": self.highlights or None,
+            "subpages": self.subpages,
         }
 
         try:
@@ -247,6 +278,10 @@ class ExaTools(Toolkit):
             "livecrawl": self.livecrawl,
             "include_domains": self.include_domains,
             "exclude_domains": self.exclude_domains,
+            "include_text": self.include_text,
+            "exclude_text": self.exclude_text,
+            "highlights": self.highlights or None,
+            "subpages": self.subpages,
             "start_crawl_date": self.start_crawl_date,
             "end_crawl_date": self.end_crawl_date,
             "start_published_date": self.start_published_date,

--- a/libs/agno/agno/tools/exa.py
+++ b/libs/agno/agno/tools/exa.py
@@ -29,6 +29,8 @@ class ExaTools(Toolkit):
         text_length_limit (int): Max length of text content per result. Default is 1000.
         api_key (Optional[str]): Exa API key. Retrieved from `EXA_API_KEY` env variable if not provided.
         num_results (Optional[int]): Default number of search results. Overrides individual searches if set.
+        livecrawl (Optional[str]): Live-crawl mode passed to Exa (e.g. "always", "fallback", "never").
+            Left unset by default, which keeps Exa's own behaviour.
         start_crawl_date (Optional[str]): Include results crawled on/after this date (`YYYY-MM-DD`).
         end_crawl_date (Optional[str]): Include results crawled on/before this date (`YYYY-MM-DD`).
         start_published_date (Optional[str]): Include results published on/after this date (`YYYY-MM-DD`).
@@ -55,7 +57,7 @@ class ExaTools(Toolkit):
         summary: bool = False,
         api_key: Optional[str] = None,
         num_results: Optional[int] = None,
-        livecrawl: str = "always",
+        livecrawl: Optional[str] = None,
         start_crawl_date: Optional[str] = None,
         end_crawl_date: Optional[str] = None,
         start_published_date: Optional[str] = None,
@@ -83,7 +85,7 @@ class ExaTools(Toolkit):
 
         self.summary: bool = summary
         self.num_results: Optional[int] = num_results
-        self.livecrawl: str = livecrawl
+        self.livecrawl: Optional[str] = livecrawl
         self.start_crawl_date: Optional[str] = start_crawl_date
         self.end_crawl_date: Optional[str] = end_crawl_date
         self.start_published_date: Optional[str] = start_published_date
@@ -135,6 +137,11 @@ class ExaTools(Toolkit):
                 if self.text_length_limit:
                     _text = _text[: self.text_length_limit]
                 result_dict["text"] = _text
+            # Summaries are requested (and billed) whenever summary=True; without this
+            # they are parsed out of the response and never reach the model.
+            summary = getattr(result, "summary", None)
+            if summary:
+                result_dict["summary"] = summary
             exa_results_parsed.append(result_dict)
         return json.dumps(exa_results_parsed, indent=4, ensure_ascii=False)
 
@@ -157,6 +164,7 @@ class ExaTools(Toolkit):
             search_kwargs: Dict[str, Any] = {
                 "text": self.text,
                 "summary": self.summary,
+                "livecrawl": self.livecrawl,
                 "num_results": self.num_results or num_results,
                 "start_crawl_date": self.start_crawl_date,
                 "end_crawl_date": self.end_crawl_date,
@@ -199,6 +207,7 @@ class ExaTools(Toolkit):
         query_kwargs: Dict[str, Any] = {
             "text": self.text,
             "summary": self.summary,
+            "livecrawl": self.livecrawl,
         }
 
         try:
@@ -235,6 +244,7 @@ class ExaTools(Toolkit):
         query_kwargs: Dict[str, Any] = {
             "text": self.text,
             "summary": self.summary,
+            "livecrawl": self.livecrawl,
             "include_domains": self.include_domains,
             "exclude_domains": self.exclude_domains,
             "start_crawl_date": self.start_crawl_date,

--- a/libs/agno/tests/unit/tools/test_exa.py
+++ b/libs/agno/tests/unit/tools/test_exa.py
@@ -35,6 +35,7 @@ def create_mock_search_result(
     published_date: str = None,
     text: str = None,
     summary: str = None,
+    highlights: list = None,
 ):
     """Helper function to create mock search result."""
     result = Mock()
@@ -44,6 +45,7 @@ def create_mock_search_result(
     result.published_date = published_date
     result.text = text
     result.summary = summary
+    result.highlights = highlights
     return result
 
 
@@ -458,3 +460,88 @@ def test_summary_absent_when_not_returned(exa_tools, mock_exa_client):
     result_data = json.loads(exa_tools.search_exa("test query"))
 
     assert "summary" not in result_data[0]
+
+
+def test_search_forwards_the_full_option_set(mock_exa_client):
+    """Options accepted by the constructor must reach the search call."""
+    with patch.dict("os.environ", {"EXA_API_KEY": "test_key"}):
+        tools = ExaTools(
+            include_text=["docket number"],
+            exclude_text=["sponsored"],
+            user_location="US",
+            moderation=True,
+            highlights=True,
+            subpages=2,
+        )
+    tools.exa = mock_exa_client
+
+    mock_response = Mock(spec=SearchResponse)
+    mock_response.results = [create_mock_search_result(url="https://example.com")]
+    mock_exa_client.search_and_contents.return_value = mock_response
+
+    tools.search_exa("test query")
+
+    kwargs = mock_exa_client.search_and_contents.call_args.kwargs
+    assert kwargs["include_text"] == ["docket number"]
+    assert kwargs["exclude_text"] == ["sponsored"]
+    assert kwargs["user_location"] == "US"
+    assert kwargs["moderation"] is True
+    assert kwargs["highlights"] is True
+    assert kwargs["subpages"] == 2
+
+
+def test_contents_options_reach_get_contents_and_find_similar(mock_exa_client):
+    """highlights/subpages apply to the contents-bearing calls too."""
+    with patch.dict("os.environ", {"EXA_API_KEY": "test_key"}):
+        tools = ExaTools(highlights=True, subpages=2, include_text=["docket number"])
+    tools.exa = mock_exa_client
+
+    mock_response = Mock(spec=SearchResponse)
+    mock_response.results = [create_mock_search_result(url="https://example.com")]
+    mock_exa_client.get_contents.return_value = mock_response
+    mock_exa_client.find_similar_and_contents.return_value = mock_response
+
+    tools.get_contents(["https://example.com"])
+    contents_kwargs = mock_exa_client.get_contents.call_args.kwargs
+    assert contents_kwargs["highlights"] is True
+    assert contents_kwargs["subpages"] == 2
+
+    tools.find_similar("https://example.com")
+    similar_kwargs = mock_exa_client.find_similar_and_contents.call_args.kwargs
+    assert similar_kwargs["highlights"] is True
+    assert similar_kwargs["subpages"] == 2
+    assert similar_kwargs["include_text"] == ["docket number"]
+
+
+def test_new_options_unset_by_default(exa_tools, mock_exa_client):
+    """None of the new options are sent unless they are configured."""
+    mock_response = Mock(spec=SearchResponse)
+    mock_response.results = [create_mock_search_result(url="https://example.com")]
+    mock_exa_client.search_and_contents.return_value = mock_response
+
+    exa_tools.search_exa("test query")
+
+    kwargs = mock_exa_client.search_and_contents.call_args.kwargs
+    for option in ("include_text", "exclude_text", "user_location", "moderation", "highlights", "subpages"):
+        assert option not in kwargs
+
+
+def test_highlights_are_returned_when_requested(mock_exa_client):
+    """Highlights that Exa returned must reach the model."""
+    with patch.dict("os.environ", {"EXA_API_KEY": "test_key"}):
+        tools = ExaTools(highlights=True)
+    tools.exa = mock_exa_client
+
+    mock_response = Mock(spec=SearchResponse)
+    mock_response.results = [
+        create_mock_search_result(
+            url="https://example.com",
+            text="Sample text content",
+            highlights=["The relevant sentence."],
+        )
+    ]
+    mock_exa_client.search_and_contents.return_value = mock_response
+
+    result_data = json.loads(tools.search_exa("test query"))
+
+    assert result_data[0]["highlights"] == ["The relevant sentence."]

--- a/libs/agno/tests/unit/tools/test_exa.py
+++ b/libs/agno/tests/unit/tools/test_exa.py
@@ -34,6 +34,7 @@ def create_mock_search_result(
     author: str = None,
     published_date: str = None,
     text: str = None,
+    summary: str = None,
 ):
     """Helper function to create mock search result."""
     result = Mock()
@@ -42,6 +43,7 @@ def create_mock_search_result(
     result.author = author
     result.published_date = published_date
     result.text = text
+    result.summary = summary
     return result
 
 
@@ -389,3 +391,70 @@ def test_research_error_handling(exa_tools, mock_exa_client):
 
     assert "error" in result_data
     assert "Research failed: API Error" in result_data["error"]
+
+
+def test_livecrawl_is_passed_to_exa(mock_exa_client):
+    """livecrawl must reach the API calls, not just sit on the toolkit."""
+    with patch.dict("os.environ", {"EXA_API_KEY": "test_key"}):
+        tools = ExaTools(livecrawl="always")
+    tools.exa = mock_exa_client
+
+    mock_response = Mock(spec=SearchResponse)
+    mock_response.results = [create_mock_search_result(url="https://example.com")]
+    mock_exa_client.search_and_contents.return_value = mock_response
+    mock_exa_client.get_contents.return_value = mock_response
+    mock_exa_client.find_similar_and_contents.return_value = mock_response
+
+    tools.search_exa("test query")
+    assert mock_exa_client.search_and_contents.call_args.kwargs["livecrawl"] == "always"
+
+    tools.get_contents(["https://example.com"])
+    assert mock_exa_client.get_contents.call_args.kwargs["livecrawl"] == "always"
+
+    tools.find_similar("https://example.com")
+    assert mock_exa_client.find_similar_and_contents.call_args.kwargs["livecrawl"] == "always"
+
+
+def test_livecrawl_unset_by_default(exa_tools, mock_exa_client):
+    """Without livecrawl configured, nothing is sent and Exa keeps its own default."""
+    mock_response = Mock(spec=SearchResponse)
+    mock_response.results = [create_mock_search_result(url="https://example.com")]
+    mock_exa_client.search_and_contents.return_value = mock_response
+
+    exa_tools.search_exa("test query")
+
+    assert "livecrawl" not in mock_exa_client.search_and_contents.call_args.kwargs
+
+
+def test_summary_is_returned_when_requested(mock_exa_client):
+    """A summary that Exa returned (and billed for) must reach the model."""
+    with patch.dict("os.environ", {"EXA_API_KEY": "test_key"}):
+        tools = ExaTools(summary=True)
+    tools.exa = mock_exa_client
+
+    mock_response = Mock(spec=SearchResponse)
+    mock_response.results = [
+        create_mock_search_result(
+            url="https://example.com",
+            title="Test Article",
+            text="Sample text content",
+            summary="A short summary of the article",
+        )
+    ]
+    mock_exa_client.search_and_contents.return_value = mock_response
+
+    result_data = json.loads(tools.search_exa("test query"))
+
+    assert mock_exa_client.search_and_contents.call_args.kwargs["summary"] is True
+    assert result_data[0]["summary"] == "A short summary of the article"
+
+
+def test_summary_absent_when_not_returned(exa_tools, mock_exa_client):
+    """No summary in the response means no summary key in the output."""
+    mock_response = Mock(spec=SearchResponse)
+    mock_response.results = [create_mock_search_result(url="https://example.com", text="Sample text content")]
+    mock_exa_client.search_and_contents.return_value = mock_response
+
+    result_data = json.loads(exa_tools.search_exa("test query"))
+
+    assert "summary" not in result_data[0]


### PR DESCRIPTION
## Summary

`ExaTools` and the Exa API had drifted apart in three ways, all in `agno/tools/exa.py`:

1. **`livecrawl` was dead.** The constructor took it and stored it on `self.livecrawl`, but nothing else referenced it — neither `search_exa`, `get_contents` nor `find_similar` put it in the request. The setting looked configured and did nothing.
2. **`summary` was billed and dropped.** It *was* sent to Exa, so summaries were generated and paid for, and then discarded: `_parse_results` built each result from `url`, `title`, `author`, `published_date` and `text` only.
3. **Six options had no way in at all:** `include_text`, `exclude_text`, `user_location`, `moderation`, `highlights`, `subpages`. `include_text` is the one that matters most — it is how you require a phrase to appear in the page body rather than in the snippet, which is what makes Exa usable for verification work.

This PR sends `livecrawl` in all three calls, carries returned summaries and highlights through to the model, and adds the missing options. Each option goes only to the calls that accept it:

| Option | `search_exa` | `get_contents` | `find_similar` |
|---|---|---|---|
| `livecrawl` | ✅ | ✅ | ✅ |
| `include_text`, `exclude_text` | ✅ | — | ✅ |
| `user_location`, `moderation` | ✅ | — | — |
| `highlights`, `subpages` | ✅ | ✅ | ✅ |

Closes #9911

Two commits, kept separate because they answer different questions — the fix first, the additions second.

**One deliberate behaviour change.** The `livecrawl` default moves from `"always"` to `None`. `None` is what callers effectively get today — nothing was sent, so Exa applied its own default — whereas keeping `"always"` would now silently switch every existing user to live crawling and its cost. Every new option is likewise unset by default, so nothing changes for anyone who does not opt in.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Tests.** Eight tests in `libs/agno/tests/unit/tools/test_exa.py`, plus `summary`/`highlights` fields on the existing `create_mock_search_result` helper:

- `test_livecrawl_is_passed_to_exa` — `livecrawl="always"` reaches all three calls.
- `test_livecrawl_unset_by_default` — nothing is sent when it is not configured.
- `test_summary_is_returned_when_requested` / `test_summary_absent_when_not_returned`.
- `test_search_forwards_the_full_option_set` — every new option reaches `search_and_contents`.
- `test_contents_options_reach_get_contents_and_find_similar`.
- `test_new_options_unset_by_default`.
- `test_highlights_are_returned_when_requested`.

Five of them fail on `main` (`KeyError` on the missing kwargs, `TypeError` on the unknown constructor arguments) and pass with the change. The full file is green (24 passed), and `./scripts/validate.sh` reports no ruff or mypy issues.

**On the option routing.** Each option was checked against `exa_py`'s own option tables — `SEARCH_OPTIONS_TYPES`, `FIND_SIMILAR_OPTIONS_TYPES`, `CONTENTS_OPTIONS_TYPES`, `CONTENTS_ENDPOINT_OPTIONS_TYPES` — so no call receives an option it would reject. `highlights=False` is sent as `None` so it is filtered out and Exa's default applies.

**Cost angle.** The `summary` half is not only a missing feature: summaries are a paid Exa option, so a user who sets `summary=True` today pays for output the toolkit throws away.

**History.** This PR previously covered only points 1 and 2, with point 3 stacked in a second PR (#9915). They touched the same two functions and had to be merged in order, which bought nothing for ~50 lines of change, so #9915 is now folded in here and closed.

**Disclosure.** This change was written with Claude Code. I have reviewed the diff, the reasoning behind it and the tests, and reproduced every failure and the fix locally.
