### PR TITLE
feat(serper): make base URL configurable via base_url / SERPER_API_BASE

### DIFF
--- a/libs/agno/agno/tools/serper.py
+++ b/libs/agno/agno/tools/serper.py
@@ -12,6 +12,7 @@ class SerperTools(Toolkit):
     def __init__(
         self,
         api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
         location: str = "us",
         language: str = "en",
         num_results: int = 10,
@@ -29,6 +30,10 @@ class SerperTools(Toolkit):
 
         Args:
             api_key Optional[str]: The Serper API key.
+            base_url Optional[str]: Base URL for the Serper API. Defaults to
+                the SERPER_API_BASE environment variable, then to
+                https://google.serper.dev. Useful for proxies, regional
+                endpoints and local mocks in tests.
             location Optional[str]: The Google location code for search results.
             language Optional[str]: The language code for search results.
             num_results Optional[int]: The number of search results to retrieve.
@@ -38,6 +43,8 @@ class SerperTools(Toolkit):
         self.api_key = api_key or getenv("SERPER_API_KEY")
         if not self.api_key:
             log_debug("No Serper API key provided")
+
+        self.base_url = (base_url or getenv("SERPER_API_BASE") or "https://google.serper.dev").rstrip("/")
 
         self.location = location
         self.language = language
@@ -72,7 +79,7 @@ class SerperTools(Toolkit):
                 log_error("No Serper API key provided")
                 return {"success": False, "error": "Please provide a Serper API key"}
 
-            url = f"https://google.serper.dev/{endpoint}"
+            url = f"{self.base_url}/{endpoint}"
             if endpoint == "scrape":
                 url = "https://scrape.serper.dev"
 

--- a/libs/agno/tests/unit/tools/test_serper.py
+++ b/libs/agno/tests/unit/tools/test_serper.py
@@ -9,8 +9,9 @@ from agno.tools.serper import SerperTools
 
 @pytest.fixture(autouse=True)
 def clear_env(monkeypatch):
-    """Ensure SERPER_API_KEY is unset unless explicitly needed."""
+    """Ensure SERPER_API_KEY and SERPER_API_BASE are unset unless explicitly needed."""
     monkeypatch.delenv("SERPER_API_KEY", raising=False)
+    monkeypatch.delenv("SERPER_API_BASE", raising=False)
 
 
 @pytest.fixture
@@ -362,3 +363,53 @@ def test_http_error_handling(api_tools):
         result_json = json.loads(result)
         assert "error" in result_json
         assert "404 Not Found" in result_json["error"]
+
+
+def test_base_url_defaults_to_serper():
+    """Without configuration the toolkit keeps pointing at Serper."""
+    tools = SerperTools(api_key="test_key")
+    assert tools.base_url == "https://google.serper.dev"
+
+
+def test_base_url_from_argument():
+    """An explicit base_url wins."""
+    tools = SerperTools(api_key="test_key", base_url="https://serpens.p.rapidapi.com")
+    assert tools.base_url == "https://serpens.p.rapidapi.com"
+
+
+def test_base_url_from_env(monkeypatch):
+    """SERPER_API_BASE configures the toolkit without touching the call site."""
+    monkeypatch.setenv("SERPER_API_BASE", "https://proxy.internal")
+    tools = SerperTools(api_key="test_key")
+    assert tools.base_url == "https://proxy.internal"
+
+
+def test_base_url_argument_beats_env(monkeypatch):
+    """The argument is the more specific setting, so it takes precedence."""
+    monkeypatch.setenv("SERPER_API_BASE", "https://proxy.internal")
+    tools = SerperTools(api_key="test_key", base_url="https://explicit.example")
+    assert tools.base_url == "https://explicit.example"
+
+
+def test_base_url_trailing_slash_stripped():
+    """A trailing slash would otherwise produce a double slash in the path."""
+    tools = SerperTools(api_key="test_key", base_url="https://proxy.internal/")
+    assert tools.base_url == "https://proxy.internal"
+
+
+def test_search_uses_custom_base_url(mock_search_response):
+    """The configured base URL is what the request actually goes to."""
+    tools = SerperTools(api_key="test_key", base_url="https://proxy.internal", num_results=5)
+    with patch("requests.request", return_value=mock_search_response) as mock_req:
+        tools.search_web("pytest testing")
+
+        assert mock_req.call_args[0][1] == "https://proxy.internal/search"
+
+
+def test_search_news_uses_custom_base_url(mock_news_response):
+    """Every endpoint built from the base URL moves with it, not just search."""
+    tools = SerperTools(api_key="test_key", base_url="https://proxy.internal", num_results=5)
+    with patch("requests.request", return_value=mock_news_response) as mock_req:
+        tools.search_news("pytest testing")
+
+        assert mock_req.call_args[0][1] == "https://proxy.internal/news"


### PR DESCRIPTION
Fixes #9959.

`SerperTools` resolves its key from an argument with an environment fallback, but the endpoint itself is hardcoded:

```python
url = f"https://google.serper.dev/{endpoint}"
```

So anyone who needs the request to go somewhere else has to edit the file and carry the edit. Three ordinary cases: an egress proxy on a restricted network, a regional endpoint chosen for latency or data residency, and a local mock during tests so the suite does not make live calls.

### Change

Adds `base_url` with the same resolution shape already used for `api_key` — argument first, then environment, then the current default:

```python
def __init__(
    self,
    api_key: Optional[str] = None,
    base_url: Optional[str] = None,
    ...
):
    self.api_key = api_key or getenv("SERPER_API_KEY")
    self.base_url = (base_url or getenv("SERPER_API_BASE") or "https://google.serper.dev").rstrip("/")
```

and `_make_request` uses it:

```python
url = f"{self.base_url}/{endpoint}"
```

### Notes

- Eight added lines, one file, no new dependency.
- New argument is optional and defaults to the current URL, so existing callers and the unit tests are unaffected.
- `rstrip("/")` so `https://host` and `https://host/` behave identically.
- The separate `https://scrape.serper.dev` endpoint is deliberately left as-is — it is a different service, and folding it into the same variable would be surprising.

---

**Update — tests added.** The triage bot asked for a linked issue and test coverage; both are in now.

`libs/agno/tests/unit/tools/test_serper.py` gains seven cases: the default, the `base_url` argument, the `SERPER_API_BASE` env var, precedence between the last two, a stripped trailing slash, and — the ones that matter — that `search_web` and `search_news` actually issue their request against the configured host rather than merely storing it.

```
31 passed
```

The `clear_env` autouse fixture now also unsets `SERPER_API_BASE`, so a variable in the developer's shell cannot make the existing assertions against `https://google.serper.dev/search` pass or fail by accident.
