### PR TITLE
[fix] keep falsy tool results (0, False, []) on the sync tool execution path

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -2347,7 +2347,7 @@ class Model(ABC):
                 if tool_result.files:
                     function_execution_result.files = tool_result.files
             else:
-                function_call_output = str(function_execution_result.result) if function_execution_result.result else ""
+                function_call_output = str(function_execution_result.result)
 
             if function_call.function.show_result and function_call_output is not None:
                 yield ModelResponse(content=function_call_output)

--- a/libs/agno/tests/unit/models/test_tool_result_falsy_values.py
+++ b/libs/agno/tests/unit/models/test_tool_result_falsy_values.py
@@ -1,0 +1,87 @@
+"""Tool results that are falsy but meaningful (0, False, [], 0.0) must reach the
+model as their string form on both the sync and the async execution paths."""
+
+from typing import Any, AsyncIterator, Iterator, List
+
+import pytest
+
+from agno.models.base import Model
+from agno.models.message import Message
+from agno.models.response import ModelResponse
+from agno.tools.function import Function, FunctionCall
+
+
+class _StubModel(Model):
+    def __init__(self):
+        super().__init__(id="stub", name="stub", provider="stub")
+
+    def invoke(self, *args, **kwargs) -> ModelResponse:
+        raise NotImplementedError
+
+    async def ainvoke(self, *args, **kwargs) -> ModelResponse:
+        raise NotImplementedError
+
+    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+        raise NotImplementedError
+
+    async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+        raise NotImplementedError
+
+    def _parse_provider_response(self, response: Any, **kwargs) -> ModelResponse:
+        raise NotImplementedError
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        raise NotImplementedError
+
+
+def _function_call(return_value: Any) -> FunctionCall:
+    def tool() -> Any:
+        """Return a fixed value."""
+        return return_value
+
+    function = Function.from_callable(tool)
+    function.process_entrypoint()
+    return FunctionCall(function=function, arguments={}, call_id="call_1")
+
+
+def _sync_tool_message(return_value: Any) -> Message:
+    results: List[Message] = []
+    for _ in _StubModel().run_function_call(_function_call(return_value), function_call_results=results):
+        pass
+    assert len(results) == 1
+    return results[0]
+
+
+async def _async_tool_message(return_value: Any) -> Message:
+    results: List[Message] = []
+    async for _ in _StubModel().arun_function_calls([_function_call(return_value)], function_call_results=results):
+        pass
+    assert len(results) == 1
+    return results[0]
+
+
+@pytest.mark.parametrize(
+    "return_value, expected",
+    [(0, "0"), (0.0, "0.0"), (False, "False"), ([], "[]"), ({}, "{}"), (1, "1"), ("text", "text")],
+)
+def test_sync_tool_result_keeps_falsy_values(return_value, expected):
+    message = _sync_tool_message(return_value)
+    assert message.role == "tool"
+    assert message.content == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "return_value, expected",
+    [(0, "0"), (0.0, "0.0"), (False, "False"), ([], "[]"), ({}, "{}"), (1, "1"), ("text", "text")],
+)
+async def test_async_tool_result_keeps_falsy_values(return_value, expected):
+    message = await _async_tool_message(return_value)
+    assert message.role == "tool"
+    assert message.content == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("return_value", [0, False, [], "text"])
+async def test_sync_and_async_tool_results_match(return_value):
+    assert _sync_tool_message(return_value).content == (await _async_tool_message(return_value)).content


### PR DESCRIPTION
## Summary

On the synchronous tool-execution path, a tool whose return value is falsy but meaningful (`0`, `0.0`, `False`, `[]`, `{}`) is sent to the model as an empty tool message. `Model.run_function_call` stringified the result only when it was truthy:

```python
function_call_output = str(function_execution_result.result) if function_execution_result.result else ""
```

while `Model.arun_function_calls` already used `str(function_call.result)`. So `agent.run()` and `agent.arun()` gave the model different tool results for the same tool, and the model could not tell "zero items" apart from "the tool produced no output". The empty string also ends up in `RunOutput.tools[i].result`, so it is what gets persisted to the session.

This PR drops the truthiness check so the sync branch matches the async one. See the note below on `None`.

Issue number: #9947

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Changes

- `libs/agno/agno/models/base.py`: one-line change in `run_function_call`, `str(function_execution_result.result)` unconditionally, matching `arun_function_calls`.
- `libs/agno/tests/unit/models/test_tool_result_falsy_values.py`: new regression test running a tool that returns `0`, `0.0`, `False`, `[]`, `{}`, `1`, `"text"` through both `run_function_call` and `arun_function_calls` with a stub `Model` (no network), asserting the tool message content on each path and that the two paths agree.

**Note on `None`:** with this change a tool returning `None` produces `"None"` on the sync path, which is what the async path has always produced (verified: both paths now give `'None'`). Previously sync gave `""`. I kept the two paths identical rather than special-casing `None`. If you would rather have `""` for `None`, the change is a one-liner (`if result is not None else ""`) and I'm happy to apply it to both paths.

## Testing

Commands actually run, in a `uv` venv (`uv pip install -e "libs/agno[dev]"` plus provider SDKs), on `main` @ `56eae14f`:

- Reproduction (Agent level, stub model that requests one tool call for a `count_items() -> int` tool returning `0`):
  - Before: `run()` tool message content `''`, `arun()` `'0'`.
  - After: both `'0'`.
- New test file: 18 passed with the fix. Sabotage check with the fix reverted and the test kept: 8 failed (all sync-path cases for `0`, `0.0`, `False`, `[]`, `{}` and the sync/async equality cases), 10 passed. Restoring the fix: 18 passed.
- `pytest libs/agno/tests/unit/models libs/agno/tests/unit/agent libs/agno/tests/unit/team libs/agno/tests/unit/tools/test_functions.py libs/agno/tests/unit/tools/test_decorator.py libs/agno/tests/unit/tools/test_toolkit.py` → 3121 passed, 12 skipped.
- `pytest libs/agno/tests/unit/workflow` → 560 passed, 7 skipped.
- `ruff format --check` and `ruff check` on the two changed files → clean.
- `mypy --config-file libs/agno/pyproject.toml libs/agno/agno/models/base.py` → 0 errors.

I did not run the entire `libs/agno/tests/unit` suite: some tool modules need optional extras not installed here. CI will cover the rest.

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (ruff format/check and mypy with the repo's `pyproject.toml` config, as `./scripts/validate.sh` does)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings) — not applicable, no public API change
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable) — not applicable
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Related open PR:** #6633 (for #6361) refactors both branches into a shared `_format_non_generator_result` helper and, in passing, changes this check to `is not None`. That PR is much broader (also touches event handling for generators and workflow events), has been conflicting since June, and does not call out the falsy-result behaviour or test it. This PR is the minimal fix for the specific bug in #9947 with a targeted regression test; if #6633 lands first this becomes redundant and can be closed.

**AI disclosure:** not entirely AI-generated. I found and reproduced the bug, decided on the fix, and ran every command listed above; an AI assistant helped draft the test file and this description, and I reviewed and understand every line.
