### PR TITLE
docs(cookbook): add NeetCode 150 study planner agent

### DIFF
--- a/cookbook/02_agents/23_neetcode_planner/README.md
+++ b/cookbook/02_agents/23_neetcode_planner/README.md
@@ -1,0 +1,14 @@
+# Technical Interview Planner Agent
+
+An Agno agent that generates a structured, 30-day technical interview study schedule based on the NeetCode 150 curriculum, with language-specific guidance for Java and C++.
+
+## Overview
+
+This cookbook example demonstrates how to configure an Agno agent with custom instructions and domain expertise to pace out complex technical preparation into balanced, daily milestones.
+
+## Prerequisites
+
+Install the required dependencies:
+
+```bash
+pip install -U agno openai

--- a/cookbook/02_agents/23_neetcode_planner/agent.py
+++ b/cookbook/02_agents/23_neetcode_planner/agent.py
@@ -1,0 +1,16 @@
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+
+planner = Agent(
+    model=OpenAIChat(id="gpt-4o"),
+    description="You are a technical recruiter specializing in pacing Data Structures and Algorithms preparation.",
+    instructions=[
+        "Break down the NeetCode 150 problem set into a manageable 30-day schedule.",
+        "Focus specifically on providing optimization tips for solving these in Java and C++.",
+        "Ensure the daily workload is balanced."
+    ],
+    markdown=True
+)
+
+if __name__ == "__main__":
+    planner.print_response("Create a 30-day plan to finish the NeetCode 150.", stream=True)


### PR DESCRIPTION
### Summary
Adds a technical interview study planner example to the cookbook (`cookbook/02_agents/neetcode_planner/`). 

### Description
This example demonstrates how an Agno agent can be used to pace out extensive preparation curricula—specifically breaking down the NeetCode 150 problem set into a balanced 30-day schedule with language-specific considerations for Java and C++. 

It provides an end-to-end example of using tailored agent instructions for structured, day-by-day technical milestones.

### Contents
- `agent.py`: Agent configuration and prompt logic
- `README.md`: Setup instructions and run steps