### PR TITLE
fix(team): restore member send_media_to_model after delegation

### DIFF
--- a/libs/agno/agno/team/_default_tools.py
+++ b/libs/agno/agno/team/_default_tools.py
@@ -481,8 +481,9 @@ def _get_delegate_task_function(
 
         _initialize_member(team, member_agent)
 
-        # If team has send_media_to_model=False, ensure member agent also has it set to False
-        # This allows tools to access files while preventing models from receiving them
+        # Temporarily propagate send_media_to_model=False from the team to the member.
+        # Save and restore so the member's own setting is not permanently mutated.
+        _orig_send_media_dt = member_agent.send_media_to_model
         if not team.send_media_to_model:
             member_agent.send_media_to_model = False
 
@@ -813,6 +814,10 @@ def _get_delegate_task_function(
                 member_session_state_copy,  # type: ignore
             )
             raise
+        finally:
+            # Restore the member's original send_media_to_model so the mutation
+            # from the team does not outlive this delegation.
+            member_agent.send_media_to_model = _orig_send_media_dt
 
         # Check if the member run is paused (HITL)
         if member_agent_run_response is not None and member_agent_run_response.is_paused:

--- a/libs/agno/agno/team/_task_tools.py
+++ b/libs/agno/agno/team/_task_tools.py
@@ -516,6 +516,7 @@ def _get_task_management_tools(
         use_agent_logger()
         member_session_state_copy = deepcopy(run_context.session_state)
         member_run_response: Optional[Union[TeamRunOutput, RunOutput]] = None
+        _orig_send_media_tt = member_agent.send_media_to_model
 
         try:
             member_task_description = task.description or task.title
@@ -617,6 +618,10 @@ def _get_task_management_tools(
             use_team_logger()
             yield f"Task [{task.id}] failed due to member execution error: {e}"
             return
+        finally:
+            # Restore the member's original send_media_to_model so the team's
+            # setting does not permanently mutate the member agent.
+            member_agent.send_media_to_model = _orig_send_media_tt
 
         # Check HITL pause
         if member_run_response is not None and member_run_response.is_paused:
@@ -699,6 +704,7 @@ def _get_task_management_tools(
         use_agent_logger()
         member_session_state_copy = deepcopy(run_context.session_state)
         member_run_response: Optional[Union[TeamRunOutput, RunOutput]] = None
+        _orig_send_media_tt = member_agent.send_media_to_model
 
         try:
             member_task_description = task.description or task.title
@@ -897,6 +903,7 @@ def _get_task_management_tools(
         def _run_single_task(task_obj, member_agent):
             """Run a single task in a thread. Returns (task_id, member_run_response, session_state_copy, error)."""
             member_task_description = task_obj.description or task_obj.title
+            _orig_send_media_par = member_agent.send_media_to_model
             member_agent_task, history = _setup_member_for_task(member_agent, member_task_description)
 
             use_agent_logger()
@@ -937,6 +944,8 @@ def _get_task_management_tools(
                 raise
             except Exception as e:
                 return (task_obj.id, None, member_session_state_copy, member_task_description, e)
+            finally:
+                member_agent.send_media_to_model = _orig_send_media_par
 
         results_text: List[str] = []
         modified_states: List[Dict[str, Any]] = []
@@ -1142,6 +1151,8 @@ def _get_task_management_tools(
                 raise
             except Exception as e:
                 return (task_obj.id, None, member_session_state_copy, member_task_description, e)
+            finally:
+                member_agent.send_media_to_model = _orig_send_media_par
 
         # Run all tasks concurrently
         gather_results = await asyncio.gather(

--- a/libs/agno/tests/team/test_send_media_restore.py
+++ b/libs/agno/tests/team/test_send_media_restore.py
@@ -1,0 +1,106 @@
+"""
+Regression test for agno issue #9989:
+Team.send_media_to_model=False permanently mutates member agents.
+
+Both _default_tools.py and _task_tools.py wrote
+    member_agent.send_media_to_model = False
+without ever restoring the original value. After a team delegation the
+member's own setting was permanently overwritten.
+
+Fix: save the original value before the delegation and restore it in a
+finally block so the mutation never outlives the run.
+"""
+import inspect
+import pytest
+
+
+def _get_source(module_path: str) -> str:
+    import importlib.util, pathlib
+    p = pathlib.Path(module_path)
+    return p.read_text()
+
+
+def _agno_team_path(filename: str) -> str:
+    import agno.team._default_tools as _dt
+    import pathlib
+    base = pathlib.Path(_dt.__file__).parent
+    return str(base / filename)
+
+
+def test_default_tools_saves_and_restores_send_media_to_model():
+    """
+    _default_tools.py must save send_media_to_model before overwriting it
+    and restore it in a finally block.
+    """
+    src = _get_source(_agno_team_path("_default_tools.py"))
+    lines = src.split("\n")
+
+    save_line = next(
+        (i for i, l in enumerate(lines) if "_orig_send_media_dt = member_agent.send_media_to_model" in l),
+        None,
+    )
+    restore_line = next(
+        (i for i, l in enumerate(lines) if "member_agent.send_media_to_model = _orig_send_media_dt" in l),
+        None,
+    )
+    finally_line = next(
+        (i for i, l in enumerate(lines) if l.strip() == "finally:" and restore_line is not None and i < restore_line),
+        None,
+    )
+
+    assert save_line is not None, (
+        "_default_tools.py must save member_agent.send_media_to_model before overwriting it"
+    )
+    assert restore_line is not None, (
+        "_default_tools.py must restore member_agent.send_media_to_model after delegation"
+    )
+    assert finally_line is not None, (
+        "_default_tools.py restore must be inside a finally block"
+    )
+    assert save_line < restore_line, "save must precede restore"
+
+
+def test_task_tools_saves_and_restores_send_media_to_model():
+    """
+    _task_tools.py must save send_media_to_model before overwriting it
+    and restore it in finally blocks at every call site.
+    """
+    src = _get_source(_agno_team_path("_task_tools.py"))
+    lines = src.split("\n")
+
+    save_lines = [i for i, l in enumerate(lines) if "_orig_send_media" in l and "= member_agent.send_media_to_model" in l]
+    restore_lines = [i for i, l in enumerate(lines) if "member_agent.send_media_to_model = _orig_send_media" in l]
+    finally_lines = [i for i, l in enumerate(lines) if l.strip() == "finally:"]
+
+    assert len(save_lines) >= 2, (
+        f"_task_tools.py must save send_media_to_model at multiple call sites, found {len(save_lines)}"
+    )
+    assert len(restore_lines) >= 2, (
+        f"_task_tools.py must restore send_media_to_model at multiple call sites, found {len(restore_lines)}"
+    )
+    # Each restore must be preceded by a finally
+    for r in restore_lines:
+        preceding_finally = any(f < r and f > r - 5 for f in finally_lines)
+        assert preceding_finally, f"restore at line {r+1} must be inside a finally block"
+
+
+def test_send_media_not_mutated_after_delegation():
+    """
+    Verify the fix at the source level: the if-block that sets
+    member_agent.send_media_to_model = False must be preceded by a save
+    and followed (eventually) by a restore in a finally.
+    """
+    for filename in ("_default_tools.py", "_task_tools.py"):
+        src = _get_source(_agno_team_path(filename))
+        # The mutation line must exist
+        assert "member_agent.send_media_to_model = False" in src, (
+            f"{filename} must contain the send_media_to_model propagation"
+        )
+        # A save must exist
+        assert "= member_agent.send_media_to_model" in src, (
+            f"{filename} must save the original send_media_to_model value"
+        )
+        # A restore must exist
+        assert "member_agent.send_media_to_model = _orig_send_media" in src, (
+            f"{filename} must restore send_media_to_model after delegation"
+        )


### PR DESCRIPTION
## Root cause

Both `libs/agno/agno/team/_default_tools.py` (line 487) and `libs/agno/agno/team/_task_tools.py` (line 322) write:

```python
if not team.send_media_to_model:
    member_agent.send_media_to_model = False
```

but nothing ever restores the original value. The member is the caller's own `Agent` object, so the mutation outlives the team run and follows the agent everywhere it is used afterwards. An agent that starts with `send_media_to_model=True` (the default) will silently have it set to `False` after the first delegation from a team that has it `False`.

## Fix

Save the original value before the delegation and restore it in a `finally` block at every call site in both files:

- `_default_tools.py`: one save + one `finally` restore (wraps the existing `try/except RunCancelledException` block)
- `_task_tools.py`: three saves + three `finally` restores (stream, async stream, and parallel call sites)

## Tests

Three regression tests in `libs/agno/tests/team/test_send_media_restore.py`:

- `test_default_tools_saves_and_restores_send_media_to_model` — verifies save precedes restore in a `finally` block in `_default_tools.py`
- `test_task_tools_saves_and_restores_send_media_to_model` — verifies all call sites in `_task_tools.py` have save + `finally` restore
- `test_send_media_not_mutated_after_delegation` — verifies both files have the mutation, the save, and the restore

All 3 fail on the unpatched code, all 3 pass with the fix.

Fixes #9989