### PR TITLE
fix: support bounded public run continuation across REST and MCP

### DIFF
--- a/cookbook/05_agent_os/27_public_pages/README.md
+++ b/cookbook/05_agent_os/27_public_pages/README.md
@@ -131,7 +131,7 @@ configuration accepts no arbitrary SQL or deadline overrides.
 
 Only the selected Agent, native MCP and protected sync Workflow are exposed. Sessions, configuration and unselected components are closed. Workflow trigger/status require verified bearer credentials even while chat is anonymous. Scoped service accounts require the workflow run/read permissions and cannot use internal-service exemptions. `PAGE_DEMO_SYNC_TOKEN` configures the existing internal-service principal for a trusted deployment hook; keep it out of browsers and MCP clients.
 
-For custom functions such as this example's MCP tools, use `MCPConfig(tools=[...], default_tools=False, stateless=True)`. No lifecycle flag is needed. If you expose agents, teams or workflows as MCP tools, also set `lifecycle_tools=False` or `exclude_tags={"lifecycle"}`: the public surface does not allow the automatically added `continue_run` and `cancel_run` tools.
+For custom functions such as this example's MCP tools, use `MCPConfig(tools=[...], default_tools=False, stateless=True)`. No lifecycle flag is needed. Exposing agents, teams or workflows as MCP tools automatically includes `continue_run` and `cancel_run`, limited to those exposed components. Set `lifecycle_tools=False` or `exclude_tags={"lifecycle"}` only when deliberately omitting MCP lifecycle operations.
 
 Public chat defaults to 10 requests/client/minute, 50 globally/minute, 80/client/day and 3,000 globally/day. Cancel and MCP use separate shared buckets. PostgreSQL counters use the stable AgentOS ID across replicas. Default identity ignores arbitrary forwarded headers; customize `PublicSurface.client_id` only for an edge-overwritten trusted header. Request bodies, output, duration and concurrency are bounded; uploads are disabled here. CORS includes admission failures and readiness checks table preparation.
 
@@ -277,3 +277,44 @@ normalizer that leaves code unchanged; run it without a database or provider key
 
 Component-specific MDX transformations, prompt rendering, citations and query
 alternatives remain application-owned.
+
+## Public human approval
+
+`public_approval.py` demonstrates a public agent that pauses before a tool executes,
+then accepts approval or rejection through native MCP. Create the PostgreSQL database
+named in `PAGE_DEMO_DB_URL` and provide `OPENAI_API_KEY`, then run:
+
+```bash
+.venvs/demo/bin/python cookbook/05_agent_os/27_public_pages/public_approval.py serve
+# In another terminal:
+.venvs/demo/bin/python cookbook/05_agent_os/27_public_pages/public_approval.py demo
+```
+
+Public REST continuation uses `POST /agents/{id}/runs/{run_id}/continue` with
+`session_id`, `stream`, and `tools` (a JSON list of resolved tool executions from the
+paused response). Teams use `requirements` with the complete run requirements;
+workflows use `step_requirements`. The run must be paused. Forking, regeneration,
+background continuation and arbitrary execution overrides are not exposed here.
+Both transports preserve stored requirement identity and accept resolution values;
+clients cannot replace tool names, arguments, member targets or step policies.
+
+Cancellation uses the native `POST /{kind}/{id}/runs/{run_id}/cancel?session_id=...`
+route or MCP `cancel_run`. REST also accepts a form `session_id` for compatibility;
+supplying it twice is rejected. Unknown or mismatched handles fail before applying
+cancellation intent. A temporary PostgreSQL binding makes an active streamed run
+verifiable before its final run row exists. Cancellation delivery still uses the
+configured Agno cancellation manager; select a shared manager when running multiple
+replicas. Shared ownership records alone do not deliver cancellation across processes.
+
+For anonymous conversations, the unguessable session and run IDs are bearer
+capabilities: keep them private. They are not a login identity, and IP-based quota
+identity does not grant access to runs. A session belonging to an authenticated
+principal requires that same principal. Required administrator approvals remain
+protected even when general AgentOS authorization is disabled.
+
+REST and MCP starts/continuations share the `run` quota and each server instance's
+`max_active_runs` allowance and honor `max_run_seconds`. MCP additionally retains its
+protocol-request quota. Cancellation has an independent quota and does not consume
+run slots. Workflow execution and continuation require verified credentials on both
+transports. Only explicitly selected REST components and explicitly published MCP
+components are reachable; publishing a Team does not publish its member routes.

--- a/cookbook/05_agent_os/27_public_pages/TEST_LOG.md
+++ b/cookbook/05_agent_os/27_public_pages/TEST_LOG.md
@@ -147,3 +147,33 @@ neither shared environment was modified. Live database/provider modes were not
 run. The focused public-configuration and MCP suites passed all 204 tests.
 
 ---
+
+### public_approval.py — public continuation (2026-09-08)
+
+**Status:** PASS
+
+**Description:** Ran `public_approval.py --check` using the demo Python with compatible
+development dependencies on `PYTHONPATH`. Public AgentOS/MCP configuration builds
+with the default lifecycle setting. The shared environments were not modified.
+
+**Result:** Configuration passed without provider calls. The native public HTTP/MCP
+regression set passed 302 tests, including 42 new PostgreSQL continuation cases:
+Agent/Team approval and rejection, cross-instance and cross-transport continuation,
+nested member approvals, workflow authentication, wrong-user/component/session
+rejection, protected administrator approvals, active cancellation bindings,
+concurrent continuation admission and timeout/capacity cleanup. The PostgreSQL
+container and test databases were disposable. The cookbook's live-provider `demo`
+mode was not run. Formatting, lint and mypy passed.
+
+---
+
+
+## 2026-09-09 continuation rebase
+
+Rebased onto main `4253dedc9`; retained the shared JWT/public route policy.
+175 public continuation, authorization, surface and request-bound regressions
+passed against disposable local PostgreSQL databases. The continuation file then
+passed 46 cases, including four new native JWT/submount/query/form regressions.
+The two runs overlap; they are not 221 distinct tests. Full format and validation
+scripts passed. Delivery between separate OS processes is a separate follow-up;
+the existing cross-instance tests only establish shared run ownership.

--- a/cookbook/05_agent_os/27_public_pages/public_approval.py
+++ b/cookbook/05_agent_os/27_public_pages/public_approval.py
@@ -1,0 +1,104 @@
+"""A public agent that pauses for confirmation and resumes through native MCP.
+
+Run `public_approval.py serve`, then `public_approval.py demo` in another terminal.
+Use `public_approval.py --check` to validate configuration without provider calls.
+"""
+
+import argparse
+import asyncio
+from os import getenv
+
+from agno.agent import Agent
+from agno.db.postgres import PostgresDb
+from agno.models.openai import OpenAIResponses
+from agno.os import AgentOS, MCPConfig
+from agno.os.public import PublicSurface
+from agno.tools import tool
+from fastmcp import Client
+
+
+# Reuse the agent; each conversation gets its own session.
+@tool(requires_confirmation=True)
+def prepare_note(title: str) -> str:
+    """Prepare a note after the caller confirms its title."""
+    return f"Prepared note: {title}"
+
+
+db = PostgresDb(
+    db_url=getenv(
+        "PAGE_DEMO_DB_URL", "postgresql+psycopg://ai:ai@localhost:5532/public_approval"
+    )
+)
+agent = Agent(
+    id="approval-agent",
+    name="Approval Agent",
+    model=OpenAIResponses(id="gpt-5.6-luna"),
+    db=db,
+    tools=[prepare_note],
+    instructions="Use prepare_note when asked to prepare a note. Report the outcome concisely.",
+)
+agent_os = AgentOS(
+    id="public-approval",
+    agents=[agent],
+    db=db,
+    public=PublicSurface(agents=[agent], mcp=True),
+    mcp=MCPConfig(
+        tools=[agent],
+        default_tools=False,
+        stateless=True,
+        allowed_hosts=["localhost:*", "127.0.0.1:*"],
+    ),
+)
+app = agent_os.get_app()
+
+
+async def demonstrate() -> None:
+    url = getenv("PAGE_DEMO_SERVER_URL", "http://localhost:7777").rstrip("/")
+    async with Client(url + "/mcp") as client:
+        result = await client.call_tool(
+            "approval-agent",
+            {"message": "Prepare a note titled My first public approval."},
+        )
+        paused = result.structured_content
+        if not paused or paused.get("status") != "PAUSED":
+            print(result)
+            return
+        requirements = paused["requirements"]
+        for requirement in requirements:
+            execution = requirement["tool_execution"]
+            print(
+                "Requested action:", execution["tool_name"], execution.get("tool_args")
+            )
+        confirmed = input("Approve this action? [y/N] ").strip().lower() == "y"
+        for requirement in requirements:
+            requirement["tool_execution"]["confirmed"] = confirmed
+        # Keep these opaque handles private: anonymous callers use them as capabilities.
+        resumed = await client.call_tool(
+            "continue_run",
+            {
+                "agent_id": paused["agent_id"],
+                "session_id": paused["session_id"],
+                "run_id": paused["run_id"],
+                "requirements": requirements,
+            },
+        )
+        print(
+            resumed.structured_content.get("content")
+            if resumed.structured_content
+            else resumed
+        )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("mode", nargs="?", choices=["serve", "demo"], default="serve")
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+    if args.check:
+        print("Public approval configuration validated.")
+    elif args.mode == "demo":
+        asyncio.run(demonstrate())
+    else:
+        agent_os.serve(
+            app="public_approval:app", host="127.0.0.1", port=7777, reload=False
+        )

--- a/libs/agno/agno/os/auth.py
+++ b/libs/agno/agno/os/auth.py
@@ -619,6 +619,7 @@ async def run_continuation_blocked_reason(
     *,
     authorization_enabled: bool,
     user_scopes: List[str],
+    fail_closed: bool = False,
 ) -> Optional[str]:
     """Whether a paused run may NOT be continued yet, as a 403 detail string (else None).
 
@@ -630,6 +631,8 @@ async def run_continuation_blocked_reason(
     Fails open only for the approval feature itself: if the db has no approvals support the
     check is skipped, so non-approval deployments are unaffected. It never fails open on the
     authorization decision — that is the caller's ``authorization_enabled`` gate.
+    Public execution sets ``fail_closed=True`` so a database failure cannot skip
+    verification of an administrator-required approval.
     """
     # Mirror require_resource_access: skip entirely when authorization is disabled.
     if not authorization_enabled or db is None or not run_id:
@@ -655,6 +658,8 @@ async def run_continuation_blocked_reason(
         if approvals:
             return "This run requires admin approval before it can be continued"
     except Exception as exc:
+        if fail_closed:
+            raise HTTPException(status_code=503, detail="Approval verification unavailable") from exc
         # DB doesn't support approvals or another transient error — let the run continue
         # so non-approval setups are unaffected.
         from agno.utils.log import log_warning

--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -1358,6 +1358,10 @@ def _make_run_ownership_verifier(os: "AgentOS"):
     ):
         if component is None:
             raise Exception(f"Component {component_id} not found")
+        from agno.os.public._execution import _lifecycle_verified
+
+        if _lifecycle_verified(_http_request_or_none(), component_type, component_id, session_id, run_id):
+            return
         scoped_user_id = _scoped_caller_user_id()
         if isinstance(component, BaseRemote):
             # Remote components keep their sessions on the remote OS: there is no local
@@ -1784,7 +1788,9 @@ def _make_exposed_run_tool(
         )
         return build_run_tool_result(run_output, result_mode, continue_run_available=continue_run_available)
 
-    return run_exposed
+    from agno.os.public._execution import _public_mcp_tool
+
+    return _public_mcp_tool(os, kind, component_id)(run_exposed)
 
 
 def _make_exposed_workflow_tool(
@@ -1830,7 +1836,9 @@ def _make_exposed_workflow_tool(
             run_output = await _consume_workflow_stream(ctx, workflow, stream, total_steps, resolved_user_id)
         return build_run_tool_result(run_output, result_mode, continue_run_available=continue_run_available)
 
-    return run_exposed_workflow
+    from agno.os.public._execution import _public_mcp_tool
+
+    return _public_mcp_tool(os, "workflows", component_id)(run_exposed_workflow)
 
 
 def _register_exposed_components(
@@ -2177,6 +2185,8 @@ def build_mcp_server(
     Split out from :func:`get_mcp_server` so the tool surface can be exercised directly
     by an in-memory MCP client in tests, without the HTTP/JWT layer.
     """
+    from agno.os.public._execution import _public_mcp_tool
+
     mcp_config: "Optional[MCPConfig]" = getattr(os, "mcp_config", None)
 
     # Create an MCP server. With AgentOS(mcp_auth=...) set, the resolved fastmcp provider
@@ -2464,6 +2474,7 @@ def build_mcp_server(
         tags={"core", "lifecycle"},
         annotations={"readOnlyHint": False, "destructiveHint": True, "openWorldHint": True},
     )  # type: ignore
+    @_public_mcp_tool(os, action="continue")
     async def continue_run(
         run_id: str,
         ctx: Context,
@@ -2536,6 +2547,7 @@ def build_mcp_server(
         tags={"core", "lifecycle"},
         annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": True, "openWorldHint": True},
     )  # type: ignore
+    @_public_mcp_tool(os, action="cancel")
     async def cancel_run(
         run_id: str,
         session_id: Optional[str] = None,

--- a/libs/agno/agno/os/public/__init__.py
+++ b/libs/agno/agno/os/public/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from contextvars import ContextVar
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 from agno.os.public._limits import PublicLimiter, RateLimit
 
@@ -43,6 +43,10 @@ class PublicSurface:
     verified JWT callers use the normal REST API with endpoint permissions. MCP
     remains restricted to its explicit tools and public limits. Scheduler and
     service-account credentials retain their existing public request contracts.
+    Selected paused runs can be continued over REST and exposed MCP components
+    retain their scoped lifecycle tools. Anonymous session/run handles are bearer
+    capabilities; authenticated sessions require the same principal. Run limits
+    apply to both transports, and public workflows always require authentication.
     """
 
     agents: List[Any] = field(default_factory=list)
@@ -58,6 +62,9 @@ class PublicSurface:
     max_output_bytes: int = 1024 * 1024
     max_active_runs: int = 8
     _limiter: Optional[PublicLimiter] = field(default=None, init=False, repr=False)
+    _bindings: Any = field(default=None, init=False, repr=False)
+    _mcp_components: Dict[Any, Any] = field(default_factory=dict, init=False, repr=False)
+    _mcp_run_tools: Set[str] = field(default_factory=set, init=False, repr=False)
 
     @property
     def limiter(self) -> PublicLimiter:
@@ -104,15 +111,18 @@ class PublicSurface:
             from agno.os.mcp import _enabled_builtin_tags, _split_tool_entries
 
             _, exposures = _split_tool_entries(config, agent_os)
-            enabled_tags = _enabled_builtin_tags(config, has_exposures=bool(exposures))
-            if enabled_tags & {"core", "lifecycle"}:
-                raise ValueError(
-                    "Public MCP cannot expose continue_run or cancel_run. Exposing agents, teams or workflows "
-                    "as MCP tools enables them automatically; set lifecycle_tools=False or "
-                    'exclude_tags={"lifecycle"} in MCPConfig to disable them.'
-                )
+            self._mcp_components = {(kind, component.id): component for kind, component, _ in exposures}
+            self._mcp_run_tools = {
+                marker.name if marker and marker.name else component.id for _, component, marker in exposures
+            }
+            if _enabled_builtin_tags(config, has_exposures=bool(exposures)) & {"core", "lifecycle"}:
+                self._mcp_run_tools.update({"continue_run", "cancel_run"})
         if self._limiter is None:
             self._limiter = PublicLimiter(agent_os.db.db_engine, namespace, self.limits)
+        if self._bindings is None:
+            from agno.os.public._execution import _RunBindings
+
+            self._bindings = _RunBindings(agent_os.db.db_engine, namespace)
 
 
 __all__ = ["PublicSurface", "RateLimit", "FileUploadLimits", "get_public_client_id"]

--- a/libs/agno/agno/os/public/_execution.py
+++ b/libs/agno/agno/os/public/_execution.py
@@ -1,0 +1,375 @@
+"""Public run ownership and admission shared by HTTP and MCP."""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import inspect
+from copy import deepcopy
+from typing import Any, Literal, cast
+from uuid import UUID, uuid4
+
+from fastapi import HTTPException
+from sqlalchemy import text
+
+from agno.os.public._limits import WORKERS
+
+
+def _handle(value: Any) -> str:
+    if not isinstance(value, str):
+        raise HTTPException(400, "invalid_handle")
+    try:
+        if str(UUID(value)) != value.lower():
+            raise ValueError()
+    except ValueError:
+        raise HTTPException(400, "invalid_handle") from None
+    return value
+
+
+class _RunBindings:
+    """Short-lived, shared ownership records for runs that have not persisted yet."""
+
+    def __init__(self, engine: Any, namespace: str):
+        from agno.db.postgres._bounded import bounded_engine
+
+        self.engine = bounded_engine(engine, capacity=8)
+        self.namespace = namespace
+
+    @staticmethod
+    def _prepare(conn: Any) -> None:
+        conn.execute(
+            text(
+                "CREATE TABLE IF NOT EXISTS public.agno_public_runs ("
+                "namespace text NOT NULL, run_id text NOT NULL, session_id text NOT NULL, "
+                "kind text NOT NULL, component_id text NOT NULL, user_id text, "
+                "lease text NOT NULL, expires_at timestamptz NOT NULL, PRIMARY KEY(namespace, run_id))"
+            )
+        )
+        conn.execute(text("CREATE INDEX IF NOT EXISTS agno_public_runs_expiry ON public.agno_public_runs(expires_at)"))
+
+    async def _claim(
+        self, kind: str, component_id: str, session_id: str, run_id: str, user_id: Any, seconds: float
+    ) -> str:
+        lease = uuid4().hex
+
+        def write(*, budget):
+            with self.engine.begin() as conn:
+                conn.execute(text("SET LOCAL statement_timeout='2500ms'"))
+                conn.execute(
+                    text(
+                        "DELETE FROM public.agno_public_runs WHERE (namespace, run_id) IN "
+                        "(SELECT namespace, run_id FROM public.agno_public_runs WHERE expires_at < now() "
+                        "LIMIT 100 FOR UPDATE SKIP LOCKED)"
+                    )
+                )
+                return conn.execute(
+                    text(
+                        "INSERT INTO public.agno_public_runs "
+                        "(namespace, run_id, session_id, kind, component_id, user_id, lease, expires_at) "
+                        "VALUES (:namespace, :run, :session, :kind, :component, :user, :lease, "
+                        "now() + :seconds * interval '1 second') ON CONFLICT DO NOTHING RETURNING lease"
+                    ),
+                    dict(
+                        namespace=self.namespace,
+                        run=run_id,
+                        session=session_id,
+                        kind=kind,
+                        component=component_id,
+                        user=user_id,
+                        lease=lease,
+                        seconds=seconds + 30,
+                    ),
+                ).scalar()
+
+        if await WORKERS.run(write, seconds=3) is None:
+            raise HTTPException(409, "run_in_progress")
+        return lease
+
+    async def _matches(self, kind: str, component_id: str, session_id: str, run_id: str, user_id: Any) -> bool:
+        def read(*, budget):
+            with self.engine.begin() as conn:
+                conn.execute(text("SET LOCAL statement_timeout='2500ms'"))
+                return (
+                    conn.execute(
+                        text(
+                            "SELECT 1 FROM public.agno_public_runs WHERE namespace=:namespace AND run_id=:run "
+                            "AND session_id=:session AND kind=:kind AND component_id=:component "
+                            "AND user_id IS NOT DISTINCT FROM :user AND expires_at > now()"
+                        ),
+                        dict(
+                            namespace=self.namespace,
+                            run=run_id,
+                            session=session_id,
+                            kind=kind,
+                            component=component_id,
+                            user=user_id,
+                        ),
+                    ).scalar()
+                    is not None
+                )
+
+        return await WORKERS.run(read, seconds=3)
+
+    async def _release(self, run_id: str, lease: str) -> None:
+        def delete(*, budget):
+            with self.engine.begin() as conn:
+                conn.execute(text("SET LOCAL statement_timeout='2500ms'"))
+                conn.execute(
+                    text(
+                        "DELETE FROM public.agno_public_runs WHERE namespace=:namespace AND run_id=:run AND lease=:lease"
+                    ),
+                    dict(namespace=self.namespace, run=run_id, lease=lease),
+                )
+
+        await WORKERS.run(delete, seconds=3)
+
+
+async def _authorize(
+    os: Any,
+    request: Any,
+    kind: str,
+    component_id: str,
+    action: str,
+    session_id: Any = None,
+    run_id: Any = None,
+    *,
+    mcp: bool = False,
+) -> Any:
+    from agno.os.auth import require_verified_public_workflow
+    from agno.os.middleware.user_scope import run_matches_component, session_matches_component
+
+    components = (
+        os.public._mcp_components
+        if mcp
+        else {(k, c.id): c for k in ("agents", "teams", "workflows") for c in getattr(os.public, k)}
+    )
+    component = components.get((kind, component_id))
+    if component is None:
+        raise HTTPException(404, "not_found")
+    component_kind = cast(Literal["agents", "teams", "workflows"], kind)
+    if kind == "workflows":
+        await require_verified_public_workflow(request, os.settings, component_id)
+    if session_id is None and action == "run":
+        return None
+    _handle(session_id)
+    user_id = getattr(request.state, "user_id", None)
+    session = await component.aget_session(session_id=session_id)
+    if session is not None:
+        if not session_matches_component(session, component_kind, component_id) or session.user_id != user_id:
+            raise HTTPException(404, "not_found")
+    if action == "run":
+        return None
+    _handle(run_id)
+    run = session.get_run(run_id=run_id) if session is not None else None
+    if run is not None and run_matches_component(run, component_kind, component_id):
+        if action == "continue" and not run.is_paused:
+            raise HTTPException(409, "run_not_paused")
+        if action == "continue":
+            from agno.os.auth import run_continuation_blocked_reason
+
+            reason = await run_continuation_blocked_reason(
+                os.db,
+                run_id,
+                authorization_enabled=True,
+                user_scopes=list(getattr(request.state, "scopes", None) or []),
+                fail_closed=True,
+            )
+            if reason:
+                raise HTTPException(403, "access_denied")
+        return run
+    if action == "cancel" and await os.public._bindings._matches(kind, component_id, session_id, run_id, user_id):
+        return None
+    raise HTTPException(404, "not_found")
+
+
+def _lifecycle_verified(request: Any, kind: str, component_id: str, session_id: Any, run_id: str) -> bool:
+    """A public gate already verified this exact operation, including active runs."""
+    return getattr(getattr(request, "state", None), "_agno_public_lifecycle", None) == (
+        kind,
+        component_id,
+        session_id,
+        run_id,
+    )
+
+
+def _resolutions(run: Any, submitted: Any, *, workflow: bool = False, legacy_tools: bool = False) -> list:
+    """Keep saved tool/step identity and policy; accept only resolution fields."""
+    if submitted is None:
+        return []
+    if not isinstance(submitted, list) or len(submitted) > 128:
+        raise HTTPException(400, "invalid_requirements")
+    saved = [req.to_dict() for req in (getattr(run, "step_requirements" if workflow else "requirements", None) or [])]
+    if legacy_tools:
+        saved = [req["tool_execution"] for req in saved]
+
+    def identity(req):
+        return req.get("step_id") if workflow else req.get("tool_call_id") if legacy_tools else req.get("id")
+
+    def merge(base, update):
+        if not isinstance(update, dict):
+            raise HTTPException(400, "invalid_requirements")
+        result = deepcopy(base)
+        mutable = {
+            "confirmed",
+            "confirmation",
+            "confirmation_note",
+            "user_input",
+            "selected_choices",
+            "rejection_feedback",
+            "edited_output",
+            "external_execution_result",
+            "answered",
+        }
+        if base.get("external_execution_required"):
+            mutable.add("result")
+        for key, value in update.items():
+            if key in mutable:
+                if (
+                    key in {"confirmed", "confirmation", "answered"}
+                    and value is not None
+                    and not isinstance(value, bool)
+                ):
+                    raise HTTPException(400, "invalid_requirements")
+                result[key] = value
+            elif key == "tool_execution" and isinstance(base.get(key), dict):
+                result[key] = merge(base[key], value)
+            elif key in ("user_input_schema", "user_feedback_schema") and isinstance(value, list):
+                original = base.get(key) or []
+                if len(original) != len(value):
+                    raise HTTPException(400, "invalid_requirements")
+                result[key] = []
+                for old, new in zip(original, value):
+                    if not isinstance(new, dict) or any(
+                        v != old.get(k)
+                        for k, v in new.items()
+                        if k not in {"value", "selected_options", "free_text_response"}
+                    ):
+                        raise HTTPException(400, "invalid_requirements")
+                    result[key].append({**old, **new})
+            elif key == "executor_requirements" and isinstance(value, list):
+                original = base.get(key) or []
+                if len(original) != len(value):
+                    raise HTTPException(400, "invalid_requirements")
+                result[key] = [merge(old, new) for old, new in zip(original, value)]
+            elif value != base.get(key):
+                raise HTTPException(400, "invalid_requirements")
+        return result
+
+    resolved, seen = [], set()
+    for item in submitted:
+        if not isinstance(item, dict):
+            raise HTTPException(400, "invalid_requirements")
+        key = identity(item)
+        matches = [req for req in saved if identity(req) == key]
+        if not isinstance(key, str) or key in seen or len(matches) != 1:
+            raise HTTPException(400, "invalid_requirements")
+        seen.add(key)
+        resolved.append(merge(matches[0], item))
+    return resolved
+
+
+def _public_mcp_tool(os: Any, kind: Any = None, component_id: Any = None, action: str = "run"):
+    """Apply public policy at invocation, after the MCP authentication bridge."""
+
+    def decorate(fn):
+        signature = inspect.signature(fn)
+
+        @functools.wraps(fn)
+        async def wrapped(*args, **kwargs):
+            from agno.os.mcp import _http_request_or_none
+
+            request = _http_request_or_none()
+            execution = getattr(getattr(request, "state", None), "_agno_public_execution", None)
+            if request is None or execution is None:
+                return await fn(*args, **kwargs)
+            bound = signature.bind(*args, **kwargs)
+            values = bound.arguments
+            target_kind, target_id = kind, component_id
+            if target_kind is None:
+                from agno.os.mcp import _classify_lifecycle_target
+
+                target_kind, target_id = _classify_lifecycle_target(
+                    values.get("agent_id"), values.get("team_id"), values.get("workflow_id")
+                )
+            lease = None
+            admitted = False
+            run_id, session_id = values.get("run_id"), values.get("session_id")
+            try:
+                actor = getattr(request.state, "user_id", None)
+                from agno.os.mcp import _require_tool_scopes
+
+                route = f"/{target_kind}/{target_id}/runs"
+                if action != "run":
+                    route += f"/{run_id}/{action}"
+                _require_tool_scopes("POST", route)
+                if values.get("user_id") is not None and values["user_id"] != actor:
+                    raise HTTPException(400, "identity_override_not_allowed")
+                if action == "run":
+                    message = values.get("message")
+                    if not isinstance(message, str) or not message.strip() or len(message.encode()) > 32768:
+                        raise HTTPException(400, "invalid_message")
+                    if target_kind == "workflows":
+                        import json
+
+                        try:
+                            json.loads(message)
+                        except ValueError:
+                            raise HTTPException(400, "invalid_message") from None
+                run = await _authorize(
+                    os, execution.request, target_kind, target_id, action, session_id, run_id, mcp=True
+                )
+                if action == "continue":
+                    values["requirements"] = _resolutions(
+                        run, values.get("requirements"), workflow=target_kind == "workflows"
+                    )
+                if action != "run":
+                    request.state._agno_public_lifecycle = (target_kind, target_id, session_id, run_id)
+                await execution.middleware._admit_execution(action, execution.identity)
+                admitted = action != "cancel"
+                if action == "continue":
+                    lease = await os.public._bindings._claim(
+                        target_kind, target_id, session_id, run_id, actor, os.public.max_run_seconds
+                    )
+                result = await asyncio.wait_for(fn(*bound.args, **bound.kwargs), timeout=os.public.max_run_seconds)
+                structured = getattr(result, "structured_content", None)
+                if isinstance(structured, dict) and structured.get("status") == "ERROR":
+                    raise HTTPException(503, "run_failed")
+                return result
+            except Exception as exc:
+                from fastmcp.exceptions import ToolError
+
+                code = (
+                    exc.detail if isinstance(exc, HTTPException) and isinstance(exc.detail, str) else "run_unavailable"
+                )
+                if code not in {
+                    "not_found",
+                    "invalid_handle",
+                    "run_not_paused",
+                    "run_in_progress",
+                    "rate_limited",
+                    "run_capacity",
+                    "invalid_message",
+                    "invalid_requirements",
+                    "identity_override_not_allowed",
+                    "run_failed",
+                }:
+                    code = (
+                        "access_denied"
+                        if isinstance(exc, HTTPException) and exc.status_code in (401, 403)
+                        else "run_unavailable"
+                    )
+                raise ToolError(str(code)) from None
+            finally:
+                if admitted:
+                    execution.middleware.active_runs -= 1
+                if lease is not None:
+                    try:
+                        await os.public._bindings._release(run_id, lease)
+                    except Exception:
+                        from agno.utils.log import log_warning
+
+                        log_warning("Public run binding cleanup failed; the binding will expire")
+
+        return wrapped
+
+    return decorate

--- a/libs/agno/agno/os/public/_limits.py
+++ b/libs/agno/agno/os/public/_limits.py
@@ -73,6 +73,9 @@ class PublicLimiter:
                 text("CREATE INDEX IF NOT EXISTS agno_public_limits_updated ON public.agno_public_limits(updated_at)")
             )
             self._cleanup(conn)
+            from agno.os.public._execution import _RunBindings
+
+            _RunBindings._prepare(conn)
         self.ready = True
 
     async def _aprepare(self) -> None:

--- a/libs/agno/agno/os/public/_middleware.py
+++ b/libs/agno/agno/os/public/_middleware.py
@@ -8,8 +8,9 @@ import json
 import zlib
 from ipaddress import IPv6Address, ip_address, ip_network
 from pathlib import PurePath
+from types import SimpleNamespace
 from typing import Any, Optional
-from urllib.parse import parse_qsl
+from urllib.parse import parse_qsl, urlencode
 from uuid import UUID, uuid4
 
 from fastapi import HTTPException
@@ -20,6 +21,7 @@ from starlette.responses import JSONResponse
 
 from agno.os.auth import require_verified_public_workflow, verify_internal_service_request
 from agno.os.public import _client_id
+from agno.os.public._execution import _authorize, _resolutions
 from agno.os.public._policy import RUN_ROUTE, PublicRoutePolicy
 from agno.utils.bounded import BoundedWorkers
 from agno.utils.log import log_warning
@@ -53,6 +55,15 @@ class PublicMiddleware:
         }
         self.oauth_paths = self.policy.oauth_paths
         self.interface_routes = set(getattr(agent_os, "_public_interface_routes", []))
+
+    async def _admit_execution(self, action: str, identity: str) -> None:
+        decision = await self.surface.limiter.aconsume("cancel" if action == "cancel" else "run", client_id=identity)
+        if not decision.allowed:
+            raise HTTPException(429, "rate_limited", headers={"Retry-After": str(decision.retry_after)})
+        if action != "cancel":
+            if self.active_runs >= self.surface.max_active_runs:
+                raise HTTPException(503, "run_capacity")
+            self.active_runs += 1
 
     async def _identity(self, request: Request) -> str:
         if self.surface.client_id is not None:
@@ -100,7 +111,9 @@ class PublicMiddleware:
         except asyncio.TimeoutError as exc:
             raise Rejected(408, "body_timeout") from exc
 
-    async def _validate_form(self, scope: Any, body: bytes, *, workflow: bool, cancel: bool) -> None:
+    async def _validate_form(
+        self, scope: Any, body: bytes, *, workflow: bool, cancel: bool, continuing: bool = False, kind: str = "agents"
+    ) -> dict:
         used = False
 
         async def receive():
@@ -123,9 +136,12 @@ class PublicMiddleware:
                 allowed = {"message", "stream", "session_id", "background"}
                 if cancel:
                     allowed = {"session_id"}
+                requirement_field = {"agents": "tools", "teams": "requirements", "workflows": "step_requirements"}[kind]
+                if continuing:
+                    allowed = {"session_id", "stream", requirement_field}
                 for key, value in form.multi_items():
                     if isinstance(value, UploadFile):
-                        if workflow or uploads is None or key != "files":
+                        if workflow or cancel or continuing or uploads is None or key != "files":
                             raise Rejected(400, "uploads_not_allowed")
                         pair = (PurePath(value.filename or "").suffix.lower(), (value.content_type or "").lower())
                         if (
@@ -140,7 +156,21 @@ class PublicMiddleware:
                         scalar[key] = value
                 if "session_id" in scalar:
                     _uuid(scalar["session_id"])
-                if not cancel:
+                if continuing:
+                    if not scalar.get("session_id"):
+                        raise Rejected(400, "invalid_handle")
+                    if scalar.get("stream", "true").lower() not in ("true", "false"):
+                        raise Rejected(400, "invalid_run_mode")
+                    raw = scalar.get(requirement_field, "")
+                    if raw:
+                        requirements = json.loads(raw)
+                        if (
+                            not isinstance(requirements, list)
+                            or len(requirements) > 128
+                            or any(not isinstance(r, dict) for r in requirements)
+                        ):
+                            raise Rejected(400, "invalid_requirements")
+                elif not cancel:
                     message = scalar.get("message", "")
                     if not isinstance(message, str) or not message.strip() or len(message.encode()) > 32768:
                         raise Rejected(400, "invalid_message")
@@ -155,6 +185,7 @@ class PublicMiddleware:
                             json.loads(message)
                         except ValueError as exc:
                             raise Rejected(400, "invalid_workflow_input") from exc
+                return scalar
             finally:
                 await form.close()
         except Rejected:
@@ -226,6 +257,7 @@ class PublicMiddleware:
         error_headers = {}
         capacity = None
         identity_token = None
+        active_binding = None
         mcp = False
         public_run = False
         decoder = None
@@ -315,6 +347,28 @@ class PublicMiddleware:
                         except ValueError:
                             event = {}
                         if isinstance(event, dict) and event.get("event") in (
+                            "RunStarted",
+                            "TeamRunStarted",
+                            "WorkflowStarted",
+                        ):
+                            nonlocal active_binding
+                            if active_binding is None and event.get("run_id") and event.get("session_id"):
+                                expected = {"agents": "agent_id", "teams": "team_id", "workflows": "workflow_id"}[
+                                    component_kind
+                                ]
+                                if event.get(expected) == component_id:
+                                    _uuid(event["run_id"])
+                                    _uuid(event["session_id"])
+                                    lease = await self.surface._bindings._claim(
+                                        component_kind,
+                                        component_id,
+                                        event["session_id"],
+                                        event["run_id"],
+                                        getattr(request.state, "user_id", None),
+                                        self.surface.max_run_seconds,
+                                    )
+                                    active_binding = (event["run_id"], lease)
+                        if isinstance(event, dict) and event.get("event") in (
                             "RunError",
                             "TeamRunError",
                             "WorkflowRunError",
@@ -344,9 +398,10 @@ class PublicMiddleware:
                 raise Rejected(401, "ambiguous_authorization")
             internal = verify_internal_service_request(request)
             match = RUN_ROUTE.fullmatch(path)
-            component_kind = component_id = run_id = cancellation = ""
+            component_kind = component_id = run_id = operation = ""
             if match:
-                component_kind, component_id, run_id, cancellation = match.groups()
+                component_kind, component_id, run_id, operation = match.groups()
+            cancellation, continuing = operation == "/cancel", operation == "/continue"
             if internal and match and component_id in self.registered[component_kind]:
                 # Verification, not bearer-header presence, grants scheduler schemas and quota bypass.
                 await self.app(scope, receive, send)
@@ -431,9 +486,9 @@ class PublicMiddleware:
                     _uuid(params[0][1])
                     await asyncio.wait_for(self.app(scope, receive, bounded_send), timeout=10)
                     return
-                if method != "POST" or (run_id and not cancellation) or (workflow and cancellation):
+                if method != "POST" or (run_id and not (cancellation or continuing)):
                     raise Rejected(404, "not_found")
-                if scope.get("query_string"):
+                if scope.get("query_string") and not cancellation:
                     raise Rejected(400, "query_overrides_not_allowed")
             else:
                 workflow = False
@@ -442,22 +497,23 @@ class PublicMiddleware:
             identity = await asyncio.wait_for(self._identity(request), timeout=3)
             scope.setdefault("state", {})["public_client_id"] = identity
             identity_token = _client_id.set(identity)
-            bucket = "mcp" if mcp else "cancel" if cancellation else "run"
-            decision = await self.surface.limiter.aconsume(bucket, client_id=identity)
-            if not decision.allowed:
-                await error(429, "rate_limited", {"Retry-After": str(decision.retry_after)})
-                return
             if mcp:
+                scope["state"]["_agno_public_execution"] = SimpleNamespace(
+                    middleware=self, identity=identity, request=Request(dict(scope))
+                )
+                decision = await self.surface.limiter.aconsume("mcp", client_id=identity)
+                if not decision.allowed:
+                    await error(429, "rate_limited", {"Retry-After": str(decision.retry_after)})
+                    return
                 if self.active_mcp >= 32:
                     raise Rejected(503, "request_capacity")
                 self.active_mcp += 1
                 capacity = "mcp"
-            elif not cancellation:
-                if self.active_runs >= self.surface.max_active_runs:
-                    raise Rejected(503, "run_capacity")
-                self.active_runs += 1
-                capacity = "run"
-            maximum = 128 * 1024 if mcp else 16 * 1024 if workflow else self.surface.max_body_bytes
+            else:
+                await self._admit_execution("cancel" if cancellation else "run", identity)
+                if not cancellation:
+                    capacity = "run"
+            maximum = 128 * 1024 if mcp or continuing else 16 * 1024 if workflow else self.surface.max_body_bytes
             body = await self._body(receive, maximum, 10 if mcp else 15)
             if mcp:
                 try:
@@ -467,8 +523,57 @@ class PublicMiddleware:
                 # The pinned stateless transport does not support JSON-RPC batches.
                 if not isinstance(payload, dict):
                     raise Rejected(400, "mcp_batch_not_supported")
+                rpc_params = payload.get("params")
+                run_tool = (
+                    payload.get("method") == "tools/call"
+                    and isinstance(rpc_params, dict)
+                    and isinstance(rpc_params.get("name"), str)
+                    and rpc_params["name"] in self.surface._mcp_run_tools
+                )
             else:
-                await self._validate_form(scope, body, workflow=workflow, cancel=bool(cancellation))
+                scalar = await self._validate_form(
+                    scope, body, workflow=workflow, cancel=cancellation, continuing=continuing, kind=component_kind
+                )
+                if cancellation:
+                    params = parse_qsl(scope.get("query_string", b"").decode(), keep_blank_values=True)
+                    if params:
+                        if len(params) != 1 or params[0][0] != "session_id" or "session_id" in scalar:
+                            raise Rejected(400, "invalid_query")
+                        scalar["session_id"] = params[0][1]
+                    if not scalar.get("session_id"):
+                        raise Rejected(400, "invalid_handle")
+                    _uuid(scalar["session_id"])
+                    scope["query_string"] = ("session_id=" + scalar["session_id"]).encode()
+                action = "cancel" if cancellation else "continue" if continuing else "run"
+                run = await _authorize(
+                    self.agent_os, request, component_kind, component_id, action, scalar.get("session_id"), run_id
+                )
+                if continuing:
+                    field = {"agents": "tools", "teams": "requirements", "workflows": "step_requirements"}[
+                        component_kind
+                    ]
+                    resolutions = _resolutions(
+                        run,
+                        json.loads(scalar.get(field) or "[]"),
+                        workflow=workflow,
+                        legacy_tools=component_kind == "agents",
+                    )
+                    scalar[field] = json.dumps(resolutions)
+                    body = urlencode(scalar).encode()
+                    scope["headers"] = [(k, v) for k, v in scope["headers"] if k.lower() != b"content-length"] + [
+                        (b"content-length", str(len(body)).encode())
+                    ]
+                    lease = await self.surface._bindings._claim(
+                        component_kind,
+                        component_id,
+                        scalar["session_id"],
+                        run_id,
+                        getattr(request.state, "user_id", None),
+                        self.surface.max_run_seconds,
+                    )
+                    active_binding = (run_id, lease)
+                if cancellation or continuing:
+                    request.state._agno_public_lifecycle = (component_kind, component_id, scalar["session_id"], run_id)
                 public_run = component_kind in ("agents", "teams") and not cancellation
             delivered = False
 
@@ -480,12 +585,29 @@ class PublicMiddleware:
                 return await receive()
 
             await asyncio.wait_for(
-                self.app(scope, replay, bounded_send), timeout=60 if mcp else self.surface.max_run_seconds
+                self.app(scope, replay, bounded_send),
+                timeout=(max(60, self.surface.max_run_seconds) if run_tool else 60)
+                if mcp
+                else self.surface.max_run_seconds,
             )
         except HTTPException as exc:
             await error(
                 exc.status_code,
-                "authentication_unavailable" if exc.status_code == 503 else "access_denied",
+                exc.detail
+                if isinstance(exc.detail, str)
+                and exc.detail
+                in {
+                    "not_found",
+                    "invalid_handle",
+                    "invalid_requirements",
+                    "run_not_paused",
+                    "run_in_progress",
+                    "rate_limited",
+                    "run_capacity",
+                }
+                else "authentication_unavailable"
+                if exc.status_code == 503
+                else "access_denied",
                 exc.headers,
             )
         except asyncio.CancelledError:
@@ -524,3 +646,8 @@ class PublicMiddleware:
                 self.active_runs -= 1
             if identity_token is not None:
                 _client_id.reset(identity_token)
+            if active_binding is not None:
+                try:
+                    await self.surface._bindings._release(*active_binding)
+                except Exception:
+                    log_warning("Public run binding cleanup failed; the binding will expire")

--- a/libs/agno/agno/os/public/_policy.py
+++ b/libs/agno/agno/os/public/_policy.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from starlette.routing import Match
 
-RUN_ROUTE = re.compile(r"^/(agents|teams|workflows)/([^/]+)/runs(?:/([^/]+)(/cancel)?)?$")
+RUN_ROUTE = re.compile(r"^/(agents|teams|workflows)/([^/]+)/runs(?:/([^/]+)(/(?:cancel|continue))?)?$")
 
 
 class PublicRoutePolicy:
@@ -48,9 +48,9 @@ class PublicRoutePolicy:
         match = RUN_ROUTE.fullmatch(path)
         if method != "POST" or match is None:
             return False
-        kind, component_id, run_id, cancellation = match.groups()
+        kind, component_id, run_id, operation = match.groups()
         return (
             kind in ("agents", "teams")
             and component_id in self.selected[kind]
-            and (run_id is None or cancellation is not None)
+            and (run_id is None or operation is not None)
         )

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -1170,8 +1170,13 @@ def get_agent_router(
         factory = find_factory_by_id(agent_id, os.agents)
         if factory:
             from agno.agent._run import acancel_run
+            from agno.os.public._execution import _lifecycle_verified
 
-            scoped_user_id = get_scoped_user_id(request)
+            scoped_user_id = (
+                None
+                if _lifecycle_verified(request, "agents", agent_id, session_id, run_id)
+                else get_scoped_user_id(request)
+            )
             if scoped_user_id is not None:
                 if not session_id:
                     raise HTTPException(status_code=400, detail=SESSION_ID_REQUIRED)
@@ -1218,7 +1223,13 @@ def get_agent_router(
 
         # Ownership check: non-admin JWT callers must supply a session_id and the
         # run must live in a session they own. Admins / unauthenticated bypass.
-        scoped_user_id = get_scoped_user_id(request)
+        from agno.os.public._execution import _lifecycle_verified
+
+        scoped_user_id = (
+            None
+            if _lifecycle_verified(request, "agents", agent_id, session_id, run_id)
+            else get_scoped_user_id(request)
+        )
         if scoped_user_id is not None:
             if not session_id:
                 raise HTTPException(status_code=400, detail=SESSION_ID_REQUIRED)

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -1123,9 +1123,14 @@ def get_team_router(
         # a global cancellation intent keyed solely on run_id.
         factory = find_factory_by_id(team_id, os.teams)
         if factory:
+            from agno.os.public._execution import _lifecycle_verified
             from agno.team._run import acancel_run
 
-            scoped_user_id = get_scoped_user_id(request)
+            scoped_user_id = (
+                None
+                if _lifecycle_verified(request, "teams", team_id, session_id, run_id)
+                else get_scoped_user_id(request)
+            )
             if scoped_user_id is not None:
                 if not session_id:
                     raise HTTPException(status_code=400, detail=SESSION_ID_REQUIRED)
@@ -1168,7 +1173,11 @@ def get_team_router(
 
         # Ownership check: non-admin JWT callers must supply a session_id and the
         # run must live in a session they own. Admins / unauthenticated bypass.
-        scoped_user_id = get_scoped_user_id(request)
+        from agno.os.public._execution import _lifecycle_verified
+
+        scoped_user_id = (
+            None if _lifecycle_verified(request, "teams", team_id, session_id, run_id) else get_scoped_user_id(request)
+        )
         if scoped_user_id is not None:
             if not session_id:
                 raise HTTPException(status_code=400, detail=SESSION_ID_REQUIRED)

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -2381,9 +2381,14 @@ def get_workflow_router(
         # a global cancellation intent keyed solely on run_id.
         factory = find_factory_by_id(workflow_id, os.workflows)
         if factory:
+            from agno.os.public._execution import _lifecycle_verified
             from agno.run.cancel import acancel_run
 
-            scoped_user_id = get_scoped_user_id(request)
+            scoped_user_id = (
+                None
+                if _lifecycle_verified(request, "workflows", workflow_id, session_id, run_id)
+                else get_scoped_user_id(request)
+            )
             if scoped_user_id is not None:
                 if not session_id:
                     raise HTTPException(status_code=400, detail=SESSION_ID_REQUIRED)
@@ -2426,7 +2431,13 @@ def get_workflow_router(
 
         # Ownership check: non-admin JWT callers must supply a session_id and the
         # run must live in a session they own. Admins / unauthenticated bypass.
-        scoped_user_id = get_scoped_user_id(request)
+        from agno.os.public._execution import _lifecycle_verified
+
+        scoped_user_id = (
+            None
+            if _lifecycle_verified(request, "workflows", workflow_id, session_id, run_id)
+            else get_scoped_user_id(request)
+        )
         if scoped_user_id is not None:
             if not session_id:
                 raise HTTPException(status_code=400, detail=SESSION_ID_REQUIRED)

--- a/libs/agno/tests/integration/os/test_public_continuation.py
+++ b/libs/agno/tests/integration/os/test_public_continuation.py
@@ -1,0 +1,618 @@
+"""Public continuation through native HTTP/MCP with shared PostgreSQL persistence."""
+
+import json
+import os
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.engine import make_url
+
+from agno.agent import Agent
+from agno.db.postgres import PostgresDb
+from agno.models.base import Model
+from agno.models.message import MessageMetrics
+from agno.models.response import ModelResponse
+from agno.os import AgentOS, MCPConfig
+from agno.os.config import AuthorizationConfig
+from agno.os.public import PublicSurface, RateLimit
+from agno.team import Team
+from agno.tools import tool
+from agno.workflow import Step, StepOutput, Workflow
+
+pytestmark = pytest.mark.skipif(not os.getenv("AGNO_PAGE_TEST_DB_URL"), reason="requires isolated local PostgreSQL")
+HEADERS = {"Accept": "application/json, text/event-stream", "MCP-Protocol-Version": "2025-03-26"}
+
+
+@pytest.fixture
+def database():
+    url = make_url(os.environ["AGNO_PAGE_TEST_DB_URL"])
+    assert url.host in ("localhost", "127.0.0.1", "::1")
+    admin = create_engine(url, isolation_level="AUTOCOMMIT")
+    name = "public_continue_" + uuid4().hex[:12]
+    with admin.connect() as conn:
+        conn.exec_driver_sql(f'CREATE DATABASE "{name}"')
+    engine = create_engine(url.set(database=name))
+    try:
+        yield PostgresDb(db_engine=engine)
+    finally:
+        engine.dispose()
+        with admin.connect() as conn:
+            conn.exec_driver_sql(f'DROP DATABASE "{name}" WITH (FORCE)')
+        admin.dispose()
+
+
+class ApprovalModel(Model):
+    def __init__(self):
+        super().__init__(id="approval-test", name="approval-test", provider="test")
+
+    def invoke(self, *args, **kwargs):
+        messages = kwargs.get("messages", args[0] if args else [])
+        if any(message.role == "tool" for message in messages):
+            return ModelResponse(role="assistant", content="Finished", response_usage=MessageMetrics())
+        return ModelResponse(
+            role="assistant",
+            tool_calls=[
+                {"id": "approval-call", "type": "function", "function": {"name": "approval_action", "arguments": "{}"}}
+            ],
+            response_usage=MessageMetrics(),
+        )
+
+    async def ainvoke(self, *args, **kwargs):
+        return self.invoke(*args, **kwargs)
+
+    def invoke_stream(self, *args, **kwargs):
+        yield self.invoke(*args, **kwargs)
+
+    async def ainvoke_stream(self, *args, **kwargs):
+        yield self.invoke(*args, **kwargs)
+
+    def _parse_provider_response(self, response, **kwargs):
+        return response
+
+    def _parse_provider_response_delta(self, response, **kwargs):
+        return response
+
+
+def application(database, effects, *, team=False, limits=None, authorization=False, **bounds):
+    @tool(requires_confirmation=True)
+    def approval_action() -> str:
+        effects.append("executed")
+        return "Approved action executed"
+
+    agent = Agent(id="public-agent", db=database, model=ApprovalModel(), tools=[approval_action], telemetry=False)
+    component = (
+        Team(
+            id="public-team",
+            db=database,
+            model=ApprovalModel(),
+            tools=[approval_action],
+            members=[agent],
+            telemetry=False,
+        )
+        if team
+        else agent
+    )
+    surface = PublicSurface(
+        agents=[] if team else [agent], teams=[component] if team else [], mcp=True, limits=limits, **bounds
+    )
+    server = AgentOS(
+        id="public-continuation",
+        authorization=authorization,
+        authorization_config=AuthorizationConfig(
+            verification_keys=["public-continuation-test-signing-key"], algorithm="HS256", user_isolation=True
+        )
+        if authorization
+        else None,
+        agents=[agent],
+        teams=[component] if team else [],
+        db=database,
+        public=surface,
+        mcp=MCPConfig(tools=[component], default_tools=False, stateless=True),
+        auto_provision_dbs=False,
+        telemetry=False,
+    )
+    return server, surface, component
+
+
+def payload(response):
+    assert response.status_code == 200, response.text
+    if response.headers.get("content-type", "").startswith("text/event-stream"):
+        events = [json.loads(line[6:]) for line in response.text.splitlines() if line.startswith("data: ")]
+        if events and "jsonrpc" in events[0]:
+            return events[0]
+        return next(
+            event
+            for event in reversed(events)
+            if event.get("event") in ("RunPaused", "RunCompleted", "TeamRunPaused", "TeamRunCompleted")
+        )
+    return response.json()
+
+
+def mcp(client, name, arguments):
+    result = payload(
+        client.post(
+            "/mcp",
+            headers=HEADERS,
+            json={"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": name, "arguments": arguments}},
+        )
+    )
+    return result["result"]
+
+
+def start(client, component, transport, stream=False):
+    if transport == "mcp":
+        result = mcp(client, component.id, {"message": "Do the action"})
+        assert not result.get("isError"), result
+        return result["structuredContent"]
+    kind = "teams" if isinstance(component, Team) else "agents"
+    return payload(
+        client.post(f"/{kind}/{component.id}/runs", data={"message": "Do the action", "stream": str(stream).lower()})
+    )
+
+
+def resume(client, component, paused, transport, confirmed=True, stream=False):
+    requirements = paused["requirements"]
+    for requirement in requirements:
+        requirement["tool_execution"]["confirmed"] = confirmed
+    kind = "teams" if isinstance(component, Team) else "agents"
+    if transport == "mcp":
+        return mcp(
+            client,
+            "continue_run",
+            {
+                "run_id": paused["run_id"],
+                "session_id": paused["session_id"],
+                kind[:-1] + "_id": component.id,
+                "requirements": requirements,
+            },
+        )
+    field = "requirements" if kind == "teams" else "tools"
+    values = requirements if kind == "teams" else [r["tool_execution"] for r in requirements]
+    return client.post(
+        f"/{kind}/{component.id}/runs/{paused['run_id']}/continue",
+        data={"session_id": paused["session_id"], "stream": str(stream).lower(), field: json.dumps(values)},
+    )
+
+
+@pytest.mark.parametrize("team", [False, True])
+@pytest.mark.parametrize(
+    "start_transport,continue_transport", [("rest", "rest"), ("mcp", "mcp"), ("rest", "mcp"), ("mcp", "rest")]
+)
+@pytest.mark.parametrize("confirmed", [False, True])
+def test_pause_and_resume_on_another_instance(database, team, start_transport, continue_transport, confirmed):
+    effects = []
+    first, _, component = application(database, effects, team=team)
+    with TestClient(first.get_app(), base_url="http://localhost") as client:
+        paused = start(client, component, start_transport)
+        assert paused["status"] == "PAUSED" and effects == []
+    second, _, component = application(database, effects, team=team)
+    with TestClient(second.get_app(), base_url="http://localhost") as client:
+        result = resume(client, component, paused, continue_transport, confirmed)
+        if continue_transport == "mcp":
+            assert not result.get("isError"), result
+            result = result["structuredContent"]
+        else:
+            result = payload(result)
+        assert result["status"] == "COMPLETED", result
+        assert effects == (["executed"] if confirmed else [])
+
+
+@pytest.mark.parametrize("team", [False, True])
+def test_streamed_pause_and_continuation(database, team):
+    effects = []
+    server, _, component = application(database, effects, team=team)
+    with TestClient(server.get_app(), base_url="http://localhost") as client:
+        paused = start(client, component, "rest", stream=True)
+        result = payload(resume(client, component, paused, "rest", stream=True))
+        assert result["event"] in ("RunCompleted", "TeamRunCompleted")
+        assert effects == ["executed"]
+
+
+@pytest.mark.parametrize("transport", ["rest", "mcp"])
+def test_wrong_session_and_unknown_runs_are_rejected(database, transport):
+    effects = []
+    server, _, component = application(database, effects)
+    with TestClient(server.get_app(), base_url="http://localhost") as client:
+        paused = start(client, component, "mcp")
+        paused["session_id"] = str(uuid4())
+        result = resume(client, component, paused, transport)
+        assert result.get("isError") if transport == "mcp" else result.status_code == 404
+        result = mcp(
+            client, "cancel_run", {"agent_id": component.id, "run_id": str(uuid4()), "session_id": str(uuid4())}
+        )
+        assert result["isError"]
+        assert effects == []
+
+
+def test_mcp_execution_shares_rest_run_quota(database):
+    server, _, component = application(database, [], limits={"run": RateLimit(1, 1)})
+    with TestClient(server.get_app(), base_url="http://localhost") as client:
+        paused = start(client, component, "rest")
+        result = resume(client, component, paused, "mcp")
+        assert result["isError"] and "rate_limited" in str(result)
+        result = mcp(
+            client,
+            "cancel_run",
+            {"agent_id": component.id, "run_id": paused["run_id"], "session_id": paused["session_id"]},
+        )
+        assert not result.get("isError"), result
+
+
+@pytest.mark.parametrize("transport", ["rest", "mcp"])
+def test_resolution_cannot_change_the_saved_tool_call(database, transport):
+    effects = []
+    server, _, component = application(database, effects)
+    with TestClient(server.get_app(), base_url="http://localhost") as client:
+        paused = start(client, component, "mcp")
+        paused["requirements"][0]["tool_execution"]["tool_args"] = {"injected": True}
+        result = resume(client, component, paused, transport)
+        assert result.get("isError") if transport == "mcp" else result.status_code == 400
+        assert effects == []
+
+
+@pytest.mark.parametrize("transport", ["rest", "mcp"])
+def test_anonymous_continuation_cannot_bypass_required_admin_approval(database, transport):
+    effects = []
+    server, _, component = application(database, effects)
+    with TestClient(server.get_app(), base_url="http://localhost") as client:
+        paused = start(client, component, "mcp")
+        database.create_approval(
+            {
+                "id": str(uuid4()),
+                "run_id": paused["run_id"],
+                "session_id": paused["session_id"],
+                "status": "pending",
+                "source_type": "agent",
+                "approval_type": "required",
+                "pause_type": "confirmation",
+            }
+        )
+        result = resume(client, component, paused, transport)
+        assert result.get("isError") if transport == "mcp" else result.status_code == 403
+        assert effects == []
+
+
+def test_public_workflow_requires_authentication_on_both_transports(database):
+    effects = []
+
+    def execute(step_input):
+        effects.append("workflow")
+        return StepOutput(content="Workflow completed")
+
+    workflow = Workflow(id="protected", steps=[Step(name="work", executor=execute)], db=database, telemetry=False)
+    surface = PublicSurface(workflows=[workflow], mcp=True)
+    server = AgentOS(
+        id="workflow-policy",
+        workflows=[workflow],
+        db=database,
+        public=surface,
+        mcp=MCPConfig(tools=[workflow], default_tools=False, stateless=True),
+        internal_service_token="test-workflow-token",
+        auto_provision_dbs=False,
+        telemetry=False,
+    )
+    with TestClient(server.get_app(), base_url="http://localhost") as client:
+        assert client.post("/workflows/protected/runs", data={"message": "{}"}).status_code == 401
+        assert mcp(client, "protected", {"message": "{}"})["isError"]
+        assert effects == []
+        client.headers["Authorization"] = "Bearer test-workflow-token"
+        result = mcp(client, "protected", {"message": "{}"})
+        assert not result.get("isError"), result
+        assert client.post("/workflows/protected/runs", data={"message": "{}", "stream": "false"}).status_code == 200
+        assert effects == ["workflow", "workflow"]
+
+
+@pytest.mark.parametrize("transport", ["rest", "mcp"])
+def test_authenticated_session_cannot_be_resumed_by_another_user(database, transport):
+    import jwt
+
+    from agno.os.middleware.jwt import JWTMiddleware
+
+    key = "public-continuation-test-signing-key"
+    effects = []
+    server, _, component = application(database, effects)
+    app = server.get_app()
+    app.add_middleware(
+        JWTMiddleware, verification_keys=[key], algorithm="HS256", user_isolation=True, authorization=True
+    )
+
+    def token(user):
+        return "Bearer " + jwt.encode({"sub": user, "scopes": ["agents:run", "mcp:read"]}, key, algorithm="HS256")
+
+    with TestClient(app, base_url="http://localhost") as client:
+        client.headers["Authorization"] = token("alice")
+        paused = start(client, component, "mcp")
+        client.headers["Authorization"] = token("bob")
+        result = resume(client, component, paused, transport)
+        assert result.get("isError") if transport == "mcp" else result.status_code == 404
+        client.headers["Authorization"] = token("alice")
+        result = resume(client, component, paused, transport)
+        assert not result.get("isError") if transport == "mcp" else result.status_code == 200
+        assert effects == ["executed"]
+    # Even possession of Alice's handles does not permit anonymous continuation.
+    second, _, component = application(database, [])
+    with TestClient(second.get_app(), base_url="http://localhost") as client:
+        result = resume(client, component, paused, transport)
+        assert result.get("isError") if transport == "mcp" else result.status_code == 404
+
+
+@pytest.mark.parametrize("transport", ["rest", "mcp"])
+@pytest.mark.parametrize("authenticated", [False, True])
+def test_live_binding_can_be_cancelled_from_another_instance(database, transport, authenticated):
+    import asyncio
+
+    from agno.run.cancel import cleanup_run, is_cancelled
+
+    first, surface, component = application(database, [])
+    second, _, _ = application(database, [])
+    run_id, session_id = str(uuid4()), str(uuid4())
+    second_app = second.get_app()
+    headers = {}
+    if authenticated:
+        import jwt
+
+        from agno.os.middleware.jwt import JWTMiddleware
+
+        key = "public-live-binding-test-signing-key"
+        second_app.add_middleware(
+            JWTMiddleware, verification_keys=[key], algorithm="HS256", user_isolation=True, authorization=True
+        )
+        headers["Authorization"] = "Bearer " + jwt.encode(
+            {"sub": "alice", "scopes": ["agents:run", "mcp:read"]}, key, algorithm="HS256"
+        )
+    with (
+        TestClient(first.get_app(), base_url="http://localhost"),
+        TestClient(second_app, base_url="http://localhost", headers=headers) as client,
+    ):
+        lease = asyncio.run(
+            surface._bindings._claim("agents", component.id, session_id, run_id, "alice" if authenticated else None, 30)
+        )
+        try:
+            if transport == "mcp":
+                bad = mcp(
+                    client, "cancel_run", {"agent_id": component.id, "session_id": str(uuid4()), "run_id": run_id}
+                )
+                assert bad["isError"] and not is_cancelled(run_id)
+                good = mcp(client, "cancel_run", {"agent_id": component.id, "session_id": session_id, "run_id": run_id})
+                assert not good.get("isError"), good
+            else:
+                route = f"/agents/{component.id}/runs/{run_id}/cancel"
+                bad = client.post(route, params={"session_id": str(uuid4())})
+                assert bad.status_code == 404 and not is_cancelled(run_id)
+                good = client.post(route, params={"session_id": session_id})
+                assert good.status_code == 200, good.text
+            assert is_cancelled(run_id)
+        finally:
+            asyncio.run(surface._bindings._release(run_id, lease))
+            cleanup_run(run_id)
+
+
+def test_concurrent_resume_claim_does_not_execute_twice(database):
+    import asyncio
+
+    effects = []
+    server, surface, component = application(database, effects)
+    with TestClient(server.get_app(), base_url="http://localhost") as client:
+        paused = start(client, component, "mcp")
+        lease = asyncio.run(
+            surface._bindings._claim("agents", component.id, paused["session_id"], paused["run_id"], None, 30)
+        )
+        try:
+            result = resume(client, component, paused, "mcp")
+            assert result["isError"] and "run_in_progress" in str(result)
+            assert effects == []
+        finally:
+            asyncio.run(surface._bindings._release(paused["run_id"], lease))
+        assert not resume(client, component, paused, "mcp").get("isError")
+        assert effects == ["executed"]
+
+
+def test_mcp_respects_run_capacity_and_releases_it_after_timeout(database):
+    import asyncio
+    import threading
+    from concurrent.futures import ThreadPoolExecutor
+
+    started, released = threading.Event(), threading.Event()
+
+    class WaitingModel(ApprovalModel):
+        async def ainvoke(self, *args, **kwargs):
+            started.set()
+            try:
+                await asyncio.sleep(10)
+            finally:
+                released.set()
+
+        async def ainvoke_stream(self, *args, **kwargs):
+            await self.ainvoke(*args, **kwargs)
+            yield ModelResponse(role="assistant", content="done", response_usage=MessageMetrics())
+
+    server, surface, component = application(database, [], max_active_runs=1, max_run_seconds=0.5)
+    component.model = WaitingModel()
+    with TestClient(server.get_app(), base_url="http://localhost") as client, ThreadPoolExecutor() as pool:
+        pending = pool.submit(mcp, client, component.id, {"message": "wait"})
+        assert started.wait(5)
+        response = client.post("/agents/public-agent/runs", data={"message": "hi", "stream": "false"})
+        assert response.status_code == 503 and response.json()["error"]["code"] == "run_capacity"
+        result = pending.result(timeout=5)
+        assert result["isError"] and released.is_set()
+        # The next request reaches the model rather than retaining the old reservation.
+        started.clear()
+        result = mcp(client, component.id, {"message": "wait again"})
+        assert result["isError"] and started.is_set() and "run_capacity" not in str(result)
+
+
+@pytest.mark.parametrize("transport", ["rest", "mcp"])
+def test_team_can_resume_its_members_paused_tool(database, transport):
+    class DelegateModel(ApprovalModel):
+        def invoke(self, *args, **kwargs):
+            messages = kwargs.get("messages", args[0] if args else [])
+            if any(message.role == "tool" for message in messages):
+                return ModelResponse(role="assistant", content="Finished", response_usage=MessageMetrics())
+            return ModelResponse(
+                role="assistant",
+                tool_calls=[
+                    {
+                        "id": "delegate-call",
+                        "type": "function",
+                        "function": {
+                            "name": "delegate_task_to_member",
+                            "arguments": json.dumps({"member_id": "public-agent", "task": "Do the action"}),
+                        },
+                    }
+                ],
+                response_usage=MessageMetrics(),
+            )
+
+    effects = []
+    server, _, component = application(database, effects, team=True)
+    component.model, component.tools = DelegateModel(), []
+    with TestClient(server.get_app(), base_url="http://localhost") as client:
+        paused = start(client, component, "mcp")
+        assert paused["status"] == "PAUSED" and effects == []
+        assert paused["requirements"][0]["member_agent_id"] == "public-agent"
+        assert client.post("/agents/public-agent/runs", data={"message": "hi"}).status_code == 404
+        result = resume(client, component, paused, transport)
+        assert not result.get("isError") if transport == "mcp" else result.status_code == 200
+        assert effects == ["executed"]
+
+
+@pytest.mark.parametrize("transport", ["rest", "mcp"])
+def test_wrong_component_handles_do_not_authorize_continuation(database, transport):
+    effects = []
+    server, surface, component = application(database, effects, team=True)
+    # Publish both components under their own identities.
+    surface.agents = server.agents
+    server.mcp = MCPConfig(tools=[component, server.agents[0]], default_tools=False, stateless=True)
+    with TestClient(server.get_app(), base_url="http://localhost") as client:
+        paused = start(client, component, "mcp")
+        result = resume(client, server.agents[0], paused, transport)
+        assert result.get("isError") if transport == "mcp" else result.status_code == 404
+        assert effects == []
+
+
+@pytest.mark.parametrize("transport", ["rest", "mcp"])
+def test_approval_storage_failure_cannot_skip_required_check(database, transport, monkeypatch):
+    effects = []
+    server, _, component = application(database, effects)
+    with TestClient(server.get_app(), base_url="http://localhost") as client:
+        paused = start(client, component, "mcp")
+
+        def unavailable(**kwargs):
+            raise RuntimeError("private approval database diagnostic")
+
+        monkeypatch.setattr(database, "get_approvals", unavailable)
+        result = resume(client, component, paused, transport)
+        assert result.get("isError") if transport == "mcp" else result.status_code == 503
+        assert "private approval database diagnostic" not in str(result)
+        assert effects == []
+
+
+@pytest.mark.parametrize("transport", ["rest", "mcp"])
+def test_authenticated_workflow_can_pause_and_resume(database, transport):
+    import jwt
+
+    from agno.os.middleware.jwt import JWTMiddleware
+    from agno.workflow.types import HumanReview
+
+    effects = []
+
+    def execute(step_input):
+        effects.append("workflow")
+        return StepOutput(content="Workflow completed")
+
+    workflow = Workflow(
+        id="protected",
+        db=database,
+        telemetry=False,
+        steps=[Step(name="work", executor=execute, human_review=HumanReview(requires_confirmation=True))],
+    )
+    server = AgentOS(
+        id="workflow-pause",
+        workflows=[workflow],
+        db=database,
+        public=PublicSurface(workflows=[workflow], mcp=True),
+        mcp=MCPConfig(tools=[workflow], default_tools=False, stateless=True),
+        auto_provision_dbs=False,
+        telemetry=False,
+    )
+    app = server.get_app()
+    key = "public-workflow-test-signing-key"
+    app.add_middleware(
+        JWTMiddleware, verification_keys=[key], algorithm="HS256", user_isolation=True, authorization=True
+    )
+    token = jwt.encode({"sub": "alice", "scopes": ["workflows:run", "mcp:read"]}, key, algorithm="HS256")
+    with TestClient(app, base_url="http://localhost") as client:
+        client.headers["Authorization"] = "Bearer " + token
+        if transport == "mcp":
+            initial = mcp(client, "protected", {"message": "{}"})
+            assert not initial.get("isError"), initial
+            paused = initial["structuredContent"]
+            requirements = paused["requirements"]
+        else:
+            paused = payload(client.post("/workflows/protected/runs", data={"message": "{}", "stream": "false"}))
+            requirements = paused["step_requirements"]
+        assert paused["status"] == "PAUSED" and effects == []
+        for requirement in requirements:
+            requirement["confirmed"] = True
+        if transport == "mcp":
+            result = mcp(
+                client,
+                "continue_run",
+                {
+                    "workflow_id": "protected",
+                    "run_id": paused["run_id"],
+                    "session_id": paused["session_id"],
+                    "requirements": requirements,
+                },
+            )
+            assert not result.get("isError"), result
+            assert result["structuredContent"]["status"] == "COMPLETED"
+        else:
+            result = payload(
+                client.post(
+                    f"/workflows/protected/runs/{paused['run_id']}/continue",
+                    data={
+                        "session_id": paused["session_id"],
+                        "step_requirements": json.dumps(requirements),
+                        "stream": "false",
+                    },
+                )
+            )
+            assert result["status"] == "COMPLETED"
+        assert effects == ["workflow"]
+
+
+@pytest.mark.parametrize("team", [False, True])
+def test_anonymous_continuation_with_native_jwt_policy(database, team):
+    effects = []
+    server, _, component = application(database, effects, team=team, authorization=True)
+    with TestClient(server.get_app(), base_url="http://localhost", root_path="/runtime") as client:
+        paused = start(client, component, "rest")
+        result = resume(client, component, paused, "rest")
+        assert result.status_code == 200, result.text
+        assert effects == ["executed"]
+        assert client.get("/config").status_code == 401
+
+
+@pytest.mark.parametrize("form", [False, True])
+def test_anonymous_cancel_with_native_jwt_policy(database, form):
+    import asyncio
+
+    from agno.run.cancel import cleanup_run, is_cancelled
+
+    server, surface, component = application(database, [], authorization=True)
+    run_id, session_id = str(uuid4()), str(uuid4())
+    with TestClient(server.get_app(), base_url="http://localhost", root_path="/runtime") as client:
+        lease = asyncio.run(surface._bindings._claim("agents", component.id, session_id, run_id, None, 30))
+        try:
+            route = f"/agents/{component.id}/runs/{run_id}/cancel"
+            duplicate = client.post(route, params={"session_id": session_id}, data={"session_id": session_id})
+            assert duplicate.status_code == 400 and not is_cancelled(run_id)
+            result = client.post(route, **{"data" if form else "params": {"session_id": session_id}})
+            assert result.status_code == 200, result.text
+            assert is_cancelled(run_id)
+        finally:
+            asyncio.run(surface._bindings._release(run_id, lease))
+            cleanup_run(run_id)

--- a/libs/agno/tests/integration/os/test_public_surface.py
+++ b/libs/agno/tests/integration/os/test_public_surface.py
@@ -297,5 +297,5 @@ def test_selected_agents_and_teams_share_run_and_cancel_limits(engine):
         assert client.post("/agents/same/runs", data={"message": "hi", "user_id": "spoof"}).status_code == 429
         run_id = str(uuid4())
         response = client.post(f"/teams/same/runs/{run_id}/cancel")
-        assert response.status_code in (200, 404), response.text
+        assert response.status_code == 400, response.text
         assert client.post(f"/agents/same/runs/{run_id}/cancel").status_code == 429

--- a/libs/agno/tests/unit/os/test_public_json_bounds.py
+++ b/libs/agno/tests/unit/os/test_public_json_bounds.py
@@ -58,6 +58,14 @@ class LocalAdmission:
         return Admission(True)
 
 
+class LocalBindings:
+    async def _claim(self, *args):
+        return "test-lease"
+
+    async def _release(self, *args):
+        pass
+
+
 def application(*, bounded=True, model=None, team_mode=False, gzip_inner=False, expose_agent=False):
     agent = Agent(id="docs-agent", model=model or ShortAnswerModel(), db=InMemoryDb(), telemetry=False)
     from fastapi import FastAPI
@@ -72,6 +80,7 @@ def application(*, bounded=True, model=None, team_mode=False, gzip_inner=False, 
         max_active_runs=1,
         uploads=FileUploadLimits(max_files=12, allowed_types=((".txt", "text/plain"),)),
     )
+    surface._bindings = LocalBindings()
     surface._limiter = LocalAdmission()  # type: ignore[assignment]
     base_app = FastAPI()
     if gzip_inner:

--- a/libs/agno/tests/unit/os/test_public_mcp_config.py
+++ b/libs/agno/tests/unit/os/test_public_mcp_config.py
@@ -50,19 +50,20 @@ async def test_public_custom_tools_need_no_lifecycle_override(public_os):
     assert public_os.mcp_config.lifecycle_tools is True
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("kind", ["agents", "teams", "workflows"])
 @pytest.mark.parametrize("named", [False, True])
-def test_public_exposed_components_explain_lifecycle_opt_out(public_os, kind, named):
+async def test_public_exposed_components_include_scoped_lifecycle_tools(public_os, kind, named):
     component = getattr(public_os, kind)[0]
     tool = component.as_tool(name="docs") if named else component
     public_os.mcp = MCPConfig(tools=[tool], default_tools=False, stateless=True)
-
-    with pytest.raises(ValueError) as error:
-        public_os.get_app()
-    message = str(error.value)
-    assert "continue_run or cancel_run" in message
-    assert "lifecycle_tools=False" in message
-    assert 'exclude_tags={"lifecycle"}' in message
+    public_os.get_app()
+    async with Client(build_mcp_server(public_os)) as client:
+        assert {tool.name for tool in await client.list_tools()} == {
+            "docs" if named else component.id,
+            "continue_run",
+            "cancel_run",
+        }
 
 
 @pytest.mark.asyncio

--- a/libs/agno/tests/unit/os/test_public_stream_bounds.py
+++ b/libs/agno/tests/unit/os/test_public_stream_bounds.py
@@ -32,7 +32,7 @@ def middleware(endpoint, **overrides):
         mcp=False,
         **overrides,
     )
-    os = SimpleNamespace(agents=[agent], teams=[], workflows=[])
+    os = SimpleNamespace(agents=[agent], teams=[], workflows=[], public=surface)
     return PublicMiddleware(endpoint, surface=surface, agent_os=os)
 
 


### PR DESCRIPTION
## Summary

Public agents could start a run and pause for human approval, but `PublicSurface` blocked both MCP lifecycle tools and REST continuation. This change makes paused Agent, Team and authenticated Workflow runs resumable through the existing REST and MCP execution services. MCP component exposure automatically includes its scoped lifecycle tools; explicit opt-outs still work.

The shared public gate verifies the component/session/run binding and authenticated principal, preserves saved requirement identity and tool arguments, and checks required administrator approvals even when general authorization is disabled. REST and MCP executions share run quotas and concurrency admission; MCP workflows inherit the public workflow authentication requirement. Short-lived PostgreSQL bindings authorize active cancellation and prevent simultaneous public continuations of the same run.

Includes a public approval cookbook and native end-to-end coverage for approval/rejection, nested Team member pauses, cross-instance and cross-transport continuation, workflow authentication, ownership failures, active cancellation and admission cleanup. Follow-up to #10060, now merged; this PR targets current main.

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Compatibility and access policy**

- Public cancellation now requires the returned `session_id` as well as `run_id`. REST accepts the native query parameter or the previous form location, but rejects duplicates. Clients currently omitting `session_id` must provide it when adopting this change.
- Explicitly exposed public MCP workflows now require verified credentials, matching public REST workflows.
- Anonymous session/run UUIDs are bearer capabilities. Authenticated sessions require the same principal; the rate-limit client identity does not authorize run access.
- Public continuation supports paused runs and bounded resolution fields. It does not open background continuation, regeneration, forking, session browsing or arbitrary execution overrides.
- Custom-function MCP configurations and global MCP lifecycle defaults are preserved. Docs Agent is not modified by this PR.

**Storage and deployment**

Public limiter setup creates the additive `public.agno_public_runs` table and expiry index. Records expire and are released after execution. These records provide shared ownership/admission checks; cancellation delivery still uses the configured Agno cancellation manager. Multiple processes need an existing shared cancellation manager for cancellation delivery across replicas. Execution concurrency remains per server instance; quotas and continuation claims are shared in PostgreSQL.

**Validation**

- 302 affected tests passed, including 42 public-continuation integration cases against disposable local PostgreSQL.
- Existing public HTTP/output bounds, MCP exposed components/toolkits and unrestricted continuation regressions passed.
- `./scripts/format.sh`, `./scripts/validate.sh` and `git diff --check` passed.
- `public_approval.py --check` passed with the demo Python and compatible development dependencies on `PYTHONPATH`. The live-provider demonstration was not run.

Validation reused existing Python environments. Temporary `types-regex` stubs supplied the development environment's missing mypy dependency; the shared environments were not modified. Integration databases were created and dropped in a disposable PostgreSQL container.


### 2026-09-09 rebase validation

Rebased onto main `4253dedc9`, retaining the shared public/JWT route policy.
175 combined public continuation, authorization, surface and bounds tests passed
against disposable PostgreSQL. The continuation suite then passed 46 tests,
including four additional native JWT/root_path/query/form regressions (overlapping
with the first run). Full format and validation scripts passed.

Cancellation delivery across separate processes remains a distinct backend task;
these tests establish admission and shared ownership, not distributed delivery.
