### PR TITLE
fix: stop yielding empty stream chunks from _populate_stream_data (#9490)

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -1972,8 +1972,13 @@ class Model(ABC):
                 else:
                     stream_data.response_provider_data[key] = value
 
-        # Update stream_data tool calls
-        if model_response_delta.tool_calls is not None:
+        # Update stream_data tool calls.
+        # Truthiness, not `is not None`: tool_calls is field(default_factory=list),
+        # so every delta carries [] and an `is not None` gate fired on metadata-only
+        # chunks, yielding zero-payload events that are only dropped further
+        # downstream. Matches provider_data/images/videos above, which already
+        # test truthiness.
+        if model_response_delta.tool_calls:
             if stream_data.response_tool_calls is None:
                 stream_data.response_tool_calls = []
             stream_data.response_tool_calls.extend(model_response_delta.tool_calls)

--- a/libs/agno/tests/unit/models/test_populate_stream_data_yield.py
+++ b/libs/agno/tests/unit/models/test_populate_stream_data_yield.py
@@ -1,0 +1,110 @@
+"""_populate_stream_data must not yield chunks that carry no payload.
+
+Regression test for #9490. ``ModelResponse.tool_calls`` is
+``field(default_factory=list)``, so the gate ``if delta.tool_calls is not
+None`` was true for *every* delta, including the metadata-only chunks
+providers emit (Anthropic's ``content_block_start``, for example). Each one
+was yielded and then dropped further downstream, costing a generator turn
+plus every hook between the model and the agent.
+
+The neighbouring branches in the same function (``provider_data``,
+``images``, ``videos``) already test truthiness, which is what makes the
+``is not None`` on ``tool_calls`` an oversight rather than a deliberate
+choice.
+"""
+
+from typing import List
+
+import pytest
+
+from agno.models.base import MessageData, Model
+from agno.models.response import ModelResponse
+
+
+class _StubModel(Model):
+    """Concrete Model; only _populate_stream_data is exercised."""
+
+    def __init__(self):
+        super().__init__(id="stub", name="Stub", provider="test")
+
+    def invoke(self, *a, **k):  # pragma: no cover
+        raise NotImplementedError
+
+    async def ainvoke(self, *a, **k):  # pragma: no cover
+        raise NotImplementedError
+
+    def invoke_stream(self, *a, **k):  # pragma: no cover
+        raise NotImplementedError
+
+    async def ainvoke_stream(self, *a, **k):  # pragma: no cover
+        raise NotImplementedError
+
+    def _parse_provider_response(self, *a, **k):  # pragma: no cover
+        raise NotImplementedError
+
+    def _parse_provider_response_delta(self, *a, **k):  # pragma: no cover
+        raise NotImplementedError
+
+
+def _drain(delta: ModelResponse) -> List[ModelResponse]:
+    return list(_StubModel()._populate_stream_data(MessageData(), delta))
+
+
+# --- the bug ---------------------------------------------------------------
+
+
+def test_empty_delta_is_not_yielded():
+    """A metadata-only chunk carries nothing to show and must not be yielded."""
+    assert _drain(ModelResponse()) == []
+
+
+def test_role_only_delta_is_not_yielded():
+    """Anthropic's content_block_start shape: a role and nothing else."""
+    assert _drain(ModelResponse(role="assistant")) == []
+
+
+def test_empty_tool_calls_list_is_not_yielded():
+    """The specific regression: [] is not None, but [] is not a payload."""
+    delta = ModelResponse(tool_calls=[])
+    assert delta.tool_calls == [], "guard the premise: default is a list, not None"
+    assert _drain(delta) == []
+
+
+# --- everything that should still be yielded -------------------------------
+
+
+def test_content_is_yielded():
+    assert len(_drain(ModelResponse(content="hi"))) == 1
+
+
+def test_populated_tool_calls_are_yielded():
+    delta = ModelResponse(tool_calls=[{"id": "c1", "function": {"name": "f", "arguments": "{}"}}])
+    out = _drain(delta)
+    assert len(out) == 1
+
+
+def test_populated_tool_calls_still_accumulate_on_stream_data():
+    """The fix must not stop tool calls being collected."""
+    sd = MessageData()
+    call = {"id": "c1", "function": {"name": "f", "arguments": "{}"}}
+    list(_StubModel()._populate_stream_data(sd, ModelResponse(tool_calls=[call])))
+    assert sd.response_tool_calls == [call]
+
+
+def test_empty_tool_calls_do_not_create_an_empty_accumulator():
+    """An empty delta should leave stream_data untouched, not seed [] onto it."""
+    sd = MessageData()
+    list(_StubModel()._populate_stream_data(sd, ModelResponse()))
+    assert not sd.response_tool_calls
+
+
+@pytest.mark.parametrize(
+    "delta",
+    [
+        ModelResponse(reasoning_content="thinking"),
+        ModelResponse(redacted_reasoning_content="[redacted]"),
+        ModelResponse(content=""),  # empty string is still a content signal
+    ],
+)
+def test_other_payloads_still_yield(delta):
+    assert len(_drain(delta)) == 1


### PR DESCRIPTION
## Summary

Fixes #9490.

`ModelResponse.tool_calls` is `field(default_factory=list)`, so the gate in `_populate_stream_data`

```python
if model_response_delta.tool_calls is not None:
```

is true for **every** delta — `[] is not None` — including the metadata-only chunks providers emit (Anthropic's `content_block_start`, for example). Each of those set `should_yield = True` and was yielded carrying no payload, costing a generator turn through `aprocess_response_stream`, `handle_model_response_chunk` and every hook in between, before finally being dropped by the content check in `agent/_response.py`.

## Fix

One line: test truthiness instead.

```python
if model_response_delta.tool_calls:
```

This matches the `provider_data`, `images` and `videos` branches in the same function, which already test truthiness — which is what makes the `is not None` on `tool_calls` look like an oversight rather than a deliberate choice.

Nothing user-visible changes: those empty events were already being filtered downstream. This stops generating them in the first place.

## Behaviour preserved

- Deltas with real tool calls still yield, and still accumulate onto `stream_data.response_tool_calls`.
- An empty delta no longer seeds an empty `response_tool_calls` accumulator as a side effect.
- `content`, `reasoning_content`, `redacted_reasoning_content` and `citations` are untouched — including `content=""`, which is still treated as a content signal.

## Tests

`libs/agno/tests/unit/models/test_populate_stream_data_yield.py` — deterministic, no API keys, no network.

- the three empty-chunk shapes: bare `ModelResponse()`, role-only (the `content_block_start` shape), and an explicit `tool_calls=[]`
- guards that content / reasoning / redacted-reasoning / populated tool calls still yield
- guards that populated tool calls still accumulate, and that an empty delta leaves `stream_data` untouched

The three bug tests **fail on `main` and pass with this patch** (10/10 with it, 3 failing without). `tests/unit/models` + `tests/unit/agent` are otherwise unchanged against baseline — 706 passed / 139 failed either way, those 139 being pre-existing failures from optional provider SDKs missing in my environment.

Fixes #9490.
