### PR TITLE
[fix] Stop response loop after tool call limit errors

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -2222,6 +2222,7 @@ class Model(ABC):
             tool_name=function_call.function.name,
             tool_args=function_call.arguments,
             tool_call_error=True,
+            stop_after_tool_call=True,
         )
 
     def run_function_call(

--- a/libs/agno/tests/unit/models/test_tool_call_limit.py
+++ b/libs/agno/tests/unit/models/test_tool_call_limit.py
@@ -1,0 +1,87 @@
+import json
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+
+import pytest
+
+from agno.models.base import Model
+from agno.models.message import Message, MessageMetrics
+from agno.models.response import ModelResponse
+from agno.tools.function import Function
+
+
+def lookup() -> str:
+    return "result"
+
+
+class LimitScriptedModel(Model):
+    """Requests a second tool call after the configured limit is exhausted."""
+
+    def __init__(self) -> None:
+        super().__init__(id="limit-scripted", provider="test")
+        self.calls = 0
+
+    def _next(self) -> ModelResponse:
+        self.calls += 1
+        if self.calls <= 2:
+            return ModelResponse(
+                role="assistant",
+                tool_calls=[
+                    {
+                        "id": f"call-{self.calls}",
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": json.dumps({})},
+                    }
+                ],
+                response_usage=MessageMetrics(),
+            )
+        raise AssertionError("the model must not be invoked after a limit error")
+
+    def invoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return self._next()
+
+    async def ainvoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return self._next()
+
+    def invoke_stream(self, *args: Any, **kwargs: Any) -> Iterator[ModelResponse]:
+        yield self._next()
+
+    async def ainvoke_stream(self, *args: Any, **kwargs: Any) -> AsyncIterator[ModelResponse]:
+        yield self._next()
+
+    def _parse_provider_response(self, response: Any, **kwargs: Any) -> ModelResponse:
+        return response
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return response
+
+
+def test_response_stops_after_tool_call_limit_error() -> None:
+    model = LimitScriptedModel()
+    messages = [Message(role="user", content="use the tool")]
+
+    model.response(
+        messages=messages,
+        tools=[Function.from_callable(lookup)],
+        tool_call_limit=1,
+    )
+
+    assert model.calls == 2
+    assert messages[-1].tool_call_error is True
+    assert messages[-1].stop_after_tool_call is True
+
+
+@pytest.mark.asyncio
+async def test_async_response_stops_after_tool_call_limit_error() -> None:
+    model = LimitScriptedModel()
+    messages = [Message(role="user", content="use the tool")]
+
+    await model.aresponse(
+        messages=messages,
+        tools=[Function.from_callable(lookup)],
+        tool_call_limit=1,
+    )
+
+    assert model.calls == 2
+    assert messages[-1].tool_call_error is True
+    assert messages[-1].stop_after_tool_call is True


### PR DESCRIPTION
## Summary
- stop the response loop when a tool call is rejected because `tool_call_limit` has been exceeded
- add sync and async regressions that fail if the model is invoked after the limit-error result

## Validation
- `pytest libs/agno/tests/unit/models/test_tool_call_limit.py -q` (2 passed)
- `ruff check libs/agno/tests/unit/models/test_tool_call_limit.py`
- `ruff format libs/agno/agno/models/base.py libs/agno/tests/unit/models/test_tool_call_limit.py`

Fixes #10041

## AI disclosure
I used an AI coding assistant to help prepare this change. I reviewed the implementation, regression coverage, and validation results.