### PR TITLE
[fix] Reject invalid fixed and recursive chunking parameters

### DIFF
--- a/libs/agno/agno/knowledge/chunking/fixed.py
+++ b/libs/agno/agno/knowledge/chunking/fixed.py
@@ -8,6 +8,11 @@ class FixedSizeChunking(ChunkingStrategy):
     """Chunking strategy that splits text into fixed-size chunks with optional overlap"""
 
     def __init__(self, chunk_size: int = 5000, overlap: int = 0):
+        if chunk_size <= 0:
+            raise ValueError(f"Invalid parameters: chunk size ({chunk_size}) must be greater than zero.")
+        if overlap < 0:
+            raise ValueError(f"Invalid parameters: overlap ({overlap}) must be non-negative.")
+
         # overlap must be less than chunk size
         if overlap >= chunk_size:
             raise ValueError(f"Invalid parameters: overlap ({overlap}) must be less than chunk size ({chunk_size}).")

--- a/libs/agno/agno/knowledge/chunking/recursive.py
+++ b/libs/agno/agno/knowledge/chunking/recursive.py
@@ -9,6 +9,11 @@ class RecursiveChunking(ChunkingStrategy):
     """Chunking strategy that recursively splits text into chunks by finding natural break points"""
 
     def __init__(self, chunk_size: int = 5000, overlap: int = 0):
+        if chunk_size <= 0:
+            raise ValueError(f"Invalid parameters: chunk size ({chunk_size}) must be greater than zero.")
+        if overlap < 0:
+            raise ValueError(f"Invalid parameters: overlap ({overlap}) must be non-negative.")
+
         # overlap must be less than chunk size
         if overlap >= chunk_size:
             raise ValueError(f"Invalid parameters: overlap ({overlap}) must be less than chunk size ({chunk_size}).")

--- a/libs/agno/tests/unit/knowledge/chunking/test_chunking_parameters.py
+++ b/libs/agno/tests/unit/knowledge/chunking/test_chunking_parameters.py
@@ -1,0 +1,34 @@
+"""Parameter boundaries shared by fixed and recursive chunking."""
+
+import pytest
+
+from agno.knowledge.chunking.fixed import FixedSizeChunking
+from agno.knowledge.chunking.recursive import RecursiveChunking
+from agno.knowledge.document.base import Document
+
+
+@pytest.mark.parametrize("strategy", [FixedSizeChunking, RecursiveChunking])
+@pytest.mark.parametrize("chunk_size, overlap", [(4, -2), (0, -1), (-1, -2)])
+def test_invalid_parameters_are_rejected_before_chunking(strategy, chunk_size, overlap):
+    with pytest.raises(ValueError):
+        strategy(chunk_size=chunk_size, overlap=overlap)
+
+
+@pytest.mark.parametrize("strategy", [FixedSizeChunking, RecursiveChunking])
+@pytest.mark.parametrize("overlap", [0, 1, 3])
+def test_valid_overlap_preserves_all_source_characters(strategy, overlap):
+    content = "abcdefghijkl"
+    chunks = strategy(chunk_size=4, overlap=overlap).chunk(Document(content=content))
+
+    covered = set()
+    for chunk in chunks:
+        start = content.index(chunk.content)
+        covered.update(range(start, start + len(chunk.content)))
+    assert covered == set(range(len(content)))
+
+
+@pytest.mark.parametrize("strategy", [FixedSizeChunking, RecursiveChunking])
+@pytest.mark.parametrize("overlap", [4, 5])
+def test_overlap_at_or_above_chunk_size_remains_invalid(strategy, overlap):
+    with pytest.raises(ValueError):
+        strategy(chunk_size=4, overlap=overlap)


### PR DESCRIPTION
## Summary

Fixes #10005.

`FixedSizeChunking` and `RecursiveChunking` accept negative overlap values, which silently skip source text. For example, chunking `abcdefghijkl` with `chunk_size=4, overlap=-2` produces only `abcd` and `ghij` in both strategies.

Reject non-positive chunk sizes and negative overlap during initialization with `ValueError`, alongside the existing overlap upper-bound check. Valid configurations keep their existing behavior. Previously accepted invalid configurations now fail explicitly.

Adds parameterized tests covering invalid values, valid source coverage, and the existing upper-bound rejection. No dependency changes.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

Prepared with Codex. AI assistance is disclosed above; validation results and limitations are documented below.

Validation on Python 3.12.13:
- Existing focused tests on unchanged main: 5 passed.
- New regression tests before the fix: 6 failed, 10 passed.
- After the fix: 35 passed across test_chunking_parameters.py, test_fixed_size_chunking.py, test_recursive_chunking.py, and test_chunk_id_generation.py.
- Repository format and validation scripts passed, including Ruff and mypy.
- A direct full unit-test collection found 15,936 tests but stopped with 119 collection errors from unavailable optional integrations (for example, pymongo, chonkie, and provider SDKs); the full suite was not executed.
- The full test script fails before invoking pytest because it does not quote paths containing spaces in its shell source statements. Full-suite success is not claimed.

This patch is limited to the fixed and recursive chunkers; it does not claim improved end-to-end retrieval metrics.

