### PR TITLE
[fix] Restore inline media bytes from model response cache

### DIFF
--- a/libs/agno/agno/models/response.py
+++ b/libs/agno/agno/models/response.py
@@ -1,12 +1,26 @@
+from base64 import b64decode
 from dataclasses import asdict, dataclass, field
 from enum import Enum
 from time import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Type, TypeVar
 
 from agno.media import Audio, File, Image, Video
 from agno.metrics import MessageMetrics, ToolCallMetrics
 from agno.models.message import Citations
 from agno.tools.function import UserFeedbackQuestion, UserInputField
+
+_Media = TypeVar("_Media", Image, Audio, Video)
+
+
+def _media_from_dict(media_type: Type[_Media], data: Dict[str, Any]) -> _Media:
+    content = data.get("content")
+    if isinstance(content, str):
+        try:
+            decoded = b64decode(content)
+        except ValueError:
+            decoded = content.encode("utf-8")
+        data = {**data, "content": decoded}
+    return media_type(**data)
 
 
 class ModelResponseEvent(str, Enum):
@@ -202,14 +216,14 @@ class ModelResponse:
         """Reconstruct ModelResponse from cached dictionary."""
         # Reconstruct media objects
         if data.get("audio"):
-            data["audio"] = Audio(**data["audio"])
+            data["audio"] = _media_from_dict(Audio, data["audio"])
 
         if data.get("images"):
-            data["images"] = [Image(**img) for img in data["images"]]
+            data["images"] = [_media_from_dict(Image, img) for img in data["images"]]
         if data.get("videos"):
-            data["videos"] = [Video(**vid) for vid in data["videos"]]
+            data["videos"] = [_media_from_dict(Video, vid) for vid in data["videos"]]
         if data.get("audios"):
-            data["audios"] = [Audio(**aud) for aud in data["audios"]]
+            data["audios"] = [_media_from_dict(Audio, aud) for aud in data["audios"]]
         if data.get("files"):
             data["files"] = [File(**f) for f in data["files"]]
 

--- a/libs/agno/tests/unit/models/test_response_media_cache.py
+++ b/libs/agno/tests/unit/models/test_response_media_cache.py
@@ -1,0 +1,125 @@
+import json
+
+import pytest
+
+from agno.media import Audio, File, Image, Video
+from agno.media.reference import MediaReference
+from agno.models.openai.chat import OpenAIChat
+from agno.models.response import ModelResponse
+
+INLINE_MEDIA_CASES = [
+    pytest.param("images", Image, "image/png", {"detail": "high", "alt_text": "A chart"}, id="image"),
+    pytest.param("audio", Audio, "audio/wav", {"transcript": "Hello", "sample_rate": 16000}, id="response-audio"),
+    pytest.param("audios", Audio, "audio/wav", {"duration": 1.5, "channels": 2}, id="audio-list"),
+    pytest.param("videos", Video, "video/mp4", {"width": 320, "height": 240, "fps": 24}, id="video"),
+]
+MEDIA_CASES = [
+    *INLINE_MEDIA_CASES,
+    pytest.param("files", File, "application/pdf", {"filename": "report.pdf", "size": 9, "name": "Report"}, id="file"),
+]
+BINARY_CONTENT = b"\x00\xff\x89\x80media"
+
+
+def response_with_media(field, media):
+    return ModelResponse(**{field: media if field == "audio" else [media]})
+
+
+def response_media(response, field):
+    media = getattr(response, field)
+    return media if field == "audio" else media[0]
+
+
+@pytest.mark.parametrize("field,media_type,mime_type,extra", INLINE_MEDIA_CASES)
+@pytest.mark.parametrize("media_id", ["media-1", ""])
+def test_binary_media_survives_model_response_json_roundtrip(field, media_type, mime_type, extra, media_id):
+    original = media_type(
+        content=BINARY_CONTENT, id=media_id, mime_type=mime_type, metadata={"source": {"tool": "generate"}}, **extra
+    )
+    payload = json.loads(json.dumps(response_with_media(field, original).to_dict()))
+
+    restored = response_media(ModelResponse.from_dict(payload), field)
+
+    assert isinstance(restored, media_type)
+    assert restored.get_content_bytes() == BINARY_CONTENT
+    assert restored.to_dict() == original.to_dict()
+
+
+@pytest.mark.parametrize("field,media_type,mime_type,extra", INLINE_MEDIA_CASES)
+@pytest.mark.parametrize("content", ["not base64", "caf\u00e9"])
+def test_model_response_keeps_non_base64_media_strings(field, media_type, mime_type, extra, content):
+    media = {"id": "media-1", "content": content, "mime_type": mime_type, **extra}
+    payload = {field: media if field == "audio" else [media]}
+
+    restored = response_media(ModelResponse.from_dict(payload), field)
+
+    assert isinstance(restored, media_type)
+    assert restored.content == content.encode("utf-8")
+
+
+@pytest.mark.parametrize("field,media_type,mime_type,extra", MEDIA_CASES)
+@pytest.mark.parametrize("source", ["url", "filepath", "media_reference"])
+def test_model_response_media_preserves_non_inline_sources(field, media_type, mime_type, extra, source):
+    sources = {
+        "url": "https://example.com/media",
+        "filepath": "cached-media.bin",
+        "media_reference": MediaReference(
+            media_id="media-1", storage_key="media/key", storage_backend="local", metadata={"owner": "session-1"}
+        ),
+    }
+    original = media_type(
+        **{source: sources[source]}, id="media-1", mime_type=mime_type, metadata={"origin": "test"}, **extra
+    )
+    payload = json.loads(json.dumps(response_with_media(field, original).to_dict()))
+
+    restored = response_media(ModelResponse.from_dict(payload), field)
+
+    assert restored.content is None
+    assert restored.to_dict() == original.to_dict()
+
+
+@pytest.mark.parametrize(
+    "mime_type,text",
+    [
+        ("text/plain", "TestData"),
+        ("text/plain", "caf\u00e9\n"),
+        ("application/json", '"test"'),
+        ("application/json", "1234"),
+        ("text/plain", ""),
+    ],
+)
+def test_model_response_keeps_file_string_content(mime_type, text):
+    original = File(id="file-1", content=text, mime_type=mime_type, metadata={"language": "en"})
+    payload = json.loads(json.dumps(ModelResponse(files=[original]).to_dict()))
+
+    restored = ModelResponse.from_dict(payload).files[0]
+
+    assert restored.content == text
+    assert restored.to_dict() == original.to_dict()
+
+
+@pytest.mark.parametrize("streaming", [False, True])
+def test_model_cache_restores_media_bytes_and_metadata(tmp_path, streaming):
+    model = OpenAIChat(cache_response=True, cache_dir=str(tmp_path))
+    response = ModelResponse(
+        content="Generated media",
+        images=[Image(content=BINARY_CONTENT, metadata={"kind": "image"})],
+        audio=Audio(content=BINARY_CONTENT, transcript="Hello"),
+        audios=[Audio(content=BINARY_CONTENT, sample_rate=16000)],
+        videos=[Video(content=BINARY_CONTENT, width=320)],
+        files=[File(content='"test"', mime_type="application/json", filename="report.json")],
+    )
+    if streaming:
+        model._save_streaming_responses_to_cache("media", [response])
+    else:
+        model._save_model_response_to_cache("media", response)
+
+    cached = model._get_cached_model_response("media")
+    assert cached is not None
+    if streaming:
+        restored = list(model._streaming_responses_from_cache(cached["streaming_responses"]))[0]
+    else:
+        restored = model._model_response_from_cache(cached)
+
+    for field in ("images", "audio", "audios", "videos"):
+        assert response_media(restored, field).get_content_bytes() == BINARY_CONTENT
+    assert restored.to_dict() == response.to_dict()


### PR DESCRIPTION
## Summary

Fixes #10025.

Model-response cache hits returned base64 text bytes instead of the original image, audio, and video bytes. `ModelResponse.to_dict()` encoded the media content, but `from_dict()` passed the encoded string directly to media constructors.

Decode string content before constructing cached `Image`, `Audio`, and `Video` objects, preserving every other field and the existing constructor's ID handling. Keep the media helpers' UTF-8 fallback for strings that cannot be base64-decoded. This covers `images`, singular `audio`, `audios`, and `videos`, through both regular and streaming cache reads.

The regression suite includes an offline JSON roundtrip and actual temporary cache-file reads. On main `f3c98a165ce1150b920504334ed7b19c530734f5` (`agno==3.0.6`), the final focused suite has 10 failures and 28 passing controls; with the patch all 38 pass.

`File` reconstruction is intentionally unchanged: binary content and original string content can serialize identically, so decoding every file string would introduce a compatibility regression. Tests preserve plain text, empty text, and JSON strings that happen to resemble base64. No new cache encoding marker or format is introduced.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed (AI-assisted implementation review and independent AI review; no claim of human review)
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Verification on a new Windows virtual environment importing this checkout:

- `python -m pytest libs/agno/tests/unit/models/test_response_media_cache.py -q --tb=short -o log_cli=false`: 38 passed; original source: 10 failed / 28 passed.
- Focused suite plus response/defaults, cache-key serialization, media reconstruction, media fields, and response-serialization suites: 93 passed.
- `scripts/format.sh`: passed.
- `scripts/validate.sh`: passed, including mypy for 1,045 Agno source files and 21 agnoctl files, plus cookbook checks. On Windows, Git Bash used the new virtual environment and a process-local `python3` mapping to its Python executable.
- `git diff --cached --check`: passed.

Implementation and validation used AI assistance. The patch was independently reviewed for ID/default preservation, metadata preservation, non-inline media sources, and the separate `File` encoding ambiguity; no blocking finding remains. No model API requests are made by the tests. No public API or cookbook usage changes, so no documentation/example changes are required.