### PR TITLE
fix: correct page serving and add selected public teams

### DIFF
--- a/cookbook/05_agent_os/27_public_pages/README.md
+++ b/cookbook/05_agent_os/27_public_pages/README.md
@@ -121,3 +121,21 @@ matching the safe error behavior of streaming Agent runs. Successful responses
 retain their content. Authenticated sync operators retain workflow diagnostics.
 
 Actual execution evidence is in [TEST_LOG.md](TEST_LOG.md).
+
+`FileSystem(db=db)` and `PgVector(db=db)` borrow the configured database engine.
+Use `FileSystem(backend=...)` for an explicit filesystem backend; Knowledge's
+content database, page store and vector store remain independently configured.
+
+`public_team.py` shows `PublicSurface(teams=[team])`: only the selected Team's
+reduced roster, run and cancel routes are public. Member routes remain private.
+Use the same database prerequisites and `OPENAI_API_KEY`, then run:
+
+```sh
+.venvs/demo/bin/python cookbook/05_agent_os/27_public_pages/public_team.py
+```
+
+Add `--check` to validate the configuration without starting the server.
+
+Successful public Team runs retain native member tool results, including member
+failure details when the leader recovers. Failed top-level runs use the same
+sanitized errors and output bounds as public Agents.

--- a/cookbook/05_agent_os/27_public_pages/TEST_LOG.md
+++ b/cookbook/05_agent_os/27_public_pages/TEST_LOG.md
@@ -51,3 +51,23 @@
 **Validation scope:** That executable used explicit instructions/pre-hook/tools and existing URL configuration. Product recording-model tests independently check prompt, multi-turn/tool-loop evidence and follow-up suggestions. Earlier automatic-reference/Team/derived-URL example results are preserved separately and do not validate this example.
 
 ---
+
+### public_team.py
+
+**Status:** PASS
+
+**Description:** Ran `public_team.py --check` with the demo environment and candidate Agno. Selected Team binding and app construction succeeded without provider calls.
+
+**Result:** Configuration validated. Server/provider execution was not run; deterministic native HTTP Team tests cover the protocol separately.
+
+---
+
+### public_pages.py
+
+**Status:** PASS
+
+**Description:** Ran `public_pages.py --help` in an isolated demo environment using the candidate framework and declared MCP 2.x/FastMCP 4.x dependencies. The initially inherited demo environment had incompatible MCP 1.x; it was left unchanged.
+
+**Result:** Constructor wiring and CLI import passed. Live sync/chat/MCP-client modes were not run. Disposable PostgreSQL publication and paired product composition tests cover deterministic operation separately.
+
+---

--- a/cookbook/05_agent_os/27_public_pages/public_pages.py
+++ b/cookbook/05_agent_os/27_public_pages/public_pages.py
@@ -32,13 +32,13 @@ db = PostgresDb(
 knowledge = Knowledge(
     content_db=db,
     page_store=FileSystem(
-        db,
+        db=db,
         namespace="public-page-demo",
         max_file_bytes=4 * 1024 * 1024,
         max_namespace_bytes=256 * 1024 * 1024,
     ),
     vector_db=PgVector(
-        db_engine=db.db_engine,
+        db=db,
         table_name="demo_page_vectors",
         vector_index=HNSW(ef_search=200),
         embedder=OpenAIEmbedder(

--- a/cookbook/05_agent_os/27_public_pages/public_team.py
+++ b/cookbook/05_agent_os/27_public_pages/public_team.py
@@ -1,0 +1,49 @@
+"""Serve a selected Team publicly; member routes remain private.
+
+Run: .venvs/demo/bin/python cookbook/05_agent_os/27_public_pages/public_team.py
+Requires PAGE_DEMO_DB_URL and OPENAI_API_KEY. Add --check to validate wiring only.
+"""
+
+import argparse
+from os import getenv
+
+from agno.agent import Agent
+from agno.db.postgres import PostgresDb
+from agno.models.openai import OpenAIResponses
+from agno.os import AgentOS
+from agno.os.public import PublicSurface
+from agno.team import Team
+
+# Reuse the member across runs; selecting the Team does not select its members.
+db = PostgresDb(
+    db_url=getenv(
+        "PAGE_DEMO_DB_URL", "postgresql+psycopg://ai:ai@localhost:5532/page_demo"
+    )
+)
+member = Agent(
+    id="researcher", name="Researcher", model=OpenAIResponses(id="gpt-5.6-luna")
+)
+team = Team(
+    id="support",
+    name="Support",
+    members=[member],
+    model=OpenAIResponses(id="gpt-5.6-luna"),
+    db=db,
+)
+agent_os = AgentOS(
+    id="public-support", db=db, teams=[team], public=PublicSurface(teams=[team])
+)
+app = agent_os.get_app()
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Validate configuration without serving or calling a model",
+    )
+    args = parser.parse_args()
+    if args.check:
+        print("Selected Team configuration is valid.")
+    else:
+        agent_os.serve(app=app)

--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -3451,8 +3451,8 @@ def continue_run_dispatch(
 
         background_tasks: BackgroundTasks = background_tasks  # type: ignore
 
-    session_id = run_response.session_id if run_response else session_id
-    run_id: str = run_response.run_id if run_response else run_id  # type: ignore
+    session_id = run_response.session_id if run_response is not None else session_id
+    run_id: str = run_response.run_id if run_response is not None else run_id  # type: ignore
 
     session_id, user_id = initialize_session(
         agent,
@@ -3524,15 +3524,6 @@ def continue_run_dispatch(
         user_id=user_id,
     )
 
-    # Resolve dependencies
-    if run_context.dependencies is not None:
-        resolve_run_dependencies(
-            agent,
-            run_context=run_context,
-            run_input=_stored_run.input if isinstance(_stored_run, RunOutput) else None,
-            session=agent_session,
-        )
-
     # Run can be continued from previous run response or from passed run_response context
     if run_response is not None:
         if run_response.status == RunStatus.cancelled:
@@ -3570,8 +3561,7 @@ def continue_run_dispatch(
         input_messages = run_response.messages or []
     elif run_id is not None:
         # The run is continued from a run_id.
-        runs = agent_session.runs or []
-        run_response = next((r for r in runs if r.run_id == run_id), None)  # type: ignore
+        run_response = cast(Optional[RunOutput], _stored_run)
         if run_response is None:
             raise RunNotFoundError(f"No runs found for run ID {run_id}")
         if run_response.status == RunStatus.cancelled:
@@ -3664,6 +3654,20 @@ def continue_run_dispatch(
             # else: nothing to resolve — fall through to resume from current state
     else:
         raise ValueError("Either run_response or run_id must be provided.")
+
+    if run_context.session_state is None:
+        run_context.session_state = {}
+    _initialize_session_state(
+        run_context.session_state, user_id=user_id, session_id=session_id, run_id=run_context.run_id
+    )
+    # Resolve dependencies
+    if run_context.dependencies is not None:
+        resolve_run_dependencies(
+            agent,
+            run_context=run_context,
+            run_input=_stored_run.input if isinstance(_stored_run, RunOutput) else None,
+            session=agent_session,
+        )
 
     # If the caller supplied a new user-message string (unified /continue body
     # field ``input``), append it to run_response.messages before building
@@ -4342,8 +4346,8 @@ def acontinue_run_dispatch(  # type: ignore
 
         background_tasks: BackgroundTasks = background_tasks  # type: ignore
 
-    session_id = run_response.session_id if run_response else session_id
-    run_id: str = run_response.run_id if run_response else run_id  # type: ignore
+    session_id = run_response.session_id if run_response is not None else session_id
+    run_id: str = run_response.run_id if run_response is not None else run_id  # type: ignore
 
     session_id, user_id = initialize_session(
         agent,
@@ -4828,25 +4832,23 @@ async def _acontinue_run(
                     if user_id is not None:
                         run_context.user_id = user_id
 
+                dependency_run = (
+                    run_response
+                    if run_response is not None
+                    else next((r for r in agent_session.runs or [] if r.run_id == run_id), None)
+                )
                 # A resumed run keeps its runtime-owned metadata (dispatch
                 # lineage, hop count, version stamp); on the async path the
                 # session may only be readable here, so the restore happens at
                 # the load point. Idempotent with the dispatch-time restore.
                 _restore_continue_context_metadata(
-                    run_context, run_response=run_response, run_id=run_id, session=agent_session
+                    run_context,
+                    run_response=cast(Optional[RunOutput], dependency_run),
+                    run_id=run_id,
+                    session=agent_session,
                 )
 
                 # 2. Resolve dependencies
-                if run_context.dependencies is not None:
-                    dependency_run = run_response or next(
-                        (r for r in agent_session.runs or [] if r.run_id == run_id), None
-                    )
-                    await aresolve_run_dependencies(
-                        agent,
-                        run_context=run_context,
-                        run_input=dependency_run.input if isinstance(dependency_run, RunOutput) else None,
-                        session=agent_session,
-                    )
 
                 # 3. Update metadata and session state
                 update_metadata(agent, session=agent_session)
@@ -4897,8 +4899,7 @@ async def _acontinue_run(
                     input_messages = run_response.messages or []
                 elif run_id is not None:
                     # The run is continued from a run_id.
-                    runs = agent_session.runs or []
-                    run_response = next((r for r in runs if r.run_id == run_id), None)  # type: ignore
+                    run_response = cast(Optional[RunOutput], dependency_run)
                     if run_response is None:
                         raise RunNotFoundError(f"No runs found for run ID {run_id}")
                     if run_response.status == RunStatus.cancelled:
@@ -4989,6 +4990,14 @@ async def _acontinue_run(
                 # If the caller supplied a new user-message string (unified /continue
                 # body field ``input``), append it to run_response.messages before
                 # building run_messages.
+                if run_context.dependencies is not None:
+                    await aresolve_run_dependencies(
+                        agent,
+                        run_context=run_context,
+                        run_input=dependency_run.input if isinstance(dependency_run, RunOutput) else None,
+                        session=agent_session,
+                    )
+
                 if input:
                     _maybe_append_input_message(run_response, input, agent)
                     input_messages = run_response.messages or []
@@ -5345,12 +5354,20 @@ async def _acontinue_run_stream(
                     if user_id is not None:
                         run_context.user_id = user_id
 
+                dependency_run = (
+                    run_response
+                    if run_response is not None
+                    else next((r for r in agent_session.runs or [] if r.run_id == run_id), None)
+                )
                 # A resumed run keeps its runtime-owned metadata (dispatch
                 # lineage, hop count, version stamp); on the async path the
                 # session may only be readable here, so the restore happens at
                 # the load point. Idempotent with the dispatch-time restore.
                 _restore_continue_context_metadata(
-                    run_context, run_response=run_response, run_id=run_id, session=agent_session
+                    run_context,
+                    run_response=cast(Optional[RunOutput], dependency_run),
+                    run_id=run_id,
+                    session=agent_session,
                 )
 
                 # 2. Update session state and metadata
@@ -5370,16 +5387,6 @@ async def _acontinue_run_stream(
                 )
 
                 # 3. Resolve dependencies
-                if run_context.dependencies is not None:
-                    dependency_run = run_response or next(
-                        (r for r in agent_session.runs or [] if r.run_id == run_id), None
-                    )
-                    await aresolve_run_dependencies(
-                        agent,
-                        run_context=run_context,
-                        run_input=dependency_run.input if isinstance(dependency_run, RunOutput) else None,
-                        session=agent_session,
-                    )
 
                 # 4. Prepare run response
                 if run_response is not None:
@@ -5415,8 +5422,7 @@ async def _acontinue_run_stream(
 
                 elif run_id is not None:
                     # The run is continued from a run_id.
-                    runs = agent_session.runs or []
-                    run_response = next((r for r in runs if r.run_id == run_id), None)  # type: ignore
+                    run_response = cast(Optional[RunOutput], dependency_run)
                     if run_response is None:
                         raise RunNotFoundError(f"No runs found for run ID {run_id}")
                     if run_response.status == RunStatus.cancelled:
@@ -5507,6 +5513,14 @@ async def _acontinue_run_stream(
                 # If the caller supplied a new user-message string (unified /continue
                 # body field ``input``), append it to run_response.messages before
                 # building run_messages.
+                if run_context.dependencies is not None:
+                    await aresolve_run_dependencies(
+                        agent,
+                        run_context=run_context,
+                        run_input=dependency_run.input if isinstance(dependency_run, RunOutput) else None,
+                        session=agent_session,
+                    )
+
                 if input:
                     _maybe_append_input_message(run_response, input, agent)
                     input_messages = run_response.messages or []

--- a/libs/agno/agno/db/postgres/_bounded.py
+++ b/libs/agno/agno/db/postgres/_bounded.py
@@ -3,10 +3,12 @@
 from contextlib import contextmanager
 from contextvars import ContextVar
 from threading import Lock
+from time import monotonic
 from weakref import WeakSet
 
 from sqlalchemy import create_engine, event
 from sqlalchemy.engine import Engine
+from sqlalchemy.exc import TimeoutError as PoolTimeout
 from sqlalchemy.pool import QueuePool
 from sqlalchemy.util.queue import Queue
 
@@ -16,6 +18,7 @@ _connecting: ContextVar[bool] = ContextVar("agno_bounded_connect", default=False
 _configured: WeakSet = WeakSet()
 _configuration_lock = Lock()
 _checkout_budget: ContextVar = ContextVar("agno_checkout_budget", default=None)
+_optional_checkout: ContextVar = ContextVar("agno_optional_checkout", default=None)
 
 
 class ConnectionUnavailable(TimeoutError):
@@ -27,6 +30,9 @@ class _BudgetQueue(Queue):
         budget = _checkout_budget.get()
         if block and budget is not None:
             remaining = budget.remaining()
+            optional_deadline = _optional_checkout.get()
+            if optional_deadline is not None:
+                remaining = min(remaining, max(0, optional_deadline - monotonic()))
             timeout = remaining if timeout is None else min(timeout, remaining)
         return super().get(block, timeout)
 
@@ -42,6 +48,19 @@ def optional_connection(budget: WorkBudget):
     A new connection's transport handshake cannot honor a subsecond SQL deadline.
     Callers can instead execute optional work serially on their existing snapshot.
     """
+    token = _optional_checkout.set(monotonic() + 0.025)
+    try:
+        with primary_connection(budget):
+            yield
+    except PoolTimeout as exc:
+        raise ConnectionUnavailable("optional_connection_unavailable") from exc
+    finally:
+        _optional_checkout.reset(token)
+
+
+@contextmanager
+def primary_connection(budget: WorkBudget):
+    """Limit pool checkout to this operation's deadline without changing shared state."""
     token = _checkout_budget.set(budget)
     try:
         budget.remaining()
@@ -78,7 +97,7 @@ def bounded_engine(source: Engine, *, capacity: int) -> Engine:
     original_pool = source.pool
 
     def create(connection_record):
-        if _checkout_budget.get() is not None:
+        if _optional_checkout.get() is not None:
             raise ConnectionUnavailable("optional_connection_unavailable")
         token = _connecting.set(True)
         try:

--- a/libs/agno/agno/fs/fs.py
+++ b/libs/agno/agno/fs/fs.py
@@ -36,6 +36,7 @@ from agno.fs.errors import InvalidPathError, QuotaExceededError
 from agno.fs.types import ContainsResult, FileMeta, NamespaceUsage, SearchMatch
 
 if TYPE_CHECKING:
+    from agno.db.base import BaseDb
     from agno.tools.toolkit import Toolkit
 
 DEFAULT_NAMESPACE = "default"
@@ -125,18 +126,28 @@ class FileSystem:
     arguments. A placeholder whose value is missing at call time fails closed.
     Programmatic use of a templated instance goes through ``resolve()``.
 
+    Use ``db=SqliteDb(...)`` or ``db=PostgresDb(...)`` to borrow a synchronous
+    database, or ``backend=`` for an explicit backend. Supply exactly one source.
+
     Cheap to construct and holds no connections; the backend owns the
     engine/pool and is shared across instances.
     """
 
     def __init__(
         self,
-        backend: Any,
+        backend: Any = None,
         namespace: str = DEFAULT_NAMESPACE,
         *,
+        db: Optional["BaseDb"] = None,
         max_file_bytes: int = 1_000_000,
         max_namespace_bytes: int = 20_000_000,
     ) -> None:
+        if (backend is None) == (db is None):
+            raise ValueError("Provide exactly one of backend or db")
+        if db is not None:
+            from agno.fs.db import DbFileSystem
+
+            backend = DbFileSystem(db=db)
         self.backend: BaseFS = _as_backend(backend)
         self.namespace = normalize_namespace(namespace)
         self.max_file_bytes = max_file_bytes

--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -266,41 +266,86 @@ class Knowledge(RemoteKnowledge):
         self, path: str, *, revision: Optional[str] = None, offset: int = 0, max_chars: int = 12000
     ) -> PageRead:
         """Read published Markdown; continuation offsets count Unicode code points."""
-        return self._pages().read(path, revision=revision, offset=offset, max_chars=max_chars)
+        from sqlalchemy.exc import DBAPIError
+        from sqlalchemy.exc import TimeoutError as PoolTimeout
+
+        from agno.knowledge.page import PageError
+
+        try:
+            return self._pages().read(path, revision=revision, offset=offset, max_chars=max_chars)
+        except (TimeoutError, asyncio.TimeoutError, PoolTimeout, DBAPIError) as exc:
+            raise PageError() from exc
 
     async def aread_page(
         self, path: str, *, revision: Optional[str] = None, offset: int = 0, max_chars: int = 12000
     ) -> PageRead:
         """Read published Markdown on bounded workers."""
+        from sqlalchemy.exc import DBAPIError
+        from sqlalchemy.exc import TimeoutError as PoolTimeout
+
+        from agno.knowledge.page import PageError
         from agno.knowledge.page._coordinator import READ_WORKERS
 
-        return await READ_WORKERS.run(
-            self._pages().read, path, revision=revision, offset=offset, max_chars=max_chars, seconds=2
-        )
+        try:
+            return await READ_WORKERS.run(
+                self._pages().read, path, revision=revision, offset=offset, max_chars=max_chars, seconds=2
+            )
+        except (TimeoutError, asyncio.TimeoutError, PoolTimeout, DBAPIError) as exc:
+            raise PageError() from exc
 
     def grep_pages(self, query: str, *, prefix: str = "/", ignore_case: bool = False, limit: int = 20) -> GrepResult:
         """Find literal text within a bounded scan; incomplete results cannot establish absence."""
-        return self._pages().grep(query, prefix=prefix, ignore_case=ignore_case, limit=limit)
+        from sqlalchemy.exc import DBAPIError
+        from sqlalchemy.exc import TimeoutError as PoolTimeout
+
+        from agno.knowledge.page import PageError
+
+        try:
+            return self._pages().grep(query, prefix=prefix, ignore_case=ignore_case, limit=limit)
+        except (TimeoutError, asyncio.TimeoutError, PoolTimeout, DBAPIError) as exc:
+            raise PageError() from exc
 
     async def agrep_pages(
         self, query: str, *, prefix: str = "/", ignore_case: bool = False, limit: int = 20
     ) -> GrepResult:
         """Find literal text without blocking the event loop."""
+        from sqlalchemy.exc import DBAPIError
+        from sqlalchemy.exc import TimeoutError as PoolTimeout
+
+        from agno.knowledge.page import PageError
         from agno.knowledge.page._coordinator import READ_WORKERS
 
-        return await READ_WORKERS.run(
-            self._pages().grep, query, prefix=prefix, ignore_case=ignore_case, limit=limit, seconds=2
-        )
+        try:
+            return await READ_WORKERS.run(
+                self._pages().grep, query, prefix=prefix, ignore_case=ignore_case, limit=limit, seconds=2
+            )
+        except (TimeoutError, asyncio.TimeoutError, PoolTimeout, DBAPIError) as exc:
+            raise PageError() from exc
 
     def list_pages(self, *, prefix: str = "/", cursor: Optional[str] = None, limit: int = 100) -> PageList:
         """List navigation metadata with a namespace-revision-bound cursor."""
-        return self._pages().list(prefix=prefix, cursor=cursor, limit=limit)
+        from sqlalchemy.exc import DBAPIError
+        from sqlalchemy.exc import TimeoutError as PoolTimeout
+
+        from agno.knowledge.page import PageError
+
+        try:
+            return self._pages().list(prefix=prefix, cursor=cursor, limit=limit)
+        except (TimeoutError, asyncio.TimeoutError, PoolTimeout, DBAPIError) as exc:
+            raise PageError() from exc
 
     async def alist_pages(self, *, prefix: str = "/", cursor: Optional[str] = None, limit: int = 100) -> PageList:
         """List navigation metadata on bounded workers."""
+        from sqlalchemy.exc import DBAPIError
+        from sqlalchemy.exc import TimeoutError as PoolTimeout
+
+        from agno.knowledge.page import PageError
         from agno.knowledge.page._coordinator import READ_WORKERS
 
-        return await READ_WORKERS.run(self._pages().list, prefix=prefix, cursor=cursor, limit=limit, seconds=2)
+        try:
+            return await READ_WORKERS.run(self._pages().list, prefix=prefix, cursor=cursor, limit=limit, seconds=2)
+        except (TimeoutError, asyncio.TimeoutError, PoolTimeout, DBAPIError) as exc:
+            raise PageError() from exc
 
     # ==========================================
     # PUBLIC API - INSERT METHODS

--- a/libs/agno/agno/knowledge/page/_coordinator.py
+++ b/libs/agno/agno/knowledge/page/_coordinator.py
@@ -14,7 +14,7 @@ from collections import Counter, deque
 from concurrent.futures import ThreadPoolExecutor, wait
 from contextlib import closing, contextmanager, nullcontext
 from threading import BoundedSemaphore
-from typing import Any, Callable, Dict, List, Optional, Tuple, cast
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, cast
 from uuid import uuid4
 
 from sqlalchemy import (
@@ -33,8 +33,9 @@ from sqlalchemy import (
     text,
     update,
 )
-from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.dialects.postgresql import dialect, insert
 from sqlalchemy.exc import DBAPIError
+from typing_extensions import TypeGuard
 
 from agno.db.postgres import PostgresDb
 from agno.db.schemas.knowledge import KnowledgeRow
@@ -86,6 +87,18 @@ def _identifier(value: Optional[str]) -> str:
     return '"' + value + '"'
 
 
+if TYPE_CHECKING:
+    from agno.knowledge.embedder.openai import OpenAIEmbedder
+
+
+def _is_openai_embedder(embedder: Any) -> TypeGuard[OpenAIEmbedder]:
+    try:
+        from agno.knowledge.embedder.openai import OpenAIEmbedder
+    except ImportError:
+        return False
+    return isinstance(embedder, OpenAIEmbedder)
+
+
 class PageCoordinator:
     def __init__(self, knowledge: Any):
         self.knowledge = knowledge
@@ -131,10 +144,8 @@ class PageCoordinator:
             raise ValueError("page storage tables must be distinct")
         if self.vector.dimensions is None or not 1 <= self.vector.dimensions <= 2000:
             raise ValueError("page storage requires 1-2000 embedding dimensions for HNSW")
-        from agno.knowledge.embedder.openai import OpenAIEmbedder
-
         if (
-            not isinstance(self.vector.embedder, OpenAIEmbedder)
+            not _is_openai_embedder(self.vector.embedder)
             and "timeout" not in inspect.signature(self.vector.embedder.get_embedding).parameters
         ):
             raise ValueError(
@@ -245,13 +256,20 @@ class PageCoordinator:
 
     def _search_indexes(self):
         namespace_literal = str(
-            literal(self.namespace).compile(dialect=self.engine.dialect, compile_kwargs={"literal_binds": True})
+            literal(self.namespace).compile(dialect=dialect(paramstyle="named"), compile_kwargs={"literal_binds": True})
+        )
+        index = self.vector.vector_index
+        build_options = (
+            f" WITH (m={int(index.m)}, ef_construction={int(index.ef_construction)})" if isinstance(index, HNSW) else ""
         )
         for suffix, definition in (
             ("page_gin", "USING gin (_agno_page_tsv)"),
             (
                 "page_hnsw_" + self.namespace,
-                "USING hnsw (embedding vector_cosine_ops) WHERE (meta_data->>'namespace') = " + namespace_literal,
+                "USING hnsw (embedding vector_cosine_ops)"
+                + build_options
+                + " WHERE (meta_data->>'namespace') = "
+                + namespace_literal,
             ),
         ):
             yield (
@@ -302,7 +320,7 @@ class PageCoordinator:
             row = (
                 conn.execute(
                     text(
-                        "SELECT pg_get_indexdef(i.indexrelid) AS definition, i.indisvalid AND i.indisready AS valid "
+                        "SELECT pg_get_indexdef(i.indexrelid) AS definition, c.reloptions, i.indisvalid AND i.indisready AS valid "
                         "FROM pg_index i JOIN pg_class c ON c.oid=i.indexrelid "
                         "JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname=:schema AND c.relname=:name"
                     ),
@@ -313,8 +331,22 @@ class PageCoordinator:
             )
             if row is None or not row["valid"]:
                 return False
-            if self._normalized_definition(definition) not in self._normalized_definition(row["definition"]):
+            # Compare build settings separately: PostgreSQL can reorder reloptions.
+            expected = re.sub(r" WITH \([^)]*\)", "", definition, flags=re.I)
+            actual = re.sub(r" WITH \([^)]*\)", "", row["definition"], flags=re.I)
+            if self._normalized_definition(expected) not in self._normalized_definition(actual):
                 raise ValueError("incompatible_page_search_index")
+            if "USING hnsw" in definition and isinstance(self.vector.vector_index, HNSW):
+                options = dict(option.split("=", 1) for option in row["reloptions"] or [])
+                index = self.vector.vector_index
+                if (
+                    int(options.get("m", 16)) != index.m
+                    or int(options.get("ef_construction", 64)) != index.ef_construction
+                ):
+                    raise ValueError(
+                        f"incompatible_page_search_index: rebuild {schema}.{name} with "
+                        f"m={index.m}, ef_construction={index.ef_construction} before setup"
+                    )
         return True
 
     @property
@@ -334,11 +366,13 @@ class PageCoordinator:
 
     @contextmanager
     def _snapshot(self, budget: Optional[WorkBudget] = None, *, snapshot: Optional[str] = None):
-        from agno.db.postgres._bounded import optional_connection
+        from agno.db.postgres._bounded import optional_connection, primary_connection
 
         self._ready()
         with (
-            optional_connection(budget or WorkBudget(2)) if snapshot is not None else nullcontext(),
+            optional_connection(budget or WorkBudget(2))
+            if snapshot is not None
+            else primary_connection(budget or WorkBudget(2)),
             self.engine.connect().execution_options(
                 isolation_level="REPEATABLE READ", postgresql_readonly=True
             ) as conn,
@@ -466,9 +500,7 @@ class PageCoordinator:
         embedder = self.vector.embedder
         # OpenAI-compatible clients support per-call transport deadlines without
         # mutating the shared embedder or its configured credentials.
-        from agno.knowledge.embedder.openai import OpenAIEmbedder
-
-        if isinstance(embedder, OpenAIEmbedder):
+        if _is_openai_embedder(embedder):
             embeddings: List[List[float]] = []
             for start in range(0, len(contents), min(100, max(1, embedder.batch_size))):
                 client = embedder.client.with_options(timeout=min(30, budget.remaining()), max_retries=0)
@@ -746,6 +778,7 @@ class PageCoordinator:
         budget: WorkBudget,
         reindex: bool,
         prepared: Optional[Dict[str, Any]] = None,
+        source_url: Optional[str] = None,
     ) -> bool:
         self._pending_publication = None
         if prepared is None:
@@ -830,7 +863,7 @@ class PageCoordinator:
             conn.execute(
                 update(self.binding)
                 .where(self.binding.c.namespace == self.namespace)
-                .values(revision=self.binding.c.revision + 1)
+                .values(revision=self.binding.c.revision + 1, **({"source": source_url} if source_url else {}))
             )
             self._pending_publication = {"page": page, "publication_id": publication_id}
         self._pending_publication = None
@@ -1049,9 +1082,7 @@ class PageCoordinator:
                 queries.append(alternative.strip())
         vectors = []
         partial = False
-        from agno.knowledge.embedder.openai import OpenAIEmbedder
-
-        if isinstance(self.vector.embedder, OpenAIEmbedder):
+        if _is_openai_embedder(self.vector.embedder):
             try:
                 vectors = list(zip(queries, self._embeddings(queries, budget)))
             except Exception as exc:
@@ -1327,9 +1358,6 @@ class PageCoordinator:
                     )
                     if binding["source"] not in (None, source.url):
                         raise ValueError("filesystem namespace is bound to another documentation source")
-                    conn.execute(
-                        update(self.binding).where(self.binding.c.namespace == self.namespace).values(source=source.url)
-                    )
                     self._source_attempt(conn, source, "processing")
                 pages = source.discover()
                 if validate_discovery is not None:
@@ -1358,7 +1386,16 @@ class PageCoordinator:
                                 raise fetch_error
                             assert isinstance(content, str)
                             updated += int(
-                                self._publish(conn, page, content, fingerprint, budget, reindex, prepared=prepared)
+                                self._publish(
+                                    conn,
+                                    page,
+                                    content,
+                                    fingerprint,
+                                    budget,
+                                    reindex,
+                                    prepared=prepared,
+                                    source_url=source.url,
+                                )
                             )
                         except Exception as exc:
                             log_warning(f"Page sync failed ({type(exc).__name__})")

--- a/libs/agno/agno/knowledge/page/_source.py
+++ b/libs/agno/agno/knowledge/page/_source.py
@@ -134,7 +134,7 @@ class PageSource:
                                 body.extend(chunk)
                             return body.decode("utf-8", errors="strict")
                 raise SyncFailed()
-            except (httpx.TimeoutException, httpx.HTTPStatusError) as exc:
+            except (httpx.TimeoutException, httpx.ConnectError, httpx.ReadError, httpx.HTTPStatusError) as exc:
                 if (
                     isinstance(exc, httpx.HTTPStatusError)
                     and exc.response.status_code != 429
@@ -146,7 +146,8 @@ class PageSource:
                 delay = min(0.25 * 2**attempt, self.budget.remaining())
                 if self.budget.cancelled.wait(delay):
                     self.budget.remaining()
-                deadline = time.monotonic() + min(30, self.budget.remaining())
+                if time.monotonic() >= deadline:
+                    raise SyncFailed() from exc
         raise SyncFailed()
 
     def discover(self) -> Dict[str, SourcePage]:
@@ -205,7 +206,9 @@ class PageSource:
                     page = SourcePage(path, fetch_url, entry.title, citation)
                     if path in collisions:
                         raise ValueError("page_path_collision")
-                    if path in pages and pages[path] != page:
+                    if path in pages and pages[path].url == page.url:
+                        continue
+                    if path in pages:
                         collisions.add(path)
                         del pages[path]
                         raise ValueError("page_path_collision")

--- a/libs/agno/agno/os/public/__init__.py
+++ b/libs/agno/agno/os/public/__init__.py
@@ -33,6 +33,13 @@ class FileUploadLimits:
 
 @dataclass
 class PublicSurface:
+    """Explicitly select components for bounded public execution.
+
+    Successful runs retain native output, including Team member tool results and
+    failure details when the leader recovers. Selecting a Team does not expose
+    independent member routes. Failed top-level runs use sanitized public errors.
+    """
+
     agents: List[Any] = field(default_factory=list)
     workflows: List[Any] = field(default_factory=list)
     mcp: bool = False
@@ -44,6 +51,7 @@ class PublicSurface:
     max_run_seconds: float = 240
     max_output_bytes: int = 1024 * 1024
     max_active_runs: int = 8
+    teams: List[Any] = field(default_factory=list)
     _limiter: Optional[PublicLimiter] = field(default=None, init=False, repr=False)
 
     @property
@@ -55,6 +63,7 @@ class PublicSurface:
     def _bind(self, agent_os: Any) -> None:
         from agno.agent import Agent
         from agno.db.postgres import PostgresDb
+        from agno.team import Team
         from agno.workflow import Workflow
 
         if not isinstance(agent_os.db, PostgresDb):
@@ -65,7 +74,7 @@ class PublicSurface:
         if min(self.max_body_bytes, self.max_run_seconds, self.max_output_bytes, self.max_active_runs) <= 0:
             raise ValueError("PublicSurface request bounds must be positive")
         self.namespace = namespace
-        for field_name, kind in (("agents", Agent), ("workflows", Workflow)):
+        for field_name, kind in (("agents", Agent), ("workflows", Workflow), ("teams", Team)):
             registered = getattr(agent_os, field_name)
             selected: List[Any] = []
             by_id: Dict[Optional[str], Any] = {}

--- a/libs/agno/agno/os/public/__init__.py
+++ b/libs/agno/agno/os/public/__init__.py
@@ -41,6 +41,7 @@ class PublicSurface:
     """
 
     agents: List[Any] = field(default_factory=list)
+    teams: List[Any] = field(default_factory=list)
     workflows: List[Any] = field(default_factory=list)
     mcp: bool = False
     namespace: Optional[str] = None
@@ -51,7 +52,6 @@ class PublicSurface:
     max_run_seconds: float = 240
     max_output_bytes: int = 1024 * 1024
     max_active_runs: int = 8
-    teams: List[Any] = field(default_factory=list)
     _limiter: Optional[PublicLimiter] = field(default=None, init=False, repr=False)
 
     @property

--- a/libs/agno/agno/os/public/_middleware.py
+++ b/libs/agno/agno/os/public/_middleware.py
@@ -208,13 +208,17 @@ class PublicMiddleware:
                 is_sse = any(
                     k.lower() == b"content-type" and b"text/event-stream" in v for k, v in message.get("headers", [])
                 )
+                encoding = next(
+                    (v.lower() for k, v in message.get("headers", []) if k.lower() == b"content-encoding"),
+                    b"identity",
+                )
+                if is_sse and encoding != b"identity":
+                    # Encoded frames cannot be inspected safely. Refuse them before
+                    # headers are sent; outer compression can still encode inspected SSE.
+                    raise Rejected(503, "unsupported_response_encoding")
                 if not is_sse:
                     # Validate the complete bounded body before committing success
                     # headers, so overflow can still return a valid error response.
-                    encoding = next(
-                        (v.lower() for k, v in message.get("headers", []) if k.lower() == b"content-encoding"),
-                        b"identity",
-                    )
                     if encoding == b"gzip":
                         decoder = zlib.decompressobj(16 + zlib.MAX_WBITS)
                     elif encoding != b"identity":

--- a/libs/agno/agno/os/public/_middleware.py
+++ b/libs/agno/agno/os/public/_middleware.py
@@ -6,6 +6,7 @@ import asyncio
 import inspect
 import json
 import re
+import zlib
 from ipaddress import IPv6Address, ip_address, ip_network
 from pathlib import PurePath
 from typing import Any
@@ -23,7 +24,7 @@ from agno.os.public import _client_id
 from agno.utils.bounded import BoundedWorkers
 from agno.utils.log import log_warning
 
-ROUTE = re.compile(r"^/(agents|workflows)/([^/]+)/runs(?:/([^/]+)(/cancel)?)?$")
+ROUTE = re.compile(r"^/(agents|teams|workflows)/([^/]+)/runs(?:/([^/]+)(/cancel)?)?$")
 IDENTITY_WORKERS = BoundedWorkers(8, "public-identity")
 
 
@@ -45,7 +46,7 @@ class PublicMiddleware:
         self.app, self.surface, self.agent_os = app, surface, agent_os
         self.active_runs = self.active_mcp = 0
         self.selected = {
-            kind: {component.id for component in getattr(surface, kind)} for kind in ("agents", "workflows")
+            kind: {component.id for component in getattr(surface, kind)} for kind in ("agents", "teams", "workflows")
         }
         self.registered = {
             kind: {component.id for component in getattr(agent_os, kind) or []} for kind in self.selected
@@ -182,7 +183,8 @@ class PublicMiddleware:
         capacity = None
         identity_token = None
         mcp = False
-        public_agent_run = False
+        public_run = False
+        decoder = None
 
         async def error(status: int, code: str, headers=None):
             await JSONResponse(
@@ -192,7 +194,7 @@ class PublicMiddleware:
             )(scope, receive, send)
 
         async def bounded_send(message):
-            nonlocal started, output_bytes, is_sse, stream_buffer, error_status, error_headers, response_start
+            nonlocal started, output_bytes, is_sse, stream_buffer, error_status, error_headers, response_start, decoder
             if message["type"] == "http.response.start":
                 status = message["status"]
                 if status >= 400:
@@ -209,6 +211,14 @@ class PublicMiddleware:
                 if not is_sse:
                     # Validate the complete bounded body before committing success
                     # headers, so overflow can still return a valid error response.
+                    encoding = next(
+                        (v.lower() for k, v in message.get("headers", []) if k.lower() == b"content-encoding"),
+                        b"identity",
+                    )
+                    if encoding == b"gzip":
+                        decoder = zlib.decompressobj(16 + zlib.MAX_WBITS)
+                    elif encoding != b"identity":
+                        raise Rejected(503, "unsupported_response_encoding")
                     response_start = message
                     return
                 started = True
@@ -225,8 +235,15 @@ class PublicMiddleware:
                     response_buffer.extend(body)
                     if message.get("more_body", False):
                         return
-                    if public_agent_run:
-                        payload = json.loads(response_buffer)
+                    logical_body = bytes(response_buffer)
+                    if decoder is not None:
+                        logical_body = decoder.decompress(logical_body, self.surface.max_output_bytes + 1)
+                        if len(logical_body) > self.surface.max_output_bytes or decoder.unconsumed_tail:
+                            raise Rejected(503, "output_limit")
+                        if not decoder.eof or decoder.unused_data:
+                            raise Rejected(503, "invalid_response_encoding")
+                    if public_run:
+                        payload = json.loads(logical_body)
                         if isinstance(payload, dict) and payload.get("status") == "ERROR":
                             # Native runs encode model failures in HTTP 200 JSON.
                             # Replace the entire failed run so nested diagnostics
@@ -251,6 +268,7 @@ class PublicMiddleware:
                             event = {}
                         if isinstance(event, dict) and event.get("event") in (
                             "RunError",
+                            "TeamRunError",
                             "WorkflowRunError",
                         ):
                             frame = (
@@ -310,7 +328,7 @@ class PublicMiddleware:
                 await WORKERS.run(ready, seconds=3)
                 await JSONResponse({"status": "ok", "database": "ok", "request_limits": "ok"})(scope, receive, send)
                 return
-            if path == "/agents" and method == "GET":
+            if path in ("/agents", "/teams") and method == "GET":
                 await JSONResponse(
                     [
                         {"id": item.id, "name": item.name, "description": (item.description or "")[:2048]}
@@ -379,7 +397,7 @@ class PublicMiddleware:
                     raise Rejected(400, "mcp_batch_not_supported")
             else:
                 await self._validate_form(scope, body, workflow=workflow, cancel=bool(cancellation))
-                public_agent_run = component_kind == "agents" and not cancellation
+                public_run = component_kind in ("agents", "teams") and not cancellation
             delivered = False
 
             async def replay():
@@ -407,13 +425,16 @@ class PublicMiddleware:
             if not started:
                 await error(status, code)
             elif is_sse:
+                event_name = "TeamRunError" if component_kind == "teams" else "RunError"
                 await send(
                     {
                         "type": "http.response.body",
-                        "body": b"event: RunError\ndata: "
+                        "body": b"event: "
+                        + event_name.encode()
+                        + b"\ndata: "
                         + json.dumps(
                             {
-                                "event": "RunError",
+                                "event": event_name,
                                 "content": "Run unavailable",
                                 "error_code": code,
                                 "correlation_id": correlation,

--- a/libs/agno/agno/vectordb/pgvector/pgvector.py
+++ b/libs/agno/agno/vectordb/pgvector/pgvector.py
@@ -554,7 +554,12 @@ class PgVector(VectorDb):
         """
         # Embed before the delete below: clearing the old chunks first would destroy
         # retrievable content if the embedder then fails.
+        for document in documents:
+            if not document.embedding:
+                document.embedding = None
         embed_before_replace(documents, self.embedder)
+        if any(not document.embedding for document in documents):
+            raise EmbeddingError("Embedding failed before replacing content")
         self._require_owner_column(user_id)
         try:
             if self.content_hash_exists(content_hash, user_id=user_id):
@@ -591,7 +596,7 @@ class PgVector(VectorDb):
                         batch_records_dict: Dict[str, Dict[str, Any]] = {}  # Use dict to deduplicate by ID
                         for doc in batch_docs:
                             try:
-                                record = self._get_document_record(doc, filters, content_hash, user_id)
+                                record = self._get_document_record(doc, filters, content_hash, user_id, prepared=True)
                                 # Use the generated record ID (which includes content_hash) for deduplication
                                 batch_records_dict[record["id"]] = record
                             except EmbeddingError:
@@ -658,8 +663,11 @@ class PgVector(VectorDb):
         filters: Optional[Dict[str, Any]] = None,
         content_hash: str = "",
         user_id: Optional[str] = None,
+        *,
+        prepared: bool = False,
     ) -> Dict[str, Any]:
-        doc.embed(embedder=self.embedder)
+        if not prepared or not doc.embedding:
+            doc.embed(embedder=self.embedder)
         cleaned_content = self._clean_content(doc.content)
         # Include content_hash in ID to ensure uniqueness across different content hashes
         # This allows the same URL/content to be inserted with different descriptions
@@ -686,13 +694,17 @@ class PgVector(VectorDb):
             record["user_id"] = user_id
         return record
 
-    async def _async_embed_documents(self, batch_docs: List[Document]) -> None:
+    async def _async_embed_documents(self, batch_docs: List[Document], *, prepared: bool = False) -> None:
         """
         Embed a batch of documents using either batch embedding or individual embedding.
 
         Args:
             batch_docs: List of documents to embed
         """
+        if prepared:
+            batch_docs = [doc for doc in batch_docs if not doc.embedding]
+        if not batch_docs:
+            return
         if self.embedder.enable_batch and hasattr(self.embedder, "async_get_embeddings_batch_and_usage"):
             # Use batch embedding when enabled and supported
             try:
@@ -749,7 +761,12 @@ class PgVector(VectorDb):
         """
         # Embed before the delete below: clearing the old chunks first would destroy
         # retrievable content if the embedder then fails.
+        for document in documents:
+            if not document.embedding:
+                document.embedding = None
         await aembed_before_replace(documents, self.embedder)
+        if any(not document.embedding for document in documents):
+            raise EmbeddingError("Embedding failed before replacing content")
         self._require_owner_column(user_id)
         try:
             if self.content_hash_exists(content_hash, user_id=user_id):
@@ -783,7 +800,7 @@ class PgVector(VectorDb):
                     log_info(f"Processing batch starting at index {i}, size: {len(batch_docs)}")
                     try:
                         # Embed all documents in the batch
-                        await self._async_embed_documents(batch_docs)
+                        await self._async_embed_documents(batch_docs, prepared=True)
                         # An unembedded chunk would be rejected by the store and take the
                         # whole batch down with it, including the chunks that did embed.
                         batch_docs = retrievable_documents(batch_docs)

--- a/libs/agno/agno/vectordb/pgvector/pgvector.py
+++ b/libs/agno/agno/vectordb/pgvector/pgvector.py
@@ -2,7 +2,7 @@ import asyncio
 import re
 from hashlib import md5
 from math import sqrt
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
 
 from agno.utils.string import generate_id
 
@@ -45,6 +45,9 @@ from agno.vectordb.pgvector.index import HNSW, Ivfflat
 from agno.vectordb.score import normalize_score, score_to_distance_threshold
 from agno.vectordb.search import SearchType
 
+if TYPE_CHECKING:
+    from agno.db.postgres import PostgresDb
+
 
 class PgVector(VectorDb):
     """
@@ -74,6 +77,8 @@ class PgVector(VectorDb):
         reranker: Optional[Reranker] = None,
         create_schema: bool = True,
         similarity_threshold: Optional[float] = None,
+        *,
+        db: Optional["PostgresDb"] = None,
     ):
         """
         Initialize the PgVector instance.
@@ -85,6 +90,8 @@ class PgVector(VectorDb):
             description (Optional[str]): Description of the vector database.
             db_url (Optional[str]): Database connection URL.
             db_engine (Optional[Engine]): SQLAlchemy database engine.
+            db (Optional[PostgresDb]): Borrow a synchronous PostgreSQL database's engine.
+                Cannot be combined with db_url or db_engine; does not transfer ownership.
             embedder (Optional[Embedder]): Embedder instance for creating embeddings.
             search_type (SearchType): Type of search to perform.
             vector_index (Union[Ivfflat, HNSW]): Vector index configuration.
@@ -101,8 +108,20 @@ class PgVector(VectorDb):
         if not table_name:
             raise ValueError("Table name must be provided.")
 
+        if db is not None:
+            from agno.db.postgres import PostgresDb
+
+            if db_url is not None or db_engine is not None:
+                raise ValueError("Provide db alone, without db_url or db_engine")
+            if (
+                not isinstance(db, PostgresDb)
+                or not isinstance(db.db_engine, Engine)
+                or db.db_engine.dialect.name != "postgresql"
+            ):
+                raise ValueError("db requires a synchronous PostgresDb; use db_engine for a direct engine")
+            db_engine = db.db_engine
         if db_engine is None and db_url is None:
-            raise ValueError("Either 'db_url' or 'db_engine' must be provided.")
+            raise ValueError("Provide db, db_url, or db_engine")
 
         if id is None:
             base_seed = db_url or str(db_engine.url)  # type: ignore

--- a/libs/agno/agno/vectordb/pgvector/pgvector.py
+++ b/libs/agno/agno/vectordb/pgvector/pgvector.py
@@ -558,8 +558,9 @@ class PgVector(VectorDb):
             if not document.embedding:
                 document.embedding = None
         embed_before_replace(documents, self.embedder)
-        if any(not document.embedding for document in documents):
-            raise EmbeddingError("Embedding failed before replacing content")
+        # Empty results retain generic partial ingestion: write the usable chunks
+        # without asking the embedder again. Raised failures above still precede deletion.
+        documents = retrievable_documents(documents)
         self._require_owner_column(user_id)
         try:
             if self.content_hash_exists(content_hash, user_id=user_id):
@@ -765,8 +766,9 @@ class PgVector(VectorDb):
             if not document.embedding:
                 document.embedding = None
         await aembed_before_replace(documents, self.embedder)
-        if any(not document.embedding for document in documents):
-            raise EmbeddingError("Embedding failed before replacing content")
+        # Empty results retain generic partial ingestion: write the usable chunks
+        # without asking the embedder again. Raised failures above still precede deletion.
+        documents = retrievable_documents(documents)
         self._require_owner_column(user_id)
         try:
             if self.content_hash_exists(content_hash, user_id=user_id):

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -228,10 +228,15 @@ def _step_on_error(step: Union[Step, Condition]) -> Union[OnError, str]:
 
 
 def _check_failed_step(step: Any, output: StepOutput, run: WorkflowRunOutput, outputs: list) -> None:
-    """Honor explicit failure policy while retaining the executor's structured report."""
+    """Honor a Step's explicit failure policy and retain its structured report.
+
+    Composite success flags also summarize tolerated child failures. Their own
+    exception policies decide whether execution aborts; do not reinterpret the
+    aggregate flag as a new exception at the workflow boundary.
+    """
     if (
         not output.success
-        and isinstance(step, (Step, Condition))
+        and isinstance(step, Step)
         and _step_on_error(step) == OnError.fail
         and not getattr(step, "skip_on_failure", False)
     ):
@@ -7070,6 +7075,7 @@ class Workflow:
 
                     previous_step_outputs[step_name] = step_output
                     collected_step_outputs.append(step_output)
+                    _check_failed_step(step, step_output, workflow_run_response, collected_step_outputs)
                     shared_images.extend(step_output.images or [])
                     shared_videos.extend(step_output.videos or [])
                     shared_audio.extend(step_output.audio or [])
@@ -7150,6 +7156,7 @@ class Workflow:
                     # Update tracking
                     previous_step_outputs[step_name] = step_output
                     collected_step_outputs.append(step_output)
+                    _check_failed_step(step, step_output, workflow_run_response, collected_step_outputs)
 
                     shared_images.extend(step_output.images or [])
                     shared_videos.extend(step_output.videos or [])
@@ -7243,6 +7250,7 @@ class Workflow:
                     # Update tracking
                     previous_step_outputs[step_name] = step_output
                     collected_step_outputs.append(step_output)
+                    _check_failed_step(step, step_output, workflow_run_response, collected_step_outputs)
 
                     shared_images.extend(step_output.images or [])
                     shared_videos.extend(step_output.videos or [])
@@ -7343,13 +7351,13 @@ class Workflow:
                     raise
                 except Exception as step_error:
                     # Handle step execution error based on on_error policy
-                    step_on_error = _step_on_error(step) if isinstance(step, Step) else "fail"
+                    step_on_error = _step_on_error(step) if isinstance(step, (Step, Condition)) else "fail"
 
                     if step_on_error == "pause":
                         # Pause workflow and let user decide to retry or skip
                         log_debug(f"Step '{step_name}' failed with on_error='pause' - pausing workflow")
 
-                        error_requirement = cast(Step, step).create_error_requirement(i, step_error)
+                        error_requirement = cast(Union[Step, Condition], step).create_error_requirement(i, step_error)
 
                         # Store the paused state
                         workflow_run_response.status = RunStatus.paused
@@ -7371,7 +7379,7 @@ class Workflow:
                             step_name, getattr(step, "step_id", str(uuid4())), step_error
                         )
                     else:
-                        # Default behavior: re-raise the exception
+                        _record_failed_step(step, step_error, workflow_run_response, collected_step_outputs)
                         raise
 
                 # Check if executor (agent/team) is paused for tool-level HITL
@@ -7435,6 +7443,7 @@ class Workflow:
 
                 previous_step_outputs[step_name] = step_output
                 collected_step_outputs.append(step_output)
+                _check_failed_step(step, step_output, workflow_run_response, collected_step_outputs)
 
                 shared_images.extend(step_output.images or [])
                 shared_videos.extend(step_output.videos or [])
@@ -7923,6 +7932,7 @@ class Workflow:
 
                     previous_step_outputs[step_name] = step_output
                     collected_step_outputs.append(step_output)
+                    _check_failed_step(step, step_output, workflow_run_response, collected_step_outputs)
                     shared_images.extend(step_output.images or [])
                     shared_videos.extend(step_output.videos or [])
                     shared_audio.extend(step_output.audio or [])
@@ -8323,6 +8333,7 @@ class Workflow:
                                     return
 
                             collected_step_outputs.append(step_output)
+                            _check_failed_step(step, step_output, workflow_run_response, collected_step_outputs)
                             previous_step_outputs[step_name] = step_output
 
                             step_output_event = self._transform_step_output_to_event(
@@ -8385,12 +8396,14 @@ class Workflow:
 
                 # Handle step execution error based on on_error policy
                 if step_error_occurred and step_error_exception is not None:
-                    step_on_error = _step_on_error(step) if isinstance(step, Step) else "fail"
+                    step_on_error = _step_on_error(step) if isinstance(step, (Step, Condition)) else "fail"
 
                     if step_on_error == "pause":
                         log_debug(f"Step '{step_name}' failed with on_error='pause' - pausing workflow")
 
-                        error_requirement = cast(Step, step).create_error_requirement(i, step_error_exception)
+                        error_requirement = cast(Union[Step, Condition], step).create_error_requirement(
+                            i, step_error_exception
+                        )
 
                         workflow_run_response.status = RunStatus.paused
                         workflow_run_response.error_requirements = [error_requirement]
@@ -8421,8 +8434,10 @@ class Workflow:
                             step_name, getattr(step, "step_id", str(uuid4())), step_error_exception
                         )
                         collected_step_outputs.append(step_output)
+                        _check_failed_step(step, step_output, workflow_run_response, collected_step_outputs)
                         previous_step_outputs[step_name] = step_output
                     else:
+                        _record_failed_step(step, step_error_exception, workflow_run_response, collected_step_outputs)
                         raise step_error_exception
 
                 # Post-execution output review check
@@ -8534,6 +8549,20 @@ class Workflow:
             logger.exception("Workflow execution failed")
             workflow_run_response.status = RunStatus.error
             workflow_run_response.content = f"Workflow execution failed: {e}"
+            from agno.run.workflow import WorkflowErrorEvent
+
+            error_event = self._handle_event(
+                WorkflowErrorEvent(
+                    run_id=workflow_run_response.run_id or "",
+                    workflow_id=self.id,
+                    workflow_name=self.name,
+                    session_id=session.session_id,
+                    error=str(e),
+                ),
+                workflow_run_response,
+            )
+            self._persist_errored_run_stream(session=session, run=workflow_run_response)
+            yield error_event
             raise e
         finally:
             cleanup_run(workflow_run_response.run_id)  # type: ignore
@@ -9110,6 +9139,7 @@ class Workflow:
 
                     previous_step_outputs[step_name] = step_output
                     collected_step_outputs.append(step_output)
+                    _check_failed_step(step, step_output, workflow_run_response, collected_step_outputs)
                     shared_images.extend(step_output.images or [])
                     shared_videos.extend(step_output.videos or [])
                     shared_audio.extend(step_output.audio or [])
@@ -9192,6 +9222,7 @@ class Workflow:
                     # Update tracking
                     previous_step_outputs[step_name] = step_output
                     collected_step_outputs.append(step_output)
+                    _check_failed_step(step, step_output, workflow_run_response, collected_step_outputs)
 
                     shared_images.extend(step_output.images or [])
                     shared_videos.extend(step_output.videos or [])
@@ -9283,6 +9314,7 @@ class Workflow:
                     # Update tracking
                     previous_step_outputs[step_name] = step_output
                     collected_step_outputs.append(step_output)
+                    _check_failed_step(step, step_output, workflow_run_response, collected_step_outputs)
 
                     shared_images.extend(step_output.images or [])
                     shared_videos.extend(step_output.videos or [])
@@ -9375,12 +9407,12 @@ class Workflow:
                     raise
                 except Exception as step_error:
                     # Handle step execution error based on on_error policy
-                    step_on_error = _step_on_error(step) if isinstance(step, Step) else "fail"
+                    step_on_error = _step_on_error(step) if isinstance(step, (Step, Condition)) else "fail"
 
                     if step_on_error == "pause":
                         log_debug(f"Step '{step_name}' failed with on_error='pause' - pausing workflow")
 
-                        error_requirement = cast(Step, step).create_error_requirement(i, step_error)
+                        error_requirement = cast(Union[Step, Condition], step).create_error_requirement(i, step_error)
 
                         workflow_run_response.status = RunStatus.paused
                         workflow_run_response.error_requirements = [error_requirement]
@@ -9399,6 +9431,7 @@ class Workflow:
                             step_name, getattr(step, "step_id", str(uuid4())), step_error
                         )
                     else:
+                        _record_failed_step(step, step_error, workflow_run_response, collected_step_outputs)
                         raise
 
                 # Check if executor (agent/team) is paused for tool-level HITL
@@ -9462,6 +9495,7 @@ class Workflow:
 
                 previous_step_outputs[step_name] = step_output
                 collected_step_outputs.append(step_output)
+                _check_failed_step(step, step_output, workflow_run_response, collected_step_outputs)
 
                 shared_images.extend(step_output.images or [])
                 shared_videos.extend(step_output.videos or [])
@@ -9663,6 +9697,7 @@ class Workflow:
 
                     previous_step_outputs[step_name] = step_output
                     collected_step_outputs.append(step_output)
+                    _check_failed_step(step, step_output, workflow_run_response, collected_step_outputs)
                     shared_images.extend(step_output.images or [])
                     shared_videos.extend(step_output.videos or [])
                     shared_audio.extend(step_output.audio or [])
@@ -10064,6 +10099,7 @@ class Workflow:
                                     return
 
                             collected_step_outputs.append(step_output)
+                            _check_failed_step(step, step_output, workflow_run_response, collected_step_outputs)
                             previous_step_outputs[step_name] = step_output
 
                             step_output_event = self._transform_step_output_to_event(
@@ -10126,12 +10162,14 @@ class Workflow:
 
                 # Handle step execution error based on on_error policy
                 if step_error_occurred and step_error_exception is not None:
-                    step_on_error = _step_on_error(step) if isinstance(step, Step) else "fail"
+                    step_on_error = _step_on_error(step) if isinstance(step, (Step, Condition)) else "fail"
 
                     if step_on_error == "pause":
                         log_debug(f"Step '{step_name}' failed with on_error='pause' - pausing workflow")
 
-                        error_requirement = cast(Step, step).create_error_requirement(i, step_error_exception)
+                        error_requirement = cast(Union[Step, Condition], step).create_error_requirement(
+                            i, step_error_exception
+                        )
 
                         workflow_run_response.status = RunStatus.paused
                         workflow_run_response.error_requirements = [error_requirement]
@@ -10162,8 +10200,10 @@ class Workflow:
                             step_name, getattr(step, "step_id", str(uuid4())), step_error_exception
                         )
                         collected_step_outputs.append(step_output)
+                        _check_failed_step(step, step_output, workflow_run_response, collected_step_outputs)
                         previous_step_outputs[step_name] = step_output
                     else:
+                        _record_failed_step(step, step_error_exception, workflow_run_response, collected_step_outputs)
                         raise step_error_exception
 
                 # Post-execution output review check
@@ -10282,6 +10322,20 @@ class Workflow:
             logger.exception("Workflow execution failed")
             workflow_run_response.status = RunStatus.error
             workflow_run_response.content = f"Workflow execution failed: {e}"
+            from agno.run.workflow import WorkflowErrorEvent
+
+            error_event = self._handle_event(
+                WorkflowErrorEvent(
+                    run_id=workflow_run_response.run_id or "",
+                    workflow_id=self.id,
+                    workflow_name=self.name,
+                    session_id=session.session_id,
+                    error=str(e),
+                ),
+                workflow_run_response,
+            )
+            await self._apersist_errored_run_stream(session=session, run=workflow_run_response)
+            yield error_event
             raise e
 
         # Yield workflow completed event

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -227,6 +227,33 @@ def _step_on_error(step: Union[Step, Condition]) -> Union[OnError, str]:
     return hr.on_error
 
 
+def _check_failed_step(step: Any, output: StepOutput, run: WorkflowRunOutput, outputs: list) -> None:
+    """Honor explicit failure policy while retaining the executor's structured report."""
+    if (
+        not output.success
+        and isinstance(step, (Step, Condition))
+        and _step_on_error(step) == OnError.fail
+        and not getattr(step, "skip_on_failure", False)
+    ):
+        run.step_results = list(outputs)
+        raise RuntimeError(output.error or f"Step {output.step_name} reported failure")
+
+
+def _record_failed_step(step: Any, error: Exception, run: WorkflowRunOutput, outputs: list) -> None:
+    """Keep exhausted exception diagnostics alongside already completed steps."""
+    if not outputs or not isinstance(outputs[-1], StepOutput) or outputs[-1].step_id != getattr(step, "step_id", None):
+        outputs.append(
+            StepOutput(
+                step_name=getattr(step, "name", None),
+                step_id=getattr(step, "step_id", None),
+                success=False,
+                error=str(error),
+                content=str(error),
+            )
+        )
+    run.step_results = list(outputs)
+
+
 def _find_inner_step_by_executor(
     step: WorkflowStep,
     executor_id: Optional[str] = None,
@@ -2979,7 +3006,7 @@ class Workflow:
                                 step_name, getattr(step, "step_id", str(uuid4())), step_error
                             )
                         else:
-                            # Default behavior: re-raise the exception
+                            _record_failed_step(step, step_error, workflow_run_response, collected_step_outputs)
                             raise
 
                     # Check if executor (agent/team) is paused for tool-level HITL
@@ -3042,6 +3069,7 @@ class Workflow:
                     # Update the workflow-level previous_step_outputs dictionary
                     previous_step_outputs[step_name] = step_output
                     collected_step_outputs.append(step_output)
+                    _check_failed_step(step, step_output, workflow_run_response, collected_step_outputs)
 
                     # Update shared media for next step
                     shared_images.extend(step_output.images or [])
@@ -3396,6 +3424,7 @@ class Workflow:
                                         return
 
                                 collected_step_outputs.append(step_output)
+                                _check_failed_step(step, step_output, workflow_run_response, collected_step_outputs)
 
                                 # Update the workflow-level previous_step_outputs dictionary
                                 previous_step_outputs[step_name] = step_output
@@ -3510,9 +3539,12 @@ class Workflow:
                                 step_name, getattr(step, "step_id", str(uuid4())), step_error_exception
                             )
                             collected_step_outputs.append(step_output)
+                            _check_failed_step(step, step_output, workflow_run_response, collected_step_outputs)
                             previous_step_outputs[step_name] = step_output
                         else:
-                            # Default behavior: re-raise the exception
+                            _record_failed_step(
+                                step, step_error_exception, workflow_run_response, collected_step_outputs
+                            )
                             raise step_error_exception
 
                     # Post-execution output review check
@@ -4027,7 +4059,7 @@ class Workflow:
                                 step_name, getattr(step, "step_id", str(uuid4())), step_error
                             )
                         else:
-                            # Default behavior: re-raise the exception
+                            _record_failed_step(step, step_error, workflow_run_response, collected_step_outputs)
                             raise
 
                     # Check if executor (agent/team) is paused for tool-level HITL
@@ -4088,6 +4120,7 @@ class Workflow:
                     # Update the workflow-level previous_step_outputs dictionary
                     previous_step_outputs[step_name] = step_output
                     collected_step_outputs.append(step_output)
+                    _check_failed_step(step, step_output, workflow_run_response, collected_step_outputs)
 
                     # Update shared media for next step
                     shared_images.extend(step_output.images or [])
@@ -4188,6 +4221,7 @@ class Workflow:
                 logger.exception("Workflow execution failed")
                 workflow_run_response.status = RunStatus.error
                 workflow_run_response.content = f"Workflow execution failed: {e}"
+                await self._apersist_errored_run_stream(session=workflow_session, run=workflow_run_response)
                 raise e
 
         # Stop timer on error
@@ -4476,6 +4510,7 @@ class Workflow:
                                         return
 
                                 collected_step_outputs.append(step_output)
+                                _check_failed_step(step, step_output, workflow_run_response, collected_step_outputs)
 
                                 # Update the workflow-level previous_step_outputs dictionary
                                 previous_step_outputs[step_name] = step_output
@@ -4594,9 +4629,12 @@ class Workflow:
                                 step_name, getattr(step, "step_id", str(uuid4())), step_error_exception
                             )
                             collected_step_outputs.append(step_output)
+                            _check_failed_step(step, step_output, workflow_run_response, collected_step_outputs)
                             previous_step_outputs[step_name] = step_output
                         else:
-                            # Default behavior: re-raise the exception
+                            _record_failed_step(
+                                step, step_error_exception, workflow_run_response, collected_step_outputs
+                            )
                             raise step_error_exception
 
                     # Post-execution output review check

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -190,7 +190,7 @@ firestore = ["google-cloud-firestore"]
 gcs = ["google-cloud-storage"]
 mysql = ["pymysql", "asyncmy"]
 postgres = ["sqlalchemy", "psycopg[binary]"]
-pages = ["agno[postgres]", "pgvector", "dnspython>=2.6.1", "beautifulsoup4"]
+pages = ["agno[postgres]", "agno[pgvector]", "dnspython>=2.6.1", "beautifulsoup4"]
 redis = ["redis>=4.5.4", "redisvl>=0.12.1"]  # >=4.5.4: safe cancellation of blocking commands (XREAD in event stream tail)
 s3 = ["boto3", "aioboto3"]
 sql = ["sqlalchemy"]

--- a/libs/agno/tests/integration/knowledge/test_page_storage.py
+++ b/libs/agno/tests/integration/knowledge/test_page_storage.py
@@ -1312,7 +1312,8 @@ def test_public_contention_preserves_completed_primary_and_cleans_up(corpus, mon
         )
         assert elapsed < 2 and primary_times and primary_times[0] - start < 1.5
         assert outcome.results and all(hit.revision == published.revision for hit in outcome.results)
-        assert outcome.partial and outcome.warnings == ("alternative_unavailable",)
+        assert not outcome.partial and outcome.warnings == ()
+        assert len(primary_times) == 2
         assert module.READ_WORKERS._capacity._value == 8
         assert knowledge._page_engine.pool.checkedout() == 1
         assert all(t < 2 for t in read_times)
@@ -1383,3 +1384,168 @@ def test_initialized_setup_during_sync_uses_validated_read_only_path(corpus, mon
         if hasattr(second, "_page_engine"):
             second._page_engine.dispose()
     assert len(outcome) == 1 and not isinstance(outcome[0], BaseException)
+
+
+def test_failed_initial_source_does_not_bind_namespace(corpus):
+    from agno.knowledge.page import SyncFailed
+
+    knowledge, embedder, site = corpus
+    with pytest.raises(SyncFailed):
+        knowledge.sync_pages(url="https://docs.example.com/typo.txt")
+    embedder.fail = True
+    assert knowledge.sync_pages(url="https://docs.example.com/llms.txt").status == "partial"
+    embedder.fail = False
+    site["https://docs.example.com/corrected.txt"] = site["https://docs.example.com/llms.txt"]
+    assert knowledge.sync_pages(url="https://docs.example.com/corrected.txt").updated == 1
+    with pytest.raises(ValueError, match="bound to another"):
+        knowledge.sync_pages(url="https://docs.example.com/llms.txt")
+
+
+@pytest.mark.parametrize("namespace", ["docs space", "docs%20encoded"])
+def test_namespace_literal_and_hnsw_build_options(engine, namespace):
+    from agno.vectordb.pgvector.index import HNSW
+
+    db = PostgresDb(db_engine=engine)
+    vector = PgVector(
+        db=db,
+        table_name="custom_" + uuid4().hex[:8],
+        embedder=RecordingEmbedder(),
+        vector_index=HNSW(m=24, ef_construction=123),
+    )
+    knowledge = Knowledge(content_db=db, page_store=FileSystem(db=db, namespace=namespace), vector_db=vector)
+    knowledge.setup()
+    knowledge.setup()
+    coordinator = knowledge._pages()
+    index_name = list(coordinator._search_indexes())[1][1]
+    with engine.connect() as conn:
+        row = conn.execute(
+            text(
+                "SELECT pg_get_expr(i.indpred, i.indrelid), c.reloptions FROM pg_class c JOIN pg_index i ON i.indexrelid=c.oid WHERE c.relname=:name"
+            ),
+            {"name": index_name},
+        ).one()
+    assert knowledge.page_store.namespace in row[0]
+    assert "%%" not in row[0]
+    assert set(row[1]) == {"m=24", "ef_construction=123"}
+    vector.vector_index = HNSW(m=16, ef_construction=200)
+    with pytest.raises(ValueError, match="rebuild"):
+        knowledge.setup()
+
+
+def test_six_namespaces_concurrently_initialize_fresh_table(engine, monkeypatch):
+    from concurrent.futures import ThreadPoolExecutor
+    from threading import Barrier
+
+    barrier = Barrier(6)
+
+    def fetch(self, url, maximum):
+        return f"- [Page]({self.base}/page.md)" if url.endswith("llms.txt") else "# " + url
+
+    monkeypatch.setattr(PageSource, "fetch", fetch)
+    table = "setup_" + uuid4().hex[:8]
+
+    def initialize(index):
+        db = PostgresDb(db_engine=engine)
+        knowledge = Knowledge(
+            content_db=db,
+            page_store=FileSystem(db=db, namespace=f"concurrent-{table}-{index}"),
+            vector_db=PgVector(db=db, table_name=table, embedder=RecordingEmbedder()),
+        )
+        barrier.wait(timeout=5)
+        knowledge.setup()
+        knowledge.sync_pages(url=f"https://docs.example.com/n{index}/llms.txt")
+        return knowledge
+
+    with ThreadPoolExecutor(max_workers=6) as pool:
+        initialized = list(pool.map(initialize, range(6)))
+    assert len(initialized) == 6
+    for index, knowledge in enumerate(initialized):
+        knowledge.setup()
+        pages = knowledge.list_pages().pages
+        assert len(pages) == 1 and pages[0].namespace == knowledge.page_store.namespace
+        assert knowledge.read_page("/page").text == f"# https://docs.example.com/n{index}/page.md"
+
+
+@pytest.mark.parametrize("held", [7, 8])
+@pytest.mark.parametrize("async_mode", [False, True])
+def test_pool_checkout_budget_and_serial_fallback(corpus, held, async_mode):
+    import asyncio
+    import time
+
+    from agno.knowledge.page import SearchUnavailable
+
+    knowledge, _, _ = corpus
+    knowledge.sync_pages(url="https://docs.example.com/llms.txt")
+    warm_search_pool(knowledge, 8)
+    with ExitStack() as stack:
+        for _ in range(held):
+            stack.enter_context(knowledge._page_engine.connect())
+        start = time.monotonic()
+        if held == 8:
+            with pytest.raises(SearchUnavailable):
+                if async_mode:
+                    asyncio.run(knowledge.asearch_pages("Agent", alternatives=["tools"]))
+                else:
+                    knowledge.search_pages("Agent", alternatives=["tools"])
+        else:
+            result = (
+                asyncio.run(knowledge.asearch_pages("Agent", alternatives=["tools"]))
+                if async_mode
+                else knowledge.search_pages("Agent", alternatives=["tools"])
+            )
+            assert result.results and not result.partial
+        elapsed = time.monotonic() - start
+        print("CHECKOUT", {"held": held, "async": async_mode, "seconds": elapsed})
+        assert elapsed < 2.35
+    deadline = time.monotonic() + 1
+    while knowledge._page_engine.pool.checkedout() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert knowledge._page_engine.pool.checkedout() == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("async_mode", [False, True])
+@pytest.mark.parametrize("batch", [False, True])
+async def test_upsert_embeds_missing_documents_once_before_replacement(engine, async_mode, batch):
+    from agno.exceptions import EmbeddingError
+    from agno.knowledge.document import Document
+
+    class Counter(RecordingEmbedder):
+        def get_embedding_and_usage(self, text):
+            return self.get_embedding(text), {"text": text}
+
+        async def async_get_embedding_and_usage(self, text):
+            return self.get_embedding_and_usage(text)
+
+        async def async_get_embeddings_batch_and_usage(self, texts):
+            pairs = [self.get_embedding_and_usage(value) for value in texts]
+            return [p[0] for p in pairs], [p[1] for p in pairs]
+
+    embedder = Counter()
+    embedder.enable_batch = batch
+    vector = PgVector(db=PostgresDb(db_engine=engine), table_name="upsert_" + uuid4().hex[:8], embedder=embedder)
+    vector.create()
+    documents = [
+        Document(content="prepared", embedding=[0.2, 0.5, 1], usage={"prepared": True}),
+        Document(content="missing"),
+        Document(content="empty", embedding=[]),
+    ]
+    if async_mode:
+        await vector.async_upsert("generation", documents)
+    else:
+        vector.upsert("generation", documents)
+    assert embedder.calls == ["missing", "empty"]
+    with engine.connect() as conn:
+        rows = {row.content: row for row in conn.execute(vector.table.select())}
+    assert len(rows) == 3
+    assert list(rows["prepared"].embedding) == pytest.approx([0.2, 0.5, 1])
+    assert rows["missing"].usage == {"text": "missing"}
+    assert rows["empty"].usage == {"text": "empty"}
+    embedder.fail = True
+    with pytest.raises((EmbeddingError, RuntimeError)):
+        if async_mode:
+            await vector.async_upsert("generation", [Document(content="replacement")])
+        else:
+            vector.upsert("generation", [Document(content="replacement")])
+    with engine.connect() as conn:
+        assert len(conn.execute(vector.table.select()).all()) == 3

--- a/libs/agno/tests/integration/knowledge/test_page_storage.py
+++ b/libs/agno/tests/integration/knowledge/test_page_storage.py
@@ -1549,3 +1549,59 @@ async def test_upsert_embeds_missing_documents_once_before_replacement(engine, a
             vector.upsert("generation", [Document(content="replacement")])
     with engine.connect() as conn:
         assert len(conn.execute(vector.table.select()).all()) == 3
+
+
+def test_concurrent_first_sync_failure_allows_corrected_source(corpus, monkeypatch):
+    from concurrent.futures import ThreadPoolExecutor
+    from threading import Event
+
+    from agno.knowledge.page import SyncFailed
+
+    knowledge, _, site = corpus
+    entered, release = Event(), Event()
+
+    def fetch(self, url, maximum):
+        if url.endswith("typo.txt"):
+            entered.set()
+            assert release.wait(5)
+            raise RuntimeError("unpublished source typo")
+        return site[url]
+
+    monkeypatch.setattr(PageSource, "fetch", fetch)
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(knowledge.sync_pages, url="https://docs.example.com/typo.txt")
+        assert entered.wait(5)
+        second = pool.submit(knowledge.sync_pages, url="https://docs.example.com/llms.txt")
+        release.set()
+        with pytest.raises(SyncFailed):
+            first.result(timeout=5)
+        assert second.result(timeout=5).updated == 1
+    assert knowledge.read_page("/agent").text == site["https://docs.example.com/agent.md"]
+
+
+def test_recycled_primary_connection_and_optional_fallback(corpus):
+    from sqlalchemy import event
+
+    knowledge, _, _ = corpus
+    knowledge.sync_pages(url="https://docs.example.com/llms.txt")
+    engine = knowledge._page_engine
+    established = []
+
+    def record_connect(connection, record):
+        established.append(1)
+
+    def age_connection(connection, record):
+        # Exercise SQLAlchemy's actual recycle branch on the next checkout.
+        record.starttime = 0
+
+    event.listen(engine, "connect", record_connect)
+    event.listen(engine, "checkin", age_connection)
+    try:
+        for _ in range(3):
+            result = knowledge.search_pages("Agent", alternatives=["tools"])
+            assert result.results and not result.partial
+        assert len(established) >= 2
+        assert engine.pool.checkedout() == 0
+    finally:
+        event.remove(engine, "connect", record_connect)
+        event.remove(engine, "checkin", age_connection)

--- a/libs/agno/tests/integration/knowledge/test_page_storage.py
+++ b/libs/agno/tests/integration/knowledge/test_page_storage.py
@@ -1605,3 +1605,112 @@ def test_recycled_primary_connection_and_optional_fallback(corpus):
     finally:
         event.remove(engine, "connect", record_connect)
         event.remove(engine, "checkin", age_connection)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("async_mode", [False, True])
+@pytest.mark.parametrize("batch", [False, True])
+@pytest.mark.parametrize("replacement", [False, True])
+async def test_generic_upsert_preserves_partial_embeddings_without_reembedding(engine, async_mode, batch, replacement):
+    from agno.knowledge.document import Document
+
+    class PartialEmbedder(RecordingEmbedder):
+        def get_embedding_and_usage(self, text):
+            self.calls.append(text)
+            if self.fail:
+                raise RuntimeError("provider failed")
+            return ([] if text == "unusable" else [1.0, 0.5, 0.2]), {"text": text}
+
+        async def async_get_embedding_and_usage(self, text):
+            return self.get_embedding_and_usage(text)
+
+        async def async_get_embeddings_batch_and_usage(self, texts):
+            pairs = [self.get_embedding_and_usage(value) for value in texts]
+            return [pair[0] for pair in pairs], [pair[1] for pair in pairs]
+
+    embedder = PartialEmbedder()
+    embedder.enable_batch = batch
+    vector = PgVector(db=PostgresDb(db_engine=engine), table_name="partial_" + uuid4().hex[:8], embedder=embedder)
+    vector.create()
+    if replacement:
+        vector.upsert("generation", [Document(content="old")])
+    embedder.calls.clear()
+    documents = [Document(content="usable"), Document(content="unusable")]
+    if async_mode:
+        await vector.async_upsert("generation", documents)
+    else:
+        vector.upsert("generation", documents)
+    assert embedder.calls == ["usable", "unusable"]
+    assert documents[1].embedding == []  # Ingestion can still account for the shortfall.
+    with engine.connect() as conn:
+        rows = conn.execute(vector.table.select()).all()
+    assert [row.content for row in rows] == ["usable"]
+    assert rows[0].usage == {"text": "usable"}
+    embedder.fail = True
+    with pytest.raises(RuntimeError, match="provider failed"):
+        if async_mode:
+            await vector.async_upsert("generation", [Document(content="replacement")])
+        else:
+            vector.upsert("generation", [Document(content="replacement")])
+    with engine.connect() as conn:
+        assert [row.content for row in conn.execute(vector.table.select())] == ["usable"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("async_mode", [False, True])
+async def test_generic_knowledge_tracks_partial_embedding_ingestion(engine, async_mode):
+    from agno.knowledge.document import Document
+    from agno.knowledge.reader.base import Reader
+
+    class PartialEmbedder(RecordingEmbedder):
+        def get_embedding_and_usage(self, text):
+            self.calls.append(text)
+            return ([] if text == "unusable" else [1.0, 0.5, 0.2]), None
+
+        async def async_get_embedding_and_usage(self, text):
+            return self.get_embedding_and_usage(text)
+
+    class SplitReader(Reader):
+        def read(self, *args, **kwargs):
+            return [Document(content="usable"), Document(content="unusable")]
+
+        async def async_read(self, *args, **kwargs):
+            return self.read()
+
+    name = "partial_knowledge_" + uuid4().hex[:8]
+    embedder = PartialEmbedder()
+    db = PostgresDb(db_engine=engine)
+    vector = PgVector(db=db, table_name=name, embedder=embedder)
+    vector.create()
+    knowledge = Knowledge(content_db=db, vector_db=vector)
+    if async_mode:
+        await knowledge.ainsert(name=name, text_content="source document", reader=SplitReader())
+    else:
+        knowledge.insert(name=name, text_content="source document", reader=SplitReader())
+    contents, _ = knowledge.get_content()
+    content = next(item for item in contents if item.name == name)
+    assert content.status.value == "partial"
+    assert "1 of 2 chunks" in content.status_message
+    assert embedder.calls == ["usable", "unusable"]
+    with engine.connect() as conn:
+        assert [row.content for row in conn.execute(vector.table.select())] == ["usable"]
+
+
+def test_legacy_default_hnsw_index_requires_explicit_operator_rebuild(corpus):
+    import re
+
+    knowledge, _, _ = corpus
+    assert knowledge.sync_pages(url="https://docs.example.com/llms.txt").updated == 1
+    coordinator = knowledge._pages()
+    schema, name, table, definition = list(coordinator._search_indexes())[1]
+    legacy = re.sub(r" WITH \([^)]*\)", "", definition)
+    with knowledge._page_engine.begin() as conn:
+        conn.execute(text(f'DROP INDEX "{schema}"."{name}"'))
+        conn.execute(text(f'CREATE INDEX "{name}" ON {table} {legacy}'))
+    with pytest.raises(ValueError, match="rebuild .*ef_construction=200"):
+        knowledge.setup()
+    with knowledge._page_engine.connect() as conn:
+        assert (
+            conn.execute(text("SELECT reloptions FROM pg_class WHERE relname=:name"), {"name": name}).scalar() is None
+        )
+    assert knowledge.read_page("/agent").text.startswith("# Agent")

--- a/libs/agno/tests/integration/os/test_public_surface.py
+++ b/libs/agno/tests/integration/os/test_public_surface.py
@@ -274,3 +274,28 @@ def test_scoped_service_credentials_and_native_mcp(engine):
             )
             assert result.status_code == 200 and "resolved-client" in result.text
     public.limiter.engine.dispose()
+
+
+def test_selected_agents_and_teams_share_run_and_cancel_limits(engine):
+    from agno.team import Team
+
+    db = PostgresDb(db_engine=engine)
+    agent = Agent(id="same")
+    team = Team(id="same", members=[agent])
+    public = PublicSurface(agents=[agent], teams=[team], limits={"run": RateLimit(1, 1), "cancel": RateLimit(1, 1)})
+    app = AgentOS(
+        id="shared-" + uuid4().hex[:8],
+        db=db,
+        agents=[agent],
+        teams=[team],
+        public=public,
+        telemetry=False,
+        auto_provision_dbs=False,
+    ).get_app()
+    with TestClient(app) as client:
+        assert client.post("/teams/same/runs", data={"message": "hi", "user_id": "spoof"}).status_code == 400
+        assert client.post("/agents/same/runs", data={"message": "hi", "user_id": "spoof"}).status_code == 429
+        run_id = str(uuid4())
+        response = client.post(f"/teams/same/runs/{run_id}/cancel")
+        assert response.status_code in (200, 404), response.text
+        assert client.post(f"/agents/same/runs/{run_id}/cancel").status_code == 429

--- a/libs/agno/tests/unit/agent/test_dependencies_merge.py
+++ b/libs/agno/tests/unit/agent/test_dependencies_merge.py
@@ -382,3 +382,72 @@ async def test_concurrent_dependency_inputs_are_run_local():
     first, second = await asyncio.gather(agent.arun("first", session_id="one"), agent.arun("second", session_id="two"))
     assert "X=one:first" in _system_content(first)
     assert "X=two:second" in _system_content(second)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("async_mode", [False, True])
+@pytest.mark.parametrize("stream", [False, True])
+async def test_continuation_dependencies_follow_persisted_state(tmp_path, async_mode, stream):
+    from agno.db.sqlite import SqliteDb
+
+    path = str(tmp_path / "agent.db")
+    original_agent = Agent(id="persistent", model=RecordingModel(), db=SqliteDb(db_file=path), telemetry=False)
+    original = original_agent.run(
+        "original", session_id="session", session_state={"published": "old"}, metadata={"tag": "original"}
+    )
+    calls = []
+
+    def dependency(run_input, session, run_context):
+        calls.append(run_input.input_content)
+        assert session.session_id == run_context.session_id == "session"
+        assert run_context.session_state["published"] == "old"
+        assert run_context.metadata["tag"] == "override"
+        return "evidence"
+
+    fresh = Agent(id="persistent", model=RecordingModel(), db=SqliteDb(db_file=path), telemetry=False)
+    result = await _execute(
+        fresh,
+        async_mode=async_mode,
+        stream=stream,
+        continuing=True,
+        run_id=original.run_id,
+        session_id="session",
+        input="supplement",
+        metadata={"tag": "override"},
+        dependencies={"evidence": dependency},
+    )
+    assert result.content == "ok" and calls == ["original"]
+    stored = Agent(id="persistent", db=SqliteDb(db_file=path), telemetry=False).get_session(session_id="session")
+    assert len(stored.runs) == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("async_mode", [False, True])
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.parametrize("cancelled", [False, True])
+async def test_invalid_continuation_does_not_resolve_dependencies(async_mode, stream, cancelled):
+    from agno.exceptions import RunNotContinuableError, RunNotFoundError
+    from agno.run.base import RunStatus
+
+    calls = []
+
+    def dependency():
+        calls.append(1)
+        return "side effect"
+
+    agent = Agent(model=RecordingModel(), db=InMemoryDb(), telemetry=False)
+    kwargs = {"run_id": "missing", "session_id": "session"}
+    if cancelled:
+        original = agent.run("original", session_id="session")
+        original.status = RunStatus.cancelled
+        kwargs = {"run_response": original}
+    with pytest.raises(RunNotContinuableError if cancelled else RunNotFoundError):
+        await _execute(
+            agent,
+            async_mode=async_mode,
+            stream=stream,
+            continuing=True,
+            dependencies={"evidence": dependency},
+            **kwargs,
+        )
+    assert calls == []

--- a/libs/agno/tests/unit/fs/test_db_convenience.py
+++ b/libs/agno/tests/unit/fs/test_db_convenience.py
@@ -1,0 +1,86 @@
+"""Shared database constructor compatibility without opening PostgreSQL connections."""
+
+from copy import deepcopy
+
+import pytest
+from sqlalchemy import create_engine
+
+from agno.db.postgres import PostgresDb
+from agno.db.sqlite import SqliteDb
+from agno.fs import FileSystem
+from agno.fs.local import LocalFileSystem
+from agno.knowledge.embedder import Embedder
+from agno.vectordb.pgvector import PgVector
+
+
+@pytest.mark.asyncio
+async def test_filesystem_database_alias(tmp_path):
+    db = SqliteDb(db_file=str(tmp_path / "files.db"))
+    fs = FileSystem(db=db, namespace="docs")
+    fs.write("one.md", "one")
+    assert FileSystem(db, "docs").read("one.md") == "one"
+    await fs.awrite("two.md", "two")
+    assert await FileSystem(backend=db, namespace="docs").aread("two.md") == "two"
+    assert fs.backend.db_engine is db.db_engine
+
+
+def test_filesystem_sources_and_resolution(tmp_path):
+    backend = LocalFileSystem(root=tmp_path)
+    fs = FileSystem(backend, "docs/{user_id}", max_file_bytes=123)
+    assert fs.resolve(user_id="alice").backend is backend
+    assert fs.resolve(user_id="alice").max_file_bytes == 123
+    for kwargs in ({}, {"db": None}, {"backend": backend, "db": backend}, {"db": backend}, {"db": "sqlite://"}):
+        with pytest.raises(ValueError):
+            FileSystem(**kwargs)
+    assert FileSystem(backend=backend, db=None).backend is backend
+
+
+def test_pgvector_borrows_engine_and_preserves_identity():
+    engine = create_engine("postgresql+psycopg://user:private@localhost/example")
+    db = PostgresDb(db_engine=engine, db_schema="sessions")
+    embedder = Embedder(dimensions=3)
+    vector = PgVector("vectors", db=db, embedder=embedder)
+    legacy = PgVector("vectors", db_engine=engine, embedder=embedder)
+    assert vector.db_engine is engine
+    assert vector.id == legacy.id
+    assert vector.db_url is None
+    assert vector.Session.session_factory.kw["bind"] is engine
+    assert vector.schema == "ai"
+    assert deepcopy(vector).db_engine is engine
+    for kwargs in ({"db_url": str(engine.url)}, {"db_engine": engine}, {"db_url": "url", "db_engine": engine}):
+        with pytest.raises(ValueError):
+            PgVector("vectors", db=db, embedder=embedder, **kwargs)
+    for invalid in (engine, str(engine.url), SqliteDb(), object()):
+        with pytest.raises(ValueError, match="synchronous PostgresDb"):
+            PgVector("vectors", db=invalid, embedder=embedder)
+    engine.dispose()
+
+
+def test_filesystem_import_and_custom_backend_need_no_sql_packages(tmp_path):
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            """
+import importlib.abc, sys, tempfile
+class NoSql(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, *args):
+        if fullname.split('.')[0] in ('sqlalchemy', 'psycopg', 'pgvector'):
+            raise ImportError('SQL dependencies deliberately unavailable')
+sys.meta_path.insert(0, NoSql())
+from agno.fs import FileSystem
+from agno.fs.local import LocalFileSystem
+with tempfile.TemporaryDirectory() as root:
+    backend = LocalFileSystem(root=root)
+    fs = FileSystem(backend=backend)
+    fs.write('test.md', 'ok')
+    assert fs.read('test.md') == 'ok' and fs.backend is backend
+""",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr

--- a/libs/agno/tests/unit/knowledge/test_page_source_reliability.py
+++ b/libs/agno/tests/unit/knowledge/test_page_source_reliability.py
@@ -1,0 +1,76 @@
+"""Pinned transport retries and canonical navigation destinations."""
+
+from asyncio import CancelledError
+
+import httpx
+import pytest
+
+from agno.knowledge.page import SyncFailed
+from agno.knowledge.page._source import PageSource
+from agno.utils.bounded import WorkBudget
+
+
+@pytest.mark.parametrize("failure", [httpx.ConnectError, httpx.ReadError, httpx.ReadTimeout])
+@pytest.mark.parametrize("exhausted", [False, True])
+def test_retry_transport_with_pinned_dns(monkeypatch, failure, exhausted):
+    import dns.resolver
+
+    seen = []
+    monkeypatch.setattr(dns.resolver.Resolver, "resolve", lambda *a, **kw: ["93.184.216.34"])
+    original = httpx.Client
+
+    def handle(request):
+        seen.append(request)
+        if len(seen) == 1 or exhausted:
+            raise failure("transient")
+        return httpx.Response(200, content=b"hello")
+
+    monkeypatch.setattr(httpx, "Client", lambda **kw: original(transport=httpx.MockTransport(handle), **kw))
+    source = PageSource("https://docs.example.com/llms.txt", None, WorkBudget(5))
+    if exhausted:
+        with pytest.raises(SyncFailed):
+            source.fetch(source.url, 10)
+        assert len(seen) == 3
+    else:
+        assert source.fetch(source.url, 10) == "hello"
+        assert len(seen) == 2
+    assert all(
+        r.url.host == "93.184.216.34"
+        and r.headers["host"] == "docs.example.com"
+        and r.extensions["sni_hostname"] == "docs.example.com"
+        for r in seen
+    )
+
+
+@pytest.mark.parametrize("mode", ["foreign", "oversize", "permanent", "cancel"])
+def test_unsafe_or_cancelled_fetch_does_not_retry(monkeypatch, mode):
+    import dns.resolver
+
+    seen = []
+    budget = WorkBudget(5)
+    monkeypatch.setattr(dns.resolver.Resolver, "resolve", lambda *a, **kw: ["93.184.216.34"])
+    original = httpx.Client
+
+    def handle(request):
+        seen.append(request)
+        if mode == "foreign":
+            return httpx.Response(302, headers={"location": "https://foreign.example.com/page"})
+        if mode == "cancel":
+            budget.cancelled.set()
+            raise httpx.ConnectError("cancelled")
+        return httpx.Response(404 if mode == "permanent" else 200, content=b"x" * 11)
+
+    monkeypatch.setattr(httpx, "Client", lambda **kw: original(transport=httpx.MockTransport(handle), **kw))
+    source = PageSource("https://docs.example.com/llms.txt", None, budget)
+    with pytest.raises((SyncFailed, TimeoutError, CancelledError)):
+        source.fetch(source.url, 10)
+    assert len(seen) == 1
+
+
+def test_duplicate_navigation_keeps_first_title(monkeypatch):
+    index = "- [First](https://docs.example.com/a)\n- [Second](https://docs.example.com/a.md)\n- [Other](https://docs.example.com/b.md)"
+    monkeypatch.setattr(PageSource, "fetch", lambda *a: index)
+    source = PageSource("https://docs.example.com/llms.txt", None, WorkBudget(5))
+    pages = source.discover()
+    assert source.complete and set(pages) == {"/a.md", "/b.md"}
+    assert pages["/a.md"].title == "First"

--- a/libs/agno/tests/unit/knowledge/test_page_timeouts.py
+++ b/libs/agno/tests/unit/knowledge/test_page_timeouts.py
@@ -66,3 +66,21 @@ async def test_public_page_search_normalizes_async_timeout(monkeypatch):
     monkeypatch.setattr(Knowledge, "_pages", lambda self: self)
     with pytest.raises(SearchUnavailable):
         await Knowledge().asearch_pages("question")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method,args", [("aread_page", ("/page",)), ("agrep_pages", ("text",)), ("alist_pages", ())])
+async def test_all_async_page_boundaries_normalize_capacity(monkeypatch, method, args):
+    import agno.knowledge.page._coordinator as pages
+    from agno.knowledge.page import PageError
+
+    async def expired(*args, **kwargs):
+        raise asyncio.TimeoutError("worker_capacity")
+
+    class Operations:
+        read = grep = list = lambda *args: None
+
+    monkeypatch.setattr(pages.READ_WORKERS, "run", expired)
+    monkeypatch.setattr(Knowledge, "_pages", lambda self: Operations())
+    with pytest.raises(PageError, match="page_unavailable"):
+        await getattr(Knowledge(), method)(*args)

--- a/libs/agno/tests/unit/os/test_public_json_bounds.py
+++ b/libs/agno/tests/unit/os/test_public_json_bounds.py
@@ -58,17 +58,29 @@ class LocalAdmission:
         return Admission(True)
 
 
-def application(*, bounded=True, model=None):
+def application(*, bounded=True, model=None, team_mode=False, gzip_inner=False, expose_agent=False):
     agent = Agent(id="docs-agent", model=model or ShortAnswerModel(), db=InMemoryDb(), telemetry=False)
+    from fastapi import FastAPI
+    from starlette.middleware.gzip import GZipMiddleware
+
+    from agno.team import Team
+
+    team = Team(id="support", members=[agent], model=model or ShortAnswerModel(), db=InMemoryDb(), telemetry=False)
     surface = PublicSurface(
-        agents=[agent],
+        agents=[agent] if not team_mode or expose_agent else [],
+        teams=[team] if team_mode else [],
         max_active_runs=1,
         uploads=FileUploadLimits(max_files=12, allowed_types=((".txt", "text/plain"),)),
     )
     surface._limiter = LocalAdmission()  # type: ignore[assignment]
+    base_app = FastAPI()
+    if gzip_inner:
+        base_app.add_middleware(GZipMiddleware, minimum_size=500)
     server = AgentOS(
         id="json-output-bounds",
+        base_app=base_app,
         agents=[agent],
+        teams=[team] if team_mode else [],
         db=PostgresDb(db_url="postgresql+psycopg://test:test@127.0.0.1:9/unused"),
         public=surface if bounded else None,
         auto_provision_dbs=False,
@@ -90,7 +102,10 @@ def post_attachment(client):
 def assert_complete_output_error(response):
     assert response.status_code == 503
     assert response.headers["content-type"] == "application/json"
-    assert int(response.headers["content-length"]) == len(response.content)
+    if "content-length" in response.headers and "content-encoding" not in response.headers:
+        assert int(response.headers["content-length"]) == len(response.content)
+    else:
+        assert response.headers.get("transfer-encoding") == "chunked" or "content-encoding" in response.headers
     assert response.headers["access-control-allow-origin"] == ORIGIN
     error = response.json()["error"]
     assert error["code"] == "output_limit" and error["message"] == "output limit"
@@ -182,3 +197,119 @@ def test_native_nonpublic_failed_run_retains_diagnostics():
         response = client.post(ROUTE, data={"message": "Hello", "stream": "false"})
     assert response.status_code == 200 and response.json()["status"] == "ERROR"
     assert "private-diagnostic-marker" in response.text
+
+
+@pytest.mark.parametrize("team_mode", [False, True])
+@pytest.mark.parametrize("gzip_position", ["inner", "outer"])
+@pytest.mark.parametrize("encoding", ["identity", "gzip"])
+def test_compressed_native_runs_over_http(team_mode, gzip_position, encoding):
+    from starlette.middleware.gzip import GZipMiddleware
+
+    app, surface = application(team_mode=team_mode, gzip_inner=gzip_position == "inner")
+    if gzip_position == "outer":
+        app = GZipMiddleware(app, minimum_size=500)
+    route = "/teams/support/runs" if team_mode else ROUTE
+    with (
+        live_server(app) as url,
+        httpx.Client(base_url=url, timeout=10, trust_env=False, headers={"Accept-Encoding": encoding}) as client,
+    ):
+        response = client.post(route, data={"message": "Hello", "stream": "false"})
+        assert response.status_code == 200, response.text
+        assert response.json()["content"] == "Short answer."
+        surface.max_output_bytes = 100
+        response = client.post(route, data={"message": "Hello", "stream": "false"}, headers={"Origin": ORIGIN})
+        assert_complete_output_error(response)
+        surface.max_output_bytes = 1024 * 1024
+        assert client.post(route, data={"message": "Again", "stream": "false"}).status_code == 200
+
+
+@pytest.mark.parametrize("stream", ["true", "false"])
+@pytest.mark.parametrize("team_mode", [False, True])
+def test_compressed_failure_is_sanitized(team_mode, stream):
+    app, _ = application(team_mode=team_mode, model=FailingModel(), gzip_inner=True)
+    route = "/teams/support/runs" if team_mode else ROUTE
+    with TestClient(app) as client:
+        response = client.post(route, data={"message": "Hello", "stream": stream}, headers={"Accept-Encoding": "gzip"})
+    assert "private-diagnostic-marker" not in response.text
+    if stream == "false":
+        assert response.status_code == 503 and response.json()["error"]["code"] == "run_failed"
+    else:
+        assert response.status_code == 200
+        assert "event: " + ("TeamRunError" if team_mode else "RunError") in response.text
+
+
+def test_selected_team_has_reduced_roster_and_private_members():
+    app, _ = application(team_mode=True)
+    with TestClient(app) as client:
+        assert client.get("/agents").json() == []
+        roster = client.get("/teams").json()
+        assert len(roster) == 1 and set(roster[0]) == {"id", "name", "description"}
+        for route in (
+            "/agents/docs-agent/runs",
+            "/teams/docs-agent/runs",
+            "/agents/support/runs",
+            "/teams/hidden/runs",
+        ):
+            assert client.post(route, data={"message": "hi"}).status_code == 404
+        assert client.get("/teams/support").status_code == 404
+        assert client.post("/teams/support/runs/not-a-uuid/cancel").status_code == 400
+        assert client.post("/teams/support/runs", data={"message": "hi", "user_id": "spoof"}).status_code == 400
+
+
+def test_recovered_public_team_preserves_native_member_results():
+    import json
+
+    class Delegate(ShortAnswerModel):
+        def invoke(self, *args, **kwargs):
+            messages = kwargs.get("messages", args[0] if args else [])
+            if not any(message.role == "tool" for message in messages):
+                return ModelResponse(
+                    role="assistant",
+                    tool_calls=[
+                        {
+                            "id": "delegate",
+                            "type": "function",
+                            "function": {
+                                "name": "delegate_task_to_member",
+                                "arguments": json.dumps({"member_id": "docs-agent", "task": "please answer"}),
+                            },
+                        }
+                    ],
+                    response_usage=MessageMetrics(),
+                )
+            return super().invoke(*args, **kwargs)
+
+    app, surface = application(team_mode=True, model=Delegate())
+    surface.teams[0].members[0].model = FailingModel()
+    with TestClient(app) as client:
+        response = client.post("/teams/support/runs", data={"message": "Hello", "stream": "false"})
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "COMPLETED" and payload["content"] == "Short answer."
+    assert any("private-diagnostic-marker" in str(message) for message in payload["messages"])
+    assert any("private-diagnostic-marker" in str(tool) for tool in payload["tools"])
+
+
+def test_selected_team_and_agent_share_active_run_capacity():
+    import asyncio
+    from concurrent.futures import ThreadPoolExecutor
+
+    entered, release = threading.Event(), threading.Event()
+
+    class BlockingModel(ShortAnswerModel):
+        async def ainvoke(self, *args, **kwargs):
+            entered.set()
+            assert await asyncio.to_thread(release.wait, 5)
+            return self.invoke(*args, **kwargs)
+
+    app, _ = application(team_mode=True, expose_agent=True, model=BlockingModel())
+    with TestClient(app) as client, ThreadPoolExecutor(max_workers=1) as pool:
+        pending = pool.submit(client.post, "/teams/support/runs", data={"message": "Hello", "stream": "false"})
+        try:
+            assert entered.wait(5)
+            response = client.post(ROUTE, data={"message": "Hello", "stream": "false"})
+            assert response.status_code == 503 and response.json()["error"]["code"] == "run_capacity"
+        finally:
+            release.set()
+        assert pending.result(timeout=5).status_code == 200
+        assert client.post(ROUTE, data={"message": "Again", "stream": "false"}).status_code == 200

--- a/libs/agno/tests/unit/os/test_public_json_bounds.py
+++ b/libs/agno/tests/unit/os/test_public_json_bounds.py
@@ -313,3 +313,42 @@ def test_selected_team_and_agent_share_active_run_capacity():
             release.set()
         assert pending.result(timeout=5).status_code == 200
         assert client.post(ROUTE, data={"message": "Again", "stream": "false"}).status_code == 200
+
+
+@pytest.mark.parametrize("team_mode", [False, True])
+@pytest.mark.parametrize("gzip_position", ["inner", "outer"])
+@pytest.mark.parametrize("compress_sse", [False, True])
+def test_encoded_sse_cannot_bypass_public_error_inspection(team_mode, gzip_position, compress_sse):
+    from starlette.middleware.gzip import GZipMiddleware
+
+    app, surface = application(team_mode=team_mode, model=FailingModel(), gzip_inner=gzip_position == "inner")
+    options = {"exclude_content_types": ()} if compress_sse else {}
+    if gzip_position == "inner" and compress_sse:
+        for middleware in app.user_middleware:
+            if middleware.cls is GZipMiddleware:
+                middleware.kwargs.update(options)
+    if gzip_position == "outer":
+        app = GZipMiddleware(app, minimum_size=500, **options)
+    route = "/teams/support/runs" if team_mode else ROUTE
+    with live_server(app) as url, httpx.Client(base_url=url, timeout=10, trust_env=False) as client:
+        response = client.post(
+            route, data={"message": "hi", "stream": "true"}, headers={"Accept-Encoding": "gzip", "Origin": ORIGIN}
+        )
+        assert "private-diagnostic-marker" not in response.text
+        assert response.headers["access-control-allow-origin"] == ORIGIN
+        if compress_sse and gzip_position == "inner":
+            assert response.status_code == 503
+            assert response.headers["content-type"] == "application/json"
+            assert "content-encoding" not in response.headers
+            assert int(response.headers["content-length"]) == len(response.content)
+            assert response.json()["error"]["code"] == "unsupported_response_encoding"
+        else:
+            assert response.status_code == 200
+            assert "event: " + ("TeamRunError" if team_mode else "RunError") in response.text
+            assert '"error_code": "run_failed"' in response.text
+        component = surface.teams[0] if team_mode else surface.agents[0]
+        component.model = ShortAnswerModel()
+        following = client.post(
+            route, data={"message": "again", "stream": "false"}, headers={"Accept-Encoding": "identity"}
+        )
+        assert following.status_code == 200 and following.json()["content"] == "Short answer."

--- a/libs/agno/tests/unit/workflow/test_failure_reporting.py
+++ b/libs/agno/tests/unit/workflow/test_failure_reporting.py
@@ -1,0 +1,108 @@
+"""Explicit failure policy survives fresh database/session reads in every run mode."""
+
+import pytest
+
+from agno.db.sqlite import SqliteDb
+from agno.run.base import RunStatus
+from agno.workflow import Step, StepOutput, Workflow
+from agno.workflow.types import HumanReview, OnError
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("async_mode", [False, True])
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.parametrize("raises", [False, True])
+@pytest.mark.parametrize("policy", [OnError.fail, OnError.skip])
+async def test_explicit_failure_persistence(tmp_path, async_mode, stream, raises, policy):
+    calls = []
+    report = {"status": "partial", "updated": 1, "failed": 2}
+
+    def execute(step_input):
+        calls.append(1)
+        if raises:
+            raise RuntimeError("operator diagnostic")
+        return StepOutput(content=report, success=False, error="operator diagnostic")
+
+    path = str(tmp_path / "workflow.db")
+    workflow = Workflow(
+        id="sync",
+        db=SqliteDb(db_file=path),
+        telemetry=False,
+        steps=[Step(name="sync", executor=execute, max_retries=0, human_review=HumanReview(on_error=policy))],
+    )
+    events = []
+    try:
+        if async_mode:
+            result = workflow.arun("sync", session_id="session", stream=stream, stream_events=stream)
+            if stream:
+                events = [event async for event in result]
+            else:
+                await result
+        else:
+            result = workflow.run("sync", session_id="session", stream=stream, stream_events=stream)
+            if stream:
+                events = list(result)
+    except RuntimeError:
+        assert policy == OnError.fail
+    fresh = Workflow(id="sync", db=SqliteDb(db_file=path), telemetry=False)
+    session = fresh.get_session(session_id="session")
+    assert session is not None and len(session.runs) == 1
+    run = session.runs[0]
+    assert run.status == (RunStatus.error if policy == OnError.fail else RunStatus.completed)
+    assert calls == [1]
+    assert run.step_results and not run.step_results[0].success
+    assert "operator diagnostic" in str(run.step_results[0].error)
+    if not raises:
+        assert run.step_results[0].content == report
+    if stream and policy == OnError.skip:
+        assert any(event.event == "WorkflowCompleted" for event in events)
+
+
+@pytest.mark.parametrize("background", [False, True])
+@pytest.mark.parametrize("raises", [False, True])
+def test_native_http_failure_persists_report(tmp_path, background, raises):
+    import time
+
+    from fastapi.testclient import TestClient
+
+    from agno.os import AgentOS
+
+    path = str(tmp_path / "http.db")
+    calls = []
+
+    def execute(step_input):
+        calls.append(1)
+        if raises:
+            raise RuntimeError("operator diagnostic")
+        return StepOutput(content={"status": "partial", "failed": 1}, success=False, error="operator diagnostic")
+
+    workflow = Workflow(
+        id="sync",
+        db=SqliteDb(db_file=path),
+        telemetry=False,
+        steps=[Step(name="sync", executor=execute, max_retries=0, human_review=HumanReview(on_error=OnError.fail))],
+    )
+    with TestClient(AgentOS(workflows=[workflow], telemetry=False).get_app(), raise_server_exceptions=False) as client:
+        response = client.post(
+            "/workflows/sync/runs",
+            data={
+                "message": "sync",
+                "session_id": "http-session",
+                "stream": "false",
+                "background": str(background).lower(),
+            },
+        )
+        assert response.status_code == (202 if background else 500), response.text
+        deadline = time.monotonic() + 3
+        while True:
+            fresh = Workflow(id="sync", db=SqliteDb(db_file=path), telemetry=False)
+            session = fresh.get_session(session_id="http-session")
+            if session and session.runs and session.runs[0].status == RunStatus.error:
+                break
+            assert time.monotonic() < deadline
+            time.sleep(0.02)
+        assert len(session.runs) == 1 and calls == [1]
+        result = session.runs[0].step_results[0]
+        assert not result.success and "operator diagnostic" in result.error
+        if not raises:
+            assert result.content == {"status": "partial", "failed": 1}

--- a/libs/agno/tests/unit/workflow/test_failure_reporting.py
+++ b/libs/agno/tests/unit/workflow/test_failure_reporting.py
@@ -106,3 +106,170 @@ def test_native_http_failure_persists_report(tmp_path, background, raises):
         assert not result.success and "operator diagnostic" in result.error
         if not raises:
             assert result.content == {"status": "partial", "failed": 1}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("async_mode", [False, True])
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.parametrize("raises", [False, True])
+@pytest.mark.parametrize("policy", [OnError.fail, OnError.skip])
+@pytest.mark.parametrize("by_id", [False, True])
+async def test_continued_failure_matches_initial_run_policy(tmp_path, async_mode, stream, raises, policy, by_id):
+    calls = []
+    report = {"failed": 1, "updated": 2}
+
+    def gate(step_input):
+        return StepOutput(content="approved")
+
+    def execute(step_input):
+        calls.append("execute")
+        if raises:
+            raise RuntimeError("operator diagnostic")
+        return StepOutput(content=report, success=False, error="operator diagnostic")
+
+    def after(step_input):
+        calls.append("after")
+        return StepOutput(content="after")
+
+    path = str(tmp_path / "continued.db")
+
+    def make_workflow():
+        return Workflow(
+            id="sync",
+            db=SqliteDb(db_file=path),
+            telemetry=False,
+            store_events=True,
+            steps=[
+                Step(name="gate", executor=gate, human_review=HumanReview(requires_confirmation=True)),
+                Step(name="execute", executor=execute, max_retries=0, human_review=HumanReview(on_error=policy)),
+                Step(name="after", executor=after),
+            ],
+        )
+
+    workflow = make_workflow()
+    paused = (
+        await workflow.arun("sync", session_id="session") if async_mode else workflow.run("sync", session_id="session")
+    )
+    assert paused.status == RunStatus.paused
+    paused.step_requirements[0].confirm()
+    if by_id:
+        workflow = make_workflow()
+        args = {"run_id": paused.run_id, "session_id": "session", "step_requirements": paused.step_requirements}
+    else:
+        args = {"run_response": paused}
+    events = []
+    try:
+        if async_mode:
+            result = await workflow.acontinue_run(**args, stream=stream, stream_events=stream)
+            if stream:
+                async for event in result:
+                    events.append(event)
+        else:
+            result = workflow.continue_run(**args, stream=stream, stream_events=stream)
+            if stream:
+                for event in result:
+                    events.append(event)
+    except RuntimeError:
+        assert policy == OnError.fail
+    session = make_workflow().get_session(session_id="session")
+    assert len(session.runs) == 1
+    saved = session.runs[0]
+    assert saved.status == (RunStatus.error if policy == OnError.fail else RunStatus.completed)
+    assert calls == (["execute"] if policy == OnError.fail else ["execute", "after"])
+    assert len(saved.step_results) == (2 if policy == OnError.fail else 3)
+    failed = saved.step_results[1]
+    assert not failed.success and "operator diagnostic" in failed.error
+    if not raises:
+        assert failed.content == report
+    if stream:
+        terminal = "WorkflowError" if policy == OnError.fail else "WorkflowCompleted"
+        assert sum(event.event == terminal for event in events) == 1
+        assert sum(event.event == terminal for event in saved.events) == 1
+        if policy == OnError.fail:
+            assert not any(event.event == "WorkflowCompleted" for event in events)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("async_mode", [False, True])
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.parametrize("skip", [False, True])
+@pytest.mark.parametrize("continued", [False, True])
+async def test_condition_preserves_child_skip_without_duplicate_diagnostics(
+    tmp_path, async_mode, stream, skip, continued
+):
+    from agno.workflow.condition import Condition
+
+    calls = []
+
+    def fail(step_input):
+        calls.append("fail")
+        raise RuntimeError("optional operation failed")
+
+    def after(step_input):
+        calls.append("after")
+        return StepOutput(content="after")
+
+    def gate(step_input):
+        return StepOutput(content="approved")
+
+    path = str(tmp_path / "condition.db")
+    steps = (
+        [Step(name="gate", executor=gate, human_review=HumanReview(requires_confirmation=True))] if continued else []
+    )
+    steps.extend(
+        [
+            Condition(
+                name="optional",
+                evaluator=True,
+                steps=[
+                    Step(name="optional-fetch", executor=fail, skip_on_failure=skip, max_retries=0),
+                ],
+                human_review=HumanReview(on_error=OnError.fail),
+            ),
+            Step(name="after", executor=after),
+        ]
+    )
+    workflow = Workflow(id="condition", db=SqliteDb(db_file=path), telemetry=False, steps=steps)
+    events = []
+    try:
+        if continued:
+            paused = (
+                await workflow.arun("go", session_id="session")
+                if async_mode
+                else workflow.run("go", session_id="session")
+            )
+            paused.step_requirements[0].confirm()
+            result = (
+                await workflow.acontinue_run(paused, stream=stream, stream_events=stream)
+                if async_mode
+                else workflow.continue_run(paused, stream=stream, stream_events=stream)
+            )
+        elif async_mode:
+            result = workflow.arun("go", session_id="session", stream=stream, stream_events=stream)
+            if not stream:
+                result = await result
+        else:
+            result = workflow.run("go", session_id="session", stream=stream, stream_events=stream)
+        if stream:
+            if async_mode:
+                async for event in result:
+                    events.append(event)
+            else:
+                for event in result:
+                    events.append(event)
+    except RuntimeError:
+        assert not skip
+    session = Workflow(id="condition", db=SqliteDb(db_file=path), telemetry=False).get_session(session_id="session")
+    assert len(session.runs) == 1
+    saved = session.runs[0]
+    assert saved.status == (RunStatus.completed if skip else RunStatus.error)
+    assert calls == (["fail", "after"] if skip else ["fail"])
+    condition_outputs = [output for output in saved.step_results if output.step_name == "optional"]
+    assert len(condition_outputs) == 1
+    output = condition_outputs[0]
+    assert not output.success
+    diagnostic = output.steps[0] if skip else output
+    assert "optional operation failed" in diagnostic.error
+    if stream:
+        terminal = "WorkflowCompleted" if skip else "WorkflowError"
+        assert sum(event.event == terminal for event in events) == 1


### PR DESCRIPTION
Current heads after requested PublicSurface field ordering: #9996 `2c13962f88808c6b663fae1767a121e97dffedab`; #9997 `2bc3e8dcb3e3cf0147a3462952581af57d80f751`; Docs Agent #14 `a3761c190304874e274c4da0456df98bd90fc52e` (pins #9997). Fields are ordered agents, teams, workflows. Required format/validate scripts pass in both framework worktrees and product; 2 existing public configuration tests and all 210 product tests pass. VFS range-diff confirms all five commits replay unchanged. Earlier detailed validation below retains its original head provenance.

## Summary

Corrects Docs Agent integration paths and adds explicitly selected Teams to PublicSurface after #9963. Commits cover shared `FileSystem(db=db)` / `PgVector(db=db)` wiring; operation-local embedding reuse; reliable source retries, canonical-link deduplication and publication-time source binding; namespace/HNSW setup; bounded page checkout/fallback and errors; Agent continuation dependency ordering; explicit workflow failure persistence; and public Team REST/gzip support.

Selected Teams share Agent admission, execution and output limits. Their roster is reduced and member routes remain private unless independently selected. Successful Team runs retain native member tool results, including failure details when the leader recovers. Failed top-level runs retain sanitized errors. No new MCP capabilities or Team dependency injection.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] Searched existing open pull requests; related work is distinguished below
- [x] If a similar PR exists, its relationship is explained below
- [x] Check if this PR was entirely AI-generated

---

## Additional Notes

Base: `f79235cf379de3893a44cf1b337ec4d180b76515`. Reviewed head: `f8e1c7be0d701478d4c57b6be7f7fb9a4177bb08`.

Initial validation at `41fab879d805be607a74fb17fe3ec717549b3456` in isolated development environments (historical results retain their original provenance):
- Required format/validate scripts pass, including Agno mypy (1,043 files), agnoctl mypy and cookbook patterns.
- Affected filesystem/vector/page/Agent/workflow/public unit suites: 1,092 passed, 7 skipped.
- Final PostgreSQL page/public and native HTTP/gzip/Team protection suites: 113 passed. Disposable databases; deterministic models/embeddings. Includes source recovery, concurrent namespace initialization/publication, actual pool recycle, 7/8 and 8/8 contention, sync/async upsert stored vectors, response completion and subsequent capacity reuse.
- Paired Docs Agent: required format/validate pass, 256 tests pass including native chat/MCP/shared feedback and durable authenticated sync on disposable PostgreSQL. Docs Agent #14 now consolidates the migration, explicit workflow fail policy and VFS adoption for the planned 3.0.7 release.
- Built the actual candidate wheel and installed its `[pages]` extra in a fresh environment. Verified dependency imports and custom-embedder page wiring without OpenAI installed; editable installs also tested.
- Demo Team `--check` and public-pages `--help` pass; TEST_LOG specifies that these are configuration/CLI checks, not live model runs.
- Independent read-only final-head review: no high-confidence findings under the clarified native Team output contract.

A deterministic identical 32-page corpus comparison (search with one alternative + direct page read) measured ordinary means around 7–9 ms with matching outputs and unchanged round trips. With 7/8 connections held, baseline 1,814 ms / 7 round trips became 42 ms / 11 round trips: identical hits/text, with partial becoming false because serial fallback executes. This is local deterministic evidence, not live-provider latency or quality improvement.

Existing page indexes from interim Git/main builds can have implicit ef_construction=64 and require an operator-managed rebuild when configuration asks for 200. Published v3.0.6 predates page storage; this is not an upgrade requirement for released-3.0.6 page installations. Setup does not rebuild indexes automatically. A PostgreSQL regression verifies the actionable error and continued readability.

Related #9805 also moves continuation dependency timing while fixing forked RunContext identity across Agents/Teams. This bundle covers the narrower Agent input/session lifecycle and invalid-run side effects; it does not absorb that broader identity change. #9912 concerns managed Agent filesystems/browser routes, which this PR does not add.

VFS extraction follows as a separate explicitly stacked PR. No pool warming/replenishment, allowance cache, Redis, Knowledge(db=...), automatic prompt orchestration, default retry/skip/planner changes, version bump, merge or release.


Product consolidation: [Docs Agent #14](https://github.com/agno-agi/docs-agent/pull/14) is the single product PR at `ee2a23284e1eb67b17ed2e1316b69ff0d828dee7`. Companion #15 is contained in its branch; GitHub automatically closed it as merged. Neither product main nor release artifacts were changed.

## Final review corrections and current validation

Continuation now honors explicit Step fail/skip policy in all four execution modes, preserves structured failure reports, and records the streamed terminal event before persistence and yielding. Conditions retain tolerated child failures without duplicate diagnostics. Explicitly compressed inner SSE is rejected with a complete sanitized 503 before headers; default SSE and outer compression remain supported. Generic PgVector retains valid chunks and PARTIAL ingestion without reembedding; actual embedding exceptions still precede replacement deletion. Atomic page publication is unchanged.

At `f8e1c7be0d701478d4c57b6be7f7fb9a4177bb08`: required format/validate PASS (Agno mypy 1,043 files); combined PostgreSQL/page/native-response/workflow regressions **748 passed, 7 skipped**; separate route checks **20 passed**, and all database-gated public native HTTP cases **6 passed**. Independent review found no high-confidence issues; all eight external workflow reproductions pass, including fresh-read terminal-event persistence. Suites overlap and should not be summed.

VFS #9997 is restacked at `6be772a712d754b59970e875546eb9bf5e90dd33`; its combined affected suite passes 329 tests. Consolidated Docs Agent #14 at `ee2a23284e1eb67b17ed2e1316b69ff0d828dee7` pins that exact head and passes required scripts plus all 210 product tests with PostgreSQL composition. Hosted CI and formal review remain separate from local validation.
