### PR TITLE
[fix] Release discarded MCP toolkits retained by finalizer

### DIFF
--- a/libs/agno/agno/tools/mcp/mcp.py
+++ b/libs/agno/agno/tools/mcp/mcp.py
@@ -1,7 +1,6 @@
 import asyncio
 import inspect
 import time
-import weakref
 from contextlib import asynccontextmanager
 from dataclasses import asdict
 from typing import TYPE_CHECKING, Any, AsyncIterator, Callable, Literal, Optional, Tuple, Union
@@ -244,6 +243,9 @@ class MCPTools(Toolkit):
     1. Direct initialization with a ClientSession
     2. As an async context manager with StdioServerParameters
     3. As an async context manager with SSE or Streamable HTTP client parameters
+
+    Use the async context manager or await close() to close the toolkit's main
+    connection. Caller-supplied sessions remain caller-owned.
     """
 
     def __init__(
@@ -422,7 +424,6 @@ class MCPTools(Toolkit):
         self._client = client
 
         self._initialized = False
-        self._connection_task = None
         self._active_contexts: list[Any] = []
         self._context = None
         self._session_context = None
@@ -433,14 +434,6 @@ class MCPTools(Toolkit):
         self._run_session_contexts: dict[str, Any] = {}  # Maps run_id to its connection context
         self._session_ttl_seconds: float = 300.0  # 5 minutes TTL for MCP sessions
         self._session_lock: Optional[asyncio.Lock] = None  # Lazily created lock for session creation
-
-        def cleanup():
-            """Cancel active connections"""
-            if self._connection_task and not self._connection_task.done():
-                self._connection_task.cancel()
-
-        # Setup cleanup logic before the instance is garbage collected
-        self._cleanup_finalizer = weakref.finalize(self, cleanup)
 
     @property
     def initialized(self) -> bool:
@@ -761,7 +754,6 @@ class MCPTools(Toolkit):
             self._context = None
             self._session_context = None
             self._initialized = False
-            self._connection_task = None
             self._active_contexts = []
 
         if self._initialized:

--- a/libs/agno/tests/unit/tools/test_mcp_garbage_collection.py
+++ b/libs/agno/tests/unit/tools/test_mcp_garbage_collection.py
@@ -1,0 +1,83 @@
+"""Discarded MCP toolkits must not be retained by process-global callbacks."""
+
+import gc
+import weakref
+
+import pytest
+from fastmcp import Client, FastMCP
+
+from agno.tools.mcp import MCPTools
+
+
+def test_unused_toolkit_releases_its_header_provider_state():
+    class RequestState:
+        pass
+
+    state = RequestState()
+    state_ref = weakref.ref(state)
+    toolkit = MCPTools(url="http://localhost:8080/mcp", header_provider=lambda state=state: {})
+    toolkit_ref = weakref.ref(toolkit)
+
+    del toolkit, state
+    gc.collect()
+
+    assert toolkit_ref() is None
+    assert state_ref() is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_context_manager", [False, True])
+async def test_closed_toolkit_can_be_collected(monkeypatch, use_context_manager):
+    """Exercise discovery and close with a real in-memory FastMCP connection."""
+    server = FastMCP("gc-test")
+
+    @server.tool
+    def echo(message: str) -> str:
+        return message
+
+    client = Client(server)
+    monkeypatch.setattr("agno.tools.mcp.mcp._build_fastmcp_client", lambda *args: client)
+    toolkit = MCPTools(url="http://localhost:8080/mcp")
+    toolkit_ref = weakref.ref(toolkit)
+
+    if use_context_manager:
+        async with toolkit:
+            assert client.is_connected()
+            assert "echo" in toolkit.functions
+    else:
+        await toolkit.connect()
+        assert client.is_connected()
+        assert "echo" in toolkit.functions
+        await toolkit.close()
+
+    assert not client.is_connected()
+    del toolkit
+    gc.collect()
+
+    assert toolkit_ref() is None
+
+
+@pytest.mark.asyncio
+async def test_failed_connection_does_not_retain_toolkit(monkeypatch):
+    class FailingClient:
+        exited = False
+
+        async def __aenter__(self):
+            raise ConnectionRefusedError("server unreachable")
+
+        async def __aexit__(self, *args):
+            self.exited = True
+
+    client = FailingClient()
+    monkeypatch.setattr("agno.tools.mcp.mcp._build_fastmcp_client", lambda *args: client)
+    toolkit = MCPTools(url="http://localhost:8080/mcp")
+    toolkit_ref = weakref.ref(toolkit)
+
+    await toolkit.connect()
+    assert client.exited
+    assert not toolkit.initialized
+    assert toolkit.session is None
+    del toolkit
+    gc.collect()
+
+    assert toolkit_ref() is None


### PR DESCRIPTION
## Summary

Fixes #10023.

Every discarded `MCPTools` instance is retained by its `weakref.finalize` callback, which closes over `self`. This also retains toolkit-owned state after a successful close or a failed connection attempt.

Remove that callback and the unused `_connection_task` field, which is never assigned a task in current main. Keep the actual connection teardown paths unchanged and clarify the main-connection lifecycle in the class docstring.

Add weak-reference regressions for unused toolkits and captured header-provider state, explicit close, async-context-manager exit, and failed connection attempts. Successful lifecycle tests use a real in-memory FastMCP server/client and assert the connection has closed before checking collection.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed (AI-assisted implementation review and independent AI review; no claim of human review)
- [x] Documentation updated (main-connection lifecycle docstring)
- [ ] Examples and guides: not applicable to this object-lifetime fix
- [x] Tested in clean environment (separate new Windows `.venv-mcp-gc`)
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

Validated on upstream main `f3c98a165ce1150b920504334ed7b19c530734f5`, Agno 3.0.6, Python 3.11.2, Windows; FastMCP 4.0.3 and MCP 2.1.1.

- With the original source file, all **4 new regression cases fail** on retained objects; with this patch, **4 pass**.
- The standalone issue reproduction was actually executed against both versions: retained `True` plus assertion failure before the fix; retained `False` and exit 0 afterward.
- `python -m pytest libs/agno/tests/unit/tools/test_mcp.py libs/agno/tests/unit/tools/test_mcp_toolbox_lifecycle.py libs/agno/tests/unit/tools/test_mcp_garbage_collection.py -q --tb=short -o log_cli=false`: **112 passed**.
- After the red/green checks in the development `.venv`, created a separate clean `.venv-mcp-gc`, installed `libs/agno[dev]` and `libs/agnoctl[dev]` in editable mode, and reran the new regressions (**4 passed**) and the same related MCP suite (**112 passed**).
- `./scripts/format.sh`: passes.
- `./scripts/validate.sh`: passes (Agno/agnoctl ruff and mypy; cookbook ruff and pattern check). These scripts ran through Git Bash, with `python3` mapped to the same Windows `.venv` Python for the cookbook check. No repository validation script was modified.
- `git diff --check`: passes.

The new regressions require no external service. The broader existing MCP suite includes a loopback connection-failure test. No model or paid-service calls were made. Investigation, implementation and verification used an AI coding assistant.

This makes discarded objects collectible; it does not add asynchronous cleanup during garbage collection. Applications still manage connections explicitly, and caller-supplied sessions remain caller-owned. This change does not rewrite dynamic-session cleanup or concurrent connection ownership.