### PR TITLE
[cookbook] Add deterministic tool governance example

### DIFF
--- a/cookbook/91_tools/tool_hooks/README.md
+++ b/cookbook/91_tools/tool_hooks/README.md
@@ -1,3 +1,15 @@
 # tool_hooks
 
-Cookbook examples for this tools subsection.
+Cookbook examples for using Agno tool hooks to wrap tool execution.
+
+Tool hooks receive the tool name, arguments, and continuation function before the
+tool body runs. This makes them the provider-neutral integration point for
+deterministic tool governance patterns such as allow/deny policy checks, audit
+receipts, result redaction, and local kill switches.
+
+## Examples
+
+- `tool_hook.py` - Log before and after a standalone tool call.
+- `tool_hook_in_toolkit.py` - Authorize and transform toolkit tool calls.
+- `tool_hooks_in_toolkit_nested.py` - Compose multiple hooks in sync and async paths.
+- `deterministic_governance.py` - Enforce allow/deny policy, PII redaction, a per-agent call budget, and a kill switch without adding a governance provider dependency.

--- a/cookbook/91_tools/tool_hooks/TEST_LOG.md
+++ b/cookbook/91_tools/tool_hooks/TEST_LOG.md
@@ -1,11 +1,11 @@
 # Test Log
 
-### Pending
+### deterministic_governance.py
 
-**Status:** NOT RUN
+**Status:** PASS
 
-**Description:** Tests for this cookbook directory have not been executed yet in this workspace.
+**Description:** Added and executed a focused unit coverage path for the deterministic governance cookbook. The tests import the cookbook module and call the registered sync and async tools through `FunctionCall` so no model credentials or network calls are required.
 
-**Result:** Add individual run results after executing examples.
+**Result:** `pytest libs/agno/tests/unit/tools/test_deterministic_governance_cookbook.py -q` passed. Coverage proves deny-before-side-effect, PII redaction, async call budgets, and the kill switch behavior.
 
 ---

--- a/cookbook/91_tools/tool_hooks/deterministic_governance.py
+++ b/cookbook/91_tools/tool_hooks/deterministic_governance.py
@@ -1,0 +1,205 @@
+"""Deterministic tool governance with Agno tool hooks.
+
+This example keeps governance provider-neutral. The hook receives the tool name,
+arguments, and continuation function before the real tool body runs, so it can
+make an allow/deny decision without asking the model.
+"""
+
+import json
+import re
+from inspect import iscoroutinefunction
+from typing import Any, Callable, Dict, Optional, Set
+
+from agno.tools import Toolkit
+from agno.utils.log import logger
+
+
+# ---------------------------------------------------------------------------
+# Governance hook
+# ---------------------------------------------------------------------------
+
+
+class DeterministicGovernance:
+    """Small provider-neutral governance hook for tool execution.
+
+    This is intentionally plain Python. Replace the policy methods with a call
+    to TealTiger, HOL Guard, or an internal policy engine while keeping the Agno
+    integration point the same: a `tool_hooks` callable that either returns a
+    deny result or calls the continuation.
+    """
+
+    EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+    PHONE_RE = re.compile(r"\b\d{3}-\d{3}-\d{4}\b")
+
+    def __init__(
+        self,
+        *,
+        allowlist: Optional[Set[str]] = None,
+        denylist: Optional[Set[str]] = None,
+        redact_pii: bool = True,
+        max_tool_calls: Optional[int] = None,
+    ) -> None:
+        self.allowlist = allowlist
+        self.denylist = denylist or set()
+        self.redact_pii = redact_pii
+        self.max_tool_calls = max_tool_calls
+        self.tool_calls = 0
+        self.freeze_reason: Optional[str] = None
+
+    def freeze(self, reason: str) -> None:
+        """Activate the kill switch for later tool calls."""
+
+        self.freeze_reason = reason
+
+    def _deny(self, reason: str) -> str:
+        return json.dumps({"allowed": False, "action": "deny", "reason": reason})
+
+    def _authorize(self, function_name: str) -> Optional[str]:
+        if self.freeze_reason is not None:
+            return f"governance kill switch active: {self.freeze_reason}"
+        if function_name in self.denylist:
+            return f"tool '{function_name}' is denied by policy"
+        if self.allowlist is not None and function_name not in self.allowlist:
+            return f"tool '{function_name}' is not on the allowlist"
+        if self.max_tool_calls is not None and self.tool_calls >= self.max_tool_calls:
+            return "tool budget exceeded"
+        return None
+
+    def _redact(self, value: Any) -> Any:
+        if not self.redact_pii or not isinstance(value, str):
+            return value
+        value = self.EMAIL_RE.sub("[REDACTED_EMAIL]", value)
+        return self.PHONE_RE.sub("[REDACTED_PHONE]", value)
+
+    def sync_hook(
+        self,
+        function_name: str,
+        function_call: Callable[..., Any],
+        arguments: Dict[str, Any],
+    ) -> Any:
+        """Authorize a sync tool call before executing the real tool body."""
+
+        denial_reason = self._authorize(function_name)
+        if denial_reason is not None:
+            return self._deny(denial_reason)
+
+        self.tool_calls += 1
+        result = function_call(**arguments)
+        return self._redact(result)
+
+    async def async_hook(
+        self,
+        function_name: str,
+        function_call: Callable[..., Any],
+        arguments: Dict[str, Any],
+    ) -> Any:
+        """Authorize an async tool call before executing the real tool body."""
+
+        denial_reason = self._authorize(function_name)
+        if denial_reason is not None:
+            return self._deny(denial_reason)
+
+        self.tool_calls += 1
+        if iscoroutinefunction(function_call):
+            result = await function_call(**arguments)
+        else:
+            result = function_call(**arguments)
+        return self._redact(result)
+
+
+# ---------------------------------------------------------------------------
+# Create demo tools
+# ---------------------------------------------------------------------------
+
+
+class CustomerAccountTools(Toolkit):
+    def __init__(self) -> None:
+        super().__init__(name="customer_account_tools")
+        self.deleted_customers: list[str] = []
+        self.register(self.lookup_customer)
+        self.register(self.delete_customer)
+
+    def lookup_customer(self, customer_id: str) -> str:
+        """Look up a customer record.
+
+        Args:
+            customer_id: Customer identifier.
+        """
+
+        return json.dumps(
+            {
+                "customer_id": customer_id,
+                "name": "Jane Customer",
+                "email": "jane.customer@example.com",
+                "phone": "555-120-4567",
+            }
+        )
+
+    def delete_customer(self, customer_id: str) -> str:
+        """Delete a customer record.
+
+        Args:
+            customer_id: Customer identifier.
+        """
+
+        self.deleted_customers.append(customer_id)
+        return json.dumps({"deleted": customer_id})
+
+
+class AsyncCustomerAccountTools(Toolkit):
+    def __init__(self) -> None:
+        super().__init__(name="async_customer_account_tools")
+        self.register(self.lookup_customer)
+
+    async def lookup_customer(self, customer_id: str) -> str:
+        """Look up a customer record asynchronously.
+
+        Args:
+            customer_id: Customer identifier.
+        """
+
+        return json.dumps(
+            {"customer_id": customer_id, "email": "jane.customer@example.com"}
+        )
+
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    from agno.agent import Agent
+    from agno.models.openai import OpenAIResponses
+
+    governance = DeterministicGovernance(
+        allowlist={"lookup_customer"},
+        denylist={"delete_customer"},
+        max_tool_calls=10,
+    )
+    agent = Agent(
+        model=OpenAIResponses(id="gpt-5.6-luna"),
+        tools=[CustomerAccountTools()],
+        tool_hooks=[governance.sync_hook],
+        instructions="Use tools only after the deterministic governance hook allows them.",
+    )
+
+    logger.info("The lookup call is allowed and PII is redacted from the tool result.")
+    agent.print_response("Look up customer cust-123")
+
+    logger.info(
+        "The delete call is denied before CustomerAccountTools.delete_customer runs."
+    )
+    agent.print_response("Delete customer cust-123")
+
+    async_governance = DeterministicGovernance(
+        allowlist={"lookup_customer"}, max_tool_calls=1
+    )
+    async_agent = Agent(
+        model=OpenAIResponses(id="gpt-5.6-luna"),
+        tools=[AsyncCustomerAccountTools()],
+        tool_hooks=[async_governance.async_hook],
+    )
+    asyncio.run(async_agent.aprint_response("Look up customer cust-456"))

--- a/libs/agno/tests/unit/tools/test_deterministic_governance_cookbook.py
+++ b/libs/agno/tests/unit/tools/test_deterministic_governance_cookbook.py
@@ -1,0 +1,89 @@
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+from agno.tools import FunctionCall
+
+
+COOKBOOK_PATH = Path(__file__).parents[5] / "cookbook" / "91_tools" / "tool_hooks" / "deterministic_governance.py"
+
+
+def load_cookbook_module():
+    spec = importlib.util.spec_from_file_location("deterministic_governance", COOKBOOK_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_governance_denies_tool_before_side_effect():
+    module = load_cookbook_module()
+    tools = module.CustomerAccountTools()
+    governance = module.DeterministicGovernance(denylist={"delete_customer"})
+    delete_tool = tools.functions["delete_customer"]
+    delete_tool.tool_hooks = [governance.sync_hook]
+
+    result = FunctionCall(function=delete_tool, arguments={"customer_id": "cust-123"}).execute()
+
+    assert result.status == "success"
+    assert isinstance(result.result, str)
+    decision = json.loads(result.result)
+    assert decision == {
+        "allowed": False,
+        "action": "deny",
+        "reason": "tool 'delete_customer' is denied by policy",
+    }
+    assert tools.deleted_customers == []
+
+
+def test_governance_redacts_pii_from_tool_result():
+    module = load_cookbook_module()
+    tools = module.CustomerAccountTools()
+    governance = module.DeterministicGovernance(allowlist={"lookup_customer"}, redact_pii=True)
+    lookup_tool = tools.functions["lookup_customer"]
+    lookup_tool.tool_hooks = [governance.sync_hook]
+
+    result = FunctionCall(function=lookup_tool, arguments={"customer_id": "cust-123"}).execute()
+
+    assert result.status == "success"
+    assert isinstance(result.result, str)
+    assert "[REDACTED_EMAIL]" in result.result
+    assert "[REDACTED_PHONE]" in result.result
+    assert "jane.customer@example.com" not in result.result
+    assert "555-120-4567" not in result.result
+
+
+@pytest.mark.asyncio
+async def test_async_governance_enforces_budget_and_freeze():
+    module = load_cookbook_module()
+    tools = module.AsyncCustomerAccountTools()
+    governance = module.DeterministicGovernance(allowlist={"lookup_customer"}, max_tool_calls=1)
+    lookup_tool = tools.async_functions["lookup_customer"]
+    lookup_tool.tool_hooks = [governance.async_hook]
+
+    first = await FunctionCall(function=lookup_tool, arguments={"customer_id": "cust-123"}).aexecute()
+    second = await FunctionCall(function=lookup_tool, arguments={"customer_id": "cust-456"}).aexecute()
+
+    assert first.status == "success"
+    assert isinstance(first.result, str)
+    assert "cust-123" in first.result
+    assert second.status == "success"
+    assert isinstance(second.result, str)
+    assert json.loads(second.result) == {
+        "allowed": False,
+        "action": "deny",
+        "reason": "tool budget exceeded",
+    }
+
+    governance.freeze("incident-42")
+    frozen = await FunctionCall(function=lookup_tool, arguments={"customer_id": "cust-789"}).aexecute()
+
+    assert isinstance(frozen.result, str)
+    assert json.loads(frozen.result) == {
+        "allowed": False,
+        "action": "deny",
+        "reason": "governance kill switch active: incident-42",
+    }


### PR DESCRIPTION
## Summary

Fixes #9151.

This adds a provider-neutral deterministic governance cookbook for Agno tool hooks:

- demonstrates allow/deny tool authorization before the real tool body runs
- demonstrates PII redaction on tool results before they return to the agent context
- demonstrates a per-agent tool-call budget and local kill switch
- keeps the example dependency-free so TealTiger, HOL Guard, or an internal policy engine can plug into the same `tool_hooks` seam
- adds focused unit coverage that imports the cookbook and verifies the sync and async hook behavior without model credentials or network calls

This is intentionally a cookbook/test PR rather than a new core middleware abstraction. Agno already has the provider-neutral pre-tool execution seam in `tool_hooks`; the issue thread asks how to register governance at that boundary, and this example makes the contract concrete without coupling core Agno to one governance provider.

Issue number: #9151

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Verification run locally:

- RED: `pytest libs/agno/tests/unit/tools/test_deterministic_governance_cookbook.py -q` initially failed because the cookbook file did not exist.
- GREEN: `pytest libs/agno/tests/unit/tools/test_deterministic_governance_cookbook.py -q` -> 3 passed.
- Existing hook regression: `pytest libs/agno/tests/unit/tools/test_functions.py::test_function_call_with_tool_hooks libs/agno/tests/unit/tools/test_functions.py::test_function_call_async_with_tool_hooks libs/agno/tests/unit/tools/test_deterministic_governance_cookbook.py -q` -> 5 passed.
- `ruff check cookbook/91_tools/tool_hooks/deterministic_governance.py libs/agno/tests/unit/tools/test_deterministic_governance_cookbook.py` -> passed.
- `ruff format --check cookbook/91_tools/tool_hooks/deterministic_governance.py libs/agno/tests/unit/tools/test_deterministic_governance_cookbook.py` -> passed.
- `python cookbook/scripts/check_cookbook_pattern.py --base-dir cookbook/91_tools/tool_hooks` -> violations 0.
- `mypy libs/agno/tests/unit/tools/test_deterministic_governance_cookbook.py --config-file libs/agno/pyproject.toml` -> success.
- `./scripts/validate.sh` -> ruff and cookbook checks passed; full `agno` mypy was blocked in this minimal worktree venv by missing optional `cryptography` imports in pre-existing files (`utils/cryptography.py`, `utils/encryption.py`, `os/interfaces/whatsapp/router.py`). I did not install new optional dependencies after the local command guard denied the install attempt.

Second-agent review:

- Preferred reviewer `claude -p` was available but failed auth with `OAuth access token has been revoked`.
- Fallback reviewer `hermes chat -Q` was run against `/tmp/oss-pr-second-agent-review.diff` and timed out after 540s with no findings emitted. Recorded as `SECOND_AGENT_TIMEOUT=540`; proceeding because the diff is cookbook/test-only, deterministic, and covered by focused tests plus lint/pattern gates.

Duplicate/overlap search:

- Searched open PRs for `9151`, `governance middleware`, `TealTiger`, `tool-call authorization`, and `tool_hooks authorization`; no open PR directly addresses #9151.
- Nearby prior/open work is not a duplicate: #8205 and #9266 are audit receipt cookbooks, #8217 is input guardrail work, #9092 is AgentOS authorization, and #7688 is a tool hook metadata enhancement. This PR is narrower: it documents and tests provider-neutral deterministic governance using the existing tool hook seam.

AI-generated PR disclosure: generated with Hermes Agent and reviewed by the operator workflow above.
