### PR TITLE
feat: name, version and instructions for the AgentOS MCP server

### DIFF
--- a/cookbook/05_agent_os/14_mcp/README.md
+++ b/cookbook/05_agent_os/14_mcp/README.md
@@ -14,6 +14,7 @@ an Agno agent consumes another MCP server belong in `cookbook/91_tools/mcp`.
 | `agents_as_tools.py` | Turn the default tools off and expose agents directly as named MCP tools. |
 | `mcp_client.py` | Discover, pause, continue, cancel, and inspect runs with a protocol-level client. |
 | `custom_tools.py` | Disable the default tools and expose one purpose-built tool. |
+| `server_identity.py` | Set the name, version and instructions the server reports to connecting clients. |
 | `toolkit_tools.py` | Serve a whole toolkit, flattened into one MCP tool per method. |
 | `secure_mcp.py` | Mint a PAT, authorize its principal, restrict hosts and tool tags, and return full results. |
 | `oauth_builtin.py` | Run AgentOS's database-backed OAuth authorization server. |
@@ -53,6 +54,34 @@ The client calls the tools directly. It continues one confirmation-required
 run, cancels a second paused run, and reads the continued session from SQLite.
 Run tools return a trimmed result by default: answer content plus
 `run_id`, `session_id`, `status`, and unresolved requirements when paused.
+
+## Server name, version and instructions
+
+`server_identity.py` sets what a client learns in the initialize response:
+
+```python
+agent_os = AgentOS(
+    name="Support AgentOS",
+    version="1.4.0",
+    agents=[support_agent],
+    mcp=MCPConfig(
+        name="Acme Support",
+        version="1.4.0",
+        instructions="This server answers questions about Acme products. Start with run_agent ...",
+    ),
+)
+```
+
+`name` defaults to the AgentOS name and `version` to `AgentOS(version=...)`; with
+neither set, the server reports fastmcp's own version. `instructions` is guidance for
+the calling model: what the tools are for, which one to start with, and any conventions
+to follow. Claude, Cursor and ChatGPT read it when they connect. Write it for the model,
+the way a tool description is written; `AgentOS(description=...)` is for humans and is
+not used here.
+
+```bash
+.venvs/demo/bin/python cookbook/05_agent_os/14_mcp/server_identity.py
+```
 
 ## Agents as tools
 

--- a/cookbook/05_agent_os/14_mcp/README.md
+++ b/cookbook/05_agent_os/14_mcp/README.md
@@ -72,12 +72,9 @@ agent_os = AgentOS(
 )
 ```
 
-`name` defaults to the AgentOS name and `version` to `AgentOS(version=...)`; with
-neither set, the server reports fastmcp's own version. `instructions` is guidance for
-the calling model: what the tools are for, which one to start with, and any conventions
-to follow. Claude, Cursor and ChatGPT read it when they connect. Write it for the model,
-the way a tool description is written; `AgentOS(description=...)` is for humans and is
-not used here.
+`name` defaults to the AgentOS name and `version` to `AgentOS(version=...)`.
+`instructions` tells the calling model what the tools are for and how to use them;
+Claude, Cursor and ChatGPT read it when they connect.
 
 ```bash
 .venvs/demo/bin/python cookbook/05_agent_os/14_mcp/server_identity.py

--- a/cookbook/05_agent_os/14_mcp/TEST_LOG.md
+++ b/cookbook/05_agent_os/14_mcp/TEST_LOG.md
@@ -169,6 +169,28 @@ PAT principal `sa:secure-mcp-client-b0ebb699ad` authenticated, exactly the six
 
 ---
 
+### server_identity.py
+
+**Status:** PASS
+
+**Test mode:** LIVE (MCP transport), MOCK (model)
+
+**Description:** Served the cookbook (agno from this branch, fastmcp 4.0.2 / mcp
+2.1.1) and connected a FastMCP streamable-HTTP client twice, once with
+`mode="legacy"` and once with `mode="auto"`, to read what a client learns about
+the server at connect time.
+
+**Result:** Both handshakes reported `server_info` name `Acme Support` and version
+`1.4.0` and the full instructions string from `MCPConfig(instructions=...)`; the
+legacy handshake carried them in the initialize result and the 2026-07-28
+negotiation exposed the same values on the client. `tools/list` returned the
+eight default tools. No `OPENAI_API_KEY` was set, so `run_agent` was not
+exercised. The four unit tests in `test_mcp_server.py` cover the AgentOS
+defaults, the fastmcp fallback when nothing is set, the `MCPConfig` overrides,
+and the initialize response.
+
+---
+
 ### oauth_builtin.py
 
 **Status:** PASS

--- a/cookbook/05_agent_os/14_mcp/server_identity.py
+++ b/cookbook/05_agent_os/14_mcp/server_identity.py
@@ -1,0 +1,71 @@
+"""
+Name, version and instructions for the MCP server
+=================================================
+
+An MCP client learns three things about a server when it connects: the name,
+the version and the instructions. The instructions tell the calling model what
+the tools are for and how to use them. Claude, Cursor and ChatGPT read them.
+
+By default the server takes the AgentOS name and the version passed to
+``AgentOS(version=...)``. ``MCPConfig`` overrides both and sets the instructions.
+
+Prerequisites: OPENAI_API_KEY
+Run: .venvs/demo/bin/python cookbook/05_agent_os/14_mcp/server_identity.py
+Try: connect an MCP client to http://localhost:7777/mcp and read the name,
+     version and instructions from the initialize response
+"""
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIResponses
+from agno.os import AgentOS, MCPConfig
+
+# ---------------------------------------------------------------------------
+# Create the agent
+# ---------------------------------------------------------------------------
+
+db = SqliteDb(
+    id="mcp-server-identity-db",
+    db_file="tmp/mcp_server_identity.db",
+)
+
+support_agent = Agent(
+    id="support-agent",
+    name="Support Agent",
+    model=OpenAIResponses(id="gpt-5.6-luna"),
+    db=db,
+    instructions="Answer product questions clearly and concisely.",
+)
+
+# ---------------------------------------------------------------------------
+# Describe the server to the clients that connect to it
+# ---------------------------------------------------------------------------
+
+agent_os = AgentOS(
+    id="mcp-server-identity-os",
+    name="Support AgentOS",
+    version="1.4.0",
+    description="AgentOS that describes its MCP server to connecting clients.",
+    db=db,
+    agents=[support_agent],
+    mcp=MCPConfig(
+        # Shown in the client's server list. Defaults to the AgentOS name.
+        name="Acme Support",
+        # Reported as serverInfo.version. Defaults to AgentOS(version=...).
+        version="1.4.0",
+        # Read by the calling model at connect time.
+        instructions=(
+            "This server answers questions about Acme products. Start with run_agent "
+            "and the support-agent. Answer from the agent's reply and say when it "
+            "does not know."
+        ),
+    ),
+)
+app = agent_os.get_app()
+
+# ---------------------------------------------------------------------------
+# Run AgentOS
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    agent_os.serve(app=app)

--- a/cookbook/05_agent_os/14_mcp/server_identity.py
+++ b/cookbook/05_agent_os/14_mcp/server_identity.py
@@ -2,17 +2,12 @@
 Name, version and instructions for the MCP server
 =================================================
 
-An MCP client learns three things about a server when it connects: the name,
-the version and the instructions. The instructions tell the calling model what
-the tools are for and how to use them. Claude, Cursor and ChatGPT read them.
-
-By default the server takes the AgentOS name and the version passed to
-``AgentOS(version=...)``. ``MCPConfig`` overrides both and sets the instructions.
+Set what a client learns about the server when it connects. The instructions
+tell the calling model what the tools are for and how to use them.
 
 Prerequisites: OPENAI_API_KEY
 Run: .venvs/demo/bin/python cookbook/05_agent_os/14_mcp/server_identity.py
-Try: connect an MCP client to http://localhost:7777/mcp and read the name,
-     version and instructions from the initialize response
+Try: connect an MCP client to http://localhost:7777/mcp and read the initialize response
 """
 
 from agno.agent import Agent
@@ -38,7 +33,7 @@ support_agent = Agent(
 )
 
 # ---------------------------------------------------------------------------
-# Describe the server to the clients that connect to it
+# Create AgentOS
 # ---------------------------------------------------------------------------
 
 agent_os = AgentOS(
@@ -49,11 +44,9 @@ agent_os = AgentOS(
     db=db,
     agents=[support_agent],
     mcp=MCPConfig(
-        # Shown in the client's server list. Defaults to the AgentOS name.
+        # Defaults: the AgentOS name and AgentOS(version=...).
         name="Acme Support",
-        # Reported as serverInfo.version. Defaults to AgentOS(version=...).
         version="1.4.0",
-        # Read by the calling model at connect time.
         instructions=(
             "This server answers questions about Acme products. Start with run_agent "
             "and the support-agent. Answer from the agent's reply and say when it "

--- a/libs/agno/agno/os/config.py
+++ b/libs/agno/agno/os/config.py
@@ -55,6 +55,17 @@ class MCPConfig(BaseModel):
     # not silently serve a different tool surface.
     model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
 
+    # What the server says about itself in the initialize response. ``name`` defaults
+    # to the AgentOS name and ``version`` to ``AgentOS(version=...)``; with neither set,
+    # fastmcp reports its own package version. ``instructions`` is guidance for the
+    # calling model -- what the tools are for, which one to start with, and any
+    # conventions to follow -- and clients such as Claude, Cursor, and ChatGPT read
+    # it at connect time. It is NOT derived from ``AgentOS(description=...)``, which
+    # is written for humans.
+    name: Optional[str] = None
+    version: Optional[str] = None
+    instructions: Optional[str] = None
+
     # The tool surface of this MCP server. Each entry may be:
     #
     #   - a plain callable or an Agno ``@tool``/``Function`` -- a custom tool

--- a/libs/agno/agno/os/config.py
+++ b/libs/agno/agno/os/config.py
@@ -55,13 +55,9 @@ class MCPConfig(BaseModel):
     # not silently serve a different tool surface.
     model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
 
-    # What the server says about itself in the initialize response. ``name`` defaults
-    # to the AgentOS name and ``version`` to ``AgentOS(version=...)``; with neither set,
-    # fastmcp reports its own package version. ``instructions`` is guidance for the
-    # calling model -- what the tools are for, which one to start with, and any
-    # conventions to follow -- and clients such as Claude, Cursor, and ChatGPT read
-    # it at connect time. It is NOT derived from ``AgentOS(description=...)``, which
-    # is written for humans.
+    # Sent in the initialize response. ``name`` defaults to the AgentOS name and
+    # ``version`` to ``AgentOS(version=...)``. ``instructions`` tells the calling
+    # model what the tools are for and how to use them.
     name: Optional[str] = None
     version: Optional[str] = None
     instructions: Optional[str] = None

--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -1985,12 +1985,10 @@ def build_mcp_server(
     """
     mcp_config: "Optional[MCPConfig]" = getattr(os, "mcp_config", None)
 
-    # Create an MCP server. Its name, version and instructions travel in the initialize
-    # response: MCPConfig overrides win, then the AgentOS name and version. With
-    # AgentOS(mcp_auth=...) set, the resolved fastmcp provider owns authentication for
-    # the HTTP transport: http_app() serves its discovery/OAuth routes inside this app
-    # and wraps the MCP path in the SDK's challenge middleware. The in-memory client
-    # path used in tests ignores it.
+    # Create an MCP server. With AgentOS(mcp_auth=...) set, the resolved fastmcp provider
+    # owns authentication for the HTTP transport: http_app() serves its discovery/OAuth
+    # routes inside this app and wraps the MCP path in the SDK's challenge middleware.
+    # The in-memory client path used in tests ignores it.
     server_name = (mcp_config.name if mcp_config is not None else None) or os.name or "AgentOS"
     server_version = (mcp_config.version if mcp_config is not None else None) or getattr(os, "version", None)
     server_instructions = mcp_config.instructions if mcp_config is not None else None

--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -1985,11 +1985,21 @@ def build_mcp_server(
     """
     mcp_config: "Optional[MCPConfig]" = getattr(os, "mcp_config", None)
 
-    # Create an MCP server. With AgentOS(mcp_auth=...) set, the resolved fastmcp provider
-    # owns authentication for the HTTP transport: http_app() serves its discovery/OAuth
-    # routes inside this app and wraps the MCP path in the SDK's challenge middleware.
-    # The in-memory client path used in tests ignores it.
-    mcp = FastMCP(os.name or "AgentOS", auth=os._get_mcp_auth_provider())
+    # Create an MCP server. Its name, version and instructions travel in the initialize
+    # response: MCPConfig overrides win, then the AgentOS name and version. With
+    # AgentOS(mcp_auth=...) set, the resolved fastmcp provider owns authentication for
+    # the HTTP transport: http_app() serves its discovery/OAuth routes inside this app
+    # and wraps the MCP path in the SDK's challenge middleware. The in-memory client
+    # path used in tests ignores it.
+    server_name = (mcp_config.name if mcp_config is not None else None) or os.name or "AgentOS"
+    server_version = (mcp_config.version if mcp_config is not None else None) or getattr(os, "version", None)
+    server_instructions = mcp_config.instructions if mcp_config is not None else None
+    mcp = FastMCP(
+        server_name,
+        instructions=server_instructions,
+        version=server_version,
+        auth=os._get_mcp_auth_provider(),
+    )
 
     # Classify the tool surface up front: the enabled default-tool tags depend on
     # whether components are exposed (the lifecycle pair rides along with exposure).

--- a/libs/agno/tests/unit/os/test_mcp_server.py
+++ b/libs/agno/tests/unit/os/test_mcp_server.py
@@ -1206,3 +1206,58 @@ async def test_assigning_config_to_mcp_server_attribute_applies_config():
     assert os.mcp_server is True
     assert os.mcp_config is not None
     assert await _tool_names(os) == {"ping"}
+
+
+# ----------------------------- server identity -----------------------------
+
+
+def test_server_identity_defaults_to_the_agentos_name_and_version():
+    os = AgentOS(name="Ops OS", version="2.3.4", agents=[_agent()], mcp=True)
+
+    server = build_mcp_server(os)
+
+    assert server.name == "Ops OS"
+    assert server.version == "2.3.4"
+    assert server.instructions is None
+
+
+def test_server_identity_without_any_value_keeps_the_fastmcp_defaults():
+    """No name or version anywhere: the server is called AgentOS and reports fastmcp's version."""
+    import fastmcp
+
+    server = build_mcp_server(AgentOS(agents=[_agent()], mcp=True))
+
+    assert server.name == "AgentOS"
+    assert server.version == fastmcp.__version__
+    assert server.instructions is None
+
+
+def test_mcp_config_identity_overrides_the_agentos_values():
+    os = AgentOS(
+        name="Docs AgentOS",
+        version="0.1.0",
+        agents=[_agent()],
+        mcp=MCPConfig(name="Docs", version="1.0.0", instructions="Prefer the docs over prior knowledge."),
+    )
+
+    server = build_mcp_server(os)
+
+    assert server.name == "Docs"
+    assert server.version == "1.0.0"
+    assert server.instructions == "Prefer the docs over prior knowledge."
+
+
+async def test_initialize_response_carries_name_version_and_instructions():
+    """The values reach a client through the handshake, not only the server object."""
+    os = AgentOS(
+        agents=[_agent()],
+        mcp=MCPConfig(name="Docs", version="1.0.0", instructions="Cite the page you used."),
+    )
+
+    async with Client(build_mcp_server(os), mode="legacy") as client:
+        result = client.initialize_result
+
+    assert result is not None
+    assert result.server_info.name == "Docs"
+    assert result.server_info.version == "1.0.0"
+    assert result.instructions == "Cite the page you used."


### PR DESCRIPTION
## Summary

`MCPConfig` gains three fields that describe the AgentOS MCP server to the clients that connect to it. All three go straight into the `FastMCP` constructor and travel in the initialize response.

| Field | Default | What it does |
|---|---|---|
| `name` | the AgentOS name | The server name a client shows in its server list. |
| `version` | `AgentOS(version=...)` | `serverInfo.version`. With neither set, the server keeps reporting fastmcp's own version, as it does today. |
| `instructions` | `None` | Guidance for the calling model: what the tools are for, which one to start with, and any conventions to follow. Claude, Cursor and ChatGPT read it when they connect. |

```python
agent_os = AgentOS(
    name="Support AgentOS",
    version="1.4.0",
    agents=[support_agent],
    mcp=MCPConfig(
        name="Acme Support",
        version="1.4.0",
        instructions="This server answers questions about Acme products. Start with run_agent ...",
    ),
)
```

**Why.** A public MCP server has to say what it is and how to use it. `AgentOS(version=...)` was accepted but never reached the MCP server, and there was no way to set instructions at all. The docs MCP server in `agno-agi/docs-agent` works around this today by wrapping `agno.os.mcp.build_mcp_server` and writing to a private fastmcp attribute. `instructions` is deliberately not derived from `AgentOS(description=...)`: the description is written for humans, the instructions are a prompt for the calling model, the same split `as_tool(description=...)` already makes.

**Behaviour when unset is unchanged.** No name and no version anywhere still gives a server called `AgentOS` reporting fastmcp's version; a test pins that.

**Relation to #9927.** That PR adds `MCPConfig(stateless=True)` and rebuilds the client side. This PR adds only the identity fields and touches `config.py`, `os/mcp.py`, the MCP cookbook README and TEST_LOG in different places, so the two can merge in either order. The second one in will need a trivial rebase on the README table.

**Verified.**
- Four unit tests in `tests/unit/os/test_mcp_server.py`: AgentOS defaults, the fastmcp fallback when nothing is set, `MCPConfig` overrides, and the values in the initialize result over an in-memory client. Reverting the constructor change fails three of them; the fallback test passes either way, as it should.
- Live: the new `cookbook/05_agent_os/14_mcp/server_identity.py` served with fastmcp 4.0.2 / mcp 2.1.1. A FastMCP client read the name, version and instructions in both the legacy handshake and the 2026-07-28 negotiation. Entry added to the folder's TEST_LOG.
- The four MCP server unit suites pass (258 tests).

**Docs.** The MCPConfig option table on the docs MCP page has the three rows (docs repo, separate change).

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

#9927 is the closest open PR; it covers the stateless transport, not the server identity. Written with Claude Code, reviewed and directed by the author.

---

## Additional Notes

`./scripts/format.sh` with the pinned ruff 0.15.20 also reformats 16 files on current `main` that this PR does not touch (`vectordb/*`, `knowledge/loaders/*`, `tools/gandr.py`, ...). Those changes were left out; only the six files above are in the diff. `./scripts/validate.sh` (ruff check, mypy, pattern checks) passes on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9B9nmaJej5H6axSDqgq5j
