### PR TITLE
[fix] Preserve text in grouped PowerPoint shapes

### DIFF
--- a/libs/agno/agno/knowledge/reader/pptx_reader.py
+++ b/libs/agno/agno/knowledge/reader/pptx_reader.py
@@ -12,6 +12,7 @@ from agno.utils.log import log_debug, log_error
 
 try:
     from pptx import Presentation  # type: ignore
+    from pptx.shapes.group import GroupShape  # type: ignore
 except ImportError:
     raise ImportError("The `python-pptx` package is not installed. Please install it via `pip install python-pptx`.")
 
@@ -60,10 +61,14 @@ class PPTXReader(Reader):
             for slide_number, slide in enumerate(presentation.slides, 1):
                 slide_text = f"Slide {slide_number}:\n"
 
-                # Extract text from shapes that contain text
+                # Traverse nested groups while preserving the slide's shape order.
                 text_content = []
-                for shape in slide.shapes:
-                    if hasattr(shape, "text") and shape.text.strip():
+                shapes = list(slide.shapes)[::-1]
+                while shapes:
+                    shape = shapes.pop()
+                    if isinstance(shape, GroupShape):
+                        shapes.extend(list(shape.shapes)[::-1])
+                    elif hasattr(shape, "text") and shape.text.strip():
                         text_content.append(shape.text.strip())
 
                 if text_content:

--- a/libs/agno/tests/unit/reader/test_pptx_reader.py
+++ b/libs/agno/tests/unit/reader/test_pptx_reader.py
@@ -4,7 +4,11 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
+from pptx import Presentation
+from pptx.enum.shapes import MSO_SHAPE
+from pptx.util import Inches
 
+from agno.knowledge.chunking.document import DocumentChunking
 from agno.knowledge.document.base import Document
 from agno.knowledge.reader.pptx_reader import PPTXReader
 
@@ -271,3 +275,62 @@ def test_pptx_reader_default_chunk_size():
     assert reader.chunk_size == 5000
     assert reader.chunking_strategy.chunk_size == 5000
     assert isinstance(reader.chunking_strategy, DocumentChunking)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("async_mode", "path_input", "chunk"),
+    [
+        (async_mode, path_input, chunk)
+        for async_mode in (False, True)
+        for path_input in (False, True)
+        for chunk in (False, True)
+    ],
+)
+async def test_pptx_reader_preserves_text_in_grouped_shapes(async_mode, path_input, chunk, tmp_path):
+    presentation = Presentation()
+    slide = presentation.slides.add_slide(presentation.slide_layouts[6])
+    before = slide.shapes.add_textbox(Inches(1), Inches(1), Inches(6), Inches(1))
+    before.text = "Before group"
+    grouped = slide.shapes.add_textbox(Inches(1), Inches(2), Inches(6), Inches(1))
+    grouped.text = "Grouped text"
+    blank = slide.shapes.add_textbox(Inches(1), Inches(3), Inches(6), Inches(1))
+    blank.text = "  "
+    nested = slide.shapes.add_textbox(Inches(1), Inches(4), Inches(6), Inches(1))
+    nested.text = "중첩 그룹"
+    nested_group = slide.shapes.add_group_shape([nested])
+    slide.shapes.add_group_shape([grouped, blank, nested_group])
+    after = slide.shapes.add_textbox(Inches(1), Inches(5), Inches(6), Inches(1))
+    after.text = "After group"
+    slide.shapes.add_shape(MSO_SHAPE.RECTANGLE, Inches(1), Inches(6), Inches(1), Inches(1))
+
+    grouped_only_slide = presentation.slides.add_slide(presentation.slide_layouts[6])
+    grouped_only = grouped_only_slide.shapes.add_textbox(Inches(1), Inches(1), Inches(6), Inches(1))
+    grouped_only.text = "Grouped only"
+    grouped_only_slide.shapes.add_group_shape([grouped_only])
+
+    empty_slide = presentation.slides.add_slide(presentation.slide_layouts[6])
+    empty_slide.shapes.add_group_shape()
+    empty_slide.shapes.add_shape(MSO_SHAPE.RECTANGLE, Inches(1), Inches(1), Inches(1), Inches(1))
+
+    stream = BytesIO()
+    presentation.save(stream)
+    payload = stream.getvalue()
+    path = tmp_path / "grouped.pptx"
+    path.write_bytes(payload)
+    source = path if path_input else BytesIO(payload)
+    expected_content = (
+        "Slide 1:\nBefore group\nGrouped text\n중첩 그룹\nAfter group"
+        "\n\nSlide 2:\nGrouped only\n\nSlide 3:\n(No text content)"
+    )
+
+    reader = PPTXReader(chunk=chunk, chunk_size=50)
+    documents = await reader.async_read(source, name="grouped") if async_mode else reader.read(source, name="grouped")
+
+    expected_documents = (
+        DocumentChunking(chunk_size=50).chunk(Document(name="grouped", id="expected", content=expected_content))
+        if chunk
+        else [Document(name="grouped", id="expected", content=expected_content)]
+    )
+    assert [document.content for document in documents] == [document.content for document in expected_documents]
+    assert all(document.name == "grouped" and document.id for document in documents)


### PR DESCRIPTION
## Summary

Grouping an ordinary PowerPoint text box currently makes its text disappear from `PPTXReader` output and downstream Knowledge documents. Visit grouped and nested shapes in their existing order so sync and async reads retain that text, with the same slide labels, blank-shape filtering, and chunking.

Fixes #9999

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Regression coverage uses real serialized PPTX files with nested Unicode text, mixed grouped and ungrouped shapes, grouped-only and empty slides, paths and streams, sync and async reading, and actual chunk splitting. The same regression fails on the upstream base because grouped text is missing.

A separate local check ingested real PPTX files into Knowledge with Chroma and retrieved the grouped text through sync/async paths and automatic/explicit reader selection. It used a deterministic local embedder to check content preservation.

Validation on `4c086ea` (Python 3.12.10, python-pptx 1.0.2):

- Official `./scripts/format.sh` and `./scripts/validate.sh` passed in a fresh environment with the documented dev extras.
- Focused PPTX/DOCX/chunk-ID regression suite: 46 passed.
- Official `./scripts/test.sh`: 19,634 passed, 94 skipped, 307 warnings; exit 0 with HTML coverage generated. MongoDB and the CI pgvector service ran in Docker. The test process used an open-file limit of 8192; the local default of 256 caused file exhaustion, also reproduced with unmodified upstream code.

Warnings include dependency deprecations, chunk-overlap warnings, mocked-type warnings, and aiosqlite thread teardown warnings. Skipped checks are not counted as passed. An initial validation with all optional provider SDKs had 49 type errors identical to the upstream base; final validation uses the documented dev environment, as the style CI job does. No new cookbook pattern is introduced.

Duplicate search on 2026-09-06 UTC included open and closed PPTX-related work. The closest open PR, #7125, changes default chunker construction and leaves this extraction loop unchanged.

This change was generated with Codex. The extraction change and regression were reviewed locally; CI results will be available after submission.
