### PR TITLE
feat: add shared PostgreSQL run cancellation

### DIFF
--- a/cookbook/05_agent_os/27_public_pages/README.md
+++ b/cookbook/05_agent_os/27_public_pages/README.md
@@ -318,3 +318,31 @@ protocol-request quota. Cancellation has an independent quota and does not consu
 run slots. Workflow execution and continuation require verified credentials on both
 transports. Only explicitly selected REST components and explicitly published MCP
 components are reachable; publishing a Team does not publish its member routes.
+
+
+## PostgreSQL cancellation across workers
+
+`postgres_cancellation.py` selects `PostgresRunCancellationManager` over the same
+`PostgresDb` used by AgentOS and its durable queue. Install it with the existing
+`set_cancellation_manager` before constructing AgentOS; call `asetup` in lifespan
+(or `setup` before serving). Every process must use the same namespace and tables.
+This is explicit: existing in-memory and Redis defaults are unchanged. Explicit
+managers are preserved by queue coordination. One manager is selected per process,
+so separate AgentOS applications in one process share that choice.
+
+The two `public.agno_run_cancellation*` tables store intent and Team membership.
+Public cancellation first verifies component, session and run handles. Never expose
+an unrestricted raw manager method to anonymous callers. Foreground runs and durable
+jobs use the same manager; a queue ticket alone cannot cancel a foreground run.
+
+The default 0.5-second poll interval bounds cache staleness, not interruption of
+arbitrary blocking code. Registered runs are refreshed in batches at checkpoints;
+there is no per-token SQL query or background poller. Tune the interval explicitly.
+Keep the default one-day TTL longer than all possible run durations and queue waits.
+Expired records are ignored; writes sweep at most 100 expired rows per table.
+
+Cancellation/registration storage failures raise. Checkpoint and terminal-cleanup
+failures preserve healthy run finalization and log unavailable coordination. Cleanup
+removes local state; failed database cleanup leaves rows to expire. Setup and reads
+use bounded workers and database timeouts, and the supplied engine is never disposed.
+The manager does not add shared event streaming or automatically scale deployment.

--- a/cookbook/05_agent_os/27_public_pages/TEST_LOG.md
+++ b/cookbook/05_agent_os/27_public_pages/TEST_LOG.md
@@ -177,3 +177,19 @@ passed 46 cases, including four new native JWT/submount/query/form regressions.
 The two runs overlap; they are not 221 distinct tests. Full format and validation
 scripts passed. Delivery between separate OS processes is a separate follow-up;
 the existing cross-instance tests only establish shared run ownership.
+
+
+## 2026-09-09 PostgreSQL cancellation
+
+- Nine PostgreSQL integration tests passed against disposable local databases:
+  sync/async early intent, fresh manager/namespace isolation, expiry, membership,
+  checkpoint caching, write/check/cleanup faults, Team cascade, concurrent
+  registration/cancel and two spawned Uvicorn servers.
+- The two-server test cancels after three content chunks through the other server,
+  rejects the wrong session, observes RunCancelled and verifies persisted CANCELLED
+  plus tracking cleanup. Native trailing RunCompleted is retained for UI finalization.
+- 60 PostgreSQL/queue/existing-cancellation tests passed before strengthening the
+  stream timing test; the nine PostgreSQL tests were then rerun (overlapping counts).
+- Six configuration and worker-capacity unit tests passed.
+- Full format and validation scripts passed. The cookbook is validated statically;
+  provider-backed manual use and production widget rollout remain release checks.

--- a/cookbook/05_agent_os/27_public_pages/postgres_cancellation.py
+++ b/cookbook/05_agent_os/27_public_pages/postgres_cancellation.py
@@ -1,0 +1,54 @@
+"""Serve with cancellation shared by workers using the existing PostgreSQL DB.
+
+Set PAGE_DEMO_DB_URL and OPENAI_API_KEY, then run:
+    python postgres_cancellation.py
+The example uses two Uvicorn workers and the public session/run ownership gate.
+"""
+
+from contextlib import asynccontextmanager
+from os import getenv
+
+from agno.agent import Agent
+from agno.db.postgres import PostgresDb
+from agno.job_queue import QueueConfig
+from agno.models.openai import OpenAIResponses
+from agno.os import AgentOS
+from agno.os.public import PublicSurface
+from agno.run.cancel import set_cancellation_manager
+from agno.run.cancellation_management import PostgresRunCancellationManager
+
+db = PostgresDb(
+    db_url=getenv(
+        "PAGE_DEMO_DB_URL",
+        "postgresql+psycopg://ai:ai@localhost:5532/cancellation_demo",
+    )
+)
+cancellation = PostgresRunCancellationManager(db, namespace="cancellation-demo")
+set_cancellation_manager(cancellation)
+
+
+@asynccontextmanager
+async def lifespan(app):
+    await cancellation.asetup()
+    yield
+
+
+agent = Agent(id="writer", model=OpenAIResponses(id="gpt-5.6-luna"), db=db)
+agent_os = AgentOS(
+    id="cancellation-demo",
+    db=db,
+    agents=[agent],
+    public=PublicSurface(agents=[agent]),
+    queue=QueueConfig(durable=True),
+    lifespan=lifespan,
+)
+app = agent_os.get_app()
+
+if __name__ == "__main__":
+    agent_os.serve(
+        "postgres_cancellation:app",
+        host="127.0.0.1",
+        port=8000,
+        workers=2,
+        reload=False,
+    )

--- a/libs/agno/agno/run/cancellation_management/__init__.py
+++ b/libs/agno/agno/run/cancellation_management/__init__.py
@@ -4,12 +4,14 @@ from agno.run.cancellation_management.base import BaseRunCancellationManager
 from agno.run.cancellation_management.in_memory_cancellation_manager import InMemoryRunCancellationManager
 
 if TYPE_CHECKING:
+    from agno.run.cancellation_management.postgres_cancellation_manager import PostgresRunCancellationManager
     from agno.run.cancellation_management.redis_cancellation_manager import RedisRunCancellationManager
 
 __all__ = [
     "BaseRunCancellationManager",
     "InMemoryRunCancellationManager",
     "RedisRunCancellationManager",
+    "PostgresRunCancellationManager",
 ]
 
 
@@ -20,4 +22,8 @@ def __getattr__(name: str) -> Any:
         from agno.run.cancellation_management.redis_cancellation_manager import RedisRunCancellationManager
 
         return RedisRunCancellationManager
+    if name == "PostgresRunCancellationManager":
+        from agno.run.cancellation_management.postgres_cancellation_manager import PostgresRunCancellationManager
+
+        return PostgresRunCancellationManager
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/libs/agno/agno/run/cancellation_management/postgres_cancellation_manager.py
+++ b/libs/agno/agno/run/cancellation_management/postgres_cancellation_manager.py
@@ -1,0 +1,337 @@
+"""PostgreSQL cancellation intent shared by independently running workers."""
+
+from __future__ import annotations
+
+import math
+import re
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Set
+
+from sqlalchemy import text
+
+from agno.db.postgres import PostgresDb
+from agno.exceptions import RunCancelledException
+from agno.run.cancellation_management.base import BaseRunCancellationManager
+from agno.utils.bounded import BoundedWorkers, WorkBudget
+from agno.utils.log import log_warning
+
+_WORKERS = BoundedWorkers(8, "postgres-cancellation")
+
+
+@dataclass
+class _LocalRun:
+    cancelled: bool
+    expires_at: float
+
+
+class PostgresRunCancellationManager(BaseRunCancellationManager):
+    """Opt-in cancellation using an existing synchronous ``PostgresDb``.
+
+    Call ``setup()`` or ``asetup()`` before installing this manager with
+    ``set_cancellation_manager`` in each worker. Use the same namespace on every
+    replica. This also covers foreground runs, which have no queue ticket.
+
+    Checkpoints use a local cache and refresh locally registered runs in batches
+    at most once per ``poll_interval`` (default 0.5 seconds). Remote cancellation
+    is observed at the first checkpoint after that interval and a database read;
+    this does not interrupt an uncooperative blocking tool or provider request.
+    There is no background task to shut down. PostgreSQL remains authoritative.
+
+    Set ``ttl_seconds`` longer than the longest possible run or queue wait.
+    Expired intent is ignored and bounded sweeps run during writes. Registration
+    and cancellation failures raise; read/cleanup failures log and retain known
+    cancellation without failing an otherwise healthy run. Quotas and ownership
+    checks belong at the API boundary, before calling ``cancel_run``.
+
+    The supplied database owns its engine. This manager never disposes it.
+    """
+
+    def __init__(self, db: PostgresDb, *, namespace: str, poll_interval: float = 0.5, ttl_seconds: float = 86400):
+        if not isinstance(db, PostgresDb):
+            raise ValueError("PostgresRunCancellationManager requires PostgresDb")
+        if not isinstance(namespace, str) or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.:-]{0,63}", namespace):
+            raise ValueError("A stable cancellation namespace is required")
+        if any(isinstance(v, bool) or not math.isfinite(v) or v <= 0 for v in (poll_interval, ttl_seconds)):
+            raise ValueError("Cancellation intervals must be finite and positive")
+        self.engine, self.namespace = db.db_engine, namespace
+        self.poll_interval, self.ttl_seconds = poll_interval, ttl_seconds
+        self._lock = threading.Lock()
+        self._local: Dict[str, _LocalRun] = {}
+        self._next_poll = 0.0
+        self._ready = False
+
+    @staticmethod
+    def _timeout(conn: Any, budget: WorkBudget) -> None:
+        conn.execute(
+            text("SELECT set_config('statement_timeout', :ms, true), set_config('lock_timeout', :ms, true)"),
+            {"ms": str(max(1, int(min(2.5, budget.remaining()) * 1000)))},
+        )
+
+    def _setup(self, *, budget: WorkBudget) -> None:
+        with self.engine.begin() as conn:
+            self._timeout(conn, budget)
+            conn.execute(text("SELECT pg_advisory_xact_lock(7148274142894)"))
+            conn.execute(
+                text("""CREATE TABLE IF NOT EXISTS public.agno_run_cancellations (
+                namespace text NOT NULL, run_id text NOT NULL, cancelled boolean NOT NULL,
+                expires_at timestamptz NOT NULL, PRIMARY KEY(namespace, run_id))""")
+            )
+            conn.execute(
+                text("""CREATE INDEX IF NOT EXISTS agno_run_cancellations_expiry
+                ON public.agno_run_cancellations(expires_at)""")
+            )
+            conn.execute(
+                text("""CREATE TABLE IF NOT EXISTS public.agno_run_cancellation_members (
+                namespace text NOT NULL, team_run_id text NOT NULL, member_run_id text NOT NULL,
+                expires_at timestamptz NOT NULL, PRIMARY KEY(namespace, team_run_id, member_run_id))""")
+            )
+            conn.execute(
+                text("""CREATE INDEX IF NOT EXISTS agno_run_cancellation_members_expiry
+                ON public.agno_run_cancellation_members(expires_at)""")
+            )
+        self._ready = True
+
+    def setup(self) -> None:
+        """Create the shared tables under a transaction-scoped setup lock."""
+        _WORKERS.run_sync(self._setup, seconds=3)
+
+    async def asetup(self) -> None:
+        """Create the shared tables without blocking the event loop."""
+        await _WORKERS.run(self._setup, seconds=3)
+
+    def _args(self, run_id: Optional[str] = None) -> dict:
+        if not self._ready:
+            raise ValueError("Call setup() or asetup() before using PostgreSQL cancellation")
+        if run_id is not None and (not isinstance(run_id, str) or not run_id or len(run_id.encode()) > 256):
+            raise ValueError("run_id must contain 1 to 256 UTF-8 bytes")
+        return {"namespace": self.namespace, "run_id": run_id, "ttl": self.ttl_seconds}
+
+    @staticmethod
+    def _sweep(conn: Any) -> None:
+        # Fixed identifiers; each sweep has bounded lock and row work.
+        for table in ("agno_run_cancellations", "agno_run_cancellation_members"):
+            conn.execute(
+                text(f"""WITH stale AS (SELECT ctid FROM public.{table}
+                WHERE expires_at <= now() ORDER BY expires_at LIMIT 100 FOR UPDATE SKIP LOCKED)
+                DELETE FROM public.{table} WHERE ctid IN (SELECT ctid FROM stale)""")
+            )
+
+    def _write(self, run_id: str, cancelled: bool, *, budget: WorkBudget) -> bool:
+        args = self._args(run_id)
+        with self.engine.begin() as conn:
+            self._timeout(conn, budget)
+            conn.execute(
+                text("SELECT pg_advisory_xact_lock(hashtextextended(:key, 0))"), {"key": self.namespace + ":" + run_id}
+            )
+            existed = (
+                conn.execute(
+                    text("""SELECT cancelled FROM public.agno_run_cancellations
+                WHERE namespace=:namespace AND run_id=:run_id AND expires_at>now()"""),
+                    args,
+                ).first()
+                is not None
+            )
+            row = conn.execute(
+                text("""INSERT INTO public.agno_run_cancellations AS r
+                (namespace, run_id, cancelled, expires_at)
+                VALUES (:namespace, :run_id, :cancelled, now()+:ttl*interval '1 second')
+                ON CONFLICT(namespace, run_id) DO UPDATE SET
+                cancelled=CASE WHEN r.expires_at>now() THEN r.cancelled OR EXCLUDED.cancelled ELSE EXCLUDED.cancelled END,
+                expires_at=CASE WHEN r.expires_at>now() AND NOT :cancelled THEN r.expires_at ELSE EXCLUDED.expires_at END
+                RETURNING cancelled, extract(epoch FROM expires_at-now())"""),
+                {**args, "cancelled": cancelled},
+            ).one()
+            self._sweep(conn)
+        with self._lock:
+            now = time.monotonic()
+            self._local = {key: state for key, state in self._local.items() if state.expires_at > now}
+            if not cancelled or run_id in self._local:
+                self._local[run_id] = _LocalRun(bool(row[0]), time.monotonic() + float(row[1]))
+        return existed
+
+    def register_run(self, run_id: str) -> None:
+        _WORKERS.run_sync(self._write, run_id, False, seconds=3)
+
+    async def aregister_run(self, run_id: str) -> None:
+        await _WORKERS.run(self._write, run_id, False, seconds=3)
+
+    def cancel_run(self, run_id: str) -> bool:
+        return _WORKERS.run_sync(self._write, run_id, True, seconds=3)
+
+    async def acancel_run(self, run_id: str) -> bool:
+        return await _WORKERS.run(self._write, run_id, True, seconds=3)
+
+    def _cached(self, run_id: str) -> Optional[bool]:
+        self._args(run_id)
+        with self._lock:
+            state = self._local.get(run_id)
+            if state is not None and state.expires_at > time.monotonic():
+                if state.cancelled or self._next_poll > time.monotonic():
+                    return state.cancelled
+        return None
+
+    def _poll(self, run_id: str, *, budget: WorkBudget) -> bool:
+        args = self._args(run_id)
+        with self._lock:
+            now = time.monotonic()
+            self._local = {key: value for key, value in self._local.items() if value.expires_at > now}
+            if run_id in self._local and now < self._next_poll:
+                return self._local[run_id].cancelled
+            self._next_poll = now + self.poll_interval
+            snapshot = dict(self._local)
+        ids = list(set(snapshot) | {run_id})
+        states = {}
+        try:
+            with self.engine.begin() as conn:
+                self._timeout(conn, budget)
+                for offset in range(0, len(ids), 500):
+                    rows = conn.execute(
+                        text("""SELECT run_id, cancelled FROM public.agno_run_cancellations
+                        WHERE namespace=:namespace AND run_id=ANY(:ids) AND expires_at>now()"""),
+                        {**args, "ids": ids[offset : offset + 500]},
+                    )
+                    states.update({row[0]: row[1] for row in rows})
+            with self._lock:
+                for key, state in snapshot.items():
+                    if self._local.get(key) is state:
+                        state.cancelled = state.cancelled or states.get(key, False)
+                return states.get(run_id, False) or bool(self._local.get(run_id) and self._local[run_id].cancelled)
+        except Exception:
+            return self._read_unavailable(run_id)
+
+    def _read_unavailable(self, run_id: str) -> bool:
+        log_warning("PostgreSQL cancellation read unavailable")
+        with self._lock:
+            return bool(self._local.get(run_id) and self._local[run_id].cancelled)
+
+    def is_cancelled(self, run_id: str) -> bool:
+        cached = self._cached(run_id)
+        if cached is not None:
+            return cached
+        try:
+            return _WORKERS.run_sync(self._poll, run_id, seconds=3)
+        except Exception:
+            return self._read_unavailable(run_id)
+
+    async def ais_cancelled(self, run_id: str) -> bool:
+        cached = self._cached(run_id)
+        if cached is not None:
+            return cached
+        try:
+            return await _WORKERS.run(self._poll, run_id, seconds=3)
+        except Exception:
+            return self._read_unavailable(run_id)
+
+    def raise_if_cancelled(self, run_id: str) -> None:
+        if self.is_cancelled(run_id):
+            raise RunCancelledException(f"Run {run_id} was cancelled")
+
+    async def araise_if_cancelled(self, run_id: str) -> None:
+        if await self.ais_cancelled(run_id):
+            raise RunCancelledException(f"Run {run_id} was cancelled")
+
+    def _cleanup(self, run_id: str, *, members: bool = False, budget: WorkBudget) -> None:
+        args = self._args(run_id)
+        if not members:
+            with self._lock:
+                self._local.pop(run_id, None)
+        try:
+            with self.engine.begin() as conn:
+                self._timeout(conn, budget)
+                query = (
+                    "DELETE FROM public.agno_run_cancellation_members WHERE namespace=:namespace AND team_run_id=:run_id"
+                    if members
+                    else "DELETE FROM public.agno_run_cancellations WHERE namespace=:namespace AND run_id=:run_id"
+                )
+                conn.execute(text(query), args)
+        except Exception:
+            log_warning("PostgreSQL cancellation cleanup unavailable; entries will expire")
+
+    def _forget(self, run_id: str) -> None:
+        self._args(run_id)
+        with self._lock:
+            self._local.pop(run_id, None)
+
+    def cleanup_run(self, run_id: str) -> None:
+        self._forget(run_id)
+        try:
+            _WORKERS.run_sync(self._cleanup, run_id, seconds=3)
+        except Exception:
+            log_warning("PostgreSQL cancellation cleanup unavailable; entries will expire")
+
+    async def acleanup_run(self, run_id: str) -> None:
+        self._forget(run_id)
+        try:
+            await _WORKERS.run(self._cleanup, run_id, seconds=3)
+        except Exception:
+            log_warning("PostgreSQL cancellation cleanup unavailable; entries will expire")
+
+    def _active(self, *, budget: WorkBudget) -> Dict[str, bool]:
+        with self.engine.begin() as conn:
+            self._timeout(conn, budget)
+            return dict(
+                conn.execute(
+                    text("""SELECT run_id, cancelled FROM public.agno_run_cancellations
+                WHERE namespace=:namespace AND expires_at>now()"""),
+                    self._args(),
+                )
+                .tuples()
+                .all()
+            )
+
+    def get_active_runs(self) -> Dict[str, bool]:
+        return _WORKERS.run_sync(self._active, seconds=3)
+
+    async def aget_active_runs(self) -> Dict[str, bool]:
+        return await _WORKERS.run(self._active, seconds=3)
+
+    def _member(self, team_run_id: str, member_run_id: Optional[str] = None, *, budget: WorkBudget) -> Set[str]:
+        args = self._args(team_run_id)
+        with self.engine.begin() as conn:
+            self._timeout(conn, budget)
+            if member_run_id is not None:
+                self._args(member_run_id)
+                conn.execute(
+                    text("""INSERT INTO public.agno_run_cancellation_members
+                    (namespace, team_run_id, member_run_id, expires_at)
+                    VALUES (:namespace, :run_id, :member, now()+:ttl*interval '1 second')
+                    ON CONFLICT(namespace, team_run_id, member_run_id) DO UPDATE SET expires_at=EXCLUDED.expires_at"""),
+                    {**args, "member": member_run_id},
+                )
+                self._sweep(conn)
+                return set()
+            return set(
+                conn.execute(
+                    text("""SELECT member_run_id FROM public.agno_run_cancellation_members
+                WHERE namespace=:namespace AND team_run_id=:run_id AND expires_at>now()"""),
+                    args,
+                ).scalars()
+            )
+
+    def register_member_run(self, team_run_id: str, member_run_id: str) -> None:
+        _WORKERS.run_sync(self._member, team_run_id, member_run_id, seconds=3)
+
+    async def aregister_member_run(self, team_run_id: str, member_run_id: str) -> None:
+        await _WORKERS.run(self._member, team_run_id, member_run_id, seconds=3)
+
+    def get_member_run_ids(self, team_run_id: str) -> Set[str]:
+        return _WORKERS.run_sync(self._member, team_run_id, seconds=3)
+
+    async def aget_member_run_ids(self, team_run_id: str) -> Set[str]:
+        return await _WORKERS.run(self._member, team_run_id, seconds=3)
+
+    def cleanup_member_runs(self, team_run_id: str) -> None:
+        self._args(team_run_id)
+        try:
+            _WORKERS.run_sync(self._cleanup, team_run_id, members=True, seconds=3)
+        except Exception:
+            log_warning("PostgreSQL member cancellation cleanup unavailable; entries will expire")
+
+    async def acleanup_member_runs(self, team_run_id: str) -> None:
+        self._args(team_run_id)
+        try:
+            await _WORKERS.run(self._cleanup, team_run_id, members=True, seconds=3)
+        except Exception:
+            log_warning("PostgreSQL member cancellation cleanup unavailable; entries will expire")

--- a/libs/agno/tests/integration/os/test_postgres_cancellation.py
+++ b/libs/agno/tests/integration/os/test_postgres_cancellation.py
@@ -1,0 +1,290 @@
+"""Database cancellation delivery, including two independently spawned servers."""
+
+import asyncio
+import json
+import multiprocessing
+import os
+import socket
+import time
+from contextlib import contextmanager
+from uuid import uuid4
+
+import httpx
+import pytest
+from sqlalchemy import create_engine, event, text
+from sqlalchemy.engine import make_url
+
+from agno.db.postgres import PostgresDb
+from agno.exceptions import RunCancelledException
+from agno.run.cancellation_management.postgres_cancellation_manager import PostgresRunCancellationManager
+
+pytestmark = pytest.mark.skipif(not os.getenv("AGNO_PAGE_TEST_DB_URL"), reason="requires isolated local PostgreSQL")
+
+
+@pytest.fixture
+def database():
+    url = make_url(os.environ["AGNO_PAGE_TEST_DB_URL"])
+    assert url.host in ("localhost", "127.0.0.1", "::1")
+    admin = create_engine(url, isolation_level="AUTOCOMMIT")
+    name = "cancellation_" + uuid4().hex[:12]
+    with admin.connect() as conn:
+        conn.exec_driver_sql(f'CREATE DATABASE "{name}"')
+    engine = create_engine(url.set(database=name))
+    try:
+        yield PostgresDb(db_engine=engine)
+    finally:
+        engine.dispose()
+        with admin.connect() as conn:
+            conn.exec_driver_sql(f'DROP DATABASE "{name}" WITH (FORCE)')
+        admin.dispose()
+
+
+def manager(db, namespace="test", **kwargs):
+    result = PostgresRunCancellationManager(db, namespace=namespace, poll_interval=0.05, **kwargs)
+    result.setup()
+    return result
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+def test_intent_registration_and_restart(database, asynchronous):
+    first, second = manager(database), manager(database)
+
+    async def check():
+        assert not await first.acancel_run("early")
+        await second.aregister_run("early")
+        with pytest.raises(RunCancelledException):
+            await second.araise_if_cancelled("early")
+        assert await second.aget_active_runs() == {"early": True}
+        await second.acleanup_run("early")
+        assert await first.aget_active_runs() == {}
+
+    if asynchronous:
+        asyncio.run(check())
+    else:
+        assert not first.cancel_run("early")
+        second.register_run("early")
+        with pytest.raises(RunCancelledException):
+            second.raise_if_cancelled("early")
+        assert second.get_active_runs() == {"early": True}
+        second.cleanup_run("early")
+        assert first.get_active_runs() == {}
+    # A fresh manager reads durable intent without inheriting another process's cache.
+    first.cancel_run("restart")
+    assert manager(database).is_cancelled("restart")
+    assert not manager(database, namespace="other").is_cancelled("restart")
+
+
+def test_expiry_and_member_tracking(database):
+    first, second = manager(database), manager(database)
+    first.register_run("old")
+    first.cancel_run("old")
+    first.register_member_run("team", "old")
+    assert second.get_member_run_ids("team") == {"old"}
+    with database.db_engine.begin() as conn:
+        conn.execute(text("UPDATE public.agno_run_cancellations SET expires_at=now()-interval '1 second'"))
+        conn.execute(text("UPDATE public.agno_run_cancellation_members SET expires_at=now()-interval '1 second'"))
+    assert second.get_active_runs() == {}
+    assert second.get_member_run_ids("team") == set()
+    second.register_run("old")
+    assert not second.is_cancelled("old")
+    asyncio.run(second.aregister_member_run("team", "new"))
+    assert asyncio.run(first.aget_member_run_ids("team")) == {"new"}
+    asyncio.run(first.acleanup_member_runs("team"))
+    assert second.get_member_run_ids("team") == set()
+
+
+def test_cached_checkpoints_and_remote_intent(database):
+    first, second = manager(database), manager(database)
+    first.register_run("active")
+    queries = []
+
+    def record(conn, cursor, statement, parameters, context, executemany):
+        if statement.startswith("SELECT run_id, cancelled"):
+            queries.append(statement)
+
+    event.listen(database.db_engine, "before_cursor_execute", record)
+    try:
+        assert not first.is_cancelled("active")
+        for _ in range(1000):
+            assert not first.is_cancelled("active")
+        assert len(queries) == 1
+        assert second.cancel_run("active")
+        time.sleep(0.06)
+        assert asyncio.run(first.ais_cancelled("active"))
+        assert len(queries) == 2
+    finally:
+        event.remove(database.db_engine, "before_cursor_execute", record)
+
+
+def _serve(url, port):
+    import uvicorn
+
+    from agno.agent import Agent
+    from agno.models.base import Model
+    from agno.models.message import MessageMetrics
+    from agno.models.response import ModelResponse
+    from agno.os import AgentOS
+    from agno.os.public import PublicSurface
+    from agno.run.cancel import set_cancellation_manager
+
+    class SlowModel(Model):
+        def __init__(self):
+            super().__init__(id="slow", name="slow", provider="test")
+
+        def invoke(self, *args, **kwargs):
+            return ModelResponse(role="assistant", content="Done", response_usage=MessageMetrics())
+
+        async def ainvoke(self, *args, **kwargs):
+            return self.invoke(*args, **kwargs)
+
+        def invoke_stream(self, *args, **kwargs):
+            for _ in range(200):
+                time.sleep(0.05)
+                yield ModelResponse(role="assistant", content="Still working ", response_usage=MessageMetrics())
+
+        async def ainvoke_stream(self, *args, **kwargs):
+            for _ in range(200):
+                await asyncio.sleep(0.05)
+                yield ModelResponse(role="assistant", content="Still working ", response_usage=MessageMetrics())
+
+        def _parse_provider_response(self, response, **kwargs):
+            return response
+
+        def _parse_provider_response_delta(self, response, **kwargs):
+            return response
+
+    db = PostgresDb(db_url=url)
+    shared = manager(db)
+    set_cancellation_manager(shared)
+    agent = Agent(id="slow", db=db, model=SlowModel(), telemetry=False)
+    server = AgentOS(
+        id="cancel-workers",
+        db=db,
+        agents=[agent],
+        public=PublicSurface(agents=[agent]),
+        telemetry=False,
+        auto_provision_dbs=False,
+    )
+    uvicorn.run(server.get_app(), host="127.0.0.1", port=port, log_level="error")
+
+
+@contextmanager
+def worker(url):
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+    process = multiprocessing.get_context("spawn").Process(target=_serve, args=(url, port))
+    process.start()
+    address = f"http://127.0.0.1:{port}"
+    try:
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:
+            assert process.is_alive(), "server exited during startup"
+            try:
+                if httpx.get(address + "/health", timeout=1).status_code == 200:
+                    break
+            except httpx.TransportError:
+                pass
+            time.sleep(0.1)
+        else:
+            raise AssertionError("server startup timed out")
+        yield address
+    finally:
+        process.terminate()
+        process.join(timeout=5)
+        if process.is_alive():
+            process.kill()
+            process.join(timeout=5)
+
+
+def test_stop_from_another_os_process(database):
+    url = database.db_engine.url.render_as_string(hide_password=False)
+    with worker(url) as first, worker(url) as second, httpx.Client(timeout=15) as client:
+        events = []
+        with client.stream("POST", first + "/agents/slow/runs", data={"message": "start", "stream": "true"}) as stream:
+            assert stream.status_code == 200
+            for line in stream.iter_lines():
+                if not line.startswith("data: "):
+                    continue
+                value = json.loads(line[6:])
+                events.append(value["event"])
+                if value["event"] == "RunStarted":
+                    run_id, session_id = value["run_id"], value["session_id"]
+                if value["event"] == "RunContent" and events.count("RunContent") == 3:
+                    route = second + f"/agents/slow/runs/{run_id}/cancel"
+                    wrong = client.post(route, params={"session_id": str(uuid4())})
+                    assert wrong.status_code == 404
+                    correct = client.post(route, params={"session_id": session_id})
+                    assert correct.status_code == 200, correct.text
+                    cancelled_at = time.monotonic()
+        assert events.count("RunCancelled") == 1, events
+        assert events.index("RunCancelled") < events.index("RunCompleted")
+        # Agno emits a completion marker after cancellation to close frontend streams.
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline:
+            session = database.get_session(session_id=session_id, session_type="agent")
+            if session and session.runs:
+                break
+            time.sleep(0.01)
+        assert session and session.runs[-1].status == "CANCELLED"
+        assert time.monotonic() - cancelled_at < 3
+        assert manager(database).get_active_runs() == {}
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+def test_cleanup_and_check_failures_preserve_run_outcome(database, monkeypatch, asynchronous):
+    shared = manager(database)
+    shared.register_run("healthy")
+
+    def unavailable(*args, **kwargs):
+        raise RuntimeError("storage unavailable")
+
+    monkeypatch.setattr(shared.engine, "begin", unavailable)
+    if asynchronous:
+        assert not asyncio.run(shared.ais_cancelled("healthy"))
+        asyncio.run(shared.acleanup_run("healthy"))
+        asyncio.run(shared.acleanup_member_runs("team"))
+        with pytest.raises(RuntimeError):
+            asyncio.run(shared.acancel_run("healthy"))
+    else:
+        assert not shared.is_cancelled("healthy")
+        shared.cleanup_run("healthy")
+        shared.cleanup_member_runs("team")
+        with pytest.raises(RuntimeError):
+            shared.cancel_run("healthy")
+    assert shared._local == {}
+
+
+def test_team_cascade_uses_shared_members(database, monkeypatch):
+    import agno.run.cancel as cancellation
+    from agno.team import Team
+
+    first, second = manager(database), manager(database)
+    first.register_run("team")
+    first.register_run("member")
+    first.register_member_run("team", "member")
+    monkeypatch.setattr(cancellation, "_cancellation_manager", second)
+    assert asyncio.run(Team.acancel_run("team"))
+    assert first.is_cancelled("team")
+    assert first.is_cancelled("member")
+
+
+def test_registration_and_cancellation_are_atomic(database):
+    from concurrent.futures import ThreadPoolExecutor
+
+    first, second = manager(database), manager(database)
+    barrier = __import__("threading").Barrier(2)
+
+    def register():
+        barrier.wait()
+        first.register_run("race")
+
+    def cancel():
+        barrier.wait()
+        second.cancel_run("race")
+
+    with ThreadPoolExecutor(2) as pool:
+        futures = [pool.submit(register), pool.submit(cancel)]
+        for future in futures:
+            future.result(timeout=5)
+    assert manager(database).is_cancelled("race")

--- a/libs/agno/tests/unit/run/test_postgres_cancellation_config.py
+++ b/libs/agno/tests/unit/run/test_postgres_cancellation_config.py
@@ -1,0 +1,47 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agno.db.postgres import PostgresDb
+from agno.run.cancellation_management import PostgresRunCancellationManager
+
+
+@pytest.mark.parametrize(
+    "option,value", [("poll_interval", 0), ("ttl_seconds", -1), ("ttl_seconds", float("inf")), ("poll_interval", True)]
+)
+def test_invalid_intervals(option, value):
+    db = PostgresDb(db_url="postgresql+psycopg://unused:unused@127.0.0.1:1/unused")
+    with pytest.raises(ValueError):
+        PostgresRunCancellationManager(db, namespace="test", **{option: value})
+
+
+def test_setup_is_explicit():
+    db = PostgresDb(db_url="postgresql+psycopg://unused:unused@127.0.0.1:1/unused")
+    with patch.object(db.db_engine, "begin") as connect:
+        manager = PostgresRunCancellationManager(db, namespace="test")
+        with pytest.raises(ValueError, match="setup"):
+            manager.is_cancelled("run")
+        connect.assert_not_called()
+
+
+async def test_worker_exhaustion_does_not_fail_terminal_cleanup():
+    db = PostgresDb(db_url="postgresql+psycopg://unused:unused@127.0.0.1:1/unused")
+    manager = PostgresRunCancellationManager(db, namespace="test")
+    manager._ready = True
+    with (
+        patch(
+            "agno.run.cancellation_management.postgres_cancellation_manager._WORKERS.run_sync", side_effect=TimeoutError
+        ),
+        patch(
+            "agno.run.cancellation_management.postgres_cancellation_manager._WORKERS.run",
+            new=AsyncMock(side_effect=TimeoutError),
+        ),
+    ):
+        assert not manager.is_cancelled("run")
+        assert not await manager.ais_cancelled("run")
+        manager.cleanup_run("run")
+        await manager.acleanup_run("run")
+        manager.cleanup_member_runs("team")
+        await manager.acleanup_member_runs("team")
+        with pytest.raises(TimeoutError):
+            manager.cancel_run("run")


### PR DESCRIPTION
## Summary

A valid Stop request can reach a different worker from the foreground chat run. Public run ownership records alone cannot deliver cancellation, and queue tickets do not cover foreground runs.

Add explicitly selected `PostgresRunCancellationManager(db, namespace=...)` through the existing `set_cancellation_manager` API. Every worker shares intent and Team membership in PostgreSQL. A bounded batch refresh at checkpoints avoids a SQL read per streamed token; the default cache interval is 0.5 seconds. Existing in-memory, Redis and explicit manager selection are unchanged.

This lets database-backed documentation templates support Stop across replicas using their existing PostgreSQL service. Includes public-API cookbook and lifecycle/expiry/failure documentation. It does not add shared event streaming or interrupt uncooperative blocking code.

**Stacked on #10064** for public ownership and native query cancellation. Retarget to main after that PR merges.

## Validation

- Nine disposable PostgreSQL integration tests passed, including two actual OS/server processes: stream three chunks on A; reject wrong session on B; cancel through B; observe RunCancelled on A; verify persisted CANCELLED and cleanup.
- Native trailing RunCompleted is intentionally preserved for frontend finalization.
- 60 integration/queue/existing cancellation checks passed before strengthening the stream test, followed by the nine PostgreSQL tests again (overlapping counts).
- Six configuration/worker-capacity unit tests passed.
- Full `scripts/format.sh` and `scripts/validate.sh` passed.
- Cookbook, README and TEST_LOG updated. No production rollout; actual widget verification follows release/adoption.

## Type of change

- [x] New feature
- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts
- [x] Self-review completed
- [x] Documentation and public-API cookbook updated
- [x] Tests added/updated
- [x] Related PRs checked: #10016 is in-process locking; #10064 is ownership, not delivery
- [x] AI-assisted implementation
- [ ] Hosted CI complete
