### PR TITLE
Release: v3.0.8

### DIFF
--- a/.github/workflows/test_on_release.yml
+++ b/.github/workflows/test_on_release.yml
@@ -1341,11 +1341,9 @@ jobs:
   # The pgvector service is on localhost:5532 — the exact host/port/creds the
   # conftest targets — so both the sqlite and postgresql lanes run in CI.
   #
-  # The page-storage suite rides along: it is skipped unless
-  # AGNO_PAGE_TEST_DB_URL points at a local server whose user can CREATE and
-  # DROP a throwaway database per module, which the service user here can.
-  # It is listed by file because the knowledge shards have no Postgres and
-  # would only ever skip it. -rs surfaces the skip if the gate ever trips.
+  # Run page-storage tests here because the knowledge jobs have no Postgres.
+  # AGNO_PAGE_TEST_DB_URL uses this service to create and drop a temporary
+  # database for the suite. Report skipped tests with -rs.
   test-fs:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/test_on_release.yml
+++ b/.github/workflows/test_on_release.yml
@@ -1340,6 +1340,12 @@ jobs:
   # so the largest Postgres-backed suite does not stretch that job's wall clock.
   # The pgvector service is on localhost:5532 — the exact host/port/creds the
   # conftest targets — so both the sqlite and postgresql lanes run in CI.
+  #
+  # The page-storage suite rides along: it is skipped unless
+  # AGNO_PAGE_TEST_DB_URL points at a local server whose user can CREATE and
+  # DROP a throwaway database per module, which the service user here can.
+  # It is listed by file because the knowledge shards have no Postgres and
+  # would only ever skip it. -rs surfaces the skip if the gate ever trips.
   test-fs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -1379,9 +1385,11 @@ jobs:
         working-directory: .
         env:
           AGNO_TELEMETRY: false
+          AGNO_PAGE_TEST_DB_URL: postgresql+psycopg://ai:ai@localhost:5532/ai
         run: |
           source .venv/bin/activate
-          python -m pytest ./libs/agno/tests/integration/fs
+          python -m pytest -rs ./libs/agno/tests/integration/fs \
+          ./libs/agno/tests/integration/knowledge/test_page_storage.py
 
   test-dev-setup:
     runs-on: ubuntu-latest

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agno"
-version = "3.0.7"
+version = "3.0.8"
 description = "The programming language for agentic software."
 requires-python = ">=3.9,<4"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Prepare Agno 3.0.8 by bumping `libs/agno/pyproject.toml` from `3.0.7` to `3.0.8`. The release workflow also runs page-storage integration tests against the PostgreSQL service in `test-fs`; the changelog below covers the four PRs merged since `v3.0.7`.

### Changelog

#### New Features

- **Complete page reads:** `Knowledge.read_full_page` and `aread_full_page` return an entire published page from one bounded SQL read and read-only snapshot. Both support revision pinning, character limits and deadlines. Oversized pages return `None`; missing or changed pages retain typed errors. Calls share the existing eight-slot page-read worker pool. (#10063)
- **Shared PostgreSQL engine factories:** `create_postgres_engine` and `create_async_postgres_engine` expose Agno's connection-pool and JSON serialization defaults with configurable SQLAlchemy options. Plain `postgres://` and `postgresql://` URLs select Psycopg 3 in these new factories; explicit drivers and TLS settings are preserved. Existing database constructor driver selection is unchanged. (#10062)

#### Improvements

- **Shared Markdown fence tracking:** `agno.utils.markdown.advance_code_fence` exposes the page chunker's fence rules for application transforms that need to preserve code examples. A full-page cookbook demonstrates reads and prose normalization. (#10063)
- **Magic Hour hosted MCP cookbook:** an example for image and video generation covers bearer authentication, long render timeouts, project ID reuse and output URL handling. (#10057)

#### Bug Fixes

- **Session data integrity (SQLite):** bulk upsert_sessions() in SqliteDb / AsyncSqliteDb now applies the same owner check as the single-row upsert_session() — previously a batch containing another user's session_id would reassign the row and overwrite its data. Rows the predicate refuses are omitted from the returned list, matching Postgres and the single-row path. (#9937)
- **Public MCP validates the tools actually exposed.** Custom-function configurations such as `MCPConfig(tools=[custom_function], default_tools=False, stateless=True)` now work without an unnecessary `lifecycle_tools=False` override. Public exposure of agents, teams or workflows still requires disabling the automatically added lifecycle tools with `lifecycle_tools=False` or `exclude_tags={"lifecycle"}`. (#10060)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [x] Other: Release version bump; included features and fixes are listed above.

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Replaces #10065 using the release branch `release-3.0.8`, matching the release integration workflow branch filter. The page-storage test comment has also been simplified.

Validation on this release branch:

- `./scripts/format.sh` and `./scripts/validate.sh` passed, including Ruff, mypy and the cookbook pattern check.
- **303 focused unit tests passed** across full-page reads, page chunking and timeouts, Markdown fences, PostgreSQL engine factories and database serialization, public MCP configuration and MCP tool exposure. Eight existing deprecation warnings were reported.
- Built the wheel and source distribution in a temporary staging directory using the release workflow's README layout. Verified both versions are `3.0.8` and the wheel includes the new modules and typing marker.
- `git diff --check` passed.

Validation used the existing `.venv` with missing dependencies supplied from a temporary directory. No new tests, docstring changes or cookbook edits are needed for this release PR. Live database/provider tests and cookbook executions were not rerun for this release PR.
