### PR TITLE
[fix] Preserve byte-backed media metadata

### DIFF
--- a/libs/agno/agno/media/media.py
+++ b/libs/agno/agno/media/media.py
@@ -782,6 +782,10 @@ class File(BaseModel):
         filename: Optional[str] = None,
         name: Optional[str] = None,
         format: Optional[str] = None,
+        file_type: Optional[str] = None,
+        size: Optional[int] = None,
+        external: Optional[Any] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> "File":
         """Create File from base64 encoded content or plain text.
 
@@ -811,6 +815,10 @@ class File(BaseModel):
             filename=filename,
             name=name,
             format=format,
+            file_type=file_type,
+            size=size,
+            external=external,
+            metadata=metadata,
         )
 
     @property

--- a/libs/agno/agno/models/message.py
+++ b/libs/agno/agno/models/message.py
@@ -163,6 +163,11 @@ class Message(BaseModel):
                                 id=img_data.get("id"),
                                 mime_type=img_data.get("mime_type"),
                                 format=img_data.get("format"),
+                                detail=img_data.get("detail"),
+                                original_prompt=img_data.get("original_prompt"),
+                                revised_prompt=img_data.get("revised_prompt"),
+                                alt_text=img_data.get("alt_text"),
+                                metadata=img_data.get("metadata"),
                             )
                         )
                     else:
@@ -185,10 +190,13 @@ class Message(BaseModel):
                                 aud_data["content"],
                                 id=aud_data.get("id"),
                                 mime_type=aud_data.get("mime_type"),
+                                format=aud_data.get("format"),
+                                duration=aud_data.get("duration"),
                                 transcript=aud_data.get("transcript"),
                                 expires_at=aud_data.get("expires_at"),
                                 sample_rate=aud_data.get("sample_rate", 24000),
                                 channels=aud_data.get("channels", 1),
+                                metadata=aud_data.get("metadata"),
                             )
                         )
                     else:
@@ -212,6 +220,14 @@ class Message(BaseModel):
                                 id=vid_data.get("id"),
                                 mime_type=vid_data.get("mime_type"),
                                 format=vid_data.get("format"),
+                                duration=vid_data.get("duration"),
+                                width=vid_data.get("width"),
+                                height=vid_data.get("height"),
+                                fps=vid_data.get("fps"),
+                                eta=vid_data.get("eta"),
+                                original_prompt=vid_data.get("original_prompt"),
+                                revised_prompt=vid_data.get("revised_prompt"),
+                                metadata=vid_data.get("metadata"),
                             )
                         )
                     else:
@@ -237,6 +253,10 @@ class Message(BaseModel):
                                 filename=file_data.get("filename"),
                                 name=file_data.get("name"),
                                 format=file_data.get("format"),
+                                file_type=file_data.get("file_type"),
+                                size=file_data.get("size"),
+                                external=file_data.get("external"),
+                                metadata=file_data.get("metadata"),
                             )
                         )
                     else:
@@ -256,10 +276,13 @@ class Message(BaseModel):
                         aud_data["content"],
                         id=aud_data.get("id"),
                         mime_type=aud_data.get("mime_type"),
+                        format=aud_data.get("format"),
+                        duration=aud_data.get("duration"),
                         transcript=aud_data.get("transcript"),
                         expires_at=aud_data.get("expires_at"),
                         sample_rate=aud_data.get("sample_rate", 24000),
                         channels=aud_data.get("channels", 1),
+                        metadata=aud_data.get("metadata"),
                     )
                 else:
                     data["audio_output"] = Audio(**aud_data)

--- a/libs/agno/tests/unit/models/test_message_media_metadata.py
+++ b/libs/agno/tests/unit/models/test_message_media_metadata.py
@@ -1,0 +1,125 @@
+from agno.media import Audio, File, Image, Video
+from agno.models.message import Message
+
+
+class TestMessageMediaMetadata:
+    def test_byte_backed_media_metadata_survives_round_trip(self):
+        message = Message(
+            role="user",
+            content="media",
+            images=[
+                Image(
+                    content=b"image-bytes",
+                    id="image-1",
+                    mime_type="image/png",
+                    format="png",
+                    detail="high",
+                    original_prompt="original image prompt",
+                    revised_prompt="revised image prompt",
+                    alt_text="an image",
+                    metadata={"source": "test"},
+                )
+            ],
+            audio=[
+                Audio(
+                    content=b"audio-bytes",
+                    id="audio-1",
+                    mime_type="audio/wav",
+                    format="wav",
+                    duration=1.5,
+                    sample_rate=16000,
+                    channels=2,
+                    transcript="hello",
+                    expires_at=123,
+                    metadata={"source": "test"},
+                )
+            ],
+            videos=[
+                Video(
+                    content=b"video-bytes",
+                    id="video-1",
+                    mime_type="video/mp4",
+                    format="mp4",
+                    duration=12.5,
+                    width=1920,
+                    height=1080,
+                    fps=24.0,
+                    eta="10s",
+                    original_prompt="original video prompt",
+                    revised_prompt="revised video prompt",
+                    metadata={"source": "test"},
+                )
+            ],
+            files=[
+                File(
+                    content=b"file-bytes",
+                    id="file-1",
+                    mime_type="application/pdf",
+                    file_type="pdf",
+                    filename="test.pdf",
+                    size=10,
+                    format="pdf",
+                    name="test-document",
+                    external={"provider_id": "external-1"},
+                    metadata={"source": "test"},
+                )
+            ],
+            audio_output=Audio(
+                content=b"output-audio",
+                id="audio-output-1",
+                mime_type="audio/wav",
+                format="wav",
+                duration=3.5,
+                transcript="generated audio",
+                metadata={"source": "test"},
+            ),
+        )
+
+        restored = Message.from_dict(message.to_dict())
+
+        image = restored.images[0]
+        assert image.content == b"image-bytes"
+        assert image.detail == "high"
+        assert image.original_prompt == "original image prompt"
+        assert image.revised_prompt == "revised image prompt"
+        assert image.alt_text == "an image"
+        assert image.metadata == {"source": "test"}
+
+        audio = restored.audio[0]
+        assert audio.content == b"audio-bytes"
+        assert audio.format == "wav"
+        assert audio.duration == 1.5
+        assert audio.sample_rate == 16000
+        assert audio.channels == 2
+        assert audio.transcript == "hello"
+        assert audio.expires_at == 123
+        assert audio.metadata == {"source": "test"}
+
+        video = restored.videos[0]
+        assert video.content == b"video-bytes"
+        assert video.duration == 12.5
+        assert video.width == 1920
+        assert video.height == 1080
+        assert video.fps == 24.0
+        assert video.eta == "10s"
+        assert video.original_prompt == "original video prompt"
+        assert video.revised_prompt == "revised video prompt"
+        assert video.metadata == {"source": "test"}
+
+        file = restored.files[0]
+        assert file.content == b"file-bytes"
+        assert file.file_type == "pdf"
+        assert file.size == 10
+        assert file.filename == "test.pdf"
+        assert file.format == "pdf"
+        assert file.name == "test-document"
+        assert file.external == {"provider_id": "external-1"}
+        assert file.metadata == {"source": "test"}
+
+        audio_output = restored.audio_output
+        assert audio_output is not None
+        assert audio_output.content == b"output-audio"
+        assert audio_output.format == "wav"
+        assert audio_output.duration == 3.5
+        assert audio_output.transcript == "generated audio"
+        assert audio_output.metadata == {"source": "test"}


### PR DESCRIPTION
## Summary

Fixes #9902.

- Preserve serialized fields when reconstructing byte-backed images, audio, videos, files, and audio output.
- Extend `File.from_base64()` to restore file metadata.
- Add a round-trip regression test covering all five affected branches.

PR #9878 covers `image_output` and `video_output`; this PR covers the remaining branches described in #9902.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

## Testing

- `test_message_media_metadata.py`
- `test_message.py`
- 9 tests passed
- Ruff check passed

## Checklist

- [x] Code complies with style guidelines
- [x] Self-review completed
- [x] Tested in a clean development environment
- [x] Tests added
- [x] I searched existing open pull requests
- [x] PR #9878 was reviewed and covers different media branches

### AI assistance

I used Codex to analyze #9902 and review the implementation. I manually applied the changes, ran the tests, and reviewed the final diff.