### PR TITLE
[fix] Remove stale discovered MCP tools on refresh

### DIFF
--- a/libs/agno/agno/tools/mcp/mcp.py
+++ b/libs/agno/agno/tools/mcp/mcp.py
@@ -420,6 +420,8 @@ class MCPTools(Toolkit):
             self.server_params = StdioServerParameters(command=cmd, args=arguments, env=env)
 
         self._client = client
+        # Track the exact functions discovery owns so refreshes preserve local registrations.
+        self._mcp_functions: dict[str, Function] = {}
 
         self._initialized = False
         self._connection_task = None
@@ -910,7 +912,8 @@ class MCPTools(Toolkit):
             if self.tool_name_prefix is not None:
                 tool_name_prefix = self.tool_name_prefix + "_"
 
-            # Register the tools with the toolkit
+            # Build the new discovery snapshot before replacing previously discovered functions.
+            discovered_functions: dict[str, Function] = {}
             for tool in filtered_tools:
                 try:
                     # Get an entrypoint for the tool
@@ -943,11 +946,17 @@ class MCPTools(Toolkit):
                         cache_ttl=self.cache_ttl,
                     )
 
-                    # Register the Function with the toolkit
-                    self.functions[f.name] = f
+                    discovered_functions[f.name] = f
                     log_debug(f"Function: {f.name} registered with {self.name}")
                 except Exception as e:
                     log_error(f"Failed to register tool {tool.name}: {str(e)}")
+
+            for name, function in self._mcp_functions.items():
+                # A caller may have replaced a discovered function through Toolkit.register().
+                if self.functions.get(name) is function:
+                    del self.functions[name]
+            self.functions.update(discovered_functions)
+            self._mcp_functions = discovered_functions
 
         except Exception:
             log_error(f"Failed to get tools for {str(self)}")

--- a/libs/agno/tests/unit/tools/test_mcp_refresh.py
+++ b/libs/agno/tests/unit/tools/test_mcp_refresh.py
@@ -1,0 +1,139 @@
+"""MCP discovery must replace its previous snapshot without dropping local tools."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from mcp.types import ListToolsResult, Tool
+
+from agno.tools.mcp import MCPTools
+
+
+def make_tool(name, **properties):
+    return Tool(name=name, description=name, inputSchema={"type": "object", "properties": properties})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("list_result", [False, True])
+@pytest.mark.parametrize("change", ["removed", "empty", "include", "exclude", "prefix"])
+async def test_refresh_removes_stale_discovered_functions(list_result, change):
+    session = AsyncMock()
+    listing = [make_tool("old"), make_tool("keep")]
+    session.list_tools.return_value = ListToolsResult(tools=listing) if list_result else listing
+    tools = MCPTools(session=session)
+    await tools.build_tools()
+    registry = tools.functions
+
+    if change == "removed":
+        listing = [make_tool("keep"), make_tool("new")]
+        expected = {"keep", "new"}
+    elif change == "empty":
+        listing = []
+        expected = set()
+    elif change == "include":
+        tools.include_tools = ["keep"]
+        expected = {"keep"}
+    elif change == "exclude":
+        tools.exclude_tools = ["old"]
+        expected = {"keep"}
+    else:
+        tools.tool_name_prefix = "remote"
+        expected = {"remote_old", "remote_keep"}
+
+    session.list_tools.return_value = ListToolsResult(tools=listing) if list_result else listing
+    await tools.build_tools()
+
+    assert tools.functions is registry
+    assert set(tools.get_functions()) == expected
+    assert set(tools.get_async_functions()) == expected
+
+
+@pytest.mark.asyncio
+async def test_refresh_updates_schema_and_keeps_tool_settings():
+    session = AsyncMock()
+    session.list_tools.return_value = [make_tool("search", query={"type": "string"})]
+    tools = MCPTools(session=session, requires_confirmation_tools=["search"], cache_results=True)
+    await tools.build_tools()
+    previous = tools.functions["search"]
+    session.list_tools.return_value = [make_tool("search", count={"type": "integer"})]
+
+    await tools.build_tools()
+
+    current = tools.functions["search"]
+    assert current is not previous
+    assert current.parameters["properties"] == {"count": {"type": "integer"}}
+    assert current.requires_confirmation is True
+    assert current.cache_results is True
+
+
+@pytest.mark.asyncio
+async def test_refresh_preserves_locally_registered_functions_and_replacements():
+    session = AsyncMock()
+    session.list_tools.return_value = [make_tool("old")]
+    tools = MCPTools(session=session)
+    await tools.build_tools()
+
+    def local() -> str:
+        return "local"
+
+    async def async_local() -> str:
+        return "async local"
+
+    tools.register(local)
+    tools.register(async_local)
+    tools.register(local, name="old")
+    replacement = tools.functions["old"]
+    session.list_tools.return_value = []
+
+    await tools.build_tools()
+
+    assert set(tools.get_async_functions()) == {"local", "async_local", "old"}
+    assert tools.functions["old"] is replacement
+
+
+@pytest.mark.asyncio
+async def test_failed_listing_preserves_registry_and_next_refresh_can_remove_it():
+    session = AsyncMock()
+    session.list_tools.return_value = [make_tool("old")]
+    tools = MCPTools(session=session)
+    await tools.build_tools()
+    previous = dict(tools.functions)
+    session.list_tools.side_effect = RuntimeError("server unavailable")
+
+    with pytest.raises(RuntimeError, match="server unavailable"):
+        await tools.build_tools()
+
+    assert tools.functions == previous
+    session.list_tools.side_effect = None
+    session.list_tools.return_value = []
+    await tools.build_tools()
+    assert tools.functions == {}
+
+
+@pytest.mark.asyncio
+async def test_refresh_follows_real_server_visibility_changes():
+    from fastmcp import Client, FastMCP
+
+    server = FastMCP("refresh-test")
+
+    @server.tool
+    def old_tool() -> str:
+        return "old"
+
+    @server.tool
+    def new_tool() -> str:
+        return "new"
+
+    server.disable(names={"new_tool"}, components={"tool"})
+    async with Client(server) as client:
+        tools = MCPTools(session=client, refresh_connection=True)
+        await tools.build_tools()
+        assert list(tools.get_async_functions()) == ["old_tool"]
+
+        server.disable(names={"old_tool"}, components={"tool"})
+        server.enable(names={"new_tool"}, components={"tool"})
+        assert [tool.name for tool in await client.list_tools()] == ["new_tool"]
+        await tools.build_tools()
+
+        assert list(tools.get_async_functions()) == ["new_tool"]
+        result = await tools.functions["new_tool"].entrypoint()
+        assert result.content == "new"


### PR DESCRIPTION
## Summary

Fixes #10006.

When an MCP server replaces `old_tool` with `new_tool`, `MCPTools.build_tools()` currently leaves both functions registered. This affects the existing `refresh_connection=True` path and also retains tools removed by updated include/exclude filters.

Track the exact Function objects owned by MCP discovery, build the new discovery result locally, and reconcile it after a successful listing. Remove an old entry only when the registered object is still the one discovery created, preserving manually registered functions and manual replacements of removed tools. Keep the existing registry object, per-tool settings, same-name overwrite policy, and per-tool conversion-error handling. A failed listing leaves the previous registry intact.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

Prepared and verified with Codex assistance. Human self-review is not asserted by the unchecked checklist item. This fixes existing MCP discovery refresh; it does not introduce the runtime ToolRegistry of #9089 or the lazy discovery API proposed in #7191.

Validation on Python 3.12.13, mcp 2.1.1 and fastmcp 4.0.3:

- Unmodified baseline: 104 existing MCP tests passed.
- Added tests before the patch: 12 failed, 2 passed.
- After the patch: 118 MCP tests passed (existing and new), plus 64 Toolkit tests passed.
- A real in-process FastMCP server changes visibility from old_tool to new_tool; the toolkit now exposes only new_tool, and its entrypoint successfully calls that tool. No LLM, API key or network service is used.
- Tests cover list and ListToolsResult responses, removals, empty listings, filters, prefixes, schema updates, tool settings, manual registrations/replacements and recovery after list failure.
- Repository format and validation scripts passed, including Ruff, mypy and cookbook pattern checks.
- Full repository unit-suite execution is not claimed; it requires additional optional integration dependencies. This patch was verified with the focused suites above.

The final registry update contains no await. This is not a new concurrency/version-ordering guarantee for multiple simultaneous refresh requests, and does not change the pagination or connection lifecycle.
