### PR TITLE
fix: detect public MCP access alongside JWT REST auth

### DIFF
--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -2831,15 +2831,22 @@ def _mcp_server_is_open(os: "AgentOS") -> bool:
     which now reports the REST/WS plane only. Otherwise this defers to that shared
     detection: ``AgentOS(authorization=True)``, JWT env vars, a manually installed
     ``JWTMiddleware`` on a ``base_app``, and the security key all count as authenticated.
-    Only the fully-anonymous case (no mcp_auth and REST mode "none") answers requests
-    carrying no bearer token -- the case a rebound web page could drive, so the one that
-    needs default transport security. A service-account verifier alone does NOT close that
-    path (PATs are checked only when presented).
+    A mixed public/JWT deployment also accepts anonymous MCP requests when
+    PublicSurface selects MCP: its route policy bypasses REST authentication for
+    those requests. Both that case and REST mode "none" need default transport
+    security. A service-account verifier alone does NOT close the anonymous path
+    (PATs are checked only when presented).
     """
     from agno.os.auth import get_effective_auth_mode
 
     if getattr(os, "mcp_auth", None) is not None:
         return False
+    # Mirror PublicRoutePolicy's mixed-mode anonymous admission. Merely selecting
+    # public MCP does not bypass a security key or JWT configured without
+    # authorization=True; the parent auth middleware still challenges those.
+    public = getattr(os, "public", None)
+    if bool(getattr(os, "authorization", False)) and public is not None and public.mcp:
+        return True
     return (
         get_effective_auth_mode(
             getattr(os, "settings", None),
@@ -2946,8 +2953,8 @@ def get_mcp_server(
     # Outermost: built-in DNS-rebinding protection (runs first, before auth and tools).
     #
     # A configured ``allowed_hosts`` always applies. On top of that, when the server is OPEN
-    # (no JWT and no security key, so /mcp answers anonymous callers) we default to
-    # localhost-only protection even without ``allowed_hosts`` -- this is the one config a
+    # (including public MCP alongside JWT-protected REST) we default to localhost-only
+    # protection even without ``allowed_hosts`` -- these are the configurations a
     # rebound web page could drive, and it restores the safe default fastmcp's own guard gave
     # before we disabled it. Authenticated deployments rely on the bearer token, which a
     # rebinding attacker cannot supply, so protection there stays opt-in: their real hostname

--- a/libs/agno/tests/integration/os/test_public_authorization.py
+++ b/libs/agno/tests/integration/os/test_public_authorization.py
@@ -516,7 +516,7 @@ def test_custom_workflow_socket_cannot_inherit_the_native_authentication_exempti
 
 
 def test_mcp_serves_only_explicit_tools_for_anonymous_and_admin_callers(runtime):
-    with TestClient(runtime.os.get_app()) as client:
+    with TestClient(runtime.os.get_app(), base_url="http://localhost") as client:
         for credentials in ({}, auth()):
             response = client.post(
                 "/mcp",
@@ -549,3 +549,54 @@ def test_configured_mcp_oauth_still_requires_its_own_authentication(runtime):
         assert response.status_code == 401, response.text
         assert "resource_metadata" in response.headers["www-authenticate"]
         assert client.get("/config", headers=auth()).status_code == 200
+
+
+@pytest.mark.parametrize("hosts,hostname", [(None, "localhost"), (["docs.example.com"], "docs.example.com")])
+def test_public_mcp_card_matches_anonymous_access_and_default_host_guard(runtime, hosts, hostname):
+    # The default host guard is localhost-only even though REST requires JWTs.
+    # An explicit deployment allowlist remains authoritative.
+    from agno.os.mcp import _mcp_server_is_open
+
+    assert _mcp_server_is_open(runtime.os) is True
+    runtime.os.mcp_config.allowed_hosts = hosts
+    with TestClient(runtime.os.get_app(), base_url=f"http://{hostname}") as client:
+        card = client.get("/mcp/server-card")
+        assert card.status_code == 200, card.text
+        assert "headers" not in card.json()["remotes"][0]
+        headers = {"Accept": "application/json, text/event-stream"}
+        payload = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {"name": "public-card-test", "version": "1"},
+            },
+        }
+        response = client.post("/mcp", json=payload, headers=headers)
+        assert response.status_code == 200 and "serverInfo" in response.text, response.text
+        assert client.get("/config").status_code == 401
+        assert client.get("/config", headers=auth()).status_code == 200
+        rejected = client.post("/mcp", json=payload, headers={**headers, "Host": "unlisted.example.com"})
+        # PublicSurface sanitizes the transport's invalid_host error.
+        assert rejected.status_code == 400, rejected.text
+
+
+@pytest.mark.parametrize("authorization,public_mcp", [(False, True), (True, False)])
+def test_public_surface_does_not_hide_required_mcp_auth(runtime, monkeypatch, authorization, public_mcp):
+    from agno.os.mcp import _mcp_server_is_open
+
+    runtime.os.authorization = authorization
+    runtime.surface.mcp = public_mcp
+    # An environment JWT source keeps authentication configured even when
+    # per-route authorization is off.
+    monkeypatch.setenv("JWT_VERIFICATION_KEY", KEY)
+    assert _mcp_server_is_open(runtime.os) is False
+
+
+def test_public_surface_does_not_override_mcp_auth_provider(runtime):
+    from agno.os.mcp import _mcp_server_is_open
+
+    runtime.os.mcp_auth = object()
+    assert _mcp_server_is_open(runtime.os) is False


### PR DESCRIPTION
## Summary

An AgentOS with `authorization=True` and `PublicSurface(mcp=True)` accepts anonymous MCP requests, but its server card currently says a bearer token is required. The same detection also skips default host validation because it mistakes REST authentication for MCP authentication.

Make MCP openness detection follow the existing mixed public/JWT route policy. Public MCP discovery omits the false required-header declaration, and the transport applies its normal localhost-only default when no host allowlist is configured. Explicit host allowlists remain authoritative. MCP OAuth, non-public JWT MCP, and JWT configured without mixed-mode authorization retain their existing authentication requirements. REST authentication and public quotas do not change.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

The corrected default host protection rejects unlisted deployed hosts in mixed public/JWT MCP configurations. Those deployments must set `MCPConfig(allowed_hosts=[...])`, as other anonymous MCP deployments already do.

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

Validation uses an isolated checkout with the existing development environment. Format and full repository validation pass. The MCP server/OAuth/public-configuration and composed public/JWT suites pass (280 tests); after extending the regression to explicit deployment hosts, all five targeted regression cases pass. The new regression fails with the base implementation of `_mcp_server_is_open`.

The composed test verifies the server card, anonymous MCP initialization, protected REST access, denied unlisted hosts, and explicit host allowlists. Existing OAuth and invalid-credential tests remain covered. No model calls or production database access are needed.

Companion docs-server improvements: https://github.com/agno-agi/docs-agent/pull/21. That PR remains compatible with released Agno 3.0.9. This framework correction reaches that deployment after release and dependency adoption.
