### PR TITLE
[fix] Paginate MCP tool discovery for ClientSession

### DIFF
--- a/libs/agno/agno/tools/mcp/mcp.py
+++ b/libs/agno/agno/tools/mcp/mcp.py
@@ -896,16 +896,12 @@ class MCPTools(Toolkit):
             available_tools = list(listed if isinstance(listed, list) else listed.tools)
             if isinstance(listed, ListToolsResult):
                 # Collect all pages before validating filters or changing the registry.
-                seen_cursors: set[str] = set()
                 page_count = 1
                 while listed.next_cursor is not None:
-                    cursor = listed.next_cursor
-                    if cursor in seen_cursors:
-                        raise RuntimeError("MCP tools/list returned a repeated pagination cursor")
                     if page_count >= _MCP_TOOL_PAGINATION_MAX_PAGES:
                         raise RuntimeError(f"MCP tools/list reached the page limit ({_MCP_TOOL_PAGINATION_MAX_PAGES})")
-                    seen_cursors.add(cursor)
-                    listed = await self.session.list_tools(params=PaginatedRequestParams(cursor=cursor))
+                    # Cursors are opaque: empty or repeated values may still advance the listing.
+                    listed = await self.session.list_tools(params=PaginatedRequestParams(cursor=listed.next_cursor))
                     available_tools.extend(listed.tools)
                     page_count += 1
 

--- a/libs/agno/agno/tools/mcp/mcp.py
+++ b/libs/agno/agno/tools/mcp/mcp.py
@@ -20,9 +20,13 @@ if TYPE_CHECKING:
 try:
     from mcp import ClientSession, StdioServerParameters
     from mcp.client.stdio import get_default_environment
+    from mcp.types import ListToolsResult, PaginatedRequestParams
 except ModuleNotFoundError:
     raise ImportError("`mcp` not installed. Please install using `pip install 'mcp>=2.1.0,<3.0.0'`")
 
+
+# Match the default bound on automatic discovery through fastmcp's Client.
+_MCP_TOOL_PAGINATION_MAX_PAGES = 250
 
 _FASTMCP_INSTALL_HINT = (
     "`fastmcp` not installed. MCPTools builds its connections with it. "
@@ -889,7 +893,21 @@ class MCPTools(Toolkit):
             listed = await self.session.list_tools()
             # fastmcp's Client yields a plain list; a user-supplied ClientSession
             # yields a ListToolsResult carrying .tools.
-            available_tools = listed if isinstance(listed, list) else listed.tools
+            available_tools = list(listed if isinstance(listed, list) else listed.tools)
+            if isinstance(listed, ListToolsResult):
+                # Collect all pages before validating filters or changing the registry.
+                seen_cursors: set[str] = set()
+                page_count = 1
+                while listed.next_cursor is not None:
+                    cursor = listed.next_cursor
+                    if cursor in seen_cursors:
+                        raise RuntimeError("MCP tools/list returned a repeated pagination cursor")
+                    if page_count >= _MCP_TOOL_PAGINATION_MAX_PAGES:
+                        raise RuntimeError(f"MCP tools/list reached the page limit ({_MCP_TOOL_PAGINATION_MAX_PAGES})")
+                    seen_cursors.add(cursor)
+                    listed = await self.session.list_tools(params=PaginatedRequestParams(cursor=cursor))
+                    available_tools.extend(listed.tools)
+                    page_count += 1
 
             self._check_tools_filters(
                 available_tools=[tool.name for tool in available_tools],

--- a/libs/agno/tests/unit/tools/test_mcp_pagination.py
+++ b/libs/agno/tests/unit/tools/test_mcp_pagination.py
@@ -1,0 +1,181 @@
+"""Raw ClientSession discovery must consume complete, bounded tool listings."""
+
+import asyncio
+from unittest.mock import AsyncMock, call, patch
+
+import pytest
+from mcp.types import ListToolsResult, PaginatedRequestParams, Tool
+
+import agno.tools.mcp.mcp as mcp_module
+from agno.tools.mcp import MCPTools
+
+
+def tool(name):
+    return Tool(name=name, input_schema={"type": "object", "properties": {}})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cursor", ["opaque:+/token==", ""])
+async def test_raw_session_follows_non_null_cursors_without_mutating_pages(cursor):
+    first = ListToolsResult(tools=[tool("first")], next_cursor=cursor)
+    session = AsyncMock()
+    session.list_tools.side_effect = [first, ListToolsResult(tools=[tool("second")])]
+    toolkit = MCPTools(session=session)
+
+    await toolkit.build_tools()
+
+    assert list(toolkit.functions) == ["first", "second"]
+    assert [item.name for item in first.tools] == ["first"]
+    assert session.list_tools.await_args_list == [call(), call(params=PaginatedRequestParams(cursor=cursor))]
+
+
+@pytest.mark.asyncio
+async def test_empty_page_with_next_cursor_does_not_end_discovery():
+    session = AsyncMock()
+    session.list_tools.side_effect = [
+        ListToolsResult(tools=[], next_cursor="first"),
+        ListToolsResult(tools=[tool("first")], next_cursor="empty"),
+        ListToolsResult(tools=[], next_cursor="last"),
+        ListToolsResult(tools=[tool("last")]),
+    ]
+    toolkit = MCPTools(session=session)
+
+    await toolkit.build_tools()
+
+    assert list(toolkit.functions) == ["first", "last"]
+    assert session.list_tools.await_count == 4
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "filters, expected",
+    [({"include_tools": ["second"]}, ["remote_second"]), ({"exclude_tools": ["second"]}, ["remote_first"])],
+)
+async def test_filters_are_checked_after_collecting_every_page(filters, expected):
+    session = AsyncMock()
+    session.list_tools.side_effect = [
+        ListToolsResult(tools=[tool("first")], next_cursor="next"),
+        ListToolsResult(tools=[tool("second")]),
+    ]
+    toolkit = MCPTools(session=session, tool_name_prefix="remote", **filters)
+
+    await toolkit.build_tools()
+
+    assert list(toolkit.functions) == expected
+    assert session.list_tools.await_count == 2
+
+
+def toolkit_with_existing_function(session):
+    toolkit = MCPTools(session=session)
+
+    def existing():
+        return "existing"
+
+    toolkit.register(existing)
+    return toolkit
+
+
+@pytest.mark.asyncio
+async def test_cursor_cycle_fails_without_registering_partial_results():
+    session = AsyncMock()
+    session.list_tools.side_effect = [
+        ListToolsResult(tools=[tool("first")], next_cursor="a"),
+        ListToolsResult(tools=[tool("second")], next_cursor="b"),
+        ListToolsResult(tools=[tool("third")], next_cursor="a"),
+    ]
+    toolkit = toolkit_with_existing_function(session)
+    existing = toolkit.functions.copy()
+
+    with pytest.raises(RuntimeError, match="repeated pagination cursor"):
+        await toolkit.build_tools()
+
+    assert toolkit.functions == existing
+    assert session.list_tools.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_unique_cursors_are_bounded_by_page_limit(monkeypatch):
+    monkeypatch.setattr(mcp_module, "_MCP_TOOL_PAGINATION_MAX_PAGES", 3, raising=False)
+    session = AsyncMock()
+    session.list_tools.side_effect = [ListToolsResult(tools=[tool(str(i))], next_cursor=str(i)) for i in range(4)]
+    toolkit = toolkit_with_existing_function(session)
+    existing = toolkit.functions.copy()
+
+    with pytest.raises(RuntimeError, match="page limit.*3"):
+        await toolkit.build_tools()
+
+    assert toolkit.functions == existing
+    assert session.list_tools.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_listing_may_finish_on_last_allowed_page(monkeypatch):
+    monkeypatch.setattr(mcp_module, "_MCP_TOOL_PAGINATION_MAX_PAGES", 3, raising=False)
+    session = AsyncMock()
+    session.list_tools.side_effect = [
+        ListToolsResult(tools=[tool("first")], next_cursor="a"),
+        ListToolsResult(tools=[tool("second")], next_cursor="b"),
+        ListToolsResult(tools=[tool("third")]),
+    ]
+    toolkit = MCPTools(session=session)
+
+    await toolkit.build_tools()
+
+    assert list(toolkit.functions) == ["first", "second", "third"]
+    assert session.list_tools.await_count == 3
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error", [RuntimeError("second page failed"), asyncio.CancelledError()])
+async def test_later_page_failure_or_cancellation_preserves_registry(error):
+    session = AsyncMock()
+    session.list_tools.side_effect = [ListToolsResult(tools=[tool("first")], next_cursor="next"), error]
+    toolkit = toolkit_with_existing_function(session)
+    existing = toolkit.functions.copy()
+
+    with pytest.raises(type(error)):
+        await toolkit.build_tools()
+
+    assert toolkit.functions == existing
+    assert session.list_tools.await_count == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("listed", [[tool("only")], ListToolsResult(tools=[tool("only")])])
+async def test_complete_listings_need_only_one_request(listed):
+    session = AsyncMock()
+    session.list_tools.return_value = listed
+    toolkit = MCPTools(session=session)
+
+    await toolkit.build_tools()
+
+    assert list(toolkit.functions) == ["only"]
+    session.list_tools.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_real_raw_session_discovers_and_calls_second_page_tool():
+    from fastmcp import Client, FastMCP
+    from mcp import ClientSession
+
+    server = FastMCP("pagination-test", list_page_size=1)
+
+    @server.tool
+    def first_tool() -> str:
+        return "first"
+
+    @server.tool
+    def second_tool() -> str:
+        return "second"
+
+    async with Client(server) as client:
+        session = client.session
+        assert isinstance(session, ClientSession)
+        toolkit = MCPTools(session=session)
+        with patch.object(session, "list_tools", wraps=session.list_tools) as list_tools:
+            await toolkit.build_tools()
+            assert list_tools.await_count == 2
+        assert set(toolkit.get_async_functions()) == {"first_tool", "second_tool"}
+        result = await toolkit.functions["second_tool"].entrypoint()
+
+    assert result.content == "second"

--- a/libs/agno/tests/unit/tools/test_mcp_pagination.py
+++ b/libs/agno/tests/unit/tools/test_mcp_pagination.py
@@ -76,28 +76,30 @@ def toolkit_with_existing_function(session):
 
 
 @pytest.mark.asyncio
-async def test_cursor_cycle_fails_without_registering_partial_results():
+@pytest.mark.parametrize("cursor", ["same", ""])
+async def test_repeated_cursor_may_advance_server_state(cursor):
     session = AsyncMock()
     session.list_tools.side_effect = [
-        ListToolsResult(tools=[tool("first")], next_cursor="a"),
-        ListToolsResult(tools=[tool("second")], next_cursor="b"),
-        ListToolsResult(tools=[tool("third")], next_cursor="a"),
+        ListToolsResult(tools=[tool("first")], next_cursor=cursor),
+        ListToolsResult(tools=[tool("second")], next_cursor=cursor),
+        ListToolsResult(tools=[tool("third")]),
     ]
     toolkit = toolkit_with_existing_function(session)
-    existing = toolkit.functions.copy()
 
-    with pytest.raises(RuntimeError, match="repeated pagination cursor"):
-        await toolkit.build_tools()
+    await toolkit.build_tools()
 
-    assert toolkit.functions == existing
+    assert list(toolkit.functions) == ["existing", "first", "second", "third"]
     assert session.list_tools.await_count == 3
 
 
 @pytest.mark.asyncio
-async def test_unique_cursors_are_bounded_by_page_limit(monkeypatch):
+@pytest.mark.parametrize("repeated", [False, True])
+async def test_non_terminating_listing_is_bounded_by_page_limit(monkeypatch, repeated):
     monkeypatch.setattr(mcp_module, "_MCP_TOOL_PAGINATION_MAX_PAGES", 3, raising=False)
     session = AsyncMock()
-    session.list_tools.side_effect = [ListToolsResult(tools=[tool(str(i))], next_cursor=str(i)) for i in range(4)]
+    session.list_tools.side_effect = [
+        ListToolsResult(tools=[tool(str(i))], next_cursor="same" if repeated else str(i)) for i in range(4)
+    ]
     toolkit = toolkit_with_existing_function(session)
     existing = toolkit.functions.copy()
 


### PR DESCRIPTION
## Summary

Fixes #10011.

When MCPTools receives a raw ClientSession, discovery currently registers only the first tools/list page. A tool on the second page is missing, and include/exclude validation can incorrectly reject its name.

Collect every ListToolsResult page with the SDK's PaginatedRequestParams before filtering or registering functions. Continue until next_cursor is None, preserving opaque cursor values, including empty and repeated tokens. Bound automatic discovery to 250 pages, matching the FastMCP Client's default page budget; reaching the budget raises instead of silently registering a partial catalog.

Copy the initial tool list so cached result objects are not extended in place. A later-page failure or cancellation leaves the existing function registry unchanged. The plain-list path used by FastMCP Client remains a single call.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Prepared and verified with Codex assistance in an existing isolated development environment. Human self-review is not asserted by the unchecked checklist item.

Validation on Python 3.12.13, mcp 2.1.1 and fastmcp 4.0.3:

- Unmodified baseline: 104 existing MCP tests passed.
- Final regression tests against unmodified main: 13 failed, 2 passed.
- After the patch: 119 tests passed across test_mcp.py and test_mcp_pagination.py.
- A real in-process FastMCP server uses list_page_size=1. Through its raw ClientSession, MCPTools now discovers both tools and successfully invokes the second-page entrypoint.
- Cases cover opaque/empty/repeated cursors, empty pages with continuation, later-page filters, non-terminating listings, completion on the last allowed page, later-page errors/cancellation, preservation of the original response list, and complete list responses.
- Repository formatting and validation passed (Ruff, mypy and cookbook pattern checks); git diff --check passed.

The [MCP pagination specification](https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/pagination) requires opaque cursor handling and termination based on the absence of a continuation token. Repeated token values alone do not establish that the server stopped advancing.

This changes list collection before registration. #10007 separately handles ownership and removal of stale registered functions; no changes from that PR are included here. Connection lifecycle, per-request timeouts and tool entrypoint behavior are unchanged. Full repository integration-suite execution and external LLM evaluation are not claimed.

