### PR TITLE
fix: preserve AG-UI conversation history without a session database

### DIFF
--- a/cookbook/05_agent_os/16_agui/README.md
+++ b/cookbook/05_agent_os/16_agui/README.md
@@ -14,7 +14,8 @@ default empty prefix those routes are `POST /agui` and `GET /status`.
 
 | File | What it teaches |
 |---|---|
-| `basic.py` | Mount one agent at the default `/agui` and `/status` routes. |
+| `basic.py` | Mount one agent at the default `/agui` and `/status` routes, reading history from its stored sessions. |
+| `stateless.py` | Hold a multi-turn conversation with no database, from the transcript the client sends. |
 | `agent_with_tools.py` | Contrast a Python backend tool with a frontend-supplied external-execution tool. |
 | `structured_output.py` | Stream a response constrained by a Pydantic output schema. |
 | `reasoning_agent.py` | Translate Agno reasoning lifecycle events into AG-UI reasoning events. |
@@ -43,6 +44,7 @@ Start one example at a time; every standalone server uses port 7777:
 
 ```bash
 .venvs/demo/bin/python cookbook/05_agent_os/16_agui/basic.py
+.venvs/demo/bin/python cookbook/05_agent_os/16_agui/stateless.py
 .venvs/demo/bin/python cookbook/05_agent_os/16_agui/agent_with_tools.py
 .venvs/demo/bin/python cookbook/05_agent_os/16_agui/structured_output.py
 .venvs/demo/bin/python cookbook/05_agent_os/16_agui/reasoning_agent.py
@@ -63,6 +65,7 @@ endpoint:
 | Running file | POST event stream | Status |
 |---|---|---|
 | `basic.py` | `http://localhost:7777/agui` | `http://localhost:7777/status` |
+| `stateless.py` | `http://localhost:7777/stateless/agui` | `http://localhost:7777/stateless/status` |
 | `agent_with_tools.py` | `http://localhost:7777/tools/agui` | `http://localhost:7777/tools/status` |
 | `structured_output.py` | `http://localhost:7777/structured-output/agui` | `http://localhost:7777/structured-output/status` |
 | `reasoning_agent.py` | `http://localhost:7777/reasoning/agui` | `http://localhost:7777/reasoning/status` |
@@ -102,6 +105,57 @@ events, and ends with `RUN_FINISHED`. Tool calls use `TOOL_CALL_*`; reasoning
 uses `REASONING_*`; shared state uses `STATE_SNAPSHOT` and `STATE_DELTA`.
 `threadId` becomes the Agno session ID, so later requests can continue the same
 conversation.
+
+## Conversation history
+
+AG-UI clients resend the whole conversation on every request, but an Agent or
+Team reads history from a session of its own. The interface uses whichever of
+those two sources the served entity has:
+
+| Configuration | Where history comes from |
+|---|---|
+| A database is configured (`basic.py`) | The Agno session named by `threadId`, windowed by `num_history_runs`, which defaults to the newest three runs. Set `add_history_to_context=True` or the model sees only the current turn, and note that a session the database does not have yet is empty history: the client's transcript is not consulted. |
+| No database (`stateless.py`) | The transcript in the request. The interface forwards the earlier user, assistant, and tool messages as additional input, and runs the entity with `add_history_to_context=False`, so nothing arrives twice. |
+| A `RemoteAgent` or `RemoteTeam` | The remote entity's own session, always. Its run route takes a single message, so the transcript cannot travel with it, and the interface warns when a request carries history it cannot forward. |
+
+The other examples in this folder leave `add_history_to_context` at its default,
+because each one demonstrates a capability rather than a conversation. They keep
+sessions but do not replay them.
+
+An in-process session cache (`cache_session=True`) is not a third source. It
+outlives a request but not the worker, and it belongs to whoever ran that thread
+on that worker first, so a database-less entity is always run with its own
+history switched off, whether or not the request carries a transcript to forward.
+
+What the forwarding path does and does not do:
+
+- Client `system` and `developer` messages are never forwarded: the entity owns
+  its own system message. `activity` and `reasoning` messages are not forwarded
+  either, since they carry nothing for the model, and one arriving in the middle
+  of a tool exchange does not break the exchange up.
+- Only what precedes the current turn is history, and the current turn is the
+  newest user message that carries text or media. A transcript that ends on an
+  assistant reply asks its newest user message again without replaying that
+  reply, and a trailing empty user message does not become the turn unless every
+  user message in the transcript is empty.
+- Tool traffic is forwarded in the shape providers accept: an assistant turn's
+  calls followed immediately by their results. A call whose result does not
+  arrive with it is dropped along with the result, a call id is forwarded once
+  however often the client reuses it, and a result carrying neither content nor
+  an error does not count as one.
+- The whole transcript the client sent is forwarded, consecutive turns of the
+  same role included, exactly as the client ordered them. `num_history_runs` and
+  `num_history_messages` do not apply here: they window a session this path does
+  not read, and the first of them defaults to three runs, so applying it would
+  silently drop conversation.
+- `add_history_to_context` does not gate this path. It selects what a session
+  contributes, and this path reads no session.
+- Frontend tools and backend confirmations still need a database. Resuming a
+  paused run reads it back from the session, so a request carrying tool results
+  streams a `RUN_ERROR` event carrying `Frontend tool resume requires a
+  database` without one, and `Frontend tool resume requires a local Agent or
+  Team` against a remote entity. A remote entity also never receives the
+  client's tool definitions; those are dropped with a server-side warning.
 
 ## Frontend tools and backend HITL are different
 

--- a/cookbook/05_agent_os/16_agui/TEST_LOG.md
+++ b/cookbook/05_agent_os/16_agui/TEST_LOG.md
@@ -6,6 +6,11 @@ Tested on 2026-07-24 against Agno source commit
 The OpenUI addition was tested on 2026-08-18 against Agno source commit
 `32e5fb9c2203fa98de19ca72750133a57a075899`.
 
+The 2026-09-04 note at the end of this file supersedes the scope of every LIVE
+result below: the AG-UI request path itself changed after they were recorded.
+Read each section as the result it was, not as a current one. That note carries
+its own live results for the two files the change touches.
+
 Each checked-in server was first booted on its default port 7777. The sweep
 asserted `GET /health`, `GET /config`, every mounted AG-UI status route, and a
 clean shutdown. Capability-specific POST tests then used
@@ -206,3 +211,76 @@ TypeScript compilation, and the Vite production build passed.
 - Repository-wide Ruff, agnoctl mypy, and cookbook pattern checks passed. The
   core Agno mypy step reported 27 existing errors in six files outside this
   integration's diff.
+
+## Update 2026-09-04: conversation history
+
+Changed here: `basic.py` gained `add_history_to_context=True` so the example
+continues its conversation instead of answering each turn from scratch;
+`stateless.py` is new and serves an agent with no database at all; and the README
+gained a section on where history comes from in each case. The AG-UI request path
+itself changed too, in turn selection, in what tool traffic is forwarded, and in
+how a database-less entity is run, so the LIVE results in the sections above
+predate the code they describe.
+
+### basic.py
+
+**Status:** PASS
+
+**Test mode:** LIVE
+
+**Description:** Booted on port 7777, asserted `/status`, then posted a two-turn
+AG-UI conversation on one `threadId` against `gpt-5.5`: "my name is Ada", then
+"what is my name?".
+
+**Result:** Status returned available. Turn one answered "Nice to meet you,
+Ada!"; turn two answered "Your name is Ada.", so history came from the stored
+session. One session row with two runs afterwards.
+
+**Observed, not diagnosed:** the first attempt ran against a `tmp/agui_basic.db`
+left behind by an earlier session, and turn two answered "I don't know your
+name." That database held one session row and one run row, and turn one's run
+was never stored. Deleting the file and repeating gave the passing result above.
+Whether a database file from an older run can silently swallow the first run of a
+new one is a storage question, outside this change and unexamined here.
+
+### stateless.py
+
+**Status:** PASS
+
+**Test mode:** LIVE
+
+**Description:** Same two-turn conversation on the `/stateless` prefix against
+`gpt-5.6-luna`, with no database anywhere in the example.
+
+**Result:** Status returned available. Turn one answered "Nice to meet you,
+Ada!"; turn two answered "Your name is Ada.", from the transcript the client
+resent rather than from any session.
+
+### Provider-shape checks, in process against `gpt-5.6-luna`
+
+The unit tests use a recording model, which accepts any message shape, so these
+six ran against the real API to confirm the forwarded shapes are ones a provider
+takes. All passed:
+
+- Two turns with no database: answered "Your name is Ada."
+- Two turns with a database: the same, as a control on the untouched path.
+- A complete tool block forwarded as history: answered from the tool's result.
+- A transcript whose tool traffic is all dropped by the pairing rules
+  (unanswered call, reused id, empty result): accepted, no error event.
+- A caption-less image in history, which the interface forwards with empty text:
+  accepted, and the model described the image.
+- A transcript ending on an assistant reply: accepted.
+
+These cover OpenAI's Responses API only. Anthropic and Gemini are argued from
+their formatters in this repo, not exercised here.
+
+### Also verified
+
+- `libs/agno/tests/unit/os/interfaces/test_agui_history.py`,
+  `test_agui_router.py` and `test_agui_history_invariants.py`, which drive the
+  AG-UI request path for an Agent, a Team and a remote entity, with and without
+  a database, asserting the exact messages that reach the model, plus the
+  ordering, pairing and partitioning properties across twenty-six transcript
+  shapes.
+- Ruff format and check on the edited and added files, and Python compilation of
+  every standalone file in the folder including `openui/server.py`.

--- a/cookbook/05_agent_os/16_agui/basic.py
+++ b/cookbook/05_agent_os/16_agui/basic.py
@@ -30,6 +30,7 @@ assistant = Agent(
     name="AG-UI Assistant",
     model=OpenAIResponses(id="gpt-5.5"),
     db=db,
+    add_history_to_context=True,
     instructions="Answer clearly and concisely.",
 )
 

--- a/cookbook/05_agent_os/16_agui/stateless.py
+++ b/cookbook/05_agent_os/16_agui/stateless.py
@@ -1,0 +1,48 @@
+"""
+Serve an Agent over AG-UI with no database
+==========================================
+
+Hold a multi-turn conversation without storing anything on the server. The client
+already sends the whole transcript on every AG-UI request, so with no database the
+interface forwards it as the agent's history instead of reading a session.
+
+Contrast with basic.py, which stores its sessions and sets add_history_to_context so the
+agent reads its own. Frontend tools and confirmations need that database; this file
+cannot resume a paused run.
+
+Prerequisites: OPENAI_API_KEY
+Run: .venvs/demo/bin/python cookbook/05_agent_os/16_agui/stateless.py
+Try: GET http://localhost:7777/stateless/status, then POST an AG-UI request to
+     /stateless/agui with two turns of messages
+"""
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.os import AgentOS
+from agno.os.interfaces.agui import AGUI
+
+# ---------------------------------------------------------------------------
+# Create AG-UI AgentOS
+# ---------------------------------------------------------------------------
+
+assistant = Agent(
+    id="agui-stateless-assistant",
+    name="AG-UI Stateless Assistant",
+    model=OpenAIResponses(id="gpt-5.6-luna"),
+    instructions="Answer clearly and concisely, and refer back to earlier turns when asked.",
+)
+
+agent_os = AgentOS(
+    id="agui-stateless-os",
+    description="An AgentOS whose AG-UI agent keeps no sessions of its own.",
+    agents=[assistant],
+    interfaces=[AGUI(agent=assistant, prefix="/stateless")],
+)
+app = agent_os.get_app()
+
+# ---------------------------------------------------------------------------
+# Run AG-UI Server
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    agent_os.serve(app=app)

--- a/libs/agno/agno/os/interfaces/agui/input.py
+++ b/libs/agno/agno/os/interfaces/agui/input.py
@@ -2,7 +2,7 @@ import base64
 import json
 import urllib.request
 from dataclasses import asdict, is_dataclass
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from ag_ui.core.types import Message as AGUIMessage
 from ag_ui.core.types import Tool as AGUITool
@@ -10,89 +10,323 @@ from ag_ui.core.types import ToolMessage as AGUIToolMessage
 from pydantic import BaseModel
 
 from agno.media import Audio, File, Image, Video
+from agno.models.message import Message
 from agno.tools.function import Function
 from agno.utils.log import log_warning
 
+_FORWARDABLE_ROLES = ("user", "assistant", "tool")
+
+
+def extract_current_turn(
+    messages: List[AGUIMessage],
+) -> Tuple[str, List[Image], List[Audio], List[Video], List[File]]:
+    """The text and media of the message this request is asking about.
+
+    Resolved and decoded once. Reading text from one message and media from another would
+    make a single turn out of two, so this is one message: the newest user message that
+    carries anything.
+
+    An empty newest user message is not the turn. Some clients append one before the user
+    has typed, and taking it would ask the model nothing. Reaching back past it means the
+    newest question the user did ask is asked again, and the answer it already got is not
+    history, because this run is about to produce that answer afresh. When no user message
+    carries anything the newest one is the turn regardless, so an all-empty transcript
+    still has a turn rather than becoming all history.
+    """
+    index = _current_turn_index(messages)
+    if index is None:
+        return "", [], [], [], []
+
+    content = _model_facing_content(messages[index])
+    if content is None:
+        return _message_text(messages[index]) or "", [], [], [], []
+    return content
+
 
 def extract_user_input(messages: List[AGUIMessage]) -> str:
-    """Extract the last user message content from AG-UI messages."""
-    for msg in reversed(messages):
-        if msg.role == "user" and msg.content is not None:
-            if isinstance(msg.content, str):
-                return msg.content
-            if isinstance(msg.content, list):
-                text_parts = []
-                for part in msg.content:
-                    if hasattr(part, "type") and part.type == "text" and hasattr(part, "text"):
-                        text_parts.append(part.text)
-                if text_parts:
-                    return "\n".join(text_parts)
-    return ""
+    """Extract the current turn's text from AG-UI messages."""
+    return extract_current_turn(messages)[0]
 
 
 def extract_media(
     messages: List[AGUIMessage],
 ) -> Tuple[List[Image], List[Audio], List[Video], List[File]]:
-    """Extract media from the last user message."""
+    """Extract media from the current turn."""
+    _, images, audio, videos, files = extract_current_turn(messages)
+    return images, audio, videos, files
+
+
+def _current_turn_index(messages: List[AGUIMessage]) -> Optional[int]:
+    """Index of the newest user message that carries anything, else the newest one."""
+    fallback: Optional[int] = None
+
+    for index in range(len(messages) - 1, -1, -1):
+        msg = messages[index]
+        if msg.role != "user":
+            continue
+        if _model_facing_content(msg) is not None:
+            return index
+        if fallback is None:
+            fallback = index
+
+    return fallback
+
+
+def _message_text(msg: AGUIMessage) -> Optional[str]:
+    """The text an AG-UI message contributes, or None when it carries none."""
+    if isinstance(msg.content, str):
+        return msg.content
+
+    if isinstance(msg.content, list):
+        # Empty parts are dropped rather than joined: they would only add blank lines.
+        text_parts = [
+            text
+            for part in msg.content
+            if getattr(part, "type", None) == "text" and (text := getattr(part, "text", None))
+        ]
+        if text_parts:
+            return "\n".join(text_parts)
+
+    return None
+
+
+def _extract_media_from_content(
+    content: Any,
+) -> Tuple[List[Image], List[Audio], List[Video], List[File]]:
+    """Extract media from one message's content parts."""
     images: List[Image] = []
     audio: List[Audio] = []
     videos: List[Video] = []
     files: List[File] = []
 
-    # 1. Find the last user message
-    for msg in reversed(messages):
-        if msg.role != "user" or msg.content is None:
-            continue
-
-        if isinstance(msg.content, str):
-            return images, audio, videos, files
-
-        # 2. Process each content part
-        for part in msg.content:
-            if not hasattr(part, "type"):
-                continue
-
-            # 3. Extract content bytes and MIME type based on part structure
-            content: Optional[bytes] = None
-            url: Optional[str] = None
-            mime: Optional[str] = None
-            filename: Optional[str] = None
-
-            if part.type == "binary":
-                # BinaryInputContent: flat structure (deprecated but still used)
-                mime = getattr(part, "mime_type", None)
-                filename = getattr(part, "filename", None)
-                url = getattr(part, "url", None)
-                data = getattr(part, "data", None)
-                if not url and data:
-                    content = _decode_base64(data)
-
-            elif part.type in ("image", "audio", "video", "document"):
-                # AG-UI wraps media in a source object with type (url/data) and value
-                source = getattr(part, "source", None)
-                if source and hasattr(source, "type"):
-                    mime = getattr(source, "mime_type", None)
-                    value = getattr(source, "value", None)
-                    if source.type == "url" and value:
-                        url = value
-                    elif source.type == "data" and value:
-                        content = _decode_base64(value)
-
-            if url or content:
-                if part.type == "image" or (mime and mime.startswith("image/")):
-                    images.append(Image(url=url, content=content, mime_type=mime))
-                elif part.type == "audio" or (mime and mime.startswith("audio/")):
-                    audio.append(Audio(url=url, content=content, mime_type=mime))
-                elif part.type == "video" or (mime and mime.startswith("video/")):
-                    videos.append(Video(url=url, content=content, mime_type=mime))
-                else:
-                    # File validates MIME — pass None for unsupported types to avoid raising
-                    safe_mime = mime if mime in File.valid_mime_types() else None
-                    files.append(File(url=url, content=content, mime_type=safe_mime, filename=filename))
-
+    if not isinstance(content, list):
         return images, audio, videos, files
 
+    for part in content:
+        if not hasattr(part, "type"):
+            continue
+
+        # Extract content bytes and MIME type based on part structure
+        part_content: Optional[bytes] = None
+        url: Optional[str] = None
+        mime: Optional[str] = None
+        filename: Optional[str] = None
+
+        if part.type == "binary":
+            # BinaryInputContent: flat structure (deprecated but still used)
+            mime = getattr(part, "mime_type", None)
+            filename = getattr(part, "filename", None)
+            url = getattr(part, "url", None)
+            data = getattr(part, "data", None)
+            if not url and data:
+                part_content = _decode_base64(data)
+
+        elif part.type in ("image", "audio", "video", "document"):
+            # AG-UI wraps media in a source object with type (url/data) and value
+            source = getattr(part, "source", None)
+            if source and hasattr(source, "type"):
+                mime = getattr(source, "mime_type", None)
+                value = getattr(source, "value", None)
+                if source.type == "url" and value:
+                    url = value
+                elif source.type == "data" and value:
+                    part_content = _decode_base64(value)
+
+        if url or part_content:
+            if part.type == "image" or (mime and mime.startswith("image/")):
+                images.append(Image(url=url, content=part_content, mime_type=mime))
+            elif part.type == "audio" or (mime and mime.startswith("audio/")):
+                audio.append(Audio(url=url, content=part_content, mime_type=mime))
+            elif part.type == "video" or (mime and mime.startswith("video/")):
+                videos.append(Video(url=url, content=part_content, mime_type=mime))
+            else:
+                # File validates MIME — pass None for unsupported types to avoid raising
+                safe_mime = mime if mime in File.valid_mime_types() else None
+                files.append(File(url=url, content=part_content, mime_type=safe_mime, filename=filename))
+
     return images, audio, videos, files
+
+
+def _prior_messages(messages: List[AGUIMessage]) -> List[AGUIMessage]:
+    """The messages that precede the current turn.
+
+    Anything after the newest user message answers that same message, and this request is
+    about to produce that answer again, so it is not history either.
+    """
+    index = _current_turn_index(messages)
+    prior = messages if index is None else messages[:index]
+    # Filtered here rather than skipped while walking: an activity or reasoning message
+    # between a tool call and its result would otherwise cut the block in half.
+    return [msg for msg in prior if msg.role in _FORWARDABLE_ROLES]
+
+
+def _model_facing_content(
+    msg: AGUIMessage,
+) -> Optional[Tuple[str, List[Image], List[Audio], List[Video], List[File]]]:
+    """The text and media a user message contributes, or None when it contributes nothing.
+
+    An empty turn costs tokens and some providers reject it, so a message that decodes to
+    nothing is neither forwarded nor chosen as the current turn. Media is decoded only
+    when there is no text to settle it, which is the common case.
+    """
+    text = _message_text(msg) or ""
+    if text.strip():
+        return (text, *_extract_media_from_content(msg.content))
+
+    media = _extract_media_from_content(msg.content)
+    if not any(media):
+        return None
+    return (text, *media)
+
+
+def extract_message_history(messages: List[AGUIMessage]) -> List[Message]:
+    """Convert the conversation that precedes the current turn into Agno messages.
+
+    The contract is deliberately narrow, because the obvious wider one duplicates
+    messages. The result is history and nothing else:
+
+    - The current turn is excluded, and so is anything after it: the turn reaches the
+      model as ``extract_user_input`` plus ``extract_media``, and a reply that follows it
+      is the answer this run is about to produce again.
+    - Client system and developer messages are excluded: the entity owns its system
+      message, and a second one inserted mid-conversation would fight it.
+    - Activity and reasoning messages are excluded: they carry no model-facing content.
+    - A message with neither text, media nor a forwarded tool call is excluded: an empty
+      turn costs tokens and some providers reject it.
+    - Tool traffic is forwarded as blocks, which is the shape providers accept: an
+      assistant turn's calls followed immediately by their results. A call whose result
+      does not arrive in that block is dropped along with the result, a call id is
+      forwarded at most once however often the client reuses it, and a result carrying
+      neither content nor an error does not count as one.
+    - History starts at a user message. Providers reject a conversation that opens on an
+      assistant turn, which is what a client's opening greeting would produce.
+
+    The whole transcript the client sent is forwarded. ``num_history_runs`` and
+    ``num_history_messages`` are not applied: they window a session this path does not
+    read, and the first of them defaults to three runs, so applying it would silently
+    drop conversation.
+
+    Only a caller that suppresses the entity's own history for the same run may forward
+    this. An entity reading a session as well would see the conversation twice.
+    """
+    prior = _prior_messages(messages)
+
+    history: List[Message] = []
+    forwarded_calls: Set[str] = set()
+    index = 0
+
+    while index < len(prior):
+        msg = prior[index]
+
+        if msg.role == "user":
+            index += 1
+            content = _model_facing_content(msg)
+            if content is None:
+                continue
+            text, images, audio, videos, files = content
+            history.append(
+                Message(
+                    role="user",
+                    # Media with no caption keeps the empty string Agno's own user message
+                    # uses for that case, so providers see one shape, not two.
+                    content=text,
+                    images=images or None,
+                    audio=audio or None,
+                    videos=videos or None,
+                    files=files or None,
+                    from_history=True,
+                )
+            )
+            continue
+
+        if msg.role != "assistant":
+            # A tool result outside an assistant's own block answers nothing.
+            index += 1
+            continue
+
+        results, index = _tool_results_following(prior, index + 1)
+        answered = [
+            tool_call
+            for tool_call in _unique_tool_calls(msg)
+            if tool_call.id in results and tool_call.id not in forwarded_calls
+        ]
+
+        if not msg.content and not answered:
+            continue
+        if not history:
+            # Nothing to answer yet: an assistant turn cannot open the conversation.
+            continue
+
+        history.append(
+            Message(
+                role="assistant",
+                content=msg.content,
+                tool_calls=[
+                    {
+                        "id": tool_call.id,
+                        "type": "function",
+                        "function": {"name": tool_call.function.name, "arguments": tool_call.function.arguments},
+                    }
+                    for tool_call in answered
+                ]
+                or None,
+                from_history=True,
+            )
+        )
+        for tool_call in answered:
+            forwarded_calls.add(tool_call.id)
+            result = results[tool_call.id]
+            error = getattr(result, "error", None)
+            history.append(
+                Message(
+                    role="tool",
+                    tool_call_id=tool_call.id,
+                    # Gemini formats a tool message with no tool_name as plain text, which
+                    # leaves the call it answers unanswered. The name comes from the call
+                    # so the two can never disagree.
+                    tool_name=tool_call.function.name,
+                    # Both halves ride along: the result the frontend produced before it
+                    # failed is context, and dropping the error replays a failure as a
+                    # success.
+                    content="\n".join(part for part in (result.content, error) if part),
+                    tool_call_error=bool(error),
+                    from_history=True,
+                )
+            )
+
+    return history
+
+
+def _unique_tool_calls(msg: AGUIMessage) -> List[Any]:
+    """An assistant message's tool calls, first occurrence of each id."""
+    seen: Set[str] = set()
+    unique: List[Any] = []
+    for tool_call in getattr(msg, "tool_calls", None) or []:
+        if tool_call.id in seen:
+            continue
+        seen.add(tool_call.id)
+        unique.append(tool_call)
+    return unique
+
+
+def _tool_results_following(prior: List[AGUIMessage], index: int) -> Tuple[Dict[str, Any], int]:
+    """The tool results in the block that starts at ``index``, and where the block ends.
+
+    Only results that carry something count: a result with neither content nor an error
+    tells the model nothing, and forwarding the call it answers without it would leave
+    the call unanswered.
+    """
+    results: Dict[str, Any] = {}
+
+    while index < len(prior) and prior[index].role == "tool":
+        result = prior[index]
+        index += 1
+        call_id = getattr(result, "tool_call_id", None)
+        if not call_id or not (result.content or getattr(result, "error", None)):
+            continue
+        results.setdefault(call_id, result)
+
+    return results, index
 
 
 def validate_state(state: Any, thread_id: str) -> Optional[Dict[str, Any]]:

--- a/libs/agno/agno/os/interfaces/agui/router.py
+++ b/libs/agno/agno/os/interfaces/agui/router.py
@@ -1,6 +1,6 @@
 import copy
 import uuid
-from typing import AsyncIterator, Optional, Union
+from typing import Any, AsyncIterator, List, Optional, Union
 
 from agno.utils.log import log_error, log_warning
 
@@ -21,11 +21,12 @@ from fastapi import APIRouter, Request
 from fastapi.responses import StreamingResponse
 
 from agno.agent import Agent, RemoteAgent
+from agno.models.message import Message
 from agno.os.interfaces.agui.input import (
     extract_context,
-    extract_media,
+    extract_current_turn,
+    extract_message_history,
     extract_tool_messages,
-    extract_user_input,
     parse_client_tools,
     validate_state,
 )
@@ -35,6 +36,43 @@ from agno.os.middleware.user_scope import assert_session_writable, caller_is_adm
 from agno.run.base import RunContext
 from agno.team.remote import RemoteTeam
 from agno.team.team import Team
+
+
+def _settle_ids(entity: Any) -> None:
+    """Give an entity and everything under it its own id before it is copied.
+
+    Ids are assigned lazily on the first run. Letting each request's copy assign its own
+    would give one entity, or one member of a team of teams, a different id per request.
+    """
+    if hasattr(entity, "set_id"):
+        entity.set_id()
+
+    # A Team's members can be a callable factory resolved per run, which is not a list.
+    members = getattr(entity, "members", None)
+    if isinstance(members, (list, tuple)):
+        for member in members:
+            _settle_ids(member)
+
+
+def _with_forwarded_history(entity: Union[Agent, Team], history: List[Message]) -> Union[Agent, Team]:
+    """Return a request-scoped copy of ``entity`` that carries ``history`` as extra input.
+
+    The entity is shared by every request, so the transcript of one conversation must
+    never be written onto it. Agno's own ``deep_copy`` is the per-request copy: it shares
+    the heavy resources that hold connections (model, database, knowledge) by reference,
+    and it re-runs initialization so the private per-run bookkeeping the run appends to
+    and clears starts clean. A plain shallow copy shares those mutable lists while the
+    clearing lands only on the copy, which leaves connectable tools registered but never
+    reconnected. Tools and a Team's members are copied rather than shared, so a toolkit's
+    own state does not carry from one forwarded turn to the next.
+
+    Ids are settled first, all the way down a team, because they are assigned lazily and
+    each request's copy would otherwise assign its own. Any additional input the caller
+    configured stays ahead of the conversation.
+    """
+    _settle_ids(entity)
+    forwarded = list(entity.additional_input or []) + list(history)
+    return entity.deep_copy(update={"additional_input": forwarded})
 
 
 async def run_entity(
@@ -54,8 +92,7 @@ async def run_entity(
         messages = run_input.messages or []
 
         # 1. Extract inputs from AG-UI message history
-        user_input = extract_user_input(messages)
-        images, audio, videos, files = extract_media(messages)
+        user_input, images, audio, videos, files = extract_current_turn(messages)
         tool_messages = extract_tool_messages(messages)
 
         # 2. Convert frontend tool definitions to Agno Functions
@@ -105,7 +142,26 @@ async def run_entity(
                 if client_tools:
                     # Dropped: the remote agent cannot pause back into this process's session.
                     log_warning("AG-UI client tools are not forwarded to remote agents or teams")
+                if extract_message_history(messages):
+                    # The remote run route takes a single message, so the transcript cannot
+                    # travel with it: only the remote entity's own session store can hold
+                    # this conversation.
+                    log_warning(
+                        "AG-UI conversation history is not forwarded to remote agents or teams. "
+                        "The remote entity's own session store has to provide it."
+                    )
             else:
+                if getattr(entity, "db", None) is None:
+                    # AG-UI clients resend the whole conversation every turn, while Agno reads
+                    # history from a session: with no database there is no session worth
+                    # reading, so the transcript the client sent is the conversation. The run
+                    # is told to add no history of its own either way, because an in-process
+                    # cached session survives between requests and belongs to whoever ran the
+                    # thread on this worker first.
+                    run_kwargs["add_history_to_context"] = False
+                    history = extract_message_history(messages)
+                    if history:
+                        entity = _with_forwarded_history(entity, history)
                 run_kwargs["run_context"] = run_context
             response_stream = entity.arun(  # type: ignore
                 input=user_input,

--- a/libs/agno/tests/unit/os/interfaces/test_agui_history.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_history.py
@@ -1,0 +1,858 @@
+"""Conversation history over the AG-UI interface.
+
+AG-UI clients send the whole transcript on every request. Agno reads history from a
+session of its own, so an Agent or Team with no session to read would otherwise see only
+the current turn and every earlier message would be dropped without a trace.
+
+These tests assert the messages that actually reach the model, per turn, for an Agent and
+a Team, with and without a session to read.
+"""
+
+import asyncio
+from typing import Any, AsyncIterator, Iterator, List, Optional, Tuple
+
+import pytest
+
+pytest.importorskip("ag_ui", reason="ag_ui not installed")
+
+from ag_ui.core import EventType, RunAgentInput
+from ag_ui.core.types import (
+    AssistantMessage,
+    Context,
+    DeveloperMessage,
+    FunctionCall,
+    ImageInputContent,
+    InputContentUrlSource,
+    ReasoningMessage,
+    SystemMessage,
+    TextInputContent,
+    ToolCall,
+    ToolMessage,
+    UserMessage,
+)
+
+from agno.agent.agent import Agent
+from agno.db.in_memory import InMemoryDb
+from agno.models.base import Model
+from agno.models.message import Message, MessageMetrics
+from agno.models.response import ModelResponse
+from agno.os.interfaces.agui.router import run_entity
+from agno.team.team import Team
+from agno.tools import Toolkit
+
+
+class RecordingModel(Model):
+    """Offline model that records the message list handed to it on every call."""
+
+    def __init__(self, content: str = "ok"):
+        super().__init__(id="test-model", name="test-model", provider="test")
+        self.calls: List[List[Message]] = []
+        self.content = content
+
+    @property
+    def _mock_response(self) -> ModelResponse:
+        return ModelResponse(content=self.content, role="assistant", response_usage=MessageMetrics())
+
+    def _record(self, kwargs) -> None:
+        self.calls.append(list(kwargs["messages"]))
+
+    def get_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    def get_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    def parse_args(self, *args, **kwargs):
+        return {}
+
+    def invoke(self, *args, **kwargs) -> ModelResponse:
+        self._record(kwargs)
+        return self._mock_response
+
+    async def ainvoke(self, *args, **kwargs) -> ModelResponse:
+        self._record(kwargs)
+        return self._mock_response
+
+    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+        self._record(kwargs)
+        yield self._mock_response
+
+    async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+        self._record(kwargs)
+        # Yield to the loop so concurrent runs actually interleave here.
+        await asyncio.sleep(0)
+        yield self._mock_response
+        return
+
+    def _parse_provider_response(self, response: Any, **kwargs) -> ModelResponse:
+        return self._mock_response
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return self._mock_response
+
+
+def _run_input(messages: List[Any], run_id: str, context: Optional[List[Context]] = None) -> RunAgentInput:
+    return RunAgentInput(
+        thread_id="thread-1",
+        run_id=run_id,
+        messages=messages,
+        state=None,
+        context=context or [],
+        tools=[],
+        forwarded_props={},
+    )
+
+
+async def _drive(entity, messages: List[Any], run_id: str = "run-1", user_id: Optional[str] = None, **kwargs) -> None:
+    """Run one AG-UI request and insist it actually completed.
+
+    ``run_entity`` turns any exception into a RUN_ERROR event instead of raising, so a
+    test that only inspects the model would pass while every run died.
+    """
+    events = [event async for event in run_entity(entity, _run_input(messages, run_id, **kwargs), user_id=user_id)]
+
+    errors = [event for event in events if event.type == EventType.RUN_ERROR]
+    assert not errors, f"run failed: {[event.message for event in errors]}"
+    assert events[-1].type == EventType.RUN_FINISHED
+
+
+def _conversation(model: RecordingModel, call_index: int) -> List[Tuple[str, Optional[str]]]:
+    """Non-system messages the model saw on a given call, as (role, content)."""
+    return [(msg.role, msg.content) for msg in model.calls[call_index] if msg.role != "system"]
+
+
+def _turn_1() -> List[Any]:
+    return [UserMessage(id="m1", role="user", content="my name is Ada")]
+
+
+def _turn_2() -> List[Any]:
+    return _turn_1() + [
+        AssistantMessage(id="m2", role="assistant", content="Hello Ada"),
+        UserMessage(id="m3", role="user", content="what is my name?"),
+    ]
+
+
+class ConnectionCountingTool(Toolkit):
+    """A toolkit Agno connects and closes around each run, counting both."""
+
+    _requires_connect = True
+
+    def __init__(self):
+        super().__init__(name="connection_counting", tools=[self.ping])
+        self.connects = 0
+        self.closes = 0
+
+    def connect(self) -> None:
+        self.connects += 1
+
+    def close(self) -> None:
+        self.closes += 1
+
+    def ping(self) -> str:
+        """Answer with a fixed string."""
+        return "pong"
+
+
+def _tool_call(call_id: str = "call-1", name: str = "weather", arguments: str = '{"c":"NO"}') -> ToolCall:
+    return ToolCall(id=call_id, type="function", function=FunctionCall(name=name, arguments=arguments))
+
+
+async def _two_turns(entity, model: RecordingModel) -> None:
+    await _drive(entity, _turn_1(), "run-1")
+    await _drive(entity, _turn_2(), "run-2")
+    assert len(model.calls) == 2
+
+
+class TestAgentWithoutDatabase:
+    @pytest.mark.asyncio
+    async def test_second_turn_sees_the_client_transcript(self):
+        model = RecordingModel()
+        agent = Agent(model=model)
+
+        await _two_turns(agent, model)
+
+        assert _conversation(model, 0) == [("user", "my name is Ada")]
+        assert _conversation(model, 1) == [
+            ("user", "my name is Ada"),
+            ("assistant", "Hello Ada"),
+            ("user", "what is my name?"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_forwarded_messages_are_marked_as_history(self):
+        model = RecordingModel()
+        agent = Agent(model=model)
+
+        await _drive(agent, _turn_2())
+
+        forwarded = [msg for msg in model.calls[0] if msg.from_history]
+        assert [(msg.role, msg.content) for msg in forwarded] == [
+            ("user", "my name is Ada"),
+            ("assistant", "Hello Ada"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_client_system_and_developer_messages_are_not_forwarded(self):
+        """The agent owns its system prompt; a client-supplied one must not displace it."""
+        model = RecordingModel()
+        agent = Agent(model=model, instructions="Be terse.")
+
+        messages = [
+            SystemMessage(id="s1", role="system", content="You are a pirate."),
+            DeveloperMessage(id="d1", role="developer", content="internal note"),
+        ] + _turn_2()
+        await _drive(agent, messages)
+
+        system_messages = [msg.content for msg in model.calls[0] if msg.role == "system"]
+        assert system_messages == ["Be terse."]
+        assert _conversation(model, 0) == [
+            ("user", "my name is Ada"),
+            ("assistant", "Hello Ada"),
+            ("user", "what is my name?"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_media_only_current_turn_is_one_message(self):
+        """A caption-less image is the whole current turn: the earlier text stays in
+        history in its own place, rather than being replayed as the new question."""
+        model = RecordingModel()
+        agent = Agent(model=model)
+
+        messages = _turn_1() + [
+            AssistantMessage(id="m2", role="assistant", content="Hello Ada"),
+            UserMessage(
+                id="m3",
+                role="user",
+                content=[
+                    ImageInputContent(
+                        source=InputContentUrlSource(value="https://example.com/a.png", mime_type="image/png")
+                    )
+                ],
+            ),
+        ]
+        await _drive(agent, messages)
+
+        assert _conversation(model, 0) == [
+            ("user", "my name is Ada"),
+            ("assistant", "Hello Ada"),
+            ("user", ""),
+        ]
+        current_turn = model.calls[0][-1]
+        assert [image.url for image in current_turn.images or []] == ["https://example.com/a.png"]
+
+    @pytest.mark.asyncio
+    async def test_history_keeps_the_media_of_an_earlier_caption_less_turn(self):
+        model = RecordingModel()
+        agent = Agent(model=model)
+
+        messages = [
+            UserMessage(
+                id="m1",
+                role="user",
+                content=[
+                    ImageInputContent(
+                        source=InputContentUrlSource(value="https://example.com/a.png", mime_type="image/png")
+                    )
+                ],
+            ),
+            AssistantMessage(id="m2", role="assistant", content="A picture"),
+            UserMessage(id="m3", role="user", content="what was it?"),
+        ]
+        await _drive(agent, messages)
+
+        forwarded_user = next(msg for msg in model.calls[0] if msg.from_history)
+        assert (forwarded_user.role, forwarded_user.content) == ("user", "")
+        assert [image.url for image in forwarded_user.images or []] == ["https://example.com/a.png"]
+
+    @pytest.mark.asyncio
+    async def test_opening_assistant_greeting_is_dropped(self):
+        """Providers reject a conversation that opens on an assistant turn."""
+        model = RecordingModel()
+        agent = Agent(model=model)
+
+        messages = [
+            AssistantMessage(id="m0", role="assistant", content="Hi, how can I help?"),
+        ] + _turn_2()
+        await _drive(agent, messages)
+
+        assert _conversation(model, 0) == [
+            ("user", "my name is Ada"),
+            ("assistant", "Hello Ada"),
+            ("user", "what is my name?"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_a_reused_tool_call_id_is_forwarded_once(self):
+        """Two calls against one result is the orphan the pairing exists to prevent."""
+        model = RecordingModel()
+        agent = Agent(model=model)
+
+        messages = [
+            UserMessage(id="m1", role="user", content="weather in Oslo?"),
+            AssistantMessage(id="m2", role="assistant", content=None, tool_calls=[_tool_call()]),
+            ToolMessage(id="m3", role="tool", content="rain", tool_call_id="call-1"),
+            AssistantMessage(id="m4", role="assistant", content="checking again", tool_calls=[_tool_call()]),
+            UserMessage(id="m5", role="user", content="and tomorrow?"),
+        ]
+        await _drive(agent, messages)
+
+        forwarded_calls = [msg.tool_calls for msg in model.calls[0] if msg.tool_calls]
+        assert forwarded_calls == [
+            [{"id": "call-1", "type": "function", "function": {"name": "weather", "arguments": '{"c":"NO"}'}}]
+        ]
+        assert [msg.content for msg in model.calls[0] if msg.role == "tool"] == ["rain"]
+
+    @pytest.mark.asyncio
+    async def test_history_media_is_forwarded(self):
+        model = RecordingModel()
+        agent = Agent(model=model)
+
+        messages = [
+            UserMessage(
+                id="m1",
+                role="user",
+                content=[
+                    TextInputContent(text="look at this"),
+                    ImageInputContent(
+                        source=InputContentUrlSource(value="https://example.com/a.png", mime_type="image/png")
+                    ),
+                ],
+            ),
+            AssistantMessage(id="m2", role="assistant", content="A picture"),
+            UserMessage(id="m3", role="user", content="what was it?"),
+        ]
+        await _drive(agent, messages)
+
+        forwarded_user = next(msg for msg in model.calls[0] if msg.from_history)
+        assert (forwarded_user.role, forwarded_user.content) == ("user", "look at this")
+        assert [image.url for image in forwarded_user.images or []] == ["https://example.com/a.png"]
+
+    @pytest.mark.asyncio
+    async def test_tool_exchange_round_trips(self):
+        model = RecordingModel()
+        agent = Agent(model=model)
+
+        messages = [
+            UserMessage(id="m1", role="user", content="weather in Oslo?"),
+            AssistantMessage(id="m2", role="assistant", content=None, tool_calls=[_tool_call()]),
+            ToolMessage(id="m3", role="tool", content="rain", tool_call_id="call-1"),
+            AssistantMessage(id="m4", role="assistant", content="It rains"),
+            UserMessage(id="m5", role="user", content="and tomorrow?"),
+        ]
+        await _drive(agent, messages)
+
+        assert _conversation(model, 0) == [
+            ("user", "weather in Oslo?"),
+            ("assistant", None),
+            ("tool", "rain"),
+            ("assistant", "It rains"),
+            ("user", "and tomorrow?"),
+        ]
+        forwarded_call = next(msg for msg in model.calls[0] if msg.tool_calls)
+        assert forwarded_call.tool_calls == [
+            {"id": "call-1", "type": "function", "function": {"name": "weather", "arguments": '{"c":"NO"}'}}
+        ]
+        forwarded_result = next(msg for msg in model.calls[0] if msg.role == "tool")
+        # Gemini formats a tool message with no tool_name as plain text, which leaves the
+        # forwarded call unanswered.
+        assert (forwarded_result.tool_call_id, forwarded_result.tool_name) == ("call-1", "weather")
+        assert forwarded_result.tool_call_error is False
+
+    @pytest.mark.asyncio
+    async def test_a_reasoning_message_does_not_break_up_a_tool_exchange(self):
+        """Clients interleave reasoning messages. They carry nothing for the model, but
+        losing the exchange around one loses what the tool actually returned."""
+        model = RecordingModel()
+        agent = Agent(model=model)
+
+        messages = [
+            UserMessage(id="m1", role="user", content="weather in Oslo?"),
+            AssistantMessage(id="m2", role="assistant", content=None, tool_calls=[_tool_call()]),
+            ReasoningMessage(id="m3", role="reasoning", content="checking the forecast"),
+            ToolMessage(id="m4", role="tool", content="rain", tool_call_id="call-1"),
+            UserMessage(id="m5", role="user", content="and tomorrow?"),
+        ]
+        await _drive(agent, messages)
+
+        assert _conversation(model, 0) == [
+            ("user", "weather in Oslo?"),
+            ("assistant", None),
+            ("tool", "rain"),
+            ("user", "and tomorrow?"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_the_first_result_for_a_call_is_the_one_forwarded(self):
+        """Two results for one call is malformed; the first is the one the model saw."""
+        model = RecordingModel()
+        agent = Agent(model=model)
+
+        messages = [
+            UserMessage(id="m1", role="user", content="weather in Oslo?"),
+            AssistantMessage(id="m2", role="assistant", content=None, tool_calls=[_tool_call()]),
+            ToolMessage(id="m3", role="tool", content="rain", tool_call_id="call-1"),
+            ToolMessage(id="m4", role="tool", content="snow", tool_call_id="call-1"),
+            UserMessage(id="m5", role="user", content="and tomorrow?"),
+        ]
+        await _drive(agent, messages)
+
+        assert [msg.content for msg in model.calls[0] if msg.role == "tool"] == ["rain"]
+
+    @pytest.mark.asyncio
+    async def test_failed_tool_result_keeps_its_error(self):
+        model = RecordingModel()
+        agent = Agent(model=model)
+
+        messages = [
+            UserMessage(id="m1", role="user", content="weather in Oslo?"),
+            AssistantMessage(id="m2", role="assistant", content=None, tool_calls=[_tool_call()]),
+            ToolMessage(id="m3", role="tool", content="partial", tool_call_id="call-1", error="upstream refused"),
+            UserMessage(id="m4", role="user", content="and tomorrow?"),
+        ]
+        await _drive(agent, messages)
+
+        forwarded_result = next(msg for msg in model.calls[0] if msg.role == "tool")
+        assert forwarded_result.content == "partial\nupstream refused"
+        assert forwarded_result.tool_call_error is True
+
+    @pytest.mark.asyncio
+    async def test_unanswered_tool_call_is_dropped(self):
+        """A tool call with no result would make providers reject the whole request."""
+        model = RecordingModel()
+        agent = Agent(model=model)
+
+        messages = [
+            UserMessage(id="m1", role="user", content="weather in Oslo?"),
+            AssistantMessage(id="m2", role="assistant", content="checking", tool_calls=[_tool_call()]),
+            UserMessage(id="m3", role="user", content="never mind"),
+        ]
+        await _drive(agent, messages)
+
+        assert _conversation(model, 0) == [
+            ("user", "weather in Oslo?"),
+            ("assistant", "checking"),
+            ("user", "never mind"),
+        ]
+        assert all(msg.tool_calls is None for msg in model.calls[0])
+
+    @pytest.mark.asyncio
+    async def test_contentless_assistant_turn_with_an_unanswered_call_is_dropped(self):
+        model = RecordingModel()
+        agent = Agent(model=model)
+
+        messages = [
+            UserMessage(id="m1", role="user", content="weather in Oslo?"),
+            AssistantMessage(id="m2", role="assistant", content="", tool_calls=[_tool_call()]),
+            UserMessage(id="m3", role="user", content="never mind"),
+        ]
+        await _drive(agent, messages)
+
+        assert _conversation(model, 0) == [
+            ("user", "weather in Oslo?"),
+            ("user", "never mind"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_tool_result_without_a_preceding_call_is_dropped(self):
+        """A result that arrives before its call, or twice, is rejected by providers."""
+        model = RecordingModel()
+        agent = Agent(model=model)
+
+        messages = [
+            UserMessage(id="m1", role="user", content="weather in Oslo?"),
+            ToolMessage(id="m2", role="tool", content="rain", tool_call_id="call-1"),
+            AssistantMessage(id="m3", role="assistant", content=None, tool_calls=[_tool_call()]),
+            ToolMessage(id="m4", role="tool", content="rain", tool_call_id="call-1"),
+            AssistantMessage(id="m5", role="assistant", content="It rains"),
+            UserMessage(id="m6", role="user", content="and tomorrow?"),
+        ]
+        await _drive(agent, messages)
+
+        assert _conversation(model, 0) == [
+            ("user", "weather in Oslo?"),
+            ("assistant", None),
+            ("tool", "rain"),
+            ("assistant", "It rains"),
+            ("user", "and tomorrow?"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_default_agent_forwards_more_than_three_turns(self):
+        """num_history_runs defaults to 3. It windows a session, not the client
+        transcript, and applying it here would drop conversation on every default agent."""
+        model = RecordingModel()
+        agent = Agent(model=model)
+        assert agent.num_history_runs == 3
+
+        await _drive(agent, _long_transcript())
+
+        assert _conversation(model, 0) == [
+            ("user", "one"),
+            ("assistant", "two"),
+            ("user", "three"),
+            ("assistant", "four"),
+            ("user", "five"),
+            ("assistant", "six"),
+            ("user", "seven"),
+            ("assistant", "eight"),
+            ("user", "nine"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_history_windows_do_not_clip_the_transcript(self):
+        model = RecordingModel()
+        agent = Agent(model=model, num_history_messages=1)
+
+        await _drive(agent, _long_transcript())
+
+        assert _conversation(model, 0) == [
+            ("user", "one"),
+            ("assistant", "two"),
+            ("user", "three"),
+            ("assistant", "four"),
+            ("user", "five"),
+            ("assistant", "six"),
+            ("user", "seven"),
+            ("assistant", "eight"),
+            ("user", "nine"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_a_reply_after_the_current_turn_is_not_replayed(self):
+        """A transcript ending on an assistant reply asks the newest user message again;
+        the reply it already got is not history."""
+        model = RecordingModel()
+        agent = Agent(model=model)
+
+        messages = _turn_2() + [AssistantMessage(id="m4", role="assistant", content="You are Ada")]
+        await _drive(agent, messages)
+
+        assert _conversation(model, 0) == [
+            ("user", "my name is Ada"),
+            ("assistant", "Hello Ada"),
+            ("user", "what is my name?"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_repeated_requests_leave_the_shared_entity_as_it_was(self):
+        """The run mutates the object it runs: it registers connectable tools, clears the
+        register afterwards, and assigns the entity an id. None of that may land on, or
+        leak out of, the entity every other request shares."""
+        model = RecordingModel()
+        tool = ConnectionCountingTool()
+        agent = Agent(name="Chat", model=model, tools=[tool])
+
+        await _drive(agent, _turn_2(), "run-1")
+        await _drive(agent, _turn_2(), "run-2")
+        await _drive(agent, _turn_2(), "run-3")
+
+        # Each forwarding request connects and closes its own copy of the toolkit, so the
+        # shared one is left untouched. A copy that shared the register would connect the
+        # shared toolkit once and then close it on every run.
+        assert (tool.connects, tool.closes) == (0, 0)
+
+        # The control: with nothing to forward there is no copy, and the shared toolkit is
+        # the one connected and closed, which is what makes the zeros above meaningful.
+        await _drive(agent, _turn_1(), "run-4")
+        assert (tool.connects, tool.closes) == (1, 1)
+        assert agent._connectable_tools_initialized_on_run == []
+        # The identity is settled on the shared entity, not invented per request.
+        assert agent.id == "chat"
+        assert agent.additional_input is None
+
+    @pytest.mark.asyncio
+    async def test_concurrent_requests_do_not_see_each_other_history(self):
+        model = RecordingModel()
+        agent = Agent(model=model)
+
+        ada = _turn_2()
+        grace = [
+            UserMessage(id="g1", role="user", content="my name is Grace"),
+            AssistantMessage(id="g2", role="assistant", content="Hello Grace"),
+            UserMessage(id="g3", role="user", content="who am I?"),
+        ]
+        await asyncio.gather(_drive(agent, ada, "run-ada"), _drive(agent, grace, "run-grace"))
+
+        conversations = sorted(_conversation(model, index) for index in (0, 1))
+        assert conversations == sorted(
+            [
+                [("user", "my name is Ada"), ("assistant", "Hello Ada"), ("user", "what is my name?")],
+                [("user", "my name is Grace"), ("assistant", "Hello Grace"), ("user", "who am I?")],
+            ]
+        )
+
+    @pytest.mark.asyncio
+    async def test_media_the_interface_cannot_decode_does_not_become_the_turn(self):
+        """A part that decodes to nothing leaves the message empty, and an empty message
+        must not take the turn from the question the user actually asked."""
+        model = RecordingModel()
+        agent = Agent(model=model)
+
+        messages = _turn_1() + [
+            AssistantMessage(id="m2", role="assistant", content="Hello Ada"),
+            UserMessage(
+                id="m3",
+                role="user",
+                content=[ImageInputContent(source=InputContentUrlSource(value="", mime_type="image/png"))],
+            ),
+        ]
+        await _drive(agent, messages)
+
+        assert _conversation(model, 0) == [("user", "my name is Ada")]
+
+    @pytest.mark.asyncio
+    async def test_whitespace_is_not_a_question(self):
+        model = RecordingModel()
+        agent = Agent(model=model)
+
+        messages = _turn_2() + [UserMessage(id="m4", role="user", content="   ")]
+        await _drive(agent, messages)
+
+        assert _conversation(model, 0)[-1] == ("user", "what is my name?")
+
+    @pytest.mark.asyncio
+    async def test_empty_text_parts_do_not_pad_the_prompt(self):
+        model = RecordingModel()
+        agent = Agent(model=model)
+
+        messages = [
+            UserMessage(
+                id="m1",
+                role="user",
+                content=[TextInputContent(text=""), TextInputContent(text="what is my name?")],
+            )
+        ]
+        await _drive(agent, messages)
+
+        assert _conversation(model, 0) == [("user", "what is my name?")]
+
+    @pytest.mark.asyncio
+    async def test_shared_entity_is_not_mutated(self):
+        model = RecordingModel()
+        agent = Agent(model=model, additional_input=[{"role": "user", "content": "few-shot"}])
+
+        await _two_turns(agent, model)
+
+        assert agent.additional_input == [{"role": "user", "content": "few-shot"}]
+        assert _conversation(model, 1) == [
+            ("user", "few-shot"),
+            ("user", "my name is Ada"),
+            ("assistant", "Hello Ada"),
+            ("user", "what is my name?"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_dependencies_still_reach_the_current_turn(self):
+        """Forwarding history must not cost the AG-UI context injection."""
+        model = RecordingModel()
+        agent = Agent(model=model)
+
+        await _drive(agent, _turn_2(), context=[Context(description="city", value="Oslo")])
+
+        current_turn = model.calls[0][-1]
+        assert current_turn.role == "user"
+        assert current_turn.content.startswith("what is my name?")
+        assert "Oslo" in current_turn.content
+
+
+def _long_transcript() -> List[Any]:
+    """Four completed turns plus the current one: more than any default history window."""
+    words = ["one", "two", "three", "four", "five", "six", "seven", "eight", "nine"]
+    return [
+        UserMessage(id=f"m{index}", role="user", content=word)
+        if index % 2 == 0
+        else AssistantMessage(id=f"m{index}", role="assistant", content=word)
+        for index, word in enumerate(words)
+    ]
+
+
+class TestAgentWithDatabase:
+    @pytest.mark.asyncio
+    async def test_history_comes_from_the_session_without_duplication(self):
+        model = RecordingModel()
+        agent = Agent(model=model, db=InMemoryDb(), add_history_to_context=True)
+
+        await _two_turns(agent, model)
+
+        assert _conversation(model, 0) == [("user", "my name is Ada")]
+        assert _conversation(model, 1) == [
+            ("user", "my name is Ada"),
+            ("assistant", "ok"),
+            ("user", "what is my name?"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_transcript_is_not_forwarded_when_the_agent_opts_out_of_history(self):
+        """With a database the agent owns the history decision; the interface stays out of it."""
+        model = RecordingModel()
+        agent = Agent(model=model, db=InMemoryDb())
+
+        await _two_turns(agent, model)
+
+        assert _conversation(model, 1) == [("user", "what is my name?")]
+
+
+class TestAgentWithACachedSession:
+    """An in-process cached session is not a substitute for a database here.
+
+    It lives and dies with the worker, so it cannot be the source of a conversation that
+    may arrive at any worker. The transcript is, and the run is told not to add history of
+    its own so the cache cannot arrive on top of it.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_warm_cache_is_not_read_even_on_a_single_turn(self):
+        """The cache outlives a request and belongs to whoever ran this thread on this
+        worker first, so a request that brings no history of its own gets none."""
+        model = RecordingModel()
+        agent = Agent(model=model, cache_session=True, add_history_to_context=True)
+
+        async for _ in agent.arun(
+            input="a conversation this client never saw",
+            session_id="thread-1",
+            stream=True,
+            stream_events=True,
+        ):
+            pass
+        await _drive(agent, _turn_1())
+
+        assert _conversation(model, 1) == [("user", "my name is Ada")]
+
+    @pytest.mark.asyncio
+    async def test_a_cached_session_is_not_replayed_on_top_of_the_transcript(self):
+        model = RecordingModel()
+        agent = Agent(model=model, cache_session=True, add_history_to_context=True)
+
+        await _two_turns(agent, model)
+
+        assert _conversation(model, 1) == [
+            ("user", "my name is Ada"),
+            ("assistant", "Hello Ada"),
+            ("user", "what is my name?"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_three_turns_stay_one_conversation(self):
+        model = RecordingModel()
+        agent = Agent(model=model, cache_session=True, add_history_to_context=True)
+
+        turn_3 = _turn_2() + [
+            AssistantMessage(id="m4", role="assistant", content="You are Ada"),
+            UserMessage(id="m5", role="user", content="and my name again?"),
+        ]
+        await _drive(agent, _turn_1(), "run-1")
+        await _drive(agent, _turn_2(), "run-2")
+        await _drive(agent, turn_3, "run-3")
+
+        assert _conversation(model, 2) == [
+            ("user", "my name is Ada"),
+            ("assistant", "Hello Ada"),
+            ("user", "what is my name?"),
+            ("assistant", "You are Ada"),
+            ("user", "and my name again?"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_a_user_switch_on_one_thread_keeps_the_transcript(self):
+        """The transcript belongs to the request, not to whoever ran the thread before."""
+        model = RecordingModel()
+        agent = Agent(model=model, cache_session=True, add_history_to_context=True)
+
+        await _drive(agent, _turn_1(), "run-1", user_id="ada")
+        await _drive(agent, _turn_2(), "run-2", user_id="grace")
+
+        assert _conversation(model, 1) == [
+            ("user", "my name is Ada"),
+            ("assistant", "Hello Ada"),
+            ("user", "what is my name?"),
+        ]
+
+
+class TestTeamWithoutDatabase:
+    @pytest.mark.asyncio
+    async def test_second_turn_sees_the_client_transcript(self):
+        leader_model = RecordingModel()
+        member = Agent(name="Member", model=RecordingModel())
+        team = Team(model=leader_model, members=[member])
+
+        await _two_turns(team, leader_model)
+
+        assert _conversation(leader_model, 0) == [("user", "my name is Ada")]
+        assert _conversation(leader_model, 1) == [
+            ("user", "my name is Ada"),
+            ("assistant", "Hello Ada"),
+            ("user", "what is my name?"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_member_identities_are_settled_once_not_per_request(self):
+        """A member with no name is given a random id. Letting each request's copy mint
+        its own would give one member a different id on every turn."""
+        leader_model = RecordingModel()
+        team = Team(model=leader_model, members=[Agent(model=RecordingModel())])
+
+        await _drive(team, _turn_2(), "run-1")
+        first = team.members[0].id
+        await _drive(team, _turn_2(), "run-2")
+
+        assert first is not None
+        assert team.members[0].id == first
+
+    @pytest.mark.asyncio
+    async def test_a_members_factory_is_not_a_list_of_members(self):
+        """Team members can be a callable resolved per run. Walking it as a list raised."""
+        leader_model = RecordingModel()
+        team = Team(model=leader_model, members=lambda: [Agent(name="Member", model=RecordingModel())])
+
+        await _two_turns(team, leader_model)
+
+        assert _conversation(leader_model, 1) == [
+            ("user", "my name is Ada"),
+            ("assistant", "Hello Ada"),
+            ("user", "what is my name?"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_shared_team_is_not_mutated(self):
+        leader_model = RecordingModel()
+        team = Team(model=leader_model, members=[Agent(name="Member", model=RecordingModel())])
+
+        await _two_turns(team, leader_model)
+
+        assert team.additional_input is None
+
+
+class TestTeamWithDatabase:
+    @pytest.mark.asyncio
+    async def test_history_comes_from_the_session_without_duplication(self):
+        leader_model = RecordingModel()
+        team = Team(
+            model=leader_model,
+            members=[Agent(name="Member", model=RecordingModel())],
+            db=InMemoryDb(),
+            add_history_to_context=True,
+        )
+
+        await _two_turns(team, leader_model)
+
+        assert _conversation(leader_model, 0) == [("user", "my name is Ada")]
+        assert _conversation(leader_model, 1) == [
+            ("user", "my name is Ada"),
+            ("assistant", "ok"),
+            ("user", "what is my name?"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_transcript_is_not_forwarded_when_the_team_opts_out_of_history(self):
+        leader_model = RecordingModel()
+        team = Team(model=leader_model, members=[Agent(name="Member", model=RecordingModel())], db=InMemoryDb())
+
+        await _two_turns(team, leader_model)
+
+        assert _conversation(leader_model, 1) == [("user", "what is my name?")]

--- a/libs/agno/tests/unit/os/interfaces/test_agui_history_invariants.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_history_invariants.py
@@ -1,0 +1,537 @@
+"""Invariants the AG-UI history extraction holds for every transcript shape.
+
+The per-shape tests beside this file assert what a particular conversation should produce.
+These assert the properties that have to hold whatever the client sends, over a catalogue
+of shapes: history and the current turn partition the transcript, order survives, nothing
+is forwarded twice, and every forwarded tool call is answered exactly once.
+
+Each fixture gives its messages distinct keys, asserted below, so a forwarded message can
+be traced back to exactly one source message.
+"""
+
+from typing import Any, List, Optional, Tuple
+
+import pytest
+
+pytest.importorskip("ag_ui", reason="ag_ui not installed")
+
+import base64
+
+from ag_ui.core.types import (
+    ActivityMessage,
+    AssistantMessage,
+    BinaryInputContent,
+    DeveloperMessage,
+    FunctionCall,
+    ImageInputContent,
+    InputContentDataSource,
+    InputContentUrlSource,
+    ReasoningMessage,
+    SystemMessage,
+    TextInputContent,
+    ToolCall,
+    ToolMessage,
+    UserMessage,
+)
+
+from agno.agent.agent import Agent
+from agno.models.message import Message
+from agno.os.interfaces.agui.input import extract_media, extract_message_history, extract_user_input
+from agno.team.team import Team
+
+
+def _tool_call(call_id: str, name: str = "weather", arguments: str = "{}") -> ToolCall:
+    return ToolCall(id=call_id, type="function", function=FunctionCall(name=name, arguments=arguments))
+
+
+def _shapes() -> List[Tuple[str, List[Any]]]:
+    """Transcript shapes a client can send, named for the failure each one guards."""
+    return [
+        ("single turn", [UserMessage(id="a1", role="user", content="q1")]),
+        (
+            "two turns",
+            [
+                UserMessage(id="b1", role="user", content="q1"),
+                AssistantMessage(id="b2", role="assistant", content="r1"),
+                UserMessage(id="b3", role="user", content="q2"),
+            ],
+        ),
+        (
+            "ends on an assistant reply",
+            [
+                UserMessage(id="c1", role="user", content="q1"),
+                AssistantMessage(id="c2", role="assistant", content="r1"),
+                UserMessage(id="c3", role="user", content="q2"),
+                AssistantMessage(id="c4", role="assistant", content="r2"),
+            ],
+        ),
+        (
+            "opens on an assistant greeting",
+            [
+                AssistantMessage(id="d0", role="assistant", content="greeting"),
+                UserMessage(id="d1", role="user", content="q1"),
+                AssistantMessage(id="d2", role="assistant", content="r1"),
+                UserMessage(id="d3", role="user", content="q2"),
+            ],
+        ),
+        (
+            "system and developer prefix",
+            [
+                SystemMessage(id="e0", role="system", content="be a pirate"),
+                DeveloperMessage(id="e0b", role="developer", content="note"),
+                UserMessage(id="e1", role="user", content="q1"),
+                AssistantMessage(id="e2", role="assistant", content="r1"),
+                UserMessage(id="e3", role="user", content="q2"),
+            ],
+        ),
+        (
+            "current turn carries media only",
+            [
+                UserMessage(id="f1", role="user", content="q1"),
+                AssistantMessage(id="f2", role="assistant", content="r1"),
+                UserMessage(
+                    id="f3",
+                    role="user",
+                    content=[
+                        ImageInputContent(
+                            source=InputContentUrlSource(value="https://example.com/f.png", mime_type="image/png")
+                        )
+                    ],
+                ),
+            ],
+        ),
+        (
+            "earlier turn carries media and a caption",
+            [
+                UserMessage(
+                    id="g1",
+                    role="user",
+                    content=[
+                        TextInputContent(text="q1"),
+                        ImageInputContent(
+                            source=InputContentUrlSource(value="https://example.com/g.png", mime_type="image/png")
+                        ),
+                    ],
+                ),
+                AssistantMessage(id="g2", role="assistant", content="r1"),
+                UserMessage(id="g3", role="user", content="q2"),
+            ],
+        ),
+        (
+            "complete tool exchange",
+            [
+                UserMessage(id="h1", role="user", content="q1"),
+                AssistantMessage(id="h2", role="assistant", content=None, tool_calls=[_tool_call("h-call")]),
+                ToolMessage(id="h3", role="tool", content="result", tool_call_id="h-call"),
+                AssistantMessage(id="h4", role="assistant", content="r1"),
+                UserMessage(id="h5", role="user", content="q2"),
+            ],
+        ),
+        (
+            "unanswered tool call",
+            [
+                UserMessage(id="i1", role="user", content="q1"),
+                AssistantMessage(id="i2", role="assistant", content="r1", tool_calls=[_tool_call("i-call")]),
+                UserMessage(id="i3", role="user", content="q2"),
+            ],
+        ),
+        (
+            "tool result before its call",
+            [
+                UserMessage(id="j1", role="user", content="q1"),
+                ToolMessage(id="j2", role="tool", content="early", tool_call_id="j-call"),
+                AssistantMessage(id="j3", role="assistant", content=None, tool_calls=[_tool_call("j-call")]),
+                ToolMessage(id="j4", role="tool", content="result", tool_call_id="j-call"),
+                UserMessage(id="j5", role="user", content="q2"),
+            ],
+        ),
+        (
+            "call id reused across two assistant messages",
+            [
+                UserMessage(id="k1", role="user", content="q1"),
+                AssistantMessage(id="k2", role="assistant", content=None, tool_calls=[_tool_call("k-call")]),
+                ToolMessage(id="k3", role="tool", content="result", tool_call_id="k-call"),
+                AssistantMessage(id="k4", role="assistant", content="r1", tool_calls=[_tool_call("k-call")]),
+                UserMessage(id="k5", role="user", content="q2"),
+            ],
+        ),
+        (
+            "call id repeated inside one assistant message",
+            [
+                UserMessage(id="l1", role="user", content="q1"),
+                AssistantMessage(
+                    id="l2",
+                    role="assistant",
+                    content=None,
+                    tool_calls=[_tool_call("l-call"), _tool_call("l-call")],
+                ),
+                ToolMessage(id="l3", role="tool", content="result", tool_call_id="l-call"),
+                UserMessage(id="l4", role="user", content="q2"),
+            ],
+        ),
+        (
+            "empty and activity messages",
+            [
+                UserMessage(id="m1", role="user", content=""),
+                ActivityMessage(id="m2", role="activity", activity_type="progress", content={"step": 1}),
+                AssistantMessage(id="m3", role="assistant", content=""),
+                UserMessage(id="m4", role="user", content="q1"),
+                AssistantMessage(id="m5", role="assistant", content="r1"),
+                UserMessage(id="m6", role="user", content="q2"),
+            ],
+        ),
+        ("no user message at all", [AssistantMessage(id="n1", role="assistant", content="r1")]),
+        ("empty transcript", []),
+        (
+            "newest user message is empty",
+            [
+                UserMessage(id="o1", role="user", content="q1"),
+                AssistantMessage(id="o2", role="assistant", content="r1"),
+                UserMessage(id="o3", role="user", content="q2"),
+                UserMessage(id="o4", role="user", content=""),
+            ],
+        ),
+        (
+            "tool result carries nothing",
+            [
+                UserMessage(id="p1", role="user", content="q1"),
+                AssistantMessage(id="p2", role="assistant", content=None, tool_calls=[_tool_call("p-call")]),
+                ToolMessage(id="p3", role="tool", content="", tool_call_id="p-call"),
+                UserMessage(id="p4", role="user", content="q2"),
+            ],
+        ),
+        (
+            "two calls then two results",
+            [
+                UserMessage(id="q1", role="user", content="q1"),
+                AssistantMessage(id="q2", role="assistant", content="calling a", tool_calls=[_tool_call("q-a")]),
+                AssistantMessage(id="q3", role="assistant", content="calling b", tool_calls=[_tool_call("q-b")]),
+                ToolMessage(id="q4", role="tool", content="ra", tool_call_id="q-a"),
+                ToolMessage(id="q5", role="tool", content="rb", tool_call_id="q-b"),
+                UserMessage(id="q6", role="user", content="q2"),
+            ],
+        ),
+        (
+            "dropped opening turn reuses a call id",
+            [
+                AssistantMessage(
+                    id="r1", role="assistant", content="calling alpha", tool_calls=[_tool_call("r-call", "alpha")]
+                ),
+                ToolMessage(id="r2", role="tool", content="ra", tool_call_id="r-call"),
+                UserMessage(id="r3", role="user", content="q1"),
+                AssistantMessage(
+                    id="r4", role="assistant", content="calling beta", tool_calls=[_tool_call("r-call", "beta")]
+                ),
+                ToolMessage(id="r5", role="tool", content="rb", tool_call_id="r-call"),
+                UserMessage(id="r6", role="user", content="q2"),
+            ],
+        ),
+        (
+            "call id answered twice in two blocks",
+            [
+                UserMessage(id="u1", role="user", content="q1"),
+                AssistantMessage(id="u2", role="assistant", content="calling once", tool_calls=[_tool_call("u-call")]),
+                ToolMessage(id="u3", role="tool", content="ra", tool_call_id="u-call"),
+                AssistantMessage(id="u4", role="assistant", content="calling twice", tool_calls=[_tool_call("u-call")]),
+                ToolMessage(id="u5", role="tool", content="rb", tool_call_id="u-call"),
+                UserMessage(id="u6", role="user", content="q2"),
+            ],
+        ),
+        (
+            "two results for one call id, adjacent",
+            [
+                UserMessage(id="v1", role="user", content="q1"),
+                AssistantMessage(id="v2", role="assistant", content=None, tool_calls=[_tool_call("v-call")]),
+                ToolMessage(id="v3", role="tool", content="first", tool_call_id="v-call"),
+                ToolMessage(id="v4", role="tool", content="second", tool_call_id="v-call"),
+                UserMessage(id="v5", role="user", content="q2"),
+            ],
+        ),
+        (
+            "inline media the interface has to decode",
+            [
+                UserMessage(
+                    id="w1",
+                    role="user",
+                    content=[
+                        TextInputContent(text="q1"),
+                        ImageInputContent(
+                            source=InputContentDataSource(
+                                value=base64.b64encode(b"inline-image-bytes").decode(), mime_type="image/png"
+                            )
+                        ),
+                    ],
+                ),
+                AssistantMessage(id="w2", role="assistant", content="r1"),
+                UserMessage(
+                    id="w3",
+                    role="user",
+                    content=[BinaryInputContent(mime_type="image/jpeg", data=base64.b64encode(b"binary").decode())],
+                ),
+                UserMessage(id="w4", role="user", content="q2"),
+            ],
+        ),
+        (
+            "reasoning message inside a tool block",
+            [
+                UserMessage(id="x1", role="user", content="q1"),
+                AssistantMessage(id="x2", role="assistant", content=None, tool_calls=[_tool_call("x-call")]),
+                ReasoningMessage(id="x3", role="reasoning", content="thinking"),
+                ToolMessage(id="x4", role="tool", content="rx", tool_call_id="x-call"),
+                UserMessage(id="x5", role="user", content="q2"),
+            ],
+        ),
+        (
+            "newest user message carries only a deprecated binary part",
+            [
+                UserMessage(id="y1", role="user", content="q1"),
+                AssistantMessage(id="y2", role="assistant", content="r1"),
+                UserMessage(
+                    id="y3",
+                    role="user",
+                    content=[BinaryInputContent(mime_type="image/png", data=base64.b64encode(b"newest").decode())],
+                ),
+            ],
+        ),
+        (
+            "reasoning message between turns",
+            [
+                UserMessage(id="s1", role="user", content="q1"),
+                ReasoningMessage(id="s2", role="reasoning", content="thinking"),
+                AssistantMessage(id="s3", role="assistant", content="r1"),
+                UserMessage(id="s4", role="user", content="q2"),
+            ],
+        ),
+        (
+            "trailing tool results with no call",
+            [
+                UserMessage(id="t1", role="user", content="q1"),
+                UserMessage(id="t2", role="user", content="q2"),
+                ToolMessage(id="t3", role="tool", content="orphan", tool_call_id="t-call"),
+            ],
+        ),
+    ]
+
+
+SHAPES = _shapes()
+SHAPE_IDS = [name for name, _ in SHAPES]
+
+
+def _turn_index(messages: List[Any]) -> Optional[int]:
+    """The turn the request asks about, derived from the protocol rather than the code
+    under test: the newest user message that carries text or media."""
+    fallback = None
+    for index in range(len(messages) - 1, -1, -1):
+        msg = messages[index]
+        if msg.role != "user":
+            continue
+        if _text_of(msg) or _media_parts(msg):
+            return index
+        if fallback is None:
+            fallback = index
+    return fallback
+
+
+def _text_of(msg: Any) -> str:
+    if isinstance(msg.content, str):
+        return msg.content
+    if isinstance(msg.content, list):
+        return "\n".join(part.text for part in msg.content if getattr(part, "type", None) == "text")
+    return ""
+
+
+def _media_parts(msg: Any) -> List[Any]:
+    if not isinstance(msg.content, list):
+        return []
+    media_types = ("binary", "image", "audio", "video", "document")
+    return [part for part in msg.content if getattr(part, "type", None) in media_types]
+
+
+def _source_keys(messages: List[Any]) -> List[Optional[Tuple[str, str]]]:
+    return [_source_key(msg) for msg in messages]
+
+
+def _source_key(msg: Any) -> Optional[Tuple[str, ...]]:
+    """How a client message would look once forwarded, or None if it never can be."""
+    if msg.role == "user":
+        return ("user", _text_of(msg))
+    if msg.role == "assistant":
+        return ("assistant", msg.content or "")
+    if msg.role == "tool":
+        # The content of a result distinguishes two results for one call id. The join with
+        # an error is the interface's rule, pinned on its own by the failed-tool test.
+        return ("tool", msg.tool_call_id, "\n".join(part for part in (msg.content, msg.error) if part))
+    return None
+
+
+def _forwarded_key(msg: Message) -> Tuple[str, ...]:
+    if msg.role == "tool":
+        return ("tool", msg.tool_call_id or "", msg.content or "")
+    return (msg.role, msg.content or "")
+
+
+@pytest.mark.parametrize("messages", [messages for _, messages in SHAPES], ids=SHAPE_IDS)
+class TestHistoryInvariants:
+    def test_history_is_the_transcript_before_the_current_turn_in_order(self, messages):
+        """Every forwarded message traces back to one distinct client message that
+        precedes the current turn, and the order they arrived in survives."""
+        history = extract_message_history(messages)
+        source_keys = _source_keys(messages)
+        turn = _turn_index(messages)
+        boundary = len(messages) if turn is None else turn
+
+        matched: List[int] = []
+        cursor = 0
+        for forwarded in history:
+            key = _forwarded_key(forwarded)
+            while cursor < len(source_keys) and source_keys[cursor] != key:
+                cursor += 1
+            assert cursor < len(source_keys), (
+                f"forwarded {key} matches no remaining client message, so history reorders, "
+                f"repeats or invents a message"
+            )
+            matched.append(cursor)
+            cursor += 1
+
+        assert all(index < boundary for index in matched), (
+            f"history reaches the current turn or past it: matched {matched}, boundary {boundary}"
+        )
+
+    def test_every_earlier_user_message_that_said_something_is_forwarded(self, messages):
+        """The complement of the ordering invariant: history drops nothing it should keep."""
+        turn = _turn_index(messages)
+        boundary = len(messages) if turn is None else turn
+        expected = [
+            _source_key(msg)
+            for index, msg in enumerate(messages[:boundary])
+            if msg.role == "user" and (_text_of(msg) or _media_parts(msg))
+        ]
+        # An opening user message can only be dropped with the whole opening block, which
+        # cannot happen: a user message opens history legally.
+        forwarded = [_forwarded_key(msg) for msg in extract_message_history(messages) if msg.role == "user"]
+        assert forwarded == expected
+
+    def test_history_opens_on_a_user_message(self, messages):
+        """Providers reject a conversation whose first message is not from the user."""
+        history = extract_message_history(messages)
+        if history:
+            assert history[0].role == "user"
+
+    def test_every_forwarded_call_is_answered_in_its_own_block(self, messages):
+        """Providers accept a call and its result adjacent, and reject either half alone."""
+        history = extract_message_history(messages)
+
+        pending: List[str] = []
+        for msg in history:
+            if msg.role == "tool":
+                assert pending, "a result was forwarded outside any call block"
+                assert msg.tool_call_id == pending.pop(0), "a result was forwarded out of its call's order"
+                continue
+            assert not pending, f"a call block was interrupted before its results: {pending}"
+            pending = [tool_call["id"] for tool_call in msg.tool_calls or []]
+
+        assert not pending, f"a forwarded call was left unanswered: {pending}"
+
+    def test_no_call_id_is_forwarded_twice(self, messages):
+        history = extract_message_history(messages)
+        called = [tool_call["id"] for msg in history for tool_call in msg.tool_calls or []]
+        assert len(called) == len(set(called))
+
+    def test_a_forwarded_result_names_the_tool_its_own_call_named(self, messages):
+        history = extract_message_history(messages)
+        names = {}
+        for msg in history:
+            for tool_call in msg.tool_calls or []:
+                names[tool_call["id"]] = tool_call["function"]["name"]
+            if msg.role == "tool":
+                assert msg.tool_name == names.get(msg.tool_call_id)
+
+    def test_forwarded_messages_carry_something_for_the_model(self, messages):
+        for msg in extract_message_history(messages):
+            assert msg.content or msg.tool_calls or msg.images or msg.audio or msg.videos or msg.files
+
+    def test_the_current_turn_is_the_newest_user_message_that_said_something(self, messages):
+        turn = _turn_index(messages)
+        assert extract_user_input(messages) == ("" if turn is None else _text_of(messages[turn]))
+
+        images, audio, videos, files = extract_media(messages)
+        expected_media = [] if turn is None else _media_parts(messages[turn])
+        assert len(images) + len(audio) + len(videos) + len(files) == len(expected_media)
+
+
+def test_a_stateless_resume_request_tells_the_client_what_is_missing():
+    """The cookbook quotes this text; a client sees it as the stream's RUN_ERROR."""
+    import asyncio
+
+    from ag_ui.core import EventType, RunAgentInput
+
+    from agno.os.interfaces.agui.router import run_entity
+
+    agent = Agent(name="Stateless", model=None)
+    run_input = RunAgentInput(
+        thread_id="thread-1",
+        run_id="run-1",
+        messages=[
+            UserMessage(id="u1", role="user", content="q1"),
+            AssistantMessage(id="a1", role="assistant", content=None, tool_calls=[_tool_call("call-1")]),
+            ToolMessage(id="t1", role="tool", content="done", tool_call_id="call-1"),
+        ],
+        state=None,
+        context=[],
+        tools=[],
+        forwarded_props={},
+    )
+
+    async def collect():
+        return [event async for event in run_entity(agent, run_input)]
+
+    events = asyncio.run(collect())
+    errors = [event for event in events if event.type == EventType.RUN_ERROR]
+    assert [event.message for event in errors] == ["Frontend tool resume requires a database"]
+
+
+def test_a_remote_resume_request_tells_the_client_what_is_missing():
+    """The cookbook quotes this text too, for the entity kind that can never resume here."""
+    import asyncio
+    from unittest.mock import MagicMock
+
+    from ag_ui.core import EventType, RunAgentInput
+
+    from agno.agent.remote import RemoteAgent
+    from agno.os.interfaces.agui.router import run_entity
+
+    remote_agent = RemoteAgent(base_url="http://fake-host", agent_id="remote-agent")
+    remote_agent.agentos_client = MagicMock()
+    run_input = RunAgentInput(
+        thread_id="thread-1",
+        run_id="run-1",
+        messages=[
+            UserMessage(id="u1", role="user", content="q1"),
+            AssistantMessage(id="a1", role="assistant", content=None, tool_calls=[_tool_call("call-1")]),
+            ToolMessage(id="t1", role="tool", content="done", tool_call_id="call-1"),
+        ],
+        state=None,
+        context=[],
+        tools=[],
+        forwarded_props={},
+    )
+
+    async def collect():
+        return [event async for event in run_entity(remote_agent, run_input)]
+
+    events = asyncio.run(collect())
+    errors = [event for event in events if event.type == EventType.RUN_ERROR]
+    assert [event.message for event in errors] == ["Frontend tool resume requires a local Agent or Team"]
+
+
+def test_every_shape_keys_its_messages_distinctly():
+    """The tracing above is only exact while no two messages in a shape look alike."""
+    for name, messages in SHAPES:
+        keys = [key for key in _source_keys(messages) if key is not None]
+        assert len(keys) == len(set(keys)), f"shape {name!r} repeats a message key: {keys}"
+
+
+def test_the_history_window_default_the_documentation_rests_on():
+    """The forwarding path documents why it ignores this; that rests on the default being set."""
+    assert Agent().num_history_runs == 3
+    assert Team(members=[Agent(name="Member")]).num_history_runs == 3

--- a/libs/agno/tests/unit/os/interfaces/test_agui_router.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_router.py
@@ -6,6 +6,7 @@ import pytest
 pytest.importorskip("ag_ui", reason="ag_ui not installed")
 
 from ag_ui.core import EventType
+from ag_ui.core.types import AssistantMessage, DeveloperMessage, SystemMessage, UserMessage
 from ag_ui.core.types import Tool as AGUITool
 
 from agno.agent.remote import RemoteAgent
@@ -27,13 +28,32 @@ class FakeRunInput:
 class CaptureKwargsEntity:
     def __init__(self):
         self.captured_kwargs = {}
-        self.dependencies = None
         self.arun_called = False
-        self.acontinue_run_called = False
+        self.additional_input = None
+        self.id = None
+        self.calls = []
+
+    def set_id(self) -> None:
+        self.id = self.id or "capture-entity"
+
+    def deep_copy(self, *, update=None):
+        copy = CaptureKwargsEntity()
+        copy.__dict__.update(self.__dict__)
+        copy.__dict__.update(update or {})
+        # The record is shared so the test reads what the copy was actually run with.
+        copy.captured_kwargs = self.captured_kwargs
+        copy.calls = self.calls
+        return copy
+
+    def forwarded_input(self):
+        """The additional input the entity the run reached was carrying."""
+        entity = self.calls[-1] if self.calls else self
+        return [(msg.role, msg.content) for msg in entity.additional_input or []]
 
     async def arun(self, **kwargs):
-        self.captured_kwargs = kwargs
+        self.captured_kwargs.update(kwargs)
         self.arun_called = True
+        self.calls.append(self)
         return
         yield
 
@@ -218,3 +238,97 @@ async def test_run_entity_remote_agent_warns_and_drops_client_tools(caplog):
     assert "run_context" not in captured
     assert any("client tools are not forwarded" in record.message for record in caplog.records)
     assert events[-1].type == EventType.RUN_FINISHED
+
+
+def _remote_agent(captured: dict):
+    """A RemoteAgent wired to a recording stream instead of a real AgentOS."""
+    remote_agent = RemoteAgent(base_url="http://fake-host", agent_id="remote-agent")
+    remote_agent.agentos_client = MagicMock(run_agent_stream=capturing_wire_stream(captured))
+    return remote_agent
+
+
+def _two_turns():
+    """Real AG-UI messages: a MagicMock would not notice a renamed protocol field."""
+    return [
+        UserMessage(id="m1", role="user", content="my name is Ada"),
+        AssistantMessage(id="m2", role="assistant", content="Hello Ada"),
+        UserMessage(id="m3", role="user", content="what is my name?"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_remote_entity_warns_that_history_is_not_forwarded(caplog):
+    """A remote run route takes a single message, so the transcript cannot travel with it."""
+    captured: dict = {}
+    remote_agent = _remote_agent(captured)
+
+    with caplog.at_level(logging.WARNING):
+        events = [event async for event in run_entity(remote_agent, FakeRunInput(messages=_two_turns()))]
+
+    assert any("history is not forwarded" in record.message for record in caplog.records)
+    assert captured["message"] == "what is my name?"
+    assert "additional_input" not in captured
+    assert events[-1].type == EventType.RUN_FINISHED
+
+
+@pytest.mark.asyncio
+async def test_remote_team_warns_that_history_is_not_forwarded(caplog):
+    captured: dict = {}
+    remote_team = RemoteTeam(base_url="http://fake-host", team_id="remote-team")
+    remote_team.agentos_client = MagicMock(run_team_stream=capturing_wire_stream(captured))
+
+    with caplog.at_level(logging.WARNING):
+        events = [event async for event in run_entity(remote_team, FakeRunInput(messages=_two_turns()))]
+
+    assert any("history is not forwarded" in record.message for record in caplog.records)
+    assert "additional_input" not in captured
+    assert events[-1].type == EventType.RUN_FINISHED
+
+
+@pytest.mark.asyncio
+async def test_remote_entity_first_turn_does_not_warn(caplog):
+    """Client system and developer messages are not a conversation.
+
+    The client-tools warning is the positive control: it proves the assertion below is
+    reading live log output rather than passing on an empty record list.
+    """
+    captured: dict = {}
+    remote_agent = _remote_agent(captured)
+    messages = [
+        SystemMessage(id="s1", role="system", content="You are a pirate."),
+        DeveloperMessage(id="d1", role="developer", content="internal note"),
+        UserMessage(id="m1", role="user", content="my name is Ada"),
+    ]
+    run_input = FakeRunInput(messages=messages, tools=[AGUITool(name="noop", description="does nothing")])
+
+    with caplog.at_level(logging.WARNING):
+        events = [event async for event in run_entity(remote_agent, run_input)]
+
+    assert any("client tools are not forwarded" in record.message for record in caplog.records)
+    assert not any("history is not forwarded" in record.message for record in caplog.records)
+    assert events[-1].type == EventType.RUN_FINISHED
+
+
+@pytest.mark.asyncio
+async def test_a_forwarded_run_carries_the_transcript_and_reads_no_session():
+    """Forwarding the transcript and reading a session would both feed the same run."""
+    entity = CaptureKwargsEntity()
+
+    async for _ in run_entity(entity, FakeRunInput(messages=_two_turns())):
+        pass
+
+    assert entity.captured_kwargs["add_history_to_context"] is False
+    assert entity.forwarded_input() == [("user", "my name is Ada"), ("assistant", "Hello Ada")]
+    assert entity.captured_kwargs["input"] == "what is my name?"
+
+
+@pytest.mark.asyncio
+async def test_a_first_turn_reads_no_session_either():
+    """A worker-local cached session belongs to whoever ran this thread on it first."""
+    entity = CaptureKwargsEntity()
+
+    async for _ in run_entity(entity, FakeRunInput(messages=[UserMessage(id="m1", role="user", content="q1")])):
+        pass
+
+    assert entity.captured_kwargs["add_history_to_context"] is False
+    assert entity.forwarded_input() == []


### PR DESCRIPTION
## Summary

AG-UI clients resend the whole conversation every request, but the interface only
passed the newest user message and read the rest from the session store. An Agent
or Team with no database has no session store, so every earlier turn was dropped
silently.

Now it uses whichever source the entity has. With a database, nothing changes.
With none, the request's transcript is forwarded as additional input and that run
adds no history of its own, so nothing arrives twice. Remote entities are
unchanged, and now log when they cannot receive the history a request carries.

It rides on `additional_input` rather than being passed as a list-of-messages
input, so the current turn still goes through Agno's normal user-message
construction: knowledge references, dependency injection and media stay intact,
and the stored input content stays the plain user string.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)
