### PR TITLE
[fix] Preserve cancellation state across sync and async calls

### DIFF
--- a/libs/agno/agno/run/cancellation_management/in_memory_cancellation_manager.py
+++ b/libs/agno/agno/run/cancellation_management/in_memory_cancellation_manager.py
@@ -1,6 +1,5 @@
 """Run cancellation management."""
 
-import asyncio
 import threading
 import time
 from typing import Dict, Optional, Set, Tuple
@@ -33,8 +32,10 @@ class InMemoryRunCancellationManager(BaseRunCancellationManager):
         # iteration order and _purge_expired only ever pops from the front.
         self._cancelled_runs: Dict[str, Tuple[bool, float]] = {}
         self._member_runs: Dict[str, Tuple[Set[str], float]] = {}
+        # Sync calls may run in worker threads while async calls run on the
+        # event loop. Both access the same dictionaries, so they must share a
+        # lock. These in-memory critical sections never await.
         self._lock = threading.Lock()
-        self._async_lock = asyncio.Lock()
         self._clock = time.monotonic
 
     def _expires_at(self) -> float:
@@ -75,7 +76,7 @@ class InMemoryRunCancellationManager(BaseRunCancellationManager):
         intent (cancel-before-start support for background runs). An existing
         entry keeps its original TTL.
         """
-        async with self._async_lock:
+        with self._lock:
             self._purge_expired()
             if run_id not in self._cancelled_runs:
                 self._cancelled_runs[run_id] = (False, self._expires_at())
@@ -96,11 +97,11 @@ class InMemoryRunCancellationManager(BaseRunCancellationManager):
             was_registered = run_id in self._cancelled_runs
             self._cancelled_runs.pop(run_id, None)
             self._cancelled_runs[run_id] = (True, self._expires_at())
-            if was_registered:
-                logger.info(f"Run {run_id} marked for cancellation")
-            else:
-                logger.info(f"Run {run_id} not yet registered, storing cancellation intent")
-            return was_registered
+        if was_registered:
+            logger.info(f"Run {run_id} marked for cancellation")
+        else:
+            logger.info(f"Run {run_id} not yet registered, storing cancellation intent")
+        return was_registered
 
     async def acancel_run(self, run_id: str) -> bool:
         """Cancel a run by marking it as cancelled (async version).
@@ -113,16 +114,16 @@ class InMemoryRunCancellationManager(BaseRunCancellationManager):
             bool: True if run was previously registered, False if storing
             cancellation intent for an unregistered run.
         """
-        async with self._async_lock:
+        with self._lock:
             self._purge_expired()
             was_registered = run_id in self._cancelled_runs
             self._cancelled_runs.pop(run_id, None)
             self._cancelled_runs[run_id] = (True, self._expires_at())
-            if was_registered:
-                logger.info(f"Run {run_id} marked for cancellation")
-            else:
-                logger.info(f"Run {run_id} not yet registered, storing cancellation intent")
-            return was_registered
+        if was_registered:
+            logger.info(f"Run {run_id} marked for cancellation")
+        else:
+            logger.info(f"Run {run_id} not yet registered, storing cancellation intent")
+        return was_registered
 
     def is_cancelled(self, run_id: str) -> bool:
         """Check if a run is cancelled."""
@@ -133,7 +134,7 @@ class InMemoryRunCancellationManager(BaseRunCancellationManager):
 
     async def ais_cancelled(self, run_id: str) -> bool:
         """Check if a run is cancelled (async version)."""
-        async with self._async_lock:
+        with self._lock:
             self._purge_expired()
             entry = self._cancelled_runs.get(run_id)
             return entry[0] if entry is not None else False
@@ -146,7 +147,7 @@ class InMemoryRunCancellationManager(BaseRunCancellationManager):
 
     async def acleanup_run(self, run_id: str) -> None:
         """Remove a run from tracking (called when run completes) (async version)."""
-        async with self._async_lock:
+        with self._lock:
             self._purge_expired()
             self._cancelled_runs.pop(run_id, None)
 
@@ -170,7 +171,7 @@ class InMemoryRunCancellationManager(BaseRunCancellationManager):
 
     async def aget_active_runs(self) -> Dict[str, bool]:
         """Get all currently tracked runs and their cancellation status (async version)."""
-        async with self._async_lock:
+        with self._lock:
             self._purge_expired()
             return {run_id: cancelled for run_id, (cancelled, _) in self._cancelled_runs.items()}
 
@@ -190,7 +191,7 @@ class InMemoryRunCancellationManager(BaseRunCancellationManager):
 
         Each registration refreshes the member set's TTL.
         """
-        async with self._async_lock:
+        with self._lock:
             self._purge_expired()
             members, _ = self._member_runs.pop(team_run_id, (set(), 0.0))
             members.add(member_run_id)
@@ -205,7 +206,7 @@ class InMemoryRunCancellationManager(BaseRunCancellationManager):
 
     async def aget_member_run_ids(self, team_run_id: str) -> Set[str]:
         """Return the in-flight member run_ids of a team run (async version)."""
-        async with self._async_lock:
+        with self._lock:
             self._purge_expired()
             entry = self._member_runs.get(team_run_id)
             return set(entry[0]) if entry is not None else set()
@@ -218,6 +219,6 @@ class InMemoryRunCancellationManager(BaseRunCancellationManager):
 
     async def acleanup_member_runs(self, team_run_id: str) -> None:
         """Drop a team run's member mapping when the team run finishes (async version)."""
-        async with self._async_lock:
+        with self._lock:
             self._purge_expired()
             self._member_runs.pop(team_run_id, None)

--- a/libs/agno/tests/unit/run/test_cancellation_concurrency.py
+++ b/libs/agno/tests/unit/run/test_cancellation_concurrency.py
@@ -1,0 +1,95 @@
+"""Sync and async cancellation calls share one process-wide state store."""
+
+import asyncio
+import inspect
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from agno.run.cancellation_management.in_memory_cancellation_manager import InMemoryRunCancellationManager
+
+
+def _overlap_writes(monkeypatch, manager, first, second):
+    """Pause the first write until the second completes or waits for its lock.
+
+    The lock probe reports contention without changing mutual exclusion. This
+    forces the lost-update interleaving when the methods use different locks,
+    and lets the first writer finish when they correctly share one. No sleeps
+    or probabilistic thread scheduling are needed.
+    """
+    first_paused = threading.Event()
+    resume_first = threading.Event()
+    second_reached = threading.Event()
+    lock = manager._lock
+    expires_at = manager._expires_at
+
+    class ObservedLock:
+        def __enter__(self):
+            if not lock.acquire(blocking=False):
+                second_reached.set()
+                lock.acquire()
+            return self
+
+        def __exit__(self, *args):
+            lock.release()
+
+    def pause_first_write():
+        if not first_paused.is_set():
+            first_paused.set()
+            assert resume_first.wait(timeout=5), "First writer was not released"
+        return expires_at()
+
+    def invoke(operation):
+        result = operation()
+        if inspect.isawaitable(result):
+            return asyncio.run(result)
+        return result
+
+    def invoke_second():
+        try:
+            return invoke(second)
+        finally:
+            second_reached.set()
+
+    monkeypatch.setattr(manager, "_lock", ObservedLock())
+    monkeypatch.setattr(manager, "_expires_at", pause_first_write)
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first_result = pool.submit(invoke, first)
+        try:
+            assert first_paused.wait(timeout=5), "First writer did not reach the write"
+            second_result = pool.submit(invoke_second)
+            assert second_reached.wait(timeout=5), "Second writer did not complete or wait for the lock"
+        finally:
+            resume_first.set()
+        first_result.result(timeout=5)
+        second_result.result(timeout=5)
+
+
+@pytest.mark.parametrize("register_async,cancel_async", [(False, False), (True, False), (False, True)])
+def test_concurrent_registration_preserves_cancellation(monkeypatch, register_async, cancel_async):
+    manager = InMemoryRunCancellationManager()
+    register = manager.aregister_run if register_async else manager.register_run
+    cancel = manager.acancel_run if cancel_async else manager.cancel_run
+
+    _overlap_writes(monkeypatch, manager, lambda: register("run-1"), lambda: cancel("run-1"))
+
+    assert manager.is_cancelled("run-1") is True
+    assert asyncio.run(manager.ais_cancelled("run-1")) is True
+
+
+@pytest.mark.parametrize("first_async,second_async", [(False, False), (True, False), (False, True)])
+def test_concurrent_member_registration_preserves_both_members(monkeypatch, first_async, second_async):
+    manager = InMemoryRunCancellationManager()
+    register_first = manager.aregister_member_run if first_async else manager.register_member_run
+    register_second = manager.aregister_member_run if second_async else manager.register_member_run
+
+    _overlap_writes(
+        monkeypatch,
+        manager,
+        lambda: register_first("team-1", "member-1"),
+        lambda: register_second("team-1", "member-2"),
+    )
+
+    assert manager.get_member_run_ids("team-1") == {"member-1", "member-2"}
+    assert asyncio.run(manager.aget_member_run_ids("team-1")) == {"member-1", "member-2"}


### PR DESCRIPTION
## Summary

Fixes #10015.

Concurrent synchronous and asynchronous cancellation calls currently protect the same dictionaries with different locks. Registration can overwrite a cancellation that already completed, and concurrent team-member registrations can lose one member's cancellation mapping.

Use the same threading lock for both API variants. The protected operations are in-memory and contain no `await`; cancellation log emission moves outside the lock. Keep the public methods, return values, and TTL behavior intact.

Add deterministic concurrency regressions for both sync/async directions and pure-sync controls. They check preserved cancellation intent and complete member mappings, using event barriers that preserve the underlying lock's mutual exclusion.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed (AI-assisted implementation review and independent AI review; no claim of human review)
- [x] Documentation updated (lock ownership comment)
- [ ] Examples and guides: not applicable to this internal concurrency fix
- [x] Tested in clean environment (new Windows virtual environment)
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

Reproduced on upstream main `8f36eaf2d18e91afa7b327eec66a3cd3685dcb87`, Agno 3.0.6, Python 3.11.2, Windows. The merged TTL change #9701 preserves the separate locks; it does not address this shared-state concurrency issue.

Validation in the new Windows `.venv`:

- With the original source file, the new regressions report **4 failed, 2 passed**: all four mixed sync/async cases fail while the pure-sync controls pass.
- With this source change, the same regressions report **6 passed**.
- The standalone issue reproduction prints `{'run-1': False}` and fails before the fix, then prints `{'run-1': True}` and passes after it.
- `python -m pytest libs/agno/tests/unit/run -q --tb=short -o log_cli=false`: **239 passed**, with one unrelated existing unawaited `AsyncMock` warning in `test_worker_owned_save_fencing.py`.
- `./scripts/format.sh`: passes.
- `./scripts/validate.sh`: passes (Agno/agnoctl ruff and mypy, cookbook ruff and pattern check). The scripts ran through Git Bash; `python3` was mapped to this `.venv`'s `python` for the cookbook check because the machine's unrelated system Python launcher is broken. No repository validation script was changed.
- `git diff --check`: passes.

All checks ran offline without model or paid-service calls. The implementation, tests, and verification used an AI coding assistant.

This remains a single-process, cooperatively checked cancellation manager. Lock contention can briefly block the event-loop thread, and existing TTL cleanup and snapshot operations can process multiple entries. This change does not add cross-process coordination or alter cancellation-expiry policy.
