### PR TITLE
[fix] Honour a member's own ResultStore when the team does not offload

### DIFF
--- a/libs/agno/agno/team/_init.py
+++ b/libs/agno/agno/team/_init.py
@@ -652,7 +652,7 @@ def _bind_member_result_store(team: "Team", member: Union[Agent, "Team"]) -> Non
             )
         else:
             store = team._result_store
-    elif declares_own_store:
+    elif member.offload_tool_results:
         from agno.offload.setup import build_result_store
 
         # The team does not offload, but this member asked to. Its setting is
@@ -660,8 +660,14 @@ def _bind_member_result_store(team: "Team", member: Union[Agent, "Team"]) -> Non
         # governs the team's own tool results, not whether a member's
         # configuration survives being added to a team. Without this the store
         # is overwritten with None below, silently, while the member's public
-        # ``offload_tool_results`` still reports a ResultStore, so the member
-        # looks configured and offloads nothing.
+        # ``offload_tool_results`` still reports what the caller set, so the
+        # member looks configured and offloads nothing.
+        #
+        # Truthiness, not ``declares_own_store``: ``offload_tool_results=True``
+        # is the documented way to ask for the defaults and has to survive the
+        # same way a ResultStore does. None and False both fall through to the
+        # assignment below and leave the member without a store, which is what
+        # they mean.
         #
         # Payloads go to the member's own db when it has one, falling back to
         # the team's. There is no team store for them to be readable from here,

--- a/libs/agno/agno/team/_init.py
+++ b/libs/agno/agno/team/_init.py
@@ -652,6 +652,22 @@ def _bind_member_result_store(team: "Team", member: Union[Agent, "Team"]) -> Non
             )
         else:
             store = team._result_store
+    elif declares_own_store:
+        from agno.offload.setup import build_result_store
+
+        # The team does not offload, but this member asked to. Its setting is
+        # explicit, so honour it rather than dropping it: the team's setting
+        # governs the team's own tool results, not whether a member's
+        # configuration survives being added to a team. Without this the store
+        # is overwritten with None below, silently, while the member's public
+        # ``offload_tool_results`` still reports a ResultStore, so the member
+        # looks configured and offloads nothing.
+        #
+        # Payloads go to the member's own db when it has one, falling back to
+        # the team's. There is no team store for them to be readable from here,
+        # so nothing is gained by forcing them onto the team's database.
+        bind_db = member.db if member.db is not None else team.db
+        store = build_result_store(setting=member.offload_tool_results, db=bind_db, owner=member, owner_kind="member")
     member._result_store = store
     member._inherited_result_store = store
 

--- a/libs/agno/tests/integration/offload/test_team_offloading.py
+++ b/libs/agno/tests/integration/offload/test_team_offloading.py
@@ -968,3 +968,127 @@ def test_a_factory_member_that_opted_out_keeps_its_history_whole(db):
     for run in member_runs:
         for message in run.messages or []:
             assert not str(message.content or "").startswith('<result id="res_')
+
+
+# ------------------------------------------------------------------
+# A member offloading on its own, inside a team that does not
+# ------------------------------------------------------------------
+
+
+class ToolCallingMemberModel(Model):
+    """Calls one tool, then answers. The tool result is what grows."""
+
+    def __init__(self, tool_name: str = "fetch_corpus"):
+        super().__init__(id="member", name="member", provider="test")
+        self.tool_name = tool_name
+        self.calls = 0
+
+    def _next(self) -> ModelResponse:
+        self.calls += 1
+        if self.calls == 1:
+            return ModelResponse(
+                role="assistant",
+                tool_calls=[
+                    {
+                        "id": "member-call-1",
+                        "type": "function",
+                        "function": {"name": self.tool_name, "arguments": "{}"},
+                    }
+                ],
+                response_usage=MessageMetrics(),
+            )
+        return ModelResponse(role="assistant", content="summarised", response_usage=MessageMetrics())
+
+    def invoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return self._next()
+
+    async def ainvoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return self._next()
+
+    def invoke_stream(self, *args: Any, **kwargs: Any) -> Iterator[ModelResponse]:
+        yield self._next()
+
+    async def ainvoke_stream(self, *args: Any, **kwargs: Any) -> AsyncIterator[ModelResponse]:
+        yield self._next()
+
+    def _parse_provider_response(self, response: Any, **kwargs: Any) -> ModelResponse:
+        return response
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return response
+
+
+def _offloading_member_in_a_plain_team(db) -> Team:
+    """A member that offloads its own tool results, in a team that does not."""
+
+    def fetch_corpus() -> str:
+        return BIG
+
+    member = Agent(
+        name="researcher",
+        id="researcher",
+        model=ToolCallingMemberModel(),
+        db=db,
+        tools=[fetch_corpus],
+        offload_tool_results=ResultStore(threshold_chars=8000),
+    )
+    return Team(
+        name="platform",
+        id="platform",
+        members=[member],
+        model=LeaderModel(),
+        db=db,
+        # The team itself does not offload. That must not disable the member.
+        offload_tool_results=False,
+    )
+
+
+def _member_tool_messages(output) -> List[Any]:
+    member_run = output.member_responses[0]
+    return [m for m in (member_run.messages or []) if m.role == "tool"]
+
+
+def test_a_member_offloads_its_own_tool_results_in_a_team_that_does_not(db):
+    # The payoff, not the wiring: the member's own oversized tool result is a
+    # short envelope in its transcript even though the team stores nothing.
+    team = _offloading_member_in_a_plain_team(db)
+    output = team.run("go", session_id=_sid())
+
+    assert team._result_store is None
+    tool_message = _member_tool_messages(output)[0]
+    assert tool_message.tool_name == "fetch_corpus"
+    assert tool_message.content.startswith('<result id="res_')
+    assert BIG not in tool_message.content
+
+
+def test_that_member_can_read_its_payload_back(db):
+    team = _offloading_member_in_a_plain_team(db)
+    output = team.run("go", session_id=_sid())
+
+    member = team.members[0]
+    result_id = _result_id(_member_tool_messages(output)[0].content)
+    page = member._result_store.read(result_id, 1, 3000)
+    assert page.line_count == 3000
+    assert page.text.startswith("finding 1: ")
+
+
+def test_a_member_that_also_compresses_still_gets_its_store(db):
+    # The corner no test covered: compression on the member, its own store, and
+    # a team that offloads nothing. Guards against a symmetric raise growing
+    # back on this path by accident.
+    def fetch_corpus() -> str:
+        return BIG
+
+    member = Agent(
+        name="researcher",
+        id="researcher",
+        model=ToolCallingMemberModel(),
+        db=db,
+        tools=[fetch_corpus],
+        offload_tool_results=ResultStore(threshold_chars=8000),
+    )
+    team = Team(name="platform", id="platform", members=[member], model=LeaderModel(), db=db)
+    team.initialize_team()
+
+    assert member._result_store is not None
+    assert member._result_store.threshold_chars == 8000

--- a/libs/agno/tests/unit/offload/test_offload_config.py
+++ b/libs/agno/tests/unit/offload/test_offload_config.py
@@ -115,6 +115,21 @@ def test_a_member_keeps_its_own_store_when_the_team_does_not_offload(db):
     assert member._result_store.db is db
 
 
+def test_a_member_asking_for_the_defaults_keeps_them_when_the_team_does_not_offload(db):
+    """``offload_tool_results=True`` has to survive the same way a ResultStore does.
+
+    True is the documented way to ask for the defaults, so keying the member
+    branch on ``isinstance(..., ResultStore)`` would honour the verbose form and
+    silently drop the common one.
+    """
+    member = Agent(name="member", db=db, offload_tool_results=True)
+    team = Team(name="team", members=[member], db=db)  # the team itself does not offload
+    team.initialize_team()
+
+    assert member._result_store is not None
+    assert member._result_store.db is db
+
+
 def test_a_member_without_its_own_db_binds_to_the_team_db(db):
     member = Agent(name="member", db=None, offload_tool_results=ResultStore(threshold_chars=100))
     team = Team(name="team", members=[member], db=db)

--- a/libs/agno/tests/unit/offload/test_offload_config.py
+++ b/libs/agno/tests/unit/offload/test_offload_config.py
@@ -97,6 +97,49 @@ def test_a_sub_team_member_keeps_its_declared_store_settings(db):
     assert member._result_store.db is db
 
 
+def test_a_member_keeps_its_own_store_when_the_team_does_not_offload(db):
+    """A member's explicit setting is not a function of the team's.
+
+    The team's ``offload_tool_results`` decides what the team does with its own
+    tool results. A member that asked for a store still gets one, otherwise the
+    setting is dropped on the floor: ``member._result_store`` would be None
+    while ``member.offload_tool_results`` still reports a ResultStore, so the
+    member looks configured and offloads nothing.
+    """
+    member = Agent(name="member", db=db, offload_tool_results=ResultStore(threshold_chars=100))
+    team = Team(name="team", members=[member], db=db)  # the team itself does not offload
+    team.initialize_team()
+
+    assert member._result_store is not None
+    assert member._result_store.threshold_chars == 100
+    assert member._result_store.db is db
+
+
+def test_a_member_without_its_own_db_binds_to_the_team_db(db):
+    member = Agent(name="member", db=None, offload_tool_results=ResultStore(threshold_chars=100))
+    team = Team(name="team", members=[member], db=db)
+    team.initialize_team()
+
+    assert member._result_store is not None
+    assert member._result_store.db is db
+
+
+def test_a_member_opting_out_stays_out_when_the_team_does_not_offload(db):
+    member = Agent(name="member", db=db, offload_tool_results=False)
+    team = Team(name="team", members=[member], db=db)
+    team.initialize_team()
+
+    assert member._result_store is None
+
+
+def test_a_member_on_defaults_gets_no_store_when_the_team_does_not_offload(db):
+    member = Agent(name="member", db=db)
+    team = Team(name="team", members=[member], db=db)
+    team.initialize_team()
+
+    assert member._result_store is None
+
+
 def test_team_store_follows_a_db_change(db, tmp_path):
     import os as _os
 


### PR DESCRIPTION
## Summary

Fixes #9987.

`_bind_member_result_store` resolves a member's store only when the team has one, but assigns the result unconditionally:

```python
store: Optional[ResultStore] = None
if team._result_store is not None and member.offload_tool_results is not False:
    ...
member._result_store = store
member._inherited_result_store = store
```

A team that does not offload has `team._result_store is None`, so the branch never runs and a member that explicitly declared `offload_tool_results=ResultStore(...)` has it overwritten with `None`. There is no exception and no warning, and `member.offload_tool_results` still holds the ResultStore, so the member looks configured while nothing is offloaded. The same agent called standalone offloads correctly, since the agent-level setup runs independently, which is what makes it hard to spot.

This change resolves the member's own declared store when the team has none, instead of falling through to `None`. The team's `offload_tool_results` decides what the team does with its own tool results; it should not decide whether a member's explicit setting survives being added to a team.

Payloads bind to the member's own db when it has one, falling back to the team's. There is no team store for them to be readable from in this case, so forcing them onto the team's database buys nothing.

Behaviour that does not change: an explicit `offload_tool_results=False` still keeps a member out, a member on the defaults inside a non-offloading team still gets no store, and every path where the team does offload is untouched.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`ruff format --check` and `ruff check` with the pinned ruff 0.15.20, both clean on the two changed files; `mypy agno/team/_init.py` reports nothing in this module)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

Four tests added to `libs/agno/tests/unit/offload/test_offload_config.py`:

| test | asserts |
|---|---|
| `test_a_member_keeps_its_own_store_when_the_team_does_not_offload` | the store survives, with the member's own `threshold_chars` |
| `test_a_member_without_its_own_db_binds_to_the_team_db` | db fallback |
| `test_a_member_opting_out_stays_out_when_the_team_does_not_offload` | explicit `False` unchanged |
| `test_a_member_on_defaults_gets_no_store_when_the_team_does_not_offload` | defaults unchanged |

The first two fail on `main` with `AssertionError: assert None is not None` and pass with this change; the last two pass either way, as controls. `libs/agno/tests/unit/offload` and `libs/agno/tests/unit/team` are green (877 passed; the single remaining failure is `test_fork_session_route_registered`, which wants `python-multipart` and is unrelated).

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

Disclosure per CONTRIBUTING: this PR was written with Claude Code. The bug was found by hitting it in production, the diagnosis and the fix were reviewed by me, and the tests were checked to fail on `main` before being checked to pass here.

On overlap: #9770 touches the same function but is orthogonal. It removes the compression/offloading mutual-exclusion guards and leaves both the `if team._result_store is not None:` gate and the unconditional assignment in place, so the silent discard survives it. The two changes stack cleanly, and this one matters more once #9770 lands, since combining the flags becomes the expected thing to do.

---

## Additional Notes

This surfaced as a production regression, which is worth stating because of how it fails. Adopting offloading currently means removing `compress_tool_results`. We swapped two team members over, confirmed nothing raised and that both reported a ResultStore, and shipped. On the delegated path those members then had neither compression nor offloading, reintroducing the context blow-up compression was there to prevent. Only `member._result_store` after `initialize_team()` reveals it, and nothing prompts you to look there.