### PR TITLE
[fix] Drop sampling params Anthropic rejects when thinking is on or on Claude Sonnet 5+

### DIFF
--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -579,8 +579,8 @@ class Claude(Model):
         if self.request_params:
             _request_params.update(self.request_params)
 
-        drop_unsupported_sampling_params(_request_params, self.id)
-        return route_sampling_params_to_extra_body(_request_params)
+        route_sampling_params_to_extra_body(_request_params)
+        return drop_unsupported_sampling_params(_request_params, self.id)
 
     @staticmethod
     def _extract_container_id_from_messages(messages: List["Message"]) -> Optional[str]:

--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -19,6 +19,7 @@ from agno.utils.models.claude import (
     MCPServerConfiguration,
     _validate_cache_ttl_order,
     build_system_blocks,
+    drop_unsupported_sampling_params,
     format_messages,
     format_tools_for_model,
     resolve_http_client,
@@ -578,6 +579,7 @@ class Claude(Model):
         if self.request_params:
             _request_params.update(self.request_params)
 
+        drop_unsupported_sampling_params(_request_params, self.id)
         return route_sampling_params_to_extra_body(_request_params)
 
     @staticmethod

--- a/libs/agno/agno/models/aws/claude.py
+++ b/libs/agno/agno/models/aws/claude.py
@@ -6,7 +6,12 @@ from pydantic import BaseModel
 
 from agno.models.anthropic import Claude as AnthropicClaude
 from agno.utils.log import log_debug, log_warning
-from agno.utils.models.claude import format_tools_for_model, resolve_http_client, route_sampling_params_to_extra_body
+from agno.utils.models.claude import (
+    drop_unsupported_sampling_params,
+    format_tools_for_model,
+    resolve_http_client,
+    route_sampling_params_to_extra_body,
+)
 
 try:
     from anthropic import AnthropicBedrock, AsyncAnthropicBedrock
@@ -214,6 +219,7 @@ class Claude(AnthropicClaude):
         if self.request_params:
             _request_params.update(self.request_params)
 
+        drop_unsupported_sampling_params(_request_params, self.id)
         route_sampling_params_to_extra_body(_request_params)
 
         if _request_params:

--- a/libs/agno/agno/models/aws/claude.py
+++ b/libs/agno/agno/models/aws/claude.py
@@ -219,8 +219,8 @@ class Claude(AnthropicClaude):
         if self.request_params:
             _request_params.update(self.request_params)
 
-        drop_unsupported_sampling_params(_request_params, self.id)
         route_sampling_params_to_extra_body(_request_params)
+        drop_unsupported_sampling_params(_request_params, self.id)
 
         if _request_params:
             log_debug(f"Calling {self.provider} with request parameters: {_request_params}", log_level=2)

--- a/libs/agno/agno/models/azure/claude.py
+++ b/libs/agno/agno/models/azure/claude.py
@@ -12,7 +12,12 @@ from agno.models.anthropic import Claude as AnthropicClaude
 from agno.models.message import Message
 from agno.utils.http import get_default_async_client, get_default_sync_client
 from agno.utils.log import log_debug, log_warning
-from agno.utils.models.claude import format_tools_for_model, resolve_http_client, route_sampling_params_to_extra_body
+from agno.utils.models.claude import (
+    drop_unsupported_sampling_params,
+    format_tools_for_model,
+    resolve_http_client,
+    route_sampling_params_to_extra_body,
+)
 
 try:
     from anthropic import AnthropicFoundry, AsyncAnthropicFoundry
@@ -142,6 +147,7 @@ class Claude(AnthropicClaude):
         if self.request_params:
             _request_params.update(self.request_params)
 
+        drop_unsupported_sampling_params(_request_params, self.id)
         route_sampling_params_to_extra_body(_request_params)
 
         if _request_params:

--- a/libs/agno/agno/models/azure/claude.py
+++ b/libs/agno/agno/models/azure/claude.py
@@ -147,8 +147,8 @@ class Claude(AnthropicClaude):
         if self.request_params:
             _request_params.update(self.request_params)
 
-        drop_unsupported_sampling_params(_request_params, self.id)
         route_sampling_params_to_extra_body(_request_params)
+        drop_unsupported_sampling_params(_request_params, self.id)
 
         if _request_params:
             log_debug(f"Calling {self.provider} with request parameters: {_request_params}", log_level=2)

--- a/libs/agno/agno/models/vertexai/claude.py
+++ b/libs/agno/agno/models/vertexai/claude.py
@@ -142,8 +142,8 @@ class Claude(AnthropicClaude):
         if self.request_params:
             _request_params.update(self.request_params)
 
-        drop_unsupported_sampling_params(_request_params, self.id)
         route_sampling_params_to_extra_body(_request_params)
+        drop_unsupported_sampling_params(_request_params, self.id)
 
         if _request_params:
             log_debug(f"Calling {self.provider} with request parameters: {_request_params}", log_level=2)

--- a/libs/agno/agno/models/vertexai/claude.py
+++ b/libs/agno/agno/models/vertexai/claude.py
@@ -6,7 +6,12 @@ from pydantic import BaseModel
 
 from agno.models.anthropic import Claude as AnthropicClaude
 from agno.utils.log import log_debug
-from agno.utils.models.claude import format_tools_for_model, resolve_http_client, route_sampling_params_to_extra_body
+from agno.utils.models.claude import (
+    drop_unsupported_sampling_params,
+    format_tools_for_model,
+    resolve_http_client,
+    route_sampling_params_to_extra_body,
+)
 
 try:
     from anthropic import AnthropicVertex, AsyncAnthropicVertex
@@ -137,6 +142,7 @@ class Claude(AnthropicClaude):
         if self.request_params:
             _request_params.update(self.request_params)
 
+        drop_unsupported_sampling_params(_request_params, self.id)
         route_sampling_params_to_extra_body(_request_params)
 
         if _request_params:

--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -99,7 +99,8 @@ def drop_unsupported_sampling_params(request_params: Dict[str, Any], model_id: s
     """Remove the sampling parameters Anthropic would reject for this request.
 
     Runs on the ``extra_body`` that ``route_sampling_params_to_extra_body`` built, so it
-    sees the model's own fields and an explicit ``extra_body`` alike. ``temperature`` and
+    sees the model's own fields and an explicit ``extra_body`` alike, ``thinking`` included
+    (the SDK merges ``extra_body`` over the request, so it wins there). ``temperature`` and
     ``top_p`` are never accepted together. With thinking on (``enabled`` or ``adaptive``)
     ``temperature`` may only be 1, ``top_p`` must be at least 0.95 and ``top_k`` must be
     unset; models without sampling support apply that on every request and reject any
@@ -109,7 +110,7 @@ def drop_unsupported_sampling_params(request_params: Dict[str, Any], model_id: s
     """
     sampling = request_params.get("extra_body") or {}
     temperature, top_p, top_k = sampling.get("temperature"), sampling.get("top_p"), sampling.get("top_k")
-    thinking = request_params.get("thinking") or {}
+    thinking = sampling.get("thinking", request_params.get("thinking")) or {}
     thinking_on = bool(thinking) and thinking.get("type") != "disabled"
     locked = not supports_sampling_params(model_id)
 

--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -128,7 +128,7 @@ def drop_unsupported_sampling_params(request_params: Dict[str, Any], model_id: s
 
     Mutates and returns the dict it is given, like ``route_sampling_params_to_extra_body``.
     """
-    thinking = request_params.get("thinking")
+    thinking = request_params.get("thinking") or {}
     thinking_on = bool(thinking) and thinking.get("type") != "disabled"
     locked = not supports_sampling_params(model_id)
     if not thinking_on and not locked:

--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -39,8 +39,40 @@ _PREFILL_SUPPORTED_ALIASES = {
 }
 
 
-def supports_prefill(model_id: str) -> bool:
-    """Return True if the given model ID supports assistant message prefill.
+# Models that honour the temperature / top_p / top_k sampling parameters. This is a
+# closed set: Claude Opus 4.7, Claude Sonnet 5 and all future models reject a
+# non-default value on every request ("`temperature` is deprecated for this model"),
+# whether or not thinking is on.
+_SAMPLING_SUPPORTED_PREFIXES = (
+    "claude-3-",
+    "claude-sonnet-4-0",
+    "claude-sonnet-4-1",
+    "claude-sonnet-4-2",
+    "claude-sonnet-4-5",
+    "claude-sonnet-4-6",
+    "claude-opus-4-0",
+    "claude-opus-4-1",
+    "claude-opus-4-2",
+    "claude-opus-4-5",
+    "claude-opus-4-6",
+    "claude-haiku-4-0",
+    "claude-haiku-4-1",
+    "claude-haiku-4-2",
+    "claude-haiku-4-5",
+    "claude-haiku-4-6",
+)
+
+# Aliases like "claude-sonnet-4" point to the latest version in that family
+# (currently 4-0). Exact matches only, for the same reason as the prefill aliases.
+_SAMPLING_SUPPORTED_ALIASES = {
+    "claude-sonnet-4",
+    "claude-opus-4",
+    "claude-haiku-4",
+}
+
+
+def _core_model_id(model_id: str) -> str:
+    """Strip provider-specific decoration from a Claude model ID.
 
     Handles provider-specific ID formats:
       - Anthropic direct:  "claude-sonnet-4-5-20250929"
@@ -57,11 +89,67 @@ def supports_prefill(model_id: str) -> bool:
     # Strip Bedrock version suffix (e.g. "claude-sonnet-4-5-20250929-v1:0")
     if ":0" in core_id:
         core_id = core_id.split("-v")[0] if "-v" in core_id else core_id.split(":")[0]
+    return core_id
+
+
+def supports_prefill(model_id: str) -> bool:
+    """Return True if the given model ID supports assistant message prefill."""
+    core_id = _core_model_id(model_id)
 
     if not core_id.startswith("claude"):
         return True  # Non-Claude models are unaffected — don't inject trailing messages
 
     return core_id in _PREFILL_SUPPORTED_ALIASES or core_id.startswith(_PREFILL_SUPPORTED_PREFIXES)
+
+
+def supports_sampling_params(model_id: str) -> bool:
+    """Return True if the given model ID accepts temperature, top_p and top_k at all.
+
+    Claude Opus 4.7, Claude Sonnet 5 and later models reject any non-default sampling
+    value on every request, whether or not thinking is on.
+    """
+    core_id = _core_model_id(model_id)
+
+    if not core_id.startswith("claude"):
+        return True  # Non-Claude models are unaffected
+
+    return core_id in _SAMPLING_SUPPORTED_ALIASES or core_id.startswith(_SAMPLING_SUPPORTED_PREFIXES)
+
+
+def drop_unsupported_sampling_params(request_params: Dict[str, Any], model_id: str) -> Dict[str, Any]:
+    """Remove the sampling parameters Anthropic would reject for this request.
+
+    With thinking on (``enabled`` or ``adaptive``) ``temperature`` may only be 1, ``top_p``
+    must be at least 0.95 and ``top_k`` must be unset. Models without sampling support
+    (see ``supports_sampling_params``) apply that on every request and reject any ``top_p``.
+    A value that would have been rejected is dropped with a warning instead, so a
+    ``temperature=0`` carried over from an older configuration degrades to the API default
+    rather than failing every request with a 400.
+
+    Mutates and returns the dict it is given, like ``route_sampling_params_to_extra_body``.
+    """
+    thinking = request_params.get("thinking")
+    thinking_on = bool(thinking) and thinking.get("type") != "disabled"
+    locked = not supports_sampling_params(model_id)
+    if not thinking_on and not locked:
+        return request_params
+
+    temperature = request_params.get("temperature")
+    top_p = request_params.get("top_p")
+    rejected = {
+        "temperature": temperature is not None and temperature != 1,
+        "top_p": top_p is not None and (locked or top_p < 0.95),
+        "top_k": request_params.get("top_k") is not None,
+    }
+    dropped = [f"{name}={request_params.pop(name)}" for name, reject in rejected.items() if reject]
+    if dropped:
+        reason = (
+            f"model '{model_id}' does not accept them"
+            if locked
+            else "Anthropic does not accept them while thinking is on"
+        )
+        log_warning(f"Dropping {', '.join(dropped)} from the request: {reason}. Unset them to silence this warning.")
+    return request_params
 
 
 @dataclass

--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -39,36 +39,14 @@ _PREFILL_SUPPORTED_ALIASES = {
 }
 
 
-# Models that honour the temperature / top_p / top_k sampling parameters. This is a
-# closed set: Claude Opus 4.7, Claude Sonnet 5 and all future models reject a
-# non-default value on every request ("`temperature` is deprecated for this model"),
-# whether or not thinking is on.
-_SAMPLING_SUPPORTED_PREFIXES = (
-    "claude-3-",
-    "claude-sonnet-4-0",
-    "claude-sonnet-4-1",
-    "claude-sonnet-4-2",
-    "claude-sonnet-4-5",
+# Models that honour the temperature / top_p / top_k sampling parameters: the prefill set
+# plus the 4.6 generation. This is a closed set: Claude Opus 4.7, Claude Sonnet 5 and all
+# future models reject a non-default value on every request.
+_SAMPLING_SUPPORTED_PREFIXES = _PREFILL_SUPPORTED_PREFIXES + (
     "claude-sonnet-4-6",
-    "claude-opus-4-0",
-    "claude-opus-4-1",
-    "claude-opus-4-2",
-    "claude-opus-4-5",
     "claude-opus-4-6",
-    "claude-haiku-4-0",
-    "claude-haiku-4-1",
-    "claude-haiku-4-2",
-    "claude-haiku-4-5",
     "claude-haiku-4-6",
 )
-
-# Aliases like "claude-sonnet-4" point to the latest version in that family
-# (currently 4-0). Exact matches only, for the same reason as the prefill aliases.
-_SAMPLING_SUPPORTED_ALIASES = {
-    "claude-sonnet-4",
-    "claude-opus-4",
-    "claude-haiku-4",
-}
 
 
 def _core_model_id(model_id: str) -> str:
@@ -113,42 +91,53 @@ def supports_sampling_params(model_id: str) -> bool:
     if not core_id.startswith("claude"):
         return True  # Non-Claude models are unaffected
 
-    return core_id in _SAMPLING_SUPPORTED_ALIASES or core_id.startswith(_SAMPLING_SUPPORTED_PREFIXES)
+    # The family aliases resolve to 4-0, which supports sampling.
+    return core_id in _PREFILL_SUPPORTED_ALIASES or core_id.startswith(_SAMPLING_SUPPORTED_PREFIXES)
 
 
 def drop_unsupported_sampling_params(request_params: Dict[str, Any], model_id: str) -> Dict[str, Any]:
     """Remove the sampling parameters Anthropic would reject for this request.
 
-    With thinking on (``enabled`` or ``adaptive``) ``temperature`` may only be 1, ``top_p``
-    must be at least 0.95 and ``top_k`` must be unset. Models without sampling support
-    (see ``supports_sampling_params``) apply that on every request and reject any ``top_p``.
-    A value that would have been rejected is dropped with a warning instead, so a
+    Runs on the ``extra_body`` that ``route_sampling_params_to_extra_body`` built, so it
+    sees the model's own fields and an explicit ``extra_body`` alike. ``temperature`` and
+    ``top_p`` are never accepted together. With thinking on (``enabled`` or ``adaptive``)
+    ``temperature`` may only be 1, ``top_p`` must be at least 0.95 and ``top_k`` must be
+    unset; models without sampling support apply that on every request and reject any
+    ``top_p``. A value that would have been rejected is dropped with a warning, so a
     ``temperature=0`` carried over from an older configuration degrades to the API default
-    rather than failing every request with a 400.
-
-    Mutates and returns the dict it is given, like ``route_sampling_params_to_extra_body``.
+    instead of failing every request with a 400.
     """
+    sampling = request_params.get("extra_body") or {}
+    temperature, top_p, top_k = sampling.get("temperature"), sampling.get("top_p"), sampling.get("top_k")
     thinking = request_params.get("thinking") or {}
     thinking_on = bool(thinking) and thinking.get("type") != "disabled"
     locked = not supports_sampling_params(model_id)
-    if not thinking_on and not locked:
+
+    why: Dict[str, str] = {}
+    if thinking_on or locked:
+        where = f"on {model_id}" if locked else "with thinking on"
+        if temperature is not None and temperature != 1:
+            why["temperature"] = f"must be 1 {where}"
+        if top_p is not None and (locked or top_p < 0.95):
+            why["top_p"] = f"must be unset {where}" if locked else f"must be at least 0.95 {where}"
+        if top_k is not None:
+            why["top_k"] = f"must be unset {where}"
+    if temperature is not None and top_p is not None and not why.keys() & {"temperature", "top_p"}:
+        # With thinking on temperature can only be the default, so top_p is the one carrying intent.
+        loser, winner = ("temperature", "top_p") if thinking_on else ("top_p", "temperature")
+        why[loser] = f"not accepted together with {winner}"
+    if not why:
         return request_params
 
-    temperature = request_params.get("temperature")
-    top_p = request_params.get("top_p")
-    rejected = {
-        "temperature": temperature is not None and temperature != 1,
-        "top_p": top_p is not None and (locked or top_p < 0.95),
-        "top_k": request_params.get("top_k") is not None,
-    }
-    dropped = [f"{name}={request_params.pop(name)}" for name, reject in rejected.items() if reject]
-    if dropped:
-        reason = (
-            f"model '{model_id}' does not accept them"
-            if locked
-            else "Anthropic does not accept them while thinking is on"
-        )
-        log_warning(f"Dropping {', '.join(dropped)} from the request: {reason}. Unset them to silence this warning.")
+    kept = {name: value for name, value in sampling.items() if name not in why}
+    if kept:
+        request_params["extra_body"] = kept
+    else:
+        del request_params["extra_body"]
+    dropped = ", ".join(f"{name}={sampling[name]} ({reason})" for name, reason in why.items())
+    log_warning(
+        f"Dropping {dropped} from the request, Anthropic rejects it with a 400. Unset the value to silence this warning."
+    )
     return request_params
 
 

--- a/libs/agno/tests/unit/models/test_claude_request_params.py
+++ b/libs/agno/tests/unit/models/test_claude_request_params.py
@@ -371,3 +371,69 @@ def test_vertexai_temperature_none_excluded():
     params = model.get_request_params()
     assert "temperature" not in params
     assert "extra_body" not in params
+
+
+# =============================================================================
+# thinking / models without sampling support: a temperature, top_p or top_k the API
+# would reject with a 400 is dropped from the request instead of failing it (#9931).
+# =============================================================================
+
+THINKING = {"type": "enabled", "budget_tokens": 1024}
+
+
+def test_anthropic_thinking_drops_temperature():
+    """temperature=0 with thinking on is rejected by Anthropic, so it must not be sent."""
+    model = AnthropicClaude(id="claude-haiku-4-5-20251001", temperature=0.0, thinking=THINKING)
+    params = model.get_request_params()
+    assert params["thinking"] == THINKING
+    assert "extra_body" not in params
+
+
+def test_anthropic_thinking_keeps_allowed_sampling_values():
+    """temperature=1 and top_p>=0.95 are accepted alongside thinking and stay in extra_body."""
+    model = AnthropicClaude(id="claude-haiku-4-5-20251001", temperature=1.0, top_p=0.95, thinking=THINKING)
+    params = model.get_request_params()
+    assert params["extra_body"] == {"temperature": 1.0, "top_p": 0.95}
+
+
+def test_anthropic_thinking_from_request_params_is_seen():
+    """thinking passed through request_params counts too: the filter runs on the merged dict."""
+    model = AnthropicClaude(id="claude-haiku-4-5-20251001", temperature=0.0, request_params={"thinking": THINKING})
+    params = model.get_request_params()
+    assert "extra_body" not in params
+
+
+def test_anthropic_model_without_sampling_support_drops_them_without_thinking():
+    """Claude Sonnet 5 rejects a non-default temperature, top_p or top_k on every request."""
+    model = AnthropicClaude(id="claude-sonnet-5", temperature=0.0, top_p=1.0, top_k=1)
+    params = model.get_request_params()
+    assert "extra_body" not in params
+
+
+def test_aws_thinking_drops_temperature():
+    pytest.importorskip("boto3")
+    from agno.models.aws.claude import Claude as AwsClaude
+
+    model = AwsClaude(id="us.anthropic.claude-sonnet-4-5-20250929-v1:0", temperature=0.0, thinking=THINKING)
+    params = model.get_request_params()
+    assert params["thinking"] == THINKING
+    assert "extra_body" not in params
+
+
+def test_vertexai_thinking_drops_temperature():
+    model = VertexAIClaude(id="claude-sonnet-4-5@20250929", temperature=0.0, thinking=THINKING)
+    params = model.get_request_params()
+    assert params["thinking"] == THINKING
+    assert "extra_body" not in params
+
+
+def test_azure_thinking_drops_temperature():
+    from agno.models.azure import AzureFoundryClaude
+
+    # 0.5 rather than 0: AzureFoundryClaude still gates sampling params on truthiness.
+    model = AzureFoundryClaude(
+        id="claude-sonnet-4-5", api_key="test-key", resource="my-resource", temperature=0.5, thinking=THINKING
+    )
+    params = model.get_request_params()
+    assert params["thinking"] == THINKING
+    assert "extra_body" not in params

--- a/libs/agno/tests/unit/models/test_claude_request_params.py
+++ b/libs/agno/tests/unit/models/test_claude_request_params.py
@@ -423,6 +423,17 @@ def test_anthropic_thinking_from_request_params_is_seen():
     assert "extra_body" not in params
 
 
+def test_anthropic_thinking_inside_extra_body_is_seen():
+    """thinking passed raw through extra_body reaches the API too, so it counts for the filter."""
+    supplied = {"extra_body": {"thinking": THINKING, "temperature": 0.0}}
+    model = AnthropicClaude(id="claude-haiku-4-5-20251001", request_params=supplied)
+    params = model.get_request_params()
+    assert params["extra_body"] == {"thinking": THINKING}
+    assert supplied == {"extra_body": {"thinking": THINKING, "temperature": 0.0}}, (
+        "the caller's request_params was mutated"
+    )
+
+
 def test_anthropic_model_without_sampling_support_drops_them_without_thinking():
     """Claude Sonnet 5 rejects a non-default temperature, top_p or top_k on every request."""
     model = AnthropicClaude(id="claude-sonnet-5", temperature=0.0, top_p=1.0, top_k=1)

--- a/libs/agno/tests/unit/models/test_claude_request_params.py
+++ b/libs/agno/tests/unit/models/test_claude_request_params.py
@@ -289,12 +289,16 @@ def test_anthropic_positive_temperature_included():
 
 
 def test_anthropic_all_sampling_params_zero():
-    """All three sampling params at zero must all survive into extra_body."""
-    model = AnthropicClaude(id="claude-haiku-4-5-20251001", temperature=0.0, top_p=0.0, top_k=0)
-    params = model.get_request_params()
-    assert params["extra_body"]["temperature"] == 0.0
-    assert params["extra_body"]["top_p"] == 0.0
-    assert params["extra_body"]["top_k"] == 0
+    """Zero sampling params must survive together into extra_body.
+
+    temperature and top_p are checked in separate pairs: Anthropic rejects those two
+    together on every current model, so that pair never reaches the request.
+    """
+    params = AnthropicClaude(id="claude-haiku-4-5-20251001", temperature=0.0, top_k=0).get_request_params()
+    assert params["extra_body"] == {"temperature": 0.0, "top_k": 0}
+
+    params = AnthropicClaude(id="claude-haiku-4-5-20251001", top_p=0.0, top_k=0).get_request_params()
+    assert params["extra_body"] == {"top_p": 0.0, "top_k": 0}
 
 
 def test_aws_temperature_zero_included():
@@ -389,11 +393,27 @@ def test_anthropic_thinking_drops_temperature():
     assert "extra_body" not in params
 
 
-def test_anthropic_thinking_keeps_allowed_sampling_values():
-    """temperature=1 and top_p>=0.95 are accepted alongside thinking and stay in extra_body."""
-    model = AnthropicClaude(id="claude-haiku-4-5-20251001", temperature=1.0, top_p=0.95, thinking=THINKING)
+def test_anthropic_thinking_keeps_temperature_one():
+    """temperature=1 is the one value accepted alongside thinking, so it stays in extra_body."""
+    model = AnthropicClaude(id="claude-haiku-4-5-20251001", temperature=1.0, thinking=THINKING)
     params = model.get_request_params()
-    assert params["extra_body"] == {"temperature": 1.0, "top_p": 0.95}
+    assert params["extra_body"] == {"temperature": 1.0}
+
+
+def test_anthropic_temperature_and_top_p_are_never_sent_together():
+    """Anthropic rejects the pair on every current model; without thinking, temperature is the one kept."""
+    model = AnthropicClaude(id="claude-haiku-4-5-20251001", temperature=0.5, top_p=0.9)
+    params = model.get_request_params()
+    assert params["extra_body"] == {"temperature": 0.5}
+
+
+def test_anthropic_explicit_extra_body_is_filtered_too():
+    """A sampling value passed straight through request_params["extra_body"] gets the same treatment."""
+    supplied = {"extra_body": {"temperature": 0.0}}
+    model = AnthropicClaude(id="claude-haiku-4-5-20251001", thinking=THINKING, request_params=supplied)
+    params = model.get_request_params()
+    assert "extra_body" not in params
+    assert supplied == {"extra_body": {"temperature": 0.0}}, "the caller's request_params was mutated"
 
 
 def test_anthropic_thinking_from_request_params_is_seen():

--- a/libs/agno/tests/unit/utils/test_claude_sampling_params.py
+++ b/libs/agno/tests/unit/utils/test_claude_sampling_params.py
@@ -1,9 +1,9 @@
-"""Sampling parameters Anthropic rejects with a 400 are dropped before the request is built.
+"""Sampling parameters Anthropic rejects with a 400 are dropped before the request is sent.
 
-With thinking on, ``temperature`` may only be 1, ``top_p`` must be at least 0.95 and
-``top_k`` must be unset. Claude Opus 4.7, Sonnet 5 and later models apply that on every
-request and reject any ``top_p``. The API answers each of these with a 400, so the
-model-side filter decides which values survive.
+``temperature`` and ``top_p`` are never accepted together. With thinking on, ``temperature``
+may only be 1, ``top_p`` must be at least 0.95 and ``top_k`` must be unset. Claude Opus 4.7,
+Sonnet 5 and later models apply that on every request and reject any ``top_p``. The filter
+runs on the ``extra_body`` the sampling parameters travel in.
 """
 
 from unittest.mock import MagicMock
@@ -15,6 +15,13 @@ from agno.utils.models.claude import drop_unsupported_sampling_params, supports_
 ENABLED = {"type": "enabled", "budget_tokens": 1024}
 ADAPTIVE = {"type": "adaptive"}
 DISABLED = {"type": "disabled"}
+
+
+def _request(sampling, thinking=None):
+    params = {"max_tokens": 2048, "extra_body": dict(sampling)}
+    if thinking is not None:
+        params["thinking"] = thinking
+    return params
 
 
 @pytest.mark.parametrize(
@@ -40,59 +47,86 @@ def test_supports_sampling_params(model_id, expected):
     assert supports_sampling_params(model_id) is expected
 
 
-def test_without_thinking_everything_is_kept():
-    params = {"max_tokens": 100, "temperature": 0.0, "top_p": 0.5, "top_k": 3}
+def test_without_thinking_single_values_are_kept():
+    params = _request({"temperature": 0.0, "top_k": 3})
 
     result = drop_unsupported_sampling_params(params, "claude-haiku-4-5-20251001")
 
     assert result is params
-    assert params == {"max_tokens": 100, "temperature": 0.0, "top_p": 0.5, "top_k": 3}
+    assert params["extra_body"] == {"temperature": 0.0, "top_k": 3}
 
 
-def test_thinking_disabled_counts_as_off():
-    params = {"thinking": DISABLED, "temperature": 0.0, "top_k": 3}
+def test_no_sampling_params_is_a_no_op():
+    params = {"max_tokens": 2048, "thinking": ENABLED}
 
     drop_unsupported_sampling_params(params, "claude-haiku-4-5-20251001")
 
-    assert params == {"thinking": DISABLED, "temperature": 0.0, "top_k": 3}
+    assert params == {"max_tokens": 2048, "thinking": ENABLED}
+
+
+def test_thinking_disabled_counts_as_off():
+    params = _request({"temperature": 0.0, "top_k": 3}, thinking=DISABLED)
+
+    drop_unsupported_sampling_params(params, "claude-haiku-4-5-20251001")
+
+    assert params["extra_body"] == {"temperature": 0.0, "top_k": 3}
 
 
 @pytest.mark.parametrize("thinking", [ENABLED, ADAPTIVE])
 def test_thinking_drops_temperature_top_k_and_low_top_p(thinking):
-    params = {"thinking": thinking, "max_tokens": 2048, "temperature": 0.0, "top_p": 0.9, "top_k": 3}
+    params = _request({"temperature": 0.0, "top_p": 0.9, "top_k": 3}, thinking=thinking)
 
     drop_unsupported_sampling_params(params, "claude-sonnet-4-6")
 
-    assert params == {"thinking": thinking, "max_tokens": 2048}
+    assert params == {"max_tokens": 2048, "thinking": thinking}
 
 
-def test_thinking_keeps_temperature_one_and_top_p_from_0_95():
-    params = {"thinking": ENABLED, "temperature": 1.0, "top_p": 0.95}
+@pytest.mark.parametrize("sampling", [{"temperature": 1.0}, {"top_p": 0.95}])
+def test_thinking_keeps_an_allowed_value_on_its_own(sampling):
+    params = _request(sampling, thinking=ENABLED)
 
     drop_unsupported_sampling_params(params, "claude-haiku-4-5-20251001")
 
-    assert params == {"thinking": ENABLED, "temperature": 1.0, "top_p": 0.95}
+    assert params["extra_body"] == sampling
+
+
+def test_temperature_and_top_p_are_never_sent_together():
+    without_thinking = _request({"temperature": 0.5, "top_p": 0.9})
+    drop_unsupported_sampling_params(without_thinking, "claude-haiku-4-5-20251001")
+    assert without_thinking["extra_body"] == {"temperature": 0.5}
+
+    # With thinking on, temperature can only be the default, so top_p is the one kept.
+    with_thinking = _request({"temperature": 1.0, "top_p": 0.95}, thinking=ENABLED)
+    drop_unsupported_sampling_params(with_thinking, "claude-haiku-4-5-20251001")
+    assert with_thinking["extra_body"] == {"top_p": 0.95}
 
 
 def test_model_without_sampling_support_drops_everything_but_temperature_one():
-    params = {"temperature": 0.0, "top_p": 1.0, "top_k": 1}
-
+    params = _request({"temperature": 0.0, "top_p": 1.0, "top_k": 1})
     drop_unsupported_sampling_params(params, "claude-sonnet-5")
+    assert "extra_body" not in params
 
-    assert params == {}
-
-    kept = {"temperature": 1, "thinking": DISABLED}
+    kept = _request({"temperature": 1}, thinking=DISABLED)
     drop_unsupported_sampling_params(kept, "claude-sonnet-5")
-    assert kept == {"temperature": 1, "thinking": DISABLED}
+    assert kept["extra_body"] == {"temperature": 1}
 
 
-def test_dropped_values_are_reported_once(monkeypatch):
+def test_other_extra_body_keys_survive():
+    params = _request({"temperature": 0.0, "service_tier": "auto"}, thinking=ENABLED)
+
+    drop_unsupported_sampling_params(params, "claude-sonnet-4-6")
+
+    assert params["extra_body"] == {"service_tier": "auto"}
+
+
+def test_dropped_values_are_reported_with_their_reason(monkeypatch):
     warn = MagicMock()
     monkeypatch.setattr("agno.utils.models.claude.log_warning", warn)
 
-    drop_unsupported_sampling_params({"thinking": ENABLED, "temperature": 0.0, "top_k": 3}, "claude-sonnet-4-6")
-    drop_unsupported_sampling_params({"thinking": ENABLED, "temperature": 1.0}, "claude-sonnet-4-6")
+    drop_unsupported_sampling_params(_request({"temperature": 0.0, "top_k": 3}, thinking=ENABLED), "claude-sonnet-4-6")
+    drop_unsupported_sampling_params(_request({"temperature": 1.0}, thinking=ENABLED), "claude-sonnet-4-6")
 
     warn.assert_called_once()
     message = warn.call_args.args[0]
-    assert "temperature=0.0" in message and "top_k=3" in message
+    assert "temperature=0.0 (must be 1 with thinking on)" in message
+    assert "top_k=3 (must be unset with thinking on)" in message

--- a/libs/agno/tests/unit/utils/test_claude_sampling_params.py
+++ b/libs/agno/tests/unit/utils/test_claude_sampling_params.py
@@ -1,0 +1,98 @@
+"""Sampling parameters Anthropic rejects with a 400 are dropped before the request is built.
+
+With thinking on, ``temperature`` may only be 1, ``top_p`` must be at least 0.95 and
+``top_k`` must be unset. Claude Opus 4.7, Sonnet 5 and later models apply that on every
+request and reject any ``top_p``. The API answers each of these with a 400, so the
+model-side filter decides which values survive.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from agno.utils.models.claude import drop_unsupported_sampling_params, supports_sampling_params
+
+ENABLED = {"type": "enabled", "budget_tokens": 1024}
+ADAPTIVE = {"type": "adaptive"}
+DISABLED = {"type": "disabled"}
+
+
+@pytest.mark.parametrize(
+    "model_id, expected",
+    [
+        ("claude-haiku-4-5-20251001", True),
+        ("claude-sonnet-4-6", True),
+        ("claude-opus-4-6", True),
+        ("claude-3-7-sonnet-20250219", True),
+        ("claude-sonnet-4", True),  # alias for 4-0
+        ("us.anthropic.claude-sonnet-4-6-v1:0", True),  # Bedrock
+        ("claude-sonnet-4-5@20250929", True),  # Vertex AI
+        ("anthropic/claude-sonnet-4-6", True),  # LiteLLM
+        ("gpt-4o", True),  # not a Claude model
+        ("claude-opus-4-7", False),
+        ("claude-sonnet-5", False),
+        ("claude-opus-5", False),
+        ("us.anthropic.claude-sonnet-5-v1:0", False),
+        ("claude-sonnet-5@20260401", False),
+    ],
+)
+def test_supports_sampling_params(model_id, expected):
+    assert supports_sampling_params(model_id) is expected
+
+
+def test_without_thinking_everything_is_kept():
+    params = {"max_tokens": 100, "temperature": 0.0, "top_p": 0.5, "top_k": 3}
+
+    result = drop_unsupported_sampling_params(params, "claude-haiku-4-5-20251001")
+
+    assert result is params
+    assert params == {"max_tokens": 100, "temperature": 0.0, "top_p": 0.5, "top_k": 3}
+
+
+def test_thinking_disabled_counts_as_off():
+    params = {"thinking": DISABLED, "temperature": 0.0, "top_k": 3}
+
+    drop_unsupported_sampling_params(params, "claude-haiku-4-5-20251001")
+
+    assert params == {"thinking": DISABLED, "temperature": 0.0, "top_k": 3}
+
+
+@pytest.mark.parametrize("thinking", [ENABLED, ADAPTIVE])
+def test_thinking_drops_temperature_top_k_and_low_top_p(thinking):
+    params = {"thinking": thinking, "max_tokens": 2048, "temperature": 0.0, "top_p": 0.9, "top_k": 3}
+
+    drop_unsupported_sampling_params(params, "claude-sonnet-4-6")
+
+    assert params == {"thinking": thinking, "max_tokens": 2048}
+
+
+def test_thinking_keeps_temperature_one_and_top_p_from_0_95():
+    params = {"thinking": ENABLED, "temperature": 1.0, "top_p": 0.95}
+
+    drop_unsupported_sampling_params(params, "claude-haiku-4-5-20251001")
+
+    assert params == {"thinking": ENABLED, "temperature": 1.0, "top_p": 0.95}
+
+
+def test_model_without_sampling_support_drops_everything_but_temperature_one():
+    params = {"temperature": 0.0, "top_p": 1.0, "top_k": 1}
+
+    drop_unsupported_sampling_params(params, "claude-sonnet-5")
+
+    assert params == {}
+
+    kept = {"temperature": 1, "thinking": DISABLED}
+    drop_unsupported_sampling_params(kept, "claude-sonnet-5")
+    assert kept == {"temperature": 1, "thinking": DISABLED}
+
+
+def test_dropped_values_are_reported_once(monkeypatch):
+    warn = MagicMock()
+    monkeypatch.setattr("agno.utils.models.claude.log_warning", warn)
+
+    drop_unsupported_sampling_params({"thinking": ENABLED, "temperature": 0.0, "top_k": 3}, "claude-sonnet-4-6")
+    drop_unsupported_sampling_params({"thinking": ENABLED, "temperature": 1.0}, "claude-sonnet-4-6")
+
+    warn.assert_called_once()
+    message = warn.call_args.args[0]
+    assert "temperature=0.0" in message and "top_k=3" in message

--- a/libs/agno/tests/unit/utils/test_claude_sampling_params.py
+++ b/libs/agno/tests/unit/utils/test_claude_sampling_params.py
@@ -111,6 +111,23 @@ def test_model_without_sampling_support_drops_everything_but_temperature_one():
     assert kept["extra_body"] == {"temperature": 1}
 
 
+def test_thinking_inside_extra_body_is_honoured():
+    params = _request({"thinking": ENABLED, "temperature": 0.0})
+
+    drop_unsupported_sampling_params(params, "claude-haiku-4-5-20251001")
+
+    assert params["extra_body"] == {"thinking": ENABLED}
+
+
+def test_thinking_inside_extra_body_outranks_the_field():
+    # The SDK merges extra_body over the request, so a disabled there is what the API sees.
+    params = _request({"thinking": DISABLED, "temperature": 0.0}, thinking=ENABLED)
+
+    drop_unsupported_sampling_params(params, "claude-haiku-4-5-20251001")
+
+    assert params["extra_body"] == {"thinking": DISABLED, "temperature": 0.0}
+
+
 def test_other_extra_body_keys_survive():
     params = _request({"temperature": 0.0, "service_tier": "auto"}, thinking=ENABLED)
 


### PR DESCRIPTION
Fixes #9931

## Summary

`Claude(temperature=0, thinking={...})` fails every request with a 400: Anthropic only accepts `temperature: 1` while thinking is on, `top_k` has to be unset and `top_p` has to be at least 0.95. Since 2.8.5 an explicit 0 is sent (correct on its own), so a config that carried `temperature: 0` for a while and then turned thinking on, or moved to a model that thinks by default, breaks on every call with an error that reads like a provider outage.

Checked live with one small call per case before writing this:

- Haiku 4.5 with thinking enabled, Sonnet 4.6 adaptive: `temperature 0` -> 400, `temperature 1` -> ok, `top_p 0.95` -> ok, `top_p 0.9` -> 400, `top_k 5` -> 400, `thinking: disabled` + `temperature 0` -> ok
- Sonnet 5 (thinks by default): `temperature 0` -> 400 "deprecated for this model" on every request, `temperature 1` -> ok, `top_p` (even 1) -> 400, `top_k` -> 400
- `temperature` + `top_p` together: 400 "cannot both be specified for this model" on Haiku 4.5, Sonnet 4.5, Sonnet 4.6 and Opus 4.6, thinking on or off (the 3.x models are retired, so this is every model still served)

That matches the docs (platform.claude.com/docs/en/build-with-claude/thinking, "Limits and feature compatibility"): Opus 4.7, 4.8, 5, Sonnet 5 and the Fable/Mythos line reject a non-default `temperature`, `top_p` or `top_k` regardless of thinking; older models only while thinking is on.

The fix is one helper in `agno/utils/models/claude.py`, `drop_unsupported_sampling_params(request_params, model_id)`, called by all four Claude providers (Anthropic, Bedrock, Vertex, Azure Foundry) right after `route_sampling_params_to_extra_body`, on the merged `extra_body`, so model fields, `request_params` and a raw `extra_body` all get the same treatment, `thinking` included (`extra_body` wins there, as in the SDK merge). With thinking on it drops `temperature` unless it is 1, `top_p` below 0.95 and `top_k`. On models without sampling support (`supports_sampling_params`, the prefill set plus the 4.6 generation; the id normalisation both share moved into `_core_model_id`) it drops all three except `temperature: 1`. When `temperature` and `top_p` both survive that, one goes: `temperature` with thinking on (it can only be the default there), `top_p` otherwise, which is what the litellm cookbook already advises. Every drop is one `log_warning` naming each value and its reason, same shape as the structured-outputs warning, and the request goes out with the API default instead of failing. `thinking: {type: "disabled"}` counts as off, other `extra_body` keys survive, the caller's `request_params` is not mutated.

One existing test changed: `test_anthropic_all_sampling_params_zero` sent `temperature 0` and `top_p 0` together, which the API rejects, so it now checks the zeros in two accepted pairs. Azure Foundry still has its own truthiness gate on 0; #9247 covers that, this PR only adds the call there.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Tests: `tests/unit/utils/test_claude_sampling_params.py` covers the helper and the id formats (Bedrock, Vertex, LiteLLM, aliases), `tests/unit/models/test_claude_request_params.py` gets one case per provider plus the `request_params` path and Sonnet 5. The live repro from the issue, re-run against this branch, completes on all four cases (Haiku 4.5 enabled + `temperature 0` + `top_k`, Sonnet 4.6 adaptive + `temperature 0`, Sonnet 5 + `temperature 0` + `top_p 1`, Haiku 4.5 without thinking keeps `temperature 0`).

The warning fires per request, like the structured-outputs one. Happy to gate it to once per model if you prefer.
