### PR TITLE
[fix] Preserve HITL pauses from custom function workflow steps

### DIFF
--- a/libs/agno/agno/workflow/step.py
+++ b/libs/agno/agno/workflow/step.py
@@ -104,6 +104,8 @@ StepExecutor = Callable[
     [StepInput],
     Union[
         StepOutput,
+        RunOutput,
+        TeamRunOutput,
         Iterator[StepOutput],
         Iterator[Any],
         Awaitable[StepOutput],
@@ -132,6 +134,32 @@ class UnresolvableCallableError(RuntimeError):
     Container evaluators that tolerate ordinary callable failures re-raise
     this one: running with the reference missing is not a recoverable error.
     """
+
+
+class MissingHitlExecutorError(ValueError):
+    """Raised when a custom function returns a paused response without hitl_executor configured."""
+
+
+class MissingHitlExecutorResponseError(ValueError):
+    """Raised when a custom function returns a paused StepOutput without a recoverable RunOutput/TeamRunOutput."""
+
+
+class HitlExecutorMismatchError(ValueError):
+    """Raised when the configured hitl_executor ID does not match the returned response."""
+
+
+class HitlExecutorTypeMismatchError(TypeError):
+    """Raised when the configured hitl_executor type does not match the returned response."""
+
+
+_FATAL_STEP_EXCEPTIONS = (
+    RunCancelledException,
+    UnresolvableCallableError,
+    MissingHitlExecutorError,
+    MissingHitlExecutorResponseError,
+    HitlExecutorMismatchError,
+    HitlExecutorTypeMismatchError,
+)
 
 
 def _unresolvable_callable_placeholder(kind: str, ref: str) -> Callable[..., Any]:
@@ -188,6 +216,11 @@ class Step:
     team: Optional[Team] = None
     executor: Optional[StepExecutor] = None
     workflow: Optional["Workflow"] = None  # Nested workflow support
+    hitl_executor: Optional[Union[Agent, Team]] = (
+        None  # Inner agent/team target for HITL routing with function executor
+    )
+    _unresolved_hitl_team_id: Optional[str] = None
+    _unresolved_hitl_agent_id: Optional[str] = None
 
     step_id: Optional[str] = None
     description: Optional[str] = None
@@ -223,6 +256,7 @@ class Step:
         add_workflow_history: Optional[bool] = None,
         num_history_runs: int = 3,
         human_review: Optional[HumanReview] = None,
+        hitl_executor: Optional[Union[Agent, Team]] = None,
     ):
         # Auto-detect HITL metadata from @pause decorator on executor function.
         # An explicit human_review= kwarg always wins over decorator metadata.
@@ -253,8 +287,17 @@ class Step:
         self.team = team
         self.executor = executor
         self.workflow = workflow
+        self.hitl_executor = hitl_executor
 
         self._validate_executor_config()
+
+        if self.hitl_executor is not None:
+            if self.executor is None:
+                raise ValueError("hitl_executor is only valid with a function executor")
+            if not isinstance(self.hitl_executor, (Agent, Team)) and not _is_team_instance(self.hitl_executor):
+                raise TypeError(
+                    f"hitl_executor must be an instance of Agent or Team, got {type(self.hitl_executor).__name__}"
+                )
 
         self.step_id = step_id
         self.description = description
@@ -263,6 +306,8 @@ class Step:
         self.strict_input_validation = strict_input_validation
         self.add_workflow_history = add_workflow_history
         self.num_history_runs = num_history_runs
+        self._unresolved_hitl_team_id = None
+        self._unresolved_hitl_agent_id = None
 
         self.human_review = human_review or decorator_review or HumanReview()
 
@@ -274,6 +319,83 @@ class Step:
             self.step_id = str(uuid4())
 
         self._set_active_executor()
+
+    def _get_hitl_executor(self) -> Optional[Union[Agent, Team]]:
+        if self._executor_type in ("agent", "team"):
+            return self.active_executor
+        if self._executor_type == "function":
+            return self.hitl_executor
+        return None
+
+    def _extract_executor_run_response(self, response: Any) -> Optional[Union[RunOutput, TeamRunOutput]]:
+        """Extract underlying RunOutput or TeamRunOutput from response if present."""
+        if isinstance(response, (RunOutput, TeamRunOutput)):
+            return response
+        candidate = getattr(response, "_executor_run_response", None)
+        if isinstance(candidate, (RunOutput, TeamRunOutput)):
+            return candidate
+        return None
+
+    def _validate_custom_executor_paused_response(self, response: Any) -> None:
+        """Validate paused executor response from a custom function step.
+
+        Ensures that if a custom function returns or yields a paused response:
+        1. hitl_executor is explicitly configured (never silently swallowed).
+        2. A recoverable RunOutput or TeamRunOutput is provided for resumption.
+        3. hitl_executor type matches the returned response (Agent vs Team).
+        4. hitl_executor ID matches the response's executor ID if specified.
+        """
+        exec_resp = self._extract_executor_run_response(response)
+        is_paused = (
+            getattr(response, "is_paused", False)
+            or getattr(response, "status", None) == RunStatus.paused
+            or (
+                exec_resp is not None
+                and (getattr(exec_resp, "is_paused", False) or getattr(exec_resp, "status", None) == RunStatus.paused)
+            )
+        )
+        if not is_paused:
+            return
+
+        if self.hitl_executor is None:
+            raise MissingHitlExecutorError(
+                f"Step '{self.name}' returned a paused executor response, but no 'hitl_executor' "
+                "was configured on the Step. Please set Step(..., hitl_executor=...) to enable HITL resumption."
+            )
+
+        if exec_resp is None:
+            raise MissingHitlExecutorResponseError(
+                f"Step '{self.name}' returned a paused StepOutput with is_paused=True, but did not "
+                "provide a recoverable RunOutput or TeamRunOutput for hitl_executor. To pause a "
+                "custom function step for executor HITL, return the paused RunOutput or "
+                "TeamRunOutput directly."
+            )
+
+        if isinstance(self.hitl_executor, Agent):
+            if isinstance(exec_resp, TeamRunOutput):
+                raise HitlExecutorTypeMismatchError(
+                    f"Step '{self.name}' configured hitl_executor of type Agent, but returned TeamRunOutput"
+                )
+            if hasattr(exec_resp, "agent_id") and exec_resp.agent_id:
+                agent_id = getattr(self.hitl_executor, "id", None) or getattr(self.hitl_executor, "agent_id", None)
+                if agent_id and agent_id != exec_resp.agent_id:
+                    raise HitlExecutorMismatchError(
+                        f"Step '{self.name}' hitl_executor agent ID '{agent_id}' does not match "
+                        f"returned response agent_id '{exec_resp.agent_id}'"
+                    )
+
+        elif isinstance(self.hitl_executor, Team) or _is_team_instance(self.hitl_executor):
+            if isinstance(exec_resp, RunOutput):
+                raise HitlExecutorTypeMismatchError(
+                    f"Step '{self.name}' configured hitl_executor of type Team, but returned RunOutput"
+                )
+            if hasattr(exec_resp, "team_id") and exec_resp.team_id:
+                team_id = getattr(self.hitl_executor, "id", None)
+                if team_id and team_id != exec_resp.team_id:
+                    raise HitlExecutorMismatchError(
+                        f"Step '{self.name}' hitl_executor team ID '{team_id}' does not match "
+                        f"returned response team_id '{exec_resp.team_id}'"
+                    )
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert step to a dictionary representation."""
@@ -296,6 +418,18 @@ class Step:
             result["team_id"] = self.team.id
         if self.workflow is not None:
             result["workflow_id"] = self.workflow.id
+        if self.hitl_executor is not None:
+            if isinstance(self.hitl_executor, Team) or _is_team_instance(self.hitl_executor):
+                result["hitl_team_id"] = self.hitl_executor.id
+            else:
+                result["hitl_agent_id"] = getattr(self.hitl_executor, "id", None) or getattr(
+                    self.hitl_executor, "agent_id", None
+                )
+        else:
+            if getattr(self, "_unresolved_hitl_team_id", None) is not None:
+                result["hitl_team_id"] = self._unresolved_hitl_team_id
+            elif getattr(self, "_unresolved_hitl_agent_id", None) is not None:
+                result["hitl_agent_id"] = self._unresolved_hitl_agent_id
         if self.executor is not None:
             unresolved = getattr(self.executor, "__agno_unresolved__", None)
             if unresolved is not None:
@@ -737,6 +871,213 @@ class Step:
                 )
                 executor = _unresolvable_ref_placeholder(config, "executor function", executor_ref)
 
+        # --- Handle hitl_executor reconstruction ---
+        hitl_executor: Optional[Union[Agent, Team]] = None
+        unresolved_hitl_team_id: Optional[str] = None
+        unresolved_hitl_agent_id: Optional[str] = None
+
+        if "hitl_team_id" in config and config["hitl_team_id"]:
+            hitl_team_id = config.get("hitl_team_id")
+            pinned = _pinned_version(hitl_team_id, "step_team")
+
+            if pinned is None and registry and hitl_team_id:
+                registry_team = registry.get_team(hitl_team_id)
+                if registry_team is not None:
+                    try:
+                        hitl_executor = registry_team.deep_copy()
+                        if strict and hitl_executor is registry_team:
+                            raise ComponentRehydrationError(
+                                f"Registry hitl team '{hitl_team_id}' deep_copy returned the shared "
+                                "instance; a strict load requires an isolated copy."
+                            )
+                        if strict and type(hitl_executor).__name__ != "Team" and not _is_team_instance(hitl_executor):
+                            raise ComponentRehydrationError(
+                                f"Registry hitl team '{hitl_team_id}' deep_copy returned a "
+                                f"{type(hitl_executor).__name__}, not a Team; a strict load refuses it."
+                            )
+                        if strict:
+                            from agno.utils.copies import copy_divergence
+
+                            divergence = copy_divergence(registry_team, hitl_executor)
+                            if divergence is not None:
+                                raise ComponentRehydrationError(
+                                    f"Registry hitl team '{hitl_team_id}' deep_copy lost state: {divergence}. "
+                                    "A strict load refuses a copy that does not serialize like its "
+                                    "original; give the subclass a faithful deep_copy."
+                                )
+                    except ComponentRehydrationError:
+                        raise
+                    except Exception as e:
+                        if strict:
+                            raise ComponentRehydrationError(
+                                f"Registry hitl team '{hitl_team_id}' could not be copied (deep_copy "
+                                f"failed: {e}); a strict load refuses the shared registry instance."
+                            ) from e
+                        log_warning(
+                            f"deep_copy() failed for registry hitl team '{hitl_team_id}', using shared instance: {e}",
+                        )
+                        hitl_executor = registry_team
+
+            if hitl_executor is None and db is not None and hitl_team_id is not None:
+                from agno.team.team import get_team_by_id
+                from agno.utils.component_scope import get_component_owner_scope
+
+                try:
+                    hitl_executor = get_team_by_id(
+                        db=db,
+                        id=hitl_team_id,
+                        version=pinned,
+                        registry=registry,
+                        strict=strict,
+                        user_id=get_component_owner_scope(),
+                    )
+                except ComponentRehydrationError as step_member_error:
+                    if pinned is not None:
+                        raise ComponentPinError(
+                            f"Step '{config.get('name')}' pins hitl team '{hitl_team_id}' at version {pinned}, "
+                            f"which failed to rebuild: {step_member_error} "
+                            "Re-save the workflow to pin the team's current version."
+                        ) from step_member_error
+                    raise
+                if hitl_executor is None and pinned is not None:
+                    if strict:
+                        raise ComponentPinError(
+                            f"Step '{config.get('name')}' pins hitl team '{hitl_team_id}' at version {pinned}, "
+                            "which was not found in the db. Restore that version, or re-save the "
+                            "workflow to pin the team's current version."
+                        )
+                    log_warning(
+                        f"Step '{config.get('name')}' pins hitl team '{hitl_team_id}' at version {pinned}, which "
+                        "was not found in the db; loading the team's current version instead."
+                    )
+                    hitl_executor = get_team_by_id(
+                        db=db, id=hitl_team_id, registry=registry, strict=False, user_id=get_component_owner_scope()
+                    )
+
+            if hitl_executor is None and pinned is not None and registry and hitl_team_id:
+                registry_team = registry.get_team(hitl_team_id)
+                if registry_team is not None:
+                    try:
+                        hitl_executor = registry_team.deep_copy()
+                    except Exception as e:
+                        log_warning(
+                            f"deep_copy() failed for registry hitl team '{hitl_team_id}', using shared instance: {e}",
+                        )
+                        hitl_executor = registry_team
+
+            if hitl_executor is None and hitl_team_id:
+                if strict:
+                    raise ComponentRehydrationError(
+                        f"Step '{config.get('name')}' references hitl team '{hitl_team_id}' which was not "
+                        "found in the registry or db. Restore the team, or pass strict=False to "
+                        "load the workflow without it."
+                    )
+                log_warning(
+                    f"Could not resolve hitl_team_id='{hitl_team_id}' from registry or DB for step '{config.get('name')}'"
+                )
+                unresolved_hitl_team_id = hitl_team_id
+
+        elif "hitl_agent_id" in config and config["hitl_agent_id"]:
+            hitl_agent_id = config.get("hitl_agent_id")
+            pinned = _pinned_version(hitl_agent_id, "step_agent")
+
+            if pinned is None and registry and hitl_agent_id:
+                registry_agent = registry.get_agent(hitl_agent_id)
+                if registry_agent is not None:
+                    try:
+                        hitl_executor = registry_agent.deep_copy()
+                        if strict and hitl_executor is registry_agent:
+                            raise ComponentRehydrationError(
+                                f"Registry hitl agent '{hitl_agent_id}' deep_copy returned the shared "
+                                "instance; a strict load requires an isolated copy."
+                            )
+                        if strict and not isinstance(hitl_executor, Agent):
+                            raise ComponentRehydrationError(
+                                f"Registry hitl agent '{hitl_agent_id}' deep_copy returned a "
+                                f"{type(hitl_executor).__name__}, not an Agent; a strict load refuses it."
+                            )
+                        if strict:
+                            from agno.utils.copies import copy_divergence
+
+                            divergence = copy_divergence(registry_agent, hitl_executor)
+                            if divergence is not None:
+                                raise ComponentRehydrationError(
+                                    f"Registry hitl agent '{hitl_agent_id}' deep_copy lost state: {divergence}. "
+                                    "A strict load refuses a copy that does not serialize like its "
+                                    "original; give the subclass a faithful deep_copy."
+                                )
+                    except ComponentRehydrationError:
+                        raise
+                    except Exception as e:
+                        if strict:
+                            raise ComponentRehydrationError(
+                                f"Registry hitl agent '{hitl_agent_id}' could not be copied (deep_copy "
+                                f"failed: {e}); a strict load refuses the shared registry instance."
+                            ) from e
+                        log_warning(
+                            f"deep_copy() failed for registry hitl agent '{hitl_agent_id}', using shared instance: {e}",
+                        )
+                        hitl_executor = registry_agent
+
+            if hitl_executor is None and db is not None and hitl_agent_id is not None:
+                from agno.agent.agent import get_agent_by_id
+                from agno.utils.component_scope import get_component_owner_scope
+
+                try:
+                    hitl_executor = get_agent_by_id(
+                        db=db,
+                        id=hitl_agent_id,
+                        version=pinned,
+                        registry=registry,
+                        strict=strict,
+                        user_id=get_component_owner_scope(),
+                    )
+                except ComponentRehydrationError as step_member_error:
+                    if pinned is not None:
+                        raise ComponentPinError(
+                            f"Step '{config.get('name')}' pins hitl agent '{hitl_agent_id}' at version {pinned}, "
+                            f"which failed to rebuild: {step_member_error} "
+                            "Re-save the workflow to pin the agent's current version."
+                        ) from step_member_error
+                    raise
+                if hitl_executor is None and pinned is not None:
+                    if strict:
+                        raise ComponentPinError(
+                            f"Step '{config.get('name')}' pins hitl agent '{hitl_agent_id}' at version {pinned}, "
+                            "which was not found in the db. Restore that version, or re-save the "
+                            "workflow to pin the agent's current version."
+                        )
+                    log_warning(
+                        f"Step '{config.get('name')}' pins hitl agent '{hitl_agent_id}' at version {pinned}, which "
+                        "was not found in the db; loading the agent's current version instead."
+                    )
+                    hitl_executor = get_agent_by_id(
+                        db=db, id=hitl_agent_id, registry=registry, strict=False, user_id=get_component_owner_scope()
+                    )
+
+            if hitl_executor is None and pinned is not None and registry and hitl_agent_id:
+                registry_agent = registry.get_agent(hitl_agent_id)
+                if registry_agent is not None:
+                    try:
+                        hitl_executor = registry_agent.deep_copy()
+                    except Exception as e:
+                        log_warning(
+                            f"deep_copy() failed for registry hitl agent '{hitl_agent_id}', using shared instance: {e}",
+                        )
+                        hitl_executor = registry_agent
+
+            if hitl_executor is None and hitl_agent_id:
+                if strict:
+                    raise ComponentRehydrationError(
+                        f"Step '{config.get('name')}' references hitl agent '{hitl_agent_id}' which was not "
+                        "found in the registry or db. Restore the agent, or pass strict=False to "
+                        "load the workflow without it."
+                    )
+                log_warning(
+                    f"Could not resolve hitl_agent_id='{hitl_agent_id}' from registry or DB for step '{config.get('name')}'"
+                )
+                unresolved_hitl_agent_id = hitl_agent_id
+
         if config.get("human_review"):
             human_review = HumanReview.from_dict(config["human_review"])
         else:
@@ -745,7 +1086,7 @@ class Step:
             drop_legacy_hitl_keys(config, StepType.STEP)
             human_review = HumanReview()
 
-        return cls(
+        reconstructed_step = cls(
             name=config.get("name"),
             step_id=config.get("step_id"),
             description=config.get("description"),
@@ -759,7 +1100,13 @@ class Step:
             team=team,
             executor=executor,
             workflow=workflow,
+            hitl_executor=hitl_executor,
         )
+        if unresolved_hitl_team_id is not None:
+            reconstructed_step._unresolved_hitl_team_id = unresolved_hitl_team_id
+        if unresolved_hitl_agent_id is not None:
+            reconstructed_step._unresolved_hitl_agent_id = unresolved_hitl_agent_id
+        return reconstructed_step
 
     def get_links(self, position: int = 0) -> List[Dict[str, Any]]:
         """Get links for this step's agent/team/workflow.
@@ -805,6 +1152,20 @@ class Step:
                     "position": position,
                 }
             )
+
+        if self.hitl_executor is not None:
+            child_id = getattr(self.hitl_executor, "id", None) or getattr(self.hitl_executor, "agent_id", None)
+            if child_id:
+                link_kind = "step_team" if isinstance(self.hitl_executor, Team) else "step_agent"
+                links.append(
+                    {
+                        "link_kind": link_kind,
+                        "link_key": link_key,
+                        "child_component_id": child_id,
+                        "child_version": None,
+                        "position": position,
+                    }
+                )
 
         return links
 
@@ -1111,10 +1472,11 @@ class Step:
                                             content += str(chunk.content)
                                 elif isinstance(chunk, (RunOutput, TeamRunOutput)):
                                     # This is the final response from the agent/team
+                                    final_response = self._process_step_output(chunk)
                                     content = chunk.content  # type: ignore[assignment]
                                 # If the chunk is a StepOutput, use it as the final response
                                 elif isinstance(chunk, StepOutput):
-                                    final_response = chunk
+                                    final_response = self._process_step_output(chunk)
                                     break
                                 # Non Agent/Team data structure that was yielded
                                 else:
@@ -1122,16 +1484,20 @@ class Step:
 
                         except StopIteration as e:
                             if hasattr(e, "value") and isinstance(e.value, StepOutput):
-                                final_response = e.value
+                                final_response = self._process_step_output(e.value)
 
                         # Merge session_state changes back
                         if run_context is None and session_state is not None:
                             merge_dictionaries(session_state, session_state_copy)
 
                         if final_response is not None:
-                            response = final_response
+                            response = self._process_step_output(final_response)
                         else:
                             response = StepOutput(content=content)
+                            response.executor_type = self._executor_type
+                            response.executor_name = self.executor_name
+                            response.step_name = self.name or "unnamed_step"
+                            response.step_id = self.step_id
                     else:
                         # Execute function with signature inspection for run_context support
                         result = self._call_custom_function(
@@ -1144,13 +1510,25 @@ class Step:
                         if run_context is None and session_state is not None:
                             merge_dictionaries(session_state, session_state_copy)
 
-                        # If function returns StepOutput, use it directly
-                        if isinstance(result, StepOutput):
-                            response = result
-                        elif isinstance(result, (RunOutput, TeamRunOutput)):
-                            response = StepOutput(content=result.content)
+                        # Normalize function execution result to StepOutput
+                        if isinstance(result, (StepOutput, RunOutput, TeamRunOutput)):
+                            response = self._process_step_output(result)
                         else:
                             response = StepOutput(content=str(result))
+                            response.executor_type = self._executor_type
+                            response.executor_name = self.executor_name
+                            response.step_name = self.name or "unnamed_step"
+                            response.step_id = self.step_id
+
+                    self._validate_custom_executor_paused_response(response)
+
+                    if store_executor_outputs and workflow_run_response is not None:
+                        exec_resp = getattr(response, "_executor_run_response", None)
+                        if exec_resp is not None:
+                            self._store_executor_response(workflow_run_response, exec_resp)
+
+                    if getattr(response, "is_paused", False):
+                        return response
                 else:
                     # For agents and teams, prepare message with context
                     message = self._prepare_message(
@@ -1277,12 +1655,7 @@ class Step:
 
                 return step_output
 
-            except RunCancelledException:
-                # Don't retry a cancelled run
-                raise
-            except UnresolvableCallableError:
-                # A placeholder for an unresolved reference can never succeed:
-                # retrying or skipping it would complete a run that did no work.
+            except _FATAL_STEP_EXCEPTIONS:
                 raise
             except Exception as e:
                 # Do not replay a nested workflow after a guardrail rejection,
@@ -1453,9 +1826,10 @@ class Step:
                                         )
                                         yield enriched_event  # type: ignore[misc]
                                 elif isinstance(event, (RunOutput, TeamRunOutput)):
+                                    final_response = self._process_step_output(event)
                                     content = event.content  # type: ignore[assignment]
                                 elif isinstance(event, StepOutput):
-                                    final_response = event
+                                    final_response = self._process_step_output(event)
                                     break
                                 else:
                                     content += str(event)
@@ -1466,9 +1840,13 @@ class Step:
 
                             if not final_response:
                                 final_response = StepOutput(content=content)
+                                final_response.executor_type = self._executor_type
+                                final_response.executor_name = self.executor_name
+                                final_response.step_name = self.name or "unnamed_step"
+                                final_response.step_id = self.step_id
                         except StopIteration as e:
                             if hasattr(e, "value") and isinstance(e.value, StepOutput):
-                                final_response = e.value
+                                final_response = self._process_step_output(e.value)
 
                     else:
                         result = self._call_custom_function(
@@ -1481,13 +1859,29 @@ class Step:
                         if run_context is None and session_state is not None:
                             merge_dictionaries(session_state, session_state_copy)
 
-                        if isinstance(result, StepOutput):
-                            final_response = result
-                        elif isinstance(result, (RunOutput, TeamRunOutput)):
-                            final_response = StepOutput(content=result.content)
+                        if isinstance(result, (StepOutput, RunOutput, TeamRunOutput)):
+                            final_response = self._process_step_output(result)
                         else:
                             final_response = StepOutput(content=str(result))
+                            final_response.executor_type = self._executor_type
+                            final_response.executor_name = self.executor_name
+                            final_response.step_name = self.name or "unnamed_step"
+                            final_response.step_id = self.step_id
                         log_debug("Function returned non-iterable, created StepOutput", log_level=2)
+
+                    self._validate_custom_executor_paused_response(final_response)
+
+                    if store_executor_outputs and workflow_run_response is not None:
+                        exec_resp = getattr(final_response, "_executor_run_response", None)
+                        if exec_resp is not None:
+                            self._store_executor_response(workflow_run_response, exec_resp)
+
+                    if final_response is not None and getattr(final_response, "is_paused", False):
+                        use_workflow_logger()
+                        paused_output = self._process_step_output(final_response)
+                        paused_output.is_paused = True
+                        yield paused_output
+                        return
                 else:
                     # For agents and teams, prepare message with context
                     message = self._prepare_message(
@@ -1676,12 +2070,7 @@ class Step:
                     )
 
                 return
-            except RunCancelledException:
-                # Don't retry a cancelled run
-                raise
-            except UnresolvableCallableError:
-                # A placeholder for an unresolved reference can never succeed:
-                # retrying or skipping it would complete a run that did no work.
+            except _FATAL_STEP_EXCEPTIONS:
                 raise
             except Exception as e:
                 # Do not replay a nested workflow after a guardrail rejection,
@@ -1773,9 +2162,10 @@ class Step:
                                             else:
                                                 content = str(chunk.content)
                                     elif isinstance(chunk, (RunOutput, TeamRunOutput)):
+                                        final_response = self._process_step_output(chunk)
                                         content = chunk.content  # type: ignore[assignment]
                                     elif isinstance(chunk, StepOutput):
-                                        final_response = chunk
+                                        final_response = self._process_step_output(chunk)
                                         break
                                     else:
                                         content += str(chunk)
@@ -1800,25 +2190,30 @@ class Step:
                                                 else:
                                                     content = str(chunk.content)
                                         elif isinstance(chunk, (RunOutput, TeamRunOutput)):
+                                            final_response = self._process_step_output(chunk)
                                             content = chunk.content  # type: ignore[assignment]
                                         elif isinstance(chunk, StepOutput):
-                                            final_response = chunk
+                                            final_response = self._process_step_output(chunk)
                                             break
                                         else:
                                             content += str(chunk)
 
                         except StopIteration as e:
                             if hasattr(e, "value") and isinstance(e.value, StepOutput):
-                                final_response = e.value
+                                final_response = self._process_step_output(e.value)
 
                         # Merge session_state changes back
                         if run_context is None and session_state is not None:
                             merge_dictionaries(session_state, session_state_copy)
 
                         if final_response is not None:
-                            response = final_response
+                            response = self._process_step_output(final_response)
                         else:
                             response = StepOutput(content=content)
+                            response.executor_type = self._executor_type
+                            response.executor_name = self.executor_name
+                            response.step_name = self.name or "unnamed_step"
+                            response.step_id = self.step_id
                     else:
                         if _is_async_callable(self.active_executor):
                             result = await self._acall_custom_function(
@@ -1837,13 +2232,25 @@ class Step:
                         if run_context is None and session_state is not None:
                             merge_dictionaries(session_state, session_state_copy)
 
-                        # If function returns StepOutput, use it directly
-                        if isinstance(result, StepOutput):
-                            response = result
-                        elif isinstance(result, (RunOutput, TeamRunOutput)):
-                            response = StepOutput(content=result.content)
+                        # Normalize function execution result to StepOutput
+                        if isinstance(result, (StepOutput, RunOutput, TeamRunOutput)):
+                            response = self._process_step_output(result)
                         else:
                             response = StepOutput(content=str(result))
+                            response.executor_type = self._executor_type
+                            response.executor_name = self.executor_name
+                            response.step_name = self.name or "unnamed_step"
+                            response.step_id = self.step_id
+
+                    self._validate_custom_executor_paused_response(response)
+
+                    if store_executor_outputs and workflow_run_response is not None:
+                        exec_resp = getattr(response, "_executor_run_response", None)
+                        if exec_resp is not None:
+                            self._store_executor_response(workflow_run_response, exec_resp)
+
+                    if getattr(response, "is_paused", False):
+                        return response
 
                 else:
                     # For agents and teams, prepare message with context
@@ -1979,12 +2386,7 @@ class Step:
 
                 return step_output
 
-            except RunCancelledException:
-                # Don't retry a cancelled run
-                raise
-            except UnresolvableCallableError:
-                # A placeholder for an unresolved reference can never succeed:
-                # retrying or skipping it would complete a run that did no work.
+            except _FATAL_STEP_EXCEPTIONS:
                 raise
             except Exception as e:
                 # Do not replay a nested workflow after a guardrail rejection,
@@ -2096,14 +2498,19 @@ class Step:
                                     )
                                     yield enriched_event  # type: ignore[misc]
                             elif isinstance(event, (RunOutput, TeamRunOutput)):
+                                final_response = self._process_step_output(event)
                                 content = event.content  # type: ignore[assignment]
                             elif isinstance(event, StepOutput):
-                                final_response = event
+                                final_response = self._process_step_output(event)
                                 break
                             else:
                                 content += str(event)
                         if not final_response:
                             final_response = StepOutput(content=content)
+                            final_response.executor_type = self._executor_type
+                            final_response.executor_name = self.executor_name
+                            final_response.step_name = self.name or "unnamed_step"
+                            final_response.step_id = self.step_id
                     elif _is_async_callable(self.active_executor):
                         # It's a regular async function - await it
                         result = await self._acall_custom_function(
@@ -2111,12 +2518,14 @@ class Step:
                             step_input,
                             run_context,
                         )
-                        if isinstance(result, StepOutput):
-                            final_response = result
-                        elif isinstance(result, (RunOutput, TeamRunOutput)):
-                            final_response = StepOutput(content=result.content)
+                        if isinstance(result, (StepOutput, RunOutput, TeamRunOutput)):
+                            final_response = self._process_step_output(result)
                         else:
                             final_response = StepOutput(content=str(result))
+                            final_response.executor_type = self._executor_type
+                            final_response.executor_name = self.executor_name
+                            final_response.step_name = self.name or "unnamed_step"
+                            final_response.step_id = self.step_id
                     elif _is_generator_function(self.active_executor):
                         content = ""
                         # It's a regular generator function - iterate over it
@@ -2145,9 +2554,10 @@ class Step:
                                     )
                                     yield enriched_event  # type: ignore[misc]
                             elif isinstance(event, (RunOutput, TeamRunOutput)):
+                                final_response = self._process_step_output(event)
                                 content = event.content  # type: ignore[assignment]
                             elif isinstance(event, StepOutput):
-                                final_response = event
+                                final_response = self._process_step_output(event)
                                 break
                             else:
                                 if isinstance(content, str):
@@ -2156,6 +2566,10 @@ class Step:
                                     content = str(event)
                         if not final_response:
                             final_response = StepOutput(content=content)
+                            final_response.executor_type = self._executor_type
+                            final_response.executor_name = self.executor_name
+                            final_response.step_name = self.name or "unnamed_step"
+                            final_response.step_id = self.step_id
                     else:
                         # It's a regular function - call it directly
                         result = self._call_custom_function(
@@ -2163,16 +2577,32 @@ class Step:
                             step_input,
                             run_context,
                         )
-                        if isinstance(result, StepOutput):
-                            final_response = result
-                        elif isinstance(result, (RunOutput, TeamRunOutput)):
-                            final_response = StepOutput(content=result.content)
+                        if isinstance(result, (StepOutput, RunOutput, TeamRunOutput)):
+                            final_response = self._process_step_output(result)
                         else:
                             final_response = StepOutput(content=str(result))
+                            final_response.executor_type = self._executor_type
+                            final_response.executor_name = self.executor_name
+                            final_response.step_name = self.name or "unnamed_step"
+                            final_response.step_id = self.step_id
 
                     # Merge session_state changes back
                     if run_context is None and session_state is not None:
                         merge_dictionaries(session_state, session_state_copy)
+
+                    self._validate_custom_executor_paused_response(final_response)
+
+                    if store_executor_outputs and workflow_run_response is not None:
+                        exec_resp = getattr(final_response, "_executor_run_response", None)
+                        if exec_resp is not None:
+                            self._store_executor_response(workflow_run_response, exec_resp)
+
+                    if final_response is not None and getattr(final_response, "is_paused", False):
+                        use_workflow_logger()
+                        paused_output = self._process_step_output(final_response)
+                        paused_output.is_paused = True
+                        yield paused_output
+                        return
                 else:
                     # For agents and teams, prepare message with context
                     message = self._prepare_message(
@@ -2369,12 +2799,7 @@ class Step:
                     )
                 return
 
-            except RunCancelledException:
-                # Don't retry a cancelled run
-                raise
-            except UnresolvableCallableError:
-                # A placeholder for an unresolved reference can never succeed:
-                # retrying or skipping it would complete a run that did no work.
+            except _FATAL_STEP_EXCEPTIONS:
                 raise
             except Exception as e:
                 # Do not replay a nested workflow after a guardrail rejection,
@@ -2496,18 +2921,19 @@ class Step:
         if executor_run_response is None:
             log_warning(f"Step '{self.name}': executor produced no response to store")
             return
-        if self._executor_type in ["agent", "team"]:
+        hitl_executor = self._get_hitl_executor()
+        if hitl_executor is not None:
             # propagate the workflow run id as parent run id to the executor response
             executor_run_response.parent_run_id = workflow_run_response.run_id
             executor_run_response.workflow_step_id = self.step_id
 
             # Scrub the executor response based on the executor's storage flags before storing
-            if (
-                not self.active_executor.store_media
-                or not self.active_executor.store_tool_messages
-                or not self.active_executor.store_history_messages
-            ):  # type: ignore
-                self.active_executor.scrub_run_output_for_storage(executor_run_response)  # type: ignore
+            store_media = getattr(hitl_executor, "store_media", True)
+            store_tool_messages = getattr(hitl_executor, "store_tool_messages", True)
+            store_history_messages = getattr(hitl_executor, "store_history_messages", True)
+            if not store_media or not store_tool_messages or not store_history_messages:
+                if hasattr(hitl_executor, "scrub_run_output_for_storage"):
+                    hitl_executor.scrub_run_output_for_storage(executor_run_response)  # type: ignore
 
             # Get the raw response from the step's active executor
             raw_response = executor_run_response
@@ -2520,9 +2946,7 @@ class Step:
                 workflow_run_response.step_executor_runs.append(raw_response)
 
                 # Add direct member agent runs (in case of a team we force store_member_responses=True here)
-                if isinstance(raw_response, TeamRunOutput) and getattr(
-                    self.active_executor, "store_member_responses", False
-                ):
+                if isinstance(raw_response, TeamRunOutput) and getattr(hitl_executor, "store_member_responses", False):
                     for member_response in raw_response.member_responses or []:
                         if isinstance(member_response, RunOutput):
                             workflow_run_response.step_executor_runs.append(member_response)
@@ -2581,9 +3005,10 @@ class Step:
         This propagates tool-level HITL requirements from the executor up to the workflow level,
         similar to how teams propagate member pauses via _propagate_member_pause().
         """
-        executor_id = getattr(self.active_executor, "id", None) or getattr(self.active_executor, "agent_id", None)
-        executor_name = getattr(self.active_executor, "name", None)
-        executor_type = ExecutorType.TEAM if isinstance(self.active_executor, Team) else ExecutorType.AGENT
+        executor = self._get_hitl_executor() or self.active_executor
+        executor_id = getattr(executor, "id", None) or getattr(executor, "agent_id", None)
+        executor_name = getattr(executor, "name", None)
+        executor_type = ExecutorType.TEAM if isinstance(executor, Team) else ExecutorType.AGENT
 
         # Serialize requirements for transport.
         # Only include UNRESOLVED requirements — the agent's requirements list
@@ -2621,6 +3046,11 @@ class Step:
                 response.step_type = StepType.STEP
             response.executor_type = self._executor_type
             response.executor_name = self.executor_name
+            exec_resp = self._extract_executor_run_response(response)
+            if exec_resp is not None:
+                response._executor_run_response = exec_resp
+                if getattr(exec_resp, "is_paused", False):
+                    response.is_paused = True
             return response
 
         # Extract media from response
@@ -2640,7 +3070,7 @@ class Step:
         success = response_status not in (RunStatus.cancelled, RunStatus.error)
         error = response.content if not success else None
 
-        return StepOutput(
+        out = StepOutput(
             step_name=self.name or "unnamed_step",
             step_id=self.step_id,
             step_type=step_type,
@@ -2655,7 +3085,11 @@ class Step:
             metrics=metrics,
             success=success,
             error=error,
+            is_paused=getattr(response, "is_paused", False),
         )
+        if isinstance(response, (RunOutput, TeamRunOutput)):
+            out._executor_run_response = response
+        return out
 
     def _convert_function_result_to_response(self, result: Any) -> RunOutput:
         """Convert function execution result to RunOutput"""

--- a/libs/agno/agno/workflow/types.py
+++ b/libs/agno/agno/workflow/types.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field as dc_field
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -572,6 +572,10 @@ class StepOutput:
     # This is a transient flag — NOT serialized. It is cleared after the workflow
     # processes it.
     requires_iteration_review_pause: bool = False
+
+    # Internal transient reference to underlying RunOutput/TeamRunOutput.
+    # Excluded from dataclass init/repr/compare to preserve positional signatures and equality semantics.
+    _executor_run_response: Optional[Any] = dc_field(default=None, init=False, repr=False, compare=False)
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary"""

--- a/libs/agno/agno/workflow/utils/hitl.py
+++ b/libs/agno/agno/workflow/utils/hitl.py
@@ -524,6 +524,8 @@ def is_executor_pause(step_output: Any) -> bool:
     executor_type_value = getattr(executor_type, "value", executor_type)
     if executor_type_value in ("agent", "team"):
         return True
+    if getattr(step_output, "_executor_run_response", None) is not None:
+        return True
     # Check nested steps — composite steps (Condition/Loop/Router) propagate
     # is_paused but don't carry executor_type themselves.
     nested = getattr(step_output, "steps", None)

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -288,22 +288,11 @@ def _find_inner_step_by_executor(
     If no executor_id or executor_name is provided, returns the first
     inner Step that has an agent or team executor.
     """
-    has_filter = bool(executor_id or executor_name)
-
-    # Base case: if this is a Step with an agent/team/hitl_executor, return it
+    # Base case: if this is a Step with an agent/team, return it
     if isinstance(step, Step):
-        executor = (
-            getattr(step, "_get_hitl_executor", lambda: None)()
-            or getattr(step, "agent", None)
-            or getattr(step, "team", None)
-        )
+        executor = getattr(step, "agent", None) or getattr(step, "team", None)
         if executor is not None:
-            if not has_filter:
-                return step
-            eid = getattr(executor, "id", None) or getattr(executor, "agent_id", None)
-            ename = getattr(executor, "name", None)
-            if (executor_id and eid == executor_id) or (executor_name and ename == executor_name):
-                return step
+            return step
         return None
 
     # Collect all inner steps from composite step types
@@ -312,13 +301,11 @@ def _find_inner_step_by_executor(
     for attr in ("steps", "else_steps", "choices"):
         inner_steps.extend(getattr(step, attr, None) or [])
 
+    has_filter = bool(executor_id or executor_name)
+
     for inner in inner_steps:
         if isinstance(inner, Step):
-            executor = (
-                getattr(inner, "_get_hitl_executor", lambda: None)()
-                or getattr(inner, "agent", None)
-                or getattr(inner, "team", None)
-            )
+            executor = getattr(inner, "agent", None) or getattr(inner, "team", None)
             if executor is not None:
                 if not has_filter:
                     # No filter — return first inner step with an agent/team executor

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -132,7 +132,15 @@ from agno.workflow.condition import Condition
 from agno.workflow.loop import Loop
 from agno.workflow.parallel import Parallel
 from agno.workflow.router import Router
-from agno.workflow.step import Step, UnresolvableCallableError
+from agno.workflow.step import (
+    HitlExecutorMismatchError,
+    HitlExecutorTypeMismatchError,
+    MissingHitlExecutorError,
+    MissingHitlExecutorResponseError,
+    Step,
+    UnresolvableCallableError,
+)
+
 from agno.workflow.steps import Steps
 from agno.workflow.types import (
     OnError,
@@ -161,6 +169,14 @@ from agno.workflow.utils import (
     resolve_executor_pause,
     save_paused_session,
     step_pause_status,
+)
+
+_FATAL_STEP_EXCEPTIONS = (
+    UnresolvableCallableError,
+    MissingHitlExecutorError,
+    MissingHitlExecutorResponseError,
+    HitlExecutorMismatchError,
+    HitlExecutorTypeMismatchError,
 )
 
 # Set to prevent background tasks from being garbage-collected
@@ -272,11 +288,22 @@ def _find_inner_step_by_executor(
     If no executor_id or executor_name is provided, returns the first
     inner Step that has an agent or team executor.
     """
-    # Base case: if this is a Step with an agent/team, return it
+    has_filter = bool(executor_id or executor_name)
+
+    # Base case: if this is a Step with an agent/team/hitl_executor, return it
     if isinstance(step, Step):
-        executor = getattr(step, "agent", None) or getattr(step, "team", None)
+        executor = (
+            getattr(step, "_get_hitl_executor", lambda: None)()
+            or getattr(step, "agent", None)
+            or getattr(step, "team", None)
+        )
         if executor is not None:
-            return step
+            if not has_filter:
+                return step
+            eid = getattr(executor, "id", None) or getattr(executor, "agent_id", None)
+            ename = getattr(executor, "name", None)
+            if (executor_id and eid == executor_id) or (executor_name and ename == executor_name):
+                return step
         return None
 
     # Collect all inner steps from composite step types
@@ -285,11 +312,13 @@ def _find_inner_step_by_executor(
     for attr in ("steps", "else_steps", "choices"):
         inner_steps.extend(getattr(step, attr, None) or [])
 
-    has_filter = bool(executor_id or executor_name)
-
     for inner in inner_steps:
         if isinstance(inner, Step):
-            executor = getattr(inner, "agent", None) or getattr(inner, "team", None)
+            executor = (
+                getattr(inner, "_get_hitl_executor", lambda: None)()
+                or getattr(inner, "agent", None)
+                or getattr(inner, "team", None)
+            )
             if executor is not None:
                 if not has_filter:
                     # No filter — return first inner step with an agent/team executor
@@ -424,6 +453,8 @@ def _step_link_specs(step: Any, position: int) -> List[Dict[str, Any]]:
         ("agent_id", "step_agent"),
         ("team_id", "step_team"),
         ("workflow_id", "step_workflow"),
+        ("hitl_agent_id", "step_agent"),
+        ("hitl_team_id", "step_team"),
     ):
         child_component_id = step.get(config_key)
         if not child_component_id:
@@ -1433,6 +1464,28 @@ class Workflow:
                 workflow_version = step.workflow.save(db=db_, stage=stage, label=label, notes=notes)
                 if step.workflow.id is not None and workflow_version is not None:
                     saved_versions[step.workflow.id] = workflow_version
+
+            # Save hitl_executor if present (Agent or Team)
+            if getattr(step, "hitl_executor", None) is not None:
+                hitl_exec = step.hitl_executor
+                if isinstance(hitl_exec, Agent):
+                    agent_version = hitl_exec.save(
+                        db=db_,
+                        stage=stage,
+                        label=label,
+                        notes=notes,
+                    )
+                    if hitl_exec.id is not None and agent_version is not None:
+                        saved_versions[hitl_exec.id] = agent_version
+                elif isinstance(hitl_exec, Team):
+                    team_version = hitl_exec.save(
+                        db=db_,
+                        stage=stage,
+                        label=label,
+                        notes=notes,
+                    )
+                    if hitl_exec.id is not None and team_version is not None:
+                        saved_versions[hitl_exec.id] = team_version
 
         def _pin_saved_version(link: Dict[str, Any]) -> Dict[str, Any]:
             """Pin a link at the version this save just wrote for that child."""
@@ -3034,9 +3087,7 @@ class Workflow:
                         )
                     except RunCancelledException:
                         raise
-                    except UnresolvableCallableError:
-                        # A placeholder for an unresolved reference executed: skipping
-                        # would silently complete a run that could not do its work.
+                    except _FATAL_STEP_EXCEPTIONS:
                         raise
                     except Exception as step_error:
                         # Handle step execution error based on on_error policy
@@ -3129,6 +3180,12 @@ class Workflow:
                         )
                         save_paused_session(self, session, workflow_run_response)
                         return workflow_run_response
+
+                    if getattr(step_output, "is_paused", False):
+                        raise MissingHitlExecutorResponseError(
+                            f"Step '{step_name}' produced a paused output, but workflow could not resolve a "
+                            "paused executor run. Ensure the step executor provides a recoverable RunOutput/TeamRunOutput."
+                        )
 
                     # Update the workflow-level previous_step_outputs dictionary
                     previous_step_outputs[step_name] = step_output
@@ -3478,6 +3535,12 @@ class Workflow:
                                         save_paused_session(self, session, workflow_run_response)
                                         return
 
+                                if getattr(step_output, "is_paused", False):
+                                    raise MissingHitlExecutorResponseError(
+                                        f"Step '{step_name}' produced a paused output, but workflow could not resolve a "
+                                        "paused executor run. Ensure the step executor provides a recoverable RunOutput/TeamRunOutput."
+                                    )
+
                                 collected_step_outputs.append(step_output)
                                 _check_failed_step(step, step_output, workflow_run_response, collected_step_outputs)
 
@@ -3541,9 +3604,7 @@ class Workflow:
                                     yield self._handle_event(enriched_event, workflow_run_response)  # type: ignore
                     except RunCancelledException:
                         raise
-                    except UnresolvableCallableError:
-                        # A placeholder for an unresolved reference executed: skipping
-                        # would silently complete a run that could not do its work.
+                    except _FATAL_STEP_EXCEPTIONS:
                         raise
                     except Exception as step_error:
                         step_error_occurred = True
@@ -4058,9 +4119,7 @@ class Workflow:
                         )
                     except RunCancelledException:
                         raise
-                    except UnresolvableCallableError:
-                        # A placeholder for an unresolved reference executed: skipping
-                        # would silently complete a run that could not do its work.
+                    except _FATAL_STEP_EXCEPTIONS:
                         raise
                     except Exception as step_error:
                         # Handle step execution error based on on_error policy
@@ -4153,6 +4212,12 @@ class Workflow:
                         )
                         await asave_paused_session(self, workflow_session, workflow_run_response)
                         return workflow_run_response
+
+                    if getattr(step_output, "is_paused", False):
+                        raise MissingHitlExecutorResponseError(
+                            f"Step '{step_name}' produced a paused output, but workflow could not resolve a "
+                            "paused executor run. Ensure the step executor provides a recoverable RunOutput/TeamRunOutput."
+                        )
 
                     # Update the workflow-level previous_step_outputs dictionary
                     previous_step_outputs[step_name] = step_output
@@ -4538,6 +4603,12 @@ class Workflow:
                                         await asave_paused_session(self, workflow_session, workflow_run_response)
                                         return
 
+                                if getattr(step_output, "is_paused", False):
+                                    raise MissingHitlExecutorResponseError(
+                                        f"Step '{step_name}' produced a paused output, but workflow could not resolve a "
+                                        "paused executor run. Ensure the step executor provides a recoverable RunOutput/TeamRunOutput."
+                                    )
+
                                 collected_step_outputs.append(step_output)
                                 _check_failed_step(step, step_output, workflow_run_response, collected_step_outputs)
 
@@ -4603,9 +4674,7 @@ class Workflow:
                             raise RunCancelledException(f"Run {workflow_run_response.run_id} was cancelled")
                     except RunCancelledException:
                         raise
-                    except UnresolvableCallableError:
-                        # A placeholder for an unresolved reference executed: skipping
-                        # would silently complete a run that could not do its work.
+                    except _FATAL_STEP_EXCEPTIONS:
                         raise
                     except Exception as step_error:
                         step_error_occurred = True
@@ -7349,9 +7418,7 @@ class Workflow:
                     )
                 except RunCancelledException:
                     raise
-                except UnresolvableCallableError:
-                    # A placeholder for an unresolved reference executed: skipping
-                    # would silently complete a run that could not do its work.
+                except _FATAL_STEP_EXCEPTIONS:
                     raise
                 except Exception as step_error:
                     # Handle step execution error based on on_error policy
@@ -7531,7 +7598,11 @@ class Workflow:
         if inner_step is None:
             inner_step = step
 
-        executor = getattr(inner_step, "agent", None) or getattr(inner_step, "team", None)
+        executor = (
+            getattr(inner_step, "_get_hitl_executor", lambda: None)()
+            or getattr(inner_step, "agent", None)
+            or getattr(inner_step, "team", None)
+        )
         if executor is None:
             raise ValueError(f"Step '{getattr(inner_step, 'name', 'unknown')}' has no agent or team executor")
 
@@ -7593,7 +7664,11 @@ class Workflow:
         if inner_step is None:
             inner_step = step
 
-        executor = getattr(inner_step, "agent", None) or getattr(inner_step, "team", None)
+        executor = (
+            getattr(inner_step, "_get_hitl_executor", lambda: None)()
+            or getattr(inner_step, "agent", None)
+            or getattr(inner_step, "team", None)
+        )
         if executor is None:
             raise ValueError(f"Step '{getattr(inner_step, 'name', 'unknown')}' has no agent or team executor")
 
@@ -7682,7 +7757,11 @@ class Workflow:
         if inner_step is None:
             inner_step = step
 
-        executor = getattr(inner_step, "agent", None) or getattr(inner_step, "team", None)
+        executor = (
+            getattr(inner_step, "_get_hitl_executor", lambda: None)()
+            or getattr(inner_step, "agent", None)
+            or getattr(inner_step, "team", None)
+        )
         if executor is None:
             raise ValueError(f"Step '{getattr(inner_step, 'name', 'unknown')}' has no agent or team executor")
 
@@ -7767,7 +7846,11 @@ class Workflow:
         if inner_step is None:
             inner_step = step
 
-        executor = getattr(inner_step, "agent", None) or getattr(inner_step, "team", None)
+        executor = (
+            getattr(inner_step, "_get_hitl_executor", lambda: None)()
+            or getattr(inner_step, "agent", None)
+            or getattr(inner_step, "team", None)
+        )
         if executor is None:
             raise ValueError(f"Step '{getattr(inner_step, 'name', 'unknown')}' has no agent or team executor")
 
@@ -8393,9 +8476,7 @@ class Workflow:
                         raise RunCancelledException(f"Run {workflow_run_response.run_id} was cancelled")
                 except RunCancelledException:
                     raise
-                except UnresolvableCallableError:
-                    # A placeholder for an unresolved reference executed: skipping
-                    # would silently complete a run that could not do its work.
+                except _FATAL_STEP_EXCEPTIONS:
                     raise
                 except Exception as step_error:
                     step_error_occurred = True
@@ -9399,9 +9480,7 @@ class Workflow:
                     )
                 except RunCancelledException:
                     raise
-                except UnresolvableCallableError:
-                    # A placeholder for an unresolved reference executed: skipping
-                    # would silently complete a run that could not do its work.
+                except _FATAL_STEP_EXCEPTIONS:
                     raise
                 except Exception as step_error:
                     # Handle step execution error based on on_error policy
@@ -10153,9 +10232,7 @@ class Workflow:
                         raise RunCancelledException(f"Run {workflow_run_response.run_id} was cancelled")
                 except RunCancelledException:
                     raise
-                except UnresolvableCallableError:
-                    # A placeholder for an unresolved reference executed: skipping
-                    # would silently complete a run that could not do its work.
+                except _FATAL_STEP_EXCEPTIONS:
                     raise
                 except Exception as step_error:
                     step_error_occurred = True
@@ -11803,6 +11880,12 @@ class Workflow:
                 step_kwargs["workflow"] = (
                     step.workflow.deep_copy() if hasattr(step.workflow, "deep_copy") else step.workflow
                 )
+            hitl_exec = getattr(step, "hitl_executor", None)
+            if hitl_exec is not None:
+                # Custom function closures capture the original Agent/Team reference. Deep-copying hitl_executor
+                # would disconnect the continue_run target from the in-memory session created during pause.
+                # Preserving the reference keeps the executor closure and resume target aligned.
+                step_kwargs["hitl_executor"] = hitl_exec
             # Copy Step configuration attributes.
             # NOTE: step_id is intentionally omitted so each copy gets a fresh uuid. Workflows are
             # deep-copied per request for isolation, and reusing a step_id across copies would make
@@ -11821,7 +11904,12 @@ class Workflow:
                     # Only include non-default values to avoid overriding defaults
                     if value is not None:
                         step_kwargs[attr] = value
-            return Step(**step_kwargs)
+            new_step = Step(**step_kwargs)
+            if getattr(step, "_unresolved_hitl_team_id", None) is not None:
+                new_step._unresolved_hitl_team_id = step._unresolved_hitl_team_id
+            if getattr(step, "_unresolved_hitl_agent_id", None) is not None:
+                new_step._unresolved_hitl_agent_id = step._unresolved_hitl_agent_id
+            return new_step
 
         # Handle direct Agent
         if isinstance(step, Agent):

--- a/libs/agno/tests/unit/workflow/test_function_executor_hitl.py
+++ b/libs/agno/tests/unit/workflow/test_function_executor_hitl.py
@@ -1,0 +1,1108 @@
+"""
+Unit tests for Human-In-The-Loop (HITL) pause and resume with custom function executor Steps.
+
+Regression test suite for Issue #9928:
+HITL pause from a custom function-executor Step is dropped end-to-end.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, List
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agno.agent.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.exceptions import ComponentRehydrationError
+from agno.models.base import Model
+from agno.models.response import ModelResponse
+from agno.run.agent import RunOutput, RunRequirement, ToolExecution
+from agno.run.base import RunStatus
+from agno.run.team import TeamRunOutput
+from agno.run.workflow import StepExecutorPausedEvent
+from agno.team.team import Team
+from agno.tools.function import Function
+from agno.workflow.step import (
+    MissingHitlExecutorError,
+    MissingHitlExecutorResponseError,
+    Step,
+)
+from agno.workflow.types import StepInput, StepOutput
+from agno.workflow.workflow import Workflow
+
+
+class ScriptedModel(Model):
+    """Offline deterministic model for testing without network or external API calls."""
+
+    def __init__(self, responses: List[ModelResponse]):
+        super().__init__(id="scripted", name="scripted", provider="test")
+        self.responses = list(responses)
+        self.call_count = 0
+
+    def invoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        resp = self.responses[min(self.call_count, len(self.responses) - 1)]
+        self.call_count += 1
+        return resp
+
+    async def ainvoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return self.invoke(*args, **kwargs)
+
+    def invoke_stream(self, *args: Any, **kwargs: Any):
+        yield self.invoke(*args, **kwargs)
+
+    async def ainvoke_stream(self, *args: Any, **kwargs: Any):
+        yield self.invoke(*args, **kwargs)
+
+    def _parse_provider_response(self, response: Any, **kwargs: Any) -> ModelResponse:
+        return self.invoke()
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return self.invoke()
+
+    def parse_args(self, *args: Any, **kwargs: Any):
+        return {}
+
+    def get_instructions_for_model(self, *args: Any, **kwargs: Any):
+        return None
+
+    def get_system_message_for_model(self, *args: Any, **kwargs: Any):
+        return None
+
+
+def _create_mock_paused_team(run_id="run-team-1", team_id="team-1", team_name="SupportTeam"):
+    """Helper to create a mock Team and a paused TeamRunOutput with an unresolved requirement."""
+    req = RunRequirement(
+        id="req-tool-1",
+        tool_execution=ToolExecution(
+            tool_call_id="call-1",
+            tool_name="ask_user_confirmation",
+            tool_args={"message": "Please confirm refund"},
+            requires_user_input=True,
+        ),
+    )
+
+    paused_output = TeamRunOutput(
+        run_id=run_id,
+        team_id=team_id,
+        team_name=team_name,
+        content="Pausing for user confirmation",
+        status=RunStatus.paused,
+        requirements=[req],
+    )
+
+    mock_team = MagicMock(spec=Team)
+    mock_team.id = team_id
+    mock_team.name = team_name
+    mock_team.store_media = True
+    mock_team.store_tool_messages = True
+    mock_team.store_history_messages = True
+
+    # Completed output on continue
+    completed_output = TeamRunOutput(
+        run_id=run_id,
+        team_id=team_id,
+        team_name=team_name,
+        content="Action completed after user confirmation",
+        status=RunStatus.completed,
+        requirements=[],
+    )
+    mock_team.run = MagicMock(return_value=paused_output)
+    mock_team.continue_run = MagicMock(return_value=completed_output)
+    mock_team.acontinue_run = AsyncMock(return_value=completed_output)
+    mock_team.deep_copy = MagicMock(return_value=mock_team)
+
+    return mock_team, paused_output, completed_output, req
+
+
+# =============================================================================
+# 1. Normal custom function behavior preservation
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_normal_custom_function_returns_string():
+    """Verify that regular custom function steps returning strings work unchanged."""
+
+    async def my_executor(step_input: StepInput) -> str:
+        return f"Echo: {step_input.input}"
+
+    wf = Workflow(id="normal-wf-1", steps=[Step(name="echo_step", executor=my_executor)])
+    out = await wf.arun(input="hello")
+
+    assert out.status == RunStatus.completed
+    assert out.is_paused is False
+    assert out.content == "Echo: hello"
+
+
+@pytest.mark.asyncio
+async def test_normal_custom_function_returns_step_output():
+    """Verify that custom function steps returning StepOutput work unchanged."""
+
+    async def my_executor(step_input: StepInput) -> StepOutput:
+        return StepOutput(content="step output result")
+
+    wf = Workflow(id="normal-wf-2", steps=[Step(name="step_output_step", executor=my_executor)])
+    out = await wf.arun(input="hello")
+
+    assert out.status == RunStatus.completed
+    assert out.is_paused is False
+    assert out.content == "step output result"
+
+
+# =============================================================================
+# 2. Issue #9928: Async non-streaming custom executor pause & storage
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_custom_function_executor_pause_propagation_and_storage():
+    """
+    Test that when an inner team in a custom executor pauses on HITL:
+    1. Workflow status becomes PAUSED
+    2. Workflow is_paused is True
+    3. Inner requirements propagate to workflow.step_requirements
+    4. The paused TeamRunOutput is saved in workflow.step_executor_runs
+    """
+    mock_team, paused_team_output, _, _ = _create_mock_paused_team()
+
+    async def run_team_executor(step_input: StepInput):
+        return paused_team_output
+
+    step = Step(
+        name="RunTeamStep",
+        executor=run_team_executor,
+        hitl_executor=mock_team,
+    )
+
+    wf = Workflow(id="wf-hitl-custom", steps=[step])
+    out = await wf.arun(input="process refund")
+
+    assert out.status == RunStatus.paused, f"Expected PAUSED, got {out.status}"
+    assert out.is_paused is True, "Expected out.is_paused to be True"
+    assert out.step_requirements is not None, "Expected step_requirements to be populated"
+    assert len(out.step_requirements) > 0, "Expected at least one step requirement"
+    assert out.step_requirements[0].requires_executor_input is True
+
+    # Verify step_executor_runs persistence
+    assert out.step_executor_runs is not None, "Expected step_executor_runs to not be None"
+    assert len(out.step_executor_runs) > 0, "Expected at least one run in step_executor_runs"
+    assert out.step_executor_runs[0].run_id == paused_team_output.run_id
+
+
+# =============================================================================
+# 3. Issue #9928: Async streaming custom executor pause propagation
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_custom_function_executor_streaming_pause_propagation():
+    """
+    Test that async streaming generator custom executor preserves pause end-to-end.
+    """
+    mock_team, paused_team_output, _, _ = _create_mock_paused_team()
+
+    async def run_team_streaming_executor(step_input: StepInput):
+        yield "Thinking..."
+        yield paused_team_output
+
+    step = Step(
+        name="StreamingTeamStep",
+        executor=run_team_streaming_executor,
+        hitl_executor=mock_team,
+    )
+
+    wf = Workflow(id="wf-hitl-streaming", steps=[step])
+
+    events = []
+    async for chunk in wf.arun(input="stream task", stream=True):
+        events.append(chunk)
+
+    paused_events = [e for e in events if isinstance(e, StepExecutorPausedEvent)]
+    assert len(paused_events) == 1, f"Expected 1 StepExecutorPausedEvent, got {events}"
+    paused_event = paused_events[0]
+    assert paused_event.step_name == "StreamingTeamStep"
+    assert getattr(paused_event.executor_type, "value", paused_event.executor_type) == "team"
+    assert paused_event.executor_requirements is not None
+    assert len(paused_event.executor_requirements) > 0
+
+
+# =============================================================================
+# 4. Issue #9928: Resume routing to hitl_executor
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_custom_function_executor_resume_routing():
+    """
+    Test that calling workflow.acontinue_run() routes back to hitl_executor.acontinue_run().
+    """
+    mock_team, paused_team_output, completed_output, _ = _create_mock_paused_team()
+
+    async def run_team_executor(step_input: StepInput):
+        return paused_team_output
+
+    step = Step(
+        name="RunTeamStep",
+        executor=run_team_executor,
+        hitl_executor=mock_team,
+    )
+
+    wf = Workflow(id="wf-hitl-resume", steps=[step], db=SqliteDb())
+    paused_wf_out = await wf.arun(input="do action")
+
+    assert paused_wf_out.is_paused is True, "Workflow must pause before it can be resumed"
+
+    # Resolve requirements
+    active_req = paused_wf_out.step_requirements[0]
+    active_req.executor_requirements[0]["user_input"] = "Approved"
+
+    # Resume the workflow
+    resumed_out = await wf.acontinue_run(
+        run_response=paused_wf_out,
+        step_requirements=paused_wf_out.step_requirements,
+    )
+
+    # Verify that mock_team.acontinue_run was invoked
+    mock_team.acontinue_run.assert_awaited_once()
+    assert resumed_out.status == RunStatus.completed
+
+
+# =============================================================================
+# 5. Sync Non-Streaming and Streaming Tests
+# =============================================================================
+
+
+def test_custom_function_executor_sync_pause_and_resume():
+    """Test sync custom function pause propagation and continue_run routing."""
+    mock_team, paused_team_output, _, _ = _create_mock_paused_team()
+
+    def run_team_sync_executor(step_input: StepInput):
+        return paused_team_output
+
+    step = Step(
+        name="SyncRunTeamStep",
+        executor=run_team_sync_executor,
+        hitl_executor=mock_team,
+    )
+    wf = Workflow(id="wf-hitl-sync", steps=[step], db=SqliteDb())
+    paused_wf_out = wf.run(input="sync action")
+
+    assert paused_wf_out.status == RunStatus.paused
+    assert paused_wf_out.is_paused is True
+    assert len(paused_wf_out.step_requirements) > 0
+    assert paused_wf_out.step_executor_runs is not None
+    assert len(paused_wf_out.step_executor_runs) > 0
+
+    # Resolve requirement and continue
+    active_req = paused_wf_out.step_requirements[0]
+    active_req.executor_requirements[0]["user_input"] = "Approved"
+
+    resumed_out = wf.continue_run(
+        run_response=paused_wf_out,
+        step_requirements=paused_wf_out.step_requirements,
+    )
+    mock_team.continue_run.assert_called_once()
+    assert resumed_out.status == RunStatus.completed
+
+
+def test_custom_function_executor_sync_streaming_pause():
+    """Test sync streaming generator custom executor preserves pause."""
+    mock_team, paused_team_output, _, _ = _create_mock_paused_team()
+
+    def run_team_sync_stream_executor(step_input: StepInput):
+        yield "Thinking sync..."
+        yield paused_team_output
+
+    step = Step(
+        name="SyncStreamingStep",
+        executor=run_team_sync_stream_executor,
+        hitl_executor=mock_team,
+    )
+    wf = Workflow(id="wf-hitl-sync-stream", steps=[step])
+    events = list(wf.run(input="stream sync task", stream=True))
+
+    paused_events = [e for e in events if isinstance(e, StepExecutorPausedEvent)]
+    assert len(paused_events) == 1
+    assert paused_events[0].step_name == "SyncStreamingStep"
+    assert getattr(paused_events[0].executor_type, "value", paused_events[0].executor_type) == "team"
+    assert len(paused_events[0].executor_requirements) > 0
+
+
+# =============================================================================
+# 6. Step Validation and Serialization Tests
+# =============================================================================
+
+
+def test_step_hitl_executor_validation():
+    """Test that hitl_executor is rejected if executor is not provided."""
+    mock_team, _, _, _ = _create_mock_paused_team()
+    with pytest.raises(ValueError, match="hitl_executor is only valid with a function executor"):
+        Step(name="InvalidStep", team=mock_team, hitl_executor=mock_team)
+
+
+def test_step_hitl_executor_invalid_type_raises():
+    """Test that non-Agent and non-Team hitl_executor is rejected with TypeError."""
+
+    def dummy_executor(step_input: StepInput):
+        return "ok"
+
+    with pytest.raises(TypeError, match="hitl_executor must be an instance of Agent or Team"):
+        Step(name="InvalidTypeStep", executor=dummy_executor, hitl_executor=object())  # type: ignore[arg-type]
+
+
+def test_custom_executor_paused_without_hitl_executor_raises():
+    """Test that returning a paused result without configuring hitl_executor raises ValueError."""
+    _, paused_team_output, _, _ = _create_mock_paused_team()
+
+    def unconfigured_sync_executor(step_input: StepInput):
+        return paused_team_output
+
+    wf = Workflow(
+        id="wf-no-hitl-sync",
+        steps=[Step(name="MissingHitlStepSync", executor=unconfigured_sync_executor)],
+    )
+    with pytest.raises(ValueError, match="no 'hitl_executor' was configured"):
+        wf.run(input="test")
+
+
+@pytest.mark.asyncio
+async def test_custom_executor_paused_without_hitl_executor_raises_async():
+    """Test that async custom executor returning paused result without hitl_executor raises ValueError."""
+    _, paused_team_output, _, _ = _create_mock_paused_team()
+
+    async def unconfigured_async_executor(step_input: StepInput):
+        return paused_team_output
+
+    wf = Workflow(
+        id="wf-no-hitl-async",
+        steps=[Step(name="MissingHitlStepAsync", executor=unconfigured_async_executor)],
+    )
+    with pytest.raises(ValueError, match="no 'hitl_executor' was configured"):
+        await wf.arun(input="test")
+
+
+def test_custom_executor_type_and_id_mismatch_raises():
+    """Test type and ID mismatch between configured hitl_executor and returned response."""
+    mock_team, paused_team_output, _, _ = _create_mock_paused_team(team_id="team-expected")
+
+    mock_agent = MagicMock(spec=Agent)
+    mock_agent.id = "agent-expected"
+
+    # 1. Configured Agent, but returned TeamRunOutput -> TypeError
+    def return_team_output(step_input: StepInput):
+        return paused_team_output
+
+    step_agent_mismatch = Step(
+        name="TypeMismatchStep1",
+        executor=return_team_output,
+        hitl_executor=mock_agent,
+    )
+    wf_type_mismatch = Workflow(id="wf-mismatch-1", steps=[step_agent_mismatch])
+    with pytest.raises(TypeError, match="configured hitl_executor of type Agent, but returned TeamRunOutput"):
+        wf_type_mismatch.run(input="test")
+
+    # 2. Configured Team, but returned RunOutput -> TypeError
+    paused_agent_output = RunOutput(
+        run_id="run-agent-1",
+        agent_id="agent-expected",
+        content="Agent paused",
+        status=RunStatus.paused,
+    )
+
+    def return_agent_output(step_input: StepInput):
+        return paused_agent_output
+
+    step_team_mismatch = Step(
+        name="TypeMismatchStep2",
+        executor=return_agent_output,
+        hitl_executor=mock_team,
+    )
+    wf_team_mismatch = Workflow(id="wf-mismatch-2", steps=[step_team_mismatch])
+    with pytest.raises(TypeError, match="configured hitl_executor of type Team, but returned RunOutput"):
+        wf_team_mismatch.run(input="test")
+
+    # 3. Configured Team with team-expected, but response has team_id="team-different" -> ValueError
+    paused_team_wrong_id = TeamRunOutput(
+        run_id="run-team-diff",
+        team_id="team-different",
+        content="Team paused",
+        status=RunStatus.paused,
+    )
+
+    def return_wrong_team_id(step_input: StepInput):
+        return paused_team_wrong_id
+
+    step_id_mismatch = Step(
+        name="IdMismatchStep",
+        executor=return_wrong_team_id,
+        hitl_executor=mock_team,
+    )
+    wf_id_mismatch = Workflow(id="wf-mismatch-3", steps=[step_id_mismatch])
+    with pytest.raises(ValueError, match="does not match returned response team_id"):
+        wf_id_mismatch.run(input="test")
+
+
+def test_step_to_dict_and_get_links_with_hitl_executor():
+    """Test serialization of hitl_executor into dict and links."""
+    mock_team, _, _, _ = _create_mock_paused_team(team_id="team-special-1")
+
+    def dummy_executor(step_input: StepInput):
+        return "ok"
+
+    step = Step(name="SerializedStep", executor=dummy_executor, hitl_executor=mock_team)
+    data = step.to_dict()
+    assert data.get("hitl_team_id") == "team-special-1"
+
+    links = step.get_links()
+    assert any(
+        link.get("child_component_id") == "team-special-1" and link.get("link_kind") == "step_team" for link in links
+    )
+
+
+def test_workflow_deep_copy_preserves_hitl_executor():
+    """Test that workflow deep_copy preserves hitl_executor and unresolved IDs."""
+    mock_team, _, _, _ = _create_mock_paused_team(team_id="team-copy-1")
+
+    def dummy_executor(step_input: StepInput):
+        return "ok"
+
+    step = Step(name="StepWithHitl", executor=dummy_executor, hitl_executor=mock_team)
+    step._unresolved_hitl_team_id = "team-unresolved-99"
+    wf = Workflow(id="wf-copy-test", steps=[step])
+
+    copied_wf = wf.deep_copy()
+    copied_step = copied_wf.steps[0]
+
+    assert copied_step.hitl_executor is not None
+    assert copied_step.hitl_executor.id == "team-copy-1"
+    assert copied_step._unresolved_hitl_team_id == "team-unresolved-99"
+
+
+def test_workflow_save_and_rehydrate_with_hitl_executor(tmp_path):
+    """Test cascading save of hitl_executor, strict load, failure on missing, and lenient roundtrip."""
+    db_file = str(tmp_path / "wf_save_test.db")
+    db = SqliteDb(db_file=db_file)
+
+    model = ScriptedModel([ModelResponse(role="assistant", content="dummy")])
+    agent = Agent(id="agent-save-1", name="AgentSave1", model=model, db=db)
+    team = Team(id="team-save-1", name="TeamSave1", members=[agent], model=model, db=db)
+
+    def custom_team_exec(step_input: StepInput):
+        return team.run(step_input.input)
+
+    step = Step(name="StepSave", executor=custom_team_exec, hitl_executor=team)
+    wf = Workflow(id="wf-save-1", name="WorkflowSave1", steps=[step], db=db)
+
+    # 1. Cascading save
+    wf_version = wf.save(db=db)
+    assert wf_version is not None
+
+    links = db.get_links(component_id="wf-save-1", version=1)
+    team_links = [link for link in links if link.get("link_kind") == "step_team"]
+    assert len(team_links) > 0
+    assert team_links[0]["child_version"] is not None
+
+    # 2. Strict rehydration loads successfully
+    from agno.registry import Registry
+    from agno.workflow.workflow import get_workflow_by_id
+
+    registry = Registry()
+    registry.add_model(model)
+    registry.add_function(custom_team_exec)
+
+    reloaded_wf = get_workflow_by_id(
+        db=db,
+        id="wf-save-1",
+        registry=registry,
+        strict=True,
+    )
+    assert reloaded_wf is not None
+    reloaded_step = reloaded_wf.steps[0]
+    assert reloaded_step.hitl_executor is not None
+    assert reloaded_step.hitl_executor.id == "team-save-1"
+
+    # 3. Strict rehydration failure when child component is missing
+    bad_step_dict = {
+        "type": "Step",
+        "name": "MissingChildStep",
+        "executor_ref": "custom_team_exec",
+        "hitl_team_id": "non-existent-team-id",
+    }
+    with pytest.raises(ComponentRehydrationError, match="references hitl team 'non-existent-team-id'"):
+        Step.from_dict(bad_step_dict, db=db, registry=registry, strict=True)
+
+    # 4. Lenient rehydration preserves unresolved ID on roundtrip to_dict()
+    lenient_step = Step.from_dict(bad_step_dict, db=db, registry=registry, strict=False)
+    assert lenient_step.hitl_executor is None
+    assert lenient_step._unresolved_hitl_team_id == "non-existent-team-id"
+    roundtrip_data = lenient_step.to_dict()
+    assert roundtrip_data.get("hitl_team_id") == "non-existent-team-id"
+
+
+def test_workflow_rehydrates_pinned_hitl_agent_version(tmp_path):
+    """A function step reloads its pinned HITL Agent version, not the latest Agent config."""
+    from agno.registry import Registry
+    from agno.workflow.workflow import get_workflow_by_id
+
+    db = SqliteDb(db_file=str(tmp_path / "wf_agent_pin.db"))
+    model = ScriptedModel([ModelResponse(role="assistant", content="dummy")])
+    agent = Agent(
+        id="hitl-agent-pin",
+        name="Pinned HITL Agent",
+        description="version one",
+        model=model,
+        db=db,
+    )
+
+    def custom_agent_exec(step_input: StepInput):
+        return agent.run(step_input.input)
+
+    workflow = Workflow(
+        id="wf-agent-pin",
+        name="Pinned HITL Agent Workflow",
+        steps=[Step(name="AgentStep", executor=custom_agent_exec, hitl_executor=agent)],
+        db=db,
+    )
+    assert workflow.save() == 1
+
+    links = db.get_links(component_id="wf-agent-pin", version=1)
+    agent_links = [link for link in links if link.get("link_kind") == "step_agent"]
+    assert len(agent_links) == 1
+    assert agent_links[0]["child_version"] == 1
+
+    agent.description = "version two"
+    assert agent.save(db=db) == 2
+
+    registry = Registry()
+    registry.add_model(model)
+    registry.add_function(custom_agent_exec)
+    reloaded = get_workflow_by_id(db=db, id="wf-agent-pin", registry=registry, strict=True)
+
+    assert reloaded is not None
+    reloaded_agent = reloaded.steps[0].hitl_executor
+    assert isinstance(reloaded_agent, Agent)
+    assert reloaded_agent.id == "hitl-agent-pin"
+    assert reloaded_agent.description == "version one"
+
+    bad_step_dict = {
+        "type": "Step",
+        "name": "MissingAgentStep",
+        "executor_ref": "custom_agent_exec",
+        "hitl_agent_id": "missing-hitl-agent",
+    }
+    with pytest.raises(ComponentRehydrationError, match="references hitl agent 'missing-hitl-agent'"):
+        Step.from_dict(bad_step_dict, db=db, registry=registry, strict=True)
+
+    lenient_step = Step.from_dict(bad_step_dict, db=db, registry=registry, strict=False)
+    assert lenient_step.hitl_executor is None
+    assert lenient_step._unresolved_hitl_agent_id == "missing-hitl-agent"
+    assert lenient_step.to_dict().get("hitl_agent_id") == "missing-hitl-agent"
+
+
+# =============================================================================
+# 7. Real Offline E2E Agent and Team Tests (ScriptedModel)
+# =============================================================================
+
+
+def test_real_offline_agent_hitl_workflow_e2e(tmp_path):
+    """Real offline Agent with ScriptedModel: tool execution on resumption."""
+    executed_args = []
+
+    def select_destination(message: str = "", choice: str = ""):
+        executed_args.append({"message": message, "choice": choice})
+        return f"Selected destination: {choice}"
+
+    ask_func = Function(
+        name="select_destination",
+        description="Ask the user to pick an option.",
+        entrypoint=select_destination,
+        requires_user_input=True,
+        user_input_fields=["choice"],
+    )
+
+    model = ScriptedModel(
+        [
+            ModelResponse(
+                role="assistant",
+                tool_calls=[
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "select_destination", "arguments": json.dumps({"message": "Where to?"})},
+                    }
+                ],
+            ),
+            ModelResponse(role="assistant", content="Successfully booked Tokyo!"),
+        ]
+    )
+
+    db_file = str(tmp_path / "test_offline_agent.db")
+    db = SqliteDb(db_file=db_file)
+    agent = Agent(id="agent_tokyo", name="travel_agent", model=model, tools=[ask_func], db=db)
+
+    def run_agent_executor(step_input: StepInput):
+        return agent.run(step_input.input)
+
+    step = Step(
+        name="TravelStep",
+        executor=run_agent_executor,
+        hitl_executor=agent,
+    )
+
+    wf = Workflow(id="wf-agent-tokyo", steps=[step], db=db)
+    wf_out = wf.run("Book trip to Tokyo")
+
+    assert wf_out.status == RunStatus.paused
+    assert wf_out.is_paused is True
+    assert wf_out.step_requirements is not None
+    assert len(wf_out.step_requirements) > 0
+
+    # Resolve requirement with choice="Tokyo"
+    step_req = wf_out.step_requirements[0]
+    inner_req_dict = step_req.executor_requirements[0]
+    inner_req = RunRequirement.from_dict(inner_req_dict)
+    inner_req.provide_user_input({"choice": "Tokyo"})
+    step_req.executor_requirements[0] = inner_req.to_dict()
+
+    resumed_out = wf.continue_run(run_response=wf_out, step_requirements=wf_out.step_requirements)
+    assert resumed_out.status == RunStatus.completed
+    assert resumed_out.is_paused is False
+    assert resumed_out.content == "Successfully booked Tokyo!"
+    assert len(executed_args) == 1
+    assert executed_args[0] == {"message": "Where to?", "choice": "Tokyo"}
+
+
+def test_real_offline_team_hitl_workflow_tokyo_scenario(tmp_path):
+    """Real offline Team with ScriptedModel: Tokyo scenario from Issue #9928."""
+    executed_args = []
+
+    def select_destination(message: str = "", choice: str = ""):
+        executed_args.append({"message": message, "choice": choice})
+        return f"Selected destination: {choice}"
+
+    ask_func = Function(
+        name="select_destination",
+        description="Ask the user to pick an option.",
+        entrypoint=select_destination,
+        requires_user_input=True,
+        user_input_fields=["choice"],
+    )
+
+    model_member = ScriptedModel(
+        [
+            ModelResponse(
+                role="assistant",
+                tool_calls=[
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "select_destination", "arguments": json.dumps({"message": "Where to?"})},
+                    }
+                ],
+            ),
+            ModelResponse(role="assistant", content="Successfully booked Tokyo in member agent!"),
+        ]
+    )
+
+    model_team = ScriptedModel(
+        [
+            ModelResponse(
+                role="assistant",
+                tool_calls=[
+                    {
+                        "id": "call_team_1",
+                        "type": "function",
+                        "function": {
+                            "name": "delegate_task_to_member",
+                            "arguments": json.dumps({"member_id": "m1", "task": "Book Tokyo trip"}),
+                        },
+                    }
+                ],
+            ),
+            ModelResponse(role="assistant", content="Team coordinating travel to Tokyo."),
+        ]
+    )
+
+    db_file = str(tmp_path / "test_offline_team.db")
+    db = SqliteDb(db_file=db_file)
+    member = Agent(id="m1", name="M1", model=model_member, tools=[ask_func], db=db)
+    team = Team(id="t1", name="T1", members=[member], model=model_team, db=db)
+
+    def run_team_executor(step_input: StepInput):
+        return team.run(step_input.input)
+
+    step = Step(
+        name="TeamTravelStep",
+        executor=run_team_executor,
+        hitl_executor=team,
+    )
+
+    wf = Workflow(id="wf-team-tokyo", steps=[step], db=db)
+    wf_out = wf.run("Book trip to Tokyo via team")
+
+    assert wf_out.status == RunStatus.paused
+    assert wf_out.is_paused is True
+    assert wf_out.step_requirements is not None
+    assert len(wf_out.step_requirements) > 0
+
+    # Resolve requirement with Tokyo
+    step_req = wf_out.step_requirements[0]
+    inner_req_dict = step_req.executor_requirements[0]
+    inner_req = RunRequirement.from_dict(inner_req_dict)
+    inner_req.provide_user_input({"choice": "Tokyo"})
+    step_req.executor_requirements[0] = inner_req.to_dict()
+
+    resumed_out = wf.continue_run(run_response=wf_out, step_requirements=wf_out.step_requirements)
+    assert resumed_out.status == RunStatus.completed
+    assert resumed_out.is_paused is False
+    assert len(executed_args) == 1
+    assert executed_args[0] == {"message": "Where to?", "choice": "Tokyo"}
+
+
+def test_step_positional_args_backward_compatibility():
+    """Verify legacy positional arguments Step('name', None, None, executor, None, 'step-id') work."""
+
+    def dummy_executor(step_input: StepInput):
+        return "ok"
+
+    # Old code passing positional parameters up to step_id
+    step = Step("legacy_step", None, None, dummy_executor, None, "legacy-step-id-123")
+    assert step.name == "legacy_step"
+    assert step.agent is None
+    assert step.team is None
+    assert step.executor is dummy_executor
+    assert step.workflow is None
+    assert step.step_id == "legacy-step-id-123"
+    assert step.hitl_executor is None
+
+
+def test_manual_step_output_paused_without_hitl_executor_raises():
+    """Verify returning StepOutput(is_paused=True) without hitl_executor raises MissingHitlExecutorError."""
+
+    def manual_pause_executor(step_input: StepInput):
+        return StepOutput(content="manual pause", is_paused=True)
+
+    step = Step(name="ManualPauseNoHitl", executor=manual_pause_executor)
+    wf = Workflow(steps=[step])
+
+    with pytest.raises(MissingHitlExecutorError):
+        wf.run("test")
+
+
+def test_manual_step_output_paused_with_hitl_executor_but_no_response_raises():
+    """Verify returning StepOutput(is_paused=True) without a recoverable RunOutput/TeamRunOutput raises MissingHitlExecutorResponseError."""
+    mock_team, _, _, _ = _create_mock_paused_team()
+
+    def manual_pause_no_response_executor(step_input: StepInput):
+        return StepOutput(content="manual pause", is_paused=True)
+
+    step = Step(
+        name="ManualPauseNoResponse",
+        executor=manual_pause_no_response_executor,
+        hitl_executor=mock_team,
+    )
+    wf = Workflow(steps=[step])
+
+    # Sync path: must raise MissingHitlExecutorResponseError (never silently complete)
+    with pytest.raises(MissingHitlExecutorResponseError) as excinfo:
+        wf.run("test")
+    assert "did not provide a recoverable RunOutput or TeamRunOutput" in str(excinfo.value)
+
+    # Async path: must also raise MissingHitlExecutorResponseError
+    async def async_test():
+        with pytest.raises(MissingHitlExecutorResponseError) as aexcinfo:
+            await wf.arun("test")
+        assert "did not provide a recoverable RunOutput or TeamRunOutput" in str(aexcinfo.value)
+
+    import asyncio
+
+    asyncio.run(async_test())
+
+
+def test_workflow_deep_copy_no_team_db_in_memory_resume(tmp_path):
+    """Verify that an in-memory Team (no DB attached) survives Workflow.deep_copy() and resumes cleanly.
+
+    When Workflow.deep_copy() is called, custom function step closures retain the original Team
+    reference. Preserving hitl_executor by reference ensures the copied workflow's continue_run
+    targets the original instance holding the in-memory session rather than an empty copy,
+    preventing 'ValueError: Could not find session with id ...' / RunNotFoundError.
+    """
+    executed_args: List[dict] = []
+
+    def select_destination(message: str = "", choice: str = ""):
+        executed_args.append({"message": message, "choice": choice})
+        return f"Selected destination: {choice}"
+
+    ask_func = Function(
+        name="select_destination",
+        description="Ask the user to pick an option.",
+        entrypoint=select_destination,
+        requires_user_input=True,
+        user_input_fields=["choice"],
+    )
+
+    model_member = ScriptedModel(
+        [
+            ModelResponse(
+                role="assistant",
+                tool_calls=[
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "select_destination", "arguments": json.dumps({"message": "Where to?"})},
+                    }
+                ],
+            ),
+            ModelResponse(role="assistant", content="Successfully booked Tokyo in member agent!"),
+        ]
+    )
+
+    model_team = ScriptedModel(
+        [
+            ModelResponse(
+                role="assistant",
+                tool_calls=[
+                    {
+                        "id": "call_team_1",
+                        "type": "function",
+                        "function": {
+                            "name": "delegate_task_to_member",
+                            "arguments": json.dumps({"member_id": "m_mem", "task": "Book Tokyo trip"}),
+                        },
+                    }
+                ],
+            ),
+            ModelResponse(role="assistant", content="Team coordinating travel to Tokyo."),
+        ]
+    )
+
+    # Note: Team and Agent have NO database attached; session is purely in-memory.
+    member = Agent(id="m_mem", name="MMem", model=model_member, tools=[ask_func])
+    team = Team(id="t_mem", name="TMem", members=[member], model=model_team)
+
+    def run_team_executor(step_input: StepInput):
+        return team.run(step_input.input)
+
+    step = Step(
+        name="TeamMemStep",
+        executor=run_team_executor,
+        hitl_executor=team,
+    )
+
+    db = SqliteDb(db_file=str(tmp_path / "wf_mem.db"))
+    wf = Workflow(id="wf-mem-tokyo", steps=[step], db=db)
+    wf_out = wf.run("Book trip to Tokyo")
+
+    assert wf_out.status == RunStatus.paused
+    assert wf_out.is_paused is True
+    assert wf_out.step_requirements is not None
+    assert len(wf_out.step_requirements) > 0
+
+    # Deep copy the workflow
+    wf_copy = wf.deep_copy()
+    assert wf_copy.steps[0].hitl_executor is team
+
+    # Resolve requirement with Tokyo
+    step_req = wf_out.step_requirements[0]
+    inner_req_dict = step_req.executor_requirements[0]
+    inner_req = RunRequirement.from_dict(inner_req_dict)
+    inner_req.provide_user_input({"choice": "Tokyo"})
+    step_req.executor_requirements[0] = inner_req.to_dict()
+
+    # Resumed on copied workflow succeeds because hitl_executor points to the in-memory team
+    resumed_out = wf_copy.continue_run(run_response=wf_out, step_requirements=wf_out.step_requirements)
+    assert resumed_out.status == RunStatus.completed
+    assert resumed_out.is_paused is False
+    assert len(executed_args) == 1
+    assert executed_args[0] == {"message": "Where to?", "choice": "Tokyo"}
+
+
+def test_sync_generator_run_output_hitl(tmp_path):
+    """Verify a sync custom generator yielding a paused TeamRunOutput pauses and resumes."""
+    mock_team, paused_team_out, _, _ = _create_mock_paused_team()
+
+    def sync_gen_executor(step_input: StepInput):
+        yield "Step progress message..."
+        yield paused_team_out
+
+    step = Step(
+        name="SyncGenPauseStep",
+        executor=sync_gen_executor,
+        hitl_executor=mock_team,
+    )
+    db = SqliteDb(db_file=str(tmp_path / "sync_gen_pause.db"))
+    wf = Workflow(steps=[step], db=db)
+    wf_out = wf.run("test sync generator pause")
+
+    assert wf_out.status == RunStatus.paused
+    assert wf_out.is_paused is True
+    assert wf_out.step_executor_runs is not None
+    assert len(wf_out.step_executor_runs) == 1
+    assert wf_out.step_executor_runs[0].team_id == "team-1"
+    assert len(wf_out.step_requirements) == 1
+
+    resumed = wf.continue_run(run_response=wf_out, step_requirements=wf_out.step_requirements)
+    assert resumed.status == RunStatus.completed
+    assert resumed.is_paused is False
+    assert mock_team.continue_run.called
+
+
+@pytest.mark.asyncio
+async def test_async_generator_streaming_workflow_run_output_hitl(tmp_path):
+    """Verify a streaming async custom generator yielding a paused TeamRunOutput pauses and resumes."""
+    mock_team, paused_team_out, _, _ = _create_mock_paused_team()
+
+    async def async_gen_executor(step_input: StepInput):
+        yield "Starting async task..."
+        yield paused_team_out
+
+    step = Step(
+        name="AsyncGenPauseStep",
+        executor=async_gen_executor,
+        hitl_executor=mock_team,
+    )
+    db = SqliteDb(db_file=str(tmp_path / "async_gen_pause.db"))
+    wf = Workflow(steps=[step], db=db)
+
+    events = []
+    async for event in wf.arun("test async generator stream", stream=True):
+        events.append(event)
+
+    paused_events = [e for e in events if isinstance(e, StepExecutorPausedEvent)]
+    assert len(paused_events) == 1
+    paused_event = paused_events[0]
+    assert paused_event.step_name == "AsyncGenPauseStep"
+    assert paused_event.executor_requirements is not None
+    assert len(paused_event.executor_requirements) == 1
+
+    # Load session and verify paused status
+    session = db.get_session(session_id=paused_event.session_id, session_type="workflow")
+    assert session is not None
+    latest_run = session.runs[-1]
+    assert latest_run.status == RunStatus.paused
+    assert latest_run.is_paused is True
+    assert len(latest_run.step_executor_runs) == 1
+
+    # Resume via acontinue_run
+    resumed = await wf.acontinue_run(run_response=latest_run, step_requirements=latest_run.step_requirements)
+    assert resumed.status == RunStatus.completed
+    assert resumed.is_paused is False
+    assert mock_team.acontinue_run.called
+
+
+@pytest.mark.asyncio
+async def test_real_offline_team_async_streaming_e2e(tmp_path):
+    """Test full async streaming pipeline end-to-end with real offline Team:
+    1. Custom async executor uses the exact streaming call shape from Issue #9928.
+    2. Model calls select_destination tool with requires_user_input=True.
+    3. Workflow pauses, emitting StepExecutorPausedEvent.
+    4. User provides 'Tokyo' via acontinue_run.
+    5. Tool executes once with provided input, and workflow completes successfully.
+    """
+    executed_args: List[dict] = []
+
+    def select_destination(message: str = "", choice: str = ""):
+        executed_args.append({"message": message, "choice": choice})
+        return f"Selected destination: {choice}"
+
+    ask_func = Function(
+        name="select_destination",
+        description="Ask the user to pick an option.",
+        entrypoint=select_destination,
+        requires_user_input=True,
+        user_input_fields=["choice"],
+    )
+
+    model_member = ScriptedModel(
+        [
+            ModelResponse(
+                role="assistant",
+                tool_calls=[
+                    {
+                        "id": "call_member_stream",
+                        "type": "function",
+                        "function": {"name": "select_destination", "arguments": json.dumps({"message": "Where to?"})},
+                    }
+                ],
+            ),
+            ModelResponse(role="assistant", content="Successfully booked Tokyo in member agent!"),
+        ]
+    )
+
+    model_team = ScriptedModel(
+        [
+            ModelResponse(
+                role="assistant",
+                tool_calls=[
+                    {
+                        "id": "call_team_stream",
+                        "type": "function",
+                        "function": {
+                            "name": "delegate_task_to_member",
+                            "arguments": json.dumps({"member_id": "m_stream", "task": "Book Tokyo trip"}),
+                        },
+                    }
+                ],
+            ),
+            ModelResponse(role="assistant", content="Team coordinating travel to Tokyo."),
+        ]
+    )
+
+    db_file = str(tmp_path / "test_async_streaming_team.db")
+    db = SqliteDb(db_file=db_file)
+    member = Agent(id="m_stream", name="MStream", model=model_member, tools=[ask_func], db=db)
+    team = Team(id="t_stream", name="TStream", members=[member], model=model_team, db=db)
+
+    async def run_team_async_streaming_executor(step_input: StepInput):
+        final_output = None
+        async for chunk in team.arun(
+            step_input.input,
+            stream=True,
+            stream_events=True,
+            yield_run_output=True,
+        ):
+            final_output = chunk
+
+        assert isinstance(final_output, TeamRunOutput)
+        return final_output
+
+    step = Step(
+        name="TeamTravelStreamStep",
+        executor=run_team_async_streaming_executor,
+        hitl_executor=team,
+    )
+
+    wf = Workflow(id="wf-team-async-stream-tokyo", steps=[step], db=db)
+
+    # Execute workflow with streaming
+    events = []
+    async for event in wf.arun("Book trip to Tokyo via async streaming team", stream=True):
+        events.append(event)
+
+    paused_events = [e for e in events if isinstance(e, StepExecutorPausedEvent)]
+    assert len(paused_events) == 1
+    paused_event = paused_events[0]
+    assert paused_event.step_name == "TeamTravelStreamStep"
+
+    # Get paused session
+    session = db.get_session(session_id=paused_event.session_id, session_type="workflow")
+    assert session is not None
+    latest_run = session.runs[-1]
+    assert latest_run.status == RunStatus.paused
+    assert latest_run.is_paused is True
+    assert len(latest_run.step_requirements) > 0
+
+    # Resolve requirement with Tokyo
+    step_req = latest_run.step_requirements[0]
+    inner_req_dict = step_req.executor_requirements[0]
+    inner_req = RunRequirement.from_dict(inner_req_dict)
+    inner_req.provide_user_input({"choice": "Tokyo"})
+    step_req.executor_requirements[0] = inner_req.to_dict()
+
+    resumed_out = await wf.acontinue_run(run_response=latest_run, step_requirements=latest_run.step_requirements)
+    assert resumed_out.status == RunStatus.completed
+    assert resumed_out.is_paused is False
+    assert len(executed_args) == 1
+    assert executed_args[0] == {"message": "Where to?", "choice": "Tokyo"}


### PR DESCRIPTION
## Summary

Fixes #9928.

This PR adds an explicit `hitl_executor=` target for `Step(executor=...)`. When a custom function returns a paused `RunOutput` or `TeamRunOutput`, the workflow can now preserve its HITL requirements and route `continue_run()` / `acontinue_run()` back to the correct Agent or Team.

This first PR is intentionally limited to the direct custom-function Step path. Composite/container routing and the separate stage-5 cancellation behavior described in the issue are not included.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other

## Changes

- Preserve paused Agent and Team run outputs returned by custom functions.
- Store the paused executor run and propagate its unresolved requirements.
- Route sync/async and streaming/non-streaming continuation through `hitl_executor`.
- Validate missing, mismatched, or non-recoverable HITL executor responses.
- Preserve the HITL target through workflow persistence and request-time copying.
- Add Agent and Team pause/resume regression coverage.

## Validation

- Focused regression suite: `25 passed`
- Ruff check, format check, and diff check pass.
- Full workflow-suite comparison against the same `origin/main` commit (`4253ded`):
  - This branch: `661 passed, 140 failed, 7 skipped`
  - `origin/main`: `636 passed, 140 failed, 7 skipped`
- The same 140 baseline failures reproduce on `origin/main`; this branch adds 25 passing tests without increasing the failure count.

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran the complete format/validation scripts
- [x] Self-review completed
- [x] Documentation updated through comments and docstrings
- [ ] Examples and guides updated
- [ ] Tested in a completely fresh dependency environment
- [x] Tests added/updated


## Additional Notes

`hitl_executor` is a public API proposal. This PR is ready for review and remains intentionally scoped to the direct custom-function `Step` path while maintainer feedback on the API direction is pending.