### PR TITLE
[feat] Paginate searches over offloaded results

### DIFF
--- a/cookbook/02_agents/22_result_offloading/02_result_store.py
+++ b/cookbook/02_agents/22_result_offloading/02_result_store.py
@@ -61,6 +61,20 @@ if __name__ == "__main__":
         f"\nsearch returned {len(matches)} matches (capped at 20); first at line {matches[0].line_number}: {matches[0].line}"
     )
 
+    # Continue the same search without dropping later hits or enlarging each reply.
+    matched_lines = [match.line_number for match in matches]
+    search_pages = 1
+    while matches and matches[-1].more:
+        matches = store.search(
+            ref.result_id, r"station N$", start_line=matches[-1].line_number + 1
+        )
+        matched_lines.extend(match.line_number for match in matches)
+        search_pages += 1
+    assert matched_lines == list(range(4, 2001, 4))
+    print(
+        f"all {len(matched_lines)} matching lines took {search_pages} bounded search pages"
+    )
+
     # live_ids: the session's stored results, newest first, capped at 20.
     print(
         "\nlive result ids for the session:",

--- a/cookbook/02_agents/22_result_offloading/README.md
+++ b/cookbook/02_agents/22_result_offloading/README.md
@@ -19,6 +19,15 @@ Nothing is summarized away, there is no model call on the write path, and
 every read back is capped. Substitution happens before the tool message is
 built, so the persisted session row carries the envelope too.
 
+Search returns at most 20 matching lines per call. When more matches follow,
+`search_result` names the `start_line` for the next call with the same pattern.
+`ResultStore.search()` and `asearch()` accept the same 1-indexed, inclusive
+argument: if `matches[-1].more` is true, continue from
+`matches[-1].line_number + 1`. Context lines can precede that point, but already
+returned matching lines are not returned again. A start beyond the last line
+returns no matches; values below 1 are rejected. Each page keeps the same
+character and match limits.
+
 Pass a `ResultStore` to change the defaults:
 
 ```python

--- a/cookbook/02_agents/22_result_offloading/TEST_LOG.md
+++ b/cookbook/02_agents/22_result_offloading/TEST_LOG.md
@@ -1,5 +1,20 @@
 # Test Log
 
+### 02_result_store.py — paginated search (2026-09-05)
+
+**Status:** PASS
+
+**Description:** Ran with Python 3.12.14 in `.venvs/demo`, local editable Agno
+and SQLite, without model calls. Continued `station N$` using the last
+returned matching line plus one as `start_line`.
+
+**Result:** All 500 matching lines in the 2,000-line report were returned in
+25 pages. The example asserted that the complete sequence was exactly lines
+4, 8, ..., 2000. Each search returned at most 20 matches, and cleanup removed
+the stored result.
+
+---
+
 Tested 2026-08-20 against `gpt-5.5` (OpenAIResponses), SQLite, with the worktree's Python (agno from this branch).
 
 ### 01_offload_tool_results.py

--- a/libs/agno/agno/offload/_scan.py
+++ b/libs/agno/agno/offload/_scan.py
@@ -25,10 +25,12 @@ def main() -> None:
     request = json.loads(sys.stdin.buffer.read().decode("utf-8"))
     compiled = re.compile(request["pattern"])
     limit = int(request["limit"])
+    start_line = int(request["start_line"])
     positions: List[List[int]] = []
     more = False
-    for index, line in enumerate(request["content"].split("\n")):
-        found = compiled.search(line)
+    lines = request["content"].split("\n")
+    for index in range(start_line - 1, len(lines)):
+        found = compiled.search(lines[index])
         if found is None:
             continue
         if len(positions) >= limit:

--- a/libs/agno/agno/offload/store.py
+++ b/libs/agno/agno/offload/store.py
@@ -111,13 +111,13 @@ def _clip_around(line: str, char_offset: int, match_len: int = 1) -> str:
 
 
 def _find_match_positions(
-    lines: List[str], compiled: "re.Pattern[str]", limit: int
+    lines: List[str], compiled: "re.Pattern[str]", limit: int, start_line: int = 1
 ) -> Tuple[List[Tuple[int, int, int]], bool]:
     """(1-indexed line number, char offset, match length) for each matching
     line, capped at ``limit``; the flag is True when one more match exists."""
     positions: List[Tuple[int, int, int]] = []
-    for index, line in enumerate(lines):
-        found = compiled.search(line)
+    for index in range(start_line - 1, len(lines)):
+        found = compiled.search(lines[index])
         if found is None:
             continue
         if len(positions) >= limit:
@@ -169,14 +169,14 @@ def _render_matches(
     return matches
 
 
-def _scan_for_matches(content: str, pattern: str, context_lines: int) -> List[ResultMatch]:
+def _scan_for_matches(content: str, pattern: str, context_lines: int, start_line: int = 1) -> List[ResultMatch]:
     """The search scan itself: at most 20 matches, one read_result page in total."""
     lines = content.split("\n")
-    positions, more = _find_match_positions(lines, re.compile(pattern), SEARCH_MAX_MATCHES)
+    positions, more = _find_match_positions(lines, re.compile(pattern), SEARCH_MAX_MATCHES, start_line)
     return _render_matches(lines, positions, more, context_lines)
 
 
-def _scan_in_subprocess(content: str, pattern: str, context_lines: int) -> List[ResultMatch]:
+def _scan_in_subprocess(content: str, pattern: str, context_lines: int, start_line: int = 1) -> List[ResultMatch]:
     """Run the match scan in a separate interpreter, killed at ``SEARCH_TIMEOUT_SECONDS``.
 
     A thread stuck inside the regex engine cannot be interrupted, so a pattern
@@ -196,9 +196,11 @@ def _scan_in_subprocess(content: str, pattern: str, context_lines: int) -> List[
         # An installation this file cannot read from disk (a zipapp, say)
         # keeps working, without the deadline.
         log_warning(f"Result search: {scan_script} is missing; the scan runs in-process without a time limit")
-        return _scan_for_matches(content, pattern, context_lines)
+        return _scan_for_matches(content, pattern, context_lines, start_line)
 
-    payload = json.dumps({"pattern": pattern, "content": content, "limit": SEARCH_MAX_MATCHES})
+    payload = json.dumps(
+        {"pattern": pattern, "content": content, "limit": SEARCH_MAX_MATCHES, "start_line": start_line}
+    )
     process = subprocess.Popen(
         [sys.executable, "-I", str(scan_script)],
         stdin=subprocess.PIPE,
@@ -863,32 +865,45 @@ class ResultStore:
         content = await self._aread_payload(row)
         return await asyncio.to_thread(self._page_from_content, content, start_line, end_line, start_char)
 
-    def _matches_from_content(self, content: str, pattern: str, context_lines: int) -> List[ResultMatch]:
+    def _matches_from_content(
+        self, content: str, pattern: str, context_lines: int, start_line: int = 1
+    ) -> List[ResultMatch]:
+        if start_line < 1:
+            raise ValueError("start_line must be at least 1")
         # Compiled here first so an invalid pattern raises re.error in the
         # caller, where the tool layer names it, never out of the subprocess.
         re.compile(pattern)
         if _BACKTRACKING_CHARS.isdisjoint(pattern):
-            return _scan_for_matches(content, pattern, context_lines)
+            return _scan_for_matches(content, pattern, context_lines, start_line)
         # The pattern can repeat, so it can backtrack without bound. It runs
         # in a subprocess a deadline can actually kill: a thread stuck inside
         # the regex engine cannot be interrupted.
-        return _scan_in_subprocess(content, pattern, context_lines)
+        return _scan_in_subprocess(content, pattern, context_lines, start_line)
 
-    def search(self, result_id: str, pattern: str, context_lines: int = 0) -> List[ResultMatch]:
-        """Regex search over a stored result; at most 20 matches, lines clipped, one page in total."""
+    def search(self, result_id: str, pattern: str, context_lines: int = 0, *, start_line: int = 1) -> List[ResultMatch]:
+        """Regex search from an inclusive, 1-indexed ``start_line``.
+
+        Returns at most 20 matching lines, clipped to one page in total.
+        When the last match has ``more=True``, continue with its ``line_number + 1``
+        as ``start_line``. Context may include earlier lines, but matches do not.
+        A start beyond the last line returns no matches; a start below 1 raises
+        ``ValueError``.
+        """
         row = self.get_row(result_id)
         if row is None:
             raise KeyError(f"unknown result id {result_id}")
-        return self._matches_from_content(self._read_payload(row), pattern, context_lines)
+        return self._matches_from_content(self._read_payload(row), pattern, context_lines, start_line)
 
-    async def asearch(self, result_id: str, pattern: str, context_lines: int = 0) -> List[ResultMatch]:
+    async def asearch(
+        self, result_id: str, pattern: str, context_lines: int = 0, *, start_line: int = 1
+    ) -> List[ResultMatch]:
         """Async variant of ``search``."""
         row = await self.aget_row(result_id)
         if row is None:
             raise KeyError(f"unknown result id {result_id}")
         # The regex scan is CPU work over the whole payload; it runs off the loop.
         content = await self._aread_payload(row)
-        return await asyncio.to_thread(self._matches_from_content, content, pattern, context_lines)
+        return await asyncio.to_thread(self._matches_from_content, content, pattern, context_lines, start_line)
 
     # ------------------------------------------------------------------
     # Listing, cleanup, sweep

--- a/libs/agno/agno/offload/tools.py
+++ b/libs/agno/agno/offload/tools.py
@@ -126,12 +126,13 @@ def get_search_result_function(owner: Any, run_context: RunContext, async_mode: 
         return _access_error(result_id, row, run_context)
 
     def _render(result_id: str, matches: Any) -> str:
-        from agno.offload.store import SEARCH_MAX_MATCHES
-
         if not matches:
             return f"No matches in {result_id}."
-        if matches[-1].more or len(matches) >= SEARCH_MAX_MATCHES:
-            lines = [f"First {len(matches)} matches in {result_id} (more follow; narrow the pattern):"]
+        if matches[-1].more:
+            lines = [
+                f"First {len(matches)} matches in {result_id} "
+                f"(more follow; search again with start_line={matches[-1].line_number + 1}):"
+            ]
         else:
             lines = [f"{len(matches)} match(es) in {result_id}:"]
         for match in matches:
@@ -143,7 +144,7 @@ def get_search_result_function(owner: Any, run_context: RunContext, async_mode: 
                 lines.append(f"{match.line_number}: {match.line}")
         return "\n".join(lines)
 
-    def search_result(result_id: str, pattern: str, context_lines: int = 0) -> str:
+    def search_result(result_id: str, pattern: str, context_lines: int = 0, *, start_line: int = 1) -> str:
         """Search a stored tool result with a regular expression.
 
         Returns at most 20 matches as line-number/line pairs, each line clipped to 500
@@ -153,6 +154,9 @@ def get_search_result_function(owner: Any, run_context: RunContext, async_mode: 
             result_id: The id from the result envelope, e.g. "res_a91c4f20b3".
             pattern: A Python regular expression.
             context_lines: Lines of context to include around each match (at most 20).
+            start_line: First line to search (1-indexed, inclusive, default 1). Use the
+                reply's continuation line to retrieve more matches with the same pattern.
+                Context can include earlier lines; matching begins at this line.
 
         A long line is shown as a window around the match with its character
         offset; read the rest with read_result(start_line, start_char=offset).
@@ -167,13 +171,13 @@ def get_search_result_function(owner: Any, run_context: RunContext, async_mode: 
             error = _resolve(result_id, store.get_row(result_id))
             if error is not None:
                 return error
-            return _render(result_id, store.search(result_id, pattern, context_lines))
+            return _render(result_id, store.search(result_id, pattern, context_lines, start_line=start_line))
         except re.error as e:
             return f"Error: invalid regular expression: {e}"
         except Exception as e:
             return f"Error searching result: {e}"
 
-    async def asearch_result(result_id: str, pattern: str, context_lines: int = 0) -> str:
+    async def asearch_result(result_id: str, pattern: str, context_lines: int = 0, *, start_line: int = 1) -> str:
         """Search a stored tool result with a regular expression.
 
         Returns at most 20 matches as line-number/line pairs, each line clipped to 500
@@ -183,6 +187,9 @@ def get_search_result_function(owner: Any, run_context: RunContext, async_mode: 
             result_id: The id from the result envelope, e.g. "res_a91c4f20b3".
             pattern: A Python regular expression.
             context_lines: Lines of context to include around each match (at most 20).
+            start_line: First line to search (1-indexed, inclusive, default 1). Use the
+                reply's continuation line to retrieve more matches with the same pattern.
+                Context can include earlier lines; matching begins at this line.
 
         A long line is shown as a window around the match with its character
         offset; read the rest with read_result(start_line, start_char=offset).
@@ -197,7 +204,7 @@ def get_search_result_function(owner: Any, run_context: RunContext, async_mode: 
             error = _resolve(result_id, await store.aget_row(result_id))
             if error is not None:
                 return error
-            return _render(result_id, await store.asearch(result_id, pattern, context_lines))
+            return _render(result_id, await store.asearch(result_id, pattern, context_lines, start_line=start_line))
         except re.error as e:
             return f"Error: invalid regular expression: {e}"
         except Exception as e:

--- a/libs/agno/tests/integration/offload/test_team_offloading.py
+++ b/libs/agno/tests/integration/offload/test_team_offloading.py
@@ -883,9 +883,9 @@ async def test_async_search_does_not_block_the_event_loop(db):
     # Stand in for a slow scan: the real one is CPU-bound regex work over the payload.
     real_matches = store._matches_from_content
 
-    def slow_matches(content, pattern, context_lines):
+    def slow_matches(content, pattern, context_lines, start_line=1):
         _time.sleep(0.3)
-        return real_matches(content, pattern, context_lines)
+        return real_matches(content, pattern, context_lines, start_line)
 
     store._matches_from_content = slow_matches  # type: ignore[method-assign]
     ticks = []

--- a/libs/agno/tests/unit/offload/test_search_pagination.py
+++ b/libs/agno/tests/unit/offload/test_search_pagination.py
@@ -1,0 +1,140 @@
+"""Search pagination preserves every matching line without widening reply limits."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from agno.db.sqlite import SqliteDb
+from agno.offload import ResultStore
+from agno.offload.store import SEARCH_MAX_CHARS, SEARCH_MAX_MATCHES
+from agno.offload.tools import get_search_result_function
+from agno.run import RunContext
+
+
+@pytest.fixture
+def stored_result(tmp_path):
+    store = ResultStore(db=SqliteDb(db_file=str(tmp_path / "results.db")))
+
+    def save(content):
+        ref = store.offload(
+            session_id="session",
+            user_id="alice",
+            run_id="run",
+            tool_call_id="call",
+            tool_name="fetch_report",
+            tool_args={},
+            output=content,
+        )
+        return store, ref.result_id
+
+    return save
+
+
+@pytest.mark.parametrize("pattern", ["needle", r"needle-\d+"])
+@pytest.mark.parametrize("context_lines", [0, 20])
+@pytest.mark.asyncio
+async def test_all_matching_lines_are_reachable_across_pages(stored_result, pattern, context_lines):
+    # Sparse hits catch confusion between a match offset and a source line number.
+    content = "\n".join(f"needle-{i} " + "x" * 480 if i % 2 else "other " + "x" * 480 for i in range(1, 106))
+    store, result_id = stored_result(content)
+    expected = list(range(1, 106, 2))
+    seen = []
+    start_line = 1
+    while True:
+        matches = store.search(result_id, pattern, context_lines, start_line=start_line)
+        assert matches == await store.asearch(result_id, pattern, context_lines, start_line=start_line)
+        assert 0 < len(matches) <= SEARCH_MAX_MATCHES
+        assert sum(len(match.line) for match in matches) <= SEARCH_MAX_CHARS
+        seen.extend(match.line_number for match in matches)
+        if not matches[-1].more:
+            break
+        start_line = matches[-1].line_number + 1
+    assert seen == expected
+
+
+@pytest.mark.parametrize("pattern", ["needle", r"needle-\d+"])
+@pytest.mark.asyncio
+async def test_start_line_is_inclusive_and_context_can_precede_it(stored_result, pattern):
+    store, result_id = stored_result("needle-1\nneedle-2\nneedle-3")
+    matches = store.search(result_id, pattern, context_lines=1, start_line=3)
+    assert matches == await store.asearch(result_id, pattern, context_lines=1, start_line=3)
+    assert [match.line_number for match in matches] == [3]
+    assert matches[0].line == "2: needle-2\n3: needle-3"
+    assert matches[0].more is False
+    assert store.search(result_id, pattern, start_line=4) == []
+    assert await store.asearch(result_id, pattern, start_line=4) == []
+
+
+@pytest.mark.parametrize("start_line", [0, -1])
+@pytest.mark.asyncio
+async def test_invalid_start_line_is_rejected(stored_result, start_line):
+    store, result_id = stored_result("needle")
+    with pytest.raises(ValueError, match="start_line must be at least 1"):
+        store.search(result_id, "needle", start_line=start_line)
+    with pytest.raises(ValueError, match="start_line must be at least 1"):
+        await store.asearch(result_id, "needle", start_line=start_line)
+
+
+def test_subprocess_does_not_evaluate_lines_before_start(stored_result, monkeypatch):
+    from agno.offload import store as store_module
+
+    monkeypatch.setattr(store_module, "SEARCH_TIMEOUT_SECONDS", 1.5)
+    store, result_id = stored_result("a" * 40_000 + "b\naaa")
+    matches = store.search(result_id, r"(a+)+$", start_line=2)
+    assert [match.line_number for match in matches] == [2]
+
+
+@pytest.mark.parametrize("async_mode", [False, True])
+@pytest.mark.parametrize("line_count", [20, 21])
+@pytest.mark.asyncio
+async def test_tool_exposes_accurate_continuation(stored_result, async_mode, line_count):
+    store, result_id = stored_result("\n".join("needle" for _ in range(line_count)))
+    tool = get_search_result_function(
+        SimpleNamespace(_result_store=store),
+        RunContext(run_id="run", session_id="session", user_id="alice"),
+        async_mode=async_mode,
+    )
+    assert tool.entrypoint is not None
+    assert "start_line" in tool.parameters["properties"]
+    assert "start_line" not in tool.parameters.get("required", [])
+    reply = tool.entrypoint(result_id=result_id, pattern="needle")
+    if async_mode:
+        reply = await reply
+    if line_count == 20:
+        assert "20 match(es)" in reply
+        assert "more follow" not in reply
+    else:
+        assert "start_line=21" in reply
+        following = tool.entrypoint(result_id=result_id, pattern="needle", start_line=21)
+        if async_mode:
+            following = await following
+        assert "1 match(es)" in following
+        assert "21: needle" in following
+        assert "more follow" not in following
+
+
+@pytest.mark.parametrize("async_mode", [False, True])
+@pytest.mark.parametrize(
+    "context", [{"session_id": "other", "user_id": "alice"}, {"session_id": "session", "user_id": "bob"}]
+)
+@pytest.mark.asyncio
+async def test_pagination_cannot_read_another_session_or_user(stored_result, async_mode, context):
+    store, result_id = stored_result("needle\nneedle")
+    tool = get_search_result_function(
+        SimpleNamespace(_result_store=store), RunContext(run_id="run", **context), async_mode=async_mode
+    )
+    assert tool.entrypoint is not None
+    reply = tool.entrypoint(result_id=result_id, pattern="needle", start_line=2)
+    if async_mode:
+        reply = await reply
+    assert reply.startswith("Error: result")
+    assert "belongs to a different" in reply
+
+
+def test_tool_reports_invalid_start_line(stored_result):
+    store, result_id = stored_result("needle")
+    tool = get_search_result_function(
+        SimpleNamespace(_result_store=store), RunContext(run_id="run", session_id="session", user_id="alice")
+    )
+    assert tool.entrypoint is not None
+    assert "start_line must be at least 1" in tool.entrypoint(result_id=result_id, pattern="needle", start_line=0)


### PR DESCRIPTION
## Summary

Closes #9962.

Offloaded logs and reports can contain more matching lines than one `search_result` reply allows. Repeating the same search currently returns the first page again. This adds an optional, inclusive, 1-indexed `start_line` to `ResultStore.search` / `asearch` and the agent-facing tools, so callers can retrieve subsequent matches without broadening the reply limits.

Continuation starts after the last returned matching line, including when context consumes the character budget before the 20-match limit. The tool reports the next start line only when more matches exist. Plain and subprocess regex scans retain original line numbers, existing clipping, and timeout handling. The existing ResultStore cookbook demonstrates collecting all 500 matching lines in 25 pages.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Validation in a fresh Python 3.12.14 environment:

- Offloading unit suite: 91 passed.
- Agent/Team offloading integration suite with SQLite: 91 passed, 1 skipped; PostgreSQL cases were not run.
- Offline `02_result_store.py` cookbook: passed, including an assertion covering all 500 expected matching lines.
- Full format and validation scripts passed; formatter-only edits to unrelated files were excluded. `git diff --check` passed.

Codex generated the implementation, tests, and this description. Automated coding agents reviewed the changes; no human review is claimed, so the self-review checkbox remains unchecked.
