### PR TITLE
fix: preserve final answer after tool limit

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -862,6 +862,14 @@ class Model(ABC):
                     if any(not req.is_resolved() for req in run_response.requirements):
                         break
 
+                # If every tool call in this batch was refused because the tool call
+                # limit was exhausted, no further tool work is possible: the budget is
+                # spent, so the next turn can only produce the same refusals. Break
+                # instead of looping. Ordinary tool failures are deliberately excluded
+                # here - the model should still see those and be able to recover.
+                if function_call_results and all(m.tool_call_limit_reached for m in function_call_results):
+                    break
+
                 # Continue loop to get next response
                 continue
 
@@ -1084,6 +1092,14 @@ class Model(ABC):
                 if run_response is not None and run_response.requirements:
                     if any(not req.is_resolved() for req in run_response.requirements):
                         break
+
+                # If every tool call in this batch was refused because the tool call
+                # limit was exhausted, no further tool work is possible: the budget is
+                # spent, so the next turn can only produce the same refusals. Break
+                # instead of looping. Ordinary tool failures are deliberately excluded
+                # here - the model should still see those and be able to recover.
+                if function_call_results and all(m.tool_call_limit_reached for m in function_call_results):
+                    break
 
                 # Continue loop to get next response
                 continue
@@ -1593,6 +1609,14 @@ class Model(ABC):
                     if any(not req.is_resolved() for req in run_response.requirements):
                         break
 
+                # If every tool call in this batch was refused because the tool call
+                # limit was exhausted, no further tool work is possible: the budget is
+                # spent, so the next turn can only produce the same refusals. Break
+                # instead of looping. Ordinary tool failures are deliberately excluded
+                # here - the model should still see those and be able to recover.
+                if function_call_results and all(m.tool_call_limit_reached for m in function_call_results):
+                    break
+
                 # Continue loop to get next response
                 continue
 
@@ -1873,6 +1897,14 @@ class Model(ABC):
                 if run_response is not None and run_response.requirements:
                     if any(not req.is_resolved() for req in run_response.requirements):
                         break
+
+                # If every tool call in this batch was refused because the tool call
+                # limit was exhausted, no further tool work is possible: the budget is
+                # spent, so the next turn can only produce the same refusals. Break
+                # instead of looping. Ordinary tool failures are deliberately excluded
+                # here - the model should still see those and be able to recover.
+                if function_call_results and all(m.tool_call_limit_reached for m in function_call_results):
+                    break
 
                 # Continue loop to get next response
                 continue
@@ -2222,6 +2254,7 @@ class Model(ABC):
             tool_name=function_call.function.name,
             tool_args=function_call.arguments,
             tool_call_error=True,
+            tool_call_limit_reached=True,
         )
 
     def run_function_call(

--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -697,6 +697,7 @@ class Model(ABC):
         _compress_tool_results = compression_manager is not None and compression_manager.compress_tool_results
         _compression_manager = compression_manager if _compress_tool_results else None
 
+        tool_calls_disabled = False
         while True:
             # Compress tool results if compression is enabled and threshold is met
             if _compression_manager is not None and _compression_manager.should_compress(
@@ -862,13 +863,18 @@ class Model(ABC):
                     if any(not req.is_resolved() for req in run_response.requirements):
                         break
 
-                # If every tool call in this batch was refused because the tool call
-                # limit was exhausted, no further tool work is possible: the budget is
-                # spent, so the next turn can only produce the same refusals. Break
-                # instead of looping. Ordinary tool failures are deliberately excluded
-                # here - the model should still see those and be able to recover.
-                if function_call_results and all(m.tool_call_limit_reached for m in function_call_results):
+                # A model may use successful earlier tool results to synthesize a final
+                # answer after its budget is exhausted. Give it one final turn with no
+                # tools. If it still returns a tool call, stop rather than looping.
+                if tool_calls_disabled:
                     break
+                if function_call_results and all(m.tool_call_limit_reached for m in function_call_results):
+                    tools = []
+                    _tool_dicts = []
+                    _functions = {}
+                    tool_choice = "none"
+                    tool_calls_disabled = True
+                    continue
 
                 # Continue loop to get next response
                 continue
@@ -928,6 +934,7 @@ class Model(ABC):
         _compression_manager = compression_manager if _compress_tool_results else None
 
         function_call_count = 0
+        tool_calls_disabled = False
 
         while True:
             # Compress existing tool results BEFORE making API call to avoid context overflow
@@ -1093,13 +1100,18 @@ class Model(ABC):
                     if any(not req.is_resolved() for req in run_response.requirements):
                         break
 
-                # If every tool call in this batch was refused because the tool call
-                # limit was exhausted, no further tool work is possible: the budget is
-                # spent, so the next turn can only produce the same refusals. Break
-                # instead of looping. Ordinary tool failures are deliberately excluded
-                # here - the model should still see those and be able to recover.
-                if function_call_results and all(m.tool_call_limit_reached for m in function_call_results):
+                # A model may use successful earlier tool results to synthesize a final
+                # answer after its budget is exhausted. Give it one final turn with no
+                # tools. If it still returns a tool call, stop rather than looping.
+                if tool_calls_disabled:
                     break
+                if function_call_results and all(m.tool_call_limit_reached for m in function_call_results):
+                    tools = []
+                    _tool_dicts = []
+                    _functions = {}
+                    tool_choice = "none"
+                    tool_calls_disabled = True
+                    continue
 
                 # Continue loop to get next response
                 continue
@@ -1427,6 +1439,7 @@ class Model(ABC):
         _compression_manager = compression_manager if _compress_tool_results else None
 
         function_call_count = 0
+        tool_calls_disabled = False
 
         while True:
             # Compress existing tool results BEFORE invoke
@@ -1609,13 +1622,18 @@ class Model(ABC):
                     if any(not req.is_resolved() for req in run_response.requirements):
                         break
 
-                # If every tool call in this batch was refused because the tool call
-                # limit was exhausted, no further tool work is possible: the budget is
-                # spent, so the next turn can only produce the same refusals. Break
-                # instead of looping. Ordinary tool failures are deliberately excluded
-                # here - the model should still see those and be able to recover.
-                if function_call_results and all(m.tool_call_limit_reached for m in function_call_results):
+                # A model may use successful earlier tool results to synthesize a final
+                # answer after its budget is exhausted. Give it one final turn with no
+                # tools. If it still returns a tool call, stop rather than looping.
+                if tool_calls_disabled:
                     break
+                if function_call_results and all(m.tool_call_limit_reached for m in function_call_results):
+                    tools = []
+                    _tool_dicts = []
+                    _functions = {}
+                    tool_choice = "none"
+                    tool_calls_disabled = True
+                    continue
 
                 # Continue loop to get next response
                 continue
@@ -1716,6 +1734,7 @@ class Model(ABC):
         _compression_manager = compression_manager if _compress_tool_results else None
 
         function_call_count = 0
+        tool_calls_disabled = False
 
         while True:
             # Compress existing tool results BEFORE making API call to avoid context overflow
@@ -1898,13 +1917,18 @@ class Model(ABC):
                     if any(not req.is_resolved() for req in run_response.requirements):
                         break
 
-                # If every tool call in this batch was refused because the tool call
-                # limit was exhausted, no further tool work is possible: the budget is
-                # spent, so the next turn can only produce the same refusals. Break
-                # instead of looping. Ordinary tool failures are deliberately excluded
-                # here - the model should still see those and be able to recover.
-                if function_call_results and all(m.tool_call_limit_reached for m in function_call_results):
+                # A model may use successful earlier tool results to synthesize a final
+                # answer after its budget is exhausted. Give it one final turn with no
+                # tools. If it still returns a tool call, stop rather than looping.
+                if tool_calls_disabled:
                     break
+                if function_call_results and all(m.tool_call_limit_reached for m in function_call_results):
+                    tools = []
+                    _tool_dicts = []
+                    _functions = {}
+                    tool_choice = "none"
+                    tool_calls_disabled = True
+                    continue
 
                 # Continue loop to get next response
                 continue

--- a/libs/agno/agno/models/message.py
+++ b/libs/agno/agno/models/message.py
@@ -104,6 +104,11 @@ class Message(BaseModel):
     tool_args: Optional[Any] = None
     # The error of the tool call
     tool_call_error: Optional[bool] = None
+    # True only when this result is the synthetic refusal produced because the
+    # tool call limit was exhausted. tool_call_error alone cannot be used to
+    # detect that case: it is also set for ordinary runtime tool failures,
+    # which the model should still be allowed to see and recover from.
+    tool_call_limit_reached: Optional[bool] = None
     # If True, the agent will stop executing after this tool call.
     stop_after_tool_call: bool = False
     # When True, the message will be added to the agent's memory.
@@ -321,6 +326,7 @@ class Message(BaseModel):
             "tool_name": self.tool_name,
             "tool_args": self.tool_args,
             "tool_call_error": self.tool_call_error,
+            "tool_call_limit_reached": self.tool_call_limit_reached,
             "tool_calls": self.tool_calls,
             "redacted_reasoning_content": self.redacted_reasoning_content,
             "provider_data": self.provider_data,

--- a/libs/agno/tests/unit/models/test_tool_call_limit_stop.py
+++ b/libs/agno/tests/unit/models/test_tool_call_limit_stop.py
@@ -13,12 +13,14 @@ These tests drive the real ``Model`` code with a local echo model, so they
 need no API keys and no network.
 """
 
-from typing import List, Optional
+import json
+from typing import Any, AsyncIterator, Iterator, List, Optional
 
 import pytest
 
+from agno.agent import Agent
 from agno.models.base import Model
-from agno.models.message import Message
+from agno.models.message import Message, MessageMetrics
 from agno.models.response import ModelResponse
 from agno.tools.function import Function, FunctionCall
 
@@ -47,6 +49,57 @@ class _EchoModel(Model):
 
     def _parse_provider_response_delta(self, *args, **kwargs):  # pragma: no cover
         raise NotImplementedError
+
+
+class _RepeatedToolCallModel(Model):
+    """Offline model that asks for the same tool after the limit is exhausted."""
+
+    def __init__(self, tool_name: str):
+        super().__init__(id="repeated-tool-call", name="Repeated tool call", provider="test")
+        self.tool_name = tool_name
+        self.invocations = 0
+
+    def _next_response(self) -> ModelResponse:
+        self.invocations += 1
+        if self.invocations <= 2:
+            return ModelResponse(
+                role="assistant",
+                tool_calls=[
+                    {
+                        "id": f"call_{self.invocations}",
+                        "type": "function",
+                        "function": {"name": self.tool_name, "arguments": json.dumps({"query": "Agno"})},
+                    }
+                ],
+                response_usage=MessageMetrics(input_tokens=1, output_tokens=1, total_tokens=2),
+            )
+        return ModelResponse(
+            role="assistant",
+            content="fallback answer",
+            response_usage=MessageMetrics(input_tokens=1, output_tokens=1, total_tokens=2),
+        )
+
+    def invoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return self._next_response()
+
+    async def ainvoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return self._next_response()
+
+    def invoke_stream(self, *args: Any, **kwargs: Any) -> Iterator[ModelResponse]:
+        yield self._next_response()
+
+    async def ainvoke_stream(self, *args: Any, **kwargs: Any) -> AsyncIterator[ModelResponse]:
+        yield self._next_response()
+
+    def _parse_provider_response(self, response: Any, **kwargs: Any) -> ModelResponse:
+        return response
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return response
+
+
+def _search_knowledge(query: str) -> str:
+    return f"result for {query}"
 
 
 def _make_call(name: str, fn) -> FunctionCall:
@@ -224,6 +277,74 @@ async def test_async_ordinary_failure_is_not_marked():
     assert results[0].tool_call_error is True
     assert results[0].tool_call_limit_reached is None
     assert _should_stop(results) is False
+
+
+# --- response loop behavior -------------------------------------------------
+
+
+def test_response_stream_stops_before_reasking_model_after_limit_refusal():
+    """Removing the stream guard makes the third scripted turn run.
+
+    The second request is refused because the only tool slot was used by the
+    first request.  A model that ignores that refusal must not receive a third
+    chance to request a tool or produce a fallback answer.
+    """
+    model = _RepeatedToolCallModel("search")
+
+    list(
+        model.response_stream(
+            messages=[Message(role="user", content="Find Agno")],
+            tools=[Function.from_callable(_search_knowledge, name="search")],
+            tool_call_limit=1,
+        )
+    )
+
+    assert model.invocations == 2
+
+
+@pytest.mark.asyncio
+async def test_aresponse_stream_stops_before_reasking_model_after_limit_refusal():
+    """Async streaming has the same no-progress termination behavior."""
+    model = _RepeatedToolCallModel("search")
+
+    _ = [
+        event
+        async for event in model.aresponse_stream(
+            messages=[Message(role="user", content="Find Agno")],
+            tools=[Function.from_callable(_search_knowledge, name="search")],
+            tool_call_limit=1,
+        )
+    ]
+
+    assert model.invocations == 2
+
+
+def test_agentic_rag_stops_after_search_knowledge_exhausts_tool_budget():
+    """Agentic-RAG stops when a repeated knowledge search is fully refused.
+
+    This exercises Agent's ``search_knowledge=True`` tool registration and
+    execution path rather than supplying the search function as a model tool.
+    Removing the limit guard invokes the scripted model a third time.
+    """
+    retrieved_queries: List[str] = []
+
+    def retrieve(query: str, num_documents: Optional[int] = None) -> List[dict]:
+        retrieved_queries.append(query)
+        return [{"content": "Agno is an agent framework."}]
+
+    model = _RepeatedToolCallModel("search_knowledge_base")
+    agent = Agent(
+        model=model,
+        search_knowledge=True,
+        knowledge_retriever=retrieve,
+        tool_call_limit=1,
+    )
+
+    result = agent.run("What is Agno?")
+
+    assert retrieved_queries == ["Agno"]
+    assert model.invocations == 2
+    assert result.content == ""
 
 
 # --- the guard is present in every response loop ----------------------------

--- a/libs/agno/tests/unit/models/test_tool_call_limit_stop.py
+++ b/libs/agno/tests/unit/models/test_tool_call_limit_stop.py
@@ -1,0 +1,247 @@
+"""Regression tests for the tool_call_limit no-progress stop guard.
+
+Covers the bug in #8304: when every tool call in a batch is refused because
+``tool_call_limit`` is exhausted, the model loop used to feed those refusals
+back to the model, which re-proposed the same tools, looping until timeout.
+
+The stop predicate must key off ``tool_call_limit_reached`` and not
+``tool_call_error``: the latter is also set for ordinary runtime tool
+failures (``create_function_call_result`` sets ``tool_call_error=not
+success``), which the model should still see and be able to recover from.
+
+These tests drive the real ``Model`` code with a local echo model, so they
+need no API keys and no network.
+"""
+
+from typing import List, Optional
+
+import pytest
+
+from agno.models.base import Model
+from agno.models.message import Message
+from agno.models.response import ModelResponse
+from agno.tools.function import Function, FunctionCall
+
+
+class _EchoModel(Model):
+    """Minimal concrete Model. Only the tool-result plumbing is exercised."""
+
+    def __init__(self):
+        super().__init__(id="echo", name="Echo", provider="test")
+
+    # The abstract request methods are never reached by these tests.
+    def invoke(self, *args, **kwargs):  # pragma: no cover - not exercised
+        raise NotImplementedError
+
+    async def ainvoke(self, *args, **kwargs):  # pragma: no cover - not exercised
+        raise NotImplementedError
+
+    def invoke_stream(self, *args, **kwargs):  # pragma: no cover - not exercised
+        raise NotImplementedError
+
+    async def ainvoke_stream(self, *args, **kwargs):  # pragma: no cover - not exercised
+        raise NotImplementedError
+
+    def _parse_provider_response(self, *args, **kwargs):  # pragma: no cover
+        raise NotImplementedError
+
+    def _parse_provider_response_delta(self, *args, **kwargs):  # pragma: no cover
+        raise NotImplementedError
+
+
+def _make_call(name: str, fn) -> FunctionCall:
+    function = Function(name=name, entrypoint=fn)
+    function.process_entrypoint()
+    return FunctionCall(function=function, arguments={}, call_id=f"call_{name}")
+
+
+def _ok_tool() -> str:
+    return "ok"
+
+
+def _boom_tool() -> str:
+    raise RuntimeError("upstream API is down")
+
+
+def _drain(model: Model, calls: List[FunctionCall], limit: Optional[int], count: int = 0) -> List[Message]:
+    results: List[Message] = []
+    for _ in model.run_function_calls(
+        function_calls=calls,
+        function_call_results=results,
+        current_function_call_count=count,
+        function_call_limit=limit,
+    ):
+        pass
+    return results
+
+
+# --- marker semantics -------------------------------------------------------
+
+
+def test_limit_refusal_is_marked_and_ordinary_success_is_not():
+    """A call refused by the limit carries the marker; an executed call does not."""
+    model = _EchoModel()
+    calls = [_make_call("first", _ok_tool), _make_call("second", _ok_tool)]
+
+    results = _drain(model, calls, limit=1)
+
+    assert len(results) == 2
+    # First call is inside the budget and runs normally.
+    assert results[0].tool_call_limit_reached is None
+    assert not results[0].tool_call_error
+    # Second call is refused by the limit.
+    assert results[1].tool_call_limit_reached is True
+    assert results[1].tool_call_error is True
+
+
+def test_ordinary_tool_failure_is_not_marked_as_limit_reached():
+    """The core of the bug: a runtime failure sets tool_call_error but not the marker.
+
+    Stopping on ``all(tool_call_error)`` would end the run here and deny the
+    model any chance to recover from a transient tool failure.
+    """
+    model = _EchoModel()
+
+    results = _drain(model, [_make_call("boom", _boom_tool)], limit=None)
+
+    assert len(results) == 1
+    assert results[0].tool_call_error is True
+    assert results[0].tool_call_limit_reached is None
+
+
+# --- stop predicate ---------------------------------------------------------
+#
+# The guard applied in each of the four response loops is:
+#     all(m.tool_call_limit_reached for m in function_call_results)
+
+
+def _should_stop(results: List[Message]) -> bool:
+    return bool(results) and all(m.tool_call_limit_reached for m in results)
+
+
+def test_all_blocked_by_limit_stops():
+    model = _EchoModel()
+    calls = [_make_call("a", _ok_tool), _make_call("b", _ok_tool)]
+
+    # Budget already spent, so every call in the batch is refused.
+    results = _drain(model, calls, limit=1, count=1)
+
+    assert [m.tool_call_limit_reached for m in results] == [True, True]
+    assert _should_stop(results) is True
+
+
+def test_all_ordinary_errors_do_not_stop():
+    model = _EchoModel()
+    calls = [_make_call("boom1", _boom_tool), _make_call("boom2", _boom_tool)]
+
+    results = _drain(model, calls, limit=None)
+
+    assert all(m.tool_call_error for m in results)
+    assert _should_stop(results) is False
+
+
+def test_mixed_batch_does_not_stop():
+    """One call succeeded, so progress was made; the model gets to use it."""
+    model = _EchoModel()
+    calls = [_make_call("a", _ok_tool), _make_call("b", _ok_tool)]
+
+    results = _drain(model, calls, limit=1)
+
+    assert results[1].tool_call_limit_reached is True
+    assert _should_stop(results) is False
+
+
+def test_budget_carries_across_turns_so_the_run_terminates():
+    """The termination guarantee for #8304, across consecutive turns.
+
+    A mixed batch does not stop the run, so this asserts the thing that makes
+    that safe: the response loops keep a single running ``function_call_count``
+    across ``while`` iterations (initialised once before the loop, incremented
+    by ``_limit_charge_for`` after each batch). The turn after the budget runs
+    out is therefore refused in full, and the guard fires.
+    """
+    model = _EchoModel()
+    budget = 1
+
+    # Turn 1: budget runs out mid-batch -> mixed, keep going.
+    turn1 = _drain(model, [_make_call("a", _ok_tool), _make_call("b", _ok_tool)], limit=budget, count=0)
+    assert _should_stop(turn1) is False
+
+    # The loop charges the batch against the running total exactly as the
+    # response loops do.
+    count = model._limit_charge_for(turn1, None)
+    assert count == 2
+
+    # Turn 2: the model re-proposes, every call is now refused, the run ends.
+    turn2 = _drain(model, [_make_call("a", _ok_tool), _make_call("b", _ok_tool)], limit=budget, count=count)
+    assert [m.tool_call_limit_reached for m in turn2] == [True, True]
+    assert _should_stop(turn2) is True
+
+
+def test_no_limit_configured_never_stops():
+    model = _EchoModel()
+    calls = [_make_call("a", _ok_tool), _make_call("b", _ok_tool)]
+
+    results = _drain(model, calls, limit=None)
+
+    assert not any(m.tool_call_limit_reached for m in results)
+    assert _should_stop(results) is False
+
+
+# --- async parity -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_limit_refusal_is_marked():
+    model = _EchoModel()
+    calls = [_make_call("a", _ok_tool), _make_call("b", _ok_tool)]
+    results: List[Message] = []
+
+    async for _ in model.arun_function_calls(
+        function_calls=calls,
+        function_call_results=results,
+        current_function_call_count=1,
+        function_call_limit=1,
+    ):
+        pass
+
+    assert [m.tool_call_limit_reached for m in results] == [True, True]
+    assert _should_stop(results) is True
+
+
+@pytest.mark.asyncio
+async def test_async_ordinary_failure_is_not_marked():
+    model = _EchoModel()
+    results: List[Message] = []
+
+    async for _ in model.arun_function_calls(
+        function_calls=[_make_call("boom", _boom_tool)],
+        function_call_results=results,
+        function_call_limit=None,
+    ):
+        pass
+
+    assert results[0].tool_call_error is True
+    assert results[0].tool_call_limit_reached is None
+    assert _should_stop(results) is False
+
+
+# --- the guard is present in every response loop ----------------------------
+
+
+def test_guard_present_in_all_four_response_loops():
+    """Sync, async, streaming and async-streaming loops must all carry the guard."""
+    import inspect
+
+    import agno.models.base as base
+
+    for fn in (
+        base.Model.response,
+        base.Model.aresponse,
+        base.Model.response_stream,
+        base.Model.aresponse_stream,
+    ):
+        source = inspect.getsource(fn)
+        assert "all(m.tool_call_limit_reached for m in function_call_results)" in source, (
+            f"{fn.__name__} is missing the tool_call_limit stop guard"
+        )

--- a/libs/agno/tests/unit/models/test_tool_call_limit_stop.py
+++ b/libs/agno/tests/unit/models/test_tool_call_limit_stop.py
@@ -58,9 +58,13 @@ class _RepeatedToolCallModel(Model):
         super().__init__(id="repeated-tool-call", name="Repeated tool call", provider="test")
         self.tool_name = tool_name
         self.invocations = 0
+        self.requested_tools: List[Any] = []
+        self.requested_tool_choices: List[Any] = []
 
-    def _next_response(self) -> ModelResponse:
+    def _next_response(self, **kwargs: Any) -> ModelResponse:
         self.invocations += 1
+        self.requested_tools.append(kwargs.get("tools"))
+        self.requested_tool_choices.append(kwargs.get("tool_choice"))
         if self.invocations <= 2:
             return ModelResponse(
                 role="assistant",
@@ -80,16 +84,16 @@ class _RepeatedToolCallModel(Model):
         )
 
     def invoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
-        return self._next_response()
+        return self._next_response(**kwargs)
 
     async def ainvoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
-        return self._next_response()
+        return self._next_response(**kwargs)
 
     def invoke_stream(self, *args: Any, **kwargs: Any) -> Iterator[ModelResponse]:
-        yield self._next_response()
+        yield self._next_response(**kwargs)
 
     async def ainvoke_stream(self, *args: Any, **kwargs: Any) -> AsyncIterator[ModelResponse]:
-        yield self._next_response()
+        yield self._next_response(**kwargs)
 
     def _parse_provider_response(self, response: Any, **kwargs: Any) -> ModelResponse:
         return response
@@ -282,16 +286,16 @@ async def test_async_ordinary_failure_is_not_marked():
 # --- response loop behavior -------------------------------------------------
 
 
-def test_response_stream_stops_before_reasking_model_after_limit_refusal():
-    """Removing the stream guard makes the third scripted turn run.
+def test_response_stream_allows_one_tool_free_final_answer_after_limit_refusal():
+    """The refused request is followed by one tool-free synthesis turn.
 
     The second request is refused because the only tool slot was used by the
-    first request.  A model that ignores that refusal must not receive a third
-    chance to request a tool or produce a fallback answer.
+    first request. The model must still get one final chance to answer from
+    the first tool result, without being offered tools again.
     """
     model = _RepeatedToolCallModel("search")
 
-    list(
+    events = list(
         model.response_stream(
             messages=[Message(role="user", content="Find Agno")],
             tools=[Function.from_callable(_search_knowledge, name="search")],
@@ -299,15 +303,18 @@ def test_response_stream_stops_before_reasking_model_after_limit_refusal():
         )
     )
 
-    assert model.invocations == 2
+    assert model.invocations == 3
+    assert model.requested_tools[2] == []
+    assert model.requested_tool_choices[2] == "none"
+    assert any(getattr(event, "content", None) == "fallback answer" for event in events)
 
 
 @pytest.mark.asyncio
-async def test_aresponse_stream_stops_before_reasking_model_after_limit_refusal():
-    """Async streaming has the same no-progress termination behavior."""
+async def test_aresponse_stream_allows_one_tool_free_final_answer_after_limit_refusal():
+    """Async streaming also preserves a final answer after the limit refusal."""
     model = _RepeatedToolCallModel("search")
 
-    _ = [
+    events = [
         event
         async for event in model.aresponse_stream(
             messages=[Message(role="user", content="Find Agno")],
@@ -316,15 +323,51 @@ async def test_aresponse_stream_stops_before_reasking_model_after_limit_refusal(
         )
     ]
 
-    assert model.invocations == 2
+    assert model.invocations == 3
+    assert model.requested_tools[2] == []
+    assert model.requested_tool_choices[2] == "none"
+    assert any(getattr(event, "content", None) == "fallback answer" for event in events)
 
 
-def test_agentic_rag_stops_after_search_knowledge_exhausts_tool_budget():
-    """Agentic-RAG stops when a repeated knowledge search is fully refused.
+def test_response_allows_one_tool_free_final_answer_after_limit_refusal():
+    """Non-streaming response also synthesizes after the limit is exhausted."""
+    model = _RepeatedToolCallModel("search")
+
+    response = model.response(
+        messages=[Message(role="user", content="Find Agno")],
+        tools=[Function.from_callable(_search_knowledge, name="search")],
+        tool_call_limit=1,
+    )
+
+    assert model.invocations == 3
+    assert model.requested_tools[2] == []
+    assert model.requested_tool_choices[2] == "none"
+    assert response.content == "fallback answer"
+
+
+@pytest.mark.asyncio
+async def test_aresponse_allows_one_tool_free_final_answer_after_limit_refusal():
+    """Async non-streaming response also synthesizes after the limit is exhausted."""
+    model = _RepeatedToolCallModel("search")
+
+    response = await model.aresponse(
+        messages=[Message(role="user", content="Find Agno")],
+        tools=[Function.from_callable(_search_knowledge, name="search")],
+        tool_call_limit=1,
+    )
+
+    assert model.invocations == 3
+    assert model.requested_tools[2] == []
+    assert model.requested_tool_choices[2] == "none"
+    assert response.content == "fallback answer"
+
+
+def test_agentic_rag_synthesizes_after_search_knowledge_exhausts_tool_budget():
+    """Agentic-RAG preserves its final answer when another search is refused.
 
     This exercises Agent's ``search_knowledge=True`` tool registration and
     execution path rather than supplying the search function as a model tool.
-    Removing the limit guard invokes the scripted model a third time.
+    The final, tool-free model turn can synthesize from the successful search.
     """
     retrieved_queries: List[str] = []
 
@@ -343,8 +386,10 @@ def test_agentic_rag_stops_after_search_knowledge_exhausts_tool_budget():
     result = agent.run("What is Agno?")
 
     assert retrieved_queries == ["Agno"]
-    assert model.invocations == 2
-    assert result.content == ""
+    assert model.invocations == 3
+    assert model.requested_tools[2] == []
+    assert model.requested_tool_choices[2] == "none"
+    assert result.content == "fallback answer"
 
 
 # --- the guard is present in every response loop ----------------------------


### PR DESCRIPTION
## Summary

Fixes the empty-response case in #8324's tool-call-limit loop guard and adds deterministic behavior coverage.

- After every tool call in a batch is refused because the budget is exhausted, disables tools and forces one final `tool_choice="none"` model turn.
- Stops if that final tool-free turn still returns a tool call, preserving the no-loop guarantee.
- Exercises real sync, async, streaming, and async-streaming model response loops.
- Reproduces Agentic-RAG with `Agent(search_knowledge=True, tool_call_limit=1)`, including actual registration and execution of `search_knowledge_base` through a local knowledge retriever.

This PR is based on #8324 and incorporates the fix identified in the automated review of the initial test-only commit.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [x] Other: regression tests

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (not applicable)
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that #8324 contains the associated production fix
- [x] This PR intentionally supplements #8324 with behavior-level regression coverage
- [x] Check if this PR was entirely AI-generated: code was generated with AI assistance and reviewed through deterministic local tests

---

## Additional Notes

`pytest libs/agno/tests/unit/models/test_tool_call_limit_stop.py -q` passes: 15 tests.

The project format script passes. The full validation script cannot start on this machine because the repository requires `mypy==2.1.0`, which is unavailable for the installed Python 3.9; the targeted import check passes.
