### PR TITLE
[fix] Resume loop iterations in streaming workflows

### DIFF
--- a/libs/agno/agno/workflow/loop.py
+++ b/libs/agno/agno/workflow/loop.py
@@ -596,8 +596,17 @@ class Loop:
         background_tasks: Optional[Any] = None,
         add_dependencies_to_context: Optional[bool] = None,
         add_session_state_to_context: Optional[bool] = None,
+        resume_from_iteration: int = 0,
+        previous_iteration_results: Optional[List[List[StepOutput]]] = None,
     ) -> Iterator[Union[WorkflowRunOutputEvent, StepOutput]]:
-        """Execute loop steps with streaming support - mirrors workflow execution logic"""
+        """Execute loop steps with streaming support - mirrors workflow execution logic.
+
+        Args:
+            resume_from_iteration: Skip iterations before this number when resuming
+                after a per-iteration review pause.
+            previous_iteration_results: Results from already-completed iterations
+                to preserve when resuming.
+        """
         log_debug(f"Loop Start: {self.name}", center=True, symbol="=")
 
         # Prepare steps first
@@ -619,8 +628,8 @@ class Loop:
                 parent_step_id=parent_step_id,
             )
 
-        all_results = []
-        iteration = 0
+        all_results: List[List[StepOutput]] = list(previous_iteration_results) if previous_iteration_results else []
+        iteration = resume_from_iteration
         early_termination = False
 
         while iteration < self.max_iterations:
@@ -993,8 +1002,17 @@ class Loop:
         background_tasks: Optional[Any] = None,
         add_dependencies_to_context: Optional[bool] = None,
         add_session_state_to_context: Optional[bool] = None,
+        resume_from_iteration: int = 0,
+        previous_iteration_results: Optional[List[List[StepOutput]]] = None,
     ) -> AsyncIterator[Union[WorkflowRunOutputEvent, TeamRunOutputEvent, RunOutputEvent, StepOutput]]:
-        """Execute loop steps with async streaming support - mirrors workflow execution logic"""
+        """Execute loop steps with async streaming support - mirrors workflow execution logic.
+
+        Args:
+            resume_from_iteration: Skip iterations before this number when resuming
+                after a per-iteration review pause.
+            previous_iteration_results: Results from already-completed iterations
+                to preserve when resuming.
+        """
         log_debug(f"Loop Start: {self.name}", center=True, symbol="=")
 
         loop_step_id = str(uuid4())
@@ -1016,8 +1034,8 @@ class Loop:
                 parent_step_id=parent_step_id,
             )
 
-        all_results = []
-        iteration = 0
+        all_results: List[List[StepOutput]] = list(previous_iteration_results) if previous_iteration_results else []
+        iteration = resume_from_iteration
         early_termination = False
 
         while iteration < self.max_iterations:

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -8231,6 +8231,13 @@ class Workflow:
                 step_output = None
                 draining_after_cancel = False
                 try:
+                    extra_kwargs: Dict[str, Any] = {}
+                    if isinstance(step, Loop) and i == start_step_index:
+                        if kwargs.get("loop_resume_from_iteration"):
+                            extra_kwargs["resume_from_iteration"] = kwargs["loop_resume_from_iteration"]
+                        if kwargs.get("loop_previous_results"):
+                            extra_kwargs["previous_iteration_results"] = kwargs["loop_previous_results"]
+
                     for event in step.execute_stream(  # type: ignore[union-attr]
                         step_input,
                         session_id=session.session_id,
@@ -8248,6 +8255,7 @@ class Workflow:
                         else None,
                         num_history_runs=self.num_history_runs,
                         background_tasks=background_tasks,
+                        **extra_kwargs,
                     ):
                         is_bypass = isinstance(event, _EXECUTOR_CANCEL_BYPASS_EVENT_TYPES)
                         if not draining_after_cancel and not is_bypass:
@@ -9972,6 +9980,13 @@ class Workflow:
                 step_output = None
                 draining_after_cancel = False
                 try:
+                    extra_kwargs: Dict[str, Any] = {}
+                    if isinstance(step, Loop) and i == start_step_index:
+                        if kwargs.get("loop_resume_from_iteration"):
+                            extra_kwargs["resume_from_iteration"] = kwargs["loop_resume_from_iteration"]
+                        if kwargs.get("loop_previous_results"):
+                            extra_kwargs["previous_iteration_results"] = kwargs["loop_previous_results"]
+
                     async for event in step.aexecute_stream(  # type: ignore[union-attr]
                         step_input,
                         session_id=session.session_id,
@@ -9989,6 +10004,7 @@ class Workflow:
                         else None,
                         num_history_runs=self.num_history_runs,
                         background_tasks=background_tasks,
+                        **extra_kwargs,
                     ):
                         is_bypass = isinstance(event, _EXECUTOR_CANCEL_BYPASS_EVENT_TYPES)
                         if not draining_after_cancel and not is_bypass:

--- a/libs/agno/tests/integration/workflows/test_hitl_output_review.py
+++ b/libs/agno/tests/integration/workflows/test_hitl_output_review.py
@@ -36,7 +36,7 @@ Loop iteration review:
 import pytest
 
 from agno.run.base import RunStatus
-from agno.run.workflow import StepOutputReviewEvent
+from agno.run.workflow import LoopIterationCompletedEvent, StepOutputReviewEvent
 from agno.workflow import Loop, OnReject, Router
 from agno.workflow.step import Step
 from agno.workflow.types import HumanReview, StepInput, StepOutput
@@ -978,6 +978,85 @@ class TestLoopIterationReviewSync:
         run.steps_requiring_output_review[0].confirm()
         run = wf.continue_run(run)
         assert run.status == RunStatus.completed
+
+
+# =============================================================================
+# LOOP iteration review — streaming
+# =============================================================================
+
+
+class TestLoopIterationReviewStreaming:
+    """Loop per-iteration output review: sync and async streaming."""
+
+    def test_streaming_reject_resumes_after_completed_iteration(self, shared_db):
+        global iteration_counter
+        iteration_counter = 0
+
+        wf = Workflow(
+            name="Streaming Loop Resume",
+            db=shared_db,
+            steps=[
+                Loop(
+                    name="refine",
+                    steps=[Step(name="analyze", executor=refine_analysis)],
+                    max_iterations=5,
+                    human_review=HumanReview(requires_iteration_review=True, on_reject=OnReject.retry),
+                ),
+            ],
+        )
+
+        list(wf.run("improve", stream=True, stream_events=True))
+        run = wf.get_session().runs[-1]
+        run.steps_requiring_output_review[0].reject()
+
+        continue_events = list(wf.continue_run(run, stream=True, stream_events=True))
+        run = wf.get_session().runs[-1]
+
+        assert run.is_paused
+        assert iteration_counter == 2
+        assert [event.iteration for event in continue_events if isinstance(event, LoopIterationCompletedEvent)] == [2]
+        loop_output = run.step_results[-1]
+        assert [step.content for step in loop_output.steps or []] == [
+            "Iteration 1: quality 70%",
+            "Iteration 2: quality 80%",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_async_streaming_reject_resumes_after_completed_iteration(self, async_shared_db):
+        global iteration_counter
+        iteration_counter = 0
+
+        wf = Workflow(
+            name="Async Streaming Loop Resume",
+            db=async_shared_db,
+            steps=[
+                Loop(
+                    name="refine",
+                    steps=[Step(name="analyze", executor=refine_analysis)],
+                    max_iterations=5,
+                    human_review=HumanReview(requires_iteration_review=True, on_reject=OnReject.retry),
+                ),
+            ],
+        )
+
+        async for _ in wf.arun("improve", stream=True, stream_events=True):
+            pass
+        run = (await wf.aget_session()).runs[-1]
+        run.steps_requiring_output_review[0].reject()
+
+        continue_events = []
+        async for event in await wf.acontinue_run(run, stream=True, stream_events=True):
+            continue_events.append(event)
+        run = (await wf.aget_session()).runs[-1]
+
+        assert run.is_paused
+        assert iteration_counter == 2
+        assert [event.iteration for event in continue_events if isinstance(event, LoopIterationCompletedEvent)] == [2]
+        loop_output = run.step_results[-1]
+        assert [step.content for step in loop_output.steps or []] == [
+            "Iteration 1: quality 70%",
+            "Iteration 2: quality 80%",
+        ]
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Forward loop resume metadata through synchronous and asynchronous streaming workflow continuation.
- Initialize streaming loop execution from the saved iteration index and preserve completed iteration results.
- Add regression coverage for both streaming paths, including iteration numbering, execution count, and retained output history.

Fixes #9955.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

This contribution was implemented with Codex assistance and is disclosed as AI-generated above.

Validation completed:

- `pytest libs/agno/tests/integration/workflows/test_hitl_output_review.py` — 35 passed
- `pytest libs/agno/tests/integration/workflows/test_loop_steps.py` — 25 passed, 9 skipped
- `pytest libs/agno/tests/unit/workflow` — 560 passed, 7 skipped
- `./scripts/validate.sh` — passed for Agno, agnoctl, and cookbook checks

The repository-wide `./scripts/test.sh` could not complete collection in the standard development environment because optional provider and database SDKs are not installed. It reported 114 import errors for unrelated optional integrations before executing tests.
