### PR TITLE
fix(knowledge): PPTXReader now extracts text from grouped shapes

### DIFF
--- a/libs/agno/agno/knowledge/reader/pptx_reader.py
+++ b/libs/agno/agno/knowledge/reader/pptx_reader.py
@@ -16,6 +16,17 @@ except ImportError:
     raise ImportError("The `python-pptx` package is not installed. Please install it via `pip install python-pptx`.")
 
 
+def _collect_shape_text(shapes) -> List[str]:
+    """Recursively collect non-empty text from shapes, descending into GroupShapes."""
+    texts: List[str] = []
+    for shape in shapes:
+        if hasattr(shape, "shapes"):  # GroupShape — recurse into children
+            texts.extend(_collect_shape_text(shape.shapes))
+        elif hasattr(shape, "text") and shape.text.strip():
+            texts.append(shape.text.strip())
+    return texts
+
+
 class PPTXReader(Reader):
     """Reader for PPTX files"""
 
@@ -60,11 +71,7 @@ class PPTXReader(Reader):
             for slide_number, slide in enumerate(presentation.slides, 1):
                 slide_text = f"Slide {slide_number}:\n"
 
-                # Extract text from shapes that contain text
-                text_content = []
-                for shape in slide.shapes:
-                    if hasattr(shape, "text") and shape.text.strip():
-                        text_content.append(shape.text.strip())
+                text_content = _collect_shape_text(slide.shapes)
 
                 if text_content:
                     slide_text += "\n".join(text_content)

--- a/libs/agno/tests/unit/knowledge/test_pptx_reader_grouped.py
+++ b/libs/agno/tests/unit/knowledge/test_pptx_reader_grouped.py
@@ -1,0 +1,80 @@
+"""
+Regression test for agno#9999:
+PPTXReader must extract text from shapes inside GroupShapes (including nested groups).
+"""
+import pytest
+from io import BytesIO
+
+from pptx import Presentation
+from pptx.util import Inches
+
+
+def _make_pptx(grouped: bool) -> BytesIO:
+    """Create a minimal PPTX with one text box, optionally inside a group."""
+    deck = Presentation()
+    slide = deck.slides.add_slide(deck.slide_layouts[6])
+    box = slide.shapes.add_textbox(Inches(1), Inches(1), Inches(6), Inches(1))
+    box.text = "Launch date: 2026-10-01"
+    if grouped:
+        slide.shapes.add_group_shape([box])
+    buf = BytesIO()
+    deck.save(buf)
+    return buf
+
+
+def _make_nested_pptx() -> BytesIO:
+    """Create a PPTX with a text box nested two levels deep in groups."""
+    deck = Presentation()
+    slide = deck.slides.add_slide(deck.slide_layouts[6])
+    box = slide.shapes.add_textbox(Inches(1), Inches(1), Inches(6), Inches(1))
+    box.text = "Nested text"
+    outer = slide.shapes.add_group_shape([box])
+    slide.shapes.add_group_shape([outer])
+    buf = BytesIO()
+    deck.save(buf)
+    return buf
+
+
+def test_grouped_text_is_extracted():
+    """Text inside a GroupShape must appear in the extracted content."""
+    from agno.knowledge.reader.pptx_reader import PPTXReader
+
+    reader = PPTXReader(chunk=False)
+    plain_docs = reader.read(BytesIO(_make_pptx(grouped=False).getvalue()))
+    grouped_docs = reader.read(BytesIO(_make_pptx(grouped=True).getvalue()))
+
+    assert plain_docs, "plain PPTX returned no documents"
+    assert grouped_docs, "grouped PPTX returned no documents"
+
+    plain_text = plain_docs[0].content
+    grouped_text = grouped_docs[0].content
+
+    assert "Launch date: 2026-10-01" in plain_text, "plain text not found"
+    assert "Launch date: 2026-10-01" in grouped_text, (
+        f"Grouped text was dropped. Got: {repr(grouped_text)}"
+    )
+    assert "(No text content)" not in grouped_text, (
+        "Reader reported no text content for a slide that has grouped text"
+    )
+
+
+def test_nested_group_text_is_extracted():
+    """Text nested two levels deep in GroupShapes must also be extracted."""
+    from agno.knowledge.reader.pptx_reader import PPTXReader
+
+    reader = PPTXReader(chunk=False)
+    docs = reader.read(BytesIO(_make_nested_pptx().getvalue()))
+
+    assert docs, "nested PPTX returned no documents"
+    assert "Nested text" in docs[0].content, (
+        f"Doubly-nested text was dropped. Got: {repr(docs[0].content)}"
+    )
+
+
+def test_ungrouped_shapes_still_work():
+    """Existing behaviour for plain (non-grouped) shapes must be preserved."""
+    from agno.knowledge.reader.pptx_reader import PPTXReader
+
+    reader = PPTXReader(chunk=False)
+    docs = reader.read(BytesIO(_make_pptx(grouped=False).getvalue()))
+    assert docs and "Launch date: 2026-10-01" in docs[0].content


### PR DESCRIPTION
## Root cause

`PPTXReader.read()` iterated over `slide.shapes` and checked `hasattr(shape, 'text')`, but a `GroupShape` exposes its children via `.shapes` and returns an empty string from `.text`. Any text box placed inside a group (including nested groups) was therefore silently dropped and the slide was reported as `(No text content)`.

Reported in #9999.

## Fix

Replace the flat loop with a recursive helper `_collect_shape_text` that descends into any shape that has a `.shapes` attribute before falling back to the `.text` check:

```python
def _collect_shape_text(shapes) -> List[str]:
    texts: List[str] = []
    for shape in shapes:
        if hasattr(shape, "shapes"):  # GroupShape — recurse into children
            texts.extend(_collect_shape_text(shape.shapes))
        elif hasattr(shape, "text") and shape.text.strip():
            texts.append(shape.text.strip())
    return texts
```

The helper handles arbitrarily deep nesting and is a pure function with no side effects. The `async_read` path is unaffected because it delegates to `read()` via `asyncio.to_thread`.

## Test evidence

New regression tests in `tests/unit/knowledge/test_pptx_reader_grouped.py`:

| Test | Unpatched | Patched |
|------|-----------|---------|
| `test_grouped_text_is_extracted` | FAILED — `'Slide 1:\n(No text content)'` | PASSED |
| `test_nested_group_text_is_extracted` | FAILED — `'Slide 1:\n(No text content)'` | PASSED |
| `test_ungrouped_shapes_still_work` | PASSED | PASSED |

```
Unpatched: 2 failed, 1 passed in 0.45s
Patched:   3 passed in 0.22s
```

Fixes #9999