### PR TITLE
fix: decouple OpenAI response storage from automatic chaining

### DIFF
--- a/cookbook/90_models/openai/responses/README.md
+++ b/cookbook/90_models/openai/responses/README.md
@@ -7,3 +7,30 @@ Run examples with:
 ```bash
 .venvs/demo/bin/python cookbook/90_models/openai/responses/<example>.py
 ```
+
+## Store responses without automatic chaining
+
+`stored_responses_without_chaining.py` uses `store=True` to keep responses in
+OpenAI's response logs and `use_previous_response_id=False` to send the context
+assembled by Agno on every request. Agno's history limits and current instructions
+therefore control the request even when prior messages contain response IDs.
+
+```python
+model=OpenAIResponses(
+    id="gpt-5.6-luna",
+    store=True,
+    use_previous_response_id=False,
+)
+```
+
+The option defaults to `True`, preserving automatic chaining for supported
+reasoning models when `store` is not `False`. Setting `store=False` continues to
+disable provider response storage and automatic chaining. History must still be
+enabled on the agent if it should include previous turns.
+
+When automatic chaining is disabled, Agno also preserves and replays encrypted
+reasoning alongside tool calls. Low-level `request_params` overrides retain their
+existing precedence; leave `previous_response_id` unset there when using this option.
+
+See [OpenAI's conversation state guide](https://developers.openai.com/api/docs/guides/conversation-state)
+for response storage and manual history management.

--- a/cookbook/90_models/openai/responses/TEST_LOG.md
+++ b/cookbook/90_models/openai/responses/TEST_LOG.md
@@ -1,5 +1,21 @@
 # TEST_LOG
 
+### stored_responses_without_chaining.py
+
+**Status:** PASS
+
+**Description:** Executed with `.venvs/demo/bin/python` using the real Agent and
+OpenAI SDK with a mocked HTTP transport. The example performs a regular first
+turn and a streaming follow-up in the same in-memory session.
+
+**Result:** Both requests sent `store=True` and omitted `previous_response_id`.
+The follow-up included the current instructions and the previous user/assistant
+exchange. Live provider execution was not run because `OPENAI_API_KEY` was not
+configured. Separate unit tests cover sync/async request construction and
+encrypted reasoning plus tool-call replay.
+
+---
+
 ### reasoning_effort.py
 
 **Status:** PASS

--- a/cookbook/90_models/openai/responses/stored_responses_without_chaining.py
+++ b/cookbook/90_models/openai/responses/stored_responses_without_chaining.py
@@ -1,0 +1,33 @@
+"""Keep OpenAI response logs while Agno controls the history sent on each turn."""
+
+from agno.agent import Agent
+from agno.db.in_memory import InMemoryDb
+from agno.models.openai import OpenAIResponses
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+agent = Agent(
+    model=OpenAIResponses(
+        id="gpt-5.6-luna",
+        store=True,
+        use_previous_response_id=False,
+    ),
+    db=InMemoryDb(),
+    session_id="stored-responses-without-chaining",
+    add_history_to_context=True,
+    num_history_runs=2,
+    instructions="Answer briefly using the conversation history when relevant.",
+    markdown=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    agent.print_response(
+        "My project is called Cedar. Remember its name for our conversation."
+    )
+    agent.print_response("What is my project called?", stream=True)

--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -51,7 +51,11 @@ class OpenAIResponses(Model):
     verbosity: Optional[Verbosity] = None
     reasoning_effort: Optional[ReasoningEffort] = None
     reasoning_summary: Optional[ReasoningSummary] = None
+    # Provider response storage is independent of automatic conversation chaining.
     store: Optional[bool] = None
+    # Set False to replay the supplied context even when responses are stored by OpenAI.
+    # Defaults to automatic chaining for supported reasoning models when store is not False.
+    use_previous_response_id: bool = True
     temperature: Optional[float] = None
     top_p: Optional[float] = None
     truncation: Optional[Literal["auto", "disabled"]] = None
@@ -363,21 +367,16 @@ class OpenAIResponses(Model):
 
         # Handle reasoning tools for o3 and o4-mini models
         if self._using_reasoning_model() and messages is not None:
-            if store is False:
-                request_params["store"] = False
+            request_params["store"] = store is not False
 
+            if store is False or not self.use_previous_response_id:
                 # Add encrypted reasoning content to include if not already present
-                include_list = request_params.get("include", []) or []
+                include_list = list(request_params.get("include") or [])
                 if "reasoning.encrypted_content" not in include_list:
                     include_list.append("reasoning.encrypted_content")
-                    if request_params.get("include") is None:
-                        request_params["include"] = include_list
-                    elif isinstance(request_params["include"], list):
-                        request_params["include"].extend(include_list)
+                request_params["include"] = include_list
 
             else:
-                request_params["store"] = True
-
                 # Check if the last assistant message has a previous_response_id to continue from
                 previous_response_id = None
                 for msg in reversed(messages):
@@ -621,7 +620,7 @@ class OpenAIResponses(Model):
         messages_to_format = messages
         previous_response_id: Optional[str] = None
 
-        if self._using_reasoning_model() and self.store is not False:
+        if self.use_previous_response_id and self._using_reasoning_model() and self.store is not False:
             # Detect whether we're chaining via previous_response_id. If so, we should NOT
             # re-send prior function_call items; the Responses API already has the state and
             # expects only the corresponding function_call_output items.
@@ -644,6 +643,17 @@ class OpenAIResponses(Model):
         fc_id_to_call_id = self._build_fc_id_to_call_id_map(messages)
 
         for message in messages_to_format:
+            # Without chaining, replay reasoning before the assistant's text or function calls.
+            if (
+                (self.store is False or not self.use_previous_response_id)
+                and message.role == "assistant"
+                and message.provider_data is not None
+                and message.provider_data.get("reasoning_output") is not None
+            ):
+                formatted_messages.append(
+                    ResponseReasoningItem.model_validate(message.provider_data["reasoning_output"])
+                )
+
             if message.role in ["user", "system"]:
                 message_dict: Dict[str, Any] = {
                     "role": self.role_map[message.role],
@@ -716,12 +726,6 @@ class OpenAIResponses(Model):
                 content = message.content if message.content is not None else ""
                 formatted_messages.append({"role": self.role_map[message.role], "content": content})
 
-                if self.store is False and hasattr(message, "provider_data") and message.provider_data is not None:
-                    if message.provider_data.get("reasoning_output") is not None:
-                        reasoning_output = ResponseReasoningItem.model_validate(
-                            message.provider_data["reasoning_output"]
-                        )
-                        formatted_messages.append(reasoning_output)
         return formatted_messages
 
     def count_tokens(
@@ -1254,8 +1258,8 @@ class OpenAIResponses(Model):
 
             # Handle reasoning output items
             elif output.type == "reasoning":
-                # Save encrypted reasoning content for ZDR mode
-                if self.store is False:
+                # Preserve reasoning for replay when automatic chaining is disabled.
+                if self.store is False or not self.use_previous_response_id:
                     if model_response.provider_data is None:
                         model_response.provider_data = {}
                     model_response.provider_data["reasoning_output"] = output.model_dump(exclude_none=True)
@@ -1373,8 +1377,8 @@ class OpenAIResponses(Model):
         elif stream_event.type == "response.completed":
             model_response = ModelResponse()
 
-            # Handle reasoning output items for ZDR mode (store=False)
-            if self.store is False:
+            # Preserve reasoning for replay when automatic chaining is disabled.
+            if self.store is False or not self.use_previous_response_id:
                 for out in getattr(stream_event.response, "output", []) or []:
                     if getattr(out, "type", None) == "reasoning":
                         if hasattr(out, "encrypted_content"):

--- a/libs/agno/tests/unit/models/openai/test_openai_responses_chaining.py
+++ b/libs/agno/tests/unit/models/openai/test_openai_responses_chaining.py
@@ -1,0 +1,157 @@
+"""Response storage and automatic conversation chaining are independent choices."""
+
+import json
+
+import httpx
+import pytest
+from openai import AsyncOpenAI, OpenAI
+
+from agno.models.message import Message
+from agno.models.openai.responses import OpenAIResponses
+
+
+@pytest.fixture
+def response_client():
+    requests = []
+    response = {
+        "id": "resp_current",
+        "object": "response",
+        "created_at": 0,
+        "model": "gpt-5.6-luna",
+        "status": "completed",
+        "error": None,
+        "usage": None,
+        "output": [
+            {"type": "reasoning", "id": "rs_current", "summary": [], "encrypted_content": "encrypted-reasoning"},
+            {
+                "type": "function_call",
+                "id": "fc_current",
+                "call_id": "call_current",
+                "name": "lookup",
+                "arguments": "{}",
+                "status": "completed",
+            },
+        ],
+    }
+
+    def handle(request):
+        payload = json.loads(request.content)
+        requests.append(payload)
+        if payload.get("stream"):
+            events = [
+                {"type": "response.created", "response": response},
+                {"type": "response.output_item.added", "output_index": 1, "item": response["output"][1]},
+                {"type": "response.output_item.done", "output_index": 1, "item": response["output"][1]},
+                {"type": "response.completed", "response": response},
+            ]
+            body = "".join(f"data: {json.dumps(event)}\n\n" for event in events)
+            return httpx.Response(200, text=body, headers={"content-type": "text/event-stream"})
+        return httpx.Response(200, json=response)
+
+    return requests, httpx.MockTransport(handle)
+
+
+async def _invoke(model, mode, messages):
+    assistant = Message(role="assistant")
+    if mode == "sync":
+        results = [model.invoke(messages, assistant)]
+    elif mode == "async":
+        results = [await model.ainvoke(messages, assistant)]
+    elif mode == "sync_stream":
+        results = list(model.invoke_stream(messages, assistant))
+    else:
+        results = [result async for result in model.ainvoke_stream(messages, assistant)]
+
+    # Collect the provider state and tool calls that the next model iteration receives.
+    provider_data = {}
+    tool_calls = []
+    for result in results:
+        provider_data.update(result.provider_data or {})
+        tool_calls.extend(result.tool_calls or [])
+    return Message(role="assistant", provider_data=provider_data, tool_calls=tool_calls)
+
+
+@pytest.mark.parametrize("mode", ["sync", "async", "sync_stream", "async_stream"])
+@pytest.mark.parametrize("store", [None, True, False])
+@pytest.mark.parametrize("disable_chaining", [False, True])
+async def test_storage_and_chaining_on_wire(response_client, mode, store, disable_chaining):
+    requests, transport = response_client
+    options = {"use_previous_response_id": False} if disable_chaining else {}
+    with OpenAI(api_key="test", http_client=httpx.Client(transport=transport)) as client:
+        async with AsyncOpenAI(api_key="test", http_client=httpx.AsyncClient(transport=transport)) as async_client:
+            model = OpenAIResponses(id="gpt-5.6-luna", store=store, client=client, async_client=async_client, **options)
+            messages = [
+                Message(role="system", content="Fresh documentation for this turn"),
+                Message(role="user", content="Recent question", from_history=True),
+                Message(
+                    role="assistant",
+                    content="Recent answer",
+                    provider_data={"response_id": "resp_previous"},
+                    from_history=True,
+                ),
+                Message(role="user", content="Follow-up question"),
+            ]
+            await _invoke(model, mode, messages)
+
+    payload = requests[0]
+    assert payload["store"] is (store is not False)
+    if not disable_chaining and store is not False:
+        assert payload["previous_response_id"] == "resp_previous"
+        assert payload["input"] == [{"role": "user", "content": "Follow-up question"}]
+    else:
+        assert "previous_response_id" not in payload
+        assert [item["content"] for item in payload["input"]] == [message.content for message in messages]
+        assert payload["include"].count("reasoning.encrypted_content") == 1
+    assert "use_previous_response_id" not in payload
+
+
+@pytest.mark.parametrize("mode", ["sync", "async", "sync_stream", "async_stream"])
+async def test_stored_response_replays_reasoning_and_tool_calls(response_client, mode):
+    requests, transport = response_client
+    with OpenAI(api_key="test", http_client=httpx.Client(transport=transport)) as client:
+        async with AsyncOpenAI(api_key="test", http_client=httpx.AsyncClient(transport=transport)) as async_client:
+            model = OpenAIResponses(
+                id="gpt-5.6-luna",
+                store=True,
+                use_previous_response_id=False,
+                include=["message.output_text.logprobs"],
+                client=client,
+                async_client=async_client,
+            )
+            messages = [
+                Message(role="system", content="Fresh instructions"),
+                Message(role="user", content="Look it up"),
+            ]
+            assistant = await _invoke(model, mode, messages)
+            assert assistant.provider_data["response_id"] == "resp_current"
+            assert assistant.provider_data["reasoning_output"]["encrypted_content"] == "encrypted-reasoning"
+            messages.extend([assistant, Message(role="tool", tool_call_id="call_current", content="Found it")])
+            await _invoke(model, mode, messages)
+
+    assert len(requests) == 2
+    for payload in requests:
+        assert payload["store"] is True
+        assert "previous_response_id" not in payload
+        assert payload["include"] == ["message.output_text.logprobs", "reasoning.encrypted_content"]
+    items = requests[1]["input"]
+    assert items[:2] == [
+        {"role": "developer", "content": "Fresh instructions"},
+        {"role": "user", "content": "Look it up"},
+    ]
+    assert [item["type"] for item in items[2:]] == ["reasoning", "function_call", "function_call_output"]
+    assert items[2]["encrypted_content"] == "encrypted-reasoning"
+    assert items[3]["call_id"] == items[4]["call_id"] == "call_current"
+    assert items[4]["output"] == "Found it"
+    assert model.include == ["message.output_text.logprobs"]
+
+
+def test_background_storage_does_not_enable_chaining():
+    model = OpenAIResponses(id="gpt-5.6-luna", store=False, background=True, use_previous_response_id=False)
+    messages = [
+        Message(role="assistant", content="Earlier answer", provider_data={"response_id": "resp_previous"}),
+        Message(role="user", content="Follow-up"),
+    ]
+    params = model.get_request_params(messages)
+    assert params["store"] is True
+    assert "previous_response_id" not in params
+    assert len(model._format_messages(messages)) == 2


### PR DESCRIPTION
## Summary

`OpenAIResponses(store=True)` currently also enables automatic `previous_response_id` chaining for supported reasoning models. Users who want OpenAI response logs while sending Agno's bounded history and refreshed instructions cannot configure those choices independently.

Add `use_previous_response_id=False` to replay the supplied context while retaining provider storage:

```python
OpenAIResponses(
    id="gpt-5.6-luna",
    store=True,
    use_previous_response_id=False,
)
```

The option defaults to `True`, preserving existing automatic chaining. Opting out disables both the automatic response-ID parameter and the corresponding message slicing. It requests and preserves encrypted reasoning in regular and streaming responses, then replays that reasoning before assistant text/function calls so tool continuation works without a server-side chain. Explicit low-level request parameter overrides keep their existing precedence.

Includes a cookbook example, usage documentation, and 29 regression cases covering all four invocation paths, storage/default combinations, background storage, and reasoning/tool replay. The tests capture actual SDK request bodies through a mocked HTTP transport.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Validation ran in an isolated worktree using the existing development environment:

- `./scripts/format.sh` and `./scripts/validate.sh` passed, including mypy and cookbook pattern checks.
- OpenAI, OpenRouter, xAI, and Responses utility unit suites: **297 passed, 1 skipped**.
- The 29 new regression cases plus the Ollama model suite: **35 passed**. The optional `ollama` package was installed into an isolated test directory, without changing the shared development environment.
- The cookbook ran with the demo interpreter, real Agent and OpenAI SDK, and mocked HTTP for a regular turn and streaming follow-up. Both requests stored responses without chaining; the follow-up retained instructions and history. No live provider request was made because `OPENAI_API_KEY` was not configured.

Related work: #9261 retries stale response IDs; this PR provides an explicit opt-out before any request. #9968 repairs reasoning replay when chaining is unavailable; this PR also needs reasoning replay for the new opt-out, so those edits overlap and may require reconciliation when either merges. Neither existing PR provides the independent storage/chaining configuration added here.
