### PR TITLE
[fix] Drop the sampling params OpenAI fixed-sampling models reject (o-series, gpt-5 family)

### DIFF
--- a/libs/agno/agno/models/openai/chat.py
+++ b/libs/agno/agno/models/openai/chat.py
@@ -17,6 +17,7 @@ from agno.models.response import ModelResponse
 from agno.run.agent import RunOutput
 from agno.run.team import TeamRunOutput
 from agno.utils.log import log_debug, log_error, log_warning
+from agno.utils.models.openai import drop_fixed_sampling_params, has_fixed_sampling_params
 from agno.utils.openai import _format_file_for_message, audio_to_message, images_to_message
 from agno.utils.reasoning import extract_thinking_content
 
@@ -264,9 +265,16 @@ class OpenAIChat(Model):
         if self.request_params:
             request_params.update(self.request_params)
 
+        if self._has_fixed_sampling_params():
+            drop_fixed_sampling_params(request_params)
+
         if request_params:
             log_debug(f"Calling {self.provider} with request parameters: {request_params}", log_level=2)
         return request_params
+
+    def _has_fixed_sampling_params(self) -> bool:
+        """Return True if the model only accepts the default sampling values (o-series, gpt-5 family)."""
+        return has_fixed_sampling_params(self.id)
 
     def to_dict(self) -> Dict[str, Any]:
         """

--- a/libs/agno/agno/models/openai/like.py
+++ b/libs/agno/agno/models/openai/like.py
@@ -29,3 +29,7 @@ class OpenAILike(OpenAIChat):
 
     def get_provider(self) -> str:
         return Model.get_provider(self)
+
+    def _has_fixed_sampling_params(self) -> bool:
+        # A compatible provider's model ids say nothing about OpenAI's sampling rules.
+        return False

--- a/libs/agno/agno/models/openai/open_responses.py
+++ b/libs/agno/agno/models/openai/open_responses.py
@@ -44,3 +44,7 @@ class OpenResponses(OpenAIResponses):
         this if they support specific reasoning models.
         """
         return False
+
+    def _has_fixed_sampling_params(self) -> bool:
+        # A compatible provider's model ids say nothing about OpenAI's sampling rules.
+        return False

--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -17,6 +17,7 @@ from agno.models.response import ModelResponse
 from agno.run.agent import RunOutput
 from agno.tools.function import Function
 from agno.utils.log import log_debug, log_error, log_warning
+from agno.utils.models.openai import drop_fixed_sampling_params, has_fixed_sampling_params
 from agno.utils.models.openai_responses import images_to_message
 from agno.utils.models.schema_utils import get_response_schema_for_provider
 from agno.utils.tokens import count_schema_tokens
@@ -104,6 +105,10 @@ class OpenAIResponses(Model):
     def _using_reasoning_model(self) -> bool:
         """Return True if the contextual used model is a known reasoning model."""
         return self.id.startswith("o3") or self.id.startswith("o4-mini") or self.id.startswith("gpt-5")
+
+    def _has_fixed_sampling_params(self) -> bool:
+        """Return True if the model only accepts the default sampling values (o-series, gpt-5 family)."""
+        return has_fixed_sampling_params(self.id)
 
     def _set_reasoning_request_param(self, base_params: Dict[str, Any]) -> Dict[str, Any]:
         """Set the reasoning request parameter."""
@@ -397,6 +402,9 @@ class OpenAIResponses(Model):
         # Add additional request params if provided
         if self.request_params:
             request_params.update(self.request_params)
+
+        if self._has_fixed_sampling_params():
+            drop_fixed_sampling_params(request_params)
 
         if request_params:
             log_debug(f"Calling {self.provider} with request parameters: {request_params}", log_level=2)

--- a/libs/agno/agno/utils/models/openai.py
+++ b/libs/agno/agno/utils/models/openai.py
@@ -1,0 +1,47 @@
+import re
+from typing import Any, Dict
+
+from agno.utils.log import log_warning
+
+# The o-series and the gpt-5 family that ships as gpt-5, gpt-5-mini, gpt-5-nano and gpt-5-pro
+# only accept the default sampling values; gpt-5.1 and later take the full set again.
+_FIXED_SAMPLING_MODEL_RE = re.compile(r"^(o\d|gpt-5(-|$))")
+
+# What the API answers for each parameter on those models: only the default value, or nothing.
+_DEFAULT_ONLY = {"temperature": 1, "top_p": 1, "presence_penalty": 0, "frequency_penalty": 0}
+_NEVER = ("logit_bias", "logprobs", "top_logprobs", "stop")
+
+
+def has_fixed_sampling_params(model_id: str) -> bool:
+    """Return True if the model rejects any non-default sampling parameter with a 400."""
+    return _FIXED_SAMPLING_MODEL_RE.match(model_id) is not None
+
+
+def drop_fixed_sampling_params(request_params: Dict[str, Any]) -> Dict[str, Any]:
+    """Remove the sampling parameters a fixed-sampling model would reject.
+
+    ``temperature`` and ``top_p`` survive only at 1, ``presence_penalty`` and ``frequency_penalty``
+    only at 0; ``logit_bias``, ``logprobs``, ``top_logprobs`` and ``stop`` never do. ``max_tokens``
+    becomes ``max_completion_tokens`` when that is not set, as the API's own error suggests.
+    A value that would have been rejected is dropped with a warning, so a ``temperature=0``
+    carried over from an older configuration degrades to the default instead of failing every
+    request. Mutates and returns the dict it is given.
+    """
+    dropped = []
+    for name, default in _DEFAULT_ONLY.items():
+        if name in request_params and request_params[name] != default:
+            dropped.append(f"{name}={request_params.pop(name)}")
+    for name in _NEVER:
+        if name in request_params:
+            dropped.append(f"{name}={request_params.pop(name)}")
+    if "max_tokens" in request_params:
+        max_tokens = request_params.pop("max_tokens")
+        if "max_completion_tokens" not in request_params:
+            request_params["max_completion_tokens"] = max_tokens
+        dropped.append(f"max_tokens={max_tokens} (sent as max_completion_tokens)")
+    if dropped:
+        log_warning(
+            f"Dropping {', '.join(dropped)} from the request: this model only accepts the default sampling "
+            "values. Unset them to silence this warning."
+        )
+    return request_params

--- a/libs/agno/tests/unit/models/openai/test_fixed_sampling_params.py
+++ b/libs/agno/tests/unit/models/openai/test_fixed_sampling_params.py
@@ -1,0 +1,147 @@
+"""OpenAI's o-series and the gpt-5 family (gpt-5, gpt-5-mini, gpt-5-nano) answer any non-default
+sampling parameter with a 400, so the request builders drop those values with a warning instead of
+sending them. gpt-5.1 and later accept the full set again, and OpenAI-compatible providers are left
+alone because their model ids say nothing about OpenAI's rules."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from agno.models.openai.chat import OpenAIChat
+from agno.models.openai.like import OpenAILike
+from agno.models.openai.open_responses import OpenResponses
+from agno.models.openai.responses import OpenAIResponses
+from agno.utils.models.openai import drop_fixed_sampling_params, has_fixed_sampling_params
+
+
+@pytest.mark.parametrize(
+    "model_id, expected",
+    [
+        ("gpt-5", True),
+        ("gpt-5-mini", True),
+        ("gpt-5-nano", True),
+        ("gpt-5-2025-08-07", True),
+        ("o1", True),
+        ("o3", True),
+        ("o3-mini", True),
+        ("o4-mini", True),
+        ("gpt-5.1", False),
+        ("gpt-5.2", False),
+        ("gpt-5.4-mini", False),
+        ("gpt-4.1-mini", False),
+        ("gpt-4o", False),
+    ],
+)
+def test_has_fixed_sampling_params(model_id, expected):
+    assert has_fixed_sampling_params(model_id) is expected
+
+
+def test_chat_drops_what_a_fixed_sampling_model_rejects():
+    model = OpenAIChat(
+        id="gpt-5-mini",
+        temperature=0,
+        top_p=0.5,
+        presence_penalty=0.5,
+        frequency_penalty=0.5,
+        logit_bias={"1": 1},
+        logprobs=True,
+        top_logprobs=1,
+        stop=["zzz"],
+        max_tokens=64,
+        seed=7,
+    )
+
+    params = model.get_request_params()
+
+    for name in (
+        "temperature",
+        "top_p",
+        "presence_penalty",
+        "frequency_penalty",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "stop",
+        "max_tokens",
+    ):
+        assert name not in params, name
+    assert params["max_completion_tokens"] == 64
+    assert params["seed"] == 7
+
+
+def test_chat_keeps_the_default_values():
+    model = OpenAIChat(
+        id="gpt-5-mini",
+        temperature=1,
+        top_p=1,
+        presence_penalty=0,
+        frequency_penalty=0,
+        max_completion_tokens=32,
+        max_tokens=64,
+    )
+
+    params = model.get_request_params()
+
+    assert params["temperature"] == 1
+    assert params["top_p"] == 1
+    assert params["presence_penalty"] == 0
+    assert params["frequency_penalty"] == 0
+    assert params["max_completion_tokens"] == 32
+    assert "max_tokens" not in params
+
+
+def test_chat_leaves_other_models_alone():
+    for model_id in ("gpt-5.4-mini", "gpt-4.1-mini"):
+        params = OpenAIChat(id=model_id, temperature=0, top_p=0.5, stop=["zzz"], max_tokens=64).get_request_params()
+        assert params["temperature"] == 0
+        assert params["top_p"] == 0.5
+        assert params["stop"] == ["zzz"]
+        assert params["max_tokens"] == 64
+
+
+def test_chat_filters_request_params_too():
+    params = OpenAIChat(id="o4-mini", request_params={"temperature": 0, "top_p": 1}).get_request_params()
+
+    assert "temperature" not in params
+    assert params["top_p"] == 1
+
+
+def test_openai_like_keeps_the_callers_values():
+    params = OpenAILike(id="gpt-5-mini", base_url="http://localhost:8000/v1", temperature=0).get_request_params()
+
+    assert params["temperature"] == 0
+
+
+def test_responses_drops_temperature_and_top_p():
+    params = OpenAIResponses(id="gpt-5-mini", temperature=0, top_p=0.5).get_request_params()
+
+    assert "temperature" not in params
+    assert "top_p" not in params
+
+
+def test_responses_keeps_them_on_other_models():
+    params = OpenAIResponses(id="gpt-5.4-mini", temperature=0, top_p=0.5).get_request_params()
+
+    assert params["temperature"] == 0
+    assert params["top_p"] == 0.5
+
+
+def test_open_responses_keeps_the_callers_values():
+    params = OpenResponses(id="gpt-5-mini", base_url="http://localhost:8000/v1", temperature=0).get_request_params()
+
+    assert params["temperature"] == 0
+
+
+def test_dropped_values_are_reported_once(monkeypatch):
+    warn = MagicMock()
+    monkeypatch.setattr("agno.utils.models.openai.log_warning", warn)
+
+    drop_fixed_sampling_params({"temperature": 0, "top_p": 1, "stop": ["zzz"], "max_tokens": 64})
+    drop_fixed_sampling_params({"temperature": 1})
+
+    warn.assert_called_once()
+    message = warn.call_args.args[0]
+    assert "temperature=0" in message
+    assert "stop=['zzz']" in message
+    assert "max_tokens=64 (sent as max_completion_tokens)" in message
+    assert "top_p" not in message


### PR DESCRIPTION
Fixes #9951

## Summary

`OpenAIChat` and `OpenAIResponses` forward every sampling parameter as set. OpenAI's o-series and the gpt-5 family that ships as `gpt-5`, `gpt-5-mini`, `gpt-5-nano` and `gpt-5-pro` answer any non-default value with a 400, so a config that carried `temperature: 0` for months fails on every call the moment the model id moves to one of them, and the error reads like a provider problem.

Checked live on both endpoints before writing this (one small call per case):

- `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `o1`, `o3`, `o3-mini`, `o4-mini`: `temperature` and `top_p` only at 1, `presence_penalty` and `frequency_penalty` only at 0, `logit_bias`, `logprobs`, `stop` rejected outright, `max_tokens` rejected with "use `max_completion_tokens`", `seed` fine
- `gpt-5.1`, `gpt-5.2`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-4.1`, `gpt-4o`: everything accepted

That second line is why the existing `_using_reasoning_model` prefix (`gpt-5`) could not be reused: the dot-versioned models reason but take the full sampling set. The new predicate is `^(o\d|gpt-5(-|$))`.

The fix is one helper, `agno/utils/models/openai.py`: `has_fixed_sampling_params(model_id)` and `drop_fixed_sampling_params(request_params)`. Both clients call it right after the `request_params` merge, so explicit overrides get the same treatment. With a fixed-sampling model it drops `temperature` and `top_p` unless 1, the two penalties unless 0, and `logit_bias`, `logprobs`, `top_logprobs`, `stop`; `max_tokens` becomes `max_completion_tokens` when that is unset. Every drop is one `log_warning` naming the values and how to silence it, and the request goes out with the defaults instead of failing. `OpenAILike` and `OpenResponses` override the predicate to False, the same way `OpenResponses` already opts out of `_using_reasoning_model`, because a compatible provider's model ids say nothing about OpenAI's rules. Same shape as #9933 on the Anthropic side.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Tests: `tests/unit/models/openai/test_fixed_sampling_params.py`, 13 predicate cases plus the drop, keep-the-defaults, other-models, `request_params`, `OpenAILike`, `OpenAIResponses`, `OpenResponses` and warning cases. `tests/unit/models/openai` at 108 passed; the wider `tests/unit/models` run has the same 30 failures on `main` with this venv (tool-call parsing tests), nothing new. Ruff and mypy clean on the touched files.

Live, from the branch in an isolated env: `OpenAIChat(gpt-5-mini, temperature=0, top_p=0.5, max_tokens=64)` and `OpenAIResponses(gpt-5-mini, temperature=0)` now complete with the warning, `OpenAIChat(gpt-5.4-mini, temperature=0)` is untouched.
