### PR TITLE
[fix] Await async chunking in text and Markdown readers

### DIFF
--- a/libs/agno/agno/knowledge/reader/markdown_reader.py
+++ b/libs/agno/agno/knowledge/reader/markdown_reader.py
@@ -132,7 +132,7 @@ class MarkdownReader(Reader):
         async def process_chunk(chunk_doc: Document) -> Document:
             return chunk_doc
 
-        chunked_documents = self.chunk_document(document)
+        chunked_documents = await self.achunk_document(document)
 
         if not chunked_documents:
             return [document]

--- a/libs/agno/agno/knowledge/reader/text_reader.py
+++ b/libs/agno/agno/knowledge/reader/text_reader.py
@@ -110,7 +110,7 @@ class TextReader(Reader):
         async def process_chunk(chunk_doc: Document) -> Document:
             return chunk_doc
 
-        chunked_documents = self.chunk_document(document)
+        chunked_documents = await self.achunk_document(document)
 
         if not chunked_documents:
             return []

--- a/libs/agno/tests/unit/reader/test_async_text_chunking.py
+++ b/libs/agno/tests/unit/reader/test_async_text_chunking.py
@@ -1,0 +1,59 @@
+import asyncio
+from io import BytesIO
+
+import pytest
+
+from agno.knowledge.chunking.strategy import ChunkingStrategy
+from agno.knowledge.document.base import Document
+from agno.knowledge.reader.markdown_reader import MarkdownReader
+from agno.knowledge.reader.text_reader import TextReader
+
+
+class SyncLineChunking(ChunkingStrategy):
+    def chunk(self, document):
+        return [Document(name=document.name, content=line) for line in document.content.splitlines()]
+
+
+class AsyncLineChunking(SyncLineChunking):
+    def chunk(self, document):
+        raise RuntimeError("Use the asynchronous chunking implementation")
+
+    async def achunk(self, document):
+        await asyncio.sleep(0)
+        return super().chunk(document)
+
+
+@pytest.fixture(params=["path", "stream"])
+def text_source(request, tmp_path):
+    content = "first line\nsecond line"
+    if request.param == "path":
+        path = tmp_path / "example.txt"
+        path.write_text(content, encoding="utf-8")
+        yield path
+    else:
+        with BytesIO(content.encode("utf-8")) as stream:
+            yield stream
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reader_cls", [TextReader, MarkdownReader])
+@pytest.mark.parametrize("chunk", [True, False])
+async def test_async_read_uses_async_chunking(reader_cls, text_source, chunk):
+    reader = reader_cls(chunk=chunk, chunking_strategy=AsyncLineChunking())
+
+    documents = await reader.async_read(text_source, name="example")
+
+    expected = ["first line", "second line"] if chunk else ["first line\nsecond line"]
+    assert [doc.content for doc in documents] == expected
+    assert all(doc.name == "example" for doc in documents)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reader_cls", [TextReader, MarkdownReader])
+async def test_async_read_supports_sync_only_chunking(reader_cls, text_source):
+    reader = reader_cls(chunking_strategy=SyncLineChunking())
+
+    documents = await reader.async_read(text_source, name="example")
+
+    assert [doc.content for doc in documents] == ["first line", "second line"]
+    assert all(doc.name == "example" for doc in documents)

--- a/libs/agno/tests/unit/reader/test_text_reader.py
+++ b/libs/agno/tests/unit/reader/test_text_reader.py
@@ -184,7 +184,7 @@ async def test_async_chunking():
 
     reader = TextReader()
     reader.chunk = True
-    reader.chunk_document = lambda doc: [
+    reader.chunking_strategy.chunk = lambda doc: [
         Document(name=f"{doc.name}_chunk_{i}", id=f"{doc.id}_chunk_{i}", content=f"chunk_{i}", meta_data={"chunk": i})
         for i in range(2)
     ]


### PR DESCRIPTION
## Summary

Fixes #9975.

`TextReader.async_read()` and `MarkdownReader.async_read()` call the synchronous chunking method, bypassing custom `ChunkingStrategy.achunk()` implementations. A strategy requiring its async implementation consequently produces an error log and an empty document list.

Await the existing `Reader.achunk_document()` hook in both helpers. Adds regression coverage for both reader classes with Path and BytesIO inputs, plus checks that `chunk=False` and strategies implementing only synchronous `chunk()` still work. The existing async chunking test now stubs the strategy rather than the synchronous reader wrapper.

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (no public API change)
- [ ] Examples and guides updated (not applicable)
- [x] Tested in an isolated virtual environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and found no PR addressing this issue
- [x] This PR was AI-generated

## Additional Notes

Prepared with AI assistance. Validation was executed locally with Python 3.12.10 on Windows:

```sh
python -m pytest libs/agno/tests/unit/reader/test_async_text_chunking.py libs/agno/tests/unit/reader/test_text_reader.py libs/agno/tests/unit/reader/test_markdown_reader.py -q
```

- Before the fix: 4 failed, 33 passed.
- After the fix: 37 passed.
- Repository format and validation scripts passed, including Ruff and mypy. Unrelated formatting changes were excluded from the diff; validation ran on the final tree.

Tests use local custom strategies and require no model or external service.
