### PR TITLE
fix: preserve team run references when forking sessions

### DIFF
--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -7327,11 +7327,43 @@ def _build_forked_team_session(source_session: TeamSession, new_user_id: Optiona
     new_session_id = str(uuid4())
     forked_runs = copy.deepcopy(source_session.runs or [])
 
-    for run in forked_runs:
-        run.run_id = str(uuid4())
+    # Collect the complete run tree first; nested and independently stored representations of one run must share one new ID.
+    pending = list(forked_runs)
+    copied_runs: List[Union[TeamRunOutput, RunOutput]] = []
+    seen: Set[int] = set()
+    run_id_map: Dict[str, str] = {}
+    while pending:
+        run = pending.pop()
+        if id(run) in seen:
+            continue
+        seen.add(id(run))
+        copied_runs.append(run)
+        if run.run_id is not None and run.run_id not in run_id_map:
+            run_id_map[run.run_id] = str(uuid4())
+        if isinstance(run, TeamRunOutput):
+            pending.extend(run.member_responses or [])
+        for requirement in run.requirements or []:
+            cached_run = requirement._member_run_response
+            if isinstance(cached_run, (TeamRunOutput, RunOutput)):
+                pending.append(cached_run)
+
+    # Rewrite references only after the full mapping is known, so traversal order and shared objects cannot break links.
+    for run in copied_runs:
+        run.run_id = run_id_map[run.run_id] if run.run_id is not None else str(uuid4())
         run.session_id = new_session_id
+        if run.parent_run_id in run_id_map:
+            run.parent_run_id = run_id_map[run.parent_run_id]
         if not getattr(run, "forked_from_session_id", None):
             run.forked_from_session_id = source_session.session_id
+        for requirement in run.requirements or []:
+            if requirement.member_run_id in run_id_map:
+                requirement.member_run_id = run_id_map[requirement.member_run_id]
+            tool_execution = requirement.tool_execution
+            if tool_execution is not None and tool_execution.child_run_id in run_id_map:
+                tool_execution.child_run_id = run_id_map[tool_execution.child_run_id]
+        for tool_execution in run.tools or []:
+            if tool_execution.child_run_id in run_id_map:
+                tool_execution.child_run_id = run_id_map[tool_execution.child_run_id]
 
     new_session_data = copy.deepcopy(source_session.session_data) or {}
     new_session_data["forked_from_session_id"] = source_session.session_id

--- a/libs/agno/tests/unit/team/test_fork_session_references.py
+++ b/libs/agno/tests/unit/team/test_fork_session_references.py
@@ -1,0 +1,130 @@
+"""Verify that run identities and references remain consistent when a session is forked."""
+
+from copy import deepcopy
+
+import pytest
+
+from agno.models.response import ToolExecution
+from agno.run.agent import RunOutput
+from agno.run.base import RunStatus
+from agno.run.requirement import RunRequirement
+from agno.run.team import TeamRunOutput
+from agno.session.team import TeamSession
+from agno.team._run import _build_forked_team_session
+
+
+def _paused_session() -> TeamSession:
+    approval = RunRequirement(
+        id="approval-1",
+        tool_execution=ToolExecution(tool_call_id="call-1", tool_name="publish", requires_confirmation=True),
+    )
+    leaf = RunOutput(
+        run_id="leaf-run",
+        agent_id="worker",
+        session_id="source",
+        parent_run_id="inner-run",
+        status=RunStatus.paused,
+        requirements=[approval],
+    )
+    member_approval = deepcopy(approval)
+    member_approval.member_agent_id = "worker"
+    member_approval.member_run_id = leaf.run_id
+    member_approval._member_run_response = leaf
+    inner = TeamRunOutput(
+        run_id="inner-run",
+        team_id="inner",
+        session_id="source",
+        parent_run_id="root-run",
+        status=RunStatus.paused,
+        member_responses=[leaf],
+        requirements=[member_approval],
+        tools=[ToolExecution(tool_call_id="delegate-leaf", child_run_id=leaf.run_id)],
+    )
+    root_approval = deepcopy(member_approval)
+    root_approval._member_run_response = inner
+    root = TeamRunOutput(
+        run_id="root-run",
+        team_id="root",
+        session_id="source",
+        parent_run_id="external-workflow-run",
+        status=RunStatus.paused,
+        member_responses=[inner],
+        requirements=[root_approval],
+        tools=[ToolExecution(tool_call_id="delegate-inner", child_run_id=inner.run_id)],
+    )
+    # After database deserialization, nested and independently stored representations of one run are different objects.
+    return TeamSession(session_id="source", team_id="root", runs=[root, deepcopy(leaf), deepcopy(inner)])
+
+
+@pytest.mark.parametrize("round_trip", [False, True])
+def test_fork_rewrites_nested_and_sibling_run_references(round_trip):
+    source = _paused_session()
+    if round_trip:
+        source = TeamSession.from_dict(source.to_dict())
+    before = source.to_dict()
+
+    forked = _build_forked_team_session(source, new_user_id=None)
+    root, sibling_leaf, sibling_inner = forked.runs
+    inner = root.member_responses[0]
+    leaf = inner.member_responses[0]
+
+    assert {root.run_id, inner.run_id, leaf.run_id}.isdisjoint({"root-run", "inner-run", "leaf-run"})
+    assert len({root.run_id, inner.run_id, leaf.run_id}) == 3
+    assert inner.run_id == sibling_inner.run_id
+    assert leaf.run_id == sibling_leaf.run_id == sibling_inner.member_responses[0].run_id
+    assert leaf.parent_run_id == sibling_leaf.parent_run_id == inner.run_id
+    assert inner.parent_run_id == sibling_inner.parent_run_id == root.run_id
+    for run in [root, inner, leaf, sibling_leaf, sibling_inner, sibling_inner.member_responses[0]]:
+        assert run.session_id == forked.session_id
+        assert run.status == RunStatus.paused
+        assert run.forked_from_session_id == "source"
+    for run in [root, inner, sibling_inner]:
+        assert run.requirements[0].member_run_id == leaf.run_id
+        assert run.requirements[0].member_agent_id == "worker"
+        assert run.requirements[0].id == "approval-1"
+        assert run.requirements[0].tool_execution.tool_call_id == "call-1"
+    assert root.tools[0].child_run_id == inner.run_id
+    assert inner.tools[0].child_run_id == leaf.run_id
+    assert root.parent_run_id == "external-workflow-run"
+    assert source.to_dict() == before
+
+
+def test_fork_rewrites_cached_member_outputs_and_shared_objects_once():
+    source = _paused_session()
+    root = source.runs[0]
+    inner = root.member_responses[0]
+    leaf = inner.member_responses[0]
+    # An in-process cache may be the only place that retains a member run, or it may share objects with stored rows.
+    root.member_responses = []
+    source.runs = [root, leaf]
+
+    forked = _build_forked_team_session(source, new_user_id=None)
+    forked_root, forked_leaf = forked.runs
+    cached_inner = forked_root.requirements[0]._member_run_response
+    cached_leaf = cached_inner.requirements[0]._member_run_response
+
+    assert cached_leaf is forked_leaf
+    assert cached_inner.run_id != "inner-run"
+    assert cached_leaf.run_id != "leaf-run"
+    assert cached_inner.parent_run_id == forked_root.run_id
+    assert cached_leaf.parent_run_id == cached_inner.run_id
+    assert forked_root.requirements[0].member_run_id == forked_leaf.run_id
+    assert cached_inner.session_id == cached_leaf.session_id == forked.session_id
+    assert inner.run_id == "inner-run"
+    assert leaf.run_id == "leaf-run"
+
+
+def test_refork_preserves_origin_but_allocates_independent_run_ids():
+    first = _build_forked_team_session(_paused_session(), new_user_id="owner")
+    second = _build_forked_team_session(first, new_user_id=None)
+    first_root = first.runs[0]
+    second_root = second.runs[0]
+    first_leaf = first_root.member_responses[0].member_responses[0]
+    second_leaf = second_root.member_responses[0].member_responses[0]
+
+    assert second.session_data["forked_from_session_id"] == first.session_id
+    assert second.user_id == "owner"
+    assert second_leaf.forked_from_session_id == "source"
+    assert second_leaf.run_id != first_leaf.run_id
+    assert second_root.requirements[0].member_run_id == second_leaf.run_id
+    assert first_root.requirements[0].member_run_id == first_leaf.run_id

--- a/libs/agno/tests/unit/team/test_paused_member_persistence.py
+++ b/libs/agno/tests/unit/team/test_paused_member_persistence.py
@@ -6058,3 +6058,62 @@ def test_a_routing_failure_restores_the_callers_team_level_requirements(tmp_path
 
     names = [r.tool_execution.tool_name for r in (run1.requirements or [])]
     assert names.count("publish") == 1, f"the caller's run object carries: {names}"
+
+
+@pytest.mark.parametrize("nested", [False, True])
+@pytest.mark.parametrize("store_member_responses", [False, True])
+def test_forked_member_pause_resumes_without_modifying_source(tmp_path, nested, store_member_responses):
+    """Resume from the database after forking and confirm that only the fork's member run executes."""
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "fork_pause.db")
+    db = SqliteDb(db_file=db_file)
+    builder = _build_nested_team if nested else _build_flat_team
+    source_team = builder(db, resuming=False)
+    source_team.store_member_responses = store_member_responses
+    paused = source_team.run("Email a@example.com", session_id="source")
+    assert paused.is_paused
+    before = db.get_runs(session_id="source", deserialize=False)
+
+    fork_id = source_team.fork_session(source_session_id="source")
+    forked = next(r for r in _reload_runs(db_file, fork_id) if getattr(r, "team_id", None) == source_team.id)
+    resumed_team = builder(SqliteDb(db_file=db_file), resuming=True)
+    resumed_team.store_member_responses = store_member_responses
+    completed = resumed_team.continue_run(
+        run_id=forked.run_id, session_id=fork_id, requirements=_wire_requirements(forked.requirements)
+    )
+
+    assert completed.status == RunStatus.completed
+    assert _EXECUTED == ["a@example.com"]
+    assert db.get_runs(session_id="source", deserialize=False) == before
+    assert all(r.session_id == fork_id for r in _reload_runs(db_file, fork_id))
+    assert all(r.status == RunStatus.completed for r in _reload_runs(db_file, fork_id))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("nested", [False, True])
+@pytest.mark.parametrize("store_member_responses", [False, True])
+async def test_async_forked_member_pause_resumes_without_modifying_source(tmp_path, nested, store_member_responses):
+    """Verify the same session-isolation guarantees for async fork and resume."""
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "async_fork_pause.db")
+    db = SqliteDb(db_file=db_file)
+    builder = _build_nested_team if nested else _build_flat_team
+    source_team = builder(db, resuming=False)
+    source_team.store_member_responses = store_member_responses
+    paused = await source_team.arun("Email a@example.com", session_id="source")
+    assert paused.is_paused
+    before = db.get_runs(session_id="source", deserialize=False)
+
+    fork_id = await source_team.afork_session(source_session_id="source")
+    forked = next(r for r in _reload_runs(db_file, fork_id) if getattr(r, "team_id", None) == source_team.id)
+    resumed_team = builder(SqliteDb(db_file=db_file), resuming=True)
+    resumed_team.store_member_responses = store_member_responses
+    completed = await resumed_team.acontinue_run(
+        run_id=forked.run_id, session_id=fork_id, requirements=_wire_requirements(forked.requirements)
+    )
+
+    assert completed.status == RunStatus.completed
+    assert _EXECUTED == ["a@example.com"]
+    assert db.get_runs(session_id="source", deserialize=False) == before
+    assert all(r.session_id == fork_id for r in _reload_runs(db_file, fork_id))
+    assert all(r.status == RunStatus.completed for r in _reload_runs(db_file, fork_id))


### PR DESCRIPTION
## Summary

Fix team session forking so nested member runs remain isolated and resumable.

Previously, `_build_forked_team_session` generated new run IDs only for top-level runs. Nested member runs and independently persisted run rows could still reference source-session IDs through `parent_run_id`, `member_run_id`, and `child_run_id`. After forking a paused team session, continuing the fork could resolve or update the wrong run.

This change:

- Collects nested, cached, and independently stored run representations.
- Creates one source-to-fork run ID mapping.
- Rewrites all related run references consistently.
- Updates session IDs while preserving fork lineage.
- Keeps the source session unchanged.
- Adds regression coverage for sync/async, nested teams, database reloads, and reforking.

Fixes #9400

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran `./scripts/validate.sh` and `ruff format --check`
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (not applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Validation completed:

- `813 passed, 2 skipped` in `libs/agno/tests/unit/team`
- `154 passed` in the focused fork and paused-member tests
- `./scripts/validate.sh` passed
- `ruff format --check` passed

No API changes, database migrations, or cookbook changes are required.