### PR TITLE
feat: add Hubris model provider

### DIFF
--- a/cookbook/90_models/README.md
+++ b/cookbook/90_models/README.md
@@ -19,6 +19,7 @@ Examples for all supported LLM providers in Agno.
 | **LM Studio** | Local GUI | Local |
 | **llama.cpp** | Local GGUF | Local |
 | **llmman** | Local models as OCI artifacts | Local |
+| **Hubris** | 500+ models via OpenAI-compatible gateway, billed in RUB | `HUBRIS_API_KEY` |
 | **Tuning Engines** | Governed OpenAI-compatible endpoint | `TUNING_ENGINES_API_KEY` |
 
 ## Getting Started

--- a/cookbook/90_models/hubris/README.md
+++ b/cookbook/90_models/hubris/README.md
@@ -1,0 +1,50 @@
+# Hubris Cookbook
+
+> Note: Fork and clone this repository if needed
+
+[Hubris](https://hubris.pw) is an OpenAI-compatible LLM gateway billed in Russian rubles: one API key
+for 500+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen and others. Model ids use the full
+`vendor/model` form from the [catalog](https://hubris.pw/models).
+
+### 1. Create and activate a virtual environment
+
+```shell
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+### 2. Export your `HUBRIS_API_KEY`
+
+Create a key at [hubris.pw/keys](https://hubris.pw/keys).
+
+```shell
+export HUBRIS_API_KEY=sk-gw-***
+```
+
+### 3. Install libraries
+
+```shell
+pip install -U openai ddgs agno
+```
+
+### 4. Run basic Agent
+
+- Streaming on
+
+```shell
+python cookbook/90_models/hubris/basic.py
+```
+
+### 5. Run Agent with Tools
+
+- Web search
+
+```shell
+python cookbook/90_models/hubris/tool_use.py
+```
+
+### 6. Run Agent that returns structured output
+
+```shell
+python cookbook/90_models/hubris/structured_output.py
+```

--- a/cookbook/90_models/hubris/basic.py
+++ b/cookbook/90_models/hubris/basic.py
@@ -1,0 +1,32 @@
+"""
+Hubris Basic
+============
+
+Cookbook example for `hubris/basic.py`.
+Refer to cookbook/90_models/hubris/README.md for installation steps.
+"""
+
+from agno.agent import Agent, RunOutput  # noqa
+from agno.models.hubris import Hubris
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+agent = Agent(model=Hubris(id="anthropic/claude-sonnet-5"), markdown=True)
+
+# The string syntax works too: Agent(model="hubris:anthropic/claude-sonnet-5", markdown=True)
+
+# Get the response in a variable
+# run: RunOutput = agent.run("Share a 2 sentence horror story")
+# print(run.content)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    # --- Sync ---
+    agent.print_response("Share a 2 sentence horror story")
+
+    # --- Sync + Streaming ---
+    agent.print_response("Share a 2 sentence horror story", stream=True)

--- a/cookbook/90_models/hubris/structured_output.py
+++ b/cookbook/90_models/hubris/structured_output.py
@@ -1,0 +1,53 @@
+"""
+Hubris Structured Output
+========================
+
+Cookbook example for `hubris/structured_output.py`.
+"""
+
+from typing import List
+
+from agno.agent import Agent
+from agno.models.hubris import Hubris
+from agno.run.agent import RunOutput
+from pydantic import BaseModel, Field
+from rich.pretty import pprint  # noqa
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+
+class MovieScript(BaseModel):
+    name: str = Field(..., description="Give a name to this movie")
+    setting: str = Field(
+        ..., description="Provide a nice setting for a blockbuster movie."
+    )
+    ending: str = Field(
+        ...,
+        description="Ending of the movie. If not available, provide a happy ending.",
+    )
+    genre: str = Field(
+        ...,
+        description="Genre of the movie. If not available, select action, thriller or romantic comedy.",
+    )
+    characters: List[str] = Field(..., description="Name of characters for this movie.")
+    storyline: str = Field(
+        ..., description="3 sentence storyline for the movie. Make it exciting!"
+    )
+
+
+# Agent that returns a structured output
+structured_output_agent = Agent(
+    model=Hubris(id="openai/gpt-5.6-luna"),
+    description="You write movie scripts.",
+    output_schema=MovieScript,
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    structured_output_response: RunOutput = structured_output_agent.run("New York")
+    pprint(structured_output_response.content)

--- a/cookbook/90_models/hubris/tool_use.py
+++ b/cookbook/90_models/hubris/tool_use.py
@@ -1,0 +1,25 @@
+"""Run `uv pip install ddgs` to install dependencies."""
+
+from agno.agent import Agent
+from agno.models.hubris import Hubris
+from agno.tools.websearch import WebSearchTools
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+agent = Agent(
+    model=Hubris(id="anthropic/claude-sonnet-5"),
+    tools=[WebSearchTools()],
+    markdown=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    # --- Sync ---
+    agent.print_response("Whats happening in France?")
+
+    # --- Sync + Streaming ---
+    agent.print_response("Whats happening in France?", stream=True)

--- a/libs/agno/agno/models/hubris/__init__.py
+++ b/libs/agno/agno/models/hubris/__init__.py
@@ -1,0 +1,5 @@
+from agno.models.hubris.hubris import Hubris
+
+__all__ = [
+    "Hubris",
+]

--- a/libs/agno/agno/models/hubris/hubris.py
+++ b/libs/agno/agno/models/hubris/hubris.py
@@ -1,0 +1,48 @@
+from dataclasses import dataclass
+from os import getenv
+from typing import Any, Dict, Optional
+
+from agno.exceptions import ModelAuthenticationError
+from agno.models.openai.like import OpenAILike
+
+
+@dataclass
+class Hubris(OpenAILike):
+    """
+    A class for interacting with models served by Hubris (https://hubris.pw), an
+    OpenAI-compatible LLM gateway billed in Russian rubles.
+
+    Model ids use the full ``vendor/model`` form shown in the catalog at
+    https://hubris.pw/models, e.g. ``anthropic/claude-sonnet-5`` or ``openai/gpt-5.6-luna``.
+
+    Attributes:
+        id (str): The model id. Defaults to "anthropic/claude-sonnet-5".
+        name (str): The model name. Defaults to "Hubris".
+        provider (str): The provider name. Defaults to "Hubris".
+        api_key (Optional[str]): The API key. Falls back to the HUBRIS_API_KEY environment variable.
+        base_url (str): The base URL. Defaults to "https://api.hubris.pw/v1".
+    """
+
+    id: str = "anthropic/claude-sonnet-5"
+    name: str = "Hubris"
+    provider: str = "Hubris"
+
+    api_key: Optional[str] = None
+    base_url: str = "https://api.hubris.pw/v1"
+
+    def _get_client_params(self) -> Dict[str, Any]:
+        """
+        Returns client parameters for API requests, checking for HUBRIS_API_KEY.
+
+        Returns:
+            Dict[str, Any]: A dictionary of client parameters for API requests.
+        """
+        if not self.api_key:
+            self.api_key = getenv("HUBRIS_API_KEY")
+            if not self.api_key:
+                raise ModelAuthenticationError(
+                    message="HUBRIS_API_KEY not set. Please set the HUBRIS_API_KEY environment variable.",
+                    model_name=self.name,
+                )
+
+        return super()._get_client_params()

--- a/libs/agno/agno/models/utils.py
+++ b/libs/agno/agno/models/utils.py
@@ -32,6 +32,7 @@ _PROVIDERS: Dict[str, Tuple[str, str, str, str]] = {
     "google": ("agno.models.google", "Gemini", "Gemini", "google"),
     "google-interactions": ("agno.models.google", "GeminiInteractions", "GeminiInteractions", "google"),
     "groq": ("agno.models.groq", "Groq", "Groq", "groq"),
+    "hubris": ("agno.models.hubris", "Hubris", "Hubris", "hubris"),
     "huggingface": ("agno.models.huggingface", "HuggingFace", "HuggingFace", "huggingface"),
     "ibm": ("agno.models.ibm", "WatsonX", "WatsonX", "ibm"),
     "inception": ("agno.models.inception", "Inception", "Inception", "inceptionlabs"),

--- a/libs/agno/tests/unit/models/hubris_model/test_hubris.py
+++ b/libs/agno/tests/unit/models/hubris_model/test_hubris.py
@@ -1,0 +1,40 @@
+import pytest
+
+pytest.importorskip("openai")
+
+from agno.models.hubris import Hubris
+from agno.models.utils import get_model
+
+
+def test_defaults():
+    """Hubris points at the gateway and defaults to a catalog model id."""
+    model = Hubris()
+    assert model.id == "anthropic/claude-sonnet-5"
+    assert model.name == "Hubris"
+    assert model.provider == "Hubris"
+    assert model.base_url == "https://api.hubris.pw/v1"
+
+
+def test_get_model_from_string():
+    """The vendor/model id survives the provider-prefixed string syntax."""
+    model = get_model("hubris:openai/gpt-5.6-luna")
+    assert isinstance(model, Hubris)
+    assert model.id == "openai/gpt-5.6-luna"
+    assert model.base_url == "https://api.hubris.pw/v1"
+
+
+def test_missing_api_key_raises(monkeypatch):
+    """Without a key the client refuses to start instead of sending an unauthenticated request."""
+    from agno.exceptions import ModelAuthenticationError
+
+    monkeypatch.delenv("HUBRIS_API_KEY", raising=False)
+    with pytest.raises(ModelAuthenticationError):
+        Hubris()._get_client_params()
+
+
+def test_api_key_from_env(monkeypatch):
+    monkeypatch.setenv("HUBRIS_API_KEY", "sk-gw-test")
+    model = Hubris()
+    params = model._get_client_params()
+    assert params["api_key"] == "sk-gw-test"
+    assert params["base_url"] == "https://api.hubris.pw/v1"

--- a/libs/agno/tests/unit/models/test_hubris.py
+++ b/libs/agno/tests/unit/models/test_hubris.py
@@ -1,0 +1,53 @@
+import os
+from unittest.mock import patch
+
+import pytest
+
+from agno.exceptions import ModelAuthenticationError
+from agno.models.hubris import Hubris
+
+
+def test_hubris_initialization_with_api_key():
+    model = Hubris(id="anthropic/claude-sonnet-5", api_key="test-api-key")
+    assert model.id == "anthropic/claude-sonnet-5"
+    assert model.api_key == "test-api-key"
+    assert model.base_url == "https://api.hubris.pw/v1"
+
+
+def test_hubris_initialization_without_api_key():
+    with patch.dict(os.environ, {}, clear=True):
+        model = Hubris(id="anthropic/claude-sonnet-5")
+        client_params = None
+        with pytest.raises(ModelAuthenticationError):
+            client_params = model._get_client_params()
+        assert client_params is None
+
+
+def test_hubris_initialization_with_env_api_key():
+    """The env var is read when the client is built, not at construction.
+
+    This model follows the majority convention here (anthropic, aws, azure,
+    cerebras and others): ``api_key`` defaults to None and the environment is
+    consulted in ``_get_client_params``. Providers using a ``default_factory``
+    resolve it earlier; both patterns are present in this codebase.
+    """
+    with patch.dict(os.environ, {"HUBRIS_API_KEY": "env-api-key"}):
+        model = Hubris(id="anthropic/claude-sonnet-5")
+        client_params = model._get_client_params()
+        assert client_params["api_key"] == "env-api-key"
+        assert model.api_key == "env-api-key"
+
+
+def test_hubris_client_params():
+    model = Hubris(id="anthropic/claude-sonnet-5", api_key="test-api-key")
+    client_params = model._get_client_params()
+    assert client_params["api_key"] == "test-api-key"
+    assert client_params["base_url"] == "https://api.hubris.pw/v1"
+
+
+def test_hubris_default_id():
+    """Model ids carry the vendor prefix and are matched exactly by the gateway."""
+    model = Hubris(api_key="test-api-key")
+    assert model.id == "anthropic/claude-sonnet-5"
+    assert model.name == "Hubris"
+    assert model.provider == "Hubris"


### PR DESCRIPTION
Adds [Hubris](https://hubris.pw) as a model provider. Hubris is an OpenAI-compatible LLM gateway billed in Russian rubles — one API key for 500+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, Z.ai, Moonshot, xAI and MiniMax; model ids use the full `vendor/model` form from the catalog (e.g. `anthropic/claude-sonnet-5`).

`Hubris` subclasses `OpenAILike` and mirrors `OpenRouter`: `base_url` `https://api.hubris.pw/v1`, API key from `HUBRIS_API_KEY` with the same `ModelAuthenticationError` when it is missing. Registration is the single `_PROVIDERS` row (`hubris:<vendor/model>`), placed alphabetically. Cookbook: `cookbook/90_models/hubris/{basic,tool_use,structured_output}.py` + README, and a row in the models README table. Unit tests: `tests/unit/models/hubris_model/test_hubris.py` (defaults, string resolution through `get_model`, missing-key error, key from env) — 4 passed locally.

No linked issue — this adds a provider rather than fixing reported behaviour (same as #9863 llmman, #9788 Synthorai).

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`ruff`-clean, no new dependencies)
- [x] Self-review completed
- [x] Documentation updated (cookbook README)
- [x] Tests added/updated (unit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)