### PR TITLE
[feat] Support min_p and repetition_penalty in VLLM

### DIFF
--- a/cookbook/90_models/vllm/README.md
+++ b/cookbook/90_models/vllm/README.md
@@ -99,6 +99,10 @@ vLLM embedders can load and run embedding models locally without requiring a ser
 
 ## Examples
 
+The basic example sets `repetition_penalty` and `min_p` directly on `VLLM`.
+Both default to `None`, leaving server defaults unchanged. Explicit values override
+the same keys in `extra_body`; other `extra_body` keys are preserved.
+
 ```shell
 python cookbook/90_models/vllm/basic.py
 ```

--- a/cookbook/90_models/vllm/basic.py
+++ b/cookbook/90_models/vllm/basic.py
@@ -15,7 +15,13 @@ from agno.models.vllm import VLLM
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=VLLM(id="Qwen/Qwen2.5-7B-Instruct", top_k=20, enable_thinking=False),
+    model=VLLM(
+        id="Qwen/Qwen2.5-7B-Instruct",
+        top_k=20,
+        enable_thinking=False,
+        repetition_penalty=1.1,
+        min_p=0.05,
+    ),
     markdown=True,
 )
 

--- a/libs/agno/agno/models/vllm/vllm.py
+++ b/libs/agno/agno/models/vllm/vllm.py
@@ -21,8 +21,10 @@ class VLLM(OpenAILike):
         base_url: vLLM server URL
         temperature: Sampling temperature
         top_p: Nucleus sampling probability
-        presence_penalty: Repetition penalty
+        presence_penalty: Penalize tokens already present in the generated text
+        repetition_penalty: Penalize tokens from the prompt and generated text
         top_k: Top-k sampling
+        min_p: Minimum token probability relative to the most likely token
         enable_thinking: Special mode flag
     """
 
@@ -38,6 +40,16 @@ class VLLM(OpenAILike):
     presence_penalty: float = 1.5
     top_k: Optional[int] = None
     enable_thinking: Optional[bool] = None
+    repetition_penalty: Optional[float] = None
+    min_p: Optional[float] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        model_dict = super().to_dict()
+        if self.repetition_penalty is not None:
+            model_dict["repetition_penalty"] = self.repetition_penalty
+        if self.min_p is not None:
+            model_dict["min_p"] = self.min_p
+        return model_dict
 
     def _get_client_params(self) -> Dict[str, Any]:
         """
@@ -71,6 +83,10 @@ class VLLM(OpenAILike):
         vllm_body: Dict[str, Any] = {}
         if self.top_k is not None:
             vllm_body["top_k"] = self.top_k
+        if self.repetition_penalty is not None:
+            vllm_body["repetition_penalty"] = self.repetition_penalty
+        if self.min_p is not None:
+            vllm_body["min_p"] = self.min_p
         if self.enable_thinking is not None:
             vllm_body.setdefault("chat_template_kwargs", {})["enable_thinking"] = self.enable_thinking
 

--- a/libs/agno/tests/unit/models/test_vllm_request_params.py
+++ b/libs/agno/tests/unit/models/test_vllm_request_params.py
@@ -1,0 +1,55 @@
+"""vLLM sampling options must survive request construction and serialization."""
+
+import pytest
+
+from agno.models.vllm import VLLM
+
+
+@pytest.mark.parametrize("repetition_penalty,min_p", [(1.1, 0.05), (1.0, 0.0)])
+def test_sampling_params_are_sent_in_extra_body(repetition_penalty, min_p):
+    model = VLLM(repetition_penalty=repetition_penalty, min_p=min_p)
+
+    params = model.get_request_params()
+
+    assert params["extra_body"] == {"repetition_penalty": repetition_penalty, "min_p": min_p}
+    assert "repetition_penalty" not in params
+    assert "min_p" not in params
+
+
+def test_unset_sampling_params_preserve_server_defaults():
+    model = VLLM()
+
+    assert "extra_body" not in model.get_request_params()
+    assert "repetition_penalty" not in model.to_dict()
+    assert "min_p" not in model.to_dict()
+
+
+@pytest.mark.parametrize("explicit", [False, True])
+def test_sampling_params_merge_without_mutating_extra_body(explicit):
+    extra_body = {"repetition_penalty": 1.2, "min_p": 0.1, "ignore_eos": True}
+    model = VLLM(
+        repetition_penalty=1.0 if explicit else None,
+        min_p=0.0 if explicit else None,
+        top_k=20,
+        enable_thinking=False,
+        extra_body=extra_body,
+    )
+
+    params = model.get_request_params()
+
+    assert params["extra_body"] == {
+        "repetition_penalty": 1.0 if explicit else 1.2,
+        "min_p": 0.0 if explicit else 0.1,
+        "ignore_eos": True,
+        "top_k": 20,
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+    assert extra_body == {"repetition_penalty": 1.2, "min_p": 0.1, "ignore_eos": True}
+
+
+def test_sampling_params_survive_model_round_trip():
+    model = VLLM(repetition_penalty=1.1, min_p=0.0, extra_body={"ignore_eos": True})
+
+    restored = VLLM.from_dict(model.to_dict())
+
+    assert restored.get_request_params() == model.get_request_params()


### PR DESCRIPTION
## Summary

Add optional `repetition_penalty` and `min_p` constructor arguments to `VLLM`, addressing #6912. These options could already be sent through `extra_body`; this change exposes them directly alongside `top_k`.

Unset values preserve server defaults. Explicit values override matching `extra_body` keys without mutating the caller's dictionary. Both fields survive model serialization and restoration. Update the existing vLLM example and add regression tests for defaults, zero values, merging, and round trips.

Closes #6912.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Validation on macOS with a fresh Python 3.12 environment:

- New regression tests: 6 passed. Before the implementation, 5 failed and 1 passed.
- New tests plus OpenAI request parameter and provider resolution suites: 193 passed, 2 skipped.
- `./scripts/format.sh` and `./scripts/validate.sh` passed. Unrelated formatter changes were reverted; the changed files also pass Ruff formatting and lint checks.
- An additional real OpenAI SDK smoke check, using `httpx.MockTransport`, verified sync, async, and both streaming request bodies without a live endpoint.
- The broader unit suite, using the CI exclusions, reached 1,400 passed and 7 skipped before being interrupted while MongoDB-dependent tests waited for an unavailable local service. This is not a full-suite pass.
- The cookbook was syntax-checked, but was not run against a live vLLM server. No throughput or latency improvement is claimed.

AI disclosure: Codex generated the implementation, tests, documentation, and this description. I reviewed and understand the changes.
