### PR TITLE
fix: dedupe Slack event retries by event_id instead of dropping them

### DIFF
--- a/libs/agno/agno/os/interfaces/slack/helpers.py
+++ b/libs/agno/agno/os/interfaces/slack/helpers.py
@@ -1,3 +1,5 @@
+import time
+from collections import OrderedDict
 from typing import Any, Dict, List, Optional, Tuple
 
 import httpx
@@ -179,6 +181,42 @@ class BotNameResolver:
         except Exception as e:
             log_warning(f"Failed to resolve bot name for {bot_user_id}: {str(e)}")
             return None
+
+
+class EventDeduplicator:
+    """Remembers recently seen Slack event_ids so a retried delivery runs at most once.
+
+    Slack retries any event not acked within 3s (immediately, then +1 min, then +5 min),
+    marking each with X-Slack-Retry-Num. A retry is only a duplicate if the original
+    delivery reached us, so the route dedupes on event_id instead of dropping every retry.
+    Instantiated once per mounted Slack interface inside ``attach_routes``.
+
+    The seen-set is per-process. With several uvicorn workers or replicas, a retry that
+    lands on a different process is not recognised and the event runs a second time,
+    tool side effects included. Run one process per Slack app or add a shared store.
+    """
+
+    # Must outlive Slack's final retry at +5 minutes
+    DEDUP_TTL_SECONDS: float = 600.0
+    DEDUP_MAX_ENTRIES: int = 4096
+
+    def __init__(self) -> None:
+        self._seen: "OrderedDict[str, float]" = OrderedDict()
+
+    def is_duplicate(self, event_id: str) -> bool:
+        now = time.monotonic()
+        expired = [eid for eid, ts in self._seen.items() if now - ts > self.DEDUP_TTL_SECONDS]
+        for eid in expired:
+            del self._seen[eid]
+        if event_id in self._seen:
+            return True
+        self._seen[event_id] = now
+        # Bounded: under heavy traffic the oldest id is evicted before its TTL, so a late
+        # retry of it is reprocessed as a duplicate run. Every signed event that reaches the
+        # route takes a slot, including ones that never start a run. Accepted over unbounded growth.
+        while len(self._seen) > self.DEDUP_MAX_ENTRIES:
+            self._seen.popitem(last=False)
+        return False
 
 
 async def resolve_channel_name(async_client: Any, channel_id: str) -> Optional[str]:

--- a/libs/agno/agno/os/interfaces/slack/router.py
+++ b/libs/agno/agno/os/interfaces/slack/router.py
@@ -11,7 +11,7 @@ from agno.agent import Agent, RemoteAgent
 
 try:
     from agno.os.interfaces.slack.event_handler import SlackEventHandler
-    from agno.os.interfaces.slack.helpers import BotNameResolver
+    from agno.os.interfaces.slack.helpers import BotNameResolver, EventDeduplicator
     from agno.os.interfaces.slack.hitl import HITLHandler
 except ImportError as e:
     raise ImportError("Slack dependencies not installed. Please install using `pip install 'agno[slack]'`") from e
@@ -25,6 +25,7 @@ from agno.os.interfaces.slack.ids import (
 from agno.os.interfaces.slack.security import verify_slack_signature
 from agno.team import RemoteTeam, Team
 from agno.tools.slack import SlackTools
+from agno.utils.log import log_warning
 from agno.workflow import RemoteWorkflow, Workflow
 
 
@@ -88,6 +89,8 @@ def attach_routes(
         pass
 
     bot_name_resolver = BotNameResolver()
+    # Per-process seen-set for Slack retries; see EventDeduplicator for the multi-replica caveat.
+    event_dedupe = EventDeduplicator()
     if entity is None:
         raise ValueError("attach_routes requires agent, team, or workflow")
     hitl = HITLHandler(
@@ -152,14 +155,26 @@ def attach_routes(
         if not verify_slack_signature(body, timestamp, slack_signature, signing_secret=signing_secret):
             raise HTTPException(status_code=403, detail="Invalid signature")
 
-        # Slack retries after ~3s if it doesn't get a 200. Since we ACK
-        # immediately and process in background, retries are always duplicates.
-        # Trade-off: if the server crashes mid-processing, the retried event
-        # carrying the same payload won't be reprocessed — acceptable for chat.
-        if request.headers.get("X-Slack-Retry-Num"):
+        try:
+            data = await request.json()
+        except json.JSONDecodeError as e:
+            # Slack treats any non-2xx as a failed delivery and retries it, so an unparseable
+            # body is acked and ignored. Before this guard, first deliveries 500ed here too.
+            log_warning(f"Ignoring Slack event with a non-JSON body: {str(e)}")
             return SlackEventResponse(status="ok")
 
-        data = await request.json()
+        # A retry is a duplicate only if the original delivery reached us, so dedupe on
+        # event_id rather than dropping every retry. Marked on receipt, before dispatch:
+        # a run that dies mid-flight forfeits its retry, as it did under the blanket drop.
+        # Nested on purpose: collapsing the inner check into the outer condition would send a
+        # retry with an unseen event_id into the elif and drop it, the loss this dedupe exists to fix.
+        event_id = data.get("event_id")
+        if isinstance(event_id, str) and event_id:
+            if event_dedupe.is_duplicate(event_id):
+                return SlackEventResponse(status="ok")
+        elif request.headers.get("X-Slack-Retry-Num"):
+            # No usable event_id to dedupe on: keep dropping the retry.
+            return SlackEventResponse(status="ok")
 
         if data.get("type") == "url_verification":
             return SlackChallengeResponse(challenge=data.get("challenge"))

--- a/libs/agno/tests/unit/os/routers/test_slack_router.py
+++ b/libs/agno/tests/unit/os/routers/test_slack_router.py
@@ -1,11 +1,16 @@
 import asyncio
+import hashlib
+import hmac
 import json
 import time
-from typing import Any, Dict
+from contextlib import contextmanager
+from typing import Any, Dict, Iterator
 from unittest.mock import AsyncMock, Mock, patch
 
+import httpx
 import pytest
 from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
 
 from agno.agent import RunEvent
 from agno.models.response import ToolExecution
@@ -23,6 +28,7 @@ from agno.os.interfaces.slack.state import StreamState
 from agno.run.requirement import RunRequirement
 
 from .conftest import (
+    SIGNING_SECRET,
     build_app,
     content_chunk,
     make_agent_mock,
@@ -137,6 +143,60 @@ def _make_check_status_payload(
             }
         ],
     }
+
+
+def _event_body(
+    event_id: Any,
+    text: str = "hello",
+    channel_type: str = "im",
+    thread_ts: str | None = None,
+    include_event_id: bool = True,
+) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "type": "event_callback",
+        "team_id": "T123",
+        "event": {
+            "type": "message",
+            "channel_type": channel_type,
+            "text": text,
+            "user": "U456",
+            "channel": "C123",
+            "ts": "1708123456.000200",
+        },
+    }
+    if include_event_id:
+        body["event_id"] = event_id
+    if thread_ts:
+        body["event"]["thread_ts"] = thread_ts
+    return body
+
+
+def _slack_headers(
+    body_bytes: bytes, retry_num: int | None = None, signing_secret: str = SIGNING_SECRET
+) -> dict[str, str]:
+    timestamp = str(int(time.time()))
+    sig_base = f"v0:{timestamp}:{body_bytes.decode()}"
+    signature = "v0=" + hmac.new(signing_secret.encode(), sig_base.encode(), hashlib.sha256).hexdigest()
+    headers = {
+        "Content-Type": "application/json",
+        "X-Slack-Request-Timestamp": timestamp,
+        "X-Slack-Signature": signature,
+    }
+    if retry_num is not None:
+        headers["X-Slack-Retry-Num"] = str(retry_num)
+        headers["X-Slack-Retry-Reason"] = "http_timeout"
+    return headers
+
+
+@contextmanager
+def _routed_app(agent_mock: Any, **kwargs: Any) -> Iterator[FastAPI]:
+    """Real router, real signature check, mocked Slack client. Patches stay active for the requests."""
+    kwargs.setdefault("signing_secret", SIGNING_SECRET)
+    with (
+        patch("agno.os.interfaces.slack.router.SlackTools", return_value=make_slack_mock(token="xoxb-test")),
+        patch("agno.os.interfaces.slack.event_handler.AsyncWebClient", return_value=make_async_client_mock()),
+    ):
+        yield build_app(agent_mock, **kwargs)
 
 
 class TestEventHandlerHelpers:
@@ -690,6 +750,225 @@ class TestRouterWiring:
 
         assert resp.status_code == 200
         assert resp.json()["status"] == "ok"
+        agent_mock.arun.assert_not_called()
+
+
+class TestEventRetryDedupe:
+    """Slack retries any delivery not acked within 3s (immediately, +1 min, +5 min) with
+    X-Slack-Retry-Num set. The route must dedupe on event_id rather than drop every retry,
+    otherwise a delivery whose original never got through is lost."""
+
+    @pytest.mark.asyncio
+    async def test_first_delivery_is_processed(self):
+        agent_mock = make_agent_mock()
+
+        with _routed_app(agent_mock) as app:
+            client = TestClient(app)
+            body = json.dumps(_event_body("Ev001")).encode()
+            resp = client.post("/events", content=body, headers=_slack_headers(body))
+
+        assert resp.status_code == 200
+        await wait_for_call(agent_mock.arun)
+        agent_mock.arun.assert_awaited_once()
+        assert agent_mock.arun.call_args.args[0] == "hello"
+
+    @pytest.mark.asyncio
+    async def test_retry_of_seen_event_id_is_skipped(self):
+        agent_mock = make_agent_mock()
+
+        with _routed_app(agent_mock) as app:
+            client = TestClient(app)
+            body = json.dumps(_event_body("Ev002")).encode()
+            first = client.post("/events", content=body, headers=_slack_headers(body))
+            retry = client.post("/events", content=body, headers=_slack_headers(body, retry_num=1))
+
+        assert first.status_code == 200
+        assert retry.status_code == 200
+        assert retry.json()["status"] == "ok"
+        await asyncio.sleep(0.1)
+        agent_mock.arun.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_retry_of_unseen_event_id_is_processed(self):
+        """The original delivery never reached the handler; Slack's retry is the only copy."""
+        agent_mock = make_agent_mock()
+
+        with _routed_app(agent_mock) as app:
+            client = TestClient(app)
+            body = json.dumps(_event_body("Ev003", text="only the retry arrived")).encode()
+            resp = client.post("/events", content=body, headers=_slack_headers(body, retry_num=2))
+
+        assert resp.status_code == 200
+        await wait_for_call(agent_mock.arun)
+        agent_mock.arun.assert_awaited_once()
+        assert agent_mock.arun.call_args.args[0] == "only the retry arrived"
+
+    @pytest.mark.asyncio
+    async def test_distinct_event_ids_are_both_processed(self):
+        agent_mock = make_agent_mock()
+
+        with _routed_app(agent_mock) as app:
+            client = TestClient(app)
+            statuses = []
+            for event_id in ("Ev004a", "Ev004b"):
+                body = json.dumps(_event_body(event_id, text=event_id)).encode()
+                statuses.append(client.post("/events", content=body, headers=_slack_headers(body)).status_code)
+
+        assert statuses == [200, 200]
+        await wait_for_call(agent_mock.arun)
+        assert agent_mock.arun.await_count == 2
+        assert [call.args[0] for call in agent_mock.arun.await_args_list] == ["Ev004a", "Ev004b"]
+
+    @pytest.mark.asyncio
+    async def test_retry_during_in_flight_run_is_skipped(self):
+        """Marked on receipt: a retry that lands while the first run is still executing must not start a second run.
+
+        TestClient is synchronous and blocks the test coroutine, so no second request can be in flight
+        concurrently. The first request is driven through ASGITransport as a task instead, and held open
+        with an Event while the retry arrives.
+        """
+        agent_mock = make_agent_mock()
+        started, release = asyncio.Event(), asyncio.Event()
+
+        async def slow_run(*args: Any, **kwargs: Any) -> Mock:
+            started.set()
+            await release.wait()
+            return Mock(
+                status="OK", content="done", reasoning_content=None, images=None, files=None, videos=None, audio=None
+            )
+
+        agent_mock.arun = AsyncMock(side_effect=slow_run)
+
+        with _routed_app(agent_mock) as app:
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app), base_url="http://slack.test"
+            ) as client:
+                body = json.dumps(_event_body("Ev005")).encode()
+                first = asyncio.create_task(client.post("/events", content=body, headers=_slack_headers(body)))
+                await asyncio.wait_for(started.wait(), timeout=5)
+
+                # Timeout: a duplicate dispatch would wait on `release` forever instead of failing
+                retry = await asyncio.wait_for(
+                    client.post("/events", content=body, headers=_slack_headers(body, retry_num=1)), timeout=5
+                )
+                assert retry.status_code == 200
+                assert agent_mock.arun.call_count == 1
+
+                release.set()
+                assert (await first).status_code == 200
+
+        assert agent_mock.arun.await_count == 1
+
+    def test_seen_set_is_bounded(self):
+        from agno.os.interfaces.slack.helpers import EventDeduplicator
+
+        with patch.object(EventDeduplicator, "DEDUP_MAX_ENTRIES", 3):
+            dedupe = EventDeduplicator()
+            assert [dedupe.is_duplicate(i) for i in ("a", "b", "c")] == [False, False, False]
+            # Past the cap: the oldest id is evicted without error
+            assert dedupe.is_duplicate("d") is False
+            # Recent ids still dedupe
+            assert dedupe.is_duplicate("d") is True
+            assert dedupe.is_duplicate("b") is True
+            # The evicted id is forgotten early: a late retry of it would run again (documented trade-off)
+            assert dedupe.is_duplicate("a") is False
+
+    def test_seen_ids_expire_after_ttl(self):
+        from agno.os.interfaces.slack import helpers
+        from agno.os.interfaces.slack.helpers import EventDeduplicator
+
+        fake_time = Mock()
+        fake_time.monotonic.return_value = 1000.0
+        with patch.object(helpers, "time", fake_time):
+            dedupe = EventDeduplicator()
+            # Slack's last retry is at +5 min; the window must outlive it
+            assert dedupe.DEDUP_TTL_SECONDS >= 5 * 60
+            assert dedupe.is_duplicate("e") is False
+            fake_time.monotonic.return_value = 1000.0 + 5 * 60
+            assert dedupe.is_duplicate("e") is True
+            fake_time.monotonic.return_value = 1000.0 + dedupe.DEDUP_TTL_SECONDS + 1
+            assert dedupe.is_duplicate("e") is False
+
+    @pytest.mark.asyncio
+    async def test_missing_or_malformed_event_id_does_not_crash(self):
+        agent_mock = make_agent_mock()
+        variants = [
+            _event_body(None, include_event_id=False),
+            _event_body(None),
+            _event_body(""),
+            _event_body(12345),
+            _event_body({"nested": "object"}),
+        ]
+
+        with _routed_app(agent_mock) as app:
+            client = TestClient(app)
+            statuses = []
+            for variant in variants:
+                body = json.dumps(variant).encode()
+                statuses.append(client.post("/events", content=body, headers=_slack_headers(body)).status_code)
+                statuses.append(
+                    client.post("/events", content=body, headers=_slack_headers(body, retry_num=1)).status_code
+                )
+
+        assert statuses == [200] * 10
+        await wait_for_call(agent_mock.arun)
+        # First deliveries are never lost because of a bad id; id-less retries stay dropped
+        assert agent_mock.arun.await_count == len(variants)
+
+    @pytest.mark.asyncio
+    async def test_non_json_body_is_acked_without_dedupe_or_run(self):
+        """Slack retries any non-2xx, so an unparseable body must be acked, not 500'd."""
+        from agno.os.interfaces.slack.helpers import EventDeduplicator
+
+        agent_mock = make_agent_mock()
+        body = b"this is not json"
+
+        with (
+            _routed_app(agent_mock) as app,
+            patch.object(EventDeduplicator, "is_duplicate", return_value=False) as is_duplicate,
+        ):
+            client = TestClient(app, raise_server_exceptions=False)
+            first = client.post("/events", content=body, headers=_slack_headers(body))
+            retry = client.post("/events", content=body, headers=_slack_headers(body, retry_num=1))
+
+        assert (first.status_code, retry.status_code) == (200, 200)
+        assert first.json()["status"] == "ok"
+        await asyncio.sleep(0.1)
+        agent_mock.arun.assert_not_called()
+        is_duplicate.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_bad_signature_is_rejected_and_never_marks_the_id_seen(self):
+        agent_mock = make_agent_mock()
+
+        with _routed_app(agent_mock) as app:
+            client = TestClient(app)
+            body = json.dumps(_event_body("Ev009")).encode()
+            forged = client.post("/events", content=body, headers=_slack_headers(body, signing_secret="not-the-secret"))
+            forged_retry = client.post(
+                "/events", content=body, headers=_slack_headers(body, retry_num=1, signing_secret="not-the-secret")
+            )
+            agent_mock.arun.assert_not_called()
+            # The genuine delivery of the same event_id must still be processed
+            genuine = client.post("/events", content=body, headers=_slack_headers(body))
+
+        assert forged.status_code == 403
+        assert forged_retry.status_code == 403
+        assert genuine.status_code == 200
+        await wait_for_call(agent_mock.arun)
+        agent_mock.arun.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_non_mention_thread_reply_still_dropped(self):
+        agent_mock = make_agent_mock()
+
+        with _routed_app(agent_mock, reply_to_mentions_only=True) as app:
+            client = TestClient(app)
+            body = json.dumps(_event_body("Ev010", channel_type="channel", thread_ts="1708123456.000100")).encode()
+            resp = client.post("/events", content=body, headers=_slack_headers(body))
+
+        assert resp.status_code == 200
+        await asyncio.sleep(0.1)
         agent_mock.arun.assert_not_called()
 
 


### PR DESCRIPTION
## Summary

**Symptom:** Slack messages to an AgentOS bot were silently lost. No reply, no error, nothing in the thread.

**Root cause:** the Slack `/events` route returned 200 and discarded every request carrying `X-Slack-Retry-Num`, with no dedupe on the event id. Slack retries any delivery it cannot ack within 3 s (immediately, then +1 min, then +5 min). When the original delivery never reached the handler, its retries were the only copies, and the router threw all of them away.

**What changes:** the route now dedupes on the envelope's `event_id` instead of the retry header. A retry whose id has already been seen is skipped with 200. A retry whose id has never been seen is processed like a first delivery. The id is marked on receipt, before the background task is dispatched, so a retry that lands while the first run is still executing is skipped rather than duplicated. A retry that carries no usable `event_id` is still dropped, as before.

```
before   X-Slack-Retry-Num present ──> 200, nothing runs          (message lost if the original never arrived)

after    event_id seen              ──> 200, nothing runs          (true duplicate)
         event_id unseen            ──> 200, run dispatched        (the lost message)
         no usable event_id + retry ──> 200, nothing runs          (unchanged)
```

Implementation mirrors Telegram's `BotState.is_duplicate_update` (`telegram/state.py:131`): `EventDeduplicator` in `slack/helpers.py`, one instance per mounted interface created inside `attach_routes` beside `BotNameResolver`, an `OrderedDict` of `event_id -> time.monotonic()` with a 600 s TTL (Slack's last retry is at +5 min) and a 4096-entry cap with oldest-first eviction. The check runs after signature verification and before `background_tasks.add_task`.

### Behaviour changes

| Path | Before | After |
|---|---|---|
| Retry with an `event_id` the process has not seen | 200, nothing runs | 200, run starts |
| Retry with an `event_id` already seen | 200, nothing runs | 200, nothing runs |
| Retry with no usable `event_id` | 200, nothing runs | 200, nothing runs |
| Valid signature, body that is not JSON | 500 (Slack retries it) | 200, logged at warning, ignored |
| `agno.os.interfaces.slack.helpers` | not exported | gains one importable class, `EventDeduplicator`, same visibility as `BotNameResolver` |

### Known limitation: the seen-set is per-process

Under `AgentOS.serve(workers=N)` or any multi-replica deployment, a retry that lands on a different process is not recognised and the event runs a second time: a second reply in the thread, and every tool side effect in that run executes again. Nothing downstream mitigates this. The Slack handler passes no `run_id`, each `arun` mints a fresh one, and there is no session-level lock.

Two things keep this proportionate. All four official deploy templates (agentos-docker, -railway, -render, -fly) run a single `uvicorn app.main:app` with no `--workers`, and the Helm chart is one replica by design, so the shipped default is not exposed. Telegram's `BotState.is_duplicate_update` (`telegram/state.py:103`) already carries the identical per-process limitation, so this matches existing agno behaviour rather than introducing a new class of problem. The remedy for anyone running multi-process is one process per Slack app, or a shared store for the seen-set.

Under the previous blanket drop a duplicate run was impossible in any topology, at the price of losing the message in every topology. This trades certain loss for a duplicate that only appears with multi-process plus a slow ack.

### Cap caveat

The 4096 slots are consumed by every signed event that reaches the route, including ones that never produce a run: bot echoes, ignored subtypes, `assistant_thread_started`, and thread replies filtered out by `reply_to_mentions_only`. In a busy channel the bot is merely present in, an id can be evicted before its TTL, and a late retry of it would then run again as a duplicate.

Marking on receipt also means a run that dies mid-flight forfeits its retry. The blanket drop lost it too, so this is not a regression, but it is a deliberate choice.

### What this does NOT fix

Why a delivery misses Slack's 3 s ack window in the first place. Plain sync tools already run in a worker thread through `Model.arun_function_call`, so tool execution does not block the loop by itself; the inline path only applies when an async tool hook is attached, or to direct `aexecute` callers such as the code-mode bridge. Process restarts, deploys, or a sleeping container all produce the same result: the retry is the only copy that arrives. This PR makes sure that copy is processed instead of thrown away, and does not change any of those triggers.

(If applicable, issue number: none. Reported internally on 2026-09-08.)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Testing**

- `TestEventRetryDedupe` adds 11 route-level and unit tests in `tests/unit/os/routers/test_slack_router.py`: first delivery, seen retry skipped, unseen retry processed, distinct ids, retry during an in-flight run, bounded seen-set, TTL expiry, malformed or missing `event_id`, forged signature still 403 and never marks the id, non-mention thread reply still dropped, non-JSON body acked. The pre-existing `test_retry_header_skips_processing` is untouched and now exercises the "no usable id" branch.
- On the rebased tip: Slack router file 55 passed, all 9 Slack unit test files 283 passed, `./scripts/format.sh` reports nothing to reformat.
- Branch rebased onto `origin/main` at 3da82342f (v3.0.8), clean fast-forward. `./scripts/validate.sh` compared against a pristine worktree at that same commit: identical results (ruff clean; the same 34 pre-existing mypy errors in 10 files on both sides, none in the Slack interface).
- Mutation checks: removing the dedupe fails the seen-retry and malformed-id tests and hangs the in-flight test on its 5 s timeout; moving the dedupe above signature verification fails the forged-signature test.
- A local reproduction driving the real router with signed payloads while the handler is deliberately held busy, re-run on the rebased tip, shows the retry of a lost original now starts a run where it was previously answered 200 and discarded.

**Not in this PR:** `/interactions` keeps its blanket retry drop, since block-action payloads carry no `event_id`. The Slack cookbook README is untouched. Concurrent runs from rapid messages in one thread are a separate, pre-existing behaviour tracked in #7597 and are not changed here.