### PR TITLE
fix: replay Anthropic assistant turns verbatim so thinking blocks are not rejected

### DIFF
--- a/cookbook/10_reasoning/models/anthropic/TEST_LOG.md
+++ b/cookbook/10_reasoning/models/anthropic/TEST_LOG.md
@@ -9,3 +9,13 @@
 **Result:** Files in this directory pass structure checks and compile successfully.
 
 ---
+
+### basic_reasoning_stream.py
+
+**Status:** PASS
+
+**Description:** Streaming reasoning with a Claude reasoning model using extended thinking.
+
+**Result:** Thinking and response panels stream and the answer is correct.
+
+---

--- a/cookbook/90_models/anthropic/TEST_LOG.md
+++ b/cookbook/90_models/anthropic/TEST_LOG.md
@@ -1,3 +1,31 @@
 # TEST_LOG
 
-No cookbook tests have been recorded for this directory yet.
+### thinking.py
+
+**Status:** PASS
+
+**Description:** Extended thinking with sync and streaming responses. Model id bumped from the retired claude-3-7-sonnet-20250219 to claude-sonnet-4-5.
+
+**Result:** Both runs return a thinking block followed by the response.
+
+---
+
+### adaptive_thinking.py
+
+**Status:** PASS
+
+**Description:** Adaptive thinking with output_config effort on claude-sonnet-4-6.
+
+**Result:** Response streams with thinking and a full markdown answer.
+
+---
+
+### financial_analyst_thinking.py
+
+**Status:** PASS
+
+**Description:** Interleaved thinking with calculator and yfinance tools, streaming. Exercises replay of stored thinking blocks alongside tool_use blocks inside a single tool-use turn. Model id bumped from the retired claude-sonnet-4-20250514 to claude-sonnet-4-5.
+
+**Result:** Thinking, tool calls and the final response complete. A transient TLS read error on one request was retried by the Anthropic SDK and did not affect the run.
+
+---

--- a/cookbook/90_models/anthropic/financial_analyst_thinking.py
+++ b/cookbook/90_models/anthropic/financial_analyst_thinking.py
@@ -25,7 +25,7 @@ task = (
 
 agent = Agent(
     model=Claude(
-        id="claude-sonnet-4-20250514",
+        id="claude-sonnet-4-5",
         thinking={"type": "enabled", "budget_tokens": 2048},
         betas=["interleaved-thinking-2025-05-14"],
     ),

--- a/cookbook/90_models/anthropic/thinking.py
+++ b/cookbook/90_models/anthropic/thinking.py
@@ -14,7 +14,7 @@ from agno.models.anthropic import Claude
 
 agent = Agent(
     model=Claude(
-        id="claude-3-7-sonnet-20250219",
+        id="claude-sonnet-4-5",
         max_tokens=2048,
         thinking={"type": "enabled", "budget_tokens": 1024},
     ),

--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -191,9 +191,11 @@ class Claude(Model):
         # Set up skills configuration if skills are enabled
         if self.skills:
             self._setup_skills_configuration()
-        # Auto-enable trailing user message for models that don't support prefill
+        # Auto-enable trailing user message for models that don't support prefill. Prefill is also
+        # rejected while thinking is on, on every model: a history ending in an assistant turn (a
+        # resumed run, or a response truncated inside its thinking) must be followed by a user turn.
         if self.append_trailing_user_message is None:
-            self.append_trailing_user_message = not supports_prefill(self.id)
+            self.append_trailing_user_message = not supports_prefill(self.id) or self._thinking_enabled()
 
     def _get_client_params(self) -> Dict[str, Any]:
         client_params: Dict[str, Any] = {}
@@ -265,6 +267,10 @@ class Claude(Model):
                         return True
 
         return False
+
+    def _thinking_enabled(self) -> bool:
+        """Return True when the request will run with thinking on."""
+        return bool(self.thinking) and self.thinking.get("type") != "disabled"  # type: ignore[union-attr]
 
     def _validate_thinking_support(self) -> None:
         """

--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -269,8 +269,13 @@ class Claude(Model):
         return False
 
     def _thinking_enabled(self) -> bool:
-        """Return True when the request will run with thinking on."""
-        return bool(self.thinking) and self.thinking.get("type") != "disabled"  # type: ignore[union-attr]
+        """Return True when the request will run with thinking on.
+
+        ``request_params`` are applied last in ``get_request_params`` and override the ``thinking``
+        field, so a thinking config supplied there decides.
+        """
+        thinking = (self.request_params or {}).get("thinking", self.thinking)
+        return isinstance(thinking, dict) and thinking.get("type") != "disabled"
 
     def _validate_thinking_support(self) -> None:
         """

--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -23,6 +23,7 @@ from agno.utils.models.claude import (
     format_tools_for_model,
     resolve_http_client,
     route_sampling_params_to_extra_body,
+    serialize_content_blocks,
     supports_prefill,
 )
 from agno.utils.tokens import count_schema_tokens
@@ -1035,6 +1036,11 @@ class Claude(Model):
                     server_blocks = model_response.provider_data.setdefault("server_tool_blocks", [])
                     server_blocks.append(block.model_dump())
 
+            # Keep the response's content blocks verbatim and in order so history replay can echo
+            # the turn back exactly; the convenience fields above are lossy views of these blocks.
+            model_response.provider_data = model_response.provider_data or {}
+            model_response.provider_data["content_blocks"] = serialize_content_blocks(response.content)
+
         # Extract tool calls from the response
         if response.stop_reason == "tool_use":
             for block in response.content:
@@ -1206,6 +1212,14 @@ class Claude(Model):
                 if model_response.provider_data is None:
                     model_response.provider_data = {}
                 model_response.provider_data.setdefault("server_tool_blocks", []).extend(server_tool_blocks)
+
+            # Keep the final content blocks verbatim and in order so history replay can echo the
+            # turn back exactly; the streamed deltas above are lossy views of these blocks.
+            content_blocks = serialize_content_blocks(response.message.content)  # type: ignore
+            if content_blocks:
+                if model_response.provider_data is None:
+                    model_response.provider_data = {}
+                model_response.provider_data["content_blocks"] = content_blocks
 
             # Handle structured outputs (JSON outputs) from accumulated text
             # Note: We parse from accumulated_text but don't set model_response.content to avoid duplication

--- a/libs/agno/agno/models/azure/claude.py
+++ b/libs/agno/agno/models/azure/claude.py
@@ -43,8 +43,8 @@ class Claude(AnthropicClaude):
 
     def __post_init__(self):
         """Validate model configuration after initialization"""
-        if self.thinking:
-            self._validate_thinking_support()
+        super().__post_init__()
+        # Overwrite output schema support for Azure AI Foundry Claude
         self.supports_native_structured_outputs = False
         self.supports_json_schema_outputs = False
 

--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 from agno.media import File, Image
 from agno.models.message import Message
-from agno.utils.log import log_error, log_info, log_warning
+from agno.utils.log import log_debug, log_error, log_info, log_warning
 
 if TYPE_CHECKING:
     from agno.models.anthropic.claude import SystemPromptBlock
@@ -123,6 +123,56 @@ def _anthropic_coerce_content_block(item: Any) -> Optional[Any]:
         if isinstance(block_dict, dict) and block_dict.get("type"):
             return block_dict
     return None
+
+
+_ANTHROPIC_THINKING_BLOCK_TYPES = ("thinking", "redacted_thinking")
+
+
+def _anthropic_block_type(block: Any) -> Optional[str]:
+    """Return the ``type`` of a content block that may be a dict or an SDK block object."""
+    block_type = block.get("type") if isinstance(block, dict) else getattr(block, "type", None)
+    return block_type if isinstance(block_type, str) else None
+
+
+def serialize_content_blocks(blocks: Any) -> List[Dict[str, Any]]:
+    """Serialize a provider response's content blocks, in order, into plain dicts.
+
+    The result is stored on the assistant message so a later request can echo the turn back
+    exactly as the API produced it. The API signs thinking blocks and verifies them on replay,
+    so the stored sequence must keep every block, its order, and its signature.
+    """
+    serialized: List[Dict[str, Any]] = []
+    for block in blocks or []:
+        block_dict = _anthropic_coerce_content_block(block)
+        if block_dict is not None:
+            serialized.append(block_dict)
+    return serialized
+
+
+def _anthropic_stored_assistant_blocks(message: Message) -> Optional[List[Dict[str, Any]]]:
+    """Return the provider content blocks stored on an assistant message, ready to replay.
+
+    Returns None when the message carries no stored blocks (it predates block storage, or was
+    produced by another provider) so the caller rebuilds the turn from the convenience fields.
+    ``tool_use`` blocks are kept only when the message still carries the matching tool call: a
+    response truncated by ``max_tokens`` can contain a tool_use that never ran, and the API
+    rejects a tool_use that has no tool_result.
+    """
+    if not message.provider_data:
+        return None
+    stored = message.provider_data.get("content_blocks")
+    if not isinstance(stored, list) or not stored:
+        return None
+    tool_call_ids = {tc.get("id") for tc in (message.tool_calls or []) if isinstance(tc, dict)}
+    replay: List[Dict[str, Any]] = []
+    for item in stored:
+        block = _anthropic_coerce_content_block(item)
+        if block is None:
+            continue
+        if block.get("type") == "tool_use" and block.get("id") not in tool_call_ids:
+            continue
+        replay.append(block)
+    return replay
 
 
 def _format_image_for_message(image: Image) -> Optional[Dict[str, Any]]:
@@ -547,16 +597,32 @@ def format_messages(
 
             content = []
 
-            if message.reasoning_content is not None and message.provider_data is not None:
-                from anthropic.types import RedactedThinkingBlock, ThinkingBlock
+            stored_blocks = _anthropic_stored_assistant_blocks(message)
+            if stored_blocks is not None:
+                # Echo the turn exactly as the API produced it: block order, text boundaries and
+                # every signed thinking block. Rebuilding the turn from the convenience fields
+                # below loses all of those, and the API rejects a modified thinking sequence.
+                content.extend(stored_blocks)
+                chat_messages.append({"role": ROLE_MAP[message.role], "content": content})  # type: ignore
+                continue
 
-                content.append(
-                    ThinkingBlock(
-                        thinking=message.reasoning_content,
-                        signature=message.provider_data.get("signature"),
-                        type="thinking",
+            if message.reasoning_content is not None and message.provider_data is not None:
+                from anthropic.types import ThinkingBlock
+
+                signature = message.provider_data.get("signature")
+                if isinstance(signature, str) and signature:
+                    content.append(
+                        ThinkingBlock(
+                            thinking=message.reasoning_content,
+                            signature=signature,
+                            type="thinking",
+                        )
                     )
-                )
+                else:
+                    # The API verifies thinking blocks by signature, so one without a signature
+                    # (reasoning from another provider, or a partially stored response) can only
+                    # be omitted. Omitting prior thinking is permitted outside a tool-use turn.
+                    log_debug("Omitting reasoning content without a thinking signature from Anthropic history")
 
             if message.redacted_reasoning_content is not None:
                 from anthropic.types import RedactedThinkingBlock
@@ -660,6 +726,16 @@ def format_messages(
             curr_blocks = (
                 curr_content if isinstance(curr_content, list) else [{"type": "text", "text": str(curr_content)}]
             )
+            if msg["role"] == "assistant":
+                # Two assistant responses can only share one message by dropping the earlier
+                # response's thinking: the API verifies an assistant message's thinking sequence
+                # against a single original response and rejects a stitched sequence. Omitting
+                # that thinking is permitted because the earlier response ended without a tool
+                # call to continue (a thinking-only response truncated by max_tokens, or an
+                # injected assistant message).
+                prev_blocks = [
+                    b for b in prev_blocks if _anthropic_block_type(b) not in _ANTHROPIC_THINKING_BLOCK_TYPES
+                ]
             merged_messages[-1]["content"] = [*prev_blocks, *curr_blocks]
         else:
             merged_messages.append(msg)

--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -602,77 +602,79 @@ def format_messages(
                 # Echo the turn exactly as the API produced it: block order, text boundaries and
                 # every signed thinking block. Rebuilding the turn from the convenience fields
                 # below loses all of those, and the API rejects a modified thinking sequence.
+                # A stored list that filters down to nothing (a truncated tool_use only) falls
+                # through to the empty-assistant skip below like any other empty turn.
                 content.extend(stored_blocks)
-                chat_messages.append({"role": ROLE_MAP[message.role], "content": content})  # type: ignore
-                continue
+            else:
+                if message.reasoning_content is not None and message.provider_data is not None:
+                    from anthropic.types import ThinkingBlock
 
-            if message.reasoning_content is not None and message.provider_data is not None:
-                from anthropic.types import ThinkingBlock
-
-                signature = message.provider_data.get("signature")
-                if isinstance(signature, str) and signature:
-                    content.append(
-                        ThinkingBlock(
-                            thinking=message.reasoning_content,
-                            signature=signature,
-                            type="thinking",
+                    signature = message.provider_data.get("signature")
+                    if isinstance(signature, str) and signature:
+                        content.append(
+                            ThinkingBlock(
+                                thinking=message.reasoning_content,
+                                signature=signature,
+                                type="thinking",
+                            )
                         )
-                    )
-                else:
-                    # The API verifies thinking blocks by signature, so one without a signature
-                    # (reasoning from another provider, or a partially stored response) can only
-                    # be omitted. Omitting prior thinking is permitted outside a tool-use turn.
-                    log_debug("Omitting reasoning content without a thinking signature from Anthropic history")
+                    else:
+                        # The API verifies thinking blocks by signature, so one without a signature
+                        # (reasoning from another provider, or a partially stored response) can only
+                        # be omitted. Omitting prior thinking is permitted outside a tool-use turn.
+                        log_debug("Omitting reasoning content without a thinking signature from Anthropic history")
 
-            if message.redacted_reasoning_content is not None:
-                from anthropic.types import RedactedThinkingBlock
+                if message.redacted_reasoning_content is not None:
+                    from anthropic.types import RedactedThinkingBlock
 
-                content.append(RedactedThinkingBlock(data=message.redacted_reasoning_content, type="redacted_thinking"))
-
-            # Extract structured blocks from list-shaped content (used when callers persist and
-            # rehydrate full assistant turns rather than the text-only + provider_data split).
-            structured_from_list: List[Any] = []
-            list_block_identities: set = set()
-            if isinstance(message.content, list):
-                for item in message.content:
-                    blk = _anthropic_coerce_content_block(item)
-                    if blk is None:
-                        continue
-                    block_type = blk.get("type") if isinstance(blk, dict) else None
-                    if block_type == "tool_use" and message.tool_calls:
-                        continue
-                    identity = _anthropic_block_identity(blk)
-                    if identity is not None:
-                        list_block_identities.add(identity)
-                    structured_from_list.append(blk)
-
-            # Reconstruct server tool blocks (web_fetch, web_search, etc.) from provider_data.
-            # Merge by identity (type, id-or-tool_use_id) so blocks already present in list-content
-            # aren't duplicated, but blocks that exist only in provider_data are still emitted.
-            if message.provider_data and message.provider_data.get("server_tool_blocks"):
-                for block_dict in message.provider_data["server_tool_blocks"]:
-                    identity = _anthropic_block_identity(block_dict)
-                    if identity is not None and identity in list_block_identities:
-                        continue
-                    content.append(block_dict)
-
-            if structured_from_list:
-                content.extend(structured_from_list)
-            elif isinstance(message.content, str) and message.content and len(message.content.strip()) > 0:
-                content.append(TextBlock(text=message.content, type="text"))
-
-            if message.tool_calls:
-                for tool_call in message.tool_calls:
                     content.append(
-                        ToolUseBlock(
-                            id=tool_call["id"],
-                            input=json.loads(tool_call["function"]["arguments"])
-                            if "arguments" in tool_call["function"]
-                            else {},
-                            name=tool_call["function"]["name"],
-                            type="tool_use",
-                        )
+                        RedactedThinkingBlock(data=message.redacted_reasoning_content, type="redacted_thinking")
                     )
+
+                # Extract structured blocks from list-shaped content (used when callers persist and
+                # rehydrate full assistant turns rather than the text-only + provider_data split).
+                structured_from_list: List[Any] = []
+                list_block_identities: set = set()
+                if isinstance(message.content, list):
+                    for item in message.content:
+                        blk = _anthropic_coerce_content_block(item)
+                        if blk is None:
+                            continue
+                        block_type = blk.get("type") if isinstance(blk, dict) else None
+                        if block_type == "tool_use" and message.tool_calls:
+                            continue
+                        identity = _anthropic_block_identity(blk)
+                        if identity is not None:
+                            list_block_identities.add(identity)
+                        structured_from_list.append(blk)
+
+                # Reconstruct server tool blocks (web_fetch, web_search, etc.) from provider_data.
+                # Merge by identity (type, id-or-tool_use_id) so blocks already present in list-content
+                # aren't duplicated, but blocks that exist only in provider_data are still emitted.
+                if message.provider_data and message.provider_data.get("server_tool_blocks"):
+                    for block_dict in message.provider_data["server_tool_blocks"]:
+                        identity = _anthropic_block_identity(block_dict)
+                        if identity is not None and identity in list_block_identities:
+                            continue
+                        content.append(block_dict)
+
+                if structured_from_list:
+                    content.extend(structured_from_list)
+                elif isinstance(message.content, str) and message.content and len(message.content.strip()) > 0:
+                    content.append(TextBlock(text=message.content, type="text"))
+
+                if message.tool_calls:
+                    for tool_call in message.tool_calls:
+                        content.append(
+                            ToolUseBlock(
+                                id=tool_call["id"],
+                                input=json.loads(tool_call["function"]["arguments"])
+                                if "arguments" in tool_call["function"]
+                                else {},
+                                name=tool_call["function"]["name"],
+                                type="tool_use",
+                            )
+                        )
         elif message.role == "tool":
             content = []
 

--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -171,7 +171,8 @@ def _anthropic_stored_assistant_blocks(message: Message) -> Optional[List[Dict[s
             continue
         if block.get("type") == "tool_use" and block.get("id") not in tool_call_ids:
             continue
-        replay.append(block)
+        # Copy so request-time edits to the payload can never reach the stored session message.
+        replay.append(dict(block))
     return replay
 
 
@@ -640,8 +641,7 @@ def format_messages(
                         blk = _anthropic_coerce_content_block(item)
                         if blk is None:
                             continue
-                        block_type = blk.get("type") if isinstance(blk, dict) else None
-                        if block_type == "tool_use" and message.tool_calls:
+                        if _anthropic_block_type(blk) == "tool_use" and message.tool_calls:
                             continue
                         identity = _anthropic_block_identity(blk)
                         if identity is not None:

--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -144,8 +144,12 @@ def serialize_content_blocks(blocks: Any) -> List[Dict[str, Any]]:
     serialized: List[Dict[str, Any]] = []
     for block in blocks or []:
         block_dict = _anthropic_coerce_content_block(block)
-        if block_dict is not None:
-            serialized.append(block_dict)
+        if block_dict is None:
+            continue
+        if block_dict.get("type") == "redacted_reasoning_content":
+            # Legacy spelling accepted from rehydrated events; the API only knows redacted_thinking.
+            block_dict = {**block_dict, "type": "redacted_thinking"}
+        serialized.append(block_dict)
     return serialized
 
 
@@ -165,10 +169,7 @@ def _anthropic_stored_assistant_blocks(message: Message) -> Optional[List[Dict[s
         return None
     tool_call_ids = {tc.get("id") for tc in (message.tool_calls or []) if isinstance(tc, dict)}
     replay: List[Dict[str, Any]] = []
-    for item in stored:
-        block = _anthropic_coerce_content_block(item)
-        if block is None:
-            continue
+    for block in serialize_content_blocks(stored):
         if block.get("type") == "tool_use" and block.get("id") not in tool_call_ids:
             continue
         # Copy so request-time edits to the payload can never reach the stored session message.

--- a/libs/agno/tests/unit/models/anthropic/test_append_trailing_user_message.py
+++ b/libs/agno/tests/unit/models/anthropic/test_append_trailing_user_message.py
@@ -369,3 +369,36 @@ class TestAutoDetectionLiteLLM:
         from agno.models.litellm.chat import LiteLLM
 
         assert LiteLLM(id="openai/gpt-4o").append_trailing_user_message is False
+
+
+class TestAutoDetectionAzureClaude:
+    """Azure Claude must run the shared auto-detection, not just its own overrides."""
+
+    def test_azure_sonnet_45_auto_disabled(self):
+        from agno.models.azure.claude import Claude
+
+        assert Claude(id="claude-sonnet-4-5-20250929").append_trailing_user_message is False
+
+    def test_azure_sonnet_46_auto_enabled(self):
+        from agno.models.azure.claude import Claude
+
+        assert Claude(id="claude-sonnet-4-6").append_trailing_user_message is True
+
+    def test_azure_thinking_auto_enabled_on_prefill_model(self):
+        from agno.models.azure.claude import Claude
+
+        model = Claude(id="claude-sonnet-4-5-20250929", thinking={"type": "enabled", "budget_tokens": 1024})
+        assert model.append_trailing_user_message is True
+
+    def test_azure_user_override_respected(self):
+        from agno.models.azure.claude import Claude
+
+        assert Claude(id="claude-sonnet-4-6", append_trailing_user_message=False).append_trailing_user_message is False
+
+    def test_azure_still_disables_structured_outputs(self):
+        # The parent post-init enables native structured outputs for supported ids; Azure overrides it.
+        from agno.models.azure.claude import Claude
+
+        model = Claude(id="claude-sonnet-4-5-20250929")
+        assert model.supports_native_structured_outputs is False
+        assert model.supports_json_schema_outputs is False

--- a/libs/agno/tests/unit/models/anthropic/test_append_trailing_user_message.py
+++ b/libs/agno/tests/unit/models/anthropic/test_append_trailing_user_message.py
@@ -282,6 +282,36 @@ class TestAutoDetection:
 
         assert Claude(id="claude-sonnet-5-0").append_trailing_user_message is True
 
+    def test_thinking_enabled_auto_enabled_on_prefill_model(self):
+        # Prefill is rejected while thinking is on, so a prefill-capable model still needs the
+        # trailing user turn (a resumed run, or a response truncated inside its thinking).
+        from agno.models.anthropic import Claude
+
+        model = Claude(id="claude-sonnet-4-5-20250929", thinking={"type": "enabled", "budget_tokens": 1024})
+        assert model.append_trailing_user_message is True
+
+    def test_adaptive_thinking_auto_enabled_on_prefill_model(self):
+        from agno.models.anthropic import Claude
+
+        model = Claude(id="claude-sonnet-4-5-20250929", thinking={"type": "adaptive"})
+        assert model.append_trailing_user_message is True
+
+    def test_thinking_disabled_type_keeps_prefill_default(self):
+        from agno.models.anthropic import Claude
+
+        model = Claude(id="claude-sonnet-4-5-20250929", thinking={"type": "disabled"})
+        assert model.append_trailing_user_message is False
+
+    def test_user_override_respected_with_thinking(self):
+        from agno.models.anthropic import Claude
+
+        model = Claude(
+            id="claude-sonnet-4-5-20250929",
+            thinking={"type": "enabled", "budget_tokens": 1024},
+            append_trailing_user_message=False,
+        )
+        assert model.append_trailing_user_message is False
+
 
 class TestAutoDetectionVertexAI:
     """Tests for VertexAI Claude auto-detection."""

--- a/libs/agno/tests/unit/models/anthropic/test_append_trailing_user_message.py
+++ b/libs/agno/tests/unit/models/anthropic/test_append_trailing_user_message.py
@@ -312,6 +312,27 @@ class TestAutoDetection:
         )
         assert model.append_trailing_user_message is False
 
+    def test_thinking_via_request_params_auto_enabled(self):
+        # request_params are applied last and override the thinking field, so thinking supplied
+        # there must also turn on the trailing user turn.
+        from agno.models.anthropic import Claude
+
+        model = Claude(
+            id="claude-sonnet-4-5-20250929",
+            request_params={"thinking": {"type": "enabled", "budget_tokens": 1024}},
+        )
+        assert model.append_trailing_user_message is True
+
+    def test_request_params_disabling_thinking_keeps_prefill_default(self):
+        from agno.models.anthropic import Claude
+
+        model = Claude(
+            id="claude-sonnet-4-5-20250929",
+            thinking={"type": "enabled", "budget_tokens": 1024},
+            request_params={"thinking": {"type": "disabled"}},
+        )
+        assert model.append_trailing_user_message is False
+
 
 class TestAutoDetectionVertexAI:
     """Tests for VertexAI Claude auto-detection."""

--- a/libs/agno/tests/unit/models/anthropic/test_thinking_replay.py
+++ b/libs/agno/tests/unit/models/anthropic/test_thinking_replay.py
@@ -1,0 +1,245 @@
+"""Assistant turns must replay to the Anthropic API exactly as the API produced them.
+
+The API signs thinking blocks and verifies the thinking sequence of an assistant message on
+replay. Rebuilding the turn from Message.reasoning_content / content / tool_calls loses block
+multiplicity, order and signatures, and merging two assistant responses into one message
+produces a thinking sequence no single response generated. Both are rejected with a 400.
+"""
+
+import pytest
+
+pytest.importorskip("anthropic")
+
+from anthropic.lib.streaming import MessageStopEvent as StreamingMessageStopEvent
+from anthropic.types import Message as AnthropicMessage
+from anthropic.types import RedactedThinkingBlock, TextBlock, ThinkingBlock, ToolUseBlock, Usage
+
+from agno.models.anthropic.claude import Claude
+from agno.models.message import Message
+from agno.utils.models.claude import format_messages
+
+
+def _block_types(blocks):
+    return [b["type"] if isinstance(b, dict) else b.type for b in blocks]
+
+
+def _signatures(blocks):
+    return [b.get("signature") if isinstance(b, dict) else getattr(b, "signature", None) for b in blocks]
+
+
+def _interleaved_response(stop_reason="tool_use") -> AnthropicMessage:
+    """One response with two thinking blocks around a tool call: thinking, tool_use, thinking, text."""
+    return AnthropicMessage(
+        id="msg_1",
+        model="claude-sonnet-4-5",
+        role="assistant",
+        type="message",
+        stop_reason=stop_reason,
+        usage=Usage(input_tokens=1, output_tokens=1),
+        content=[
+            ThinkingBlock(type="thinking", thinking="think A", signature="SIG-A"),
+            ToolUseBlock(type="tool_use", id="tu_1", name="f", input={"x": 1}),
+            ThinkingBlock(type="thinking", thinking="think B", signature="SIG-B"),
+            TextBlock(type="text", text="done"),
+        ],
+    )
+
+
+def _assistant_from(model_response) -> Message:
+    return Message(
+        role="assistant",
+        content=model_response.content,
+        reasoning_content=model_response.reasoning_content,
+        redacted_reasoning_content=model_response.redacted_reasoning_content,
+        provider_data=model_response.provider_data,
+        tool_calls=model_response.tool_calls,
+    )
+
+
+def test_non_streaming_parse_stores_ordered_content_blocks():
+    model = Claude(id="claude-sonnet-4-5", api_key="x")
+    parsed = model._parse_provider_response(_interleaved_response())
+
+    stored = parsed.provider_data["content_blocks"]
+    assert _block_types(stored) == ["thinking", "tool_use", "thinking", "text"]
+    assert [b.get("signature") for b in stored] == ["SIG-A", None, "SIG-B", None]
+    # Convenience fields keep working as views.
+    assert parsed.content == "done"
+    assert parsed.tool_calls[0]["id"] == "tu_1"
+
+
+def test_round_trip_replays_blocks_verbatim():
+    model = Claude(id="claude-sonnet-4-5", api_key="x")
+    assistant = _assistant_from(model._parse_provider_response(_interleaved_response()))
+
+    api_messages, _ = format_messages([Message(role="user", content="hi"), assistant])
+
+    blocks = api_messages[1]["content"]
+    assert _block_types(blocks) == ["thinking", "tool_use", "thinking", "text"]
+    assert _signatures(blocks) == ["SIG-A", None, "SIG-B", None]
+    assert blocks[1]["input"] == {"x": 1}
+
+
+def test_streaming_message_stop_stores_content_blocks():
+    model = Claude(id="claude-sonnet-4-5", api_key="x")
+    stop_event = StreamingMessageStopEvent(type="message_stop", message=_interleaved_response())
+
+    delta = model._parse_provider_response_delta(stop_event)
+
+    stored = delta.provider_data["content_blocks"]
+    assert _block_types(stored) == ["thinking", "tool_use", "thinking", "text"]
+    assert [b.get("signature") for b in stored] == ["SIG-A", None, "SIG-B", None]
+
+
+def test_truncated_tool_use_without_tool_call_is_not_replayed():
+    # stop_reason=max_tokens: the tool_use never ran, so no tool_result exists for it. Replaying
+    # it would make the API reject the request for a tool_use without a tool_result.
+    model = Claude(id="claude-sonnet-4-5", api_key="x")
+    assistant = _assistant_from(model._parse_provider_response(_interleaved_response(stop_reason="max_tokens")))
+    assert not assistant.tool_calls
+
+    api_messages, _ = format_messages([Message(role="user", content="hi"), assistant])
+
+    assert _block_types(api_messages[1]["content"]) == ["thinking", "thinking", "text"]
+
+
+def test_replay_keeps_redacted_thinking_in_place():
+    model = Claude(id="claude-sonnet-4-5", api_key="x")
+    response = AnthropicMessage(
+        id="msg_1",
+        model="claude-sonnet-4-5",
+        role="assistant",
+        type="message",
+        stop_reason="end_turn",
+        usage=Usage(input_tokens=1, output_tokens=1),
+        content=[
+            RedactedThinkingBlock(type="redacted_thinking", data="ENC-1"),
+            ThinkingBlock(type="thinking", thinking="visible", signature="SIG-1"),
+            TextBlock(type="text", text="answer"),
+        ],
+    )
+    assistant = _assistant_from(model._parse_provider_response(response))
+
+    api_messages, _ = format_messages([Message(role="user", content="hi"), assistant])
+
+    blocks = api_messages[1]["content"]
+    assert _block_types(blocks) == ["redacted_thinking", "thinking", "text"]
+    assert blocks[0]["data"] == "ENC-1"
+
+
+def test_legacy_message_without_stored_blocks_still_rebuilds():
+    # Sessions written before blocks were stored only have the convenience fields.
+    assistant = Message(
+        role="assistant",
+        content="Here is the summary.",
+        reasoning_content="The report has three sections...",
+        provider_data={"signature": "SIG-2"},
+    )
+
+    api_messages, _ = format_messages([Message(role="user", content="hi"), assistant])
+
+    blocks = api_messages[1]["content"]
+    assert _block_types(blocks) == ["thinking", "text"]
+    assert _signatures(blocks) == ["SIG-2", None]
+
+
+def test_merged_assistant_messages_keep_only_the_later_thinking():
+    # A thinking-only response truncated by max_tokens, followed by the continuation response
+    # with no user or tool message in between (continue_run without input).
+    truncated = Message(
+        role="assistant",
+        content=None,
+        reasoning_content="I will read the report first...",
+        provider_data={"signature": "SIG-1"},
+    )
+    continuation = Message(
+        role="assistant",
+        content="Here is the summary.",
+        reasoning_content="The report has three sections...",
+        provider_data={"signature": "SIG-2"},
+    )
+
+    api_messages, _ = format_messages([Message(role="user", content="hi"), truncated, continuation])
+
+    assert [m["role"] for m in api_messages] == ["user", "assistant"]
+    blocks = api_messages[1]["content"]
+    assert _block_types(blocks) == ["thinking", "text"]
+    assert _signatures(blocks) == ["SIG-2", None]
+
+
+def test_merged_assistant_messages_with_stored_blocks_keep_only_the_later_thinking():
+    truncated = Message(
+        role="assistant",
+        content=None,
+        reasoning_content="partial",
+        provider_data={
+            "signature": "SIG-1",
+            "content_blocks": [{"type": "thinking", "thinking": "partial", "signature": "SIG-1"}],
+        },
+    )
+    continuation = Message(
+        role="assistant",
+        content="answer",
+        reasoning_content="full",
+        provider_data={
+            "signature": "SIG-2",
+            "content_blocks": [
+                {"type": "redacted_thinking", "data": "ENC"},
+                {"type": "thinking", "thinking": "full", "signature": "SIG-2"},
+                {"type": "text", "text": "answer"},
+            ],
+        },
+    )
+
+    api_messages, _ = format_messages([Message(role="user", content="hi"), truncated, continuation])
+
+    blocks = api_messages[1]["content"]
+    assert _block_types(blocks) == ["redacted_thinking", "thinking", "text"]
+    assert _signatures(blocks) == [None, "SIG-2", None]
+    # Merging must not mutate the stored blocks of either message.
+    assert len(truncated.provider_data["content_blocks"]) == 1
+    assert len(continuation.provider_data["content_blocks"]) == 3
+
+
+def test_merged_user_messages_are_untouched():
+    first = Message(role="user", content="FIRST")
+    second = Message(role="user", content="SECOND")
+
+    api_messages, _ = format_messages([first, second])
+
+    assert api_messages == [
+        {"role": "user", "content": [{"type": "text", "text": "FIRST"}, {"type": "text", "text": "SECOND"}]}
+    ]
+
+
+def test_reasoning_without_signature_is_omitted_instead_of_raising():
+    # Reasoning stored by another provider (or a partially stored response) has no signature the
+    # API could verify. Previously this raised a pydantic ValidationError building ThinkingBlock.
+    assistant = Message(
+        role="assistant",
+        content="x",
+        reasoning_content="r",
+        provider_data={"response_id": "resp_123"},
+    )
+
+    api_messages, _ = format_messages([Message(role="user", content="hi"), assistant])
+
+    assert _block_types(api_messages[1]["content"]) == ["text"]
+
+
+def test_stored_blocks_take_precedence_over_convenience_fields():
+    # Two text blocks in the original response must replay as two blocks, not one concatenation.
+    assistant = Message(
+        role="assistant",
+        content="onetwo",
+        provider_data={
+            "content_blocks": [
+                {"type": "text", "text": "one"},
+                {"type": "text", "text": "two"},
+            ]
+        },
+    )
+
+    api_messages, _ = format_messages([Message(role="user", content="hi"), assistant])
+
+    assert api_messages[1]["content"] == [{"type": "text", "text": "one"}, {"type": "text", "text": "two"}]

--- a/libs/agno/tests/unit/models/anthropic/test_thinking_replay.py
+++ b/libs/agno/tests/unit/models/anthropic/test_thinking_replay.py
@@ -257,3 +257,61 @@ def test_stored_blocks_that_filter_to_nothing_skip_the_assistant_message():
     api_messages, _ = format_messages([Message(role="user", content="hi"), assistant])
 
     assert [m["role"] for m in api_messages] == ["user"]
+
+
+def test_streamed_omitted_display_thinking_round_trips():
+    # With display omitted, a thinking block streams no thinking_delta at all: only the signature
+    # arrives. reasoning_content stays empty on the message, so the legacy rebuild would drop the
+    # block, but the stored blocks still carry it and it must accompany the tool_use it belongs to.
+    model = Claude(id="claude-sonnet-4-5", api_key="x")
+    response = AnthropicMessage(
+        id="msg_1",
+        model="claude-sonnet-4-5",
+        role="assistant",
+        type="message",
+        stop_reason="tool_use",
+        usage=Usage(input_tokens=1, output_tokens=1),
+        content=[
+            ThinkingBlock(type="thinking", thinking="", signature="SIG-ONLY"),
+            ToolUseBlock(type="tool_use", id="tu_1", name="f", input={}),
+        ],
+    )
+    delta = model._parse_provider_response_delta(StreamingMessageStopEvent(type="message_stop", message=response))
+    assistant = Message(
+        role="assistant",
+        content=None,
+        reasoning_content=None,
+        provider_data=delta.provider_data,
+        tool_calls=[{"id": "tu_1", "type": "function", "function": {"name": "f", "arguments": "{}"}}],
+    )
+
+    api_messages, _ = format_messages([Message(role="user", content="hi"), assistant])
+
+    blocks = api_messages[1]["content"]
+    assert _block_types(blocks) == ["thinking", "tool_use"]
+    assert blocks[0]["thinking"] == ""
+    assert blocks[0]["signature"] == "SIG-ONLY"
+
+
+def test_stored_blocks_survive_message_serialization():
+    # Session storage goes through Message.to_dict / from_dict; the blocks must come back intact.
+    model = Claude(id="claude-sonnet-4-5", api_key="x")
+    assistant = _assistant_from(model._parse_provider_response(_interleaved_response()))
+
+    restored = Message.from_dict(assistant.to_dict())
+
+    api_messages, _ = format_messages([Message(role="user", content="hi"), restored])
+    assert _signatures(api_messages[1]["content"]) == ["SIG-A", None, "SIG-B", None]
+
+
+def test_replayed_blocks_do_not_alias_stored_blocks():
+    assistant = Message(
+        role="assistant",
+        content="x",
+        provider_data={"content_blocks": [{"type": "text", "text": "x"}]},
+    )
+
+    api_messages, _ = format_messages([Message(role="user", content="hi"), assistant])
+    api_messages[1]["content"][0]["cache_control"] = {"type": "ephemeral"}
+
+    assert "cache_control" not in assistant.provider_data["content_blocks"][0]

--- a/libs/agno/tests/unit/models/anthropic/test_thinking_replay.py
+++ b/libs/agno/tests/unit/models/anthropic/test_thinking_replay.py
@@ -357,3 +357,42 @@ def test_legacy_redacted_block_type_in_stored_blocks_replays_as_redacted_thinkin
     assert blocks[0]["data"] == "ENC-LEGACY"
     # The stored session data is left as it was written.
     assert assistant.provider_data["content_blocks"][0]["type"] == "redacted_reasoning_content"
+
+
+def test_merged_assistant_messages_keep_earlier_text_and_later_thinking():
+    # A response truncated after thinking and partial text, followed by the continuation response.
+    # Only the later response's thinking survives; the earlier text is kept for context. The API
+    # verifies the thinking sequence, not its position relative to text: this exact shape, followed
+    # by a user turn, was accepted live by claude-sonnet-4-5.
+    truncated = Message(
+        role="assistant",
+        content="The bicycle began",
+        reasoning_content="brief plan",
+        provider_data={
+            "signature": "SIG-1",
+            "content_blocks": [
+                {"type": "thinking", "thinking": "brief plan", "signature": "SIG-1"},
+                {"type": "text", "text": "The bicycle began"},
+            ],
+        },
+    )
+    continuation = Message(
+        role="assistant",
+        content="in the 1810s.",
+        reasoning_content="continue the essay",
+        provider_data={
+            "signature": "SIG-2",
+            "content_blocks": [
+                {"type": "thinking", "thinking": "continue the essay", "signature": "SIG-2"},
+                {"type": "text", "text": "in the 1810s."},
+            ],
+        },
+    )
+
+    api_messages, _ = format_messages(
+        [Message(role="user", content="hi"), truncated, continuation, Message(role="user", content="ok?")]
+    )
+
+    blocks = api_messages[1]["content"]
+    assert _block_types(blocks) == ["text", "thinking", "text"]
+    assert _signatures(blocks) == [None, "SIG-2", None]

--- a/libs/agno/tests/unit/models/anthropic/test_thinking_replay.py
+++ b/libs/agno/tests/unit/models/anthropic/test_thinking_replay.py
@@ -243,3 +243,17 @@ def test_stored_blocks_take_precedence_over_convenience_fields():
     api_messages, _ = format_messages([Message(role="user", content="hi"), assistant])
 
     assert api_messages[1]["content"] == [{"type": "text", "text": "one"}, {"type": "text", "text": "two"}]
+
+
+def test_stored_blocks_that_filter_to_nothing_skip_the_assistant_message():
+    # A max_tokens response holding only a tool_use that never ran: after filtering, nothing is
+    # left to replay, and an assistant message with empty content must not be sent.
+    assistant = Message(
+        role="assistant",
+        content=None,
+        provider_data={"content_blocks": [{"type": "tool_use", "id": "tu_1", "name": "f", "input": {}}]},
+    )
+
+    api_messages, _ = format_messages([Message(role="user", content="hi"), assistant])
+
+    assert [m["role"] for m in api_messages] == ["user"]

--- a/libs/agno/tests/unit/models/anthropic/test_thinking_replay.py
+++ b/libs/agno/tests/unit/models/anthropic/test_thinking_replay.py
@@ -315,3 +315,45 @@ def test_replayed_blocks_do_not_alias_stored_blocks():
     api_messages[1]["content"][0]["cache_control"] = {"type": "ephemeral"}
 
     assert "cache_control" not in assistant.provider_data["content_blocks"][0]
+
+
+def test_legacy_redacted_block_type_is_normalized_when_stored():
+    # The parser accepts the legacy redacted_reasoning_content spelling from rehydrated events.
+    # The API only accepts redacted_thinking, so the stored list must carry the canonical type.
+    from agno.utils.models.claude import serialize_content_blocks
+
+    stored = serialize_content_blocks(
+        [
+            {"type": "redacted_reasoning_content", "data": "ENC-LEGACY"},
+            RedactedThinkingBlock(type="redacted_thinking", data="ENC-SDK"),
+            {"type": "text", "text": "answer"},
+        ]
+    )
+
+    assert stored == [
+        {"type": "redacted_thinking", "data": "ENC-LEGACY"},
+        {"type": "redacted_thinking", "data": "ENC-SDK"},
+        {"type": "text", "text": "answer"},
+    ]
+
+
+def test_legacy_redacted_block_type_in_stored_blocks_replays_as_redacted_thinking():
+    # Sessions that stored the legacy spelling before normalization must still replay a valid type.
+    assistant = Message(
+        role="assistant",
+        content="answer",
+        provider_data={
+            "content_blocks": [
+                {"type": "redacted_reasoning_content", "data": "ENC-LEGACY"},
+                {"type": "text", "text": "answer"},
+            ]
+        },
+    )
+
+    api_messages, _ = format_messages([Message(role="user", content="hi"), assistant])
+
+    blocks = api_messages[1]["content"]
+    assert _block_types(blocks) == ["redacted_thinking", "text"]
+    assert blocks[0]["data"] == "ENC-LEGACY"
+    # The stored session data is left as it was written.
+    assert assistant.provider_data["content_blocks"][0]["type"] == "redacted_reasoning_content"


### PR DESCRIPTION
## Summary

Fixes #9923.

Claude signs `thinking` blocks and verifies the thinking sequence of an assistant message when it is replayed. Agno rebuilt every assistant turn from the convenience fields (`reasoning_content`, `content`, `tool_calls`, `provider_data["signature"]`), which is lossy: only the last thinking block and its signature survived a multi-thinking response, blocks were emitted in a fixed order, and two consecutive assistant messages were stitched into one message carrying two signed thinking sequences. The API rejects those with `thinking or redacted_thinking blocks in the latest assistant message cannot be modified`, and because the session replays identically on every retry the run stays stuck.

Changes:

- Store the ordered content blocks of every Claude response on the assistant message as `provider_data["content_blocks"]`, from both the non-streaming parse and the streaming `MessageStop` event. `content`, `reasoning_content` and `tool_calls` keep working as derived views.
- Replay stored blocks verbatim from `format_messages`. A `tool_use` block is replayed only when the message still carries the matching tool call, so a tool call truncated by `max_tokens` (which never ran and has no `tool_result`) is not sent back.
- When two consecutive assistant messages are merged into one API message, drop the earlier message's `thinking` and `redacted_thinking` blocks instead of stitching two signed sequences. Omitting thinking is permitted outside a tool-use turn, and the earlier message in this position never has a tool call to continue. This also heals sessions that are already stuck.
- Omit the thinking block when the stored signature is missing instead of raising a pydantic `ValidationError` from `ThinkingBlock` (hit when a session carries `reasoning_content` from another provider).
- Messages without stored blocks (sessions written by earlier versions) keep the existing rebuild path.
- Default `append_trailing_user_message` to True whenever thinking is on. Prefill is rejected while thinking is on regardless of model, so `continue_run` without input after a response truncated inside its thinking failed with `The final block in an assistant message cannot be thinking` on prefill-capable models such as Sonnet 4.5. With the trailing user turn the truncated turn is a prior turn and the continuation succeeds. The check also honours a thinking config supplied through `request_params`, which is applied last and overrides the `thinking` field.
- Replayed blocks are shallow-copied so request-time edits never reach the stored session message.
- Azure Claude now runs the shared post-init. It defined its own without calling the parent's, so the trailing-user-message auto-detection never ran there, neither the existing prefill rule for 4.6 and later nor the new thinking rule. Its structured-output overrides are kept.
- The legacy `redacted_reasoning_content` block type the parser accepts from rehydrated events is normalized to `redacted_thinking` when stored blocks are serialized, and replay goes through the same serializer so a stored legacy type also replays as the canonical one.

Bedrock and Vertex AI Claude subclass the Anthropic model and share `format_messages`, so all three are covered.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Tests in `libs/agno/tests/unit/models/anthropic/test_thinking_replay.py` cover: ordered block capture on both parse paths, verbatim round trip of an interleaved `thinking, tool_use, thinking, text` response, redacted thinking kept in place, truncated `tool_use` not replayed, the legacy rebuild path, the assistant-merge rule with and without stored blocks, the missing-signature guard, text block boundaries, omitted-display thinking that streams only a signature, the `Message.to_dict` round trip, aliasing, and stored lists that filter down to nothing. `test_append_trailing_user_message.py` covers the thinking-enabled default and the Azure auto-detection. Legacy redacted-type normalization is covered at serialization and at replay.

The issue's minimal reproduction now produces `assistant ['thinking', 'text']` with the second response's signature only.

Live verification against the Anthropic API with `claude-sonnet-4-5` (extended thinking, interleaved beta):

- Agent with two tools, sqlite session, three runs (sync, streaming, history replay): stored assistant turns are `thinking, tool_use` and `thinking, text` sequences and replay inside the tool-use turn, where the API verifies them.
- Same flow async, and with native structured output (`output_schema`) through the beta parse path.
- Team with a thinking leader delegating to a thinking member, three runs.
- A forced `max_tokens` truncation that leaves a thinking-only turn, followed by another assistant turn and a user turn: the merged message replays as the later turn's `thinking, text` and the API accepts it.
- `continue_run` with no input after that truncation completes.
- The same flow with a response truncated after thinking and partial text: the next run sends the merged `text, thinking, text` shape followed by the user turn, and the API accepts it. The API verifies the thinking sequence, not its position relative to text.
- Cookbooks: `90_models/anthropic/thinking.py`, `adaptive_thinking.py`, `financial_analyst_thinking.py`, and `10_reasoning/models/anthropic/basic_reasoning_stream.py` pass. Two of them needed their retired model ids bumped to `claude-sonnet-4-5`; results are recorded in the folder `TEST_LOG.md` files.

Streamed run events already carried `server_tool_blocks` through `model_provider_data`; they now carry `content_blocks` the same way.

Storage note: `server_tool_blocks` is still written for backward compatibility, so web search and web fetch result blocks are now stored twice per message. Dropping `server_tool_blocks` once nothing reads it is a possible follow-up.

Known remaining edge: an injected assistant message (`StopAgentRun` / `RetryAgentRun` with `agent_message`) followed by a thinking response merges to `text, thinking, ...` when thinking is off or the trailing user turn is disabled. With thinking on, the new trailing user turn separates the two, so no merge happens.

`./scripts/validate.sh` reports 32 pre-existing mypy errors in files this PR does not touch (google, aws, and the web fetch section of the Anthropic model); none are introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)