### PR TITLE
fix(chunking): prevent RecursiveChunking from skipping text when overlap exceeds chunk length

### DIFF
--- a/libs/agno/agno/knowledge/chunking/recursive.py
+++ b/libs/agno/agno/knowledge/chunking/recursive.py
@@ -56,10 +56,11 @@ class RecursiveChunking(ChunkingStrategy):
                 break
 
             new_start = end - self.overlap
-            if new_start <= start:  # Prevent infinite loop
-                new_start = min(
-                    len(content), start + max(1, self.chunk_size // 10)
-                )  # Move forward by at least 10% of chunk size
+            if new_start <= start:  # Prevent infinite loop when chunk is shorter than overlap
+                # Start the next chunk at the end of the current one so no text is skipped.
+                # end is always > start (guaranteed by the separator search and chunk_size > 0),
+                # so this still makes forward progress.
+                new_start = end
             start = new_start
 
         return chunks

--- a/libs/agno/tests/unit/knowledge/chunking/test_recursive_chunking.py
+++ b/libs/agno/tests/unit/knowledge/chunking/test_recursive_chunking.py
@@ -25,3 +25,51 @@ def test_last_chunk_ends_the_document_and_repeats_no_earlier_chunk():
     assert content.endswith(chunks[-1].content)
     for position, chunk in enumerate(chunks):
         assert not any(chunk.content in earlier.content for earlier in chunks[:position])
+
+
+def test_short_heading_with_overlap_does_not_skip_text():
+    """Regression test for issue #9969.
+
+    When a short heading is followed by a longer body and overlap is enabled,
+    the first chunk ends after the heading. The forward-progress fallback must
+    not jump past body text — every word must appear in at least one chunk.
+    """
+    words = [f"word{i:03d}" for i in range(300)]
+    content = "Intro\n" + " ".join(words)
+    strategy = RecursiveChunking(chunk_size=1000, overlap=100)
+    doc = Document(content=content)
+
+    chunks = strategy.chunk(doc)
+
+    # Every word must appear in at least one chunk — no text skipped.
+    missing = [w for w in words if not any(w in c.content for c in chunks)]
+    assert not missing, f"Skipped words: {missing}"
+
+
+def test_multiple_short_headings_with_overlap_does_not_skip_text():
+    """Multiple consecutive short headings must not cause text loss."""
+    words = [f"word{i:03d}" for i in range(200)]
+    content = "H1\nH2\nH3\n" + " ".join(words)
+    strategy = RecursiveChunking(chunk_size=500, overlap=50)
+    doc = Document(content=content)
+
+    chunks = strategy.chunk(doc)
+
+    missing = [w for w in words if not any(w in c.content for c in chunks)]
+    assert not missing, f"Skipped words: {missing}"
+
+
+def test_short_heading_with_overlap_makes_forward_progress():
+    """Ensure the fix does not cause an infinite loop with short headings."""
+    content = "A\n" + "b" * 50
+    strategy = RecursiveChunking(chunk_size=10, overlap=5)
+    doc = Document(content=content)
+
+    chunks = strategy.chunk(doc)
+
+    # Should terminate (no infinite loop) and cover the heading.
+    assert len(chunks) > 0
+    assert "A" in chunks[0].content
+    # Every 'b' from the body must appear in at least one chunk.
+    combined = "".join(chunk.content for chunk in chunks)
+    assert combined.count("b") >= 50


### PR DESCRIPTION
## Summary

Fixes #9969

`RecursiveChunking` with overlap enabled silently skips text when a short heading causes the first chunk to end before the overlap offset.

## Root Cause

In `chunk()`'s forward-progress fallback (line 58-63 of `recursive.py`):

```python
new_start = end - self.overlap
if new_start <= start:  # Prevent infinite loop
    new_start = min(
        len(content), start + max(1, self.chunk_size // 10)
    )  # Move forward by at least 10% of chunk size
```

When a short heading (e.g. `"Intro\n"`) causes the first chunk to end at position 6, `new_start = 6 - 100 = -94` triggers the fallback. The fallback jumps to `start + chunk_size // 10 = 0 + 100 = 100`, **skipping all text from position 6 to 100** (12 words in the issue's reproduction).

The fallback advances from `start` (the beginning of the current chunk) by 10% of `chunk_size`, but the chunk ended much earlier at `end`. This jumps past `end`, omitting the text between.

## Fix

Changed the fallback to advance to `end` (the current chunk's end) instead of `start + chunk_size // 10`:

```python
new_start = end - self.overlap
if new_start <= start:  # Prevent infinite loop when chunk is shorter than overlap
    new_start = end  # Start next chunk at end of current — no text skipped
start = new_start
```

This guarantees:
1. **No text is skipped** — the next chunk begins at `end`, not past it
2. **Forward progress** — `end > start` always holds (guaranteed by `chunk_size > 0` and separator search)
3. **No infinite loop** — `end` strictly advances past `start` each iteration

The overlap is only lost in this edge case (chunk shorter than overlap), which is acceptable — you cannot overlap a chunk that's shorter than the overlap amount.

## How to Test

```bash
cd libs/agno
pip install -e .
pytest tests/unit/knowledge/chunking/test_recursive_chunking.py -v
```

Reproduction from the issue:

```python
from agno.knowledge.chunking.recursive import RecursiveChunking
from agno.knowledge.document.base import Document

words = [f"word{i:03d}" for i in range(300)]
content = "Intro\n" + " ".join(words)
chunks = RecursiveChunking(chunk_size=1000, overlap=100).chunk(Document(content=content))
missing = [w for w in words if not any(w in c.content for c in chunks)]
assert not missing  # passes with fix, fails without (12 words skipped)
```

## Test Results

```
$ pytest test_recursive_chunking.py -v

test_long_document_still_chunks_with_overlap_and_no_duplication PASSED
test_last_chunk_ends_the_document_and_repeats_no_earlier_chunk PASSED
test_short_heading_with_overlap_does_not_skip_text PASSED
test_multiple_short_headings_with_overlap_does_not_skip_text PASSED
test_short_heading_with_overlap_makes_forward_progress PASSED

5 passed, 3 warnings in 0.08s
```

3 new regression tests added. Existing tests continue to pass — no regression.

## Type

- [x] Bug fix
