### PR TITLE
feat: add Magic Hour hosted MCP cookbook

### DIFF
--- a/cookbook/91_tools/mcp/README.md
+++ b/cookbook/91_tools/mcp/README.md
@@ -76,6 +76,12 @@ Export your API keys:
 export OPENAI_API_KEY="your_openai_api_key"
 ```
 
+For the Magic Hour example, create a key in the [developer dashboard](https://magichour.ai/developer) and export it:
+
+```bash
+export MAGIC_HOUR_API_KEY="your_magic_hour_api_key"
+```
+
 > For the GitHub example, create a Github PAT following [these steps](https://github.com/modelcontextprotocol/servers/tree/main/src/github#setup).
 
 ### Run the Examples

--- a/cookbook/91_tools/mcp/README.md
+++ b/cookbook/91_tools/mcp/README.md
@@ -53,6 +53,10 @@ This example connects to the published Peer Cash MCP server to discover fiat pay
 
 This example shows how to choose which MCP protocol era `MCPTools` negotiates. The default `"legacy"` keeps the session-based era, where the connection is long-lived and `is_alive()` pings it. `"auto"` negotiates the newest era both sides support; the 2026-07-28 era is sessionless, so requests are self-contained and there is no connection to keep alive. Keep `"legacy"` for a server that gates access on initialize, holds per-session state, or elicits input mid-tool.
 
+13. Magic Hour Agent (`magic_hour.py`)
+
+This example connects to Magic Hour's hosted MCP server to create images and videos. It shows bearer authentication, long-running render handling, reuse of project IDs after timeouts, and exact output URL retrieval.
+
 ## Getting Started
 
 ### Prerequisites
@@ -83,6 +87,7 @@ python bgpt.py
 python structured_content.py
 python emem.py
 python peer_cash.py
+python magic_hour.py
 ```
 
 ## How It Works

--- a/cookbook/91_tools/mcp/TEST_LOG.md
+++ b/cookbook/91_tools/mcp/TEST_LOG.md
@@ -1,5 +1,15 @@
 # Test Log
 
+### magic_hour.py
+
+**Status:** PASS
+
+**Description:** Connects to Magic Hour's production Streamable HTTP MCP endpoint through Agno's `MCPTools` with bearer authentication and discovers the available media-generation and project workflow tools. The check uses an invalid test token so it cannot create a billable project.
+
+**Result:** MCP initialization completed, Agno discovered 44 tools, and `ping` returned `pong`. The authenticated `account_retrieve` tool rejected the invalid token with HTTP 401, so the check could not create a billable project. The example also passes Python compilation, Ruff formatting, and Ruff lint checks. A paid end-to-end generation remains intentionally untested until a reviewer credential is provided securely.
+
+---
+
 ### peer_cash.py
 
 **Status:** PASS

--- a/cookbook/91_tools/mcp/magic_hour.py
+++ b/cookbook/91_tools/mcp/magic_hour.py
@@ -15,14 +15,25 @@ Magic Hour MCP docs: https://docs.magichour.ai/integration/model-context-protoco
 
 import asyncio
 from os import getenv
+from pathlib import Path
 from textwrap import dedent
+from typing import Optional
+from urllib.parse import urlparse
 
+import httpx
 from agno.agent import Agent
 from agno.models.openai import OpenAIResponses
 from agno.tools.mcp import MCPTools
-from agno.utils.log import log_error
+from agno.utils.log import log_error, log_info
+from pydantic import BaseModel
 
 MAGIC_HOUR_MCP_URL = "https://mcp.magichour.ai/"
+
+
+class MediaResult(BaseModel):
+    project_id: str
+    download_url: str
+    summary: str
 
 
 async def run_agent(task: str) -> None:
@@ -40,21 +51,50 @@ async def run_agent(task: str) -> None:
     ) as magic_hour_tools:
         agent = Agent(
             name="MagicHourAgent",
-            model=OpenAIResponses(id="gpt-5.6-luna"),
+            model=OpenAIResponses(id="gpt-5.6-luna", parallel_tool_calls=False),
             tools=[magic_hour_tools],
+            output_schema=MediaResult,
+            # Keep the final response structured without forcing OpenAI's strict
+            # schema rules onto externally defined MCP tool schemas.
+            use_json_mode=True,
             instructions=dedent("""\
                 You create media with Magic Hour's tools.
 
                 - Choose the creation tool that matches the requested media
-                - Start exactly one project and retain its returned project ID
+                - Call the creation tool once and only once; every call bills credits
+                - Request 640px resolution unless the user asks for something larger,
+                  since higher resolutions need a paid Magic Hour plan
+                - If a call is rejected, report why instead of retrying with different
+                  settings; a retry that succeeds bills a second project
+                - Retain the returned project ID
                 - Call the matching wait_for_*_project tool until it reaches a terminal state
                 - If waiting times out, resume with the same project ID; do not create a duplicate
-                - Return the exact completed download URL without changing its query parameters
                 - Report terminal errors clearly and never claim completion without an output URL
+                - Copy the download URL exactly; its query parameters are a signature
+                  and stop working if altered
             """),
-            markdown=True,
         )
         await agent.aprint_response(input=task, stream=True)
+
+        run_output = await agent.aget_last_run_output()
+        result: Optional[MediaResult] = getattr(run_output, "content", None)
+        if not isinstance(result, MediaResult):
+            log_error("Agent did not return a MediaResult.")
+            return
+
+        print(result.download_url)
+
+        output_path = (
+            Path(__file__).parent
+            / "tmp"
+            / Path(urlparse(result.download_url).path).name
+        )
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        async with httpx.AsyncClient(timeout=120) as client:
+            response = await client.get(result.download_url)
+            response.raise_for_status()
+            output_path.write_bytes(response.content)
+        log_info(f"Saved {output_path}")
 
 
 if __name__ == "__main__":
@@ -64,7 +104,6 @@ if __name__ == "__main__":
             "background. Wait for completion and return the final image URL."
         )
     )
-
 
 # More example prompts:
 """

--- a/cookbook/91_tools/mcp/magic_hour.py
+++ b/cookbook/91_tools/mcp/magic_hour.py
@@ -1,0 +1,74 @@
+"""Magic Hour MCP Agent - Generate AI Images and Videos
+
+Connect an Agno agent to Magic Hour's hosted MCP server. The server exposes
+image, video, and audio generation tools plus project-status helpers.
+
+Setup:
+1. Install dependencies: `uv pip install "agno[mcp,openai]"`
+2. Create a Magic Hour API key at https://magichour.ai/developer
+3. Set `MAGIC_HOUR_API_KEY` and `OPENAI_API_KEY` in your environment
+
+Run: `python cookbook/91_tools/mcp/magic_hour.py`
+
+Magic Hour MCP docs: https://docs.magichour.ai/integration/model-context-protocol
+"""
+
+import asyncio
+from os import getenv
+from textwrap import dedent
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.tools.mcp import MCPTools
+from agno.utils.log import log_error
+
+MAGIC_HOUR_MCP_URL = "https://mcp.magichour.ai/"
+
+
+async def run_agent(task: str) -> None:
+    """Connect to Magic Hour and run one media-generation task."""
+    magic_hour_api_key = getenv("MAGIC_HOUR_API_KEY")
+    if not magic_hour_api_key:
+        log_error("MAGIC_HOUR_API_KEY environment variable not set.")
+        return
+
+    async with MCPTools(
+        url=MAGIC_HOUR_MCP_URL,
+        transport="streamable-http",
+        headers={"Authorization": f"Bearer {magic_hour_api_key}"},
+        timeout_seconds=600,
+    ) as magic_hour_tools:
+        agent = Agent(
+            name="MagicHourAgent",
+            model=OpenAIResponses(id="gpt-5.6-luna"),
+            tools=[magic_hour_tools],
+            instructions=dedent("""\
+                You create media with Magic Hour's tools.
+
+                - Choose the creation tool that matches the requested media
+                - Start exactly one project and retain its returned project ID
+                - Call the matching wait_for_*_project tool until it reaches a terminal state
+                - If waiting times out, resume with the same project ID; do not create a duplicate
+                - Return the exact completed download URL without changing its query parameters
+                - Report terminal errors clearly and never claim completion without an output URL
+            """),
+            markdown=True,
+        )
+        await agent.aprint_response(input=task, stream=True)
+
+
+if __name__ == "__main__":
+    asyncio.run(
+        run_agent(
+            "Create a square product image of a ceramic coffee mug on a warm studio "
+            "background. Wait for completion and return the final image URL."
+        )
+    )
+
+
+# More example prompts:
+"""
+- "Animate this product photo into a five-second video with a slow camera push-in: <public image URL>"
+- "Create a 16:9 cinematic video of a neon ramen shop in the rain. Wait for the final video."
+- "Generate a campaign image from this approved brief, then return the project ID and final image URL."
+"""


### PR DESCRIPTION
## Summary

Add a Magic Hour hosted MCP cookbook example for image and video generation. The example demonstrates bearer authentication, long render timeouts, one-project semantics, project ID reuse, exact output URL handling, and three revenue-relevant media workflows without adding an Agno runtime dependency.

Closes #10056

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Validation:

- `./scripts/format.sh`
- `./scripts/validate.sh` (Ruff, mypy across 1,067 source files, cookbook pattern check)
- `python -m py_compile cookbook/91_tools/mcp/magic_hour.py`
- Production MCP initialization through Agno discovered 44 tools
- Public `ping` returned `pong`
- Authenticated `account_retrieve` with an intentionally invalid token returned HTTP 401 and created no billable project

A paid end-to-end generation is not included because no reviewer API credential was available. The example requires contributors to provide their own `MAGIC_HOUR_API_KEY` and `OPENAI_API_KEY`.

This contribution is AI-generated and was reviewed against the repository's contribution instructions and automated validation gates.
