### PR TITLE
[fix] Honor explicit encoding for JSON uploads

### DIFF
--- a/libs/agno/agno/knowledge/reader/json_reader.py
+++ b/libs/agno/agno/knowledge/reader/json_reader.py
@@ -49,7 +49,10 @@ class JSONReader(Reader):
                 log_debug(f"Reading uploaded file: {getattr(path, 'name', 'BytesIO')}")
                 json_name = name or getattr(path, "name", "json_file").split(".")[0]
                 path.seek(0)
-                json_contents = json.load(path)
+                content = path.read()
+                if self.encoding and isinstance(content, bytes):
+                    content = content.decode(self.encoding)
+                json_contents = json.loads(content)
             else:
                 raise ValueError("Unsupported file type. Must be Path or file-like object.")
 

--- a/libs/agno/tests/unit/reader/test_json_reader.py
+++ b/libs/agno/tests/unit/reader/test_json_reader.py
@@ -1,11 +1,53 @@
 import json
-from io import BytesIO
+from io import BytesIO, StringIO
 from pathlib import Path
 
 import pytest
 
 from agno.knowledge.document.base import Document
 from agno.knowledge.reader.json_reader import JSONReader
+
+
+@pytest.fixture(
+    params=[
+        ("latin-1", "latin-1", "café"),
+        ("cp1251", "cp1251", "Привет"),
+        ("utf-8", None, "值"),
+        ("utf-16", None, "值"),
+        ("utf-32", None, "值"),
+        (None, "latin-1", "值"),
+    ],
+    ids=["latin-1", "cp1251", "auto-utf-8", "auto-utf-16", "auto-utf-32", "text-stream"],
+)
+def encoded_json_stream(request):
+    source_encoding, reader_encoding, value = request.param
+    data = {"key": value}
+    content = json.dumps(data, ensure_ascii=False)
+    stream = BytesIO(content.encode(source_encoding)) if source_encoding else StringIO(content)
+    stream.seek(0, 2)
+    with stream:
+        yield stream, reader_encoding, data
+
+
+def test_read_json_stream_encoding(encoded_json_stream):
+    stream, encoding, data = encoded_json_stream
+    documents = JSONReader(chunk=False, encoding=encoding).read(stream, name="upload")
+
+    assert len(documents) == 1
+    assert documents[0].name == "upload"
+    assert json.loads(documents[0].content) == data
+    assert not stream.closed
+
+
+@pytest.mark.asyncio
+async def test_async_read_json_stream_encoding(encoded_json_stream):
+    stream, encoding, data = encoded_json_stream
+    documents = await JSONReader(chunk=False, encoding=encoding).async_read(stream, name="upload")
+
+    assert len(documents) == 1
+    assert documents[0].name == "upload"
+    assert json.loads(documents[0].content) == data
+    assert not stream.closed
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Fixes #9973.

`JSONReader(encoding="latin-1")` currently raises `UnicodeDecodeError` for a Latin-1 binary upload because the file-like branch ignores `encoding`. Decode binary stream contents when an explicit encoding is supplied, matching the existing Path behavior. Keep Python's JSON encoding detection when no encoding is supplied, and leave already-decoded text streams unchanged.

Adds sync/async regression coverage for Latin-1 and Windows-1251, plus compatibility coverage for UTF-8/16/32 autodetection, text streams, rewinding, explicit document names, and caller-owned stream lifetime.

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (no public API change)
- [ ] Examples and guides updated (not applicable)
- [x] Tested in an isolated virtual environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and found no PR addressing this issue
- [x] This PR was AI-generated

## Additional Notes

Prepared with AI assistance. Validation was executed locally with Python 3.12.10 on Windows:

- Before the fix: `test_json_reader.py` — 4 failed, 32 passed.
- After the fix: `python -m pytest libs/agno/tests/unit/reader/test_json_reader.py -q` — 36 passed.
- Repository format and validation scripts passed, including Ruff and mypy. Unrelated formatting changes were excluded from the diff; validation ran on the final tree.

No API keys or external services are needed for these tests.
