### PR TITLE
feat: add AnyAPITools toolkit

### DIFF
--- a/cookbook/91_tools/anyapi_tools.py
+++ b/cookbook/91_tools/anyapi_tools.py
@@ -1,0 +1,40 @@
+"""
+This is an example of how to use the AnyAPITools.
+
+AnyAPI is a unified marketplace for scraping and data APIs: any API, one wallet, USD, no
+subscriptions. Reach hundreds of third-party APIs (social media, search results, web data)
+through one key and one normalized interface; pay per request in real dollars; failed calls
+are never charged - AnyAPI fails over across providers automatically under one price.
+
+Prerequisites:
+- Install the AnyAPI SDK: pip install getanyapi
+- Get an API key at https://getanyapi.com/dashboard. New accounts start with free trial credit.
+- Set the API key as an environment variable:
+    export ANYAPI_API_KEY=<your-api-key>
+"""
+
+from agno.agent import Agent
+from agno.tools.anyapi import AnyAPITools
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+agent = Agent(
+    tools=[AnyAPITools(enable_get_balance=True)],
+    instructions=[
+        "Find an API with search_apis, read its input schema and USD price with get_api, then run it with run_api.",
+        "Build the input from the schema get_api returns. Every input schema is strict.",
+    ],
+    markdown=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    # Should search the catalog and run the API it finds
+    agent.print_response("Get the top Google search results for 'agno agent framework'")
+
+    # Should report the wallet balance
+    agent.print_response("How much USD is left on my AnyAPI wallet?")

--- a/libs/agno/agno/tools/anyapi.py
+++ b/libs/agno/agno/tools/anyapi.py
@@ -1,0 +1,135 @@
+"""
+AnyAPITools - discover and run any API in the AnyAPI catalog.
+
+AnyAPI is a unified marketplace for scraping and data APIs: any API, one wallet, USD, no
+subscriptions. Reach hundreds of third-party APIs (social media, search results, web data)
+through one key and one normalized interface; pay per request in real dollars; failed calls
+are never charged - AnyAPI fails over across providers automatically under one price.
+
+Prerequisites:
+- Get an API key at https://getanyapi.com/dashboard. New accounts start with free trial credit.
+- Set the API key as an environment variable:
+    export ANYAPI_API_KEY=<your-api-key>
+
+Tools:
+- search_apis: ranked search over the catalog for an API that returns the data you need
+- get_api: one API's normalized input and output JSON Schema, plus its USD price
+- run_api: execute one API by slug with a normalized input
+- get_balance: remaining USD wallet balance for the key
+"""
+
+import json
+from os import getenv
+from typing import Any, Dict, List, Optional
+
+from agno.tools import Toolkit
+from agno.utils.log import log_error
+
+try:
+    from getanyapi import AnyAPI
+except ImportError:
+    raise ImportError("`getanyapi` not installed. Please install using `pip install getanyapi`")
+
+
+class AnyAPITools(Toolkit):
+    """
+    AnyAPI is a gateway to hundreds of scraping and data APIs behind one key, billed per request
+    in USD. An agent finds an API with search_apis, reads its input schema and price with get_api,
+    then executes it with run_api.
+
+    Args:
+        api_key (Optional[str]): AnyAPI key. Read from the `ANYAPI_API_KEY` env variable if not provided.
+        enable_search_apis (bool): Enable catalog search. Default is True.
+        enable_get_api (bool): Enable reading one API's schema and price. Default is True.
+        enable_run_api (bool): Enable running an API. Default is True.
+        enable_get_balance (bool): Enable reading the wallet balance. Default is False.
+        all (bool): Enable all tools. Overrides individual flags when True. Default is False.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        enable_search_apis: bool = True,
+        enable_get_api: bool = True,
+        enable_run_api: bool = True,
+        enable_get_balance: bool = False,
+        all: bool = False,
+        **kwargs,
+    ):
+        self.api_key: Optional[str] = api_key or getenv("ANYAPI_API_KEY")
+        if not self.api_key:
+            log_error("ANYAPI_API_KEY not set. Please set the ANYAPI_API_KEY environment variable.")
+
+        self.client: AnyAPI = AnyAPI(api_key=self.api_key, base_url="https://api.getanyapi.com")
+
+        tools: List[Any] = []
+        if all or enable_search_apis:
+            tools.append(self.search_apis)
+        if all or enable_get_api:
+            tools.append(self.get_api)
+        if all or enable_run_api:
+            tools.append(self.run_api)
+        if all or enable_get_balance:
+            tools.append(self.get_balance)
+
+        super().__init__(name="anyapi_tools", tools=tools, **kwargs)
+
+    def search_apis(
+        self,
+        query: str,
+        category: Optional[str] = None,
+        platform: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> str:
+        """Use this function to search the AnyAPI catalog for an API that returns the data you need.
+
+        Args:
+            query (str): What the API should return, for example "instagram profile" or "google maps reviews".
+            category (Optional[str]): Restrict results to one catalog category.
+            platform (Optional[str]): Restrict results to one platform, for example "instagram".
+            limit (Optional[int]): Maximum number of APIs to return.
+
+        Returns:
+            str: JSON string of the matching APIs, each with its slug, description and USD price.
+        """
+        results = self.client.search(query=query, category=category, platform=platform, limit=limit)
+        return json.dumps(results.model_dump(mode="json"), default=str)
+
+    def get_api(self, slug: str) -> str:
+        """Use this function to read one API's normalized input and output JSON Schema and its USD price.
+
+        Call this before the first run_api on a slug and build the input from the schema it returns.
+        Every input schema is strict, so an invented field name fails the call.
+
+        Args:
+            slug (str): The API to describe, as returned by search_apis.
+
+        Returns:
+            str: JSON string with the API's input and output schema, USD pricing and latency.
+        """
+        entry = self.client.describe(slug)
+        return json.dumps(entry.model_dump(mode="json"), default=str)
+
+    def run_api(self, slug: str, input: Dict[str, Any]) -> str:
+        """Use this function to run one AnyAPI endpoint and get its normalized output.
+
+        The wallet is charged in USD on success only. Read the input schema with get_api first.
+
+        Args:
+            slug (str): The API to run, as returned by search_apis.
+            input (Dict[str, Any]): The input object, matching the input schema returned by get_api.
+
+        Returns:
+            str: JSON string with the output, the USD cost of the call and the number of items returned.
+        """
+        result = self.client.run(slug, input)
+        return json.dumps(result.model_dump(mode="json"), default=str)
+
+    def get_balance(self) -> str:
+        """Use this function to read the remaining USD wallet balance for the AnyAPI key.
+
+        Returns:
+            str: JSON string with the remaining balance in USD.
+        """
+        balance = self.client.balance()
+        return json.dumps(balance.model_dump(mode="json"), default=str)

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -116,6 +116,7 @@ cel = ["cel-python"]
 
 # Dependencies for Tools
 agentql = ["agentql"]
+anyapi = ["getanyapi>=0.35.3"]
 apify = ["apify-client"]
 arxiv = ["arxiv"]
 brave = ["brave-search"]
@@ -290,6 +291,7 @@ models = [
 # All tools
 tools = [
   "agno[agentql]",
+  "agno[anyapi]",
   "agno[apify]",
   "agno[arxiv]",
   # "agno[brave]",  # Excluded: brave-search 0.2.0 ships invalid metadata (bad httpx specifier) that uv cannot parse; test_setup.sh installs it with --no-deps
@@ -583,6 +585,7 @@ module = [
   "fastmcp.*",
   "filetype.*",
   "firecrawl.*",
+  "getanyapi.*",
   "github.*",
   "gitlab.*",
   "google.*",

--- a/libs/agno/tests/unit/tools/test_anyapi.py
+++ b/libs/agno/tests/unit/tools/test_anyapi.py
@@ -1,0 +1,176 @@
+import json
+import os
+from unittest.mock import Mock, patch
+
+import pytest
+from getanyapi import AnyAPI  # noqa
+
+from agno.tools.anyapi import AnyAPITools
+
+TEST_API_KEY = os.environ.get("ANYAPI_API_KEY", "test_api_key")
+TEST_BASE_URL = "https://api.getanyapi.com"
+
+
+@pytest.fixture
+def mock_anyapi():
+    """Create a mock AnyAPI client instance."""
+    with patch("agno.tools.anyapi.AnyAPI") as mock_anyapi_cls:
+        mock_client = Mock()
+        mock_anyapi_cls.return_value = mock_client
+        return mock_client
+
+
+@pytest.fixture
+def anyapi_tools(mock_anyapi):
+    """Create an AnyAPITools instance with mocked dependencies."""
+    with patch.dict("os.environ", {"ANYAPI_API_KEY": TEST_API_KEY}):
+        tools = AnyAPITools()
+        # Directly set the client to our mock to avoid initialization issues
+        tools.client = mock_anyapi
+        return tools
+
+
+def _mock_response(payload):
+    """Build a mock that serializes to the given payload."""
+    response = Mock(spec=["model_dump"])
+    response.model_dump.return_value = payload
+    return response
+
+
+def test_init_with_env_vars():
+    """Test initialization with environment variables."""
+    with patch("agno.tools.anyapi.AnyAPI") as mock_anyapi_cls:
+        with patch.dict("os.environ", {"ANYAPI_API_KEY": TEST_API_KEY}, clear=True):
+            tools = AnyAPITools()
+            assert tools.api_key == TEST_API_KEY
+            assert tools.client is not None
+            mock_anyapi_cls.assert_called_once_with(api_key=TEST_API_KEY, base_url=TEST_BASE_URL)
+
+
+def test_init_with_params():
+    """Test initialization with parameters."""
+    with patch("agno.tools.anyapi.AnyAPI") as mock_anyapi_cls:
+        tools = AnyAPITools(api_key="param_api_key")
+        assert tools.api_key == "param_api_key"
+        assert tools.client is not None
+        mock_anyapi_cls.assert_called_once_with(api_key="param_api_key", base_url=TEST_BASE_URL)
+
+
+def test_default_tools_registered():
+    """Test that the default flags register discovery and execution but not the balance tool."""
+    with patch("agno.tools.anyapi.AnyAPI"):
+        tools = AnyAPITools(api_key=TEST_API_KEY)
+        registered = [func.name for func in tools.functions.values()]
+        assert "search_apis" in registered
+        assert "get_api" in registered
+        assert "run_api" in registered
+        assert "get_balance" not in registered
+
+
+def test_all_flag_registers_every_tool():
+    """Test that `all=True` registers every tool."""
+    with patch("agno.tools.anyapi.AnyAPI"):
+        tools = AnyAPITools(api_key=TEST_API_KEY, all=True)
+        registered = [func.name for func in tools.functions.values()]
+        assert registered == ["search_apis", "get_api", "run_api", "get_balance"]
+
+
+def test_individual_flags_registered():
+    """Test that individual flags select the tools."""
+    with patch("agno.tools.anyapi.AnyAPI"):
+        tools = AnyAPITools(
+            api_key=TEST_API_KEY,
+            enable_search_apis=False,
+            enable_get_api=False,
+            enable_run_api=False,
+            enable_get_balance=True,
+        )
+        registered = [func.name for func in tools.functions.values()]
+        assert registered == ["get_balance"]
+
+
+def test_search_apis(anyapi_tools, mock_anyapi):
+    """Test search_apis method."""
+    mock_anyapi.search.return_value = _mock_response(
+        {
+            "results": [{"slug": "instagram.profile", "provider": "AnyAPI"}],
+            "total": 1,
+            "ranking": "semantic",
+        }
+    )
+
+    result = anyapi_tools.search_apis("instagram profile")
+    result_data = json.loads(result)
+
+    assert result_data["results"][0]["slug"] == "instagram.profile"
+    assert result_data["total"] == 1
+    mock_anyapi.search.assert_called_once_with(query="instagram profile", category=None, platform=None, limit=None)
+
+
+def test_search_apis_with_filters(anyapi_tools, mock_anyapi):
+    """Test that search_apis forwards every filter to the client."""
+    mock_anyapi.search.return_value = _mock_response({"results": [], "total": 0, "ranking": "keyword"})
+
+    anyapi_tools.search_apis("reviews", category="maps", platform="google", limit=5)
+
+    mock_anyapi.search.assert_called_once_with(query="reviews", category="maps", platform="google", limit=5)
+
+
+def test_get_api(anyapi_tools, mock_anyapi):
+    """Test get_api method."""
+    mock_anyapi.describe.return_value = _mock_response(
+        {
+            "slug": "instagram.profile",
+            "input_schema": {"type": "object", "properties": {"username": {"type": "string"}}},
+            "pricing": {"maxUsd": 0.002},
+        }
+    )
+
+    result = anyapi_tools.get_api("instagram.profile")
+    result_data = json.loads(result)
+
+    assert result_data["slug"] == "instagram.profile"
+    assert result_data["input_schema"]["properties"]["username"]["type"] == "string"
+    mock_anyapi.describe.assert_called_once_with("instagram.profile")
+
+
+def test_run_api(anyapi_tools, mock_anyapi):
+    """Test run_api method."""
+    mock_anyapi.run.return_value = _mock_response(
+        {
+            "output": {"found": True, "data": {"username": "agno"}},
+            "provider": "AnyAPI",
+            "cost_usd": 0.002,
+            "items": 1,
+        }
+    )
+
+    result = anyapi_tools.run_api("instagram.profile", {"username": "agno"})
+    result_data = json.loads(result)
+
+    assert result_data["output"]["data"]["username"] == "agno"
+    assert result_data["cost_usd"] == 0.002
+    assert result_data["items"] == 1
+    mock_anyapi.run.assert_called_once_with("instagram.profile", {"username": "agno"})
+
+
+def test_get_balance(anyapi_tools, mock_anyapi):
+    """Test get_balance method."""
+    mock_anyapi.balance.return_value = _mock_response({"usd": 4.21})
+
+    result = anyapi_tools.get_balance()
+    result_data = json.loads(result)
+
+    assert result_data["usd"] == 4.21
+    mock_anyapi.balance.assert_called_once_with()
+
+
+def test_results_are_json_serializable(anyapi_tools, mock_anyapi):
+    """Test that a value the JSON encoder cannot handle is stringified rather than raising."""
+    mock_anyapi.describe.return_value = _mock_response({"slug": "web.scrape", "latency": object()})
+
+    result = anyapi_tools.get_api("web.scrape")
+    result_data = json.loads(result)
+
+    assert result_data["slug"] == "web.scrape"
+    assert isinstance(result_data["latency"], str)


### PR DESCRIPTION
Closes #9946

## Summary

Adds `AnyAPITools`, a toolkit for [AnyAPI](https://getanyapi.com) - a gateway to hundreds of scraping and data APIs behind one key, billed per request in USD with no subscription. It sits alongside the existing Apify, Bright Data, Exa, Firecrawl, Jina, Scrapegraph, SerpApi, Serper, Serply and Tavily toolkits, but is catalog-shaped rather than single-purpose: an agent searches for the API it needs, reads that API's schema, then runs it.

Four tools, following the `enable_*` plus `all` convention:

| Tool | Purpose | Default |
|---|---|---|
| `search_apis` | ranked search over the catalog | on |
| `get_api` | one API's input/output JSON Schema, USD price and latency | on |
| `run_api` | execute an API by slug | on |
| `get_balance` | remaining USD wallet balance | off |

The toolkit deliberately holds no catalog knowledge - no hardcoded endpoint list, no per-platform convenience methods, no caching. Routing, pricing and schemas belong to the gateway, so the toolkit stays a thin transport layer and does not need a release when the catalog changes.

Built on the official `getanyapi` SDK, added as an optional `anyapi` extra the same way the sibling toolkits declare theirs.

## Type of change

- [x] New feature

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

`./scripts/validate.sh` is green (`ruff check` and `mypy` clean across all 1034 source files). `pytest libs/agno/tests/unit/tools/test_anyapi.py` passes 11 tests.

On formatting: I ran `ruff format` and the import sort on my three files only. Running the full `./scripts/format.sh` would have rewritten 13 unrelated pre-existing files (`vectordb/*`, `knowledge/loaders/*`, `tools/gandr.py`, one test), so I left those alone to keep the diff to this feature.

Beyond the mocked unit tests, I smoke tested the toolkit against the live production API with a real key: all four tools register, `search_apis` returns real ranked results, `get_api` returns the input and output schemas, and `get_balance` returns a USD figure.

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

To be straight about that last box: this was drafted with Claude Code and then reviewed by a human against the live API before submitting. I am from AnyAPI, so this is a vendor-contributed integration.

---

## Additional Notes

Two small deviations from `firecrawl.py` worth flagging for a reviewer:

- **Version specifier.** Firecrawl pins `firecrawl-py==3.4.0`, but the majority convention for tool SDKs here is a floor (`exa_py>=2.0.0`, `tavily-python>=0.7.9`), so I used `getanyapi>=0.35.3`.
- **Missing key behaviour.** `AnyAPITools()` with no key logs the usual `ANYAPI_API_KEY not set` error and then raises from the SDK constructor, because our client refuses to build without a key where Firecrawl's tolerates `None`. Happy to catch and defer if you would rather it construct and fail at call time.

`getanyapi` requires Python 3.10+ while agno declares 3.9+. I followed the dominant convention here and declared it plainly with no environment marker, matching `docling`, `crawl4ai` and `daytona`.
