### PR TITLE
fix: pretty-print MCP server-card JSON

### DIFF
--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -2104,8 +2104,10 @@ def _register_server_card(
     card_url: Optional[str] = None,
     allowed_hosts: Optional[List[str]] = None,
 ) -> None:
+    import json
+
     from starlette.requests import Request
-    from starlette.responses import JSONResponse, Response
+    from starlette.responses import Response
 
     # The body varies with the request host unless a URL was configured, so a shared cache must
     # key on the headers that shape it -- otherwise one caller's card is served to everyone.
@@ -2113,8 +2115,15 @@ def _register_server_card(
 
     @mcp.custom_route(MCP_SERVER_CARD_PATH, methods=["GET"], include_in_schema=False)
     async def server_card(request: Request) -> Response:
-        return JSONResponse(
-            await _server_card(mcp, os, request, version, card_url, allowed_hosts),
+        # Discovery should be readable directly in a browser without a JSON formatter.
+        return Response(
+            json.dumps(
+                await _server_card(mcp, os, request, version, card_url, allowed_hosts),
+                ensure_ascii=False,
+                allow_nan=False,
+                indent=2,
+            )
+            + "\n",
             media_type=SERVER_CARD_MEDIA_TYPE,
             headers={
                 "Cache-Control": "public, max-age=300",

--- a/libs/agno/tests/unit/os/test_mcp_server.py
+++ b/libs/agno/tests/unit/os/test_mcp_server.py
@@ -1355,7 +1355,9 @@ def test_card_name_is_reverse_dns_and_slugged():
 
 async def test_server_card_describes_the_server_and_its_endpoint(monkeypatch):
     monkeypatch.setattr(mcp_mod, "_mcp_server_is_open", lambda os: True)
-    app = get_mcp_server(_docs_os())
+    os = _docs_os()
+    os.description = "Search the docs — café."
+    app = get_mcp_server(os)
 
     async with _mcp_client(app) as client:
         response = await client.get("/mcp/server-card", headers={"accept": "application/mcp-server-card+json"})
@@ -1364,6 +1366,9 @@ async def test_server_card_describes_the_server_and_its_endpoint(monkeypatch):
     assert response.headers["content-type"].startswith("application/mcp-server-card+json")
     assert response.headers["access-control-allow-origin"] == "*"
     assert response.headers["cache-control"] == "public, max-age=300"
+    assert response.text.startswith('{\n  "$schema": ')
+    assert "Search the docs — café." in response.text
+    assert int(response.headers["content-length"]) == len(response.content)
     card = response.json()
     # The tool entries have their own tests; everything else is pinned exactly.
     assert {key: value for key, value in card.items() if key != "tools"} == {
@@ -1371,7 +1376,7 @@ async def test_server_card_describes_the_server_and_its_endpoint(monkeypatch):
         "name": "com.example/agno-docs",
         "title": "Agno Docs",
         "version": "1.0.0",
-        "description": "Search the docs.",
+        "description": "Search the docs — café.",
         "remotes": [{"type": "streamable-http", "url": "http://example.com/mcp"}],
     }
 


### PR DESCRIPTION
## Summary

The MCP server card currently renders as one long line in a browser. Serialize this discovery response with two-space indentation and a trailing newline so it is readable without enabling a browser's Pretty Print option.

Preserve the JSON data, UTF-8 text, strict JSON encoding, MCP server-card media type, cache policy and CORS headers. The existing endpoint test now checks readable indentation, unescaped Unicode and the correct content length alongside the parsed card and headers.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

Validation uses an isolated checkout with the existing development environment. Full format and validation scripts pass; all 138 MCP server tests pass. No cookbook is needed for a discovery-response formatting change.

Independent of #10083, which corrects public MCP authentication metadata and host protection. This change affects only the server-card HTTP response, not MCP protocol messages or tool results. Deployments receive it after a framework release and dependency update.
