### PR TITLE
feat: extract bounded read-only page filesystem

### DIFF
--- a/cookbook/05_agent_os/27_public_pages/README.md
+++ b/cookbook/05_agent_os/27_public_pages/README.md
@@ -139,3 +139,28 @@ Add `--check` to validate the configuration without starting the server.
 Successful public Team runs retain native member tool results, including member
 failure details when the leader recovers. Failed top-level runs use the same
 sanitized errors and output bounds as public Agents.
+
+### Read-only page commands
+
+`PageFileSystem(knowledge=knowledge)` provides explicit `run_command` and
+`arun_command` methods for `ls`, `tree`, `find`, `cat`, `head`, `tail`, `wc`,
+`rg` and `grep`. Install `agno[pages]`; regex is optional outside this adapter.
+After publishing the demo corpus:
+
+```sh
+.venvs/demo/bin/python cookbook/05_agent_os/27_public_pages/page_filesystem.py 'cat /introduction'
+```
+
+Commands cannot execute processes, expand shell expressions or write files.
+Direct reads use the requested page; directory listings fetch scoped metadata;
+literal grep uses bounded Knowledge scans. Cache bodies belong to one adapter
+instance and remain subject to publication checks. Command workers retain their
+capacity through cancellation until work exits. Output defaults to 30,000
+characters plus a continuation notice. Constructor limits also bound regex time,
+command lifetime, cache bytes/entries, command read volume and catalog entries.
+An unavailable publication raises `PageError`; the application owns its wording.
+
+The adapter does not register tools or change retrieval, prompts or citations.
+Keep an instance alongside the configured Knowledge and wrap it with the desired
+tool name and description. `get_corpus`/`aget_corpus` expose metadata snapshots
+for offline evaluation; subsequent mapping reads are synchronous.

--- a/cookbook/05_agent_os/27_public_pages/README.md
+++ b/cookbook/05_agent_os/27_public_pages/README.md
@@ -160,7 +160,26 @@ characters plus a continuation notice. Constructor limits also bound regex time,
 command lifetime, cache bytes/entries, command read volume and catalog entries.
 An unavailable publication raises `PageError`; the application owns its wording.
 
-The adapter does not register tools or change retrieval, prompts or citations.
-Keep an instance alongside the configured Knowledge and wrap it with the desired
-tool name and description. `get_corpus`/`aget_corpus` expose metadata snapshots
-for offline evaluation; subsequent mapping reads are synchronous.
+Expose a command tool explicitly with `tools()`. Agno selects its sync or async
+implementation for the run, and page errors become readable tool results:
+
+```python
+knowledge.setup()  # Once during application startup.
+page_files = PageFileSystem(knowledge=knowledge)
+agent = Agent(tools=[page_files.tools()])
+```
+
+Customize the model-visible name and description without a wrapper:
+
+```python
+agent = Agent(tools=[page_files.tools(
+    tool_name="query_docs_filesystem",
+    description="Read or search the published docs using ls, cat or rg.",
+)])
+```
+
+Direct `run_command`/`arun_command` calls still raise `PageError`. Applications
+can retain custom wrappers for their own error wording or tracing. Creating the
+toolkit does not initialize storage, retrieve context or add prompt instructions.
+`get_corpus`/`aget_corpus` expose command-local metadata snapshots for offline
+evaluation; subsequent mapping reads are synchronous.

--- a/cookbook/05_agent_os/27_public_pages/TEST_LOG.md
+++ b/cookbook/05_agent_os/27_public_pages/TEST_LOG.md
@@ -85,3 +85,16 @@ and calls setup; no preinitialized instance is injected into the example.
 **Result:** PASS for all three standalone commands. The previous script fails
 in the same environment with the missing `Knowledge.setup()` error. No live
 provider, production database, deployment or release was used.
+
+### page_filesystem.py explicit tools
+
+**Status:** PASS
+
+**Description:** Reran standalone cat, rg and ls in fresh demo-environment
+processes after replacing the handwritten wrapper with `page_files.tools()` and
+adding optional `--ask` Agent execution. The default CLI constructs the Agent
+and toolkit but reads directly, without a provider call.
+
+**Result:** All three commands returned the expected published content. Separate
+deterministic Agent-loop tests cover sync/async tool selection, schemas, custom
+descriptions and page-error results. The live-provider `--ask` mode was not run.

--- a/cookbook/05_agent_os/27_public_pages/TEST_LOG.md
+++ b/cookbook/05_agent_os/27_public_pages/TEST_LOG.md
@@ -71,3 +71,15 @@
 **Result:** Constructor wiring and CLI import passed. Live sync/chat/MCP-client modes were not run. Disposable PostgreSQL publication and paired product composition tests cover deterministic operation separately.
 
 ---
+
+### page_filesystem.py
+
+**Status:** PASS
+
+**Description:** Ran `--help` and the asynchronous `cat /agent` cookbook entrypoint
+in the isolated `.venvs/demo` environment. A deterministic embedder and source
+published a real disposable PostgreSQL corpus, then the harness supplied that
+Knowledge instance to the example.
+
+**Result:** Returned the published Markdown and header through `arun_command`.
+No live provider, production database, deployment or release was used.

--- a/cookbook/05_agent_os/27_public_pages/TEST_LOG.md
+++ b/cookbook/05_agent_os/27_public_pages/TEST_LOG.md
@@ -76,10 +76,12 @@
 
 **Status:** PASS
 
-**Description:** Ran `--help` and the asynchronous `cat /agent` cookbook entrypoint
-in the isolated `.venvs/demo` environment. A deterministic embedder and source
-published a real disposable PostgreSQL corpus, then the harness supplied that
-Knowledge instance to the example.
+**Description:** Published a deterministic corpus in a disposable PostgreSQL database,
+then ran the documented script in three fresh `.venvs/demo/bin/python` processes
+with `PAGE_DEMO_DB_URL` selecting that database. Invocations were `cat /agent`,
+`rg Standalone /agent`, and `ls /`. Each process imports its own Knowledge instance
+and calls setup; no preinitialized instance is injected into the example.
 
-**Result:** Returned the published Markdown and header through `arun_command`.
-No live provider, production database, deployment or release was used.
+**Result:** PASS for all three standalone commands. The previous script fails
+in the same environment with the missing `Knowledge.setup()` error. No live
+provider, production database, deployment or release was used.

--- a/cookbook/05_agent_os/27_public_pages/page_filesystem.py
+++ b/cookbook/05_agent_os/27_public_pages/page_filesystem.py
@@ -1,0 +1,36 @@
+"""Explicit read-only commands over a published Knowledge namespace.
+
+Uses the same demo database as public_pages.py. Run sync there first.
+"""
+
+import argparse
+import asyncio
+
+from agno.knowledge.page import PageError, PageFileSystem, tool_error
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Read published pages with bounded commands"
+    )
+    parser.add_argument("command", nargs="?", default="ls /")
+    args = parser.parse_args()
+
+    from public_pages import knowledge
+
+    page_files = PageFileSystem(knowledge=knowledge, max_output_chars=30_000)
+
+    # Applications retain their tool name, description, error wording and prompts.
+    async def query_pages(command: str) -> str:
+        """Read or search published Markdown using cat, ls, tree, find or rg."""
+        try:
+            return await page_files.arun_command(command)
+        except PageError as exc:
+            return tool_error(exc)
+
+    print(asyncio.run(query_pages(args.command)))
+    # Synchronous callers can use page_files.run_command(args.command).
+
+
+if __name__ == "__main__":
+    main()

--- a/cookbook/05_agent_os/27_public_pages/page_filesystem.py
+++ b/cookbook/05_agent_os/27_public_pages/page_filesystem.py
@@ -18,6 +18,7 @@ def main() -> None:
 
     from public_pages import knowledge
 
+    knowledge.setup()
     page_files = PageFileSystem(knowledge=knowledge, max_output_chars=30_000)
 
     # Applications retain their tool name, description, error wording and prompts.

--- a/cookbook/05_agent_os/27_public_pages/page_filesystem.py
+++ b/cookbook/05_agent_os/27_public_pages/page_filesystem.py
@@ -6,7 +6,9 @@ Uses the same demo database as public_pages.py. Run sync there first.
 import argparse
 import asyncio
 
-from agno.knowledge.page import PageError, PageFileSystem, tool_error
+from agno.agent import Agent
+from agno.knowledge.page import PageFileSystem
+from agno.models.openai import OpenAIResponses
 
 
 def main() -> None:
@@ -14,6 +16,11 @@ def main() -> None:
         description="Read published pages with bounded commands"
     )
     parser.add_argument("command", nargs="?", default="ls /")
+    parser.add_argument(
+        "--ask",
+        action="store_true",
+        help="Let the agent explore pages to answer the command text",
+    )
     args = parser.parse_args()
 
     from public_pages import knowledge
@@ -21,15 +28,15 @@ def main() -> None:
     knowledge.setup()
     page_files = PageFileSystem(knowledge=knowledge, max_output_chars=30_000)
 
-    # Applications retain their tool name, description, error wording and prompts.
-    async def query_pages(command: str) -> str:
-        """Read or search published Markdown using cat, ls, tree, find or rg."""
-        try:
-            return await page_files.arun_command(command)
-        except PageError as exc:
-            return tool_error(exc)
-
-    print(asyncio.run(query_pages(args.command)))
+    # Tool exposure is explicit; setup and retrieval policy stay in the application.
+    agent = Agent(
+        model=OpenAIResponses(id="gpt-5.6-luna"),
+        tools=[page_files.tools()],
+    )
+    if args.ask:
+        agent.print_response(args.command)
+    else:
+        print(asyncio.run(page_files.arun_command(args.command)))
     # Synchronous callers can use page_files.run_command(args.command).
 
 

--- a/libs/agno/agno/knowledge/page/__init__.py
+++ b/libs/agno/agno/knowledge/page/__init__.py
@@ -1,5 +1,6 @@
 """Public page types; storage and discovery are loaded only when needed."""
 
+from agno.knowledge.page.filesystem import PageFileSystem
 from agno.knowledge.page.types import (
     GrepMatch,
     GrepResult,
@@ -24,6 +25,7 @@ __all__ = [
     "GrepMatch",
     "GrepResult",
     "Page",
+    "PageFileSystem",
     "PageChanged",
     "PageError",
     "PageList",

--- a/libs/agno/agno/knowledge/page/_commands.py
+++ b/libs/agno/agno/knowledge/page/_commands.py
@@ -1,0 +1,584 @@
+"""Bounded read-only command grammar over published page mappings; never executes a shell."""
+
+from __future__ import annotations
+
+import fnmatch
+import shlex
+import time
+from collections.abc import Callable, Mapping
+
+import regex
+
+MAX_OUTPUT = 30_000
+MAX_PATTERN_CHARS = 256
+REGEX_MATCH_TIMEOUT = 0.05  # seconds, per line
+REGEX_COMMAND_BUDGET = 2.0  # seconds, per command
+
+USAGE = """\
+Supported commands (read-only, no pipes, stateless):
+  ls [dir|file ...]                     list a directory (or show that a file exists)
+  tree [dir] [-L depth]                 directory tree
+  find [dir] [-name <glob>]             list files, optionally filtered by name glob
+  rg [-i] [-l] [-c] [-w] [-F] [-C n] [-A n] [-B n] <pattern> [path ...]
+                                        regex search (grep is an alias; -r is accepted)
+  cat <file> ...                        full file contents
+  head [-n N] <file> ...                first N lines (default 10)
+  tail [-n N] <file> ...                last N lines (default 10)
+  wc [-l] <file> ...                    line (and word/char) counts
+Paths may omit the .md extension: `cat /concepts/agents` works.\
+"""
+
+
+class CommandError(Exception):
+    """User-facing command error; its message is returned as the tool output."""
+
+
+class _PageRead(str):
+    """Rendered single-page output with the source line represented by its first body line."""
+
+    path: str
+    first_source_line: int
+
+    def __new__(cls, value: str, path: str, first_source_line: int):
+        result = super().__new__(cls, value)
+        result.path = path
+        result.first_source_line = first_source_line
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Path helpers. Files is a dict of '/section/page.md' -> content.
+# ---------------------------------------------------------------------------
+
+
+def _norm(path: str) -> str:
+    return "/" + path.strip().strip("/")
+
+
+def _resolve_file(path: str, files: Mapping[str, str]) -> str:
+    clean = _norm(path)
+    for candidate in (clean, f"{clean}.md", f"{clean}/index.md"):
+        if candidate in files:
+            return candidate
+    raise CommandError(f"{path}: no such file. Use ls/tree to explore, or rg to search.")
+
+
+def _files_under(directory: str, files: Mapping[str, str]) -> list[str]:
+    clean = _norm(directory)
+    prefix = "/" if clean == "/" else f"{clean}/"
+    paths_under = getattr(files, "paths_under", None)
+    if callable(paths_under):
+        return sorted(paths_under(prefix))
+    return sorted(f for f in files if f.startswith(prefix))
+
+
+def _is_dir(path: str, files: Mapping[str, str]) -> bool:
+    clean = _norm(path)
+    return clean == "/" or bool(_files_under(clean, files))
+
+
+def _dir_entries(directory: str, files: Mapping[str, str]) -> list[str]:
+    clean = _norm(directory)
+    prefix = "/" if clean == "/" else f"{clean}/"
+    entries = set()
+    for path in _files_under(directory, files):
+        if not path.startswith(prefix):
+            continue
+        rest = path[len(prefix) :]
+        first = rest.split("/", 1)[0]
+        entries.add(first + "/" if "/" in rest else first)
+    return sorted(entries)
+
+
+def _int_value(flag: str, raw: str) -> int:
+    try:
+        value = int(raw)
+    except ValueError:
+        raise CommandError(f"{flag} expects a number, got {raw!r}") from None
+    if value < 0:
+        raise CommandError(f"{flag} expects a non-negative number")
+    return value
+
+
+def _int_flag(args: list[str], *flags: str, default: int) -> tuple[int, list[str]]:
+    """Extract one integer-valued flag (e.g. -n 20, -n20, or -20) from args."""
+    value, rest, i = default, [], 0
+    while i < len(args):
+        arg = args[i]
+        if arg in flags and i + 1 < len(args):
+            value, i = _int_value(arg, args[i + 1]), i + 1
+        elif any(arg.startswith(f) and len(arg) > len(f) for f in flags) and arg[1:2] != "-":
+            flag = next(f for f in flags if arg.startswith(f))
+            value = _int_value(flag, arg[len(flag) :].lstrip("=").lstrip("+"))
+        elif regex.fullmatch(r"-\d+", arg):
+            value = int(arg[1:])
+        else:
+            rest.append(arg)
+        i += 1
+    return value, rest
+
+
+def _strip_flags(args: list[str], accepted: set[str]) -> list[str]:
+    """Drop cosmetic flags an LLM tends to add (ls -la, tree -a, cat -n)."""
+    positional = []
+    for arg in args:
+        if arg.startswith("-") and len(arg) > 1:
+            if arg.lstrip("-") and set(arg.lstrip("-")) <= accepted:
+                continue
+            raise CommandError(f"unsupported flag {arg}\n\n{USAGE}")
+        positional.append(arg)
+    return positional
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+
+def _has_file(path: str, files: Mapping[str, str]) -> bool:
+    metadata_contains = getattr(files, "_metadata_contains", None)
+    return metadata_contains(path) if callable(metadata_contains) else path in files
+
+
+def _cmd_ls(args: list[str], files: Mapping[str, str]) -> str:
+    targets = _strip_flags(args, {"l", "a", "h", "1", "R"}) or ["/"]
+    blocks = []
+    for target in targets:
+        clean = _norm(target)
+        lines: list[str] = []
+        if _is_dir(clean, files):
+            lines.extend(_dir_entries(clean, files))
+        for candidate in (clean, f"{clean}.md"):
+            if _has_file(candidate, files) and candidate not in lines:
+                lines.append(candidate)
+        if not lines:
+            raise CommandError(f"{target}: no such file or directory")
+        header = f"{clean}:\n" if len(targets) > 1 else ""
+        blocks.append(header + "\n".join(lines))
+    return "\n\n".join(blocks)
+
+
+def _cmd_tree(args: list[str], files: Mapping[str, str]) -> str:
+    depth, rest = _int_flag(args, "-L", default=99)
+    rest = _strip_flags(rest, {"a", "d"})
+    root = _norm(rest[0]) if rest else "/"
+    paths = _files_under(root, files)
+    if not paths:
+        for candidate in (root, f"{root}.md"):
+            if _has_file(candidate, files):
+                return candidate
+        raise CommandError(f"{root}: no such directory")
+    lines = [root]
+    seen_dirs = set()
+    for path in paths:
+        relative = path[1:] if root == "/" else path[len(root) + 1 :]
+        parts = relative.split("/")
+        for level, part in enumerate(parts):
+            if level + 1 > depth:
+                break
+            is_file = level == len(parts) - 1
+            node = "/".join(parts[: level + 1])
+            if not is_file:
+                if node in seen_dirs:
+                    continue
+                seen_dirs.add(node)
+            lines.append("  " * (level + 1) + part + ("" if is_file else "/"))
+    return "\n".join(lines)
+
+
+def _cmd_find(args: list[str], files: Mapping[str, str]) -> str:
+    root, pattern, ignore_case = "/", None, False
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg in ("-name", "-iname"):
+            if i + 1 >= len(args):
+                raise CommandError(f"find: {arg} needs a glob, e.g. find / -name '*agent*'")
+            pattern, ignore_case = args[i + 1], arg == "-iname"
+            i += 1
+        elif arg in ("-type", "-maxdepth", "-path"):
+            i += 1  # accepted and ignored: everything here is a file
+        elif arg.startswith("-"):
+            raise CommandError(f"find: unsupported option {arg}\n\n{USAGE}")
+        else:
+            root = arg
+        i += 1
+    candidates = _files_under(root, files)
+    if not candidates:
+        raise CommandError(f"find: {root}: no such directory")
+    if pattern is None:
+        return "\n".join(candidates)
+    matches = [
+        p
+        for p in candidates
+        if fnmatch.fnmatch(
+            p.rsplit("/", 1)[-1].lower() if ignore_case else p.rsplit("/", 1)[-1],
+            pattern.lower() if ignore_case else pattern,
+        )
+    ]
+    return "\n".join(matches) if matches else f"find: no files matching {pattern!r} under {_norm(root)}"
+
+
+def _read_files(paths: list[str], files: Mapping[str, str], render: Callable[[str, str], tuple[str, int]]) -> str:
+    """Apply `render` per file; its integer is the first rendered source line (one-based)."""
+    parts = []
+    single_page: tuple[str, int] | None = None
+    for p in paths:
+        try:
+            resolved = _resolve_file(p, files)
+        except CommandError as exc:
+            parts.append(str(exc))
+            continue
+        rendered, first_source_line = render(resolved, files[resolved])
+        parts.append(f"==> {resolved} <==\n" + rendered)
+        if len(paths) == 1:
+            single_page = resolved, first_source_line
+    output = "\n\n".join(parts)
+    return _PageRead(output, *single_page) if single_page is not None else output
+
+
+def _cmd_cat(args: list[str], files: Mapping[str, str]) -> str:
+    paths = _strip_flags(args, {"n", "s", "b"})
+    if not paths:
+        raise CommandError("usage: cat <file> ...")
+    return _read_files(paths, files, lambda _p, content: (content, 1))
+
+
+def _cmd_head(args: list[str], files: Mapping[str, str]) -> str:
+    n, paths = _int_flag(args, "-n", default=10)
+    if not paths:
+        raise CommandError("usage: head [-n N] <file> ...")
+    return _read_files(paths, files, lambda _p, content: ("\n".join(content.splitlines()[:n]), 1))
+
+
+def _cmd_tail(args: list[str], files: Mapping[str, str]) -> str:
+    # `tail -n +N` (or -n+N) means "from line N to the end", as in GNU tail.
+    from_start = any(
+        (arg == "-n" and i + 1 < len(args) and args[i + 1].startswith("+")) or arg.startswith("-n+")
+        for i, arg in enumerate(args)
+    )
+    n, paths = _int_flag(args, "-n", default=10)
+    if not paths:
+        raise CommandError("usage: tail [-n N | -n +N] <file> ...")
+
+    def render(_path: str, content: str) -> tuple[str, int]:
+        lines = content.splitlines()
+        if from_start:
+            first_source_line = max(n, 1)
+            return "\n".join(lines[max(n - 1, 0) :]), first_source_line
+        first_source_line = max(len(lines) - n + 1, 1)
+        return ("\n".join(lines[-n:]) if n else ""), first_source_line
+
+    return _read_files(paths, files, render)
+
+
+def _cmd_wc(args: list[str], files: Mapping[str, str]) -> str:
+    flags = {a for a in args if a.startswith("-")}
+    paths = [a for a in args if not a.startswith("-")]
+    unknown = {f for f in flags if f not in ("-l", "-w", "-c", "-m")}
+    if unknown:
+        raise CommandError(f"wc: unsupported flag {' '.join(sorted(unknown))} (supported: -l, -w, -c)")
+    if not paths:
+        raise CommandError("usage: wc [-l] <file> ...")
+    lines = []
+    for p in paths:
+        try:
+            resolved = _resolve_file(p, files)
+        except CommandError as exc:
+            lines.append(str(exc))
+            continue
+        content = files[resolved]
+        counts = {"-l": len(content.splitlines()), "-w": len(content.split()), "-c": len(content)}
+        shown = [counts[f] for f in ("-l", "-w", "-c") if f in flags or ("-m" in flags and f == "-c")] or list(
+            counts.values()
+        )
+        lines.append(" ".join(f"{c:>7}" for c in shown) + f" {resolved}")
+    return "\n".join(lines)
+
+
+RG_LONG_FLAGS = {
+    "--ignore-case": "i",
+    "--files-with-matches": "l",
+    "--count": "c",
+    "--word-regexp": "w",
+    "--fixed-strings": "F",
+    "--recursive": "r",
+    "--line-number": "n",
+    "--no-heading": "",
+    "--color": "",
+}
+
+
+def _rg_targets(roots: list[str], files: Mapping[str, str]) -> list[str]:
+    targets: list[str] = []
+    for root in roots:
+        clean = _norm(root)
+        found = False
+        for candidate in (clean, f"{clean}.md"):
+            if candidate in files:
+                targets.append(candidate)
+                found = True
+        under = _files_under(clean, files)
+        if under:
+            targets.extend(under)
+            found = True
+        if not found:
+            raise CommandError(f"rg: {root}: no such file or directory")
+    if not targets:
+        raise CommandError(f"rg: no files under {', '.join(roots)}")
+    return targets
+
+
+def _cmd_rg(args: list[str], files: Mapping[str, str]) -> str:
+    limits = getattr(files, "filesystem", None)
+    max_output = getattr(limits, "max_output_chars", MAX_OUTPUT)
+    max_pattern = getattr(limits, "max_pattern_chars", MAX_PATTERN_CHARS)
+    match_timeout = getattr(limits, "regex_match_timeout", REGEX_MATCH_TIMEOUT)
+    command_budget = getattr(limits, "regex_command_seconds", REGEX_COMMAND_BUDGET)
+    deadline = time.monotonic() + command_budget
+    flags: set[str] = set()
+    before = after = 0
+    positional: list[str] = []
+    pattern_from_e: str | None = None
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg == "--":
+            positional.extend(args[i + 1 :])
+            break
+        if arg in ("-e", "--regexp") and i + 1 < len(args):
+            pattern_from_e, i = args[i + 1], i + 1
+        elif arg in ("-C", "-A", "-B") and i + 1 < len(args):
+            n = _int_value(arg, args[i + 1])
+            before, after = (n, n) if arg == "-C" else (n, after) if arg == "-B" else (before, n)
+            i += 1
+        elif regex.fullmatch(r"-[CAB]\d+", arg):
+            n = int(arg[2:])
+            before, after = (n, n) if arg[1] == "C" else (n, after) if arg[1] == "B" else (before, n)
+        elif arg.startswith("--"):
+            if arg.split("=", 1)[0] in RG_LONG_FLAGS:
+                short = RG_LONG_FLAGS[arg.split("=", 1)[0]]
+                if short:
+                    flags.add(short)
+            elif arg.startswith(("--type", "--glob", "--max-count")):
+                if "=" not in arg:
+                    i += 1
+            else:
+                raise CommandError(
+                    f"rg: unsupported option {arg} (supported: -i -l -c -w -F -n -r -C/-A/-B n, -e PATTERN)"
+                )
+        elif arg.startswith("-") and len(arg) > 1:
+            letters = set(arg[1:])
+            unknown = letters - {"i", "l", "c", "w", "F", "n", "r", "R", "H", "s"}
+            if unknown:
+                raise CommandError(
+                    f"rg: unsupported flag -{''.join(sorted(unknown))} "
+                    "(supported: -i -l -c -w -F -n -r -C/-A/-B n, -e PATTERN)"
+                )
+            flags |= letters
+        else:
+            positional.append(arg)
+        i += 1
+    if pattern_from_e is not None:
+        positional.insert(0, pattern_from_e)
+    if not positional:
+        raise CommandError("usage: rg [-i] [-l] [-c] [-C n] <pattern> [path ...]")
+    pattern, roots = positional[0], positional[1:] or ["/"]
+    if len(pattern) > max_pattern:
+        raise CommandError(f"rg: pattern longer than {max_pattern} characters")
+    if "F" in flags:
+        pattern = regex.escape(pattern)
+    if "w" in flags:
+        pattern = rf"\b(?:{pattern})\b"
+    try:
+        rx = regex.compile(pattern, regex.IGNORECASE if "i" in flags else 0)
+        # One MULTILINE search per page decides whether the per-line loop runs at all (the loop
+        # keeps the exact per-line semantics). Anchors, lookarounds and inline flags that see
+        # across line boundaries (\A, \Z, \z, \G, (?<...), (?!...), (?=...), (?-m)) would reject
+        # pages the per-line search accepts, so those patterns scan every line; only the plain
+        # non-capturing group (?:...) keeps the prefilter.
+        rx_page = (
+            None if regex.search(r"\\[AZzG]|\(\?[^:]", pattern) else regex.compile(pattern, rx.flags | regex.MULTILINE)
+        )
+    except (regex.error, RecursionError, OverflowError, ValueError) as exc:
+        raise CommandError(f"rg: invalid regex {positional[0]!r}: {exc}") from None
+
+    # Preserve richer regex/context/count presentation in this adapter. Simple
+    # literal matching can use Knowledge's bounded snapshot without loading pages.
+    from agno.knowledge.page.filesystem import PageCorpus
+
+    literal_pattern = "F" in flags or not regex.search(r"[.^$*+?{}\[\]\\|()]", positional[0])
+    if (
+        isinstance(files, PageCorpus)
+        and literal_pattern
+        and "w" not in flags
+        and not before
+        and not after
+        and len(roots) == 1
+    ):
+        clean = _norm(roots[0])
+        selected = None
+        if clean == "/":
+            prefix = "/"
+        elif clean.endswith(".md") or any(candidate in files for candidate in (clean, f"{clean}.md")):
+            # An extensionless target can select both a file and its same-name
+            # directory. Keep that union, and exact .md selection, unchanged.
+            selected = set(_rg_targets(roots, files))
+            prefix = clean
+        else:
+            prefix = clean + "/"
+            if not files.has_directory(prefix):
+                raise CommandError(f"rg: {roots[0]}: no such file or directory")
+        result = files.grep(positional[0], prefix=prefix, ignore_case="i" in flags)
+        matches = [
+            match
+            for match in result.matches
+            if (match.path in selected if selected is not None else match.path.startswith(prefix))
+        ]
+        if not matches and result.complete:
+            return f"rg: no matches for {positional[0]!r}"
+        count = len({match.path for match in matches})
+        summary = f"[{len(matches)} matching lines in {count} files]"
+        if not result.complete:
+            summary = (
+                f"[stopped at {result.stop_reason}: {len(matches)} matching lines "
+                f"in {count} files so far; narrow the path]"
+            )
+        if "l" in flags:
+            entries = list(dict.fromkeys(m.path for m in matches))
+        elif "c" in flags:
+            from collections import Counter
+
+            entries = [f"{path}:{count}" for path, count in Counter(m.path for m in matches).items()]
+        else:
+            entries = [f"{m.path}:{m.line_number}:{m.text}" for m in matches]
+        return "\n".join([summary, *entries])
+
+    targets = _rg_targets(roots, files)
+    files_only, count_only = "l" in flags, "c" in flags
+    out: list[str] = []
+    out_chars = matched_files = total_hits = 0
+    truncated_by_time = truncated_by_size = False
+    for path in sorted(set(targets)):
+        if time.monotonic() > deadline:
+            truncated_by_time = True
+            break
+        if out_chars > max_output:
+            truncated_by_size = True
+            break
+        content = files[path]
+        try:
+            if rx_page is not None and not rx_page.search(
+                content, timeout=min(match_timeout, max(0.001, deadline - time.monotonic()))
+            ):
+                continue
+            lines = content.splitlines()
+            hits = []
+            for idx, line in enumerate(lines):
+                if time.monotonic() > deadline:
+                    truncated_by_time = True
+                    break
+                if rx.search(line, timeout=min(match_timeout, max(0.001, deadline - time.monotonic()))):
+                    hits.append(idx)
+        except TimeoutError:
+            raise CommandError(
+                f"rg: pattern {positional[0]!r} is too expensive to evaluate; "
+                "simplify the regex or use -F for a literal"
+            ) from None
+        if not hits:
+            continue
+        matched_files += 1
+        total_hits += len(hits)
+        if files_only:
+            entries = [path]
+        elif count_only:
+            entries = [f"{path}:{len(hits)}"]
+        else:
+            entries, shown = [], set()
+            for hit in hits:
+                for j in range(max(0, hit - before), min(len(lines), hit + after + 1)):
+                    if time.monotonic() > deadline:
+                        truncated_by_time = True
+                        break
+                    if j not in shown:
+                        shown.add(j)
+                        sep = ":" if j == hit else "-"
+                        entries.append(f"{path}{sep}{j + 1}{sep}{lines[j]}")
+            if before or after:
+                entries.append("--")
+        out.extend(entries)
+        out_chars += sum(len(entry) + 1 for entry in entries)
+        if truncated_by_time:
+            break
+    if not out and not truncated_by_time and not truncated_by_size:
+        return f"rg: no matches for {positional[0]!r}"
+    # The summary goes first so the output cap can never cut it off.
+    summary = f"[{total_hits} matching lines in {matched_files} files]"
+    if truncated_by_time:
+        summary = (
+            f"[stopped after {command_budget:.0f}s: {total_hits} matching lines in "
+            f"{matched_files} files so far; narrow the path]"
+        )
+    elif truncated_by_size:
+        summary = (
+            f"[stopped at the output cap: {total_hits} matching lines in {matched_files} files so far; "
+            "narrow the path or use rg -l]"
+        )
+    return "\n".join([summary, *out])
+
+
+_COMMANDS: dict[str, Callable[[list[str], Mapping[str, str]], str]] = {
+    "ls": _cmd_ls,
+    "tree": _cmd_tree,
+    "find": _cmd_find,
+    "cat": _cmd_cat,
+    "head": _cmd_head,
+    "tail": _cmd_tail,
+    "wc": _cmd_wc,
+    "rg": _cmd_rg,
+    "grep": _cmd_rg,
+}
+
+
+def _execute_command(command: str, files: Mapping[str, str]) -> str:
+    """Parse and execute one emulated command against the corpus. Never raises."""
+    if not files:
+        return "The page index is empty."
+    try:
+        argv = shlex.split(command or "")
+    except ValueError as exc:
+        return f"parse error: {exc}\n\n{USAGE}"
+    if not argv:
+        return USAGE
+    if any(token in ("|", ">", ">>", "&&", ";", "<") for token in argv):
+        return f"pipes and command chaining are not supported; run one command per call.\n\n{USAGE}"
+    handler = _COMMANDS.get(argv[0])
+    if handler is None:
+        return f"unsupported command: {argv[0]!r}\n\n{USAGE}"
+    try:
+        output = handler(argv[1:], files)
+    except CommandError as exc:
+        return str(exc)
+    except (ValueError, RecursionError, OverflowError, MemoryError, TimeoutError) as exc:
+        return f"{argv[0]}: could not run this command ({exc.__class__.__name__}: {exc})\n\n{USAGE}"
+    return output if output else "(no output)"
+
+
+def run_command(command: str, files: Mapping[str, str]) -> str:
+    """Apply the same output bound to successful commands and readable errors."""
+    output = _execute_command(command, files)
+    max_output = getattr(getattr(files, "filesystem", None), "max_output_chars", MAX_OUTPUT)
+    if len(output) > max_output:
+        # Cut on a line boundary and say where it stopped. Only a single resolved page read
+        # carries enough information to give an exact source-file continuation command.
+        page_read = output if isinstance(output, _PageRead) else None
+        body = output.rstrip("\n")
+        kept = body[:max_output].rsplit("\n", 1)[0]
+        shown, total = kept.count("\n") + 1, body.count("\n") + 1
+        advice = "narrow the path or use rg -l"
+        if page_read is not None:
+            # `shown` includes the `==> path <==` header, hence `shown - 1` source lines.
+            next_source_line = page_read.first_source_line + shown - 1
+            advice += f", or continue with tail -n +{next_source_line} {shlex.quote(page_read.path)}"
+        output = f"{kept}\n... [output truncated: {shown} of {total} lines shown — {advice}]"
+    return str(output) if output else "(no output)"

--- a/libs/agno/agno/knowledge/page/_commands.py
+++ b/libs/agno/agno/knowledge/page/_commands.py
@@ -68,9 +68,18 @@ def _canonical(path: str, files: Mapping[str, str]) -> str:
         ) from None
 
 
+def _file_candidates(clean: str, *, index: bool = False) -> tuple[str, ...]:
+    if clean == "/":
+        return ("/index.md",) if index else ()
+    if clean.endswith(".md"):
+        return (clean,)
+    candidates = (clean, f"{clean}.md")
+    return (*candidates, f"{clean}/index.md") if index else candidates
+
+
 def _resolve_file(path: str, files: Mapping[str, str]) -> str:
     clean = _canonical(path, files)
-    for candidate in (clean, f"{clean}.md", f"{clean}/index.md"):
+    for candidate in _file_candidates(clean, index=True):
         if candidate in files:
             return candidate
     raise CommandError(f"{path}: no such file. Use ls/tree to explore, or rg to search.")
@@ -78,6 +87,8 @@ def _resolve_file(path: str, files: Mapping[str, str]) -> str:
 
 def _files_under(directory: str, files: Mapping[str, str]) -> list[str]:
     clean = _canonical(directory, files)
+    if clean.endswith(".md"):
+        return []
     prefix = "/" if clean == "/" else f"{clean}/"
     paths_under = getattr(files, "paths_under", None)
     if callable(paths_under):
@@ -161,7 +172,7 @@ def _cmd_ls(args: list[str], files: Mapping[str, str]) -> str:
         lines: list[str] = []
         if _is_dir(clean, files):
             lines.extend(_dir_entries(clean, files))
-        for candidate in (clean, f"{clean}.md"):
+        for candidate in _file_candidates(clean):
             if _has_file(candidate, files) and candidate not in lines:
                 lines.append(candidate)
         if not lines:
@@ -177,7 +188,7 @@ def _cmd_tree(args: list[str], files: Mapping[str, str]) -> str:
     root = _norm(rest[0]) if rest else "/"
     paths = _files_under(root, files)
     if not paths:
-        for candidate in (root, f"{root}.md"):
+        for candidate in _file_candidates(root):
             if _has_file(candidate, files):
                 return candidate
         raise CommandError(f"{root}: no such directory")
@@ -328,7 +339,7 @@ def _rg_targets(roots: list[str], files: Mapping[str, str]) -> list[str]:
     for root in roots:
         clean = _canonical(root, files)
         found = False
-        for candidate in (clean, f"{clean}.md"):
+        for candidate in _file_candidates(clean):
             if candidate in files:
                 targets.append(candidate)
                 found = True
@@ -431,36 +442,55 @@ def _cmd_rg(args: list[str], files: Mapping[str, str]) -> str:
         and len(roots) == 1
     ):
         clean = _canonical(roots[0], files)
+        exact = None
         if clean == "/":
             prefix = "/"
-        elif clean.endswith(".md") or any(candidate in files for candidate in (clean, f"{clean}.md")):
-            # Public grep uses a prefix limit. Scan only resolved targets below so
-            # similarly named siblings cannot consume an exact file's match budget.
+        elif clean.endswith(".md"):
+            # An explicit file never expands into a same-name directory.
             prefix = None
         else:
-            prefix = clean + "/"
-            if not files.has_directory(prefix):
+            exact = next((candidate for candidate in _file_candidates(clean) if candidate in files), None)
+            prefix = clean + "/" if files.has_directory(clean + "/") else None
+            if prefix is None and exact is None:
                 raise CommandError(f"rg: {roots[0]}: no such file or directory")
         if prefix is not None:
             result = files.grep(positional[0], prefix=prefix, ignore_case="i" in flags)
-            matches = [match for match in result.matches if match.path.startswith(prefix)]
-            if not matches and result.complete:
+            matches = [(m.path, m.line_number, m.text) for m in result.matches if m.path.startswith(prefix)]
+            complete, stop_reason = result.complete, result.stop_reason
+            if exact is not None:
+                # Keep the exact page outside the directory prefix so similarly named
+                # siblings cannot consume its match budget. Only this page is loaded.
+                exact_matches = []
+                for number, line in enumerate(files[exact].splitlines(), 1):
+                    if time.monotonic() > deadline:
+                        complete, stop_reason = False, "deadline"
+                        break
+                    if rx.search(line, timeout=min(match_timeout, max(0.001, deadline - time.monotonic()))):
+                        exact_matches.append((exact, number, line))
+                        if len(exact_matches) >= 100:
+                            complete, stop_reason = False, "limit"
+                            break
+                matches = sorted([*exact_matches, *matches])
+                if len(matches) > 100:
+                    matches = matches[:100]
+                    complete, stop_reason = False, "limit"
+            if not matches and complete:
                 return f"rg: no matches for {positional[0]!r}"
-            count = len({match.path for match in matches})
+            count = len({path for path, _, _ in matches})
             summary = f"[{len(matches)} matching lines in {count} files]"
-            if not result.complete:
+            if not complete:
                 summary = (
-                    f"[stopped at {result.stop_reason}: {len(matches)} matching lines "
+                    f"[stopped at {stop_reason}: {len(matches)} matching lines "
                     f"in {count} files so far; narrow the path]"
                 )
             if "l" in flags:
-                entries = list(dict.fromkeys(m.path for m in matches))
+                entries = list(dict.fromkeys(path for path, _, _ in matches))
             elif "c" in flags:
                 from collections import Counter
 
-                entries = [f"{path}:{count}" for path, count in Counter(m.path for m in matches).items()]
+                entries = [f"{path}:{count}" for path, count in Counter(path for path, _, _ in matches).items()]
             else:
-                entries = [f"{m.path}:{m.line_number}:{m.text}" for m in matches]
+                entries = [f"{path}:{number}:{text}" for path, number, text in matches]
             return "\n".join([summary, *entries])
 
     targets = _rg_targets(roots, files)

--- a/libs/agno/agno/knowledge/page/_commands.py
+++ b/libs/agno/agno/knowledge/page/_commands.py
@@ -55,8 +55,21 @@ def _norm(path: str) -> str:
     return "/" + path.strip().strip("/")
 
 
-def _resolve_file(path: str, files: Mapping[str, str]) -> str:
+def _canonical(path: str, files: Mapping[str, str]) -> str:
+    from agno.fs.errors import InvalidPathError
+
     clean = _norm(path)
+    normalize = getattr(files, "canonical_prefix", None)
+    try:
+        return normalize(clean) if callable(normalize) else clean
+    except (ValueError, InvalidPathError):
+        raise CommandError(
+            f"{path}: invalid page path. Use an absolute page path without dot segments, query or fragment."
+        ) from None
+
+
+def _resolve_file(path: str, files: Mapping[str, str]) -> str:
+    clean = _canonical(path, files)
     for candidate in (clean, f"{clean}.md", f"{clean}/index.md"):
         if candidate in files:
             return candidate
@@ -64,7 +77,7 @@ def _resolve_file(path: str, files: Mapping[str, str]) -> str:
 
 
 def _files_under(directory: str, files: Mapping[str, str]) -> list[str]:
-    clean = _norm(directory)
+    clean = _canonical(directory, files)
     prefix = "/" if clean == "/" else f"{clean}/"
     paths_under = getattr(files, "paths_under", None)
     if callable(paths_under):
@@ -78,7 +91,7 @@ def _is_dir(path: str, files: Mapping[str, str]) -> bool:
 
 
 def _dir_entries(directory: str, files: Mapping[str, str]) -> list[str]:
-    clean = _norm(directory)
+    clean = _canonical(directory, files)
     prefix = "/" if clean == "/" else f"{clean}/"
     entries = set()
     for path in _files_under(directory, files):
@@ -170,8 +183,9 @@ def _cmd_tree(args: list[str], files: Mapping[str, str]) -> str:
         raise CommandError(f"{root}: no such directory")
     lines = [root]
     seen_dirs = set()
+    canonical_root = _canonical(root, files)
     for path in paths:
-        relative = path[1:] if root == "/" else path[len(root) + 1 :]
+        relative = path[1:] if canonical_root == "/" else path[len(canonical_root) + 1 :]
         parts = relative.split("/")
         for level, part in enumerate(parts):
             if level + 1 > depth:
@@ -312,7 +326,7 @@ RG_LONG_FLAGS = {
 def _rg_targets(roots: list[str], files: Mapping[str, str]) -> list[str]:
     targets: list[str] = []
     for root in roots:
-        clean = _norm(root)
+        clean = _canonical(root, files)
         found = False
         for candidate in (clean, f"{clean}.md"):
             if candidate in files:
@@ -416,43 +430,38 @@ def _cmd_rg(args: list[str], files: Mapping[str, str]) -> str:
         and not after
         and len(roots) == 1
     ):
-        clean = _norm(roots[0])
-        selected = None
+        clean = _canonical(roots[0], files)
         if clean == "/":
             prefix = "/"
         elif clean.endswith(".md") or any(candidate in files for candidate in (clean, f"{clean}.md")):
-            # An extensionless target can select both a file and its same-name
-            # directory. Keep that union, and exact .md selection, unchanged.
-            selected = set(_rg_targets(roots, files))
-            prefix = clean
+            # Public grep uses a prefix limit. Scan only resolved targets below so
+            # similarly named siblings cannot consume an exact file's match budget.
+            prefix = None
         else:
             prefix = clean + "/"
             if not files.has_directory(prefix):
                 raise CommandError(f"rg: {roots[0]}: no such file or directory")
-        result = files.grep(positional[0], prefix=prefix, ignore_case="i" in flags)
-        matches = [
-            match
-            for match in result.matches
-            if (match.path in selected if selected is not None else match.path.startswith(prefix))
-        ]
-        if not matches and result.complete:
-            return f"rg: no matches for {positional[0]!r}"
-        count = len({match.path for match in matches})
-        summary = f"[{len(matches)} matching lines in {count} files]"
-        if not result.complete:
-            summary = (
-                f"[stopped at {result.stop_reason}: {len(matches)} matching lines "
-                f"in {count} files so far; narrow the path]"
-            )
-        if "l" in flags:
-            entries = list(dict.fromkeys(m.path for m in matches))
-        elif "c" in flags:
-            from collections import Counter
+        if prefix is not None:
+            result = files.grep(positional[0], prefix=prefix, ignore_case="i" in flags)
+            matches = [match for match in result.matches if match.path.startswith(prefix)]
+            if not matches and result.complete:
+                return f"rg: no matches for {positional[0]!r}"
+            count = len({match.path for match in matches})
+            summary = f"[{len(matches)} matching lines in {count} files]"
+            if not result.complete:
+                summary = (
+                    f"[stopped at {result.stop_reason}: {len(matches)} matching lines "
+                    f"in {count} files so far; narrow the path]"
+                )
+            if "l" in flags:
+                entries = list(dict.fromkeys(m.path for m in matches))
+            elif "c" in flags:
+                from collections import Counter
 
-            entries = [f"{path}:{count}" for path, count in Counter(m.path for m in matches).items()]
-        else:
-            entries = [f"{m.path}:{m.line_number}:{m.text}" for m in matches]
-        return "\n".join([summary, *entries])
+                entries = [f"{path}:{count}" for path, count in Counter(m.path for m in matches).items()]
+            else:
+                entries = [f"{m.path}:{m.line_number}:{m.text}" for m in matches]
+            return "\n".join([summary, *entries])
 
     targets = _rg_targets(roots, files)
     files_only, count_only = "l" in flags, "c" in flags

--- a/libs/agno/agno/knowledge/page/filesystem.py
+++ b/libs/agno/agno/knowledge/page/filesystem.py
@@ -101,17 +101,17 @@ class PageFileSystem:
         Mapping access is synchronous. Async callers should use arun_command
         instead of iterating or loading this mapping on the event loop.
         """
-        corpus = PageCorpus(self)
+        corpus = PageCorpus(self, prefix=prefix)
         if not lazy:
-            corpus._pages = corpus._list(prefix)
+            corpus._pages = corpus._list(corpus.prefix)
         return corpus
 
     async def aget_corpus(self, *, prefix: str = "/") -> PageCorpus:
         """Fetch a metadata snapshot off the event loop; later mapping access is sync."""
 
         def listing(*, budget: WorkBudget) -> PageCorpus:
-            corpus = PageCorpus(self, budget=budget)
-            corpus._pages = corpus._list(prefix)
+            corpus = PageCorpus(self, budget=budget, prefix=prefix)
+            corpus._pages = corpus._list(corpus.prefix)
             return corpus
 
         try:
@@ -129,7 +129,9 @@ class PageCorpus(Mapping[str, str]):
         pages: Optional[dict[str, Page]] = None,
         *,
         budget: Optional[WorkBudget] = None,
+        prefix: str = "/",
     ):
+        self.prefix = self.canonical_prefix(prefix)
         self.filesystem = filesystem
         self._pages = pages
         self._selected: dict[str, Page] = {}
@@ -138,6 +140,22 @@ class PageCorpus(Mapping[str, str]):
         self._read_chars = 0
         self._budget = budget or WorkBudget(filesystem.command_seconds)
 
+    @staticmethod
+    def canonical_prefix(path: str) -> str:
+        from agno.knowledge.page._source import page_prefix
+
+        if path != "/" and path.endswith("/"):
+            return page_prefix(path[:-1]) + "/"
+        return page_prefix(path)
+
+    def _scoped_prefix(self, prefix: str) -> Optional[str]:
+        prefix = self.canonical_prefix(prefix)
+        if prefix.startswith(self.prefix):
+            return prefix
+        if self.prefix.startswith(prefix):
+            return self.prefix
+        return None
+
     def _check(self) -> None:
         try:
             self._budget.remaining()
@@ -145,6 +163,10 @@ class PageCorpus(Mapping[str, str]):
             raise PageError() from exc
 
     def _list(self, prefix: str) -> dict[str, Page]:
+        scoped = self._scoped_prefix(prefix)
+        if scoped is None:
+            return {}
+        prefix = scoped
         for _ in range(2):
             pages: dict[str, Page] = {}
             cursor = None
@@ -153,7 +175,7 @@ class PageCorpus(Mapping[str, str]):
                 result = self.filesystem.knowledge.list_pages(prefix=prefix, cursor=cursor, limit=200)
                 if result.restart_required:
                     break
-                pages.update((page.path, page) for page in result.pages)
+                pages.update((page.path, page) for page in result.pages if page.path.startswith(prefix))
                 if len(pages) > self.filesystem.max_catalog_entries:
                     raise PageError()
                 cursor = result.next_cursor
@@ -164,7 +186,7 @@ class PageCorpus(Mapping[str, str]):
     @property
     def pages(self) -> dict[str, Page]:
         if self._pages is None:
-            self._pages = self._list("/")
+            self._pages = self._list(self.prefix)
             self.loaded.clear()
             self._selected.clear()
         return self._pages
@@ -173,17 +195,22 @@ class PageCorpus(Mapping[str, str]):
         self._check()
         if self._pages is not None:
             return bool(self._pages)
-        return bool(self.filesystem.knowledge.list_pages(limit=1).pages)
+        kwargs = {} if self.prefix == "/" else {"prefix": self.prefix}
+        return bool(self.filesystem.knowledge.list_pages(limit=1, **kwargs).pages)
 
     def paths_under(self, prefix: str) -> list[str]:
+        scoped = self._scoped_prefix(prefix)
+        if scoped is None:
+            return []
+        prefix = scoped
         if self._pages is not None or prefix == "/":
             return [path for path in self.pages if path.startswith(prefix)]
         if prefix not in self._prefixes:
-            scoped = {path: page for path, page in self._list(prefix).items() if path.startswith(prefix)}
-            self._selected.update(scoped)
-            for path in scoped:
+            scoped_pages = self._list(prefix)
+            self._selected.update(scoped_pages)
+            for path in scoped_pages:
                 self.loaded.pop(path, None)
-            self._prefixes[prefix] = list(scoped)
+            self._prefixes[prefix] = list(scoped_pages)
         return self._prefixes[prefix]
 
     def __iter__(self) -> Iterator[str]:
@@ -191,6 +218,10 @@ class PageCorpus(Mapping[str, str]):
 
     def has_directory(self, prefix: str) -> bool:
         self._check()
+        scoped = self._scoped_prefix(prefix)
+        if scoped is None:
+            return False
+        prefix = scoped
         if self._pages is not None:
             return any(path.startswith(prefix) for path in self._pages)
         if prefix in self._prefixes:
@@ -209,6 +240,8 @@ class PageCorpus(Mapping[str, str]):
             return False
         # Public page APIs return canonical paths even when the caller uses URL encoding.
         path = page_path(path)
+        if not path.startswith(self.prefix):
+            return False
         if self._pages is not None:
             return path in self._pages
         if path in self._selected:
@@ -217,12 +250,15 @@ class PageCorpus(Mapping[str, str]):
         return any(page.path == path for page in result.pages)
 
     def __contains__(self, path: object) -> bool:
-        if self._pages is not None:
-            return path in self._pages
-        if isinstance(path, str) and path in self._selected:
-            return True
         if not isinstance(path, str) or not path.endswith(".md"):
             return False
+        path = self.canonical_prefix(path)
+        if not path.startswith(self.prefix):
+            return False
+        if self._pages is not None:
+            return path in self._pages
+        if path in self._selected:
+            return True
         try:
             self[path]
             return True
@@ -230,7 +266,12 @@ class PageCorpus(Mapping[str, str]):
             return False
 
     def __getitem__(self, path: str) -> str:
+        from agno.knowledge.page._source import page_path
+
         self._check()
+        path = page_path(path)
+        if not path.startswith(self.prefix):
+            raise KeyError(path)
         page = self._pages[path] if self._pages is not None else self._selected.get(path)
         if path in self.loaded:
             return self.loaded[path]
@@ -264,6 +305,8 @@ class PageCorpus(Mapping[str, str]):
                         revision = result.revision
                 body = "".join(parts)
         except PageNotFound:
+            if page is not None or revision is not None:
+                raise  # A selected publication disappeared; retain the typed storage error.
             raise KeyError(path) from None
         if cached is not None:
             self._read_chars += len(body)
@@ -281,7 +324,10 @@ class PageCorpus(Mapping[str, str]):
 
     def grep(self, query: str, *, prefix: str, ignore_case: bool) -> GrepResult:
         self._check()
-        return self.filesystem.knowledge.grep_pages(query, prefix=prefix, ignore_case=ignore_case, limit=100)
+        scoped = self._scoped_prefix(prefix)
+        if scoped is None:
+            return GrepResult()
+        return self.filesystem.knowledge.grep_pages(query, prefix=scoped, ignore_case=ignore_case, limit=100)
 
     @property
     def stamp(self) -> str:

--- a/libs/agno/agno/knowledge/page/filesystem.py
+++ b/libs/agno/agno/knowledge/page/filesystem.py
@@ -14,12 +14,13 @@ from agno.utils.bounded import BoundedWorkers, WorkBudget
 
 if TYPE_CHECKING:
     from agno.knowledge.knowledge import Knowledge
+    from agno.tools.toolkit import Toolkit
 
 _COMMAND_WORKERS = BoundedWorkers(8, "page-filesystem")
 
 
 class PageFileSystem:
-    """Explicit read-only command adapter; no tool registration or prompt insertion.
+    """Read-only command adapter with opt-in tools and no prompt insertion.
 
     Commands use public Knowledge page APIs. Each command gets a fresh metadata
     snapshot, and cached bodies are validated against current publication before
@@ -94,6 +95,50 @@ class PageFileSystem:
             return await _COMMAND_WORKERS.run(self._run, command, seconds=self.command_seconds)
         except TimeoutError as exc:
             raise PageError() from exc
+
+    def tools(self, *, tool_name: str = "query_pages", description: Optional[str] = None) -> Toolkit:
+        """Build one read-only command tool for ``Agent(tools=[files.tools()])``.
+
+        Sync and async runs select their corresponding command implementation.
+        The tool returns readable page errors; direct command methods still raise
+        PageError. Applications retain setup, retrieval timing and instructions.
+        """
+        from agno.knowledge.page._commands import USAGE
+        from agno.knowledge.page.types import tool_error
+        from agno.tools.toolkit import Toolkit
+
+        if not tool_name or not tool_name.strip():
+            raise ValueError("tool_name must not be empty")
+
+        def query_pages(command: str) -> str:
+            try:
+                return self.run_command(command)
+            except PageError as exc:
+                return tool_error(exc)
+
+        async def aquery_pages(command: str) -> str:
+            try:
+                return await self.arun_command(command)
+            except PageError as exc:
+                return tool_error(exc)
+
+        query_pages.__name__ = tool_name
+        toolkit = Toolkit(name="page_filesystem", tools=[query_pages], async_tools=[(aquery_pages, tool_name)])
+        tool_description = (
+            description
+            if description is not None
+            else (
+                "Browse, read or search published documentation pages as Markdown files. "
+                "Commands are emulated against indexed pages; they cannot execute a shell or write files. "
+                "Incomplete searches do not establish absence. "
+                f"Output is bounded to {self.max_output_chars} characters plus a continuation notice.\n\n"
+                + USAGE
+                + '\nExamples: cat /agents/overview; ls /agents; rg -C 2 "tool_call_limit" /agents.'
+            )
+        )
+        for function in (toolkit.functions[tool_name], toolkit.async_functions[tool_name]):
+            function.description = tool_description
+        return toolkit
 
     def get_corpus(self, *, lazy: bool = False, prefix: str = "/") -> PageCorpus:
         """Get a bounded command-local page mapping, optionally scoped to a prefix.

--- a/libs/agno/agno/knowledge/page/filesystem.py
+++ b/libs/agno/agno/knowledge/page/filesystem.py
@@ -202,13 +202,17 @@ class PageCorpus(Mapping[str, str]):
         return len(self.pages)
 
     def _metadata_contains(self, path: str) -> bool:
+        from agno.knowledge.page._source import page_path
+
         self._check()
+        if not path.endswith(".md"):
+            return False
+        # Public page APIs return canonical paths even when the caller uses URL encoding.
+        path = page_path(path)
         if self._pages is not None:
             return path in self._pages
         if path in self._selected:
             return True
-        if not path.endswith(".md"):
-            return False
         result = self.filesystem.knowledge.list_pages(prefix=path, limit=1)
         return any(page.path == path for page in result.pages)
 

--- a/libs/agno/agno/knowledge/page/filesystem.py
+++ b/libs/agno/agno/knowledge/page/filesystem.py
@@ -1,0 +1,286 @@
+"""Read-only commands and lazy, revision-coherent access to one Knowledge namespace."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from collections import OrderedDict
+from collections.abc import Iterator, Mapping
+from threading import Lock
+from typing import TYPE_CHECKING, Optional
+
+from agno.knowledge.page.types import GrepResult, Page, PageError, PageNotFound
+from agno.utils.bounded import BoundedWorkers, WorkBudget
+
+if TYPE_CHECKING:
+    from agno.knowledge.knowledge import Knowledge
+
+_COMMAND_WORKERS = BoundedWorkers(8, "page-filesystem")
+
+
+class PageFileSystem:
+    """Explicit read-only command adapter; no tool registration or prompt insertion.
+
+    Commands use public Knowledge page APIs. Each command gets a fresh metadata
+    snapshot, and cached bodies are validated against current publication before
+    reuse. Cache storage belongs to this instance, never another store/namespace.
+    Output is capped at max_output_chars plus a short continuation notice.
+    Async cancellation retains worker capacity until the actual work finishes.
+    """
+
+    def __init__(
+        self,
+        *,
+        knowledge: Knowledge,
+        max_output_chars: int = 30_000,
+        max_pattern_chars: int = 256,
+        regex_match_timeout: float = 0.05,
+        regex_command_seconds: float = 2.0,
+        command_seconds: float = 10.0,
+        max_cached_bytes: int = 32 * 1024 * 1024,
+        max_cached_entries: int = 8192,
+        max_read_chars: int = 32 * 1024 * 1024,
+        max_catalog_entries: int = 100_000,
+    ):
+        try:
+            import regex  # noqa: F401
+        except ImportError as exc:
+            raise ImportError("PageFileSystem requires regex. Install it with `pip install 'agno[pages]'`.") from exc
+        for name, value in locals().copy().items():
+            if name.startswith("max_"):
+                if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+                    raise ValueError(f"{name} must be a positive integer")
+            elif name in ("regex_match_timeout", "regex_command_seconds", "command_seconds"):
+                if (
+                    isinstance(value, bool)
+                    or not isinstance(value, (float, int))
+                    or not math.isfinite(value)
+                    or value <= 0
+                ):
+                    raise ValueError(f"{name} must be finite and positive")
+        self.knowledge = knowledge
+        self.max_output_chars = max_output_chars
+        self.max_pattern_chars = max_pattern_chars
+        self.regex_match_timeout = regex_match_timeout
+        self.regex_command_seconds = regex_command_seconds
+        self.command_seconds = command_seconds
+        self.max_cached_bytes = max_cached_bytes
+        self.max_cached_entries = max_cached_entries
+        self.max_read_chars = max_read_chars
+        self.max_catalog_entries = max_catalog_entries
+        self._bodies: OrderedDict[tuple[str, str, int], tuple[str, int]] = OrderedDict()
+        self._body_bytes = 0
+        self._body_lock = Lock()
+
+    def _run(self, command: str, *, budget: WorkBudget) -> str:
+        from agno.knowledge.page._commands import run_command
+
+        return run_command(command, PageCorpus(self, budget=budget))
+
+    def run_command(self, command: str) -> str:
+        """Run ls/tree/find/cat/head/tail/wc/rg/grep within bounded worker capacity.
+
+        Grammar errors return readable text. Publication/storage errors raise
+        PageError so applications can retain their own unavailable wording.
+        """
+        try:
+            return _COMMAND_WORKERS.run_sync(self._run, command, seconds=self.command_seconds)
+        except TimeoutError as exc:
+            raise PageError() from exc
+
+    async def arun_command(self, command: str) -> str:
+        """Run the same command without blocking the event loop."""
+        try:
+            return await _COMMAND_WORKERS.run(self._run, command, seconds=self.command_seconds)
+        except TimeoutError as exc:
+            raise PageError() from exc
+
+    def get_corpus(self, *, lazy: bool = False, prefix: str = "/") -> PageCorpus:
+        """Get a bounded command-local page mapping, optionally scoped to a prefix.
+
+        Mapping access is synchronous. Async callers should use arun_command
+        instead of iterating or loading this mapping on the event loop.
+        """
+        corpus = PageCorpus(self)
+        if not lazy:
+            corpus._pages = corpus._list(prefix)
+        return corpus
+
+    async def aget_corpus(self, *, prefix: str = "/") -> PageCorpus:
+        """Fetch a metadata snapshot off the event loop; later mapping access is sync."""
+
+        def listing(*, budget: WorkBudget) -> PageCorpus:
+            corpus = PageCorpus(self, budget=budget)
+            corpus._pages = corpus._list(prefix)
+            return corpus
+
+        try:
+            return await _COMMAND_WORKERS.run(listing, seconds=self.command_seconds)
+        except TimeoutError as exc:
+            raise PageError() from exc
+
+
+class PageCorpus(Mapping[str, str]):
+    """One command's metadata snapshot; page bodies load only when requested."""
+
+    def __init__(
+        self,
+        filesystem: PageFileSystem,
+        pages: Optional[dict[str, Page]] = None,
+        *,
+        budget: Optional[WorkBudget] = None,
+    ):
+        self.filesystem = filesystem
+        self._pages = pages
+        self._selected: dict[str, Page] = {}
+        self._prefixes: dict[str, list[str]] = {}
+        self.loaded: dict[str, str] = {}
+        self._read_chars = 0
+        self._budget = budget or WorkBudget(filesystem.command_seconds)
+
+    def _check(self) -> None:
+        try:
+            self._budget.remaining()
+        except TimeoutError as exc:
+            raise PageError() from exc
+
+    def _list(self, prefix: str) -> dict[str, Page]:
+        for _ in range(2):
+            pages: dict[str, Page] = {}
+            cursor = None
+            while True:
+                self._check()
+                result = self.filesystem.knowledge.list_pages(prefix=prefix, cursor=cursor, limit=200)
+                if result.restart_required:
+                    break
+                pages.update((page.path, page) for page in result.pages)
+                if len(pages) > self.filesystem.max_catalog_entries:
+                    raise PageError()
+                cursor = result.next_cursor
+                if cursor is None:
+                    return pages
+        raise PageError()
+
+    @property
+    def pages(self) -> dict[str, Page]:
+        if self._pages is None:
+            self._pages = self._list("/")
+            self.loaded.clear()
+            self._selected.clear()
+        return self._pages
+
+    def __bool__(self) -> bool:
+        self._check()
+        if self._pages is not None:
+            return bool(self._pages)
+        return bool(self.filesystem.knowledge.list_pages(limit=1).pages)
+
+    def paths_under(self, prefix: str) -> list[str]:
+        if self._pages is not None or prefix == "/":
+            return [path for path in self.pages if path.startswith(prefix)]
+        if prefix not in self._prefixes:
+            scoped = {path: page for path, page in self._list(prefix).items() if path.startswith(prefix)}
+            self._selected.update(scoped)
+            for path in scoped:
+                self.loaded.pop(path, None)
+            self._prefixes[prefix] = list(scoped)
+        return self._prefixes[prefix]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.pages)
+
+    def has_directory(self, prefix: str) -> bool:
+        self._check()
+        if self._pages is not None:
+            return any(path.startswith(prefix) for path in self._pages)
+        if prefix in self._prefixes:
+            return bool(self._prefixes[prefix])
+        result = self.filesystem.knowledge.list_pages(prefix=prefix, limit=1)
+        return any(page.path.startswith(prefix) for page in result.pages)
+
+    def __len__(self) -> int:
+        return len(self.pages)
+
+    def _metadata_contains(self, path: str) -> bool:
+        self._check()
+        if self._pages is not None:
+            return path in self._pages
+        if path in self._selected:
+            return True
+        if not path.endswith(".md"):
+            return False
+        result = self.filesystem.knowledge.list_pages(prefix=path, limit=1)
+        return any(page.path == path for page in result.pages)
+
+    def __contains__(self, path: object) -> bool:
+        if self._pages is not None:
+            return path in self._pages
+        if isinstance(path, str) and path in self._selected:
+            return True
+        if not isinstance(path, str) or not path.endswith(".md"):
+            return False
+        try:
+            self[path]
+            return True
+        except KeyError:
+            return False
+
+    def __getitem__(self, path: str) -> str:
+        self._check()
+        page = self._pages[path] if self._pages is not None else self._selected.get(path)
+        if path in self.loaded:
+            return self.loaded[path]
+        fs = self.filesystem
+        key = (page.content_id, page.revision, page.filesystem_version) if page is not None else None
+        with fs._body_lock:
+            cached = fs._bodies.get(key) if key is not None else None
+            if cached is not None and key is not None:
+                fs._bodies.move_to_end(key)
+        revision = page.revision if page is not None else None
+        try:
+            if cached is not None:
+                # Even a retained mapping must not resurrect an unpublished revision.
+                fs.knowledge.read_page(path, revision=revision, max_chars=1)
+                body = cached[0]
+            else:
+                parts, offset = [], 0
+                while True:
+                    self._check()
+                    result = fs.knowledge.read_page(path, revision=revision, offset=offset, max_chars=24000)
+                    self._read_chars += len(result.text)
+                    if self._read_chars > fs.max_read_chars:
+                        raise PageError()
+                    parts.append(result.text)
+                    if result.next_offset is None:
+                        break
+                    if result.next_offset <= offset:
+                        raise PageError()
+                    offset = result.next_offset
+                    if revision is None:
+                        revision = result.revision
+                body = "".join(parts)
+        except PageNotFound:
+            raise KeyError(path) from None
+        if cached is not None:
+            self._read_chars += len(body)
+            if self._read_chars > fs.max_read_chars:
+                raise PageError()
+        self.loaded[path] = body
+        size = len(body.encode("utf-8"))
+        with fs._body_lock:
+            if key is not None and key not in fs._bodies and size <= fs.max_cached_bytes:
+                fs._bodies[key] = (body, size)
+                fs._body_bytes += size
+                while fs._body_bytes > fs.max_cached_bytes or len(fs._bodies) > fs.max_cached_entries:
+                    fs._body_bytes -= fs._bodies.popitem(last=False)[1][1]
+        return body
+
+    def grep(self, query: str, *, prefix: str, ignore_case: bool) -> GrepResult:
+        self._check()
+        return self.filesystem.knowledge.grep_pages(query, prefix=prefix, ignore_case=ignore_case, limit=100)
+
+    @property
+    def stamp(self) -> str:
+        return hashlib.sha256(
+            "\n".join(f"{p.path}:{p.revision}:{p.filesystem_version}" for p in self.pages.values()).encode()
+        ).hexdigest()

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
   "timeout-decorator",
   "types-pyyaml",
   "types-aiofiles",
+  "types-regex",
   "fastapi",
   "python-multipart>=0.0.18",
   "uvicorn",
@@ -190,7 +191,7 @@ firestore = ["google-cloud-firestore"]
 gcs = ["google-cloud-storage"]
 mysql = ["pymysql", "asyncmy"]
 postgres = ["sqlalchemy", "psycopg[binary]"]
-pages = ["agno[postgres]", "agno[pgvector]", "dnspython>=2.6.1", "beautifulsoup4"]
+pages = ["agno[postgres]", "agno[pgvector]", "dnspython>=2.6.1", "beautifulsoup4", "regex>=2024.5.15"]
 redis = ["redis>=4.5.4", "redisvl>=0.12.1"]  # >=4.5.4: safe cancellation of blocking commands (XREAD in event stream tail)
 s3 = ["boto3", "aioboto3"]
 sql = ["sqlalchemy"]
@@ -416,6 +417,7 @@ embedders = [
 
 # All libraries for testing
 tests = [
+  "agno[pages]",
     "agno[a2a]",
     "agno[slack]",
     "agno[dev]",
@@ -437,6 +439,7 @@ tests = [
 
 # Models integration test dependencies
 integration-tests = [
+  "agno[pages]",
     "exa_py>=2.0.0",
     "ddgs",
     "yfinance",

--- a/libs/agno/tests/integration/knowledge/test_page_storage.py
+++ b/libs/agno/tests/integration/knowledge/test_page_storage.py
@@ -1819,3 +1819,128 @@ async def test_page_filesystem_encoded_file_listing_uses_canonical_metadata(
     files = PageFileSystem(knowledge=knowledge)
     output = await files.arun_command(command) if async_command else files.run_command(command)
     assert output == "/Getting%20Started.md"
+
+
+def _publish_filesystem_pages(corpus, documents):
+    knowledge, _, site = corpus
+    site["https://docs.example.com/llms.txt"] = "\n".join(
+        f"- [Page](https://docs.example.com{path})" for path in documents
+    )
+    site.update(("https://docs.example.com" + path, body) for path, body in documents.items())
+    assert knowledge.sync_pages(url="https://docs.example.com/llms.txt").status == "completed"
+    return knowledge
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("async_mode", [False, True])
+@pytest.mark.parametrize("target", ["/concepts/agent", "/concepts/agent.md"])
+async def test_page_filesystem_exact_search_cannot_be_starved_by_sibling(corpus, monkeypatch, async_mode, target):
+    from agno.knowledge.page import PageFileSystem
+
+    knowledge = _publish_filesystem_pages(
+        corpus,
+        {
+            "/concepts/agent-intro.md": "needle sibling\n" * 110,
+            "/concepts/agent.md": "needle requested\n",
+            "/concepts/agent/child.md": "needle child\n",
+        },
+    )
+    original = knowledge.list_pages
+
+    def scoped_listing(**kwargs):
+        assert kwargs == {"limit": 1} or kwargs["prefix"].startswith("/concepts/agent")
+        return original(**kwargs)
+
+    monkeypatch.setattr(knowledge, "list_pages", scoped_listing)
+    files = PageFileSystem(knowledge=knowledge)
+    command = "rg needle " + target
+    result = await files.arun_command(command) if async_mode else files.run_command(command)
+    assert "/concepts/agent.md:1:needle requested" in result
+    assert "sibling" not in result
+    assert ("needle child" in result) == (not target.endswith(".md"))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["lazy", "eager", "async"])
+async def test_page_filesystem_canonical_paths_and_scope_cover_all_access(corpus, mode):
+    from agno.knowledge.page import PageFileSystem
+    from agno.knowledge.page._commands import run_command
+
+    knowledge = _publish_filesystem_pages(
+        corpus,
+        {
+            "/Getting%20Started/a%20b.md": "needle requested\n",
+            "/Getting%20Started/index.md": "needle index\n",
+            "/Getting%20Started-sibling.md": "needle sibling\n",
+            "/outside.md": "needle outside\n",
+        },
+    )
+    files = PageFileSystem(knowledge=knowledge)
+    prefix = "/Getting%20Started/"
+    mapping = (
+        await files.aget_corpus(prefix=prefix)
+        if mode == "async"
+        else files.get_corpus(lazy=mode == "lazy", prefix=prefix)
+    )
+    assert mapping["/Getting%20Started/a%20b.md"] == "needle requested\n"
+    assert "/Getting%20Started/a%20b.md" in mapping
+    assert "/outside.md" not in mapping and mapping.get("/outside.md") is None
+    assert set(mapping) == {"/Getting Started/a b.md", "/Getting Started/index.md"}
+    for command in ("ls", "find", "tree", "rg needle", 'rg "needl[e]"'):
+        result = run_command(command + " /Getting%20Started", mapping)
+        assert "a b.md" in result
+        assert "outside" not in result and "sibling" not in result
+    for command in ("cat", "head", "tail", "wc", "rg needle", 'rg "needl[e]"'):
+        result = run_command(command + " /Getting%20Started/a%20b", mapping)
+        assert "a b.md" in result and "no such" not in result
+    assert "needle index" in run_command("cat /Getting%20Started", mapping)
+    assert "needle outside" not in run_command("cat /outside /Getting%20Started/a%20b", mapping)
+    for command in ("rg needle /", 'rg "needl[e]" /'):
+        result = run_command(command, mapping)
+        assert "needle requested" in result and "outside" not in result and "sibling" not in result
+    # A bare prefix keeps public page API prefix semantics, including sibling names.
+    assert "/Getting Started-sibling.md" in files.get_corpus(prefix="/Getting%20Started")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("async_mode", [False, True])
+@pytest.mark.parametrize("command", ["cat", "head", "tail", "wc"])
+async def test_page_filesystem_invalid_targets_do_not_abort_later_reads(corpus, async_mode, command):
+    from agno.knowledge.page import PageFileSystem
+
+    knowledge = _publish_filesystem_pages(corpus, {"/valid.md": "needle requested\n"})
+    files = PageFileSystem(knowledge=knowledge)
+    query = command + " /scope/../valid /scope/./valid /valid#heading /valid?query /valid"
+    result = await files.arun_command(query) if async_mode else files.run_command(query)
+    assert result.count("invalid page path") == 4
+    assert "/valid.md" in result
+    if command != "wc":
+        assert "needle requested" in result
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("async_mode", [False, True])
+@pytest.mark.parametrize("direct", [False, True])
+async def test_page_filesystem_unpublished_selected_page_retains_typed_error(corpus, monkeypatch, async_mode, direct):
+    from agno.knowledge.page import PageFileSystem, PageNotFound
+
+    documents = {"/scope/a.md": "needle\n" * 4000, "/scope/b.md": "needle\n"}
+    knowledge = _publish_filesystem_pages(corpus, documents)
+    original = knowledge.read_page
+    refreshed = False
+
+    def unpublish(path, **kwargs):
+        nonlocal refreshed
+        if path == "/scope/a.md" and not refreshed and (not direct or kwargs.get("offset", 0) > 0):
+            refreshed = True
+            _publish_filesystem_pages(corpus, {"/scope/b.md": documents["/scope/b.md"]})
+        return original(path, **kwargs)
+
+    monkeypatch.setattr(knowledge, "read_page", unpublish)
+    files = PageFileSystem(knowledge=knowledge)
+    command = "cat /scope/a" if direct else 'rg "needl[e]" /scope'
+    with pytest.raises(PageNotFound):
+        if async_mode:
+            await files.arun_command(command)
+        else:
+            files.run_command(command)

--- a/libs/agno/tests/integration/knowledge/test_page_storage.py
+++ b/libs/agno/tests/integration/knowledge/test_page_storage.py
@@ -1793,3 +1793,29 @@ def test_page_filesystem_real_publication_invalidates_cached_and_continued_reads
     with pytest.raises(PageChanged):
         files.run_command("cat /agent")
     assert "New body" in files.run_command("cat /agent")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("async_command", [False, True])
+@pytest.mark.parametrize(
+    "command",
+    ["ls /Getting%20Started", "ls /Getting%20Started.md", "tree /Getting%20Started", "tree /Getting%20Started.md"],
+)
+async def test_page_filesystem_encoded_file_listing_uses_canonical_metadata(
+    corpus, monkeypatch, command, async_command
+):
+    from agno.knowledge.page import PageFileSystem
+
+    knowledge, _, site = corpus
+    site["https://docs.example.com/llms.txt"] = "- [Getting Started](https://docs.example.com/Getting%20Started.md)"
+    site["https://docs.example.com/Getting%20Started.md"] = "# Getting Started\n\nPublished body.\n"
+    knowledge.sync_pages(url="https://docs.example.com/llms.txt")
+    assert knowledge.list_pages().pages[0].path == "/Getting Started.md"
+
+    def no_body_reads(*args, **kwargs):
+        pytest.fail("file listing must use metadata only")
+
+    monkeypatch.setattr(knowledge, "read_page", no_body_reads)
+    files = PageFileSystem(knowledge=knowledge)
+    output = await files.arun_command(command) if async_command else files.run_command(command)
+    assert output == "/Getting%20Started.md"

--- a/libs/agno/tests/integration/knowledge/test_page_storage.py
+++ b/libs/agno/tests/integration/knowledge/test_page_storage.py
@@ -1714,3 +1714,82 @@ def test_legacy_default_hnsw_index_requires_explicit_operator_rebuild(corpus):
             conn.execute(text("SELECT reloptions FROM pg_class WHERE relname=:name"), {"name": name}).scalar() is None
         )
     assert knowledge.read_page("/agent").text.startswith("# Agent")
+
+
+@pytest.mark.asyncio
+async def test_page_filesystem_public_reads_are_lazy_scoped_and_async_equivalent(corpus, monkeypatch):
+    from agno.knowledge.page import PageFileSystem
+
+    knowledge, _, site = corpus
+    site["https://docs.example.com/llms.txt"] += "\n- [Scoped](https://docs.example.com/scope/a.md)"
+    site["https://docs.example.com/scope/a.md"] = "# Scoped\n\nneedle\n"
+    knowledge.sync_pages(url="https://docs.example.com/llms.txt")
+    listing, reading, grepping = knowledge.list_pages, knowledge.read_page, knowledge.grep_pages
+    calls = []
+
+    def list_pages(**kwargs):
+        calls.append(("list", kwargs))
+        return listing(**kwargs)
+
+    def read_page(path, **kwargs):
+        calls.append(("read", path))
+        return reading(path, **kwargs)
+
+    def grep_pages(*args, **kwargs):
+        calls.append(("grep", kwargs))
+        return grepping(*args, **kwargs)
+
+    monkeypatch.setattr(knowledge, "list_pages", list_pages)
+    monkeypatch.setattr(knowledge, "read_page", read_page)
+    monkeypatch.setattr(knowledge, "grep_pages", grep_pages)
+    files = PageFileSystem(knowledge=knowledge)
+    sync = files.run_command("cat /agent")
+    assert "Use Agent with tools" in sync
+    assert calls == [("list", {"limit": 1}), ("read", "/agent.md")]
+    calls.clear()
+    assert await files.arun_command("cat /agent") == sync
+    assert calls == [("list", {"limit": 1}), ("read", "/agent.md")]
+    calls.clear()
+    assert files.run_command("ls /scope") == "a.md"
+    lists = [kwargs for kind, kwargs in calls if kind == "list"]
+    assert lists == [
+        {"limit": 1},
+        {"prefix": "/scope/", "cursor": None, "limit": 200},
+        {"prefix": "/scope.md", "limit": 1},
+    ]
+    assert not any(kind == "read" for kind, _ in calls)
+    calls.clear()
+    assert files.run_command("rg -l needle /") == "[1 matching lines in 1 files]\n/scope/a.md"
+    assert calls == [("list", {"limit": 1}), ("grep", {"prefix": "/", "ignore_case": False, "limit": 100})]
+
+
+def test_page_filesystem_real_publication_invalidates_cached_and_continued_reads(corpus, monkeypatch):
+    from agno.knowledge.page import PageFileSystem
+
+    knowledge, _, site = corpus
+    url = "https://docs.example.com/agent.md"
+    site[url] = "# Old\n" + "old text\n" * 4000
+    knowledge.sync_pages(url="https://docs.example.com/llms.txt")
+    files = PageFileSystem(knowledge=knowledge)
+    assert "old text" in files.get_corpus()["/agent.md"]
+    old_snapshot = files.get_corpus()
+    site[url] = "# New\n\nNew body\n"
+    knowledge.sync_pages(url="https://docs.example.com/llms.txt")
+    with pytest.raises(PageChanged):
+        old_snapshot["/agent.md"]
+    assert "New body" in files.run_command("cat /agent")
+    site[url] = "# Long\n" + "old text\n" * 4000
+    knowledge.sync_pages(url="https://docs.example.com/llms.txt")
+    original = knowledge.read_page
+
+    def refresh_after_first_read(path, **kwargs):
+        result = original(path, **kwargs)
+        if result.next_offset is not None and kwargs.get("offset", 0) == 0:
+            site[url] = "# Refreshed\n\nNew body\n"
+            knowledge.sync_pages(url="https://docs.example.com/llms.txt")
+        return result
+
+    monkeypatch.setattr(knowledge, "read_page", refresh_after_first_read)
+    with pytest.raises(PageChanged):
+        files.run_command("cat /agent")
+    assert "New body" in files.run_command("cat /agent")

--- a/libs/agno/tests/integration/knowledge/test_page_storage.py
+++ b/libs/agno/tests/integration/knowledge/test_page_storage.py
@@ -1944,3 +1944,38 @@ async def test_page_filesystem_unpublished_selected_page_retains_typed_error(cor
             await files.arun_command(command)
         else:
             files.run_command(command)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("async_mode", [False, True])
+async def test_page_filesystem_tool_reads_published_pages_and_preserves_revision_errors(
+    corpus, monkeypatch, async_mode
+):
+    import json
+
+    from agno.knowledge.page import PageFileSystem
+    from agno.tools.function import FunctionCall
+
+    knowledge, _, _ = corpus
+    assert knowledge.sync_pages(url="https://docs.example.com/llms.txt").updated == 1
+    files = PageFileSystem(knowledge=knowledge)
+    toolkit = files.tools(tool_name="query_docs_filesystem", description="Read published docs.")
+    functions = toolkit.get_async_functions() if async_mode else toolkit.get_functions()
+    function = functions["query_docs_filesystem"]
+    function.process_entrypoint()
+    call = FunctionCall(function=function, arguments={"command": "cat /agent"})
+    result = await call.aexecute() if async_mode else call.execute()
+    assert result.status == "success" and "# Agent" in result.result
+
+    def changed(*args, **kwargs):
+        raise PageChanged(current_revision="new-publication")
+
+    monkeypatch.setattr(knowledge, "read_page", changed)
+    call = FunctionCall(function=function, arguments={"command": "cat /agent"})
+    result = await call.aexecute() if async_mode else call.execute()
+    assert result.status == "success"
+    assert json.loads(result.result) == {
+        "schema_version": 1,
+        "error": "page_changed",
+        "current_revision": "new-publication",
+    }

--- a/libs/agno/tests/integration/knowledge/test_page_storage.py
+++ b/libs/agno/tests/integration/knowledge/test_page_storage.py
@@ -1979,3 +1979,61 @@ async def test_page_filesystem_tool_reads_published_pages_and_preserves_revision
         "error": "page_changed",
         "current_revision": "new-publication",
     }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("async_mode", [False, True])
+async def test_page_filesystem_section_search_and_explicit_files_bound_database_access(corpus, monkeypatch, async_mode):
+    from agno.knowledge.page import PageFileSystem
+
+    documents = {f"/agents/child-{i:03}.md": "ordinary child\n" for i in range(250)}
+    documents.update(
+        {
+            "/agents.md": "needle overview\n",
+            "/agents/child-249.md": "needle child\n",
+            "/agents-other.md": "needle sibling\n" * 110,
+            "/index.md": "root index\n",
+        }
+    )
+    knowledge = _publish_filesystem_pages(corpus, documents)
+    original_list, original_read, original_grep = knowledge.list_pages, knowledge.read_page, knowledge.grep_pages
+    calls = []
+
+    def listing(**kwargs):
+        # Directory existence and exact-file metadata may each need one record;
+        # no command here should enumerate any of the 250 children.
+        assert kwargs.get("limit") == 1
+        calls.append(("list", kwargs.get("prefix")))
+        return original_list(**kwargs)
+
+    def read(path, **kwargs):
+        assert path in ("/agents.md", "/index.md")
+        calls.append(("read", path))
+        return original_read(path, **kwargs)
+
+    def grep(query, **kwargs):
+        assert kwargs["prefix"] == "/agents/" and kwargs["limit"] == 100
+        calls.append(("grep", query))
+        return original_grep(query, **kwargs)
+
+    monkeypatch.setattr(knowledge, "list_pages", listing)
+    monkeypatch.setattr(knowledge, "read_page", read)
+    monkeypatch.setattr(knowledge, "grep_pages", grep)
+
+    for command, expected in (
+        ("rg absent /agents", "rg: no matches for 'absent'"),
+        (
+            "rg needle /agents",
+            "[2 matching lines in 2 files]\n/agents.md:1:needle overview\n/agents/child-249.md:1:needle child",
+        ),
+        ("ls /agents.md", "/agents.md"),
+        ("rg absent /agents.md", "rg: no matches for 'absent'"),
+        ("cat / /agents.md", "==> /index.md <==\nroot index\n\n\n==> /agents.md <==\nneedle overview\n"),
+    ):
+        calls.clear()
+        files = PageFileSystem(knowledge=knowledge)
+        result = await files.arun_command(command) if async_mode else files.run_command(command)
+        assert result == expected
+        assert sum(kind == "grep" for kind, _ in calls) == int(command.endswith(" /agents"))
+        if command.endswith(".md") and not command.startswith("cat"):
+            assert ("list", "/agents/") not in calls

--- a/libs/agno/tests/unit/knowledge/fixtures/page_commands_baseline.json
+++ b/libs/agno/tests/unit/knowledge/fixtures/page_commands_baseline.json
@@ -1,0 +1,280 @@
+{
+  "source": "docs-agent b0a464b (command implementation unchanged from #14 490099f)",
+  "corpus": {
+    "/index.md": "# Welcome\n\nStart here.\n",
+    "/quickstart.md": "# Quickstart\n\n```python\nfrom agno.agent import Agent\nagent = Agent()\n```\n",
+    "/concepts.md": "# Concepts overview page\n\nSee the sub-pages.\n",
+    "/concepts/agents.md": "# Agents\n\nAn Agent has a model.\nUse enable_agentic_memory=True to remember.\n",
+    "/concepts/agents/tools.md": "# Tools\n\nAgents call tools.\n",
+    "/concepts/teams.md": "# Teams\n\nA Team coordinates agents.\n",
+    "/examples/basic.md": "# Basic example\n\nagent = Agent(model=OpenAIChat())\n",
+    "/i18n/unicode.md": "# \u00dcn\u00efc\u00f6d\u00e9\n\nna\u00efve caf\u00e9 \u2014 \u65e5\u672c\u8a9e\n",
+    "/empty.md": ""
+  },
+  "commands": [
+    {
+      "command": "",
+      "output": "Supported commands (read-only, no pipes, stateless):\n  ls [dir|file ...]                     list a directory (or show that a file exists)\n  tree [dir] [-L depth]                 directory tree\n  find [dir] [-name <glob>]             list files, optionally filtered by name glob\n  rg [-i] [-l] [-c] [-w] [-F] [-C n] [-A n] [-B n] <pattern> [path ...]\n                                        regex search (grep is an alias; -r is accepted)\n  cat <file> ...                        full file contents\n  head [-n N] <file> ...                first N lines (default 10)\n  tail [-n N] <file> ...                last N lines (default 10)\n  wc [-l] <file> ...                    line (and word/char) counts\nPaths may omit the .md extension: `cat /concepts/agents` works."
+    },
+    {
+      "command": "cat /empty",
+      "output": "==> /empty.md <==\n"
+    },
+    {
+      "command": "cat /quickstart",
+      "output": "==> /quickstart.md <==\n# Quickstart\n\n```python\nfrom agno.agent import Agent\nagent = Agent()\n```\n"
+    },
+    {
+      "command": "cat /quickstart | head",
+      "output": "pipes and command chaining are not supported; run one command per call.\n\nSupported commands (read-only, no pipes, stateless):\n  ls [dir|file ...]                     list a directory (or show that a file exists)\n  tree [dir] [-L depth]                 directory tree\n  find [dir] [-name <glob>]             list files, optionally filtered by name glob\n  rg [-i] [-l] [-c] [-w] [-F] [-C n] [-A n] [-B n] <pattern> [path ...]\n                                        regex search (grep is an alias; -r is accepted)\n  cat <file> ...                        full file contents\n  head [-n N] <file> ...                first N lines (default 10)\n  tail [-n N] <file> ...                last N lines (default 10)\n  wc [-l] <file> ...                    line (and word/char) counts\nPaths may omit the .md extension: `cat /concepts/agents` works."
+    },
+    {
+      "command": "find / -name '*.rst'",
+      "output": "find: no files matching '*.rst' under /"
+    },
+    {
+      "command": "find / -name '*agent*'",
+      "output": "/concepts/agents.md"
+    },
+    {
+      "command": "find /concepts",
+      "output": "/concepts/agents.md\n/concepts/agents/tools.md\n/concepts/teams.md"
+    },
+    {
+      "command": "find /concepts -type f -name 'agents.md'",
+      "output": "/concepts/agents.md"
+    },
+    {
+      "command": "find /nope -name x",
+      "output": "find: /nope: no such directory"
+    },
+    {
+      "command": "grep -r Agents /concepts",
+      "output": "[2 matching lines in 2 files]\n/concepts/agents.md:1:# Agents\n/concepts/agents/tools.md:3:Agents call tools."
+    },
+    {
+      "command": "head -1 /concepts/agents",
+      "output": "==> /concepts/agents.md <==\n# Agents"
+    },
+    {
+      "command": "head -n -3 /quickstart",
+      "output": "-n expects a non-negative number"
+    },
+    {
+      "command": "head -n 1 /quickstart /nope /concepts/agents",
+      "output": "==> /quickstart.md <==\n# Quickstart\n\n/nope: no such file. Use ls/tree to explore, or rg to search.\n\n==> /concepts/agents.md <==\n# Agents"
+    },
+    {
+      "command": "head -n abc /quickstart",
+      "output": "-n expects a number, got 'abc'"
+    },
+    {
+      "command": "head -n1 /concepts/agents",
+      "output": "==> /concepts/agents.md <==\n# Agents"
+    },
+    {
+      "command": "ls",
+      "output": "concepts.md\nconcepts/\nempty.md\nexamples/\ni18n/\nindex.md\nquickstart.md"
+    },
+    {
+      "command": "ls -la /concepts",
+      "output": "agents.md\nagents/\nteams.md\n/concepts.md"
+    },
+    {
+      "command": "ls /",
+      "output": "concepts.md\nconcepts/\nempty.md\nexamples/\ni18n/\nindex.md\nquickstart.md"
+    },
+    {
+      "command": "ls /concepts",
+      "output": "agents.md\nagents/\nteams.md\n/concepts.md"
+    },
+    {
+      "command": "ls /nope",
+      "output": "/nope: no such file or directory"
+    },
+    {
+      "command": "ls /quickstart",
+      "output": "/quickstart.md"
+    },
+    {
+      "command": "ls /quickstart.md",
+      "output": "/quickstart.md"
+    },
+    {
+      "command": "rg \"unbalanced /",
+      "output": "parse error: No closing quotation\n\nSupported commands (read-only, no pipes, stateless):\n  ls [dir|file ...]                     list a directory (or show that a file exists)\n  tree [dir] [-L depth]                 directory tree\n  find [dir] [-name <glob>]             list files, optionally filtered by name glob\n  rg [-i] [-l] [-c] [-w] [-F] [-C n] [-A n] [-B n] <pattern> [path ...]\n                                        regex search (grep is an alias; -r is accepted)\n  cat <file> ...                        full file contents\n  head [-n N] <file> ...                first N lines (default 10)\n  tail [-n N] <file> ...                last N lines (default 10)\n  wc [-l] <file> ...                    line (and word/char) counts\nPaths may omit the .md extension: `cat /concepts/agents` works."
+    },
+    {
+      "command": "rg '(' /",
+      "output": "rg: invalid regex '(': missing ) at position 1"
+    },
+    {
+      "command": "rg -- Agents /concepts",
+      "output": "[2 matching lines in 2 files]\n/concepts/agents.md:1:# Agents\n/concepts/agents/tools.md:3:Agents call tools."
+    },
+    {
+      "command": "rg --glob '*.md' Agent /concepts",
+      "output": "[3 matching lines in 2 files]\n/concepts/agents.md:1:# Agents\n/concepts/agents.md:3:An Agent has a model.\n/concepts/agents/tools.md:3:Agents call tools."
+    },
+    {
+      "command": "rg --ignore-case \"AGENTS\" /concepts",
+      "output": "[3 matching lines in 3 files]\n/concepts/agents.md:1:# Agents\n/concepts/agents/tools.md:3:Agents call tools.\n/concepts/teams.md:3:A Team coordinates agents."
+    },
+    {
+      "command": "rg --type md Agent /concepts",
+      "output": "[3 matching lines in 2 files]\n/concepts/agents.md:1:# Agents\n/concepts/agents.md:3:An Agent has a model.\n/concepts/agents/tools.md:3:Agents call tools."
+    },
+    {
+      "command": "rg --type=md Agent /concepts",
+      "output": "[3 matching lines in 2 files]\n/concepts/agents.md:1:# Agents\n/concepts/agents.md:3:An Agent has a model.\n/concepts/agents/tools.md:3:Agents call tools."
+    },
+    {
+      "command": "rg -A 1 \"has a model\" /concepts",
+      "output": "[1 matching lines in 1 files]\n/concepts/agents.md:3:An Agent has a model.\n/concepts/agents.md-4-Use enable_agentic_memory=True to remember.\n--"
+    },
+    {
+      "command": "rg -B 1 \"has a model\" /concepts",
+      "output": "[1 matching lines in 1 files]\n/concepts/agents.md-2-\n/concepts/agents.md:3:An Agent has a model.\n--"
+    },
+    {
+      "command": "rg -C 1 \"has a model\" /concepts",
+      "output": "[1 matching lines in 1 files]\n/concepts/agents.md-2-\n/concepts/agents.md:3:An Agent has a model.\n/concepts/agents.md-4-Use enable_agentic_memory=True to remember.\n--"
+    },
+    {
+      "command": "rg -C x foo /",
+      "output": "-C expects a number, got 'x'"
+    },
+    {
+      "command": "rg -C1 'has a model' /concepts",
+      "output": "[1 matching lines in 1 files]\n/concepts/agents.md-2-\n/concepts/agents.md:3:An Agent has a model.\n/concepts/agents.md-4-Use enable_agentic_memory=True to remember.\n--"
+    },
+    {
+      "command": "rg -F 'Agent()' /",
+      "output": "[1 matching lines in 1 files]\n/quickstart.md:5:agent = Agent()"
+    },
+    {
+      "command": "rg -Q foo /",
+      "output": "rg: unsupported flag -Q (supported: -i -l -c -w -F -n -r -C/-A/-B n, -e PATTERN)"
+    },
+    {
+      "command": "rg -e Agents /concepts",
+      "output": "[2 matching lines in 2 files]\n/concepts/agents.md:1:# Agents\n/concepts/agents/tools.md:3:Agents call tools."
+    },
+    {
+      "command": "rg -i",
+      "output": "usage: rg [-i] [-l] [-c] [-C n] <pattern> [path ...]"
+    },
+    {
+      "command": "rg -ic agent /concepts/agents",
+      "output": "[4 matching lines in 2 files]\n/concepts/agents.md:3\n/concepts/agents/tools.md:1"
+    },
+    {
+      "command": "rg -il 'overview|agents' /concepts",
+      "output": "[4 matching lines in 4 files]\n/concepts.md\n/concepts/agents.md\n/concepts/agents/tools.md\n/concepts/teams.md"
+    },
+    {
+      "command": "rg -il agent /concepts",
+      "output": "[5 matching lines in 3 files]\n/concepts/agents.md\n/concepts/agents/tools.md\n/concepts/teams.md"
+    },
+    {
+      "command": "rg -l \"\u65e5\u672c\u8a9e\" /",
+      "output": "[1 matching lines in 1 files]\n/i18n/unicode.md"
+    },
+    {
+      "command": "rg -w Agent /concepts",
+      "output": "[1 matching lines in 1 files]\n/concepts/agents.md:3:An Agent has a model."
+    },
+    {
+      "command": "rg agents /concepts -i",
+      "output": "[3 matching lines in 3 files]\n/concepts/agents.md:1:# Agents\n/concepts/agents/tools.md:3:Agents call tools.\n/concepts/teams.md:3:A Team coordinates agents."
+    },
+    {
+      "command": "rg enable_agentic_memory /",
+      "output": "[1 matching lines in 1 files]\n/concepts/agents.md:4:Use enable_agentic_memory=True to remember."
+    },
+    {
+      "command": "rg foo /nope",
+      "output": "rg: /nope: no such file or directory"
+    },
+    {
+      "command": "rg zzz-not-here /",
+      "output": "rg: no matches for 'zzz-not-here'"
+    },
+    {
+      "command": "rm -rf /",
+      "output": "unsupported command: 'rm'\n\nSupported commands (read-only, no pipes, stateless):\n  ls [dir|file ...]                     list a directory (or show that a file exists)\n  tree [dir] [-L depth]                 directory tree\n  find [dir] [-name <glob>]             list files, optionally filtered by name glob\n  rg [-i] [-l] [-c] [-w] [-F] [-C n] [-A n] [-B n] <pattern> [path ...]\n                                        regex search (grep is an alias; -r is accepted)\n  cat <file> ...                        full file contents\n  head [-n N] <file> ...                first N lines (default 10)\n  tail [-n N] <file> ...                last N lines (default 10)\n  wc [-l] <file> ...                    line (and word/char) counts\nPaths may omit the .md extension: `cat /concepts/agents` works."
+    },
+    {
+      "command": "tail -n +3 /concepts/agents",
+      "output": "==> /concepts/agents.md <==\nAn Agent has a model.\nUse enable_agentic_memory=True to remember."
+    },
+    {
+      "command": "tail -n 0 /concepts/agents",
+      "output": "==> /concepts/agents.md <==\n"
+    },
+    {
+      "command": "tail -n 1 /concepts/agents",
+      "output": "==> /concepts/agents.md <==\nUse enable_agentic_memory=True to remember."
+    },
+    {
+      "command": "tail -n 2 /concepts/agents",
+      "output": "==> /concepts/agents.md <==\nAn Agent has a model.\nUse enable_agentic_memory=True to remember."
+    },
+    {
+      "command": "tail -n+2 /concepts/agents",
+      "output": "==> /concepts/agents.md <==\n\nAn Agent has a model.\nUse enable_agentic_memory=True to remember."
+    },
+    {
+      "command": "tree / -L 1",
+      "output": "/\n  concepts.md\n  concepts/\n  empty.md\n  examples/\n  i18n/\n  index.md\n  quickstart.md"
+    },
+    {
+      "command": "tree /concepts",
+      "output": "/concepts\n  agents.md\n  agents/\n    tools.md\n  teams.md"
+    },
+    {
+      "command": "tree /nope",
+      "output": "/nope: no such directory"
+    },
+    {
+      "command": "tree /quickstart.md",
+      "output": "/quickstart.md"
+    },
+    {
+      "command": "wc -l /concepts/agents",
+      "output": "      4 /concepts/agents.md"
+    },
+    {
+      "command": "wc -l /nope",
+      "output": "/nope: no such file. Use ls/tree to explore, or rg to search."
+    },
+    {
+      "command": "cat /concepts/agents",
+      "output": "==> /concepts/agents.md <==\n# Agents\n\nAn Agent has a model.\nUse enable_agentic_memory=True to remember.\n"
+    },
+    {
+      "command": "ls /",
+      "output": "concepts.md\nconcepts/\nempty.md\nexamples/\ni18n/\nindex.md\nquickstart.md"
+    },
+    {
+      "command": "tail -n +2 /concepts/agents.md",
+      "output": "==> /concepts/agents.md <==\n\nAn Agent has a model.\nUse enable_agentic_memory=True to remember."
+    },
+    {
+      "command": "cat /missing",
+      "output": "/missing: no such file. Use ls/tree to explore, or rg to search."
+    },
+    {
+      "command": "",
+      "output": "Supported commands (read-only, no pipes, stateless):\n  ls [dir|file ...]                     list a directory (or show that a file exists)\n  tree [dir] [-L depth]                 directory tree\n  find [dir] [-name <glob>]             list files, optionally filtered by name glob\n  rg [-i] [-l] [-c] [-w] [-F] [-C n] [-A n] [-B n] <pattern> [path ...]\n                                        regex search (grep is an alias; -r is accepted)\n  cat <file> ...                        full file contents\n  head [-n N] <file> ...                first N lines (default 10)\n  tail [-n N] <file> ...                last N lines (default 10)\n  wc [-l] <file> ...                    line (and word/char) counts\nPaths may omit the .md extension: `cat /concepts/agents` works."
+    },
+    {
+      "command": "cat a | head",
+      "output": "pipes and command chaining are not supported; run one command per call.\n\nSupported commands (read-only, no pipes, stateless):\n  ls [dir|file ...]                     list a directory (or show that a file exists)\n  tree [dir] [-L depth]                 directory tree\n  find [dir] [-name <glob>]             list files, optionally filtered by name glob\n  rg [-i] [-l] [-c] [-w] [-F] [-C n] [-A n] [-B n] <pattern> [path ...]\n                                        regex search (grep is an alias; -r is accepted)\n  cat <file> ...                        full file contents\n  head [-n N] <file> ...                first N lines (default 10)\n  tail [-n N] <file> ...                last N lines (default 10)\n  wc [-l] <file> ...                    line (and word/char) counts\nPaths may omit the .md extension: `cat /concepts/agents` works."
+    },
+    {
+      "command": "rm /a",
+      "output": "unsupported command: 'rm'\n\nSupported commands (read-only, no pipes, stateless):\n  ls [dir|file ...]                     list a directory (or show that a file exists)\n  tree [dir] [-L depth]                 directory tree\n  find [dir] [-name <glob>]             list files, optionally filtered by name glob\n  rg [-i] [-l] [-c] [-w] [-F] [-C n] [-A n] [-B n] <pattern> [path ...]\n                                        regex search (grep is an alias; -r is accepted)\n  cat <file> ...                        full file contents\n  head [-n N] <file> ...                first N lines (default 10)\n  tail [-n N] <file> ...                last N lines (default 10)\n  wc [-l] <file> ...                    line (and word/char) counts\nPaths may omit the .md extension: `cat /concepts/agents` works."
+    }
+  ]
+}

--- a/libs/agno/tests/unit/knowledge/test_page_commands.py
+++ b/libs/agno/tests/unit/knowledge/test_page_commands.py
@@ -1,0 +1,262 @@
+import re
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+import agno.knowledge.page._commands as vfs
+from agno.knowledge.page._commands import MAX_OUTPUT, USAGE, run_command
+
+CORPUS = {
+    "/index.md": "# Welcome\n\nStart here.\n",
+    "/quickstart.md": "# Quickstart\n\n```python\nfrom agno.agent import Agent\nagent = Agent()\n```\n",
+    "/concepts.md": "# Concepts overview page\n\nSee the sub-pages.\n",
+    "/concepts/agents.md": "# Agents\n\nAn Agent has a model.\nUse enable_agentic_memory=True to remember.\n",
+    "/concepts/agents/tools.md": "# Tools\n\nAgents call tools.\n",
+    "/concepts/teams.md": "# Teams\n\nA Team coordinates agents.\n",
+    "/examples/basic.md": "# Basic example\n\nagent = Agent(model=OpenAIChat())\n",
+    "/i18n/unicode.md": "# Ünïcödé\n\nnaïve café — 日本語\n",
+    "/empty.md": "",
+}
+
+
+def run(cmd: str) -> str:
+    out = run_command(cmd, CORPUS)
+    assert isinstance(out, str)
+    return out
+
+
+def test_ls_root_dir_file_and_missing():
+    assert "concepts/" in run("ls /") and "quickstart.md" in run("ls")
+    assert run("ls /concepts").splitlines() == ["agents.md", "agents/", "teams.md", "/concepts.md"]
+    assert run("ls /quickstart.md") == "/quickstart.md"
+    assert run("ls /quickstart") == "/quickstart.md"
+    assert "no such file or directory" in run("ls /nope")
+    assert "agents.md" in run("ls -la /concepts")
+
+
+def test_tree_depth_and_file_argument():
+    out = run("tree / -L 1")
+    assert "concepts/" in out and "agents.md" not in out
+    assert "tools.md" in run("tree /concepts")
+    assert run("tree /quickstart.md") == "/quickstart.md"
+    assert "no such directory" in run("tree /nope")
+
+
+def test_find_supports_name_and_type_and_reports_missing_dirs():
+    assert "/concepts/agents.md" in run("find / -name '*agent*'")
+    assert "/concepts/agents.md" in run("find /concepts -type f -name 'agents.md'")
+    assert run("find /concepts").splitlines() == [
+        "/concepts/agents.md",
+        "/concepts/agents/tools.md",
+        "/concepts/teams.md",
+    ]
+    assert "no files matching" in run("find / -name '*.rst'")
+    assert "no such directory" in run("find /nope -name x")
+
+
+def test_rg_basic_flags_and_context():
+    assert "/concepts/agents.md:4:Use enable_agentic_memory=True" in run("rg enable_agentic_memory /")
+    assert run("rg -il agent /concepts").splitlines()[1:] == [
+        "/concepts/agents.md",
+        "/concepts/agents/tools.md",
+        "/concepts/teams.md",
+    ]
+    assert "/concepts/agents.md:3" in run("rg -ic agent /concepts/agents")
+    ctx = run('rg -C 1 "has a model" /concepts')
+    assert "/concepts/agents.md-2-" in ctx and "/concepts/agents.md:3:" in ctx and "--" in ctx
+    assert "/concepts/agents.md-4-Use enable_agentic_memory" in ctx
+    after = run('rg -A 1 "has a model" /concepts')
+    assert "-4-" in after and "-2-" not in after
+    before = run('rg -B 1 "has a model" /concepts')
+    assert "-2-" in before and "-4-" not in before
+    assert "no matches" in run("rg zzz-not-here /")
+
+
+def test_rg_accepts_llm_idioms():
+    assert "/concepts/agents.md" in run("grep -r Agents /concepts")
+    assert "/concepts/agents.md" in run("rg -e Agents /concepts")
+    assert "/concepts/agents.md" in run("rg -- Agents /concepts")
+    assert "/concepts/agents.md" in run('rg --ignore-case "AGENTS" /concepts')
+    assert "/quickstart.md" in run("rg -F 'Agent()' /")
+    out = run("rg -w Agent /concepts")
+    assert "/concepts/agents.md" in out and "/concepts/teams.md" not in out
+    assert "/concepts/agents.md:3" in run("rg --type md Agent /concepts")
+    assert "/concepts/agents.md:3" in run("rg --type=md Agent /concepts")
+    assert "/concepts/agents.md:3" in run("rg --glob '*.md' Agent /concepts")
+    assert "/concepts/agents.md-4-" in run("rg -C1 'has a model' /concepts")
+    assert "/concepts/agents.md" in run("rg agents /concepts -i")
+
+
+def test_rg_searches_page_and_directory_when_names_collide():
+    assert run("rg -il 'overview|agents' /concepts").splitlines()[1:] == [
+        "/concepts.md",
+        "/concepts/agents.md",
+        "/concepts/agents/tools.md",
+        "/concepts/teams.md",
+    ]
+
+
+def test_rg_errors_are_readable():
+    assert "invalid regex" in run("rg '(' /")
+    assert "expects a number" in run("rg -C x foo /")
+    assert "unsupported flag" in run("rg -Q foo /")
+    assert "no such file or directory" in run("rg foo /nope")
+    assert "longer than" in run("rg " + "a" * 300 + " /")
+    assert "usage: rg" in run("rg -i")
+
+
+def test_rg_catastrophic_regex_is_bounded():
+    corpus = {"/big.md": ("a" * 5000 + "b\n") * 20}
+    result: list[str] = []
+    # Bounded join: without REGEX_MATCH_TIMEOUT this pattern backtracks for minutes, so fail fast instead of stalling.
+    t = threading.Thread(target=lambda: result.append(run_command("rg '(a+)+$' /", corpus)), daemon=True)
+    t.start()
+    t.join(5)
+    assert not t.is_alive(), "rg no longer bounded by REGEX_MATCH_TIMEOUT"
+    assert "too expensive" in result[0]
+
+
+def test_rg_command_budget_stops_between_files(monkeypatch):
+    ticks = iter([0.0] * 8 + [10.0] * 100)
+    monkeypatch.setattr(vfs, "time", SimpleNamespace(monotonic=lambda: next(ticks)))
+    out = run_command("rg x /", {"/a.md": "x\n", "/b.md": "x\n"})
+    assert out.splitlines()[0] == "[stopped after 2s: 1 matching lines in 1 files so far; narrow the path]"
+    assert out.splitlines()[1] == "/a.md:1:x"
+    assert "/b.md" not in out
+
+
+def test_rg_budget_stop_before_the_first_hit_is_not_reported_as_no_matches(monkeypatch):
+    ticks = iter([0.0] * 3 + [10.0] * 100)
+    monkeypatch.setattr(vfs, "time", SimpleNamespace(monotonic=lambda: next(ticks)))
+    out = run_command("rg x /", {"/a.md": "y\n", "/b.md": "x\n"})
+    assert "no matches" not in out
+    assert out == "[stopped after 2s: 0 matching lines in 0 files so far; narrow the path]"
+
+
+def test_rg_stops_scanning_at_the_output_cap_and_says_so_first():
+    corpus = {f"/p{i:03d}.md": "match " + "y" * 200 + "\n" for i in range(300)}
+    out = run_command("rg match /", corpus)
+    first, last = out.splitlines()[0], out.splitlines()[-1]
+    assert first.startswith("[stopped at the output cap:") and "so far" in first
+    assert "lines shown" in last and "tail -n" not in last and "/p299.md" not in out
+    assert run_command("rg match /p001", corpus).splitlines()[0] == "[1 matching lines in 1 files]"
+
+
+def test_rg_page_prefilter_keeps_per_line_semantics():
+    corpus = {"/a.md": "import x\nAgent here\n", "/b.md": "  Agent\nimport y\n"}
+    per_line = ["/a.md:1:import x", "/b.md:2:import y"]
+    assert run_command("rg '^import' /", corpus).splitlines()[1:] == per_line
+    assert run_command("rg '\\Aimport' /", corpus).splitlines()[1:] == per_line
+    assert run_command("rg '(?<!\\s)Agent' /", corpus).splitlines()[1:] == ["/a.md:2:Agent here"]
+    # a lookahead at the line end sees the newline in a whole-page search: per-line, it sees the end
+    assert run_command("rg 'here(?!\\s)' /", corpus).splitlines()[1:] == ["/a.md:2:Agent here"]
+    assert run_command("rg -w Agent /", corpus).splitlines()[1:] == ["/a.md:2:Agent here", "/b.md:1:  Agent"]
+
+
+def test_cat_head_tail_wc_and_missing_files():
+    assert "==> /quickstart.md <==" in run("cat /quickstart") and "from agno.agent" in run("cat /quickstart")
+    out = run("head -n 1 /quickstart /nope /concepts/agents")
+    assert "# Quickstart" in out and "no such file" in out and "# Agents" in out
+    assert run("head -1 /concepts/agents").endswith("# Agents")
+    assert run("head -n1 /concepts/agents").endswith("# Agents")
+    assert run("tail -n 1 /concepts/agents").endswith("Use enable_agentic_memory=True to remember.")
+    assert run("tail -n 0 /concepts/agents").endswith("<==\n")
+    assert "expects a number" in run("head -n abc /quickstart")
+    assert "non-negative" in run("head -n -3 /quickstart")
+    assert run("wc -l /concepts/agents").split()[0] == "4"
+    assert "no such file" in run("wc -l /nope")
+    assert "==> /empty.md <==" in run("cat /empty")
+
+
+def test_unicode_patterns_match_and_unbalanced_quotes_are_a_parse_error():
+    assert "/i18n/unicode.md" in run('rg -l "日本語" /')
+    assert "parse error" in run('rg "unbalanced /')
+
+
+def test_unsupported_commands_pipes_and_empty_corpus():
+    assert "unsupported command" in run("rm -rf /")
+    assert "pipes" in run("cat /quickstart | head")
+    assert run("") == USAGE
+    assert "empty" in run_command("ls /", {})
+
+
+def test_output_truncation():
+    corpus = {f"/p{i}.md": "x" * 1000 + "\n" for i in range(60)}
+    out = run_command("cat " + " ".join(f"/p{i}" for i in range(60)), corpus)
+    assert len(out) <= MAX_OUTPUT + 200 and "truncated" in out
+
+
+def test_page_read_truncates_on_a_line_and_says_where_to_resume():
+    corpus = {"/big.md": "\n".join(f"line {i} " + "x" * 90 for i in range(600)) + "\n"}
+    out = run_command("cat /big", corpus)
+    lines = out.splitlines()
+    assert lines[-1].startswith("... [output truncated:") and lines[-1].endswith("]")
+    assert lines[-2].endswith("x" * 90)  # cut on a line boundary, never inside a line
+    cut = re.search(r"(\d+) of (\d+) lines shown", lines[-1])
+    assert cut is not None
+    shown, total = map(int, cut.groups())
+    assert total == 601 and shown == len(lines) - 1
+    assert lines[-2] == f"line {shown - 2} " + "x" * 90  # output line 1 is the ==> header
+    assert lines[-1].endswith(f"tail -n +{shown} /big.md]")
+    resumed = run_command(f"tail -n +{shown} /big", corpus).splitlines()
+    assert resumed[1] == f"line {shown - 1} " + "x" * 90
+
+
+@pytest.mark.parametrize(
+    ("command", "first_source_line"),
+    [
+        ("cat /big", 1),
+        ("head -n 1000 /big", 1),
+        ("tail -n +201 /big", 201),
+        ("tail -n 800 /big", 201),
+    ],
+)
+def test_single_page_read_continuation_uses_an_absolute_source_line(command, first_source_line):
+    corpus = {"/big.md": "\n".join(f"line {i} " + "x" * 190 for i in range(1000)) + "\n"}
+    footer = run_command(command, corpus).splitlines()[-1]
+    cut = re.search(r"(\d+) of \d+ lines shown .* tail -n \+(\d+) /big\.md", footer)
+    assert cut is not None
+    shown, next_source_line = map(int, cut.groups())
+    assert next_source_line == first_source_line + shown - 1
+
+
+def test_following_page_continuations_advances_instead_of_looping():
+    corpus = {"/big.md": "\n".join(f"line {i} " + "x" * 190 for i in range(1000)) + "\n"}
+    command = "cat /big"
+    cursors: list[int] = []
+    for _ in range(10):
+        output = run_command(command, corpus)
+        if "output truncated" not in output:
+            break
+        match = re.search(r"tail -n \+(\d+) (/[^\]]+)]$", output)
+        assert match is not None
+        cursor, path = int(match.group(1)), match.group(2)
+        assert not cursors or cursor > cursors[-1]
+        cursors.append(cursor)
+        command = f"tail -n +{cursor} {path}"
+    else:
+        pytest.fail("following the emitted continuation did not reach the end of the page")
+    assert "line 999 " in output
+
+
+def test_multi_file_truncation_does_not_emit_a_misleading_page_continuation():
+    corpus = {
+        "/a.md": "\n".join(f"a{i} " + "x" * 190 for i in range(100)) + "\n",
+        "/b.md": "\n".join(f"b{i} " + "x" * 190 for i in range(400)) + "\n",
+    }
+    footer = run_command("cat /a /b", corpus).splitlines()[-1]
+    assert "output truncated" in footer
+    assert "tail -n" not in footer
+
+
+@pytest.mark.parametrize("cmd", ["ls --bogus", "tree -Z /", "wc -q /quickstart", "cat -Z /quickstart"])
+def test_unknown_flags_are_reported(cmd):
+    assert "unsupported flag" in run(cmd)
+
+
+def test_tail_from_line_n_like_gnu():
+    lines = CORPUS["/concepts/agents.md"].splitlines()
+    assert run("tail -n +3 /concepts/agents").split("\n", 1)[1] == "\n".join(lines[2:])
+    assert run("tail -n+2 /concepts/agents").split("\n", 1)[1] == "\n".join(lines[1:])
+    assert run("tail -n 2 /concepts/agents").split("\n", 1)[1] == "\n".join(lines[-2:])

--- a/libs/agno/tests/unit/knowledge/test_page_contract.py
+++ b/libs/agno/tests/unit/knowledge/test_page_contract.py
@@ -30,7 +30,7 @@ def test_page_public_imports_preserve_types_without_loading_storage():
                 class BlockStorageImports:
                     def find_spec(self, fullname, path=None, target=None):
                         blocked = (
-                            "sqlalchemy", "psycopg", "pgvector", "agno.vectordb",
+                            "sqlalchemy", "psycopg", "pgvector", "agno.vectordb", "regex",
                             "agno.knowledge.page._coordinator", "agno.knowledge.page._source",
                         )
                         if any(fullname == name or fullname.startswith(name + ".") for name in blocked):
@@ -45,7 +45,7 @@ def test_page_public_imports_preserve_types_without_loading_storage():
                     "PageNotFound", "PageRead", "PageResult", "PageSearchConfig", "SearchHit", "SearchResult",
                     "SearchUnavailable", "SyncFailed", "SyncReport", "encoded_size", "tool_error",
                 }
-                assert set(page.__all__) == expected
+                assert set(page.__all__) == expected | {"PageFileSystem"}
                 for name in expected:
                     assert getattr(page, name) is getattr(types, name)
                 assert page.SearchResult().model_dump() == {

--- a/libs/agno/tests/unit/knowledge/test_page_filesystem.py
+++ b/libs/agno/tests/unit/knowledge/test_page_filesystem.py
@@ -234,3 +234,22 @@ def test_listing_never_reads_page_bodies_even_for_same_name_files(command, expec
 
     fs = PageFileSystem(knowledge=SimpleNamespace(list_pages=listing, read_page=read), max_read_chars=1)
     assert fs.run_command(command) == expected
+
+
+@pytest.mark.parametrize("snapshot", [False, True])
+def test_encoded_metadata_existence_uses_canonical_paths(snapshot):
+    from agno.knowledge.page._source import page_prefix
+
+    metadata = page("/Getting Started.md")
+    calls = []
+
+    def listing(**kwargs):
+        calls.append(kwargs)
+        prefix = page_prefix(kwargs.get("prefix", "/"))
+        return PageList(pages=(metadata,) if metadata.path.startswith(prefix) else ())
+
+    fs = PageFileSystem(knowledge=SimpleNamespace(list_pages=listing))
+    corpus = fs.get_corpus(lazy=not snapshot)
+    calls.clear()
+    assert corpus._metadata_contains("/Getting%20Started.md")
+    assert calls == ([] if snapshot else [{"prefix": "/Getting Started.md", "limit": 1}])

--- a/libs/agno/tests/unit/knowledge/test_page_filesystem.py
+++ b/libs/agno/tests/unit/knowledge/test_page_filesystem.py
@@ -1,0 +1,236 @@
+import asyncio
+import json
+import sys
+import threading
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from agno.knowledge.page import Page, PageChanged, PageError, PageFileSystem, PageList
+from agno.knowledge.page._commands import run_command
+from agno.utils.bounded import BoundedWorkers
+
+
+def page(path="/a.md", revision="one"):
+    return Page(
+        content_id=path,
+        namespace="test",
+        path=path,
+        url="https://docs.example.com" + path,
+        title=path,
+        revision=revision,
+        digest=revision,
+        index_fingerprint="test",
+        filesystem_version=1,
+        expected_chunk_count=1,
+    )
+
+
+def test_archived_command_outputs_are_identical():
+    baseline = json.loads((Path(__file__).parent / "fixtures/page_commands_baseline.json").read_text())
+    assert len(baseline["commands"]) == 66
+    for case in baseline["commands"]:
+        assert run_command(case["command"], baseline["corpus"]) == case["output"], case["command"]
+
+
+def test_cache_is_instance_scoped_bounded_and_validates_publication():
+    current = page()
+    reads = []
+
+    def read(path, **kwargs):
+        reads.append(kwargs)
+        if kwargs["revision"] != current.revision:
+            raise PageChanged(current_revision=current.revision)
+        return SimpleNamespace(text="body", next_offset=None, revision=current.revision)
+
+    knowledge = SimpleNamespace(list_pages=lambda **kwargs: PageList(pages=(current,)), read_page=read)
+    fs = PageFileSystem(knowledge=knowledge, max_cached_bytes=8, max_cached_entries=1)
+    assert fs.get_corpus()["/a.md"] == "body"
+    retained = fs.get_corpus()
+    assert retained["/a.md"] == "body"
+    assert [r["max_chars"] for r in reads] == [24000, 1]
+    stale = fs.get_corpus()
+    current = page(revision="two")
+    with pytest.raises(PageChanged):
+        stale["/a.md"]
+    assert fs.get_corpus()["/a.md"] == "body"
+    assert len(fs._bodies) == 1 and fs._body_bytes == 4
+    other = PageFileSystem(
+        knowledge=SimpleNamespace(
+            list_pages=lambda **kwargs: PageList(pages=(current,)),
+            read_page=lambda *args, **kwargs: SimpleNamespace(text="different store", next_offset=None),
+        )
+    )
+    assert other.get_corpus()["/a.md"] == "different store"
+    assert fs.get_corpus()["/a.md"] == "body"
+
+
+def test_cache_byte_eviction_and_oversized_body():
+    pages = [page("/a.md"), page("/b.md"), page("/c.md")]
+    fs = PageFileSystem(
+        knowledge=SimpleNamespace(
+            list_pages=lambda **kw: PageList(pages=tuple(pages)),
+            read_page=lambda path, **kw: SimpleNamespace(text="four" if path != "/c.md" else "x" * 9, next_offset=None),
+        ),
+        max_cached_bytes=8,
+    )
+    corpus = fs.get_corpus()
+    assert [corpus[p.path] for p in pages] == ["four", "four", "x" * 9]
+    assert fs._body_bytes == 8 and len(fs._bodies) == 2
+
+
+def test_listing_restart_discards_the_old_snapshot_and_is_bounded():
+    calls = iter(
+        [
+            PageList(pages=(page("/old.md"),), next_cursor="cursor"),
+            PageList(restart_required=True),
+            PageList(pages=(page("/new.md"),)),
+        ]
+    )
+    fs = PageFileSystem(knowledge=SimpleNamespace(list_pages=lambda **kw: next(calls)))
+    assert list(fs.get_corpus()) == ["/new.md"]
+    fs.knowledge.list_pages = lambda **kw: PageList(restart_required=True)
+    with pytest.raises(PageError):
+        fs.get_corpus()
+
+
+@pytest.mark.parametrize(
+    "option,value",
+    [
+        ("max_output_chars", 0),
+        ("max_cached_entries", True),
+        ("command_seconds", float("inf")),
+        ("regex_match_timeout", -1),
+    ],
+)
+def test_limits_are_validated(option, value):
+    with pytest.raises(ValueError):
+        PageFileSystem(knowledge=SimpleNamespace(), **{option: value})
+
+
+def test_optional_regex_has_actionable_construction_error(monkeypatch):
+    monkeypatch.setitem(sys.modules, "regex", None)
+    with pytest.raises(ImportError, match=r"agno\[pages\]"):
+        PageFileSystem(knowledge=SimpleNamespace())
+
+
+def test_read_and_catalog_limits():
+    fs = PageFileSystem(
+        knowledge=SimpleNamespace(
+            list_pages=lambda **kw: PageList(pages=(page(), page("/b.md"))),
+            read_page=lambda *a, **kw: SimpleNamespace(text="too large", next_offset=None),
+        ),
+        max_catalog_entries=1,
+        max_read_chars=2,
+    )
+    with pytest.raises(PageError):
+        fs.get_corpus()
+    with pytest.raises(PageError):
+        fs.run_command("cat /a")
+
+
+@pytest.mark.asyncio
+async def test_async_matches_sync_and_keeps_the_loop_responsive(monkeypatch):
+    fs = PageFileSystem(
+        knowledge=SimpleNamespace(
+            list_pages=lambda **kw: PageList(pages=(page(),)),
+            read_page=lambda *a, **kw: SimpleNamespace(text="body", next_offset=None),
+        )
+    )
+    assert await fs.arun_command("cat /a") == fs.run_command("cat /a")
+    assert list(await fs.aget_corpus()) == ["/a.md"]
+    original = fs.knowledge.read_page
+
+    def slow(*a, **kw):
+        time.sleep(0.05)
+        return original(*a, **kw)
+
+    fs.knowledge.read_page = slow
+    task = asyncio.create_task(fs.arun_command("cat /a"))
+    await asyncio.sleep(0.01)
+    assert not task.done()
+    assert "body" in await task
+
+
+@pytest.mark.asyncio
+async def test_cancelled_command_retains_capacity_until_worker_finishes(monkeypatch):
+    import agno.knowledge.page.filesystem as module
+
+    workers = BoundedWorkers(1, "test-vfs-cancel")
+    monkeypatch.setattr(module, "_COMMAND_WORKERS", workers)
+    entered, release = threading.Event(), threading.Event()
+
+    def read(*args, **kwargs):
+        entered.set()
+        release.wait(2)
+        return SimpleNamespace(text="body", next_offset=None)
+
+    fs = PageFileSystem(knowledge=SimpleNamespace(list_pages=lambda **kw: PageList(pages=(page(),)), read_page=read))
+    task = asyncio.create_task(fs.arun_command("cat /a"))
+    try:
+        for _ in range(100):
+            if entered.is_set():
+                break
+            await asyncio.sleep(0.005)
+        assert entered.is_set()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        with pytest.raises(PageError):
+            await fs.arun_command("cat /a")
+    finally:
+        release.set()
+    for _ in range(100):
+        try:
+            assert "body" in await fs.arun_command("cat /a")
+            break
+        except PageError:
+            await asyncio.sleep(0.005)
+    else:
+        pytest.fail("worker capacity was not released")
+    workers._executor.shutdown(wait=True)
+
+
+def test_regex_budget_stops_inside_a_large_page(monkeypatch):
+    import agno.knowledge.page._commands as commands
+
+    ticks = iter([0.0] * 10 + [3.0] * 100)
+    monkeypatch.setattr(commands, "time", SimpleNamespace(monotonic=lambda: next(ticks)))
+    output = run_command("rg '(?=needle)' /", {"/a.md": "needle\n" * 10000})
+    assert output.startswith("[stopped after 2s:")
+    assert "no matches" not in output
+
+
+@pytest.mark.parametrize("command", ["x" * 10000, "cat --" + "z" * 10000, "cat /" + "z" * 10000])
+def test_invalid_commands_obey_configured_output_bounds(command):
+    from agno.knowledge.page import PageNotFound
+
+    def missing(*args, **kwargs):
+        raise PageNotFound()
+
+    fs = PageFileSystem(
+        knowledge=SimpleNamespace(list_pages=lambda **kw: PageList(pages=(page(),)), read_page=missing),
+        max_output_chars=100,
+    )
+    output = fs.run_command(command)
+    assert len(output) <= 300
+    assert "truncated" in output
+
+
+@pytest.mark.parametrize(
+    "command,expected",
+    [("ls /scope", "a.md\n/scope.md"), ("ls /scope.md", "/scope.md"), ("tree /scope.md", "/scope.md")],
+)
+def test_listing_never_reads_page_bodies_even_for_same_name_files(command, expected):
+    metadata = [page("/scope/a.md"), page("/scope.md")]
+
+    def listing(**kwargs):
+        return PageList(pages=tuple(p for p in metadata if p.path.startswith(kwargs.get("prefix", "/"))))
+
+    def read(*args, **kwargs):
+        pytest.fail("metadata-only listing downloaded a body")
+
+    fs = PageFileSystem(knowledge=SimpleNamespace(list_pages=listing, read_page=read), max_read_chars=1)
+    assert fs.run_command(command) == expected

--- a/libs/agno/tests/unit/knowledge/test_page_filesystem_lazy.py
+++ b/libs/agno/tests/unit/knowledge/test_page_filesystem_lazy.py
@@ -1,0 +1,278 @@
+"""Lazy I/O and command compatibility ported from the Docs Agent adapter."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from agno.knowledge.page import PageFileSystem
+
+
+class CorpusFactory:
+    """Test indirection to exercise the same assertions against arbitrary public page APIs."""
+
+    def get_docs_knowledge(self):
+        raise AssertionError("test must select a Knowledge instance")
+
+    def get_corpus(self, **kwargs):
+        return PageFileSystem(knowledge=self.get_docs_knowledge()).get_corpus(**kwargs)
+
+
+pages = CorpusFactory()
+
+
+def test_plain_case_insensitive_vfs_search_uses_bounded_public_grep(monkeypatch):
+    from agno.knowledge.page import GrepMatch, GrepResult, Page
+    from agno.knowledge.page._commands import run_command
+    from agno.knowledge.page.filesystem import PageCorpus
+
+    page = Page(
+        content_id="vfs-literal",
+        namespace="test",
+        path="/z.md",
+        url="https://docs.example.com/z",
+        title="Z",
+        revision="one",
+        digest="one",
+        index_fingerprint="test",
+        filesystem_version=1,
+        expected_chunk_count=1,
+    )
+    corpus = PageCorpus(PageFileSystem(knowledge=SimpleNamespace()), {page.path: page})
+    calls = []
+
+    def grep(query, *, prefix, ignore_case):
+        calls.append((query, prefix, ignore_case))
+        return GrepResult(
+            matches=(GrepMatch(path=page.path, url=page.url, revision=page.revision, line_number=2, text="ZepTools"),)
+        )
+
+    monkeypatch.setattr(corpus, "grep", grep)
+    assert "/z.md" in run_command('rg -il "ZepTools" /', corpus)
+    assert calls == [("ZepTools", "/", True)]
+    assert not corpus.loaded
+
+
+@pytest.mark.parametrize("complete,reason", [(True, None), (False, "deadline"), (False, "limit")])
+def test_root_literal_grep_never_traverses_catalog(monkeypatch, complete, reason):
+    from types import SimpleNamespace
+
+    from agno.knowledge.page import GrepMatch, GrepResult
+    from agno.knowledge.page._commands import run_command
+
+    calls = []
+
+    def listing(**kwargs):
+        # run_command's emptiness check is bounded to one metadata record.
+        assert kwargs == {"limit": 1}
+        calls.append("exists")
+        return SimpleNamespace(pages=[object()])
+
+    def grep(query, **kwargs):
+        assert query == "tool_call_limit"
+        assert kwargs == {"prefix": "/", "ignore_case": True, "limit": 100}
+        calls.append("grep")
+        return GrepResult(
+            matches=(
+                GrepMatch(
+                    path="/agents.md", url="https://docs.example.com/agents", revision="r", line_number=2, text=query
+                ),
+            ),
+            complete=complete,
+            stop_reason=reason,
+        )
+
+    monkeypatch.setattr(pages, "get_docs_knowledge", lambda: SimpleNamespace(list_pages=listing, grep_pages=grep))
+    result = run_command('rg -il "tool_call_limit" /', pages.get_corpus(lazy=True))
+    assert result.endswith("\n/agents.md")
+    assert ("[1 matching lines in 1 files]" if complete else f"[stopped at {reason}:") in result
+    assert calls == ["exists", "grep"]
+
+
+@pytest.mark.parametrize("root", ["/scope", "/scope/", "/missing"])
+def test_literal_directory_grep_checks_existence_without_enumeration(monkeypatch, root):
+    from types import SimpleNamespace
+
+    from agno.knowledge.page import GrepMatch, GrepResult, PageNotFound
+    from agno.knowledge.page._commands import run_command
+
+    prefixes = []
+
+    def listing(**kwargs):
+        if kwargs == {"limit": 1}:
+            return SimpleNamespace(pages=[object()])
+        assert kwargs == {"prefix": root.rstrip("/") + "/", "limit": 1}
+        return SimpleNamespace(pages=[SimpleNamespace(path="/scope/a.md")] if root != "/missing" else [])
+
+    def read(*args, **kwargs):
+        raise PageNotFound()
+
+    def grep(query, **kwargs):
+        prefixes.append(kwargs["prefix"])
+        assert kwargs["prefix"] == "/scope/"
+        return GrepResult(
+            matches=(
+                GrepMatch(
+                    path="/scope/a.md", url="https://docs.example.com/a", revision="r", line_number=1, text=query
+                ),
+            )
+        )
+
+    monkeypatch.setattr(
+        pages, "get_docs_knowledge", lambda: SimpleNamespace(list_pages=listing, read_page=read, grep_pages=grep)
+    )
+    result = run_command(f"rg -l needle {root}", pages.get_corpus(lazy=True))
+    if root == "/missing":
+        assert result == "rg: /missing: no such file or directory"
+        assert not prefixes
+    else:
+        assert result == "[1 matching lines in 1 files]\n/scope/a.md"
+        assert prefixes == ["/scope/"]
+
+
+@pytest.mark.parametrize("command", ["cat /a", "head -2 /a", "tail -2 /a", "wc -l /a", "cat /missing /a"])
+def test_explicit_file_commands_do_not_enumerate_the_corpus(monkeypatch, command):
+    from types import SimpleNamespace
+
+    from agno.knowledge.page import PageNotFound
+    from agno.knowledge.page._commands import run_command
+
+    body = "# A\n第一行\nLast line\n"
+    reads = []
+
+    def listing(**kwargs):
+        assert kwargs == {"limit": 1}
+        return SimpleNamespace(pages=[object()])
+
+    def read(path, **kwargs):
+        reads.append(path)
+        if path != "/a.md":
+            raise PageNotFound()
+        return SimpleNamespace(text=body, next_offset=None, revision="first")
+
+    monkeypatch.setattr(pages, "get_docs_knowledge", lambda: SimpleNamespace(list_pages=listing, read_page=read))
+    assert run_command(command, pages.get_corpus(lazy=True)) == run_command(command, {"/a.md": body})
+    assert reads.count("/a.md") == 1
+
+
+def test_scoped_directory_commands_preserve_output_and_revisions(monkeypatch):
+    from types import SimpleNamespace
+
+    from agno.knowledge.page import Page, PageList, PageNotFound
+    from agno.knowledge.page._commands import run_command
+
+    page = Page(
+        content_id="scoped-vfs",
+        namespace="test",
+        path="/scope/a.md",
+        url="https://docs.example.com/scope/a",
+        title="A",
+        revision="r",
+        digest="r",
+        index_fingerprint="test",
+        filesystem_version=1,
+        expected_chunk_count=1,
+    )
+    body = "# A\nneedle\nlast\n"
+    prefixes = []
+
+    def listing(**kwargs):
+        if kwargs == {"limit": 1}:
+            return PageList(pages=(page,))
+        if kwargs["prefix"] == "/scope.md":
+            return PageList()
+        prefixes.append(kwargs["prefix"])
+        assert kwargs["prefix"] == "/scope/"
+        return PageList(pages=(page,))
+
+    def read(path, **kwargs):
+        if path != page.path:
+            raise PageNotFound()
+        assert kwargs["revision"] == "r"
+        return SimpleNamespace(text=body, next_offset=None)
+
+    monkeypatch.setattr(pages, "get_docs_knowledge", lambda: SimpleNamespace(list_pages=listing, read_page=read))
+    source = {page.path: body, "/elsewhere.md": "needle\n"}
+    for command in ("ls /scope", "tree /scope", "find /scope", "rg -C 1 needle /scope"):
+        assert run_command(command, pages.get_corpus(lazy=True)) == run_command(command, source)
+    assert prefixes == ["/scope/"] * 4
+
+
+def test_lazy_page_continuations_reject_refresh_and_next_command_reads_current_text(monkeypatch):
+    from types import SimpleNamespace
+
+    from agno.knowledge.page import PageChanged
+
+    calls = []
+
+    def changing(path, **kwargs):
+        calls.append(kwargs)
+        if kwargs["offset"] == 0:
+            return SimpleNamespace(text="old", next_offset=3, revision="old")
+        assert kwargs["revision"] == "old"
+        raise PageChanged(current_revision="new")
+
+    knowledge = SimpleNamespace(read_page=changing)
+    monkeypatch.setattr(pages, "get_docs_knowledge", lambda: knowledge)
+    with pytest.raises(PageChanged):
+        pages.get_corpus(lazy=True)["/a.md"]
+    knowledge.read_page = lambda *a, **kw: SimpleNamespace(text="new", next_offset=None, revision="new")
+    assert pages.get_corpus(lazy=True)["/a.md"] == "new"
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "rg -C 1 needle /scope/a.md",
+        "rg -l needle /scope/a.md",
+        "rg -l needle /scope/a",
+        "tree /scope/a.md",
+        "find /scope/a.md",
+    ],
+)
+def test_explicit_md_file_does_not_expand_into_same_name_directory(monkeypatch, command):
+    from types import SimpleNamespace
+
+    from agno.knowledge.page import GrepMatch, GrepResult, Page, PageList, PageNotFound
+    from agno.knowledge.page._commands import run_command
+    from agno.knowledge.page._source import page_prefix
+
+    source = {"/scope/a.md": "needle in file\n", "/scope/a/child.md": "needle in child\n"}
+    metadata = {
+        path: Page(
+            content_id=path,
+            namespace="test",
+            path=path,
+            url="https://docs.example.com" + path,
+            title=path,
+            revision="r",
+            digest="r",
+            index_fingerprint="test",
+            filesystem_version=1,
+            expected_chunk_count=1,
+        )
+        for path in source
+    }
+
+    def listing(**kwargs):
+        prefix = page_prefix(kwargs.get("prefix", "/"))
+        return PageList(pages=tuple(page for path, page in metadata.items() if path.startswith(prefix)))
+
+    def read(path, **kwargs):
+        if path not in source:
+            raise PageNotFound()
+        return SimpleNamespace(text=source[path], next_offset=None, revision="r")
+
+    def grep(query, **kwargs):
+        prefix = page_prefix(kwargs["prefix"])
+        return GrepResult(
+            matches=tuple(
+                GrepMatch(path=path, url=metadata[path].url, revision="r", line_number=1, text=body.rstrip("\n"))
+                for path, body in sorted(source.items())
+                if path.startswith(prefix) and query in body
+            )
+        )
+
+    monkeypatch.setattr(
+        pages, "get_docs_knowledge", lambda: SimpleNamespace(list_pages=listing, read_page=read, grep_pages=grep)
+    )
+    assert run_command(command, pages.get_corpus(lazy=True)) == run_command(command, source)

--- a/libs/agno/tests/unit/knowledge/test_page_filesystem_lazy.py
+++ b/libs/agno/tests/unit/knowledge/test_page_filesystem_lazy.py
@@ -276,3 +276,139 @@ def test_explicit_md_file_does_not_expand_into_same_name_directory(monkeypatch, 
         pages, "get_docs_knowledge", lambda: SimpleNamespace(list_pages=listing, read_page=read, grep_pages=grep)
     )
     assert run_command(command, pages.get_corpus(lazy=True)) == run_command(command, source)
+
+
+@pytest.mark.parametrize("command", ["cat /", "head /", "tail /", "wc /", "cat / /a", "wc / /a"])
+@pytest.mark.parametrize("has_index", [False, True])
+def test_root_read_alias_uses_index_and_preserves_later_targets(command, has_index):
+    from agno.knowledge.page import PageNotFound
+    from agno.knowledge.page._commands import run_command
+
+    source = {"/a.md": "valid later page\n"}
+    if has_index:
+        source["/index.md"] = "root index\n"
+    reads = []
+
+    def listing(**kwargs):
+        assert kwargs == {"limit": 1}
+        return SimpleNamespace(pages=[object()])
+
+    def read(path, **kwargs):
+        reads.append(path)
+        assert path in ("/index.md", "/a.md")
+        if path not in source:
+            raise PageNotFound()
+        return SimpleNamespace(text=source[path], next_offset=None, revision="r")
+
+    files = PageFileSystem(knowledge=SimpleNamespace(list_pages=listing, read_page=read))
+    output = files.run_command(command)
+    assert output == run_command(command, source)
+    assert "ValueError" not in output
+    assert reads[0] == "/index.md"
+    if "/a" in command:
+        assert "/a.md" in output
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "ls /agents.md",
+        "tree /agents.md",
+        "find /agents.md",
+        "rg absent /agents.md",
+        "rg -C 1 absent /agents.md",
+        "cat /agents.md",
+    ],
+)
+def test_explicit_file_never_probes_redundant_aliases_or_directory(command):
+    from test_page_filesystem import page
+
+    from agno.knowledge.page import PageList
+    from agno.knowledge.page._commands import run_command
+
+    metadata = page("/agents.md")
+    reads = []
+
+    def listing(**kwargs):
+        assert kwargs == {"limit": 1} or kwargs == {"prefix": "/agents.md", "limit": 1}
+        return PageList(pages=(metadata,))
+
+    def read(path, **kwargs):
+        assert path == "/agents.md"
+        reads.append(path)
+        return SimpleNamespace(text="body", next_offset=None, revision="one")
+
+    files = PageFileSystem(knowledge=SimpleNamespace(list_pages=listing, read_page=read))
+    assert files.run_command(command) == run_command(command, {"/agents.md": "body"})
+    assert len(reads) == (1 if command.startswith(("rg", "cat")) else 0)
+
+
+@pytest.mark.parametrize("flag", ["", "-l", "-c", "-i", "-F"])
+@pytest.mark.parametrize("complete,reason", [(True, None), (False, "deadline"), (False, "limit")])
+def test_literal_file_and_directory_search_keeps_bounded_grep(flag, complete, reason):
+    from agno.knowledge.page import GrepMatch, GrepResult
+
+    calls = []
+
+    def listing(**kwargs):
+        assert kwargs in ({"limit": 1}, {"prefix": "/agents/", "limit": 1})
+        return SimpleNamespace(pages=[SimpleNamespace(path="/agents/child.md")])
+
+    def read(path, **kwargs):
+        assert path == "/agents.md"
+        calls.append("read")
+        return SimpleNamespace(text="needle file\n", next_offset=None, revision="r")
+
+    def grep(query, **kwargs):
+        assert kwargs == {"prefix": "/agents/", "ignore_case": flag == "-i", "limit": 100}
+        calls.append("grep")
+        return GrepResult(
+            matches=(
+                GrepMatch(
+                    path="/agents/child.md",
+                    url="https://example.com/child",
+                    revision="r",
+                    line_number=1,
+                    text="needle child",
+                ),
+            ),
+            complete=complete,
+            stop_reason=reason,
+        )
+
+    files = PageFileSystem(knowledge=SimpleNamespace(list_pages=listing, read_page=read, grep_pages=grep))
+    output = files.run_command(f"rg {flag} needle /agents")
+    assert "/agents.md" in output and "/agents/child.md" in output
+    assert (
+        "[2 matching lines in 2 files]" if complete else f"[stopped at {reason}: 2 matching lines in 2 files so far;"
+    ) in output
+    assert calls == ["read", "grep"]
+
+
+def test_literal_file_and_directory_results_share_the_match_bound():
+    from agno.knowledge.page import GrepMatch, GrepResult
+
+    def grep(*args, **kwargs):
+        return GrepResult(
+            matches=tuple(
+                GrepMatch(
+                    path="/agents/child.md",
+                    url="https://example.com/child",
+                    revision="r",
+                    line_number=i,
+                    text="needle child",
+                )
+                for i in range(1, 101)
+            ),
+            complete=False,
+            stop_reason="limit",
+        )
+
+    knowledge = SimpleNamespace(
+        list_pages=lambda **kwargs: SimpleNamespace(pages=[SimpleNamespace(path="/agents/child.md")]),
+        read_page=lambda *args, **kwargs: SimpleNamespace(text="needle file\n" * 110, next_offset=None, revision="r"),
+        grep_pages=grep,
+    )
+    output = PageFileSystem(knowledge=knowledge).run_command("rg needle /agents")
+    assert output.startswith("[stopped at limit: 100 matching lines in 1 files so far;")
+    assert len(output.splitlines()) == 101

--- a/libs/agno/tests/unit/knowledge/test_page_tools.py
+++ b/libs/agno/tests/unit/knowledge/test_page_tools.py
@@ -1,0 +1,121 @@
+"""Exercise explicit page tool registration through the actual Agent tool loop."""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from agno.agent import Agent
+from agno.knowledge.page import PageChanged, PageError, PageFileSystem, PageList, tool_error
+from agno.models.base import Model
+from agno.models.message import MessageMetrics
+from agno.models.response import ModelResponse
+
+
+class QueryModel(Model):
+    def __init__(self, tool_name, description):
+        super().__init__(id="page-tool-test", name="page-tool-test", provider="test")
+        self.tool_name = tool_name
+        self.description = description
+
+    def invoke(self, messages, tools=None, **kwargs):
+        assert len(tools) == 1
+        function = tools[0]["function"]
+        assert function["name"] == self.tool_name
+        assert function["description"] == self.description
+        assert function["parameters"]["properties"] == {"command": {"type": "string"}}
+        assert function["parameters"]["required"] == ["command"]
+        assert all(self.description not in str(message.content) for message in messages if message.role == "system")
+        results = [message for message in messages if message.role == "tool"]
+        if results:
+            return ModelResponse(role="assistant", content=results[-1].content, response_usage=MessageMetrics())
+        return ModelResponse(
+            role="assistant",
+            tool_calls=[
+                {
+                    "id": "read",
+                    "type": "function",
+                    "function": {
+                        "name": self.tool_name,
+                        "arguments": json.dumps({"command": "cat /a"}),
+                    },
+                }
+            ],
+            response_usage=MessageMetrics(),
+        )
+
+    async def ainvoke(self, *args, **kwargs):
+        return self.invoke(*args, **kwargs)
+
+    def invoke_stream(self, *args, **kwargs):
+        yield self.invoke(*args, **kwargs)
+
+    async def ainvoke_stream(self, *args, **kwargs):
+        yield self.invoke(*args, **kwargs)
+
+    def _parse_provider_response(self, response, **kwargs):
+        return response
+
+    def _parse_provider_response_delta(self, response):
+        return response
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("async_mode", [False, True])
+@pytest.mark.parametrize("custom", [False, True])
+@pytest.mark.parametrize("error", [None, PageError(), PageChanged(current_revision="new")])
+async def test_page_tool_agent_registration_execution_and_errors(monkeypatch, async_mode, custom, error):
+    calls = []
+    files = PageFileSystem(knowledge=SimpleNamespace())
+
+    def execute(command):
+        assert command == "cat /a"
+        if error:
+            raise error
+        return "==> /a.md <==\nPublished page"
+
+    def sync_command(command):
+        calls.append("sync")
+        return execute(command)
+
+    async def async_command(command):
+        calls.append("async")
+        return execute(command)
+
+    monkeypatch.setattr(files, "run_command", sync_command)
+    monkeypatch.setattr(files, "arun_command", async_command)
+    kwargs = {"tool_name": "query_docs_filesystem", "description": "Product-owned exact description."} if custom else {}
+    toolkit = files.tools(**kwargs)
+    name = kwargs.get("tool_name", "query_pages")
+    assert list(toolkit.get_functions()) == list(toolkit.get_async_functions()) == [name]
+    assert not toolkit.add_instructions and toolkit.instructions is None
+    assert calls == []  # Construction does not set up storage or retrieve context.
+    description = toolkit.functions[name].description
+    if not custom:
+        for example in ("cat", "rg", "ls", "30000", "Incomplete"):
+            assert example in description
+    agent = Agent(model=QueryModel(name, description), tools=[toolkit], telemetry=False)
+    result = await agent.arun("Read the page") if async_mode else agent.run("Read the page")
+    assert result.content == (tool_error(error) if error else "==> /a.md <==\nPublished page")
+    assert calls == (["async"] if async_mode else ["sync"])
+    # Direct callers retain typed failures, independent of the tool presentation.
+    if error:
+        with pytest.raises(type(error)):
+            files.run_command("cat /a")
+
+
+@pytest.mark.asyncio
+async def test_page_tools_retain_command_bounds_and_readable_grammar_errors():
+    knowledge = SimpleNamespace(
+        list_pages=lambda **kwargs: PageList(pages=()),
+    )
+    files = PageFileSystem(knowledge=knowledge, max_output_chars=80)
+    toolkit = files.tools()
+    sync = toolkit.get_functions()["query_pages"].entrypoint
+    async_ = toolkit.get_async_functions()["query_pages"].entrypoint
+    assert sync("ls /") == await async_("ls /") == "The page index is empty."
+    knowledge.list_pages = lambda **kwargs: SimpleNamespace(pages=[object()])
+    command = "unsupported" * 1000
+    assert sync(command) == files.run_command(command)
+    assert await async_(command) == files.run_command(command)
+    assert len(sync(command)) < 400


### PR DESCRIPTION
## Summary

Moves reusable read-only page commands from Docs Agent into `PageFileSystem(knowledge=...)`, with synchronous and asynchronous execution. Applications keep their tool names/descriptions, prompts, explicit pre-hook retrieval, rendering, citations and error wording.

The adapter uses public Knowledge APIs for lazy, revision-pinned page reads, scoped metadata listings and bounded literal grep. Regex scans, command workers and caches are bounded; cancellation retains capacity until work finishes. Body caches are instance-scoped and validate publication before reuse. Tool exposure is explicit through `files.tools()`. Commands cannot execute a shell or write files; prompt orchestration remains application-controlled.

Current head: `3adee8b487ba24cdfc479517daa460e1c66f61f9`, based on main `229908e2155769cd63d1377bf0837c488ef90847` containing merged #9996. The branch was rebased after that dependency merged; this review diff contains only VFS work.

The opt-in toolkit removes the handwritten command wrapper:

```python
knowledge.setup()
files = PageFileSystem(knowledge=knowledge)
agent = Agent(tools=[files.tools()])
```

`files.tools(tool_name="query_docs_filesystem", description="...")` customizes the model-visible tool. Sync and async Agent runs select corresponding implementations under one tool name. Page errors become `tool_error` results, while direct command methods still raise typed PageError. Toolkit creation performs no setup, retrieval, or prompt insertion. Custom product wrappers remain supported.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] Searched existing open pull requests; related work is distinguished below
- [x] If a similar PR exists, its relationship is explained below
- [x] Check if this PR was entirely AI-generated

---

## Additional Notes

Validation for current head `3adee8b487ba24cdfc479517daa460e1c66f61f9`:
- Required Agno format/validate PASS (mypy 1,045 framework files; agnoctl validation also passed).
- Combined page/VFS/PostgreSQL/native HTTP/public-response/workflow tests: **399 passed**, including all 66 archived command outputs.
- Confirmed review fixes: root read aliases resolve `/index.md` and preserve later targets; explicit `.md` commands avoid directory enumeration and redundant aliases; literal searches over a same-name file and directory retain bounded database grep for the directory and read only the exact file. Existing shared match/output/time bounds and incomplete-result summaries remain enforced.
- 34 new unit cases and two sync/async PostgreSQL regressions cover those paths. Against the previous command implementation, 33 of the 34 unit cases fail; all pass with this fix. Independent delta review found no high-confidence issues.
- Same local PostgreSQL corpus (one overview plus 250 child pages), connected existing pool and fresh adapter caches: `rg absent /agents` retained identical output while changing 251 page reads / 523 SQL statements / 634ms to one read + one bounded grep / 11 statements / 13ms. Explicit `ls /agents.md` changed 27 to 6 SQL statements; explicit `rg absent /agents.md` changed 25 to 5. Single-run diagnostic timings, not production latency claims.
- An isolated archive of consolidated [Docs Agent #14](https://github.com/agno-agi/docs-agent/pull/14) source `4feb2425d60d4f5c87f77316f855324ebb74936e` was tested against this exact Agno source: required validator PASS (format check, lint, mypy 52 files), **210 tests passed in 19.35s**, including PostgreSQL composition. This result validates the stated product baseline. The product owner subsequently consolidated #14 at `e77b33513f22f5fb22a2450fe0e3ced52eddfcce`, pinning this exact Agno revision in both dependency files, and reports required format/validate PASS, **227 PostgreSQL-inclusive tests PASS**, and exact-commit production-image native smoke PASS. Both product hosted checks are verified SUCCESS. The product owner subsequently reports a completed local corpus (3,886 pages / 12,721 chunks / zero failures) and a passing search gate, but the full agent release gate **FAILED 9/11** (citation placement and an outage answer incorrectly inferring documentation absence). Focused repeats do not replace that result. The website index correction remains local/unpublished; product deployment/release readiness remains open.

Earlier validation at `8b9a5ee0c2c2a6d8f8ff1fd776199c07999065d4` includes the standalone cookbook cat/rg/ls in fresh demo processes against disposable PostgreSQL. Optional live-provider `--ask` mode was not run. Toolkit tests cover one schema, sync/async selection, custom names/descriptions, typed error conversion and absence of prompt injection; they also pass in the current combined suite.

Other regressions cover exact search targets before prefix limits, encoded aliases, lazy/eager/async corpus scope, per-target errors, typed publication disappearance, metadata-only listings and bounded capacity. Command-local mapping lifetime, cache behavior, explicit partial results and bare-prefix semantics are unchanged.

Historical extraction validation at `6d70a1be7ac7223a626bcadfcb8bc7c17b12f199` includes a real wheel in clean Python 3.10 with 66 VFS tests passing and optional-import checks. A deterministic 32-page comparison returned identical outputs; direct cat retained 5 SQL round trips, scoped ls changed 8 to 9 for metadata-only existence, literal grep retained 22. Those are historical/local results, not new live-provider performance claims. Suites overlap and should not be summed.

#9912 concerns separate managed filesystem/browser routes. This adapter adds read-only commands over published Knowledge pages. No cache policy, overload queue, automatic fallback or orchestration redesign. PR1 was merged externally; this update does not merge, deploy, release or bump versions. Agno 3.0.7 is the intended target; VFS inclusion remains a separate release decision. Hosted CI and formal review are reported separately from local validation.

Final hosted verification: all 12 Agno checks SUCCESS at `3adee8b487ba24cdfc479517daa460e1c66f61f9`; both product checks SUCCESS at `e77b33513f22f5fb22a2450fe0e3ced52eddfcce`. Formal review remains required for both PRs.
