### PR TITLE
fix: read text from grouped shapes in PPTXReader

### DIFF
--- a/libs/agno/agno/knowledge/reader/pptx_reader.py
+++ b/libs/agno/agno/knowledge/reader/pptx_reader.py
@@ -12,8 +12,28 @@ from agno.utils.log import log_debug, log_error
 
 try:
     from pptx import Presentation  # type: ignore
+    from pptx.shapes.group import GroupShape  # type: ignore
 except ImportError:
     raise ImportError("The `python-pptx` package is not installed. Please install it via `pip install python-pptx`.")
+
+
+def _shape_texts(shapes: Any) -> List[str]:
+    """Collect the text of every shape, descending into groups.
+
+    A group holds its children in `.shapes` and has no `.text` of its own, so a
+    flat pass over `slide.shapes` drops every text box inside it. The group is
+    matched by type because `.shape_type` raises NotImplementedError on shapes
+    python-pptx cannot name.
+    """
+    texts: List[str] = []
+    for shape in shapes:
+        if isinstance(shape, GroupShape):
+            texts.extend(_shape_texts(shape.shapes))
+            continue
+        text = getattr(shape, "text", "")
+        if text and text.strip():
+            texts.append(text.strip())
+    return texts
 
 
 class PPTXReader(Reader):
@@ -61,10 +81,7 @@ class PPTXReader(Reader):
                 slide_text = f"Slide {slide_number}:\n"
 
                 # Extract text from shapes that contain text
-                text_content = []
-                for shape in slide.shapes:
-                    if hasattr(shape, "text") and shape.text.strip():
-                        text_content.append(shape.text.strip())
+                text_content = _shape_texts(slide.shapes)
 
                 if text_content:
                     slide_text += "\n".join(text_content)

--- a/libs/agno/tests/unit/reader/test_pptx_reader.py
+++ b/libs/agno/tests/unit/reader/test_pptx_reader.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
+from pptx import Presentation as PptxPresentation
+from pptx.util import Emu
 
 from agno.knowledge.document.base import Document
 from agno.knowledge.reader.pptx_reader import PPTXReader
@@ -251,6 +253,30 @@ def test_pptx_reader_shapes_without_text():
         assert len(documents) == 1
         expected_content = "Slide 1:\nValid text"
         assert documents[0].content == expected_content
+
+
+def _add_textbox(shapes, text, column):
+    box = shapes.add_textbox(Emu(column * 914400), Emu(0), Emu(914400), Emu(457200))
+    box.text_frame.text = text
+
+
+def test_pptx_reader_grouped_shapes(tmp_path):
+    """Test reading text from shapes inside a group and inside a nested group"""
+    path = tmp_path / "grouped.pptx"
+    presentation = PptxPresentation()
+    slide = presentation.slides.add_slide(presentation.slide_layouts[6])
+    _add_textbox(slide.shapes, "Top level text", 0)
+    group = slide.shapes.add_group_shape()
+    _add_textbox(group.shapes, "Grouped text", 1)
+    nested = group.shapes.add_group_shape()
+    _add_textbox(nested.shapes, "Nested group text", 2)
+    presentation.save(str(path))
+
+    reader = PPTXReader()
+    documents = reader.read(path)
+
+    assert len(documents) == 1
+    assert documents[0].content == "Slide 1:\nTop level text\nGrouped text\nNested group text"
 
 
 def test_pptx_reader_chunk_size_propagation():


### PR DESCRIPTION
## Summary

`PPTXReader` reads only the top level of `slide.shapes`. A group shape keeps its children in `.shapes` and has no `.text` of its own, so every text box inside a group is dropped. A slide whose text sits in one group reads as `(No text content)`.

The reader now walks into a group and collects the text of its children, including nested groups. The rest of the behavior is unchanged. A shape with no `.text` is still skipped, and the join and the `(No text content)` fallback stay the same.

The group is matched with `isinstance(shape, GroupShape)`, not a `shape_type` check. `shape_type` raises `NotImplementedError` for a shape python-pptx cannot name, at `pptx/shapes/base.py:191` and `pptx/shapes/autoshape.py:325`. `read()` catches every exception and returns an empty list, so one unnamed shape would drop the whole file instead of one shape.

`async_read` delegates to `read` through `asyncio.to_thread`, so it takes the same fix.

The reproduction from the issue, run on this branch:

```text
Before grouping: 'Slide 1:\nLaunch date: 2026-10-01'
After grouping:  'Slide 1:\nLaunch date: 2026-10-01'
```

On `main` the second line reads `'Slide 1:\n(No text content)'`.

(If applicable, issue number: #9999)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

`test_pptx_reader_grouped_shapes` builds a real PPTX with python-pptx: one text box on the slide, one in a group, and one in a group nested inside that group. It asserts that all three come back, in order.

I mutation tested it twice. With the reader reverted to `main` the new test fails and the other 13 pass. With the group branch collecting only one level, it fails on the nested text alone.

`./scripts/format.sh` leaves the tree unchanged. `./scripts/validate.sh` passes: ruff check and mypy over 1046 agno source files, plus agnoctl and cookbook.

Run on Python 3.12.12 with python-pptx 1.0.2, ruff 0.15.20 and mypy 2.1.0, the versions pinned in `libs/agno/pyproject.toml`.

No cookbook change. The fix sits inside the reader and no example covers PPTX group handling.

AI tool used: Claude Code CLI with Opus 5.
