### PR TITLE
fix: preserve Control Plane access with public surfaces

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           python-version: "3.10"
       - name: Install focused test dependencies
-        run: python -m pip install -e libs/agnoctl -e 'libs/agno[os,mcp,pages]' pytest pytest-asyncio
+        run: python -m pip install -e libs/agnoctl -e 'libs/agno[os,mcp,pages,openai]' pytest pytest-asyncio
       - name: Check supported-runtime timeouts and public responses
         run: >-
           python -m pytest -q
@@ -38,6 +38,7 @@ jobs:
           libs/agno/tests/unit/knowledge/test_page_contract.py
           libs/agno/tests/unit/os/test_public_stream_bounds.py
           libs/agno/tests/unit/os/test_public_json_bounds.py
+          libs/agno/tests/integration/os/test_public_authorization.py
           libs/agno/tests/unit/test_py39_compat.py
 
   style-check-agno:

--- a/cookbook/05_agent_os/27_public_pages/README.md
+++ b/cookbook/05_agent_os/27_public_pages/README.md
@@ -15,13 +15,23 @@ Anonymous clients retain the selected chat routes, compact roster and public
 limits. `/info` reports the authentication mode so the Control Plane can connect.
 JWT callers get the normal REST API only after signature and endpoint permission
 checks; their responses are private and non-cacheable. Invalid credentials are
-rejected, including on anonymous routes. Do not use `excluded_route_paths` for
-public chat: exclusions skip credential verification altogether.
+rejected, including on anonymous routes. Public chat does not need
+`excluded_route_paths`: in mixed mode those exclusions do not bypass credential
+verification on selected public routes. Excluding a management route skips JWT
+verification, so the public layer returns 404 even with an admin JWT.
 
 Workflow WebSockets authenticate through their existing message-based protocol.
+Public upgrades use the `socket` quota (30/client/minute, 120/global/minute,
+500/client/day and 5,000/global/day). Each worker admits at most 32 connections
+awaiting authentication. Clients must authenticate within 10 seconds; five failed
+authentication attempts close the connection. Authentication releases pending
+capacity, and ordinary authenticated connections have no authentication deadline.
 MCP always keeps its explicit tool catalog and public admission limits, even for
 admin JWTs. Use `mcp_auth` if MCP itself requires OAuth authentication. Internal
 scheduler and service-account requests retain their existing public contracts.
+With a public surface, service-account tokens can use selected public routes and
+permitted protected workflows, but cannot reach management REST routes; use a JWT
+for management access.
 Without `authorization=True`, the public surface continues to close management
 routes and WebSockets.
 

--- a/cookbook/05_agent_os/27_public_pages/README.md
+++ b/cookbook/05_agent_os/27_public_pages/README.md
@@ -12,7 +12,9 @@ one runtime URL. Configure the Control Plane's RS256 public key in
 ```
 
 Anonymous clients retain the selected chat routes, compact roster and public
-limits. `/info` reports the authentication mode so the Control Plane can connect.
+limits. Anonymous `/info` reports the authentication mode and counts only selected
+public components. Verified JWT callers receive the full runtime counts. Discovery
+keeps the same response fields so the Control Plane can connect.
 JWT callers get the normal REST API only after signature and endpoint permission
 checks; their responses are private and non-cacheable. Invalid credentials are
 rejected, including on anonymous routes. Public chat does not need
@@ -32,6 +34,8 @@ scheduler and service-account requests retain their existing public contracts.
 With a public surface, service-account tokens can use selected public routes and
 permitted protected workflows, but cannot reach management REST routes; use a JWT
 for management access.
+Mounted runtimes apply JWT and service-account permissions to the route within
+AgentOS, independent of the mount prefix, including without a public surface.
 Without `authorization=True`, the public surface continues to close management
 routes and WebSockets.
 

--- a/cookbook/05_agent_os/27_public_pages/README.md
+++ b/cookbook/05_agent_os/27_public_pages/README.md
@@ -1,5 +1,32 @@
 # Public documentation pages
 
+## Public chat with Control Plane access
+
+`public_control_plane.py` combines `authorization=True` with `PublicSurface` on
+one runtime URL. Configure the Control Plane's RS256 public key in
+`JWT_VERIFICATION_KEY` (or use `JWT_JWKS_FILE`) before starting it:
+
+```sh
+.venvs/demo/bin/python cookbook/05_agent_os/27_public_pages/public_control_plane.py --check
+.venvs/demo/bin/python cookbook/05_agent_os/27_public_pages/public_control_plane.py
+```
+
+Anonymous clients retain the selected chat routes, compact roster and public
+limits. `/info` reports the authentication mode so the Control Plane can connect.
+JWT callers get the normal REST API only after signature and endpoint permission
+checks; their responses are private and non-cacheable. Invalid credentials are
+rejected, including on anonymous routes. Do not use `excluded_route_paths` for
+public chat: exclusions skip credential verification altogether.
+
+Workflow WebSockets authenticate through their existing message-based protocol.
+MCP always keeps its explicit tool catalog and public admission limits, even for
+admin JWTs. Use `mcp_auth` if MCP itself requires OAuth authentication. Internal
+scheduler and service-account requests retain their existing public contracts.
+Without `authorization=True`, the public surface continues to close management
+routes and WebSockets.
+
+## Page storage and retrieval
+
 `public_pages.py` uses one PostgreSQL database for the Knowledge catalog, quota-bounded FileSystem, vectors, sessions, durable jobs and shared public request counters. It demonstrates application-owned retrieval through an explicit callable dependency, explicit search/read/grep tools, native MCP and a typed protected sync workflow.
 
 The `docs_context` dependency is an async function that receives `run_input`, calls the application's `search_docs` function and returns evidence. Agno awaits it before pre-hooks and prompt construction. The application chooses the query and places the result through `{docs_context}` in its instructions. `add_dependencies_to_context` already defaults to `False`; it stays unset so dependencies are not additionally appended to the user message. Callables can also request `session` for previous-turn retrieval policy, plus `agent` and `run_context`.

--- a/cookbook/05_agent_os/27_public_pages/TEST_LOG.md
+++ b/cookbook/05_agent_os/27_public_pages/TEST_LOG.md
@@ -1,5 +1,20 @@
 # Public pages test log
 
+### public_control_plane.py (2026-09-08)
+
+**Status:** PASS
+
+**Description:** Ran `public_control_plane.py --check` with the demo environment,
+this worktree on `PYTHONPATH`, and a locally generated RS256 verification public
+key. No model or database call was needed for the configuration check.
+
+**Result:** Public chat, the explicit MCP tool and JWT API access assembled
+successfully. Composed HTTP/WebSocket coverage is in
+`libs/agno/tests/integration/os/test_public_authorization.py`; a hosted Control
+Plane connection remains a deployment check.
+
+---
+
 ### full_page.py — complete page reads and fence-aware normalization (2026-09-08)
 
 **Status:** PASS

--- a/cookbook/05_agent_os/27_public_pages/implementation.md
+++ b/cookbook/05_agent_os/27_public_pages/implementation.md
@@ -1,0 +1,8 @@
+# Public Control Plane integration
+
+- [x] Optional credential verification on selected anonymous routes with JWT authorization enabled.
+- [x] Verified JWT REST access preserves native endpoint permissions and response schemas.
+- [x] Public MCP limits and tool selection remain independent of JWT REST access.
+- [x] Discovery and the existing authenticated workflow WebSocket protocol are reachable in mixed mode.
+- [x] Composed HTTP tests cover public access, scoped JWTs, invalid credentials, mounts and CORS.
+- [ ] Live hosted Control Plane connection after framework release and deployment configuration.

--- a/cookbook/05_agent_os/27_public_pages/implementation.md
+++ b/cookbook/05_agent_os/27_public_pages/implementation.md
@@ -7,4 +7,6 @@
 - [x] Composed HTTP tests cover public access, scoped JWTs, invalid credentials, mounts and CORS.
 - [x] Public workflow WebSocket admission, authentication deadlines and attempt limits.
 - [x] Composed public authorization suite runs in PR CI.
+- [x] Mounted runtime scope checks cover JWTs and service accounts outside mixed mode.
+- [x] Anonymous discovery counts only public components while retaining the discovery schema.
 - [ ] Live hosted Control Plane connection after framework release and deployment configuration.

--- a/cookbook/05_agent_os/27_public_pages/implementation.md
+++ b/cookbook/05_agent_os/27_public_pages/implementation.md
@@ -5,4 +5,6 @@
 - [x] Public MCP limits and tool selection remain independent of JWT REST access.
 - [x] Discovery and the existing authenticated workflow WebSocket protocol are reachable in mixed mode.
 - [x] Composed HTTP tests cover public access, scoped JWTs, invalid credentials, mounts and CORS.
+- [x] Public workflow WebSocket admission, authentication deadlines and attempt limits.
+- [x] Composed public authorization suite runs in PR CI.
 - [ ] Live hosted Control Plane connection after framework release and deployment configuration.

--- a/cookbook/05_agent_os/27_public_pages/public_control_plane.py
+++ b/cookbook/05_agent_os/27_public_pages/public_control_plane.py
@@ -1,0 +1,51 @@
+"""Serve anonymous chat and MCP alongside a JWT-authenticated Control Plane.
+
+Set PAGE_DEMO_DB_URL and JWT_VERIFICATION_KEY (the Control Plane's RS256 public
+key), then run this file. Add --check to validate configuration without starting
+PostgreSQL or making a model call. OPENAI_API_KEY is needed for live chat.
+"""
+
+import argparse
+from os import getenv
+
+from agno.agent import Agent
+from agno.db.postgres import PostgresDb
+from agno.models.openai import OpenAIResponses
+from agno.os import AgentOS, MCPConfig
+from agno.os.public import PublicSurface
+
+
+def service_description() -> str:
+    """Describe the support service."""
+    return "Ask the support agent for help with Agno."
+
+
+db = PostgresDb(
+    db_url=getenv(
+        "PAGE_DEMO_DB_URL", "postgresql+psycopg://ai:ai@localhost:5532/page_demo"
+    )
+)
+agent = Agent(
+    id="support", name="Support", model=OpenAIResponses(id="gpt-5.6-luna"), db=db
+)
+agent_os = AgentOS(
+    id="public-support",
+    agents=[agent],
+    db=db,
+    authorization=True,
+    public=PublicSurface(agents=[agent], mcp=True),
+    mcp=MCPConfig(tools=[service_description], default_tools=False, stateless=True),
+    cors_allowed_origins=["https://os.agno.com", "http://localhost:3000"],
+)
+app = agent_os.get_app()
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check", action="store_true", help="Validate configuration without serving"
+    )
+    args = parser.parse_args()
+    if args.check:
+        print("Public chat, explicit MCP tools and JWT API access are configured.")
+    else:
+        agent_os.serve(app=app)

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -1562,6 +1562,9 @@ class AgentOS:
             from contextlib import asynccontextmanager
 
             from agno.os.public._middleware import PublicMiddleware
+            from agno.os.public._policy import PublicRoutePolicy
+
+            fastapi_app.state.public_route_policy = PublicRoutePolicy(self.public, self)
 
             original_lifespan = fastapi_app.router.lifespan_context
 
@@ -1573,7 +1576,9 @@ class AgentOS:
                     yield state
 
             fastapi_app.router.lifespan_context = public_lifespan
-            fastapi_app.add_middleware(PublicMiddleware, surface=self.public, agent_os=self)
+            fastapi_app.add_middleware(
+                PublicMiddleware, surface=self.public, agent_os=self, policy=fastapi_app.state.public_route_policy
+            )
 
         auth_configured = bool(self.authorization or jwt_env_configured or security_key)
         if auth_configured:

--- a/libs/agno/agno/os/middleware/jwt.py
+++ b/libs/agno/agno/os/middleware/jwt.py
@@ -34,6 +34,10 @@ if TYPE_CHECKING:
 # flag, so no other middleware can trip it.
 _AUTH_COMPLETE_ATTR = "_agno_auth_complete"
 
+# Set only after signature verification AND endpoint permission checks. Unlike the
+# completion marker, this is never set by unverified development mode or scheduler/PAT auth.
+_VERIFIED_API_JWT = object()
+
 
 # The built-in MCP OAuth server mints request identities as ``__oauth__:<client_id>``.
 # A double-underscore sentinel (like ``__scheduler__``), not a bare ``oauth:`` prefix, so
@@ -918,12 +922,30 @@ class AuthMiddleware(BaseHTTPMiddleware):
         path = request.url.path
         method = request.method
 
+        from starlette._utils import get_route_path
+
+        public_policy = getattr(request.app.state, "public_route_policy", None)
+        public_path = get_route_path(request.scope)
+        mixed_public = public_policy is not None and public_policy.authenticated_api
+        if mixed_public:
+            path = public_path
+        if mixed_public and len(request.headers.getlist("authorization")) > 1:
+            return self._create_error_response(401, "Ambiguous Authorization header")
+
         # Skip OPTIONS requests (CORS preflight)
         if method == "OPTIONS":
             return await call_next(request)
 
         # Skip excluded routes
-        if self._is_route_excluded(path):
+        if self._is_route_excluded(path) and not (
+            mixed_public
+            and public_policy is not None
+            and (
+                public_policy.allows_anonymous(method, path)
+                or path in ("/docs", "/redoc", "/openapi.json", "/docs/oauth2-redirect")
+            )
+            and not public_policy.is_mcp(path)
+        ):
             return await call_next(request)
 
         # Already authenticated by an OUTER instance of THIS middleware in a manually
@@ -947,6 +969,12 @@ class AuthMiddleware(BaseHTTPMiddleware):
         # or the OS security key -- this middleware is the single auth layer).
         token = self._extract_token(request)
         if not token:
+            if mixed_public and request.headers.getlist("authorization"):
+                return self._create_error_response(401, "Invalid authentication token", origin, cors_allowed_origins)
+            if mixed_public and public_policy is not None and public_policy.allows_anonymous(method, public_path):
+                # This does not mark the caller authenticated or grant scopes. The
+                # public middleware must still validate the selected route and body.
+                return await call_next(request)
             if not self._jwt_configured and not self.security_key:
                 # Open instance with only a service-account verifier: PATs are
                 # verified when presented, anonymous requests pass (mirrors REST).
@@ -1088,6 +1116,9 @@ class AuthMiddleware(BaseHTTPMiddleware):
             request.state.token = token
             request.state.authenticated = True
             setattr(request.state, _AUTH_COMPLETE_ATTR, True)
+
+            if mixed_public and self.authorization and self.validate:
+                request.state._agno_verified_api_jwt = _VERIFIED_API_JWT
 
         except jwt.InvalidAudienceError as e:
             log_warning(f"Invalid token audience - expected: {expected_audience}: {str(e)}")

--- a/libs/agno/agno/os/middleware/jwt.py
+++ b/libs/agno/agno/os/middleware/jwt.py
@@ -919,16 +919,13 @@ class AuthMiddleware(BaseHTTPMiddleware):
             request.app.state.admin_scope = self.admin_scope
             request.app.state.user_isolation_enabled = self.user_isolation
 
-        path = request.url.path
-        method = request.method
-
         from starlette._utils import get_route_path
 
+        path = get_route_path(request.scope)
+        method = request.method
         public_policy = getattr(request.app.state, "public_route_policy", None)
-        public_path = get_route_path(request.scope)
+        public_path = path
         mixed_public = public_policy is not None and public_policy.authenticated_api
-        if mixed_public:
-            path = public_path
         if mixed_public and len(request.headers.getlist("authorization")) > 1:
             return self._create_error_response(401, "Ambiguous Authorization header")
 

--- a/libs/agno/agno/os/public/__init__.py
+++ b/libs/agno/agno/os/public/__init__.py
@@ -38,6 +38,11 @@ class PublicSurface:
     Successful runs retain native output, including Team member tool results and
     failure details when the leader recovers. Selecting a Team does not expose
     independent member routes. Failed top-level runs use sanitized public errors.
+
+    With AgentOS(authorization=True), anonymous requests retain these limits while
+    verified JWT callers use the normal REST API with endpoint permissions. MCP
+    remains restricted to its explicit tools and public limits. Scheduler and
+    service-account credentials retain their existing public request contracts.
     """
 
     agents: List[Any] = field(default_factory=list)

--- a/libs/agno/agno/os/public/_limits.py
+++ b/libs/agno/agno/os/public/_limits.py
@@ -42,6 +42,7 @@ DEFAULT_LIMITS = {
     "run": RateLimit(10, 50, 80, 3000),
     "cancel": RateLimit(10, 30, 50, 1000),
     "mcp": RateLimit(600, 1200, 5000, 20000),
+    "socket": RateLimit(30, 120, 500, 5000),
     "feedback": RateLimit(3, 30, 10, 500),
 }
 

--- a/libs/agno/agno/os/public/_middleware.py
+++ b/libs/agno/agno/os/public/_middleware.py
@@ -25,6 +25,7 @@ from agno.utils.bounded import BoundedWorkers
 from agno.utils.log import log_warning
 
 IDENTITY_WORKERS = BoundedWorkers(8, "public-identity")
+MAX_PENDING_WEBSOCKETS = 32
 
 
 class Rejected(Exception):
@@ -45,6 +46,7 @@ class PublicMiddleware:
         self.app, self.surface, self.agent_os = app, surface, agent_os
         self.policy = policy or PublicRoutePolicy(surface, agent_os)
         self.active_runs = self.active_mcp = 0
+        self.pending_websockets = 0
         self.selected = self.policy.selected
         self.registered = {
             kind: {component.id for component in getattr(agent_os, kind) or []} for kind in self.selected
@@ -160,6 +162,40 @@ class PublicMiddleware:
         except Exception as exc:
             raise Rejected(400, "invalid_request_body") from exc
 
+    async def _websocket(self, scope: Any, receive: Any, send: Any) -> None:
+        if self.pending_websockets >= MAX_PENDING_WEBSOCKETS:
+            await send({"type": "websocket.close", "code": 1008})
+            return
+        self.pending_websockets += 1
+        pending = True
+
+        def release():
+            nonlocal pending
+            if pending:
+                pending = False
+                self.pending_websockets -= 1
+
+        try:
+            try:
+                # Preserve the Request contract of application-owned identity callbacks
+                # while resolving the identity of the HTTP upgrade request.
+                request = Request({**scope, "type": "http", "method": "GET"})
+                identity = await asyncio.wait_for(self._identity(request), timeout=3)
+                decision = await self.surface.limiter.aconsume("socket", client_id=identity)
+            except Exception:
+                log_warning("Public WebSocket admission unavailable")
+                await send({"type": "websocket.close", "code": 1008})
+                return
+            if not decision.allowed:
+                await send({"type": "websocket.close", "code": 1008})
+                return
+            # Only the native authenticated handler receives this callback. Release
+            # pending capacity after verification, or on any disconnect/failure below.
+            scope["_agno_public_ws_authenticated"] = release
+            await self.app(scope, receive, send)
+        finally:
+            release()
+
     async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
         if scope["type"] == "lifespan":
             await self.app(scope, receive, send)
@@ -173,7 +209,7 @@ class PublicMiddleware:
             ):
                 # The native workflow socket authenticates its first message and
                 # enforces scopes before any execution or subscription.
-                await self.app(scope, receive, send)
+                await self._websocket(scope, receive, send)
                 return
             await send({"type": "websocket.close", "code": 1008})
             return

--- a/libs/agno/agno/os/public/_middleware.py
+++ b/libs/agno/agno/os/public/_middleware.py
@@ -5,11 +5,10 @@ from __future__ import annotations
 import asyncio
 import inspect
 import json
-import re
 import zlib
 from ipaddress import IPv6Address, ip_address, ip_network
 from pathlib import PurePath
-from typing import Any
+from typing import Any, Optional
 from urllib.parse import parse_qsl
 from uuid import UUID, uuid4
 
@@ -21,10 +20,10 @@ from starlette.responses import JSONResponse
 
 from agno.os.auth import require_verified_public_workflow, verify_internal_service_request
 from agno.os.public import _client_id
+from agno.os.public._policy import RUN_ROUTE, PublicRoutePolicy
 from agno.utils.bounded import BoundedWorkers
 from agno.utils.log import log_warning
 
-ROUTE = re.compile(r"^/(agents|teams|workflows)/([^/]+)/runs(?:/([^/]+)(/cancel)?)?$")
 IDENTITY_WORKERS = BoundedWorkers(8, "public-identity")
 
 
@@ -42,16 +41,15 @@ def _uuid(value: str) -> None:
 
 
 class PublicMiddleware:
-    def __init__(self, app: Any, *, surface: Any, agent_os: Any):
+    def __init__(self, app: Any, *, surface: Any, agent_os: Any, policy: Optional[PublicRoutePolicy] = None):
         self.app, self.surface, self.agent_os = app, surface, agent_os
+        self.policy = policy or PublicRoutePolicy(surface, agent_os)
         self.active_runs = self.active_mcp = 0
-        self.selected = {
-            kind: {component.id for component in getattr(surface, kind)} for kind in ("agents", "teams", "workflows")
-        }
+        self.selected = self.policy.selected
         self.registered = {
             kind: {component.id for component in getattr(agent_os, kind) or []} for kind in self.selected
         }
-        self.oauth_paths = agent_os.mcp_auth_exempt_paths() if surface.mcp else []
+        self.oauth_paths = self.policy.oauth_paths
         self.interface_routes = set(getattr(agent_os, "_public_interface_routes", []))
 
     async def _identity(self, request: Request) -> str:
@@ -167,6 +165,16 @@ class PublicMiddleware:
             await self.app(scope, receive, send)
             return
         if scope["type"] != "http":
+            if (
+                scope["type"] == "websocket"
+                and self.policy.authenticated_api
+                and get_route_path(scope) == "/workflows/ws"
+                and self.policy.allows_authenticated_websocket(scope)
+            ):
+                # The native workflow socket authenticates its first message and
+                # enforces scopes before any execution or subscription.
+                await self.app(scope, receive, send)
+                return
             await send({"type": "websocket.close", "code": 1008})
             return
         path, method = get_route_path(scope), scope["method"]
@@ -299,7 +307,7 @@ class PublicMiddleware:
             if len(request.headers.getlist("authorization")) > 1:
                 raise Rejected(401, "ambiguous_authorization")
             internal = verify_internal_service_request(request)
-            match = ROUTE.fullmatch(path)
+            match = RUN_ROUTE.fullmatch(path)
             component_kind = component_id = run_id = cancellation = ""
             if match:
                 component_kind, component_id, run_id, cancellation = match.groups()
@@ -307,7 +315,30 @@ class PublicMiddleware:
                 # Verification, not bearer-header presence, grants scheduler schemas and quota bypass.
                 await self.app(scope, receive, send)
                 return
+            from agno.os.middleware.jwt import _VERIFIED_API_JWT
+
+            if (
+                self.policy.authenticated_api
+                and getattr(request.state, "_agno_verified_api_jwt", None) is _VERIFIED_API_JWT
+                and not self.policy.is_mcp(path)
+                and path not in ("/", "/health", "/readyz")
+            ):
+
+                async def private_send(message):
+                    if message["type"] == "http.response.start":
+                        headers = [
+                            (key, value) for key, value in message.get("headers", []) if key.lower() != b"cache-control"
+                        ]
+                        headers.append((b"cache-control", b"private, no-store"))
+                        message = {**message, "headers": headers}
+                    await send(message)
+
+                await self.app(scope, receive, private_send)
+                return
             if (method, path) in self.interface_routes:
+                await self.app(scope, receive, send)
+                return
+            if self.policy.authenticated_api and path == "/info" and method == "GET":
                 await self.app(scope, receive, send)
                 return
             if path in ("/", "/health") and method in ("GET", "HEAD"):
@@ -337,7 +368,8 @@ class PublicMiddleware:
                     [
                         {"id": item.id, "name": item.name, "description": (item.description or "")[:2048]}
                         for item in getattr(self.surface, path[1:])
-                    ]
+                    ],
+                    headers={"Vary": "Authorization"} if self.policy.authenticated_api else None,
                 )(scope, receive, send)
                 return
             mcp = self.surface.mcp and path in ("/mcp", "/mcp/server-card")

--- a/libs/agno/agno/os/public/_policy.py
+++ b/libs/agno/agno/os/public/_policy.py
@@ -1,0 +1,56 @@
+"""Route selection shared by public admission and optional JWT authentication."""
+
+import re
+from typing import Any
+
+from starlette.routing import Match
+
+RUN_ROUTE = re.compile(r"^/(agents|teams|workflows)/([^/]+)/runs(?:/([^/]+)(/cancel)?)?$")
+
+
+class PublicRoutePolicy:
+    def __init__(self, surface: Any, agent_os: Any):
+        self.authenticated_api = bool(getattr(agent_os, "authorization", False))
+        self.selected = {
+            kind: {component.id for component in getattr(surface, kind)} for kind in ("agents", "teams", "workflows")
+        }
+        self.mcp = surface.mcp
+        self.oauth_paths = agent_os.mcp_auth_exempt_paths() if surface.mcp else []
+
+    def is_mcp(self, path: str) -> bool:
+        return path == "/mcp" or path.startswith("/mcp/") or path in self.oauth_paths
+
+    def allows_authenticated_websocket(self, scope: Any) -> bool:
+        # A custom base-app route can take precedence over Agno's workflow socket.
+        # Only the native handler guarantees authentication before any operation.
+        from agno.os.utils import flatten_routes
+
+        for route in scope["app"].routes:
+            match, _ = route.matches(scope)
+            if match == Match.FULL:
+                # New FastAPI versions retain an included router as a branch.
+                # The native socket is registered in its own one-endpoint router.
+                candidates = flatten_routes([route])
+                return len(candidates) == 1 and bool(
+                    getattr(getattr(candidates[0], "endpoint", None), "_agno_authenticated_workflow_socket", False)
+                )
+        return False
+
+    def allows_anonymous(self, method: str, path: str) -> bool:
+        if path in ("/", "/health") and method in ("GET", "HEAD"):
+            return True
+        if method == "GET" and path in ("/readyz", "/agents", "/teams"):
+            return True
+        if self.authenticated_api and method == "GET" and path == "/info":
+            return True
+        if self.mcp and path in ("/mcp", "/mcp/server-card"):
+            return True  # MCP transport and any OAuth provider enforce their own methods/authentication.
+        match = RUN_ROUTE.fullmatch(path)
+        if method != "POST" or match is None:
+            return False
+        kind, component_id, run_id, cancellation = match.groups()
+        return (
+            kind in ("agents", "teams")
+            and component_id in self.selected[kind]
+            and (run_id is None or cancellation is not None)
+        )

--- a/libs/agno/agno/os/router.py
+++ b/libs/agno/agno/os/router.py
@@ -7,6 +7,7 @@ from fastapi import (
     Depends,
     HTTPException,
     Request,
+    Response,
     WebSocket,
 )
 
@@ -20,7 +21,7 @@ from agno.os.auth import (
     verify_websocket_service_account,
 )
 from agno.os.managers import websocket_manager
-from agno.os.middleware.jwt import JWTValidator, is_reserved_principal, resolve_expected_audience
+from agno.os.middleware.jwt import _VERIFIED_API_JWT, JWTValidator, is_reserved_principal, resolve_expected_audience
 from agno.os.middleware.user_scope import (
     INSUFFICIENT_PERMISSIONS_WS_RECONNECT,
     WORKFLOW_ID_REQUIRED_RECONNECT,
@@ -245,7 +246,16 @@ def get_info_router(os: "AgentOS") -> APIRouter:
         description="Return lightweight, unauthenticated metadata about this AgentOS instance.",
         response_model=InfoResponse,
     )
-    async def get_info(request: Request) -> InfoResponse:
+    async def get_info(request: Request, response: Response) -> InfoResponse:
+        policy = getattr(request.app.state, "public_route_policy", None)
+        public_selection = None
+        if (
+            policy is not None
+            and policy.authenticated_api
+            and getattr(request.state, "_agno_verified_api_jwt", None) is not _VERIFIED_API_JWT
+        ):
+            public_selection = policy.selected
+            response.headers["Vary"] = "Authorization"
         mcp_enabled = bool(os.mcp)
         mcp_oauth = None
         if mcp_enabled and getattr(os, "mcp_auth", None) is not None:
@@ -260,9 +270,9 @@ def get_info_router(os: "AgentOS") -> APIRouter:
             name=os.name,
             os_version=os.version or "1.0.0",
             agno_version=agno_version,
-            agent_count=len(os.agents or []),
-            team_count=len(os.teams or []),
-            workflow_count=len(os.workflows or []),
+            agent_count=len(public_selection["agents"] if public_selection is not None else os.agents or []),
+            team_count=len(public_selection["teams"] if public_selection is not None else os.teams or []),
+            workflow_count=len(public_selection["workflows"] if public_selection is not None else os.workflows or []),
             mcp=McpInfo(enabled=mcp_enabled, path="/mcp" if mcp_enabled else None, oauth=mcp_oauth),
             auth_mode=get_effective_auth_mode(
                 settings=os.settings,

--- a/libs/agno/agno/os/router.py
+++ b/libs/agno/agno/os/router.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
@@ -273,6 +274,10 @@ def get_info_router(os: "AgentOS") -> APIRouter:
     return router
 
 
+PUBLIC_WS_AUTH_TIMEOUT = 10.0
+PUBLIC_WS_MAX_AUTH_ATTEMPTS = 5
+
+
 def get_websocket_router(
     os: "AgentOS",
     settings: AgnoAPISettings = AgnoAPISettings(),
@@ -321,6 +326,10 @@ def get_websocket_router(
 
         await websocket_manager.connect(websocket, requires_auth=requires_auth)
 
+        public_authenticated = websocket.scope.get("_agno_public_ws_authenticated")
+        auth_deadline = asyncio.get_running_loop().time() + PUBLIC_WS_AUTH_TIMEOUT
+        auth_attempts = 0
+
         # Store user context from the authenticated identity (JWT or service account)
         websocket_user_context: Dict[str, Any] = {}
 
@@ -333,12 +342,32 @@ def get_websocket_router(
 
         try:
             while True:
-                data = await websocket.receive_text()
+                if public_authenticated is not None and requires_auth:
+                    if websocket_manager.is_authenticated(websocket):
+                        public_authenticated()
+                        public_authenticated = None
+                        data = await websocket.receive_text()
+                    else:
+                        if auth_attempts >= PUBLIC_WS_MAX_AUTH_ATTEMPTS:
+                            await websocket.close(code=1008)
+                            return
+                        # A fixed deadline prevents ping/auth messages from extending
+                        # the lifetime of an unauthenticated public connection.
+                        remaining = auth_deadline - asyncio.get_running_loop().time()
+                        try:
+                            data = await asyncio.wait_for(websocket.receive_text(), timeout=remaining)
+                        except asyncio.TimeoutError:
+                            await websocket.close(code=1008)
+                            return
+                else:
+                    data = await websocket.receive_text()
                 message = json.loads(data)
                 action = message.get("action")
 
                 # Handle authentication first
                 if action == "authenticate":
+                    if public_authenticated is not None:
+                        auth_attempts += 1
                     token = message.get("token")
                     if not token:
                         await websocket.send_text(json.dumps({"event": "auth_error", "error": "Token is required"}))

--- a/libs/agno/agno/os/router.py
+++ b/libs/agno/agno/os/router.py
@@ -632,4 +632,5 @@ def get_websocket_router(
             await cancel_subscription_pump(websocket)
             await websocket_manager.disconnect_websocket(websocket)
 
+    setattr(workflow_websocket_endpoint, "_agno_authenticated_workflow_socket", True)
     return ws_router

--- a/libs/agno/agno/os/service_accounts.py
+++ b/libs/agno/agno/os/service_accounts.py
@@ -28,6 +28,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+from starlette._utils import get_route_path
 from starlette.concurrency import run_in_threadpool
 
 from agno.db.base import AsyncBaseDb, BaseDb
@@ -385,7 +386,7 @@ async def authenticate_service_account_request(
         list(account.scopes),
         scope_mappings,
         request.method,
-        request.url.path,
+        get_route_path(request.scope),
         admin_scope=admin_scope,
     )
     request.state.required_scopes = scope_check.required_scopes

--- a/libs/agno/tests/integration/os/test_public_authorization.py
+++ b/libs/agno/tests/integration/os/test_public_authorization.py
@@ -1,0 +1,382 @@
+"""One runtime serving anonymous clients and the JWT-authenticated Control Plane."""
+
+import time
+from types import SimpleNamespace
+
+import jwt
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from agno.agent import Agent
+from agno.db.postgres import PostgresDb
+from agno.db.sqlite import SqliteDb
+from agno.models.base import Model
+from agno.models.message import MessageMetrics
+from agno.models.response import ModelResponse
+from agno.os import AgentOS, MCPConfig
+from agno.os.config import AuthorizationConfig
+from agno.os.middleware.jwt import AuthMiddleware
+from agno.os.public import PublicSurface
+from agno.os.public._limits import Admission
+
+KEY = "public-control-plane-test-signing-key"
+ORIGIN = "https://os.agno.com"
+
+
+class AnswerModel(Model):
+    def __init__(self):
+        super().__init__(id="test-answer", name="test-answer", provider="test")
+
+    def invoke(self, *args, **kwargs):
+        return ModelResponse(role="assistant", content="Hello", response_usage=MessageMetrics())
+
+    async def ainvoke(self, *args, **kwargs):
+        return self.invoke(*args, **kwargs)
+
+    def invoke_stream(self, *args, **kwargs):
+        yield self.invoke(*args, **kwargs)
+
+    async def ainvoke_stream(self, *args, **kwargs):
+        yield self.invoke(*args, **kwargs)
+
+    def _parse_provider_response(self, response, **kwargs):
+        return response
+
+    def _parse_provider_response_delta(self, response):
+        return response
+
+
+class AdmissionRecorder:
+    ready = True
+
+    def __init__(self):
+        self.calls = []
+        self.allowed = True
+
+    async def aconsume(self, bucket, *, client_id):
+        self.calls.append(bucket)
+        return Admission(self.allowed, retry_after=60)
+
+    async def _aprepare(self):
+        pass
+
+
+def token(scopes=None, *, key=KEY, audience="mixed-os", expires=300):
+    return jwt.encode(
+        {
+            "sub": "operator",
+            "scopes": scopes if scopes is not None else ["agent_os:admin"],
+            "aud": audience,
+            "exp": int(time.time()) + expires,
+        },
+        key,
+        algorithm="HS256",
+    )
+
+
+def auth(value=None):
+    return {"Authorization": "Bearer " + (value if value is not None else token())}
+
+
+def echo(message: str) -> str:
+    return message
+
+
+@pytest.fixture
+def runtime(monkeypatch, tmp_path):
+    for name in ("JWT_VERIFICATION_KEY", "JWT_JWKS_FILE", "OS_SECURITY_KEY"):
+        monkeypatch.delenv(name, raising=False)
+    # Code-defined component discovery needs no PostgreSQL connection. Session
+    # requests below use a real SQLite store; quota calls are recorded separately.
+    monkeypatch.setattr("agno.agent.agent.get_agents", lambda **kwargs: [])
+    db = SqliteDb(id="sessions", db_file=str(tmp_path / "sessions.db"))
+    agent = Agent(id="docs", name="Docs", db=db, model=AnswerModel(), telemetry=False)
+    hidden = Agent(id="private", db=db, model=AnswerModel(), telemetry=False)
+    surface = PublicSurface(agents=[agent], mcp=True)
+    limiter = AdmissionRecorder()
+    surface._limiter = limiter
+    os = AgentOS(
+        id="mixed-os",
+        agents=[agent, hidden],
+        db=PostgresDb(db_url="postgresql+psycopg://unused:unused@127.0.0.1:1/unused"),
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[KEY], algorithm="HS256", verify_audience=True, user_isolation=True
+        ),
+        public=surface,
+        mcp=MCPConfig(tools=[echo], default_tools=False, lifecycle_tools=False, stateless=True),
+        internal_service_token="scheduler-secret",
+        telemetry=False,
+        auto_provision_dbs=False,
+        cors_allowed_origins=[ORIGIN],
+    )
+    return SimpleNamespace(os=os, surface=surface, limiter=limiter, db=db)
+
+
+def test_public_chat_and_authenticated_control_plane_share_one_app(runtime):
+    client = TestClient(runtime.os.get_app())
+    public = client.get("/agents")
+    assert public.json() == [{"id": "docs", "name": "Docs", "description": ""}]
+    assert "Authorization" in public.headers["vary"]
+    assert client.get("/info").json()["auth_mode"] == "jwt"
+    assert client.get("/config").status_code == 401
+    assert client.get("/agents/private").status_code == 401
+
+    run = client.post("/agents/docs/runs", data={"message": "hi", "stream": "false"})
+    assert run.status_code == 200, run.text
+    assert run.json()["content"] == "Hello"
+    assert runtime.limiter.calls == ["run"]
+
+    config = client.get("/config", headers=auth())
+    assert config.status_code == 200, config.text
+    assert config.json()["os_id"] == "mixed-os"
+    assert config.headers["cache-control"] == "private, no-store"
+    agents = client.get("/agents", headers=auth())
+    assert {item["id"] for item in agents.json()} == {"docs", "private"}
+    assert "model" in agents.json()[0]
+    assert client.get("/agents/private", headers=auth()).status_code == 200
+    assert client.get("/openapi.json").status_code == 401
+    assert client.get("/openapi.json", headers=auth()).status_code == 200
+    assert client.head("/health", headers=auth()).status_code == 200
+    sessions = client.get("/sessions", params={"db_id": "sessions"}, headers=auth())
+    assert sessions.status_code == 200, sessions.text
+    assert run.json()["session_id"] in sessions.text
+    assert runtime.limiter.calls == ["run"]
+
+
+def test_scoped_jwt_uses_existing_permissions_and_native_run_schema(runtime):
+    client = TestClient(runtime.os.get_app())
+    headers = auth(token(["agents:docs:read", "agents:docs:run"]))
+    assert client.get("/config", headers=headers).status_code == 403
+    assert client.get("/sessions", headers=headers).status_code == 403
+    assert client.get("/agents/private", headers=headers).status_code == 403
+    assert [item["id"] for item in client.get("/agents", headers=headers).json()] == ["docs"]
+    fields = {"message": "hi", "stream": "false", "user_id": "cannot-impersonate"}
+    assert client.post("/agents/docs/runs", data=fields).status_code == 400
+    result = client.post("/agents/docs/runs", data=fields, headers=headers)
+    assert result.status_code == 200, result.text
+    assert result.json()["user_id"] == "operator"
+    assert runtime.limiter.calls == ["run"]
+    assert client.post("/agents/private/runs", data=fields, headers=headers).status_code == 403
+
+
+@pytest.mark.parametrize(
+    "credential",
+    ["", "garbage", token(key="wrong-signing-key-at-least-32-bytes"), token(audience="another-os"), token(expires=-60)],
+)
+@pytest.mark.parametrize("path", ["/config", "/agents", "/info", "/agents/docs/runs", "/mcp"])
+def test_bad_credentials_never_fall_back_to_public(runtime, credential, path):
+    client = TestClient(runtime.os.get_app())
+    response = client.request(
+        "POST" if path.endswith("runs") or path == "/mcp" else "GET", path, headers=auth(credential)
+    )
+    assert response.status_code == 401
+    assert runtime.limiter.calls == []
+
+
+def test_duplicate_bearers_and_insufficient_scopes_fail_before_admission(runtime):
+    client = TestClient(runtime.os.get_app())
+    headers = [("Authorization", "Bearer " + token()), ("Authorization", "Bearer invalid")]
+    assert client.get("/config", headers=headers).status_code == 401
+    response = client.post("/agents/docs/runs", data={"message": "hi"}, headers=auth(token(["config:read"])))
+    assert response.status_code == 403
+    assert not runtime.limiter.calls
+
+
+def test_public_limits_remain_independent_of_authenticated_rest(runtime):
+    runtime.limiter.allowed = False
+    client = TestClient(runtime.os.get_app())
+    response = client.post("/agents/docs/runs", data={"message": "hi"})
+    assert response.status_code == 429
+    assert response.headers["retry-after"] == "60"
+    assert client.get("/config", headers=auth()).status_code == 200
+    # Even a verified admin JWT cannot bypass public MCP admission.
+    for headers in ({}, auth()):
+        assert (
+            client.post("/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"}, headers=headers).status_code
+            == 429
+        )
+    assert runtime.limiter.calls == ["run", "mcp", "mcp"]
+
+
+def test_scheduler_keeps_its_narrow_access(runtime):
+    client = TestClient(runtime.os.get_app())
+    headers = auth("scheduler-secret")
+    assert client.get("/config", headers=headers).status_code == 403
+    result = client.post(
+        "/agents/private/runs", headers=headers, data={"message": "hi", "stream": "false", "user_id": "owner"}
+    )
+    assert result.status_code == 200, result.text
+    assert not runtime.limiter.calls
+
+
+def test_scoped_workflow_service_account_keeps_public_input_and_quota_rules(runtime):
+    from uuid import uuid4
+
+    from pydantic import BaseModel
+
+    from agno.db.schemas.service_accounts import ServiceAccount
+    from agno.os.service_accounts import ServiceAccountVerifier, generate_token
+    from agno.workflow import Step, StepInput, StepOutput, Workflow
+
+    class SyncInput(BaseModel):
+        reason: str
+
+    def sync(step_input: StepInput) -> StepOutput:
+        return StepOutput(content="synchronized")
+
+    workflow = Workflow(id="sync", input_schema=SyncInput, db=runtime.db, steps=[Step(name="sync", executor=sync)])
+    runtime.os.workflows = [workflow]
+    runtime.surface.workflows = [workflow]
+    runtime.os._service_account_verifier = ServiceAccountVerifier(runtime.db)
+    plaintext, digest, prefix = generate_token()
+    runtime.db.create_service_account(
+        ServiceAccount(
+            id=str(uuid4()),
+            name="sync-hook",
+            token_hash=digest,
+            token_prefix=prefix,
+            scopes=["workflows:sync:run", "workflows:sync:read"],
+            created_at=int(time.time()),
+        ).to_dict()
+    )
+    client = TestClient(runtime.os.get_app())
+    route = "/workflows/sync/runs"
+    fields = {"message": '{"reason":"test"}', "stream": "false"}
+    assert client.post(route, data=fields).status_code == 401
+    assert client.post(route, data={**fields, "user_id": "owner"}, headers=auth(plaintext)).status_code == 400
+    response = client.post(route, data=fields, headers=auth(plaintext))
+    assert response.status_code == 200, response.text
+    run = response.json()
+    response = client.get(
+        route + "/" + run["run_id"], params={"session_id": run["session_id"]}, headers=auth(plaintext)
+    )
+    assert response.status_code == 200, response.text
+    assert client.get("/config", headers=auth(plaintext)).status_code == 403
+    assert runtime.limiter.calls == ["run", "run"]
+
+
+@pytest.mark.parametrize("scopes", [["agent_os:admin"], ["config:read"]])
+def test_workflow_socket_requires_authentication_even_before_first_http_request(runtime, scopes):
+    client = TestClient(runtime.os.get_app())
+    with client.websocket_connect("/workflows/ws") as socket:
+        assert socket.receive_json()["event"] == "connected"
+        socket.send_json({"action": "ping"})
+        assert socket.receive_json()["event"] == "auth_required"
+        socket.send_json({"action": "authenticate", "token": "invalid"})
+        assert socket.receive_json()["event"] == "auth_error"
+        socket.send_json({"action": "authenticate", "token": token(scopes)})
+        assert socket.receive_json()["event"] == "authenticated"
+        assert socket.receive_json()["event"] == "authenticated"
+        socket.send_json({"action": "ping"})
+        assert socket.receive_json()["event"] == "pong"
+        if scopes == ["config:read"]:
+            socket.send_json({"action": "start-workflow", "workflow_id": "private-workflow"})
+            assert socket.receive_json() == {"event": "error", "error": "Insufficient permissions to run this workflow"}
+
+
+def test_mounted_runtime_keeps_route_permissions_and_public_selection(runtime):
+    parent = FastAPI()
+    parent.mount("/runtime", runtime.os.get_app())
+    client = TestClient(parent)
+    assert client.get("/runtime/agents").status_code == 200
+    assert client.get("/runtime/config", headers=auth()).status_code == 200
+    assert client.get("/runtime/config", headers=auth(token(["agents:read"]))).status_code == 403
+    assert client.post("/runtime/agents/private/runs", data={"message": "hi"}).status_code == 401
+    with client.websocket_connect("/runtime/workflows/ws") as socket:
+        assert socket.receive_json()["event"] == "connected"
+        socket.send_json({"action": "ping"})
+        assert socket.receive_json()["event"] == "auth_required"
+
+
+def test_cors_covers_preflights_and_authorization_errors(runtime):
+    client = TestClient(runtime.os.get_app())
+    response = client.options(
+        "/config",
+        headers={
+            "Origin": ORIGIN,
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "authorization",
+        },
+    )
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == ORIGIN
+    response = client.get("/config", headers={"Origin": ORIGIN, **auth("invalid")})
+    assert response.status_code == 401
+    assert response.headers["access-control-allow-origin"] == ORIGIN
+
+
+def test_unverified_development_middleware_cannot_open_the_public_api(runtime):
+    app = runtime.os.get_app()
+    app.add_middleware(AuthMiddleware, validate=False, authorization=True)
+    response = TestClient(app).get("/config", headers=auth(token(key="untrusted-signature-key-at-least-32-bytes")))
+    assert response.status_code == 404
+
+
+def test_public_only_mode_retains_its_closed_api_and_sockets(runtime):
+    runtime.os.authorization = False
+    runtime.os.authorization_config = None
+    client = TestClient(runtime.os.get_app())
+    assert client.get("/config", headers=auth()).status_code == 404
+    assert client.get("/info").status_code == 404
+    assert client.get("/agents").status_code == 200
+    with pytest.raises(WebSocketDisconnect) as error:
+        with client.websocket_connect("/workflows/ws"):
+            pass
+    assert error.value.code == 1008
+
+
+def test_custom_workflow_socket_cannot_inherit_the_native_authentication_exemption(runtime):
+    from fastapi import WebSocket
+
+    base = FastAPI()
+
+    @base.websocket("/workflows/ws")
+    async def custom_socket(socket: WebSocket):
+        await socket.accept()
+        await socket.send_json({"private": "custom-handler"})
+
+    runtime.os.base_app = base
+    client = TestClient(runtime.os.get_app())
+    with pytest.raises(WebSocketDisconnect) as error:
+        with client.websocket_connect("/workflows/ws"):
+            pass
+    assert error.value.code == 1008
+
+
+def test_mcp_serves_only_explicit_tools_for_anonymous_and_admin_callers(runtime):
+    with TestClient(runtime.os.get_app()) as client:
+        for credentials in ({}, auth()):
+            response = client.post(
+                "/mcp",
+                headers={"Accept": "application/json, text/event-stream", **credentials},
+                json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+            )
+            assert response.status_code == 200, response.text
+            import json
+
+            data = (
+                response.json()
+                if response.headers["content-type"].startswith("application/json")
+                else json.loads(next(line[6:] for line in response.text.splitlines() if line.startswith("data: ")))
+            )
+            assert [tool["name"] for tool in data["result"]["tools"]] == ["echo"]
+    assert runtime.limiter.calls == ["mcp", "mcp"]
+
+
+def test_configured_mcp_oauth_still_requires_its_own_authentication(runtime):
+    from fastmcp.server.auth.providers.in_memory import InMemoryOAuthProvider
+
+    runtime.os.mcp_auth = InMemoryOAuthProvider(base_url="http://localhost")
+    with TestClient(runtime.os.get_app(), base_url="http://localhost") as client:
+        assert client.get("/.well-known/oauth-authorization-server").status_code == 200
+        response = client.post(
+            "/mcp",
+            headers={"Accept": "application/json, text/event-stream"},
+            json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+        )
+        assert response.status_code == 401, response.text
+        assert "resource_metadata" in response.headers["www-authenticate"]
+        assert client.get("/config", headers=auth()).status_code == 200

--- a/libs/agno/tests/integration/os/test_public_authorization.py
+++ b/libs/agno/tests/integration/os/test_public_authorization.py
@@ -1,6 +1,7 @@
 """One runtime serving anonymous clients and the JWT-authenticated Control Plane."""
 
 import time
+from contextlib import ExitStack
 from types import SimpleNamespace
 
 import jwt
@@ -53,10 +54,12 @@ class AdmissionRecorder:
 
     def __init__(self):
         self.calls = []
+        self.client_ids = []
         self.allowed = True
 
     async def aconsume(self, bucket, *, client_id):
         self.calls.append(bucket)
+        self.client_ids.append(client_id)
         return Admission(self.allowed, retry_after=60)
 
     async def _aprepare(self):
@@ -289,6 +292,91 @@ def test_mounted_runtime_keeps_route_permissions_and_public_selection(runtime):
         assert socket.receive_json()["event"] == "connected"
         socket.send_json({"action": "ping"})
         assert socket.receive_json()["event"] == "auth_required"
+
+
+@pytest.mark.parametrize("unavailable", [False, True])
+def test_public_socket_admission_rejects_before_accept(runtime, unavailable):
+    runtime.surface.client_id = lambda request: request.headers["x-real-ip"]
+    runtime.limiter.allowed = False
+    if unavailable:
+
+        async def fail(*args, **kwargs):
+            raise RuntimeError("quota store unavailable")
+
+        runtime.limiter.aconsume = fail
+    with pytest.raises(WebSocketDisconnect) as closed:
+        with TestClient(runtime.os.get_app()).websocket_connect("/workflows/ws", headers={"x-real-ip": "8.8.8.8"}):
+            pytest.fail("Rejected upgrade must not be accepted")
+    assert closed.value.code == 1008
+    if not unavailable:
+        assert runtime.limiter.calls == ["socket"]
+        assert runtime.limiter.client_ids == ["8.8.8.8"]
+
+
+def test_public_socket_pending_capacity_releases_on_authentication_and_disconnect(runtime, monkeypatch):
+    monkeypatch.setattr("agno.os.public._middleware.MAX_PENDING_WEBSOCKETS", 2)
+    client = TestClient(runtime.os.get_app())
+    with ExitStack() as stack:
+        first = stack.enter_context(client.websocket_connect("/workflows/ws"))
+        second = stack.enter_context(client.websocket_connect("/workflows/ws"))
+        assert first.receive_json()["event"] == second.receive_json()["event"] == "connected"
+        with pytest.raises(WebSocketDisconnect) as closed:
+            with client.websocket_connect("/workflows/ws"):
+                pytest.fail("Pending capacity must be enforced")
+        assert closed.value.code == 1008
+        assert runtime.limiter.calls == ["socket", "socket"]
+        first.send_json({"action": "authenticate", "token": token()})
+        assert first.receive_json()["event"] == "authenticated"
+        assert first.receive_json()["event"] == "authenticated"
+        first.send_json({"action": "ping"})
+        assert first.receive_json()["event"] == "pong"
+        with client.websocket_connect("/workflows/ws") as third:
+            assert third.receive_json()["event"] == "connected"
+        with client.websocket_connect("/workflows/ws") as fourth:
+            assert fourth.receive_json()["event"] == "connected"
+        assert runtime.limiter.calls == ["socket"] * 4
+
+
+@pytest.mark.parametrize("keep_alive", [False, True])
+def test_public_socket_authentication_deadline_cannot_be_extended(runtime, monkeypatch, keep_alive):
+    monkeypatch.setattr("agno.os.router.PUBLIC_WS_AUTH_TIMEOUT", 0.2)
+    client = TestClient(runtime.os.get_app())
+    with client.websocket_connect("/workflows/ws") as socket:
+        assert socket.receive_json()["event"] == "connected"
+        started = time.monotonic()
+        with pytest.raises(WebSocketDisconnect) as closed:
+            if keep_alive:
+                while time.monotonic() - started < 2:
+                    socket.send_json({"action": "ping"})
+                    assert socket.receive_json()["event"] == "auth_required"
+                    time.sleep(0.03)
+                pytest.fail("Messages must not extend the authentication deadline")
+            else:
+                socket.receive_json()
+        assert closed.value.code == 1008
+
+
+def test_public_socket_closes_after_five_failed_authentication_attempts(runtime):
+    with TestClient(runtime.os.get_app()).websocket_connect("/workflows/ws") as socket:
+        assert socket.receive_json()["event"] == "connected"
+        for _ in range(5):
+            socket.send_json({"action": "authenticate", "token": "invalid"})
+            assert socket.receive_json()["event"] == "auth_error"
+        with pytest.raises(WebSocketDisconnect) as closed:
+            socket.receive_json()
+        assert closed.value.code == 1008
+
+
+def test_public_socket_authentication_deadline_ends_after_verification(runtime, monkeypatch):
+    monkeypatch.setattr("agno.os.router.PUBLIC_WS_AUTH_TIMEOUT", 0.2)
+    with TestClient(runtime.os.get_app()).websocket_connect("/workflows/ws") as socket:
+        assert socket.receive_json()["event"] == "connected"
+        socket.send_json({"action": "authenticate", "token": token()})
+        assert socket.receive_json()["event"] == "authenticated"
+        assert socket.receive_json()["event"] == "authenticated"
+        time.sleep(0.3)
+        socket.send_json({"action": "ping"})
+        assert socket.receive_json()["event"] == "pong"
 
 
 def test_cors_covers_preflights_and_authorization_errors(runtime):

--- a/libs/agno/tests/integration/os/test_public_authorization.py
+++ b/libs/agno/tests/integration/os/test_public_authorization.py
@@ -294,6 +294,87 @@ def test_mounted_runtime_keeps_route_permissions_and_public_selection(runtime):
         assert socket.receive_json()["event"] == "auth_required"
 
 
+@pytest.mark.parametrize("mounted", [False, True])
+@pytest.mark.parametrize("credential_kind", ["jwt", "pat"])
+@pytest.mark.parametrize("path", ["/config", "/sessions", "/metrics", "/schedules"])
+def test_native_management_scopes_are_enforced_with_and_without_mounts(runtime, mounted, credential_kind, path):
+    from uuid import uuid4
+
+    from agno.db.schemas.service_accounts import ServiceAccount
+    from agno.os.service_accounts import ServiceAccountVerifier, generate_token
+
+    runtime.os.public = None
+    runtime.os.db = runtime.db
+    runtime.os._service_account_verifier = ServiceAccountVerifier(runtime.db)
+
+    def credential(scopes):
+        if credential_kind == "jwt":
+            return token(scopes)
+        plaintext, digest, prefix = generate_token()
+        runtime.db.create_service_account(
+            ServiceAccount(
+                id=str(uuid4()),
+                name="test-" + uuid4().hex,
+                token_hash=digest,
+                token_prefix=prefix,
+                scopes=scopes,
+                created_at=int(time.time()),
+            ).to_dict()
+        )
+        return plaintext
+
+    app = runtime.os.get_app()
+    if mounted:
+        parent = FastAPI()
+        parent.mount("/runtime", app)
+        app = parent
+    client = TestClient(app)
+    url = ("/runtime" if mounted else "") + path
+    params = {"db_id": "sessions"} if path in ("/sessions", "/metrics") else {}
+    assert client.get(url, params=params).status_code == 401
+    denied = client.get(url, params=params, headers=auth(credential([])))
+    assert denied.status_code == 403, denied.text
+    allowed = client.get(url, params=params, headers=auth(credential(["agent_os:admin"])))
+    assert allowed.status_code == 200, allowed.text
+
+
+@pytest.mark.parametrize("mounted", [False, True])
+def test_public_info_counts_only_selected_components_and_preserves_discovery_schema(runtime, mounted):
+    from agno.team import Team
+    from agno.workflow import Workflow
+
+    public_team = Team(id="public-team", members=[runtime.os.agents[0]], model=AnswerModel(), telemetry=False)
+    private_team = Team(id="private-team", members=[runtime.os.agents[1]], model=AnswerModel(), telemetry=False)
+    public_workflow = Workflow(id="public-workflow", steps=[], telemetry=False)
+    private_workflow = Workflow(id="private-workflow", steps=[], telemetry=False)
+    runtime.os.teams = [public_team, private_team]
+    runtime.os.workflows = [public_workflow, private_workflow]
+    runtime.surface.teams = [public_team]
+    runtime.surface.workflows = [public_workflow]
+    app = runtime.os.get_app()
+    path = "/info"
+    if mounted:
+        parent = FastAPI()
+        parent.mount("/runtime", app)
+        app = parent
+        path = "/runtime/info"
+    client = TestClient(app)
+    anonymous = client.get(path)
+    authenticated = client.get(path, headers=auth())
+    assert anonymous.status_code == authenticated.status_code == 200
+    public_info = anonymous.json()
+    native_info = authenticated.json()
+    assert public_info.keys() == native_info.keys()
+    for kind in ("agent", "team", "workflow"):
+        assert public_info[kind + "_count"] == 1
+        assert native_info[kind + "_count"] == 2
+    for field in ("os_id", "name", "os_version", "agno_version", "auth_mode", "mcp"):
+        assert public_info[field] == native_info[field]
+    assert public_info["auth_mode"] == "jwt"
+    assert "Authorization" in anonymous.headers["vary"]
+    assert authenticated.headers["cache-control"] == "private, no-store"
+
+
 @pytest.mark.parametrize("unavailable", [False, True])
 def test_public_socket_admission_rejects_before_accept(runtime, unavailable):
     runtime.surface.client_id = lambda request: request.headers["x-real-ip"]


### PR DESCRIPTION
## Summary

An AgentOS configured with both `PublicSurface` and JWT authorization cannot currently serve the Control Plane: a valid admin JWT passes authentication, then `/config` and component details return 404. Enabling authorization also rejects anonymous chat, and public middleware closes workflow WebSockets before their authentication handler runs.

Compose public admission with the existing JWT verifier and endpoint permissions on one runtime URL. Selected anonymous chat requests retain public input validation and quotas. Verified, permission-checked JWT requests reach the normal REST API with private, non-cacheable responses. Lightweight `/info` discovery with anonymous counts limited to public components and the native authenticated workflow WebSocket handler remain reachable. Public WebSocket upgrades consume a shared socket quota, with a per-worker pending-connection cap, a fixed authentication deadline and a failed-attempt limit. Invalid credentials never fall back to anonymous access.

Mounted runtimes now check JWT and service-account scopes against the AgentOS-relative path, fixing a pre-existing permission bypass outside mixed mode. This applies with or without a public surface.

Public MCP retains its explicit tool catalog, admission limits and configured OAuth policy even for admin JWTs. Scheduler and scoped service-account credentials keep their existing public request contracts. Public-only deployments without `authorization=True` remain closed to management routes and WebSockets.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Compatibility:** deployments combining `authorization=True` with `PublicSurface` now accept anonymous requests on their explicitly selected public chat/MCP paths, while authorized JWTs regain native REST access. Operators requiring authentication on MCP should use `mcp_auth`; its authentication challenge is preserved. Existing authorization exclusions for self-authenticating interfaces and OAuth endpoints remain in effect. There is no new configuration flag.

**Validation:**

- 65 composed authentication cases passed, covering native REST/session access, per-resource scopes, invalid/expired/wrong-audience JWTs, public limits, explicit MCP tools, MCP OAuth, workflow service accounts, scheduler access, root/mounted workflow WebSockets, custom-route precedence, CORS and public-only compatibility. Mounted/unmounted tests cover empty-scope JWT and PAT rejection on configuration, sessions, metrics and schedules, along with permitted admin access. Discovery tests cover all three component counts and retain the response schema. WebSocket cases also cover quota denial/unavailability, pending capacity release, fixed deadlines and failed authentication attempts.
- The eight-file JWT, authorization, service-account, interface and discovery regression run passed all 326 tests. Another 50 workflow-run and WebSocket configuration tests passed. The focused PR CI command passed all 150 tests in an isolated Python 3.12 environment with the CI dependency set; hosted CI uses Python 3.10. The public authorization suite is now included in that PR CI job.
- Existing JWT, service-account, MCP OAuth and public response/streaming regression suites passed. Tests needing loopback sockets were rerun with local socket access after sandbox permission denials.
- Six existing public-surface PostgreSQL integration tests passed using a disposable local database.
- Both Docs Agent product flows passed against this framework source with JWT disabled and enabled: anonymous chat/MCP, shared feedback quotas, durable indexing, and JWT configuration/component/session/trace/readiness access.
- `public_control_plane.py --check` passed with the demo environment and a locally generated RS256 public key.
- Required format/validate scripts and `git diff --check` passed. Validation reused the existing development environments; the already-declared `types-regex` dependency was installed to complete mypy validation.

**Related work:** #10064 covers bounded public run continuation; this PR restores the authenticated Control Plane API and does not add continuation behavior. #9092 proposes a broader authorization-provider system; this fix reuses the current JWT/scope implementation.

**Rollout:** the product configuration is in [Docs Agent #14](https://github.com/agno-agi/docs-agent/pull/14). Publish this framework fix and upgrade that product's Agno 3.0.8 pin before enabling its Control Plane verification key. A hosted Control Plane connection remains a deployment verification step.
