### PR TITLE
[fix] resolve tokenizers per model family instead of silently using OpenAI's

### DIFF
--- a/libs/agno/agno/utils/tokens.py
+++ b/libs/agno/agno/utils/tokens.py
@@ -21,10 +21,13 @@ DEFAULT_IMAGE_HEIGHT = 1024
 # Tokenizer sources, most to least faithful.
 #
 # "huggingface"      the model family's own tokenizer
+# "huggingface-unavailable"  the family is mapped, but the tokenizers package is missing,
+#                    so counting falls back to the estimate below
 # "tiktoken-exact"   tiktoken recognised the model id, so the encoding is the model's own
 # "tiktoken-estimate" no tokenizer for this family; OpenAI's o200k_base is used as an estimate
 # "none"             no tokenizer library available; character-based estimation
 TOKENIZER_SOURCE_HUGGINGFACE = "huggingface"
+TOKENIZER_SOURCE_HUGGINGFACE_UNAVAILABLE = "huggingface-unavailable"
 TOKENIZER_SOURCE_TIKTOKEN = "tiktoken"
 TOKENIZER_SOURCE_TIKTOKEN_EXACT = "tiktoken-exact"
 TOKENIZER_SOURCE_TIKTOKEN_ESTIMATE = "tiktoken-estimate"
@@ -133,19 +136,51 @@ def _warn_estimated_token_count(model_id: str) -> None:
     )
 
 
-def resolve_tokenizer_source(model_id: str) -> str:
-    """Report which tokenizer count_text_tokens() would use for a model id.
+@lru_cache(maxsize=1)
+def _tokenizers_available() -> bool:
+    try:
+        import tokenizers  # noqa: F401
 
-    Returns one of the TOKENIZER_SOURCE_* constants. Exposed so callers, and the test suite,
-    can tell an exact count from an estimate without triggering a tokenizer download.
-    """
-    if _match_hf_tokenizer_repo(model_id) is not None:
-        return TOKENIZER_SOURCE_HUGGINGFACE
-    if _is_exact_tiktoken_model(model_id):
-        return TOKENIZER_SOURCE_TIKTOKEN_EXACT
+        return True
+    except ImportError:
+        return False
+
+
+@lru_cache(maxsize=1)
+def _tiktoken_available() -> bool:
     try:
         import tiktoken  # noqa: F401
+
+        return True
     except ImportError:
+        return False
+
+
+def is_family_mapped(model_id: str) -> bool:
+    """Whether a model id belongs to a family agno knows a real tokenizer for.
+
+    Independent of which optional packages are installed: this answers whether the mapping
+    has a gap, not whether this machine can act on it.
+    """
+    return _match_hf_tokenizer_repo(model_id) is not None or _is_exact_tiktoken_model(model_id)
+
+
+def resolve_tokenizer_source(model_id: str) -> str:
+    """Report which tokenizer count_text_tokens() will use for a model id, on this machine.
+
+    Returns one of the TOKENIZER_SOURCE_* constants, without downloading anything. Note that
+    TOKENIZER_SOURCE_HUGGINGFACE means the family is mapped and the tokenizers package is
+    importable; fetching that tokenizer can still fail at runtime, in which case the count
+    falls back to the estimate and _warn_estimated_token_count reports it.
+    """
+    if _match_hf_tokenizer_repo(model_id) is not None:
+        if _tokenizers_available():
+            return TOKENIZER_SOURCE_HUGGINGFACE
+        # The family is mapped, but without the tokenizers package the count is an estimate.
+        return TOKENIZER_SOURCE_HUGGINGFACE_UNAVAILABLE
+    if _is_exact_tiktoken_model(model_id):
+        return TOKENIZER_SOURCE_TIKTOKEN_EXACT
+    if not _tiktoken_available():
         return TOKENIZER_SOURCE_NONE
     return TOKENIZER_SOURCE_TIKTOKEN_ESTIMATE
 

--- a/libs/agno/agno/utils/tokens.py
+++ b/libs/agno/agno/utils/tokens.py
@@ -18,43 +18,103 @@ DEFAULT_IMAGE_WIDTH = 1024
 DEFAULT_IMAGE_HEIGHT = 1024
 
 
+# Tokenizer sources, most to least faithful.
+#
+# "huggingface"      the model family's own tokenizer
+# "tiktoken-exact"   tiktoken recognised the model id, so the encoding is the model's own
+# "tiktoken-estimate" no tokenizer for this family; OpenAI's o200k_base is used as an estimate
+# "none"             no tokenizer library available; character-based estimation
+TOKENIZER_SOURCE_HUGGINGFACE = "huggingface"
+TOKENIZER_SOURCE_TIKTOKEN = "tiktoken"
+TOKENIZER_SOURCE_TIKTOKEN_EXACT = "tiktoken-exact"
+TOKENIZER_SOURCE_TIKTOKEN_ESTIMATE = "tiktoken-estimate"
+TOKENIZER_SOURCE_NONE = "none"
+
+# Encoding used when a model id matches no known family. It is OpenAI's, so counts for
+# non-OpenAI families are estimates: token counts can differ substantially from the real
+# tokenizer, especially on non-Latin scripts.
+ESTIMATE_ENCODING = "o200k_base"
+
+# Model families with a tokenizer we can load locally, matched on substrings of the model id.
+# Adding a family is a data change here; keep the most specific patterns first.
+HF_TOKENIZER_PATTERNS: Tuple[Tuple[Tuple[str, ...], str], ...] = (
+    # Llama-3 models use a different tokenizer than Llama-2
+    (("llama-3", "llama3"), "Xenova/llama-3-tokenizer"),
+    # Llama-2 models and Replicate models (LiteLLM uses llama tokenizer for replicate)
+    (("llama-2", "llama2", "replicate"), "hf-internal-testing/llama-tokenizer"),
+    # Cohere Command models, including command-a and the plain command-* ids
+    (("command-r", "command-a", "command"), "Xenova/c4ai-command-r-v01-tokenizer"),
+)
+
+
+def _match_hf_tokenizer_repo(model_id: str) -> Optional[str]:
+    """Return the HuggingFace tokenizer repo for a model id, or None if no family matches."""
+    model_id = model_id.lower()
+    for patterns, repo in HF_TOKENIZER_PATTERNS:
+        if any(pattern in model_id for pattern in patterns):
+            return repo
+    return None
+
+
+def _tiktoken_candidates(model_id: str) -> Tuple[str, ...]:
+    """Model id spellings to try against tiktoken, most to least specific.
+
+    Providers namespace ids ("openai/gpt-4.1", "accounts/fireworks/models/gpt-oss-120b"),
+    which tiktoken does not recognise, so the bare model name is tried as well.
+    """
+    model_id = model_id.lower()
+    candidates = [model_id]
+    if "/" in model_id:
+        tail = model_id.rsplit("/", 1)[1]
+        if tail and tail not in candidates:
+            candidates.append(tail)
+    return tuple(candidates)
+
+
 # Different models use different encodings
 @lru_cache(maxsize=16)
 def _get_tiktoken_encoding(model_id: str):
-    model_id = model_id.lower()
     try:
         import tiktoken
 
-        try:
-            # Use model-specific encoding
-            return tiktoken.encoding_for_model(model_id)
-        except KeyError:
-            return tiktoken.get_encoding("o200k_base")
+        for candidate in _tiktoken_candidates(model_id):
+            try:
+                # Use model-specific encoding
+                return tiktoken.encoding_for_model(candidate)
+            except KeyError:
+                continue
+        return tiktoken.get_encoding(ESTIMATE_ENCODING)
     except ImportError as e:
         log_warning(f"tiktoken not installed. Please install it using `pip install tiktoken`.: {str(e)}")
         return None
 
 
 @lru_cache(maxsize=16)
+def _is_exact_tiktoken_model(model_id: str) -> bool:
+    """Whether tiktoken recognises this model id, as opposed to falling back to an estimate."""
+    try:
+        import tiktoken
+    except ImportError:
+        return False
+
+    for candidate in _tiktoken_candidates(model_id):
+        try:
+            tiktoken.encoding_for_model(candidate)
+            return True
+        except KeyError:
+            continue
+    return False
+
+
+@lru_cache(maxsize=16)
 def _get_hf_tokenizer(model_id: str):
+    repo = _match_hf_tokenizer_repo(model_id)
+    if repo is None:
+        return None
     try:
         from tokenizers import Tokenizer
 
-        model_id = model_id.lower()
-
-        # Llama-3 models use a different tokenizer than Llama-2
-        if "llama-3" in model_id or "llama3" in model_id:
-            return Tokenizer.from_pretrained("Xenova/llama-3-tokenizer")
-
-        # Llama-2 models and Replicate models (LiteLLM uses llama tokenizer for replicate)
-        if "llama-2" in model_id or "llama2" in model_id or "replicate" in model_id:
-            return Tokenizer.from_pretrained("hf-internal-testing/llama-tokenizer")
-
-        # Cohere command-r models have their own tokenizer
-        if "command-r" in model_id:
-            return Tokenizer.from_pretrained("Xenova/c4ai-command-r-v01-tokenizer")
-
-        return None
+        return Tokenizer.from_pretrained(repo)
     except ImportError as e:
         log_warning(f"tokenizers not installed. Please install it using `pip install tokenizers`.: {str(e)}")
         return None
@@ -62,19 +122,49 @@ def _get_hf_tokenizer(model_id: str):
         return None
 
 
+@lru_cache(maxsize=64)
+def _warn_estimated_token_count(model_id: str) -> None:
+    """Warn once per model id that its token counts are estimated with a foreign tokenizer."""
+    log_warning(
+        f"No tokenizer available for '{model_id}'; counting tokens with OpenAI's {ESTIMATE_ENCODING} "
+        f"as an estimate. Counts can differ substantially from this model's real tokenizer, "
+        f"especially on non-Latin scripts, so any token-based threshold (for example "
+        f"CompressionManager's compress_token_limit) is approximate for this model."
+    )
+
+
+def resolve_tokenizer_source(model_id: str) -> str:
+    """Report which tokenizer count_text_tokens() would use for a model id.
+
+    Returns one of the TOKENIZER_SOURCE_* constants. Exposed so callers, and the test suite,
+    can tell an exact count from an estimate without triggering a tokenizer download.
+    """
+    if _match_hf_tokenizer_repo(model_id) is not None:
+        return TOKENIZER_SOURCE_HUGGINGFACE
+    if _is_exact_tiktoken_model(model_id):
+        return TOKENIZER_SOURCE_TIKTOKEN_EXACT
+    try:
+        import tiktoken  # noqa: F401
+    except ImportError:
+        return TOKENIZER_SOURCE_NONE
+    return TOKENIZER_SOURCE_TIKTOKEN_ESTIMATE
+
+
 def _select_tokenizer(model_id: str) -> Tuple[str, Any]:
     # Priority 1: HuggingFace tokenizers for models with specific tokenizers
     hf_tokenizer = _get_hf_tokenizer(model_id)
     if hf_tokenizer is not None:
-        return ("huggingface", hf_tokenizer)
+        return (TOKENIZER_SOURCE_HUGGINGFACE, hf_tokenizer)
 
-    # Priority 2: tiktoken for OpenAI models
+    # Priority 2: tiktoken. Exact for OpenAI model ids, an estimate for everything else.
     tiktoken_enc = _get_tiktoken_encoding(model_id)
     if tiktoken_enc is not None:
-        return ("tiktoken", tiktoken_enc)
+        if not _is_exact_tiktoken_model(model_id):
+            _warn_estimated_token_count(model_id)
+        return (TOKENIZER_SOURCE_TIKTOKEN, tiktoken_enc)
 
     # Fallback: No tokenizer available, will use character-based estimation
-    return ("none", None)
+    return (TOKENIZER_SOURCE_NONE, None)
 
 
 # =============================================================================
@@ -404,9 +494,9 @@ def count_text_tokens(text: str, model_id: str = "gpt-4o") -> int:
     if not text:
         return 0
     tokenizer_type, tokenizer = _select_tokenizer(model_id)
-    if tokenizer_type == "huggingface":
+    if tokenizer_type == TOKENIZER_SOURCE_HUGGINGFACE:
         return len(tokenizer.encode(text).ids)
-    elif tokenizer_type == "tiktoken":
+    elif tokenizer_type == TOKENIZER_SOURCE_TIKTOKEN:
         # disallowed_special=() allows all special tokens to be encoded
         return len(tokenizer.encode(text, disallowed_special=()))
     else:

--- a/libs/agno/tests/unit/utils/test_tokens.py
+++ b/libs/agno/tests/unit/utils/test_tokens.py
@@ -444,3 +444,177 @@ async def test_model_acount_tokens_with_schema():
 
     # Schema should add tokens
     assert tokens_with_schema > tokens_no_schema
+
+
+# =============================================================================
+# Tokenizer selection
+# =============================================================================
+# count_text_tokens() falls back to OpenAI's encoding for any model id it does not
+# recognise. That fallback is an estimate, and token-based thresholds such as
+# CompressionManager's compress_token_limit are evaluated against it, so which
+# tokenizer a model resolves to is asserted here rather than left implicit.
+
+# Provider defaults whose token counts are estimates because no tokenizer for the family
+# can be loaded locally. Each entry is a deliberate choice, not an oversight: a newly added
+# provider fails test_provider_default_ids_have_a_known_tokenizer until it is mapped in
+# HF_TOKENIZER_PATTERNS or listed here.
+ESTIMATED_PROVIDER_DEFAULTS = {
+    # Anthropic and Google families. Claude, Gemini and Bedrock override Model.count_tokens()
+    # with a provider API call, so their real counts do not come from this path.
+    "claude-sonnet-4-5-20250929": "no offline Anthropic tokenizer",
+    "claude-sonnet-4-5": "no offline Anthropic tokenizer",
+    "claude-sonnet-4@20250514": "no offline Anthropic tokenizer",
+    "claude-opus-5": "no offline Anthropic tokenizer",
+    "global.anthropic.claude-sonnet-4-5-20250929-v1:0": "no offline Anthropic tokenizer",
+    "gemini-3.7-flash": "no offline Gemini tokenizer",
+    # Families with no publicly downloadable tokenizer
+    "mistral-large-latest": "no offline Mistral tokenizer",
+    "mistral.mistral-small-2402-v1:0": "no offline Mistral tokenizer",
+    "deepseek-v4-flash": "no offline DeepSeek tokenizer",
+    "qwen-plus": "no offline Qwen tokenizer",
+    "qwen2.5-7b-instruct-1m": "no offline Qwen tokenizer",
+    "qwen3:0.6b-q4_K_M": "no offline Qwen tokenizer",
+    "Qwen/QwQ-32B": "no offline Qwen tokenizer",
+    "grok-4-1-fast-non-reasoning-latest": "no offline xAI tokenizer",
+    "grok-4.1-fast-non-reasoning": "no offline xAI tokenizer",
+    "kimi-k3": "no offline Moonshot tokenizer",
+    "MiniMax-M3": "no offline MiniMax tokenizer",
+    "MiniMaxAI/MiniMax-M2.7": "no offline MiniMax tokenizer",
+    "internlm2.5-latest": "no offline InternLM tokenizer",
+    "mimo-v2.5-pro": "no offline Xiaomi tokenizer",
+    "mercury-2": "no offline Inception tokenizer",
+    "sonar": "no offline Perplexity tokenizer",
+    "v0-1.0-md": "no offline Vercel tokenizer",
+    "ibm/granite-20b-code-instruct": "no offline Granite tokenizer",
+    "Llama-4-Maverick-17B-128E-Instruct-FP8": "no offline Llama-4 tokenizer",
+    "gpt-oss:20b": "Ollama tag syntax is not a tiktoken model id",
+    # Placeholders: the real model id is supplied at runtime
+    "not-provided": "placeholder id",
+    "not-set": "placeholder id",
+    "trustedrouter/zdr": "router alias, resolved upstream",
+}
+
+
+def _provider_default_model_ids():
+    """Default `id` of every Model subclass under agno/models, read statically.
+
+    Parsed rather than imported so the check does not require every provider SDK.
+    """
+    import ast
+    from pathlib import Path
+
+    import agno.models
+
+    root = Path(agno.models.__file__).parent
+    defaults = {}
+    for path in sorted(root.rglob("*.py")):
+        if path.name == "__init__.py":
+            continue
+        try:
+            tree = ast.parse(path.read_text())
+        except SyntaxError:  # pragma: no cover - a provider module that cannot be parsed
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            for stmt in node.body:
+                if (
+                    isinstance(stmt, ast.AnnAssign)
+                    and getattr(stmt.target, "id", None) == "id"
+                    and isinstance(stmt.value, ast.Constant)
+                    and isinstance(stmt.value.value, str)
+                ):
+                    defaults[stmt.value.value] = f"{path.relative_to(root)}::{node.name}"
+    return defaults
+
+
+def _tiktoken_installed() -> bool:
+    try:
+        import tiktoken  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+@pytest.mark.skipif(not _tiktoken_installed(), reason="tiktoken is not installed")
+def test_provider_default_ids_have_a_known_tokenizer():
+    """Every provider's default model id resolves to a known tokenizer, or is a listed estimate."""
+    from agno.utils.tokens import TOKENIZER_SOURCE_TIKTOKEN_ESTIMATE, resolve_tokenizer_source
+
+    unlisted = {
+        model_id: where
+        for model_id, where in _provider_default_model_ids().items()
+        if resolve_tokenizer_source(model_id) == TOKENIZER_SOURCE_TIKTOKEN_ESTIMATE
+        and model_id not in ESTIMATED_PROVIDER_DEFAULTS
+    }
+    assert not unlisted, (
+        "These provider defaults silently fall back to OpenAI's encoding. Map the family in "
+        f"HF_TOKENIZER_PATTERNS, or add it to ESTIMATED_PROVIDER_DEFAULTS with a reason: {unlisted}"
+    )
+
+
+@pytest.mark.skipif(not _tiktoken_installed(), reason="tiktoken is not installed")
+def test_estimated_provider_defaults_has_no_stale_entries():
+    """The estimate list does not outlive the ids it excuses."""
+    from agno.utils.tokens import TOKENIZER_SOURCE_TIKTOKEN_ESTIMATE, resolve_tokenizer_source
+
+    defaults = _provider_default_model_ids()
+    stale = {
+        model_id: ("no longer a provider default" if model_id not in defaults else "now has a real tokenizer")
+        for model_id in ESTIMATED_PROVIDER_DEFAULTS
+        if model_id not in defaults or resolve_tokenizer_source(model_id) != TOKENIZER_SOURCE_TIKTOKEN_ESTIMATE
+    }
+    assert not stale, f"Remove these from ESTIMATED_PROVIDER_DEFAULTS: {stale}"
+
+
+def test_cohere_default_model_maps_to_the_cohere_tokenizer():
+    """Cohere's own default id is command-a-*, which the command-r-only pattern used to miss."""
+    from agno.utils.tokens import _match_hf_tokenizer_repo
+
+    assert _match_hf_tokenizer_repo("command-a-03-2025") == "Xenova/c4ai-command-r-v01-tokenizer"
+    assert _match_hf_tokenizer_repo("command-r-plus") == "Xenova/c4ai-command-r-v01-tokenizer"
+
+
+def test_unknown_family_matches_no_hf_tokenizer():
+    from agno.utils.tokens import _match_hf_tokenizer_repo
+
+    assert _match_hf_tokenizer_repo("mistral-large-latest") is None
+
+
+@pytest.mark.skipif(not _tiktoken_installed(), reason="tiktoken is not installed")
+@pytest.mark.parametrize(
+    "model_id, expected_encoding",
+    [
+        ("openai/gpt-4", "cl100k_base"),
+        ("openai/gpt-4.1", "o200k_base"),
+        ("openai/gpt-oss-120b", "o200k_harmony"),
+        ("accounts/fireworks/models/gpt-oss-120b", "o200k_harmony"),
+    ],
+)
+def test_namespaced_model_ids_resolve_to_the_real_encoding(model_id, expected_encoding):
+    """Provider-namespaced ids are tried without their namespace before falling back."""
+    from agno.utils.tokens import TOKENIZER_SOURCE_TIKTOKEN_EXACT, _get_tiktoken_encoding, resolve_tokenizer_source
+
+    assert resolve_tokenizer_source(model_id) == TOKENIZER_SOURCE_TIKTOKEN_EXACT
+    assert _get_tiktoken_encoding(model_id).name == expected_encoding
+
+
+@pytest.mark.skipif(not _tiktoken_installed(), reason="tiktoken is not installed")
+def test_estimated_count_warns_once_per_model_id(monkeypatch):
+    """An estimated count is announced, and not repeated for the same model."""
+    from agno.utils import tokens as tokens_module
+
+    warnings = []
+    monkeypatch.setattr(tokens_module, "log_warning", lambda message: warnings.append(message))
+    tokens_module._warn_estimated_token_count.cache_clear()
+    tokens_module._get_tiktoken_encoding.cache_clear()
+
+    tokens_module._select_tokenizer("some-unmapped-model-v1")
+    tokens_module._select_tokenizer("some-unmapped-model-v1")
+
+    assert len(warnings) == 1
+    assert "some-unmapped-model-v1" in warnings[0]
+
+    tokens_module._select_tokenizer("gpt-4o")
+    assert len(warnings) == 1, "an exactly matched model must not be reported as an estimate"

--- a/libs/agno/tests/unit/utils/test_tokens.py
+++ b/libs/agno/tests/unit/utils/test_tokens.py
@@ -498,7 +498,10 @@ ESTIMATED_PROVIDER_DEFAULTS = {
 def _provider_default_model_ids():
     """Default `id` of every Model subclass under agno/models, read statically.
 
-    Parsed rather than imported so the check does not require every provider SDK.
+    Parsed rather than imported so the check does not require every provider SDK. Returns
+    (defaults, unresolved): `unresolved` holds `id` declarations whose default this parser
+    could not reduce to a string, so an unreadable declaration fails the coverage test
+    instead of quietly dropping out of it.
     """
     import ast
     from pathlib import Path
@@ -507,25 +510,46 @@ def _provider_default_model_ids():
 
     root = Path(agno.models.__file__).parent
     defaults = {}
+    unresolved = {}
     for path in sorted(root.rglob("*.py")):
-        if path.name == "__init__.py":
+        # Providers live in subpackages; agno/models/*.py holds Model, Message and friends.
+        if path.name == "__init__.py" or path.parent == root:
             continue
         try:
             tree = ast.parse(path.read_text())
         except SyntaxError:  # pragma: no cover - a provider module that cannot be parsed
             continue
+
+        # Module-level string constants, so `id: str = DEFAULT_GATEWAY_MODEL` resolves.
+        constants = {}
+        for node in tree.body:
+            if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant):
+                if isinstance(node.value.value, str):
+                    for target in node.targets:
+                        if isinstance(target, ast.Name):
+                            constants[target.id] = node.value.value
+
         for node in ast.walk(tree):
             if not isinstance(node, ast.ClassDef):
                 continue
             for stmt in node.body:
-                if (
-                    isinstance(stmt, ast.AnnAssign)
-                    and getattr(stmt.target, "id", None) == "id"
-                    and isinstance(stmt.value, ast.Constant)
-                    and isinstance(stmt.value.value, str)
-                ):
-                    defaults[stmt.value.value] = f"{path.relative_to(root)}::{node.name}"
-    return defaults
+                is_id = (isinstance(stmt, ast.AnnAssign) and getattr(stmt.target, "id", None) == "id") or (
+                    isinstance(stmt, ast.Assign) and any(getattr(t, "id", None) == "id" for t in stmt.targets)
+                )
+                if not is_id or stmt.value is None:
+                    continue
+
+                where = f"{path.relative_to(root)}::{node.name}"
+                if isinstance(stmt.value, ast.Constant):
+                    if isinstance(stmt.value.value, str):
+                        defaults[stmt.value.value] = where
+                    # `id: Optional[str] = None` means the provider has no default id
+                    continue
+                if isinstance(stmt.value, ast.Name) and stmt.value.id in constants:
+                    defaults[constants[stmt.value.id]] = where
+                    continue
+                unresolved[where] = ast.unparse(stmt.value)
+    return defaults, unresolved
 
 
 def _tiktoken_installed() -> bool:
@@ -538,15 +562,30 @@ def _tiktoken_installed() -> bool:
 
 
 @pytest.mark.skipif(not _tiktoken_installed(), reason="tiktoken is not installed")
-def test_provider_default_ids_have_a_known_tokenizer():
-    """Every provider's default model id resolves to a known tokenizer, or is a listed estimate."""
-    from agno.utils.tokens import TOKENIZER_SOURCE_TIKTOKEN_ESTIMATE, resolve_tokenizer_source
+def test_every_provider_default_id_is_readable():
+    """A default `id` this parser cannot read would drop out of the coverage check below."""
+    _, unresolved = _provider_default_model_ids()
+    assert not unresolved, (
+        "These providers declare a default id this check cannot resolve, so they are not "
+        f"covered by test_provider_default_ids_have_a_known_tokenizer: {unresolved}"
+    )
 
+
+@pytest.mark.skipif(not _tiktoken_installed(), reason="tiktoken is not installed")
+def test_provider_default_ids_have_a_known_tokenizer():
+    """Every provider's default model id belongs to a mapped family, or is a listed estimate.
+
+    Asks whether the mapping has a gap, via is_family_mapped(), rather than what this machine
+    resolves to -- otherwise a machine without the optional tokenizers package would report
+    every mapped family as a gap, or worse, pass while silently counting with the estimate.
+    """
+    from agno.utils.tokens import is_family_mapped
+
+    defaults, _ = _provider_default_model_ids()
     unlisted = {
         model_id: where
-        for model_id, where in _provider_default_model_ids().items()
-        if resolve_tokenizer_source(model_id) == TOKENIZER_SOURCE_TIKTOKEN_ESTIMATE
-        and model_id not in ESTIMATED_PROVIDER_DEFAULTS
+        for model_id, where in defaults.items()
+        if not is_family_mapped(model_id) and model_id not in ESTIMATED_PROVIDER_DEFAULTS
     }
     assert not unlisted, (
         "These provider defaults silently fall back to OpenAI's encoding. Map the family in "
@@ -557,13 +596,13 @@ def test_provider_default_ids_have_a_known_tokenizer():
 @pytest.mark.skipif(not _tiktoken_installed(), reason="tiktoken is not installed")
 def test_estimated_provider_defaults_has_no_stale_entries():
     """The estimate list does not outlive the ids it excuses."""
-    from agno.utils.tokens import TOKENIZER_SOURCE_TIKTOKEN_ESTIMATE, resolve_tokenizer_source
+    from agno.utils.tokens import is_family_mapped
 
-    defaults = _provider_default_model_ids()
+    defaults, _ = _provider_default_model_ids()
     stale = {
         model_id: ("no longer a provider default" if model_id not in defaults else "now has a real tokenizer")
         for model_id in ESTIMATED_PROVIDER_DEFAULTS
-        if model_id not in defaults or resolve_tokenizer_source(model_id) != TOKENIZER_SOURCE_TIKTOKEN_ESTIMATE
+        if model_id not in defaults or is_family_mapped(model_id)
     }
     assert not stale, f"Remove these from ESTIMATED_PROVIDER_DEFAULTS: {stale}"
 
@@ -618,3 +657,34 @@ def test_estimated_count_warns_once_per_model_id(monkeypatch):
 
     tokens_module._select_tokenizer("gpt-4o")
     assert len(warnings) == 1, "an exactly matched model must not be reported as an estimate"
+
+
+@pytest.mark.skipif(not _tiktoken_installed(), reason="tiktoken is not installed")
+def test_mapped_family_reports_the_estimate_when_tokenizers_is_missing(monkeypatch):
+    """tokenizers is optional: a mapped family must not be reported as exact without it.
+
+    Setting sys.modules["tokenizers"] to None makes `import tokenizers` raise ImportError,
+    so this exercises the real resolution path rather than a stubbed one.
+    """
+    import sys
+
+    from agno.utils import tokens as tokens_module
+
+    monkeypatch.setitem(sys.modules, "tokenizers", None)
+    tokens_module._tokenizers_available.cache_clear()
+    tokens_module._get_hf_tokenizer.cache_clear()
+    try:
+        model_id = "command-a-03-2025"
+
+        # The family is still mapped; only this machine cannot act on it.
+        assert tokens_module.is_family_mapped(model_id)
+        assert tokens_module.resolve_tokenizer_source(model_id) == (
+            tokens_module.TOKENIZER_SOURCE_HUGGINGFACE_UNAVAILABLE
+        )
+
+        # And the reported source matches what counting actually does.
+        source, _ = tokens_module._select_tokenizer(model_id)
+        assert source == tokens_module.TOKENIZER_SOURCE_TIKTOKEN
+    finally:
+        tokens_module._tokenizers_available.cache_clear()
+        tokens_module._get_hf_tokenizer.cache_clear()


### PR DESCRIPTION
## Summary

`count_text_tokens()` fell back to OpenAI's `o200k_base` for any model id it did not recognise, silently. Token-based thresholds are evaluated against that number — `CompressionManager.should_compress()` gates `compress_token_limit` on it — so an inaccurate count changes behaviour, not just reporting.

Closes #9993

(If applicable, issue number: #9993)

### Changes

- **Declarative family mapping.** The tokenizer rules move into `HF_TOKENIZER_PATTERNS`. The Cohere entry widens from `command-r` to the whole `command-*` family: Cohere's own default id, `command-a-03-2025`, previously missed the tokenizer agno already ships for it. On Hindi text that default now counts 1953 tokens instead of 752.
- **Namespaced ids.** A model id is retried without its namespace before giving up, so `openai/gpt-4.1` and `accounts/fireworks/models/gpt-oss-120b` reach their real encodings. Across the 48 provider default ids this moves 6 from estimate to exact (12 exact / 6 mapped / 29 estimated, from 6 / 6 / 35).
- **Estimates are announced.** `_warn_estimated_token_count()` warns once per model id, naming the model and the encoding actually used.
- **Two questions, two functions.** `is_family_mapped()` answers whether the mapping has a gap (independent of installed packages); `resolve_tokenizer_source()` answers what this machine will actually use, including a distinct `huggingface-unavailable` when the family is mapped but the optional `tokenizers` package is missing.
- **Coverage gate.** Every provider default id under `agno/models/` is enumerated statically (no provider SDK needed) and must either belong to a mapped family or be listed in `ESTIMATED_PROVIDER_DEFAULTS` with a reason, so a newly added provider fails the test rather than silently inheriting `o200k_base`. A default id the parser cannot read also fails, rather than dropping out of the check.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`ruff==0.15.20`, the pinned version: `ruff check libs/agno` and `ruff format --check` both clean; `mypy agno/utils/tokens.py` reports nothing for this file)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: no cookbook change — this is internal to token counting
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Behaviour change to be aware of.** Stripping the namespace changes counts for ids that previously fell through to the estimate: `openai/gpt-4` now resolves to `cl100k_base` and `openai/gpt-oss-*` to `o200k_harmony`. These are corrections, but anyone who tuned `compress_token_limit` against the old numbers will see a different threshold trigger point.

**Not implemented from the issue.** Item 3 of the proposal in #9993 — annotating the `Token limit hit:` log line in `CompressionManager` when the count is an estimate — is **not** part of this PR. The warning added here fires at tokenizer-selection time in `agno/utils/tokens.py`, not at threshold time, so a reader of the compression log still cannot tell an estimate from an exact count. Happy to add it here or in a follow-up, whichever you prefer.

**Known remaining gap.** When `tokenizers` is installed but `Tokenizer.from_pretrained()` fails at runtime (no network, for example), counting falls back to the estimate and the warning fires, but `resolve_tokenizer_source()` will already have reported `huggingface`. The docstring states this limit; testing it would require faking the download, which did not seem worth the fixture.

**On the new public helpers.** `resolve_tokenizer_source()` and `is_family_mapped()` currently have no caller inside the library — they exist so callers, and the coverage test, can tell an exact count from an estimate. If you would rather not widen the public surface, `is_family_mapped()` can become private; it is the one that is purely a test seam.

**On tooling.** Parts of this change were drafted with AI assistance. I have reviewed every line and can defend each one; the measurement behind the issue (the 10-language comparison) and the design of the coverage gate are mine.

**Verification.** `tests/unit/utils` goes from 375 to 386 passing against `upstream/main`, with an identical set of 23 pre-existing failures (all `cryptography` missing in my environment); `tests/unit/compression` 12 passed. Each of the four gates was mutation-checked: an unmapped provider, a stale allowlist entry, an unreadable `id` declaration, and an availability-blind `resolve_tokenizer_source` each fail their own test, and all 50 pass once reverted.
