### PR TITLE
[fix] prevent cross-user in-memory run upserts

### DIFF
--- a/libs/agno/agno/db/in_memory/in_memory_db.py
+++ b/libs/agno/agno/db/in_memory/in_memory_db.py
@@ -572,6 +572,11 @@ class InMemoryDb(BaseDb):
                 log_debug(f"upsert_run: session {session_id} not found; skipping")
                 return
 
+            existing_uid = session.get("user_id")
+            if user_id is not None and existing_uid is not None and existing_uid != user_id:
+                log_warning(f"upsert_run: user {user_id} does not own session {session_id}; skipping")
+                return
+
             # The stored row holds "runs": None until the first run lands
             runs = session.get("runs") or []
             session["runs"] = runs

--- a/libs/agno/tests/unit/db/test_in_memory_runs.py
+++ b/libs/agno/tests/unit/db/test_in_memory_runs.py
@@ -178,6 +178,16 @@ class TestUpsertRun:
         row = next(r for r in rows if r["run_id"] == "rNEW")
         assert row.get("run_index") == 7
 
+    def test_explicit_other_user_cannot_insert_or_replace_run(self, db_with_two_sessions):
+        injected = _make_run("rNEW", "s1", "injected")
+        replacement = _make_run("r1", "s1", "replaced")
+
+        db_with_two_sessions.upsert_run(run=injected, session_id="s1", user_id="bob")
+        db_with_two_sessions.upsert_run(run=replacement, session_id="s1", user_id="bob")
+
+        assert db_with_two_sessions.get_run("rNEW") is None
+        assert db_with_two_sessions.get_run("r1").content == "hello"
+
     def test_unknown_session_is_a_noop(self, db_with_two_sessions):
         new_run = _make_run("rGHOST", "nonexistent-session", "orphan")
         db_with_two_sessions.upsert_run(run=new_run, session_id="nonexistent-session")


### PR DESCRIPTION
## Summary

`InMemoryDb.upsert_run` accepted an explicit `user_id` but did not compare it with the session owner. As a result, a caller could append a run to another user's session or replace an existing run in that session.

This change aligns run upserts with the existing session ownership checks: an explicit mismatched user is rejected, while `user_id=None` retains the existing wildcard behavior. A regression test covers both cross-user insertion and replacement.

Fixes #9965

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (not applicable; behavior is covered by the regression test)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (not applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

This PR was prepared with Codex. I reviewed and understand every changed line and reproduced the cross-user insert/replace behavior locally before applying the fix.

Validation:

- `pytest -q libs/agno/tests/unit/db/test_in_memory_runs.py libs/agno/tests/unit/db/test_session_isolation.py` (50 passed)
- `./scripts/format.sh`
- `./scripts/validate.sh`
