### PR TITLE
feat: list the served tools on the MCP Server Card

### DIFF
--- a/cookbook/05_agent_os/14_mcp/README.md
+++ b/cookbook/05_agent_os/14_mcp/README.md
@@ -80,7 +80,13 @@ Open `/mcp` in a browser and you are sent to `/mcp/server-card`, a JSON Server C
 with the name, description and endpoint URL in the shape of the MCP Server Card
 extension. The `version` is the one the server reports at connect time, so set it on
 `MCPConfig` or `AgentOS` to publish your deployment's version rather than the default.
-It lists no tools; `tools/list` does that. `MCPConfig(server_card=False)` turns it off.
+`MCPConfig(server_card=False)` turns it off.
+
+The card also lists the served tools in the same shape `tools/list` returns — name,
+title, description and `inputSchema` — built from each tool's own MCP representation,
+so it cannot drift from the live surface. That makes the endpoint readable by people
+and crawlers who never speak the protocol, while `tools/list` stays the authority a
+connected client calls.
 
 Behind a proxy or load balancer, set the public endpoint explicitly:
 

--- a/libs/agno/agno/os/config.py
+++ b/libs/agno/agno/os/config.py
@@ -65,9 +65,10 @@ class MCPConfig(BaseModel):
     version: Optional[str] = None
     instructions: Optional[str] = None
 
-    # Publish a Server Card at ``/mcp/server-card`` (name, version, description and the
-    # endpoint URL, no tools) and send a browser that opens ``/mcp`` to it. The card is
-    # public even when the server is gated; it carries nothing secret.
+    # Publish a Server Card at ``/mcp/server-card`` (name, version, description, the endpoint
+    # URL, and the served tools by name and description) and send a browser that opens ``/mcp``
+    # to it. The card is public even when the server is gated; it carries nothing secret --
+    # the tool names it lists are the same ones ``tools/list`` returns to any caller.
     server_card: bool = True
 
     # The public URL of the MCP endpoint, e.g. ``https://docs.agno.com/mcp``. Set this when the

--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -16,6 +16,7 @@ from typing import (
     Literal,
     NamedTuple,
     Optional,
+    Set,
     Union,
     get_type_hints,
 )
@@ -2017,7 +2018,28 @@ def _truncate(value: str, limit: int) -> str:
     return value if len(value) <= limit else value[: limit - 1].rstrip() + "…"
 
 
-def _server_card(
+async def _card_tools(mcp: FastMCP) -> List[Dict[str, Any]]:
+    """The published tools in the same shape ``tools/list`` returns.
+
+    Built from each tool's own MCP representation, so the card cannot drift from the live
+    surface and a reader gets what a connected client would get: name, title, description and
+    ``inputSchema``. Descriptions are published whole -- they are written for the calling model,
+    and a clipped one is worse than none. Internal transport metadata (``_meta``) is dropped.
+    """
+    entries: List[Dict[str, Any]] = []
+    seen: Set[str] = set()
+    # list_tools returns every version of a tool; the card names each one once.
+    for tool in await mcp.list_tools():
+        if tool.name in seen:
+            continue
+        seen.add(tool.name)
+        entry = tool.to_mcp_tool().model_dump(exclude_none=True, by_alias=True)
+        entry.pop("_meta", None)
+        entries.append(entry)
+    return entries
+
+
+async def _server_card(
     mcp: FastMCP,
     os: "AgentOS",
     request: Any,
@@ -2068,6 +2090,10 @@ def _server_card(
     # even though fastmcp defaults that to its own library version. Set ``MCPConfig(version=...)``
     # or ``AgentOS(version=...)`` to publish the deployment's real version instead.
     card["version"] = _truncate(version or str(mcp.version), _CARD_VERSION_MAX)
+    # Not part of the Server Card schema, which leaves the tool surface to ``tools/list``. It is
+    # carried anyway (the schema allows extra keys) because the card is what a person or a crawler
+    # opening the endpoint in a browser sees, and they never speak the protocol.
+    card["tools"] = await _card_tools(mcp)
     return card
 
 
@@ -2088,7 +2114,7 @@ def _register_server_card(
     @mcp.custom_route(MCP_SERVER_CARD_PATH, methods=["GET"], include_in_schema=False)
     async def server_card(request: Request) -> Response:
         return JSONResponse(
-            _server_card(mcp, os, request, version, card_url, allowed_hosts),
+            await _server_card(mcp, os, request, version, card_url, allowed_hosts),
             media_type=SERVER_CARD_MEDIA_TYPE,
             headers={
                 "Cache-Control": "public, max-age=300",

--- a/libs/agno/tests/unit/os/test_mcp_server.py
+++ b/libs/agno/tests/unit/os/test_mcp_server.py
@@ -1305,7 +1305,9 @@ async def test_server_card_describes_the_server_and_its_endpoint(monkeypatch):
     assert response.headers["content-type"].startswith("application/mcp-server-card+json")
     assert response.headers["access-control-allow-origin"] == "*"
     assert response.headers["cache-control"] == "public, max-age=300"
-    assert response.json() == {
+    card = response.json()
+    # The tool entries have their own tests; everything else is pinned exactly.
+    assert {key: value for key, value in card.items() if key != "tools"} == {
         "$schema": SERVER_CARD_SCHEMA,
         "name": "com.example/agno-docs",
         "title": "Agno Docs",
@@ -1681,3 +1683,95 @@ async def test_the_published_url_always_matches_the_schema_pattern(monkeypatch):
         url = (await client.get("/mcp/server-card")).json()["remotes"][0]["url"]
 
     assert re.fullmatch(r"^(https?://[^\s]+|\{[a-zA-Z_][a-zA-Z0-9_]*\}[^\s]*)$", url), url
+
+
+# ----------------------------- server card tools -----------------------------
+
+
+async def test_the_card_lists_the_served_tools(monkeypatch):
+    """A browser or crawler reading the card never speaks the protocol, so it needs the names."""
+    monkeypatch.setattr(mcp_mod, "_mcp_server_is_open", lambda os: True)
+    app = get_mcp_server(_docs_os())
+
+    async with _mcp_client(app) as client:
+        card = (await client.get("/mcp/server-card")).json()
+
+    names = [entry["name"] for entry in card["tools"]]
+    assert names == sorted(names, key=names.index)  # order preserved, no duplicates injected
+    assert set(names) == {
+        "get_agentos_config",
+        "run_agent",
+        "run_team",
+        "run_workflow",
+        "continue_run",
+        "cancel_run",
+        "get_sessions",
+        "get_session_runs",
+    }
+    assert all(entry.get("description") for entry in card["tools"])
+
+
+async def test_the_card_tools_match_tools_list(monkeypatch):
+    """The card reads the same registry, so it cannot drift from the live surface."""
+    monkeypatch.setattr(mcp_mod, "_mcp_server_is_open", lambda os: True)
+    os = _docs_os()
+    app = get_mcp_server(os)
+
+    async with _mcp_client(app) as client:
+        card = (await client.get("/mcp/server-card")).json()
+
+    assert {entry["name"] for entry in card["tools"]} == await _tool_names(os)
+
+
+async def test_the_card_follows_a_custom_tool_surface(monkeypatch):
+    """default_tools=False plus custom tools: the card shows exactly what is served."""
+    monkeypatch.setattr(mcp_mod, "_mcp_server_is_open", lambda os: True)
+
+    @tool
+    def search_docs(query: str) -> str:
+        """Search the documentation."""
+        return ""
+
+    app = get_mcp_server(_docs_os(default_tools=False, tools=[search_docs]))
+
+    async with _mcp_client(app) as client:
+        card = (await client.get("/mcp/server-card")).json()
+
+    assert [entry["name"] for entry in card["tools"]] == ["search_docs"]
+    assert card["tools"][0]["description"] == "Search the documentation."
+
+
+async def test_a_card_tool_description_is_published_whole(monkeypatch):
+    """Tool descriptions are prompts for the calling model; a clipped one is worse than none."""
+    monkeypatch.setattr(mcp_mod, "_mcp_server_is_open", lambda os: True)
+
+    @tool
+    def verbose(query: str) -> str:
+        return ""
+
+    verbose.description = "d" * 500
+    app = get_mcp_server(_docs_os(default_tools=False, tools=[verbose]))
+
+    async with _mcp_client(app) as client:
+        card = (await client.get("/mcp/server-card")).json()
+
+    assert card["tools"][0]["description"] == "d" * 500
+
+
+async def test_the_card_tool_entries_match_the_tools_list_wire_format(monkeypatch):
+    """A reader of the card gets what a connected client gets, inputSchema included."""
+    monkeypatch.setattr(mcp_mod, "_mcp_server_is_open", lambda os: True)
+    os = _docs_os()
+    app = get_mcp_server(os)
+
+    async with _mcp_client(app) as client:
+        card = (await client.get("/mcp/server-card")).json()
+
+    by_name = {entry["name"]: entry for entry in card["tools"]}
+    async with Client(build_mcp_server(os)) as client:
+        for served in await client.list_tools():
+            entry = by_name[served.name]
+            assert entry["description"] == served.description
+            assert entry["inputSchema"] == served.input_schema
+    # No internal transport metadata leaks into the published card.
+    assert all("_meta" not in entry for entry in card["tools"])


### PR DESCRIPTION
## Summary

Follow up to https://github.com/agno-agi/agno/pull/9932 where the Server Card at `/mcp/server-card` now lists the tools the server serves, in the same  shape `tools/list` returns them: `name`, `title`, `description`, `inputSchema`,  `outputSchema` and `annotations`.  

```json                                                                                                                                                                                                                                                                                       
  {                                                                                                                                                                                                                                                                                             
    "$schema": "https://static.modelcontextprotocol.io/schemas/v1/server-card.schema.json",                                                                                                                                                                                                     
    "name": "com.agno.docs/agno-docs",                                                                                                                                                                                                                                                          
    "title": "Agno Docs",                                                                                                                                                                                                                                                                       
    "version": "1.0.0",                                                                                                                                                                                                                                                                         
    "description": "Search the docs.",                                                                                                                                                                                                                                                          
    "remotes": [{"type": "streamable-http", "url": "https://docs.agno.com/mcp"}],                                                                                                                                                                                                               
    "tools": [                                                                                                                                                                                                                                                                                  
      {                                                                                                                                                                                                                                                                                         
        "name": "search_docs",                                                                                                                                                                                                                                                                  
        "title": "Search Docs",                                                                                                                                                                                                                                                                 
        "description": "Search the Agno documentation for relevant content, code examples, and guides. ...",                                                                                                                                                                                    
        "inputSchema": {                                                                                                                                                                                                                                                                        
          "type": "object",                                                                                                                                                                                                                                                                     
          "properties": {"query": {"type": "string"}},                                                                                                                                                                                                                                          
          "required": ["query"],                                                                                                                                                                                                                                                                
          "additionalProperties": false                                                                                                                                                                                                                                                         
        }                                                                                                                                                                                                                                                                                       
      }                                                                                                                                                                                                                                                                                         
    ]                                                                                                                                                                                                                                                                                           
  }                                                                                                                                                                                                                                                                                             
  ```    

Tested using `cookbook/05_agent_os/14_mcp/server_identity.py`. 

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
