### PR TITLE
feat: MCP Server Card at /mcp/server-card

### DIFF
--- a/cookbook/05_agent_os/14_mcp/README.md
+++ b/cookbook/05_agent_os/14_mcp/README.md
@@ -76,6 +76,11 @@ agent_os = AgentOS(
 `instructions` tells the calling model what the tools are for and how to use them;
 Claude, Cursor and ChatGPT read it when they connect.
 
+Open `/mcp` in a browser and you are sent to `/mcp/server-card`, a JSON Server Card
+with the name, version, description and endpoint URL in the shape of the MCP Server
+Card extension. It lists no tools; `tools/list` does that. `MCPConfig(server_card=False)`
+turns it off.
+
 ```bash
 .venvs/demo/bin/python cookbook/05_agent_os/14_mcp/server_identity.py
 ```

--- a/cookbook/05_agent_os/14_mcp/README.md
+++ b/cookbook/05_agent_os/14_mcp/README.md
@@ -77,9 +77,20 @@ agent_os = AgentOS(
 Claude, Cursor and ChatGPT read it when they connect.
 
 Open `/mcp` in a browser and you are sent to `/mcp/server-card`, a JSON Server Card
-with the name, version, description and endpoint URL in the shape of the MCP Server
-Card extension. It lists no tools; `tools/list` does that. `MCPConfig(server_card=False)`
-turns it off.
+with the name, description and endpoint URL in the shape of the MCP Server Card
+extension. The `version` is the one the server reports at connect time, so set it on
+`MCPConfig` or `AgentOS` to publish your deployment's version rather than the default.
+It lists no tools; `tools/list` does that. `MCPConfig(server_card=False)` turns it off.
+
+Behind a proxy or load balancer, set the public endpoint explicitly:
+
+```python
+mcp=MCPConfig(name="Acme Support", server_card_url="https://docs.agno.com/mcp")
+```
+
+Without it the URL is derived from the request, and `X-Forwarded-Host` is honoured only
+when that hostname is itself listed in `allowed_hosts` — the card is publicly cacheable,
+so an unvalidated forwarded host is never echoed into it.
 
 ```bash
 .venvs/demo/bin/python cookbook/05_agent_os/14_mcp/server_identity.py

--- a/cookbook/05_agent_os/14_mcp/TEST_LOG.md
+++ b/cookbook/05_agent_os/14_mcp/TEST_LOG.md
@@ -189,6 +189,15 @@ exercised. The four unit tests in `test_mcp_server.py` cover the AgentOS
 defaults, the fastmcp fallback when nothing is set, the `MCPConfig` overrides,
 and the initialize response.
 
+Re-run with the Server Card: a browser-style `GET /mcp` (Accept `text/html`)
+answered 302 to `/mcp/server-card`. The card came back as
+`application/mcp-server-card+json` with the extension's CORS and cache headers,
+name `localhost/acme-support`, title `Acme Support`, version `1.4.0`, the
+AgentOS description and the endpoint URL. With `X-Forwarded-Proto: https` and
+`X-Forwarded-Host: docs.agno.com` the name became `com.agno.docs/acme-support`
+and the URL `https://docs.agno.com/mcp`. A GET with `Accept: text/event-stream`
+was not redirected; fastmcp answered it with its own 400 for a missing session.
+
 ---
 
 ### oauth_builtin.py

--- a/cookbook/05_agent_os/14_mcp/server_identity.py
+++ b/cookbook/05_agent_os/14_mcp/server_identity.py
@@ -7,7 +7,8 @@ tell the calling model what the tools are for and how to use them.
 
 Prerequisites: OPENAI_API_KEY
 Run: .venvs/demo/bin/python cookbook/05_agent_os/14_mcp/server_identity.py
-Try: connect an MCP client to http://localhost:7777/mcp and read the initialize response
+Try: open http://localhost:7777/mcp in a browser to see the server card, or connect
+     an MCP client and read the initialize response
 """
 
 from agno.agent import Agent

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -1746,7 +1746,13 @@ class AgentOS:
             from agno.os.mcp_auth import mcp_auth_route_paths
 
             mcp_auth_paths = mcp_auth_route_paths(mcp_auth_provider)
-        if interface_prefixes or mcp_auth_paths:
+        # The Server Card is discovery before authentication: public by design, no secrets.
+        server_card_paths: List[str] = []
+        if self.mcp and (self.mcp_config is None or self.mcp_config.server_card):
+            from agno.os.config import MCP_SERVER_CARD_PATH
+
+            server_card_paths = [MCP_SERVER_CARD_PATH]
+        if interface_prefixes or mcp_auth_paths or server_card_paths:
             excluded_route_paths = (
                 [
                     "/",
@@ -1759,6 +1765,7 @@ class AgentOS:
                 ]
                 + interface_prefixes
                 + mcp_auth_paths
+                + server_card_paths
             )
 
         middleware_kwargs["excluded_route_paths"] = excluded_route_paths

--- a/libs/agno/agno/os/config.py
+++ b/libs/agno/agno/os/config.py
@@ -70,6 +70,13 @@ class MCPConfig(BaseModel):
     # public even when the server is gated; it carries nothing secret.
     server_card: bool = True
 
+    # The public URL of the MCP endpoint, e.g. ``https://docs.agno.com/mcp``. Set this when the
+    # deployment sits behind a proxy or load balancer: it is what the card advertises, verbatim.
+    # Without it the card derives the URL from the request, and ``X-Forwarded-Host`` is honoured
+    # only when that hostname is itself listed in ``allowed_hosts`` -- an unvalidated forwarded
+    # host would otherwise be echoed into a publicly cacheable document.
+    server_card_url: Optional[str] = None
+
     # The tool surface of this MCP server. Each entry may be:
     #
     #   - a plain callable or an Agno ``@tool``/``Function`` -- a custom tool
@@ -238,6 +245,54 @@ class MCPConfig(BaseModel):
         if update and "enable_builtin_tools" in update:
             update = _apply_legacy_enable_builtin_tools(update)
         return super().model_copy(update=update, deep=deep)
+
+    @model_validator(mode="after")
+    def _check_server_card_url(self) -> "MCPConfig":
+        """Refuse a card URL that is not a well-formed absolute http(s) URL.
+
+        The value is published verbatim as the endpoint clients connect to, so a relative path,
+        a non-transport scheme, or a malformed host would produce a card that no client can use
+        (and that the Server Card schema rejects). Fail at construction rather than at request
+        time. Whitespace is rejected outright rather than left to the URL parser, which silently
+        strips it -- this value lands in a publicly cacheable response, so a newline must never
+        be quietly accepted and reshaped.
+        """
+        if self.server_card_url is None:
+            return self
+
+        from pydantic import AnyHttpUrl, TypeAdapter
+        from pydantic import ValidationError as _ValidationError
+
+        invalid = f"MCPConfig(server_card_url={self.server_card_url!r}) must be an absolute http(s) URL "
+        if any(character.isspace() for character in self.server_card_url):
+            raise ValueError(invalid + "with no whitespace, e.g. 'https://docs.agno.com/mcp'.")
+        try:
+            parsed = TypeAdapter(AnyHttpUrl).validate_python(self.server_card_url)
+        except _ValidationError as exc:
+            raise ValueError(invalid + "including the host, e.g. 'https://docs.agno.com/mcp'.") from exc
+        if parsed.username or parsed.password:
+            # The card is public and cacheable; anything in a userinfo segment would be published.
+            raise ValueError(
+                f"MCPConfig(server_card_url={self.server_card_url!r}) must not contain credentials: "
+                "the Server Card is published publicly. Use 'https://docs.agno.com/mcp' and let "
+                "clients authenticate with the Authorization header the card declares."
+            )
+        # Structure, not canonical form: the parser also normalises (``https:///mcp`` becomes host
+        # ``mcp``), and the card publishes the original string, so the scheme and host it resolved
+        # to must be the ones actually written. A default port or uppercase host is fine.
+        if parsed.scheme not in ("http", "https"):
+            raise ValueError(invalid + "including the host, e.g. 'https://docs.agno.com/mcp'.")
+        written = self.server_card_url.split("//", 1)[-1].split("/", 1)[0].rsplit("@", 1)[-1]
+        # Drop the port, but not the colons inside an ipv6 literal.
+        written = written[: written.index("]") + 1] if written.startswith("[") else written.rsplit(":", 1)[0]
+        if not parsed.host or parsed.host.strip("[]").lower() != written.strip("[]").lower():
+            raise ValueError(invalid + "including the host, e.g. 'https://docs.agno.com/mcp'.")
+        # The card's URL pattern matches lowercase ``http(s)://`` only, so a scheme written in any
+        # other case is lowercased here rather than published as an invalid card.
+        scheme_written = self.server_card_url.split("://", 1)[0]
+        if scheme_written != scheme_written.lower():
+            self.server_card_url = parsed.scheme + self.server_card_url[len(scheme_written) :]
+        return self
 
     @model_validator(mode="after")
     def _check_has_tools(self) -> "MCPConfig":

--- a/libs/agno/agno/os/config.py
+++ b/libs/agno/agno/os/config.py
@@ -14,6 +14,9 @@ MCP_BUILTIN_TAGS: frozenset = frozenset({"core", "session", "lifecycle"})
 # string values while keeping the API stringly-typed (callers still pass ``{"core"}``).
 MCPBuiltinTag = Literal["core", "session", "lifecycle"]
 
+# Where the MCP server publishes its Server Card: the MCP endpoint path plus ``/server-card``.
+MCP_SERVER_CARD_PATH = "/mcp/server-card"
+
 
 def _apply_legacy_enable_builtin_tools(data: Dict[str, Any]) -> Dict[str, Any]:
     """Map the deprecated ``enable_builtin_tools`` key onto ``default_tools`` in a dict
@@ -61,6 +64,11 @@ class MCPConfig(BaseModel):
     name: Optional[str] = None
     version: Optional[str] = None
     instructions: Optional[str] = None
+
+    # Publish a Server Card at ``/mcp/server-card`` (name, version, description and the
+    # endpoint URL, no tools) and send a browser that opens ``/mcp`` to it. The card is
+    # public even when the server is gated; it carries nothing secret.
+    server_card: bool = True
 
     # The tool surface of this MCP server. Each entry may be:
     #

--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -1985,54 +1985,133 @@ def _server_card_enabled(mcp_config: "Optional[MCPConfig]") -> bool:
 
 
 def _card_name(hostname: str, server_name: str) -> str:
-    """The card's reverse-DNS name: the request host reversed, a slash, the server name as a slug."""
+    """The card's reverse-DNS name: the request host reversed, a slash, the server name as a slug.
+
+    The schema caps the whole name at 200 characters and requires exactly one slash, so the two
+    halves are clipped separately -- truncating the joined string could drop the slash entirely.
+    """
     is_ip_literal = hostname.startswith("[") or re.fullmatch(r"[\d.]+", hostname) is not None
     namespace = "" if is_ip_literal else ".".join(reversed(hostname.lower().split(".")))
     namespace = re.sub(r"[^a-z0-9.-]+", "", namespace).strip(".-")
     slug = re.sub(r"[^A-Za-z0-9._-]+", "-", server_name).strip("-.").lower()
-    return f"{namespace or 'localhost'}/{slug or 'agentos'}"
+    namespace = namespace or "localhost"
+    slug = slug or "agentos"
+    # Keep the slug whole where possible; give the namespace whatever the slug leaves.
+    slug = slug[:_CARD_SLUG_MAX].rstrip("-._") or "agentos"
+    namespace = namespace[: _CARD_NAME_MAX - len(slug) - 1].rstrip("-.") or "localhost"
+    return f"{namespace}/{slug}"
 
 
-def _server_card(mcp: FastMCP, os: "AgentOS", request: Any) -> Dict[str, Any]:
-    """The Server Card for one request. The endpoint URL follows the proxy headers when present."""
-    scheme = request.headers.get("x-forwarded-proto", "").split(",")[0].strip() or request.url.scheme
-    host = (
-        request.headers.get("x-forwarded-host", "").split(",")[0].strip()
-        or request.headers.get("host")
-        or request.url.netloc
-    )
-    remote: Dict[str, Any] = {"type": "streamable-http", "url": f"{scheme}://{host}{_MCP_PATH}"}
+# Length limits from the Server Card schema. An AgentOS name or description is free text and
+# routinely longer, so values are truncated rather than published as an invalid card.
+_CARD_NAME_MAX = 200
+# Half the name budget, so a very long server name cannot squeeze the namespace out entirely.
+_CARD_SLUG_MAX = 100
+_CARD_TITLE_MAX = 100
+_CARD_TEXT_MAX = 100
+_CARD_VERSION_MAX = 255
+
+
+def _truncate(value: str, limit: int) -> str:
+    """Clip to the schema's limit, marking the clip with an ellipsis so it does not read as complete."""
+    return value if len(value) <= limit else value[: limit - 1].rstrip() + "…"
+
+
+def _server_card(
+    mcp: FastMCP,
+    os: "AgentOS",
+    request: Any,
+    version: Optional[str] = None,
+    card_url: Optional[str] = None,
+    allowed_hosts: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """The Server Card for one request.
+
+    A configured ``server_card_url`` is authoritative. Otherwise the endpoint URL is derived from
+    the request. ``X-Forwarded-Host`` is honoured only when its value is itself listed in
+    ``allowed_hosts``: the header is attacker-controlled even on a request whose ``Host`` is
+    allowed, and this response is publicly cacheable, so an unvalidated value would let a caller
+    plant a card naming their own host.
+    """
+    from urllib.parse import urlparse
+
+    if card_url:
+        host = urlparse(card_url).netloc or request.headers.get("host") or request.url.netloc
+        url = card_url
+    else:
+        scheme = request.url.scheme
+        host = request.headers.get("host") or request.url.netloc
+        forwarded_host = request.headers.get("x-forwarded-host", "").split(",")[0].strip()
+        if forwarded_host and allowed_hosts:
+            host_set = {_mcp_request_hostname(h) for h in list(allowed_hosts) + list(_MCP_LOCALHOST_HOSTS)}
+            if _mcp_host_allowed(_mcp_request_hostname(forwarded_host), host_set):
+                host = forwarded_host
+                # Only the two transport schemes; the header is caller-supplied, and anything
+                # else here would be published as the endpoint's URL.
+                forwarded_proto = request.headers.get("x-forwarded-proto", "").split(",")[0].strip().lower()
+                scheme = forwarded_proto if forwarded_proto in ("http", "https") else scheme
+        url = f"{scheme}://{host}{_MCP_PATH}"
+    remote: Dict[str, Any] = {"type": "streamable-http", "url": url}
     if not _mcp_server_is_open(os):
         remote["headers"] = [
             {"name": "Authorization", "description": "Bearer token", "isRequired": True, "isSecret": True}
         ]
-    return {
+    card = {
         "$schema": SERVER_CARD_SCHEMA,
         "name": _card_name(_mcp_request_hostname(host), mcp.name),
-        "title": mcp.name,
-        "version": str(mcp.version),
-        "description": getattr(os, "description", None) or f"{mcp.name} MCP server",
+        "title": _truncate(mcp.name, _CARD_TITLE_MAX),
+        "description": _truncate(getattr(os, "description", None) or f"{mcp.name} MCP server", _CARD_TEXT_MAX),
         "remotes": [remote],
     }
+    # ``version`` is required by the schema and must match what the runtime reports in
+    # ``serverInfo.version``, so the card mirrors ``mcp.version`` when nothing was configured --
+    # even though fastmcp defaults that to its own library version. Set ``MCPConfig(version=...)``
+    # or ``AgentOS(version=...)`` to publish the deployment's real version instead.
+    card["version"] = _truncate(version or str(mcp.version), _CARD_VERSION_MAX)
+    return card
 
 
-def _register_server_card(mcp: FastMCP, os: "AgentOS") -> None:
+def _register_server_card(
+    mcp: FastMCP,
+    os: "AgentOS",
+    version: Optional[str] = None,
+    card_url: Optional[str] = None,
+    allowed_hosts: Optional[List[str]] = None,
+) -> None:
     from starlette.requests import Request
     from starlette.responses import JSONResponse, Response
+
+    # The body varies with the request host unless a URL was configured, so a shared cache must
+    # key on the headers that shape it -- otherwise one caller's card is served to everyone.
+    vary = "Origin" if card_url else "Origin, Host, X-Forwarded-Host, X-Forwarded-Proto"
 
     @mcp.custom_route(MCP_SERVER_CARD_PATH, methods=["GET"], include_in_schema=False)
     async def server_card(request: Request) -> Response:
         return JSONResponse(
-            _server_card(mcp, os, request),
+            _server_card(mcp, os, request, version, card_url, allowed_hosts),
             media_type=SERVER_CARD_MEDIA_TYPE,
             headers={
                 "Cache-Control": "public, max-age=300",
+                "Vary": vary,
                 "Access-Control-Allow-Origin": "*",
                 "Access-Control-Allow-Methods": "GET",
                 "Access-Control-Allow-Headers": "Content-Type, If-None-Match",
                 "Access-Control-Expose-Headers": "ETag",
             },
         )
+
+
+def _accepts_event_stream(accept_header: str) -> bool:
+    """True when the Accept header explicitly names ``text/event-stream``.
+
+    Media types are case-insensitive and may carry parameters (``;q=0.9``), so each entry is
+    normalised the way the MCP SDK's own Accept parsing does before comparing. A bare ``*/*``
+    is deliberately NOT treated as a match: every browser sends it, and the redirect exists
+    for browsers. An MCP client always names the type explicitly.
+    """
+    return any(
+        media_type.split(";")[0].strip().lower() == "text/event-stream" for media_type in accept_header.split(",")
+    )
 
 
 def _add_browser_redirect_middleware(mcp_app: StarletteWithLifespan) -> None:
@@ -2053,7 +2132,7 @@ def _add_browser_redirect_middleware(mcp_app: StarletteWithLifespan) -> None:
                 and scope.get("path", "").rstrip("/") == _MCP_PATH
             ):
                 accept = next((v.decode("latin-1") for k, v in scope.get("headers", []) if k == b"accept"), "")
-                if "text/event-stream" not in accept:
+                if not _accepts_event_stream(accept):
                     headers = [(b"location", MCP_SERVER_CARD_PATH.encode()), (b"content-length", b"0")]
                     await send({"type": "http.response.start", "status": 302, "headers": headers})
                     await send({"type": "http.response.body", "body": b""})
@@ -2088,7 +2167,15 @@ def build_mcp_server(
         auth=os._get_mcp_auth_provider(),
     )
     if _server_card_enabled(mcp_config):
-        _register_server_card(mcp, os)
+        # allowed_hosts is the operator declaring the hostnames this deployment answers to; a
+        # forwarded host is advertised only if it appears in that list.
+        _register_server_card(
+            mcp,
+            os,
+            server_version,
+            card_url=(mcp_config.server_card_url if mcp_config is not None else None),
+            allowed_hosts=(mcp_config.allowed_hosts if mcp_config is not None else None),
+        )
 
     # Classify the tool surface up front: the enabled default-tool tags depend on
     # whether components are exposed (the lifecycle pair rides along with exposure).

--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -74,6 +74,7 @@ logger = logging.getLogger(__name__)
 # tag set lives in agno/os/config.py next to the MCPConfig fields that consume it --
 # single source of truth so adding a new tag is a one-place change.
 from agno.os.config import MCP_BUILTIN_TAGS as _BUILTIN_TOOL_TAGS  # noqa: E402
+from agno.os.config import MCP_SERVER_CARD_PATH  # noqa: E402
 
 # Names of the default (built-in) tools by tag set, used to detect name collisions with
 # exposed components before registration. Keep in sync with the ``name=`` / ``tags=``
@@ -1974,6 +1975,94 @@ def _register_exposed_components(
         mcp.tool(name=tool_name, title=title, description=description, annotations=annotations)(fn)
 
 
+SERVER_CARD_SCHEMA = "https://static.modelcontextprotocol.io/schemas/v1/server-card.schema.json"
+SERVER_CARD_MEDIA_TYPE = "application/mcp-server-card+json"
+_MCP_PATH = "/mcp"
+
+
+def _server_card_enabled(mcp_config: "Optional[MCPConfig]") -> bool:
+    return mcp_config is None or mcp_config.server_card
+
+
+def _card_name(hostname: str, server_name: str) -> str:
+    """The card's reverse-DNS name: the request host reversed, a slash, the server name as a slug."""
+    is_ip_literal = hostname.startswith("[") or re.fullmatch(r"[\d.]+", hostname) is not None
+    namespace = "" if is_ip_literal else ".".join(reversed(hostname.lower().split(".")))
+    namespace = re.sub(r"[^a-z0-9.-]+", "", namespace).strip(".-")
+    slug = re.sub(r"[^A-Za-z0-9._-]+", "-", server_name).strip("-.").lower()
+    return f"{namespace or 'localhost'}/{slug or 'agentos'}"
+
+
+def _server_card(mcp: FastMCP, os: "AgentOS", request: Any) -> Dict[str, Any]:
+    """The Server Card for one request. The endpoint URL follows the proxy headers when present."""
+    scheme = request.headers.get("x-forwarded-proto", "").split(",")[0].strip() or request.url.scheme
+    host = (
+        request.headers.get("x-forwarded-host", "").split(",")[0].strip()
+        or request.headers.get("host")
+        or request.url.netloc
+    )
+    remote: Dict[str, Any] = {"type": "streamable-http", "url": f"{scheme}://{host}{_MCP_PATH}"}
+    if not _mcp_server_is_open(os):
+        remote["headers"] = [
+            {"name": "Authorization", "description": "Bearer token", "isRequired": True, "isSecret": True}
+        ]
+    return {
+        "$schema": SERVER_CARD_SCHEMA,
+        "name": _card_name(_mcp_request_hostname(host), mcp.name),
+        "title": mcp.name,
+        "version": str(mcp.version),
+        "description": getattr(os, "description", None) or f"{mcp.name} MCP server",
+        "remotes": [remote],
+    }
+
+
+def _register_server_card(mcp: FastMCP, os: "AgentOS") -> None:
+    from starlette.requests import Request
+    from starlette.responses import JSONResponse, Response
+
+    @mcp.custom_route(MCP_SERVER_CARD_PATH, methods=["GET"], include_in_schema=False)
+    async def server_card(request: Request) -> Response:
+        return JSONResponse(
+            _server_card(mcp, os, request),
+            media_type=SERVER_CARD_MEDIA_TYPE,
+            headers={
+                "Cache-Control": "public, max-age=300",
+                "Access-Control-Allow-Origin": "*",
+                "Access-Control-Allow-Methods": "GET",
+                "Access-Control-Allow-Headers": "Content-Type, If-None-Match",
+                "Access-Control-Expose-Headers": "ETag",
+            },
+        )
+
+
+def _add_browser_redirect_middleware(mcp_app: StarletteWithLifespan) -> None:
+    """Send a browser that opens the MCP endpoint to the Server Card.
+
+    MCP clients send ``Accept: text/event-stream`` on a GET; a GET without it is a person
+    in a browser, who would otherwise get a JSON-RPC 406 or a 405.
+    """
+
+    class _BrowserRedirectMiddleware:
+        def __init__(self, app: Any) -> None:
+            self.app = app
+
+        async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
+            if (
+                scope["type"] == "http"
+                and scope.get("method") == "GET"
+                and scope.get("path", "").rstrip("/") == _MCP_PATH
+            ):
+                accept = next((v.decode("latin-1") for k, v in scope.get("headers", []) if k == b"accept"), "")
+                if "text/event-stream" not in accept:
+                    headers = [(b"location", MCP_SERVER_CARD_PATH.encode()), (b"content-length", b"0")]
+                    await send({"type": "http.response.start", "status": 302, "headers": headers})
+                    await send({"type": "http.response.body", "body": b""})
+                    return
+            await self.app(scope, receive, send)
+
+    mcp_app.add_middleware(_BrowserRedirectMiddleware)
+
+
 def build_mcp_server(
     os: "AgentOS",
 ) -> FastMCP:
@@ -1998,6 +2087,8 @@ def build_mcp_server(
         version=server_version,
         auth=os._get_mcp_auth_provider(),
     )
+    if _server_card_enabled(mcp_config):
+        _register_server_card(mcp, os)
 
     # Classify the tool surface up front: the enabled default-tool tags depend on
     # whether components are exposed (the lifecycle pair rides along with exposure).
@@ -2730,6 +2821,9 @@ def get_mcp_server(
         for mw in reversed(mcp_config.middleware):
             cls, args, kwargs = mw
             mcp_app.add_middleware(cls, *args, **kwargs)
+
+    if _server_card_enabled(mcp_config):
+        _add_browser_redirect_middleware(mcp_app)
 
     # Outermost: built-in DNS-rebinding protection (runs first, before auth and tools).
     #

--- a/libs/agno/tests/unit/os/test_mcp_server.py
+++ b/libs/agno/tests/unit/os/test_mcp_server.py
@@ -1261,3 +1261,117 @@ async def test_initialize_response_carries_name_version_and_instructions():
     assert result.server_info.name == "Docs"
     assert result.server_info.version == "1.0.0"
     assert result.instructions == "Cite the page you used."
+
+
+# ----------------------------- server card -----------------------------
+
+SERVER_CARD_SCHEMA = "https://static.modelcontextprotocol.io/schemas/v1/server-card.schema.json"
+
+
+def _docs_os(**mcp_kwargs) -> AgentOS:
+    return AgentOS(
+        name="Docs AgentOS",
+        version="1.0.0",
+        description="Search the docs.",
+        agents=[_agent()],
+        mcp=MCPConfig(name="Agno Docs", allowed_hosts=["example.com"], **mcp_kwargs),
+    )
+
+
+@asynccontextmanager
+async def _mcp_client(app, base_url: str = "http://example.com") -> AsyncIterator[httpx.AsyncClient]:
+    """An HTTP client on the app with its lifespan running, so fastmcp's transport is live."""
+    async with app.router.lifespan_context(app):
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url=base_url) as client:
+            yield client
+
+
+def test_card_name_is_reverse_dns_and_slugged():
+    assert mcp_mod._card_name("docs.agno.com", "Agno Docs AgentOS") == "com.agno.docs/agno-docs-agentos"
+    assert mcp_mod._card_name("localhost", "Ops") == "localhost/ops"
+    assert mcp_mod._card_name("[::1]", "") == "localhost/agentos"
+    assert mcp_mod._card_name("127.0.0.1", "Ops") == "localhost/ops"
+
+
+async def test_server_card_describes_the_server_and_its_endpoint(monkeypatch):
+    monkeypatch.setattr(mcp_mod, "_mcp_server_is_open", lambda os: True)
+    app = get_mcp_server(_docs_os())
+
+    async with _mcp_client(app) as client:
+        response = await client.get("/mcp/server-card", headers={"accept": "application/mcp-server-card+json"})
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/mcp-server-card+json")
+    assert response.headers["access-control-allow-origin"] == "*"
+    assert response.headers["cache-control"] == "public, max-age=300"
+    assert response.json() == {
+        "$schema": SERVER_CARD_SCHEMA,
+        "name": "com.example/agno-docs",
+        "title": "Agno Docs",
+        "version": "1.0.0",
+        "description": "Search the docs.",
+        "remotes": [{"type": "streamable-http", "url": "http://example.com/mcp"}],
+    }
+
+
+async def test_server_card_endpoint_follows_the_proxy_headers(monkeypatch):
+    monkeypatch.setattr(mcp_mod, "_mcp_server_is_open", lambda os: True)
+    app = get_mcp_server(_docs_os())
+
+    async with _mcp_client(app) as client:
+        response = await client.get(
+            "/mcp/server-card", headers={"x-forwarded-proto": "https", "x-forwarded-host": "docs.agno.com"}
+        )
+
+    card = response.json()
+    assert card["remotes"][0]["url"] == "https://docs.agno.com/mcp"
+    assert card["name"] == "com.agno.docs/agno-docs"
+
+
+async def test_gated_server_card_declares_the_bearer_header(monkeypatch):
+    monkeypatch.setattr(mcp_mod, "_mcp_server_is_open", lambda os: False)
+    app = get_mcp_server(_docs_os())
+
+    async with _mcp_client(app) as client:
+        card = (await client.get("/mcp/server-card")).json()
+
+    assert card["remotes"][0]["headers"] == [
+        {"name": "Authorization", "description": "Bearer token", "isRequired": True, "isSecret": True}
+    ]
+
+
+async def test_browser_get_on_mcp_redirects_to_the_card():
+    app = get_mcp_server(_docs_os())
+
+    async with _mcp_client(app) as client:
+        for path in ("/mcp", "/mcp/"):
+            response = await client.get(path, headers={"accept": "text/html,*/*"})
+            assert response.status_code == 302, path
+            assert response.headers["location"] == "/mcp/server-card"
+        # An MCP client's GET (it always accepts text/event-stream) is left to fastmcp.
+        response = await client.get("/mcp", headers={"accept": "text/event-stream"})
+        assert response.status_code != 302
+
+
+async def test_server_card_can_be_turned_off():
+    app = get_mcp_server(_docs_os(server_card=False))
+
+    async with _mcp_client(app) as client:
+        assert (await client.get("/mcp/server-card")).status_code == 404
+        assert (await client.get("/mcp", headers={"accept": "text/html"})).status_code == 406
+
+
+async def test_server_card_is_public_on_an_authorized_agentos():
+    os = AgentOS(
+        agents=[_agent()],
+        authorization=True,
+        authorization_config=AuthorizationConfig(verification_keys=["dummy"]),
+        mcp=True,
+    )
+    app = os.get_app()
+
+    async with _mcp_client(app, base_url="http://localhost") as client:
+        assert (await client.get("/mcp/server-card")).status_code == 200
+        assert (await client.get("/sessions")).status_code == 401  # the auth layer is on
+        # The endpoint itself stays behind the auth layer; only the card is public.
+        assert (await client.get("/mcp", headers={"accept": "text/html"})).status_code == 401

--- a/libs/agno/tests/unit/os/test_mcp_server.py
+++ b/libs/agno/tests/unit/os/test_mcp_server.py
@@ -14,6 +14,7 @@ import pytest
 pytest.importorskip("fastmcp")
 
 import asyncio  # noqa: E402
+import re  # noqa: E402
 import time  # noqa: E402
 from contextlib import asynccontextmanager  # noqa: E402
 from typing import Any, AsyncIterator, Iterator, Optional  # noqa: E402
@@ -1315,8 +1316,16 @@ async def test_server_card_describes_the_server_and_its_endpoint(monkeypatch):
 
 
 async def test_server_card_endpoint_follows_the_proxy_headers(monkeypatch):
+    """A forwarded host is advertised only when it is itself an allowed host."""
     monkeypatch.setattr(mcp_mod, "_mcp_server_is_open", lambda os: True)
-    app = get_mcp_server(_docs_os())
+    os = AgentOS(
+        name="Docs AgentOS",
+        version="1.0.0",
+        description="Search the docs.",
+        agents=[_agent()],
+        mcp=MCPConfig(name="Agno Docs", allowed_hosts=["example.com", "docs.agno.com"]),
+    )
+    app = get_mcp_server(os)
 
     async with _mcp_client(app) as client:
         response = await client.get(
@@ -1375,3 +1384,300 @@ async def test_server_card_is_public_on_an_authorized_agentos():
         assert (await client.get("/sessions")).status_code == 401  # the auth layer is on
         # The endpoint itself stays behind the auth layer; only the card is public.
         assert (await client.get("/mcp", headers={"accept": "text/html"})).status_code == 401
+
+
+@pytest.mark.parametrize(
+    "accept",
+    ["text/event-stream", "TEXT/EVENT-STREAM", "Text/Event-Stream", "application/json, text/event-stream"],
+)
+async def test_an_mcp_clients_get_is_never_redirected_whatever_the_header_case(accept):
+    """Media types are case-insensitive, so an MCP client must reach fastmcp in any casing."""
+    app = get_mcp_server(_docs_os())
+
+    async with _mcp_client(app) as client:
+        assert (await client.get("/mcp", headers={"accept": accept})).status_code != 302
+
+
+@pytest.mark.parametrize("accept", ["text/html", "text/html,application/xhtml+xml,*/*;q=0.8", "*/*", ""])
+async def test_a_browser_get_is_still_redirected(accept):
+    """A bare wildcard is a browser, not an MCP client: the redirect is the point of the card."""
+    app = get_mcp_server(_docs_os())
+
+    async with _mcp_client(app) as client:
+        response = await client.get("/mcp", headers={"accept": accept})
+
+    assert response.status_code == 302
+    assert response.headers["location"] == "/mcp/server-card"
+
+
+async def test_card_version_matches_the_runtime_server_info(monkeypatch):
+    """The extension expects the card's identity to match what the runtime reports."""
+    import fastmcp
+
+    monkeypatch.setattr(mcp_mod, "_mcp_server_is_open", lambda os: True)
+    os = AgentOS(
+        name="Docs AgentOS",
+        description="Search the docs.",
+        agents=[_agent()],
+        mcp=MCPConfig(name="Agno Docs", allowed_hosts=["example.com"]),
+    )
+    app = get_mcp_server(os)
+
+    async with _mcp_client(app) as client:
+        card = (await client.get("/mcp/server-card")).json()
+
+    # Required by the schema and must agree with serverInfo.version, which fastmcp defaults
+    # to its own version when the deployment configures none.
+    assert card["version"] == build_mcp_server(os).version == fastmcp.__version__
+
+
+async def test_card_publishes_a_configured_version(monkeypatch):
+    monkeypatch.setattr(mcp_mod, "_mcp_server_is_open", lambda os: True)
+    app = get_mcp_server(_docs_os(version="2.5.0"))
+
+    async with _mcp_client(app) as client:
+        card = (await client.get("/mcp/server-card")).json()
+
+    assert card["version"] == "2.5.0"
+
+
+async def test_forwarded_headers_are_ignored_without_allowed_hosts(monkeypatch):
+    """The card is publicly cacheable, so an unvalidated forwarded host must not reach it."""
+    monkeypatch.setattr(mcp_mod, "_mcp_server_is_open", lambda os: True)
+    os = AgentOS(
+        name="Docs AgentOS",
+        version="1.0.0",
+        description="Search the docs.",
+        agents=[_agent()],
+        mcp=MCPConfig(name="Agno Docs"),
+    )
+    app = get_mcp_server(os)
+
+    async with _mcp_client(app, base_url="http://localhost") as client:
+        response = await client.get(
+            "/mcp/server-card",
+            headers={"x-forwarded-proto": "https", "x-forwarded-host": "evil.attacker.com"},
+        )
+
+    card = response.json()
+    assert "evil.attacker.com" not in card["remotes"][0]["url"]
+    assert card["remotes"][0]["url"] == "http://localhost/mcp"
+    assert "attacker" not in card["name"]
+
+
+async def test_the_card_varies_on_the_headers_that_shape_it(monkeypatch):
+    monkeypatch.setattr(mcp_mod, "_mcp_server_is_open", lambda os: True)
+    app = get_mcp_server(_docs_os())
+
+    async with _mcp_client(app) as client:
+        vary = (await client.get("/mcp/server-card")).headers["vary"]
+
+    assert "X-Forwarded-Host" in vary
+    assert "Host" in vary
+
+
+async def test_a_configured_url_is_authoritative_and_ignores_forwarded_headers(monkeypatch):
+    monkeypatch.setattr(mcp_mod, "_mcp_server_is_open", lambda os: True)
+    app = get_mcp_server(_docs_os(server_card_url="https://docs.agno.com/mcp"))
+
+    async with _mcp_client(app) as client:
+        response = await client.get("/mcp/server-card", headers={"x-forwarded-host": "evil.attacker.com"})
+
+    assert response.json()["remotes"][0]["url"] == "https://docs.agno.com/mcp"
+    assert response.headers["vary"] == "Origin"
+
+
+async def test_card_fields_are_clipped_to_the_schema_limits(monkeypatch):
+    """The schema caps title/description at 100 and name at 200; AgentOS text is unbounded."""
+    monkeypatch.setattr(mcp_mod, "_mcp_server_is_open", lambda os: True)
+    os = AgentOS(
+        name="Docs AgentOS",
+        version="1.0.0",
+        description="d" * 400,
+        agents=[_agent()],
+        mcp=MCPConfig(name="N" * 400, allowed_hosts=["example.com"]),
+    )
+    app = get_mcp_server(os)
+
+    async with _mcp_client(app) as client:
+        card = (await client.get("/mcp/server-card")).json()
+
+    assert len(card["description"]) <= 100
+    assert len(card["title"]) <= 100
+    assert len(card["name"]) <= 200
+
+
+# The constraints the MCP Server Card schema puts on the fields this card publishes.
+# Mirrored here so the card is checked without fetching the schema over the network.
+_CARD_FIELD_RULES = {
+    "name": {"max": 200, "min": 3, "pattern": r"^[a-zA-Z0-9.-]+/[a-zA-Z0-9._-]+$"},
+    "title": {"max": 100, "min": 1},
+    "description": {"max": 100, "min": 1},
+    "version": {"max": 255},
+}
+
+
+@pytest.mark.parametrize(
+    "description, server_name",
+    [
+        ("Search the docs.", "Agno Docs"),
+        ("d" * 400, "N" * 400),  # unbounded AgentOS text must not produce an invalid card
+        ("d", "N"),
+    ],
+)
+async def test_the_card_conforms_to_the_server_card_schema(monkeypatch, description, server_name):
+    monkeypatch.setattr(mcp_mod, "_mcp_server_is_open", lambda os: True)
+    os = AgentOS(
+        name="Docs AgentOS",
+        version="1.0.0",
+        description=description,
+        agents=[_agent()],
+        mcp=MCPConfig(name=server_name, allowed_hosts=["example.com"]),
+    )
+    app = get_mcp_server(os)
+
+    async with _mcp_client(app) as client:
+        card = (await client.get("/mcp/server-card")).json()
+
+    # Required by the schema.
+    for field in ("$schema", "description", "name", "version"):
+        assert field in card, field
+
+    for field, rule in _CARD_FIELD_RULES.items():
+        value = card[field]
+        assert len(value) <= rule["max"], f"{field} too long: {len(value)}"
+        assert len(value) >= rule.get("min", 0), f"{field} too short: {len(value)}"
+        if "pattern" in rule:
+            assert re.fullmatch(rule["pattern"], value), f"{field} violates the schema pattern: {value!r}"
+
+
+async def test_an_unlisted_forwarded_host_is_not_advertised(monkeypatch):
+    """X-Forwarded-Host is attacker-controlled even when the request's own Host is allowed."""
+    monkeypatch.setattr(mcp_mod, "_mcp_server_is_open", lambda os: True)
+    os = AgentOS(
+        name="Docs AgentOS",
+        version="1.0.0",
+        description="Search the docs.",
+        agents=[_agent()],
+        mcp=MCPConfig(name="Agno Docs", allowed_hosts=["docs.agno.com"]),
+    )
+    app = get_mcp_server(os)
+
+    async with _mcp_client(app, base_url="http://docs.agno.com") as client:
+        card = (
+            await client.get(
+                "/mcp/server-card",
+                headers={"x-forwarded-proto": "https", "x-forwarded-host": "evil.attacker.com"},
+            )
+        ).json()
+
+    assert "evil.attacker.com" not in card["remotes"][0]["url"]
+    assert "attacker" not in card["name"]
+    assert card["remotes"][0]["url"] == "http://docs.agno.com/mcp"
+
+
+def test_card_name_keeps_its_slash_when_the_host_is_very_long():
+    """The schema requires exactly one slash; clipping the joined string could drop it."""
+    name = mcp_mod._card_name(".".join(["segment"] * 80), "Ops")
+
+    assert len(name) <= 200
+    assert re.fullmatch(r"^[a-zA-Z0-9.-]+/[a-zA-Z0-9._-]+$", name), name
+    assert name.endswith("/ops")
+
+
+def test_card_name_keeps_its_namespace_when_the_server_name_is_very_long():
+    name = mcp_mod._card_name("docs.agno.com", "N" * 400)
+
+    assert len(name) <= 200
+    assert re.fullmatch(r"^[a-zA-Z0-9.-]+/[a-zA-Z0-9._-]+$", name), name
+    assert name.startswith("com.agno.docs/")
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "/relative/mcp",
+        "ftp://docs.agno.com/mcp",
+        "javascript:alert(1)",
+        "not a url",
+        "https:///mcp",
+        "https://exa mple.com/mcp",  # whitespace inside the host
+        "http://:80/mcp",  # port with no host
+        "https://docs.agno.com/mcp\nX-Injected: y",  # newline must not be quietly stripped
+        "https://docs.agno.com:notaport/mcp",  # non-numeric port
+        "https://a\tb.com/mcp",  # tab inside the host
+        "https://[bad/mcp",  # unterminated ipv6 literal
+    ],
+)
+def test_server_card_url_must_be_an_absolute_http_url(url):
+    """The value is published verbatim as the endpoint, so it is checked at construction."""
+    with pytest.raises(ValueError, match="absolute http"):
+        MCPConfig(name="Agno Docs", server_card_url=url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://user:secret@docs.agno.com/mcp",
+        "https://token@docs.agno.com/mcp",
+        "https://evil.com@docs.agno.com/mcp",
+    ],
+)
+def test_server_card_url_must_not_carry_credentials(url):
+    """The card is published publicly, so a userinfo segment would leak whatever it holds."""
+    with pytest.raises(ValueError, match="must not contain credentials"):
+        MCPConfig(name="Agno Docs", server_card_url=url)
+
+
+@pytest.mark.parametrize("url", ["http://localhost:7777/mcp", "https://docs.agno.com/mcp", "http://127.0.0.1:7777/mcp"])
+def test_a_valid_server_card_url_is_accepted(url):
+    assert MCPConfig(name="Agno Docs", server_card_url=url).server_card_url == url
+
+
+@pytest.mark.parametrize("proto", ["javascript", "ftp", "file", "HTTPS"])
+async def test_only_http_schemes_are_taken_from_the_forwarded_proto(monkeypatch, proto):
+    """The header is caller-supplied; anything but http(s) must not reach the advertised URL."""
+    monkeypatch.setattr(mcp_mod, "_mcp_server_is_open", lambda os: True)
+    os = AgentOS(
+        name="Docs AgentOS",
+        version="1.0.0",
+        description="Search the docs.",
+        agents=[_agent()],
+        mcp=MCPConfig(name="Agno Docs", allowed_hosts=["docs.agno.com"]),
+    )
+    app = get_mcp_server(os)
+
+    async with _mcp_client(app, base_url="http://docs.agno.com") as client:
+        card = (
+            await client.get(
+                "/mcp/server-card",
+                headers={"x-forwarded-host": "docs.agno.com", "x-forwarded-proto": proto},
+            )
+        ).json()
+
+    url = card["remotes"][0]["url"]
+    assert url.startswith(("http://", "https://")), url
+    assert proto.lower() not in url or proto.lower() == "https"
+
+
+@pytest.mark.parametrize(
+    "written, published",
+    [
+        ("HTTPS://docs.agno.com/mcp", "https://docs.agno.com/mcp"),
+        ("Http://docs.agno.com/mcp", "http://docs.agno.com/mcp"),
+        ("HTTP://[::1]:7777/mcp", "http://[::1]:7777/mcp"),
+    ],
+)
+def test_an_uppercase_scheme_is_lowercased(written, published):
+    """The card's URL pattern matches lowercase http(s):// only."""
+    assert MCPConfig(name="Agno Docs", server_card_url=written).server_card_url == published
+
+
+async def test_the_published_url_always_matches_the_schema_pattern(monkeypatch):
+    monkeypatch.setattr(mcp_mod, "_mcp_server_is_open", lambda os: True)
+    app = get_mcp_server(_docs_os(server_card_url="HTTPS://docs.agno.com/mcp"))
+
+    async with _mcp_client(app) as client:
+        url = (await client.get("/mcp/server-card")).json()["remotes"][0]["url"]
+
+    assert re.fullmatch(r"^(https?://[^\s]+|\{[a-zA-Z_][a-zA-Z0-9_]*\}[^\s]*)$", url), url


### PR DESCRIPTION
## Summary

An MCP Server Card at `/mcp/server-card`, on by default, and a redirect for people who open `/mcp` in a browser. Stacked on #9930 (base branch `feat/mcp-server-identity`); retarget to `main` once that merges.

**The card** follows the MCP Server Card extension (SEP-2127, experimental): `$schema`, a reverse-DNS `name` built from the request host and the server name, `title`, `version`, `description` from the AgentOS description, and one `remotes` entry with the endpoint URL. Proxy headers (`X-Forwarded-Proto`, `X-Forwarded-Host`) are honoured, so a deployment behind Railway or a load balancer reports its public URL. When the server is gated, the remote declares the required `Authorization` header. The card lists no tools; the extension leaves those to `tools/list`.

```json
{
  "$schema": "https://static.modelcontextprotocol.io/schemas/v1/server-card.schema.json",
  "name": "com.agno.docs/acme-support",
  "title": "Acme Support",
  "version": "1.4.0",
  "description": "AgentOS that describes its MCP server to connecting clients.",
  "remotes": [{"type": "streamable-http", "url": "https://docs.agno.com/mcp"}]
}
```

**The redirect.** A GET on `/mcp` whose `Accept` header lacks `text/event-stream` gets a 302 to the card. MCP clients always send that header on a GET, and the draft transport revision has no GET at all, so only browsers and curl ever see the redirect. Today they see a JSON-RPC 406 error, or a 405 once the stateless transport lands.

**Public by design.** The card path is exempt from the AgentOS auth middleware the same way the OAuth well-known routes are. Under `mcp_auth` the fastmcp challenge guards only the MCP endpoint, so the card is public there too. On a JWT-gated AgentOS the endpoint itself stays behind auth; only the card is public.

**Off switch.** `MCPConfig(server_card=False)` removes the route and the redirect.

**Why.** The docs site tells users to add `https://docs.agno.com/mcp`. Pasting that into a browser today shows an error, and `agno-agi/docs-agent` carries a hand-rolled manifest middleware to cover it. With the card in the framework, docs-agent can delete that middleware and any AgentOS gets discovery in the extension's shape and location.

**Verified.**
- Eight unit tests in `tests/unit/os/test_mcp_server.py`: card contents, proxy headers, the bearer hint on a gated server, the redirect and its pass-through for MCP clients, the off switch, the auth exemption on an authorized AgentOS, and the name derivation.
- Three mutation checks: removing the auth exemption fails the public-card test, removing the redirect middleware fails the redirect test, removing the route fails four card tests.
- 438 tests across the MCP, MCP auth, OAuth and JWT helper suites pass.
- Live: `cookbook/05_agent_os/14_mcp/server_identity.py` served with fastmcp 4.0.2. A browser-style GET on `/mcp` answered 302; the card came back with the extension's media type, CORS and cache headers; forwarded headers produced the public URL; a GET with `Accept: text/event-stream` was left to fastmcp. Recorded in the folder's TEST_LOG.

**Docs.** The MCPConfig option table on the docs MCP page has the `server_card` row (docs repo, separate change).

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

No open PR covers discovery. #9927 covers the stateless transport and #9930 the server identity this card reads. Written with Claude Code, reviewed and directed by the author.

---

## Additional Notes

The extension is experimental and its `v1` schema is marked pre-release. The card builder is one function, so a shape change is a small follow-up. The domain-level `/.well-known/ai-catalog.json` that points at cards belongs at a domain root and is not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9B9nmaJej5H6axSDqgq5j
