### PR TITLE
chore: release 3.0.7

### DIFF
--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agno"
-version = "3.0.6"
+version = "3.0.7"
 description = "The programming language for agentic software."
 requires-python = ">=3.9,<4"
 readme = "README.md"


### PR DESCRIPTION
# Changelog

## New Features

- **Page storage in `agno.knowledge.page`.** Knowledge atomically publishes catalog metadata, filesystem text and vectors, preserves previous revisions when a refresh fails, and exposes bounded sync and async setup, source synchronization, search, read, list and grep APIs. Installed through the new `agno[pages]` extra. (#9963)
  - `Knowledge(page_search=PageSearchConfig(...))` provides typed, transaction-local planner controls. Unset scan preferences, costs, worker counts and thresholds inherit the PostgreSQL settings.
- **`PublicSurface` for public serving**: serves selected Agents, native stateless MCP and authenticated durable-sync Workflows, with shared quotas, request and output bounds, CORS and internal-service authentication. (#9963)
  - Explicitly selected **Teams** are now servable too, with REST and gzip support. They share the Agent admission, execution and output limits; the roster is reduced and member routes stay private unless independently selected. (#9996)
- **`PageFileSystem(knowledge=...)`**: a bounded read-only page filesystem toolkit with sync and async execution, exposed explicitly through `files.tools()`. Commands read pages lazily against pinned revisions, list scoped metadata and run bounded literal grep; they cannot execute a shell or write files. (#9997)
- **Agent dependency callables can receive `run_input` and `session`**, alongside the existing `agent` and `run_context`. Resolution runs before pre-hooks and reuses successful values on model retries. `add_dependencies_to_context` still defaults to False. (#9963)
- **AIMLAPI**: requests carry a fixed, analytics-only attribution header set, inspectable as `agno.models.aimlapi.AIMLAPI_HEADERS` and overridable per model via `default_headers`, where caller-supplied keys win. The headers carry no user data and do not affect routing, model selection or billing. The default model also moves from the retired `gpt-4o-mini` to `gpt-5.6-terra`. (#9898)

## Improvements

- **Workflows report failed steps as `StepError`** for both raised executor failures and explicitly failed outputs, carrying the current step's identity. Function reports are still preserved as `StepOutput`, and Agent, Team and nested Workflow content keeps its existing executor stream. Both console streaming printers render `StepError` explicitly, showing the original failure and clearing stale progress output. (#10001)

## Bug Fixes

- **Failed workflow runs are finalized before their terminal streaming event.** A workflow that paused during a background stream could fail during a non-streaming continuation, save `ERROR` to the database and leave its tracked stream stuck at `PAUSED`; fresh streaming failures yielded `WorkflowError` before the failed run was saved, so a consumer closing at that event could lose the run entirely. Streaming execution and guardrail failures now persist before yielding, draining a guardrail-failed stream re-raises the original `InputCheckError`/`OutputCheckError` rather than falling through to `WorkflowCompleted`, and completed-step outputs are preserved when a run hits a hard error. `WorkflowAgent` failures stay `ERROR` even when the model catches the tool exception and replies. (#10001)
  - Nested workflow guardrail rejections are no longer retried, which previously replayed earlier child side effects. Explicit `skip_on_failure` is honoured through the existing final-attempt policy and ordinary executor retries are preserved.
- **Meta Llama and AIMLAPI: every run crashed.** Both providers' `_format_message` overrides had drifted from `OpenAIChat`, which passes `compress_tool_results` positionally, so each call raised `TypeError: _format_message() takes 2 positional arguments but 3 were given`. The model layer swallowed it and returned that text as the assistant's answer rather than failing loudly. Both overrides now track the base class, and `LlamaOpenAI` forwards the flag rather than only accepting it, so tool-result compression actually applies. (#10031, #9898, fixes #9034)
- **Anthropic: empty tool arguments are preserved.** A zero-argument Claude tool call is an empty input object, which the adapter treated as falsy and omitted `function.arguments` for. Streaming and non-streaming parsing now serialize every tool input, so empty input becomes `"{}"`. Replaying such a persisted history through an OpenAI model previously failed with a missing `arguments` request error. (#8970, fixes #8971)
- **Cached tool wrappers no longer pin the caller's frame.** `validate_call` stores the caller's `f_locals` on the wrapper it builds and `Function` caches those wrappers for the life of the process, so on Python 3.13 every cached tool kept the wrapping frame alive along with the Agent, session and run state on the stack. The namespace resolver is cleared once the validators are built. (#9941, fixes #9940)
- **Anonymous native Agent JSON no longer leaks diagnostics**: a failed run returned HTTP 200 carrying status `ERROR` and nested model diagnostics, and is now a safe `503 run_failed`, matching the streaming error protection. Authenticated operator diagnostics are unaffected. (#9963)
- **Page serving corrections** across source retries, canonical-link deduplication, publication-time source binding, bounded page checkout and Agent continuation dependency ordering. (#9996)

## Breaking Changes

- **`Knowledge` constructor arguments are keyword-only.** Positional calls such as `Knowledge("docs")` must become `Knowledge(name="docs")`. `content_db` is now the preferred spelling; `contents_db` remains a supported read/write alias sharing the same dataclass field, so serialization, copy and `dataclasses.replace(..., contents_db=...)` are unchanged. Passing both keywords requires the same object. (#9963)
- **Page search honours the configured `PgVector` HNSW `ef_search`** instead of silently forcing 200, so deployments that relied on the implicit 200 should set it explicitly. Page indexes built from interim main builds can carry an implicit `ef_construction=64` and need an operator-managed rebuild; setup reports an actionable error rather than rebuilding automatically. (#9963)