### PR TITLE
[fix] Preserve text after short recursive chunks

### DIFF
--- a/libs/agno/agno/knowledge/chunking/recursive.py
+++ b/libs/agno/agno/knowledge/chunking/recursive.py
@@ -57,9 +57,8 @@ class RecursiveChunking(ChunkingStrategy):
 
             new_start = end - self.overlap
             if new_start <= start:  # Prevent infinite loop
-                new_start = min(
-                    len(content), start + max(1, self.chunk_size // 10)
-                )  # Move forward by at least 10% of chunk size
+                # Advance without skipping text beyond the chunk we just emitted.
+                new_start = min(end, start + max(1, self.chunk_size // 10))
             start = new_start
 
         return chunks

--- a/libs/agno/tests/unit/knowledge/chunking/test_recursive_chunking.py
+++ b/libs/agno/tests/unit/knowledge/chunking/test_recursive_chunking.py
@@ -1,4 +1,6 @@
-"""Tests for RecursiveChunking at the end of a document."""
+"""Tests for RecursiveChunking preserving document content."""
+
+import pytest
 
 from agno.knowledge.chunking.recursive import RecursiveChunking
 from agno.knowledge.document.base import Document
@@ -25,3 +27,19 @@ def test_last_chunk_ends_the_document_and_repeats_no_earlier_chunk():
     assert content.endswith(chunks[-1].content)
     for position, chunk in enumerate(chunks):
         assert not any(chunk.content in earlier.content for earlier in chunks[:position])
+
+
+@pytest.mark.parametrize("separator", ["\n", "."])
+@pytest.mark.parametrize("overlap", [50, 100])
+def test_short_natural_chunk_does_not_skip_content(separator, overlap):
+    """A short heading must not cause the progress guard to skip the following text."""
+    words = [f"word{index:03d}" for index in range(300)]
+    content = f"Intro{separator}" + " ".join(words)
+    strategy = RecursiveChunking(chunk_size=1000, overlap=overlap)
+
+    chunks = strategy.chunk(Document(content=content))
+
+    assert all(any(word in chunk.content for chunk in chunks) for word in words)
+    assert all(0 < len(chunk.content) <= strategy.chunk_size for chunk in chunks)
+    assert chunks[0].content.startswith("Intro")
+    assert content.endswith(chunks[-1].content)


### PR DESCRIPTION
## Summary

Fixes #9969.

`RecursiveChunking` can silently discard text after a short heading when overlap is enabled. With `chunk_size=1000`, `overlap=100`, and a six-character heading, the first chunk ends at offset 6 but the forward-progress fallback starts the next one at offset 100. The intervening 94 characters never reach any chunk.

I capped that fallback at the end of the emitted chunk, so it still advances without skipping unread text. Four regression cases cover newline and period boundaries with two overlap values, checking that every input word survives and chunks stay within the size limit.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: not applicable to this correction of existing behavior
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated

## Additional Notes

Validation on Windows with Python 3.12.10: the four new cases fail on the base revision and pass with the fix. Focused chunking and ingestion checks passed (27 passed, 6 skipped for optional readers). The broader chunking directory requires optional `chonkie`/`numpy` dependencies absent from this environment.

`validate.sh` passed on the final diff, including mypy across 1,033 Agno source files. `format.sh` was run; unrelated formatting changes were excluded from this PR. AI assistance was used to prepare and review the code and tests.
