### PR TITLE
fix(memory): scope clear_memory tool to calling user's memories

### DIFF
--- a/libs/agno/agno/memory/manager.py
+++ b/libs/agno/agno/memory/manager.py
@@ -1416,7 +1416,7 @@ class MemoryManager:
             Returns:
                 str: A message indicating if the memory was cleared successfully or not.
             """
-            db.clear_memories()
+            self.clear_user_memories(user_id=user_id)
             log_debug("Memory cleared")
             return "Memory cleared successfully"
 
@@ -1556,10 +1556,7 @@ class MemoryManager:
             Returns:
                 str: A message indicating if the memory was cleared successfully or not.
             """
-            if isinstance(db, AsyncBaseDb):
-                await db.clear_memories()
-            else:
-                db.clear_memories()
+            await self.aclear_user_memories(user_id=user_id)
             log_debug("Memory cleared")
             return "Memory cleared successfully"
 

--- a/libs/agno/tests/unit/memory/test_clear_memory_scoped.py
+++ b/libs/agno/tests/unit/memory/test_clear_memory_scoped.py
@@ -1,0 +1,80 @@
+"""
+Regression test for agno#9983:
+clear_memory LLM tool must only clear the calling user's memories, not all users'.
+"""
+import pytest
+from agno.db.base import UserMemory
+from agno.db.sqlite.sqlite import SqliteDb
+from agno.memory.manager import MemoryManager
+
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    db_file = str(tmp_path / "test_memories.db")
+    db = SqliteDb(db_file=db_file)
+    return db
+
+
+def test_clear_memory_tool_is_user_scoped(tmp_db):
+    """clear_memory tool must only delete the calling user's memories."""
+    db = tmp_db
+
+    # Seed two users
+    db.upsert_user_memory(UserMemory(user_id="alice", memory="alice-fact-1"))
+    db.upsert_user_memory(UserMemory(user_id="alice", memory="alice-fact-2"))
+    db.upsert_user_memory(UserMemory(user_id="bob", memory="bob-fact-1"))
+
+    assert len(db.get_user_memories(user_id="alice")) == 2
+    assert len(db.get_user_memories(user_id="bob")) == 1
+
+    # Build the tool functions for alice's session
+    manager = MemoryManager(db=db)
+    tools = manager._get_db_tools(
+        user_id="alice",
+        db=db,
+        input_string="",
+        enable_clear_memory=True,
+    )
+    clear_fn = next(f for f in tools if f.__name__ == "clear_memory")
+
+    # Invoke the tool as alice
+    result = clear_fn()
+    assert result == "Memory cleared successfully"
+
+    # Alice's memories are gone
+    assert len(db.get_user_memories(user_id="alice")) == 0
+
+    # Bob's memories are untouched
+    bob_memories = db.get_user_memories(user_id="bob")
+    assert len(bob_memories) == 1, (
+        f"clear_memory wiped bob's memories too — unscoped db.clear_memories() was called. "
+        f"Bob has {len(bob_memories)} memories (expected 1)."
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_clear_memory_tool_is_user_scoped(tmp_db):
+    """Async clear_memory tool must only delete the calling user's memories."""
+    db = tmp_db
+
+    db.upsert_user_memory(UserMemory(user_id="alice", memory="alice-async-1"))
+    db.upsert_user_memory(UserMemory(user_id="bob", memory="bob-async-1"))
+
+    manager = MemoryManager(db=db)
+    tools = await manager._aget_db_tools(
+        user_id="alice",
+        db=db,
+        input_string="",
+        enable_clear_memory=True,
+    )
+    clear_fn = next(f for f in tools if f.__name__ == "clear_memory")
+
+    result = await clear_fn()
+    assert result == "Memory cleared successfully"
+
+    assert len(db.get_user_memories(user_id="alice")) == 0
+    bob_memories = db.get_user_memories(user_id="bob")
+    assert len(bob_memories) == 1, (
+        f"Async clear_memory wiped bob's memories — unscoped db.clear_memories() was called. "
+        f"Bob has {len(bob_memories)} memories (expected 1)."
+    )


### PR DESCRIPTION
## Root cause

`MemoryManager._get_db_tools` and `_aget_db_tools` register a `clear_memory` LLM tool that calls `db.clear_memories()` — an unconditional wipe of the whole `memories` table (all `user_id` / `agent_id` / `team_id` values). Every sibling tool in the same factory is user-scoped:

```python
# add_memory, update_memory, delete_memory — all scoped:
db.upsert_user_memory(UserMemory(user_id=user_id, ...))
db.delete_user_memory(memory_id=memory_id, user_id=user_id)

# clear_memory — NOT scoped (before this fix):
db.clear_memories()  # wipes every user's memories
```

The programmatic path `MemoryManager.clear_user_memories(user_id=...)` is correctly scoped. The LLM-invoked tool was the one unguarded path, so a single agent session (or an LLM misfire) could destroy all users' long-term memory in any deployment that shares one DB across users.

Reported in #9983.

## Fix

Replace `db.clear_memories()` with `self.clear_user_memories(user_id=user_id)` in the sync closure and `await self.aclear_user_memories(user_id=user_id)` in the async closure. Both methods already exist on `MemoryManager` and are correctly scoped; the closures already capture `self` and `user_id`.

**Sync** (`_get_db_tools`):
```python
# before
db.clear_memories()
# after
self.clear_user_memories(user_id=user_id)
```

**Async** (`_aget_db_tools`):
```python
# before
if isinstance(db, AsyncBaseDb):
    await db.clear_memories()
else:
    db.clear_memories()
# after
await self.aclear_user_memories(user_id=user_id)
```

## Test evidence

New regression test `tests/unit/memory/test_clear_memory_scoped.py`:
- Seeds alice (2 memories) and bob (1 memory)
- Invokes the `clear_memory` tool as alice
- Asserts alice's memories are cleared and bob's are untouched

**Unpatched** (fails):
```
AssertionError: clear_memory wiped bob's memories too — unscoped db.clear_memories() was called. Bob has 0 memories (expected 1).
1 failed in 0.64s
```

**Patched** (passes):
```
tests/unit/memory/test_clear_memory_scoped.py::test_clear_memory_tool_is_user_scoped PASSED
tests/unit/memory/test_clear_memory_scoped.py::test_async_clear_memory_tool_is_user_scoped PASSED
2 passed in 0.45s
```

Fixes #9983