### PR TITLE
[fix] Claude: log retryable overloaded errors at WARNING, not ERROR

### DIFF
--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -727,11 +727,16 @@ class Claude(Model):
             log_warning("Rate limit exceeded")
             raise ModelRateLimitError(message=e.message, model_name=self.name, model_id=self.id) from e
         if isinstance(e, APIStatusError):
-            log_error(f"Claude API error (status {e.status_code})")
             if e.status_code == 529 or "overloaded_error" in str(e):
+                # Retryable: `base.py` already logs every retry attempt at WARNING, so an ERROR
+                # line here mislabels overloads that recover. The HTTP status is not what went
+                # wrong in the in-stream case (it is the stream's status, 200), so name the
+                # error type instead.
+                log_warning(f"Claude API overloaded: {e.message}")
                 raise ModelRateLimitError(
                     message=e.message, status_code=e.status_code, model_name=self.name, model_id=self.id
                 ) from e
+            log_error(f"Claude API error (status {e.status_code})")
             raise ModelProviderError(
                 message=e.message, status_code=e.status_code, model_name=self.name, model_id=self.id
             ) from e

--- a/libs/agno/tests/unit/models/anthropic/test_handle_api_error.py
+++ b/libs/agno/tests/unit/models/anthropic/test_handle_api_error.py
@@ -1,0 +1,69 @@
+"""
+Tests for `Claude._handle_api_error` logging (#9952).
+
+A 529 or an in-stream `overloaded_error` (which surfaces with the stream's HTTP
+status, 200) is retried by `base.py`, which already logs every attempt at WARNING.
+The old code logged ERROR before classifying, so each recovered overload left a
+misleading `Claude API error (status 200)` ERROR line behind — the noisiest line
+in some production logs.
+"""
+
+from typing import List, Tuple
+
+import httpx
+import pytest
+from anthropic import APIStatusError
+
+from agno.exceptions import ModelProviderError, ModelRateLimitError
+from agno.models.anthropic.claude import Claude
+
+
+def _status_error(status_code: int, message: str) -> APIStatusError:
+    """Build an `APIStatusError` the way the Anthropic SDK does, with the given HTTP status."""
+    request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    response = httpx.Response(status_code, request=request, text=message)
+    return APIStatusError(message, response=response, body=None)
+
+
+@pytest.fixture
+def model() -> Claude:
+    return Claude()
+
+
+@pytest.fixture
+def log_calls(monkeypatch) -> List[Tuple[str, str]]:
+    """Record `(level, message)` for every `log_warning`/`log_error` call in the module under test."""
+    calls: List[Tuple[str, str]] = []
+    monkeypatch.setattr("agno.models.anthropic.claude.log_warning", lambda msg, *a, **k: calls.append(("WARNING", msg)))
+    monkeypatch.setattr("agno.models.anthropic.claude.log_error", lambda msg, *a, **k: calls.append(("ERROR", msg)))
+    return calls
+
+
+def test_in_stream_overloaded_error_warns_and_names_the_error(model, log_calls):
+    e = _status_error(200, "overloaded_error: Overloaded")
+
+    with pytest.raises(ModelRateLimitError) as exc_info:
+        model._handle_api_error(e)
+
+    assert exc_info.value.status_code == 200
+    # No ERROR line for a retryable overload, and the message names the error type
+    # instead of the stream's meaningless HTTP status.
+    assert log_calls == [("WARNING", "Claude API overloaded: overloaded_error: Overloaded")]
+
+
+def test_529_overloaded_warns(model, log_calls):
+    e = _status_error(529, "Overloaded")
+
+    with pytest.raises(ModelRateLimitError):
+        model._handle_api_error(e)
+
+    assert log_calls == [("WARNING", "Claude API overloaded: Overloaded")]
+
+
+def test_other_api_status_error_still_logs_error(model, log_calls):
+    e = _status_error(400, "invalid_request_error: max_tokens is required")
+
+    with pytest.raises(ModelProviderError):
+        model._handle_api_error(e)
+
+    assert log_calls == [("ERROR", "Claude API error (status 400)")]


### PR DESCRIPTION
## Description

This PR fixes #9952.

`Claude._handle_api_error` logged every `APIStatusError` at ERROR **before** classifying it. A 529 or an in-stream `overloaded_error` (which surfaces with the stream's HTTP status, 200) is retryable — `base.py` retries it and already logs each attempt at WARNING — so every overload that recovered on retry still left a misleading `Claude API error (status 200)` ERROR line behind. Per the issue, this is the single noisiest line in some production logs, and every occurrence recovered on the retry.

## Changes

- `libs/agno/agno/models/anthropic/claude.py` — in `_handle_api_error`, move logging into the classification branches:
  - retryable branch (529 / in-stream `overloaded_error`): `log_warning(f"Claude API overloaded: {e.message}")` — no ERROR line for errors the model recovers from, and the message names the error type instead of the stream's meaningless HTTP status
  - non-retryable branch: unchanged `log_error(f"Claude API error (status {e.status_code})")`
- `libs/agno/tests/unit/models/anthropic/test_handle_api_error.py` — new unit tests covering the in-stream 200/`overloaded_error` case (WARNING + `ModelRateLimitError`), the 529 case, and a 400 still logging at ERROR and raising `ModelProviderError`.

## Verification

- `pytest libs/agno/tests/unit/models/anthropic/test_handle_api_error.py` → 3 passed
- `pytest libs/agno/tests/unit/models/anthropic/` → 233 passed
- `pytest libs/agno/tests/unit/models/` → 1383 passed, 2 skipped
- `./scripts/format.sh` clean; mypy reports no new errors (the 49 pre-existing errors on `main` in this local environment are unchanged by this PR)

## AI assistance disclosure

This PR was prepared with AI assistance (ZCode). The change was reviewed, tested, and validated end-to-end by the author.
