### PR TITLE
feat: report queue capabilities on /config

### DIFF
--- a/libs/agno/agno/os/router.py
+++ b/libs/agno/agno/os/router.py
@@ -40,6 +40,7 @@ from agno.os.schema import (
     McpInfo,
     Model,
     NotFoundResponse,
+    QueueCapabilities,
     TeamSummaryResponse,
     UnauthenticatedResponse,
     ValidationErrorResponse,
@@ -204,6 +205,10 @@ def get_base_router(
             teams=team_summaries,
             workflows=workflow_summaries,
             traces=os._get_traces_config(),
+            queue=QueueCapabilities(
+                durable=bool(os.queue is not None and os.queue.durable),
+                queue_per_session=bool(os.queue is not None and os.queue.durable and os.queue.queue_per_session),
+            ),
             interfaces=[
                 InterfaceResponse(type=interface.type, version=interface.version, route=interface.prefix)
                 for interface in os.interfaces

--- a/libs/agno/agno/os/schema.py
+++ b/libs/agno/agno/os/schema.py
@@ -333,6 +333,28 @@ class InfoResponse(BaseModel):
     )
 
 
+class QueueCapabilities(BaseModel):
+    """Deployment-level background-run capabilities: what a client may rely on
+    when deciding whether to render queue-aware UI (e.g. a chat tray).
+
+    Reported as EFFECTIVE behavior, not raw settings: queue_per_session is
+    true only when a durable queue actually enforces the per-session gate -
+    a queue_per_session flag without durable=True gates nothing and is
+    reported false. Readable by any authenticated caller (deployment
+    capability, not operator data - the admin-scoped /queue surface stays
+    the only view of actual jobs)."""
+
+    durable: bool = Field(
+        ...,
+        description="Accepted background runs survive crashes and deploys (ticketed queue with a worker)",
+    )
+    queue_per_session: bool = Field(
+        ...,
+        description="Same-session background submissions execute at most one at a time, FIFO by submission; "
+        "false when no durable queue enforces the gate",
+    )
+
+
 class ConfigResponse(BaseModel):
     """Response schema for the general config endpoint"""
 
@@ -358,6 +380,9 @@ class ConfigResponse(BaseModel):
     knowledge: Optional[KnowledgeConfig] = Field(None, description="Knowledge configuration")
     evals: Optional[EvalsConfig] = Field(None, description="Evaluations configuration")
     traces: Optional[TracesConfig] = Field(None, description="Traces configuration")
+    # Optional for CLIENT compatibility (the SDK parses this same schema, and
+    # older servers omit the field); the server always populates it.
+    queue: Optional[QueueCapabilities] = Field(None, description="Background-run queue capabilities")
 
     agents: List[AgentSummaryResponse] = Field(..., description="List of registered agents")
     teams: List[TeamSummaryResponse] = Field(..., description="List of registered teams")

--- a/libs/agno/tests/unit/os/test_config_queue_capabilities.py
+++ b/libs/agno/tests/unit/os/test_config_queue_capabilities.py
@@ -1,0 +1,46 @@
+"""The /config queue block: capability discovery for queue-aware clients.
+
+A chat tray cannot probe the admin-scoped /queue surface, so /config reports
+EFFECTIVE background-run capabilities to any authenticated caller: whether
+acceptance is durable, and whether same-session submissions actually run
+FIFO (the serialize flag gates durable claims only - without a durable
+queue it enforces nothing and must be reported false).
+"""
+
+from fastapi.testclient import TestClient
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.job_queue.config import QueueConfig
+from agno.job_queue.store import InMemoryQueueStore
+from agno.os import AgentOS
+
+
+def _queue_block(tmp_path, queue=None):
+    agent = Agent(id="cfg-agent", name="Cfg Agent", db=SqliteDb(db_file=str(tmp_path / "t.db")))
+    app = AgentOS(agents=[agent], queue=queue, telemetry=False).get_app()
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get("/config")
+    assert resp.status_code == 200, resp.text
+    return resp.json()["queue"]
+
+
+class TestQueueCapabilities:
+    def test_no_queue_config_reports_nothing_enabled(self, tmp_path):
+        assert _queue_block(tmp_path) == {"durable": False, "queue_per_session": False}
+
+    def test_bounded_only_queue_is_not_durable(self, tmp_path):
+        block = _queue_block(tmp_path, QueueConfig(max_concurrency=4))
+        assert block == {"durable": False, "queue_per_session": False}
+
+    def test_durable_defaults_report_serialized(self, tmp_path):
+        block = _queue_block(tmp_path, QueueConfig(durable=True, db=InMemoryQueueStore()))
+        assert block == {"durable": True, "queue_per_session": True}
+
+    def test_serialize_opt_out_is_visible(self, tmp_path):
+        block = _queue_block(tmp_path, QueueConfig(durable=True, db=InMemoryQueueStore(), queue_per_session=False))
+        assert block == {"durable": True, "queue_per_session": False}
+
+    def test_serialize_flag_without_durable_reports_false(self, tmp_path):
+        block = _queue_block(tmp_path, QueueConfig(max_concurrency=2, queue_per_session=True))
+        assert block == {"durable": False, "queue_per_session": False}


### PR DESCRIPTION
## Summary

Capability discovery for queue-aware clients (the chat tray's gating question from the team thread): `GET /config` now includes

```json
"queue": {"durable": true, "queue_per_session": true}
```

readable by any authenticated caller. The tray cannot probe the admin-scoped `/queue` surface, and a 200 from `/sessions/{id}/runs?summary=true` only proves run summaries exist - this block answers the actual question (will multi-submit queue FIFO?) once, cacheably, with no auth special-casing.

Design notes:
- **Effective behavior, not raw settings**: `queue_per_session` reports true only when a durable queue actually enforces the gate. `QueueConfig(queue_per_session=True)` without `durable=True` gates nothing and reports false - a client rendering a FIFO tray on this signal is never lied to.
- **SDK-compatible**: the field is `Optional` on `ConfigResponse` because the Python client parses the same schema and older servers omit it; the server always populates it.
- **Capability only**: actual job rows remain behind the admin-scoped `/queue` surface.

Based on `feat/serialize-sessions-per-queue` (#9587) because the `queue_per_session` field exists there; merge after it.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (schema docstrings, field descriptions)
- [ ] Examples and guides: not applicable
- [x] Tested in clean environment
- [x] Tests added/updated

## Additional context

Tests cover all four postures: no queue config, bounded-only, durable defaults (reports serialized), serialize opt-out, and the flag-without-durable case reporting false. 45 tests green including the SDK client suite; changed files mypy-clean (only pre-existing transitive mcp-stub noise). Answers Monalisha's capability-discovery request; the version-pinned durable-queueing question from the same thread is tracked separately.