### PR TITLE
[fix] Preserve Team framework tools on name collisions (refresh)

### DIFF
--- a/libs/agno/agno/team/_init.py
+++ b/libs/agno/agno/team/_init.py
@@ -131,6 +131,7 @@ def __init__(
     max_tool_calls_from_history: Optional[int] = None,
     skills: Optional[Skills] = None,
     tools: Optional[Union[List[Union[Toolkit, Callable, Function, Dict]], Callable[..., List]]] = None,
+    error_on_tool_name_collision: bool = False,
     tool_call_limit: Optional[int] = None,
     tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
     tool_hooks: Optional[List[Callable]] = None,
@@ -296,6 +297,8 @@ def __init__(
     team.send_media_to_model = send_media_to_model
 
     team.skills = skills
+
+    team.error_on_tool_name_collision = error_on_tool_name_collision
 
     if tools is None:
         team.tools = None

--- a/libs/agno/agno/team/_storage.py
+++ b/libs/agno/agno/team/_storage.py
@@ -695,6 +695,8 @@ def to_dict(team: "Team") -> Dict[str, Any]:
         config["tool_call_limit"] = team.tool_call_limit
     if team.get_member_information_tool:
         config["get_member_information_tool"] = team.get_member_information_tool
+    if team.error_on_tool_name_collision:
+        config["error_on_tool_name_collision"] = team.error_on_tool_name_collision
 
     # --- Schema settings ---
     if team.input_schema is not None:
@@ -1359,6 +1361,7 @@ def from_dict(
             tool_call_limit=config.get("tool_call_limit"),
             tool_choice=config.get("tool_choice"),
             get_member_information_tool=config.get("get_member_information_tool", False),
+            error_on_tool_name_collision=config.get("error_on_tool_name_collision", False),
             # --- Schema settings ---
             input_schema=config.get("input_schema"),
             output_schema=config.get("output_schema"),

--- a/libs/agno/agno/team/_tools.py
+++ b/libs/agno/agno/team/_tools.py
@@ -175,8 +175,10 @@ def _determine_tools_for_model(
         team,
     )
 
-    # Prepare tools
+    # Prepare tools. Framework tools are registered before provided tools so a
+    # user-defined name cannot silently replace a Team capability.
     _tools: List[Union[Toolkit, Callable, Function, Dict]] = []
+    provided_tools: List[Union[Toolkit, Callable, Function, Dict]] = []
 
     # Add provided tools
     if resolved_tools is not None:
@@ -186,7 +188,7 @@ def _determine_tools_for_model(
                 # Only add the tool if it successfully connected and built its tools
                 if check_mcp_tools and not tool.initialized:  # type: ignore
                     continue
-            _tools.append(tool)
+            provided_tools.append(tool)
 
     if team.read_chat_history:
         _tools.append(_get_chat_history_function(team, session=session, async_mode=async_mode))
@@ -331,6 +333,8 @@ def _determine_tools_for_model(
         _tools.append(delegate_task_func)
         if team.get_member_information_tool:
             _tools.append(team.get_member_information)
+
+    _tools.extend(provided_tools)
 
     # Get Agent tools
     if len(_tools) > 0:

--- a/libs/agno/agno/team/_tools.py
+++ b/libs/agno/agno/team/_tools.py
@@ -402,10 +402,7 @@ def _determine_tools_for_model(
             toolkit_functions = tool.get_async_functions() if async_mode else tool.get_functions()
             for name, _func in toolkit_functions.items():
                 if name in _function_names:
-                    log_warning(
-                        f"Duplicate tool name '{name}' from toolkit '{tool.name}' "
-                        f"already registered on team; skipping the duplicate."
-                    )
+                    _handle_tool_name_collision(team, name)
                     continue
                 _function_names.append(name)
                 _func = _func._per_run_copy()
@@ -436,7 +433,7 @@ def _determine_tools_for_model(
                 source_toolkit, tool_index
             )
             if tool.name in _function_names:
-                log_warning(f"Duplicate tool name '{tool.name}' already registered on team; skipping the duplicate.")
+                _handle_tool_name_collision(team, tool.name)
                 if emit_toolkit_instructions and source_toolkit is not None:
                     add_toolkit_instructions(source_toolkit)
                 continue
@@ -473,9 +470,7 @@ def _determine_tools_for_model(
                 # per-run copy, so no further copy is needed before mutating it.
                 _func = Function.from_callable(tool, strict=strict)
                 if _func.name in _function_names:
-                    log_warning(
-                        f"Duplicate tool name '{_func.name}' already registered on team; skipping the duplicate."
-                    )
+                    _handle_tool_name_collision(team, _func.name)
                     continue
                 _function_names.append(_func.name)
 
@@ -512,6 +507,15 @@ def _determine_tools_for_model(
                 func._videos = joint_videos
 
     return _functions
+
+
+def _handle_tool_name_collision(team: "Team", name: str) -> None:
+    if team.error_on_tool_name_collision:
+        raise ValueError(
+            f"Duplicate tool name '{name}' already registered on team; set "
+            "error_on_tool_name_collision=False to keep skip-by-default behavior."
+        )
+    log_warning(f"Duplicate tool name '{name}' already registered on team; skipping the duplicate.")
 
 
 def get_member_information(team: "Team", run_context: Optional["RunContext"] = None) -> str:

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -240,6 +240,8 @@ class Team:
     references_format: Literal["json", "yaml"] = "json"
 
     # --- Tools ---
+    # If True, raise when any tool name collision is detected (default False)
+    error_on_tool_name_collision: bool = False
     # If True, add a tool to get information about the team members
     get_member_information_tool: bool = False
     # Add a tool to search the knowledge base (aka Agentic RAG)

--- a/libs/agno/tests/unit/team/test_get_tool_names.py
+++ b/libs/agno/tests/unit/team/test_get_tool_names.py
@@ -10,6 +10,7 @@ Regression test for: https://github.com/agno-agi/agno/issues/7039
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+from agno.agent import Agent
 from agno.registry import Registry
 from agno.run.base import RunContext
 from agno.run.team import TeamRunOutput
@@ -187,8 +188,8 @@ def _make_tool_model():
     return model
 
 
-def _resolve(team: Team) -> None:
-    _determine_tools_for_model(
+def _resolve(team: Team) -> list:
+    return _determine_tools_for_model(
         team=team,
         model=_make_tool_model(),
         run_response=_make_tool_run_response(),
@@ -197,6 +198,29 @@ def _resolve(team: Team) -> None:
         session=_make_tool_session(),
         async_mode=False,
     )
+
+
+def test_framework_tool_wins_name_collision():
+    def user_delegate() -> str:
+        return "user tool"
+
+    team = Team(
+        name="team",
+        members=[Agent(id="member", telemetry=False)],
+        tools=[
+            Function(
+                name="delegate_task_to_member",
+                entrypoint=user_delegate,
+            )
+        ],
+        telemetry=False,
+    )
+
+    tools = _resolve(team)
+    delegation_tools = [tool for tool in tools if isinstance(tool, Function) and tool.name == "delegate_task_to_member"]
+
+    assert len(delegation_tools) == 1
+    assert delegation_tools[0].entrypoint is not user_delegate
 
 
 def test_bare_function_instructions_reach_team():

--- a/libs/agno/tests/unit/team/test_get_tool_names.py
+++ b/libs/agno/tests/unit/team/test_get_tool_names.py
@@ -8,6 +8,7 @@ Regression test for: https://github.com/agno-agi/agno/issues/7039
 """
 
 from types import SimpleNamespace
+import pytest
 from unittest.mock import MagicMock
 
 from agno.agent import Agent
@@ -221,6 +222,30 @@ def test_framework_tool_wins_name_collision():
 
     assert len(delegation_tools) == 1
     assert delegation_tools[0].entrypoint is not user_delegate
+
+
+def test_tool_collision_can_raise_when_enabled():
+    def user_delegate() -> str:
+        return "user tool"
+
+    team = Team(
+        name="team",
+        members=[Agent(id="member", telemetry=False)],
+        tools=[
+            Function(
+                name="delegate_task_to_member",
+                entrypoint=user_delegate,
+            )
+        ],
+        error_on_tool_name_collision=True,
+        telemetry=False,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"Duplicate tool name 'delegate_task_to_member' already registered on team",
+    ):
+        _resolve(team)
 
 
 def test_bare_function_instructions_reach_team():

--- a/libs/agno/tests/unit/team/test_team_config.py
+++ b/libs/agno/tests/unit/team/test_team_config.py
@@ -233,6 +233,24 @@ class TestTeamToDict:
 
         assert config["add_search_knowledge_instructions"] is False
 
+    def test_error_on_tool_name_collision_default_is_false(self):
+        """By default, collision handling should remain skip-by-default and not be serialized."""
+        team = Team(id="collision-default-team", members=[])
+
+        assert team.error_on_tool_name_collision is False
+        assert "error_on_tool_name_collision" not in team.to_dict()
+
+    def test_error_on_tool_name_collision_true_is_serialized(self):
+        """When enabled, the collision policy is serialized for persistence and reload."""
+        team = Team(
+            id="collision-flag-team",
+            members=[],
+            error_on_tool_name_collision=True,
+        )
+        config = team.to_dict()
+
+        assert config["error_on_tool_name_collision"] is True
+
     def test_to_dict_with_db(self, basic_team, mock_db):
         """Test to_dict includes database configuration."""
         basic_team.db = mock_db
@@ -444,6 +462,18 @@ class TestTeamFromDict:
         assert team.respond_directly is True
         assert team.delegate_to_all_members is True
         assert team.add_datetime_to_context is True
+        assert team.error_on_tool_name_collision is False
+
+    def test_from_dict_with_tool_collision_flag(self):
+        config = {
+            "id": "collision-team",
+            "name": "Collision Team",
+            "error_on_tool_name_collision": True,
+        }
+
+        team = Team.from_dict(config)
+
+        assert team.error_on_tool_name_collision is True
 
     def test_from_dict_with_db_postgres(self):
         """Test from_dict reconstructs PostgresDb."""


### PR DESCRIPTION
Reopened on top of latest main to avoid stale base from #9872.

Carries forward the Team framework name-collision fix.

Replaces old PR branch: #9872