### PR TITLE
Release: v3.0.9

### DIFF
--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agno"
-version = "3.0.8"
+version = "3.0.9"
 description = "The programming language for agentic software."
 requires-python = ">=3.9,<4"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Prepare Agno 3.0.9 by bumping `libs/agno/pyproject.toml` from `3.0.8` to `3.0.9`. The changelog below covers the two PRs merged since `v3.0.8`. `agnoctl` and `agno_infra` are unchanged since `v3.0.8` and keep their current versions.

### Changelog

#### Bug Fixes

- **Control Plane access with public surfaces:** an AgentOS configured with both `PublicSurface` and JWT authorization can now serve the Control Plane. Public admission composes with the existing JWT verifier and endpoint permissions on one runtime URL: selected anonymous chat requests keep public input validation and quotas, while permission-checked JWT requests reach the normal REST API with private, non-cacheable responses. Public workflow WebSocket upgrades now reach their authentication handler and are bounded by a shared socket quota, a per-worker pending-connection cap, a fixed authentication deadline and a failed-attempt limit. Invalid credentials never fall back to anonymous access. Mounted runtimes now check JWT and service-account scopes against the AgentOS-relative path, closing a pre-existing permission bypass that applied with or without a public surface. (#10074)
- **Durable queue startup:** sync and async PostgreSQL queue storage is prepared before worker polling starts, so a fresh durable queue no longer logs repeated errors until the first enqueue and ticketless continuations are not blocked. `auto_provision_dbs=False` is respected, stores without the optional hook keep working, and concurrent table-creation races are recovered without masking other provisioning failures. (#10071)

#### Improvements

- **Quieter startup logs:** bounded PostgreSQL pools no longer inherit the Agno logger under `AGNO_DEBUG=True`; pool diagnostics stay under `sqlalchemy.pool`. Non-terminal logs are plain and unwrapped, terminal and Jupyter Rich output is preserved, and absent stdout or application-configured loggers are tolerated. Table-created and storage-ready messages are concise; queue acceptance stays at INFO and workflow lifecycle, step and outcome summaries move to DEBUG with run IDs. (#10071)

#### Notes

- With `authorization=True` and `PublicSurface` together, anonymous requests are accepted only on the explicitly selected public chat and MCP paths, and authorized JWTs get native REST access. Operators requiring authentication on MCP should use `mcp_auth`. Public-only deployments without `authorization=True` remain closed to management routes and WebSockets. There is no new configuration flag. (#10074)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [x] Other: Release version bump; included fixes and improvements are listed above.

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Release branch `release-3.0.9`, matching the release integration workflow branch filter; pushing the branch triggers the full Main Validation matrix.

Validation on this release branch:

- The only change is the version bump; `git diff --check` passed.
- Built the wheel and source distribution from `libs/agno`; both report version `3.0.9`.
- No new integration test files were added under `tests/integration/teams` or `tests/integration/knowledge` since `v3.0.8`, so the release split-coverage guard has nothing new to list.
- `PublicSurface` first shipped in `v3.0.8`, so the authorization composition in #10074 completes that feature rather than changing behaviour an existing deployment relies on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cwbi2MsjxKvXZ2PgYrjxGN
