### PR TITLE
fix: preserve validation for mixed framework unions

### DIFF
--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -7,6 +7,7 @@ from importlib.metadata import version
 from threading import RLock
 from typing import (
     Any,
+    Annotated,
     Callable,
     Dict,
     List,
@@ -17,7 +18,9 @@ from typing import (
     Tuple,
     Type,
     TypeVar,
+    Union,
     get_args,
+    get_origin,
     get_type_hints,
 )
 
@@ -336,6 +339,59 @@ def _member_is_only(arg: Any, wanted: tuple) -> bool:
     first for the same reason as _member_names_type."""
     arg = unwrap_annotation(arg)
     return (isinstance(arg, type) and issubclass(arg, wanted)) or _union_is_only(arg, wanted)
+
+
+def _replace_framework_types_for_validation(hint: Any, framework_types: tuple, depth: int = 0) -> Any:
+    """Replace framework classes in a validation-only annotation.
+
+    Pydantic should verify an already-injected Agent or Team instance without
+    recursively resolving the framework object's internal forward references.
+    Other annotation branches remain available for normal coercion.
+    """
+    from pydantic import InstanceOf
+
+    if depth > 16:
+        return hint
+
+    hint = unwrap_annotation(hint)
+    if isinstance(hint, type):
+        try:
+            if issubclass(hint, framework_types):
+                return InstanceOf[hint]  # type: ignore[misc]
+        except TypeError:
+            pass
+        return hint
+
+    args = get_args(hint)
+    origin = get_origin(hint)
+    if not args or origin is Literal:
+        return hint
+
+    if origin is Annotated:
+        validated_type = _replace_framework_types_for_validation(args[0], framework_types, depth + 1)
+        return hint if validated_type is args[0] else Annotated[(validated_type, *args[1:])]
+
+    replaced_args = tuple(
+        _replace_framework_types_for_validation(argument, framework_types, depth + 1) for argument in args
+    )
+    if replaced_args == args:
+        return hint
+
+    if is_union(hint):
+        return Union[replaced_args]
+
+    try:
+        if len(replaced_args) == 1:
+            return origin[replaced_args[0]]
+        return origin[replaced_args]
+    except (AttributeError, TypeError):
+        copy_with = getattr(hint, "copy_with", None)
+        if copy_with is not None:
+            try:
+                return copy_with(replaced_args)
+            except (AttributeError, TypeError):
+                pass
+        return hint
 
 
 _hidden_media_warned: Set[Tuple[str, str]] = set()
@@ -1734,21 +1790,59 @@ class Function(BaseModel):
         return wrapped
 
     @staticmethod
-    def _validate_callable(func: Callable) -> Callable:
-        from inspect import isasyncgenfunction, iscoroutinefunction, signature
+    def _validate_callable_with_framework_types(
+        func: Callable, sig: Any, hints: Dict[str, Any], framework_types: tuple
+    ) -> Callable:
+        """Validate a callable without expanding Agent or Team internals."""
+        from inspect import Parameter, isasyncgenfunction, iscoroutinefunction, isgeneratorfunction
 
-        pydantic_version = _get_pydantic_version()
+        safe_parameters = []
+        for parameter in sig.parameters.values():
+            hint = hints.get(parameter.name, parameter.annotation)
+            if hint is not Parameter.empty:
+                hint = _replace_framework_types_for_validation(hint, framework_types)
+            safe_parameters.append(parameter.replace(annotation=hint))
+        safe_signature = sig.replace(parameters=safe_parameters)
 
-        # Async generators need special handling: validate_call turns an `async def ... yield`
-        # into a plain function that returns an async_generator, which makes
-        # inspect.isasyncgenfunction return False. Downstream dispatch (models/base.py,
-        # FunctionCall.aexecute) uses that predicate to route the call, so we wrap the
-        # validated callable in an outer `async def ... yield` shim that preserves the
-        # async-generator identity while still coercing arguments through Pydantic.
         if isasyncgenfunction(func):
-            if getattr(func, "_wrapped_for_validation", False):
-                return func
-            validated = validate_call(func, config=dict(arbitrary_types_allowed=True))  # type: ignore
+
+            @wraps(func)
+            async def validation_proxy(*args, **kwargs):
+                async for item in func(*args, **kwargs):
+                    yield item
+
+        elif iscoroutinefunction(func):
+
+            @wraps(func)
+            async def validation_proxy(*args, **kwargs):
+                return await func(*args, **kwargs)
+
+        elif isgeneratorfunction(func):
+
+            @wraps(func)
+            def validation_proxy(*args, **kwargs):
+                yield from func(*args, **kwargs)
+
+        else:
+
+            @wraps(func)
+            def validation_proxy(*args, **kwargs):
+                return func(*args, **kwargs)
+
+        # Only the validation proxy exposes safe framework types; the user's callable
+        # and its model-facing schema keep their original annotations.
+        validation_proxy.__signature__ = safe_signature  # type: ignore[attr-defined]
+        validation_proxy.__annotations__ = {
+            parameter.name: parameter.annotation
+            for parameter in safe_signature.parameters.values()
+            if parameter.annotation is not Parameter.empty
+        }
+        if safe_signature.return_annotation is not Parameter.empty:
+            validation_proxy.__annotations__["return"] = safe_signature.return_annotation
+
+        validated = validate_call(validation_proxy, config=dict(arbitrary_types_allowed=True))  # type: ignore
+
+        if isasyncgenfunction(func):
 
             @wraps(func)
             async def async_gen_wrapper(*args, **kwargs):
@@ -1762,6 +1856,15 @@ class Function(BaseModel):
             async_gen_wrapper._wrapped_for_validation = True  # type: ignore[attr-defined]
             return async_gen_wrapper
 
+        validated._wrapped_for_validation = True  # type: ignore[attr-defined]
+        return validated
+
+    @staticmethod
+    def _validate_callable(func: Callable) -> Callable:
+        from inspect import isasyncgenfunction, iscoroutinefunction, signature
+
+        pydantic_version = _get_pydantic_version()
+
         # Don't wrap coroutines with validate_call if pydantic version is less than 2.10.0
         if iscoroutinefunction(func) and pydantic_version < Version("2.10.0"):
             log_debug(
@@ -1770,7 +1873,7 @@ class Function(BaseModel):
             return func
 
         # Don't wrap callables that are already wrapped with validate_call
-        elif getattr(func, "_wrapped_for_validation", False):
+        if getattr(func, "_wrapped_for_validation", False):
             return func
 
         # Don't wrap functions with framework-injected parameters
@@ -1781,11 +1884,11 @@ class Function(BaseModel):
         if framework_params & set(sig.parameters.keys()):
             return func
 
-        # Also skip validation when a PARAMETER's type is Agent or Team, even
-        # if the parameter name differs (e.g. my_agent: Agent) or the annotation
-        # is a union (owner: Optional[Agent]).
-        # validate_call uses get_type_hints() which fails to resolve types
-        # from Agent/Team class hierarchies (like BaseDb) in the user's module globals.
+        # Also handle validation when a PARAMETER's type contains Agent or Team,
+        # even if the parameter name differs (e.g. my_agent: Agent) or the annotation
+        # is a union (owner: Optional[Agent]). validate_call uses get_type_hints()
+        # which fails to resolve types from Agent/Team class hierarchies in the
+        # user's module globals.
         # The return annotation is not a parameter: validate_call is called
         # without validate_return, so it never introspects one.
         try:
@@ -1794,18 +1897,53 @@ class Function(BaseModel):
             from agno.team.team import Team
 
             framework_types = (Agent, Team)
+            needs_safe_validation = False
             for name, hint in hints.items():
                 if name == "return" or name not in sig.parameters:
                     continue
-                # The same structural search the schema rule uses. Reading only
-                # a bare annotation or a direct union left `Union[str,
-                # list[Agent]]` to validate_call, which then failed to resolve
-                # Agent's own forward references and took registration of the
-                # whole tool down.
                 if annotation_reaches(hint, framework_types):
+                    if not is_framework_typed(hint):
+                        needs_safe_validation = True
+            if needs_safe_validation:
+                try:
+                    return Function._validate_callable_with_framework_types(func, sig, hints, framework_types)
+                except Exception as e:
+                    # Preserve the pre-existing registration fallback for annotation
+                    # shapes that cannot be rebuilt, but make the lost validation visible.
+                    log_warning(
+                        f"Skipping validate_call for {func.__name__}: could not build a validation-safe "
+                        f"Agent/Team annotation ({e})"
+                    )
                     return func
+
+            if any(
+                name != "return" and name in sig.parameters and annotation_reaches(hint, framework_types)
+                for name, hint in hints.items()
+            ):
+                return func
         except Exception:
             pass
+
+        # Async generators need special handling: validate_call turns an `async def ... yield`
+        # into a plain function that returns an async_generator, which makes
+        # inspect.isasyncgenfunction return False. Downstream dispatch (models/base.py,
+        # FunctionCall.aexecute) uses that predicate to route the call, so we wrap the
+        # validated callable in an outer `async def ... yield` shim that preserves the
+        # async-generator identity while still coercing arguments through Pydantic.
+        if isasyncgenfunction(func):
+            validated = validate_call(func, config=dict(arbitrary_types_allowed=True))  # type: ignore
+
+            @wraps(func)
+            async def async_gen_wrapper(*args, **kwargs):
+                inner = validated(*args, **kwargs)
+                try:
+                    async for item in inner:
+                        yield item
+                finally:
+                    await inner.aclose()
+
+            async_gen_wrapper._wrapped_for_validation = True  # type: ignore[attr-defined]
+            return async_gen_wrapper
 
         # Wrap the callable with validate_call
         wrapped = validate_call(func, config=dict(arbitrary_types_allowed=True))  # type: ignore

--- a/libs/agno/tests/unit/tools/test_async_generator_deserialize.py
+++ b/libs/agno/tests/unit/tools/test_async_generator_deserialize.py
@@ -19,11 +19,12 @@ async generator function, and (b) argument coercion works end-to-end through
 """
 
 from inspect import isasyncgen, isasyncgenfunction, iscoroutinefunction, isgeneratorfunction
-from typing import Literal
+from typing import Literal, Union
 
 import pytest
 from pydantic import BaseModel
 
+from agno.agent.agent import Agent
 from agno.tools.function import Function, FunctionCall
 
 
@@ -173,3 +174,28 @@ async def test_async_gen_validation_error_surfaces_on_iteration():
     with pytest.raises(ValidationError, match="time_range"):
         async for _ in result:
             pass
+
+
+@pytest.mark.asyncio
+async def test_async_gen_framework_union_keeps_argument_validation():
+    """Agent in one union must not disable coercion or async-generator dispatch."""
+
+    class Ticket(BaseModel):
+        title: str
+        priority: int
+
+    async def create_ticket(ticket: Union[Ticket, Agent], count: int):
+        yield type(ticket).__name__, type(count).__name__, ticket.priority
+
+    func = Function(name="create_ticket", entrypoint=create_ticket)
+    func.process_entrypoint()
+    call = FunctionCall(
+        function=func,
+        arguments={"ticket": {"title": "Login failed", "priority": "2"}, "count": "7"},
+    )
+
+    result = await call.aexecute()
+
+    assert result.status == "success"
+    assert isasyncgenfunction(func.entrypoint)
+    assert [item async for item in call.result] == [("Ticket", "int", 2)]

--- a/libs/agno/tests/unit/tools/test_functions.py
+++ b/libs/agno/tests/unit/tools/test_functions.py
@@ -617,6 +617,31 @@ async def test_function_call_async_execution():
 
 
 @pytest.mark.asyncio
+async def test_framework_union_preserves_validation_for_async_callable():
+    """A framework type in a union must not disable async argument validation."""
+    from typing import Union
+
+    from agno.agent.agent import Agent
+
+    class Ticket(BaseModel):
+        title: str
+        priority: int
+
+    async def create_ticket(ticket: Union[Ticket, Agent], count: int) -> tuple[str, str, int]:
+        return type(ticket).__name__, type(count).__name__, ticket.priority
+
+    function = Function(name="create_ticket", entrypoint=create_ticket)
+    function.process_entrypoint()
+    result = await FunctionCall(
+        function=function,
+        arguments={"ticket": {"title": "Login failed", "priority": "2"}, "count": "7"},
+    ).aexecute()
+
+    assert result.status == "success"
+    assert result.result == ("Ticket", "int", 2)
+
+
+@pytest.mark.asyncio
 async def test_function_call_async_execution_with_error():
     """Test async function call execution with error handling."""
 
@@ -972,6 +997,74 @@ def test_tool_decorator_with_agent_team_type_annotations():
     assert not getattr(func_with_team_type.entrypoint, "_wrapped_for_validation", False)
     assert "query" in func_with_team_type.parameters["properties"]
     assert "my_team" not in func_with_team_type.parameters["properties"]
+
+
+@pytest.mark.parametrize("registration_path", ["from_callable", "process_entrypoint"])
+def test_framework_union_preserves_validation_for_other_parameters(registration_path):
+    """A framework type in one union must not disable validation for the callable."""
+    from typing import Union
+
+    from agno.agent.agent import Agent
+
+    class Ticket(BaseModel):
+        title: str
+        priority: int
+
+    def create_ticket(ticket: Union[Ticket, Agent], count: int) -> tuple[str, str, int]:
+        priority = ticket["priority"] if isinstance(ticket, dict) else ticket.priority
+        return type(ticket).__name__, type(count).__name__, priority
+
+    if registration_path == "from_callable":
+        function = Function.from_callable(create_ticket)
+    else:
+        function = Function(name="create_ticket", entrypoint=create_ticket)
+        function.process_entrypoint()
+
+    result = FunctionCall(
+        function=function,
+        arguments={"ticket": {"title": "Login failed", "priority": "2"}, "count": "7"},
+    ).execute()
+
+    assert result.status == "success"
+    assert result.result == ("Ticket", "int", 2)
+
+
+@pytest.mark.parametrize("registration_path", ["from_callable", "process_entrypoint"])
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        {"ticket": {"title": "Login failed", "priority": "not-an-int"}, "count": "7"},
+        {"ticket": {"title": "Login failed", "priority": "2"}, "count": "not-an-int"},
+    ],
+    ids=["invalid-model", "invalid-sibling"],
+)
+def test_framework_union_rejects_invalid_arguments(registration_path, arguments):
+    """A framework type in one union must not let other invalid input through."""
+    from typing import Union
+
+    from agno.agent.agent import Agent
+
+    class Ticket(BaseModel):
+        title: str
+        priority: int
+
+    def create_ticket(ticket: Union[Ticket, Agent], count: int) -> str:
+        return "created"
+
+    if registration_path == "from_callable":
+        function = Function.from_callable(create_ticket)
+    else:
+        function = Function(name="create_ticket", entrypoint=create_ticket)
+        function.process_entrypoint()
+
+    result = FunctionCall(
+        function=function,
+        arguments=arguments,
+    ).execute()
+
+    assert result.status == "failure"
+    assert result.error is not None
+    assert "validation error" in result.error.lower()
 
 
 def test_tool_decorator_with_complex_types():
@@ -2151,7 +2244,7 @@ def test_identity_only_union_is_excluded_and_injected():
 
 def test_run_context_union_is_excluded_even_beside_an_ordinary_type():
     """RunContext is the one identity type pydantic can build from a model dict:
-    validate_call is skipped for Agent/Team parameters but not for this one. An
+    bare framework-owned Agent/Team parameters are skipped, but not this one. An
     exposed `Union[str, RunContext]` would coerce {"user_id": ...} into a live
     RunContext and hand the model the caller's identity."""
     from typing import Union as Un
@@ -2389,8 +2482,8 @@ def test_the_whole_annotation_graph_decides_identity():
     ]
     fillable = [
         # Agent beside an ordinary type is the documented model-fillable shape:
-        # validate_call is skipped for it, so the tool receives a string or a
-        # plain dict, never a live Agent. That holds inside a list too.
+        # The model can fill the ordinary branch, while the validation-only
+        # annotation treats Agent as an existing instance rather than expanding it.
         Union[str, Agent],
         Optional[Union[str, Agent]],
         List[Union[str, Agent]],


### PR DESCRIPTION
## Summary

Fixes #9415.

When a callable parameter contains `Agent` or `Team` alongside a model-fillable type, such as `Union[Ticket, Agent]`, Agno currently skips Pydantic `validate_call` for the entire callable. This leaves runtime behavior inconsistent with the generated tool schema: model dictionaries are not converted, sibling parameters lose coercion, and invalid values can reach the tool implementation.

This change builds a validation-only proxy signature that replaces framework types with `pydantic.InstanceOf`. Normal union branches retain Pydantic parsing, existing `Agent` and `Team` instances remain valid, and Pydantic does not expand framework-internal forward references.

The original callable annotations and model-facing JSON schema remain unchanged. Pure framework-owned annotations keep the existing injection behavior. If a safe signature cannot be built, registration retains the previous fallback and emits a warning instead of silently losing validation.

The proxy preserves sync, coroutine, generator, and async-generator execution behavior.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (not applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I searched existing open pull requests and confirmed that no other PR currently addresses this issue
- [x] This change was developed with AI assistance and manually directed and verified

---

## Additional Notes

Focused regression tests:

```text
8 passed, 192 deselected
```

Related async-generator, wrapper-lifecycle, and schema-cache tests:

```text
34 passed
```

Full `test_functions.py` result on Windows:

```text
189 passed, 4 failed
```

The four failures are unrelated Windows platform limitations: three assert Unix permission bits and one requires symbolic-link privileges (`WinError 1314`).

Focused static checks completed successfully:

- `ruff check`
- `ruff format --check`
- `mypy libs/agno/agno/tools/function.py`
- `git diff --check`
- Python 3.9 syntax parsing

The repository shell scripts were not run directly because the local development environment is Windows.