### PR TITLE
fix: preserve reasoning output for tool-call replay

### DIFF
--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -700,6 +700,13 @@ class OpenAIResponses(Model):
                 if self._using_reasoning_model() and previous_response_id is not None:
                     continue
 
+                if hasattr(message, "provider_data") and message.provider_data is not None:
+                    if message.provider_data.get("reasoning_output") is not None:
+                        reasoning_output = ResponseReasoningItem.model_validate(
+                            message.provider_data["reasoning_output"]
+                        )
+                        formatted_messages.append(reasoning_output)
+
                 for tool_call in message.tool_calls:
                     formatted_messages.append(
                         {
@@ -1254,11 +1261,9 @@ class OpenAIResponses(Model):
 
             # Handle reasoning output items
             elif output.type == "reasoning":
-                # Save encrypted reasoning content for ZDR mode
-                if self.store is False:
-                    if model_response.provider_data is None:
-                        model_response.provider_data = {}
-                    model_response.provider_data["reasoning_output"] = output.model_dump(exclude_none=True)
+                if model_response.provider_data is None:
+                    model_response.provider_data = {}
+                model_response.provider_data["reasoning_output"] = output.model_dump(exclude_none=True)
 
                 if reasoning_summaries := getattr(output, "summary", None):
                     for summary in reasoning_summaries:
@@ -1373,14 +1378,12 @@ class OpenAIResponses(Model):
         elif stream_event.type == "response.completed":
             model_response = ModelResponse()
 
-            # Handle reasoning output items for ZDR mode (store=False)
-            if self.store is False:
-                for out in getattr(stream_event.response, "output", []) or []:
-                    if getattr(out, "type", None) == "reasoning":
-                        if hasattr(out, "encrypted_content"):
-                            if model_response.provider_data is None:
-                                model_response.provider_data = {}
-                            model_response.provider_data["reasoning_output"] = out.model_dump(exclude_none=True)
+            # Preserve reasoning output for replay if response ID chaining is unavailable.
+            for out in getattr(stream_event.response, "output", []) or []:
+                if getattr(out, "type", None) == "reasoning":
+                    if model_response.provider_data is None:
+                        model_response.provider_data = {}
+                    model_response.provider_data["reasoning_output"] = out.model_dump(exclude_none=True)
 
             # Add metrics
             if stream_event.response.usage is not None:

--- a/libs/agno/tests/unit/models/openai/test_openai_responses_id_handling.py
+++ b/libs/agno/tests/unit/models/openai/test_openai_responses_id_handling.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict, List, Optional
 
+from openai.types.responses import ResponseReasoningItem
+
 from agno.models.message import Message
 from agno.models.openai.responses import OpenAIResponses
 from agno.models.response import ModelResponse
@@ -188,3 +190,60 @@ def test_reasoning_previous_response_skips_prior_function_call_items(monkeypatch
 
     # Expect no re-sent function_call when previous_response_id is present for reasoning models
     assert all(x.get("type") != "function_call" for x in fm)
+
+
+def test_parse_provider_response_keeps_reasoning_output_with_default_storage():
+    model = OpenAIResponses(id="gpt-5")
+    reasoning_item = ResponseReasoningItem.construct(id="rs_123", type="reasoning", summary=[])
+    fake_resp = _FakeResponse(_id="resp_1", output=[reasoning_item])
+
+    model_response = model._parse_provider_response(fake_resp)  # type: ignore[arg-type]
+
+    assert model_response.provider_data is not None
+    assert model_response.provider_data["reasoning_output"]["id"] == "rs_123"
+
+
+def test_parse_completed_stream_keeps_reasoning_output_with_default_storage():
+    model = OpenAIResponses(id="gpt-5")
+    assistant_message = Message(role="assistant")
+    reasoning_item = ResponseReasoningItem.construct(id="rs_123", type="reasoning", summary=[])
+    completed = _FakeStreamEvent(
+        type="response.completed",
+        response=_FakeResponse(_id="resp_1", output=[reasoning_item]),
+    )
+
+    model_response, _ = model._parse_provider_response_delta(completed, assistant_message, {})  # type: ignore[arg-type]
+
+    assert model_response.provider_data is not None
+    assert model_response.provider_data["reasoning_output"]["id"] == "rs_123"
+
+
+def test_reasoning_item_precedes_replayed_function_call_without_previous_response_id():
+    model = OpenAIResponses(id="gpt-5")
+    reasoning_item = ResponseReasoningItem.construct(id="rs_123", type="reasoning", summary=[])
+    assistant_with_tool_call = Message(
+        role="assistant",
+        tool_calls=[
+            {
+                "id": "fc_abc123",
+                "call_id": "call_def456",
+                "type": "function",
+                "function": {"name": "execute_shell_command", "arguments": "{}"},
+            }
+        ],
+        provider_data={"reasoning_output": reasoning_item.model_dump(exclude_none=True)},
+    )
+
+    formatted = model._format_messages(
+        messages=[
+            Message(role="user", content="u"),
+            assistant_with_tool_call,
+            Message(role="tool", tool_call_id="fc_abc123", content="ok"),
+        ]
+    )
+
+    reasoning_index = next(index for index, item in enumerate(formatted) if getattr(item, "type", None) == "reasoning")
+    function_call_index = next(
+        index for index, item in enumerate(formatted) if isinstance(item, dict) and item.get("type") == "function_call"
+    )
+    assert reasoning_index + 1 == function_call_index


### PR DESCRIPTION
## Summary

- persist OpenAI Responses reasoning output for both stored and zero-data-retention responses
- replay the reasoning item immediately before prior function calls when response ID chaining is unavailable
- cover default-storage parsing in sync and streaming paths, plus tool-call replay ordering

Fixes #9960

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

This PR was entirely generated by Codex and then self-reviewed against the repository contribution rules and focused regression tests. No documentation or cookbook change is needed because this restores internal Responses API state continuity without changing the public API.

Validation:

- `.venv/bin/pytest -q libs/agno/tests/unit/models/openai/test_openai_responses_id_handling.py`
- `.venv/bin/pytest -q libs/agno/tests/unit/models/openai`
- `./scripts/validate.sh`