### PR TITLE
fix: Preserve CSV data rows when skipping headers across pages

### DIFF
--- a/libs/agno/agno/knowledge/chunking/row.py
+++ b/libs/agno/agno/knowledge/chunking/row.py
@@ -17,12 +17,11 @@ class RowChunking(ChunkingStrategy):
             raise ValueError("Document content must be a string")
 
         rows = document.content.splitlines()
+        start_index = document.meta_data.get("start_row", 1)
 
-        if self.skip_header and rows:
+        if self.skip_header and rows and start_index == 1:
             rows = rows[1:]
-            start_index = 2
-        else:
-            start_index = 1
+            start_index += 1
 
         chunks = []
         for i, row in enumerate(rows):

--- a/libs/agno/tests/unit/reader/test_csv_reader.py
+++ b/libs/agno/tests/unit/reader/test_csv_reader.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+from agno.knowledge.chunking.row import RowChunking
 from agno.knowledge.document.base import Document
 from agno.knowledge.reader.csv_reader import CSVReader
 
@@ -225,6 +226,22 @@ async def test_async_read_multi_page_csv(csv_reader, multi_page_csv_file):
     assert documents[10].meta_data["page"] == 3
     assert documents[10].meta_data["start_row"] == 11
     assert documents[10].meta_data["rows"] == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("skip_header", [False, True])
+@pytest.mark.parametrize("page_size", [1, 5, 1000])
+async def test_async_read_multi_page_csv_preserves_rows_and_numbers(multi_page_csv_file, skip_header, page_size):
+    reader = CSVReader(chunking_strategy=RowChunking(skip_header=skip_header))
+
+    sync_documents = reader.read(multi_page_csv_file)
+    async_documents = await reader.async_read(multi_page_csv_file, page_size=page_size)
+
+    assert [document.content for document in async_documents] == [document.content for document in sync_documents]
+    assert [document.meta_data["row_number"] for document in async_documents] == list(
+        range(2 if skip_header else 1, 12)
+    )
+    assert reader.chunking_strategy.skip_header is skip_header
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`CSVReader.async_read()` creates a document for each page. With `RowChunking(skip_header=True)`, the first data row on every continuation page is currently removed as though it were another header. For a CSV containing one header and 1,002 data records, synchronous reading returns 1,002 records while asynchronous reading returns 1,001.

Use the existing `start_row` metadata in `RowChunking` to skip only the original header and retain logical row numbers across pages. Add regression coverage for both header modes, a header-only first page, continuation pages, and single-page input. Standalone documents and Excel sheets retain their existing behavior.

Fixes #9994.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

The implementation and regression test were generated by Codex. Review covered the complete diff, public reader behavior, affected callers and real local knowledge ingestion; two independent automated reviews also completed without findings. No new API or cookbook pattern is introduced, so documentation/example updates are not applicable.

Verified against main `d1a388446e1b44b20498c772e91303588e2734cf` on 2026-09-06 with Python 3.12.10 on macOS arm64:

- The regression failed before the fix and passed afterward. CSV, field-labeled CSV, chunk-ID and Excel checks: 153 passed.
- Public reader reproductions pass for Path, string path and BytesIO, including the default page size and concurrent reuse.
- Offline `Knowledge.ainsert()` with a local embedder and temporary LanceDB stored all 2,002 records after the fix; unmodified main stored 2,000. Ordered content and row numbers were checked.
- Standalone row cleaning and IDs, per-sheet XLS/XLSX header handling, custom async chunking, encoding, delimiters, multiline cells and page metadata were checked.
- `./scripts/format.sh` succeeded. Its unrelated existing formatting changes were excluded from this contribution. `./scripts/validate.sh` passed with the documented development dependencies.
- Adding the optional LanceDB SDK exposes 11 mypy errors in unchanged `lance_db.py`; all 11 reproduce against unmodified main with that SDK installed.
- `./scripts/test.sh`: 19,453 passed, 202 skipped, 307 warnings; exit code 0. On macOS, this required a process-local file descriptor limit of 4096; the initial default limit of 256 caused cascading `Too many open files` errors. Skipped service/provider checks, including unavailable PostgreSQL, remain unverified. Warnings include dependency deprecations, test-key checks, Pydantic mock types and unrelated mock/tool coroutine warnings; no warnings were suppressed. Linux CI remains to be run for this contribution.

Related work checked on 2026-09-06: #8025 fixed newline joining and is already merged; #9972 concerns text-stream decoding, #9460 concerns Excel memory use, and #7125 concerns default strategy construction. None addresses continuation-page header removal.

Classification: bug fix. Applying the repository’s `bug` label returned an `AddLabelsToLabelable` permission error for this account. Please apply it to this PR and the linked issue.
