### PR TITLE
[fix] Harden network XML parsing without breaking PubMed imports

### DIFF
--- a/libs/agno/agno/knowledge/reader/sitemap_reader.py
+++ b/libs/agno/agno/knowledge/reader/sitemap_reader.py
@@ -13,9 +13,9 @@ reads run concurrently.
 import gzip
 from typing import Generator, List, Optional, Tuple
 from urllib.parse import urlparse
-from xml.etree import ElementTree
 
 import httpx
+from defusedxml import ElementTree
 
 from agno.knowledge.chunking.fixed import FixedSizeChunking
 from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyType

--- a/libs/agno/agno/knowledge/reader/sitemap_reader.py
+++ b/libs/agno/agno/knowledge/reader/sitemap_reader.py
@@ -16,6 +16,7 @@ from urllib.parse import urlparse
 
 import httpx
 from defusedxml import ElementTree
+from defusedxml.common import DefusedXmlException
 
 from agno.knowledge.chunking.fixed import FixedSizeChunking
 from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyType
@@ -121,7 +122,7 @@ class SitemapReader(Reader):
         """
         try:
             root = ElementTree.fromstring(SitemapReader._decode_sitemap_bytes(raw))
-        except ElementTree.ParseError:
+        except (ElementTree.ParseError, DefusedXmlException):
             return None
         tag = root.tag.rsplit("}", 1)[-1]
         if tag not in ("urlset", "sitemapindex"):

--- a/libs/agno/agno/tools/pubmed.py
+++ b/libs/agno/agno/tools/pubmed.py
@@ -1,8 +1,8 @@
 import json
 from typing import Any, Dict, List, Optional
-from xml.etree import ElementTree
 
 import httpx
+from defusedxml import ElementTree
 
 from agno.tools import Toolkit
 from agno.utils.log import log_debug

--- a/libs/agno/agno/tools/pubmed.py
+++ b/libs/agno/agno/tools/pubmed.py
@@ -1,5 +1,6 @@
 import json
 from typing import Any, Dict, List, Optional
+from xml.etree.ElementTree import Element
 
 import httpx
 from defusedxml import ElementTree
@@ -43,14 +44,14 @@ class PubmedTools(Toolkit):
         root = ElementTree.fromstring(response.content)
         return [id_elem.text for id_elem in root.findall(".//Id") if id_elem.text is not None]
 
-    def fetch_details(self, pubmed_ids: List[str]) -> ElementTree.Element:
+    def fetch_details(self, pubmed_ids: List[str]) -> Element:
         url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
         params = {"db": "pubmed", "id": ",".join(pubmed_ids), "retmode": "xml"}
         response = httpx.get(url, params=params, timeout=self.timeout)
         response.raise_for_status()
         return ElementTree.fromstring(response.content)
 
-    def parse_details(self, xml_root: ElementTree.Element) -> List[Dict[str, Any]]:
+    def parse_details(self, xml_root: Element) -> List[Dict[str, Any]]:
         articles = []
         for article in xml_root.findall(".//PubmedArticle"):
             # Get existing fields

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -51,6 +51,7 @@ dev = [
   "timeout-decorator",
   "types-pyyaml",
   "types-aiofiles",
+  "types-defusedxml",
   "fastapi",
   "python-multipart>=0.0.18",
   "uvicorn",

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 
 dependencies = [
   "agnoctl>=0.2.0",
+  "defusedxml",
   "docstring-parser",
   # Prevent the request-smuggling CVE in h11 < 0.16
   "h11>=0.16.0",

--- a/libs/agno/tests/unit/reader/test_sitemap_reader.py
+++ b/libs/agno/tests/unit/reader/test_sitemap_reader.py
@@ -46,6 +46,17 @@ def sitemapindex_xml(*locs: str) -> str:
     return f'<?xml version="1.0" encoding="UTF-8"?><sitemapindex xmlns="{SITEMAP_NS}">{entries}</sitemapindex>'
 
 
+@pytest.mark.parametrize("compressed", [False, True])
+def test_parse_sitemap_rejects_xml_entities(compressed):
+    payload = (
+        b'<!DOCTYPE urlset [<!ENTITY page "https://example.com/injected">]>'
+        b"<urlset><url><loc>&page;</loc></url></urlset>"
+    )
+    if compressed:
+        payload = gzip.compress(payload)
+    assert SitemapReader._parse_sitemap(payload) is None
+
+
 def html_page(title: str, body: str) -> str:
     return f"<html><head><title>{title}</title></head><body><main>{body}</main></body></html>"
 
@@ -578,20 +589,36 @@ def test_reader_factory_sitemap(monkeypatch):
 # ----------------------------------------------------------------------
 
 
-def test_failed_index_child_marks_documents_discovery_incomplete():
+@pytest.mark.parametrize("async_mode", [False, True])
+@pytest.mark.parametrize(
+    "child_xml",
+    [
+        None,
+        '<!DOCTYPE urlset [<!ENTITY page "https://example.com/injected">]><urlset><url><loc>&page;</loc></url></urlset>',
+    ],
+)
+def test_failed_index_child_marks_documents_discovery_incomplete(async_mode, child_xml):
     routes = {
         "https://example.com/sitemap.xml": (
             sitemapindex_xml("https://example.com/sitemap-a.xml", "https://example.com/sitemap-b.xml"),
             "application/xml",
         ),
         "https://example.com/sitemap-a.xml": (urlset_xml("https://example.com/page-a"), "application/xml"),
-        # sitemap-b.xml is unrouted -> 404: an entire shard is missing from this read
+        # An unavailable or rejected sitemap shard must not be interpreted as removed content.
         "https://example.com/page-a": (html_page("A", "Alpha content"), "text/html"),
     }
+    if child_xml is not None:
+        routes["https://example.com/sitemap-b.xml"] = (child_xml, "application/xml")
     with mock_site(routes):
-        documents = make_reader().read("https://example.com/sitemap.xml")
+        reader = make_reader()
+        documents = (
+            asyncio.run(reader.async_read("https://example.com/sitemap.xml"))
+            if async_mode
+            else reader.read("https://example.com/sitemap.xml")
+        )
 
-    assert documents, "the reachable shard's pages are still read"
+    assert len(documents) == 1, "only the reachable shard's page is read"
+    assert documents[0].meta_data["url"] == "https://example.com/page-a"
     assert all(doc.meta_data.get("discovery_incomplete") is True for doc in documents), (
         "every document must carry the incomplete-discovery flag so the insert path suppresses pruning"
     )

--- a/libs/agno/tests/unit/tools/test_pubmed.py
+++ b/libs/agno/tests/unit/tools/test_pubmed.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
+from defusedxml.common import EntitiesForbidden
 
 from agno.tools.pubmed import PubmedTools
 
@@ -12,6 +13,27 @@ ESEARCH_XML = b"""<?xml version="1.0"?>
 
 EFETCH_XML = b"""<?xml version="1.0"?>
 <PubmedArticleSet></PubmedArticleSet>"""
+
+
+@pytest.mark.parametrize("endpoint", ["esearch", "efetch"])
+def test_pubmed_rejects_xml_entities(endpoint):
+    payload = b'<!DOCTYPE result [<!ENTITY item "111">]><result><Id>&item;</Id></result>'
+    response = httpx.Response(200, content=payload, request=httpx.Request("GET", "https://example.com"))
+    tools = PubmedTools()
+    with patch("agno.tools.pubmed.httpx.get", return_value=response), pytest.raises(EntitiesForbidden):
+        if endpoint == "esearch":
+            tools.fetch_pubmed_ids("test query", 1, "user@example.com")
+        else:
+            tools.fetch_details(["111"])
+
+
+def test_pubmed_accepts_document_type_without_entity_expansion():
+    payload = b'<!DOCTYPE result SYSTEM "https://example.com/unused.dtd"><result><Id>111</Id></result>'
+    response = httpx.Response(200, content=payload, request=httpx.Request("GET", "https://example.com"))
+    tools = PubmedTools()
+    with patch("agno.tools.pubmed.httpx.get", return_value=response):
+        assert tools.fetch_pubmed_ids("test query", 1, "user@example.com") == ["111"]
+        assert tools.fetch_details(["111"]).tag == "result"
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Fixes #9920.

- Parse network XML in SitemapReader and both PubMed endpoints with `defusedxml.ElementTree`.
- Preserve PubMed's standard-library `Element` return annotations: defusedxml does not expose that type, so the first submitted revision failed at import time.
- Treat rejected sitemap XML as an unavailable shard, retaining the existing `discovery_incomplete` guard against pruning previously indexed pages.
- Include parser stubs in development dependencies so the repository's mypy checks also work after a normal development install.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed (automated code review; no human-review claim)
- [ ] Documentation updated (not applicable)
- [ ] Examples and guides updated (not applicable)
- [x] Tested in a fresh Python 3.12 virtual environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] Searched open pull requests; no other active PR found for this issue
- [ ] If a similar PR exists, explained why this approach is better (not applicable)
- [x] This PR was AI-generated

## Verification

- Before this update: PubMed pytest collection failed with `AttributeError: module 'defusedxml.ElementTree' has no attribute 'Element'`; both retained plain/gzip sitemap entity tests failed with uncaught `EntitiesForbidden`.
- After this update: both complete affected test files passed, **47 tests**. They cover tiny entity payloads, gzip, both PubMed parsing paths, valid DTD-only documents, and sync/async rejected-index-shard recovery with the incomplete-discovery flag.
- Full `./scripts/validate.sh`: Ruff, mypy (1,033 Agno and 21 agnoctl source files), and cookbook pattern checks passed. `./scripts/format.sh`, changed-file Ruff format/check, and `git diff --check` passed. Unrelated formatter-only changes were excluded.
- Remote CI still requires maintainer approval; it is not claimed to have passed.

## Additional Notes

Only tiny local/mocked XML inputs were exercised. This does not address gzip decompression bombs, and it does not claim that modern Expat lacks amplification protection. Valid DTD declarations without entity expansion remain supported.

The initial patch was made with Cursor. Codex performed the follow-up import/exception-handling repairs, added regression tests, ran the checks, and used an independent agent review. Maintainer review is welcome.
