### PR TITLE
fix: use UTF-8 for agnoctl client config text

### DIFF
--- a/libs/agnoctl/agnoctl/clients/base.py
+++ b/libs/agnoctl/agnoctl/clients/base.py
@@ -75,7 +75,7 @@ def read_json_lenient(path: Path) -> Optional[Dict[str, Any]]:
     if not path.exists():
         return None
     try:
-        parsed = json.loads(path.read_text())
+        parsed = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return None
     return parsed if isinstance(parsed, dict) else None
@@ -86,7 +86,7 @@ def read_json_strict(path: Path) -> Dict[str, Any]:
     if not path.exists():
         return {}
     try:
-        parsed = json.loads(path.read_text())
+        parsed = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as e:
         raise CLIError(
             "Refusing to modify " + str(path) + ": the existing file is not valid JSON (" + str(e) + ").",
@@ -127,7 +127,7 @@ def atomic_write_text(path: Path, text: str, *, secure: bool) -> None:
     fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix="." + path.name + ".", suffix=".tmp")
     tmp = Path(tmp_name)
     try:
-        with os.fdopen(fd, "w") as handle:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
             handle.write(text)
             handle.flush()
             os.fsync(handle.fileno())

--- a/libs/agnoctl/tests/test_adapters.py
+++ b/libs/agnoctl/tests/test_adapters.py
@@ -16,7 +16,12 @@ else:
     import tomli as tomllib
 
 import agnoctl.clients.base as base_module
-from agnoctl.clients.base import atomic_write_text
+from agnoctl.clients.base import (
+    atomic_write_text,
+    read_json_lenient,
+    read_json_strict,
+    write_servers_entry,
+)
 from agnoctl.clients.claude_code import ClaudeCodeAdapter
 from agnoctl.clients.claude_desktop import ClaudeDesktopAdapter
 from agnoctl.clients.codex import CodexAdapter
@@ -541,6 +546,21 @@ def test_atomic_write_text_direct_secure(tmp_path: Path, permissive_umask):
     atomic_write_text(target, "s3cr3t", secure=True)
     assert target.read_text() == "s3cr3t"
     assert _mode(target) == 0o600
+
+
+def test_json_helpers_use_utf8_text(tmp_path: Path):
+    path = tmp_path / ".cursor" / "mcp.json"
+    path.parent.mkdir()
+    path.write_text(json.dumps({"note": "cafe \u2615"}), encoding="utf-8")
+
+    assert read_json_lenient(path) == {"note": "cafe \u2615"}
+    assert read_json_strict(path) == {"note": "cafe \u2615"}
+
+    write_servers_entry(path, "agno", {"url": URL, "note": "cafe \u2615"}, secure=False)
+
+    config = json.loads(path.read_text(encoding="utf-8"))
+    assert config["note"] == "cafe \u2615"
+    assert config["mcpServers"]["agno"]["note"] == "cafe \u2615"
 
 
 # -- remove ------------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The shared agnoctl client config helpers read and write JSON/TOML-adjacent text through Python's platform-default encoding. These files are user configuration files, so relying on the process locale can make behavior differ across machines.

Closes #10039

## Before / after

Before:
- `read_json_lenient()` and `read_json_strict()` used `Path.read_text()` without an encoding
- `atomic_write_text()` opened the temporary file without an encoding before replacing the target config

After:
- all three paths explicitly use UTF-8 text encoding
- the existing atomic replace and file-mode behavior stays unchanged
- a focused adapter test covers non-ASCII JSON content through the helpers

## Verification

- `PYTHONPATH=D:\fable 5 files\GitHub-Regular-Session-2026-09-08\agno\libs\agnoctl python -m pytest libs/agnoctl/tests/test_adapters.py::test_json_helpers_use_utf8_text`

Notes:
- `uv run --project libs/agnoctl pytest ...` is currently blocked locally because the project advertises Python `>=3.9,<4` while the dev dependency `mypy==2.1.0` requires Python `>=3.10`.
- I also ran the full `libs/agnoctl/tests/test_adapters.py` file via `PYTHONPATH`; 48 tests passed, and the remaining 9 failures are existing Windows permission-mode assertions around chmod/0600 behavior rather than this encoding change.