### PR TITLE
fix: stop RecursiveChunking from emitting duplicate trailing chunks

### DIFF
--- a/libs/agno/agno/knowledge/chunking/recursive.py
+++ b/libs/agno/agno/knowledge/chunking/recursive.py
@@ -51,6 +51,10 @@ class RecursiveChunking(ChunkingStrategy):
             meta_data["chunk_size"] = len(chunk)
             chunks.append(Document(id=chunk_id, name=document.name, meta_data=meta_data, content=chunk))
 
+            # Stop once a chunk reaches the end of the content
+            if end >= len(content):
+                break
+
             new_start = end - self.overlap
             if new_start <= start:  # Prevent infinite loop
                 new_start = min(

--- a/libs/agno/tests/unit/knowledge/chunking/test_recursive_chunking.py
+++ b/libs/agno/tests/unit/knowledge/chunking/test_recursive_chunking.py
@@ -11,7 +11,6 @@ def test_long_document_still_chunks_with_overlap_and_no_duplication():
 
     chunks = strategy.chunk(doc)
 
-    assert len(chunks) == 7
     assert [len(c.content) for c in chunks] == [20, 20, 20, 20, 20, 20, 10]
 
 

--- a/libs/agno/tests/unit/knowledge/chunking/test_recursive_chunking.py
+++ b/libs/agno/tests/unit/knowledge/chunking/test_recursive_chunking.py
@@ -1,0 +1,28 @@
+"""Tests for RecursiveChunking at the end of a document."""
+
+from agno.knowledge.chunking.recursive import RecursiveChunking
+from agno.knowledge.document.base import Document
+
+
+def test_long_document_still_chunks_with_overlap_and_no_duplication():
+    """Test that a long document chunks with overlap and no duplicate tail."""
+    strategy = RecursiveChunking(chunk_size=20, overlap=5)
+    doc = Document(name="long", content="a" * 100)
+
+    chunks = strategy.chunk(doc)
+
+    assert len(chunks) == 7
+    assert [len(c.content) for c in chunks] == [20, 20, 20, 20, 20, 20, 10]
+
+
+def test_last_chunk_ends_the_document_and_repeats_no_earlier_chunk():
+    """Test that the final chunk reaches the end and is not a repeat."""
+    content = "".join(f"{index:04d}" for index in range(75))
+    strategy = RecursiveChunking(chunk_size=100, overlap=20)
+    doc = Document(name="long", content=content)
+
+    chunks = strategy.chunk(doc)
+
+    assert content.endswith(chunks[-1].content)
+    for position, chunk in enumerate(chunks):
+        assert not any(chunk.content in earlier.content for earlier in chunks[:position])


### PR DESCRIPTION
## Summary

`RecursiveChunking.chunk()` had no exit for a chunk that reaches the end of the content. After the last full chunk, `start` rewound by `overlap`, so `start < len(content)` still held and the loop emitted a shorter suffix of text an earlier chunk already held. It repeated until `start` passed the end.

A 300 character document with `chunk_size=100` and `overlap=20` produced 6 chunks instead of 4. Chunks 5 and 6 sit inside chunk 4. Those duplicates reach the vector store as separate documents, which inflates the embedding cost and returns near-identical hits.

`FixedSizeChunking` already breaks out of its loop at `libs/agno/agno/knowledge/chunking/fixed.py:52-54`:

```python
# Stop once a chunk reaches the end of the content
if end >= content_length:
    break
```

This adds the same guard to `recursive.py`.

(If applicable, issue number: #9918)

Fixes #9918

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Measured before and after, on text with no `\n` and no `.` so the separator search at `recursive.py:39-44` finds no break point:

| chunk_size | overlap | length | before | after | FixedSizeChunking |
|---|---|---|---|---|---|
| 100 | 20 | 300 | `[100, 100, 100, 60, 20, 10]` | `[100, 100, 100, 60]` | `[100, 100, 100, 60]` |
| 1000 | 100 | 3000 | `[1000, 1000, 1000, 300, 100]` | `[1000, 1000, 1000, 300]` | `[1000, 1000, 1000, 300]` |
| 50 | 5 | 300 | 8 chunks | 7 chunks | 7 chunks |

Tests are in a new `libs/agno/tests/unit/knowledge/chunking/test_recursive_chunking.py`, which mirrors `test_fixed_size_chunking.py`. They are not in `test_chunking_split.py` because that module calls `pytest.importorskip("unstructured")` at import time, so the whole file skips where `unstructured` is absent.

With the change reverted both new tests fail. `pytest tests/unit/knowledge/chunking/` gives 37 passed and 8 skipped, unchanged from before. The 8 skips and the two ignored modules are pre-existing `chonkie` import errors.

`ruff check libs/agno` reports no findings, and `ruff format` leaves both files unchanged.

I ran `./scripts/format.sh` and it reformatted 16 files this PR does not touch, so I reverted those. The ruff version here differs from the one that last formatted them.
