### PR TITLE
fix: clean startup logs and initialize durable queue storage

### DIFF
--- a/cookbook/05_agent_os/background_tasks/README.md
+++ b/cookbook/05_agent_os/background_tasks/README.md
@@ -17,10 +17,10 @@ A preparation failure is reported; the existing lazy enqueue path remains
 available, but queue operations may fail until storage is provisioned.
 
 Agno prints plain, unwrapped log lines to container/file output and retains Rich
-formatting in interactive terminals. Custom application loggers are preserved.
-Workflow run summaries include the workflow and run IDs and the actual outcome;
-normal debug output includes session and step information. Set `AGNO_DEBUG=True`
-and `AGNO_DEBUG_LEVEL=2` for detailed preparation and storage diagnostics.
+formatting in interactive terminals and Jupyter notebooks. Custom application
+loggers are preserved. Set `AGNO_DEBUG=True` for workflow lifecycle summaries,
+including workflow/run IDs, session and step information, and the actual outcome.
+Set `AGNO_DEBUG_LEVEL=2` for detailed preparation and storage diagnostics.
 
 Connection pool health checks stay enabled. To diagnose pool activity explicitly:
 
@@ -34,15 +34,16 @@ logging.getLogger("sqlalchemy.pool").setLevel(logging.DEBUG)
 Alternatively, pass `echo_pool="debug"` to `create_postgres_engine`. Routine
 Agno debug output does not enable connection checkouts, pre-pings or resets.
 
-Example workflow output:
+Example workflow output with `AGNO_DEBUG=True`:
 
 ```text
 INFO    Workflow queued: sync-docs run=<run-id>
 DEBUG   Session: <session-id>
-INFO    Workflow started: sync-docs run=<run-id>
+DEBUG   Workflow started: sync-docs run=<run-id>
 DEBUG   Step started: sync-docs step=1/1 streaming=true
-INFO    Workflow completed: sync-docs run=<run-id> duration=2.31s
+DEBUG   Workflow completed: sync-docs run=<run-id> duration=2.31s
 ```
 
-A failed workflow reports `Workflow failed`; a paused or cancelled workflow keeps
-that status. A successful health/status HTTP request is not workflow completion.
+Debug summaries report `Workflow failed`, paused, or cancelled as appropriate.
+Existing execution errors remain visible without debug logging. A successful
+health/status HTTP request is not workflow completion.

--- a/cookbook/05_agent_os/background_tasks/README.md
+++ b/cookbook/05_agent_os/background_tasks/README.md
@@ -1,0 +1,48 @@
+# Background tasks
+
+- `durable_queue.py`: submit, poll, stream and recover durable background runs.
+- `durable_continue.py`: resume a paused run through its durable queue ticket.
+- `redis_event_stream.py`: share queued-run events across replicas.
+
+Run `durable_queue.py` with PostgreSQL available and `OPENAI_API_KEY` set. Set
+`DATABASE_URL` to override the example's local PostgreSQL connection.
+
+## Startup and run logs
+
+The durable PostgreSQL worker creates its jobs table before polling when AgentOS
+`auto_provision_dbs=True` (the default). An idle queue produces no routine polling
+messages. Set `auto_provision_dbs=False` for an externally managed schema. Stores
+without the optional `ensure_jobs_table()` hook retain read-only startup priming.
+A preparation failure is reported; the existing lazy enqueue path remains
+available, but queue operations may fail until storage is provisioned.
+
+Agno prints plain, unwrapped log lines to container/file output and retains Rich
+formatting in interactive terminals. Custom application loggers are preserved.
+Workflow run summaries include the workflow and run IDs and the actual outcome;
+normal debug output includes session and step information. Set `AGNO_DEBUG=True`
+and `AGNO_DEBUG_LEVEL=2` for detailed preparation and storage diagnostics.
+
+Connection pool health checks stay enabled. To diagnose pool activity explicitly:
+
+```python
+import logging
+
+logging.basicConfig()
+logging.getLogger("sqlalchemy.pool").setLevel(logging.DEBUG)
+```
+
+Alternatively, pass `echo_pool="debug"` to `create_postgres_engine`. Routine
+Agno debug output does not enable connection checkouts, pre-pings or resets.
+
+Example workflow output:
+
+```text
+INFO    Workflow queued: sync-docs run=<run-id>
+DEBUG   Session: <session-id>
+INFO    Workflow started: sync-docs run=<run-id>
+DEBUG   Step started: sync-docs step=1/1 streaming=true
+INFO    Workflow completed: sync-docs run=<run-id> duration=2.31s
+```
+
+A failed workflow reports `Workflow failed`; a paused or cancelled workflow keeps
+that status. A successful health/status HTTP request is not workflow completion.

--- a/cookbook/05_agent_os/background_tasks/TEST_LOG.md
+++ b/cookbook/05_agent_os/background_tasks/TEST_LOG.md
@@ -88,3 +88,17 @@
 **Result:** PASS end to end.
 
 ---
+
+### durable_queue.py
+
+**Status:** PASS
+
+**Description:** Started the example under FastAPI TestClient using the demo
+virtual environment and a disposable PostgreSQL database. Verified `/health`,
+creation of `ai.agno_jobs` before the first enqueue, and a strict lookup with no
+ticket. Captured concise startup logs and clean worker shutdown.
+
+**Result:** Startup and queue provisioning passed. No model calls, recovery
+scenario, or live streaming exercise was performed in this smoke check.
+
+---

--- a/cookbook/05_agent_os/background_tasks/durable_queue.py
+++ b/cookbook/05_agent_os/background_tasks/durable_queue.py
@@ -42,6 +42,11 @@ Try it:
    guaranteed via polling; reconnecting replays missed events. Durability
    attaches to the RUN; the stream is the best-effort live view.
 
+With auto-provisioning enabled, the worker prepares agno_jobs before polling;
+a fresh database needs no priming enqueue. With auto_provision_dbs=False, provision
+queue storage yourself. A failed startup prepare logs a warning and preserves
+lazy creation on enqueue.
+
 The queue store defaults to the AgentOS db (the Postgres below - zero extra
 infrastructure). To isolate queue load on a dedicated Redis instead:
 
@@ -60,12 +65,16 @@ Requirements:
 - OPENAI_API_KEY set
 """
 
+from os import getenv
+
 from agno.agent import Agent
 from agno.db.postgres import PostgresDb
 from agno.models.openai import OpenAIResponses
 from agno.os import AgentOS, QueueConfig
 
-db = PostgresDb(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai")
+db = PostgresDb(
+    db_url=getenv("DATABASE_URL", "postgresql+psycopg://ai:ai@localhost:5532/ai")
+)
 
 agent = Agent(
     name="Durable Agent",

--- a/libs/agno/agno/agent/_init.py
+++ b/libs/agno/agno/agent/_init.py
@@ -302,7 +302,7 @@ def initialize_agent(agent: Agent, debug_mode: Optional[bool] = None) -> None:
     if agent.learning is not None and agent.learning is not False:
         set_learning_machine(agent)
 
-    log_debug(f"Agent ID: {agent.id}", center=True)
+    log_debug(f"Agent initialized: {agent.id}")
 
     if agent._formatter is None:
         agent._formatter = SafeFormatter()

--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -259,7 +259,7 @@ class TableResolutionCache:
         for key in [k for k in self._tables if k[1] == table_name]:
             self._tables.pop(key, None)
             evicted += 1
-        log_debug(f"Table cache: invalidated '{table_name}' ({evicted} cached resolution(s) evicted)")
+        log_debug(f"Table cache: invalidated '{table_name}' ({evicted} cached resolution(s) evicted)", log_level=2)
 
     def clear(self) -> None:
         self._tables.clear()
@@ -388,7 +388,7 @@ class BaseDb(ABC):
         if cached is not None:
             return cached
         if not create_table_if_not_found and not self.table_exists(table_name):
-            log_debug(f"Table '{table_name}' does not exist")
+            log_debug(f"Table '{table_name}' does not exist", log_level=2)
             return None
         with self._resolve_lock:
             cached = self._table_cache.get(table_type, table_name)
@@ -2176,7 +2176,7 @@ class AsyncBaseDb(ABC):
         if cached is not None:
             return cached
         if not create_table_if_not_found and not await self.table_exists(table_name):
-            log_debug(f"Table '{table_name}' does not exist")
+            log_debug(f"Table '{table_name}' does not exist", log_level=2)
             return None
         async with self._resolve_lock_async:
             cached = self._table_cache.get(table_type, table_name)

--- a/libs/agno/agno/db/postgres/_bounded.py
+++ b/libs/agno/agno/db/postgres/_bounded.py
@@ -38,6 +38,8 @@ class _BudgetQueue(Queue):
 
 
 class _BudgetPool(QueuePool):
+    # Keep SQLAlchemy diagnostics independent of the application debug level.
+    _sqla_logger_namespace = "sqlalchemy.pool.agno"
     _queue_class = _BudgetQueue
 
 
@@ -112,6 +114,7 @@ def bounded_engine(source: Engine, *, capacity: int) -> Engine:
         max_overflow=0,
         timeout=3,
         pre_ping=True,
+        echo=source.pool.echo,
         recycle=300,
         _dispatch=source.pool.dispatch,
         dialect=source.dialect,

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -373,10 +373,10 @@ class AsyncPostgresDb(AsyncBaseDb):
             if not await self.table_exists(table_name):
                 async with self.db_engine.begin() as conn:
                     await conn.run_sync(table.create, checkfirst=True)
-                log_debug(f"Successfully created table '{table_name}'")
+                log_debug(f"Created table {self.db_schema}.{table_name}")
                 table_created = True
             else:
-                log_debug(f"Table '{self.db_schema}.{table_name}' already exists, skipping creation")
+                log_debug(f"Table {self.db_schema}.{table_name} already exists", log_level=2)
 
             # Create indexes
             for idx in table.indexes:
@@ -403,14 +403,22 @@ class AsyncPostgresDb(AsyncBaseDb):
                 # Also store the schema version for the created table
                 latest_schema_version = MigrationManager(self).latest_schema_version
                 await self.upsert_schema_version(table_name=table_name, version=latest_schema_version.public)
-                log_info(
-                    f"Successfully stored version {latest_schema_version.public} in database for table {table_name}"
+                log_debug(
+                    f"Stored schema version {latest_schema_version.public}: {self.db_schema}.{table_name}", log_level=2
                 )
 
             return table
 
         except Exception as e:
-            log_error(f"Could not create table {self.db_schema}.{table_name}: {str(e)}")
+            # Concurrent CREATE TABLE may lose the catalog's uniqueness race.
+            # The caller still receives the exception and decides whether it can
+            # resolve the winner; an existing winner is not a database outage.
+            cause = getattr(e, "orig", e)
+            sqlstate = getattr(cause, "sqlstate", getattr(cause, "pgcode", None))
+            if sqlstate in ("42P07", "23505") and await self.table_exists(table_name):
+                log_debug(f"Concurrent table creation: {self.db_schema}.{table_name}", log_level=2)
+            else:
+                log_error(f"Could not create table {self.db_schema}.{table_name}: {str(e)}")
             raise
 
     async def _get_table(self, table_type: str, create_table_if_not_found: Optional[bool] = False) -> Optional[Table]:
@@ -4729,6 +4737,25 @@ class AsyncPostgresDb(AsyncBaseDb):
         except Exception as e:
             log_warning(f"Error inserting session if absent (caller falls back): {e}")
             return None
+
+    async def ensure_jobs_table(self) -> None:
+        """Prepare durable queue storage before polling or accepting continuations.
+
+        Stores without this optional hook retain lazy initialization. Propagate
+        provisioning failures so the worker can report unavailable storage.
+        """
+        try:
+            table = await self._get_table(table_type="jobs", create_table_if_not_found=True)
+        except Exception as exc:
+            # Another replica may have completed the first-time DDL meanwhile.
+            cause = getattr(exc, "orig", exc)
+            sqlstate = getattr(cause, "sqlstate", getattr(cause, "pgcode", None))
+            if sqlstate not in ("42P07", "23505") or not await self.table_exists(self.job_table_name):
+                raise
+            self._invalidate_table_cache(self.job_table_name)
+            table = await self._get_table(table_type="jobs")
+        if table is None:
+            raise RuntimeError("Job queue table is unavailable after provisioning")
 
     async def enqueue_job(self, job: Dict[str, Any], max_depth: int = 0) -> Dict[str, Any]:
         """Insert an accepted run job.

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -512,10 +512,10 @@ class PostgresDb(BaseDb):
             table_created = False
             if not self.table_exists(table_name):
                 table.create(self.db_engine, checkfirst=True)
-                log_debug(f"Successfully created table '{self.db_schema}.{table_name}'")
+                log_debug(f"Created table {self.db_schema}.{table_name}")
                 table_created = True
             else:
-                log_debug(f"Table {self.db_schema}.{table_name} already exists, skipping creation")
+                log_debug(f"Table {self.db_schema}.{table_name} already exists", log_level=2)
 
             # Create indexes (Postgres)
             for idx in table.indexes:
@@ -545,7 +545,15 @@ class PostgresDb(BaseDb):
             return table
 
         except Exception as e:
-            log_error(f"Could not create table {self.db_schema}.{table_name}: {str(e)}")
+            # Concurrent CREATE TABLE may lose the catalog's uniqueness race.
+            # The caller still receives the exception and decides whether it can
+            # resolve the winner; an existing winner is not a database outage.
+            cause = getattr(e, "orig", e)
+            sqlstate = getattr(cause, "sqlstate", getattr(cause, "pgcode", None))
+            if sqlstate in ("42P07", "23505") and self.table_exists(table_name):
+                log_debug(f"Concurrent table creation: {self.db_schema}.{table_name}", log_level=2)
+            else:
+                log_error(f"Could not create table {self.db_schema}.{table_name}: {str(e)}")
             raise
 
     def _resolve_fk_reference(self, fk_ref: str) -> str:
@@ -7395,6 +7403,25 @@ class PostgresDb(BaseDb):
         except Exception as e:
             log_warning(f"Error inserting session if absent (caller falls back): {e}")
             return None
+
+    def ensure_jobs_table(self) -> None:
+        """Prepare durable queue storage before polling or accepting continuations.
+
+        Stores without this optional hook retain lazy initialization. Propagate
+        provisioning failures so the worker can report unavailable storage.
+        """
+        try:
+            table = self._get_table(table_type="jobs", create_table_if_not_found=True)
+        except Exception as exc:
+            # Another replica may have completed the first-time DDL meanwhile.
+            cause = getattr(exc, "orig", exc)
+            sqlstate = getattr(cause, "sqlstate", getattr(cause, "pgcode", None))
+            if sqlstate not in ("42P07", "23505") or not self.table_exists(self.job_table_name):
+                raise
+            self._invalidate_table_cache(self.job_table_name)
+            table = self._get_table(table_type="jobs")
+        if table is None:
+            raise RuntimeError("Job queue table is unavailable after provisioning")
 
     def enqueue_job(self, job: Dict[str, Any], max_depth: int = 0) -> Dict[str, Any]:
         """Insert an accepted run job.

--- a/libs/agno/agno/db/postgres/utils.py
+++ b/libs/agno/agno/db/postgres/utils.py
@@ -68,7 +68,7 @@ def create_schema(session: Session, db_schema: str) -> None:
         db_schema (str): The definition of the database schema to create
     """
     try:
-        log_debug(f"Creating schema if not exists: {db_schema}")
+        log_debug(f"Ensuring schema {db_schema}", log_level=2)
         session.execute(text(f"CREATE SCHEMA IF NOT EXISTS {db_schema};"))
     except Exception as e:
         log_warning(f"Could not create schema {db_schema}: {str(e)}")
@@ -82,7 +82,7 @@ async def acreate_schema(session: AsyncSession, db_schema: str) -> None:
         db_schema (str): The definition of the database schema to create
     """
     try:
-        log_debug(f"Creating schema if not exists: {db_schema}")
+        log_debug(f"Ensuring schema {db_schema}", log_level=2)
         await session.execute(text(f"CREATE SCHEMA IF NOT EXISTS {db_schema};"))
     except Exception as e:
         log_warning(f"Could not create schema {db_schema}: {str(e)}")

--- a/libs/agno/agno/job_queue/store.py
+++ b/libs/agno/agno/job_queue/store.py
@@ -8,6 +8,11 @@ settle_swept_job, get_job, count_queued_jobs) against process memory.
 This is the contract-test fixture and the single-process dev fallback - it is
 NOT durable (a restart loses the queue) and is never a substitute for the
 DB-backed store in production. One instance per process.
+
+Persistent stores may provide an optional ``ensure_jobs_table()`` hook (sync or
+async, matching their other methods). Workers call it before polling when
+auto-provisioning is enabled; failures are reported and lazy enqueue remains
+available. Third-party stores without the hook keep read-only startup priming.
 """
 
 import asyncio

--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -167,13 +167,19 @@ class Knowledge(RemoteKnowledge):
 
     def setup(self) -> None:
         """Prepare and validate coordinated page storage before query traffic."""
-        self._pages().setup()
+        pages = self._pages()
+        log_info(f"Preparing knowledge storage: namespace={pages.namespace}")
+        pages.setup()
+        log_info(f"Knowledge storage ready: namespace={pages.namespace}")
 
     async def asetup(self) -> None:
         """Prepare page storage on bounded workers."""
         from agno.knowledge.page._coordinator import SYNC_WORKERS
 
-        await SYNC_WORKERS.run(self._pages().setup, seconds=60)
+        pages = self._pages()
+        log_info(f"Preparing knowledge storage: namespace={pages.namespace}")
+        await SYNC_WORKERS.run(pages.setup, seconds=60)
+        log_info(f"Knowledge storage ready: namespace={pages.namespace}")
 
     def sync_pages(
         self,

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -2035,6 +2035,7 @@ class AgentOS:
             try:
                 if hasattr(db, "_create_all_tables") and callable(db._create_all_tables):
                     db._create_all_tables()
+                    log_info(f"Database ready: {db.__class__.__name__} id={db.id}")
             except Exception as e:
                 log_warning(f"Failed to initialize {db.__class__.__name__} (id: {db.id}): {str(e)}")
 
@@ -2059,6 +2060,7 @@ class AgentOS:
             try:
                 if hasattr(db, "_create_all_tables") and callable(db._create_all_tables):
                     await db._create_all_tables()
+                    log_info(f"Database ready: {db.__class__.__name__} id={db.id}")
             except Exception as e:
                 log_warning(f"Failed to initialize async {db.__class__.__name__} (id: {db.id}): {str(e)}")
 

--- a/libs/agno/agno/os/job_queue.py
+++ b/libs/agno/agno/os/job_queue.py
@@ -353,6 +353,7 @@ class QueueWorker:
         config: QueueConfig,
         worker_id: Optional[str] = None,
         stop_timeout: int = _DEFAULT_STOP_TIMEOUT,
+        auto_provision: bool = True,
     ) -> None:
         from uuid import uuid4
 
@@ -361,6 +362,7 @@ class QueueWorker:
         self.config = config
         self.worker_id = worker_id or f"worker-{uuid4().hex[:8]}"
         self.stop_timeout = stop_timeout
+        self.auto_provision = auto_provision
         if stop_timeout >= config.lock_grace_seconds:
             # Hard validation, not a warning: violating this GUARANTEES the
             # drain-sweep race - a draining run's lease can expire mid-drain
@@ -385,6 +387,7 @@ class QueueWorker:
         if self._running:
             return
         self._running = True
+        await self._prepare_store()
         # Lease renewal runs on a DEDICATED THREAD wherever the store allows
         # it: a liveness signal must not depend on the health of the thing
         # whose liveness it certifies. The old loop-task heartbeat died
@@ -393,12 +396,6 @@ class QueueWorker:
         # lock_grace and a peer swept a healthy worker; sync I/O releases
         # the GIL, so a thread keeps beating precisely when the loop cannot.
         if isinstance(self.store, _SyncStoreAdapter):
-            # Prime the store's lazy table init from the loop's thread pool
-            # first: the sync Postgres adapter's first _get_table is not
-            # safe under two first-callers, and the heartbeat thread is
-            # about to become a second caller.
-            with contextlib.suppress(Exception):
-                await self.store.get_job(self.worker_id)
             self._start_heartbeat_thread(self.store._store.heartbeat_jobs)
         else:
             # Async persistent stores (e.g. AsyncPostgresDb) face the same
@@ -408,14 +405,6 @@ class QueueWorker:
             # event loop instead.
             thread_store = self._clone_store_for_heartbeat_thread()
             if thread_store is not None:
-                # Prime the worker's OWN store first (symmetric with the sync
-                # branch): the clone is a distinct instance with its own lazy
-                # table cache, and without an existing table its first beat
-                # could race the poll loop's first call into concurrent
-                # CREATE TABLE IF NOT EXISTS (checkfirst is not atomic).
-                # After this, both instances only reflect an existing table.
-                with contextlib.suppress(Exception):
-                    await self.store.get_job(self.worker_id)
                 self._start_heartbeat_thread(thread_store.heartbeat_jobs, owned_store=thread_store)
             else:
                 from agno.job_queue.store import InMemoryQueueStore
@@ -441,7 +430,24 @@ class QueueWorker:
         # never begin executing (and potentially block the loop) before the
         # heartbeat exists.
         self._task = asyncio.create_task(self._poll_loop())
-        log_info(f"Job queue worker started (worker={self.worker_id}, poll={self.config.poll_interval}s)")
+        log_info(f"Job queue worker started: worker={self.worker_id} poll={self.config.poll_interval:g}s")
+
+    async def _prepare_store(self) -> None:
+        """Finish optional provisioning before heartbeat and poll tasks race to resolve tables."""
+        ensure = getattr(self.store, "ensure_jobs_table", None)
+        if self.auto_provision and callable(ensure):
+            try:
+                await ensure()
+            except Exception as exc:
+                log_warning(
+                    f"Job queue storage preparation failed ({type(exc).__name__}); "
+                    "provision the jobs table and verify database permissions. Jobs may be unavailable.",
+                )
+        else:
+            # Third-party stores and externally provisioned databases keep the
+            # existing read-only startup probe. An empty store is normal.
+            with contextlib.suppress(Exception):
+                await self.store.get_job(self.worker_id)
 
     def _clone_store_for_heartbeat_thread(self) -> Optional[Any]:
         """A second instance of an async persistent store, owned by the
@@ -2255,7 +2261,6 @@ async def aprepare_accepted_or_abort(
     """
     try:
         await aprepare_queued_run(component, component_type, run_id, session_id, user_id, input)
-        return
     except Exception as e:
         cancelled = False
         with contextlib.suppress(Exception):
@@ -2287,6 +2292,8 @@ async def aprepare_accepted_or_abort(
             detail=f"Run acceptance aborted: the run row could not be prepared ({type(e).__name__}); "
             "the queued job was cancelled and will not execute. Retry the submission.",
         )
+
+    log_info(f"{component_type.capitalize()} queued: {getattr(component, 'id', component_type)} run={run_id}")
 
 
 async def aticket_poll_fallback(
@@ -2390,13 +2397,7 @@ async def queue_lifespan(app: Any, agent_os: Any):
     warn_unfenced_session_stores(agent_os)
 
     if isinstance(get_event_stream(), InMemoryEventStream):
-        log_warning(
-            "Durable queue with the in-memory event stream: streamed views of queued runs are "
-            "replica-local. In a multi-replica deployment, a stream request accepted on one "
-            "replica cannot see events produced by another replica's worker - the tail will idle "
-            "until client timeout even though the run completes durably. Set queue.redis to wire "
-            "a shared event stream."
-        )
+        log_warning("Queued-run streams are replica-local; configure queue.redis for cross-replica streaming.")
 
     def resolve_component(component_type: str, component_id: str) -> Any:
         registry = {
@@ -2427,7 +2428,11 @@ async def queue_lifespan(app: Any, agent_os: Any):
         return None
 
     worker = QueueWorker(
-        store=store, resolve_component=resolve_component, config=config, stop_timeout=resolve_stop_timeout(config)
+        store=store,
+        resolve_component=resolve_component,
+        config=config,
+        stop_timeout=resolve_stop_timeout(config),
+        auto_provision=getattr(agent_os, "auto_provision_dbs", True),
     )
     app.state.queue_worker = worker
     set_active_queue_worker(worker)

--- a/libs/agno/agno/os/managers.py
+++ b/libs/agno/agno/os/managers.py
@@ -463,7 +463,7 @@ class SSESubscriberManager:
             self._subscribers[run_id] = []
         queue: asyncio.Queue[Optional[tuple[int, str]]] = asyncio.Queue()
         self._subscribers[run_id].append(queue)
-        log_debug(f"SSE subscriber registered for run {run_id}")
+        log_debug(f"Event subscriber connected: run={run_id}")
         return queue
 
     def unsubscribe(self, run_id: str, queue: "asyncio.Queue[Optional[tuple[int, str]]]") -> None:

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -1740,7 +1740,7 @@ def get_workflow_router(
         if session_id:
             logger.debug(f"Continuing session: {session_id}")
         else:
-            logger.debug("Creating new session")
+            log_debug("Creating new session", log_level=2)
             session_id = str(uuid4())
 
         # Extract auth token for remote workflows

--- a/libs/agno/agno/utils/log.py
+++ b/libs/agno/agno/utils/log.py
@@ -4,6 +4,7 @@ from functools import lru_cache
 from os import getenv
 from typing import Any, Literal, Optional
 
+from rich import get_console
 from rich.logging import RichHandler
 from rich.text import Text
 
@@ -87,8 +88,10 @@ def build_logger(logger_name: str, source_type: Optional[str] = None) -> Any:
     # https://rich.readthedocs.io/en/latest/reference/logging.html#rich.logging.RichHandler
     # https://rich.readthedocs.io/en/latest/logging.html#handle-exceptions
     handler: logging.Handler
-    if sys.stdout.isatty():
+    console = get_console()
+    if console.is_terminal or console.is_jupyter:
         handler = ColoredRichHandler(
+            console=console,
             show_time=False,
             rich_tracebacks=False,
             show_path=getenv("AGNO_API_RUNTIME") == "dev",
@@ -168,7 +171,7 @@ def set_log_level_to_error(source_type: Optional[str] = None):
 
 
 def center_header(message: str, symbol: str = "*") -> str:
-    if not sys.stdout.isatty():
+    if not get_console().is_terminal:
         return message
     try:
         import shutil

--- a/libs/agno/agno/utils/log.py
+++ b/libs/agno/agno/utils/log.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from functools import lru_cache
 from os import getenv
 from typing import Any, Literal, Optional
@@ -70,6 +71,10 @@ def build_logger(logger_name: str, source_type: Optional[str] = None) -> Any:
     if _logger.handlers or _logger.level != logging.NOTSET:
         return _logger
 
+    configured = logging.Logger.manager.loggerDict.get(logger_name)
+    if isinstance(configured, logging.Logger) and (configured.handlers or configured.level != logging.NOTSET):
+        return configured
+
     # Set the custom logger class as the default for this logger
     logging.setLoggerClass(AgnoLogger)
 
@@ -81,21 +86,21 @@ def build_logger(logger_name: str, source_type: Optional[str] = None) -> Any:
 
     # https://rich.readthedocs.io/en/latest/reference/logging.html#rich.logging.RichHandler
     # https://rich.readthedocs.io/en/latest/logging.html#handle-exceptions
-    rich_handler = ColoredRichHandler(
-        show_time=False,
-        rich_tracebacks=False,
-        show_path=True if getenv("AGNO_API_RUNTIME") == "dev" else False,
-        tracebacks_show_locals=False,
-        source_type=source_type or "agent",
-    )
-    rich_handler.setFormatter(
-        logging.Formatter(
-            fmt="%(message)s",
-            datefmt="[%X]",
+    handler: logging.Handler
+    if sys.stdout.isatty():
+        handler = ColoredRichHandler(
+            show_time=False,
+            rich_tracebacks=False,
+            show_path=getenv("AGNO_API_RUNTIME") == "dev",
+            tracebacks_show_locals=False,
+            source_type=source_type or "agent",
         )
-    )
-
-    _logger.addHandler(rich_handler)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+    else:
+        # Container/file collectors supply timestamps and wrapping themselves.
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setFormatter(logging.Formatter("%(levelname)-7s %(message)s"))
+    _logger.addHandler(handler)
     _logger.setLevel(logging.INFO)
     _logger.propagate = False
     return _logger
@@ -163,6 +168,8 @@ def set_log_level_to_error(source_type: Optional[str] = None):
 
 
 def center_header(message: str, symbol: str = "*") -> str:
+    if not sys.stdout.isatty():
+        return message
     try:
         import shutil
 

--- a/libs/agno/agno/vectordb/pgvector/pgvector.py
+++ b/libs/agno/agno/vectordb/pgvector/pgvector.py
@@ -188,7 +188,7 @@ class PgVector(VectorDb):
         self._owner_column_exists: Optional[bool] = None
         # Database table
         self.table: Table = self.get_table()
-        log_debug(f"Initialized PgVector with table '{self.schema}.{self.table_name}'")
+        log_debug(f"Initialized PgVector with table '{self.schema}.{self.table_name}'", log_level=2)
 
     def _replace_page_on(self, conn, content_id: str, records: List[Dict[str, Any]]) -> None:
         """Replace already embedded page records using the caller's transaction."""
@@ -251,7 +251,7 @@ class PgVector(VectorDb):
         Returns:
             bool: True if the table exists, False otherwise.
         """
-        log_debug(f"Checking if table '{self.table.fullname}' exists.")
+        log_debug(f"Checking table {self.table.fullname}", log_level=2)
         try:
             return inspect(self.db_engine).has_table(self.table_name, schema=self.schema)
         except Exception as e:
@@ -264,16 +264,16 @@ class PgVector(VectorDb):
         """
         if not self.table_exists():
             with self.Session() as sess, sess.begin():
-                log_debug("Creating extension: vector")
+                log_debug("Ensuring extension vector", log_level=2)
                 sess.execute(text("CREATE EXTENSION IF NOT EXISTS vector;"))
                 if self.create_schema and self.schema is not None:
                     try:
-                        log_debug(f"Creating schema: {self.schema}")
+                        log_debug(f"Ensuring schema {self.schema}", log_level=2)
                         sess.execute(text(f"CREATE SCHEMA IF NOT EXISTS {self.schema};"))
                     except Exception as e:
                         log_warning(f"Could not create schema {self.schema}: {str(e)}")
-            log_debug(f"Creating table: {self.table_name}")
             self.table.create(self.db_engine)
+            log_debug(f"Created table {self.table.fullname}")
             self._owner_column_exists = True
 
     async def async_create(self) -> None:

--- a/libs/agno/agno/workflow/step.py
+++ b/libs/agno/agno/workflow/step.py
@@ -1057,7 +1057,7 @@ class Step:
         add_session_state_to_context: Optional[bool] = None,
     ) -> StepOutput:
         """Execute the step with StepInput, returning final StepOutput (non-streaming)"""
-        log_debug(f"Executing step: {self.name}")
+        log_debug(f"Executing step: {self.name}", log_level=2)
 
         # Shallow-copy run_context so options resolved here don't leak into the next step
         run_context = copy(run_context) if run_context is not None else None
@@ -1417,16 +1417,16 @@ class Step:
         # Execute with retries and streaming
         for attempt in range(self.max_retries + 1):
             try:
-                log_debug(f"Step {self.name} streaming attempt {attempt + 1}/{self.max_retries + 1}")
+                log_debug(f"Step {self.name} streaming attempt {attempt + 1}/{self.max_retries + 1}", log_level=2)
                 final_response = None
 
                 self._rehydrate_step_input_media(step_input, self._resolve_media_storage(workflow_media_storage))
                 if self._executor_type == "function":
-                    log_debug(f"Executing function executor for step: {self.name}")
+                    log_debug(f"Executing function executor for step: {self.name}", log_level=2)
                     if _is_async_callable(self.active_executor) or _is_async_generator_function(self.active_executor):
                         raise ValueError("Cannot use async function with synchronous execution")
                     if _is_generator_function(self.active_executor):
-                        log_debug("Function returned iterable, streaming events")
+                        log_debug("Function returned iterable, streaming events", log_level=2)
                         content = ""
                         try:
                             iterator = self._call_custom_function(
@@ -1487,7 +1487,7 @@ class Step:
                             final_response = StepOutput(content=result.content)
                         else:
                             final_response = StepOutput(content=str(result))
-                        log_debug("Function returned non-iterable, created StepOutput")
+                        log_debug("Function returned non-iterable, created StepOutput", log_level=2)
                 else:
                     # For agents and teams, prepare message with context
                     message = self._prepare_message(
@@ -1652,7 +1652,7 @@ class Step:
                 # If we didn't get a final response, create one
                 if final_response is None:
                     final_response = StepOutput(content="")
-                    log_debug("Created empty StepOutput as fallback")
+                    log_debug("Created empty StepOutput as fallback", log_level=2)
 
                 # Switch back to workflow logger after execution
                 use_workflow_logger()
@@ -1722,8 +1722,8 @@ class Step:
         add_session_state_to_context: Optional[bool] = None,
     ) -> StepOutput:
         """Execute the step with StepInput, returning final StepOutput (non-streaming)"""
-        logger.info(f"Executing async step (non-streaming): {self.name}")
-        log_debug(f"Executor type: {self._executor_type}")
+        log_debug(f"Executing async step (non-streaming): {self.name}", log_level=2)
+        log_debug(f"Executor type: {self._executor_type}", log_level=2)
 
         # Shallow-copy run_context so options resolved here don't leak into the next step
         run_context = copy(run_context) if run_context is not None else None
@@ -2060,12 +2060,12 @@ class Step:
         # Execute with retries and streaming
         for attempt in range(self.max_retries + 1):
             try:
-                log_debug(f"Async step {self.name} streaming attempt {attempt + 1}/{self.max_retries + 1}")
+                log_debug(f"Async step {self.name} streaming attempt {attempt + 1}/{self.max_retries + 1}", log_level=2)
                 final_response = None
 
                 await self._arehydrate_step_input_media(step_input, self._resolve_media_storage(workflow_media_storage))
                 if self._executor_type == "function":
-                    log_debug(f"Executing async function executor for step: {self.name}")
+                    log_debug(f"Executing async function executor for step: {self.name}", log_level=2)
 
                     # Check if the function is an async generator
                     if _is_async_generator_function(self.active_executor):

--- a/libs/agno/agno/workflow/utils/hitl.py
+++ b/libs/agno/agno/workflow/utils/hitl.py
@@ -248,6 +248,7 @@ def save_paused_session(
         workflow_run_response: The workflow run output.
     """
     workflow._update_session_metrics(session=session, workflow_run_response=workflow_run_response)
+    workflow._log_run_outcome(workflow_run_response)
     session.upsert_run(run=workflow_run_response)
     workflow._persist_session_and_run(session=session, run=workflow_run_response)
 
@@ -268,6 +269,7 @@ async def asave_paused_session(
         workflow_run_response: The workflow run output.
     """
     workflow._update_session_metrics(session=session, workflow_run_response=workflow_run_response)
+    workflow._log_run_outcome(workflow_run_response)
     session.upsert_run(run=workflow_run_response)
     # asave_* absorbs a sync DB; branching would take the sync media path, which raises on an async backend.
     await workflow._apersist_session_and_run(session=session, run=workflow_run_response)

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -10628,7 +10628,7 @@ class Workflow:
             run_id=run_id,
         )
 
-        log_info(f"Workflow started: {self.id or self.name} run={run_id}")
+        log_debug(f"Workflow started: {self.id or self.name} run={run_id}")
 
         # Use stream override value when necessary
         if stream is None:
@@ -10934,7 +10934,7 @@ class Workflow:
             metadata=resolved["metadata"],
         )
 
-        log_info(f"Workflow started: {self.id or self.name} run={run_id}")
+        log_debug(f"Workflow started: {self.id or self.name} run={run_id}")
 
         # Use stream override value when necessary
         if stream is None:
@@ -11367,10 +11367,7 @@ class Workflow:
             elapsed = f" duration={duration:.2f}s" if duration is not None else ""
             outcome = "failed" if status == RunStatus.error else status.value.lower()
             message = f"Workflow {outcome}: {self.id or self.name} run={run.run_id}{elapsed}"
-            if status == RunStatus.error:
-                log_error(message)
-            else:
-                log_info(message)
+            log_debug(message)
 
     def _update_session_metrics(self, session: WorkflowSession, workflow_run_response: WorkflowRunOutput):
         """Calculate and update session metrics - convert run Metrics to SessionMetrics."""

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -903,7 +903,7 @@ class Workflow:
     def initialize_workflow(self):
         if self.id is None:
             self.set_id()
-            log_debug(f"Generated new workflow_id: {self.id}")
+            log_debug(f"Generated new workflow_id: {self.id}", log_level=2)
 
     def _initialize_session(
         self,
@@ -920,7 +920,7 @@ class Workflow:
                 # We make the session_id sticky to the agent instance if no session_id is provided
                 self.session_id = session_id
 
-        log_debug(f"Session ID: {session_id}", center=True)
+        log_debug(f"Session: {session_id}")
 
         # Use the default user_id when necessary
         if user_id is None or user_id == "":
@@ -1694,13 +1694,13 @@ class Workflow:
         # Try to load from database
         workflow_session = None
         if self.db is not None:
-            log_debug(f"Reading WorkflowSession: {session_id}")
+            log_debug(f"Reading WorkflowSession: {session_id}", log_level=2)
 
             workflow_session = cast(WorkflowSession, self._read_session(session_id=session_id, user_id=user_id))
 
         if workflow_session is None:
             # Creating new session if none found
-            log_debug(f"Creating new WorkflowSession: {session_id}")
+            log_debug(f"Creating new WorkflowSession: {session_id}", log_level=2)
             from copy import deepcopy
 
             session_data = {}
@@ -1738,13 +1738,13 @@ class Workflow:
         # Try to load from database
         workflow_session = None
         if self.db is not None:
-            log_debug(f"Reading WorkflowSession: {session_id}")
+            log_debug(f"Reading WorkflowSession: {session_id}", log_level=2)
 
             workflow_session = cast(WorkflowSession, await self._aread_session(session_id=session_id, user_id=user_id))
 
         if workflow_session is None:
             # Creating new session if none found
-            log_debug(f"Creating new WorkflowSession: {session_id}")
+            log_debug(f"Creating new WorkflowSession: {session_id}", log_level=2)
             from copy import deepcopy
 
             session_data = {}
@@ -1854,7 +1854,7 @@ class Workflow:
             if result is None:
                 log_warning(f"WorkflowSession not persisted (ownership mismatch): {session.session_id}")
             else:
-                log_debug(f"Created or updated WorkflowSession record: {session.session_id}")
+                log_debug(f"Created or updated WorkflowSession record: {session.session_id}", log_level=2)
 
     def save_session(self, session: WorkflowSession) -> None:
         """Save the WorkflowSession to storage
@@ -1884,7 +1884,7 @@ class Workflow:
             if result is None:
                 log_warning(f"WorkflowSession not persisted (ownership mismatch): {session.session_id}")
             else:
-                log_debug(f"Created or updated WorkflowSession record: {session.session_id}")
+                log_debug(f"Created or updated WorkflowSession record: {session.session_id}", log_level=2)
 
     def _persist_cancelled_run_in_background(
         self, workflow_run_response: WorkflowRunOutput, session: WorkflowSession
@@ -2986,7 +2986,7 @@ class Workflow:
                     step_name = getattr(step, "name", f"step_{i + 1}")
                     current_step_name = step_name
                     current_step = step
-                    log_debug(f"Executing step {i + 1}/{self._get_step_count()}: {step_name}")
+                    log_debug(f"Step started: {step_name} step={i + 1}/{self._get_step_count()} streaming=false")
 
                     # Create enhanced StepInput
                     step_input = self._create_step_input(
@@ -3379,7 +3379,7 @@ class Workflow:
                 for i, step in enumerate(self.steps):  # type: ignore[arg-type]
                     raise_if_cancelled(workflow_run_response.run_id)  # type: ignore
                     step_name = getattr(step, "name", f"step_{i + 1}")
-                    log_debug(f"Streaming step {i + 1}/{self._get_step_count()}: {step_name}")
+                    log_debug(f"Step started: {step_name} step={i + 1}/{self._get_step_count()} streaming=true")
 
                     # Track current step for cancellation handler
                     current_step_name = step_name
@@ -4010,7 +4010,7 @@ class Workflow:
                     step_name = getattr(step, "name", f"step_{i + 1}")
                     current_step_name = step_name
                     current_step = step
-                    log_debug(f"Async Executing step {i + 1}/{self._get_step_count()}: {step_name}")
+                    log_debug(f"Step started: {step_name} step={i + 1}/{self._get_step_count()} streaming=false")
 
                     # Create enhanced StepInput
                     step_input = self._create_step_input(
@@ -4428,7 +4428,7 @@ class Workflow:
                     if workflow_run_response.run_id:
                         await araise_if_cancelled(workflow_run_response.run_id)
                     step_name = getattr(step, "name", f"step_{i + 1}")
-                    log_debug(f"Async streaming step {i + 1}/{self._get_step_count()}: {step_name}")
+                    log_debug(f"Step started: {step_name} step={i + 1}/{self._get_step_count()} streaming=true")
 
                     current_step_name = step_name
                     current_step = step
@@ -10628,7 +10628,7 @@ class Workflow:
             run_id=run_id,
         )
 
-        log_debug(f"Workflow Run Start: {self.name}", center=True)
+        log_info(f"Workflow started: {self.id or self.name} run={run_id}")
 
         # Use stream override value when necessary
         if stream is None:
@@ -10639,8 +10639,8 @@ class Workflow:
         if stream is False:
             stream_events = False
 
-        log_debug(f"Stream: {stream}")
-        log_debug(f"Total steps: {self._get_step_count()}")
+        log_debug(f"Stream: {stream}", log_level=2)
+        log_debug(f"Total steps: {self._get_step_count()}", log_level=2)
 
         # Prepare steps
         self._prepare_steps()
@@ -10654,7 +10654,8 @@ class Workflow:
             files=files,  # type: ignore
         )
         log_debug(
-            f"Created pipeline input with session state keys: {list(session_state.keys()) if session_state else 'None'}"
+            f"Created pipeline input with session state keys: {list(session_state.keys()) if session_state else 'None'}",
+            log_level=2,
         )
 
         self.update_agents_and_teams_session_info()
@@ -10933,7 +10934,7 @@ class Workflow:
             metadata=resolved["metadata"],
         )
 
-        log_debug(f"Async Workflow Run Start: {self.name}", center=True)
+        log_info(f"Workflow started: {self.id or self.name} run={run_id}")
 
         # Use stream override value when necessary
         if stream is None:
@@ -10944,7 +10945,7 @@ class Workflow:
         if stream is False:
             stream_events = False
 
-        log_debug(f"Stream: {stream}")
+        log_debug(f"Stream: {stream}", log_level=2)
 
         # Prepare steps
         self._prepare_steps()
@@ -10958,7 +10959,8 @@ class Workflow:
             files=files,
         )
         log_debug(
-            f"Created async pipeline input with session state keys: {list(session_state.keys()) if session_state else 'None'}"
+            f"Created async pipeline input with session state keys: {list(session_state.keys()) if session_state else 'None'}",
+            log_level=2,
         )
 
         self.update_agents_and_teams_session_info()
@@ -11027,19 +11029,19 @@ class Workflow:
             for i, step in enumerate(self.steps):  # type: ignore
                 if callable(step) and hasattr(step, "__name__"):
                     step_name = step.__name__
-                    log_debug(f"Step {i + 1}: Wrapping callable function '{step_name}'")
+                    log_debug(f"Step {i + 1}: Wrapping callable function '{step_name}'", log_level=2)
                     prepared_steps.append(Step(name=step_name, description="User-defined callable step", executor=step))  # type: ignore
                 elif isinstance(step, Agent):
                     step_name = step.name or f"step_{i + 1}"
-                    log_debug(f"Step {i + 1}: Agent '{step_name}'")
+                    log_debug(f"Step {i + 1}: Agent '{step_name}'", log_level=2)
                     prepared_steps.append(Step(name=step_name, description=step.description, agent=step))
                 elif isinstance(step, Team):
                     step_name = step.name or f"step_{i + 1}"
-                    log_debug(f"Step {i + 1}: Team '{step_name}' with {len(step.members)} members")
+                    log_debug(f"Step {i + 1}: Team '{step_name}' with {len(step.members)} members", log_level=2)
                     prepared_steps.append(Step(name=step_name, description=step.description, team=step))
                 elif isinstance(step, Workflow):
                     step_name = step.name or f"step_{i + 1}"
-                    log_debug(f"Step {i + 1}: Nested Workflow '{step_name}'")
+                    log_debug(f"Step {i + 1}: Nested Workflow '{step_name}'", log_level=2)
                     prepared_steps.append(Step(name=step_name, description=step.description, workflow=step))
                 elif isinstance(step, Step) and step.add_workflow_history is True and self.db is None:
                     log_warning(
@@ -11050,13 +11052,13 @@ class Workflow:
                 elif isinstance(step, (Step, Steps, Loop, Parallel, Condition, Router)):
                     step_type = type(step).__name__
                     step_name = getattr(step, "name", f"unnamed_{step_type.lower()}")
-                    log_debug(f"Step {i + 1}: {step_type} '{step_name}'")
+                    log_debug(f"Step {i + 1}: {step_type} '{step_name}'", log_level=2)
                     prepared_steps.append(step)
                 else:
                     raise ValueError(f"Invalid step type: {type(step).__name__}")
 
             self.steps = prepared_steps  # type: ignore
-            log_debug("Step preparation completed")
+            log_debug("Step preparation completed", log_level=2)
 
     def print_response(
         self,
@@ -11355,8 +11357,27 @@ class Workflow:
                     )
         return SessionMetrics()
 
+    def _log_run_outcome(self, run: WorkflowRunOutput) -> None:
+        """Report execution status without implying that a persistence operation succeeded."""
+        # Execution summaries follow the actual terminal status, including paused
+        # and failed runs. Never report success just because a request returned.
+        status = run.status
+        if status in (RunStatus.completed, RunStatus.error, RunStatus.cancelled, RunStatus.paused):
+            duration = run.metrics.duration if run.metrics else None
+            elapsed = f" duration={duration:.2f}s" if duration is not None else ""
+            outcome = "failed" if status == RunStatus.error else status.value.lower()
+            message = f"Workflow {outcome}: {self.id or self.name} run={run.run_id}{elapsed}"
+            if status == RunStatus.error:
+                log_error(message)
+            else:
+                log_info(message)
+
     def _update_session_metrics(self, session: WorkflowSession, workflow_run_response: WorkflowRunOutput):
         """Calculate and update session metrics - convert run Metrics to SessionMetrics."""
+        # Pauses are reported by save_paused_session; the enclosing non-stream
+        # finalizer may aggregate the same paused run again.
+        if workflow_run_response.status != RunStatus.paused:
+            self._log_run_outcome(workflow_run_response)
         # Get existing session metrics
         session_metrics = self._get_session_metrics(session=session)
 
@@ -11396,7 +11417,7 @@ class Workflow:
 
     def update_agents_and_teams_session_info(self):
         """Update agents and teams with workflow session information"""
-        log_debug("Updating agents and teams with session information")
+        log_debug("Updating agents and teams with session information", log_level=2)
         # Initialize steps - only if steps is iterable (not callable)
         if self.steps and not callable(self.steps):
             steps_list = self.steps.steps if isinstance(self.steps, Steps) else self.steps
@@ -11723,7 +11744,7 @@ class Workflow:
         # Create a new Workflow
         try:
             new_workflow = self.__class__(**fields_for_new_workflow)
-            log_debug(f"Created new {self.__class__.__name__}")
+            log_debug(f"Created new {self.__class__.__name__}", log_level=2)
             return new_workflow
         except Exception as e:
             log_error(f"Failed to create deep copy of {self.__class__.__name__}: {str(e)}")

--- a/libs/agno/tests/integration/db/test_queue_startup.py
+++ b/libs/agno/tests/integration/db/test_queue_startup.py
@@ -1,0 +1,106 @@
+"""Fresh PostgreSQL queue startup, including concurrent replicas and no first enqueue."""
+
+import asyncio
+import os
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine, text
+
+from agno.db.postgres import AsyncPostgresDb, PostgresDb
+from agno.job_queue.config import QueueConfig
+from agno.os.job_queue import QueueWorker, araise_if_ticket_owns_continue, resolve_queue_store
+
+PG_URL = os.getenv("AGNO_TEST_POSTGRES_URL", "postgresql+psycopg://ai:ai@localhost:5532/ai")
+
+
+@pytest.fixture
+def database_schema():
+    engine = create_engine(PG_URL)
+    schema = "queue_startup_" + uuid4().hex[:12]
+    try:
+        with engine.begin() as connection:
+            connection.execute(text(f'CREATE SCHEMA "{schema}"'))
+    except Exception as exc:
+        engine.dispose()
+        pytest.skip(f"Local PostgreSQL unavailable: {type(exc).__name__}")
+    try:
+        yield schema
+    finally:
+        with engine.begin() as connection:
+            connection.execute(text(f'DROP SCHEMA "{schema}" CASCADE'))
+        engine.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("async_db", [False, True])
+async def test_worker_start_provisions_idle_store_and_allows_continue(database_schema, async_db, caplog):
+    db_type = AsyncPostgresDb if async_db else PostgresDb
+    db = db_type(db_url=PG_URL, db_schema=database_schema)
+    config = QueueConfig(poll_interval=0.01)
+    store = resolve_queue_store(config, db)
+    worker = QueueWorker(store, lambda *_: None, config)
+    exists = await db.table_exists(db.job_table_name) if async_db else db.table_exists(db.job_table_name)
+    assert not exists
+    await worker.start()
+    try:
+        exists = await db.table_exists(db.job_table_name) if async_db else db.table_exists(db.job_table_name)
+        assert exists
+        await araise_if_ticket_owns_continue(worker, "inline-run")
+        await asyncio.sleep(0.035)
+        assert await store.count_queued_jobs() == 0
+        assert not any("preparation failed" in record.message for record in caplog.records)
+    finally:
+        await worker.stop()
+    # Restart should resolve the existing table and still admit ticketless continuations.
+    await worker.start()
+    try:
+        await araise_if_ticket_owns_continue(worker, "another-inline-run")
+    finally:
+        await worker.stop()
+        if async_db:
+            await db.close()
+        else:
+            db.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("async_db", [False, True])
+async def test_concurrent_queue_provisioning(database_schema, async_db, caplog):
+    db_type = AsyncPostgresDb if async_db else PostgresDb
+    dbs = [db_type(db_url=PG_URL, db_schema=database_schema) for _ in range(2)]
+    try:
+        if async_db:
+            await asyncio.gather(*(db.ensure_jobs_table() for db in dbs))
+        else:
+            await asyncio.gather(*(asyncio.to_thread(db.ensure_jobs_table) for db in dbs))
+        stores = [resolve_queue_store(QueueConfig(), db) for db in dbs]
+        assert await stores[0].get_job("no-ticket", strict=True) is None
+        assert await stores[1].get_job("no-ticket", strict=True) is None
+        assert not [record for record in caplog.records if record.levelno >= 30]
+    finally:
+        for db in dbs:
+            if async_db:
+                await db.close()
+            else:
+                db.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("async_db", [False, True])
+async def test_external_provisioning_does_not_create_queue_table(database_schema, async_db):
+    db_type = AsyncPostgresDb if async_db else PostgresDb
+    db = db_type(db_url=PG_URL, db_schema=database_schema)
+    config = QueueConfig(poll_interval=0.01)
+    worker = QueueWorker(resolve_queue_store(config, db), lambda *_: None, config, auto_provision=False)
+    try:
+        await worker.start()
+        await asyncio.sleep(0.025)
+        exists = await db.table_exists(db.job_table_name) if async_db else db.table_exists(db.job_table_name)
+        assert not exists
+    finally:
+        await worker.stop()
+        if async_db:
+            await db.close()
+        else:
+            db.close()

--- a/libs/agno/tests/unit/os/test_queue_startup.py
+++ b/libs/agno/tests/unit/os/test_queue_startup.py
@@ -1,0 +1,130 @@
+"""Provision optional queue storage before its heartbeat and poll tasks start."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from agno.job_queue.config import QueueConfig
+from agno.job_queue.store import InMemoryQueueStore
+from agno.os.job_queue import QueueWorker, _SyncStoreAdapter, araise_if_ticket_owns_continue
+
+
+class FreshStore(InMemoryQueueStore):
+    def __init__(self):
+        super().__init__()
+        self.ready = False
+        self.prepared = 0
+
+    async def ensure_jobs_table(self):
+        self.prepared += 1
+        self.ready = True
+
+    async def get_job(self, job_id, strict=False):
+        if not self.ready and strict:
+            raise RuntimeError("jobs table unavailable")
+        return await super().get_job(job_id)
+
+
+def worker(store, **kwargs):
+    return QueueWorker(store, lambda *_: None, QueueConfig(poll_interval=0.01), **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_prepare_precedes_polling_and_unblocks_inline_continue(monkeypatch):
+    from fastapi import HTTPException
+
+    store = FreshStore()
+    instance = worker(store)
+    with pytest.raises(HTTPException) as error:
+        await araise_if_ticket_owns_continue(instance, "inline-run")
+    assert error.value.status_code == 503
+
+    async def poll():
+        assert store.ready
+
+    monkeypatch.setattr(instance, "_poll_loop", poll)
+    await instance.start()
+    try:
+        await instance.start()
+        await asyncio.sleep(0)
+        assert store.prepared == 1
+        await araise_if_ticket_owns_continue(instance, "inline-run")
+    finally:
+        await instance.stop()
+
+
+@pytest.mark.asyncio
+async def test_external_provisioning_keeps_read_only_probe():
+    store = FreshStore()
+    instance = worker(store, auto_provision=False)
+    await instance.start()
+    try:
+        assert store.prepared == 0
+    finally:
+        await instance.stop()
+
+
+@pytest.mark.asyncio
+async def test_store_without_hook_still_starts():
+    instance = worker(InMemoryQueueStore())
+    await instance.start()
+    try:
+        assert instance._task is not None
+    finally:
+        await instance.stop()
+
+
+@pytest.mark.asyncio
+async def test_prepare_failure_is_reported_once_and_keeps_lazy_fallback(caplog):
+    store = FreshStore()
+    store.ensure_jobs_table = AsyncMock(side_effect=PermissionError("private connection details"))
+    instance = worker(store)
+    await instance.start()
+    try:
+        await asyncio.sleep(0.025)
+        warnings = [record.message for record in caplog.records if "storage preparation failed" in record.message]
+        assert len(warnings) == 1
+        assert "PermissionError" in warnings[0]
+        assert "private connection details" not in warnings[0]
+        assert instance._task is not None and not instance._task.done()
+    finally:
+        await instance.stop()
+
+
+@pytest.mark.asyncio
+async def test_sync_prepare_finishes_before_heartbeat_thread(monkeypatch):
+    calls = []
+    store = SimpleNamespace(ensure_jobs_table=lambda: calls.append("prepare"), heartbeat_jobs=lambda *_: 0)
+    instance = worker(_SyncStoreAdapter(store))
+    monkeypatch.setattr(instance, "_start_heartbeat_thread", lambda *_: calls.append("heartbeat"))
+    monkeypatch.setattr(instance, "_poll_loop", AsyncMock())
+    await instance.start()
+    try:
+        assert calls == ["prepare", "heartbeat"]
+    finally:
+        await instance.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("async_db", [False, True])
+async def test_native_preparation_does_not_mask_non_race_errors(monkeypatch, async_db):
+    from agno.db.postgres import AsyncPostgresDb, PostgresDb
+
+    db_type = AsyncPostgresDb if async_db else PostgresDb
+    db = db_type(db_url="postgresql+psycopg://unused:unused@localhost/unused")
+    mock_type = AsyncMock if async_db else Mock
+    monkeypatch.setattr(db, "_get_table", mock_type(side_effect=PermissionError("index creation denied")))
+    monkeypatch.setattr(db, "table_exists", mock_type(return_value=True))
+    try:
+        with pytest.raises(PermissionError, match="index creation denied"):
+            if async_db:
+                await db.ensure_jobs_table()
+            else:
+                db.ensure_jobs_table()
+    finally:
+        if async_db:
+            await db.close()
+        else:
+            db.close()

--- a/libs/agno/tests/unit/utils/test_startup_logging.py
+++ b/libs/agno/tests/unit/utils/test_startup_logging.py
@@ -1,0 +1,60 @@
+"""Application debug output must not enable pool chatter or terminal wrapping."""
+
+import io
+import logging
+from uuid import uuid4
+
+import pytest
+from rich.logging import RichHandler
+from sqlalchemy import create_engine
+
+from agno.db.postgres._bounded import bounded_engine
+from agno.utils.log import build_logger, center_header
+
+
+@pytest.mark.parametrize("terminal", [False, True])
+def test_default_handler_matches_output_destination(monkeypatch, terminal):
+    output = io.StringIO()
+    monkeypatch.setattr(output, "isatty", lambda: terminal)
+    monkeypatch.setattr("sys.stdout", output)
+    logger = build_logger("agno.test_" + uuid4().hex)
+    try:
+        assert isinstance(logger.handlers[0], RichHandler) is terminal
+        message = "Storage ready: " + "x" * 200
+        logger.info(message)
+        if not terminal:
+            assert output.getvalue() == f"INFO    {message}\n"
+            assert center_header("Session: example") == "Session: example"
+    finally:
+        logger.handlers.clear()
+
+
+def test_existing_application_handler_and_level_are_preserved():
+    logger = logging.getLogger("agno.test_" + uuid4().hex)
+    handler = logging.NullHandler()
+    logger.addHandler(handler)
+    logger.setLevel(logging.ERROR)
+    assert build_logger(logger.name) is logger
+    assert logger.handlers == [handler]
+    assert logger.level == logging.ERROR
+
+
+def test_pool_debug_is_independent_and_remains_opt_in(caplog):
+    source = create_engine("postgresql+psycopg://unused:unused@localhost/unused")
+    pool = bounded_engine(source, capacity=1).pool
+    assert pool.logger.name.startswith("sqlalchemy.pool.")
+    with caplog.at_level(logging.DEBUG, logger="agno"):
+        assert not pool.logger.isEnabledFor(logging.DEBUG)
+        pool.logger.debug("pool noise")
+        pool.logger.warning("pool unavailable")
+    assert "pool noise" not in caplog.text
+    assert "pool unavailable" in caplog.text
+    with caplog.at_level(logging.DEBUG, logger="sqlalchemy.pool"):
+        pool.logger.debug("explicit pool diagnostics")
+        assert pool.recreate().logger.isEnabledFor(logging.DEBUG)
+    assert "explicit pool diagnostics" in caplog.text
+
+
+def test_bounded_pool_preserves_explicit_echo():
+    source = create_engine("postgresql+psycopg://unused:unused@localhost/unused", echo_pool="debug")
+    assert bounded_engine(source, capacity=1).pool.echo == "debug"

--- a/libs/agno/tests/unit/utils/test_startup_logging.py
+++ b/libs/agno/tests/unit/utils/test_startup_logging.py
@@ -2,6 +2,9 @@
 
 import io
 import logging
+import subprocess
+import sys
+import textwrap
 from uuid import uuid4
 
 import pytest
@@ -10,6 +13,46 @@ from sqlalchemy import create_engine
 
 from agno.db.postgres._bounded import bounded_engine
 from agno.utils.log import build_logger, center_header
+
+
+def test_import_and_headers_without_stdout():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            textwrap.dedent("""
+            import sys
+            sys.stdout = None
+            from agno.agent import Agent
+            from agno.utils.log import center_header
+            assert center_header("probe") == "probe"
+        """),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_jupyter_keeps_rich_handler():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            textwrap.dedent("""
+            import builtins
+            builtins.get_ipython = lambda: type("ZMQInteractiveShell", (), {})()
+            from agno.utils.log import agent_logger
+            from rich.logging import RichHandler
+            handler = agent_logger.handlers[0]
+            assert isinstance(handler, RichHandler)
+            assert handler.console.is_jupyter
+        """),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
 
 
 @pytest.mark.parametrize("terminal", [False, True])

--- a/libs/agno/tests/unit/workflow/test_fastapi_optional.py
+++ b/libs/agno/tests/unit/workflow/test_fastapi_optional.py
@@ -28,7 +28,8 @@ def _run_masked(code: str) -> None:
         check=False,
     )
     assert result.returncode == 0, f"subprocess failed. stdout={result.stdout!r} stderr={result.stderr!r}"
-    assert result.stdout.strip() == "OK"
+    # Lifecycle logs may precede the sentinel printed after the subprocess assertions.
+    assert result.stdout.splitlines()[-1] == "OK"
 
 
 def test_workflow_usable_without_fastapi():

--- a/libs/agno/tests/unit/workflow/test_fastapi_optional.py
+++ b/libs/agno/tests/unit/workflow/test_fastapi_optional.py
@@ -28,8 +28,7 @@ def _run_masked(code: str) -> None:
         check=False,
     )
     assert result.returncode == 0, f"subprocess failed. stdout={result.stdout!r} stderr={result.stderr!r}"
-    # Lifecycle logs may precede the sentinel printed after the subprocess assertions.
-    assert result.stdout.splitlines()[-1] == "OK"
+    assert result.stdout.strip() == "OK"
 
 
 def test_workflow_usable_without_fastapi():

--- a/libs/agno/tests/unit/workflow/test_run_logging.py
+++ b/libs/agno/tests/unit/workflow/test_run_logging.py
@@ -1,6 +1,9 @@
 """Workflow lifecycle summaries retain useful identifiers and truthful outcomes."""
 
 import logging
+import os
+import subprocess
+import sys
 
 import pytest
 
@@ -15,6 +18,38 @@ def output(step_input: StepInput) -> StepOutput:
 
 def broken(step_input: StepInput) -> StepOutput:
     raise ValueError("step failed")
+
+
+@pytest.mark.parametrize("async_mode", [False, True])
+@pytest.mark.parametrize("stream", [False, True])
+def test_default_run_is_silent(async_mode, stream):
+    code = """
+import asyncio
+from agno.workflow import Step, StepOutput, Workflow
+
+workflow = Workflow(steps=[Step(name="work", executor=lambda step_input: StepOutput(content="done"))], telemetry=False)
+async def run():
+    if ASYNC_MODE:
+        if STREAM:
+            async for _ in workflow.arun("hello", stream=True):
+                pass
+        else:
+            await workflow.arun("hello")
+    else:
+        result = workflow.run("hello", stream=STREAM)
+        if STREAM:
+            list(result)
+asyncio.run(run())
+""".replace("ASYNC_MODE", repr(async_mode)).replace("STREAM", repr(stream))
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        env={**os.environ, "AGNO_DEBUG": "false"},
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert result.stderr == ""
 
 
 @pytest.mark.parametrize("stream", [False, True])
@@ -73,6 +108,12 @@ async def test_async_run_summary(caplog, stream, fails):
 
 
 def assert_summary(caplog, fails):
+    summaries = [
+        r
+        for r in caplog.records
+        if r.message.startswith(("Workflow started:", "Workflow failed:", "Workflow completed:"))
+    ]
+    assert all(r.levelno == logging.DEBUG for r in summaries)
     messages = [r.message for r in caplog.records]
     assert sum("Workflow started: logging-workflow run=logged-run" in m for m in messages) == 1
     outcome = "failed" if fails else "completed"
@@ -89,6 +130,7 @@ async def test_paused_run_has_one_pause_summary_and_no_success(caplog, async_mod
     workflow = Workflow(
         id="paused-workflow",
         steps=[Step(name="confirm", executor=output, human_review=HumanReview(requires_confirmation=True))],
+        debug_mode=True,
         telemetry=False,
     )
     if async_mode:

--- a/libs/agno/tests/unit/workflow/test_run_logging.py
+++ b/libs/agno/tests/unit/workflow/test_run_logging.py
@@ -1,0 +1,106 @@
+"""Workflow lifecycle summaries retain useful identifiers and truthful outcomes."""
+
+import logging
+
+import pytest
+
+from agno.workflow.step import Step, StepInput, StepOutput
+from agno.workflow.types import HumanReview, OnError
+from agno.workflow.workflow import Workflow
+
+
+def output(step_input: StepInput) -> StepOutput:
+    return StepOutput(content="done")
+
+
+def broken(step_input: StepInput) -> StepOutput:
+    raise ValueError("step failed")
+
+
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.parametrize("fails", [False, True])
+def test_sync_run_summary(caplog, stream, fails):
+    workflow = Workflow(
+        id="logging-workflow",
+        steps=[
+            Step(
+                name="work",
+                executor=broken if fails else output,
+                max_retries=0,
+                human_review=HumanReview(on_error=OnError.fail),
+            )
+        ],
+        debug_mode=True,
+        telemetry=False,
+    )
+    with caplog.at_level(logging.DEBUG, logger="agno-workflow"):
+        try:
+            result = workflow.run("hello", run_id="logged-run", session_id="logged-session", stream=stream)
+            if stream:
+                list(result)
+        except ValueError:
+            assert fails
+    assert_summary(caplog, fails)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.parametrize("fails", [False, True])
+async def test_async_run_summary(caplog, stream, fails):
+    workflow = Workflow(
+        id="logging-workflow",
+        steps=[
+            Step(
+                name="work",
+                executor=broken if fails else output,
+                max_retries=0,
+                human_review=HumanReview(on_error=OnError.fail),
+            )
+        ],
+        debug_mode=True,
+        telemetry=False,
+    )
+    with caplog.at_level(logging.DEBUG, logger="agno-workflow"):
+        try:
+            if stream:
+                async for _ in workflow.arun("hello", run_id="logged-run", session_id="logged-session", stream=True):
+                    pass
+            else:
+                await workflow.arun("hello", run_id="logged-run", session_id="logged-session")
+        except ValueError:
+            assert fails
+    assert_summary(caplog, fails)
+
+
+def assert_summary(caplog, fails):
+    messages = [r.message for r in caplog.records]
+    assert sum("Workflow started: logging-workflow run=logged-run" in m for m in messages) == 1
+    outcome = "failed" if fails else "completed"
+    assert sum(f"Workflow {outcome}: logging-workflow run=logged-run" in m for m in messages) == 1
+    if fails:
+        assert not any("Workflow completed:" in m for m in messages)
+    assert not any("Step preparation completed" in m or "Reading WorkflowSession:" in m for m in messages)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("async_mode", [False, True])
+@pytest.mark.parametrize("stream", [False, True])
+async def test_paused_run_has_one_pause_summary_and_no_success(caplog, async_mode, stream):
+    workflow = Workflow(
+        id="paused-workflow",
+        steps=[Step(name="confirm", executor=output, human_review=HumanReview(requires_confirmation=True))],
+        telemetry=False,
+    )
+    if async_mode:
+        if stream:
+            async for _ in workflow.arun("check", stream=True):
+                pass
+        else:
+            await workflow.arun("check")
+    else:
+        result = workflow.run("check", stream=stream)
+        if stream:
+            list(result)
+    messages = [r.message for r in caplog.records]
+    assert sum("Workflow paused: paused-workflow" in message for message in messages) == 1
+    assert not any("Workflow completed: paused-workflow" in message for message in messages)


### PR DESCRIPTION
## Summary

With `AGNO_DEBUG=True`, bounded PostgreSQL pools inherited the Agno logger and flooded container output with checkouts, pre-pings and resets. A fresh durable queue also started polling before `agno_jobs` existed, producing repeated errors until the first enqueue and blocking ticketless continuations.

- Keep pool diagnostics under `sqlalchemy.pool`, preserving health checks and explicit pool debug/echo.
- Use plain, unwrapped non-terminal logs; preserve terminal/Jupyter Rich output and tolerate absent stdout and application-configured loggers.
- Prepare sync/async PostgreSQL queue storage before worker polling. Respect `auto_provision_dbs=False`, retain compatibility with stores without the optional hook, and recover concurrent table-creation races without masking other provisioning failures.
- Show concise table-created and storage-ready messages. Keep server-side queue acceptance at INFO and workflow lifecycle/step/outcome summaries at DEBUG, with run IDs on lifecycle summaries. Keep detailed preparation/schema diagnostics at debug level 2; failed, paused and cancelled runs retain their actual status.

Representative output (`AGNO_DEBUG=True`, fresh database):

```text
DEBUG   Agent initialized: durable-agent
DEBUG   Created table ai.agno_sessions
DEBUG   Created table ai.agno_schema_versions
...
INFO    Database ready: PostgresDb id=<database-id>
WARNING Queued-run streams are replica-local; configure queue.redis for cross-replica streaming.
DEBUG   Created table ai.agno_jobs
INFO    Job queue worker started: worker=<worker-id> poll=1s
```

```text
INFO    Workflow queued: sync-docs run=<run-id>
DEBUG   Session: <session-id>
DEBUG   Workflow started: sync-docs run=<run-id>
DEBUG   Step started: sync-docs step=1/1 streaming=true
DEBUG   Workflow completed: sync-docs run=<run-id> duration=2.31s
```

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Original implementation validation (`b6a3db4df`):
- Both required repository scripts pass. Validation used the existing development venv with temporary `types-regex` stubs on `PYTHONPATH`; this was not a fresh dependency installation.
- Agno utils/AgentOS/workflow and queue-store logging regression suite: 4,354 passed, 31 skipped. Gemini and Telegram integration modules were excluded because their optional SDKs are absent; local HTTP test servers ran with socket access.
- Final queue matrix: 13 passed, including six real PostgreSQL cases covering fresh startup before any enqueue, concurrent provisioning, restart, strict ticketless continuation, and externally managed schemas; also verifies that non-race provisioning failures propagate.
- Docs Agent composition against the built candidate package: 189 passed, including its PostgreSQL tests. The final narrowing of native provisioning exception recovery was subsequently covered by the queue matrix above.
- Durable queue cookbook startup passed in the demo venv against a disposable PostgreSQL database, with `/health`, jobs-table creation and strict lookup verified. No model calls or full streaming/recovery demo were run.

The adjacent migration PRs #9674 and #9679 concern migration visibility/auto-migration; this PR does not change migration policy. Container entrypoint banners and Uvicorn access logging remain application/server configuration.

Follow-up validation after logging compatibility fixes:
- Restored quiet default workflow execution and the strict optional-FastAPI stdout assertion. Lifecycle summaries (including failures) are DEBUG; existing execution errors remain visible.
- Added subprocess regressions for sync/async streaming and non-streaming silence, importing Agent with `sys.stdout=None`, and Rich handler selection in a simulated Jupyter host. No live notebook frontend was exercised.
- Queue, workflow HITL, logging and utility regression suite: 696 passed, 1 skipped. Two Gemini modules were excluded because their optional SDK is absent.
- All six real PostgreSQL queue startup integration tests passed.
- Both required format/validation scripts passed, using the existing development venv and the same temporary `types-regex` stubs described above.
