### PR TITLE
[feat] add The Grid as a model provider

### DIFF
--- a/cookbook/90_models/thegrid/README.md
+++ b/cookbook/90_models/thegrid/README.md
@@ -1,0 +1,18 @@
+# The Grid
+
+Cookbook examples for `cookbook/90_models/thegrid`.
+
+[The Grid](https://thegrid.ai) is a spot market for inference. An id names a market
+instrument -- a task type (`text`, `code`, `agent`) paired with a quality tier
+(`standard`, `prime`, `max`) -- rather than a fixed model, so the model that serves
+a request differs from the instrument requested. Set your API key first:
+
+```bash
+export THEGRID_API_KEY=***
+```
+
+Run examples with:
+
+```bash
+.venvs/demo/bin/python cookbook/90_models/thegrid/<example>.py
+```

--- a/cookbook/90_models/thegrid/basic.py
+++ b/cookbook/90_models/thegrid/basic.py
@@ -1,0 +1,41 @@
+"""
+The Grid Basic
+==============
+
+Cookbook example for `thegrid/basic.py`.
+"""
+
+import asyncio
+
+from agno.agent import Agent
+from agno.models.thegrid import TheGrid
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+agent = Agent(
+    model=TheGrid(id="text-standard"),
+    markdown=True,
+)
+
+# The string form resolves through the provider registry:
+#   agent = Agent(model="thegrid:text-standard")
+
+# Print the response in the terminal
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    # --- Sync ---
+    agent.print_response("write a two sentence horror story", stream=True)
+
+    # --- Sync + Streaming ---
+    agent.print_response("write a two sentence horror story", stream=True)
+
+    # --- Async ---
+    asyncio.run(agent.aprint_response("write a two sentence horror story", stream=True))
+
+    # --- Async + Streaming ---
+    asyncio.run(agent.aprint_response("write a two sentence horror story", stream=True))

--- a/cookbook/90_models/thegrid/structured_output.py
+++ b/cookbook/90_models/thegrid/structured_output.py
@@ -1,0 +1,53 @@
+"""
+The Grid Structured Output
+==========================
+
+Cookbook example for `thegrid/structured_output.py`.
+"""
+
+from typing import List
+
+from agno.agent import Agent, RunOutput  # noqa
+from agno.models.thegrid import TheGrid
+from pydantic import BaseModel, Field
+from rich.pretty import pprint  # noqa
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+
+class MovieScript(BaseModel):
+    setting: str = Field(
+        ..., description="Provide a nice setting for a blockbuster movie."
+    )
+    ending: str = Field(
+        ...,
+        description="Ending of the movie. If not available, provide a happy ending.",
+    )
+    genre: str = Field(
+        ...,
+        description="Genre of the movie. If not available, select action, thriller or romantic comedy.",
+    )
+    name: str = Field(..., description="Give a name to this movie")
+    characters: List[str] = Field(..., description="Name of characters for this movie.")
+    storyline: str = Field(
+        ..., description="3 sentence storyline for the movie. Make it exciting!"
+    )
+
+
+# Agent that uses a structured output
+structured_output_agent = Agent(
+    model=TheGrid(id="text-prime"),
+    description="You are a helpful assistant. Summarize the movie script based on the location in a JSON object.",
+    output_schema=MovieScript,
+)
+
+structured_output_agent.print_response("New York")
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    pass

--- a/cookbook/90_models/thegrid/tool_use.py
+++ b/cookbook/90_models/thegrid/tool_use.py
@@ -1,0 +1,43 @@
+"""
+The Grid Tool Use
+=================
+
+Cookbook example for `thegrid/tool_use.py`.
+"""
+
+import asyncio
+
+from agno.agent import Agent
+from agno.models.thegrid import TheGrid
+from agno.tools.websearch import WebSearchTools
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+agent = Agent(
+    model=TheGrid(id="agent-standard"),
+    tools=[WebSearchTools()],
+    markdown=True,
+)
+
+# The string form resolves through the provider registry:
+#   agent = Agent(model="thegrid:agent-standard", tools=[WebSearchTools()])
+
+# Print the response in the terminal
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    # --- Sync ---
+    agent.print_response("Whats happening in France?", stream=True)
+
+    # --- Sync + Streaming ---
+    agent.print_response("Whats happening in France?", stream=True)
+
+    # --- Async ---
+    asyncio.run(agent.aprint_response("Whats happening in France?", stream=True))
+
+    # --- Async + Streaming ---
+    asyncio.run(agent.aprint_response("Whats happening in France?", stream=True))

--- a/libs/agno/agno/models/thegrid/__init__.py
+++ b/libs/agno/agno/models/thegrid/__init__.py
@@ -1,0 +1,5 @@
+from agno.models.thegrid.thegrid import TheGrid
+
+__all__ = [
+    "TheGrid",
+]

--- a/libs/agno/agno/models/thegrid/thegrid.py
+++ b/libs/agno/agno/models/thegrid/thegrid.py
@@ -1,0 +1,43 @@
+from dataclasses import dataclass, field
+from os import getenv
+from typing import Any, Dict, Optional
+
+from agno.exceptions import ModelAuthenticationError
+from agno.models.openai.like import OpenAILike
+
+
+@dataclass
+class TheGrid(OpenAILike):
+    """
+    A class for using instruments served by The Grid.
+
+    The Grid is a spot market for inference. An id names a market instrument -- a
+    task type (text, code, agent) paired with a quality tier (standard, prime,
+    max) -- rather than a fixed model, so the model that serves a request differs
+    from the instrument that was requested.
+
+    Attributes:
+        id (str): The instrument id. Defaults to "text-standard".
+        name (str): The model name. Defaults to "TheGrid".
+        provider (str): The provider name. Defaults to "TheGrid".
+        api_key (Optional[str]): The API key.
+        base_url (str): The base URL. Defaults to "https://api.thegrid.ai/v1".
+    """
+
+    id: str = "text-standard"
+    name: str = "TheGrid"
+    provider: str = "TheGrid"
+
+    api_key: Optional[str] = field(default_factory=lambda: getenv("THEGRID_API_KEY"))
+    base_url: str = "https://api.thegrid.ai/v1"
+
+    def _get_client_params(self) -> Dict[str, Any]:
+        if not self.api_key:
+            self.api_key = getenv("THEGRID_API_KEY")
+            if not self.api_key:
+                raise ModelAuthenticationError(
+                    message="THEGRID_API_KEY not set. Please set the THEGRID_API_KEY environment variable.",
+                    model_name=self.name,
+                )
+
+        return super()._get_client_params()

--- a/libs/agno/agno/models/utils.py
+++ b/libs/agno/agno/models/utils.py
@@ -69,6 +69,7 @@ _PROVIDERS: Dict[str, Tuple[str, str, str, str]] = {
     "synthorai": ("agno.models.synthorai", "Synthorai", "Synthorai", "synthorai"),
     "together": ("agno.models.together", "Together", "Together", "together"),
     "tokenlab": ("agno.models.tokenlab", "TokenLab", "TokenLab", "tokenlab"),
+    "thegrid": ("agno.models.thegrid", "TheGrid", "TheGrid", "thegrid"),
     "trustedrouter": ("agno.models.trustedrouter", "TrustedRouter", "TrustedRouter", "trustedrouter"),
     "tuning-engines": ("agno.models.tuning_engines", "TuningEngines", "Tuning Engines", "tuning engines"),
     "vercel": ("agno.models.vercel", "V0", "v0", "vercel"),

--- a/libs/agno/tests/unit/models/thegrid_model/test_thegrid.py
+++ b/libs/agno/tests/unit/models/thegrid_model/test_thegrid.py
@@ -1,0 +1,49 @@
+"""Unit tests for The Grid model class.
+
+The Grid is an OpenAI-compatible inference market, so the class is a thin
+OpenAILike subclass. These tests pin the defaults and the missing-key behavior
+without any network access. (The to_dict/from_dict round-trip is covered
+generically by ``test_provider_resolution.py`` via the provider registry.)
+"""
+
+import pytest
+
+from agno.exceptions import ModelAuthenticationError
+from agno.models.openai.like import OpenAILike
+from agno.models.thegrid import TheGrid
+
+
+def test_defaults():
+    """Defaults match The Grid OpenAI-compatible endpoint."""
+    model = TheGrid(api_key="test-key")
+    assert isinstance(model, OpenAILike)
+    assert model.id == "text-standard"
+    assert model.name == "TheGrid"
+    assert model.provider == "TheGrid"
+    assert model.base_url == "https://api.thegrid.ai/v1"
+
+
+def test_api_key_from_env(monkeypatch):
+    """The API key is read from THEGRID_API_KEY when not passed explicitly."""
+    monkeypatch.setenv("THEGRID_API_KEY", "env-key")
+    assert TheGrid().api_key == "env-key"
+
+
+def test_client_params_include_base_url():
+    """Client params carry the configured key and base URL through to the SDK."""
+    params = TheGrid(api_key="test-key")._get_client_params()
+    assert params["api_key"] == "test-key"
+    assert params["base_url"] == "https://api.thegrid.ai/v1"
+
+
+def test_instrument_id_is_configurable():
+    """Any instrument can be selected; ids name a market, not a fixed model."""
+    model = TheGrid(id="agent-max", api_key="test-key")
+    assert model.id == "agent-max"
+
+
+def test_missing_api_key_raises(monkeypatch):
+    """A missing API key raises ModelAuthenticationError rather than a client error."""
+    monkeypatch.delenv("THEGRID_API_KEY", raising=False)
+    with pytest.raises(ModelAuthenticationError):
+        TheGrid(api_key=None)._get_client_params()


### PR DESCRIPTION
closes #9981

Adds [The Grid](https://thegrid.ai) as a model provider, following the "Adding a new Model Provider" recipe in CONTRIBUTING.

**Disclosure:** I work on The Grid, and this was written with AI assistance. I reviewed every line and ran everything below myself.

### What it is

The Grid is a spot market for inference. An id names a **market instrument** — a task type (`text`, `code`, `agent`) paired with a quality tier (`standard`, `prime`, `max`), plus lab-scoped markets like `claude-opus-latest` — rather than a fixed model. Each request is filled by whichever supplier is competitive at the time, so the model that serves a request differs from the instrument requested. That's called out in the class docstring so it doesn't read as a bug later.

The API is OpenAI-compatible, so this is a thin `OpenAILike` subclass modelled on `models/tokenlab/tokenlab.py`.

### Files

| File | |
|---|---|
| `libs/agno/agno/models/thegrid/{__init__,thegrid}.py` | the provider, 43 lines |
| `libs/agno/agno/models/utils.py` | one `_PROVIDERS` row |
| `libs/agno/tests/unit/models/thegrid_model/test_thegrid.py` | 5 unit tests, no network |
| `cookbook/90_models/thegrid/` | README + basic + tool_use + structured_output |

No `pyproject.toml` change is needed.

### Verified against the live API

Both the class form and the registry string form:

```
class form   -> 'OK'
string form  -> '```javascript\nconst add = (a, b) => a + b;\n```'
resolved     -> TheGrid code-prime
```

Tests:

```
pytest libs/agno/tests/unit/models/thegrid_model/     5 passed
pytest libs/agno/tests/unit/models/test_provider_resolution.py
                                                    138 passed, 44 skipped
```

That second one includes `test_every_model_subclass_is_registered`, which is what enforces the `_PROVIDERS` row.

`ruff format --check` is clean. `ruff check` reports the same three findings on `models/thegrid/thegrid.py` as it does on the `models/tokenlab/tokenlab.py` it was modelled on (`UP006`/`UP035`/`FA100`, all from `target-version = "py39"` requiring `typing.Dict`), so the new file matches the existing house style rather than diverging from it. The 19 findings in `models/utils.py` are pre-existing — identical count with my change stashed.

### For the reviewer

I know you test cookbooks against the live endpoint. Sign-up is self-serve at [thegrid.ai](https://thegrid.ai) — if you hit any allow-listing friction, say the word and I'll get it sorted immediately rather than have you work around it.

Two things deliberately not included: embeddings (The Grid returns `404` for `/v1/embeddings`, so nothing advertises them), and a docs PR to `agno-agi/docs`, which I'll send as a companion once this lands if you'd like it.

