### PR TITLE
[fix] Preserve serialized input when reconstructing messages

### DIFF
--- a/libs/agno/agno/models/message.py
+++ b/libs/agno/agno/models/message.py
@@ -147,6 +147,9 @@ class Message(BaseModel):
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "Message":
+        """Reconstruct a message without modifying the input dictionary."""
+        data = data.copy()
+
         # Handle image reconstruction properly
         if "images" in data and data["images"]:
             reconstructed_images = []

--- a/libs/agno/tests/unit/models/test_message.py
+++ b/libs/agno/tests/unit/models/test_message.py
@@ -1,6 +1,10 @@
 """Tests for the Message class."""
 
 import json
+from copy import deepcopy
+
+import pytest
+from pydantic import ValidationError
 
 from agno.models.message import Message
 
@@ -58,3 +62,49 @@ class TestGetContentString:
         content = ["item1", "item2"]
         message = Message(role="assistant", content=content)
         assert message.get_content_string() == json.dumps(content)
+
+
+class TestFromDict:
+    @pytest.mark.parametrize(
+        "field", ["images", "audio", "videos", "files", "audio_output", "image_output", "video_output"]
+    )
+    def test_media_reconstruction_preserves_serialized_input(self, field):
+        media = {"id": "media-1", "content": "bWVkaWE="}
+        payload = {
+            "id": "message-1",
+            "created_at": 0,
+            "role": "user",
+            field: [media] if field in {"images", "audio", "videos", "files"} else media,
+        }
+        original = deepcopy(payload)
+
+        first = Message.from_dict(payload)
+        second = Message.from_dict(payload)
+
+        reconstructed = getattr(first, field)
+        if isinstance(reconstructed, list):
+            reconstructed = reconstructed[0]
+        assert reconstructed.content == b"media"
+        assert reconstructed.id == "media-1"
+        assert first.model_dump() == second.model_dump()
+        assert payload == original
+        assert json.loads(json.dumps(payload)) == original
+
+    @pytest.mark.parametrize("metrics", [{"input_tokens": 2}, None, "invalid"])
+    def test_metrics_reconstruction_preserves_serialized_input(self, metrics):
+        payload = {"role": "assistant", "metrics": metrics}
+        original = deepcopy(payload)
+
+        message = Message.from_dict(payload)
+
+        assert message.metrics.input_tokens == (2 if isinstance(metrics, dict) else 0)
+        assert payload == original
+
+    def test_failed_validation_preserves_serialized_input(self):
+        payload = {"images": [{"id": "image-1", "content": "aW1hZ2U="}], "metrics": None}
+        original = deepcopy(payload)
+
+        with pytest.raises(ValidationError):
+            Message.from_dict(payload)
+
+        assert payload == original


### PR DESCRIPTION
## Summary

Fixes #10013.

Loading a serialized media message with `Message.from_dict(payload)` currently replaces entries in `payload` with media/metrics model instances. A subsequent `json.dumps(payload)` fails. Invalid metrics can also be removed from the caller's dictionary, even when final message validation fails.

Copy the outer dictionary before reconstruction. Existing branches replace top-level values and build new media lists, so a shallow copy preserves the supplied payload without recursively copying arbitrary content or provider data. Reconstruction behavior stays the same.

The input-mutation observation was also noted in #9902. PR #9926 addresses that issue's media metadata loss; this PR addresses the separate ownership problem and does not replace that work.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed (AI-assisted source and diff review)
- [x] Documentation updated (method docstring)
- [ ] Examples and guides: not applicable to this internal deserialization fix
- [ ] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

Reproduced on Agno 3.0.6, main `8f36eaf2d18e91afa7b327eec66a3cd3685dcb87`, Python 3.12.13. The issue contains a minimal offline reproduction. Code and validation were completed by an AI coding assistant; no claim of human review is made.

Validation:

- The 11 new regressions fail without the source change and pass with it. They cover all seven media fields, repeated reconstruction, JSON serialization, metrics conversion/removal, and failed validation.
- `.venv/bin/python -m pytest libs/agno/tests/unit/models/test_message.py libs/agno/tests/unit/test_response_serialization.py libs/agno/tests/unit/utils/test_media_reconstruction.py libs/agno/tests/unit/media/test_reference.py libs/agno/tests/unit/media/test_media_fields.py -q`: 64 passed.
- `./scripts/format.sh`: passes.
- `./scripts/validate.sh`: passes (ruff, mypy, cookbook pattern checks).
- `git diff --check`: passes.

Tests ran offline in the existing development environment; no LLM or paid service calls were made. This change prevents mutation during reconstruction; it does not promise recursive isolation from later mutations of arbitrary nested user data.
