### PR TITLE
cookbook: add gemini-3.8-flash examples

### DIFF
--- a/cookbook/90_models/google/gemini/README.md
+++ b/cookbook/90_models/google/gemini/README.md
@@ -125,3 +125,17 @@ python cookbook/90_models/google/gemini/grounding.py
 python cookbook/90_models/google/gemini/vertex_ai_search.py
 ```
 
+### 18. Run a basic agent on Gemini 3.8 Flash
+
+```shell
+python cookbook/90_models/google/gemini/gemini_3_8_flash.py
+```
+
+### 19. Run a market brief agent on Gemini 3.8 Flash
+
+Combines Google Search grounding, URL context, and a structured output schema
+to produce a source-backed competitive brief.
+
+```shell
+python cookbook/90_models/google/gemini/gemini_3_8_flash_market_brief.py
+```

--- a/cookbook/90_models/google/gemini/gemini_3_8_flash.py
+++ b/cookbook/90_models/google/gemini/gemini_3_8_flash.py
@@ -1,0 +1,49 @@
+"""
+Gemini 3.8 Flash
+================
+
+Basic cookbook example for `gemini-3.8-flash`, using tools.
+
+Run `uv pip install -U google-genai ddgs agno` to install dependencies.
+Export `GOOGLE_API_KEY` before running.
+"""
+
+import asyncio
+
+from agno.agent import Agent, RunOutput  # noqa
+from agno.models.google import Gemini
+from agno.tools.websearch import WebSearchTools
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+agent = Agent(
+    model=Gemini(id="gemini-3.8-flash"),
+    tools=[WebSearchTools()],
+    markdown=True,
+)
+
+# Get the response in a variable
+# run: RunOutput = agent.run("What are the latest developments in AI agents?")
+# print(run.content)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    prompt = (
+        "Search for the latest developments in AI agents and summarize the top three."
+    )
+
+    # --- Sync ---
+    agent.print_response(prompt)
+
+    # --- Sync + Streaming ---
+    agent.print_response(prompt, stream=True)
+
+    # --- Async ---
+    asyncio.run(agent.aprint_response(prompt))
+
+    # --- Async + Streaming ---
+    asyncio.run(agent.aprint_response(prompt, stream=True))

--- a/cookbook/90_models/google/gemini/gemini_3_8_flash_market_brief.py
+++ b/cookbook/90_models/google/gemini/gemini_3_8_flash_market_brief.py
@@ -1,0 +1,169 @@
+"""Competitive Market Brief with Gemini 3.8 Flash.
+
+A research desk that turns an open-ended question about a company or product
+into a structured, source-backed brief.
+
+The pattern combines three things Gemini 3.8 Flash is well suited for:
+
+- Google Search grounding, so claims come from current pages rather than
+  training data
+- URL context, so the model reads the specific pages it finds
+- A Pydantic `output_schema`, so the brief lands as typed data you can store,
+  diff between runs, or feed into another agent
+
+Because 3.8 Flash keeps the discounted pricing of 3.7 Flash, a research loop
+like this stays cheap enough to run on every company in a watchlist.
+
+Run `uv pip install -U google-genai agno` to install dependencies.
+Export `GOOGLE_API_KEY` before running.
+"""
+
+import asyncio
+from typing import List, Literal, Optional
+
+from agno.agent import Agent
+from agno.models.google import Gemini
+from pydantic import BaseModel, Field
+
+# ---------------------------------------------------------------------------
+# Output Schema
+# ---------------------------------------------------------------------------
+
+
+class Source(BaseModel):
+    """A page the brief drew from."""
+
+    title: str = Field(description="Title of the page or article")
+    url: str = Field(description="Full URL of the source")
+    takeaway: str = Field(description="The single most useful fact from this source")
+
+
+class Competitor(BaseModel):
+    """A rival product or company worth tracking."""
+
+    name: str = Field(description="Competitor name")
+    positioning: str = Field(
+        description="How the competitor positions itself, in one sentence"
+    )
+    edge: str = Field(description="Where the competitor is stronger than the subject")
+    gap: str = Field(description="Where the competitor is weaker than the subject")
+
+
+class MarketBrief(BaseModel):
+    subject: str = Field(description="The company or product the brief is about")
+    one_liner: str = Field(description="What the subject does, in a single sentence")
+
+    momentum: Literal["accelerating", "steady", "slowing", "unclear"] = Field(
+        description="Current trajectory of the subject"
+    )
+    momentum_evidence: str = Field(
+        description="The specific, dated evidence behind the momentum rating"
+    )
+
+    recent_developments: List[str] = Field(
+        description="Notable events from the last few months, newest first"
+    )
+    competitors: List[Competitor] = Field(
+        description="Two to four competitors worth tracking"
+    )
+
+    open_questions: List[str] = Field(
+        description="What a researcher still needs to find out"
+    )
+    confidence: Literal["high", "medium", "low"] = Field(
+        description="How well sourced this brief is"
+    )
+    caveat: Optional[str] = Field(
+        description="Anything that undercuts the brief, such as thin or dated sourcing",
+        default=None,
+    )
+
+    sources: List[Source] = Field(description="Pages the brief drew from")
+
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+# search=True gives the model Google Search grounding.
+# url_context=True lets it read the pages that search surfaces.
+market_analyst = Agent(
+    name="Market Analyst",
+    model=Gemini(id="gemini-3.8-flash", search=True, url_context=True),
+    output_schema=MarketBrief,
+    instructions="""\
+You are a market analyst. Produce briefs a product team can act on.
+
+## Method
+
+- Search before you answer. Never rely on what you remember about a company.
+- Read the pages you find rather than summarizing search snippets.
+- Prefer primary sources: company blogs, filings, release notes, docs.
+- Attach a date to every claim about momentum or recent developments.
+
+## Rules
+
+- If sourcing is thin or dated, say so in the caveat and lower the confidence.
+- Never invent a competitor, a funding round, or a launch to fill out the schema.
+- Keep positioning and edge/gap statements to one sentence each.
+- No emojis.\
+""",
+)
+
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+def print_brief(brief: MarketBrief) -> None:
+    print(f"\n{brief.subject} - {brief.one_liner}")
+    print(f"Momentum: {brief.momentum} ({brief.confidence} confidence)")
+    print(f"  {brief.momentum_evidence}")
+
+    print("\nRecent developments")
+    for development in brief.recent_developments:
+        print(f"  - {development}")
+
+    print("\nCompetitors")
+    for competitor in brief.competitors:
+        print(f"  {competitor.name}: {competitor.positioning}")
+        print(f"    Edge: {competitor.edge}")
+        print(f"    Gap:  {competitor.gap}")
+
+    print("\nOpen questions")
+    for question in brief.open_questions:
+        print(f"  - {question}")
+
+    if brief.caveat:
+        print(f"\nCaveat: {brief.caveat}")
+
+    print("\nSources")
+    for source in brief.sources:
+        print(f"  - {source.title}: {source.url}")
+        print(f"    {source.takeaway}")
+
+
+async def brief_watchlist(subjects: List[str]) -> List[MarketBrief]:
+    """Research a whole watchlist concurrently, reusing the one agent."""
+    runs = await asyncio.gather(
+        *(
+            market_analyst.arun(f"Write a market brief on {subject}.")
+            for subject in subjects
+        )
+    )
+    return [run.content for run in runs]
+
+
+if __name__ == "__main__":
+    # --- Sync: a single brief ---
+    run = market_analyst.run(
+        "Write a market brief on the open-source AI agent framework Agno."
+    )
+    print_brief(run.content)
+
+    # --- Async: a watchlist, researched in parallel ---
+    watchlist = [
+        "the vector database company Qdrant",
+        "the observability company LangSmith",
+    ]
+    for brief in asyncio.run(brief_watchlist(watchlist)):
+        print_brief(brief)


### PR DESCRIPTION
## Summary

Adds cookbook examples for the new `gemini-3.8-flash` model id, launching Wed Sep 2 at 7am PT. It carries the same discounted pricing structure as 3.7 Flash.

Two examples in `cookbook/90_models/google/gemini/`:

**`gemini_3_8_flash.py`** — a basic agent on the new model id, using `WebSearchTools()`. Follows the folder's existing `basic.py` / `tool_use.py` shape, covering sync, sync + streaming, async, and async + streaming variants.

**`gemini_3_8_flash_market_brief.py`** — a use case rather than a plain example. A competitive market-brief research desk that combines three capabilities in one agent:

- `search=True` for Google Search grounding, so claims come from current pages rather than training data
- `url_context=True` so the model reads the pages search surfaces instead of summarizing snippets
- `output_schema=MarketBrief`, a Pydantic schema with nested `Competitor` / `Source` models, `Literal`-constrained `momentum` and `confidence` fields, and an optional `caveat`

It includes both a single sync brief and an async `brief_watchlist()` that researches several subjects concurrently via `asyncio.gather`, reusing the one agent instance rather than constructing agents in a loop. The discounted pricing carried over from 3.7 Flash is what makes running this across a whole watchlist practical.

`README.md` gains sections 18 and 19 following the folder's numbered convention.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [x] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Not yet verified against the live model.** Both examples were confirmed to import and construct cleanly (correct model id, `search`/`url_context` flags set, tools registered, schema resolves), and both pass `ruff check` and `ruff format --check`. Neither has been run end-to-end against the API, since the model was not live at authoring time. Worth one live run of each before merge to confirm search grounding and structured output land together.

**A note on `Field(enum=[...])`.** The market brief initially used the `enum=` kwarg on `Field`, copied from the existing `structured_output.py` in this folder. That is a Pydantic v1 idiom which emits `PydanticDeprecatedSince20` warnings under the repo's Pydantic 2.13 and is slated for removal in v3. It has been switched to `Literal` types here, which is what the rest of the cookbooks use and which additionally constrains the Python type, not just the JSON schema. The generated schema still carries the `enum` constraint that reaches Gemini, so model behavior is unchanged. `structured_output.py` still uses the old form and emits the same warnings — left alone here to keep this PR scoped, but worth a follow-up cleanup.

**Formatting scope.** `./scripts/format.sh` reformats 15 unrelated pre-existing files (vectordb adapters, knowledge loaders, `tools/gandr.py`). Those were reverted to keep this diff scoped to the cookbook, but they will keep resurfacing for anyone who runs the script and may deserve a separate formatting-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
