### PR TITLE
fix: stream model-native reasoning over AG-UI

### DIFF
--- a/libs/agno/agno/os/interfaces/agui/handlers.py
+++ b/libs/agno/agno/os/interfaces/agui/handlers.py
@@ -1,7 +1,7 @@
 import copy
 import json
 import uuid
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from ag_ui.core import (
     BaseEvent,
@@ -92,6 +92,39 @@ def _format_reasoning_step(step: Optional[ReasoningStep], step_number: int = 0) 
     return "\n".join(parts) + "\n\n" if parts else ""
 
 
+def _close_text_message(state: StreamState) -> List[BaseEvent]:
+    if not state.text_message_open:
+        return []
+    events: List[BaseEvent] = [TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=state.text_message_id)]
+    state.close_text_message()
+    return events
+
+
+def _open_reasoning(state: StreamState) -> Tuple[List[BaseEvent], str]:
+    """Close any open text message and make sure a reasoning span is open. Returns its message id."""
+    events = _close_text_message(state)
+    reasoning_id, is_new = state.ensure_reasoning_started()
+    if is_new:
+        events.append(ReasoningStartEvent(type=EventType.REASONING_START, message_id=reasoning_id))
+        events.append(
+            ReasoningMessageStartEvent(
+                type=EventType.REASONING_MESSAGE_START, message_id=reasoning_id, role="reasoning"
+            )
+        )
+    return events, reasoning_id
+
+
+def _close_reasoning(state: StreamState) -> List[BaseEvent]:
+    if state.reasoning_message_id is None:
+        return []
+    reasoning_id = state.reasoning_message_id
+    state.end_reasoning()
+    return [
+        ReasoningMessageEndEvent(type=EventType.REASONING_MESSAGE_END, message_id=reasoning_id),
+        ReasoningEndEvent(type=EventType.REASONING_END, message_id=reasoning_id),
+    ]
+
+
 def _emit_state_delta(state: StreamState) -> List[BaseEvent]:
     if state.run_state is None:
         return []
@@ -104,15 +137,7 @@ def _emit_state_delta(state: StreamState) -> List[BaseEvent]:
 
 def _close_open_spans(state: StreamState) -> List[BaseEvent]:
     """End any reasoning, tool call, or text message still open, so a terminal event never leaves a dangling span."""
-    events: List[BaseEvent] = []
-
-    # Close orphaned reasoning session
-    if state.reasoning_message_id is not None:
-        events.append(
-            ReasoningMessageEndEvent(type=EventType.REASONING_MESSAGE_END, message_id=state.reasoning_message_id)
-        )
-        events.append(ReasoningEndEvent(type=EventType.REASONING_END, message_id=state.reasoning_message_id))
-        state.end_reasoning()
+    events: List[BaseEvent] = _close_reasoning(state)
 
     # Close remaining active tool calls
     for tool_call_id in list(state.active_tool_call_ids):
@@ -120,11 +145,7 @@ def _close_open_spans(state: StreamState) -> List[BaseEvent]:
             events.append(ToolCallEndEvent(type=EventType.TOOL_CALL_END, tool_call_id=tool_call_id))
             state.end_tool_call(tool_call_id)
 
-    # Close open text message
-    if state.text_message_open:
-        events.append(TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=state.text_message_id))
-        state.close_text_message()
-
+    events.extend(_close_text_message(state))
     return events
 
 
@@ -138,6 +159,41 @@ def on_run_content(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEv
         content = _extract_team_response_chunk_content(chunk)  # type: ignore
     else:
         content = ""
+
+    # Assistant text and reasoning alternate on one timeline of non-overlapping spans: whichever
+    # channel produces a delta closes the other channel's open span first, and every delta is emitted
+    # the moment it arrives. Three consequences follow and are accepted. A chunk carrying both text
+    # and its own differing reasoning yields a reasoning span and then a fresh assistant message, so
+    # consecutive such chunks give one message each. A reasoning-only chunk arriving mid-answer ends
+    # that message and the rest of the answer streams under a new id. And a tool call arriving before
+    # any assistant message exists has to mint one, which ends the reasoning span, while the same call
+    # after assistant text does not, so one chain of thought reaches the client as a single reasoning
+    # block or as several depending on where the tool calls fall.
+
+    # Models that stream their own reasoning deliver it on the content stream rather than as
+    # reasoning events, so it has to be routed to the reasoning span here or it never reaches AG-UI.
+    # Some providers mirror the assistant text into reasoning_content, so a value byte-identical to
+    # this chunk's own content is the answer repeated, not reasoning, and must not open a span.
+    reasoning_content = getattr(chunk, "reasoning_content", None)
+    if reasoning_content and reasoning_content != content:
+        reasoning_events, reasoning_id = _open_reasoning(state)
+        events.extend(reasoning_events)
+        events.append(
+            ReasoningMessageContentEvent(
+                type=EventType.REASONING_MESSAGE_CONTENT,
+                message_id=reasoning_id,
+                delta=reasoning_content,
+            )
+        )
+        if not content:
+            return events
+
+    # A chunk carrying only citations, provider data or media has no text, so it neither ends the
+    # reasoning span nor opens a message inside it.
+    if content:
+        events.extend(_close_reasoning(state))
+    elif state.reasoning_message_id is not None:
+        return events
 
     if not state.text_message_open:
         message_id = state.open_text_message()
@@ -168,16 +224,18 @@ def on_tool_call_started(chunk: BaseRunOutputEvent, state: StreamState) -> List[
     if tool is None:
         return events
 
-    # Close open text message before tool call
+    # Close open text message before tool call, then parent the tool call to it
     if state.text_message_open:
-        events.append(TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=state.text_message_id))
+        events.extend(_close_text_message(state))
         state.set_pending_tool_calls_parent_id(state.text_message_id)
-        state.close_text_message()
 
     parent_message_id = state.get_parent_message_id_for_tool_call()
 
     # Create empty parent message if none exists (AG-UI protocol requirement)
     if not parent_message_id:
+        # A message span must not open inside the reasoning span, so the synthetic parent
+        # ends reasoning first. A tool call on its own leaves the span open.
+        events.extend(_close_reasoning(state))
         parent_message_id = str(uuid.uuid4())
         events.append(
             TextMessageStartEvent(
@@ -240,12 +298,9 @@ def on_tool_call_completed(chunk: BaseRunOutputEvent, state: StreamState) -> Lis
 
 
 def on_reasoning_started(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
-    events: List[BaseEvent] = []
-
-    # Close open text message before reasoning
-    if state.text_message_open:
-        events.append(TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=state.text_message_id))
-        state.close_text_message()
+    events: List[BaseEvent] = _close_text_message(state)
+    # A span may already be open; end it before minting a new id, or it never gets its end events.
+    events.extend(_close_reasoning(state))
 
     reasoning_id = state.start_reasoning()
     events.append(ReasoningStartEvent(type=EventType.REASONING_START, message_id=reasoning_id))
@@ -256,21 +311,7 @@ def on_reasoning_started(chunk: BaseRunOutputEvent, state: StreamState) -> List[
 
 
 def on_reasoning_content_delta(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
-    events: List[BaseEvent] = []
-
-    # Close open text message before reasoning
-    if state.text_message_open:
-        events.append(TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=state.text_message_id))
-        state.close_text_message()
-
-    reasoning_id, is_new = state.ensure_reasoning_started()
-    if is_new:
-        events.append(ReasoningStartEvent(type=EventType.REASONING_START, message_id=reasoning_id))
-        events.append(
-            ReasoningMessageStartEvent(
-                type=EventType.REASONING_MESSAGE_START, message_id=reasoning_id, role="reasoning"
-            )
-        )
+    events, reasoning_id = _open_reasoning(state)
 
     content = getattr(chunk, "reasoning_content", None)
     if content:
@@ -283,21 +324,7 @@ def on_reasoning_content_delta(chunk: BaseRunOutputEvent, state: StreamState) ->
 
 
 def on_reasoning_step(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
-    events: List[BaseEvent] = []
-
-    # Close open text message before reasoning
-    if state.text_message_open:
-        events.append(TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=state.text_message_id))
-        state.close_text_message()
-
-    reasoning_id, is_new = state.ensure_reasoning_started()
-    if is_new:
-        events.append(ReasoningStartEvent(type=EventType.REASONING_START, message_id=reasoning_id))
-        events.append(
-            ReasoningMessageStartEvent(
-                type=EventType.REASONING_MESSAGE_START, message_id=reasoning_id, role="reasoning"
-            )
-        )
+    events, reasoning_id = _open_reasoning(state)
 
     step_num = state.next_reasoning_step()
     step_content = getattr(chunk, "content", None)
@@ -310,15 +337,7 @@ def on_reasoning_step(chunk: BaseRunOutputEvent, state: StreamState) -> List[Bas
 
 
 def on_reasoning_completed(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
-    events: List[BaseEvent] = []
-
-    if state.reasoning_message_id is not None:
-        reasoning_id = state.reasoning_message_id
-        events.append(ReasoningMessageEndEvent(type=EventType.REASONING_MESSAGE_END, message_id=reasoning_id))
-        events.append(ReasoningEndEvent(type=EventType.REASONING_END, message_id=reasoning_id))
-        state.end_reasoning()
-
-    return events
+    return _close_reasoning(state)
 
 
 def on_custom_event(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:

--- a/libs/agno/agno/os/interfaces/agui/state.py
+++ b/libs/agno/agno/os/interfaces/agui/state.py
@@ -19,6 +19,22 @@ class StreamState:
         text_message_open=F   text_message_open=T    text_message_open=F
 
     The text_message_id persists after close so tool calls can parent to it.
+
+    Reasoning Span Lifecycle:
+        CLOSED (initial)           OPEN                     CLOSED
+        reasoning_message_id=None  reasoning_message_id=X   reasoning_message_id=None
+
+    The reasoning id is dropped on close rather than persisted, so every span gets a fresh id and
+    one run opens and closes as many spans as the text/reasoning alternation calls for.
+
+    The reasoning_step_count is per run, not per span, so step numbering keeps counting however
+    many spans a run opens and closes.
+
+    Tool Call Parenting:
+        pending_tool_calls_parent_id, when set, wins over the persisted text_message_id. It holds
+        the message a tool call was parented to, either the text message closed to make room for
+        it or a synthetic empty one, and is cleared when a new text message opens, so a run of
+        sequential tool calls all parent to that same message.
     """
 
     # Text message tracking
@@ -73,7 +89,6 @@ class StreamState:
 
     def start_reasoning(self) -> str:
         self.reasoning_message_id = str(uuid.uuid4())
-        self.reasoning_step_count = 0
         return self.reasoning_message_id
 
     def ensure_reasoning_started(self) -> Tuple[str, bool]:
@@ -87,7 +102,6 @@ class StreamState:
 
     def end_reasoning(self) -> None:
         self.reasoning_message_id = None
-        self.reasoning_step_count = 0
 
     def set_state_snapshot(self, state: Dict[str, Any]) -> None:
         self._last_snapshot = copy.deepcopy(state)

--- a/libs/agno/tests/unit/app/test_agui_reasoning_tools.py
+++ b/libs/agno/tests/unit/app/test_agui_reasoning_tools.py
@@ -1,6 +1,10 @@
+import re
+
 import pytest
 from ag_ui.core import EventType
 
+from agno.models.message import Citations
+from agno.models.response import ToolExecution
 from agno.os.interfaces.agui.stream import async_stream_agno_response_as_agui_events
 from agno.reasoning.step import ReasoningStep
 from agno.run.agent import (
@@ -10,21 +14,114 @@ from agno.run.agent import (
     ReasoningStepEvent,
     RunCompletedEvent,
     RunContentEvent,
+    ToolCallCompletedEvent,
+    ToolCallStartedEvent,
 )
+from agno.run.team import RunCompletedEvent as TeamRunCompletedEvent
+from agno.run.team import RunContentEvent as TeamRunContentEvent
 
 
-def _check_no_reasoning_inside_text_message(event_types: list) -> None:
-    """Verify REASONING_START never occurs between TEXT_MESSAGE_START and TEXT_MESSAGE_END."""
-    text_start_indices = [i for i, t in enumerate(event_types) if t == EventType.TEXT_MESSAGE_START]
-    text_end_indices = [i for i, t in enumerate(event_types) if t == EventType.TEXT_MESSAGE_END]
-    reasoning_start_indices = [i for i, t in enumerate(event_types) if t == EventType.REASONING_START]
+async def _collect(stream) -> list:
+    return [event async for event in async_stream_agno_response_as_agui_events(stream, "thread_1", "run_1")]
 
-    for text_start_idx in text_start_indices:
-        matching_end_indices = [i for i in text_end_indices if i > text_start_idx]
-        if matching_end_indices:
-            text_end_idx = min(matching_end_indices)
-            violating = [i for i in reasoning_start_indices if text_start_idx < i < text_end_idx]
-            assert not violating, f"REASONING_START at {violating} between TEXT_MESSAGE_START and END"
+
+class _ReasoningSteps:
+    """Builds ReasoningStepEvents carrying a title and a thought, with reasoning_content
+    accumulated across the events one builder instance produced.
+
+    Parity with the producer stops there. The reasoning-tools path accumulates reasoning_content
+    the same way for a step of that shape, but it also fills action, confidence and next_action on
+    the step, and the reasoning manager path derives reasoning_content differently again.
+    """
+
+    def __init__(self) -> None:
+        self._reasoning_content = ""
+
+    def event(self, title: str, reasoning: str) -> ReasoningStepEvent:
+        self._reasoning_content += f"## {title}\n{reasoning}\n\n"
+        step = ReasoningStepEvent()
+        step.content = ReasoningStep(title=title, reasoning=reasoning)
+        step.reasoning_content = self._reasoning_content
+        return step
+
+
+def _deltas(events: list, event_type: EventType) -> str:
+    return "".join(e.delta for e in events if e.type == event_type)
+
+
+def _span_events(events: list) -> list:
+    span_types = {
+        EventType.REASONING_START,
+        EventType.REASONING_MESSAGE_START,
+        EventType.REASONING_MESSAGE_CONTENT,
+        EventType.REASONING_MESSAGE_END,
+        EventType.REASONING_END,
+        EventType.TEXT_MESSAGE_START,
+        EventType.TEXT_MESSAGE_CONTENT,
+        EventType.TEXT_MESSAGE_END,
+    }
+    return [(e.type, e.message_id) for e in events if e.type in span_types]
+
+
+def _message_deltas(events: list, event_type: EventType) -> list:
+    """Ordered (message_id, delta) pairs, so a span fragmented across ids cannot pass as one."""
+    return [(e.message_id, e.delta) for e in events if e.type == event_type]
+
+
+def _span_id_at(span_events: list, position: int) -> str:
+    """Message id of the span event at this position, reported as an assertion when it is missing."""
+    assert len(span_events) > position, f"expected a span event at position {position}, got {span_events}"
+    return span_events[position][1]
+
+
+def _span_id_of(span_events: list, event_type: EventType, occurrence: int = 0, other_than: str = "") -> str:
+    """Message id of the nth span event of this type, reported as an assertion when it is missing."""
+    message_ids = [mid for kind, mid in span_events if kind == event_type and mid != other_than]
+    assert len(message_ids) > occurrence, f"expected {occurrence + 1} or more {event_type}, got {span_events}"
+    return message_ids[occurrence]
+
+
+def _first_event(events: list, event_type: EventType):
+    """First event of this type, reported as an assertion when it is missing."""
+    matching = [e for e in events if e.type == event_type]
+    assert matching, f"expected a {event_type}, got {[e.type for e in events]}"
+    return matching[0]
+
+
+def _span_end_position(events: list, start_position: int, end_type: EventType) -> int:
+    """Position of the end event closing the span opened at start_position, paired by message id."""
+    start = events[start_position]
+    end_positions = [
+        i
+        for i, e in enumerate(events)
+        if i > start_position and e.type == end_type and e.message_id == start.message_id
+    ]
+    assert end_positions, f"{start.type} for {start.message_id} at {start_position} never ends"
+    return min(end_positions)
+
+
+def _check_no_reasoning_inside_text_message(events: list) -> None:
+    """Verify REASONING_START never occurs inside a text message span, paired by message id."""
+    reasoning_start_positions = [i for i, e in enumerate(events) if e.type == EventType.REASONING_START]
+
+    for text_start_position, event in enumerate(events):
+        if event.type != EventType.TEXT_MESSAGE_START:
+            continue
+        text_end_position = _span_end_position(events, text_start_position, EventType.TEXT_MESSAGE_END)
+        violating = [i for i in reasoning_start_positions if text_start_position < i < text_end_position]
+        assert not violating, f"REASONING_START at {violating} inside text message {event.message_id}"
+
+
+def _check_no_text_inside_reasoning(events: list) -> None:
+    """Verify TEXT_MESSAGE_START never occurs inside a reasoning message span, paired by message id."""
+    text_start_positions = [i for i, e in enumerate(events) if e.type == EventType.TEXT_MESSAGE_START]
+
+    for reasoning_start_position, event in enumerate(events):
+        if event.type != EventType.REASONING_MESSAGE_START:
+            continue
+        reasoning_end_position = _span_end_position(events, reasoning_start_position, EventType.REASONING_MESSAGE_END)
+        violating = [i for i in text_start_positions if reasoning_start_position < i < reasoning_end_position]
+        assert not violating, f"TEXT_MESSAGE_START at {violating} inside reasoning message {event.message_id}"
 
 
 @pytest.mark.asyncio
@@ -36,10 +133,7 @@ async def test_reasoning_started_closes_open_text_message():
 
         yield ReasoningStartedEvent()
 
-        step = ReasoningStepEvent()
-        step.content = ReasoningStep(title="Analyze", reasoning="Thinking...")
-        step.reasoning_content = "## Analyze\nThinking..."
-        yield step
+        yield _ReasoningSteps().event(title="Analyze", reasoning="Thinking...")
 
         yield ReasoningCompletedEvent()
 
@@ -59,7 +153,7 @@ async def test_reasoning_started_closes_open_text_message():
     assert EventType.TEXT_MESSAGE_START in event_types
     assert EventType.TEXT_MESSAGE_END in event_types
 
-    _check_no_reasoning_inside_text_message(event_types)
+    _check_no_reasoning_inside_text_message(events)
 
 
 @pytest.mark.asyncio
@@ -88,7 +182,7 @@ async def test_reasoning_content_delta_closes_open_text_message():
     event_types = [e.type for e in events]
 
     assert EventType.REASONING_START in event_types
-    _check_no_reasoning_inside_text_message(event_types)
+    _check_no_reasoning_inside_text_message(events)
 
 
 @pytest.mark.asyncio
@@ -98,10 +192,7 @@ async def test_reasoning_step_closes_open_text_message():
         text1.content = "Analyzing..."
         yield text1
 
-        step = ReasoningStepEvent()
-        step.content = ReasoningStep(title="Step 1", reasoning="First step...")
-        step.reasoning_content = "## Step 1\nFirst step..."
-        yield step
+        yield _ReasoningSteps().event(title="Analyze", reasoning="First step...")
 
         yield ReasoningCompletedEvent()
         yield RunCompletedEvent()
@@ -113,4 +204,911 @@ async def test_reasoning_step_closes_open_text_message():
     event_types = [e.type for e in events]
 
     assert EventType.REASONING_START in event_types
-    _check_no_reasoning_inside_text_message(event_types)
+    _check_no_reasoning_inside_text_message(events)
+
+
+@pytest.mark.asyncio
+async def test_native_reasoning_on_run_content_reaches_agui():
+    """Providers that stream reasoning summaries deliver them on RunContent, not as reasoning events."""
+
+    async def mock_stream():
+        for delta in ("Weighing ", "the ", "options."):
+            reasoning_chunk = RunContentEvent()
+            reasoning_chunk.reasoning_content = delta
+            yield reasoning_chunk
+
+        answer = RunContentEvent()
+        answer.content = "The answer is 42."
+        yield answer
+
+        yield RunCompletedEvent()
+
+    events = await _collect(mock_stream())
+    span_events = _span_events(events)
+
+    reasoning_id = _span_id_at(span_events, 0)
+    text_id = _span_id_of(span_events, EventType.TEXT_MESSAGE_START)
+
+    assert span_events == [
+        (EventType.REASONING_START, reasoning_id),
+        (EventType.REASONING_MESSAGE_START, reasoning_id),
+        (EventType.REASONING_MESSAGE_CONTENT, reasoning_id),
+        (EventType.REASONING_MESSAGE_CONTENT, reasoning_id),
+        (EventType.REASONING_MESSAGE_CONTENT, reasoning_id),
+        (EventType.REASONING_MESSAGE_END, reasoning_id),
+        (EventType.REASONING_END, reasoning_id),
+        (EventType.TEXT_MESSAGE_START, text_id),
+        (EventType.TEXT_MESSAGE_CONTENT, text_id),
+        (EventType.TEXT_MESSAGE_END, text_id),
+    ]
+    assert reasoning_id != text_id
+
+    # RUN_FINISHED is the only event outside the spans asserted above
+    assert len(events) == len(span_events) + 1
+    assert events[-1].type == EventType.RUN_FINISHED
+
+    assert _message_deltas(events, EventType.REASONING_MESSAGE_CONTENT) == [
+        (reasoning_id, "Weighing "),
+        (reasoning_id, "the "),
+        (reasoning_id, "options."),
+    ]
+    assert _message_deltas(events, EventType.TEXT_MESSAGE_CONTENT) == [(text_id, "The answer is 42.")]
+
+
+@pytest.mark.asyncio
+async def test_native_reasoning_survives_several_tool_calls_in_one_turn():
+    async def mock_stream():
+        first_reasoning = RunContentEvent()
+        first_reasoning.reasoning_content = "I need two lookups."
+        yield first_reasoning
+
+        weather = ToolExecution(tool_call_id="tc_1", tool_name="get_weather", tool_args={"city": "London"})
+        population = ToolExecution(tool_call_id="tc_2", tool_name="get_population", tool_args={"city": "London"})
+
+        yield ToolCallStartedEvent(tool=weather)
+        yield ToolCallStartedEvent(tool=population)
+
+        weather.result = "15C"
+        yield ToolCallCompletedEvent(tool=weather)
+        population.result = "8900000"
+        yield ToolCallCompletedEvent(tool=population)
+
+        second_reasoning = RunContentEvent()
+        second_reasoning.reasoning_content = "Both results are in."
+        yield second_reasoning
+
+        answer = RunContentEvent()
+        answer.content = "Cold and crowded."
+        yield answer
+
+        yield RunCompletedEvent()
+
+    events = await _collect(mock_stream())
+    event_types = [e.type for e in events]
+    span_events = _span_events(events)
+
+    first_reasoning_id = _span_id_at(span_events, 0)
+    second_reasoning_id = _span_id_of(span_events, EventType.REASONING_START, other_than=first_reasoning_id)
+    parent_id = _span_id_of(span_events, EventType.TEXT_MESSAGE_START)
+    answer_id = _span_id_of(span_events, EventType.TEXT_MESSAGE_START, other_than=parent_id)
+
+    assert event_types == [
+        EventType.REASONING_START,
+        EventType.REASONING_MESSAGE_START,
+        EventType.REASONING_MESSAGE_CONTENT,
+        EventType.REASONING_MESSAGE_END,
+        EventType.REASONING_END,
+        EventType.TEXT_MESSAGE_START,
+        EventType.TEXT_MESSAGE_END,
+        EventType.TOOL_CALL_START,
+        EventType.TOOL_CALL_ARGS,
+        EventType.TOOL_CALL_START,
+        EventType.TOOL_CALL_ARGS,
+        EventType.TOOL_CALL_END,
+        EventType.TOOL_CALL_RESULT,
+        EventType.TOOL_CALL_END,
+        EventType.TOOL_CALL_RESULT,
+        EventType.REASONING_START,
+        EventType.REASONING_MESSAGE_START,
+        EventType.REASONING_MESSAGE_CONTENT,
+        EventType.REASONING_MESSAGE_END,
+        EventType.REASONING_END,
+        EventType.TEXT_MESSAGE_START,
+        EventType.TEXT_MESSAGE_CONTENT,
+        EventType.TEXT_MESSAGE_END,
+        EventType.RUN_FINISHED,
+    ]
+
+    assert span_events == [
+        (EventType.REASONING_START, first_reasoning_id),
+        (EventType.REASONING_MESSAGE_START, first_reasoning_id),
+        (EventType.REASONING_MESSAGE_CONTENT, first_reasoning_id),
+        (EventType.REASONING_MESSAGE_END, first_reasoning_id),
+        (EventType.REASONING_END, first_reasoning_id),
+        (EventType.TEXT_MESSAGE_START, parent_id),
+        (EventType.TEXT_MESSAGE_END, parent_id),
+        (EventType.REASONING_START, second_reasoning_id),
+        (EventType.REASONING_MESSAGE_START, second_reasoning_id),
+        (EventType.REASONING_MESSAGE_CONTENT, second_reasoning_id),
+        (EventType.REASONING_MESSAGE_END, second_reasoning_id),
+        (EventType.REASONING_END, second_reasoning_id),
+        (EventType.TEXT_MESSAGE_START, answer_id),
+        (EventType.TEXT_MESSAGE_CONTENT, answer_id),
+        (EventType.TEXT_MESSAGE_END, answer_id),
+    ]
+
+    assert len({first_reasoning_id, second_reasoning_id, parent_id, answer_id}) == 4
+
+    assert [(e.type, e.tool_call_id) for e in events if getattr(e, "tool_call_id", None) is not None] == [
+        (EventType.TOOL_CALL_START, "tc_1"),
+        (EventType.TOOL_CALL_ARGS, "tc_1"),
+        (EventType.TOOL_CALL_START, "tc_2"),
+        (EventType.TOOL_CALL_ARGS, "tc_2"),
+        (EventType.TOOL_CALL_END, "tc_1"),
+        (EventType.TOOL_CALL_RESULT, "tc_1"),
+        (EventType.TOOL_CALL_END, "tc_2"),
+        (EventType.TOOL_CALL_RESULT, "tc_2"),
+    ]
+
+    # Both tool calls hang off the empty message minted once the first reasoning span closed
+    assert [e.parent_message_id for e in events if e.type == EventType.TOOL_CALL_START] == [parent_id, parent_id]
+
+    assert _message_deltas(events, EventType.REASONING_MESSAGE_CONTENT) == [
+        (first_reasoning_id, "I need two lookups."),
+        (second_reasoning_id, "Both results are in."),
+    ]
+    assert _message_deltas(events, EventType.TEXT_MESSAGE_CONTENT) == [(answer_id, "Cold and crowded.")]
+
+
+@pytest.mark.asyncio
+async def test_native_reasoning_on_team_run_content_reaches_agui():
+    async def mock_stream():
+        reasoning_chunk = TeamRunContentEvent()
+        reasoning_chunk.reasoning_content = "Delegating."
+        yield reasoning_chunk
+
+        answer = TeamRunContentEvent()
+        answer.content = "Done."
+        yield answer
+
+        yield TeamRunCompletedEvent()
+
+    events = await _collect(mock_stream())
+    span_events = _span_events(events)
+
+    reasoning_id = _span_id_at(span_events, 0)
+    text_id = _span_id_of(span_events, EventType.TEXT_MESSAGE_START)
+
+    assert span_events == [
+        (EventType.REASONING_START, reasoning_id),
+        (EventType.REASONING_MESSAGE_START, reasoning_id),
+        (EventType.REASONING_MESSAGE_CONTENT, reasoning_id),
+        (EventType.REASONING_MESSAGE_END, reasoning_id),
+        (EventType.REASONING_END, reasoning_id),
+        (EventType.TEXT_MESSAGE_START, text_id),
+        (EventType.TEXT_MESSAGE_CONTENT, text_id),
+        (EventType.TEXT_MESSAGE_END, text_id),
+    ]
+    assert reasoning_id != text_id
+
+    assert len(events) == len(span_events) + 1
+    assert events[-1].type == EventType.RUN_FINISHED
+
+    assert _message_deltas(events, EventType.REASONING_MESSAGE_CONTENT) == [(reasoning_id, "Delegating.")]
+    assert _message_deltas(events, EventType.TEXT_MESSAGE_CONTENT) == [(text_id, "Done.")]
+
+
+@pytest.mark.asyncio
+async def test_run_completed_while_reasoning_is_open_closes_the_span():
+    """A run that ends before any assistant text must still close the reasoning span it left open."""
+
+    async def mock_stream():
+        for delta in ("Still ", "thinking."):
+            reasoning_chunk = RunContentEvent()
+            reasoning_chunk.reasoning_content = delta
+            yield reasoning_chunk
+
+        yield RunCompletedEvent()
+
+    events = await _collect(mock_stream())
+    span_events = _span_events(events)
+
+    reasoning_id = _span_id_at(span_events, 0)
+
+    assert span_events == [
+        (EventType.REASONING_START, reasoning_id),
+        (EventType.REASONING_MESSAGE_START, reasoning_id),
+        (EventType.REASONING_MESSAGE_CONTENT, reasoning_id),
+        (EventType.REASONING_MESSAGE_CONTENT, reasoning_id),
+        (EventType.REASONING_MESSAGE_END, reasoning_id),
+        (EventType.REASONING_END, reasoning_id),
+    ]
+
+    assert [e.type for e in events[-3:]] == [
+        EventType.REASONING_MESSAGE_END,
+        EventType.REASONING_END,
+        EventType.RUN_FINISHED,
+    ]
+    assert len(events) == len(span_events) + 1
+
+    assert _message_deltas(events, EventType.REASONING_MESSAGE_CONTENT) == [
+        (reasoning_id, "Still "),
+        (reasoning_id, "thinking."),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_reasoning_mirroring_the_answer_is_not_emitted_as_reasoning():
+    """Providers that mirror the assistant text into reasoning_content must not produce a reasoning span."""
+
+    async def mock_stream():
+        for delta in ("The ", "answer ", "is 42."):
+            chunk = RunContentEvent()
+            chunk.content = delta
+            chunk.reasoning_content = delta
+            yield chunk
+
+        yield RunCompletedEvent()
+
+    events = await _collect(mock_stream())
+    event_types = [e.type for e in events]
+
+    assert event_types == [
+        EventType.TEXT_MESSAGE_START,
+        EventType.TEXT_MESSAGE_CONTENT,
+        EventType.TEXT_MESSAGE_CONTENT,
+        EventType.TEXT_MESSAGE_CONTENT,
+        EventType.TEXT_MESSAGE_END,
+        EventType.RUN_FINISHED,
+    ]
+
+    message_ids = {e.message_id for e in events if e.type == EventType.TEXT_MESSAGE_CONTENT}
+    assert len(message_ids) == 1
+    assert _deltas(events, EventType.TEXT_MESSAGE_CONTENT) == "The answer is 42."
+
+
+@pytest.mark.asyncio
+async def test_reasoning_started_ends_a_span_already_open():
+    """A reasoning-started event arriving mid-span must close that span instead of orphaning it."""
+
+    async def mock_stream():
+        native_reasoning = RunContentEvent()
+        native_reasoning.reasoning_content = "Native thinking."
+        yield native_reasoning
+
+        yield ReasoningStartedEvent()
+
+        delta = ReasoningContentDeltaEvent()
+        delta.reasoning_content = "Structured thinking."
+        yield delta
+
+        yield ReasoningCompletedEvent()
+
+        answer = RunContentEvent()
+        answer.content = "The answer is 42."
+        yield answer
+
+        yield RunCompletedEvent()
+
+    events = await _collect(mock_stream())
+    span_events = _span_events(events)
+
+    first_id = _span_id_at(span_events, 0)
+    second_id = _span_id_of(span_events, EventType.REASONING_START, other_than=first_id)
+    text_id = _span_id_of(span_events, EventType.TEXT_MESSAGE_START)
+
+    assert span_events == [
+        (EventType.REASONING_START, first_id),
+        (EventType.REASONING_MESSAGE_START, first_id),
+        (EventType.REASONING_MESSAGE_CONTENT, first_id),
+        (EventType.REASONING_MESSAGE_END, first_id),
+        (EventType.REASONING_END, first_id),
+        (EventType.REASONING_START, second_id),
+        (EventType.REASONING_MESSAGE_START, second_id),
+        (EventType.REASONING_MESSAGE_CONTENT, second_id),
+        (EventType.REASONING_MESSAGE_END, second_id),
+        (EventType.REASONING_END, second_id),
+        (EventType.TEXT_MESSAGE_START, text_id),
+        (EventType.TEXT_MESSAGE_CONTENT, text_id),
+        (EventType.TEXT_MESSAGE_END, text_id),
+    ]
+
+    assert len({first_id, second_id, text_id}) == 3
+
+    assert len(events) == len(span_events) + 1
+    assert events[-1].type == EventType.RUN_FINISHED
+
+    started = [mid for kind, mid in span_events if kind == EventType.REASONING_START]
+    ended = [mid for kind, mid in span_events if kind == EventType.REASONING_END]
+    message_started = [mid for kind, mid in span_events if kind == EventType.REASONING_MESSAGE_START]
+    message_ended = [mid for kind, mid in span_events if kind == EventType.REASONING_MESSAGE_END]
+
+    assert started == ended
+    assert message_started == message_ended
+    assert len(set(started)) == 2
+
+
+@pytest.mark.asyncio
+async def test_tool_call_with_existing_parent_message_keeps_the_reasoning_span_open():
+    """A tool call parents to the existing assistant message and leaves the reasoning span open."""
+
+    async def mock_stream():
+        answer = RunContentEvent()
+        answer.content = "Let me check the forecast."
+        yield answer
+
+        reasoning_chunk = RunContentEvent()
+        reasoning_chunk.reasoning_content = "I should look up the weather."
+        yield reasoning_chunk
+
+        weather = ToolExecution(tool_call_id="tc_1", tool_name="get_weather", tool_args={"city": "London"})
+        yield ToolCallStartedEvent(tool=weather)
+
+        weather.result = "15C"
+        yield ToolCallCompletedEvent(tool=weather)
+
+        yield RunCompletedEvent()
+
+    events = await _collect(mock_stream())
+    event_types = [e.type for e in events]
+
+    assert event_types == [
+        EventType.TEXT_MESSAGE_START,
+        EventType.TEXT_MESSAGE_CONTENT,
+        EventType.TEXT_MESSAGE_END,
+        EventType.REASONING_START,
+        EventType.REASONING_MESSAGE_START,
+        EventType.REASONING_MESSAGE_CONTENT,
+        EventType.TOOL_CALL_START,
+        EventType.TOOL_CALL_ARGS,
+        EventType.TOOL_CALL_END,
+        EventType.TOOL_CALL_RESULT,
+        EventType.REASONING_MESSAGE_END,
+        EventType.REASONING_END,
+        EventType.RUN_FINISHED,
+    ]
+
+    # The existing assistant message parents the tool call, so no synthetic message is minted
+    text_start = _first_event(events, EventType.TEXT_MESSAGE_START)
+    tool_start = _first_event(events, EventType.TOOL_CALL_START)
+    assert tool_start.parent_message_id == text_start.message_id
+
+    _check_no_text_inside_reasoning(events)
+
+
+@pytest.mark.asyncio
+async def test_reasoning_tools_tool_calls_do_not_split_the_reasoning_span():
+    """ReasoningTools interleaves think calls with steps. The think calls must not end the reasoning span, so
+    all three steps land in one reasoning message, and the step headings run 1, 2, 3."""
+
+    async def mock_stream():
+        steps = _ReasoningSteps()
+        for index in (1, 2, 3):
+            think = ToolExecution(
+                tool_call_id=f"tc_{index}",
+                tool_name="think",
+                tool_args={"thought": f"thought {index}"},
+            )
+            yield ToolCallStartedEvent(tool=think)
+
+            think.result = "ok"
+            yield ToolCallCompletedEvent(tool=think)
+
+            yield steps.event(title=f"Consider {index}", reasoning=f"Reasoning {index}")
+
+        answer = RunContentEvent()
+        answer.content = "The answer is 42."
+        yield answer
+
+        yield RunCompletedEvent()
+
+    events = await _collect(mock_stream())
+    span_events = _span_events(events)
+
+    parent_id = _span_id_at(span_events, 0)
+    reasoning_id = _span_id_of(span_events, EventType.REASONING_START)
+    answer_id = _span_id_of(span_events, EventType.TEXT_MESSAGE_START, other_than=parent_id)
+
+    assert [e.type for e in events] == [
+        EventType.TEXT_MESSAGE_START,
+        EventType.TEXT_MESSAGE_END,
+        EventType.TOOL_CALL_START,
+        EventType.TOOL_CALL_ARGS,
+        EventType.TOOL_CALL_END,
+        EventType.TOOL_CALL_RESULT,
+        EventType.REASONING_START,
+        EventType.REASONING_MESSAGE_START,
+        EventType.REASONING_MESSAGE_CONTENT,
+        EventType.TOOL_CALL_START,
+        EventType.TOOL_CALL_ARGS,
+        EventType.TOOL_CALL_END,
+        EventType.TOOL_CALL_RESULT,
+        EventType.REASONING_MESSAGE_CONTENT,
+        EventType.TOOL_CALL_START,
+        EventType.TOOL_CALL_ARGS,
+        EventType.TOOL_CALL_END,
+        EventType.TOOL_CALL_RESULT,
+        EventType.REASONING_MESSAGE_CONTENT,
+        EventType.REASONING_MESSAGE_END,
+        EventType.REASONING_END,
+        EventType.TEXT_MESSAGE_START,
+        EventType.TEXT_MESSAGE_CONTENT,
+        EventType.TEXT_MESSAGE_END,
+        EventType.RUN_FINISHED,
+    ]
+
+    assert span_events == [
+        (EventType.TEXT_MESSAGE_START, parent_id),
+        (EventType.TEXT_MESSAGE_END, parent_id),
+        (EventType.REASONING_START, reasoning_id),
+        (EventType.REASONING_MESSAGE_START, reasoning_id),
+        (EventType.REASONING_MESSAGE_CONTENT, reasoning_id),
+        (EventType.REASONING_MESSAGE_CONTENT, reasoning_id),
+        (EventType.REASONING_MESSAGE_CONTENT, reasoning_id),
+        (EventType.REASONING_MESSAGE_END, reasoning_id),
+        (EventType.REASONING_END, reasoning_id),
+        (EventType.TEXT_MESSAGE_START, answer_id),
+        (EventType.TEXT_MESSAGE_CONTENT, answer_id),
+        (EventType.TEXT_MESSAGE_END, answer_id),
+    ]
+
+    assert len({parent_id, reasoning_id, answer_id}) == 3
+
+    # Every think call hangs off the one synthetic parent minted before the span opened
+    assert [e.parent_message_id for e in events if e.type == EventType.TOOL_CALL_START] == [parent_id] * 3
+
+    reasoning_text = _deltas(events, EventType.REASONING_MESSAGE_CONTENT)
+    assert reasoning_text.count("## Step 1: Consider 1") == 1
+    assert reasoning_text.count("## Step 2: Consider 2") == 1
+    assert reasoning_text.count("## Step 3: Consider 3") == 1
+    assert _deltas(events, EventType.TEXT_MESSAGE_CONTENT) == "The answer is 42."
+
+
+@pytest.mark.asyncio
+async def test_reasoning_step_numbering_is_per_run_not_per_span():
+    """Numbering counts steps in the turn, not in the span. Assistant text between steps closes the
+    span, so each step lands in a span of its own, and the count must keep going up all the same."""
+
+    async def mock_stream():
+        steps = _ReasoningSteps()
+        for index in (1, 2, 3):
+            yield steps.event(title=f"Consider {index}", reasoning=f"Reasoning {index}")
+
+            partial = RunContentEvent()
+            partial.content = f"Partial {index}. "
+            yield partial
+
+        yield RunCompletedEvent()
+
+    events = await _collect(mock_stream())
+    span_events = _span_events(events)
+
+    # Each step opens its own span, so the alternation really did reset-test the counter
+    reasoning_ids = [mid for kind, mid in span_events if kind == EventType.REASONING_START]
+    assert len(set(reasoning_ids)) == 3, f"expected three distinct reasoning spans, got {span_events}"
+
+    reasoning_text = _deltas(events, EventType.REASONING_MESSAGE_CONTENT)
+    headings = re.findall(r"## Step \d+: Consider \d+", reasoning_text)
+    assert headings == [
+        "## Step 1: Consider 1",
+        "## Step 2: Consider 2",
+        "## Step 3: Consider 3",
+    ]
+
+    assert _deltas(events, EventType.TEXT_MESSAGE_CONTENT) == "Partial 1. Partial 2. Partial 3. "
+
+    _check_no_reasoning_inside_text_message(events)
+    _check_no_text_inside_reasoning(events)
+
+
+@pytest.mark.asyncio
+async def test_content_less_chunk_does_not_split_the_reasoning_span():
+    """A chunk carrying only citations must not end the reasoning span or open an empty message inside it."""
+
+    async def mock_stream():
+        first_reasoning = RunContentEvent()
+        first_reasoning.reasoning_content = "Weighing "
+        yield first_reasoning
+
+        citations_only = RunContentEvent()
+        citations_only.citations = Citations(raw=[{"url": "https://example.com"}])
+        yield citations_only
+
+        second_reasoning = RunContentEvent()
+        second_reasoning.reasoning_content = "the options."
+        yield second_reasoning
+
+        answer = RunContentEvent()
+        answer.content = "The answer is 42."
+        yield answer
+
+        yield RunCompletedEvent()
+
+    events = await _collect(mock_stream())
+    span_events = _span_events(events)
+
+    reasoning_id = _span_id_at(span_events, 0)
+    text_id = _span_id_of(span_events, EventType.TEXT_MESSAGE_START)
+
+    assert span_events == [
+        (EventType.REASONING_START, reasoning_id),
+        (EventType.REASONING_MESSAGE_START, reasoning_id),
+        (EventType.REASONING_MESSAGE_CONTENT, reasoning_id),
+        (EventType.REASONING_MESSAGE_CONTENT, reasoning_id),
+        (EventType.REASONING_MESSAGE_END, reasoning_id),
+        (EventType.REASONING_END, reasoning_id),
+        (EventType.TEXT_MESSAGE_START, text_id),
+        (EventType.TEXT_MESSAGE_CONTENT, text_id),
+        (EventType.TEXT_MESSAGE_END, text_id),
+    ]
+
+    assert reasoning_id != text_id
+
+    assert len(events) == len(span_events) + 1
+    assert events[-1].type == EventType.RUN_FINISHED
+
+    assert _deltas(events, EventType.REASONING_MESSAGE_CONTENT) == "Weighing the options."
+    assert _deltas(events, EventType.TEXT_MESSAGE_CONTENT) == "The answer is 42."
+
+    _check_no_text_inside_reasoning(events)
+
+
+@pytest.mark.asyncio
+async def test_content_less_chunk_without_reasoning_still_opens_the_assistant_message():
+    """With no reasoning span open, a content-less chunk keeps opening the message that parents tool calls."""
+
+    async def mock_stream():
+        citations_only = RunContentEvent()
+        citations_only.citations = Citations(raw=[{"url": "https://example.com"}])
+        yield citations_only
+
+        yield RunCompletedEvent()
+
+    events = await _collect(mock_stream())
+    span_events = _span_events(events)
+
+    text_id = _span_id_at(span_events, 0)
+    assert span_events == [
+        (EventType.TEXT_MESSAGE_START, text_id),
+        (EventType.TEXT_MESSAGE_END, text_id),
+    ]
+
+    assert len(events) == len(span_events) + 1
+    assert events[-1].type == EventType.RUN_FINISHED
+
+
+@pytest.mark.asyncio
+async def test_mixed_text_and_reasoning_chunks_produce_one_message_each():
+    """Accepted cost of alternation: a chunk carrying both text and its own differing reasoning opens a
+    reasoning span and then a fresh assistant message, so consecutive such chunks give one message each.
+
+    No provider stream has been observed doing this. Every reasoning delta and every text delta still
+    reaches the client, in order, and the spans never nest.
+    """
+
+    async def mock_stream():
+        for text, reasoning in (("The ", "Weighing "), ("answer ", "the "), ("is 42.", "options.")):
+            chunk = RunContentEvent()
+            chunk.content = text
+            chunk.reasoning_content = reasoning
+            yield chunk
+
+        yield RunCompletedEvent()
+
+    events = await _collect(mock_stream())
+    span_events = _span_events(events)
+
+    reasoning_ids = [mid for kind, mid in span_events if kind == EventType.REASONING_START]
+    text_ids = [mid for kind, mid in span_events if kind == EventType.TEXT_MESSAGE_START]
+    assert len(reasoning_ids) == 3, f"expected three reasoning spans, got {span_events}"
+    assert len(text_ids) == 3, f"expected three assistant messages, got {span_events}"
+
+    assert span_events == [
+        (EventType.REASONING_START, reasoning_ids[0]),
+        (EventType.REASONING_MESSAGE_START, reasoning_ids[0]),
+        (EventType.REASONING_MESSAGE_CONTENT, reasoning_ids[0]),
+        (EventType.REASONING_MESSAGE_END, reasoning_ids[0]),
+        (EventType.REASONING_END, reasoning_ids[0]),
+        (EventType.TEXT_MESSAGE_START, text_ids[0]),
+        (EventType.TEXT_MESSAGE_CONTENT, text_ids[0]),
+        (EventType.TEXT_MESSAGE_END, text_ids[0]),
+        (EventType.REASONING_START, reasoning_ids[1]),
+        (EventType.REASONING_MESSAGE_START, reasoning_ids[1]),
+        (EventType.REASONING_MESSAGE_CONTENT, reasoning_ids[1]),
+        (EventType.REASONING_MESSAGE_END, reasoning_ids[1]),
+        (EventType.REASONING_END, reasoning_ids[1]),
+        (EventType.TEXT_MESSAGE_START, text_ids[1]),
+        (EventType.TEXT_MESSAGE_CONTENT, text_ids[1]),
+        (EventType.TEXT_MESSAGE_END, text_ids[1]),
+        (EventType.REASONING_START, reasoning_ids[2]),
+        (EventType.REASONING_MESSAGE_START, reasoning_ids[2]),
+        (EventType.REASONING_MESSAGE_CONTENT, reasoning_ids[2]),
+        (EventType.REASONING_MESSAGE_END, reasoning_ids[2]),
+        (EventType.REASONING_END, reasoning_ids[2]),
+        (EventType.TEXT_MESSAGE_START, text_ids[2]),
+        (EventType.TEXT_MESSAGE_CONTENT, text_ids[2]),
+        (EventType.TEXT_MESSAGE_END, text_ids[2]),
+    ]
+    assert len(set(reasoning_ids + text_ids)) == 6
+
+    assert _message_deltas(events, EventType.REASONING_MESSAGE_CONTENT) == [
+        (reasoning_ids[0], "Weighing "),
+        (reasoning_ids[1], "the "),
+        (reasoning_ids[2], "options."),
+    ]
+    assert _message_deltas(events, EventType.TEXT_MESSAGE_CONTENT) == [
+        (text_ids[0], "The "),
+        (text_ids[1], "answer "),
+        (text_ids[2], "is 42."),
+    ]
+
+    assert len(events) == len(span_events) + 1
+    assert events[-1].type == EventType.RUN_FINISHED
+
+    _check_no_reasoning_inside_text_message(events)
+    _check_no_text_inside_reasoning(events)
+
+
+@pytest.mark.asyncio
+async def test_reasoning_then_mixed_chunk_then_text_stays_one_span_and_one_message():
+    """The provider shape: thought-only chunks, one chunk carrying both, then text-only chunks."""
+
+    async def mock_stream():
+        for delta in ("Weighing ", "the "):
+            reasoning_chunk = RunContentEvent()
+            reasoning_chunk.reasoning_content = delta
+            yield reasoning_chunk
+
+        mixed = RunContentEvent()
+        mixed.content = "The "
+        mixed.reasoning_content = "options."
+        yield mixed
+
+        for delta in ("answer ", "is 42."):
+            text_chunk = RunContentEvent()
+            text_chunk.content = delta
+            yield text_chunk
+
+        yield RunCompletedEvent()
+
+    events = await _collect(mock_stream())
+    span_events = _span_events(events)
+
+    reasoning_id = _span_id_at(span_events, 0)
+    text_id = _span_id_of(span_events, EventType.TEXT_MESSAGE_START)
+
+    assert span_events == [
+        (EventType.REASONING_START, reasoning_id),
+        (EventType.REASONING_MESSAGE_START, reasoning_id),
+        (EventType.REASONING_MESSAGE_CONTENT, reasoning_id),
+        (EventType.REASONING_MESSAGE_CONTENT, reasoning_id),
+        (EventType.REASONING_MESSAGE_CONTENT, reasoning_id),
+        (EventType.REASONING_MESSAGE_END, reasoning_id),
+        (EventType.REASONING_END, reasoning_id),
+        (EventType.TEXT_MESSAGE_START, text_id),
+        (EventType.TEXT_MESSAGE_CONTENT, text_id),
+        (EventType.TEXT_MESSAGE_CONTENT, text_id),
+        (EventType.TEXT_MESSAGE_CONTENT, text_id),
+        (EventType.TEXT_MESSAGE_END, text_id),
+    ]
+
+    assert reasoning_id != text_id
+
+    assert _message_deltas(events, EventType.REASONING_MESSAGE_CONTENT) == [
+        (reasoning_id, "Weighing "),
+        (reasoning_id, "the "),
+        (reasoning_id, "options."),
+    ]
+    assert _message_deltas(events, EventType.TEXT_MESSAGE_CONTENT) == [
+        (text_id, "The "),
+        (text_id, "answer "),
+        (text_id, "is 42."),
+    ]
+
+    assert len(events) == len(span_events) + 1
+    assert events[-1].type == EventType.RUN_FINISHED
+
+
+@pytest.mark.asyncio
+async def test_mixed_chunk_mid_answer_parents_a_later_tool_call_to_the_new_message():
+    """Reasoning sharing a chunk with text ends the message open at the time, so the text that came with
+    it starts a new one, and that new message is what a following tool call parents to."""
+
+    async def mock_stream():
+        opener = RunContentEvent()
+        opener.content = "Let me check. "
+        yield opener
+
+        mixed = RunContentEvent()
+        mixed.content = "One moment."
+        mixed.reasoning_content = "I should look up the weather."
+        yield mixed
+
+        weather = ToolExecution(tool_call_id="tc_1", tool_name="get_weather", tool_args={"city": "London"})
+        yield ToolCallStartedEvent(tool=weather)
+
+        weather.result = "15C"
+        yield ToolCallCompletedEvent(tool=weather)
+
+        later_reasoning = RunContentEvent()
+        later_reasoning.reasoning_content = "The result is in."
+        yield later_reasoning
+
+        yield RunCompletedEvent()
+
+    events = await _collect(mock_stream())
+    span_events = _span_events(events)
+
+    opener_id = _span_id_at(span_events, 0)
+    first_reasoning_id = _span_id_of(span_events, EventType.REASONING_START)
+    answer_id = _span_id_of(span_events, EventType.TEXT_MESSAGE_START, other_than=opener_id)
+    second_reasoning_id = _span_id_of(span_events, EventType.REASONING_START, other_than=first_reasoning_id)
+
+    assert span_events == [
+        (EventType.TEXT_MESSAGE_START, opener_id),
+        (EventType.TEXT_MESSAGE_CONTENT, opener_id),
+        (EventType.TEXT_MESSAGE_END, opener_id),
+        (EventType.REASONING_START, first_reasoning_id),
+        (EventType.REASONING_MESSAGE_START, first_reasoning_id),
+        (EventType.REASONING_MESSAGE_CONTENT, first_reasoning_id),
+        (EventType.REASONING_MESSAGE_END, first_reasoning_id),
+        (EventType.REASONING_END, first_reasoning_id),
+        (EventType.TEXT_MESSAGE_START, answer_id),
+        (EventType.TEXT_MESSAGE_CONTENT, answer_id),
+        (EventType.TEXT_MESSAGE_END, answer_id),
+        (EventType.REASONING_START, second_reasoning_id),
+        (EventType.REASONING_MESSAGE_START, second_reasoning_id),
+        (EventType.REASONING_MESSAGE_CONTENT, second_reasoning_id),
+        (EventType.REASONING_MESSAGE_END, second_reasoning_id),
+        (EventType.REASONING_END, second_reasoning_id),
+    ]
+
+    assert len({opener_id, first_reasoning_id, answer_id, second_reasoning_id}) == 4
+
+    # Each delta is emitted where it arrived, never carried over into a later span
+    assert _message_deltas(events, EventType.REASONING_MESSAGE_CONTENT) == [
+        (first_reasoning_id, "I should look up the weather."),
+        (second_reasoning_id, "The result is in."),
+    ]
+    assert _message_deltas(events, EventType.TEXT_MESSAGE_CONTENT) == [
+        (opener_id, "Let me check. "),
+        (answer_id, "One moment."),
+    ]
+
+    # No synthetic parent is minted: the message the mixed chunk's text opened is the live one
+    tool_start = _first_event(events, EventType.TOOL_CALL_START)
+    assert tool_start.parent_message_id == answer_id
+
+    _check_no_reasoning_inside_text_message(events)
+    _check_no_text_inside_reasoning(events)
+
+
+@pytest.mark.asyncio
+async def test_reasoning_only_chunk_mid_answer_ends_that_assistant_message():
+    """Accepted cost of alternation: a reasoning-only chunk arriving mid-answer ends the open assistant
+    message, and the rest of the answer streams under a new message id.
+
+    This is the same thing the dedicated reasoning-event path has always done, so a client that renders
+    the reasoning-event shape correctly already renders this one.
+    """
+
+    async def mock_stream():
+        opener = RunContentEvent()
+        opener.content = "The answer"
+        yield opener
+
+        interruption = RunContentEvent()
+        interruption.reasoning_content = "Still thinking."
+        yield interruption
+
+        rest = RunContentEvent()
+        rest.content = " is 42."
+        yield rest
+
+        yield RunCompletedEvent()
+
+    events = await _collect(mock_stream())
+    span_events = _span_events(events)
+
+    first_text_id = _span_id_at(span_events, 0)
+    reasoning_id = _span_id_of(span_events, EventType.REASONING_START)
+    second_text_id = _span_id_of(span_events, EventType.TEXT_MESSAGE_START, other_than=first_text_id)
+
+    assert span_events == [
+        (EventType.TEXT_MESSAGE_START, first_text_id),
+        (EventType.TEXT_MESSAGE_CONTENT, first_text_id),
+        (EventType.TEXT_MESSAGE_END, first_text_id),
+        (EventType.REASONING_START, reasoning_id),
+        (EventType.REASONING_MESSAGE_START, reasoning_id),
+        (EventType.REASONING_MESSAGE_CONTENT, reasoning_id),
+        (EventType.REASONING_MESSAGE_END, reasoning_id),
+        (EventType.REASONING_END, reasoning_id),
+        (EventType.TEXT_MESSAGE_START, second_text_id),
+        (EventType.TEXT_MESSAGE_CONTENT, second_text_id),
+        (EventType.TEXT_MESSAGE_END, second_text_id),
+    ]
+
+    assert len({first_text_id, reasoning_id, second_text_id}) == 3
+
+    # The reasoning reaches the client as it arrives, not after the answer has finished
+    assert _message_deltas(events, EventType.TEXT_MESSAGE_CONTENT) == [
+        (first_text_id, "The answer"),
+        (second_text_id, " is 42."),
+    ]
+    assert _deltas(events, EventType.REASONING_MESSAGE_CONTENT) == "Still thinking."
+
+    assert len(events) == len(span_events) + 1
+    assert events[-1].type == EventType.RUN_FINISHED
+
+    _check_no_reasoning_inside_text_message(events)
+    _check_no_text_inside_reasoning(events)
+
+
+@pytest.mark.asyncio
+async def test_reasoning_after_a_content_less_opener_streams_before_the_answer():
+    """The reasoning-capable model shape: an empty opening chunk, native reasoning, then the answer.
+
+    A run's first chunk carries no text yet still opens an assistant message, and every native
+    reasoning delta arrives while that message is open. Reasoning must not wait for the answer to
+    finish: the span opens as soon as the first delta lands, so the client sees thinking live.
+    """
+
+    async def mock_stream():
+        opener = RunContentEvent()
+        opener.content = ""
+        yield opener
+
+        for delta in ("Weighing ", "the ", "options."):
+            reasoning_chunk = RunContentEvent()
+            reasoning_chunk.reasoning_content = delta
+            yield reasoning_chunk
+
+        answer = RunContentEvent()
+        answer.content = "The answer is 42."
+        yield answer
+
+        yield RunCompletedEvent()
+
+    events = await _collect(mock_stream())
+    span_events = _span_events(events)
+
+    opener_id = _span_id_at(span_events, 0)
+    reasoning_id = _span_id_of(span_events, EventType.REASONING_START)
+    answer_id = _span_id_of(span_events, EventType.TEXT_MESSAGE_START, occurrence=1)
+
+    assert span_events == [
+        (EventType.TEXT_MESSAGE_START, opener_id),
+        (EventType.TEXT_MESSAGE_END, opener_id),
+        (EventType.REASONING_START, reasoning_id),
+        (EventType.REASONING_MESSAGE_START, reasoning_id),
+        (EventType.REASONING_MESSAGE_CONTENT, reasoning_id),
+        (EventType.REASONING_MESSAGE_CONTENT, reasoning_id),
+        (EventType.REASONING_MESSAGE_CONTENT, reasoning_id),
+        (EventType.REASONING_MESSAGE_END, reasoning_id),
+        (EventType.REASONING_END, reasoning_id),
+        (EventType.TEXT_MESSAGE_START, answer_id),
+        (EventType.TEXT_MESSAGE_CONTENT, answer_id),
+        (EventType.TEXT_MESSAGE_END, answer_id),
+    ]
+
+    assert len({opener_id, reasoning_id, answer_id}) == 3
+
+    # Each delta reaches the client as its own event, in order, rather than as one lump at the end
+    assert _message_deltas(events, EventType.REASONING_MESSAGE_CONTENT) == [
+        (reasoning_id, "Weighing "),
+        (reasoning_id, "the "),
+        (reasoning_id, "options."),
+    ]
+
+    # The whole reasoning span is over before the answer starts, never emitted after it
+    event_types = [e.type for e in events]
+    assert event_types.index(EventType.REASONING_END) < event_types.index(EventType.TEXT_MESSAGE_CONTENT)
+    assert max(i for i, t in enumerate(event_types) if t == EventType.REASONING_MESSAGE_CONTENT) < event_types.index(
+        EventType.TEXT_MESSAGE_CONTENT
+    )
+
+    assert len(events) == len(span_events) + 1
+    assert events[-1].type == EventType.RUN_FINISHED
+
+    _check_no_reasoning_inside_text_message(events)
+    _check_no_text_inside_reasoning(events)


### PR DESCRIPTION
## Summary

The AG-UI integration for Agno was throwing away the model's thinking. When a
model reasons on its own, the thinking comes back on the same channel as the
answer, and the interface only read the answer. Against a live model that meant
582 characters of reasoning produced and nothing reaching the client.

This PR streams it through. Thinking and answer share one timeline and are not
allowed to overlap, so the two now take turns: whichever one speaks closes the
other. A tool call is not a message and leaves thinking open, apart from the
empty placeholder message a tool call has to invent when there is nothing to hang
itself on. Step numbers count per run instead of per block, so they keep counting
however the blocks fall.

One guard comes with it. Some providers echo the answer back as thinking, so
thinking identical to its own chunk's text is ignored as the answer repeated.
OpenAI's Responses models do this whenever you ask for reasoning without asking
for a summary, and without the guard every token would open its own message.
Separate reasoning models and tool call handling are unchanged.

One thing left for its own pull request: `create_run_output_content_event`
concatenates `reasoning_content` and `redacted_reasoning_content` into one field,
and for Anthropic the redacted half is an opaque blob. Now that reasoning reaches
the client, that blob renders as reasoning text. Separating them needs a change
outside this interface plus a mapping onto `REASONING_ENCRYPTED_VALUE`.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)
