### PR TITLE
[fix] agno 3.x: never place a new run below the session's existing run_index

### DIFF
--- a/libs/agno/agno/db/mysql/async_mysql.py
+++ b/libs/agno/agno/db/mysql/async_mysql.py
@@ -660,33 +660,24 @@ class AsyncMySQLDb(AsyncBaseDb):
             async with self.async_session_factory() as sess:
                 try:
                     async with sess.begin():
-                        # Backfill a monotonic run_index when the run arrives without one
-                        # (e.g. a background/continue save that couldn't resolve its position).
-                        # A NULL index has no position and breaks ORDER BY run_index. ON DUPLICATE KEY
-                        # preserves the existing index, so this only sets it on a genuine insert.
-                        if row.get("run_index") is None:
-                            # Serialize same-session backfills: two concurrent
-                            # max-reads can both see the same MAX and land
-                            # duplicate indexes. GET_LOCK is connection-scoped
-                            # and survives COMMIT, so it is released in the
-                            # finally below - AFTER the row is durable.
-                            backfill_lock = run_index_lock_name(session_id)
-                            acquired = (
-                                await sess.execute(text("SELECT GET_LOCK(:name, 5)"), {"name": backfill_lock})
-                            ).scalar()
-                            if not acquired:
-                                log_warning(
-                                    f"run_index backfill lock timed out for session {session_id}; "
-                                    "proceeding unserialized"
-                                )
-                            current_max = (
-                                await sess.execute(
-                                    select(func.max(runs_table.c.run_index)).where(
-                                        runs_table.c.session_id == session_id
-                                    )
-                                )
-                            ).scalar()
-                            row["run_index"] = (current_max + 1) if current_max is not None else 0
+                        # A new run always lands after the session's existing rows.
+                        # The lock serializes same-session inserts around MAX+1.
+                        backfill_lock = run_index_lock_name(session_id)
+                        acquired = (
+                            await sess.execute(text("SELECT GET_LOCK(:name, 5)"), {"name": backfill_lock})
+                        ).scalar()
+                        if not acquired:
+                            log_warning(
+                                f"run_index backfill lock timed out for session {session_id}; proceeding unserialized"
+                            )
+                        current_max = (
+                            await sess.execute(
+                                select(func.max(runs_table.c.run_index)).where(runs_table.c.session_id == session_id)
+                            )
+                        ).scalar()
+                        next_index = (current_max + 1) if current_max is not None else 0
+                        provided_index = row.get("run_index")
+                        row["run_index"] = next_index if provided_index is None else max(provided_index, next_index)
 
                         stmt = mysql.insert(runs_table).values(**row)  # type: ignore
                         stmt = stmt.on_duplicate_key_update(

--- a/libs/agno/agno/db/mysql/mysql.py
+++ b/libs/agno/agno/db/mysql/mysql.py
@@ -653,27 +653,26 @@ class MySQLDb(BaseDb):
             with self.Session() as sess:
                 try:
                     with sess.begin():
-                        # Backfill a monotonic run_index when the run arrives without one
-                        # (e.g. a background/continue save that couldn't resolve its position).
-                        # A NULL index has no position and breaks ORDER BY run_index. ON DUPLICATE KEY
-                        # preserves the existing index, so this only sets it on a genuine insert.
-                        if row.get("run_index") is None:
-                            # Serialize same-session backfills: two concurrent
-                            # max-reads can both see the same MAX and land
-                            # duplicate indexes. GET_LOCK is connection-scoped
-                            # and survives COMMIT, so it is released in the
-                            # finally below - AFTER the row is durable.
-                            backfill_lock = run_index_lock_name(session_id)
-                            acquired = sess.execute(text("SELECT GET_LOCK(:name, 5)"), {"name": backfill_lock}).scalar()
-                            if not acquired:
-                                log_warning(
-                                    f"run_index backfill lock timed out for session {session_id}; "
-                                    "proceeding unserialized"
-                                )
-                            current_max = sess.execute(
-                                select(func.max(runs_table.c.run_index)).where(runs_table.c.session_id == session_id)
-                            ).scalar()
-                            row["run_index"] = (current_max + 1) if current_max is not None else 0
+                        # A new run always lands after the session's existing rows. Callers
+                        # pass the run's position in the in-memory ``session.runs`` list, and
+                        # after runs were deleted from the front of that list the position
+                        # collides with, or sorts before, rows that still exist. ON DUPLICATE
+                        # KEY preserves the existing index, so this only affects a genuine
+                        # insert. GET_LOCK serializes same-session inserts so two concurrent
+                        # max-reads cannot land duplicate indexes; it is connection-scoped and
+                        # survives COMMIT, so it is released in the finally below.
+                        backfill_lock = run_index_lock_name(session_id)
+                        acquired = sess.execute(text("SELECT GET_LOCK(:name, 5)"), {"name": backfill_lock}).scalar()
+                        if not acquired:
+                            log_warning(
+                                f"run_index backfill lock timed out for session {session_id}; proceeding unserialized"
+                            )
+                        current_max = sess.execute(
+                            select(func.max(runs_table.c.run_index)).where(runs_table.c.session_id == session_id)
+                        ).scalar()
+                        next_index = (current_max + 1) if current_max is not None else 0
+                        provided_index = row.get("run_index")
+                        row["run_index"] = next_index if provided_index is None else max(provided_index, next_index)
 
                         stmt = mysql.insert(runs_table).values(**row)  # type: ignore
                         stmt = stmt.on_duplicate_key_update(

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -854,26 +854,20 @@ class AsyncPostgresDb(AsyncBaseDb):
 
             async with self.async_session_factory() as sess:
                 async with sess.begin():
-                    # Backfill a monotonic run_index when the run arrives without one
-                    # (e.g. a background/continue save that couldn't resolve its position).
-                    # A NULL index has no position and breaks ORDER BY run_index. ON CONFLICT
-                    # preserves the existing index, so this only sets it on a genuine insert.
-                    if row.get("run_index") is None:
-                        # Serialize same-session backfills: under READ COMMITTED two
-                        # concurrent max-reads can both see the same MAX and land
-                        # duplicate indexes. The advisory lock is transaction-scoped
-                        # (released at COMMIT/ROLLBACK) and keyed on session_id, so
-                        # only same-session backfilling inserts queue behind it.
+                    # A new run always lands after the session's existing rows.
+                    # The advisory lock serializes same-session inserts around MAX+1.
+                    await sess.execute(
+                        text("SELECT pg_advisory_xact_lock(hashtext('agno_run_index'), hashtext(:sid))"),
+                        {"sid": session_id},
+                    )
+                    current_max = (
                         await sess.execute(
-                            text("SELECT pg_advisory_xact_lock(hashtext('agno_run_index'), hashtext(:sid))"),
-                            {"sid": session_id},
+                            select(func.max(runs_table.c.run_index)).where(runs_table.c.session_id == session_id)
                         )
-                        current_max = (
-                            await sess.execute(
-                                select(func.max(runs_table.c.run_index)).where(runs_table.c.session_id == session_id)
-                            )
-                        ).scalar()
-                        row["run_index"] = (current_max + 1) if current_max is not None else 0
+                    ).scalar()
+                    next_index = (current_max + 1) if current_max is not None else 0
+                    provided_index = row.get("run_index")
+                    row["run_index"] = next_index if provided_index is None else max(provided_index, next_index)
 
                     stmt = postgresql.insert(runs_table).values(**row)
                     stmt = stmt.on_conflict_do_update(

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -1039,24 +1039,24 @@ class PostgresDb(BaseDb):
             row["run_data"] = sanitize_postgres_strings(row["run_data"])
 
             with self.Session() as sess, sess.begin():
-                # Backfill a monotonic run_index when the run arrives without one
-                # (e.g. a background/continue save that couldn't resolve its position).
-                # A NULL index has no position and breaks ORDER BY run_index. ON CONFLICT
-                # preserves the existing index, so this only sets it on a genuine insert.
-                if row.get("run_index") is None:
-                    # Serialize same-session backfills: under READ COMMITTED two
-                    # concurrent max-reads can both see the same MAX and land
-                    # duplicate indexes. The advisory lock is transaction-scoped
-                    # (released at COMMIT/ROLLBACK) and keyed on session_id, so
-                    # only same-session backfilling inserts queue behind it.
-                    sess.execute(
-                        text("SELECT pg_advisory_xact_lock(hashtext('agno_run_index'), hashtext(:sid))"),
-                        {"sid": session_id},
-                    )
-                    current_max = sess.execute(
-                        select(func.max(runs_table.c.run_index)).where(runs_table.c.session_id == session_id)
-                    ).scalar()
-                    row["run_index"] = (current_max + 1) if current_max is not None else 0
+                # A new run always lands after the session's existing rows. Callers
+                # pass the run's position in the in-memory ``session.runs`` list, and
+                # after runs were deleted from the front of that list the position
+                # collides with, or sorts before, rows that still exist. ON CONFLICT
+                # preserves the existing index, so this only affects a genuine insert.
+                # Serialize same-session inserts: under READ COMMITTED two concurrent
+                # max-reads can both see the same MAX and land duplicate indexes. The
+                # advisory lock is transaction-scoped and keyed on session_id.
+                sess.execute(
+                    text("SELECT pg_advisory_xact_lock(hashtext('agno_run_index'), hashtext(:sid))"),
+                    {"sid": session_id},
+                )
+                current_max = sess.execute(
+                    select(func.max(runs_table.c.run_index)).where(runs_table.c.session_id == session_id)
+                ).scalar()
+                next_index = (current_max + 1) if current_max is not None else 0
+                provided_index = row.get("run_index")
+                row["run_index"] = next_index if provided_index is None else max(provided_index, next_index)
 
                 stmt = postgresql.insert(runs_table).values(**row)
                 stmt = stmt.on_conflict_do_update(

--- a/libs/agno/agno/db/singlestore/singlestore.py
+++ b/libs/agno/agno/db/singlestore/singlestore.py
@@ -728,21 +728,18 @@ class SingleStoreDb(BaseDb):
             )
 
             with self.Session() as sess, sess.begin():
-                # Backfill a monotonic run_index when the run arrives without one
-                # (e.g. a background/continue save that couldn't resolve its position).
-                # A NULL index has no position and breaks ORDER BY run_index. ON DUPLICATE KEY
-                # preserves the existing index, so this only sets it on a genuine insert.
-                if row.get("run_index") is None:
-                    # Single-statement backfill: SingleStore has no user-level
-                    # locks (no GET_LOCK), so the MAX is computed inside the
-                    # INSERT via a materialized derived table (the MySQL
-                    # dialect rejects a direct same-table subquery). This
-                    # closes the two-statement read-then-insert window; truly
-                    # simultaneous same-session first-saves can still read the
-                    # same MAX under snapshot isolation - best effort without
-                    # engine support.
-                    prior_runs = select(runs_table.c.run_index).where(runs_table.c.session_id == session_id).subquery()
-                    row["run_index"] = select(func.coalesce(func.max(prior_runs.c.run_index) + 1, 0)).scalar_subquery()
+                # A new run always lands after the session's existing rows. Callers
+                # pass the run's position in the in-memory ``session.runs`` list, and
+                # after runs were deleted from the front of that list the position
+                # collides with, or sorts before, rows that still exist. ON CONFLICT
+                # preserves the existing index, so this only affects a genuine insert.
+                # Single-statement: SingleStore has no user-level locks (no GET_LOCK),
+                # so the MAX is computed inside the INSERT via a materialized derived
+                # table (the MySQL dialect rejects a direct same-table subquery).
+                prior_runs = select(runs_table.c.run_index).where(runs_table.c.session_id == session_id).subquery()
+                next_index = select(func.coalesce(func.max(prior_runs.c.run_index) + 1, 0)).scalar_subquery()
+                provided_index = row.get("run_index")
+                row["run_index"] = next_index if provided_index is None else func.greatest(provided_index, next_index)
 
                 stmt = mysql.insert(runs_table).values(**row)  # type: ignore
                 stmt = stmt.on_duplicate_key_update(

--- a/libs/agno/agno/db/singlestore/singlestore.py
+++ b/libs/agno/agno/db/singlestore/singlestore.py
@@ -731,11 +731,13 @@ class SingleStoreDb(BaseDb):
                 # A new run always lands after the session's existing rows. Callers
                 # pass the run's position in the in-memory ``session.runs`` list, and
                 # after runs were deleted from the front of that list the position
-                # collides with, or sorts before, rows that still exist. ON CONFLICT
+                # collides with, or sorts before, rows that still exist. ON DUPLICATE KEY
                 # preserves the existing index, so this only affects a genuine insert.
                 # Single-statement: SingleStore has no user-level locks (no GET_LOCK),
                 # so the MAX is computed inside the INSERT via a materialized derived
-                # table (the MySQL dialect rejects a direct same-table subquery).
+                # table (the MySQL dialect rejects a direct same-table subquery). Truly
+                # simultaneous same-session inserts can still read the same MAX under
+                # snapshot isolation; best effort without engine support, as before.
                 prior_runs = select(runs_table.c.run_index).where(runs_table.c.session_id == session_id).subquery()
                 next_index = select(func.coalesce(func.max(prior_runs.c.run_index) + 1, 0)).scalar_subquery()
                 provided_index = row.get("run_index")

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -842,22 +842,15 @@ class AsyncSqliteDb(AsyncBaseDb):
             )
 
             async with self.async_session_factory() as sess, sess.begin():
-                # Backfill a monotonic run_index when the run arrives without one
-                # (e.g. a background/continue save that couldn't resolve its position).
-                # A NULL index has no position and breaks ORDER BY run_index. ON CONFLICT
-                # preserves the existing index, so this only sets it on a genuine insert.
-                if row.get("run_index") is None:
-                    # Computed INSIDE the insert statement: SQLite holds the
-                    # database write lock for the whole statement, so two
-                    # concurrent backfills cannot read the same MAX (the old
-                    # two-statement read-then-insert could - a busy-waiting
-                    # second writer landed a duplicate index after the first
-                    # committed).
-                    row["run_index"] = (
-                        select(func.coalesce(func.max(runs_table.c.run_index) + 1, 0))
-                        .where(runs_table.c.session_id == session_id)
-                        .scalar_subquery()
-                    )
+                # A new run always lands after the session's existing rows. Compute
+                # MAX+1 inside the insert so concurrent SQLite writers serialize it.
+                next_index = (
+                    select(func.coalesce(func.max(runs_table.c.run_index) + 1, 0))
+                    .where(runs_table.c.session_id == session_id)
+                    .scalar_subquery()
+                )
+                provided_index = row.get("run_index")
+                row["run_index"] = next_index if provided_index is None else func.max(provided_index, next_index)
 
                 stmt = sqlite.insert(runs_table).values(**row)
                 stmt = stmt.on_conflict_do_update(

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -1056,21 +1056,21 @@ class SqliteDb(BaseDb):
             )
 
             with self.Session() as sess, sess.begin():
-                # Backfill a monotonic run_index when the run arrives without one
-                # (e.g. a background/continue save that couldn't resolve its position).
-                # A NULL index has no position and breaks ORDER BY run_index.
-                if row.get("run_index") is None:
-                    # Computed INSIDE the insert statement: SQLite holds the
-                    # database write lock for the whole statement, so two
-                    # concurrent backfills cannot read the same MAX (the old
-                    # two-statement read-then-insert could - a busy-waiting
-                    # second writer landed a duplicate index after the first
-                    # committed). ON CONFLICT still preserves existing indexes.
-                    row["run_index"] = (
-                        select(func.coalesce(func.max(runs_table.c.run_index) + 1, 0))
-                        .where(runs_table.c.session_id == session_id)
-                        .scalar_subquery()
-                    )
+                # A new run always lands after the session's existing rows. Callers
+                # pass the run's position in the in-memory ``session.runs`` list, and
+                # after runs were deleted from the front of that list the position
+                # collides with, or sorts before, rows that still exist. ON CONFLICT
+                # preserves the existing index, so this only affects a genuine insert.
+                # Computed INSIDE the insert statement: SQLite holds the database
+                # write lock for the whole statement, so two concurrent inserts cannot
+                # read the same MAX.
+                next_index = (
+                    select(func.coalesce(func.max(runs_table.c.run_index) + 1, 0))
+                    .where(runs_table.c.session_id == session_id)
+                    .scalar_subquery()
+                )
+                provided_index = row.get("run_index")
+                row["run_index"] = next_index if provided_index is None else func.max(provided_index, next_index)
 
                 stmt = sqlite.insert(runs_table).values(**row)
                 stmt = stmt.on_conflict_do_update(

--- a/libs/agno/tests/unit/db/test_run_index_after_delete.py
+++ b/libs/agno/tests/unit/db/test_run_index_after_delete.py
@@ -11,7 +11,10 @@ from __future__ import annotations
 
 import sqlite3
 
+import pytest
+
 from agno.db.sqlite import SqliteDb
+from agno.db.sqlite.async_sqlite import AsyncSqliteDb
 from agno.run.agent import RunOutput
 from agno.session.agent import AgentSession
 
@@ -41,6 +44,21 @@ def test_new_run_lands_after_survivors_when_leading_runs_were_deleted(tmp_path):
 
     assert _rows(db_file) == [("r2", 2), ("r3", 3)]
     assert [run.run_id for run in db.get_session("s1").runs] == ["r2", "r3"]
+
+
+@pytest.mark.asyncio
+async def test_async_new_run_lands_after_survivors_when_leading_runs_were_deleted(tmp_path):
+    db_file = str(tmp_path / "t.db")
+    db = AsyncSqliteDb(db_file=db_file)
+    await db.upsert_session(AgentSession(session_id="s1", agent_id="a1", created_at=1000, updated_at=1000))
+    for index, run_id in enumerate(["r0", "r1", "r2"]):
+        await db.upsert_run(_run(run_id), session_id="s1", run_index=index)
+
+    await db.delete_runs(["r0", "r1"])
+    await db.upsert_run(_run("r3"), session_id="s1", run_index=1)
+
+    assert _rows(db_file) == [("r2", 2), ("r3", 3)]
+    assert [run.run_id for run in (await db.get_session("s1")).runs] == ["r2", "r3"]
 
 
 def test_existing_rows_keep_their_index_on_update(tmp_path):

--- a/libs/agno/tests/unit/db/test_run_index_after_delete.py
+++ b/libs/agno/tests/unit/db/test_run_index_after_delete.py
@@ -1,0 +1,66 @@
+"""A new run must sort after the session's existing rows, whatever position the caller computed.
+
+``resolve_run_index`` hands ``upsert_run`` the run's position in the in-memory
+``session.runs`` list. After runs are deleted from the front of that list (a
+compaction, a redaction, ``delete_runs``), that position collides with or sorts
+before rows that still exist, and ``get_session`` returns history out of order.
+The adapter knows the real maximum; it should never place a new row below it.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from agno.db.sqlite import SqliteDb
+from agno.run.agent import RunOutput
+from agno.session.agent import AgentSession
+
+
+def _run(run_id: str) -> RunOutput:
+    return RunOutput(run_id=run_id, agent_id="a1", session_id="s1")
+
+
+def _rows(db_file: str):
+    con = sqlite3.connect(db_file)
+    try:
+        return con.execute("SELECT run_id, run_index FROM agno_runs ORDER BY run_index").fetchall()
+    finally:
+        con.close()
+
+
+def test_new_run_lands_after_survivors_when_leading_runs_were_deleted(tmp_path):
+    db_file = str(tmp_path / "t.db")
+    db = SqliteDb(db_file=db_file)
+    db.upsert_session(AgentSession(session_id="s1", agent_id="a1", created_at=1000, updated_at=1000))
+    for index, run_id in enumerate(["r0", "r1", "r2"]):
+        db.upsert_run(_run(run_id), session_id="s1", run_index=index)
+
+    db.delete_runs(["r0", "r1"])
+    # The in-memory list is now ["r2", "r3"], so the caller computes position 1.
+    db.upsert_run(_run("r3"), session_id="s1", run_index=1)
+
+    assert _rows(db_file) == [("r2", 2), ("r3", 3)]
+    assert [run.run_id for run in db.get_session("s1").runs] == ["r2", "r3"]
+
+
+def test_existing_rows_keep_their_index_on_update(tmp_path):
+    db_file = str(tmp_path / "t.db")
+    db = SqliteDb(db_file=db_file)
+    db.upsert_session(AgentSession(session_id="s1", agent_id="a1", created_at=1000, updated_at=1000))
+    db.upsert_run(_run("r0"), session_id="s1", run_index=0)
+    db.upsert_run(_run("r1"), session_id="s1", run_index=1)
+
+    db.upsert_run(_run("r0"), session_id="s1", run_index=7)  # a status update re-sends the run
+
+    assert _rows(db_file) == [("r0", 0), ("r1", 1)]
+
+
+def test_an_explicit_higher_index_is_kept(tmp_path):
+    db_file = str(tmp_path / "t.db")
+    db = SqliteDb(db_file=db_file)
+    db.upsert_session(AgentSession(session_id="s1", agent_id="a1", created_at=1000, updated_at=1000))
+    db.upsert_run(_run("r0"), session_id="s1", run_index=0)
+
+    db.upsert_run(_run("r9"), session_id="s1", run_index=9)
+
+    assert _rows(db_file) == [("r0", 0), ("r9", 9)]


### PR DESCRIPTION
## Summary

`resolve_run_index()` passes the run's position in the in-memory `session.runs` list. After runs were deleted from the front of that list, that position is lower than the `run_index` of rows still in the table, and `get_session()` returns history out of order from then on.

Change, in the SQL adapters (`SqliteDb`, `PostgresDb`, `MySQLDb`, `SingleStoreDb` and the async SQLite, Postgres and MySQL variants): the `MAX(run_index)+1` computation that already ran for `run_index=None` now runs for every insert, and the stored index is `max(provided, MAX+1)`. An explicit index above the session's maximum is kept; `ON CONFLICT` / `ON DUPLICATE KEY` still preserves the index of existing rows, so updates are unaffected. Lock types are unchanged (advisory lock on Postgres, `GET_LOCK` on MySQL, single-statement subquery on SQLite and SingleStore); Postgres and MySQL now take their per-session lock on every `upsert_run`, including updates, which was previously only the `None` path.

Tests: `tests/unit/db/test_run_index_after_delete.py`. Three runs, delete the first two, insert with the caller's position 1: the new row gets index 3 and loads after the survivor, sync and async. Existing rows keep their index on update; an explicit higher index is kept.

Known caveat, unchanged from before: SingleStore has no user-level lock and MySQL proceeds unserialized after a 5 s lock timeout, so truly simultaneous same-session inserts can still pick the same index there.

This is the narrow fix. #9342 moves `run_index` onto the run objects across every adapter; if that lands first, this can be closed.

Found while upgrading MindRoom to 3.0.5 (mindroom-ai/mindroom#1944), worked around there by passing `run_index=None`.

Fixes #9936

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Why this over #9342 for the reported bug: the adapter already knows the session's real maximum and never needs to place a new row below it. That is a few lines per adapter and no change to the run model or the read path. #9342 is the broader redesign and may still be the right long-term shape.

Drafted with Claude Code (Fable 5.1) and independently reviewed with Codex (GPT-5.6 sol), both at xhigh reasoning effort; I reviewed the result myself and ran the tests, ruff and mypy locally. A second model review caught the missing async adapters, fixed in the second commit.

