### PR TITLE
feat: report directory registrations on the existing metrics routes

### DIFF
--- a/libs/agno/agno/db/authz_store.py
+++ b/libs/agno/agno/db/authz_store.py
@@ -24,6 +24,9 @@ from sqlalchemy import delete, func, insert, or_, select
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import IntegrityError
 
+# Directory rows carry epoch-second timestamps; day buckets are UTC midnights.
+SECONDS_PER_DAY = 24 * 60 * 60
+
 
 def _upsert(conn: Any, table: Any, values: Dict[str, Any], conflict_cols: List[str], update_cols: List[str]) -> None:
     """One INSERT ... ON CONFLICT, rather than DELETE-then-INSERT.
@@ -394,3 +397,27 @@ def count_events(
             stmt = stmt.where(or_(*[c.like(needle) for c in columns]))
     with engine.connect() as conn:
         return int(conn.execute(stmt).scalar() or 0)
+
+
+def count_users_by_day(
+    engine: Engine,
+    table: Any,
+    starting_at: Optional[int] = None,
+    ending_before: Optional[int] = None,
+) -> Dict[int, int]:
+    """How many directory rows were created on each UTC day, keyed by the day's epoch start.
+
+    Read straight from the directory rather than from a cached aggregate: the table holds
+    one row per user, so this stays a small grouped count, and a deleted user drops out of
+    the history immediately instead of at the next refresh. ``starting_at`` /
+    ``ending_before`` bound the scan on the indexed ``created_at`` column.
+    """
+    day_start = (table.c.created_at - (table.c.created_at % SECONDS_PER_DAY)).label("date")
+    filters = []
+    if starting_at is not None:
+        filters.append(table.c.created_at >= starting_at)
+    if ending_before is not None:
+        filters.append(table.c.created_at < ending_before)
+    statement = select(day_start, func.count().label("users_created_count")).where(*filters).group_by(day_start)
+    with engine.connect() as conn:
+        return {int(row.date): int(row.users_created_count) for row in conn.execute(statement)}

--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -2157,6 +2157,17 @@ class BaseDb(ABC):
         """How many directory rows match, for pagination alongside list_authz_users."""
         raise NotImplementedError
 
+    def count_authz_users_by_day(
+        self, starting_at: Optional[int] = None, ending_before: Optional[int] = None
+    ) -> Dict[int, int]:
+        """Directory rows created on each UTC day, keyed by the day's epoch start.
+
+        Bounded by ``starting_at`` / ``ending_before`` (epoch seconds) when given.
+        Computed on read from the directory itself, so a deleted user leaves the
+        history immediately.
+        """
+        raise NotImplementedError
+
     def upsert_authz_user(self, user_id: str, values: Dict[str, Any]) -> None:
         """Create or update a directory row's profile fields. Never overwrites
         ``disabled`` on an existing row -- that is the revocation tombstone, changed only

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -8536,6 +8536,12 @@ class PostgresDb(BaseDb):
         table = self._get_table(table_type=AUTHZ_USERS, create_table_if_not_found=True)
         return authz_store.count_users(self.db_engine, table, include_disabled, search)
 
+    def count_authz_users_by_day(
+        self, starting_at: Optional[int] = None, ending_before: Optional[int] = None
+    ) -> Dict[int, int]:
+        table = self._get_table(table_type=AUTHZ_USERS, create_table_if_not_found=True)
+        return authz_store.count_users_by_day(self.db_engine, table, starting_at, ending_before)
+
     def upsert_authz_user(self, user_id: str, values: Dict[str, Any]) -> None:
         table = self._get_table(table_type=AUTHZ_USERS, create_table_if_not_found=True)
         authz_store.upsert_user(self.db_engine, table, user_id, values)

--- a/libs/agno/agno/db/schemas/authz.py
+++ b/libs/agno/agno/db/schemas/authz.py
@@ -76,7 +76,8 @@ AUTHZ_USERS_TABLE_SCHEMA = {
     "email": {"type": String, "nullable": True},
     "name": {"type": String, "nullable": True},
     "disabled": {"type": Boolean, "nullable": False},
-    "created_at": {"type": BigInteger, "nullable": False},
+    # Indexed: registration metrics scan this column by date range.
+    "created_at": {"type": BigInteger, "nullable": False, "index": True},
     "updated_at": {"type": BigInteger, "nullable": False, "index": True},
     "user_metadata": {"type": Text, "nullable": True},
 }

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -7654,6 +7654,12 @@ class SqliteDb(BaseDb):
         table = self._get_table(table_type=AUTHZ_USERS, create_table_if_not_found=True)
         return authz_store.count_users(self.db_engine, table, include_disabled, search)
 
+    def count_authz_users_by_day(
+        self, starting_at: Optional[int] = None, ending_before: Optional[int] = None
+    ) -> Dict[int, int]:
+        table = self._get_table(table_type=AUTHZ_USERS, create_table_if_not_found=True)
+        return authz_store.count_users_by_day(self.db_engine, table, starting_at, ending_before)
+
     def upsert_authz_user(self, user_id: str, values: Dict[str, Any]) -> None:
         table = self._get_table(table_type=AUTHZ_USERS, create_table_if_not_found=True)
         authz_store.upsert_user(self.db_engine, table, user_id, values)

--- a/libs/agno/agno/db/utils.py
+++ b/libs/agno/agno/db/utils.py
@@ -861,7 +861,10 @@ def merge_registration_counts(
                 "users_created_count": count,
                 "token_metrics": {},
                 "model_metrics": [],
-                "created_at": now,
+                # The row is derived per request, so it has no creation event of its own.
+                # Anchored to the day it describes rather than to "now", which would churn
+                # on every poll and make an unchanged day look like a new record.
+                "created_at": day_epoch,
                 "updated_at": now,
             }
         )

--- a/libs/agno/agno/db/utils.py
+++ b/libs/agno/agno/db/utils.py
@@ -816,6 +816,60 @@ def aggregate_metrics_by_date(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]
     return list(by_bucket.values())
 
 
+def merge_registration_counts(
+    rows: Sequence[Dict[str, Any]], registrations_by_day: Dict[int, int]
+) -> List[Dict[str, Any]]:
+    """Attach directory registration counts to day-aggregated metric records.
+
+    ``registrations_by_day`` maps a UTC day's epoch start to the number of users who
+    joined the directory that day. Counts are OS-level rather than per-owner, so this
+    runs on the aggregated day rows, after per-user buckets have been collapsed.
+
+    A day with registrations but no traffic has no stored record to attach to, so one is
+    synthesised with every session/token counter at zero. Without it a directory-only
+    deployment -- a user signs up today, runs nothing -- would report no day at all.
+    """
+    if not registrations_by_day:
+        return list(rows)
+
+    merged: List[Dict[str, Any]] = []
+    covered: set = set()
+    for row in rows:
+        bucket = metric_bucket_key(row)
+        if bucket is None or bucket[1] != "daily":
+            merged.append(row)
+            continue
+        day_iso, _ = bucket
+        day_epoch = int(datetime.fromisoformat(day_iso).replace(tzinfo=timezone.utc).timestamp())
+        covered.add(day_epoch)
+        merged.append({**row, "users_created_count": registrations_by_day.get(day_epoch, 0)})
+
+    now = int(time.time())
+    for day_epoch, count in registrations_by_day.items():
+        if day_epoch in covered or not count:
+            continue
+        day_date = datetime.fromtimestamp(day_epoch, tz=timezone.utc).date()
+        merged.append(
+            {
+                # Every traffic counter is present and zero, so a synthesised row has the
+                # same shape as a stored one and no reader has to special-case it.
+                **{field: 0 for field in _METRIC_COUNT_FIELDS},
+                "id": f"{day_date.isoformat()}_daily",
+                "date": day_date,
+                "aggregation_period": "daily",
+                "user_id": "",
+                "users_created_count": count,
+                "token_metrics": {},
+                "model_metrics": [],
+                "created_at": now,
+                "updated_at": now,
+            }
+        )
+
+    merged.sort(key=lambda record: _metric_day(record) or date.min)
+    return merged
+
+
 def identify_metrics_by_owner(rows: Sequence[Dict[str, Any]], user_id: str) -> List[Dict[str, Any]]:
     """Give one owner's rows the same id on every backend.
 

--- a/libs/agno/agno/os/authz/user_store.py
+++ b/libs/agno/agno/os/authz/user_store.py
@@ -344,6 +344,32 @@ class ManagedUserStore:
 
         return int(self._db.count_authz_users(include_disabled=include_disabled, search=search))
 
+    def registrations_by_day(
+        self, starting_at: Optional[int] = None, ending_before: Optional[int] = None
+    ) -> Dict[int, int]:
+        """How many users joined the directory on each UTC day, keyed by the day's epoch start.
+
+        Derived on read from the directory table, which holds one row per user: there is no
+        cached aggregate to refresh, and a removed user drops out of the history straight
+        away. ``starting_at`` / ``ending_before`` (epoch seconds) bound the scan to the range
+        a caller is reporting on.
+        """
+        if self._mem is None:
+            return self._db.count_authz_users_by_day(starting_at=starting_at, ending_before=ending_before)
+
+        from agno.db.authz_store import SECONDS_PER_DAY
+
+        counts: Dict[int, int] = {}
+        for user in self._mem.values():
+            created_at = int(user["created_at"])
+            if starting_at is not None and created_at < starting_at:
+                continue
+            if ending_before is not None and created_at >= ending_before:
+                continue
+            day_start = created_at - (created_at % SECONDS_PER_DAY)
+            counts[day_start] = counts.get(day_start, 0) + 1
+        return counts
+
     def is_disabled(self, id: Optional[str]) -> bool:
         """Fast path for the enforcement point: True only if the user exists AND is
         disabled. Unknown subjects are NOT disabled (the app may legitimately mint

--- a/libs/agno/agno/os/routers/metrics/metrics.py
+++ b/libs/agno/agno/os/routers/metrics/metrics.py
@@ -1,13 +1,18 @@
 import logging
 from datetime import date, datetime, timezone
-from typing import List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from fastapi import BackgroundTasks, Depends, HTTPException, Query, Request, Response
 from fastapi.routing import APIRouter
 from starlette.concurrency import run_in_threadpool
 
 from agno.db.base import AsyncBaseDb, BaseDb
-from agno.db.utils import aggregate_metrics_by_date, identify_metrics_by_owner, is_legacy_metric
+from agno.db.utils import (
+    aggregate_metrics_by_date,
+    identify_metrics_by_owner,
+    is_legacy_metric,
+    merge_registration_counts,
+)
 from agno.exceptions import AgnoError
 from agno.os.auth import get_auth_token_from_request, get_authentication_dependency
 from agno.os.middleware.user_scope import resolve_db_and_scope
@@ -47,6 +52,48 @@ def get_metrics_router(
         },
     )
     return attach_routes(router=router, dbs=dbs)
+
+
+SECONDS_PER_DAY = 24 * 60 * 60
+
+
+def _day_bounds(starting_date: Optional[date], ending_date: Optional[date]) -> tuple[Optional[int], Optional[int]]:
+    """The requested range as epoch seconds: inclusive lower bound, exclusive upper bound."""
+    starting_at = (
+        int(datetime.combine(starting_date, datetime.min.time(), tzinfo=timezone.utc).timestamp())
+        if starting_date is not None
+        else None
+    )
+    ending_before = (
+        int(datetime.combine(ending_date, datetime.min.time(), tzinfo=timezone.utc).timestamp()) + SECONDS_PER_DAY
+        if ending_date is not None
+        else None
+    )
+    return starting_at, ending_before
+
+
+async def _with_registration_counts(
+    request: Request,
+    metrics: List[Dict[str, Any]],
+    starting_date: Optional[date],
+    ending_date: Optional[date],
+) -> List[Dict[str, Any]]:
+    """Fold managed-directory registration counts into the day rows.
+
+    A no-op unless AgentOS was given a user directory. The counts are read from the
+    directory on every request instead of being cached and refreshed: the table holds one
+    row per user, so the grouped count is cheap, and it cannot drift from the directory
+    the way a stored aggregate does.
+    """
+    user_store = getattr(request.app.state, "user_store", None)
+    if user_store is None:
+        return metrics
+
+    starting_at, ending_before = _day_bounds(starting_date, ending_date)
+    registrations = await run_in_threadpool(
+        user_store.registrations_by_day, starting_at=starting_at, ending_before=ending_before
+    )
+    return merge_registration_counts(metrics, registrations)
 
 
 def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBaseDb, RemoteDb]]]) -> APIRouter:
@@ -141,6 +188,9 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
             # legacy one-row-per-day shape.
             if effective_user_id is None:
                 metrics = aggregate_metrics_by_date(metrics)
+                # Directory registrations are OS-level, not one owner's traffic, so they are
+                # attached only to the collapsed day rows an unscoped/admin read returns.
+                metrics = await _with_registration_counts(request, metrics, starting_date, ending_date)
             else:
                 # The unowned bucket is asked for by the same sentinel the SQL adapters stamp
                 # pre-ownership records with, and those hold every user's traffic

--- a/libs/agno/agno/os/routers/metrics/schemas.py
+++ b/libs/agno/agno/os/routers/metrics/schemas.py
@@ -18,6 +18,15 @@ class DayAggregatedMetrics(BaseModel):
     workflow_runs_count: int = Field(..., description="Total number of workflow runs", ge=0)
     workflow_sessions_count: int = Field(..., description="Total number of workflow sessions", ge=0)
     users_count: int = Field(..., description="Total number of unique users", ge=0)
+    users_created_count: int = Field(
+        0,
+        description=(
+            "Users who joined the managed user directory on this day. Always 0 unless "
+            "AgentOS is configured with a user directory; derived from the directory on "
+            "read, so a removed user leaves the history immediately."
+        ),
+        ge=0,
+    )
     token_metrics: Dict[str, Any] = Field(..., description="Token usage metrics (input, output, cached, etc.)")
     model_metrics: List[Dict[str, Any]] = Field(..., description="Metrics grouped by model (model_id, provider, count)")
 
@@ -41,6 +50,7 @@ class DayAggregatedMetrics(BaseModel):
             created_at=created_at,
             updated_at=updated_at,
             users_count=metrics_dict.get("users_count", 0),
+            users_created_count=metrics_dict.get("users_created_count", 0),
             workflow_runs_count=metrics_dict.get("workflow_runs_count", 0),
             workflow_sessions_count=metrics_dict.get("workflow_sessions_count", 0),
         )

--- a/libs/agno/tests/integration/db/test_authz_store.py
+++ b/libs/agno/tests/integration/db/test_authz_store.py
@@ -165,6 +165,50 @@ def test_user_listing_filters_and_sorts(db):
     assert [u["id"] for u in db.list_authz_users(sort_by="created_at", order="asc")] == ["u0", "u1", "u2"]
 
 
+def test_users_are_counted_by_utc_day(db):
+    for i, created_at in enumerate([100, 200, 86400 + 300]):
+        db.upsert_authz_user(
+            f"metric-user-{i}",
+            {
+                "email": None,
+                "name": None,
+                "disabled": False,
+                "created_at": created_at,
+                "updated_at": created_at,
+                "metadata": None,
+            },
+        )
+
+    assert db.count_authz_users_by_day() == {0: 2, 86400: 1}
+
+    # The range bounds the scan: lower bound inclusive, upper bound exclusive.
+    assert db.count_authz_users_by_day(starting_at=86400) == {86400: 1}
+    assert db.count_authz_users_by_day(ending_before=86400) == {0: 2}
+    assert db.count_authz_users_by_day(starting_at=0, ending_before=0) == {}
+
+
+def test_deleted_users_leave_the_daily_counts_immediately(db):
+    # No cached aggregate to refresh, so a removal is visible on the very next read.
+    for user_id in ("keep", "drop"):
+        db.upsert_authz_user(
+            user_id,
+            {"email": None, "name": None, "disabled": False, "created_at": 100, "updated_at": 100, "metadata": None},
+        )
+    assert db.count_authz_users_by_day() == {0: 2}
+
+    db.delete_authz_user("drop")
+    assert db.count_authz_users_by_day() == {0: 1}
+
+
+def test_disabled_users_still_count_as_registrations(db):
+    db.upsert_authz_user(
+        "revoked",
+        {"email": None, "name": None, "disabled": True, "created_at": 100, "updated_at": 100, "metadata": None},
+    )
+    # Revocation is not un-registration: the sign-up still happened that day.
+    assert db.count_authz_users_by_day() == {0: 1}
+
+
 def test_both_audit_trails_are_separate_and_searchable(db):
     db.record_authz_audit_event(
         {

--- a/libs/agno/tests/integration/os/test_managed_users.py
+++ b/libs/agno/tests/integration/os/test_managed_users.py
@@ -80,6 +80,24 @@ def test_store_crud_and_disable(tmp_path, db_url):
     assert store.remove("u2") is False
 
 
+@pytest.mark.parametrize("db_url", [None, "sqlite"])
+def test_store_registrations_by_day(tmp_path, db_url, monkeypatch):
+    url = None if db_url is None else f"sqlite:///{tmp_path / 'registrations.db'}"
+    store = ManagedUserStore(db_url=url)
+    timestamps = iter([100, 200, 86400 + 300])
+    monkeypatch.setattr("agno.os.authz.user_store._now", lambda: next(timestamps))
+
+    for user_id in ("u1", "u2", "u3"):
+        store.upsert(user_id)
+
+    assert store.registrations_by_day() == {0: 2, 86400: 1}
+    assert store.registrations_by_day(starting_at=86400) == {86400: 1}
+    assert store.registrations_by_day(ending_before=86400) == {0: 2}
+
+    store.remove("u1")
+    assert store.registrations_by_day() == {0: 1, 86400: 1}
+
+
 def test_store_emits_audit_with_actor_and_diff():
     sink = _CapturingSink()
     store = ManagedUserStore(audit=sink)
@@ -213,6 +231,85 @@ def test_users_api_is_admin_only():
 
     assert client.get("/users", headers=_auth("bob")).status_code == 403  # non-admin
     assert client.get("/users").status_code == 401  # anonymous
+
+
+def test_metrics_include_directory_registrations():
+    roles = ManagedRoleStore(db_url=_db_url())
+    roles.set_role_scopes("admin", ["agent_os:admin"])
+    roles.assign("alice", "admin")
+    users = ManagedUserStore(db_url=_db_url())
+
+    client = TestClient(_os(roles, users).get_app())
+    client.post("/users", headers=_auth("alice"), json={"id": "bob"})
+    client.post("/users", headers=_auth("alice"), json={"id": "carol"})
+
+    # No agent traffic at all, so the day exists only because of the registrations.
+    metrics = client.get("/metrics", headers=_auth("alice")).json()["metrics"]
+    assert len(metrics) == 1
+    assert metrics[0]["users_created_count"] == 2
+    assert metrics[0]["agent_runs_count"] == 0
+
+    # Read straight from the directory, so a removal shows up without any refresh call.
+    client.delete("/users/bob", headers=_auth("alice"))
+    metrics = client.get("/metrics", headers=_auth("alice")).json()["metrics"]
+    assert metrics[0]["users_created_count"] == 1
+
+
+def test_metrics_registrations_honour_the_date_range():
+    roles = ManagedRoleStore(db_url=_db_url())
+    roles.set_role_scopes("admin", ["agent_os:admin"])
+    roles.assign("alice", "admin")
+    users = ManagedUserStore(db_url=_db_url())
+
+    client = TestClient(_os(roles, users).get_app())
+    client.post("/users", headers=_auth("alice"), json={"id": "bob"})
+
+    assert (
+        client.get("/metrics?starting_date=1999-01-01&ending_date=1999-12-31", headers=_auth("alice")).json()["metrics"]
+        == []
+    )
+
+
+def test_metrics_without_a_directory_report_no_registrations():
+    roles = ManagedRoleStore(db_url=_db_url())
+    roles.set_role_scopes("admin", ["agent_os:admin"])
+    roles.assign("alice", "admin")
+
+    # A plain roles-only OS has no user directory; /metrics must be unaffected.
+    agent = Agent(id="research-agent", name="Research Agent", db=InMemoryDb())
+    app = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET], algorithm="HS256", verify_audience=True, audience=OS_ID, role_store=roles
+        ),
+    ).get_app()
+
+    response = TestClient(app).get("/metrics", headers=_auth("alice"))
+    assert response.status_code == 200, response.text
+    assert all(row["users_created_count"] == 0 for row in response.json()["metrics"])
+
+
+def test_registrations_are_not_exposed_to_a_user_scoped_read():
+    roles = ManagedRoleStore(db_url=_db_url())
+    roles.set_role_scopes("admin", ["agent_os:admin"])
+    roles.set_role_scopes("viewer", ["metrics:read"])
+    roles.assign("alice", "admin")
+    roles.assign("bob", "viewer")
+    users = ManagedUserStore(db_url=_db_url())
+
+    # user_isolation is what makes a non-admin read a scoped one. Without it /metrics is
+    # an OS-wide view for every metrics:read holder, registrations included, exactly as
+    # users_count and the run counters already are.
+    client = TestClient(_os(roles, users, user_isolation=True).get_app())
+    client.post("/users", headers=_auth("alice"), json={"id": "carol"})
+
+    # A scoped caller reads only their own rows, so OS-level directory totals are not
+    # theirs to see -- the directory holds a registration, and none of it reaches bob.
+    assert users.registrations_by_day() != {}
+    metrics = client.get("/metrics", headers=_auth("bob")).json()["metrics"]
+    assert all(row["users_created_count"] == 0 for row in metrics)
 
 
 def test_disabled_user_is_denied_even_with_valid_token():

--- a/libs/agno/tests/integration/os/test_managed_users.py
+++ b/libs/agno/tests/integration/os/test_managed_users.py
@@ -137,6 +137,7 @@ from agno.agent import Agent  # noqa: E402
 from agno.db.in_memory import InMemoryDb  # noqa: E402
 from agno.os import AgentOS  # noqa: E402
 from agno.os.authz.role_store import ManagedRoleStore  # noqa: E402
+from agno.os.authz.scope_provider import ScopeAuthorizationProvider  # noqa: E402
 from agno.os.config import AuthorizationConfig, UserDirectoryConfig  # noqa: E402
 
 
@@ -310,6 +311,31 @@ def test_registrations_are_not_exposed_to_a_user_scoped_read():
     assert users.registrations_by_day() != {}
     metrics = client.get("/metrics", headers=_auth("bob")).json()["metrics"]
     assert all(row["users_created_count"] == 0 for row in metrics)
+
+
+def test_registrations_reported_with_a_composite_authorization_provider():
+    # A composite/custom provider names no role_store, so AgentOS auto-mounts less for it.
+    # /metrics is a core router and the directory is seeded onto app.state either way, so
+    # registration counts must still be reported here.
+    roles = ManagedRoleStore(db_url=_db_url())
+    users = ManagedUserStore(db_url=_db_url())
+    users.upsert("someone")
+
+    app = AgentOS(
+        id=OS_ID,
+        agents=[Agent(id="research-agent", name="Research Agent", db=InMemoryDb())],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            authorization_provider=[ScopeAuthorizationProvider(), roles.provider],
+        ),
+        user_directory=UserDirectoryConfig(user_store=users),
+    ).get_app()
+
+    response = TestClient(app).get("/metrics", headers=_auth("operator", scopes=["metrics:read"]))
+    assert response.status_code == 200, response.text
+    assert [row["users_created_count"] for row in response.json()["metrics"]] == [1]
 
 
 def test_disabled_user_is_denied_even_with_valid_token():

--- a/libs/agno/tests/unit/db/test_metrics_registration_counts.py
+++ b/libs/agno/tests/unit/db/test_metrics_registration_counts.py
@@ -59,6 +59,13 @@ class TestMergeRegistrationCounts:
         assert merged[0]["agent_runs_count"] == 0
         assert merged[0]["id"] == "2026-01-05_daily"
 
+    def test_synthesised_created_at_is_stable_across_calls(self):
+        # Derived per request, so created_at must not be "now": a client polling the
+        # endpoint would otherwise see an unchanged day as a new record every time.
+        first = merge_registration_counts([], {_day_epoch(2026, 1, 5): 4})[0]
+        second = merge_registration_counts([], {_day_epoch(2026, 1, 5): 4})[0]
+        assert first["created_at"] == second["created_at"] == _day_epoch(2026, 1, 5)
+
     def test_synthesised_and_stored_rows_come_back_in_date_order(self):
         merged = merge_registration_counts(
             [_metric_row(date(2026, 1, 3))],

--- a/libs/agno/tests/unit/db/test_metrics_registration_counts.py
+++ b/libs/agno/tests/unit/db/test_metrics_registration_counts.py
@@ -1,0 +1,77 @@
+"""Unit tests for folding directory registration counts into day-aggregated metrics.
+
+``merge_registration_counts`` runs after per-user buckets have been collapsed, so it
+sees one record per day. Registrations are OS-level, and a day can have them without
+any traffic at all.
+"""
+
+from datetime import date, datetime, timezone
+
+from agno.db.utils import merge_registration_counts
+
+
+def _day_epoch(year, month, day):
+    return int(datetime(year, month, day, tzinfo=timezone.utc).timestamp())
+
+
+def _metric_row(day, agent_runs_count=1, period="daily"):
+    return {
+        "id": f"{day.isoformat()}_{period}",
+        "date": day,
+        "aggregation_period": period,
+        "user_id": "",
+        "agent_runs_count": agent_runs_count,
+        "users_count": 0,
+        "token_metrics": {},
+        "model_metrics": [],
+        "created_at": 1,
+        "updated_at": 2,
+    }
+
+
+class TestMergeRegistrationCounts:
+    def test_no_registrations_leaves_rows_untouched(self):
+        rows = [_metric_row(date(2026, 1, 1))]
+        assert merge_registration_counts(rows, {}) == rows
+
+    def test_count_is_attached_to_the_matching_day(self):
+        rows = [_metric_row(date(2026, 1, 1)), _metric_row(date(2026, 1, 2))]
+        merged = merge_registration_counts(rows, {_day_epoch(2026, 1, 2): 3})
+        assert [(r["date"], r["users_created_count"]) for r in merged] == [
+            (date(2026, 1, 1), 0),
+            (date(2026, 1, 2), 3),
+        ]
+
+    def test_traffic_is_preserved_when_a_count_is_attached(self):
+        merged = merge_registration_counts(
+            [_metric_row(date(2026, 1, 1), agent_runs_count=7)], {_day_epoch(2026, 1, 1): 2}
+        )
+        assert merged[0]["agent_runs_count"] == 7
+        assert merged[0]["users_created_count"] == 2
+
+    def test_a_day_with_registrations_and_no_traffic_is_synthesised(self):
+        # A directory-only deployment: someone signed up, nothing ran. Without the
+        # synthesised row the day would not be reported at all.
+        merged = merge_registration_counts([], {_day_epoch(2026, 1, 5): 4})
+        assert len(merged) == 1
+        assert merged[0]["date"] == date(2026, 1, 5)
+        assert merged[0]["users_created_count"] == 4
+        assert merged[0]["agent_runs_count"] == 0
+        assert merged[0]["id"] == "2026-01-05_daily"
+
+    def test_synthesised_and_stored_rows_come_back_in_date_order(self):
+        merged = merge_registration_counts(
+            [_metric_row(date(2026, 1, 3))],
+            {_day_epoch(2026, 1, 1): 1, _day_epoch(2026, 1, 9): 2},
+        )
+        assert [r["date"] for r in merged] == [date(2026, 1, 1), date(2026, 1, 3), date(2026, 1, 9)]
+
+    def test_zero_count_days_are_not_synthesised(self):
+        assert merge_registration_counts([], {_day_epoch(2026, 1, 1): 0}) == []
+
+    def test_non_daily_buckets_are_left_alone(self):
+        rows = [_metric_row(date(2026, 1, 1), period="monthly")]
+        merged = merge_registration_counts(rows, {_day_epoch(2026, 1, 1): 5})
+        # The monthly row keeps its shape, and the day still gets reported on its own row.
+        assert merged[0] == rows[0]
+        assert [r["users_created_count"] for r in merged if r.get("aggregation_period") == "daily"] == [5]


### PR DESCRIPTION
## Summary

Adds `users_created_count` to `GET /metrics`: how many users joined the managed user directory on each UTC day.

**This is not a replacement for [#9904](https://github.com/agno-agi/agno/pull/9904).** #9904 ships two metrics behind a new `/metrics/os` router and an `agno_os_metrics` cache table; this PR covers one of them (registrations) as a field on the existing `/metrics` route. It does not carry the authorization decision counts, and it does not provide #9904's endpoints, so anything written against that contract would not work against this. It targets the same base branch, `feat/agentos-authz`.

Treat it as a narrower alternative for the registration metric only, not as a superset.

**The count is derived from the directory on read, not cached.** The directory table holds one row per user, so grouping it by day is a small query. That buys three things over a stored aggregate:

- It cannot drift from the directory, so there is nothing to refresh and no refresh endpoint to call.
- A removed user leaves the history immediately, rather than at the next refresh.
- No new table, so no schema migration.

That last point is load-bearing: `agno_metrics` is a released table, and adding a column to it would make `is_valid_table` reject every existing deployment's table until a new migration version ran, across four SQL dialects. Reading the count at request time avoids the migration entirely, and the response field is additive with a default of `0`.

## What it reuses

`/metrics` already provides everything the OS-metrics router in #9904 rebuilds:

| Need | Already in `/metrics` |
|---|---|
| Refresh state machine | `refresh_states`, keyed per db id |
| Date-range filtering and response shaping | `starting_date` / `ending_date`, `to_utc_datetime` |
| Incremental recomputation | the `completed` flag plus `_get_metrics_calculation_starting_date` |
| Scope mapping | `GET /metrics` -> `metrics:read` |

So this PR adds no router, no endpoint, no scope, and no refresh pipeline.

## Behaviour

- Counts are attached only on the unscoped/admin read, after per-user buckets are collapsed. A user-scoped caller (`user_isolation=True`, non-admin) reads their own rows and gets no OS-level totals.
- A day with registrations but no traffic gets a synthesised row with every traffic counter at zero, so a directory-only deployment still reports the day. Without it, an OS where someone signed up and nothing ran would report nothing at all.
- `users_created_count` is `0` when AgentOS has no user directory; `GET /metrics` is otherwise unchanged.
- Disabled users still count as registrations: revocation is not un-registration.
- `authz_users.created_at` is now indexed, since the range bound scans it.

## Parity against #9904

Everything #9904 delivers, and where it lands here:

| #9904 | Here |
|---|---|
| `users_created_count` per UTC day | Same, on `GET /metrics` |
| `authorization_allowed/denied_count` per day | **Not carried** (see below) |
| `GET /metrics/os` | `GET /metrics` |
| `POST /metrics/os/refresh` (sync + background) | Not needed: derived on read |
| `GET /metrics/os/refresh/status` | Not needed: nothing runs |
| `metrics:read` / `metrics:write` mappings | Reuses the existing `GET /metrics` mapping |
| `agno_os_metrics` cache table | None |
| Incremental refresh (`decisions_since`, merge rules) | Not needed |
| Days with no data dropped | Same |
| Stable `created_at` per day | Same, anchored to the day it describes |
| Works with composite/custom authz providers | Same, with a test |
| In-memory / SQLite / PostgreSQL directories | Same |
| `authz_users.created_at` index | Same |

Three smaller differences worth knowing:

- **Inverted date ranges.** #9904's new endpoint returns 422 when `starting_date > ending_date`. `GET /metrics` returns `200 []` for that today. Reusing the endpoint inherits its existing contract; tightening it would be a breaking change to a shipped route.
- **`updated_at` on a directory-only OS.** The top-level `updated_at` reflects the stored metrics table, so it is `null` when an OS has a directory and no traffic. #9904's response carried its cache's write time instead. The per-row `updated_at` is populated either way.
- **`db_id`.** #9904's endpoint takes none. Here the counts attach to whichever database the caller selected, as described under Additional Notes.

## What this deliberately leaves out

#9904 also adds daily authorization allow/deny counts. Those are not carried over, because the metrics endpoints are authorized like any other route and so record their own `access.allowed` decisions. On that branch, with zero users and zero application traffic, 20 dashboard polls produce this:

```
after 1st refresh:        allowed=1
after 20 polls + refresh: allowed=23
```

A dashboard polling every 30s would contribute ~2,880 allows/day on its own, before any real traffic. Allow-by-default routes also record an allow, and a request that passes the route gate then fails a per-resource gate records both an allow and a deny. That belongs upstream in the audit trail rather than in a metrics endpoint, so it is left for a follow-up.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Tests.** 14 new tests across three levels: `merge_registration_counts` as a pure function, `count_authz_users_by_day` against SQLite, and the API path through `TestClient`. Every one of them was confirmed to fail against `feat/agentos-authz` before the implementation landed. The two whose assertions are trivially true on the base branch (an empty-list result) were additionally mutation-tested: dropping the date bounds breaks the range test, and dropping the no-directory guard breaks the no-directory test.

**Scope of the reuse.** `/metrics?db_id=` selects one database, while the directory is a single OS-level store, so registration counts are attached to whichever database the caller selected. In the normal `user_directory=True` path the directory adopts `AgentOS(db=...)`, which is the database `/metrics` reaches anyway. A client that sums responses across several `db_id` values would double-count the registration column; every other column is per-database and unaffected.

**Not covered.** MySQL, SingleStore and the async backends do not implement the authz storage contract, so `count_authz_users_by_day` follows the existing `NotImplementedError` pattern there. `ManagedUserStore` cannot be used with those backends in the first place (`supports_authz` rejects them), so the path is unreachable rather than broken.

**No cookbook.** The change is a field on an existing endpoint's response, not a new pattern, so there is nothing to demonstrate that the authorization cookbooks do not already cover. Happy to add one if you would rather it be shown explicitly.

This does not close [#9904](https://github.com/agno-agi/agno/pull/9904). #9904's authorization decision counts have no equivalent here, and its `/metrics/os` endpoints are not provided.