### PR TITLE
[fix] restore direct answers for simple route-mode requests

### DIFF
--- a/libs/agno/agno/team/_messages.py
+++ b/libs/agno/agno/team/_messages.py
@@ -204,9 +204,12 @@ def _get_mode_instructions(team: "Team", has_sub_team: bool = False) -> str:
         )
     elif team.mode == TeamMode.route:
         content += (
-            "You work in route mode: you hand the request to exactly one member with "
+            "You work in route mode. When the request needs a member's expertise or tools, "
+            "hand the request to exactly one member with "
             "`delegate_task_to_member`, and its reply is returned to the user as written and ends the "
-            "run.\n\n"
+            "run. For requests that do not need member expertise or tools, such as greetings or "
+            "questions about the team's capabilities, answer directly without delegating.\n\n"
+            "When routing to a member:\n"
             f"- Pick the member whose {selector} are the closest match; if none is a clear fit, pick the "
             "closest and carry the shortfall into the task.\n"
             "- Pass the request whole. Do not reinterpret, narrow, or summarize what the user asked.\n"

--- a/libs/agno/tests/unit/team/test_team_system_prompt.py
+++ b/libs/agno/tests/unit/team/test_team_system_prompt.py
@@ -259,6 +259,22 @@ def test_tasks_block_matches_the_loop_it_runs():
     assert "finishes at once instead of after a reminder" in content
 
 
+@pytest.mark.parametrize("determine_input_for_members", [True, False])
+@pytest.mark.asyncio
+async def test_route_prompt_allows_direct_answers_without_member_expertise(determine_input_for_members):
+    team = _team(mode=TeamMode.route, determine_input_for_members=determine_input_for_members)
+    for message in (
+        team.get_system_message(session=_session()),
+        await team.aget_system_message(session=_session()),
+    ):
+        delegation = message.content.split("<delegation>", 1)[1].split("</delegation>", 1)[0]
+        assert "When the request needs a member's expertise or tools" in delegation
+        assert "hand the request to exactly one member" in delegation
+        assert "reply is returned to the user as written and ends the run" in delegation
+        assert "answer directly without delegating" in delegation
+        assert "questions about the team's capabilities" in delegation
+
+
 def test_inner_members_of_a_sub_team_render_without_ids():
     """Only a directly delegable member shows an id.
 


### PR DESCRIPTION
## Summary

In route mode, a question such as "What can this team do?" is instructed to go to a member even when it needs no member expertise. The v3 route prompt removed the earlier permission to answer these requests directly, contradicting the shared team opening that still permits it.

Restore that permission for greetings and capability questions. Requests requiring a member's expertise or tools still go to exactly one member, whose response is returned unchanged and ends the run. Scope the remaining routing instructions to requests that are delegated.

Fixes #10058

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

The generated prompt is updated directly. No new public option or cookbook workflow is introduced.

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

Codex implemented the change, reviewed the diff, and ran the checks below. These are agent-run checks, not a claim of independent human validation.

## Additional Notes

Validation on Windows with Python 3.12:

- The two new regression cases failed before the prompt change.
- `python -m pytest libs/agno/tests/unit/team/test_team_system_prompt.py libs/agno/tests/unit/team/test_team_mode.py -q`: 56 passed.
- Coverage includes synchronous/asynchronous system-message builders and both values of `determine_input_for_members`.
- `scripts/format.sh`: passed using Git Bash.
- Ruff checks and the quickstart cookbook pattern check passed.
- `git diff --check`: passed.
- `scripts/validate.sh`: passed using Git Bash, including mypy across 1,048 Agno files and 21 agnoctl files.

These tests check the generated prompt contract. No paid/live-model evaluation was run, so they do not establish model-specific routing accuracy.
