### PR TITLE
feat: attribute team subagent work over AG-UI

### DIFF
--- a/cookbook/05_agent_os/16_agui/README.md
+++ b/cookbook/05_agent_os/16_agui/README.md
@@ -22,6 +22,7 @@ default empty prefix those routes are `POST /agui` and `GET /status`.
 | `shared_state.py` | Send state snapshots and JSON Patch deltas as session state changes. |
 | `human_in_the_loop.py` | Pause and resume a real backend tool that uses `requires_confirmation`. |
 | `research_team.py` | Stream a coordinated Team and its member activity over AG-UI. |
+| `team_subagent_lineage.py` | Serve one Team twice, attributing each message and tool call to the member that produced it and streaming the same run without attribution. |
 | `multiple_instances.py` | Mount two independent AG-UI interfaces on one AgentOS. |
 | `openui/` | Render an Agent as streaming charts, follow-ups, and validated forms with OpenUI. |
 
@@ -35,7 +36,19 @@ export OPENAI_API_KEY=...
 export GOOGLE_API_KEY=...  # agent_with_media.py only
 ```
 
-`research_team.py` also needs internet access for `WebSearchTools`.
+`research_team.py` and `team_subagent_lineage.py` also need internet access for
+`WebSearchTools`.
+
+`team_subagent_lineage.py` asks for `subagent_visibility="attributed"`, which
+needs the AG-UI subagent lineage events from `ag-ui-protocol` 0.1.21 or newer.
+The `agui` extra allows older releases, so upgrade the demo environment if it
+resolved one; otherwise the interface refuses the setting at startup.
+`demo_setup.sh` builds that environment with `uv venv`, which seeds no `pip`, so
+upgrade it the same way the setup script installs into it:
+
+```bash
+VIRTUAL_ENV=.venvs/demo uv pip install -U 'ag-ui-protocol>=0.1.21'
+```
 
 ## Run
 
@@ -50,6 +63,7 @@ Start one example at a time; every standalone server uses port 7777:
 .venvs/demo/bin/python cookbook/05_agent_os/16_agui/shared_state.py
 .venvs/demo/bin/python cookbook/05_agent_os/16_agui/human_in_the_loop.py
 .venvs/demo/bin/python cookbook/05_agent_os/16_agui/research_team.py
+.venvs/demo/bin/python cookbook/05_agent_os/16_agui/team_subagent_lineage.py
 .venvs/demo/bin/python cookbook/05_agent_os/16_agui/multiple_instances.py
 ```
 
@@ -70,6 +84,7 @@ endpoint:
 | `shared_state.py` | `http://localhost:7777/shared-state/agui` | `http://localhost:7777/shared-state/status` |
 | `human_in_the_loop.py` | `http://localhost:7777/human-in-the-loop/agui` | `http://localhost:7777/human-in-the-loop/status` |
 | `research_team.py` | `http://localhost:7777/research-team/agui` | `http://localhost:7777/research-team/status` |
+| `team_subagent_lineage.py` | `http://localhost:7777/lineage/agui` and `http://localhost:7777/lineage-inline/agui` | `/lineage/status` and `/lineage-inline/status` |
 | `multiple_instances.py` | `http://localhost:7777/chat/agui` and `http://localhost:7777/analyst/agui` | `/chat/status` and `/analyst/status` |
 | `openui/server.py` | `http://localhost:7777/agui` | `http://localhost:7777/status` |
 
@@ -138,6 +153,170 @@ returns its tool-call ID; after the browser performs the change, it sends a
 trailing tool message with that ID to resume the persisted run. By contrast,
 the email function in `human_in_the_loop.py` is present and executable on the
 server, but cannot run until its confirmation requirement is resolved.
+
+## Team member attribution
+
+A Team run mixes the leader's own output with the output of every member it
+delegated to. `AGUI(..., subagent_visibility=...)` decides how much of that
+distinction the client sees. The setting concerns delegated runs, and a Team's
+members are where they usually come from. A single Agent usually has none, but
+a context provider that runs an inner agent inside the outer run is one: that
+inner run reports the outer run as its parent, so under `"attributed"` it
+becomes a lane of its own, and under `"hidden"` its own output is withheld the
+way a member's is.
+
+| Value | What the client receives |
+|---|---|
+| `"inline"` (default) | Member work streams as the team's own, exactly as it did before this option existed. No lineage events, no lineage fields. A paused run's own three pending-call lists are read whichever entity reported the pause, an Agent's as much as a Team's. What the default reads on a Team's pause only is the other place a pending call arrives, the run's active requirements, which is how a delegated run and an inner agent report one; so a pause reported by a single Agent whose pending call arrives only that way reaches the client as a plain finished run with nothing to confirm. The other two settings read the requirements on both pause shapes and prompt that call. |
+| `"attributed"` | The full member surface: `SUBAGENT_STARTED`, `SUBAGENT_FINISHED` and `SUBAGENT_ERROR` per delegation, plus a `subagentRunId` on the events that carry a member's own output: its text messages, its tool calls and their results, its reasoning, and any custom or otherwise unrecognized event it emitted. |
+| `"hidden"` | The member surface is withheld: no `SUBAGENT_*` event, no `subagentRunId`, and nothing a member streamed. What the client receives is the leader's own work, its delegation tool call included, and that call's arguments name the member and carry the task text it was given, exactly as the default sends them, followed by the call's result and the leader's own reply. Two things a member caused also reach the client, neither attributed to it: a session-state change one of the member's tools made, because that state is one shared document, and the pending tool call of a member that paused, because the client has to render it to answer, parented to an unattributed assistant message. What that member said while pausing does not reach the client: a prompt is not licence to send a member's words as the run's own reply. A member's failure withholds that same identity: no `SUBAGENT_ERROR`, no stamp, and nothing on it names the member that failed, while the reason the run stopped still reaches the client, because a member's terminal can be the only account the stream carries of how the run ended and is then read as the run's own. The prompt is de-duplicated here, as it is under `"attributed"`, in one case only: a pending call reported both on the paused run's own lists and in a member's requirement is prompted once, carrying the member's attribution. A call the paused run's own lists report twice, by carrying it on two of them at once, is prompted once per listing under every setting, duplicate tool call id and all, because that is the default's stream and the default stream is what it was before this option existed. Under `"attributed"` one more call is left out, a member's own that the client already has a start for; the top-level entity's own pending call is prompted under every setting, so a run with no member on the wire streams what the default streams. |
+
+`"inline"` is the default because a client already in production cannot be
+protected after the fact from event types its transport rejects. Opting in is a
+deliberate choice by whoever owns the frontend.
+
+Under `"attributed"`, Agno's own run identity is what lineage is built from.
+Every streamed chunk reports the run it came from and, for a member, the run
+that delegated to it, which maps onto AG-UI as follows:
+
+| AG-UI field | Agno source |
+|---|---|
+| `subagentRunId` | The member run's own run ID. Agno mints one per delegation, so a member invoked twice occupies two lanes. |
+| `SUBAGENT_STARTED.name` | The member's name, or its ID when the chunk carries no name, or the member run ID itself when it carries neither. Each of those is read defensively: a value whose own text cannot be rendered is treated as absent and the next one is tried, so a member with an unreadable name is announced under its run ID instead of ending the run. |
+| `SUBAGENT_STARTED.description` | The `task` the delegation call in the `parentToolCallId` row carried, identified by exactly the rule that row states and so absent whenever that call is. Absent too when the call carried no task text: the tasks-mode delegation tools, `execute_task` and `execute_tasks_parallel`, take a task id instead, so a member a task list delegated to has no description rather than an invented one. |
+| `SUBAGENT_STARTED.parentSubagentRunId` | The delegating member's run ID for a nested Team. Absent means that no member is named as the parent, so the client places the lane directly under the run itself, and that is the one thing absence means here. It is what a delegation by the top-level team reports; it is also what a member gets when nothing identifies a deeper parent, which includes a member whose first appearance is a pause that no single delegation call can be matched to. It is absent as well when the delegating lane's own terminal has already gone out, because a child must not resolve inside a lane the client has closed, and when this stream has not announced that parent yet: a grandchild's first event can outrun its parent's, and a link to a lane the client has not been given is one it cannot resolve. |
+| `SUBAGENT_STARTED.parentToolCallId` | The delegation call the member was spawned inside, when exactly one call identifies it. A call qualifies when it is still open, its tool is one the framework delegates through, and its `member_id` argument names this member. Which calls are searched depends on where the member first appears. For a member that streams, only the delegating lane's own open calls are searched, and exactly one of them has to name the member. For a member whose first appearance is a pause, the open calls of every lane are searched instead, and the one match has to be unique across all of them: two lanes each delegating to the same member therefore yield a link, and a description with it, when that member streams, and neither when it pauses. A lane the announcement cannot name is searched in neither case, and then no link, no parent message and no description is reported at all: that covers a lane whose own terminal has already gone out, and a lane this stream has not announced yet. Falling back to the top-level entity's open calls would hand a grandchild the leader's call, the leader's parent message and the leader's task text as its own description. Absent otherwise: when no open delegation names this member, when more than one does, and when the delegation names no member at all. The broadcast tools, `delegate_task_to_members` and `execute_tasks_parallel`, are that last case, so a member one of them spawned carries no link rather than whichever of the leader's own calls happened to be open. |
+| `SUBAGENT_STARTED.parentMessageId` | The assistant message that delegation tool call was parented to. Absent whenever the delegation call is, since the message is read off that call, and absent when that call carried no parent message of its own. |
+| `SUBAGENT_FINISHED.result` | The member run's final content, serialized when it is not already text, and absent when the run reported no content at all. A value that neither serialization nor a plain text conversion can render becomes a short note naming its type, so a member that produced something unrenderable still finishes rather than failing the run. |
+| `SUBAGENT_ERROR.message` | The member run's error, or the reason it was cancelled, or the interface's own wording when the run reported neither, or reported one whose text cannot be rendered. A cancelled member terminates as an error too, because it produced no result to report, and a lane that errored is never also reported as finished. |
+| `SUBAGENT_ERROR.code` | The `error_type` the member run's failure carried, or `"cancelled"` when the member was cancelled rather than failing. Absent when the failure named no type, so a client should treat a missing code as an unclassified failure rather than a successful lane. |
+
+Those last three rows describe a member that reaches its own terminal event.
+That terminal is emitted for that member alone: it ends the member's own text
+and reasoning spans, so it never lands inside a message, and it ends nothing
+else. A member still open when the whole run ends is terminated by the run
+instead, deepest lane first. Those two are the only places a member's terminal
+comes from. If the run failed, every lane still open is closed with a
+`SUBAGENT_ERROR` whose message is the run's error, not the member's, so that
+message says why the run stopped rather than what that member did, and which
+carries no `code`, because the run's failure is not a diagnosis of that member.
+Where the stream itself died rather than the run reporting a failure of its own,
+that message is the text of whatever raised, or the name of its type when it
+raised without any text, so the lane never errors for no stated reason. If the
+run completed or paused, every lane still open is closed with a
+`SUBAGENT_FINISHED` that carries no `result`.
+
+A member's terminal can also become the run's own. When a member's failure or
+cancellation is the last thing the stream carries, the top-level entity reported
+no terminal of its own, so that member's is read as the run's: the run ends with
+a `RUN_ERROR` carrying the member's error text, or the reason it was cancelled
+under the code `"cancelled"`, rather than with a completion that would report a
+run stopped part-way as a success. Which member terminal that is, is simply the
+last one the stream carried: nothing ranks a failure above a later completion,
+so a member that fails and is then followed by another member completing ends
+the run as a completion, and a member that pauses followed by another member
+completing loses the pending call it was waiting on. Both hold under every
+setting, the default included. A failure ends the run that way under every
+setting. A cancellation does so only under `"attributed"` and `"hidden"`, which
+are the settings that recognise a member's terminal as a member's: cancellation
+is not one of the events that end a run in its own right, so under the default,
+where every chunk is the run's own, the same chunk streams as an unrecognized
+event and the run still finishes.
+
+A `RUN_ERROR` built from a reported failure also carries the failing Agno event
+verbatim in its `rawEvent` field, and which failures come with one depends on
+the setting. The top-level entity's own failure supplies it under all three. A
+member's does not under `"attributed"` or `"hidden"`: that chunk names the
+member, its run, and the run that delegated to it, which is the identity those
+two settings exist to attribute or to withhold, so the terminal goes out without
+it. Only the default embeds it, whose stream is what it was before this option
+existed. A run whose stream died rather than reporting a failure has no such
+chunk at all, so its terminal carries only the text of whatever raised.
+
+A member paused awaiting outside input is one of those lanes: pausing is not
+finishing, so the member's lane stays open, the confirmation tool calls the
+client must render are emitted inside it, and the run-end drain closes it
+afterwards. A tool call belongs to the message that carries it, so the two
+always name the same member: a member's pending calls are parented to an
+assistant message carrying that member's `subagentRunId`, and the leader's own
+to an unattributed one. One pause can be waiting on several members at once,
+and one message cannot name two, so the prompt is one message per member rather
+than one message with everybody's calls under it. Where the pause was reported
+by a member rather than by the leader, whatever that member said while pausing
+goes out on that member's own message too, and under `"hidden"`, which will not
+name the lane, it does not go out at all.
+
+No outcome is attached to that terminal. The protocol pairs a suspended member
+with a run-level interrupt outcome, which this interface does not emit, and
+sending only the member half would tell a client the member is waiting while
+the run reports plain completion.
+
+These are the events that carry a `subagentRunId`:
+
+```text
+TEXT_MESSAGE_START TEXT_MESSAGE_CONTENT TEXT_MESSAGE_END
+TOOL_CALL_START TOOL_CALL_ARGS TOOL_CALL_END TOOL_CALL_RESULT
+REASONING_START REASONING_MESSAGE_START REASONING_MESSAGE_CONTENT
+REASONING_MESSAGE_END REASONING_END
+CUSTOM RAW
+```
+
+Three kinds of event carry none. The `SUBAGENT_*` events name their member in a
+dedicated field instead. The `RUN_*` lifecycle events belong to the run as a
+whole. And `STATE_SNAPSHOT` and `STATE_DELTA` are left unattributed
+deliberately: a team's session state is one shared document, so a client
+filtering by member must not lose state written during a delegation.
+
+Message, reasoning, and tool-parent state is tracked per member, so a member's
+text never lands in the leader's bubble and two members streaming at once keep
+independent spans. Independent spans are interleaved spans: while two of them
+are open the wire carries both members' content events mixed together rather
+than one whole message and then the next, so a client has to route each event by
+the message it names rather than by arrival order. A member's terminal event is
+emitted once and is final for the id it names, but it is not a fence. Two things
+put events carrying a member after that member's terminal. One is output the
+source stream itself produces from a run that has already ended: it stays
+attributed to that member rather than being reparented, because giving one
+invocation a second lifecycle would be worse than a late event. The other is
+this interface's own run-end close, which writes the end of a tool call the
+member left open, since a member's terminal ends no tool call: only that call's
+own completion carries its result and whatever it wrote to the session state.
+Either way a client should keep resolving a member's id after its terminal.
+
+Ordering promises nesting as far as the runs themselves nest: a nested member's
+terminal precedes its parent's. A parent run that reports its own completion
+while a member it delegated to is still streaming is the exception, because each
+terminal goes out when its own run reports one and the member below it is left
+to the run end, so that child resolves after its parent. Agno delegates
+synchronously, so a run does not normally report the two in that order.
+
+The run end closes what is open before it emits anything of its own. Once the
+stream has announced a member lane, it does that in two passes: every reasoning
+span and text message still open, children before parents; then every tool call
+still open, children before parents; then the pause prompt, if the run paused;
+then a terminal for every member lane the run left open. A stream that announced
+no member lane has nothing to order across lanes and closes the single lane it
+has in one pass instead: its reasoning span, then its tool calls, then its text
+message, and then the pause prompt. That is every `"inline"` and `"hidden"` run,
+and an `"attributed"` run that never delegated. The difference is visible when a
+run ends with both a message and a tool call open: `TOOL_CALL_END` precedes
+`TEXT_MESSAGE_END` with no member on the wire, and follows it once there is one.
+
+Either way, nothing the run end emits is nested inside a span, and the pause
+prompt in particular opens its message and its tool calls with the delegation
+that spawned them already closed. A member whose first appearance is that pause
+is announced at the head of the prompt, since a client cannot resolve a call
+stamped with a lane it has not been told about. The prompt still precedes the
+member terminals, because its calls carry the `subagentRunId` of the members it
+is prompting for and nothing may carry a member after that member's terminal.
+During the run itself a member's announcement and its own events do sit inside
+the still open delegation call: that call is what
+`SUBAGENT_STARTED.parentToolCallId` names.
+
+Lineage needs the AG-UI subagent events, which arrived in `ag-ui-protocol`
+0.1.21. Asking for `"attributed"` on an older release fails at startup rather
+than silently dropping attribution; `"inline"` and `"hidden"` work on any
+supported release.
 
 ## State and media
 

--- a/cookbook/05_agent_os/16_agui/TEST_LOG.md
+++ b/cookbook/05_agent_os/16_agui/TEST_LOG.md
@@ -6,6 +6,19 @@ Tested on 2026-07-24 against Agno source commit
 The OpenUI addition was tested on 2026-08-18 against Agno source commit
 `32e5fb9c2203fa98de19ca72750133a57a075899`.
 
+The Team member attribution addition was tested on the attribution branch
+itself, across two dates that cover different things. The server boot sweep and
+the resolved-visibility checks for `team_subagent_lineage.py` were measured on
+2026-09-04. The unit suites named in that entry were re-run on 2026-09-08,
+after the review rounds that added
+`libs/agno/tests/unit/os/interfaces/test_agui_stream_invariants.py` and changed
+what a member's own terminal event closes; that later date is the one the suite
+results here describe. The branch is based on Agno source commit
+`d1a388446e1b44b20498c772e91303588e2734cf`, which is the base it was written
+against and does not contain the work: the results below were measured on the
+branch, not on that tree. The branch squashes into one commit whose id does not
+exist yet, so the base is the only commit this log can name.
+
 Each checked-in server was first booted on its default port 7777. The sweep
 asserted `GET /health`, `GET /config`, every mounted AG-UI status route, and a
 clean shutdown. Capability-specific POST tests then used
@@ -148,6 +161,74 @@ and a final two-fact brief before `RUN_FINISHED`.
 
 ---
 
+### team_subagent_lineage.py
+
+**Status:** PASS
+
+**Test mode:** AUTOMATED
+
+**Description:** Added on 2026-09-04. Booted the two-interface server, checked
+`/health`, `/config`, and both status routes, and asserted the visibility each
+mounted interface resolved to. No live model turn ran, because this environment
+has no provider key; the streamed payloads this file demonstrates are covered
+by the AG-UI attribution modules under
+`libs/agno/tests/unit/os/interfaces/` instead:
+`libs/agno/tests/unit/os/interfaces/test_agui_subagent_lineage.py` for the
+attribution surface,
+`libs/agno/tests/unit/os/interfaces/test_agui_stream_failure.py` for the
+failure path, where a source stream that raises mid-run still has to close
+every span and member lane it opened,
+`libs/agno/tests/unit/os/interfaces/test_agui_hostile_run_content.py` for run
+content no serializer handles cleanly, driven through every boundary that
+builds an AG-UI event out of run content,
+`libs/agno/tests/unit/os/interfaces/test_agui_documented_contract.py`, which
+reads the enumerable claims out of this folder's README and this log and
+compares them with the interface's own constants, and
+`libs/agno/tests/unit/os/interfaces/test_agui_stream_invariants.py`, which
+feeds the shared definition of a well-formed stream a stream that breaks each
+invariant in turn and asserts it is reported.
+
+The definition those suites share lives beside them in
+`libs/agno/tests/unit/os/interfaces/agui_stream_invariants.py`. It carries no
+tests of its own and pytest collects nothing from it; the collectors in the
+suites above run it on every stream they gather, and the module named just
+above is what proves each of its invariants bites.
+
+**Result:** Health returned `ok`; config returned OS `agui-lineage-os` with
+AG-UI routes `/lineage` and `/lineage-inline`. Both status routes returned
+`available`. The `/lineage` interface resolved to `attributed` and
+`/lineage-inline` to the default `inline`. Every suite named above passed,
+under `pytest libs/agno/tests/unit/os/interfaces -k agui`, which also runs the
+AG-UI suites that predate attribution. That selector is written instead of a
+list of paths on purpose: it names no count and picks the suites up by name, so
+it stays correct as suites are added to the folder or removed from it.
+Per-suite test counts are deliberately not recorded here either. Tests keep
+being added to these suites, so a count written down goes stale while the pass
+stays true; run the command above for the current tally.
+Wherever a scripted offline model can drive the behavior the assertions run
+against a real `Team.run` and `Team.arun` stream: per-member messages and tool
+calls, the delegation link, one terminal per member carrying its result, two
+members whose runs report identical content staying two lanes, the same member
+delegated twice taking a lane and a run id per delegation, the nested-team
+parent chain, parallel delegation, a member whose own run fails, the unchanged
+inline stream, and a single Agent with no inner run, whose stream the setting
+leaves unchanged, pauses included: a pending call one paused Agent reports
+twice, by carrying it on two of its lists at once, is prompted once per
+listing under all three settings, duplicate tool call id and all, because
+that is what the default sends. A team member that pauses is driven from a
+real run too: a member whose tool needs a confirmation pauses under a scripted
+model, and its announcement and the pending call prompted on its own lane are
+asserted against that stream. Reasoning inside a member, output trailing a
+member's terminal, a lane whose parent lane terminated before it and a run that
+fails with member lanes still open are not reachable from a scripted model, and
+neither are the pause shapes a single run cannot produce: a leader and a member
+paused at once, a pause naming a member whose lane already terminated, a paused
+grandchild, and a pause reported only through requirements. Those cases
+hand-build the chunk sequence from the same `run_id`, `parent_run_id`, and
+member-identity fields the framework stamps on a member's chunks.
+
+---
+
 ### multiple_instances.py
 
 **Status:** PASS
@@ -190,11 +271,20 @@ TypeScript compilation, and the Vite production build passed.
 
 ## Validation
 
-- All 9 standalone files booted, exposed their expected `/status` route, and
-  shut down cleanly.
-- All 9 files completed a real capability-specific AG-UI POST flow.
-- Recursive pattern validation checked exactly 9 Python files with 0
-  violations.
+- All 11 server files booted, exposed their expected `/status` route, and
+  shut down cleanly. The count is every Python file under this folder: the 10
+  in its root plus `openui/server.py`, which is the backend half of the nested
+  OpenUI example rather than a standalone one. `multiple_instances.py` and
+  `team_subagent_lineage.py` each mount two interfaces and exposed both of
+  their `/status` routes.
+- 10 of the 11 files completed a real capability-specific AG-UI POST flow.
+  `team_subagent_lineage.py` was verified without a provider key, so its POST
+  flow is covered by the unit suites instead.
+- Recursive pattern validation checked exactly 11 Python files, the same root 10
+  plus `openui/server.py`, with 0 violations, from
+  `python cookbook/scripts/check_cookbook_pattern.py --base-dir cookbook/05_agent_os/16_agui --recursive`.
+  Without `--recursive` that command sees 10 files, so the flag is what makes
+  the two counts above comparable.
 - Targeted Ruff format and check passed.
 - Python compilation, banned-model, stale-route, scope, Unicode/emoji,
   non-PASS status, and `git diff --check` gates passed.
@@ -203,6 +293,18 @@ TypeScript compilation, and the Vite production build passed.
 - The OpenUI server passed Python compilation, import, Ruff format, and Ruff
   check. Its frontend passed five tests, TypeScript compilation, and a
   production build.
-- Repository-wide Ruff, agnoctl mypy, and cookbook pattern checks passed. The
-  core Agno mypy step reported 27 existing errors in six files outside this
-  integration's diff.
+- Repository-wide Ruff, agnoctl mypy, and cookbook pattern checks passed. On
+  2026-07-24 the core Agno mypy step reported 27 existing errors in six files
+  outside this integration's diff; re-run on 2026-09-08 by `./scripts/validate.sh`
+  it reported none, across 1033 Agno source files and 21 agnoctl ones.
+- Re-measured on 2026-09-08 against the current tree: `./scripts/validate.sh`
+  passed every step it runs, the recursive pattern check saw 11 files and the
+  non-recursive one 10 with 0 violations either way, Ruff format and check
+  passed on this folder's 11 files, `python -m compileall` and
+  `git diff --check` passed, and
+  `pytest libs/agno/tests/unit/os/interfaces -k agui` passed on an install
+  whose `ag-ui-protocol` serves the lineage events.
+- Not re-run on 2026-09-08: the server boots, the per-file AG-UI POST flows and
+  the OpenUI frontend checks recorded above, which need the servers started and
+  a provider key. Those stand as measured on the dates given with them, and the
+  dated line above covers only the checks named in it.

--- a/cookbook/05_agent_os/16_agui/team_subagent_lineage.py
+++ b/cookbook/05_agent_os/16_agui/team_subagent_lineage.py
@@ -1,0 +1,99 @@
+"""
+Attribute Team member work over AG-UI
+=====================================
+
+A Team run mixes the leader's own output with the output of every member it
+delegated to. By default AG-UI streams all of it as the team's work, which is
+what released clients already expect. Set subagent_visibility="attributed" and
+the same run also carries lineage: SUBAGENT_STARTED, then SUBAGENT_FINISHED or
+SUBAGENT_ERROR, per delegation, and a subagentRunId on the events that carry a
+member's own output, so a client can label its messages, tool calls and
+reasoning per member.
+Session state events are left unattributed on purpose: a team's session state is
+one shared document, so a client filtering by member must not lose a change a
+member's tool made.
+
+The same team is mounted twice so the two streams can be compared side by side.
+Send the same prompt to each mount, but give each request its own threadId, for
+example "lineage-attributed" for /lineage and "lineage-inline" for
+/lineage-inline. A threadId becomes the Agno session id, so reusing one across
+both mounts is guaranteed to do one thing: the second request continues the
+first request's session, that session's history included. Whether the leader
+delegates again from there is the model's decision, not something this file can
+promise, but the answer is already in the history it reads, so it will most
+likely reply straight from it and leave the second stream with little or no
+member work to compare.
+
+Prerequisites: OPENAI_API_KEY, internet access, and ag-ui-protocol 0.1.21 or newer
+Run: .venvs/demo/bin/python cookbook/05_agent_os/16_agui/team_subagent_lineage.py
+Try: POST one prompt per threadId to http://localhost:7777/lineage/agui, then /lineage-inline/agui
+"""
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIResponses
+from agno.os import AgentOS
+from agno.os.interfaces.agui import AGUI
+from agno.team import Team
+from agno.tools.websearch import WebSearchTools
+
+# ---------------------------------------------------------------------------
+# Create Team and Interface Mounts
+# ---------------------------------------------------------------------------
+
+db = SqliteDb(
+    id="agui-lineage-db",
+    db_file="tmp/agui_team_lineage.db",
+)
+
+researcher = Agent(
+    id="lineage-researcher",
+    name="Researcher",
+    role="Find current, relevant source material.",
+    model=OpenAIResponses(id="gpt-5.6-luna"),
+    db=db,
+    tools=[WebSearchTools()],
+    instructions="Search the web, prefer primary sources, and return concise findings with URLs.",
+)
+
+writer = Agent(
+    id="lineage-writer",
+    name="Writer",
+    role="Turn research into a short, readable brief.",
+    model=OpenAIResponses(id="gpt-5.6-luna"),
+    db=db,
+    instructions="Synthesize supplied research without inventing unsupported facts.",
+)
+
+research_team = Team(
+    id="lineage-research-team",
+    name="AG-UI Lineage Team",
+    model=OpenAIResponses(id="gpt-5.6-luna"),
+    db=db,
+    members=[researcher, writer],
+    instructions=[
+        "Delegate research to the Researcher and synthesis to the Writer.",
+        "Return a concise brief with source links.",
+    ],
+)
+
+agent_os = AgentOS(
+    id="agui-lineage-os",
+    description="One Team served twice, with and without member attribution.",
+    teams=[research_team],
+    interfaces=[
+        # Members are announced, and the events carrying a member's own output
+        # are tagged with its run id. Session state events are not, as above.
+        AGUI(team=research_team, prefix="/lineage", subagent_visibility="attributed"),
+        # The default: member work streams as the team's own.
+        AGUI(team=research_team, prefix="/lineage-inline"),
+    ],
+)
+app = agent_os.get_app()
+
+# ---------------------------------------------------------------------------
+# Run Multi-Interface Server
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    agent_os.serve(app=app)

--- a/libs/agno/agno/os/interfaces/agui/agui.py
+++ b/libs/agno/agno/os/interfaces/agui/agui.py
@@ -6,6 +6,7 @@ from fastapi.routing import APIRouter
 
 from agno.agent import Agent
 from agno.agent.remote import RemoteAgent
+from agno.os.interfaces.agui.handlers import validate_subagent_visibility
 from agno.os.interfaces.agui.router import attach_routes
 from agno.os.interfaces.base import BaseInterface
 from agno.team import Team
@@ -23,6 +24,7 @@ class AGUI(BaseInterface):
         team: Optional[Union[Team, RemoteTeam]] = None,
         prefix: str = "",
         tags: Optional[List[str]] = None,
+        subagent_visibility: Optional[str] = None,
     ):
         """
         Initialize the AGUI interface.
@@ -32,23 +34,70 @@ class AGUI(BaseInterface):
             team: The team to expose via AG-UI
             prefix: Custom prefix for the router (e.g., "/agui/v1", "/chat/public")
             tags: Custom tags for the router (e.g., ["AGUI", "Chat"], defaults to ["AGUI"])
+            subagent_visibility: How a Team's members appear on the wire.
+                "inline" (the default) streams their work as the team's own, exactly as
+                before this option existed. "attributed" adds SUBAGENT_STARTED /
+                SUBAGENT_FINISHED / SUBAGENT_ERROR and tags the messages, tool calls
+                and reasoning a member produced with its subagent run id, so a client
+                can tell them apart per member; state events stay unattributed,
+                because a team's session state is one shared document. "hidden"
+                withholds the member lifecycle events and the per-event member
+                stamps, and streams nothing a member produced as its own work;
+                what the client receives is the team's own work, which includes
+                the delegation tool call, whose arguments name the member and
+                carry the task it was given exactly as the default sends them,
+                that call's result, and the team's own reply. Two things a member
+                produced also reach the client, a change one of its tools made to
+                the session state and a pending tool call it paused on, because
+                the first is that shared document and the run cannot continue
+                without the second; neither is attributed to the member. A
+                member's failure withholds that same identity: the lineage
+                events and the per-event stamps stay off the wire and nothing on
+                it names the member that failed, while the reason the run
+                stopped still reaches the client, because a member's terminal
+                can be the run's only account of how it ended and is then read
+                as the run's own.
+                A single Agent that runs no agent of its own has one lane, and its
+                stream is the same under all three settings, a pause included. That
+                covers a pending call the pause reports more than once, by carrying
+                it on two of its lists at once: every setting prompts such a call
+                once per listing, duplicate tool call id and all, because that is
+                what the default sends. An agent a context provider runs inside the
+                outer run does report that run as its parent, and that inner run is
+                the one thing the setting changes here: under "attributed" it
+                becomes a lane of its own, under "hidden" its internals are
+                withheld, and both read a pending tool call it paused on off the
+                outer run's requirements, which the default leaves unread and so
+                does not prompt.
         """
         self.agent = agent
         self.team = team
         self.prefix = prefix
         self.tags = tags or ["AGUI"]
 
-        if not (self.agent or self.team):
+        # The missing entity is checked first: it is the more fundamental error,
+        # so it is the one reported when both are wrong. Presence, never
+        # truthiness, exactly as the routes and the scope mapping decide it.
+        if self.agent is None and self.team is None:
             raise ValueError("AGUI requires an agent or a team")
+
+        self.subagent_visibility = validate_subagent_visibility(subagent_visibility)
 
     def get_router(self) -> APIRouter:
         self.router = APIRouter(prefix=self.prefix, tags=self.tags)  # type: ignore
 
-        self.router = attach_routes(router=self.router, agent=self.agent, team=self.team)
+        self.router = attach_routes(
+            router=self.router,
+            agent=self.agent,
+            team=self.team,
+            subagent_visibility=self.subagent_visibility,
+        )
 
         return self.router
 
     def get_scope_mappings(self) -> dict:
-        # Agent-wins precedence must match router dispatch (entity = agent or team)
+        # An agent takes precedence over a team, on presence, which is how the
+        # routes pick the entity a request runs: a scope naming the other family
+        # would authorize something the route never dispatches to.
         family = "agents" if self.agent is not None else "teams"
         return {f"POST {self.prefix}/agui": [f"{family}:run"]}

--- a/libs/agno/agno/os/interfaces/agui/handlers.py
+++ b/libs/agno/agno/os/interfaces/agui/handlers.py
@@ -1,7 +1,15 @@
 import copy
 import json
 import uuid
-from typing import Any, Callable, Dict, List, Optional
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type
+
+try:
+    import ag_ui.core  # noqa: F401
+except ImportError as e:
+    # The AG-UI interface is an optional extra; say which package is missing
+    # rather than surfacing a bare ModuleNotFoundError from deep in the import.
+    raise ImportError("`ag_ui` not installed. Please install it with `pip install -U ag-ui-protocol`") from e
 
 from ag_ui.core import (
     BaseEvent,
@@ -28,19 +36,341 @@ from ag_ui.core import (
     RunErrorEvent as AGUIRunErrorEvent,
 )
 
+try:
+    from ag_ui.core import (
+        SubagentErrorEvent,
+        SubagentFinishedEvent,
+        SubagentStartedEvent,
+    )
+
+    SUBAGENT_EVENTS_AVAILABLE = True
+except ImportError:  # ag-ui-protocol older than the subagent lineage events
+    from agno.utils.log import log_debug
+
+    SUBAGENT_EVENTS_AVAILABLE = False
+    log_debug(
+        "AG-UI subagent lineage events (SUBAGENT_STARTED / SUBAGENT_FINISHED / SUBAGENT_ERROR) are "
+        "missing from the installed ag_ui.core, so Team member attribution is unavailable. "
+        "Please upgrade with `pip install -U ag-ui-protocol`."
+    )
+
 from agno.models.response import ToolExecution
-from agno.os.interfaces.agui.state import StreamState
+from agno.os.interfaces.agui.state import (
+    ROOT_LANE,
+    SUBAGENT_VISIBILITY_ATTRIBUTED,
+    SUBAGENT_VISIBILITY_INLINE,
+    SUBAGENT_VISIBILITY_VALUES,
+    StreamState,
+)
 from agno.os.interfaces.agui.utils import to_json_str
 from agno.reasoning.step import ReasoningStep
 from agno.run.agent import RunContentEvent, RunEvent
 from agno.run.agent import RunPausedEvent as AgentRunPausedEvent
 from agno.run.base import BaseRunOutputEvent
+from agno.run.requirement import RunRequirement
 from agno.run.team import RunContentEvent as TeamRunContentEvent
 from agno.run.team import RunPausedEvent as TeamRunPausedEvent
 from agno.run.team import TeamRunEvent
+from agno.utils.log import log_error, log_warning
 from agno.utils.message import get_text_from_message
+from agno.utils.string import url_safe_string
 
 EventHandler = Callable[[BaseRunOutputEvent, StreamState], List[BaseEvent]]
+
+# The events that carry a ``subagent_run_id`` and are stamped with the lane of
+# the chunk they were mapped from, so the stream is self-describing per event and
+# a client never has to reconstruct attribution from an earlier event. Each type
+# is kept against the class this interface builds it from, which is what lets
+# the startup check feature-detect the field on every one of them.
+# Run-lifecycle and SUBAGENT_* events are excluded: the former belong to the run
+# as a whole, the latter carry their subagent id in a dedicated field. STATE_* is
+# excluded too, because a team's session state is one shared document; a client
+# filtering by lane must not lose state written during a delegation.
+_ATTRIBUTABLE_EVENT_CLASSES: Dict[EventType, Type[BaseEvent]] = {
+    EventType.TEXT_MESSAGE_START: TextMessageStartEvent,
+    EventType.TEXT_MESSAGE_CONTENT: TextMessageContentEvent,
+    EventType.TEXT_MESSAGE_END: TextMessageEndEvent,
+    EventType.TOOL_CALL_START: ToolCallStartEvent,
+    EventType.TOOL_CALL_ARGS: ToolCallArgsEvent,
+    EventType.TOOL_CALL_END: ToolCallEndEvent,
+    EventType.TOOL_CALL_RESULT: ToolCallResultEvent,
+    EventType.REASONING_START: ReasoningStartEvent,
+    EventType.REASONING_MESSAGE_START: ReasoningMessageStartEvent,
+    EventType.REASONING_MESSAGE_CONTENT: ReasoningMessageContentEvent,
+    EventType.REASONING_MESSAGE_END: ReasoningMessageEndEvent,
+    EventType.REASONING_END: ReasoningEndEvent,
+    EventType.CUSTOM: CustomEvent,
+    EventType.RAW: RawEvent,
+}
+
+# Derived from the classes, so the set the stamp tests an event against and the
+# classes the startup check feature-detects cannot drift apart.
+_SUBAGENT_ATTRIBUTABLE_EVENT_TYPES = frozenset(_ATTRIBUTABLE_EVENT_CLASSES)
+
+# The field those events carry the lane in.
+_SUBAGENT_RUN_ID_FIELD = "subagent_run_id"
+
+# The code a cancelled subagent's terminal carries, so a client can tell a
+# cancellation from a failure.
+_SUBAGENT_CANCELLED_CODE = "cancelled"
+
+# The pending-call lists a paused run's terminal carries, in the order the pause
+# prompt reads them. One pending call can be flagged for several of these at
+# once, and is then listed by each of them; the prompt sends it once per
+# listing, whichever visibility is set, which is what this interface has always
+# done.
+_PAUSE_TOOL_LISTS: Tuple[str, ...] = (
+    "tools_awaiting_external_execution",
+    "tools_requiring_confirmation",
+    "tools_requiring_user_input",
+)
+
+# What the ``hidden`` record of a subagent terminal says about the text beside
+# it. Such a terminal can be the only account the stream carries of how the run
+# stopped, and is then read as the run's own, so the text is on the wire even
+# though nothing on the wire names the subagent it came from. Written once and
+# shared by every terminal that can end the run that way, so a record of one of
+# them cannot claim the client was told nothing.
+_REASON_STILL_REACHES_THE_CLIENT = "the run terminal still reports this reason if the run ends here"
+
+
+def _chunk_run_ids(chunk: BaseRunOutputEvent) -> Tuple[Optional[str], Optional[str]]:
+    """The chunk's own run id, and the run that delegated to it when there is one."""
+    return getattr(chunk, "run_id", None), getattr(chunk, "parent_run_id", None)
+
+
+def _readable(value: Any, described: str) -> Optional[str]:
+    """A value as display text, or None when it is falsy or reading it raises.
+
+    A name reaches the chunk straight off the caller's own Agent or Team, so
+    rendering one can raise. A label is never worth ending a run for, so a value
+    that cannot be read is recorded and treated as absent.
+
+    Falsy is absent too, and deliberately: every caller is choosing a label, and
+    the empty string, an empty mapping and zero are all nothing to show, so each
+    of them falls through to whatever the caller offers next rather than
+    reaching the wire as ``""`` or ``"0"``. A caller that has to tell an empty
+    value from a missing one cannot use this.
+    """
+    try:
+        return str(value) if value else None
+    except Exception as error:
+        log_warning(f"AG-UI could not read {described}: {error}")
+        return None
+
+
+def _member_id(chunk: BaseRunOutputEvent) -> Optional[str]:
+    """The member id the framework's delegation tools name this run's entity by.
+
+    Derived as ``agno.utils.team.get_member_id`` derives it: an explicit id
+    verbatim, and otherwise the url-safe form of the member's name. Initializing
+    a Team assigns an id to every Agent and Team member it holds, so a member of
+    a locally built Team is matched by its id and never reaches the name branch.
+    That branch is for the chunks that assignment does not stand behind: a
+    remote entity's are rebuilt from what its stream sent rather than stamped by
+    this process, and reading the id alone would leave a member arriving that
+    way unmatched against the call that spawned it.
+    """
+    for id_attribute, name_attribute in (("agent_id", "agent_name"), ("team_id", "team_name")):
+        explicit = _readable(getattr(chunk, id_attribute, None), f"a member id from {id_attribute}")
+        if explicit:
+            return explicit
+        name = _readable(getattr(chunk, name_attribute, None), f"a member name from {name_attribute}")
+        if name:
+            return url_safe_string(name)
+    return None
+
+
+def _subagent_name(chunk: BaseRunOutputEvent, subagent_run_id: str) -> str:
+    for attribute in ("agent_name", "team_name", "agent_id", "team_id"):
+        name = _readable(getattr(chunk, attribute, None), f"a subagent name from {attribute}")
+        if name:
+            return name
+    return subagent_run_id
+
+
+def _stamp_lane(events: List[BaseEvent], lane: Optional[str]) -> List[BaseEvent]:
+    """Attribute events to a subagent lane, leaving any explicit id in place.
+
+    The protocol models accept extra attributes, so a plain write would succeed on
+    an event type that does not declare the field and hand the client an
+    undeclared one instead. Only a declared field is ever written. A protocol
+    that declares none on an event this interface attributes is refused when the
+    routes are mounted, so nothing reaches the skip below; it is a skip rather
+    than a raise because this runs while a client is already reading the stream,
+    where nothing may abort the run.
+    """
+    if lane is None:
+        return events
+    for event in events:
+        if event.type not in _SUBAGENT_ATTRIBUTABLE_EVENT_TYPES:
+            continue
+        if _SUBAGENT_RUN_ID_FIELD not in type(event).model_fields:
+            continue
+        if getattr(event, _SUBAGENT_RUN_ID_FIELD, None) is None:
+            setattr(event, _SUBAGENT_RUN_ID_FIELD, lane)
+    return events
+
+
+def _announce_subagent(chunk: BaseRunOutputEvent, state: StreamState, lane: Optional[str]) -> List[BaseEvent]:
+    """Emit SUBAGENT_STARTED the first time a subagent's lane appears.
+
+    A terminal is final for the id it names, so a lane that already closed is
+    never announced again: trailing output from a finished subagent stays
+    attributed to it without giving one invocation two lifecycles.
+
+    The parent named here is always a member this stream has already announced.
+    A parent link the client cannot resolve against an announcement it has
+    already received is a forward reference, which a validating client rejects,
+    so a grandchild whose first event outruns its parent's is announced with no
+    parent and sits directly under the run. A parent whose own terminal has
+    already gone out is left out for a different reason: it can no longer
+    terminate after a child of its own, and its delegation call is no longer a
+    link a client can follow.
+
+    A parent left out takes the rest of the delegation with it: no parent tool
+    call, no parent message and no description. Those are read from the
+    delegating lane's own open calls, and a lane that cannot be named has none
+    to read; falling back to the top-level entity's would announce this
+    subagent with the leader's call, the leader's parent message and the
+    leader's task text as its own description.
+    """
+    if lane is None or lane in state.open_subagents or lane in state.closed_subagents:
+        return []
+
+    member_id = _member_id(chunk)
+    _, parent_run_id = _chunk_run_ids(chunk)
+    parent_lane, delegation_call_id = state.delegating_lane_for(parent_run_id, member_id)
+    name = _subagent_name(chunk, lane)
+
+    state.open_subagent(lane, name=name, parent_lane=parent_lane)
+    return [
+        SubagentStartedEvent(
+            type=EventType.SUBAGENT_STARTED,
+            subagent_run_id=lane,
+            name=name,
+            description=state.delegation_task(parent_lane, delegation_call_id),
+            parent_subagent_run_id=parent_lane,
+            parent_tool_call_id=delegation_call_id,
+            parent_message_id=state.delegation_parent_message_id(parent_lane, delegation_call_id),
+        )
+    ]
+
+
+def _correlation(details: Optional[Dict[str, Any]]) -> str:
+    """The identifiers that let an operator correlate a failure, absent ones omitted.
+
+    Every value comes off the run that failed, so rendering one can raise, and
+    each is read through the same guard every other label is: a value that
+    cannot be read is left out. Building the line an operator reads is never
+    worth ending a run for. That holds for both callers: the lane terminal,
+    which has already closed the lane, and the withheld-failure record under
+    ``hidden``, where the lane never reaches the wire at all and this line is
+    the only trace of the failure.
+    """
+    rendered: List[str] = []
+    for key, value in (details or {}).items():
+        if value is None:
+            continue
+        text = _readable(value, f"the {key} of a subagent failure")
+        if text is not None:
+            rendered.append(f", {key}={text}")
+    return "".join(rendered)
+
+
+def _lane_finished(state: StreamState, lane: Optional[str], result: Any = None) -> List[BaseEvent]:
+    """One lane's terminal event, and nothing at all when it already owns one.
+
+    Only this lane is terminated, and only its own message and reasoning spans
+    are closed, which is the same rule output trailing a terminal follows. A
+    lane below this one belongs to a run that has not stopped, and a tool call
+    still open here belongs to work that can still report its own end; ending
+    either from here sends a terminal for a member that is still going and
+    discards whatever it reports afterwards.
+
+    No outcome is ever attached. The protocol pairs a suspended subagent with a
+    run-level interrupt outcome, and this interface emits none, so a lone
+    suspended half would tell a client the subagent is waiting while the run says
+    it finished.
+    """
+    if lane is None:
+        return []
+    already_closed = lane in state.closed_subagents
+    state.close_subagent(lane)
+    if already_closed:
+        return []
+    return [
+        *_close_lane_messages(state, lane),
+        SubagentFinishedEvent(type=EventType.SUBAGENT_FINISHED, subagent_run_id=lane, result=result),
+    ]
+
+
+def _lane_errored(
+    state: StreamState,
+    lane: Optional[str],
+    message: str,
+    code: Optional[str] = None,
+    details: Optional[Dict[str, Any]] = None,
+) -> List[BaseEvent]:
+    """One lane's error terminal, or the record of a failure that arrives too late.
+
+    Closes and terminates exactly what the finish path does, for the same
+    reasons, and the failure belongs to this lane alone: a member below it never
+    failed and must not be made to report somebody else's error.
+
+    A lane that already terminated gets no second terminal: a terminal is final
+    for the id it names, and a second one would be a protocol violation. The
+    failure is still recorded, saying that the lane had already terminated and
+    that nothing about it reached the client, so a failure no client can be told
+    about is not a failure nobody is told about.
+
+    The failure is recorded here and nowhere else, once either way. The wire
+    event carries only a message and a code, so whatever identifiers would let
+    an operator correlate the failure travel in ``details``.
+    """
+    if lane is None:
+        return []
+    already_closed = lane in state.closed_subagents
+    state.close_subagent(lane)
+    correlation = _correlation(details)
+    if already_closed:
+        log_error(
+            f"AG-UI subagent lane {lane} reported a failure after it had already terminated, so no "
+            f"SUBAGENT_ERROR was sent for it (code={code}): {message}{correlation}"
+        )
+        return []
+    log_error(f"AG-UI subagent lane {lane} ended in failure (code={code}): {message}{correlation}")
+    return [
+        *_close_lane_messages(state, lane),
+        SubagentErrorEvent(type=EventType.SUBAGENT_ERROR, subagent_run_id=lane, message=message, code=code),
+    ]
+
+
+def _drain_subagents(state: StreamState) -> List[BaseEvent]:
+    """Terminate every subagent still open when the run ends.
+
+    A subagent's terminal comes from exactly two places: its own terminal event,
+    and this drain. The drain covers one whose own terminal never arrived, for
+    instance because the run paused inside it, or because it was still streaming
+    when the run ended. A run that failed goes down the error path instead, which
+    errors these lanes rather than finishing them. Deepest first, so a child's
+    terminal precedes its parent's.
+    """
+    events: List[BaseEvent] = []
+    for lane in state.subagents_deepest_first():
+        events.extend(_lane_finished(state, lane))
+    return events
+
+
+def _error_open_subagents(state: StreamState, error_message: str) -> List[BaseEvent]:
+    """Error every subagent still open when the run's stream failed.
+
+    Deepest first, so a child's terminal precedes its parent's.
+    """
+    events: List[BaseEvent] = []
+    for lane in state.subagents_deepest_first():
+        events.extend(_lane_errored(state, lane, error_message))
+    return events
 
 
 def _extract_response_chunk_content(response: RunContentEvent) -> str:
@@ -102,29 +432,115 @@ def _emit_state_delta(state: StreamState) -> List[BaseEvent]:
     return [StateDeltaEvent(type=EventType.STATE_DELTA, delta=ops)]
 
 
-def _close_open_spans(state: StreamState) -> List[BaseEvent]:
-    """End any reasoning, tool call, or text message still open, so a terminal event never leaves a dangling span."""
+def _end_lane_reasoning(state: StreamState, lane_key: Optional[str]) -> List[BaseEvent]:
+    lane = state.lane(lane_key)
+    if lane.reasoning_message_id is None:
+        return []
+    reasoning_id = lane.reasoning_message_id
+    lane.reasoning_message_id = None
+    lane.reasoning_step_count = 0
+    return [
+        ReasoningMessageEndEvent(type=EventType.REASONING_MESSAGE_END, message_id=reasoning_id),
+        ReasoningEndEvent(type=EventType.REASONING_END, message_id=reasoning_id),
+    ]
+
+
+def _end_lane_tool_calls(state: StreamState, lane_key: Optional[str]) -> List[BaseEvent]:
     events: List[BaseEvent] = []
-
-    # Close orphaned reasoning session
-    if state.reasoning_message_id is not None:
-        events.append(
-            ReasoningMessageEndEvent(type=EventType.REASONING_MESSAGE_END, message_id=state.reasoning_message_id)
-        )
-        events.append(ReasoningEndEvent(type=EventType.REASONING_END, message_id=state.reasoning_message_id))
-        state.end_reasoning()
-
-    # Close remaining active tool calls
-    for tool_call_id in list(state.active_tool_call_ids):
+    # In the order the run opened them: these ends are swept out of a set of
+    # open calls, whose iteration order would otherwise decide the wire order.
+    for tool_call_id in state.active_tool_calls_in_order():
+        if state.lane_of_tool_call(tool_call_id) != lane_key:
+            continue
         if tool_call_id not in state.ended_tool_call_ids:
             events.append(ToolCallEndEvent(type=EventType.TOOL_CALL_END, tool_call_id=tool_call_id))
             state.end_tool_call(tool_call_id)
+    return events
 
-    # Close open text message
-    if state.text_message_open:
-        events.append(TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=state.text_message_id))
-        state.close_text_message()
 
+def _end_lane_text_message(state: StreamState, lane_key: Optional[str]) -> List[BaseEvent]:
+    lane = state.lane(lane_key)
+    if not lane.text_message_open:
+        return []
+    lane.text_message_open = False
+    return [TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=lane.text_message_id)]
+
+
+def _close_lane_spans(state: StreamState, lane_key: Optional[str]) -> List[BaseEvent]:
+    """End every reasoning, tool call and text message still open in one lane."""
+    events = [
+        *_end_lane_reasoning(state, lane_key),
+        *_end_lane_tool_calls(state, lane_key),
+        *_end_lane_text_message(state, lane_key),
+    ]
+    return _stamp_lane(events, lane_key)
+
+
+def _close_lane_messages(state: StreamState, lane_key: Optional[str]) -> List[BaseEvent]:
+    """End the reasoning and text spans open in one lane, leaving its tool calls open."""
+    events = [*_end_lane_reasoning(state, lane_key), *_end_lane_text_message(state, lane_key)]
+    return _stamp_lane(events, lane_key)
+
+
+def _close_lane_tool_calls(state: StreamState, lane_key: Optional[str]) -> List[BaseEvent]:
+    """End every tool call still open in one lane."""
+    return _stamp_lane(_end_lane_tool_calls(state, lane_key), lane_key)
+
+
+def _close_all_lane_spans(state: StreamState) -> List[BaseEvent]:
+    """End every span still open in any lane, and every tool call still open.
+
+    Every lane, not only the root and the ones still being drained: a text or
+    reasoning span opened in a lane whose subagent already terminated would
+    otherwise still be open when the run terminal arrives, and a conforming
+    client rejects a run that ends inside a message. The lanes iterated include
+    every lane that owns an open tool call, so no tool call reaches the run
+    terminal without an end event. Children before parents.
+    """
+    events: List[BaseEvent] = []
+    for lane_key in state.lanes_deepest_first():
+        events.extend(_close_lane_spans(state, lane_key))
+    return events
+
+
+def _close_run_end_spans(
+    state: StreamState,
+    terminate_members: Callable[[], List[BaseEvent]],
+    interlude: Optional[Callable[[], List[BaseEvent]]] = None,
+) -> List[BaseEvent]:
+    """The single closing order both run-ending paths use.
+
+    Everything the run end emits after the sweep lands outside every span the
+    stream had open, which is the one position that holds for all three
+    visibilities. ``interlude`` is the pause prompt: it opens a message and tool
+    calls of its own, so it goes out once no message and no tool call is still
+    open, and before ``terminate_members``, because the calls it carries are
+    stamped with the members it is prompting for and nothing may carry a member
+    after that member's terminal. That leaves the member terminals last, outside
+    the delegation call that spawned them rather than inside it.
+
+    With member lanes on the wire the spans close in two passes, children before
+    parents in each, so a member's terminal never lands inside another lane's
+    message. With none there is no terminal to position, so one pass per lane
+    closes everything and the emitted stream is exactly what it was before member
+    attribution existed.
+    """
+    events: List[BaseEvent] = []
+    if not state.announced_subagents:
+        # No lane was ever announced, so no lane can be open and there is nothing
+        # for ``terminate_members`` to produce.
+        events.extend(_close_all_lane_spans(state))
+        if interlude is not None:
+            events.extend(interlude())
+        return events
+
+    for lane_key in state.lanes_deepest_first():
+        events.extend(_close_lane_messages(state, lane_key))
+    for lane_key in state.lanes_deepest_first():
+        events.extend(_close_lane_tool_calls(state, lane_key))
+    if interlude is not None:
+        events.extend(interlude())
+    events.extend(terminate_members())
     return events
 
 
@@ -207,6 +623,10 @@ def on_tool_call_started(chunk: BaseRunOutputEvent, state: StreamState) -> List[
     )
 
     state.start_tool_call(tool.tool_call_id)
+    # A delegation is one of these calls; remembering the arguments and the parent
+    # message lets a subagent be linked back to the exact call that spawned it
+    # once its first event arrives.
+    state.record_open_tool_call(tool.tool_call_id, tool.tool_name, tool.tool_args, parent_message_id)
     return events
 
 
@@ -343,21 +763,65 @@ def on_unknown_event(chunk: BaseRunOutputEvent, state: StreamState) -> List[Base
     return [RawEvent(type=EventType.RAW, event=raw_dict, source="agno")]
 
 
-def on_run_error(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
-    """Close open spans, then emit the terminal AG-UI error event. Nothing may follow RUN_ERROR."""
+def close_open_spans(state: StreamState, error_message: str) -> List[BaseEvent]:
+    """End every span and member lane the stream left open, without a run terminal.
+
+    The open member lanes terminate as errored rather than finished, since the
+    run they belonged to did not reach its own end. No run terminal is included:
+    the caller owns that, and nothing may follow one on the wire.
+    """
+    return _close_run_end_spans(state, lambda: _error_open_subagents(state, error_message))
+
+
+def _terminal_raw_event(chunk: BaseRunOutputEvent, state: StreamState) -> Optional[Dict[str, Any]]:
+    """The failing chunk, verbatim, when it is the run's own account of the failure.
+
+    A run that died inside a subagent has no terminal of its own, so the
+    subagent's is read as the run's. The chunk itself is not: it is a subagent's
+    record, and it names the subagent, its run and the run that delegated to it.
+    Under ``hidden`` that is the identity the whole visibility withholds, put
+    back on the wire by the event that follows the line recording the failure was
+    kept off it; under ``attributed`` it is a subagent's own event dressed as the
+    run's. Only the default embeds it, whose stream is what it was before member
+    attribution existed.
+    """
+    if state.lane_for(*_chunk_run_ids(chunk)) is not ROOT_LANE:
+        return None
     try:
-        raw_event: Any = chunk.to_dict()
+        return chunk.to_dict()
     except Exception:
-        raw_event = {"event": str(getattr(chunk, "event", "RunError"))}
+        return {"event": str(getattr(chunk, "event", "RunError"))}
 
-    message = getattr(chunk, "content", None) or "Run failed"
-    error_type = getattr(chunk, "error_type", None)
 
-    events = _close_open_spans(state)
+def _terminal_failure(chunk: BaseRunOutputEvent, normalized: str) -> Tuple[str, Optional[str]]:
+    """What a failed run terminal says, and the code it says it under.
+
+    A cancellation is not a failure of the run's own making, so it reports the
+    reason it was cancelled for under the same code a cancelled member's
+    terminal carries. Only a subagent's cancellation ever reaches here: the
+    top-level entity's is not read as a run terminal at all.
+    """
+    if normalized == RunEvent.run_cancelled.value:
+        reason = _readable(getattr(chunk, "reason", None), "a cancelled run reason")
+        return reason or "Run cancelled", _SUBAGENT_CANCELLED_CODE
+    return str(getattr(chunk, "content", None) or "Run failed"), getattr(chunk, "error_type", None)
+
+
+def on_run_error(chunk: BaseRunOutputEvent, state: StreamState, normalized: str) -> List[BaseEvent]:
+    """Close open spans, then emit the terminal AG-UI error event. Nothing may follow RUN_ERROR.
+
+    ``normalized`` is the chunk's event name, which says which kind of failed
+    terminal this is. It is required rather than defaulted: a default would read
+    every cancellation as a plain failure and report the wrong code for it.
+    """
+    raw_event = _terminal_raw_event(chunk, state)
+    message, error_type = _terminal_failure(chunk, normalized)
+
+    events: List[BaseEvent] = close_open_spans(state, message)
     events.append(
         AGUIRunErrorEvent(
             type=EventType.RUN_ERROR,
-            message=str(message),
+            message=message,
             code=error_type,
             rawEvent=raw_event,
         )
@@ -365,72 +829,415 @@ def on_run_error(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEven
     return events
 
 
-def on_run_completed(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
-    events = _close_open_spans(state)
+@dataclass
+class _PausedMemberLane:
+    """A member lane a paused run needs on the wire, resolved but not yet announced."""
 
-    # 1. Collect paused tools for frontend rendering
-    paused_tools: List[ToolExecution] = []
-    if isinstance(chunk, AgentRunPausedEvent):
-        paused_tools = (
-            chunk.tools_awaiting_external_execution
-            + chunk.tools_requiring_confirmation
-            + chunk.tools_requiring_user_input
-        )
-    elif isinstance(chunk, TeamRunPausedEvent):
-        # Leader tools from .tools, member tools from active_requirements
-        paused_tools = (
-            chunk.tools_awaiting_external_execution
-            + chunk.tools_requiring_confirmation
-            + chunk.tools_requiring_user_input
-        )
-        for req in chunk.active_requirements:
-            if req.member_agent_id and req.tool_execution:
-                paused_tools.append(req.tool_execution)
+    run_id: str
+    name: str
+    parent_lane: Optional[str]
+    delegation_call_id: Optional[str]
 
-    if paused_tools:
-        assistant_message_id = str(uuid.uuid4())
+
+@dataclass
+class _PausedToolCall:
+    """One pending tool call a paused run can prompt the client with.
+
+    The id and the name are both required rather than optional: an event cannot
+    be built without the id and nothing can be rendered without the name, so a
+    pending call missing either is dropped before it becomes one of these.
+    """
+
+    tool_call_id: str
+    tool_name: str
+    tool_args: Any
+    lane: Optional[str]
+
+
+@dataclass
+class _PausedPrompt:
+    """What a paused run's terminal asks the client to resolve.
+
+    ``carried`` counts the pending calls the terminal listed before any were
+    dropped or deduplicated, because whether the pause is announced at all
+    turns on the terminal having listed one, never on what survived. ``dropped``
+    counts the ones the client cannot be shown.
+
+    ``content`` is the paused run's own text and ``content_lane`` the lane that
+    text belongs to. A pause reported by a member carries the member's words, so
+    they go out on the member's lane or not at all; the leader's own pause
+    carries the leader's, on the root lane.
+    """
+
+    lanes: Dict[str, _PausedMemberLane]
+    tool_calls: List[_PausedToolCall]
+    carried: int
+    dropped: int
+    content: Optional[str]
+    content_lane: Optional[str]
+
+
+def _prompt_lane(state: StreamState, lane: Optional[str]) -> Optional[str]:
+    """The lane a pause prompt may stamp, or the root lane when none can be named.
+
+    Only ``attributed`` names members on the wire: ``inline`` has one lane, and
+    ``hidden`` must not let a confirmation prompt reveal which member asked. A
+    lane whose terminal has already gone out is not named either, since a
+    terminal is final for the id it names and nothing may carry a member after
+    it.
+    """
+    if lane is ROOT_LANE or state.subagent_visibility != SUBAGENT_VISIBILITY_ATTRIBUTED:
+        return ROOT_LANE
+    return lane if lane in state.open_subagents else ROOT_LANE
+
+
+def _paused_member_lane(
+    state: StreamState,
+    requirement: RunRequirement,
+    pending: Dict[str, _PausedMemberLane],
+) -> Optional[str]:
+    """The lane a paused member's tool call is stamped with, resolving a new one.
+
+    Only ``attributed`` names members on the wire: ``inline`` has one lane, and
+    ``hidden`` must not let a confirmation prompt reveal which member asked.
+
+    A lane the client was never given a start for is unreadable, so a lane this
+    is the first sight of is recorded in ``pending`` for the caller to announce.
+    Nothing is announced from here: whether the prompt these lanes are for is
+    emitted at all is not known until every paused tool has been read, and a
+    lane announced for a prompt that is then dropped leaves the client a
+    terminal for a member it never saw start.
+
+    When no lane can be named, because the member's run is unknown or because
+    its terminal has already gone out and a terminal is final for the id it
+    names, the tool call falls back to the root lane instead of carrying an id
+    the client cannot resolve.
+    """
+    member_run_id = requirement.member_run_id
+    if member_run_id is None or member_run_id == state.root_run_id:
+        return ROOT_LANE
+    if state.subagent_visibility != SUBAGENT_VISIBILITY_ATTRIBUTED:
+        return ROOT_LANE
+    if member_run_id in state.open_subagents or member_run_id in pending:
+        return member_run_id
+    if member_run_id in state.closed_subagents:
+        return ROOT_LANE
+
+    # A member pauses inside the call that delegated to it, so the lane holding
+    # that call is the parent, at whatever depth the pause was reported. Without
+    # an open delegation naming this member there is nothing that establishes
+    # either, so both are left out: reaching past for the leader's own open call
+    # gives the member a parent it never had, the task text of somebody else's
+    # delegation, and a depth that puts a grandchild level with the member that
+    # really delegated to it.
+    parent_lane: Optional[str] = ROOT_LANE
+    delegation_call_id: Optional[str] = None
+    delegation = state.find_member_delegation(requirement.member_agent_id)
+    if delegation is not None:
+        parent_lane, delegation_call_id = delegation
+
+    # The member's name and id come off the paused run, so both are read through
+    # the same guard every other label is: a lane whose name cannot be rendered
+    # is announced under its run id rather than ending a run that is only
+    # waiting for an answer.
+    name = (
+        _readable(requirement.member_agent_name, "a paused member name")
+        or _readable(requirement.member_agent_id, "a paused member id")
+        or member_run_id
+    )
+    pending[member_run_id] = _PausedMemberLane(
+        run_id=member_run_id,
+        name=name,
+        parent_lane=parent_lane,
+        delegation_call_id=delegation_call_id,
+    )
+    return member_run_id
+
+
+def _announce_paused_lanes(state: StreamState, pending: Dict[str, _PausedMemberLane]) -> List[BaseEvent]:
+    """Announce the member lanes a pause prompt is about to carry."""
+    events: List[BaseEvent] = []
+    for lane in pending.values():
+        state.open_subagent(lane.run_id, name=lane.name, parent_lane=lane.parent_lane)
         events.append(
-            TextMessageStartEvent(
-                type=EventType.TEXT_MESSAGE_START,
-                message_id=assistant_message_id,
-                role="assistant",
+            SubagentStartedEvent(
+                type=EventType.SUBAGENT_STARTED,
+                subagent_run_id=lane.run_id,
+                name=lane.name,
+                description=state.delegation_task(lane.parent_lane, lane.delegation_call_id),
+                parent_subagent_run_id=lane.parent_lane,
+                parent_tool_call_id=lane.delegation_call_id,
+                parent_message_id=state.delegation_parent_message_id(lane.parent_lane, lane.delegation_call_id),
             )
         )
+    return events
 
-        content = getattr(chunk, "content", None)
-        if content:
-            events.append(
-                TextMessageContentEvent(
-                    type=EventType.TEXT_MESSAGE_CONTENT,
-                    message_id=assistant_message_id,
-                    delta=str(content),
-                )
+
+def _active_requirements(chunk: BaseRunOutputEvent) -> List[RunRequirement]:
+    """The requirements a paused run still needs resolved, on a release that reports them.
+
+    Both paused event types declare the field, and one that does not is read as
+    reporting none: a pause is what the client has to be told about, so a
+    missing field withholds the attribution rather than the prompt.
+    """
+    requirements = getattr(chunk, "active_requirements", None)
+    return list(requirements) if requirements else []
+
+
+def _paused_tools_with_lanes(chunk: BaseRunOutputEvent, state: StreamState) -> _PausedPrompt:
+    """The tool calls a paused run is waiting on, each with the lane that owns it.
+
+    A tool can be reported twice, once on the terminal event's own lists, which
+    carry copies of what its members are waiting on as well as the leader's own
+    tools, and once on the requirement that names the member waiting on it. It
+    is one pending call, so it is prompted once, on the member's lane. A call
+    already on the wire under a member's lane is then not prompted at all: the
+    client has a start for it and a second one would be a duplicate id. A call
+    of the top-level entity's own is prompted whichever visibility is set, so a
+    run with no member on the wire streams exactly what the default streams.
+    Neither the merge nor the drop applies under the default itself, whose
+    stream stays what it was before member attribution existed.
+
+    Only a requirement's copy ever merges into one already recorded. The
+    terminal's own lists are read as they are, so a pending call flagged for
+    several of them, and therefore listed by each, is prompted once per listing
+    under every visibility: that duplicate is the default's stream, and the
+    default's stream is the one every setting has to match on a run with no
+    member on the wire.
+
+    The terminal's own lists belong to the run that reported the pause. That is
+    the leader's for a leader's pause, and a member's where a member's pause was
+    the last thing the stream carried and became the run terminal, so those
+    tools are stamped with the run that is really waiting on them.
+
+    A tool without both an id and a name is dropped and recorded: there is
+    nothing the client could render and nothing to tell a duplicate by, and the
+    resume then waits on a call nothing asked for. Lanes come back alongside,
+    unannounced and only for the members a surviving tool call is stamped with,
+    since a lane the prompt carries nothing for tells the client about a member
+    it will never hear from again.
+    """
+    pending: Dict[str, _PausedMemberLane] = {}
+    recorded: List[_PausedToolCall] = []
+    carried = 0
+    dropped = 0
+    lineage = state.subagent_visibility != SUBAGENT_VISIBILITY_INLINE
+    terminal_lane = state.lane_for(*_chunk_run_ids(chunk))
+    reporting_lane = _prompt_lane(state, terminal_lane)
+
+    def record(tool: ToolExecution, lane: Optional[str], merges: bool) -> None:
+        nonlocal carried, dropped
+        carried += 1
+        if tool.tool_call_id is None or tool.tool_name is None:
+            dropped += 1
+            log_warning(
+                f"AG-UI dropped a pending tool call from the pause of run {state.run_id} in session "
+                f"{state.thread_id}, because the client cannot be shown it: tool_call_id={tool.tool_call_id}, "
+                f"tool_name={tool.tool_name}. A resume waits on that call with nothing on the wire to resolve it."
             )
+            return
+        prompted = _PausedToolCall(
+            tool_call_id=tool.tool_call_id, tool_name=tool.tool_name, tool_args=tool.tool_args, lane=lane
+        )
+        if merges:
+            for index, already in enumerate(recorded):
+                if already.tool_call_id == prompted.tool_call_id:
+                    # The member's attribution wins over the unattributed copy,
+                    # in the position the call was first reported in.
+                    recorded[index] = prompted
+                    return
+        recorded.append(prompted)
 
-        events.append(TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=assistant_message_id))
+    if isinstance(chunk, (AgentRunPausedEvent, TeamRunPausedEvent)):
+        for list_name in _PAUSE_TOOL_LISTS:
+            for tool in getattr(chunk, list_name, None) or ():
+                record(tool, reporting_lane, merges=False)
+        # A subagent's tools live in the requirements, which name the run waiting
+        # on them, and that attribution wins over the unattributed copy above. An
+        # agent that ran an inner agent reports them exactly as a team reports a
+        # member's, so lineage reads both paused shapes: a pending call the client
+        # is not shown is one the run can never be resumed past.
+        # The default is the pre-change stream, which read this on a team's pause only: an agent's is lineage behavior.
+        if lineage or isinstance(chunk, TeamRunPausedEvent):
+            for requirement in _active_requirements(chunk):
+                if not (requirement.member_agent_id and requirement.tool_execution):
+                    continue
+                record(
+                    requirement.tool_execution,
+                    _paused_member_lane(state, requirement, pending),
+                    merges=lineage,
+                )
 
-        for tool in paused_tools:
-            if tool.tool_call_id is None or tool.tool_name is None:
-                continue
+    if lineage:
+        # Read once every copy of a call has been merged, so a call the wire
+        # already carries under its member's lane is dropped whichever of the two
+        # places reported it first.
+        recorded = [
+            tool_call
+            for tool_call in recorded
+            if tool_call.lane is ROOT_LANE or not state.tool_call_started(tool_call.tool_call_id)
+        ]
 
-            events.append(
+    stamped = {tool_call.lane for tool_call in recorded}
+    return _PausedPrompt(
+        lanes={run_id: lane for run_id, lane in pending.items() if run_id in stamped},
+        tool_calls=recorded,
+        carried=carried,
+        dropped=dropped,
+        content=_pause_content(chunk, terminal_lane, reporting_lane),
+        content_lane=reporting_lane,
+    )
+
+
+def _pause_content(
+    chunk: BaseRunOutputEvent,
+    terminal_lane: Optional[str],
+    reporting_lane: Optional[str],
+) -> Optional[str]:
+    """The paused run's own words, or None when there are none to send.
+
+    A member's pause carries the member's words, so they go out on the member's
+    lane. A visibility that will not name that lane withholds them instead of
+    passing a member's prose off as the run's own reply.
+    """
+    content = getattr(chunk, "content", None)
+    if not content:
+        return None
+    if terminal_lane is not ROOT_LANE and reporting_lane is ROOT_LANE:
+        return None
+    return str(content)
+
+
+def _pause_prompt(
+    state: StreamState,
+    announcements: List[BaseEvent],
+    prompt: _PausedPrompt,
+) -> List[BaseEvent]:
+    """The assistant messages and tool calls a paused run asks the client to resolve.
+
+    One message per lane, each carrying that lane's own pending calls. A tool
+    call belongs to the message that carries it, so the two must agree about
+    which member they are: one message stamped for two members is unreadable,
+    and an unstamped message carrying a member's call is a call a client cannot
+    place. One pause can be waiting on several members at once, so one message
+    is not enough and the split is per lane rather than one message with mixed
+    calls under it.
+
+    A pause with nothing left to show still says something when the client was
+    never shown what the run is waiting on: a bare message tells it the run is
+    waiting rather than finished. A call left out because the client already has
+    a start for it is the case that needs nothing, being already on the wire to
+    be acted on.
+    """
+    if not prompt.carried:
+        return []
+
+    events: List[BaseEvent] = list(announcements)
+    blocks = _prompt_blocks(prompt)
+    if not blocks:
+        if not prompt.dropped:
+            return events
+        blocks = [(prompt.content_lane, [])]
+
+    for lane, tool_calls in blocks:
+        events.extend(_prompt_block(state, lane, tool_calls, prompt.content if lane == prompt.content_lane else None))
+    return events
+
+
+def _prompt_blocks(prompt: _PausedPrompt) -> List[Tuple[Optional[str], List[_PausedToolCall]]]:
+    """The pause prompt split into one message per lane, in the order it was reported.
+
+    The lane the paused run's own words belong to leads, since that message is
+    the prompt's opening line whether or not any pending call is stamped with
+    the same lane.
+    """
+    grouped: Dict[Optional[str], List[_PausedToolCall]] = {}
+    if prompt.content is not None:
+        grouped[prompt.content_lane] = []
+    for tool_call in prompt.tool_calls:
+        grouped.setdefault(tool_call.lane, []).append(tool_call)
+    return list(grouped.items())
+
+
+def _prompt_block(
+    state: StreamState,
+    lane: Optional[str],
+    tool_calls: List[_PausedToolCall],
+    content: Optional[str],
+) -> List[BaseEvent]:
+    """One lane's share of a pause prompt: its message, and the calls parented to it."""
+    message_id = str(uuid.uuid4())
+    events: List[BaseEvent] = [
+        TextMessageStartEvent(
+            type=EventType.TEXT_MESSAGE_START,
+            message_id=message_id,
+            role="assistant",
+        )
+    ]
+    if content:
+        events.append(
+            TextMessageContentEvent(
+                type=EventType.TEXT_MESSAGE_CONTENT,
+                message_id=message_id,
+                delta=content,
+            )
+        )
+    events.append(TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=message_id))
+
+    for tool_call in tool_calls:
+        events.extend(
+            [
                 ToolCallStartEvent(
                     type=EventType.TOOL_CALL_START,
-                    tool_call_id=tool.tool_call_id,
-                    tool_call_name=tool.tool_name,
-                    parent_message_id=assistant_message_id,
-                )
-            )
-
-            events.append(
+                    tool_call_id=tool_call.tool_call_id,
+                    tool_call_name=tool_call.tool_name,
+                    parent_message_id=message_id,
+                ),
                 ToolCallArgsEvent(
                     type=EventType.TOOL_CALL_ARGS,
-                    tool_call_id=tool.tool_call_id,
-                    delta=json.dumps(tool.tool_args),
-                )
+                    tool_call_id=tool_call.tool_call_id,
+                    delta=json.dumps(tool_call.tool_args),
+                ),
+                ToolCallEndEvent(type=EventType.TOOL_CALL_END, tool_call_id=tool_call.tool_call_id),
+            ]
+        )
+        # The client has been given an end for this call, so the run-end sweep
+        # must not write a second one.
+        state.end_tool_call(tool_call.tool_call_id)
+
+    return _stamp_lane(events, lane)
+
+
+def on_run_completed(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
+    prompt = _paused_tools_with_lanes(chunk, state)
+    # Announced here, before the closing order is chosen, because it is only now
+    # certain which lanes the prompt really carries, and because a lane
+    # announced needs the run end to terminate it.
+    announcements = _announce_paused_lanes(state, prompt.lanes)
+    if isinstance(chunk, (AgentRunPausedEvent, TeamRunPausedEvent)) and prompt.dropped == prompt.carried:
+        # The run is waiting on something nobody can resolve, and the two ways
+        # that happens reach the client differently, so they are recorded
+        # differently. A call left out because the client already has a start
+        # for it is neither of them: that one is on the wire to be acted on.
+        if prompt.carried:
+            log_warning(
+                f"AG-UI run {state.run_id} in session {state.thread_id} paused on tool calls the client "
+                "cannot be shown, so it is told the run is waiting with nothing on the wire to act on"
+            )
+        else:
+            # No pending call was READ, which is not the same as none existing.
+            # Under the default an Agent's active requirements are left unread,
+            # so a pause whose only pending call arrives that way lands here.
+            log_warning(
+                f"AG-UI run {state.run_id} in session {state.thread_id} paused with no pending tool call "
+                "this visibility reads, so the pause reaches the client as a plain finished run"
             )
 
-            events.append(ToolCallEndEvent(type=EventType.TOOL_CALL_END, tool_call_id=tool.tool_call_id))
+    events = _close_run_end_spans(
+        state,
+        lambda: _drain_subagents(state),
+        lambda: _pause_prompt(state, announcements, prompt),
+    )
 
     # Emit final state snapshot
     if state.run_state is not None:
@@ -472,8 +1279,219 @@ _COMPLETION_EVENTS = frozenset(
 )
 
 
-def is_completion_event(chunk: BaseRunOutputEvent) -> bool:
-    """Check if this event is terminal for the stream (completed, paused, or error)."""
+def _subagent_result(content: Any) -> Optional[str]:
+    """A member's output as its terminal's result, serialized when it is not text.
+
+    A terminal event must never be the thing that fails a run that otherwise
+    succeeded, so every step here falls back rather than raising: a model dump
+    can raise on a partly-built object, and the JSON encoder raises on cyclic
+    content. The last resort is the object's own text, and failing that a note
+    naming its type.
+    """
+    if content is None or isinstance(content, str):
+        return content
+
+    model_dump_json = getattr(content, "model_dump_json", None)
+    if callable(model_dump_json):
+        try:
+            return str(model_dump_json())
+        except Exception as error:
+            log_warning(f"AG-UI could not dump a subagent result of type {type(content).__name__}: {error}")
+
+    try:
+        return to_json_str(content)
+    except Exception as error:
+        log_warning(f"AG-UI could not serialize a subagent result of type {type(content).__name__}: {error}")
+
+    try:
+        return str(content)
+    except Exception as error:
+        log_warning(f"AG-UI could not render a subagent result of type {type(content).__name__}: {error}")
+        return f"<unrenderable {type(content).__name__} result>"
+
+
+def on_subagent_completed(chunk: BaseRunOutputEvent, state: StreamState, lane: Optional[str]) -> List[BaseEvent]:
+    return _lane_finished(state, lane, result=_subagent_result(getattr(chunk, "content", None)))
+
+
+def on_subagent_error(chunk: BaseRunOutputEvent, state: StreamState, lane: Optional[str]) -> List[BaseEvent]:
+    # The failure text comes off the failing run, so it is read through the same
+    # guard every other label is: one that cannot be rendered leaves the lane
+    # reporting a failure without a message of its own, never a live run ended
+    # by the attempt to describe a dead one.
+    message = _readable(getattr(chunk, "content", None), "a subagent failure message") or "Subagent run failed"
+    return _lane_errored(
+        state,
+        lane,
+        message,
+        getattr(chunk, "error_type", None),
+        details={
+            "error_id": getattr(chunk, "error_id", None),
+            "additional_data": getattr(chunk, "additional_data", None),
+        },
+    )
+
+
+def on_subagent_cancelled(chunk: BaseRunOutputEvent, state: StreamState, lane: Optional[str]) -> List[BaseEvent]:
+    """A cancelled member is terminated as errored: it produced no result to report."""
+    reason = _readable(getattr(chunk, "reason", None), "a subagent cancellation reason") or "Subagent run cancelled"
+    return _lane_errored(state, lane, reason, _SUBAGENT_CANCELLED_CODE)
+
+
+# A subagent's own terminal, which ends that subagent rather than the stream.
+# A member's pause is deliberately absent: a paused member has not finished, so
+# its lane stays open and the run-end drain terminates it.
+_SUBAGENT_TERMINAL_HANDLERS: Dict[str, Callable[[BaseRunOutputEvent, StreamState, Optional[str]], List[BaseEvent]]] = {
+    RunEvent.run_completed.value: on_subagent_completed,
+    RunEvent.run_error.value: on_subagent_error,
+    RunEvent.run_cancelled.value: on_subagent_cancelled,
+}
+
+# A member's own pause carries nothing the client needs: the pending tool call
+# reaches it from the delegating run's requirements, so dumping the internal
+# payload would both leak it and duplicate that call.
+_SUBAGENT_WITHHELD_EVENTS = frozenset({RunEvent.run_paused.value})
+
+# Every chunk that stops a subagent, normalized. Derived from the terminal table
+# rather than listed beside it, so a terminal type this interface learns to
+# handle cannot be one the stream fails to recognize as ending a subagent: the
+# two would then disagree, and a stream whose last chunk was that terminal would
+# report the run finished after saying the subagent did not. A pause is here
+# too, and only here: it stops the subagent without terminating its lane, so it
+# has no entry in the table.
+_SUBAGENT_RUN_ENDING_EVENTS = frozenset(_SUBAGENT_TERMINAL_HANDLERS) | _SUBAGENT_WITHHELD_EVENTS
+
+
+def _events_missing_the_lane_field() -> List[str]:
+    """The event classes this interface attributes that cannot carry a lane."""
+    return sorted(
+        event_class.__name__
+        for event_class in _ATTRIBUTABLE_EVENT_CLASSES.values()
+        if _SUBAGENT_RUN_ID_FIELD not in event_class.model_fields
+    )
+
+
+def _lineage_event_fields() -> Dict[Type[BaseEvent], Tuple[str, ...]]:
+    """Every SUBAGENT_* field this interface writes, per class it writes it on.
+
+    Built here rather than at import, because on a protocol release without the
+    lineage events there are no classes to key it by.
+    """
+    return {
+        SubagentStartedEvent: (
+            _SUBAGENT_RUN_ID_FIELD,
+            "name",
+            "description",
+            "parent_subagent_run_id",
+            "parent_tool_call_id",
+            "parent_message_id",
+        ),
+        SubagentFinishedEvent: (_SUBAGENT_RUN_ID_FIELD, "result"),
+        SubagentErrorEvent: (_SUBAGENT_RUN_ID_FIELD, "message", "code"),
+    }
+
+
+def _lineage_fields_the_protocol_omits() -> List[str]:
+    """The SUBAGENT_* fields this interface writes that the installed protocol omits.
+
+    Named class by field, so the refusal says exactly what is missing. The
+    protocol models accept attributes they do not declare, so an omitted field
+    would otherwise leave the run: the value goes out under the name written
+    here instead of the one the wire format defines, and a client reads a lane
+    with no description, no parent and no result rather than a refusal.
+    """
+    if not SUBAGENT_EVENTS_AVAILABLE:
+        return []
+    return sorted(
+        f"{event_class.__name__}.{field}"
+        for event_class, fields in _lineage_event_fields().items()
+        for field in fields
+        if field not in event_class.model_fields
+    )
+
+
+def validate_subagent_visibility(visibility: Optional[str]) -> str:
+    """Normalize a subagent_visibility value, refusing one this install cannot serve.
+
+    Everything ``attributed`` needs is feature-detected here: the lineage event
+    types, every field this interface writes on one of them, and the per-event
+    field the lane is stamped in. They belong in this check rather than at the
+    events themselves, which are built with a client already reading the stream.
+    """
+    resolved = visibility or SUBAGENT_VISIBILITY_INLINE
+    if resolved not in SUBAGENT_VISIBILITY_VALUES:
+        raise ValueError(f"subagent_visibility must be one of {SUBAGENT_VISIBILITY_VALUES}, got {visibility!r}")
+    if resolved == SUBAGENT_VISIBILITY_ATTRIBUTED:
+        if not SUBAGENT_EVENTS_AVAILABLE:
+            raise ValueError(
+                "subagent_visibility='attributed' needs the AG-UI subagent lineage events. "
+                "Please upgrade with `pip install -U ag-ui-protocol`."
+            )
+        undeclared = _lineage_fields_the_protocol_omits()
+        if undeclared:
+            raise ValueError(
+                "subagent_visibility='attributed' needs every field it writes on the AG-UI subagent "
+                f"lineage events, which the installed ag_ui.core omits: {', '.join(undeclared)}. "
+                "Please upgrade with `pip install -U ag-ui-protocol`."
+            )
+        cannot_carry_a_lane = _events_missing_the_lane_field()
+        if cannot_carry_a_lane:
+            raise ValueError(
+                f"subagent_visibility='attributed' needs {_SUBAGENT_RUN_ID_FIELD} on every event it "
+                f"attributes, which the installed ag_ui.core omits on {', '.join(cannot_carry_a_lane)}. "
+                "Please upgrade with `pip install -U ag-ui-protocol`."
+            )
+    return resolved
+
+
+def _log_withheld_failure(chunk: BaseRunOutputEvent, lane: Optional[str], normalized: str) -> None:
+    """Record a member failure or cancellation that ``hidden`` keeps off the wire.
+
+    Every way a member can fail belongs here, its own run and any one of its
+    tool calls alike: with nothing on the wire naming the member, this line is
+    the only trace an operator gets of which member it was.
+
+    What ``hidden`` withholds is that identity, not always the text. A member's
+    own terminal can be the only account the stream carries of how the run
+    stopped, and is then read as the run terminal, so its failure text or its
+    cancellation reason reaches the client as the reason the run ended. Those
+    two lines say so rather than claiming the client was told nothing. A tool
+    call's failure ends no run, so nothing of it reaches the client and its line
+    says exactly that.
+    """
+    if normalized == RunEvent.run_error.value:
+        details = {
+            "error_type": getattr(chunk, "error_type", None),
+            "error_id": getattr(chunk, "error_id", None),
+            "additional_data": getattr(chunk, "additional_data", None),
+        }
+        message = _readable(getattr(chunk, "content", None), "a withheld subagent failure message")
+        log_error(
+            f"AG-UI withheld the identity of a subagent that failed in lane {lane}, so no SUBAGENT_ERROR "
+            f"named it; {_REASON_STILL_REACHES_THE_CLIENT}: "
+            f"{message or 'Subagent run failed'}{_correlation(details)}"
+        )
+    elif normalized == RunEvent.tool_call_error.value:
+        tool = getattr(chunk, "tool", None)
+        details = {
+            "tool_call_id": getattr(tool, "tool_call_id", None),
+            "tool_name": getattr(tool, "tool_name", None),
+        }
+        error = _readable(getattr(chunk, "error", None), "a withheld subagent tool call failure")
+        log_error(
+            f"AG-UI withheld a subagent tool call failure in lane {lane}: "
+            f"{error or 'Tool call failed'}{_correlation(details)}"
+        )
+    elif normalized == RunEvent.run_cancelled.value:
+        reason = _readable(getattr(chunk, "reason", None), "a withheld subagent cancellation reason")
+        log_warning(
+            f"AG-UI withheld the identity of a subagent cancelled in lane {lane}, so no SUBAGENT_ERROR "
+            f"named it; {_REASON_STILL_REACHES_THE_CLIENT}: {reason or 'Subagent run cancelled'}"
+        )
+
+
+def _ends_a_run(chunk: BaseRunOutputEvent) -> bool:
+    """Whether a chunk is one of the events that end a run: completed, paused or error."""
     event = getattr(chunk, "event", None)
     if event is None:
         return False
@@ -481,26 +1499,118 @@ def is_completion_event(chunk: BaseRunOutputEvent) -> bool:
     return event_value in _COMPLETION_EVENTS
 
 
-def process_event(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
-    """Process a single Agno event and return AG-UI events to emit."""
+def _ends_a_subagent(chunk: BaseRunOutputEvent) -> bool:
+    """Whether a chunk stops the subagent it came from."""
+    return _normalized_event_of(chunk) in _SUBAGENT_RUN_ENDING_EVENTS
+
+
+def _normalized_event_of(chunk: BaseRunOutputEvent) -> str:
+    """A chunk's event name with the Team prefix stripped, or empty when it has none."""
     event = getattr(chunk, "event", None)
     if event is None:
-        return on_unknown_event(chunk, state)
+        return ""
+    return _normalize_event(event.value if hasattr(event, "value") else str(event))
 
-    event_value = event.value if hasattr(event, "value") else str(event)
-    normalized = _normalize_event(event_value)
 
-    handler = HANDLERS.get(normalized)
-    if handler:
-        return handler(chunk, state)
+def is_completion_event(chunk: BaseRunOutputEvent, state: StreamState) -> bool:
+    """Check if this event is terminal for the stream (completed, paused, or error).
 
-    return on_unknown_event(chunk, state)
+    A subagent's own completion is terminal for that subagent only. It still
+    reads as a stream terminal under inline visibility, where the wire carries
+    no subagent lifecycle and the top-level terminal that follows supersedes it.
+    The state is what says which of the two a chunk is, so there is no answering
+    without it.
+    """
+    return _ends_a_run(chunk) and state.lane_for(*_chunk_run_ids(chunk)) is ROOT_LANE
+
+
+def is_subagent_completion_event(chunk: BaseRunOutputEvent, state: StreamState) -> bool:
+    """Whether a chunk ends one subagent rather than the run.
+
+    A stream whose last chunk is one of these ended on a subagent's terminal and
+    reported no terminal of its own, so that chunk is the only account of how the
+    run ended: read as anything else, a run that died inside a subagent is
+    reported to the client as a success. Under inline visibility every such chunk
+    is already the run's own terminal, so this is what makes the other
+    visibilities end that stream the same way.
+
+    What counts is read from the subagent terminal table rather than from the
+    run-terminal set, which a cancellation is deliberately absent from: the
+    top-level entity's cancellation is not a run terminal this interface builds
+    from, but a subagent's is a subagent terminal, and every one of those has to
+    be recognized here.
+    """
+    return _ends_a_subagent(chunk) and state.lane_for(*_chunk_run_ids(chunk)) is not ROOT_LANE
+
+
+def process_event(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
+    """Process a single Agno event and return AG-UI events to emit."""
+    lane = state.resolve_lane(*_chunk_run_ids(chunk))
+
+    event = getattr(chunk, "event", None)
+    event_value = event.value if event is not None and hasattr(event, "value") else str(event)
+    normalized = _normalize_event(event_value) if event is not None else ""
+
+    events: List[BaseEvent] = []
+    if lane is not ROOT_LANE:
+        if state.hides_subagents:
+            # Invisible delegation: nothing the subagent streamed is sent as its
+            # own work, and no lineage event or stamp goes out. The parent's own
+            # delegation tool call and its result still do, arguments included.
+            # Two things the subagent produced also reach the client. One is a
+            # change a tool of its own made to the session state, which is one
+            # shared document, delivered here. The other is a pending tool call
+            # it paused on, which the run cannot continue without and which
+            # reaches the client from the delegating run's requirements.
+            if normalized == RunEvent.tool_call_completed.value:
+                return _emit_state_delta(state)
+            # Hidden withholds what identifies a member, not the fact that one
+            # failed: nothing else would tell the operator it happened.
+            _log_withheld_failure(chunk, lane, normalized)
+            return []
+        events.extend(_announce_subagent(chunk, state, lane))
+        if normalized in _SUBAGENT_WITHHELD_EVENTS:
+            return events
+        subagent_terminal = _SUBAGENT_TERMINAL_HANDLERS.get(normalized)
+        if subagent_terminal:
+            events.extend(subagent_terminal(chunk, state, lane))
+            return events
+
+    handler = HANDLERS.get(normalized) if event is not None else None
+    mapped = handler(chunk, state) if handler else on_unknown_event(chunk, state)
+    events.extend(_stamp_lane(mapped, lane))
+    if lane is not ROOT_LANE and lane in state.closed_subagents:
+        # These events carry a member after that member's terminal, which the
+        # rest of this interface refuses to do: the run end orders the pause
+        # prompt before the member terminals, and the prompt itself declines to
+        # name a lane that has already terminated, both for that reason. This is
+        # the exemption, and it is the source stream's doing rather than a
+        # choice made here. A member whose own run already ended is still
+        # emitting, and the alternatives are worse: reparenting its output to
+        # the leader would report a member's words as somebody else's, and a
+        # second announcement would give one invocation two lifecycles.
+        #
+        # The span it opens does close with it. Left open, it swallows
+        # everything the rest of the run emits, starting with the parent's
+        # result for the delegation this member was running inside. Tool calls
+        # keep their own lifecycle, so a result still arrives for one opened
+        # here.
+        events.extend(_close_lane_messages(state, lane))
+    return events
+
+
+# The terminal chunks that end the run in failure rather than completion. A
+# cancellation is one of them: the run stopped without producing what it was
+# asked for, so telling the client it finished would report a success that never
+# happened. Only a subagent's cancellation can be the chunk the run terminal is
+# built from, since the top-level entity's is not read as a run terminal at all.
+_FAILED_RUN_TERMINALS = frozenset({RunEvent.run_error.value, RunEvent.run_cancelled.value})
 
 
 def process_completion(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
     """Process a terminal event and return the corresponding AG-UI events."""
-    event = getattr(chunk, "event", None)
-    event_value = event.value if event is not None and hasattr(event, "value") else str(event)
-    if _normalize_event(event_value) == RunEvent.run_error.value:
-        return on_run_error(chunk, state)
+    state.resolve_lane(*_chunk_run_ids(chunk))
+    normalized = _normalized_event_of(chunk)
+    if normalized in _FAILED_RUN_TERMINALS:
+        return on_run_error(chunk, state, normalized)
     return on_run_completed(chunk, state)

--- a/libs/agno/agno/os/interfaces/agui/router.py
+++ b/libs/agno/agno/os/interfaces/agui/router.py
@@ -21,6 +21,7 @@ from fastapi import APIRouter, Request
 from fastapi.responses import StreamingResponse
 
 from agno.agent import Agent, RemoteAgent
+from agno.os.interfaces.agui.handlers import validate_subagent_visibility
 from agno.os.interfaces.agui.input import (
     extract_context,
     extract_media,
@@ -41,6 +42,7 @@ async def run_entity(
     entity: Union[Agent, RemoteAgent, Team, RemoteTeam],
     run_input: RunAgentInput,
     user_id: Optional[str] = None,
+    subagent_visibility: Optional[str] = None,
 ) -> AsyncIterator[BaseEvent]:
     """Shared handler for running an Agent or Team with AG-UI input/output mapping.
 
@@ -126,6 +128,7 @@ async def run_entity(
             thread_id=run_input.thread_id,
             run_id=run_id,
             run_state=session_state,
+            subagent_visibility=subagent_visibility,
         ):
             yield event
 
@@ -135,12 +138,21 @@ async def run_entity(
 
 
 def attach_routes(
-    router: APIRouter, agent: Optional[Union[Agent, RemoteAgent]] = None, team: Optional[Union[Team, RemoteTeam]] = None
+    router: APIRouter,
+    agent: Optional[Union[Agent, RemoteAgent]] = None,
+    team: Optional[Union[Team, RemoteTeam]] = None,
+    subagent_visibility: Optional[str] = None,
 ) -> APIRouter:
     if agent is None and team is None:
         raise ValueError("Either agent or team must be provided.")
 
-    entity = agent or team
+    # Validated at mount time, not per request: an unserveable setting is a
+    # startup failure, never an in-band error after a run has already begun.
+    subagent_visibility = validate_subagent_visibility(subagent_visibility)
+
+    # An agent takes precedence over a team, decided on presence, so the entity a
+    # request runs is the one the interface's scope mapping named.
+    entity = agent if agent is not None else team
     encoder = EventEncoder()
 
     @router.post("/agui", name="run_agent")
@@ -160,7 +172,12 @@ def attach_routes(
         )
 
         async def event_generator():
-            async for event in run_entity(entity, run_input, user_id=user_id):  # type: ignore
+            async for event in run_entity(
+                entity,  # type: ignore[arg-type]
+                run_input,
+                user_id=user_id,
+                subagent_visibility=subagent_visibility,
+            ):
                 yield encoder.encode(event)
 
         return StreamingResponse(

--- a/libs/agno/agno/os/interfaces/agui/state.py
+++ b/libs/agno/agno/os/interfaces/agui/state.py
@@ -1,17 +1,92 @@
 import copy
 import uuid
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from agno.utils.log import log_warning
 
+# The three client-facing presentations of a delegation to a subagent. Values
+# name what the CLIENT SEES, not an internal switch:
+#   "inline"     - the subagent's output streams as the parent's own work,
+#                  byte-identical to the pre-lineage behavior. The safe default:
+#                  a client already in production cannot be protected after the
+#                  fact from event types its transport rejects.
+#   "attributed" - the full subagent surface: SUBAGENT_* lifecycle events, and a
+#                  subagent_run_id on the message, tool call and reasoning events
+#                  a subagent produced. State events stay unstamped, because a
+#                  team's session state is one shared document.
+#   "hidden"     - invisible delegation: no SUBAGENT_* lifecycle event and no
+#                  per-event subagent stamp reaches the wire, and nothing a
+#                  subagent streamed is sent as its own work. What the client
+#                  sees is the parent's: the delegation tool call, whose
+#                  arguments name the member and carry the task text just as the
+#                  default sends them, that call's result, and the parent's own
+#                  reply. Two things a subagent produced also arrive: a change
+#                  its tool made to the session state, which is one shared
+#                  document, and a pending tool call it paused on, which the run
+#                  cannot continue without. Neither is attributed to it. What a
+#                  subagent's failure withholds is that same identity: the
+#                  lineage events and the per-event stamps stay off the wire and
+#                  nothing on it names the subagent that failed, while the
+#                  reason the run stopped still reaches the client, because a
+#                  subagent's terminal can be the run's only account of how it
+#                  ended and is then read as the run's own.
+SUBAGENT_VISIBILITY_INLINE = "inline"
+SUBAGENT_VISIBILITY_ATTRIBUTED = "attributed"
+SUBAGENT_VISIBILITY_HIDDEN = "hidden"
+SUBAGENT_VISIBILITY_VALUES = (
+    SUBAGENT_VISIBILITY_INLINE,
+    SUBAGENT_VISIBILITY_ATTRIBUTED,
+    SUBAGENT_VISIBILITY_HIDDEN,
+)
+
+# Lane key for the top-level entity's own streaming state. Subagent lanes are
+# keyed by the subagent's run id.
+ROOT_LANE: Optional[str] = None
+
+
+# The tools a Team delegates through, named exactly as the framework registers
+# them: two for member delegation, and two more when the team works a task list.
+# The decision keys on the name because argument shape does not identify a
+# delegation: Agno's own ``update_user_memory`` also takes a ``task``, and the
+# tasks-mode tools take none.
+DELEGATION_TOOL_NAMES = frozenset(
+    {
+        "delegate_task_to_member",
+        "delegate_task_to_members",
+        "execute_task",
+        "execute_tasks_parallel",
+    }
+)
+
 
 @dataclass
-class StreamState:
-    """Per-stream state for AG-UI event translation.
+class OpenToolCall:
+    """One tool call still open in a lane.
 
-    Tracks message lifecycle, tool calls, reasoning sessions, and state deltas.
-    All handlers receive this object and mutate it as events flow through.
+    The tool name is a required part of the record: it is what identifies a
+    delegation, and without it a reader is left inferring intent from the
+    arguments, which mistakes any tool taking a ``task`` for a delegation.
+    """
+
+    name: str
+    args: Dict[str, Any]
+    parent_message_id: str
+
+    @property
+    def is_delegation(self) -> bool:
+        return self.name in DELEGATION_TOOL_NAMES
+
+
+@dataclass
+class Lane:
+    """Streaming state for one attribution lane.
+
+    A lane is the top-level entity or a single subagent invocation. Message,
+    reasoning and tool-parent state is per-lane so a subagent's text never
+    lands in the parent's bubble and two subagents streaming at once keep
+    independent spans.
 
     Text Message Lifecycle:
         CLOSED (initial)      OPEN                   CLOSED
@@ -21,18 +96,42 @@ class StreamState:
     The text_message_id persists after close so tool calls can parent to it.
     """
 
-    # Text message tracking
     text_message_id: str = ""
     text_message_open: bool = False
-
-    # Tool call tracking
-    active_tool_call_ids: Set[str] = field(default_factory=set)
-    ended_tool_call_ids: Set[str] = field(default_factory=set)
     pending_tool_calls_parent_id: str = ""
-
-    # Reasoning tracking
     reasoning_message_id: Optional[str] = None
     reasoning_step_count: int = 0
+
+
+@dataclass
+class Subagent:
+    """A subagent invocation announced on the wire."""
+
+    name: str
+    parent_lane: Optional[str] = None
+
+
+@dataclass
+class StreamState:
+    """Per-stream state for AG-UI event translation.
+
+    Tracks message lifecycle, tool calls, reasoning sessions, state deltas and
+    subagent lineage. All handlers receive this object and mutate it as events
+    flow through.
+
+    Lane-scoped state lives in ``lanes``; the message, reasoning and tool-parent
+    properties below read whichever lane the chunk being mapped belongs to, and
+    the methods beside them are what writes it. Under ``inline`` visibility every
+    chunk resolves to ROOT_LANE, so there is exactly one lane and the emitted
+    stream is unchanged.
+    """
+
+    # Tool call tracking. Tool call ids are unique across the run, so these stay
+    # flat; ``tool_call_lanes`` remembers which lane each one belongs to so a
+    # tool call closed at run end is still attributed to its own subagent.
+    active_tool_call_ids: Set[str] = field(default_factory=set)
+    ended_tool_call_ids: Set[str] = field(default_factory=set)
+    tool_call_lanes: Dict[str, Optional[str]] = field(default_factory=dict)
 
     # State delta tracking
     _last_snapshot: Optional[Dict[str, Any]] = field(default=None, repr=False)
@@ -42,52 +141,354 @@ class StreamState:
     run_id: str = ""
     run_state: Optional[Dict[str, Any]] = None
 
+    # Lineage
+    subagent_visibility: str = SUBAGENT_VISIBILITY_INLINE
+    lanes: Dict[Optional[str], Lane] = field(default_factory=dict)
+    current_lane: Optional[str] = ROOT_LANE
+    # Run id of the top-level entity, learned from the first chunk that reports
+    # no parent, so a subagent whose parent IS the top-level run reports no parent
+    # subagent. It is deliberately not seeded from ``run_id``: a resumed run
+    # executes under the stored paused run's id, not the request's, and seeding
+    # would read every chunk of it as a subagent's.
+    root_run_id: Optional[str] = None
+    open_subagents: Dict[str, Subagent] = field(default_factory=dict)
+    # Every subagent ever announced, kept after its terminal so a lane drained at
+    # run end still knows where it sits in the delegation tree.
+    announced_subagents: Dict[str, Subagent] = field(default_factory=dict)
+    # SUBAGENT_FINISHED / SUBAGENT_ERROR are terminal for the id they name, so a
+    # closed subagent may neither be re-announced nor own a second terminal.
+    closed_subagents: Set[str] = field(default_factory=set)
+    # Open tool calls per lane, each holding its name, its arguments and the
+    # message it was parented to. A delegation is one of these calls, so this is
+    # what links a subagent back to the exact call that spawned it.
+    open_tool_calls: Dict[Optional[str], Dict[str, OpenToolCall]] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        # Validated here as well as at the interface boundary, so a value that
+        # reached this object by any other route cannot become a silent fourth
+        # mode that behaves like none of the three.
+        if self.subagent_visibility not in SUBAGENT_VISIBILITY_VALUES:
+            raise ValueError(
+                f"subagent_visibility must be one of {SUBAGENT_VISIBILITY_VALUES}, got {self.subagent_visibility!r}"
+            )
+
+    @property
+    def hides_subagents(self) -> bool:
+        return self.subagent_visibility == SUBAGENT_VISIBILITY_HIDDEN
+
+    def lane(self, key: Optional[str]) -> Lane:
+        """The state of one named lane, created on first use.
+
+        The key is always explicit: ROOT_LANE is ``None``, so a "current lane"
+        default here would make a root-lane lookup indistinguishable from one.
+        """
+        existing = self.lanes.get(key)
+        if existing is None:
+            existing = Lane()
+            self.lanes[key] = existing
+        return existing
+
+    def active_lane(self) -> Lane:
+        """The state of the lane the chunk being mapped belongs to."""
+        return self.lane(self.current_lane)
+
+    # --- Lane-scoped message state -------------------------------------------
+
+    @property
+    def text_message_id(self) -> str:
+        return self.active_lane().text_message_id
+
+    @property
+    def text_message_open(self) -> bool:
+        return self.active_lane().text_message_open
+
+    @property
+    def reasoning_message_id(self) -> Optional[str]:
+        return self.active_lane().reasoning_message_id
+
     def open_text_message(self) -> str:
-        self.text_message_id = str(uuid.uuid4())
-        self.text_message_open = True
-        return self.text_message_id
+        lane = self.active_lane()
+        lane.text_message_id = str(uuid.uuid4())
+        lane.text_message_open = True
+        return lane.text_message_id
 
     def close_text_message(self) -> None:
         # ID persists for tool call parenting — only flag changes
-        self.text_message_open = False
+        self.active_lane().text_message_open = False
 
     def start_tool_call(self, tool_call_id: str) -> None:
         self.active_tool_call_ids.add(tool_call_id)
+        self.tool_call_lanes[tool_call_id] = self.current_lane
 
     def end_tool_call(self, tool_call_id: str) -> None:
         self.active_tool_call_ids.discard(tool_call_id)
         self.ended_tool_call_ids.add(tool_call_id)
+        self.open_tool_calls.get(self.lane_of_tool_call(tool_call_id), {}).pop(tool_call_id, None)
+
+    def lane_of_tool_call(self, tool_call_id: str) -> Optional[str]:
+        return self.tool_call_lanes.get(tool_call_id, ROOT_LANE)
+
+    def tool_call_started(self, tool_call_id: str) -> bool:
+        """Whether a start has gone out for a call the run itself opened.
+
+        Every call opened from the run's own tool-call event is recorded in
+        ``tool_call_lanes`` and stays there once it ends, so this holds whatever
+        state such a call is in now, and a call the client already has a start
+        for is never given a second one. The starts a pause prompt writes are
+        not recorded here: one terminal produces one prompt, which dedupes
+        against the calls it is building rather than against this.
+        """
+        return tool_call_id in self.tool_call_lanes
+
+    def active_tool_calls_in_order(self) -> List[str]:
+        """Tool calls still open, in the order the run opened them.
+
+        The close order reaches the client, so it is read from
+        ``tool_call_lanes``, which records every call as it starts, rather than
+        from the unordered active set. A call that somehow never reached that
+        record still has to be closed, so any such id follows, sorted.
+        """
+        ordered = [tool_call_id for tool_call_id in self.tool_call_lanes if tool_call_id in self.active_tool_call_ids]
+        ordered.extend(sorted(self.active_tool_call_ids.difference(ordered)))
+        return ordered
 
     def get_parent_message_id_for_tool_call(self) -> str:
+        lane = self.active_lane()
         # pending_tool_calls_parent_id used for sequential tools after message close
-        if self.pending_tool_calls_parent_id:
-            return self.pending_tool_calls_parent_id
+        if lane.pending_tool_calls_parent_id:
+            return lane.pending_tool_calls_parent_id
         # text_message_id persists after close
-        return self.text_message_id
+        return lane.text_message_id
 
     def set_pending_tool_calls_parent_id(self, parent_id: str) -> None:
-        self.pending_tool_calls_parent_id = parent_id
+        self.active_lane().pending_tool_calls_parent_id = parent_id
 
     def clear_pending_tool_calls_parent_id(self) -> None:
-        self.pending_tool_calls_parent_id = ""
+        self.active_lane().pending_tool_calls_parent_id = ""
 
     def start_reasoning(self) -> str:
-        self.reasoning_message_id = str(uuid.uuid4())
-        self.reasoning_step_count = 0
-        return self.reasoning_message_id
+        lane = self.active_lane()
+        lane.reasoning_message_id = str(uuid.uuid4())
+        lane.reasoning_step_count = 0
+        return lane.reasoning_message_id
 
     def ensure_reasoning_started(self) -> Tuple[str, bool]:
-        if self.reasoning_message_id is not None:
-            return self.reasoning_message_id, False
+        lane = self.active_lane()
+        if lane.reasoning_message_id is not None:
+            return lane.reasoning_message_id, False
         return self.start_reasoning(), True
 
     def next_reasoning_step(self) -> int:
-        self.reasoning_step_count += 1
-        return self.reasoning_step_count
+        lane = self.active_lane()
+        lane.reasoning_step_count += 1
+        return lane.reasoning_step_count
 
     def end_reasoning(self) -> None:
-        self.reasoning_message_id = None
-        self.reasoning_step_count = 0
+        lane = self.active_lane()
+        lane.reasoning_message_id = None
+        lane.reasoning_step_count = 0
+
+    # --- Lineage -------------------------------------------------------------
+
+    def lane_for(self, run_id: Optional[str], parent_run_id: Optional[str]) -> Optional[str]:
+        """The lane a chunk belongs to, without changing any state.
+
+        Agno stamps every chunk with its own ``run_id`` and, for a subagent, the
+        ``parent_run_id`` of the run that delegated to it. A chunk that reports
+        no parent is the top-level entity's own work. Under ``inline`` visibility
+        every chunk is the top-level entity's work as far as the wire is
+        concerned, which is what keeps that stream unchanged.
+        """
+        if self.subagent_visibility == SUBAGENT_VISIBILITY_INLINE:
+            return ROOT_LANE
+        if parent_run_id is None or run_id is None or run_id == self.root_run_id:
+            return ROOT_LANE
+        return run_id
+
+    def resolve_lane(self, run_id: Optional[str], parent_run_id: Optional[str]) -> Optional[str]:
+        """Make the chunk's lane current, learning the top-level run id on the way."""
+        if parent_run_id is None and run_id is not None and self.root_run_id is None:
+            self.root_run_id = run_id
+        self.current_lane = self.lane_for(run_id, parent_run_id)
+        return self.current_lane
+
+    def delegating_lane_for(
+        self, parent_run_id: Optional[str], member_id: Optional[str]
+    ) -> Tuple[Optional[str], Optional[str]]:
+        """The lane that delegated to a subagent, and the call it delegated through.
+
+        The call is only ever looked for in the lane reported beside it, so what
+        a subagent is announced with comes from the run that really delegated to
+        it and from nowhere else. When the delegating lane cannot be named, no
+        call is reported either: the delegating run's own open calls are not
+        this run's, and searching the top-level entity's instead would hand a
+        grandchild the leader's call, the leader's parent message, and the
+        leader's task text as its own description.
+
+        A lane goes unnamed for two reasons, and neither leaves a link behind.
+        One is a lane this stream has not announced: a parent link is resolved
+        by the client against a lane it was told about, so a grandchild whose
+        first event outruns its parent's is placed directly under the run rather
+        than pointed at a lane the client cannot follow. The other is a lane
+        whose terminal has already gone out, which delegates nothing more:
+        naming it would hand the client a child that resolves inside a lane it
+        has already closed.
+        """
+        # A chunk reporting no parent at all, and one whose parent is the run
+        # this stream learned as the root, are both the top-level entity's work.
+        if parent_run_id is None or parent_run_id == self.root_run_id:
+            return ROOT_LANE, self.find_delegation_call(ROOT_LANE, member_id)
+        if parent_run_id in self.closed_subagents or parent_run_id not in self.announced_subagents:
+            return None, None
+        return parent_run_id, self.find_delegation_call(parent_run_id, member_id)
+
+    def record_open_tool_call(
+        self, tool_call_id: str, tool_name: Optional[str], tool_args: Any, parent_message_id: str
+    ) -> None:
+        # Name and arguments reach here straight off the model, so anything at all
+        # can arrive. Only a mapping of arguments is kept, which is all a
+        # delegation lookup reads.
+        self.open_tool_calls.setdefault(self.current_lane, {})[tool_call_id] = OpenToolCall(
+            name=str(tool_name) if tool_name else "",
+            args=dict(tool_args) if isinstance(tool_args, Mapping) else {},
+            parent_message_id=parent_message_id,
+        )
+
+    def find_delegation_call(self, parent_lane: Optional[str], member_id: Optional[str]) -> Optional[str]:
+        """Tool call id of the delegation that spawned a subagent, when identifiable.
+
+        Only a call still open in the delegating lane, whose tool name is one the
+        framework delegates through, and whose ``member_id`` argument names this
+        member. Naming the member is what makes such a call evidence: an open
+        delegation to somebody else would otherwise hand this lane another
+        member's parent call, task text and parent message. Two open delegations
+        naming the same member point at no single call, so nothing is reported
+        rather than one of them picked. The broadcast tools name no member at
+        all, so a member one of those spawned gets no link rather than the
+        leader's own call.
+        """
+        if not member_id:
+            return None
+        named = [
+            tool_call_id
+            for tool_call_id, entry in (self.open_tool_calls.get(parent_lane) or {}).items()
+            if entry.is_delegation and entry.args.get("member_id") == member_id
+        ]
+        return named[0] if len(named) == 1 else None
+
+    def find_member_delegation(self, member_id: Optional[str]) -> Optional[Tuple[Optional[str], str]]:
+        """The lane that delegated to a member and the call it delegated through.
+
+        A member run pauses inside the call that spawned it, so that call is
+        still open and the lane holding it is the member's parent, however deep
+        the run that reported the pause sits. Only a delegation naming this
+        member counts, and only while exactly one is open: two delegations
+        naming the same member, in one lane or in two, point at no single
+        parent, so nothing is reported rather than guessed.
+
+        A lane whose own terminal has already gone out is not searched. Whatever
+        it still holds open, that lane can no longer be named as a parent: its
+        terminal would then precede a child's, which is a lane the client has
+        already closed.
+        """
+        if not member_id:
+            return None
+        matches = [
+            (lane, tool_call_id)
+            for lane, calls in self.open_tool_calls.items()
+            if lane not in self.closed_subagents
+            for tool_call_id, entry in calls.items()
+            if entry.is_delegation and entry.args.get("member_id") == member_id
+        ]
+        if len(matches) != 1:
+            return None
+        return matches[0]
+
+    def _delegation_entry(self, parent_lane: Optional[str], tool_call_id: Optional[str]) -> Optional[OpenToolCall]:
+        if tool_call_id is None:
+            return None
+        return (self.open_tool_calls.get(parent_lane) or {}).get(tool_call_id)
+
+    def delegation_task(self, parent_lane: Optional[str], tool_call_id: Optional[str]) -> Optional[str]:
+        """The task text the delegation call carried, which describes the subagent's work.
+
+        Only a delegation's own arguments are read, so a ``task`` belonging to
+        some other tool can never become a subagent's description. The tasks-mode
+        delegations carry a task id instead of task text, so a subagent spawned by
+        one has no description rather than an invented one.
+        """
+        entry = self._delegation_entry(parent_lane, tool_call_id)
+        task = entry.args.get("task") if entry is not None and entry.is_delegation else None
+        return task if isinstance(task, str) and task else None
+
+    def delegation_parent_message_id(self, parent_lane: Optional[str], tool_call_id: Optional[str]) -> Optional[str]:
+        entry = self._delegation_entry(parent_lane, tool_call_id)
+        if entry is None or not entry.is_delegation:
+            return None
+        return entry.parent_message_id or None
+
+    def open_subagent(self, subagent_run_id: str, name: str, parent_lane: Optional[str]) -> None:
+        subagent = Subagent(name=name, parent_lane=parent_lane)
+        self.open_subagents[subagent_run_id] = subagent
+        self.announced_subagents[subagent_run_id] = subagent
+
+    def close_subagent(self, subagent_run_id: str) -> None:
+        self.open_subagents.pop(subagent_run_id, None)
+        self.closed_subagents.add(subagent_run_id)
+
+    def ancestor_lanes(self, lane_key: Optional[str]) -> List[str]:
+        """The announced subagent lanes above a lane, nearest first.
+
+        The walk stops on a lane it has already passed, so a parent chain that
+        somehow closes on itself ends the walk instead of looping.
+        """
+        ancestors: List[str] = []
+        seen = {lane_key}
+        entry = self.announced_subagents.get(lane_key) if lane_key is not None else None
+        parent = entry.parent_lane if entry else None
+        while parent is not None and parent not in seen:
+            ancestors.append(parent)
+            seen.add(parent)
+            entry = self.announced_subagents.get(parent)
+            parent = entry.parent_lane if entry else None
+        return ancestors
+
+    def lane_depth(self, lane_key: Optional[str]) -> int:
+        """How many announced subagent lanes sit above a lane.
+
+        A direct child of the top-level entity has none above it, so it reports 0,
+        the same as the root lane. The value exists to order children before
+        parents, not to measure how deep a delegation went.
+        """
+        return len(self.ancestor_lanes(lane_key))
+
+    def subagents_deepest_first(self) -> List[str]:
+        """Open subagents ordered so a child's terminal precedes its parent's."""
+        return sorted(self.open_subagents, key=self.lane_depth, reverse=True)
+
+    def lanes_deepest_first(self) -> List[Optional[str]]:
+        """Every lane the stream created, children before parents, then the root.
+
+        The root lane is always last whether or not it holds anything, so a
+        caller sweeping these closes nothing there rather than skipping it.
+
+        Every lane the mapper opens a tool call through already has a record here,
+        so the sweep over open tool calls adds nothing in practice; it is kept so
+        that the guarantee no tool call reaches the run terminal unended does not
+        rest on its lane happening to hold a span of its own. Ordering is taken
+        from insertion order rather than from the tool call sets, so lanes of equal
+        depth keep the order the stream created them in.
+        """
+        keys: List[Optional[str]] = list(self.lanes)
+        seen = set(keys)
+        for tool_call_id, lane_key in self.tool_call_lanes.items():
+            if tool_call_id in self.active_tool_call_ids and lane_key not in seen:
+                seen.add(lane_key)
+                keys.append(lane_key)
+        subagent_lanes = [key for key in keys if key is not ROOT_LANE]
+        return [*sorted(subagent_lanes, key=self.lane_depth, reverse=True), ROOT_LANE]
+
+    # --- State deltas --------------------------------------------------------
 
     def set_state_snapshot(self, state: Dict[str, Any]) -> None:
         self._last_snapshot = copy.deepcopy(state)

--- a/libs/agno/agno/os/interfaces/agui/stream.py
+++ b/libs/agno/agno/os/interfaces/agui/stream.py
@@ -1,12 +1,87 @@
 from collections.abc import Iterator
-from typing import Any, AsyncIterator, Dict, Optional, Union
+from typing import Any, AsyncIterator, Dict, List, Optional, Union
 
 from ag_ui.core import BaseEvent
 
-from agno.os.interfaces.agui.handlers import is_completion_event, process_completion, process_event
+from agno.os.interfaces.agui.handlers import (
+    close_open_spans,
+    is_completion_event,
+    is_subagent_completion_event,
+    process_completion,
+    process_event,
+    validate_subagent_visibility,
+)
+from agno.os.interfaces.agui.handlers import (
+    _readable as readable_value,
+)
 from agno.os.interfaces.agui.state import StreamState
 from agno.run.agent import RunCompletedEvent, RunOutputEvent
+from agno.run.base import BaseRunOutputEvent
 from agno.run.team import TeamRunOutputEvent
+from agno.utils.log import log_exception
+
+
+def _failure_message(error: Exception) -> str:
+    """What a failed stream tells the client: the exception's text, or its type name.
+
+    The text is read through the same guard every other label is. Rendering an
+    exception runs its own ``__str__``, which can raise, and this runs before the
+    cleanup's try: unguarded, an exception that cannot describe itself would
+    close no span and no subagent lane, and would replace the run's real failure
+    with the one raised while naming it.
+    """
+    return readable_value(error, "a stream failure message") or type(error).__name__
+
+
+def _failure_detail(error: Exception) -> str:
+    """The failure as an operator needs it: what raised, and its text when it has any.
+
+    Guarded exactly as the message above is, and for the same reason: this is
+    what the failure is recorded with, so raising here would lose the record too.
+    """
+    message = readable_value(error, "a stream failure detail")
+    return f"{type(error).__name__}: {message}" if message else type(error).__name__
+
+
+def _run_terminal(
+    root_terminal: Optional[BaseRunOutputEvent], subagent_terminal: Optional[BaseRunOutputEvent]
+) -> BaseRunOutputEvent:
+    """The chunk the run terminal is built from.
+
+    The top-level entity's own terminal is it whenever the stream carried one. A
+    stream that ended on a subagent's terminal instead reported no other account
+    of how the run ended, so that one is read as the run's: a run that died
+    inside a subagent must not reach the client as a success. A stream that
+    reported no terminal at all completed, which is what it was before subagent
+    lineage existed.
+
+    Which subagent terminal, when the stream carried more than one, is simply
+    the last of them: nothing here ranks a failure above a later completion. A
+    subagent that fails and is then followed by another subagent completing
+    therefore ends the run as a completion, the failure surviving as that
+    subagent's own ``SUBAGENT_ERROR`` and the line recording it. The pause
+    variant is the same shape: a subagent pause followed by another subagent's
+    completion loses the pending call, because the completion is what the run
+    terminal is then built from and a completion has no pending call to prompt
+    with. Both hold under every visibility, the default included, which has no
+    other account of how the run ended either.
+    """
+    return root_terminal or subagent_terminal or RunCompletedEvent()
+
+
+def _cleanup_events(state: StreamState, run_id: str, error_message: str) -> List[BaseEvent]:
+    """The spans a failed stream still has to close, for a cleanup that cannot fail.
+
+    The caller re-raises the run's own failure straight after this, and that
+    failure is what the run terminal is built from. A raise from in here would
+    replace it with one from the cleanup and skip the re-raise, so a cleanup
+    that fails is recorded and yields what it can.
+    """
+    try:
+        return close_open_spans(state, error_message)
+    except Exception as error:
+        log_exception(f"AG-UI stream for run {run_id} could not close its open spans: {_failure_detail(error)}")
+        return []
 
 
 def stream_agno_response_as_agui_events(
@@ -14,25 +89,47 @@ def stream_agno_response_as_agui_events(
     thread_id: str,
     run_id: str,
     run_state: Optional[Dict[str, Any]] = None,
+    subagent_visibility: Optional[str] = None,
 ) -> Iterator[BaseEvent]:
     """Map the Agno response stream to AG-UI format."""
-    state = StreamState(thread_id=thread_id, run_id=run_id, run_state=run_state)
+    state = StreamState(
+        thread_id=thread_id,
+        run_id=run_id,
+        run_state=run_state,
+        subagent_visibility=validate_subagent_visibility(subagent_visibility),
+    )
 
     if run_state is not None:
         state.set_state_snapshot(run_state)
 
-    terminal_chunk = None
+    terminal_chunk: Optional[BaseRunOutputEvent] = None
+    subagent_terminal_chunk: Optional[BaseRunOutputEvent] = None
 
-    for chunk in response_stream:
-        if is_completion_event(chunk):
-            terminal_chunk = chunk
-        else:
-            for event in process_event(chunk, state):
-                yield event
+    try:
+        for chunk in response_stream:
+            if is_completion_event(chunk, state):
+                terminal_chunk = chunk
+            else:
+                for event in process_event(chunk, state):
+                    yield event
+                # Read after the chunk was mapped, so the lane it decides
+                # against is the one the mapper settled on for that chunk.
+                if is_subagent_completion_event(chunk, state):
+                    subagent_terminal_chunk = chunk
+    except Exception as error:
+        # A source stream that dies mid-run leaves every span this mapper opened
+        # unclosed, so a client would keep spinning on a message, a tool call or
+        # a member that never resolves. Close them and re-raise: the caller turns
+        # the propagated failure into the run terminal, and nothing may follow a
+        # terminal event. The failure is recorded first, with what raised and
+        # where, because the cleanup that follows it is otherwise the only trace
+        # that anything went wrong.
+        log_exception(f"AG-UI stream for run {run_id} failed mid-run, closing open spans: {_failure_detail(error)}")
+        for event in _cleanup_events(state, run_id, _failure_message(error)):
+            yield event
+        raise
 
-    # Process completion (or synthesize one if stream ended naturally)
-    final_chunk = terminal_chunk or RunCompletedEvent()
-    for event in process_completion(final_chunk, state):
+    for event in process_completion(_run_terminal(terminal_chunk, subagent_terminal_chunk), state):
         yield event
 
 
@@ -41,23 +138,45 @@ async def async_stream_agno_response_as_agui_events(
     thread_id: str,
     run_id: str,
     run_state: Optional[Dict[str, Any]] = None,
+    subagent_visibility: Optional[str] = None,
 ) -> AsyncIterator[BaseEvent]:
     """Map the Agno response stream to AG-UI format."""
-    state = StreamState(thread_id=thread_id, run_id=run_id, run_state=run_state)
+    state = StreamState(
+        thread_id=thread_id,
+        run_id=run_id,
+        run_state=run_state,
+        subagent_visibility=validate_subagent_visibility(subagent_visibility),
+    )
 
     if run_state is not None:
         state.set_state_snapshot(run_state)
 
-    terminal_chunk = None
+    terminal_chunk: Optional[BaseRunOutputEvent] = None
+    subagent_terminal_chunk: Optional[BaseRunOutputEvent] = None
 
-    async for chunk in response_stream:
-        if is_completion_event(chunk):
-            terminal_chunk = chunk
-        else:
-            for event in process_event(chunk, state):
-                yield event
+    try:
+        async for chunk in response_stream:
+            if is_completion_event(chunk, state):
+                terminal_chunk = chunk
+            else:
+                for event in process_event(chunk, state):
+                    yield event
+                # Read after the chunk was mapped, so the lane it decides
+                # against is the one the mapper settled on for that chunk.
+                if is_subagent_completion_event(chunk, state):
+                    subagent_terminal_chunk = chunk
+    except Exception as error:
+        # A source stream that dies mid-run leaves every span this mapper opened
+        # unclosed, so a client would keep spinning on a message, a tool call or
+        # a member that never resolves. Close them and re-raise: the caller turns
+        # the propagated failure into the run terminal, and nothing may follow a
+        # terminal event. The failure is recorded first, with what raised and
+        # where, because the cleanup that follows it is otherwise the only trace
+        # that anything went wrong.
+        log_exception(f"AG-UI stream for run {run_id} failed mid-run, closing open spans: {_failure_detail(error)}")
+        for event in _cleanup_events(state, run_id, _failure_message(error)):
+            yield event
+        raise
 
-    # Process completion (or synthesize one if stream ended naturally)
-    final_chunk = terminal_chunk or RunCompletedEvent()
-    for event in process_completion(final_chunk, state):
+    for event in process_completion(_run_terminal(terminal_chunk, subagent_terminal_chunk), state):
         yield event

--- a/libs/agno/tests/unit/os/interfaces/agui_stream_invariants.py
+++ b/libs/agno/tests/unit/os/interfaces/agui_stream_invariants.py
@@ -1,0 +1,1349 @@
+"""An executable definition of a well-formed AG-UI stream, shared by the suites.
+
+Three shapes of weak test kept reappearing in the AG-UI member attribution
+suites: an assertion that passed because it folded two emissions into one key, an
+assertion made against a fixture that emitted nothing of the kind it reasoned
+about, and a wire-level invariant that no test checked at all. A fourth kept
+reappearing too: a use of the subagent lineage protocol on an install that has
+none, which fails rather than skipping. Each helper here is the one way the
+suites do the thing that kept going wrong:
+
+``assert_well_formed_stream``
+    Every structural promise the protocol and this interface make, checked at
+    once. Every collector below runs it, and so does every collector in the
+    suites, so a new test inherits the whole set without opting in. Each of
+    those promises has a stream that breaks it in
+    ``test_agui_stream_invariants``, so one going quiet is a failure there
+    rather than a silence everywhere.
+``in_emitted_order``
+    Ordered tuples of what was emitted, in place of a mapping keyed by a wire id
+    or by content. A mapping silently folds a duplicate emission, and two
+    members that produced identical text, into one entry.
+``assert_stream_contains`` / ``assert_stream_carries_exactly``
+    A census, so an assertion about reasoning, pauses or state cannot be made
+    against a stream that carries none of it. A test that means "none of it"
+    says the count, which the first of the two refuses to be handed.
+``collect_sync`` / ``collect_async``
+    The same chunk list driven through the sync and the async mapper, so the two
+    bodies cannot drift. The ``*_recording_violations`` pair is for the one
+    suite whose subject is streams that are NOT well formed today.
+``attributed`` / ``event_type_named`` / ``needs_lineage_events``
+    The single door to everything the subagent lineage protocol release added.
+    Asking for the attributed setting, or for a ``SUBAGENT_*`` event type, on an
+    install that has neither skips the test instead of failing it.
+``HOSTILE_VALUES`` / ``encoding_failures``
+    Values a run's content can hold that serialization handles badly or not at
+    all, to drive through every boundary that builds an event out of run
+    content, and the protocol's own encoder to say whether what came out could
+    have reached a client at all.
+``LINEAGE_EVENTS_PROTOCOL_FLOOR`` / ``lineage_announcement_fields_missing``
+    The protocol release member attribution needs, beside the fields this
+    checker actually reads off an announcement, so the floor is recomputed
+    against those fields rather than left standing as a comment.
+``captured_agno_logs``
+    Log capture at every logger this codebase writes through, at a level that
+    can only widen what a test sees, never narrow it.
+"""
+
+import logging
+from collections import Counter
+from collections.abc import Iterator
+from contextlib import ExitStack, contextmanager
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as installed_version
+from typing import Any, AsyncIterator, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Union
+
+import ag_ui.core
+import pytest
+from ag_ui.core import BaseEvent, EventType
+from ag_ui.encoder import EventEncoder
+
+from agno.os.interfaces.agui.handlers import validate_subagent_visibility
+from agno.os.interfaces.agui.state import SUBAGENT_VISIBILITY_ATTRIBUTED
+from agno.os.interfaces.agui.stream import (
+    async_stream_agno_response_as_agui_events,
+    stream_agno_response_as_agui_events,
+)
+from agno.run.agent import RunContentEvent
+from agno.run.team import RunContentEvent as TeamRunContentEvent
+from agno.utils.log import LOGGER_NAME, TEAM_LOGGER_NAME, WORKFLOW_LOGGER_NAME
+
+# --- The one door to the lineage protocol -----------------------------------
+
+# The lineage events arrived in the ag-ui-protocol release named by
+# ``LINEAGE_EVENTS_PROTOCOL_FLOOR`` below, and this package's agui extra still
+# permits older ones, so everything that needs them skips instead of failing
+# while the settings that work on any release keep running.
+# Both halves of what ``attributed`` needs are feature-detected by the interface
+# itself, so this asks the interface rather than guessing.
+_NO_LINEAGE_REASON = "installed ag-ui-protocol cannot serve subagent_visibility='attributed'"
+
+
+def _attributed_is_servable() -> bool:
+    try:
+        validate_subagent_visibility(SUBAGENT_VISIBILITY_ATTRIBUTED)
+    except ValueError:
+        return False
+    return True
+
+
+ATTRIBUTED_IS_SERVABLE = _attributed_is_servable()
+
+needs_lineage_events = pytest.mark.skipif(not ATTRIBUTED_IS_SERVABLE, reason=_NO_LINEAGE_REASON)
+
+
+def require_lineage_events() -> None:
+    """Skip unless this install can serve member attribution."""
+    if not ATTRIBUTED_IS_SERVABLE:
+        pytest.skip(_NO_LINEAGE_REASON)
+
+
+def attributed() -> str:
+    """The attributed visibility, skipping when this install cannot serve it.
+
+    Every request for member attribution in the suites comes through here, so an
+    install without the lineage events cannot be asked for a setting the
+    interface refuses at startup.
+    """
+    require_lineage_events()
+    return SUBAGENT_VISIBILITY_ATTRIBUTED
+
+
+# The same value without the skip, for the tests whose subject IS the refusal:
+# on an install that lacks the lineage events those are the only tests that
+# still have something to assert, so they must not skip there.
+ATTRIBUTED_EVEN_WHEN_REFUSED = SUBAGENT_VISIBILITY_ATTRIBUTED
+
+
+def event_type_named(name: str) -> "EventType":
+    """One AG-UI event type by name, skipping when this install lacks it.
+
+    The ``SUBAGENT_*`` members arrived with the lineage release, so naming one
+    directly is what breaks a suite on an older install. Reaching an event type
+    through here means a test that needs one this install does not define skips.
+    """
+    event_type = _event_type(name)
+    if event_type is None:
+        require_lineage_events()
+        raise AssertionError(f"the installed ag_ui.core defines no {name} event type")
+    return event_type
+
+
+# --- Reading an event -------------------------------------------------------
+
+
+def lane_of(event: BaseEvent) -> Optional[str]:
+    """The member lane an event is stamped with, or None for the top-level entity."""
+    return getattr(event, "subagent_run_id", None)
+
+
+def of_type(events: Sequence[BaseEvent], event_type: "EventType") -> List[BaseEvent]:
+    return [event for event in events if event.type == event_type]
+
+
+def short_type(event: BaseEvent) -> str:
+    return str(event.type).removeprefix("EventType.")
+
+
+def declared_fields_of(event_class: Any) -> Optional[Iterable[str]]:
+    """The field names one event class declares, or None for a class with no model.
+
+    A protocol event's model accepts attributes it does not declare, so the
+    presence of an attribute on an instance says nothing about whether the wire
+    format carries it. A class with no model at all, which is what a stand-in
+    for a renamed event is, declares nothing to compare against.
+    """
+    return getattr(event_class, "model_fields", None)
+
+
+def field_of(event: BaseEvent, name: str) -> Any:
+    """One declared field of an event, refusing to read one its model does not declare.
+
+    Defaulting a missing attribute to None makes a renamed or removed field
+    compare equal to itself on both sides of an assertion, so the comparison
+    passes while nothing is being compared. Declared, not merely present: the
+    protocol models accept extra attributes, so a field the wire format no
+    longer carries can still be read back off an event something set it on, and
+    the comparison is then between a test's own writes.
+    """
+    declared = declared_fields_of(type(event))
+    carried = hasattr(event, name) if declared is None else name in declared
+    assert carried, f"{short_type(event)} declares no {name} field, so nothing here compares it"
+    return getattr(event, name)
+
+
+def _event_type(name: str) -> Optional["EventType"]:
+    """One protocol event type, or None on a release that does not define it.
+
+    The lineage event types arrived after this interface's minimum protocol
+    release, so this module has to import on an install that lacks them.
+    """
+    return getattr(EventType, name, None)
+
+
+SUBAGENT_STARTED = _event_type("SUBAGENT_STARTED")
+SUBAGENT_FINISHED = _event_type("SUBAGENT_FINISHED")
+SUBAGENT_ERROR = _event_type("SUBAGENT_ERROR")
+
+_MEMBER_TERMINAL_TYPES = tuple(t for t in (SUBAGENT_FINISHED, SUBAGENT_ERROR) if t is not None)
+_RUN_TERMINAL_TYPES = (EventType.RUN_FINISHED, EventType.RUN_ERROR)
+# The lifecycle of the run itself. Derived from the terminals rather than listed
+# beside them, so the two cannot come to disagree about what ends a run.
+_RUN_LEVEL_TYPES = (EventType.RUN_STARTED,) + _RUN_TERMINAL_TYPES
+_STATE_TYPES = (EventType.STATE_SNAPSHOT, EventType.STATE_DELTA)
+
+# Each link an announcement can carry beyond its parent member: the field, the
+# event that has to have put what it names on the wire, and that event's own id
+# field. The parent member link is not here; it resolves against the
+# announcements themselves, which is a different lookup and its own invariant.
+_ANNOUNCEMENT_PARENT_LINKS: Tuple[Tuple[str, "EventType", str], ...] = (
+    ("parent_tool_call_id", EventType.TOOL_CALL_START, "tool_call_id"),
+    ("parent_message_id", EventType.TEXT_MESSAGE_START, "message_id"),
+)
+
+# Each span family: a label, the event that opens a span, the one that closes
+# it, and the field both carry the span's id in.
+_SPAN_FAMILIES: Tuple[Tuple[str, "EventType", "EventType", str], ...] = (
+    ("text message", EventType.TEXT_MESSAGE_START, EventType.TEXT_MESSAGE_END, "message_id"),
+    ("tool call", EventType.TOOL_CALL_START, EventType.TOOL_CALL_END, "tool_call_id"),
+    ("reasoning", EventType.REASONING_START, EventType.REASONING_END, "message_id"),
+    (
+        "reasoning message",
+        EventType.REASONING_MESSAGE_START,
+        EventType.REASONING_MESSAGE_END,
+        "message_id",
+    ),
+)
+
+# Each content event, and the span it has to arrive inside. TOOL_CALL_RESULT is
+# absent on purpose: the interface emits a call's result after that call's end,
+# which is the shape the protocol asks for and which
+# ``_assert_every_tool_result_follows_its_calls_end`` holds it to.
+_CONTENT_IN_SPAN: Tuple[Tuple[str, "EventType", "EventType", "EventType", str], ...] = (
+    (
+        "text message content",
+        EventType.TEXT_MESSAGE_CONTENT,
+        EventType.TEXT_MESSAGE_START,
+        EventType.TEXT_MESSAGE_END,
+        "message_id",
+    ),
+    (
+        "tool call arguments",
+        EventType.TOOL_CALL_ARGS,
+        EventType.TOOL_CALL_START,
+        EventType.TOOL_CALL_END,
+        "tool_call_id",
+    ),
+    (
+        "reasoning content",
+        EventType.REASONING_MESSAGE_CONTENT,
+        EventType.REASONING_MESSAGE_START,
+        EventType.REASONING_MESSAGE_END,
+        "message_id",
+    ),
+)
+
+
+# --- Ordered comparison instead of id-keyed folding -------------------------
+
+Projection = Union[str, Callable[[BaseEvent], Any]]
+
+
+def in_emitted_order(
+    events: Sequence[BaseEvent],
+    event_type: "EventType",
+    *projections: Projection,
+) -> List[Tuple[Any, ...]]:
+    """Ordered tuples of the named fields, one entry per event of that type.
+
+    A mapping keyed by a wire id or by content is the wrong shape for comparing
+    what was emitted: a second emission of the same id overwrites the first, and
+    two members that produced identical text collapse into one key. The list
+    this returns keeps both, so a duplicate is a diff rather than a silence.
+
+    A projection is a field name, which the event has to declare, or a callable
+    given the event. A single projection still yields one-tuples, so every
+    comparison reads the same way.
+    """
+    assert projections, "in_emitted_order needs at least one projection to compare"
+    rows: List[Tuple[Any, ...]] = []
+    for event in of_type(events, event_type):
+        row = tuple(
+            projection(event) if callable(projection) else field_of(event, projection) for projection in projections
+        )
+        rows.append(row)
+    return rows
+
+
+def joined_text_in_emitted_order(events: Sequence[BaseEvent]) -> List[Tuple[Optional[str], str]]:
+    """(lane, joined text) per text message, in the order the messages opened.
+
+    Ordered rather than keyed by message id or by the text itself, so a message
+    emitted twice and two lanes saying the same thing both stay visible.
+    """
+    deltas: Dict[str, str] = {}
+    for event in of_type(events, EventType.TEXT_MESSAGE_CONTENT):
+        message_id = field_of(event, "message_id")
+        deltas[message_id] = deltas.get(message_id, "") + field_of(event, "delta")
+    return [
+        (lane_of(event), deltas.get(field_of(event, "message_id"), ""))
+        for event in of_type(events, EventType.TEXT_MESSAGE_START)
+    ]
+
+
+# --- The fixture census -----------------------------------------------------
+
+
+def assert_stream_contains(events: Sequence[BaseEvent], event_type: "EventType", at_least: int = 1) -> None:
+    """The stream really carries the kind of event the test is about to reason about.
+
+    An assertion about reasoning, or a pause, or a state change, run against a
+    stream that emitted none of it passes no matter what the implementation
+    does. Stating the subject up front is what makes deleting the code that
+    produces it fail a test.
+
+    A lower bound of zero is refused rather than allowed to read as a check: it
+    holds for every stream ever emitted. A test whose subject is an absence
+    states the count instead.
+    """
+    assert at_least >= 1, (
+        f"a lower bound of {at_least} {short_type_name(event_type)} events holds for any stream at all; "
+        "state the count with assert_stream_carries_exactly instead"
+    )
+    found = len(of_type(events, event_type))
+    assert found >= at_least, (
+        f"this stream carries {found} {short_type_name(event_type)} events, "
+        f"but the test reasons about at least {at_least}: the assertions below "
+        "cannot exercise what they claim to"
+    )
+
+
+def assert_stream_carries_exactly(events: Sequence[BaseEvent], event_type: "EventType", count: int) -> None:
+    """The stream carries exactly this many of an event, zero included."""
+    found = len(of_type(events, event_type))
+    assert found == count, f"this stream carries {found} {short_type_name(event_type)} events, not {count}"
+
+
+def short_type_name(event_type: "EventType") -> str:
+    return str(event_type).removeprefix("EventType.")
+
+
+# --- The named invariants ---------------------------------------------------
+
+# One name per structural promise, so an exemption can waive exactly the one it
+# was written for and nothing else.
+NO_SPAN_OPENS_TWICE = "no_span_opens_twice"
+NO_SPAN_CLOSES_TWICE = "no_span_closes_twice"
+NO_SPAN_CLOSES_UNOPENED = "no_span_closes_unopened"
+EVERY_SPAN_CLOSES = "every_span_closes"
+NO_SPAN_CLOSES_BEFORE_IT_OPENS = "no_span_closes_before_it_opens"
+CONTENT_LANDS_INSIDE_ITS_SPAN = "content_lands_inside_its_span"
+CONTENT_CARRIES_ITS_SPANS_MEMBER = "content_carries_its_spans_member"
+A_SPAN_CLOSES_IN_THE_MEMBER_IT_OPENED_IN = "a_span_closes_in_the_member_it_opened_in"
+EVERY_TOOL_CALL_PARENT_MESSAGE_WAS_OPENED = "every_tool_call_parent_message_was_opened"
+A_TOOL_CALL_SITS_IN_ITS_PARENT_MESSAGES_MEMBER = "a_tool_call_sits_in_its_parent_messages_member"
+EVERY_TOOL_RESULT_NAMES_A_STARTED_CALL = "every_tool_result_names_a_started_call"
+EVERY_TOOL_RESULT_FOLLOWS_ITS_CALLS_END = "every_tool_result_follows_its_calls_end"
+A_TOOL_RESULT_CARRIES_ITS_CALLS_MEMBER = "a_tool_result_carries_its_calls_member"
+ONE_RUN_TERMINAL_AND_NOTHING_AFTER_IT = "one_run_terminal_and_nothing_after_it"
+NO_MEMBER_IS_ANNOUNCED_TWICE = "no_member_is_announced_twice"
+EVERY_STAMP_NAMES_AN_ANNOUNCED_MEMBER = "every_stamp_names_an_announced_member"
+EVERY_ANNOUNCED_PARENT_IS_ANNOUNCED_TOO = "every_announced_parent_is_announced_too"
+AN_ANNOUNCED_PARENT_PRECEDES_ITS_CHILD = "an_announced_parent_precedes_its_child"
+EVERY_ANNOUNCED_PARENT_LINK_RESOLVES = "every_announced_parent_link_resolves"
+EVERY_ANNOUNCED_MEMBER_TERMINATES = "every_announced_member_terminates"
+NOTHING_CARRIES_A_MEMBER_AFTER_ITS_TERMINAL = "nothing_carries_a_member_after_its_terminal"
+A_CHILDS_TERMINAL_PRECEDES_ITS_PARENTS = "a_childs_terminal_precedes_its_parents"
+STATE_EVENTS_ARE_NEVER_STAMPED = "state_events_are_never_stamped"
+RUN_EVENTS_ARE_NEVER_STAMPED = "run_events_are_never_stamped"
+
+INVARIANTS = (
+    NO_SPAN_OPENS_TWICE,
+    NO_SPAN_CLOSES_TWICE,
+    NO_SPAN_CLOSES_UNOPENED,
+    EVERY_SPAN_CLOSES,
+    NO_SPAN_CLOSES_BEFORE_IT_OPENS,
+    CONTENT_LANDS_INSIDE_ITS_SPAN,
+    CONTENT_CARRIES_ITS_SPANS_MEMBER,
+    A_SPAN_CLOSES_IN_THE_MEMBER_IT_OPENED_IN,
+    EVERY_TOOL_CALL_PARENT_MESSAGE_WAS_OPENED,
+    A_TOOL_CALL_SITS_IN_ITS_PARENT_MESSAGES_MEMBER,
+    EVERY_TOOL_RESULT_NAMES_A_STARTED_CALL,
+    EVERY_TOOL_RESULT_FOLLOWS_ITS_CALLS_END,
+    A_TOOL_RESULT_CARRIES_ITS_CALLS_MEMBER,
+    ONE_RUN_TERMINAL_AND_NOTHING_AFTER_IT,
+    NO_MEMBER_IS_ANNOUNCED_TWICE,
+    EVERY_STAMP_NAMES_AN_ANNOUNCED_MEMBER,
+    EVERY_ANNOUNCED_PARENT_IS_ANNOUNCED_TOO,
+    AN_ANNOUNCED_PARENT_PRECEDES_ITS_CHILD,
+    EVERY_ANNOUNCED_PARENT_LINK_RESOLVES,
+    EVERY_ANNOUNCED_MEMBER_TERMINATES,
+    NOTHING_CARRIES_A_MEMBER_AFTER_ITS_TERMINAL,
+    A_CHILDS_TERMINAL_PRECEDES_ITS_PARENTS,
+    STATE_EVENTS_ARE_NEVER_STAMPED,
+    RUN_EVENTS_ARE_NEVER_STAMPED,
+)
+
+
+# --- Exemptions -------------------------------------------------------------
+
+# A stream that legitimately breaks one invariant names its exemption. Each
+# exemption waives exactly one named invariant and is justified here and nowhere
+# else, so an unexplained one cannot be introduced by passing a bare string and
+# a waiver cannot quietly widen to cover a second promise.
+TRAILING_OUTPUT_AFTER_A_MEMBER_TERMINAL = "trailing_output_after_a_member_terminal"
+ABANDONED_MID_STREAM = "abandoned_mid_stream"
+ABANDONED_WITH_A_MEMBER_STILL_OPEN = "abandoned_with_a_member_still_open"
+
+_EXEMPTIONS: Dict[str, Tuple[str, str]] = {
+    TRAILING_OUTPUT_AFTER_A_MEMBER_TERMINAL: (
+        NOTHING_CARRIES_A_MEMBER_AFTER_ITS_TERMINAL,
+        "something still carries the member after its terminal, from one of the "
+        "two places that can. The source stream emits a chunk from a member "
+        "whose own run already completed, and a terminal is final for the id it "
+        "names, so the interface keeps that output attributed to the member "
+        "rather than giving one invocation a second lifecycle. Or the run-end "
+        "sweep writes the end of a tool call that member left open, because a "
+        "member's terminal ends no tool call: only the call's own completion "
+        "knows what it produced. Either way the terminal is still unique.",
+    ),
+    ABANDONED_MID_STREAM: (
+        EVERY_SPAN_CLOSES,
+        "the consumer walked away mid-message, so the collected events are a "
+        "deliberate prefix of a stream: the spans open at that point are never "
+        "closed, because there is no client left to write them to.",
+    ),
+    ABANDONED_WITH_A_MEMBER_STILL_OPEN: (
+        EVERY_ANNOUNCED_MEMBER_TERMINATES,
+        "the consumer walked away while a member was streaming, so the member "
+        "announced in that prefix never reaches a terminal, for the same reason "
+        "its spans never close: nothing is written to a client that left.",
+    ),
+}
+
+EXEMPTIONS = tuple(_EXEMPTIONS)
+
+
+def exemption_waives(exemption: str) -> str:
+    """The single invariant one exemption waives."""
+    return _EXEMPTIONS[exemption][0]
+
+
+def _assert_exemptions_are_justified(exempt: Sequence[str]) -> None:
+    for granted in exempt:
+        assert granted in _EXEMPTIONS, f"{granted!r} is not a justified stream invariant exemption"
+
+
+def _waived(exempt: Sequence[str], invariant: str) -> bool:
+    """Whether one named invariant is waived, refusing an exemption nobody justified."""
+    _assert_exemptions_are_justified(exempt)
+    return any(_EXEMPTIONS[granted][0] == invariant for granted in exempt)
+
+
+# --- One executable definition of a well-formed stream ----------------------
+
+
+def _assert_invariants(events: Sequence[BaseEvent], exempt: Sequence[str]) -> None:
+    """The invariant set itself, run once per set of granted exemptions."""
+    _assert_spans_open_once_and_close(events, exempt)
+    _assert_content_lands_inside_its_span(events)
+    _assert_content_carries_its_spans_member(events)
+    _assert_a_span_closes_in_the_member_it_opened_in(events)
+    _assert_every_tool_call_parent_message_was_opened(events)
+    _assert_a_tool_call_sits_in_its_parent_messages_member(events)
+    _assert_every_tool_result_names_a_started_call(events)
+    _assert_every_tool_result_follows_its_calls_end(events)
+    _assert_a_tool_result_carries_its_calls_member(events)
+    _assert_nothing_follows_the_run_terminal(events)
+    _assert_no_member_is_announced_twice(events)
+    _assert_every_stamp_names_an_announced_member(events)
+    _assert_every_announced_parent_is_announced_too(events)
+    _assert_an_announced_parent_precedes_its_child(events)
+    _assert_every_announced_parent_link_resolves(events)
+    _assert_each_member_owns_exactly_one_terminal(events, exempt)
+    _assert_a_childs_terminal_precedes_its_parents(events)
+    _assert_state_events_are_never_stamped(events)
+    _assert_run_events_are_never_stamped(events)
+
+
+def assert_well_formed_stream(events: Sequence[BaseEvent], exempt: Sequence[str] = ()) -> None:
+    """Every structural invariant the protocol and member attribution promise.
+
+    Called by every collector in this module, and by every collector in the
+    suites, so each test gets the whole set whether or not it thought to ask. A
+    stream that breaks one of these for a correct reason names its exemption; a
+    bare string is refused, and so is an exemption this stream turns out not to
+    need: a waiver granted for a case that no longer arises silently stops the
+    invariant from being checked on every later run of that same stream.
+    """
+    _assert_exemptions_are_justified(exempt)
+    _assert_invariants(events, exempt)
+
+    for granted in exempt:
+        narrowed = [other for other in exempt if other != granted]
+        try:
+            _assert_invariants(events, narrowed)
+        except AssertionError:
+            continue
+        raise AssertionError(
+            f"this stream is well formed without the {granted} exemption, so granting it waives "
+            f"{exemption_waives(granted)} on a stream that does not break it"
+        )
+
+
+def stream_invariant_violation(events: Sequence[BaseEvent], exempt: Sequence[str] = ()) -> Optional[str]:
+    """The first invariant a stream breaks, or None when it is well formed.
+
+    For the few callers that have to state, and pin, that a stream is NOT well
+    formed today. Everything else asserts well-formedness directly.
+    """
+    try:
+        assert_well_formed_stream(events, exempt)
+    except AssertionError as violation:
+        return str(violation)
+    return None
+
+
+def _assert_spans_open_once_and_close(events: Sequence[BaseEvent], exempt: Sequence[str]) -> None:
+    allow_open = _waived(exempt, EVERY_SPAN_CLOSES)
+    for label, start_type, end_type, id_field in _SPAN_FAMILIES:
+        opened = [field_of(event, id_field) for event in of_type(events, start_type)]
+        closed = [field_of(event, id_field) for event in of_type(events, end_type)]
+
+        repeated = sorted(span_id for span_id, count in Counter(opened).items() if count > 1)
+        assert not repeated, f"{label} ids opened more than once: {repeated}"
+
+        # Counted before the two set comparisons below, which cannot see a
+        # duplicate at all: a span opened once and closed twice subtracts to a
+        # balance of zero, and reporting the leftover close as a span that never
+        # opened names the wrong fault on an id the stream did open.
+        closed_twice = sorted(span_id for span_id, count in Counter(closed).items() if count > 1)
+        assert not closed_twice, f"{label} ids closed more than once: {closed_twice}"
+
+        # Sets, now that neither side can hold a duplicate: a count difference
+        # here could only restate the two assertions above.
+        unopened = sorted(set(closed) - set(opened))
+        assert not unopened, f"{label} ids closed without ever being opened: {unopened}"
+
+        if not allow_open:
+            unclosed = sorted(set(opened) - set(closed))
+            assert not unclosed, f"{label} ids opened and never closed: {unclosed}"
+
+        # Ordering is checked whether or not a span is allowed to stay open: a
+        # close that precedes its own open is malformed in either stream.
+        first_close: Dict[Any, int] = {}
+        for index, event in enumerate(events):
+            if event.type == end_type:
+                first_close.setdefault(field_of(event, id_field), index)
+        for index, event in enumerate(events):
+            if event.type != start_type:
+                continue
+            span_id = field_of(event, id_field)
+            closed_at = first_close.get(span_id)
+            assert closed_at is None or closed_at > index, f"{label} {span_id} was closed before it opened"
+
+
+def _assert_content_lands_inside_its_span(events: Sequence[BaseEvent]) -> None:
+    """A delta belongs to a span the client has a start for and not yet an end.
+
+    Without this, a delta naming an id that was never opened, and one arriving
+    after that id's own end, are both accepted as well formed, and a client has
+    nowhere to put either.
+    """
+    for label, content_type, start_type, end_type, id_field in _CONTENT_IN_SPAN:
+        opened: Dict[Any, int] = {}
+        closed: Dict[Any, int] = {}
+        for index, event in enumerate(events):
+            if event.type == start_type:
+                opened.setdefault(field_of(event, id_field), index)
+            elif event.type == end_type:
+                closed.setdefault(field_of(event, id_field), index)
+            elif event.type == content_type:
+                span_id = field_of(event, id_field)
+                assert span_id in opened, (
+                    f"{label} at index {index} names {span_id}, which no earlier {short_type_name(start_type)} opened"
+                )
+                assert span_id not in closed, (
+                    f"{label} at index {index} names {span_id}, whose "
+                    f"{short_type_name(end_type)} already went out at index {closed[span_id]}"
+                )
+
+
+def _assert_content_carries_its_spans_member(events: Sequence[BaseEvent]) -> None:
+    """A delta is stamped with the member whose span it belongs to.
+
+    A client routes an event by the span it names and renders it in the member
+    it is stamped with. Those two disagreeing puts one member's words inside
+    another member's bubble, which no other check here would notice: the delta
+    names an open span, and its lane names an announced member.
+    """
+    for label, content_type, start_type, _end_type, id_field in _CONTENT_IN_SPAN:
+        lane_of_span: Dict[Any, Optional[str]] = {}
+        for event in events:
+            if event.type == start_type:
+                lane_of_span.setdefault(field_of(event, id_field), lane_of(event))
+            elif event.type == content_type:
+                span_id = field_of(event, id_field)
+                if span_id not in lane_of_span:
+                    # The span itself was never opened, which the check above reports.
+                    continue
+                assert lane_of(event) == lane_of_span[span_id], (
+                    f"{label} for {span_id} is stamped with member {lane_of(event)}, while the "
+                    f"{short_type_name(start_type)} that opened it named {lane_of_span[span_id]}"
+                )
+
+
+def _assert_a_span_closes_in_the_member_it_opened_in(events: Sequence[BaseEvent]) -> None:
+    """A span's end is stamped with the member its start named.
+
+    The end is what tells a client the bubble is finished, so an end stamped
+    with another member, or with none, closes a bubble in a lane that never
+    opened one and leaves the real one open forever. The delta check above
+    compares content against its start and would not notice either.
+    """
+    for label, start_type, end_type, id_field in _SPAN_FAMILIES:
+        lane_of_span: Dict[Any, Optional[str]] = {}
+        for event in events:
+            if event.type == start_type:
+                lane_of_span.setdefault(field_of(event, id_field), lane_of(event))
+            elif event.type == end_type:
+                span_id = field_of(event, id_field)
+                if span_id not in lane_of_span:
+                    # The span was closed without ever opening, which the span
+                    # check above reports.
+                    continue
+                assert lane_of(event) == lane_of_span[span_id], (
+                    f"the {short_type_name(end_type)} for {label} {span_id} is stamped with member "
+                    f"{lane_of(event)}, while the {short_type_name(start_type)} that opened it named "
+                    f"{lane_of_span[span_id]}"
+                )
+
+
+def _assert_every_tool_call_parent_message_was_opened(events: Sequence[BaseEvent]) -> None:
+    """A call's parent message is one this stream opened.
+
+    A conforming client attaches a call to the assistant message its
+    ``parent_message_id`` names, so a call naming a message the stream never
+    opened is one the client has nowhere to attach and no way to render in
+    place. The lane rule below compares the pair only where both halves are
+    present, which is exactly what an unresolvable parent is not.
+    """
+    opened = {field_of(event, "message_id") for event in of_type(events, EventType.TEXT_MESSAGE_START)}
+    for event in of_type(events, EventType.TOOL_CALL_START):
+        parent = field_of(event, "parent_message_id")
+        if parent is None:
+            # A call parented to nothing is rendered on its own, which is a
+            # shape the protocol allows and this rule has no subject in.
+            continue
+        assert parent in opened, (
+            f"tool call {field_of(event, 'tool_call_id')} names parent message {parent}, which no "
+            "TEXT_MESSAGE_START in this stream opened, so a client has nothing to attach it to"
+        )
+
+
+def _assert_a_tool_call_sits_in_its_parent_messages_member(events: Sequence[BaseEvent]) -> None:
+    """A tool call is stamped with the member of the message it names as its parent.
+
+    A conforming client attaches a call to the assistant message its
+    ``parent_message_id`` names and renders each of the two in the member it is
+    stamped with, so a call and its parent message disagreeing puts the call in
+    a lane where its own message was never drawn. Every other lane check
+    compares an event against its own span, and a call's parent message is
+    another span, so none of them looks at this pair.
+    """
+    lane_of_message: Dict[Any, Optional[str]] = {}
+    for event in events:
+        if event.type == EventType.TEXT_MESSAGE_START:
+            lane_of_message.setdefault(field_of(event, "message_id"), lane_of(event))
+
+    for event in of_type(events, EventType.TOOL_CALL_START):
+        parent = field_of(event, "parent_message_id")
+        if parent is None or parent not in lane_of_message:
+            # A call parented to no message has no pair here to disagree, and
+            # one parented to a message this stream never opened is refused by
+            # the check above rather than by comparing it against nothing.
+            continue
+        assert lane_of(event) == lane_of_message[parent], (
+            f"tool call {field_of(event, 'tool_call_id')} is stamped with member {lane_of(event)}, while the "
+            f"message {parent} it names as its parent was opened in member {lane_of_message[parent]}"
+        )
+
+
+def _assert_every_tool_result_names_a_started_call(events: Sequence[BaseEvent]) -> None:
+    """A result belongs to a call the client already has a start for.
+
+    The result arrives outside its call's span, so the in-span check deliberately
+    skips it, which left a result naming a call that was never started, and one
+    arriving ahead of its own start, as well-formed streams: in both the client
+    has no card to put the result in at the moment it arrives.
+    """
+    started_at: Dict[Any, int] = {}
+    for index, event in enumerate(events):
+        if event.type == EventType.TOOL_CALL_START:
+            started_at.setdefault(field_of(event, "tool_call_id"), index)
+
+    orphans = [
+        field_of(event, "tool_call_id")
+        for event in of_type(events, EventType.TOOL_CALL_RESULT)
+        if field_of(event, "tool_call_id") not in started_at
+    ]
+    assert not orphans, f"tool call results name calls no TOOL_CALL_START opened: {orphans}"
+
+    for index, event in enumerate(events):
+        if event.type != EventType.TOOL_CALL_RESULT:
+            continue
+        call_id = field_of(event, "tool_call_id")
+        assert started_at[call_id] < index, (
+            f"the result for tool call {call_id} went out at index {index}, ahead of the "
+            f"TOOL_CALL_START that opened it at index {started_at[call_id]}"
+        )
+
+
+def _assert_every_tool_result_follows_its_calls_end(events: Sequence[BaseEvent]) -> None:
+    """A result goes out after its own call's end, not inside the call's span.
+
+    The result is the reason TOOL_CALL_RESULT is left out of the in-span table:
+    it belongs after the end rather than between the start and the end. Holding
+    it only to the start is a weaker promise than that, and it accepts the shape
+    the table is written around, a result delivered while the client still has
+    the call open and its arguments still streaming.
+    """
+    started_at: Dict[Any, int] = {}
+    ended_at: Dict[Any, int] = {}
+    for index, event in enumerate(events):
+        if event.type == EventType.TOOL_CALL_START:
+            started_at.setdefault(field_of(event, "tool_call_id"), index)
+        elif event.type == EventType.TOOL_CALL_END:
+            ended_at.setdefault(field_of(event, "tool_call_id"), index)
+
+    for index, event in enumerate(events):
+        if event.type != EventType.TOOL_CALL_RESULT:
+            continue
+        call_id = field_of(event, "tool_call_id")
+        if call_id not in started_at or index < started_at[call_id]:
+            # No start, or a result ahead of it, which the check above reports.
+            continue
+        if call_id not in ended_at:
+            # The call never closed, which the span check reports, except on the
+            # abandoned prefix where it is waived and there is no end to follow.
+            continue
+        assert ended_at[call_id] < index, (
+            f"the result for tool call {call_id} went out at index {index}, inside the call's own span: "
+            f"the TOOL_CALL_END that closed it is at index {ended_at[call_id]}"
+        )
+
+
+def _assert_a_tool_result_carries_its_calls_member(events: Sequence[BaseEvent]) -> None:
+    """A result is stamped with the member whose call produced it.
+
+    A result stamped with another member puts one member's tool output in
+    another member's card. The result sits outside its call's span, so neither
+    the in-span check nor the span-lane check above looks at it.
+    """
+    lane_of_call: Dict[Any, Optional[str]] = {}
+    for event in events:
+        if event.type == EventType.TOOL_CALL_START:
+            lane_of_call.setdefault(field_of(event, "tool_call_id"), lane_of(event))
+            continue
+        if event.type != EventType.TOOL_CALL_RESULT:
+            continue
+        call_id = field_of(event, "tool_call_id")
+        if call_id not in lane_of_call:
+            # No start for this result, which the check above reports.
+            continue
+        assert lane_of(event) == lane_of_call[call_id], (
+            f"the result for tool call {call_id} is stamped with member {lane_of(event)}, while the "
+            f"TOOL_CALL_START that opened it named {lane_of_call[call_id]}"
+        )
+
+
+def _assert_nothing_follows_the_run_terminal(events: Sequence[BaseEvent]) -> None:
+    terminals = [index for index, event in enumerate(events) if event.type in _RUN_TERMINAL_TYPES]
+    assert len(terminals) <= 1, (
+        f"a run carries at most one terminal, got {[short_type(events[index]) for index in terminals]}"
+    )
+    if terminals:
+        following = [short_type(event) for event in events[terminals[0] + 1 :]]
+        assert not following, f"events followed the run terminal: {following}"
+        return
+
+    # A run the client was told began owes it an end. No terminal at all is
+    # nonetheless well formed for a list that is a fragment of a response body
+    # rather than a whole one: the router writes RUN_STARTED and owns the
+    # terminal when the source stream raises, and a source that never says the
+    # run completed gets no terminal written for it. What the fragment must not
+    # do is announce a start and stop, which leaves a client waiting forever.
+    started = of_type(events, EventType.RUN_STARTED)
+    assert not started, (
+        f"this stream carries {len(started)} RUN_STARTED and no terminal, so a client is left "
+        "waiting on a run it was told had begun"
+    )
+
+
+def announcements(events: Sequence[BaseEvent]) -> List[BaseEvent]:
+    """Every member announcement in order, of which an old install can carry none.
+
+    An install without the lineage events cannot put a SUBAGENT_STARTED on the
+    wire, so an empty list is the truth there rather than a waived check. A test
+    that needs the event type itself asks ``event_type_named`` and skips.
+    """
+    if SUBAGENT_STARTED is None:
+        return []
+    return of_type(events, SUBAGENT_STARTED)
+
+
+def announced_lane(announcement: BaseEvent) -> Any:
+    """The member one announcement names, read as a declared field.
+
+    Every check that resolves a stamp, a parent link or a terminal against the
+    announcements reads the announced id through here. The permissive lookup
+    would default a renamed field to None, which leaves every announcement
+    naming the top-level entity: stamps stop resolving to anything, parent links
+    and terminals resolve to each other, and the checks pass while nothing about
+    member attribution is being compared.
+    """
+    return field_of(announcement, "subagent_run_id")
+
+
+def _assert_no_member_is_announced_twice(events: Sequence[BaseEvent]) -> None:
+    """One announcement per member.
+
+    A member id is one invocation, and Agno mints a fresh one per delegation, so
+    a second announcement of the same id either restarts a lane the client has
+    already drawn or splits one invocation across two. Its own promise rather
+    than a line inside the stamp check: a stamp resolves against the announced
+    ids either way, so the stamp check cannot be what holds this.
+    """
+    seen: Dict[Any, int] = {}
+    for index, event in enumerate(announcements(events)):
+        lane = announced_lane(event)
+        assert lane not in seen, f"member {lane} was announced more than once"
+        seen[lane] = index
+
+
+def _assert_every_stamp_names_an_announced_member(events: Sequence[BaseEvent]) -> None:
+    announced: Dict[Optional[str], int] = {}
+    for index, event in enumerate(events):
+        lane = lane_of(event)
+        if SUBAGENT_STARTED is not None and event.type == SUBAGENT_STARTED:
+            announced.setdefault(announced_lane(event), index)
+            continue
+        if lane is None:
+            continue
+        assert lane in announced, (
+            f"{short_type(event)} at index {index} is stamped with member {lane}, "
+            "which no earlier announcement named, so a client cannot resolve it"
+        )
+
+
+def _assert_every_announced_parent_is_announced_too(events: Sequence[BaseEvent]) -> None:
+    """A member's parent link names a member this stream also announces.
+
+    Left unchecked, an announcement can hand the client a parent id that appears
+    nowhere on the wire, which is a lane the client can neither draw nor resolve.
+
+    Announced anywhere in the stream, which is the floor: it refuses the case no
+    ordering can rescue, a parent the stream never announces at all.
+    ``_assert_an_announced_parent_precedes_its_child`` holds the rest, that the
+    announcement comes first.
+    """
+    announced = {announced_lane(event) for event in announcements(events)}
+    for event in announcements(events):
+        # Read as a declared field: defaulting a renamed one to None would make
+        # every announcement look parentless and this check pass on anything.
+        parent = field_of(event, "parent_subagent_run_id")
+        if parent is None:
+            continue
+        assert parent in announced, (
+            f"member {announced_lane(event)} names parent {parent}, which this stream never "
+            "announces, so a client cannot place it under anything"
+        )
+
+
+def _assert_an_announced_parent_precedes_its_child(events: Sequence[BaseEvent]) -> None:
+    """A parent link names a member this stream has already announced.
+
+    A client reads the stream in order and resolves a parent link when it
+    arrives, so a link to a member announced further down is one it cannot place
+    at the moment it is handed it. The check above is the floor under this and
+    refuses only a parent the stream never announces at all; this one refuses
+    the forward reference the interface avoids by announcing a parent before any
+    child that names it.
+    """
+    announced_at: Dict[Any, int] = {}
+    in_order = [
+        (index, event)
+        for index, event in enumerate(events)
+        if SUBAGENT_STARTED is not None and event.type == SUBAGENT_STARTED
+    ]
+    for index, event in in_order:
+        announced_at.setdefault(announced_lane(event), index)
+
+    for index, event in in_order:
+        parent = field_of(event, "parent_subagent_run_id")
+        if parent is None or parent not in announced_at:
+            # A parent this stream never announces, which the check above reports.
+            continue
+        assert announced_at[parent] < index, (
+            f"member {announced_lane(event)} announced at index {index} names parent {parent}, which this "
+            f"stream does not announce until index {announced_at[parent]}, so a client reading in order "
+            "cannot place it when it arrives"
+        )
+
+
+def _assert_every_announced_parent_link_resolves(events: Sequence[BaseEvent]) -> None:
+    """The call and the message an announcement names are ones this stream carries.
+
+    An announcement places the member under a delegating tool call and under the
+    assistant message that call hangs off, which is what a client nests the
+    member's lane inside. Either of those naming something the stream never put
+    on the wire leaves the client a lane it cannot place, exactly as a parent
+    member it never announced does, and only the member link was resolved.
+    """
+    for field, start_type, id_field in _ANNOUNCEMENT_PARENT_LINKS:
+        carried = {field_of(event, id_field) for event in of_type(events, start_type)}
+        for event in announcements(events):
+            named = field_of(event, field)
+            if named is None:
+                # A member announced under no call or no message: a top-level
+                # delegation the interface reports without either, which is a
+                # lane the client draws at the top rather than nested.
+                continue
+            assert named in carried, (
+                f"member {announced_lane(event)} names {field} {named}, which no "
+                f"{short_type_name(start_type)} in this stream carries, so a client cannot place it"
+            )
+
+
+def _assert_each_member_owns_exactly_one_terminal(events: Sequence[BaseEvent], exempt: Sequence[str]) -> None:
+    announced = [announced_lane(event) for event in announcements(events)]
+    terminals: Dict[Optional[str], List[int]] = {}
+    for index, event in enumerate(events):
+        if event.type in _MEMBER_TERMINAL_TYPES:
+            terminals.setdefault(lane_of(event), []).append(index)
+
+    # A member may always own at most one terminal. Owning none is what the
+    # abandonment exemption waives, and nothing else.
+    at_most_one_only = _waived(exempt, EVERY_ANNOUNCED_MEMBER_TERMINATES)
+    for lane in announced:
+        count = len(terminals.get(lane, []))
+        if at_most_one_only:
+            assert count <= 1, f"member {lane} owns {count} terminals, expected at most one"
+        else:
+            assert count == 1, f"member {lane} owns {count} terminals, expected exactly one"
+
+    # A terminal naming a member nothing announced is not checked here. It
+    # carries that member's lane, so the stamp check above already refuses it,
+    # and a second assertion for it can never be reached to be trusted.
+
+    if _waived(exempt, NOTHING_CARRIES_A_MEMBER_AFTER_ITS_TERMINAL):
+        return
+    for lane in announced:
+        indexes = terminals.get(lane, [])
+        if not indexes:
+            continue
+        after = [
+            short_type(event) for index, event in enumerate(events) if index > indexes[0] and lane_of(event) == lane
+        ]
+        assert not after, f"events carrying member {lane} followed its terminal: {after}"
+
+
+def _assert_a_childs_terminal_precedes_its_parents(events: Sequence[BaseEvent]) -> None:
+    # The parent link is read as a declared field: defaulting a renamed one to
+    # None would leave every lane parentless and this check ordering nothing.
+    parent_of = {announced_lane(event): field_of(event, "parent_subagent_run_id") for event in announcements(events)}
+    # The first terminal a lane owns, as every other helper here keeps the first
+    # of anything: a member owning a second one is refused by the check above,
+    # and under the waiver that permits owning none this ordering would
+    # otherwise be read off whichever terminal happened to come last.
+    first_terminal_at: Dict[Optional[str], int] = {}
+    for index, event in enumerate(events):
+        if event.type in _MEMBER_TERMINAL_TYPES:
+            first_terminal_at.setdefault(lane_of(event), index)
+    for lane, parent in parent_of.items():
+        if parent is None or parent not in first_terminal_at or lane not in first_terminal_at:
+            continue
+        assert first_terminal_at[lane] < first_terminal_at[parent], (
+            f"member {lane} terminated after its parent {parent}, so a client would "
+            "see a child resolve inside a member it had already closed"
+        )
+
+
+def _assert_state_events_are_never_stamped(events: Sequence[BaseEvent]) -> None:
+    # Presence, not truthiness: an empty lane is still a lane on the wire, and a
+    # client filtering by member drops the document just as surely.
+    stamped = [
+        (short_type(event), lane_of(event))
+        for event in events
+        if event.type in _STATE_TYPES and lane_of(event) is not None
+    ]
+    assert not stamped, (
+        f"state events carry a member lane: {stamped}. A team's session state is one "
+        "shared document, so a client filtering by member must not lose it"
+    )
+
+
+def _assert_run_events_are_never_stamped(events: Sequence[BaseEvent]) -> None:
+    """The run's own lifecycle belongs to the run, not to a member.
+
+    A member lane on RUN_STARTED or on a run terminal tells a client the run
+    itself began or ended inside one member, which a client filtering by member
+    either misplaces or drops: the start it needs to open the run, or the
+    terminal it needs to stop waiting for one. Read for presence, as the state
+    rule is, because an empty lane is still a lane on the wire.
+    """
+    stamped = [
+        (short_type(event), lane_of(event))
+        for event in events
+        if event.type in _RUN_LEVEL_TYPES and lane_of(event) is not None
+    ]
+    assert not stamped, (
+        f"run lifecycle events carry a member lane: {stamped}. A run begins and ends once, "
+        "for the whole stream, so no member owns either end of it"
+    )
+
+
+# --- The protocol release member attribution needs --------------------------
+
+# The release the subagent lineage events arrived in. Nothing gates on it: what
+# ``attributed`` needs is feature-detected, above and in the interface itself.
+# It is here to be recomputed against those features by
+# ``test_agui_stream_invariants``, which is what keeps the number in the comment
+# at the head of this module, and in the interface's own documentation, from
+# drifting away from the release that actually carries them.
+LINEAGE_EVENTS_PROTOCOL_FLOOR = (0, 1, 21)
+
+# Every field this checker reads off an announcement. The parent links come from
+# the table the invariant reads, so a link added there is one the floor is
+# recomputed against too.
+LINEAGE_ANNOUNCEMENT_FIELDS_READ_HERE = ("subagent_run_id", "parent_subagent_run_id") + tuple(
+    field for field, _start_type, _id_field in _ANNOUNCEMENT_PARENT_LINKS
+)
+
+
+def installed_protocol_release() -> Tuple[int, ...]:
+    """The installed ag-ui-protocol release, as its leading numeric components.
+
+    Parsed rather than compared as a string, where 0.1.9 sorts above 0.1.21, and
+    truncated at the first component that is not a plain number, so a
+    pre-release or a local build compares as the release it is built from.
+    """
+    try:
+        raw = installed_version("ag-ui-protocol")
+    except PackageNotFoundError as missing:  # pragma: no cover - ag_ui imported from somewhere else
+        raise AssertionError(f"ag_ui is importable but its distribution metadata is not: {missing}")
+    components: List[int] = []
+    for piece in raw.split("."):
+        digits = ""
+        for character in piece:
+            if not character.isdigit():
+                break
+            digits += character
+        if not digits:
+            break
+        components.append(int(digits))
+    return tuple(components)
+
+
+def announcement_fields_missing_from(event_class: Any) -> List[str]:
+    """The fields this checker reads that one announcement class does not declare."""
+    declared = declared_fields_of(event_class) or ()
+    return sorted(field for field in LINEAGE_ANNOUNCEMENT_FIELDS_READ_HERE if field not in declared)
+
+
+def lineage_announcement_fields_missing() -> List[str]:
+    """Those fields the installed announcement omits, of which an old release omits all."""
+    announcement = getattr(ag_ui.core, "SubagentStartedEvent", None)
+    if announcement is None:
+        return sorted(LINEAGE_ANNOUNCEMENT_FIELDS_READ_HERE)
+    return announcement_fields_missing_from(announcement)
+
+
+# --- What the protocol's own encoder can put on a wire ----------------------
+
+
+def encoding_failures(events: Sequence[BaseEvent]) -> List[Tuple[str, str]]:
+    """(event type, failure) for every event the protocol's encoder refuses.
+
+    The interface hands its events to this same encoder, so an event it cannot
+    serialize reaches no client at all: the response body stops there, with
+    whatever was written before it and no run terminal.
+    """
+    encoder = EventEncoder()
+    refused: List[Tuple[str, str]] = []
+    for event in events:
+        try:
+            encoder.encode(event)
+        except Exception as error:
+            refused.append((short_type(event), type(error).__name__))
+    return refused
+
+
+# --- Log capture at the loggers this codebase writes through ----------------
+
+# ``log_error`` and ``log_warning`` write to whichever of these the last agent,
+# team or workflow run selected, and agno's level setters run on every one of
+# those runs, so any of the three can be sitting at a level that drops the
+# records a test is about to assert on.
+AGNO_LOGGER_NAMES = (LOGGER_NAME, TEAM_LOGGER_NAME, WORKFLOW_LOGGER_NAME)
+
+
+@contextmanager
+def captured_agno_logs(caplog: Any, level: str) -> Iterator[None]:
+    """Capture at every logger agno's log helpers can write through, never above it.
+
+    ``caplog.at_level`` sets the level it is given on the logger it names, so
+    asking for ERROR on a logger sitting at INFO RAISES that logger's threshold
+    and drops every warning underneath. The threshold entered here is therefore
+    the most permissive of the level asked for and the levels the three loggers
+    already have, which can only widen what a test sees.
+    """
+    # Looked up with a default so a name that is not a level is reported as one
+    # rather than raising AttributeError out of a context manager's entry. A
+    # bool is refused explicitly: it passes an int check, and the module holds
+    # bool settings, so a true one would enter capture at level 1 and quietly
+    # read as the widest capture there is.
+    wanted = getattr(logging, level, None)
+    assert isinstance(wanted, int) and not isinstance(wanted, bool), f"{level!r} is not a logging level name"
+    floor = min([wanted, *(logging.getLogger(name).getEffectiveLevel() for name in AGNO_LOGGER_NAMES)])
+    with ExitStack() as stack:
+        for name in AGNO_LOGGER_NAMES:
+            stack.enter_context(caplog.at_level(floor, logger=name))
+        yield
+
+
+# --- The same chunks through both mappers -----------------------------------
+
+Collected = Tuple[List[BaseEvent], Optional[Exception]]
+MalformedCollected = Tuple[List[BaseEvent], Optional[Exception], Optional[str]]
+
+
+class SideEffect:
+    """A chunk list entry the source runs for its effect, emitting nothing.
+
+    A fixture that changes the session state partway through a run only produces
+    the delta the client should see if the change happens while the stream is
+    being consumed, not while the chunk list is being built.
+    """
+
+    def __init__(self, action: Callable[[], Any]) -> None:
+        self.action = action
+
+
+def sync_source(chunks: Iterable[Any]) -> Iterator[Any]:
+    """A sync source stream that raises any exception placed in the chunk list."""
+    for chunk in chunks:
+        if isinstance(chunk, BaseException):
+            raise chunk
+        if isinstance(chunk, SideEffect):
+            chunk.action()
+            continue
+        yield chunk
+
+
+async def async_source(chunks: Iterable[Any]) -> AsyncIterator[Any]:
+    """An async source stream that raises any exception placed in the chunk list."""
+    for chunk in chunks:
+        if isinstance(chunk, BaseException):
+            raise chunk
+        if isinstance(chunk, SideEffect):
+            chunk.action()
+            continue
+        yield chunk
+
+
+def _servable(visibility: Optional[str]) -> Optional[str]:
+    """The visibility to drive with, keeping a configuration error out of the stream.
+
+    A setting this install cannot serve skips, and an invalid one is raised from
+    here rather than from inside the drivers below, where it would be collected
+    as though the source stream itself had failed.
+    """
+    if visibility == SUBAGENT_VISIBILITY_ATTRIBUTED:
+        require_lineage_events()
+    validate_subagent_visibility(visibility)
+    return visibility
+
+
+def _drive_sync(
+    chunks: Iterable[Any],
+    visibility: Optional[str],
+    thread_id: str,
+    run_id: str,
+    run_state: Optional[Dict[str, Any]],
+) -> Collected:
+    resolved = _servable(visibility)
+    events: List[BaseEvent] = []
+    error: Optional[Exception] = None
+    try:
+        for event in stream_agno_response_as_agui_events(
+            sync_source(chunks),
+            thread_id=thread_id,
+            run_id=run_id,
+            run_state=run_state,
+            subagent_visibility=resolved,
+        ):
+            events.append(event)
+    except Exception as raised:
+        error = raised
+    return events, error
+
+
+async def _drive_async(
+    chunks: Iterable[Any],
+    visibility: Optional[str],
+    thread_id: str,
+    run_id: str,
+    run_state: Optional[Dict[str, Any]],
+) -> Collected:
+    resolved = _servable(visibility)
+    events: List[BaseEvent] = []
+    error: Optional[Exception] = None
+    try:
+        async for event in async_stream_agno_response_as_agui_events(
+            async_source(chunks),
+            thread_id=thread_id,
+            run_id=run_id,
+            run_state=run_state,
+            subagent_visibility=resolved,
+        ):
+            events.append(event)
+    except Exception as raised:
+        error = raised
+    return events, error
+
+
+async def collect_sync(
+    chunks: Iterable[Any],
+    visibility: Optional[str] = None,
+    *,
+    thread_id: str,
+    run_id: str,
+    run_state: Optional[Dict[str, Any]] = None,
+    exempt: Sequence[str] = (),
+) -> Collected:
+    events, error = _drive_sync(chunks, visibility, thread_id, run_id, run_state)
+    assert_well_formed_stream(events, exempt)
+    return events, error
+
+
+async def collect_async(
+    chunks: Iterable[Any],
+    visibility: Optional[str] = None,
+    *,
+    thread_id: str,
+    run_id: str,
+    run_state: Optional[Dict[str, Any]] = None,
+    exempt: Sequence[str] = (),
+) -> Collected:
+    events, error = await _drive_async(chunks, visibility, thread_id, run_id, run_state)
+    assert_well_formed_stream(events, exempt)
+    return events, error
+
+
+async def collect_sync_recording_violations(
+    chunks: Iterable[Any],
+    visibility: Optional[str] = None,
+    *,
+    thread_id: str,
+    run_id: str,
+    run_state: Optional[Dict[str, Any]] = None,
+    exempt: Sequence[str] = (),
+) -> MalformedCollected:
+    """As ``collect_sync``, reporting the invariant a stream broke instead of failing.
+
+    For the callers whose subject is a stream that is not well formed today. The
+    invariants still run, on exactly the same definition, so a stream that stops
+    being malformed is a diff rather than a silence.
+    """
+    events, error = _drive_sync(chunks, visibility, thread_id, run_id, run_state)
+    return events, error, stream_invariant_violation(events, exempt)
+
+
+async def collect_async_recording_violations(
+    chunks: Iterable[Any],
+    visibility: Optional[str] = None,
+    *,
+    thread_id: str,
+    run_id: str,
+    run_state: Optional[Dict[str, Any]] = None,
+    exempt: Sequence[str] = (),
+) -> MalformedCollected:
+    events, error = await _drive_async(chunks, visibility, thread_id, run_id, run_state)
+    return events, error, stream_invariant_violation(events, exempt)
+
+
+# --- The lineage fields a source chunk carries ------------------------------
+
+# The id the suites give the top-level entity's own run. Shared, because a
+# member chunk's ``parent_run_id`` has to name it for the chunk to be a
+# member's at all.
+TOP_LEVEL_RUN = "top-level-run"
+
+
+def member_chunk_kwargs(member: str, run: str, parent: str = TOP_LEVEL_RUN) -> Dict[str, Any]:
+    """The lineage fields Agno stamps on one member Agent's chunks."""
+    return {"agent_id": member, "agent_name": member.capitalize(), "run_id": run, "parent_run_id": parent}
+
+
+def team_chunk_kwargs(team_id: str, name: str, run: str, parent: Optional[str] = None) -> Dict[str, Any]:
+    """The lineage fields Agno stamps on one Team's chunks, top-level or nested."""
+    kwargs: Dict[str, Any] = {"team_id": team_id, "team_name": name, "run_id": run}
+    if parent is not None:
+        kwargs["parent_run_id"] = parent
+    return kwargs
+
+
+def agent_said(content: Any, **kwargs: Any) -> RunContentEvent:
+    """One Agent content chunk carrying whatever a run's content can hold.
+
+    The content is assigned rather than passed to the constructor, so a value
+    the field's own type refuses still reaches the mapper.
+    """
+    chunk = RunContentEvent(**kwargs)
+    chunk.content = content
+    return chunk
+
+
+def team_said(content: Any, **kwargs: Any) -> TeamRunContentEvent:
+    """One Team content chunk carrying whatever a run's content can hold."""
+    chunk = TeamRunContentEvent(**kwargs)
+    chunk.content = content
+    return chunk
+
+
+# --- Hostile values ---------------------------------------------------------
+
+
+class RaisesOnSerialization:
+    """A value every serialization route refuses, as a partly-built object can be."""
+
+    def model_dump_json(self) -> str:
+        raise RuntimeError("dump exploded")
+
+    def __repr__(self) -> str:
+        raise RuntimeError("repr exploded")
+
+    def to_dict(self) -> Dict[str, Any]:
+        raise RuntimeError("to_dict exploded")
+
+
+def circular() -> Dict[str, Any]:
+    """A mapping that holds itself, which the JSON encoder refuses."""
+    cycle: Dict[str, Any] = {}
+    cycle["self"] = cycle
+    return cycle
+
+
+# The values a run's content can hold that serialization handles badly, driven
+# through every boundary that builds an AG-UI event out of run content. Not all
+# of them are unserializable: ``not_a_number`` and ``none`` are the two most
+# serializers do handle, and what they are here for is that the boundaries
+# disagree about them, which the hostile suite's own table records.
+HOSTILE_VALUES: Tuple[Tuple[str, Callable[[], Any]], ...] = (
+    ("circular", circular),
+    ("raises_on_serialization", RaisesOnSerialization),
+    ("set", lambda: {"a", "b"}),
+    ("not_a_number", lambda: float("nan")),
+    ("none", lambda: None),
+)

--- a/libs/agno/tests/unit/os/interfaces/conftest.py
+++ b/libs/agno/tests/unit/os/interfaces/conftest.py
@@ -1,0 +1,50 @@
+"""Assert rewriting for the shared stream-invariant helper.
+
+The helper is not a test module, so pytest rewrites its asserts only when it is
+registered, and it has to be registered before any suite here imports it, which
+is what a conftest guarantees. Unregistered, a broken invariant arrives as a
+bare AssertionError without the values that say what the stream actually did.
+
+Registration takes a dotted path and says nothing when it names no module, so a
+mistyped or stale path leaves every suite here running against an unrewritten
+helper and passing. Both ways that can happen are checked rather than trusted:
+the path has to resolve to the helper sitting beside this file, and the helper
+must not already be imported, since registering after the import is the other
+way this silently does nothing.
+
+The order of those two matters. Resolving the dotted path is what imports the
+packages along it, so the helper cannot yet be in ``sys.modules`` when the
+lookup has not run, and an import check placed first passes on a tree where one
+of those packages imports the helper. The lookup goes first, the import check
+second.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_HELPER = "tests.unit.os.interfaces.agui_stream_invariants"
+_HELPER_FILE = Path(__file__).with_name("agui_stream_invariants.py").resolve()
+
+assert _HELPER_FILE.exists(), f"the shared stream-invariant helper is gone from {_HELPER_FILE.parent}"
+
+try:
+    _spec = importlib.util.find_spec(_HELPER)
+except ModuleNotFoundError:  # a package along the dotted path does not exist
+    _spec = None
+# Both sides resolved: a checkout reached through a symlink gives the spec an
+# origin naming this very file by another path, which a string comparison reads
+# as some other module and refuses a registration that would have worked.
+_origin = Path(_spec.origin).resolve() if _spec is not None and _spec.origin is not None else None
+assert _origin == _HELPER_FILE, (
+    f"{_HELPER} resolves to {_origin or 'nothing'}, not {_HELPER_FILE}: "
+    "registering that path rewrites nothing, and every invariant here would then fail without its values"
+)
+
+assert _HELPER not in sys.modules, (
+    f"{_HELPER} was imported before this conftest ran, so registering its assert rewrite here does nothing"
+)
+
+pytest.register_assert_rewrite(_HELPER)

--- a/libs/agno/tests/unit/os/interfaces/test_agui_documented_contract.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_documented_contract.py
@@ -1,0 +1,850 @@
+"""The AG-UI cookbook's documented contract, read out of the document and checked.
+
+The 16_agui README and TEST_LOG restate facts that live in the interface: which
+events carry a member's ``subagentRunId``, which visibility values exist and
+which one is the default, what an announcement's parent links are called, which
+files the folder holds. A restatement that nothing recomputes drifts silently,
+so every enumerable claim is parsed out of the document here and compared with
+the implementation's own constants rather than with a second copy of them.
+Adding an event type to the interface, or a visibility value, or a field to an
+announcement, without saying so in the README fails one of these tests.
+
+Genuine prose is left alone. Only claims that enumerate something the code
+already enumerates are pinned.
+"""
+
+import ast
+import importlib
+import inspect
+import re
+from pathlib import Path
+from types import ModuleType
+from typing import Dict, List, Optional, Set, Tuple
+
+import pytest
+
+pytest.importorskip("ag_ui", reason="ag_ui not installed")
+
+from ag_ui.core import BaseEvent
+
+from agno.os.interfaces.agui import AGUI
+from agno.os.interfaces.agui import handlers as agui_handlers
+from agno.os.interfaces.agui import state as agui_state
+from agno.os.interfaces.agui.handlers import validate_subagent_visibility
+from agno.os.interfaces.agui.state import SUBAGENT_VISIBILITY_VALUES
+
+from .agui_stream_invariants import needs_lineage_events, require_lineage_events
+
+_REPO_ROOT = Path(__file__).resolve().parents[6]
+_COOKBOOK = _REPO_ROOT / "cookbook" / "05_agent_os" / "16_agui"
+_README = _COOKBOOK / "README.md"
+_TEST_LOG = _COOKBOOK / "TEST_LOG.md"
+_EXAMPLE = _COOKBOOK / "team_subagent_lineage.py"
+_PACKAGE_PYPROJECT = _REPO_ROOT / "libs" / "agno" / "pyproject.toml"
+
+# The root is identified by the package these tests are about, which sits at a
+# fixed place under it. Counted wrong, the walk above lands somewhere with no
+# cookbook under it, and every document read below then reads as a checkout
+# that ships none: moving this file one directory turned most of this module
+# into skips, the protocol-floor check among them.
+assert (_REPO_ROOT / "libs" / "agno" / "agno" / "os" / "interfaces" / "agui").is_dir(), (
+    f"{_REPO_ROOT} is not this repository's root, so every document this module reads would be "
+    "reported as absent from the checkout rather than checked"
+)
+
+# The sentence the machine-checkable event list hangs off. Kept as one string so
+# a README that drops the list fails here instead of passing vacuously.
+_ATTRIBUTED_LIST_MARKER = "These are the events that carry a `subagentRunId`:"
+_UNATTRIBUTED_MARKER = "kinds of event carry none."
+
+# The unattributed marker does carry a count, one word ahead of it, so that word
+# is recomputed from the same paragraph rather than left to be edited in
+# lockstep. Spelled numbers only, which is how the document writes it.
+_SPELLED_COUNTS = {"one": 1, "two": 2, "three": 3, "four": 4, "five": 5, "six": 6, "seven": 7}
+
+
+def _doc(path: Path) -> str:
+    """One document of the cookbook folder, skipped only when the folder itself is gone.
+
+    A checkout can ship without the cookbook, which is the one thing worth
+    skipping for. A file missing from a folder that is there is a document this
+    module was written against and no longer holds, so it fails.
+    """
+    if not _COOKBOOK.is_dir():
+        pytest.skip("cookbook not present in this checkout")
+    assert path.exists(), f"the cookbook folder no longer holds {path.name}, which this module reads"
+    return path.read_text(encoding="utf-8")
+
+
+def _section(text: str, heading: str) -> str:
+    """One `##` section of a markdown document, heading excluded.
+
+    Anchored at the start of a line, so a heading named in a sentence somewhere
+    above cannot be mistaken for the section itself, and reported rather than
+    raised bare, so a renamed heading says which one went missing.
+    """
+    found = re.search(rf"^{re.escape(heading)}$", text, re.MULTILINE)
+    assert found is not None, f"the document no longer has a {heading!r} section, so nothing here can read it"
+    rest = text[found.end() :]
+    end = rest.find("\n## ")
+    return rest if end == -1 else rest[:end]
+
+
+def _attribution_section() -> str:
+    return _section(_doc(_README), "## Team member attribution")
+
+
+_FIRST_CELL = re.compile(r"^\| `([^`]+)`([^|]*)\|")
+
+
+def _table_rows(section: str) -> List[Tuple[str, str]]:
+    """(backticked value, rest of that first cell) per table row, first cell only.
+
+    Read with one pattern rather than by splitting on backticks and pipes,
+    which raises an index error of its own on a row shaped differently, and cut
+    at the first cell so a word in the row's description cannot be read as a
+    mark on its value.
+    """
+    rows: List[Tuple[str, str]] = []
+    for line in section.splitlines():
+        if not line.startswith("| `"):
+            continue
+        found = _FIRST_CELL.match(line)
+        assert found is not None, f"this table row does not open with a backticked cell: {line}"
+        rows.append((found.group(1), found.group(2)))
+    return rows
+
+
+def _first_column_entries(section: str) -> List[str]:
+    """The backticked value opening every table row in a section."""
+    return [value for value, _ in _table_rows(section)]
+
+
+def _backticked(text: str) -> List[str]:
+    return re.findall(r"`([^`\n]+)`", text)
+
+
+def _expand_event_token(token: str) -> Set[str]:
+    """An event name, or the documented ``PREFIX_*`` family, within what is emitted.
+
+    Expanded over the events this interface emits rather than over the installed
+    protocol's whole enumeration. A family covers whatever the protocol adds to
+    it, and an addition this interface never emits is not something the README
+    can be expected to have accounted for.
+    """
+    emitted = _implementation_emitted_events()
+    if token.endswith("_*"):
+        prefix = token[:-1]
+        return {name for name in emitted if name.startswith(prefix)}
+    return {token} & emitted
+
+
+def _implementation_attributed_events() -> Set[str]:
+    return {event_type.value for event_type in agui_handlers._SUBAGENT_ATTRIBUTABLE_EVENT_TYPES}
+
+
+_AG_UI = "ag_ui"
+_AG_UI_CORE = "ag_ui.core"
+_CORE = "core"
+
+
+def _dotted(node: ast.expr) -> Optional[str]:
+    """A ``Name`` or dotted ``Attribute`` chain rendered back as source text."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        base = _dotted(node.value)
+        return f"{base}.{node.attr}" if base is not None else None
+    return None
+
+
+def _protocol_module(name: str) -> Optional[ModuleType]:
+    """One module of the installed protocol, or None on a release that has no such module."""
+    if name != _AG_UI_CORE and not name.startswith(_AG_UI_CORE + "."):
+        return None
+    try:
+        return importlib.import_module(name)
+    except ImportError:
+        return None
+
+
+def _names_the_protocol(module: Optional[str]) -> bool:
+    """Whether a from-import's module is ``ag_ui.core`` or a submodule of it.
+
+    The package re-exports its event classes and the interface imports them
+    from there, but importing the same class out of the submodule that defines
+    it is the same construction and this census has to see it.
+    """
+    return module == _AG_UI_CORE or (module or "").startswith(_AG_UI_CORE + ".")
+
+
+def _event_class_named(name: str, module: str = _AG_UI_CORE) -> Optional[type]:
+    """An AG-UI event class of the protocol, by the name the protocol gives it.
+
+    Looked for on the module the import named and then on the package that
+    re-exports it, so a class taken out of a submodule resolves whichever of the
+    two the installed release defines it on.
+    """
+    for where in (module, _AG_UI_CORE):
+        found = getattr(_protocol_module(where), name, None)
+        if isinstance(found, type) and issubclass(found, BaseEvent):
+            return found
+    return None
+
+
+def _event_classes_by_local_name(tree: ast.Module) -> Dict[str, type]:
+    """Every AG-UI event class one module imported, under the name it uses locally.
+
+    Aliased imports are what make a text search unreliable here: the interface
+    imports the protocol's run-error event under a name of its own.
+    """
+    classes: Dict[str, type] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom) or not _names_the_protocol(node.module):
+            continue
+        for alias in node.names:
+            imported = _event_class_named(alias.name, node.module or _AG_UI_CORE)
+            if imported is not None:
+                classes[alias.asname or alias.name] = imported
+    return classes
+
+
+def _core_module_aliases(tree: ast.Module) -> Dict[str, str]:
+    """Every local dotted prefix that reaches the protocol, against the module it names.
+
+    An event built through the module rather than through a from-imported class
+    is the same construction, and reading only ``Call`` nodes whose callee is a
+    bare name misses it. Reading any attribute call by its last segment instead
+    would credit ``anything.RawEvent(...)``, so the prefixes are resolved here
+    and nothing else is treated as the protocol.
+
+    ``import ag_ui`` binds the package alone, and the protocol is then reached
+    one attribute further along, which is why the prefix recorded for it carries
+    that attribute rather than the bound name.
+    """
+    aliases: Dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == _AG_UI:
+                    aliases[f"{alias.asname or _AG_UI}.{_CORE}"] = _AG_UI_CORE
+                elif alias.name == _AG_UI_CORE or alias.name.startswith(_AG_UI_CORE + "."):
+                    # Without an alias the whole dotted path is what the source
+                    # writes, since the name bound is the top package.
+                    aliases[alias.asname or alias.name] = alias.name
+        elif isinstance(node, ast.ImportFrom) and node.module == _AG_UI:
+            for alias in node.names:
+                if alias.name == _CORE:
+                    aliases[alias.asname or _CORE] = _AG_UI_CORE
+    return aliases
+
+
+def _constructed_event_class(func: ast.expr, classes: Dict[str, type], aliases: Dict[str, str]) -> Optional[type]:
+    """The AG-UI event class a call constructs, or None when it constructs none."""
+    if isinstance(func, ast.Name):
+        return classes.get(func.id)
+    if isinstance(func, ast.Attribute):
+        prefix = _dotted(func.value)
+        module = aliases.get(prefix) if prefix is not None else None
+        if module is not None:
+            return _event_class_named(func.attr, module)
+    return None
+
+
+def _event_type_default(event_class: type) -> str:
+    """The event type a protocol class declares, reported rather than raised for.
+
+    A class with no concrete default has nothing to name it by. Read straight
+    through, that arrives as an attribute error from inside the scan, which
+    takes down this module and the hostile-content suite whose census rests on
+    it instead of saying which class is unreadable.
+    """
+    declared = event_class.model_fields["type"].default  # type: ignore[attr-defined]
+    assert getattr(declared, "value", None) is not None, (
+        f"{event_class.__name__} declares {declared!r} as its event type, which names no event: "
+        "the census cannot say what a scope building one of these builds"
+    )
+    return str(declared.value)
+
+
+# Every node that starts a scope of its own. A construction inside one belongs
+# to that scope and not to the scope holding it, so a helper defined inside a
+# function cannot be covered by driving the function around it.
+def _scan_scope(
+    body: List[ast.stmt],
+    scope: str,
+    classes: Dict[str, type],
+    aliases: Dict[str, str],
+    built: Dict[str, Set[str]],
+) -> None:
+    for statement in body:
+        _scan_node(statement, scope, classes, aliases, built)
+
+
+def _scan_node(
+    node: ast.AST,
+    scope: str,
+    classes: Dict[str, type],
+    aliases: Dict[str, str],
+    built: Dict[str, Set[str]],
+) -> None:
+    """Record the event constructions in one scope, nested scopes named separately."""
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        # A decorator, a default and a base class are evaluated where the
+        # definition is written, so they stay in the enclosing scope.
+        for outer in [*node.decorator_list, *getattr(node, "bases", [])]:
+            _scan_node(outer, scope, classes, aliases, built)
+        if not isinstance(node, ast.ClassDef):
+            for outer in [*node.args.defaults, *(d for d in node.args.kw_defaults if d is not None)]:
+                _scan_node(outer, scope, classes, aliases, built)
+        _scan_scope(node.body, f"{scope}.{node.name}", classes, aliases, built)
+        return
+    if isinstance(node, ast.Lambda):
+        for outer in [*node.args.defaults, *(d for d in node.args.kw_defaults if d is not None)]:
+            _scan_node(outer, scope, classes, aliases, built)
+        _scan_node(node.body, f"{scope}.<lambda>", classes, aliases, built)
+        return
+    if isinstance(node, ast.Call):
+        event_class = _constructed_event_class(node.func, classes, aliases)
+        if event_class is not None:
+            built.setdefault(scope, set()).add(_event_type_default(event_class))
+    for child in ast.iter_child_nodes(node):
+        _scan_node(child, scope, classes, aliases, built)
+
+
+MODULE_SCOPE = "<module>"
+
+
+def event_constructions_in(module_name: str, source: str) -> Dict[str, Set[str]]:
+    """Every AG-UI event type one module's source builds, per scope that builds it.
+
+    Scopes are named ``module.function``, and a scope nested inside another is
+    named through it, so two modules holding a function of the same name are two
+    entries rather than one merged set. Code at a module's top level is named
+    ``module.<module>``: an event built there is built once at import and never
+    driven by any run, which is a fact about the package rather than something
+    to leave unreported.
+    """
+    tree = ast.parse(source)
+    built: Dict[str, Set[str]] = {}
+    _scan_scope(
+        tree.body,
+        module_name,
+        _event_classes_by_local_name(tree),
+        _core_module_aliases(tree),
+        built,
+    )
+    return {f"{scope}.{MODULE_SCOPE}" if scope == module_name else scope: events for scope, events in built.items()}
+
+
+def event_constructions_by_function() -> Dict[str, Set[str]]:
+    """Every AG-UI event type the interface builds, per source scope that builds it.
+
+    Read off the event classes the package constructs rather than off mentions
+    of ``EventType.X``, which count a comparison against a type this interface
+    never emits. It is a scan of source, so it says which scopes build which
+    events, not which of them any particular run reaches.
+
+    Shared with the hostile-content suite, which uses the same scan to check
+    that its table of event-building boundaries names every one of them.
+    """
+    package = Path(agui_handlers.__file__).parent
+    built: Dict[str, Set[str]] = {}
+    for module in sorted(package.glob("*.py")):
+        for scope, events in event_constructions_in(module.stem, module.read_text(encoding="utf-8")).items():
+            built.setdefault(scope, set()).update(events)
+    assert built, "found no AG-UI event constructions in the interface package"
+    return built
+
+
+# Sources that build one AG-UI event by a route the scan above has to see. Each
+# was a way a construction went unrecorded, so each is written out here rather
+# than described: a scan that stops seeing one of these stops being the census
+# the coverage test in the hostile-content suite rests on.
+_CONSTRUCTIONS_THE_SCAN_HAS_TO_SEE: Dict[str, Tuple[str, str]] = {
+    "through the module it was imported from": (
+        "import ag_ui.core\n\ndef builds():\n    ag_ui.core.RawEvent()\n",
+        "scanned.builds",
+    ),
+    "through an aliased module": (
+        "import ag_ui.core as protocol\n\ndef builds():\n    protocol.RawEvent()\n",
+        "scanned.builds",
+    ),
+    "through a module imported from its package": (
+        "from ag_ui import core\n\ndef builds():\n    core.RawEvent()\n",
+        "scanned.builds",
+    ),
+    "from the submodule that defines it": (
+        "from ag_ui.core.events import RawEvent\n\ndef builds():\n    RawEvent()\n",
+        "scanned.builds",
+    ),
+    "through the top package alone": (
+        "import ag_ui\n\ndef builds():\n    ag_ui.core.RawEvent()\n",
+        "scanned.builds",
+    ),
+    "through the top package under an alias": (
+        "import ag_ui as protocol\n\ndef builds():\n    protocol.core.RawEvent()\n",
+        "scanned.builds",
+    ),
+    "through an imported submodule": (
+        "import ag_ui.core.events\n\ndef builds():\n    ag_ui.core.events.RawEvent()\n",
+        "scanned.builds",
+    ),
+    "at a module's own top level": (
+        "from ag_ui.core import RawEvent\n\nPRELUDE = RawEvent()\n",
+        f"scanned.{MODULE_SCOPE}",
+    ),
+    "in a function nested inside another": (
+        "from ag_ui.core import RawEvent\n\ndef outer():\n    def inner():\n        RawEvent()\n\n    return inner\n",
+        "scanned.outer.inner",
+    ),
+    "in a method of a class": (
+        "from ag_ui.core import RawEvent\n\nclass Builder:\n    def build(self):\n        RawEvent()\n",
+        "scanned.Builder.build",
+    ),
+    "in a lambda": (
+        "from ag_ui.core import RawEvent\n\ndef outer():\n    return lambda: RawEvent()\n",
+        "scanned.outer.<lambda>",
+    ),
+}
+
+
+@pytest.mark.parametrize("route", sorted(_CONSTRUCTIONS_THE_SCAN_HAS_TO_SEE))
+def test_the_event_scan_records_a_construction_reached_by_each_route(route):
+    """One construction per route, credited to the scope that really writes it."""
+    source, scope = _CONSTRUCTIONS_THE_SCAN_HAS_TO_SEE[route]
+    assert event_constructions_in("scanned", source) == {scope: {"RAW"}}
+
+
+def test_the_event_scan_credits_no_scope_that_only_encloses_the_construction():
+    """A nested scope's construction is that scope's alone.
+
+    Credited to the function around it, a helper defined inside another is
+    covered by driving the outer one, which drives none of it.
+    """
+    source = (
+        "from ag_ui.core import RawEvent\n\ndef outer():\n    def inner():\n        RawEvent()\n\n    return inner\n"
+    )
+    assert "scanned.outer" not in event_constructions_in("scanned", source)
+
+
+def test_the_event_scan_reads_no_event_off_an_attribute_of_something_else():
+    """Only ``ag_ui.core`` itself is the protocol.
+
+    Reading any attribute call by its last segment would credit a scope with an
+    event it never built, which is the other way this census can go wrong.
+    """
+    source = "from ag_ui.core import RawEvent\n\ndef builds(registry):\n    registry.RawEvent()\n"
+    assert event_constructions_in("scanned", source) == {}
+
+
+def test_the_event_scan_keeps_two_modules_same_named_functions_apart():
+    """One name in two modules is two scopes.
+
+    Merged, a function that builds nothing is credited with what its namesake
+    elsewhere builds, and a row of the hostile-content table claiming either one
+    accounts for both.
+    """
+    source = "from ag_ui.core import RawEvent\n\ndef build():\n    RawEvent()\n"
+    first = event_constructions_in("one", source)
+    second = event_constructions_in("two", source)
+    assert set(first) == {"one.build"}
+    assert set(second) == {"two.build"}
+    assert not set(first) & set(second)
+
+
+def _implementation_emitted_events() -> Set[str]:
+    """Every AG-UI event type the interface's own source constructs an event of."""
+    return set().union(*event_constructions_by_function().values())
+
+
+def _documented_attributed_events() -> Set[str]:
+    """The event names listed in the README's fenced block, which must be exact."""
+    section = _attribution_section()
+    assert _ATTRIBUTED_LIST_MARKER in section, (
+        f"the attribution section no longer contains {_ATTRIBUTED_LIST_MARKER!r}, "
+        "so the documented event list cannot be checked against the code"
+    )
+    after = section[section.index(_ATTRIBUTED_LIST_MARKER) + len(_ATTRIBUTED_LIST_MARKER) :]
+    fence = re.search(r"```[a-z]*\n(.*?)```", after, re.DOTALL)
+    assert fence is not None, "the documented event list is no longer a fenced block"
+    return set(fence.group(1).split())
+
+
+def _unattributed_paragraph() -> str:
+    """The paragraph that accounts for the events carrying no ``subagentRunId``."""
+    section = _attribution_section()
+    assert _UNATTRIBUTED_MARKER in section, f"the attribution section no longer contains {_UNATTRIBUTED_MARKER!r}"
+    return section[section.index(_UNATTRIBUTED_MARKER) :].split("\n\n")[0]
+
+
+def _documented_unattributed_events() -> Set[str]:
+    """The event families the README says carry no ``subagentRunId``."""
+    paragraph = _unattributed_paragraph()
+    documented: Set[str] = set()
+    for token in _backticked(paragraph):
+        expanded = _expand_event_token(token)
+        assert expanded, f"the README names {token!r} as unattributed, and this interface emits no such event"
+        documented.update(expanded)
+    return documented
+
+
+def _subagent_event_classes() -> Dict[str, type]:
+    require_lineage_events()
+    from ag_ui.core import SubagentErrorEvent, SubagentFinishedEvent, SubagentStartedEvent
+
+    return {
+        "SUBAGENT_STARTED": SubagentStartedEvent,
+        "SUBAGENT_FINISHED": SubagentFinishedEvent,
+        "SUBAGENT_ERROR": SubagentErrorEvent,
+    }
+
+
+def _own_field_aliases(event_class: type) -> Set[str]:
+    """The event's own payload fields, named as the wire names them.
+
+    A field the protocol gave no alias is named as the model names it, so a
+    documented field name can carry underscores.
+    """
+    return {
+        field.alias or name
+        for name, field in event_class.model_fields.items()  # type: ignore[attr-defined]
+        if name not in BaseEvent.model_fields
+    }
+
+
+def test_the_documented_event_list_is_the_implementations_own_set():
+    assert _documented_attributed_events() == _implementation_attributed_events(), (
+        "the README's list of events carrying a subagentRunId no longer matches "
+        "_SUBAGENT_ATTRIBUTABLE_EVENT_TYPES in agno/os/interfaces/agui/handlers.py"
+    )
+
+
+@needs_lineage_events
+def test_every_event_the_interface_emits_unattributed_is_documented_as_such():
+    # The documented families include the lineage events, which an install
+    # without them cannot name at all.
+    unattributed = _implementation_emitted_events() - _implementation_attributed_events()
+    assert _documented_unattributed_events() == unattributed, (
+        "the README's account of which events carry no subagentRunId no longer "
+        "matches what the interface emits without one"
+    )
+
+
+def test_the_documented_count_of_unattributed_kinds_matches_the_kinds_it_then_names():
+    """The count one word ahead of the marker, against the families the paragraph names.
+
+    Recomputed from the same paragraph, so the sentence cannot keep saying
+    "three" while naming a fourth family underneath it. A family is an event
+    name prefix: the two state events are one kind, which is how the paragraph
+    itself accounts for them.
+    """
+    paragraph = _unattributed_paragraph()
+    section = _attribution_section()
+    counted = re.search(r"(\w+) " + re.escape(_UNATTRIBUTED_MARKER), section)
+    assert counted is not None, f"nothing in the attribution section counts the {_UNATTRIBUTED_MARKER!r}"
+    word = counted.group(1).lower()
+    assert word in _SPELLED_COUNTS, f"the unattributed kinds are counted as {word!r}, which is not a spelled number"
+
+    families = {token.split("_")[0] for token in _backticked(paragraph)}
+    assert families, "the paragraph counting the unattributed kinds then names none of them"
+    assert _SPELLED_COUNTS[word] == len(families), (
+        f"the README counts {word} kinds of unattributed event and then names {sorted(families)}"
+    )
+
+
+def test_the_documented_visibility_values_are_the_supported_ones():
+    # The visibility table is the one whose first cell is a quoted value; the
+    # field table in the same section is keyed by event field instead.
+    documented = {entry.strip('"') for entry in _first_column_entries(_attribution_section()) if entry.startswith('"')}
+    assert documented == set(SUBAGENT_VISIBILITY_VALUES)
+
+
+def test_the_value_documented_as_the_default_is_the_default():
+    """Both defaults, because a caller can reach either without passing through the other.
+
+    The interface resolves an unset keyword through the validator, and a
+    ``StreamState`` built by any other route falls back to the field's own
+    default. Pinning one leaves the document true of half the code.
+    """
+    marked = [value.strip('"') for value, rest in _table_rows(_attribution_section()) if "(default)" in rest]
+    assert marked == [validate_subagent_visibility(None)], (
+        "the README marks a default the validator does not resolve to"
+    )
+    assert marked == [agui_state.StreamState().subagent_visibility], (
+        "the README marks a default that is not the one a StreamState carries when nobody sets it"
+    )
+
+
+def _hidden_row() -> str:
+    """The visibility table's row for ``hidden``, whole.
+
+    Read as the entire line rather than through the first-cell reader above,
+    which deliberately stops before a row's description.
+    """
+    rows = [line for line in _attribution_section().splitlines() if line.startswith('| `"hidden"`')]
+    assert len(rows) == 1, f"the attribution section holds {len(rows)} rows describing the hidden visibility, not one"
+    return rows[0]
+
+
+# The two claims every account of ``hidden`` has to make, because the delegation
+# call it keeps carries the member id and the task text verbatim. Both, because
+# a description that keeps one and drops the other still promises a client that
+# half of what the member was given stays off the wire.
+_WHAT_THE_DELEGATION_STILL_CARRIES = ("name the member", "carry the task")
+
+
+def _hidden_visibility_comment() -> str:
+    """The state module's own account of ``hidden``, and only that account.
+
+    Matched against the whole module, the claim below is satisfied by the words
+    turning up anywhere in five hundred lines, the paragraph describing a
+    different visibility included, so the description of ``hidden`` could drift
+    off the constant while the check stayed green. The bullet is read from the
+    line naming the value to the line before the next bullet or the end of the
+    comment block.
+    """
+    lines = Path(agui_state.__file__).read_text(encoding="utf-8").splitlines()
+    opens = [index for index, line in enumerate(lines) if re.match(r'^#\s+"hidden"', line)]
+    assert len(opens) == 1, f"the state module opens {len(opens)} comment bullets for the hidden visibility, not one"
+    bullet = [lines[opens[0]]]
+    for line in lines[opens[0] + 1 :]:
+        if not line.startswith("#") or re.match(r'^#\s+"', line):
+            break
+        bullet.append(line)
+    return "\n".join(bullet)
+
+
+def _accounts_of_hidden() -> Dict[str, str]:
+    """Every place this repository describes the ``hidden`` visibility, as prose.
+
+    Read with the line breaks and comment markers taken out, so a sentence that
+    says something and happens to wrap in the middle of a phrase still counts as
+    saying it. Shared by the claim checks below, so a claim added to one of them
+    is checked against every account rather than against whichever was handy,
+    and an account added here is held to all of them.
+    """
+    constructor_doc = inspect.getdoc(AGUI.__init__)
+    assert constructor_doc, "the AGUI constructor carries no docstring, so nothing here can check what it claims"
+    return {
+        where: " ".join(text.replace("#", " ").split())
+        for where, text in (
+            ("the README's hidden row", _hidden_row()),
+            ("the AGUI constructor docstring", constructor_doc),
+            ("the hidden bullet in the state module", _hidden_visibility_comment()),
+        )
+    }
+
+
+def test_every_account_of_the_hidden_visibility_says_the_delegation_call_names_the_member():
+    """Hidden withholds the member surface, and what it keeps still names the member.
+
+    A description that says nothing reaching the client names a member is false
+    in the direction that matters: it reads as a promise to keep a member's
+    identity and its task off the wire, which this interface does not make.
+    """
+    for where, prose in _accounts_of_hidden().items():
+        missing = [claim for claim in _WHAT_THE_DELEGATION_STILL_CARRIES if claim not in prose]
+        assert not missing, (
+            f"{where} does not say that the delegation call hidden keeps carries arguments that {missing}"
+        )
+
+
+# What every account of ``hidden`` has to say about a member's failure. It
+# withholds the member's identity, and the interface goes on emitting a run
+# terminal whose message is that member's own failure text, so an account that
+# stops at "withheld" reads as a promise the operator's client will not see why
+# the run stopped.
+_WHAT_HIDDEN_STILL_LETS_THROUGH = (
+    "nothing on it names the",
+    "the reason the run stopped still reaches the client",
+)
+
+
+def test_every_account_of_the_hidden_visibility_says_the_reason_the_run_stopped_still_reaches_the_client():
+    """Hidden withholds a failing member's identity, not the reason the run ended.
+
+    A member's terminal can be the only account the stream carries of how the
+    run ended, and is then read as the run's own, so the failure text reaches
+    the client as the run's reason with nothing beside it naming the member.
+    Every description of the setting has to say both halves: one that says only
+    that the failure is withheld describes an interface that stops the operator
+    finding out why their run died, which this is not.
+    """
+    for where, prose in _accounts_of_hidden().items():
+        missing = [claim for claim in _WHAT_HIDDEN_STILL_LETS_THROUGH if claim not in prose]
+        assert not missing, f"{where} does not say, of a member's failure, that {missing}"
+
+
+# The single-Agent guarantee is that the setting changes nothing for a run with
+# no member on the wire, and a pause is where it is easiest to lose: a paused
+# run's terminal carries several lists of pending calls, one call can sit on
+# more than one of them, and it goes out once per listing. An account that
+# states the guarantee without that case reads as a promise that every setting
+# sends the well-formed stream, which none of them does.
+_WHAT_THE_SINGLE_AGENT_GUARANTEE_COVERS = ("once per listing", "duplicate tool call id and all")
+
+
+def test_every_account_of_the_single_agent_guarantee_covers_a_pending_call_listed_twice():
+    """The guarantee is stated with the case it is hardest to keep, in all three places."""
+    constructor_doc = inspect.getdoc(AGUI.__init__)
+    assert constructor_doc, "the AGUI constructor carries no docstring, so nothing here can check what it claims"
+    documented = {
+        "the AGUI constructor docstring": constructor_doc,
+        "the README's attribution section": _attribution_section(),
+        "the TEST_LOG's lineage entry": _doc(_TEST_LOG),
+    }
+
+    for where, text in documented.items():
+        prose = " ".join(text.split())
+        missing = [claim for claim in _WHAT_THE_SINGLE_AGENT_GUARANTEE_COVERS if claim not in prose]
+        assert not missing, f"{where} states the single-Agent guarantee without saying {missing}"
+
+
+def test_the_documented_keyword_is_the_one_the_interface_takes():
+    assert "subagent_visibility" in inspect.signature(AGUI.__init__).parameters
+    assert "subagent_visibility" in _doc(_README)
+    assert "subagent_visibility" in _doc(_EXAMPLE)
+
+
+@needs_lineage_events
+def test_every_field_of_an_announcement_is_documented():
+    # Matched against the section's backticked tokens rather than its raw text:
+    # a field named "name" or "description" occurs in ordinary prose, so a
+    # substring search finds those two whether or not anything documents them.
+    documented = set(_backticked(_attribution_section()))
+    started = _subagent_event_classes()["SUBAGENT_STARTED"]
+    missing = sorted(
+        alias
+        for alias in _own_field_aliases(started)
+        if alias not in documented and f"SUBAGENT_STARTED.{alias}" not in documented
+    )
+    assert not missing, f"the attribution section does not describe SUBAGENT_STARTED fields {missing}"
+
+
+@needs_lineage_events
+def test_every_documented_subagent_field_exists_on_its_event():
+    classes = _subagent_event_classes()
+    # The field name is read whole, underscores included. Stopping at the first
+    # non-letter let a documented field validate as its own prefix, so
+    # SUBAGENT_ERROR.message_id passed on the strength of the message field.
+    named = re.findall(r"(SUBAGENT_[A-Z]+)\.([A-Za-z_][A-Za-z0-9_]*)", _attribution_section())
+    assert named, "the attribution section names no subagent event fields at all"
+    for event_name, field in named:
+        assert event_name in classes, f"the README names an unknown event {event_name}"
+        assert field in _own_field_aliases(classes[event_name]), (
+            f"the README documents {event_name}.{field}, which the protocol event does not carry"
+        )
+
+
+def _root_examples() -> Set[str]:
+    """The standalone example files in the folder's own root.
+
+    The nested OpenUI server is a server too, and the log counts it, but it is
+    the backend half of one example rather than a standalone one, so it is not
+    in here.
+    """
+    return {path.name for path in _COOKBOOK.glob("*.py")}
+
+
+def test_the_files_table_lists_every_example_in_the_folder():
+    if not _COOKBOOK.exists():
+        pytest.skip("cookbook not present in this checkout")
+    listed = set(_first_column_entries(_section(_doc(_README), "## Files")))
+    present = _root_examples()
+    present |= {
+        f"{path.name}/"
+        for path in _COOKBOOK.iterdir()
+        if path.is_dir() and not path.name.startswith((".", "_")) and any(path.rglob("*.py"))
+    }
+    assert listed == present
+
+
+def test_the_protocol_floor_is_stated_the_same_way_everywhere():
+    pattern = r"ag-ui-protocol[`'\s>=]{1,4}(\d+\.\d+\.\d+)"
+    # Per document, because one set of versions gathered from all of them is
+    # satisfied by a single document stating the floor while the rest go silent.
+    stated = {
+        name: set(re.findall(pattern, text)) for name, text in (("README", _doc(_README)), ("example", _doc(_EXAMPLE)))
+    }
+    silent = sorted(name for name, versions in stated.items() if not versions)
+    assert not silent, f"these documents no longer state the lineage protocol floor: {silent}"
+    versions = set().union(*stated.values())
+    assert len(versions) == 1, f"the lineage protocol floor is documented as {sorted(versions)}"
+
+
+def test_the_packaged_extra_still_permits_a_release_below_the_documented_floor():
+    """The README tells the reader to upgrade by hand, which the extra must justify."""
+    # The packaged extra is read straight off the package, which the root check
+    # at the top of this module guarantees is there: it is not a cookbook file
+    # and a checkout without the cookbook still has it.
+    documented = re.search(r"ag-ui-protocol>=(\d+\.\d+\.\d+)", _doc(_README))
+    packaged = re.search(r"ag-ui-protocol>=(\d+\.\d+\.\d+)", _PACKAGE_PYPROJECT.read_text(encoding="utf-8"))
+    assert documented is not None and packaged is not None
+
+    def parts(match: re.Match) -> tuple:
+        return tuple(int(piece) for piece in match.group(1).split("."))
+
+    assert parts(packaged) < parts(documented), (
+        "the agui extra now requires the lineage events, so the README should stop "
+        "saying it allows older releases and stop teaching a manual upgrade"
+    )
+
+
+def _bullet_naming(log: str, phrase: str) -> str:
+    """The one list item that makes a claim, so names are read from that claim alone."""
+    assert phrase in log, f"the Validation section no longer says {phrase!r}"
+    return log[log.index(phrase) :].split("\n- ")[0]
+
+
+def test_the_validation_counts_match_the_folder():
+    log = _doc(_TEST_LOG)
+    if not _COOKBOOK.exists():
+        pytest.skip("cookbook not present in this checkout")
+    root = _root_examples()
+
+    # The document states its own breakdown, and the files beyond the root are
+    # read from that sentence rather than from a recursive walk: a walk counts
+    # anything a nested frontend's installed dependencies bring with them, and
+    # would disagree with the non-recursive count the files table is checked
+    # against.
+    breakdown = re.search(r"the (\d+) in its root plus ((?:`[^`]+\.py`(?:,| and)? ?)+)", " ".join(log.split()))
+    assert breakdown is not None, "the Validation section no longer states how its count is made up"
+    assert int(breakdown.group(1)) == len(root), (
+        f"the Validation section counts {breakdown.group(1)} files in the folder root, which holds {len(root)}"
+    )
+    nested = re.findall(r"`([^`]+\.py)`", breakdown.group(2))
+    assert nested, "the Validation section names no file beyond the root, so its total cannot be checked"
+    absent = sorted(name for name in nested if not (_COOKBOOK / name).exists())
+    assert not absent, f"the Validation section counts files that are gone: {absent}"
+    servers = len(root) + len(nested)
+
+    booted = re.search(r"All (\d+) server files", log)
+    assert booted is not None, "the Validation section no longer counts the server files it booted"
+    assert int(booted.group(1)) == servers
+
+    scanned = re.search(r"checked exactly (\d+) Python files", log)
+    assert scanned is not None, "the Validation section no longer counts the scanned Python files"
+    assert int(scanned.group(1)) == servers
+
+    posted = re.search(r"(\d+) of the (\d+) files completed", log)
+    assert posted is not None, "the Validation section no longer counts the completed POST flows"
+    assert int(posted.group(2)) == servers
+    # The shortfall is derived from the files the same claim names as covered
+    # elsewhere, rather than from a hard-coded allowance of one.
+    # The same pattern the nested files are read with: a name written with a
+    # directory in front of it is one of the files this claim can excuse, and a
+    # pattern that could not match one reported it as excusing something the
+    # folder does not hold.
+    uncovered = re.findall(r"`([^`]+\.py)`", _bullet_naming(log, "of the {} files completed".format(servers)))
+    assert uncovered, "the Validation section no longer names the files whose POST flow it did not run"
+    missing = sorted(name for name in uncovered if name not in root and name not in nested)
+    assert not missing, f"the Validation section excuses files the folder does not hold: {missing}"
+    assert int(posted.group(1)) == servers - len(set(uncovered))
+
+
+def test_the_test_log_cites_suites_that_exist():
+    cited = re.findall(r"`(libs/agno/tests/[^`\n]+\.py)`", _doc(_TEST_LOG))
+    assert cited, "the test log cites no unit suite for the payloads it does not run itself"
+    missing = sorted(path for path in cited if not (_REPO_ROOT / path).exists())
+    assert not missing, f"the test log cites suites that are gone: {missing}"

--- a/libs/agno/tests/unit/os/interfaces/test_agui_hostile_run_content.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_hostile_run_content.py
@@ -1,0 +1,1436 @@
+"""Hostile run content driven through every AG-UI event-building boundary.
+
+A member result that could not be serialized once turned a successful run into a
+failed one, so that one boundary was hardened to fall back rather than raise.
+Nothing checked the others. This module drives one table of hostile values
+through every place the interface builds an AG-UI event out of run content, and
+pins, per cell, what actually happens today:
+
+``TERMINATES``
+    The run reaches its own terminal with the value rendered, dropped or
+    replaced, the stream is well formed, and every event it carries is one the
+    protocol's own encoder can put on a wire.
+``TERMINATES_UNSENDABLE``
+    The run reaches its terminal in memory, but the event THIS boundary built is
+    one that encoder refuses. On a real wire the response body stops at that
+    event: the client is left with a truncated stream and no terminal at all.
+    Worse than a failed run, and reported as a finding rather than fixed here.
+``dies_on(...)``
+    The run reaches its terminal, this boundary's own event is one the encoder
+    accepts, and the stream dies at some other event instead. The verdict names
+    that event, because the same value can be harmless where this boundary
+    reads it and fatal where another one does, and a cell that did not say
+    which credited the wrong boundary with the failure.
+``DROPPED_BEFORE_THE_BOUNDARY``
+    The run terminates, every event it carries is sendable, and the event this
+    boundary builds was never emitted: the value was discarded before the
+    boundary was reached. Such a cell pins the extractor that swallowed it
+    rather than the boundary, which is why it is named instead of counted as a
+    success.
+``dropped_and_dies_on(...)``
+    The value was discarded before the boundary AND the stream is one the
+    encoder refuses elsewhere, so the client never sees the run's terminal. Read
+    without consulting the encoder, such a cell reported a truncated stream as a
+    run that reached the client.
+``ENDS_THE_RUN``
+    Building the event raises, the mapper's own cleanup closes what it opened,
+    and the failure propagates instead of the run terminal. The client sees a
+    failed run rather than a rendered one, but nothing is left dangling.
+``ENDS_THE_RUN_MALFORMED``
+    Building the event raises AFTER the mapper recorded the span in its state,
+    so the wire is left with a span the client can never resolve: a tool call
+    with no end, a reasoning block ended without a start, or a text message left
+    open. This is worse than a failed run and is reported as a finding rather
+    than fixed here.
+
+Five things keep a cell from going green, or red, for the wrong reason. Every
+cell drives its boundary with content the boundary handles, so a verdict is
+attributable to the value the case injected rather than to a broken fixture or a
+misconfigured stream. Each fixture injects the value at one boundary only: a
+fixture that put it in two places reported whichever the interface read first
+under the name of the other. The verdict says whether the boundary's own event
+reached the wire before it attributes a refusal, and it consults the encoder
+either way, so a stream carrying some other unsendable event cannot stand in for
+this boundary building one and a boundary that built nothing cannot hide one.
+Every boundary is driven with every hostile value, checked against an
+independent list of those values, so a row cannot quietly stop being swept and a
+value added to the shared table cannot go undriven. And the set of boundaries
+itself is recomputed from the interface's own source, per function AND per event
+type: every event each scope of the package constructs is claimed by a row,
+covered by a named test here, or justified as built out of no run content, so a
+function that builds six events cannot be counted as driven because one row
+drives one of them.
+
+One row is not an event boundary at all: the identifiers a member's failure is
+recorded with never reach the wire, so that row drives its value through the log
+line the member's terminal is accompanied by, and pins the terminal it must not
+prevent. Everything else in that row reads exactly like the others.
+
+The table is the point. Hardening any boundary flips its cells, which fails this
+module and forces the table to be brought up to date rather than letting the new
+behavior go unrecorded. The same cells are asserted under the default
+visibility, which differs only by the member lifecycle, so a boundary that
+behaves differently there is a difference the default was not supposed to have.
+A boundary that builds nothing under the default is still held to what the rest
+of that stream did with the value, the encoder included, since the member's own
+chunks go out there as RAW.
+
+The whole module holds on a protocol release without the lineage events too. The
+interface builds those behind a guarded import, so on such a release its source
+constructs none of them; the coverage check leaves an event type the installed
+protocol does not define out of the comparison on both sides rather than
+reporting the rows naming it as claims about nothing.
+"""
+
+from types import MappingProxyType
+from typing import Any, Callable, Dict, List, Mapping, NamedTuple, Optional, Set, Tuple
+
+import pytest
+
+pytest.importorskip("ag_ui", reason="ag_ui not installed")
+
+from ag_ui.core import BaseEvent, EventType, RunAgentInput, UserMessage
+
+from agno.models.response import ToolExecution
+from agno.os.interfaces.agui.router import run_entity
+from agno.reasoning.step import ReasoningStep
+from agno.run.agent import (
+    CustomEvent,
+    ReasoningContentDeltaEvent,
+    ReasoningStepEvent,
+    RunCancelledEvent,
+    RunCompletedEvent,
+    RunErrorEvent,
+    RunStartedEvent,
+    ToolCallCompletedEvent,
+    ToolCallStartedEvent,
+)
+from agno.run.requirement import RunRequirement
+from agno.run.team import RunCompletedEvent as TeamRunCompletedEvent
+from agno.run.team import RunContentEvent as TeamRunContentEvent
+from agno.run.team import RunErrorEvent as TeamRunErrorEvent
+from agno.run.team import RunPausedEvent as TeamRunPausedEvent
+from agno.run.team import RunStartedEvent as TeamRunStartedEvent
+
+from .agui_stream_invariants import (
+    HOSTILE_VALUES,
+    TOP_LEVEL_RUN,
+    MalformedCollected,
+    SideEffect,
+    agent_said,
+    assert_stream_contains,
+    attributed,
+    collect_async_recording_violations,
+    collect_sync_recording_violations,
+    encoding_failures,
+    event_type_named,
+    lane_of,
+    member_chunk_kwargs,
+    of_type,
+    short_type_name,
+    team_chunk_kwargs,
+    team_said,
+)
+from .test_agui_documented_contract import event_constructions_by_function
+
+THREAD_ID = "hostile-session"
+# The same lineage fields the attribution suite builds its chunks from.
+_TOP_LEVEL = team_chunk_kwargs("research-team", "Research Team", TOP_LEVEL_RUN)
+_MEMBER = member_chunk_kwargs("scout", "run-scout")
+
+TERMINATES = "terminates"
+TERMINATES_UNSENDABLE = "terminates in memory and dies on the wire at this boundary's own event"
+DROPPED_BEFORE_THE_BOUNDARY = "terminates, with the value dropped before the boundary"
+ENDS_THE_RUN = "ends the run"
+ENDS_THE_RUN_MALFORMED = "ends the run and leaves the stream malformed"
+
+_DIES_ELSEWHERE = "terminates, with this boundary's own event sendable and the stream dying on "
+_DROPPED_AND_DIES_ELSEWHERE = "terminates, with the value dropped before the boundary and the stream dying on "
+
+
+def _naming(prefix: str, event_names: Tuple[str, ...]) -> str:
+    assert event_names, "a verdict about a refused event has to name the event"
+    return prefix + ", ".join(sorted(event_names))
+
+
+def dies_on(*event_names: str) -> str:
+    """The verdict for a stream the encoder refuses somewhere other than here.
+
+    The event is named, so a cell cannot report a stream-wide refusal as though
+    this boundary had built the event the encoder choked on.
+    """
+    return _naming(_DIES_ELSEWHERE, event_names)
+
+
+def dropped_and_dies_on(*event_names: str) -> str:
+    """The verdict for a value dropped before the boundary on a stream that still dies.
+
+    "Dropped" alone is a claim that the run reached the client, which is false
+    of a stream the encoder refuses partway through. The value never reached
+    this boundary AND the client is left with a truncated stream, so the cell
+    has to say both and name the event that truncated it.
+    """
+    return _naming(_DROPPED_AND_DIES_ELSEWHERE, event_names)
+
+
+# What every surviving verdict has in common, for the one claim that holds
+# across all of them.
+REACHES_ITS_TERMINAL = "reaches its terminal"
+_ENDED = (ENDS_THE_RUN, ENDS_THE_RUN_MALFORMED)
+
+
+def _survives(verdict: str) -> bool:
+    return verdict not in _ENDED
+
+
+def _is_a_verdict(outcome: str) -> bool:
+    """Whether an outcome is one this module can actually reach."""
+    return outcome in (TERMINATES, TERMINATES_UNSENDABLE, DROPPED_BEFORE_THE_BOUNDARY, *_ENDED) or outcome.startswith(
+        (_DIES_ELSEWHERE, _DROPPED_AND_DIES_ELSEWHERE)
+    )
+
+
+_HOSTILE = dict(HOSTILE_VALUES)
+_RUN_TERMINALS = (EventType.RUN_FINISHED, EventType.RUN_ERROR)
+
+
+class Fixture(NamedTuple):
+    """One boundary's chunk list, and the session state the run carries with it."""
+
+    chunks: List[Any]
+    run_state: Optional[Dict[str, Any]] = None
+
+
+# --- Chunk lists, one per event-building boundary ----------------------------
+
+
+def _member_run(*inner: Any) -> List[Any]:
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**_MEMBER),
+        *inner,
+        RunCompletedEvent(content="scout done", **_MEMBER),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+def _member_terminal_result(value: Any) -> Fixture:
+    """The member terminal's ``result``, built by the one hardened boundary."""
+    return Fixture(
+        [
+            TeamRunStartedEvent(**_TOP_LEVEL),
+            RunStartedEvent(**_MEMBER),
+            RunCompletedEvent(content=value, **_MEMBER),
+            TeamRunCompletedEvent(**_TOP_LEVEL),
+        ]
+    )
+
+
+def _agent_text_delta(value: Any) -> Fixture:
+    """TEXT_MESSAGE_CONTENT built from an Agent chunk's content."""
+    return Fixture(_member_run(agent_said(value, **_MEMBER)))
+
+
+def _team_text_delta(value: Any) -> Fixture:
+    """TEXT_MESSAGE_CONTENT built from a Team chunk's own content."""
+    leader = TeamRunContentEvent(**_TOP_LEVEL)
+    leader.content = value
+    return Fixture([TeamRunStartedEvent(**_TOP_LEVEL), leader, TeamRunCompletedEvent(**_TOP_LEVEL)])
+
+
+def _team_member_response_delta(value: Any) -> Fixture:
+    """TEXT_MESSAGE_CONTENT built by folding a Team chunk's nested member outputs.
+
+    The leader says nothing of its own here. Its own text would put a delta on
+    the wire whatever the fold did with the member's output, which is a green
+    cell for a boundary the case never exercised.
+    """
+    leader = TeamRunContentEvent(**_TOP_LEVEL)
+    leader.member_responses = [agent_said(value, **_MEMBER)]
+    return Fixture([TeamRunStartedEvent(**_TOP_LEVEL), leader, TeamRunCompletedEvent(**_TOP_LEVEL)])
+
+
+def _tool_call_args(value: Any) -> Fixture:
+    """TOOL_CALL_ARGS built from a tool call's arguments."""
+    tool = ToolExecution(tool_call_id="tc-hostile", tool_name="do_it", tool_args=value)
+    return Fixture(
+        _member_run(ToolCallStartedEvent(tool=tool, **_MEMBER), ToolCallCompletedEvent(tool=tool, **_MEMBER))
+    )
+
+
+def _tool_call_result(value: Any) -> Fixture:
+    """TOOL_CALL_RESULT built from a tool call's result."""
+    tool = ToolExecution(tool_call_id="tc-hostile", tool_name="do_it", tool_args={}, result=value)
+    return Fixture(
+        _member_run(ToolCallStartedEvent(tool=tool, **_MEMBER), ToolCallCompletedEvent(tool=tool, **_MEMBER))
+    )
+
+
+def _reasoning_content_delta(value: Any) -> Fixture:
+    """REASONING_MESSAGE_CONTENT built from a streamed reasoning delta."""
+    chunk = ReasoningContentDeltaEvent(**_MEMBER)
+    chunk.reasoning_content = value
+    return Fixture(_member_run(chunk))
+
+
+def _reasoning_step_payload(value: Any) -> Fixture:
+    """REASONING_MESSAGE_CONTENT built from a reasoning step that is not one."""
+    chunk = ReasoningStepEvent(**_MEMBER)
+    chunk.content = value
+    return Fixture(_member_run(chunk))
+
+
+def _reasoning_step_field(value: Any) -> Fixture:
+    """REASONING_MESSAGE_CONTENT built from a reasoning step holding hostile text."""
+    step = ReasoningStep(title="scout plan", reasoning="scout is thinking")
+    step.reasoning = value
+    chunk = ReasoningStepEvent(**_MEMBER)
+    chunk.content = step
+    return Fixture(_member_run(chunk))
+
+
+def _custom_event_payload(value: Any) -> Fixture:
+    """CUSTOM built from a custom chunk's own dump."""
+    chunk = CustomEvent(**_MEMBER)
+    chunk.to_dict = lambda: {"payload": value}  # type: ignore[method-assign]
+    return Fixture(_member_run(chunk))
+
+
+def _raw_event_payload(value: Any) -> Fixture:
+    """RAW built from an unmapped chunk's own dump.
+
+    The stream opens on the leader's own text rather than on a run-started
+    chunk, which this interface passes through as RAW itself. With one of those
+    ahead of it, a RAW is on the wire whatever this boundary does, so the
+    boundary's own event can never be reported missing and a dump discarded
+    before the boundary would read as one that reached it.
+    """
+    chunk = RunStartedEvent(**_MEMBER)
+    chunk.to_dict = lambda: {"event": "RunStarted", "payload": value}  # type: ignore[method-assign]
+    return Fixture(
+        [
+            team_said("leader speaking", **_TOP_LEVEL),
+            chunk,
+            RunCompletedEvent(content="scout done", **_MEMBER),
+            TeamRunCompletedEvent(**_TOP_LEVEL),
+        ]
+    )
+
+
+def _failing_run_with_a_member_mid_sentence(value: Any) -> Fixture:
+    """A run that fails on hostile content while a member is still streaming.
+
+    Two boundaries read that content: the run terminal the client is told about,
+    and the terminal every member lane still open is closed with.
+    """
+    return Fixture(
+        [
+            TeamRunStartedEvent(**_TOP_LEVEL),
+            RunStartedEvent(**_MEMBER),
+            agent_said("half a sen", **_MEMBER),
+            TeamRunErrorEvent(content=value, error_type="RuntimeError", **_TOP_LEVEL),
+        ]
+    )
+
+
+def _state_delta(value: Any) -> Fixture:
+    """STATE_DELTA built by diffing the session state a member's tool changed."""
+    session_state: Dict[str, Any] = {"approved": False}
+    tool = ToolExecution(tool_call_id="tc-approve", tool_name="approve", tool_args={}, result="ok")
+    return Fixture(
+        [
+            TeamRunStartedEvent(**_TOP_LEVEL),
+            RunStartedEvent(**_MEMBER),
+            ToolCallStartedEvent(tool=tool, **_MEMBER),
+            # Applied while the stream is being consumed, so the delta really is
+            # computed from a change the client had not seen yet.
+            SideEffect(lambda: session_state.__setitem__("value", value)),
+            ToolCallCompletedEvent(tool=tool, **_MEMBER),
+            RunCompletedEvent(content="scout done", **_MEMBER),
+            TeamRunCompletedEvent(**_TOP_LEVEL),
+        ],
+        run_state=session_state,
+    )
+
+
+# What a caller that says nothing about the paused run's words passes. A missing
+# argument cannot be spelled None here: None is one of the hostile values, and a
+# cell keyed on it would pin what an unset content does rather than what an
+# explicitly empty one does.
+_SAYS_NOTHING = object()
+
+
+def _paused_run(tool: ToolExecution, content: Any = _SAYS_NOTHING) -> Fixture:
+    """A run that pauses on one pending call, and says what it says while pausing.
+
+    One hostile value per fixture, never two. A pause reads its own words before
+    it builds any of the prompt, so a fixture injecting the value into both the
+    words and the call credited the call's boundary with whatever the words did
+    first: the value that cannot be rendered ends the run from inside
+    ``_pause_content``, several events before the arguments are serialized.
+    """
+    paused = TeamRunPausedEvent(tools=[tool], **_TOP_LEVEL)
+    if content is not _SAYS_NOTHING:
+        paused.content = content
+    return Fixture([TeamRunStartedEvent(**_TOP_LEVEL), paused])
+
+
+def _pause_prompt_args(value: Any) -> Fixture:
+    """TOOL_CALL_ARGS built from the arguments of a call a paused run waits on."""
+    return _paused_run(
+        ToolExecution(
+            tool_call_id="tc-hostile-confirm", tool_name="confirm", tool_args=value, requires_confirmation=True
+        )
+    )
+
+
+def _benign_pending_call() -> ToolExecution:
+    return ToolExecution(
+        tool_call_id="tc-hostile-confirm", tool_name="confirm", tool_args={"to": "ops"}, requires_confirmation=True
+    )
+
+
+def _pause_prompt_content(value: Any) -> Fixture:
+    """TEXT_MESSAGE_CONTENT built from what a paused run says while it waits."""
+    return _paused_run(_benign_pending_call(), content=value)
+
+
+def _pause_tool_name(value: Any) -> Fixture:
+    """TOOL_CALL_START built from the name of a call a paused run waits on."""
+    return _paused_run(
+        ToolExecution(
+            tool_call_id="tc-hostile-confirm", tool_name=value, tool_args={"to": "ops"}, requires_confirmation=True
+        )
+    )
+
+
+def _pause_tool_id(value: Any) -> Fixture:
+    """TOOL_CALL_START built from the id of a call a paused run waits on."""
+    return _paused_run(
+        ToolExecution(tool_call_id=value, tool_name="confirm", tool_args={"to": "ops"}, requires_confirmation=True)
+    )
+
+
+def _tool_call_name(value: Any) -> Fixture:
+    """TOOL_CALL_START built from the name the model gave the tool it called.
+
+    The call completes, as it does at the two boundaries above: a member's
+    terminal ends no tool call, so a call left dangling here would make the
+    benign row of this boundary a stream the run end closes after the member's
+    terminal, which is a shape of its own rather than anything this boundary is
+    about.
+    """
+    tool = ToolExecution(tool_call_id="tc-hostile", tool_name=value, tool_args={})
+    return Fixture(
+        _member_run(ToolCallStartedEvent(tool=tool, **_MEMBER), ToolCallCompletedEvent(tool=tool, **_MEMBER))
+    )
+
+
+def _tool_call_id(value: Any) -> Fixture:
+    """TOOL_CALL_START built from the id the model gave the call, which may be missing."""
+    tool = ToolExecution(tool_call_id=value, tool_name="do_it", tool_args={})
+    return Fixture(
+        _member_run(ToolCallStartedEvent(tool=tool, **_MEMBER), ToolCallCompletedEvent(tool=tool, **_MEMBER))
+    )
+
+
+def _subagent_error_message(value: Any) -> Fixture:
+    """SUBAGENT_ERROR's message, built from what a member's failing run reported.
+
+    The team finishes afterwards, so the member's failure is this boundary's
+    subject rather than the run terminal: read as the run's own terminal, which
+    is what the default does with it, the value would land at the RUN_ERROR
+    boundary above instead.
+    """
+    failure = RunErrorEvent(error_type="RuntimeError", **_MEMBER)
+    failure.content = value
+    return Fixture(
+        [
+            TeamRunStartedEvent(**_TOP_LEVEL),
+            RunStartedEvent(**_MEMBER),
+            failure,
+            TeamRunCompletedEvent(**_TOP_LEVEL),
+        ]
+    )
+
+
+def _subagent_error_correlation(value: Any) -> Fixture:
+    """The identifiers a member's failure is recorded with, alongside its SUBAGENT_ERROR."""
+    failure = RunErrorEvent(content="member exploded", error_type="RuntimeError", error_id="err-42", **_MEMBER)
+    failure.additional_data = {"attempt": value}
+    return Fixture(
+        [
+            TeamRunStartedEvent(**_TOP_LEVEL),
+            RunStartedEvent(**_MEMBER),
+            failure,
+            TeamRunCompletedEvent(**_TOP_LEVEL),
+        ]
+    )
+
+
+def _subagent_cancellation_reason(value: Any) -> Fixture:
+    """SUBAGENT_ERROR's message, built from the reason a member's run was cancelled."""
+    cancelled = RunCancelledEvent(**_MEMBER)
+    cancelled.reason = value
+    return Fixture(
+        [
+            TeamRunStartedEvent(**_TOP_LEVEL),
+            RunStartedEvent(**_MEMBER),
+            cancelled,
+            TeamRunCompletedEvent(**_TOP_LEVEL),
+        ]
+    )
+
+
+def _paused_member_name(value: Any) -> Fixture:
+    """SUBAGENT_STARTED's name, built from the identity a paused run names its member by.
+
+    The member id stays readable, so a name that cannot be read has somewhere to
+    fall back to and the announcement is still expected on the wire.
+    """
+    tool = ToolExecution(
+        tool_call_id="tc-member-confirm", tool_name="send_email", tool_args={"to": "ops"}, requires_confirmation=True
+    )
+    requirement = RunRequirement(tool)
+    requirement.member_agent_id = "scout"
+    requirement.member_run_id = "run-scout"
+    requirement.member_agent_name = value
+    return Fixture(
+        [
+            TeamRunStartedEvent(**_TOP_LEVEL),
+            TeamRunPausedEvent(tools=[], requirements=[requirement], **_TOP_LEVEL),
+        ]
+    )
+
+
+def _member_identity(value: Any) -> Fixture:
+    """SUBAGENT_STARTED built from the name and id a member's chunks carry."""
+    member = {"agent_id": value, "agent_name": value, "run_id": "run-anonymous", "parent_run_id": TOP_LEVEL_RUN}
+    return Fixture(
+        [
+            TeamRunStartedEvent(**_TOP_LEVEL),
+            RunStartedEvent(**member),
+            agent_said("member speaking", **member),
+            RunCompletedEvent(content="done", **member),
+            TeamRunCompletedEvent(**_TOP_LEVEL),
+        ]
+    )
+
+
+_ALL_VALUES = tuple(name for name, _ in HOSTILE_VALUES)
+
+# The values this table was written against, named rather than derived from the
+# shared list the sweep reads. Derived, the completeness check compares the
+# shared list with itself and holds however that list changes; named, a value
+# added to it lands here first and every row has to state an outcome for it.
+_HOSTILE_VALUE_NAMES = (
+    "circular",
+    "raises_on_serialization",
+    "set",
+    "not_a_number",
+    "none",
+)
+
+
+def _everywhere(outcome: str) -> Dict[str, str]:
+    return {name: outcome for name in _ALL_VALUES}
+
+
+def _terminates_except(**overrides: str) -> Dict[str, str]:
+    expected = _everywhere(TERMINATES)
+    expected.update(overrides)
+    return expected
+
+
+def _dropped_except(**overrides: str) -> Dict[str, str]:
+    expected = _everywhere(DROPPED_BEFORE_THE_BOUNDARY)
+    expected.update(overrides)
+    return expected
+
+
+_NO_DEFAULT_OVERRIDES: Mapping[str, str] = MappingProxyType({})
+
+
+class Boundary(NamedTuple):
+    """One place the interface builds an AG-UI event out of run content."""
+
+    name: str
+    builder: Callable[[Any], Fixture]
+    # The event this boundary builds, by name, so a cell that emitted none of it
+    # cannot pass as one that exercised the boundary.
+    event: str
+    # The interface function that constructs that event, named as the source
+    # scan names it: module, then the scope inside it. Checked against a scan of
+    # the package's own source, so a row cannot claim a function that builds
+    # something else, and a function-and-event pair nothing here claims fails
+    # the coverage check below.
+    builds: str
+    # A value the boundary handles, to prove the fixture reaches it at all.
+    # Built per case, so no two cases share one object.
+    benign: Callable[[], Any]
+    # What every hostile value does here. Every boundary is driven with every
+    # value, so this states one outcome per value and nothing narrows the sweep.
+    outcomes: Dict[str, str]
+    # Whether that event exists on the wire only under member attribution.
+    lineage_only: bool = False
+    # What the same fixture does under the default visibility, stated only where
+    # that differs from the run merely reaching its terminal. Only a
+    # lineage-only boundary can need one: it builds nothing there, so the cell
+    # is about what the rest of the stream did with the value instead, and the
+    # member's own unmapped chunks still carry it out as RAW.
+    #
+    # A NamedTuple default is one object shared by every row that leaves it
+    # unset, so this one is immutable: a row reaching for it and writing into it
+    # would otherwise state that cell for every other row too.
+    under_the_default: Mapping[str, str] = _NO_DEFAULT_OVERRIDES
+
+
+# Every boundary that builds an AG-UI event out of run content, the values it is
+# driven with, and what happens today under member attribution. ``not_a_number``
+# and ``none`` are the two values most serializers handle, which is why they are
+# the quiet column. Each row names the interface function that builds its event,
+# which the coverage test at the bottom of this module checks the whole table
+# against.
+_BOUNDARIES: Tuple[Boundary, ...] = (
+    # The one hardened boundary: every route falls back rather than raising.
+    Boundary(
+        "member_terminal_result",
+        _member_terminal_result,
+        "SUBAGENT_FINISHED",
+        "handlers._lane_finished",
+        lambda: "scout done",
+        _everywhere(TERMINATES),
+        lineage_only=True,
+    ),
+    # json.dumps of the content is unguarded, so a cycle ends the run. Every
+    # other value is swallowed by the text extractor before a delta is built,
+    # so those cells reach the extractor and stop there.
+    Boundary(
+        "agent_text_delta",
+        _agent_text_delta,
+        "TEXT_MESSAGE_CONTENT",
+        "handlers.on_run_content",
+        lambda: "hello",
+        _dropped_except(circular=ENDS_THE_RUN),
+    ),
+    Boundary(
+        "team_text_delta",
+        _team_text_delta,
+        "TEXT_MESSAGE_CONTENT",
+        "handlers.on_run_content",
+        lambda: "hello",
+        _dropped_except(circular=ENDS_THE_RUN),
+    ),
+    # The leader says nothing of its own here, so a nested member output that
+    # folds into nothing leaves no delta on the wire at all: the leader's text
+    # message opens and closes empty.
+    Boundary(
+        "team_member_response_delta",
+        _team_member_response_delta,
+        "TEXT_MESSAGE_CONTENT",
+        "handlers.on_run_content",
+        lambda: "hello",
+        _dropped_except(circular=ENDS_THE_RUN),
+    ),
+    # json.dumps of the arguments is unguarded, so anything it refuses ends the
+    # run. The tool call itself is never announced, so nothing dangles.
+    Boundary(
+        "tool_call_args",
+        _tool_call_args,
+        "TOOL_CALL_ARGS",
+        "handlers.on_tool_call_started",
+        lambda: {"query": "agno"},
+        _terminates_except(circular=ENDS_THE_RUN, raises_on_serialization=ENDS_THE_RUN, set=ENDS_THE_RUN),
+    ),
+    # The call is marked ended in the mapper's state before its result is
+    # serialized, so a result the serializer refuses discards the end event and
+    # leaves the tool call open on the wire for good.
+    Boundary(
+        "tool_call_result",
+        _tool_call_result,
+        "TOOL_CALL_RESULT",
+        "handlers.on_tool_call_completed",
+        lambda: "three sources",
+        _terminates_except(
+            circular=ENDS_THE_RUN_MALFORMED,
+            raises_on_serialization=ENDS_THE_RUN_MALFORMED,
+            set=ENDS_THE_RUN_MALFORMED,
+            none=DROPPED_BEFORE_THE_BOUNDARY,
+        ),
+    ),
+    # The reasoning span is opened in the mapper's state before the content
+    # event is built, so a delta the protocol model refuses discards the start
+    # while the state keeps the span, and the cleanup ends an id the client was
+    # never given a start for.
+    Boundary(
+        "reasoning_content_delta",
+        _reasoning_content_delta,
+        "REASONING_MESSAGE_CONTENT",
+        "handlers.on_reasoning_content_delta",
+        lambda: "first I ",
+        _terminates_except(
+            circular=ENDS_THE_RUN_MALFORMED,
+            raises_on_serialization=ENDS_THE_RUN_MALFORMED,
+            set=ENDS_THE_RUN_MALFORMED,
+            not_a_number=ENDS_THE_RUN_MALFORMED,
+            none=DROPPED_BEFORE_THE_BOUNDARY,
+        ),
+    ),
+    Boundary(
+        "reasoning_step_payload",
+        _reasoning_step_payload,
+        "REASONING_MESSAGE_CONTENT",
+        "handlers.on_reasoning_step",
+        lambda: ReasoningStep(title="scout plan", reasoning="scout is thinking"),
+        _terminates_except(
+            circular=ENDS_THE_RUN_MALFORMED,
+            raises_on_serialization=ENDS_THE_RUN_MALFORMED,
+            set=ENDS_THE_RUN_MALFORMED,
+            not_a_number=ENDS_THE_RUN_MALFORMED,
+            none=DROPPED_BEFORE_THE_BOUNDARY,
+        ),
+    ),
+    # The step's own title still renders, so a step whose reasoning text is
+    # missing leaves a delta on the wire rather than nothing.
+    Boundary(
+        "reasoning_step_field",
+        _reasoning_step_field,
+        "REASONING_MESSAGE_CONTENT",
+        "handlers.on_reasoning_step",
+        lambda: "scout is thinking",
+        _terminates_except(
+            circular=ENDS_THE_RUN_MALFORMED,
+            raises_on_serialization=ENDS_THE_RUN_MALFORMED,
+            set=ENDS_THE_RUN_MALFORMED,
+            not_a_number=ENDS_THE_RUN_MALFORMED,
+        ),
+    ),
+    # These two dump the chunk behind a guard, so a dump that RAISES is caught.
+    # A dump that succeeds is not filtered at all: both events declare their
+    # payload as an untyped field, so a value inside the dump rides out on the
+    # event and the protocol's encoder is where the stream then dies.
+    Boundary(
+        "custom_event_payload",
+        _custom_event_payload,
+        "CUSTOM",
+        "handlers.on_custom_event",
+        lambda: {"payload": "fine"},
+        _terminates_except(circular=TERMINATES_UNSENDABLE, raises_on_serialization=TERMINATES_UNSENDABLE),
+    ),
+    Boundary(
+        "raw_event_payload",
+        _raw_event_payload,
+        "RAW",
+        "handlers.on_unknown_event",
+        lambda: {"payload": "fine"},
+        _terminates_except(circular=TERMINATES_UNSENDABLE, raises_on_serialization=TERMINATES_UNSENDABLE),
+    ),
+    # The run terminal is built after the mapper's own cleanup has run, so a
+    # message that cannot be rendered leaves the open text message unclosed and
+    # writes no terminal at all.
+    Boundary(
+        "run_error_message",
+        _failing_run_with_a_member_mid_sentence,
+        "RUN_ERROR",
+        "handlers.on_run_error",
+        lambda: "the team blew up",
+        _terminates_except(raises_on_serialization=ENDS_THE_RUN_MALFORMED),
+    ),
+    # The same content, read at the other boundary it reaches: closing the run
+    # writes it as the terminal of every member lane still open. It is rendered
+    # with a bare stringification here, unlike a member's own failure message,
+    # so the value that cannot be rendered ends the run from inside the record
+    # of why it stopped, before either terminal is built.
+    Boundary(
+        "run_error_lane_message",
+        _failing_run_with_a_member_mid_sentence,
+        "SUBAGENT_ERROR",
+        "handlers._lane_errored",
+        lambda: "the team blew up",
+        _terminates_except(raises_on_serialization=ENDS_THE_RUN_MALFORMED),
+        lineage_only=True,
+    ),
+    # The delta is a diff of the session state, which holds anything, and the
+    # ops it carries are untyped, so the value reaches the encoder unfiltered.
+    Boundary(
+        "state_delta",
+        _state_delta,
+        "STATE_DELTA",
+        "handlers._emit_state_delta",
+        lambda: "approved",
+        _terminates_except(circular=TERMINATES_UNSENDABLE, raises_on_serialization=TERMINATES_UNSENDABLE),
+    ),
+    # The four things a paused run puts on the wire out of its own content, one
+    # row each rather than one fixture carrying the value into several of them:
+    # the prompt is built in this order, so a fixture that injected the value
+    # twice reported whichever boundary came first under the name of the later
+    # one.
+    Boundary(
+        "pause_prompt_content",
+        _pause_prompt_content,
+        "TEXT_MESSAGE_CONTENT",
+        "handlers._prompt_block",
+        lambda: "confirm this before I send it",
+        # Rendered with a bare stringification, which only the value that raises
+        # from its own repr refuses. A run that says nothing while pausing sends
+        # no delta, which is where the empty value stops.
+        _terminates_except(raises_on_serialization=ENDS_THE_RUN, none=DROPPED_BEFORE_THE_BOUNDARY),
+    ),
+    # The protocol model requires a string name and a string id here as much as
+    # it does on a streamed call, and nothing coerces either. The one difference
+    # from the streamed rows is the empty value: a pending call missing either
+    # is dropped, with a warning, before the prompt is built, so the client is
+    # told the run is waiting with nothing on the wire to act on.
+    Boundary(
+        "pause_tool_name",
+        _pause_tool_name,
+        "TOOL_CALL_START",
+        "handlers._prompt_block",
+        lambda: "confirm",
+        _everywhere(ENDS_THE_RUN) | {"none": DROPPED_BEFORE_THE_BOUNDARY},
+    ),
+    Boundary(
+        "pause_tool_id",
+        _pause_tool_id,
+        "TOOL_CALL_START",
+        "handlers._prompt_block",
+        lambda: "tc-benign",
+        _everywhere(ENDS_THE_RUN) | {"none": DROPPED_BEFORE_THE_BOUNDARY},
+    ),
+    Boundary(
+        "pause_prompt_args",
+        _pause_prompt_args,
+        "TOOL_CALL_ARGS",
+        "handlers._prompt_block",
+        lambda: {"to": "ops"},
+        _terminates_except(circular=ENDS_THE_RUN, raises_on_serialization=ENDS_THE_RUN, set=ENDS_THE_RUN),
+    ),
+    # The protocol model requires a string name, and nothing coerces the value
+    # or drops the call before the event is built.
+    Boundary(
+        "tool_call_name",
+        _tool_call_name,
+        "TOOL_CALL_START",
+        "handlers.on_tool_call_started",
+        lambda: "do_it",
+        _everywhere(ENDS_THE_RUN),
+    ),
+    # The id the model gave the call: the protocol model requires a string there
+    # too, and nothing coerces the value or drops the call before it is built.
+    Boundary(
+        "tool_call_id",
+        _tool_call_id,
+        "TOOL_CALL_START",
+        "handlers.on_tool_call_started",
+        lambda: "tc-benign",
+        _everywhere(ENDS_THE_RUN),
+    ),
+    # The member's own identity, which the announcement's name is read off.
+    # Every value is read through the same guarded stringification, so a name
+    # that cannot be rendered leaves the lane announced under its run id and the
+    # run finishes, announcement included. The one exception is nothing this
+    # boundary built: the member's unmapped chunks are passed through as RAW,
+    # whose payload is the chunk's own dump, so an identity object the encoder
+    # refuses rides out on that event and the stream dies there.
+    Boundary(
+        "member_identity",
+        _member_identity,
+        "SUBAGENT_STARTED",
+        "handlers._announce_subagent",
+        lambda: "Scout",
+        _terminates_except(raises_on_serialization=dies_on("RAW")),
+        lineage_only=True,
+        # The default announces no member, so nothing here builds an event at
+        # all; the member's unmapped chunks still go out as RAW, and the
+        # identity the encoder refuses rides out on one of those.
+        under_the_default={"raises_on_serialization": dies_on("RAW")},
+    ),
+    # The three ways a member's own terminal reports what happened to it, each
+    # read through the same guarded stringification the names are: a failure
+    # that cannot be described leaves the lane errored with the interface's own
+    # wording rather than ending a run that is still going.
+    Boundary(
+        "subagent_error_message",
+        _subagent_error_message,
+        "SUBAGENT_ERROR",
+        "handlers._lane_errored",
+        lambda: "member exploded",
+        _everywhere(TERMINATES),
+        lineage_only=True,
+    ),
+    Boundary(
+        "subagent_cancellation_reason",
+        _subagent_cancellation_reason,
+        "SUBAGENT_ERROR",
+        "handlers._lane_errored",
+        lambda: "user cancelled the run",
+        _everywhere(TERMINATES),
+        lineage_only=True,
+        # The default builds no lane terminal, and reads the member's
+        # cancellation as the run's own: the RUN_ERROR it writes embeds the
+        # cancelled chunk verbatim, reason included, so the reason the encoder
+        # refuses truncates the stream at the run's own terminal.
+        under_the_default={"raises_on_serialization": dies_on("RAW")},
+    ),
+    # The identifiers that failure is recorded with never reach the wire, so the
+    # value is driven through the log line the terminal is accompanied by: one
+    # that cannot be rendered used to end the run from inside the record of why
+    # a lane had already closed.
+    Boundary(
+        "subagent_error_correlation",
+        _subagent_error_correlation,
+        "SUBAGENT_ERROR",
+        "handlers._lane_errored",
+        lambda: "second try",
+        _everywhere(TERMINATES),
+        lineage_only=True,
+    ),
+    # The identity a paused run names its member by, which the announcement the
+    # pause prompt needs is built from.
+    Boundary(
+        "paused_member_name",
+        _paused_member_name,
+        "SUBAGENT_STARTED",
+        "handlers._announce_paused_lanes",
+        lambda: "Scout",
+        _everywhere(TERMINATES),
+        lineage_only=True,
+    ),
+)
+
+# Named rather than counted, so a boundary cannot be swapped for a different one
+# while the total stays the same.
+_BOUNDARY_NAMES = (
+    "member_terminal_result",
+    "agent_text_delta",
+    "team_text_delta",
+    "team_member_response_delta",
+    "tool_call_args",
+    "tool_call_result",
+    "reasoning_content_delta",
+    "reasoning_step_payload",
+    "reasoning_step_field",
+    "custom_event_payload",
+    "raw_event_payload",
+    "run_error_message",
+    "run_error_lane_message",
+    "state_delta",
+    "pause_prompt_content",
+    "pause_tool_name",
+    "pause_tool_id",
+    "pause_prompt_args",
+    "tool_call_name",
+    "tool_call_id",
+    "member_identity",
+    "subagent_error_message",
+    "subagent_cancellation_reason",
+    "subagent_error_correlation",
+    "paused_member_name",
+)
+
+
+# --- Collectors -------------------------------------------------------------
+
+# Both collectors are the shared ones, so this module's streams are checked
+# against exactly the same definition of a well-formed stream as every other
+# suite's. They report the invariant a stream broke rather than failing on it,
+# because a malformed stream is this module's subject.
+
+Collect = Callable[..., Any]
+
+mappers = pytest.mark.parametrize(
+    "collect",
+    [collect_sync_recording_violations, collect_async_recording_violations],
+    ids=["sync", "async"],
+)
+
+
+async def _collect(collect: Collect, fixture: Fixture, visibility: Optional[str]) -> MalformedCollected:
+    return await collect(
+        fixture.chunks,
+        visibility,
+        thread_id=THREAD_ID,
+        run_id=TOP_LEVEL_RUN,
+        run_state=fixture.run_state,
+    )
+
+
+# A cell the table does not state arrives as None and is reported by the test
+# body. Read at collection instead, a missing cell raises a bare KeyError from
+# import, which takes the whole module down and leaves the completeness check
+# below unable to say what is missing.
+_CASES = [
+    pytest.param(boundary, value, boundary.outcomes.get(value), id=f"{boundary.name}-{value}")
+    for boundary in _BOUNDARIES
+    for value in _ALL_VALUES
+]
+
+
+def _stated(boundary: Boundary, value: str, expected: Optional[str]) -> str:
+    assert expected is not None, (
+        f"the table states no outcome for a {value} value at the {boundary.name} boundary. "
+        "Drive it, and add the cell saying what it does."
+    )
+    return expected
+
+
+def _survival(events: List[BaseEvent], error: Optional[Exception], violation: Optional[str]) -> str:
+    """Whether the run reached a terminal at all, and what it left behind if not."""
+    if error is None:
+        assert violation is None, f"a run that terminated left the stream malformed: {violation}"
+        assert events, "a run that terminated emitted nothing at all"
+        assert events[-1].type in _RUN_TERMINALS, f"a run that terminated ended on {events[-1].type}"
+        return REACHES_ITS_TERMINAL
+    # Nothing may follow a run terminal, so a failure must not have written one.
+    assert not [event for event in events if event.type in _RUN_TERMINALS], (
+        "the failure path wrote a run terminal of its own"
+    )
+    return ENDS_THE_RUN if violation is None else ENDS_THE_RUN_MALFORMED
+
+
+def _verdict(
+    events: List[BaseEvent],
+    error: Optional[Exception],
+    violation: Optional[str],
+    boundary_event: "EventType",
+) -> str:
+    """What became of the value, including whether the boundary ran at all.
+
+    Whether the boundary's own event reached the wire is decided before a
+    refusal is attributed. Attributed the other way round, a stream carrying any
+    unsendable event at all reports as unsendable even where this boundary never
+    built anything, which is the one thing the verdict has to distinguish.
+
+    The encoder is consulted either way. A boundary whose event never appeared
+    says so, but the stream can still be one the client never sees the end of,
+    and a cell that stopped at "dropped" reported such a run as one that reached
+    the client. So a drop names the event the encoder refused too, when there
+    was one.
+
+    A refusal is attributed by event type: this boundary's own event if the
+    encoder refused one of those, and otherwise the event it did refuse, named.
+    A cell that says only "unsendable" credits this boundary with a failure some
+    unrelated event on the same stream caused.
+    """
+    survival = _survival(events, error, violation)
+    if survival != REACHES_ITS_TERMINAL:
+        return survival
+    refused = {refused_type for refused_type, _ in encoding_failures(events)}
+    if not of_type(events, boundary_event):
+        return dropped_and_dies_on(*refused) if refused else DROPPED_BEFORE_THE_BOUNDARY
+    if not refused:
+        return TERMINATES
+    if short_type_name(boundary_event) in refused:
+        return TERMINATES_UNSENDABLE
+    return dies_on(*refused)
+
+
+async def _assert_the_fixture_reaches_its_boundary(
+    collect: Collect, boundary: Boundary, visibility: Optional[str], boundary_event: Optional["EventType"]
+) -> None:
+    """The same boundary with content it handles, so a verdict above is the value's.
+
+    Without this the verdict cannot tell a failure the injected value caused
+    from any other failure the run happened to hit, and a cell whose event never
+    appears cannot be told from a fixture that never reached the boundary.
+    """
+    events, error, violation = await _collect(collect, boundary.builder(boundary.benign()), visibility)
+
+    assert error is None, f"the {boundary.name} fixture fails on content the boundary handles: {error!r}"
+    assert violation is None, f"the {boundary.name} fixture is malformed on benign content: {violation}"
+    refused = encoding_failures(events)
+    assert not refused, f"the {boundary.name} fixture writes an unsendable event on benign content: {refused}"
+    if boundary_event is not None:
+        assert_stream_contains(events, boundary_event)
+
+
+def _outcome_without_a_boundary(events: List[BaseEvent], error: Optional[Exception], violation: Optional[str]) -> str:
+    """What became of a run whose stream this boundary builds no event on.
+
+    The encoder is consulted here too. A lineage-only boundary builds nothing
+    under the default, but the member's own chunks still reach the wire, mapped
+    or passed through as RAW, so a value the encoder refuses can still truncate
+    the stream. Stopping at whether the run reached its terminal reported such a
+    stream as one the client saw the end of.
+    """
+    survival = _survival(events, error, violation)
+    if survival != REACHES_ITS_TERMINAL:
+        return survival
+    refused = {refused_type for refused_type, _ in encoding_failures(events)}
+    return dies_on(*refused) if refused else REACHES_ITS_TERMINAL
+
+
+def _default_outcome(boundary: Boundary, value: str, stated: str) -> str:
+    """What the table says the default does where this boundary builds nothing.
+
+    Derived from the attributed cell, since the two streams differ only by the
+    member lifecycle, unless the row states otherwise: the member's own chunks
+    are passed through as RAW here, which carries out a value that member
+    attribution kept off the wire.
+    """
+    return boundary.under_the_default.get(value, REACHES_ITS_TERMINAL if _survives(stated) else stated)
+
+
+def _boundary_event(boundary: Boundary, visibility: Optional[str]) -> Optional["EventType"]:
+    """The event type this boundary builds, or None when this stream cannot carry it."""
+    if boundary.lineage_only and visibility is None:
+        return None
+    return event_type_named(boundary.event)
+
+
+@pytest.mark.asyncio
+@mappers
+@pytest.mark.parametrize("boundary,value,expected", _CASES)
+async def test_hostile_run_content_through_an_event_boundary(collect, boundary, value, expected):
+    stated = _stated(boundary, value, expected)
+    visibility = attributed()
+    boundary_event = _boundary_event(boundary, visibility)
+
+    await _assert_the_fixture_reaches_its_boundary(collect, boundary, visibility, boundary_event)
+    events, error, violation = await _collect(collect, boundary.builder(_HOSTILE[value]()), visibility)
+
+    assert _verdict(events, error, violation, boundary_event) == stated, (
+        f"the {boundary.name} boundary now does something else with a {value} value. "
+        "Update the table in this module to say what, and say whether the change "
+        "was intended."
+    )
+
+
+@pytest.mark.asyncio
+@mappers
+@pytest.mark.parametrize("boundary,value,expected", _CASES)
+async def test_hostile_run_content_under_the_default_visibility(collect, boundary, value, expected):
+    """The default visibility reaches the same verdict, cell for cell.
+
+    The default stream differs from the attributed one only by the member
+    lifecycle, so every boundary whose event is not one of those has to do
+    exactly what it does above, verdict and all, rather than merely surviving
+    where it survived. A lineage-only boundary builds nothing here, which is
+    what the two assertions about member events below say.
+    """
+    stated = _stated(boundary, value, expected)
+    boundary_event = _boundary_event(boundary, None)
+
+    await _assert_the_fixture_reaches_its_boundary(collect, boundary, None, boundary_event)
+    events, error, violation = await _collect(collect, boundary.builder(_HOSTILE[value]()), None)
+
+    if boundary_event is None:
+        assert _outcome_without_a_boundary(events, error, violation) == _default_outcome(boundary, value, stated), (
+            f"the {boundary.name} fixture does something else with a {value} value under the default "
+            "visibility, where this boundary builds no event of its own"
+        )
+    else:
+        assert _verdict(events, error, violation, boundary_event) == stated, (
+            f"the {boundary.name} boundary does something else with a {value} value under the default "
+            "visibility than it does under member attribution"
+        )
+    assert not [event for event in events if "SUBAGENT" in str(event.type)]
+    assert not [event for event in events if lane_of(event) is not None]
+
+
+@pytest.mark.asyncio
+@mappers
+@pytest.mark.parametrize("value", list(_HOSTILE), ids=list(_HOSTILE))
+async def test_hostile_session_state_still_reaches_the_state_snapshot(collect, value):
+    """STATE_SNAPSHOT is built by deep-copying the run's state, which holds anything."""
+    injected = _HOSTILE[value]()
+    fixture = Fixture(
+        [
+            TeamRunStartedEvent(**_TOP_LEVEL),
+            RunStartedEvent(**_MEMBER),
+            RunCompletedEvent(content="scout done", **_MEMBER),
+            TeamRunCompletedEvent(**_TOP_LEVEL),
+        ],
+        run_state={"value": injected},
+    )
+    # Two of these snapshots are ones the protocol's encoder refuses, so the run
+    # terminates in memory while the client's stream stops at the snapshot.
+    unsendable = value in ("circular", "raises_on_serialization")
+
+    events, error, violation = await _collect(collect, fixture, attributed())
+
+    assert _verdict(events, error, violation, EventType.STATE_SNAPSHOT) == (
+        TERMINATES_UNSENDABLE if unsendable else TERMINATES
+    )
+    snapshots = of_type(events, EventType.STATE_SNAPSHOT)
+    assert len(snapshots) == 1
+    snapshot = snapshots[0].snapshot  # type: ignore[attr-defined]
+    # Compared by type, never by value: one of these values raises from its own
+    # repr, which an equality failure would try to render.
+    assert "value" in snapshot, "the hostile value never reached the snapshot"
+    assert type(snapshot["value"]) is type(injected), "the snapshot holds something other than the injected value"
+
+
+# --- The router's own terminal ----------------------------------------------
+
+
+class _StubEntity:
+    """An entity whose run is the chunk list, so the router's own mapping is driven.
+
+    The router hands whatever the entity's ``arun`` returns to the async mapper.
+    Nothing else about an Agent or a Team is read on this path, so a stub is what
+    keeps the test about the terminal the router writes.
+    """
+
+    def __init__(self, chunks: List[Any]) -> None:
+        self._chunks = chunks
+
+    def arun(self, **_: Any) -> Any:
+        chunks = self._chunks
+
+        async def source() -> Any:
+            for chunk in chunks:
+                yield chunk
+
+        return source()
+
+
+def _run_input() -> "RunAgentInput":
+    return RunAgentInput(
+        thread_id=THREAD_ID,
+        run_id=TOP_LEVEL_RUN,
+        state={},
+        messages=[UserMessage(id="message-1", role="user", content="go")],
+        tools=[],
+        context=[],
+        forwarded_props={},
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value", list(_HOSTILE), ids=list(_HOSTILE))
+async def test_the_router_terminal_reports_a_stream_the_hostile_value_ended(value):
+    """The RUN_ERROR the router writes when the mapper raises on run content.
+
+    This is the one event the interface builds that no boundary row can reach:
+    the mapper raising is what produces it, so the row for the boundary that
+    raised has already ended before the router writes anything. Driven with
+    every hostile value through the boundary that ends the run on one of them,
+    so the cells that do not end it pin that the router writes no terminal of
+    its own instead.
+    """
+    injected = _HOSTILE[value]()
+    chunks = [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**_MEMBER),
+        agent_said(injected, **_MEMBER),
+        RunCompletedEvent(content="scout done", **_MEMBER),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+    events: List[BaseEvent] = []
+    async for event in run_entity(_StubEntity(chunks), _run_input()):  # type: ignore[arg-type]
+        events.append(event)
+
+    assert not encoding_failures(events), "the router wrote an event the protocol's own encoder refuses"
+    errors = of_type(events, EventType.RUN_ERROR)
+    if value != "circular":
+        # Every other value is swallowed by the text extractor, so the mapper
+        # never raises and the router's terminal is the run's own completion.
+        assert not errors
+        assert events[-1].type == EventType.RUN_FINISHED
+        return
+    # The mapper raises on a cycle, so the router turns the propagated failure
+    # into the run's terminal. The message is the failure's own text, and the
+    # run terminal is the last thing on the wire.
+    assert [error.message for error in errors] == ["Circular reference detected"]  # type: ignore[attr-defined]
+    assert events[-1].type == EventType.RUN_ERROR
+    assert not of_type(events, EventType.RUN_FINISHED), "the router wrote two run terminals"
+
+
+# --- What the whole table is checked against --------------------------------
+
+
+def _because(reason: str, *pairs: Tuple[str, str]) -> Dict[Tuple[str, str], str]:
+    """One justification, against each function-and-event pair it accounts for."""
+    return {pair: reason for pair in pairs}
+
+
+def _one_justification_each(*groups: Dict[Tuple[str, str], str]) -> Dict[Tuple[str, str], str]:
+    """Merge the justifications, refusing to let one pair be justified twice.
+
+    A pair justified in two groups would have one of them silently discarded,
+    leaving a reason in this module that accounts for nothing.
+    """
+    merged: Dict[Tuple[str, str], str] = {}
+    for group in groups:
+        clashing = sorted(set(group) & set(merged))
+        assert not clashing, f"these pairs are justified more than once: {clashing}"
+        merged.update(group)
+    return merged
+
+
+# Every event the interface builds without reading anything a run produced,
+# named as a function-and-event pair rather than as a bare function: a function
+# that builds six events out of one of them is driven for that one and unchecked
+# for the other five, which is how two events of the pause path went undriven
+# while this module stayed green. Each pair is justified here and nowhere else.
+_BUILDS_NOTHING_OUT_OF_RUN_CONTENT: Dict[Tuple[str, str], str] = _one_justification_each(
+    _because(
+        "closes a span by an id this interface minted when it opened it",
+        ("handlers._end_lane_text_message", "TEXT_MESSAGE_END"),
+        ("handlers._end_lane_reasoning", "REASONING_MESSAGE_END"),
+        ("handlers._end_lane_reasoning", "REASONING_END"),
+        ("handlers.on_reasoning_completed", "REASONING_MESSAGE_END"),
+        ("handlers.on_reasoning_completed", "REASONING_END"),
+        ("handlers.on_reasoning_started", "TEXT_MESSAGE_END"),
+        ("handlers.on_reasoning_content_delta", "TEXT_MESSAGE_END"),
+        ("handlers.on_reasoning_step", "TEXT_MESSAGE_END"),
+        ("handlers.on_tool_call_started", "TEXT_MESSAGE_END"),
+        ("handlers._prompt_block", "TEXT_MESSAGE_END"),
+    ),
+    _because(
+        "opens a span, carrying an id this interface minted and a role, and none of what the run said",
+        ("handlers.on_run_content", "TEXT_MESSAGE_START"),
+        ("handlers.on_tool_call_started", "TEXT_MESSAGE_START"),
+        ("handlers.on_reasoning_started", "REASONING_START"),
+        ("handlers.on_reasoning_started", "REASONING_MESSAGE_START"),
+        ("handlers.on_reasoning_content_delta", "REASONING_START"),
+        ("handlers.on_reasoning_content_delta", "REASONING_MESSAGE_START"),
+        ("handlers.on_reasoning_step", "REASONING_START"),
+        ("handlers.on_reasoning_step", "REASONING_MESSAGE_START"),
+        ("handlers._prompt_block", "TEXT_MESSAGE_START"),
+    ),
+    _because(
+        "closes a tool call by an id the client already has a start for, which the tool_call_id and "
+        "pause_tool_id boundaries are where the run's own value first reaches the wire",
+        ("handlers._end_lane_tool_calls", "TOOL_CALL_END"),
+        ("handlers.on_tool_call_completed", "TOOL_CALL_END"),
+        ("handlers._prompt_block", "TOOL_CALL_END"),
+    ),
+    _because(
+        "writes the run's own terminal, carrying the thread and run ids the request named and nothing "
+        "the response stream produced",
+        ("handlers.on_run_completed", "RUN_FINISHED"),
+    ),
+    _because(
+        "writes the run's opening and the request's own state, neither of which comes out of the "
+        "response stream this module drives",
+        ("router.run_entity", "RUN_STARTED"),
+        ("router.run_entity", "STATE_SNAPSHOT"),
+    ),
+)
+
+# Pairs no row drives because a test of this module's own drives them instead,
+# each naming that test. A pair here is covered, not excused.
+_COVERED_BY_ANOTHER_TEST: Dict[Tuple[str, str], str] = {
+    # The snapshot is built out of the run's session state, which is content,
+    # but by a route no chunk of the stream carries.
+    ("handlers.on_run_completed", "STATE_SNAPSHOT"): "test_hostile_session_state_still_reaches_the_state_snapshot",
+    # The router's own terminal, built from the stringified failure the mapper
+    # raised rather than from a chunk, so it is reached by driving a run that
+    # ends the run rather than by a row of the table.
+    ("router.run_entity", "RUN_ERROR"): "test_the_router_terminal_reports_a_stream_the_hostile_value_ended",
+}
+
+
+def _the_protocol_defines(event_name: str) -> bool:
+    """Whether the installed ag_ui.core has an event type of this name.
+
+    The lineage events arrived after this package's minimum protocol release. On
+    a release without them the interface imports their constructions inside a
+    guarded import that fails, so the source scan finds none of them and every
+    pair naming one is a pair the scan cannot report. Read off the protocol
+    rather than off a skip marker, so any future event the interface builds
+    behind a version guard is accounted the same way, and so this module holds
+    on both releases instead of failing on one where its siblings skip.
+    """
+    return getattr(EventType, event_name, None) is not None
+
+
+def _servable(pairs: Dict[Tuple[str, str], Any]) -> Set[Tuple[str, str]]:
+    return {pair for pair in pairs if _the_protocol_defines(pair[1])}
+
+
+def _claimed_pairs() -> Set[Tuple[str, str]]:
+    """The (function, event) pair every row of the table claims, on this install."""
+    return _servable({(boundary.builds, boundary.event): None for boundary in _BOUNDARIES})
+
+
+def _built_pairs() -> Set[Tuple[str, str]]:
+    return {(function, event) for function, events in event_constructions_by_function().items() for event in events}
+
+
+def test_every_hostile_value_is_driven_through_every_boundary():
+    """The table is complete: every boundary, every value, one stated outcome.
+
+    Checked against the value names this module was written against, which are
+    independent of the shared list the sweep is built from: comparing that list
+    with itself holds whatever it says. So a value added to it fails here until
+    every row states an outcome for it, a row cannot quietly stop being driven
+    with one, and an outcome cannot be stated for a value that no longer exists.
+    """
+    assert _ALL_VALUES == _HOSTILE_VALUE_NAMES, (
+        f"the shared hostile values are now {list(_ALL_VALUES)}, and this table is written against "
+        f"{list(_HOSTILE_VALUE_NAMES)}: state an outcome per boundary for whatever changed"
+    )
+    for boundary in _BOUNDARIES:
+        assert set(boundary.outcomes) == set(_ALL_VALUES), (
+            f"the {boundary.name} boundary states outcomes for {sorted(boundary.outcomes)}, not {sorted(_ALL_VALUES)}"
+        )
+        undefined = sorted(outcome for outcome in boundary.outcomes.values() if not _is_a_verdict(outcome))
+        assert not undefined, f"the {boundary.name} boundary states an outcome this module does not define: {undefined}"
+        assert boundary.lineage_only or not boundary.under_the_default, (
+            f"the {boundary.name} boundary builds its own event under the default, so the cell above already "
+            "states what happens there and a second statement can disagree with it"
+        )
+        unknown = sorted(set(boundary.under_the_default) - set(_ALL_VALUES))
+        assert not unknown, f"the {boundary.name} boundary states a default outcome for {unknown}, which is no value"
+        undefined = sorted(
+            outcome
+            for outcome in boundary.under_the_default.values()
+            if outcome != REACHES_ITS_TERMINAL and not _is_a_verdict(outcome)
+        )
+        assert not undefined, (
+            f"the {boundary.name} boundary states a default outcome this module does not define: {undefined}"
+        )
+    assert tuple(boundary.name for boundary in _BOUNDARIES) == _BOUNDARY_NAMES, (
+        "the boundaries in the table are no longer the ones it is written against"
+    )
+    assert len(_CASES) == len(_BOUNDARY_NAMES) * len(_HOSTILE), (
+        "some boundary is no longer driven with every hostile value"
+    )
+
+
+def test_the_table_names_every_event_the_interface_builds_one_of():
+    """The boundary list, recomputed from the interface's own source.
+
+    The table's claim is that it covers every place an AG-UI event is built out
+    of run content. Nothing recomputed that, so a new event-building function
+    could ship uncovered while every cell here stayed green.
+
+    Accounted per function AND event, not per function: a function that builds
+    six event types is driven for the one a row names and unchecked for the
+    other five. So each event each scope of the package constructs has to be
+    claimed by a row, covered by a named test, or justified above as built out
+    of no run content.
+
+    An event type the installed protocol does not define is left out of the
+    comparison on both sides. The interface builds those behind a guarded
+    import, so on such a release the source scan reports none of them and the
+    rows naming them have nothing to be checked against, which used to fail this
+    one test where every sibling skipped.
+    """
+    built = _built_pairs()
+    claimed = _claimed_pairs()
+    excused = _servable(_BUILDS_NOTHING_OUT_OF_RUN_CONTENT)
+    covered = _servable(_COVERED_BY_ANOTHER_TEST)
+
+    overlapping = sorted(claimed & (excused | covered))
+    assert not overlapping, f"a boundary claims what this module also accounts for another way: {overlapping}"
+    doubly_accounted = sorted(excused & covered)
+    assert not doubly_accounted, f"these pairs are both excused and covered by a test: {doubly_accounted}"
+
+    unclaimed = sorted(built - (claimed | excused | covered))
+    assert not unclaimed, (
+        f"the interface builds these events and no row of this table drives them: {unclaimed}. "
+        "Drive each one with every hostile value and add its row, or justify it above."
+    )
+    imaginary = sorted((claimed | excused | covered) - built)
+    assert not imaginary, f"the interface builds none of these any more: {imaginary}"
+
+    # A pair is only covered if the test it names is really in this module: a
+    # renamed or deleted test would otherwise leave the pair accounted for by a
+    # string.
+    absent = sorted(name for name in _COVERED_BY_ANOTHER_TEST.values() if name not in globals())
+    assert not absent, f"these pairs name a test this module does not define: {absent}"

--- a/libs/agno/tests/unit/os/interfaces/test_agui_stream_failure.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_stream_failure.py
@@ -1,0 +1,916 @@
+"""AG-UI mapping of an Agno stream that ends badly, or ends somewhere unexpected.
+
+A run's event stream can raise mid-flight: a model call dies, a tool raises, the
+connection to a remote entity drops. Both mappers open spans as events flow, so
+a failure that escapes without closing them leaves the client holding a text
+bubble and tool cards that spin forever and, under ``attributed`` visibility,
+member lanes that never resolve.
+
+A stream can also stop on a subagent's own terminal, with the top-level entity
+reporting none of its own. That chunk is then the only account of how the run
+ended, so which chunk the run terminal is built from is pinned here too, under
+every visibility: a run that died inside a member must not reach the client as a
+success.
+
+Every test here runs against the sync mapper and the async mapper, so the two
+cannot drift apart.
+"""
+
+import inspect
+import json
+from typing import Any, AsyncGenerator, Iterable, List, Optional
+
+import pytest
+
+pytest.importorskip("ag_ui", reason="ag_ui not installed")
+
+from ag_ui.core import BaseEvent, EventType
+
+from agno.models.response import ToolExecution
+from agno.os.interfaces.agui import handlers
+from agno.os.interfaces.agui import stream as stream_module
+from agno.os.interfaces.agui.state import SUBAGENT_VISIBILITY_HIDDEN, SUBAGENT_VISIBILITY_INLINE, StreamState
+from agno.os.interfaces.agui.stream import (
+    async_stream_agno_response_as_agui_events,
+    stream_agno_response_as_agui_events,
+)
+from agno.run.agent import (
+    RunCancelledEvent,
+    RunCompletedEvent,
+    RunErrorEvent,
+    RunEvent,
+    RunStartedEvent,
+    ToolCallStartedEvent,
+)
+from agno.run.agent import RunPausedEvent as AgentRunPausedEvent
+from agno.run.team import RunCompletedEvent as TeamRunCompletedEvent
+from agno.run.team import RunErrorEvent as TeamRunErrorEvent
+from agno.run.team import RunStartedEvent as TeamRunStartedEvent
+from agno.run.team import ToolCallStartedEvent as TeamToolCallStartedEvent
+
+from .agui_stream_invariants import (
+    ABANDONED_MID_STREAM,
+    ABANDONED_WITH_A_MEMBER_STILL_OPEN,
+    TOP_LEVEL_RUN,
+    Collected,
+    agent_said,
+    assert_stream_contains,
+    assert_well_formed_stream,
+    async_source,
+    attributed,
+    captured_agno_logs,
+    collect_async,
+    collect_sync,
+    event_type_named,
+    field_of,
+    in_emitted_order,
+    lane_of,
+    member_chunk_kwargs,
+    of_type,
+    short_type,
+    sync_source,
+)
+
+THREAD_ID = "failure-session"
+
+
+# --- Streams ----------------------------------------------------------------
+
+
+class _Boom(RuntimeError):
+    """The failure a source stream raises. Distinct so a test can match it exactly."""
+
+
+# The member's lineage fields and the content chunk come from the shared module,
+# which the attribution suite builds the same chunks from.
+_member_kwargs = member_chunk_kwargs
+_content = agent_said
+
+
+def _open_text_message_chunks(message: str) -> List[Any]:
+    """A run that opened a text message and then died."""
+    return [
+        RunStartedEvent(run_id=TOP_LEVEL_RUN),
+        _content("half a sen", run_id=TOP_LEVEL_RUN),
+        _Boom(message),
+    ]
+
+
+def _open_tool_call_chunks(message: str) -> List[Any]:
+    """A run that started a tool call and then died before its result."""
+    return [
+        RunStartedEvent(run_id=TOP_LEVEL_RUN),
+        ToolCallStartedEvent(
+            run_id=TOP_LEVEL_RUN,
+            tool=ToolExecution(tool_call_id="tc-search", tool_name="search_docs", tool_args={"query": "agno"}),
+        ),
+        _Boom(message),
+    ]
+
+
+def _delegation() -> ToolExecution:
+    return ToolExecution(
+        tool_call_id="tc-delegate-scout",
+        tool_name="delegate_task_to_member",
+        tool_args={"member_id": "scout", "task": "scout the topic"},
+    )
+
+
+def _open_member_lane_chunks(message: str) -> List[Any]:
+    """A team whose member was mid-sentence inside a delegation when the stream died."""
+    member = _member_kwargs("scout", "run-scout")
+    return [
+        TeamRunStartedEvent(team_id="research-team", team_name="Research Team", run_id=TOP_LEVEL_RUN),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=_delegation()),
+        RunStartedEvent(**member),
+        _content("scouting so", **member),
+        _Boom(message),
+    ]
+
+
+_MEMBER = _member_kwargs("scout", "run-scout")
+
+
+def _ends_on_the_members_terminal_chunks(*terminals: Any) -> List[Any]:
+    """A team that reported no terminal of its own, so a member's is the last thing on it.
+
+    The delegation the member ran inside is left open, so the run terminal is
+    also what has to close the leader's own call.
+    """
+    return [
+        TeamRunStartedEvent(team_id="research-team", team_name="Research Team", run_id=TOP_LEVEL_RUN),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=_delegation()),
+        RunStartedEvent(**_MEMBER),
+        _content("half a sen", **_MEMBER),
+        *terminals,
+    ]
+
+
+def _member_failed() -> Any:
+    return RunErrorEvent(content="member exploded", error_type="RuntimeError", **_MEMBER)
+
+
+def _member_finished() -> Any:
+    return RunCompletedEvent(content="scout done", **_MEMBER)
+
+
+def _member_cancelled() -> Any:
+    return RunCancelledEvent(reason="the operator stopped it", **_MEMBER)
+
+
+def _pending_member_tool() -> ToolExecution:
+    return ToolExecution(
+        tool_call_id="tc-member-confirm",
+        tool_name="send_email",
+        tool_args={"to": "ops"},
+        requires_confirmation=True,
+    )
+
+
+def _member_paused() -> Any:
+    return AgentRunPausedEvent(tools=[_pending_member_tool()], **_MEMBER)
+
+
+def _member_paused_saying_something() -> Any:
+    """The same pause, with words of the member's own on it."""
+    return AgentRunPausedEvent(tools=[_pending_member_tool()], content="I need approval to email ops.", **_MEMBER)
+
+
+def _team_finished() -> Any:
+    return TeamRunCompletedEvent(team_id="research-team", team_name="Research Team", run_id=TOP_LEVEL_RUN)
+
+
+def _team_failed() -> Any:
+    return TeamRunErrorEvent(
+        content="the team blew up", error_type="RuntimeError", team_id="research-team", run_id=TOP_LEVEL_RUN
+    )
+
+
+def _visibilities() -> List[Any]:
+    """The settings a stream is driven under, the attributed one resolved lazily.
+
+    Named through the shared door, so an install that cannot serve member
+    attribution skips those cases instead of failing them, and resolved inside
+    the test rather than at collection time.
+    """
+    return [
+        pytest.param(lambda: None, id="default"),
+        pytest.param(lambda: SUBAGENT_VISIBILITY_INLINE, id="inline"),
+        pytest.param(attributed, id="attributed"),
+        pytest.param(lambda: SUBAGENT_VISIBILITY_HIDDEN, id="hidden"),
+    ]
+
+
+visibilities = pytest.mark.parametrize("visibility", _visibilities())
+
+
+# --- Collectors -------------------------------------------------------------
+
+# Both collectors run the shared stream-invariant helper before handing the
+# events back, so every test in this module inherits the whole invariant set.
+
+
+async def _collect_sync(chunks: Iterable[Any], visibility: Optional[str] = None) -> Collected:
+    return await collect_sync(chunks, visibility, thread_id=THREAD_ID, run_id=TOP_LEVEL_RUN)
+
+
+async def _collect_async(chunks: Iterable[Any], visibility: Optional[str] = None) -> Collected:
+    return await collect_async(chunks, visibility, thread_id=THREAD_ID, run_id=TOP_LEVEL_RUN)
+
+
+mappers = pytest.mark.parametrize("collect", [_collect_sync, _collect_async], ids=["sync", "async"])
+
+
+# --- Assertions helpers -----------------------------------------------------
+
+_lane = lane_of
+_of_type = of_type
+
+
+def _only(events: List[BaseEvent], described: str = "event") -> BaseEvent:
+    assert len(events) == 1, f"expected exactly one {described}, got {len(events)}"
+    return events[0]
+
+
+def _one(events: List[BaseEvent], event_type: EventType) -> BaseEvent:
+    return _only(_of_type(events, event_type), str(event_type))
+
+
+def _terminals(events: List[BaseEvent]) -> List[str]:
+    return [str(e.type) for e in events if e.type in (EventType.RUN_FINISHED, EventType.RUN_ERROR)]
+
+
+# The field each closing event names its span by. Read through this rather than
+# through the first of two attributes that happens to be set: that reads a
+# renamed message_id as an absent one and falls through to the tool call id,
+# which is the comparison passing while nothing is compared.
+_SPAN_ID_FIELD = {
+    EventType.TEXT_MESSAGE_END: "message_id",
+    EventType.TOOL_CALL_END: "tool_call_id",
+}
+
+
+def _span_id(event: BaseEvent) -> Optional[str]:
+    """The id of the span an event closes, or None for an event that closes none."""
+    field = _SPAN_ID_FIELD.get(event.type)
+    return None if field is None else field_of(event, field)
+
+
+def _terminals_with_reason(events: List[BaseEvent]) -> List[tuple]:
+    """(terminal, message, code) per run terminal, in order.
+
+    One list for both terminals, so a run reported as finished where the client
+    had to be told it failed is a diff here rather than an absence somewhere
+    else. RUN_FINISHED declares neither field, so only the error terminal's are
+    read, and those are read as declared fields.
+    """
+    rows: List[tuple] = []
+    for event in events:
+        if event.type == EventType.RUN_ERROR:
+            rows.append((short_type(event), field_of(event, "message"), field_of(event, "code")))
+        elif event.type == EventType.RUN_FINISHED:
+            rows.append((short_type(event), None, None))
+    return rows
+
+
+# --- The failure path -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@mappers
+async def test_an_open_text_message_is_ended_when_the_source_stream_fails(collect):
+    events, error = await collect(_open_text_message_chunks("model connection dropped"))
+
+    assert_stream_contains(events, EventType.TEXT_MESSAGE_END)
+    started = _one(events, EventType.TEXT_MESSAGE_START)
+    ended = _one(events, EventType.TEXT_MESSAGE_END)
+    assert ended.message_id == started.message_id
+    # The close is the last thing on the wire, after the partial content.
+    assert [str(e.type) for e in events[-2:]] == [
+        str(EventType.TEXT_MESSAGE_CONTENT),
+        str(EventType.TEXT_MESSAGE_END),
+    ]
+    assert isinstance(error, _Boom) and str(error) == "model connection dropped"
+
+
+@pytest.mark.asyncio
+@mappers
+async def test_an_open_tool_call_is_ended_when_the_source_stream_fails(collect):
+    events, error = await collect(_open_tool_call_chunks("tool executor died"))
+
+    assert_stream_contains(events, EventType.TOOL_CALL_END)
+    # Ordered, so a call started or ended twice is a diff rather than a silence.
+    assert in_emitted_order(events, EventType.TOOL_CALL_START, "tool_call_id") == [("tc-search",)]
+    assert in_emitted_order(events, EventType.TOOL_CALL_END, "tool_call_id") == [("tc-search",)]
+    assert str(events[-1].type) == str(EventType.TOOL_CALL_END)
+    assert isinstance(error, _Boom) and str(error) == "tool executor died"
+
+
+# What a lane still open is told the run failed of. A failure carrying no text
+# of its own is described by the type that raised, which is the only thing left
+# to name it by: an empty message would leave the client a lane that errored for
+# no stated reason.
+_FAILURE_DESCRIPTIONS = [
+    pytest.param("member exploded mid-stream", "member exploded mid-stream", id="with_a_message"),
+    pytest.param("", "_Boom", id="with_no_message"),
+]
+
+
+@pytest.mark.asyncio
+@mappers
+@pytest.mark.parametrize("raised,described", _FAILURE_DESCRIPTIONS)
+async def test_a_member_lane_still_open_is_errored_when_the_source_stream_fails(collect, raised, described):
+    subagent_error = event_type_named("SUBAGENT_ERROR")
+    events, error = await collect(_open_member_lane_chunks(raised), attributed())
+
+    assert_stream_contains(events, subagent_error)
+    # The other open message is the leader's empty parent for the delegation call.
+    member_message = _only([e for e in _of_type(events, EventType.TEXT_MESSAGE_START) if _lane(e) == "run-scout"])
+
+    # The member's span closes, then the leader's delegation call, and the
+    # member's lane errors last: a terminal lands outside every span the stream
+    # had open, never inside the delegation call that spawned it.
+    assert [(str(e.type), _lane(e), _span_id(e)) for e in events[-3:]] == [
+        (str(EventType.TEXT_MESSAGE_END), "run-scout", member_message.message_id),
+        (str(EventType.TOOL_CALL_END), None, "tc-delegate-scout"),
+        (str(subagent_error), "run-scout", None),
+    ]
+
+    assert in_emitted_order(events, subagent_error, "subagent_run_id", "message", "code") == [
+        ("run-scout", described, None)
+    ]
+    # A lane that errored is not also reported as finished.
+    assert not _of_type(events, event_type_named("SUBAGENT_FINISHED"))
+    assert isinstance(error, _Boom) and str(error) == raised
+
+
+# Each stream with the visibility its own shape needs. Driving the two that
+# carry no member under ``attributed`` skipped them wholesale on a protocol
+# release without the lineage events, which the packaged extra still permits,
+# and neither has anything to do with member lanes.
+_DEAD_STREAMS = [
+    pytest.param(_open_text_message_chunks, lambda: None, id="text"),
+    pytest.param(_open_tool_call_chunks, lambda: SUBAGENT_VISIBILITY_INLINE, id="tool_call"),
+    pytest.param(_open_member_lane_chunks, attributed, id="member_lane"),
+]
+
+
+@pytest.mark.asyncio
+@mappers
+@pytest.mark.parametrize("chunk_factory,visibility", _DEAD_STREAMS)
+async def test_the_failure_path_emits_no_terminal_of_its_own(collect, chunk_factory, visibility):
+    # Built per case: a chunk list assembled at collection time would share one
+    # exception instance, and its traceback, across every case that uses it.
+    events, error = await collect(chunk_factory("boom"), visibility())
+
+    # The caller writes the run terminal, and nothing may follow one on the wire.
+    assert _terminals(events) == []
+    assert isinstance(error, _Boom)
+
+
+@pytest.mark.asyncio
+@mappers
+async def test_the_failure_propagates_unchanged(collect):
+    boom = _Boom("keep me")
+    events, error = await collect([RunStartedEvent(run_id=TOP_LEVEL_RUN), boom])
+
+    assert error is boom
+    assert _terminals(events) == []
+
+
+@pytest.mark.asyncio
+@mappers
+async def test_a_stream_that_does_not_fail_still_gets_exactly_one_terminal(collect):
+    events, error = await collect(
+        [RunStartedEvent(run_id=TOP_LEVEL_RUN), _content("all done", run_id=TOP_LEVEL_RUN)],
+        SUBAGENT_VISIBILITY_INLINE,
+    )
+
+    assert error is None
+    assert_stream_contains(events, EventType.RUN_FINISHED)
+    assert _terminals(events) == [str(EventType.RUN_FINISHED)]
+    assert str(events[-1].type) == str(EventType.RUN_FINISHED)
+    # The synthesized completion closes the open message, exactly as before.
+    assert _one(events, EventType.TEXT_MESSAGE_END).message_id == _one(events, EventType.TEXT_MESSAGE_START).message_id
+
+
+# --- A stream that stops on a member's own terminal -------------------------
+
+# A source stream can end on a subagent's terminal without the top-level entity
+# reporting one of its own. That terminal is then the only account of how the run
+# ended, and every visibility has to read it the same way: the default already
+# does, because it knows no member lanes.
+
+_TERMINAL_CASES = [
+    pytest.param(_member_failed, [("RUN_ERROR", "member exploded", "RuntimeError")], id="error"),
+    pytest.param(_member_finished, [("RUN_FINISHED", None, None)], id="completed"),
+]
+
+_MEMBER_TERMINALS = [pytest.param(_member_failed, id="error"), pytest.param(_member_finished, id="completed")]
+
+
+@pytest.mark.asyncio
+@mappers
+@visibilities
+@pytest.mark.parametrize("terminal,expected", _TERMINAL_CASES)
+async def test_a_stream_that_ends_on_a_members_terminal_reports_what_that_terminal_said(
+    collect, visibility, terminal, expected
+):
+    events, error = await collect(_ends_on_the_members_terminal_chunks(terminal()), visibility())
+
+    assert error is None, f"the source stream raised {error!r}"
+    assert _terminals_with_reason(events) == expected
+    # The terminal is the last thing on the wire, as it is on any other stream.
+    assert short_type(events[-1]) == expected[0][0]
+
+
+@pytest.mark.asyncio
+@mappers
+@visibilities
+@pytest.mark.parametrize("terminal", _MEMBER_TERMINALS)
+async def test_the_top_level_entitys_own_terminal_supersedes_a_members(collect, visibility, terminal):
+    """The member ended, the run went on and finished, so the run finished."""
+    events, error = await collect(_ends_on_the_members_terminal_chunks(terminal(), _team_finished()), visibility())
+
+    assert error is None, f"the source stream raised {error!r}"
+    assert _terminals_with_reason(events) == [("RUN_FINISHED", None, None)]
+
+
+@pytest.mark.asyncio
+@mappers
+@pytest.mark.parametrize(
+    "visibility",
+    [pytest.param(attributed, id="attributed"), pytest.param(lambda: SUBAGENT_VISIBILITY_HIDDEN, id="hidden")],
+)
+async def test_a_member_terminal_after_the_top_level_entitys_own_does_not_replace_it(collect, visibility):
+    """The run's own failure is what the client is told, whatever a member reports afterwards.
+
+    The default is not driven here: it reads every terminal as the run's, so the
+    last one on the stream wins there, which is the stream it has always emitted.
+    """
+    events, error = await collect(
+        _ends_on_the_members_terminal_chunks(_team_failed(), _member_finished()), visibility()
+    )
+
+    assert error is None, f"the source stream raised {error!r}"
+    assert _terminals_with_reason(events) == [("RUN_ERROR", "the team blew up", "RuntimeError")]
+
+
+@pytest.mark.asyncio
+@mappers
+@visibilities
+async def test_a_stream_that_ends_on_a_members_pause_still_prompts_the_client(collect, visibility):
+    """A pause is a terminal too, and no resume can get past a call nobody was shown."""
+    events, error = await collect(_ends_on_the_members_terminal_chunks(_member_paused()), visibility())
+
+    assert error is None, f"the source stream raised {error!r}"
+    assert _terminals_with_reason(events) == [("RUN_FINISHED", None, None)]
+    assert in_emitted_order(events, EventType.TOOL_CALL_START, "tool_call_id") == [
+        ("tc-delegate-scout",),
+        ("tc-member-confirm",),
+    ]
+    assert in_emitted_order(events, EventType.TOOL_CALL_ARGS, "tool_call_id", lambda e: json.loads(e.delta)) == [
+        ("tc-delegate-scout", {"member_id": "scout", "task": "scout the topic"}),
+        ("tc-member-confirm", {"to": "ops"}),
+    ]
+
+
+@pytest.mark.asyncio
+@mappers
+async def test_the_member_whose_failure_ended_the_run_still_owns_its_own_terminal(collect):
+    subagent_error = event_type_named("SUBAGENT_ERROR")
+    events, error = await collect(_ends_on_the_members_terminal_chunks(_member_failed()), attributed())
+
+    assert error is None, f"the source stream raised {error!r}"
+    assert_stream_contains(events, subagent_error)
+    assert in_emitted_order(events, subagent_error, "subagent_run_id", "message", "code") == [
+        ("run-scout", "member exploded", "RuntimeError")
+    ]
+    # The member's lane resolves first, then the run reports the same failure.
+    assert _terminals_with_reason(events) == [("RUN_ERROR", "member exploded", "RuntimeError")]
+
+
+@pytest.mark.asyncio
+@mappers
+async def test_hidden_still_reports_a_run_that_ended_on_a_member_failure(collect):
+    """Hidden withholds which member failed, never that the run failed."""
+    events, error = await collect(_ends_on_the_members_terminal_chunks(_member_failed()), SUBAGENT_VISIBILITY_HIDDEN)
+
+    assert error is None, f"the source stream raised {error!r}"
+    assert _terminals_with_reason(events) == [("RUN_ERROR", "member exploded", "RuntimeError")]
+    assert not [event for event in events if "SUBAGENT" in str(event.type)]
+    assert not [event for event in events if _lane(event) is not None]
+
+
+# --- Every terminal a member can end a stream on ----------------------------
+
+# The chunk types that stop a member, each with the chunk that reports it and
+# what the run terminal has to say when the stream ends there. The interface
+# splits them in two: a terminal ends the member's lane, and a withheld chunk
+# stops the member without ending it. Both halves are driven, one table each, so
+# a type added to either is a stream ending on it rather than a set that grew.
+
+_LINEAGE_RUN_TERMINAL = {
+    RunEvent.run_completed.value: (_member_finished, ("RUN_FINISHED", None, None)),
+    RunEvent.run_error.value: (_member_failed, ("RUN_ERROR", "member exploded", "RuntimeError")),
+    RunEvent.run_cancelled.value: (_member_cancelled, ("RUN_ERROR", "the operator stopped it", "cancelled")),
+}
+
+_LINEAGE_WITHHELD = {
+    RunEvent.run_paused.value: (_member_paused, ("RUN_FINISHED", None, None)),
+}
+
+_STOPS_A_SUBAGENT = {**_LINEAGE_RUN_TERMINAL, **_LINEAGE_WITHHELD}
+
+
+def test_every_chunk_that_stops_a_subagent_is_driven_here():
+    """Both halves of the set the stream reads, each against the table that drives it.
+
+    Which chunks stop a member decides how a stream ending on one is read: the
+    run terminal is built from that chunk rather than reported as a plain
+    completion. The interface unions its terminal table with its withheld set to
+    get there, so comparing the union against either half holds however the
+    other grows, and adding a withheld type would end a lane with nothing here
+    to say so. Each half is compared against the table this module drives, and
+    the union against the two together.
+    """
+    handled = set(handlers._SUBAGENT_TERMINAL_HANDLERS)
+    assert handled == set(_LINEAGE_RUN_TERMINAL), (
+        "the subagent terminals the mapper handles and the ones driven here have diverged: "
+        f"handled={sorted(handled)}, driven={sorted(_LINEAGE_RUN_TERMINAL)}"
+    )
+    withheld = set(handlers._SUBAGENT_WITHHELD_EVENTS)
+    assert withheld == set(_LINEAGE_WITHHELD), (
+        "the chunks the mapper withholds from a member's lane and the ones driven here have diverged: "
+        f"withheld={sorted(withheld)}, driven={sorted(_LINEAGE_WITHHELD)}"
+    )
+    assert not handled & withheld, (
+        f"these chunks both end a member's lane and are withheld from it: {sorted(handled & withheld)}"
+    )
+    assert set(handlers._SUBAGENT_RUN_ENDING_EVENTS) == set(_STOPS_A_SUBAGENT), (
+        "the chunks the stream reads as stopping a subagent are no longer the terminals plus the "
+        f"withheld ones: {sorted(handlers._SUBAGENT_RUN_ENDING_EVENTS)} against {sorted(_STOPS_A_SUBAGENT)}. "
+        "A stream ending on one it no longer reads reports the run finished after saying the subagent did not."
+    )
+
+
+@pytest.mark.asyncio
+@mappers
+@pytest.mark.parametrize(
+    "visibility",
+    [pytest.param(attributed, id="attributed"), pytest.param(lambda: SUBAGENT_VISIBILITY_HIDDEN, id="hidden")],
+)
+@pytest.mark.parametrize("normalized", sorted(_STOPS_A_SUBAGENT))
+async def test_a_lineage_stream_ending_on_a_member_terminal_reports_what_that_terminal_said(
+    collect, visibility, normalized
+):
+    """A chunk that stopped a member is the run's only account of how it ended.
+
+    Cancellation included, and a pause included: the run terminal is built from
+    whichever of them the stream ended on, and is the last thing on the wire.
+    """
+    terminal, expected = _STOPS_A_SUBAGENT[normalized]
+    events, error = await collect(_ends_on_the_members_terminal_chunks(terminal()), visibility())
+
+    assert error is None, f"the source stream raised {error!r}"
+    assert _terminals_with_reason(events) == [expected]
+    assert short_type(events[-1]) == expected[0]
+
+
+@pytest.mark.asyncio
+@mappers
+@visibilities
+async def test_a_run_terminal_promoted_from_a_member_carries_no_chunk_of_that_members_own(collect, visibility):
+    """The chunk names the member, its run and the run above it, so only the default embeds it.
+
+    Hidden spends the whole stream keeping that identity off the wire and then
+    logs that it withheld the failure, so shipping the member's own chunk in the
+    very next event undoes both. Attributed has the member on the wire already,
+    but the terminal is the run's and carries nothing of the member's. The
+    default is the stream from before member attribution existed, raw event and
+    all.
+    """
+    resolved = visibility()
+    events, error = await collect(_ends_on_the_members_terminal_chunks(_member_failed()), resolved)
+
+    assert error is None, f"the source stream raised {error!r}"
+    raw_event = field_of(_one(events, EventType.RUN_ERROR), "raw_event")
+    if resolved in (None, SUBAGENT_VISIBILITY_INLINE):
+        assert raw_event is not None, "the default stream no longer embeds the chunk it always did"
+        assert (raw_event.get("run_id"), raw_event.get("agent_id"), raw_event.get("parent_run_id")) == (
+            "run-scout",
+            "scout",
+            TOP_LEVEL_RUN,
+        )
+    else:
+        assert raw_event is None, f"a lineage terminal shipped the member's own chunk: {raw_event}"
+    # Either way the run says why it stopped.
+    assert _terminals_with_reason(events) == [("RUN_ERROR", "member exploded", "RuntimeError")]
+
+
+@pytest.mark.asyncio
+@mappers
+async def test_a_members_pause_that_becomes_the_run_terminal_stays_that_members(collect):
+    """The words and the pending call are the member's, so both go out on its lane."""
+    subagent_finished = event_type_named("SUBAGENT_FINISHED")
+    events, error = await collect(_ends_on_the_members_terminal_chunks(_member_paused_saying_something()), attributed())
+
+    assert error is None, f"the source stream raised {error!r}"
+    assert_stream_contains(events, subagent_finished)
+    assert in_emitted_order(events, EventType.TEXT_MESSAGE_CONTENT, "delta", _lane) == [
+        ("half a sen", "run-scout"),
+        ("I need approval to email ops.", "run-scout"),
+    ]
+    assert in_emitted_order(events, EventType.TOOL_CALL_START, "tool_call_id", _lane) == [
+        ("tc-delegate-scout", None),
+        ("tc-member-confirm", "run-scout"),
+    ]
+    # The call and the message carrying it name the same member.
+    lane_of_message = {
+        event.message_id: _lane(event)  # type: ignore[attr-defined]
+        for event in _of_type(events, EventType.TEXT_MESSAGE_START)
+    }
+    prompted = [e for e in _of_type(events, EventType.TOOL_CALL_START) if e.tool_call_id == "tc-member-confirm"]  # type: ignore[attr-defined]
+    assert [lane_of_message[e.parent_message_id] for e in prompted] == ["run-scout"]  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+@mappers
+async def test_hidden_does_not_stream_a_paused_members_words_as_the_runs_own_reply(collect):
+    """The pending call still reaches the client, because no resume gets past it.
+
+    Its words do not: nothing a member produced is sent as the run's own work,
+    and a prompt is not a licence to relabel the member's prose as the leader's.
+    """
+    events, error = await collect(
+        _ends_on_the_members_terminal_chunks(_member_paused_saying_something()), SUBAGENT_VISIBILITY_HIDDEN
+    )
+
+    assert error is None, f"the source stream raised {error!r}"
+    assert in_emitted_order(events, EventType.TOOL_CALL_START, "tool_call_id", _lane) == [
+        ("tc-delegate-scout", None),
+        ("tc-member-confirm", None),
+    ]
+    assert in_emitted_order(events, EventType.TEXT_MESSAGE_CONTENT, "delta") == []
+    assert not [event for event in events if _lane(event) is not None]
+
+
+# --- Abandonment ------------------------------------------------------------
+
+
+_UP_TO_OPEN_MESSAGE = [
+    str(EventType.RAW),
+    str(EventType.TEXT_MESSAGE_START),
+    str(EventType.TEXT_MESSAGE_CONTENT),
+]
+
+_AGEN_CLOSED = "closed"
+
+
+def _async_generator_state(generator: AsyncGenerator[Any, None]) -> str:
+    """Whether an async generator is closed, running, or still holding its frame.
+
+    ``inspect.getasyncgenstate`` and its ``AGEN_CLOSED`` constant are Python
+    3.12, and this package supports 3.9, so the state is read the way that
+    helper reads it: a closed async generator has dropped its frame. The sync
+    twin below keeps ``inspect.getgeneratorstate``, which has been there since
+    3.2.
+    """
+    if generator.ag_running:
+        return "running"
+    return _AGEN_CLOSED if generator.ag_frame is None else "still holding its frame"
+
+
+def _recorded_cleanups(monkeypatch) -> List[str]:
+    """A spy on the mapper's own cleanup, so its absence can be observed rather than assumed.
+
+    Collecting events up to the abandonment and inspecting the list afterwards
+    cannot see a cleanup: whatever the closed generator does next is not written
+    into any list the test still holds.
+    """
+    called: List[str] = []
+
+    def spy(state: StreamState, error_message: str) -> List[BaseEvent]:
+        called.append(error_message)
+        return []
+
+    monkeypatch.setattr(stream_module, "close_open_spans", spy)
+    return called
+
+
+def test_abandoning_the_sync_mapper_mid_message_emits_no_cleanup(monkeypatch):
+    """A consumer that walks away is not a failure: the client is gone, so nothing is written to it."""
+    cleanups = _recorded_cleanups(monkeypatch)
+    generator = stream_agno_response_as_agui_events(
+        sync_source(_open_text_message_chunks("never raised")), thread_id=THREAD_ID, run_id=TOP_LEVEL_RUN
+    )
+    seen = [next(generator) for _ in _UP_TO_OPEN_MESSAGE]
+
+    generator.close()
+    # A closed generator yields nothing ever, so draining it here would observe
+    # nothing an abandonment wrote. The spy is what observes the cleanup's
+    # absence; this pins that the close really left the generator closed rather
+    # than resuming it into one.
+    assert inspect.getgeneratorstate(generator) == inspect.GEN_CLOSED
+
+    assert cleanups == []
+    assert [str(e.type) for e in seen] == _UP_TO_OPEN_MESSAGE
+    assert_well_formed_stream(seen, exempt=[ABANDONED_MID_STREAM])
+
+
+@pytest.mark.asyncio
+async def test_abandoning_the_async_mapper_mid_message_emits_no_cleanup(monkeypatch):
+    cleanups = _recorded_cleanups(monkeypatch)
+    generator = async_stream_agno_response_as_agui_events(
+        async_source(_open_text_message_chunks("never raised")), thread_id=THREAD_ID, run_id=TOP_LEVEL_RUN
+    )
+    seen = [await generator.__anext__() for _ in _UP_TO_OPEN_MESSAGE]
+
+    await generator.aclose()
+    assert _async_generator_state(generator) == _AGEN_CLOSED
+
+    assert cleanups == []
+    assert [str(e.type) for e in seen] == _UP_TO_OPEN_MESSAGE
+    assert_well_formed_stream(seen, exempt=[ABANDONED_MID_STREAM])
+
+
+def _assert_the_abandoned_member_never_resolved(seen: List[BaseEvent], cleanups: List[str]) -> None:
+    assert cleanups == []
+    assert_stream_contains(seen, event_type_named("SUBAGENT_STARTED"))
+    assert not _of_type(seen, event_type_named("SUBAGENT_ERROR"))
+    assert not _of_type(seen, event_type_named("SUBAGENT_FINISHED"))
+    assert_well_formed_stream(seen, exempt=[ABANDONED_MID_STREAM, ABANDONED_WITH_A_MEMBER_STILL_OPEN])
+
+
+def test_abandoning_the_sync_mapper_inside_a_member_leaves_that_member_unterminated(monkeypatch):
+    """The member is announced and then abandoned, so its lane never resolves either."""
+    cleanups = _recorded_cleanups(monkeypatch)
+    generator = stream_agno_response_as_agui_events(
+        sync_source(_open_member_lane_chunks("never raised")),
+        thread_id=THREAD_ID,
+        run_id=TOP_LEVEL_RUN,
+        subagent_visibility=attributed(),
+    )
+    seen: List[BaseEvent] = []
+    for event in generator:
+        seen.append(event)
+        if event.type == EventType.TEXT_MESSAGE_CONTENT and _lane(event) == "run-scout":
+            break
+
+    generator.close()
+    assert inspect.getgeneratorstate(generator) == inspect.GEN_CLOSED
+
+    _assert_the_abandoned_member_never_resolved(seen, cleanups)
+
+
+@pytest.mark.asyncio
+async def test_abandoning_the_async_mapper_inside_a_member_leaves_that_member_unterminated(monkeypatch):
+    cleanups = _recorded_cleanups(monkeypatch)
+    generator = async_stream_agno_response_as_agui_events(
+        async_source(_open_member_lane_chunks("never raised")),
+        thread_id=THREAD_ID,
+        run_id=TOP_LEVEL_RUN,
+        subagent_visibility=attributed(),
+    )
+    seen: List[BaseEvent] = []
+    async for event in generator:
+        seen.append(event)
+        if event.type == EventType.TEXT_MESSAGE_CONTENT and _lane(event) == "run-scout":
+            break
+
+    await generator.aclose()
+    assert _async_generator_state(generator) == _AGEN_CLOSED
+
+    _assert_the_abandoned_member_never_resolved(seen, cleanups)
+
+
+# --- A cleanup that fails itself --------------------------------------------
+
+
+def _explodes(state, error_message: str) -> List[BaseEvent]:
+    raise RuntimeError("cleanup exploded")
+
+
+def test_a_failed_cleanup_does_not_replace_the_sync_failure_it_followed(monkeypatch, caplog):
+    """The failure the caller turns into the run terminal is the run's own, never the cleanup's."""
+    visibility = attributed()
+    monkeypatch.setattr(stream_module, "close_open_spans", _explodes)
+    events: List[BaseEvent] = []
+
+    with captured_agno_logs(caplog, "ERROR"):
+        with pytest.raises(_Boom, match="keep me"):
+            for event in stream_agno_response_as_agui_events(
+                sync_source(_open_member_lane_chunks("keep me")),
+                thread_id=THREAD_ID,
+                run_id=TOP_LEVEL_RUN,
+                subagent_visibility=visibility,
+            ):
+                events.append(event)
+
+    assert _terminals(events) == []
+    logged = "\n".join(r.message for r in caplog.records)
+    assert "keep me" in logged
+    assert "cleanup exploded" in logged
+
+
+@pytest.mark.asyncio
+async def test_a_failed_cleanup_does_not_replace_the_async_failure_it_followed(monkeypatch, caplog):
+    visibility = attributed()
+    monkeypatch.setattr(stream_module, "close_open_spans", _explodes)
+    events: List[BaseEvent] = []
+
+    with captured_agno_logs(caplog, "ERROR"):
+        with pytest.raises(_Boom, match="keep me"):
+            async for event in async_stream_agno_response_as_agui_events(
+                async_source(_open_member_lane_chunks("keep me")),
+                thread_id=THREAD_ID,
+                run_id=TOP_LEVEL_RUN,
+                subagent_visibility=visibility,
+            ):
+                events.append(event)
+
+    assert _terminals(events) == []
+    logged = "\n".join(r.message for r in caplog.records)
+    assert "keep me" in logged
+    assert "cleanup exploded" in logged
+
+
+@pytest.mark.asyncio
+@mappers
+async def test_the_cleanup_after_a_failed_stream_is_recorded(collect, caplog):
+    """The cleanup is invisible to the operator unless the failure it followed is logged."""
+    subagent_error = event_type_named("SUBAGENT_ERROR")
+    with captured_agno_logs(caplog, "ERROR"):
+        events, error = await collect(_open_member_lane_chunks("member exploded mid-stream"), attributed())
+
+    assert isinstance(error, _Boom)
+    assert_stream_contains(events, subagent_error)
+    logged = "\n".join(r.message for r in caplog.records)
+    assert "member exploded mid-stream" in logged
+
+
+@pytest.mark.asyncio
+@mappers
+async def test_the_recorded_mid_run_failure_names_its_type_and_carries_its_traceback(collect, caplog):
+    """The message alone says where a failure surfaced, never what raised or from where.
+
+    This package logs tracebacks only when they are switched on, so the one
+    record an operator gets for a dead stream has to carry both by itself.
+    """
+    with captured_agno_logs(caplog, "ERROR"):
+        events, error = await collect(_open_text_message_chunks("model connection dropped"))
+
+    assert isinstance(error, _Boom)
+    assert_stream_contains(events, EventType.TEXT_MESSAGE_END)
+    recorded = [record for record in caplog.records if "model connection dropped" in record.message]
+    assert len(recorded) == 1, f"the mid-run failure was recorded {len(recorded)} times"
+    assert "_Boom" in recorded[0].message, f"the record does not name what raised: {recorded[0].message}"
+    assert recorded[0].exc_info is not None, "the record carries no traceback, so the raise site is lost"
+
+
+# --- A failure that cannot describe itself ----------------------------------
+
+
+class _Unspeakable(RuntimeError):
+    """A failure whose own text cannot be rendered, as a proxy object's cannot."""
+
+    def __str__(self) -> str:
+        raise RuntimeError("str exploded")
+
+
+def _member_lane_open_when_an_unspeakable_failure_arrives() -> List[Any]:
+    member = _member_kwargs("scout", "run-scout")
+    return [
+        TeamRunStartedEvent(team_id="research-team", team_name="Research Team", run_id=TOP_LEVEL_RUN),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=_delegation()),
+        RunStartedEvent(**member),
+        _content("scouting so", **member),
+        _Unspeakable(),
+    ]
+
+
+@pytest.mark.asyncio
+@mappers
+async def test_a_failure_whose_text_cannot_be_read_still_closes_every_span_it_left_open(collect, caplog):
+    """Naming a failure must never become the failure.
+
+    The message and the record are both built from the exception before any
+    cleanup runs, so rendering one unguarded ends the stream with no record, no
+    closed span, no terminated member lane, and the run's real failure replaced
+    by whatever the attempt to describe it raised.
+    """
+    subagent_error = event_type_named("SUBAGENT_ERROR")
+    with captured_agno_logs(caplog, "WARNING"):
+        events, error = await collect(_member_lane_open_when_an_unspeakable_failure_arrives(), attributed())
+
+    assert type(error) is _Unspeakable, f"the run's own failure was replaced by {type(error).__name__}"
+    # The lane still resolves, under the name of what raised, since it has no
+    # text of its own to report.
+    assert_stream_contains(events, subagent_error)
+    assert in_emitted_order(events, subagent_error, "subagent_run_id", "message", "code") == [
+        ("run-scout", "_Unspeakable", None)
+    ]
+    assert_stream_contains(events, EventType.TEXT_MESSAGE_END)
+    assert in_emitted_order(events, EventType.TOOL_CALL_END, "tool_call_id") == [("tc-delegate-scout",)]
+    logged = "\n".join(record.message for record in caplog.records)
+    assert "_Unspeakable" in logged, f"the failure was not recorded at all: {logged}"

--- a/libs/agno/tests/unit/os/interfaces/test_agui_stream_invariants.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_stream_invariants.py
@@ -1,0 +1,1130 @@
+"""Negative controls for the shared definition of a well-formed AG-UI stream.
+
+``agui_stream_invariants`` is what every AG-UI suite's collectors assert their
+streams against, so an invariant that has stopped biting takes the whole set
+down with it silently: every suite keeps passing, and nothing says the promise
+went unchecked. A reviewer demonstrated exactly that by deleting six of the
+individual checks with the suites still green.
+
+Each invariant therefore gets a stream here that breaks it and nothing else,
+built as a plain list of protocol events rather than by driving the interface,
+so a control cannot drift into agreeing with whatever the interface does today.
+The table below is keyed by the invariant each case is for, and one test asserts
+that every invariant the checker names is in it.
+
+An invariant reads its event types out of a table, so a case per invariant is
+not enough on its own: a row deleted from ``_SPAN_FAMILIES``, ``_CONTENT_IN_SPAN``,
+``_ANNOUNCEMENT_PARENT_LINKS``, the run terminal types, the run-level types, the
+member terminal types or the state types leaves the invariant biting on every
+other row and silently blind to that one. Every row therefore has a case whose
+reported violation can only come from that row.
+"""
+
+import logging
+from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple, cast
+
+import pytest
+
+pytest.importorskip("ag_ui", reason="ag_ui not installed")
+
+import ag_ui.core
+from ag_ui.core import (
+    BaseEvent,
+    EventType,
+    ReasoningEndEvent,
+    ReasoningMessageContentEvent,
+    ReasoningMessageEndEvent,
+    ReasoningMessageStartEvent,
+    ReasoningStartEvent,
+    RunErrorEvent,
+    RunFinishedEvent,
+    RunStartedEvent,
+    StateDeltaEvent,
+    StateSnapshotEvent,
+    TextMessageContentEvent,
+    TextMessageEndEvent,
+    TextMessageStartEvent,
+    ToolCallArgsEvent,
+    ToolCallEndEvent,
+    ToolCallResultEvent,
+    ToolCallStartEvent,
+)
+
+from .agui_stream_invariants import (
+    A_CHILDS_TERMINAL_PRECEDES_ITS_PARENTS,
+    A_SPAN_CLOSES_IN_THE_MEMBER_IT_OPENED_IN,
+    A_TOOL_CALL_SITS_IN_ITS_PARENT_MESSAGES_MEMBER,
+    A_TOOL_RESULT_CARRIES_ITS_CALLS_MEMBER,
+    ABANDONED_MID_STREAM,
+    ABANDONED_WITH_A_MEMBER_STILL_OPEN,
+    AGNO_LOGGER_NAMES,
+    AN_ANNOUNCED_PARENT_PRECEDES_ITS_CHILD,
+    ATTRIBUTED_IS_SERVABLE,
+    CONTENT_CARRIES_ITS_SPANS_MEMBER,
+    CONTENT_LANDS_INSIDE_ITS_SPAN,
+    EVERY_ANNOUNCED_MEMBER_TERMINATES,
+    EVERY_ANNOUNCED_PARENT_IS_ANNOUNCED_TOO,
+    EVERY_ANNOUNCED_PARENT_LINK_RESOLVES,
+    EVERY_SPAN_CLOSES,
+    EVERY_STAMP_NAMES_AN_ANNOUNCED_MEMBER,
+    EVERY_TOOL_CALL_PARENT_MESSAGE_WAS_OPENED,
+    EVERY_TOOL_RESULT_FOLLOWS_ITS_CALLS_END,
+    EVERY_TOOL_RESULT_NAMES_A_STARTED_CALL,
+    EXEMPTIONS,
+    INVARIANTS,
+    LINEAGE_ANNOUNCEMENT_FIELDS_READ_HERE,
+    LINEAGE_EVENTS_PROTOCOL_FLOOR,
+    NO_MEMBER_IS_ANNOUNCED_TWICE,
+    NO_SPAN_CLOSES_BEFORE_IT_OPENS,
+    NO_SPAN_CLOSES_TWICE,
+    NO_SPAN_CLOSES_UNOPENED,
+    NO_SPAN_OPENS_TWICE,
+    NOTHING_CARRIES_A_MEMBER_AFTER_ITS_TERMINAL,
+    ONE_RUN_TERMINAL_AND_NOTHING_AFTER_IT,
+    RUN_EVENTS_ARE_NEVER_STAMPED,
+    STATE_EVENTS_ARE_NEVER_STAMPED,
+    TRAILING_OUTPUT_AFTER_A_MEMBER_TERMINAL,
+    announced_lane,
+    announcement_fields_missing_from,
+    assert_stream_carries_exactly,
+    assert_stream_contains,
+    assert_well_formed_stream,
+    captured_agno_logs,
+    circular,
+    encoding_failures,
+    event_type_named,
+    exemption_waives,
+    field_of,
+    in_emitted_order,
+    installed_protocol_release,
+    lineage_announcement_fields_missing,
+    require_lineage_events,
+    stream_invariant_violation,
+)
+
+THREAD_ID = "invariant-session"
+RUN_ID = "invariant-run"
+
+
+# --- Building one event at a time -------------------------------------------
+
+
+def _stamped(event: BaseEvent, lane: Optional[str]) -> BaseEvent:
+    """One event carrying a member lane, set directly rather than by the interface.
+
+    The protocol models accept extra attributes, so this reaches even an event
+    type the interface refuses to attribute, which is what the state-event
+    control needs.
+    """
+    if lane is not None:
+        setattr(event, "subagent_run_id", lane)
+    return event
+
+
+def _text_start(message_id: str, lane: Optional[str] = None) -> BaseEvent:
+    return _stamped(
+        TextMessageStartEvent(type=EventType.TEXT_MESSAGE_START, message_id=message_id, role="assistant"), lane
+    )
+
+
+def _text_content(message_id: str, delta: str = "hello", lane: Optional[str] = None) -> BaseEvent:
+    return _stamped(
+        TextMessageContentEvent(type=EventType.TEXT_MESSAGE_CONTENT, message_id=message_id, delta=delta), lane
+    )
+
+
+def _text_end(message_id: str, lane: Optional[str] = None) -> BaseEvent:
+    return _stamped(TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=message_id), lane)
+
+
+def _tool_start(tool_call_id: str, lane: Optional[str] = None, parent_message_id: Optional[str] = None) -> BaseEvent:
+    return _stamped(
+        ToolCallStartEvent(
+            type=EventType.TOOL_CALL_START,
+            tool_call_id=tool_call_id,
+            tool_call_name="do_it",
+            parent_message_id=parent_message_id,
+        ),
+        lane,
+    )
+
+
+def _tool_args(tool_call_id: str, delta: str = "{}", lane: Optional[str] = None) -> BaseEvent:
+    return _stamped(ToolCallArgsEvent(type=EventType.TOOL_CALL_ARGS, tool_call_id=tool_call_id, delta=delta), lane)
+
+
+def _tool_end(tool_call_id: str, lane: Optional[str] = None) -> BaseEvent:
+    return _stamped(ToolCallEndEvent(type=EventType.TOOL_CALL_END, tool_call_id=tool_call_id), lane)
+
+
+def _tool_result(tool_call_id: str, lane: Optional[str] = None) -> BaseEvent:
+    return _stamped(
+        ToolCallResultEvent(
+            type=EventType.TOOL_CALL_RESULT,
+            tool_call_id=tool_call_id,
+            message_id=tool_call_id,
+            content="done",
+            role="tool",
+        ),
+        lane,
+    )
+
+
+def _reasoning_start(message_id: str, lane: Optional[str] = None) -> BaseEvent:
+    return _stamped(ReasoningStartEvent(type=EventType.REASONING_START, message_id=message_id), lane)
+
+
+def _reasoning_end(message_id: str, lane: Optional[str] = None) -> BaseEvent:
+    return _stamped(ReasoningEndEvent(type=EventType.REASONING_END, message_id=message_id), lane)
+
+
+def _reasoning_message_start(message_id: str, lane: Optional[str] = None) -> BaseEvent:
+    return _stamped(
+        ReasoningMessageStartEvent(type=EventType.REASONING_MESSAGE_START, message_id=message_id, role="reasoning"),
+        lane,
+    )
+
+
+def _reasoning_message_content(message_id: str, delta: str = "thinking", lane: Optional[str] = None) -> BaseEvent:
+    return _stamped(
+        ReasoningMessageContentEvent(type=EventType.REASONING_MESSAGE_CONTENT, message_id=message_id, delta=delta),
+        lane,
+    )
+
+
+def _reasoning_message_end(message_id: str, lane: Optional[str] = None) -> BaseEvent:
+    return _stamped(ReasoningMessageEndEvent(type=EventType.REASONING_MESSAGE_END, message_id=message_id), lane)
+
+
+def _state_delta(lane: Optional[str] = None) -> BaseEvent:
+    return _stamped(
+        StateDeltaEvent(type=EventType.STATE_DELTA, delta=[{"op": "replace", "path": "/approved", "value": True}]),
+        lane,
+    )
+
+
+def _state_snapshot(lane: Optional[str] = None) -> BaseEvent:
+    return _stamped(StateSnapshotEvent(type=EventType.STATE_SNAPSHOT, snapshot={"approved": True}), lane)
+
+
+def _run_started(lane: Optional[str] = None) -> BaseEvent:
+    return _stamped(RunStartedEvent(type=EventType.RUN_STARTED, thread_id=THREAD_ID, run_id=RUN_ID), lane)
+
+
+def _run_finished(lane: Optional[str] = None) -> BaseEvent:
+    return _stamped(RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id=THREAD_ID, run_id=RUN_ID), lane)
+
+
+def _run_error(lane: Optional[str] = None) -> BaseEvent:
+    return _stamped(RunErrorEvent(type=EventType.RUN_ERROR, message="the run failed"), lane)
+
+
+def _lineage_event(class_name: str, **fields: Any) -> BaseEvent:
+    """One SUBAGENT_* event, skipping on a release that defines none.
+
+    The class is reached by name off the installed module and its event type
+    off the class itself. Naming ``EventType.SUBAGENT_*`` in a caller would not
+    do: the argument is evaluated before this function is entered, so the skip
+    below never runs and the case fails instead on a release the packaged extra
+    still permits.
+    """
+    require_lineage_events()
+    event_class = getattr(ag_ui.core, class_name)
+    return event_class(**fields)
+
+
+def _announced(
+    lane: str,
+    parent: Optional[str] = None,
+    parent_tool_call_id: Optional[str] = None,
+    parent_message_id: Optional[str] = None,
+) -> BaseEvent:
+    return _lineage_event(
+        "SubagentStartedEvent",
+        subagent_run_id=lane,
+        name=lane.capitalize(),
+        parent_subagent_run_id=parent,
+        parent_tool_call_id=parent_tool_call_id,
+        parent_message_id=parent_message_id,
+    )
+
+
+def _member_finished(lane: str) -> BaseEvent:
+    return _lineage_event("SubagentFinishedEvent", subagent_run_id=lane)
+
+
+def _member_errored(lane: str) -> BaseEvent:
+    return _lineage_event("SubagentErrorEvent", subagent_run_id=lane, message="the member failed")
+
+
+# --- One stream per invariant ------------------------------------------------
+
+
+class Control(NamedTuple):
+    """One stream that breaks exactly one invariant, and how it is reported."""
+
+    invariant: str
+    case: str
+    # Built when the case runs, so a member case skips rather than failing on a
+    # protocol release without the lineage events.
+    build: Callable[[], List[BaseEvent]]
+    # Part of what the checker says. Enough to tell this violation from every
+    # other one the same stream could plausibly break.
+    reported: str
+
+
+_CONTROLS: Tuple[Control, ...] = (
+    # Each of these opens twice and closes once, so the second open is the only
+    # thing wrong with the stream: opening and closing twice would break the
+    # duplicate-close promise below as well.
+    Control(
+        NO_SPAN_OPENS_TWICE,
+        "one message id opened twice",
+        lambda: [_text_start("m-1"), _text_start("m-1"), _text_end("m-1"), _run_finished()],
+        "text message ids opened more than once: ['m-1']",
+    ),
+    Control(
+        NO_SPAN_OPENS_TWICE,
+        "one tool call id opened twice",
+        lambda: [_tool_start("tc-1"), _tool_start("tc-1"), _tool_end("tc-1"), _run_finished()],
+        "tool call ids opened more than once: ['tc-1']",
+    ),
+    Control(
+        NO_SPAN_OPENS_TWICE,
+        "one reasoning span opened twice",
+        lambda: [
+            _reasoning_start("r-1"),
+            _reasoning_start("r-1"),
+            _reasoning_end("r-1"),
+            _run_finished(),
+        ],
+        "reasoning ids opened more than once: ['r-1']",
+    ),
+    Control(
+        NO_SPAN_CLOSES_TWICE,
+        "one message closed twice",
+        # A second end for an id the stream did open. Counting the closes
+        # against the opens nets this to zero and reports nothing, and reporting
+        # the leftover close as a span that never opened names the wrong fault.
+        lambda: [_text_start("m-1"), _text_end("m-1"), _text_end("m-1"), _run_finished()],
+        "text message ids closed more than once: ['m-1']",
+    ),
+    Control(
+        NO_SPAN_CLOSES_UNOPENED,
+        "a message closed that never opened",
+        lambda: [_text_end("m-ghost"), _run_finished()],
+        "text message ids closed without ever being opened: ['m-ghost']",
+    ),
+    Control(
+        EVERY_SPAN_CLOSES,
+        "a tool call left open at the run terminal",
+        lambda: [_text_start("m-1"), _text_content("m-1"), _text_end("m-1"), _tool_start("tc-1"), _run_finished()],
+        "tool call ids opened and never closed: ['tc-1']",
+    ),
+    Control(
+        NO_SPAN_CLOSES_BEFORE_IT_OPENS,
+        "a reasoning message closed before it opened",
+        lambda: [
+            _reasoning_message_end("r-1"),
+            _reasoning_message_start("r-1"),
+            _run_finished(),
+        ],
+        "reasoning message r-1 was closed before it opened",
+    ),
+    Control(
+        CONTENT_LANDS_INSIDE_ITS_SPAN,
+        "a delta after its message ended",
+        lambda: [_text_start("m-1"), _text_end("m-1"), _text_content("m-1"), _run_finished()],
+        "text message content at index 2 names m-1, whose TEXT_MESSAGE_END already went out",
+    ),
+    Control(
+        CONTENT_LANDS_INSIDE_ITS_SPAN,
+        "tool arguments for a call that never started",
+        lambda: [_tool_args("tc-ghost"), _run_finished()],
+        "tool call arguments at index 0 names tc-ghost, which no earlier TOOL_CALL_START opened",
+    ),
+    Control(
+        CONTENT_LANDS_INSIDE_ITS_SPAN,
+        "a reasoning delta after its reasoning message ended",
+        lambda: [
+            _reasoning_message_start("r-1"),
+            _reasoning_message_end("r-1"),
+            _reasoning_message_content("r-1"),
+            _run_finished(),
+        ],
+        "reasoning content at index 2 names r-1, whose REASONING_MESSAGE_END already went out",
+    ),
+    Control(
+        CONTENT_CARRIES_ITS_SPANS_MEMBER,
+        "one member's delta inside another member's message",
+        lambda: [
+            _announced("run-alpha"),
+            _announced("run-beta"),
+            _text_start("m-1", lane="run-alpha"),
+            _text_content("m-1", lane="run-beta"),
+            _text_end("m-1", lane="run-alpha"),
+            _member_finished("run-alpha"),
+            _member_finished("run-beta"),
+            _run_finished(),
+        ],
+        "text message content for m-1 is stamped with member run-beta, while the "
+        "TEXT_MESSAGE_START that opened it named run-alpha",
+    ),
+    Control(
+        A_SPAN_CLOSES_IN_THE_MEMBER_IT_OPENED_IN,
+        "one member's message closed in another member",
+        lambda: [
+            _announced("run-alpha"),
+            _announced("run-beta"),
+            _text_start("m-1", lane="run-alpha"),
+            _text_end("m-1", lane="run-beta"),
+            _member_finished("run-alpha"),
+            _member_finished("run-beta"),
+            _run_finished(),
+        ],
+        "the TEXT_MESSAGE_END for text message m-1 is stamped with member run-beta, while the "
+        "TEXT_MESSAGE_START that opened it named run-alpha",
+    ),
+    Control(
+        A_SPAN_CLOSES_IN_THE_MEMBER_IT_OPENED_IN,
+        "a member's tool call closed with no member at all",
+        lambda: [
+            _announced("run-alpha"),
+            _tool_start("tc-1", lane="run-alpha"),
+            _tool_end("tc-1"),
+            _member_finished("run-alpha"),
+            _run_finished(),
+        ],
+        "the TOOL_CALL_END for tool call tc-1 is stamped with member None, while the "
+        "TOOL_CALL_START that opened it named run-alpha",
+    ),
+    Control(
+        EVERY_TOOL_CALL_PARENT_MESSAGE_WAS_OPENED,
+        "a tool call hung off a message this stream never opened",
+        lambda: [_tool_start("tc-1", parent_message_id="m-ghost"), _tool_end("tc-1"), _run_finished()],
+        "tool call tc-1 names parent message m-ghost, which no TEXT_MESSAGE_START in this stream opened",
+    ),
+    Control(
+        A_TOOL_CALL_SITS_IN_ITS_PARENT_MESSAGES_MEMBER,
+        "a member's tool call hung off a message attributed to nobody",
+        lambda: [
+            _announced("run-alpha"),
+            _text_start("m-1"),
+            _text_end("m-1"),
+            _tool_start("tc-1", lane="run-alpha", parent_message_id="m-1"),
+            _tool_end("tc-1", lane="run-alpha"),
+            _member_finished("run-alpha"),
+            _run_finished(),
+        ],
+        "tool call tc-1 is stamped with member run-alpha, while the message m-1 it names as its "
+        "parent was opened in member None",
+    ),
+    Control(
+        A_TOOL_CALL_SITS_IN_ITS_PARENT_MESSAGES_MEMBER,
+        "an unattributed tool call hung off a member's message",
+        lambda: [
+            _announced("run-alpha"),
+            _text_start("m-1", lane="run-alpha"),
+            _text_end("m-1", lane="run-alpha"),
+            _tool_start("tc-1", parent_message_id="m-1"),
+            _tool_end("tc-1"),
+            _member_finished("run-alpha"),
+            _run_finished(),
+        ],
+        "tool call tc-1 is stamped with member None, while the message m-1 it names as its "
+        "parent was opened in member run-alpha",
+    ),
+    Control(
+        A_TOOL_CALL_SITS_IN_ITS_PARENT_MESSAGES_MEMBER,
+        "one member's tool call hung off another member's message",
+        lambda: [
+            _announced("run-alpha"),
+            _announced("run-beta"),
+            _text_start("m-1", lane="run-alpha"),
+            _text_end("m-1", lane="run-alpha"),
+            _tool_start("tc-1", lane="run-beta", parent_message_id="m-1"),
+            _tool_end("tc-1", lane="run-beta"),
+            _member_finished("run-alpha"),
+            _member_finished("run-beta"),
+            _run_finished(),
+        ],
+        "tool call tc-1 is stamped with member run-beta, while the message m-1 it names as its "
+        "parent was opened in member run-alpha",
+    ),
+    Control(
+        EVERY_TOOL_RESULT_NAMES_A_STARTED_CALL,
+        "a result for a call the client never saw start",
+        lambda: [_tool_result("tc-ghost"), _run_finished()],
+        "tool call results name calls no TOOL_CALL_START opened: ['tc-ghost']",
+    ),
+    Control(
+        EVERY_TOOL_RESULT_NAMES_A_STARTED_CALL,
+        "a result ahead of its own call's start",
+        lambda: [_tool_result("tc-1"), _tool_start("tc-1"), _tool_end("tc-1"), _run_finished()],
+        "the result for tool call tc-1 went out at index 0, ahead of the TOOL_CALL_START that opened it at index 1",
+    ),
+    Control(
+        EVERY_TOOL_RESULT_FOLLOWS_ITS_CALLS_END,
+        "a result delivered while its own call was still open",
+        lambda: [
+            _tool_start("tc-1"),
+            _tool_args("tc-1"),
+            _tool_result("tc-1"),
+            _tool_end("tc-1"),
+            _run_finished(),
+        ],
+        "the result for tool call tc-1 went out at index 2, inside the call's own span: "
+        "the TOOL_CALL_END that closed it is at index 3",
+    ),
+    Control(
+        A_TOOL_RESULT_CARRIES_ITS_CALLS_MEMBER,
+        "one member's tool result against another member's call",
+        lambda: [
+            _announced("run-alpha"),
+            _announced("run-beta"),
+            _tool_start("tc-1", lane="run-alpha"),
+            _tool_end("tc-1", lane="run-alpha"),
+            _tool_result("tc-1", lane="run-beta"),
+            _member_finished("run-alpha"),
+            _member_finished("run-beta"),
+            _run_finished(),
+        ],
+        "the result for tool call tc-1 is stamped with member run-beta, while the "
+        "TOOL_CALL_START that opened it named run-alpha",
+    ),
+    Control(
+        ONE_RUN_TERMINAL_AND_NOTHING_AFTER_IT,
+        "two run terminals",
+        lambda: [_run_finished(), _run_finished()],
+        "a run carries at most one terminal",
+    ),
+    Control(
+        ONE_RUN_TERMINAL_AND_NOTHING_AFTER_IT,
+        "an event after the run terminal",
+        lambda: [_run_finished(), _text_start("m-1"), _text_end("m-1")],
+        "events followed the run terminal:",
+    ),
+    Control(
+        ONE_RUN_TERMINAL_AND_NOTHING_AFTER_IT,
+        "an event after the run error",
+        lambda: [_run_error(), _text_start("m-1"), _text_end("m-1")],
+        "events followed the run terminal:",
+    ),
+    Control(
+        ONE_RUN_TERMINAL_AND_NOTHING_AFTER_IT,
+        "a run announced as started and never ended",
+        lambda: [_run_started(), _text_start("m-1"), _text_end("m-1")],
+        "this stream carries 1 RUN_STARTED and no terminal",
+    ),
+    Control(
+        EVERY_STAMP_NAMES_AN_ANNOUNCED_MEMBER,
+        "a stamp naming a member nothing announced",
+        lambda: [
+            _text_start("m-1", lane="run-ghost"),
+            _text_end("m-1", lane="run-ghost"),
+            _run_finished(),
+        ],
+        "is stamped with member run-ghost, which no earlier announcement named",
+    ),
+    Control(
+        NO_MEMBER_IS_ANNOUNCED_TWICE,
+        "one member announced twice",
+        lambda: [
+            _announced("run-alpha"),
+            _announced("run-alpha"),
+            _member_finished("run-alpha"),
+            _run_finished(),
+        ],
+        "member run-alpha was announced more than once",
+    ),
+    Control(
+        EVERY_ANNOUNCED_PARENT_IS_ANNOUNCED_TOO,
+        "a parent link naming a member nothing announces",
+        lambda: [
+            _announced("run-child", parent="run-ghost"),
+            _member_finished("run-child"),
+            _run_finished(),
+        ],
+        "member run-child names parent run-ghost, which this stream never announces",
+    ),
+    Control(
+        AN_ANNOUNCED_PARENT_PRECEDES_ITS_CHILD,
+        "a parent link naming a member announced further down the stream",
+        lambda: [
+            _announced("run-child", parent="run-parent"),
+            _announced("run-parent"),
+            _member_finished("run-child"),
+            _member_finished("run-parent"),
+            _run_finished(),
+        ],
+        "member run-child announced at index 0 names parent run-parent, which this stream does not "
+        "announce until index 1",
+    ),
+    Control(
+        EVERY_ANNOUNCED_PARENT_LINK_RESOLVES,
+        "a member announced under a delegating call this stream never carried",
+        lambda: [
+            _announced("run-alpha", parent_tool_call_id="tc-ghost"),
+            _member_finished("run-alpha"),
+            _run_finished(),
+        ],
+        "member run-alpha names parent_tool_call_id tc-ghost, which no TOOL_CALL_START in this stream carries",
+    ),
+    Control(
+        EVERY_ANNOUNCED_PARENT_LINK_RESOLVES,
+        "a member announced under a message this stream never opened",
+        lambda: [
+            _announced("run-alpha", parent_message_id="m-ghost"),
+            _member_finished("run-alpha"),
+            _run_finished(),
+        ],
+        "member run-alpha names parent_message_id m-ghost, which no TEXT_MESSAGE_START in this stream carries",
+    ),
+    Control(
+        EVERY_ANNOUNCED_MEMBER_TERMINATES,
+        "a member announced and never terminated",
+        lambda: [_announced("run-alpha"), _run_finished()],
+        "member run-alpha owns 0 terminals, expected exactly one",
+    ),
+    # A member owning two terminals is not in this table: a second terminal is
+    # itself an event carrying that member after the first, so the stream breaks
+    # what-follows-a-terminal as well and cannot be narrowed to one promise. It
+    # is held to the count by the two exemption tests below, under each of the
+    # waivers that could otherwise let a second terminal through.
+    Control(
+        NOTHING_CARRIES_A_MEMBER_AFTER_ITS_TERMINAL,
+        "output stamped with a member the stream already closed",
+        lambda: [
+            _announced("run-alpha"),
+            _member_finished("run-alpha"),
+            _text_start("m-1", lane="run-alpha"),
+            _text_end("m-1", lane="run-alpha"),
+            _run_finished(),
+        ],
+        "events carrying member run-alpha followed its terminal",
+    ),
+    Control(
+        NOTHING_CARRIES_A_MEMBER_AFTER_ITS_TERMINAL,
+        "output stamped with a member the stream already errored",
+        lambda: [
+            _announced("run-alpha"),
+            _member_errored("run-alpha"),
+            _text_start("m-1", lane="run-alpha"),
+            _text_end("m-1", lane="run-alpha"),
+            _run_finished(),
+        ],
+        "events carrying member run-alpha followed its terminal",
+    ),
+    Control(
+        A_CHILDS_TERMINAL_PRECEDES_ITS_PARENTS,
+        "a parent terminating before its child",
+        lambda: [
+            _announced("run-parent"),
+            _announced("run-child", parent="run-parent"),
+            _member_finished("run-parent"),
+            _member_finished("run-child"),
+            _run_finished(),
+        ],
+        "member run-child terminated after its parent run-parent",
+    ),
+    Control(
+        RUN_EVENTS_ARE_NEVER_STAMPED,
+        "a run start stamped with the member the run happened to begin in",
+        lambda: [
+            _announced("run-alpha"),
+            _run_started(lane="run-alpha"),
+            _member_finished("run-alpha"),
+            _run_finished(),
+        ],
+        "run lifecycle events carry a member lane: [('RUN_STARTED', 'run-alpha')]",
+    ),
+    Control(
+        RUN_EVENTS_ARE_NEVER_STAMPED,
+        "a run start stamped with an empty lane",
+        # An empty lane is a stamp a client filters on like any other, so this
+        # check reads presence rather than truth, as the state one does.
+        lambda: [
+            _announced(""),
+            _run_started(lane=""),
+            _member_finished(""),
+            _run_finished(),
+        ],
+        "run lifecycle events carry a member lane: [('RUN_STARTED', '')]",
+    ),
+    Control(
+        STATE_EVENTS_ARE_NEVER_STAMPED,
+        "a state delta stamped with the member that caused it",
+        lambda: [
+            _announced("run-alpha"),
+            _state_delta(lane="run-alpha"),
+            _member_finished("run-alpha"),
+            _run_finished(),
+        ],
+        "state events carry a member lane: [('STATE_DELTA', 'run-alpha')]",
+    ),
+    Control(
+        STATE_EVENTS_ARE_NEVER_STAMPED,
+        "a state snapshot stamped with the member that caused it",
+        lambda: [
+            _announced("run-alpha"),
+            _state_snapshot(lane="run-alpha"),
+            _member_finished("run-alpha"),
+            _run_finished(),
+        ],
+        "state events carry a member lane: [('STATE_SNAPSHOT', 'run-alpha')]",
+    ),
+    Control(
+        STATE_EVENTS_ARE_NEVER_STAMPED,
+        "a state delta stamped with an empty lane",
+        # An empty lane is a stamp a client filters on like any other, so the
+        # check has to read presence rather than truth.
+        lambda: [
+            _announced(""),
+            _state_delta(lane=""),
+            _member_finished(""),
+            _run_finished(),
+        ],
+        "state events carry a member lane: [('STATE_DELTA', '')]",
+    ),
+)
+
+_CASES = [pytest.param(control, id=f"{control.invariant}-{control.case}") for control in _CONTROLS]
+
+
+@pytest.mark.parametrize("control", _CASES)
+def test_a_stream_breaking_one_invariant_is_reported_as_breaking_it(control):
+    events = control.build()
+
+    violation = stream_invariant_violation(events)
+
+    assert violation is not None, (
+        f"a stream that breaks {control.invariant} passed as well formed, so nothing checks that promise"
+    )
+    assert control.reported in violation, (
+        f"a stream that breaks {control.invariant} was reported as something else: {violation}"
+    )
+
+
+def test_every_invariant_the_checker_names_has_a_stream_that_breaks_it():
+    """An invariant with no control is one whose deletion nothing would notice."""
+    covered = {control.invariant for control in _CONTROLS}
+    assert covered == set(INVARIANTS), (
+        f"invariants with no negative control: {sorted(set(INVARIANTS) - covered)}; "
+        f"controls for invariants the checker does not name: {sorted(covered - set(INVARIANTS))}"
+    )
+
+
+# --- What the two pair rules have to let through ------------------------------
+
+# The controls above are each rule's rejecting half. A rule that rejected every
+# pair would satisfy them and fail every real stream, so the agreeing shapes are
+# stated here as well.
+
+
+def test_a_tool_call_and_its_parent_message_agreeing_on_a_member_is_well_formed():
+    """One agreeing shape: a single member owning both the call and its parent message."""
+    in_one_member = [
+        _announced("run-alpha"),
+        _text_start("m-1", lane="run-alpha"),
+        _text_end("m-1", lane="run-alpha"),
+        _tool_start("tc-1", lane="run-alpha", parent_message_id="m-1"),
+        _tool_end("tc-1", lane="run-alpha"),
+        _member_finished("run-alpha"),
+        _run_finished(),
+    ]
+
+    assert_well_formed_stream(in_one_member)
+
+
+def test_a_tool_call_and_its_parent_message_both_unattributed_is_well_formed():
+    """The other agreeing shape: neither the call nor the message it hangs off attributed.
+
+    Its own test rather than a second stream inside the member one above, which
+    cannot be built at all on a protocol release without the lineage events: this
+    shape would skip along with it while needing none of them.
+    """
+    at_the_top_level = [
+        _text_start("m-1"),
+        _text_end("m-1"),
+        _tool_start("tc-1", parent_message_id="m-1"),
+        _tool_end("tc-1"),
+        _run_finished(),
+    ]
+
+    assert_well_formed_stream(at_the_top_level)
+
+
+def test_an_announced_parent_ahead_of_its_child_is_well_formed():
+    """The agreeing half of the parent-ordering rule: the parent announced first."""
+    ordered = [
+        _announced("run-parent"),
+        _announced("run-child", parent="run-parent"),
+        _member_finished("run-child"),
+        _member_finished("run-parent"),
+        _run_finished(),
+    ]
+
+    assert_well_formed_stream(ordered)
+
+
+def test_a_tool_call_parented_to_a_message_the_stream_opened_is_well_formed():
+    """The agreeing half of the parent-message rule, and the shape it must not refuse.
+
+    A call parented to nothing is rendered on its own, which is the protocol's
+    own shape and not a dangling reference, so the rule has to let it through.
+    """
+    attached = [
+        _text_start("m-1"),
+        _text_end("m-1"),
+        _tool_start("tc-1", parent_message_id="m-1"),
+        _tool_end("tc-1"),
+        _run_finished(),
+    ]
+    parented_to_nothing = [_tool_start("tc-1"), _tool_end("tc-1"), _run_finished()]
+
+    assert_well_formed_stream(attached)
+    assert_well_formed_stream(parented_to_nothing)
+
+
+def test_an_announcement_whose_links_the_stream_carries_is_well_formed():
+    """The agreeing half of the parent-link rule, in the shape the interface emits.
+
+    The member is announced inside the still open delegation call, which is what
+    ``parent_tool_call_id`` names, and under the assistant message that call
+    hangs off. A member announced under neither is well formed too: that is a
+    lane a client draws at the top rather than nested.
+    """
+    nested = [
+        _text_start("m-1"),
+        _text_end("m-1"),
+        _tool_start("tc-1", parent_message_id="m-1"),
+        _announced("run-alpha", parent_tool_call_id="tc-1", parent_message_id="m-1"),
+        _member_finished("run-alpha"),
+        _tool_end("tc-1"),
+        _run_finished(),
+    ]
+    linked_to_nothing = [_announced("run-alpha"), _member_finished("run-alpha"), _run_finished()]
+
+    assert_well_formed_stream(nested)
+    assert_well_formed_stream(linked_to_nothing)
+
+
+def test_an_unstamped_run_lifecycle_is_well_formed():
+    """The agreeing half of the run-lifecycle rule: a run that begins and ends unattributed."""
+    around_a_member = [
+        _run_started(),
+        _announced("run-alpha"),
+        _text_start("m-1", lane="run-alpha"),
+        _text_end("m-1", lane="run-alpha"),
+        _member_finished("run-alpha"),
+        _run_finished(),
+    ]
+
+    assert_well_formed_stream(around_a_member)
+
+
+def test_the_run_lifecycle_rule_refuses_a_stamped_terminal_as_well_as_a_stamped_start():
+    """The terminals, which no control can isolate, held under the waiver that isolates them.
+
+    A run terminal is the last event in the stream and a member's own terminal
+    comes before it, so a stamped run terminal always carries a member after
+    that member's terminal too. Granting the waiver for that second promise
+    leaves the run-lifecycle stamp as the only thing left wrong.
+    """
+    for terminal, reported in ((_run_finished, "RUN_FINISHED"), (_run_error, "RUN_ERROR")):
+        stamped = [_announced("run-alpha"), _member_finished("run-alpha"), terminal(lane="run-alpha")]
+
+        violation = stream_invariant_violation(stamped, exempt=[TRAILING_OUTPUT_AFTER_A_MEMBER_TERMINAL])
+
+        assert violation is not None and f"run lifecycle events carry a member lane: [('{reported}', 'run-alpha')]" in (
+            violation
+        ), f"a stamped {reported} passed as well formed: {violation}"
+
+
+# --- The exemptions ---------------------------------------------------------
+
+
+def test_an_exemption_nobody_justified_is_refused():
+    with pytest.raises(AssertionError, match="not a justified stream invariant exemption"):
+        assert_well_formed_stream([_run_finished()], exempt=["whatever_i_felt_like"])
+
+
+def test_an_exemption_the_stream_does_not_need_is_refused():
+    """A waiver granted where nothing breaks stops the invariant being checked at all."""
+    well_formed = [_text_start("m-1"), _text_content("m-1"), _text_end("m-1"), _run_finished()]
+
+    assert_well_formed_stream(well_formed)
+    with pytest.raises(AssertionError, match="well formed without the abandoned_mid_stream exemption"):
+        assert_well_formed_stream(well_formed, exempt=[ABANDONED_MID_STREAM])
+
+
+@pytest.mark.parametrize("exemption", list(EXEMPTIONS))
+def test_every_exemption_waives_an_invariant_the_checker_runs(exemption):
+    waived = exemption_waives(exemption)
+    assert waived in INVARIANTS, f"{exemption} waives {waived!r}, which is not an invariant this checker runs"
+
+
+# A case per exemption and control rather than one case per exemption looping
+# over the controls: a control that needs the lineage events cannot be built on
+# a protocol release without them, and inside a loop that skip takes every
+# remaining control with it. Built from the invariant names alone, so assembling
+# the list needs no lineage event either.
+_EXEMPTION_CASES = [
+    pytest.param(exemption, control, id=f"{exemption}-{control.invariant}-{control.case}")
+    for exemption in EXEMPTIONS
+    for control in _CONTROLS
+    if control.invariant != exemption_waives(exemption)
+]
+
+
+@pytest.mark.parametrize(("exemption", "control"), _EXEMPTION_CASES)
+def test_each_exemption_waives_its_invariant_and_only_that_one(exemption, control):
+    """The stream an exemption is for still gets every other invariant checked."""
+    violation = stream_invariant_violation(control.build(), exempt=[exemption])
+
+    assert violation is not None and control.reported in violation, (
+        f"granting {exemption} stopped {control.invariant} being reported on a stream that breaks it, "
+        f"so it waives more than {exemption_waives(exemption)}: {violation}"
+    )
+
+
+def test_the_abandonment_exemptions_permit_the_stream_they_were_written_for():
+    """A prefix of a stream: spans left open and a member left unterminated."""
+    prefix = [_announced("run-alpha"), _text_start("m-1", lane="run-alpha"), _text_content("m-1", lane="run-alpha")]
+
+    assert_well_formed_stream(prefix, exempt=[ABANDONED_MID_STREAM, ABANDONED_WITH_A_MEMBER_STILL_OPEN])
+    assert stream_invariant_violation(prefix) is not None
+
+
+def test_the_trailing_output_exemption_permits_the_stream_it_was_written_for():
+    """A member's own run emitted after its terminal, still attributed to it."""
+    trailing = [
+        _announced("run-alpha"),
+        _member_finished("run-alpha"),
+        _text_start("m-1", lane="run-alpha"),
+        _text_end("m-1", lane="run-alpha"),
+        _run_finished(),
+    ]
+
+    assert_well_formed_stream(trailing, exempt=[TRAILING_OUTPUT_AFTER_A_MEMBER_TERMINAL])
+    assert stream_invariant_violation(trailing) is not None
+
+
+def test_the_trailing_output_exemption_still_holds_a_member_to_one_terminal():
+    """The exemption's own promise: whatever follows a terminal, the terminal is unique."""
+    twice = [
+        _announced("run-alpha"),
+        _member_finished("run-alpha"),
+        _member_finished("run-alpha"),
+        _run_finished(),
+    ]
+
+    violation = stream_invariant_violation(twice, exempt=[TRAILING_OUTPUT_AFTER_A_MEMBER_TERMINAL])
+    assert violation is not None and "member run-alpha owns 2 terminals" in violation, (
+        f"a member owning two terminals passed under {TRAILING_OUTPUT_AFTER_A_MEMBER_TERMINAL}: {violation}"
+    )
+
+
+def test_the_abandonment_waiver_still_holds_a_member_to_one_terminal():
+    """Owning none is what the waiver permits; owning two is malformed either way."""
+    twice = [
+        _announced("run-alpha"),
+        _member_finished("run-alpha"),
+        _member_finished("run-alpha"),
+        _run_finished(),
+    ]
+
+    violation = stream_invariant_violation(twice, exempt=[ABANDONED_WITH_A_MEMBER_STILL_OPEN])
+    assert violation is not None and "member run-alpha owns 2 terminals, expected at most one" in violation, (
+        f"a member owning two terminals passed under {ABANDONED_WITH_A_MEMBER_STILL_OPEN}: {violation}"
+    )
+
+
+# --- The census -------------------------------------------------------------
+
+
+def test_the_census_refuses_a_bound_that_holds_for_any_stream():
+    events = [_text_start("m-1"), _text_end("m-1"), _run_finished()]
+
+    assert_stream_contains(events, EventType.TEXT_MESSAGE_START)
+    with pytest.raises(AssertionError, match="holds for any stream at all"):
+        assert_stream_contains(events, EventType.REASONING_START, 0)
+    assert_stream_carries_exactly(events, EventType.REASONING_START, 0)
+    with pytest.raises(AssertionError, match="carries 1 TEXT_MESSAGE_START events, not 2"):
+        assert_stream_carries_exactly(events, EventType.TEXT_MESSAGE_START, 2)
+
+
+def test_the_census_refuses_a_stream_that_carries_less_than_the_test_reasons_about():
+    """The anti-vacuity guard itself: a fixture short of its subject is not a pass."""
+    events = [_text_start("m-1"), _text_end("m-1"), _run_finished()]
+
+    with pytest.raises(AssertionError, match="carries 0 REASONING_START events, but the test reasons about at least 1"):
+        assert_stream_contains(events, EventType.REASONING_START)
+    with pytest.raises(AssertionError, match="cannot exercise what they claim to"):
+        assert_stream_contains(events, EventType.TEXT_MESSAGE_START, 2)
+
+
+def test_reading_a_field_an_event_does_not_carry_is_refused():
+    """A renamed field read with a default compares equal to itself on both sides."""
+    assert field_of(_text_start("m-1"), "message_id") == "m-1"
+    with pytest.raises(AssertionError, match="declares no invented_field"):
+        field_of(_text_start("m-1"), "invented_field")
+
+
+def test_reading_a_field_the_event_carries_only_as_an_extra_is_refused():
+    """Declared, not merely present: the models accept attributes they never declare.
+
+    A run terminal cannot carry a member on the wire, and setting one on the
+    object anyway is what a test comparing its own writes looks like. Reading it
+    back through a permissive attribute lookup is what makes that comparison
+    pass.
+    """
+    stamped_where_the_wire_carries_nothing = _stamped(_run_started(), "run-alpha")
+
+    assert getattr(stamped_where_the_wire_carries_nothing, "subagent_run_id") == "run-alpha"
+    with pytest.raises(AssertionError, match="declares no subagent_run_id"):
+        field_of(stamped_where_the_wire_carries_nothing, "subagent_run_id")
+
+
+class _AnnouncementWithoutItsLane:
+    """An announcement with the lane field gone, as a protocol rename would leave it.
+
+    Built by hand because the installed models all declare the field: a rename
+    is the case the strict read exists for, and no real event can stand in for
+    it.
+    """
+
+    def __init__(self, event_type: EventType) -> None:
+        self.type = event_type
+
+
+def test_reading_an_announcement_that_names_no_member_is_refused():
+    """The announced id is what every stamp, parent link and terminal resolves against.
+
+    Read with a default, a renamed field would leave every announcement naming
+    the top-level entity, and those three checks would resolve to each other and
+    pass without comparing any member attribution at all.
+    """
+    require_lineage_events()
+    renamed = cast(BaseEvent, _AnnouncementWithoutItsLane(event_type_named("SUBAGENT_STARTED")))
+
+    assert announced_lane(_announced("run-alpha")) == "run-alpha"
+    with pytest.raises(AssertionError, match="declares no subagent_run_id"):
+        announced_lane(renamed)
+
+
+def test_the_projection_helper_refuses_a_comparison_of_nothing():
+    with pytest.raises(AssertionError, match="at least one projection"):
+        in_emitted_order([_text_start("m-1")], EventType.TEXT_MESSAGE_START)
+
+
+# --- Log capture at the agno loggers -----------------------------------------
+
+
+def test_capturing_agno_logs_refuses_a_name_that_is_not_a_level(caplog):
+    with pytest.raises(AssertionError, match="not a logging level name"):
+        with captured_agno_logs(caplog, "SHOUTING"):
+            pass
+
+    with pytest.raises(AssertionError, match="not a logging level name"):
+        with captured_agno_logs(caplog, "getLogger"):
+            pass
+
+    # A bool passes an int check and reads as level 1, the widest capture there
+    # is, so a test asking for a name that happens to be a bool setting would
+    # capture everything and never say it had asked for nothing.
+    assert logging.raiseExceptions is True
+    with pytest.raises(AssertionError, match="not a logging level name"):
+        with captured_agno_logs(caplog, "raiseExceptions"):
+            pass
+
+
+def test_capturing_agno_logs_widens_a_narrow_logger_rather_than_narrowing_a_wide_one(caplog):
+    """The level entered is the most permissive of the one asked for and the ones in place.
+
+    Asking for ERROR on a logger already sitting lower has to keep the lower
+    one: raising it instead drops the warnings the test is about to assert on,
+    and a test that then finds nothing reads as the code not having warned.
+    """
+    logger = logging.getLogger(AGNO_LOGGER_NAMES[0])
+    previous = logger.level
+    logger.setLevel(logging.DEBUG)
+    try:
+        with captured_agno_logs(caplog, "ERROR"):
+            logger.warning("a warning below the level that was asked for")
+    finally:
+        logger.setLevel(previous)
+
+    assert "a warning below the level that was asked for" in caplog.text, (
+        "asking for ERROR raised a logger that was sitting at DEBUG, so records under ERROR were dropped"
+    )
+
+
+# --- The protocol release member attribution needs ----------------------------
+
+
+class _AnnouncementDeclaringNoLineage:
+    """An announcement class from before the lineage fields, declaring none of them.
+
+    Built by hand: the installed class declares every one, so the release this
+    checker's floor is about cannot be stood in for by a real event.
+    """
+
+    model_fields = {"type": object()}
+
+
+def test_every_lineage_field_this_checker_reads_is_reported_when_it_is_missing():
+    """The floor recomputed against the fields, rather than asserted as a number.
+
+    Each of these is read off an announcement by an invariant, so a release that
+    declares none of them cannot serve member attribution, whatever the version
+    string says. Listed here rather than derived from the checker's own tuple,
+    which would agree with itself however that tuple shrank.
+    """
+    assert announcement_fields_missing_from(_AnnouncementDeclaringNoLineage) == [
+        "parent_message_id",
+        "parent_subagent_run_id",
+        "parent_tool_call_id",
+        "subagent_run_id",
+    ]
+    assert sorted(LINEAGE_ANNOUNCEMENT_FIELDS_READ_HERE) == [
+        "parent_message_id",
+        "parent_subagent_run_id",
+        "parent_tool_call_id",
+        "subagent_run_id",
+    ]
+
+
+def test_the_lineage_protocol_floor_agrees_with_what_this_install_can_serve():
+    """The version claim and the feature detection have to say the same thing.
+
+    Everything member attribution needs is feature-detected, so the floor is a
+    claim about which release carries those features and nothing enforces it.
+    An install at or above it whose announcement omits a field this checker
+    reads, or one below it that serves attribution anyway, means the floor names
+    the wrong release.
+    """
+    installed = installed_protocol_release()
+    assert installed, "the installed ag-ui-protocol version parsed to no numeric components"
+    at_or_above_the_floor = installed >= LINEAGE_EVENTS_PROTOCOL_FLOOR
+
+    assert at_or_above_the_floor == ATTRIBUTED_IS_SERVABLE, (
+        f"ag-ui-protocol {installed} sits {'at or above' if at_or_above_the_floor else 'below'} the "
+        f"{LINEAGE_EVENTS_PROTOCOL_FLOOR} floor this module names, while member attribution is "
+        f"{'servable' if ATTRIBUTED_IS_SERVABLE else 'not servable'} on it"
+    )
+    assert (lineage_announcement_fields_missing() == []) == at_or_above_the_floor, (
+        f"ag-ui-protocol {installed} against the {LINEAGE_EVENTS_PROTOCOL_FLOOR} floor, with these "
+        f"announcement fields missing: {lineage_announcement_fields_missing()}"
+    )
+
+
+# --- What the encoder can put on a wire --------------------------------------
+
+
+def test_the_encoder_check_reports_the_event_a_wire_would_die_on():
+    assert encoding_failures([_text_start("m-1"), _run_finished()]) == []
+    refused: Dict[str, Any] = {"op": "replace", "path": "/value", "value": circular()}
+    assert [name for name, _ in encoding_failures([StateDeltaEvent(type=EventType.STATE_DELTA, delta=[refused])])] == [
+        "STATE_DELTA"
+    ]

--- a/libs/agno/tests/unit/os/interfaces/test_agui_subagent_lineage.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_subagent_lineage.py
@@ -1,0 +1,5197 @@
+"""AG-UI subagent lineage for Team runs.
+
+Agno stamps every streamed chunk with the run it came from and, for a member,
+the run that delegated to it. These tests assert, from the emitted payloads,
+that each message, tool call and reasoning block is attributed to the member
+that produced it.
+
+Wherever a scripted (no-network) model can drive the behavior, the stream is a
+real entity run: one test drives the whole interface over SSE, and the state,
+stamp and startup checks call the interface directly. A member that pauses is
+one of those: a member whose tool needs a confirmation pauses for real under a
+scripted model, and the announcement and the prompt on its lane are asserted
+against that run. Reasoning inside a member, output that trails a member's own
+terminal, a lane whose parent lane terminated before it and a run that fails
+with member lanes still open are not reachable from a scripted model, and
+neither are the pause shapes one run cannot produce: a leader and a member
+paused at once, a pause naming a member whose lane already terminated, a paused
+grandchild, and a pause reported only through requirements. Those tests
+hand-build the chunk sequence. A hand-built chunk carries the lineage fields the framework
+really stamps on a member's chunks: ``run_id`` for the run the chunk came from,
+``parent_run_id`` for the run that delegated to it, and
+``agent_id``/``agent_name`` or ``team_id``/``team_name`` for the member's
+identity, which the real-stream tests in this module pin independently.
+
+The default ``inline`` visibility is asserted to emit the same stream as before
+lineage existed, and a single Agent is asserted to be unaffected by the setting.
+"""
+
+import ast
+import inspect
+import json
+import threading
+from dataclasses import fields
+from functools import partial
+from itertools import combinations
+from pathlib import Path
+from typing import Any, AsyncIterator, Callable, Dict, Iterable, Iterator, List, Optional, Sequence, Set, Tuple
+
+import pytest
+
+pytest.importorskip("ag_ui", reason="ag_ui not installed")
+
+from ag_ui.core import BaseEvent, EventType
+from pydantic import BaseModel
+
+from agno.agent import Agent
+from agno.db.in_memory import InMemoryDb
+from agno.models.base import Model
+from agno.models.response import ModelResponse, ModelResponseEvent, ToolExecution
+from agno.os.interfaces.agui import handlers
+from agno.os.interfaces.agui.handlers import validate_subagent_visibility
+from agno.os.interfaces.agui.state import (
+    ROOT_LANE,
+    SUBAGENT_VISIBILITY_HIDDEN,
+    SUBAGENT_VISIBILITY_INLINE,
+    StreamState,
+)
+from agno.os.interfaces.agui.stream import (
+    async_stream_agno_response_as_agui_events,
+    stream_agno_response_as_agui_events,
+)
+from agno.reasoning.step import ReasoningStep
+from agno.run.agent import (
+    CustomEvent,
+    ReasoningCompletedEvent,
+    ReasoningContentDeltaEvent,
+    ReasoningStartedEvent,
+    ReasoningStepEvent,
+    RunCancelledEvent,
+    RunCompletedEvent,
+    RunErrorEvent,
+    RunEvent,
+    RunStartedEvent,
+    ToolCallCompletedEvent,
+    ToolCallErrorEvent,
+    ToolCallStartedEvent,
+)
+from agno.run.agent import RunPausedEvent as AgentRunPausedEvent
+from agno.run.requirement import RunRequirement
+from agno.run.team import RunCompletedEvent as TeamRunCompletedEvent
+from agno.run.team import RunErrorEvent as TeamRunErrorEvent
+from agno.run.team import RunPausedEvent as TeamRunPausedEvent
+from agno.run.team import RunStartedEvent as TeamRunStartedEvent
+from agno.run.team import ToolCallCompletedEvent as TeamToolCallCompletedEvent
+from agno.run.team import ToolCallStartedEvent as TeamToolCallStartedEvent
+from agno.team import Team
+from agno.tools import tool
+
+from .agui_stream_invariants import (
+    ATTRIBUTED_EVEN_WHEN_REFUSED,
+    TOP_LEVEL_RUN,
+    TRAILING_OUTPUT_AFTER_A_MEMBER_TERMINAL,
+    SideEffect,
+    agent_said,
+    announcements,
+    assert_stream_carries_exactly,
+    assert_stream_contains,
+    assert_well_formed_stream,
+    attributed,
+    captured_agno_logs,
+    circular,
+    collect_async,
+    collect_async_recording_violations,
+    collect_sync,
+    collect_sync_recording_violations,
+    event_type_named,
+    in_emitted_order,
+    joined_text_in_emitted_order,
+    lane_of,
+    member_chunk_kwargs,
+    needs_lineage_events,
+    of_type,
+    require_lineage_events,
+    stream_invariant_violation,
+    team_chunk_kwargs,
+    team_said,
+)
+
+THREAD_ID = "lineage-session"
+
+
+class ScriptedModel(Model):
+    """Emits scripted turns offline: ('tool', name, args, id) or ('content', text)."""
+
+    def __init__(self, model_id: str, script: List[tuple], fail_with: Optional[str] = None):
+        super().__init__(id=model_id, name=model_id, provider="test")
+        self._script = list(script)
+        self._i = 0
+        self._fail_with = fail_with
+
+    def _next(self) -> ModelResponse:
+        if self._fail_with:
+            raise RuntimeError(self._fail_with)
+        if not self._script:
+            raise AssertionError(f"{self.id} was asked for a turn but was given an empty script")
+        turn = self._script[min(self._i, len(self._script) - 1)]
+        self._i += 1
+        if turn[0] == "tool":
+            _, name, args, tcid = turn
+            response = ModelResponse(role="assistant")
+            response.tool_calls = [
+                {"id": tcid, "type": "function", "function": {"name": name, "arguments": json.dumps(args)}}
+            ]
+            return response
+        response = ModelResponse(content=turn[1], role="assistant")
+        response.event = ModelResponseEvent.assistant_response.value
+        return response
+
+    def invoke(self, *args, **kwargs):
+        return self._next()
+
+    async def ainvoke(self, *args, **kwargs):
+        return self._next()
+
+    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+        yield self._next()
+
+    async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+        yield self._next()
+
+    def _parse_provider_response(self, response: Any, **kwargs) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+
+@tool
+def search_docs(query: str) -> str:
+    return f"docs about {query}"
+
+
+@tool
+def spell_check(text: str) -> str:
+    return f"checked: {text}"
+
+
+def _researcher(db: InMemoryDb) -> Agent:
+    return Agent(
+        name="Researcher",
+        id="researcher",
+        model=ScriptedModel(
+            "m-researcher",
+            [
+                ("tool", "search_docs", {"query": "agno"}, "tc-search"),
+                ("content", "Found three sources."),
+            ],
+        ),
+        tools=[search_docs],
+        db=db,
+        telemetry=False,
+    )
+
+
+def _writer(db: InMemoryDb) -> Agent:
+    return Agent(
+        name="Writer",
+        id="writer",
+        model=ScriptedModel(
+            "m-writer",
+            [
+                ("tool", "spell_check", {"text": "draft"}, "tc-spell"),
+                ("content", "Here is the brief."),
+            ],
+        ),
+        tools=[spell_check],
+        db=db,
+        telemetry=False,
+    )
+
+
+def _team(db: InMemoryDb, members: List[Agent], calls: List[tuple]) -> Team:
+    script: List[tuple] = [("tool", "delegate_task_to_member", args, tcid) for args, tcid in calls]
+    script.append(("content", "Final synthesis."))
+    return Team(
+        name="Research Team",
+        id="research-team",
+        model=ScriptedModel("m-leader", script),
+        members=members,
+        db=db,
+        telemetry=False,
+    )
+
+
+def _two_member_team(db: InMemoryDb) -> Team:
+    return _team(
+        db,
+        [_researcher(db), _writer(db)],
+        [
+            ({"member_id": "researcher", "task": "research the topic"}, "tc-delegate-researcher"),
+            ({"member_id": "writer", "task": "write the brief"}, "tc-delegate-writer"),
+        ],
+    )
+
+
+def _twin(db: InMemoryDb, member_id: str, name: str) -> Agent:
+    """One member whose run reports the same words as its twin's."""
+    return Agent(
+        name=name,
+        id=member_id,
+        model=ScriptedModel(f"m-{member_id}", [("content", "identical wording")]),
+        db=db,
+        telemetry=False,
+    )
+
+
+def _twins_team(db: InMemoryDb) -> Team:
+    """A leader that delegates to two members which report identical content."""
+    return _team(
+        db,
+        [_twin(db, "alpha", "Alpha"), _twin(db, "beta", "Beta")],
+        [
+            ({"member_id": "alpha", "task": "say it"}, "tc-delegate-alpha"),
+            ({"member_id": "beta", "task": "say it too"}, "tc-delegate-beta"),
+        ],
+    )
+
+
+# Every collector below runs the shared stream-invariant helper before handing
+# the events back, so each test in this module inherits the whole invariant set
+# whether or not it thought to ask for it.
+
+
+async def _collect_entity_sync(
+    entity: Any, visibility: Optional[str] = None, prompt: str = "Write a brief"
+) -> List[BaseEvent]:
+    """One real entity run, mapped by the sync mapper."""
+    events = list(
+        stream_agno_response_as_agui_events(
+            entity.run(prompt, session_id=THREAD_ID, stream=True, stream_events=True, run_id=TOP_LEVEL_RUN),
+            thread_id=THREAD_ID,
+            run_id=TOP_LEVEL_RUN,
+            subagent_visibility=visibility,
+        )
+    )
+    assert_well_formed_stream(events)
+    return events
+
+
+async def _collect_entity_async(
+    entity: Any, visibility: Optional[str] = None, prompt: str = "Write a brief"
+) -> List[BaseEvent]:
+    """One real entity run, mapped by the async mapper."""
+    stream = entity.arun(prompt, session_id=THREAD_ID, stream=True, stream_events=True, run_id=TOP_LEVEL_RUN)
+    events = [
+        event
+        async for event in async_stream_agno_response_as_agui_events(
+            stream, thread_id=THREAD_ID, run_id=TOP_LEVEL_RUN, subagent_visibility=visibility
+        )
+    ]
+    assert_well_formed_stream(events)
+    return events
+
+
+# The two mappers duplicate the same body, so the attribution cases run through
+# both rather than trusting the async one to stand for the pair.
+entity_mappers = pytest.mark.parametrize(
+    "collect_entity", [_collect_entity_sync, _collect_entity_async], ids=["sync", "async"]
+)
+
+_lane = lane_of
+_of_type = of_type
+
+
+async def _collect_chunks_sync(
+    chunks: Iterable[Any],
+    visibility: Optional[str] = None,
+    *,
+    run_id: str = TOP_LEVEL_RUN,
+    run_state: Optional[Dict[str, Any]] = None,
+    exempt: Sequence[str] = (),
+) -> List[BaseEvent]:
+    """One hand-built chunk list, mapped by the sync mapper."""
+    events, error = await collect_sync(
+        chunks, visibility, thread_id=THREAD_ID, run_id=run_id, run_state=run_state, exempt=exempt
+    )
+    assert error is None, f"the source stream raised {error!r}"
+    return events
+
+
+async def _collect_chunks_async(
+    chunks: Iterable[Any],
+    visibility: Optional[str] = None,
+    *,
+    run_id: str = TOP_LEVEL_RUN,
+    run_state: Optional[Dict[str, Any]] = None,
+    exempt: Sequence[str] = (),
+) -> List[BaseEvent]:
+    """One hand-built chunk list, mapped by the async mapper."""
+    events, error = await collect_async(
+        chunks, visibility, thread_id=THREAD_ID, run_id=run_id, run_state=run_state, exempt=exempt
+    )
+    assert error is None, f"the source stream raised {error!r}"
+    return events
+
+
+chunk_mappers = pytest.mark.parametrize("collect", [_collect_chunks_sync, _collect_chunks_async], ids=["sync", "async"])
+
+# For the few streams whose subject is a shape the shared checker calls
+# malformed. The invariants still run, on the same definition, so a stream that
+# stops breaking one is a diff rather than a silence.
+malformed_mappers = pytest.mark.parametrize(
+    "collect_malformed",
+    [collect_sync_recording_violations, collect_async_recording_violations],
+    ids=["sync", "async"],
+)
+
+
+def _announcements(events: List[BaseEvent]) -> List[BaseEvent]:
+    """Every SUBAGENT_STARTED in order.
+
+    A list rather than a mapping, so a second announcement, or two lanes sharing
+    a name, stays visible in whatever the caller compares. A lane announced twice
+    is refused by the shared checker every collector here runs, so this does not
+    assert it a second time.
+
+    Built on the shared announcement reader, which names no event type an older
+    protocol release lacks, so the visibility settings that work on such a
+    release keep running here.
+    """
+    return announcements(events)
+
+
+def _is_terminal(event: BaseEvent) -> bool:
+    """Whether an event is a member's terminal, refusing to read the announcement as one.
+
+    Matched on the two terminal types rather than on ``SUBAGENT`` appearing in
+    the type name, which also matches ``SUBAGENT_STARTED``: the announcement
+    precedes everything its lane carries, so an ordering claim made against it
+    holds no matter what the stream does afterwards.
+    """
+    require_lineage_events()
+    return event.type in (EventType.SUBAGENT_FINISHED, EventType.SUBAGENT_ERROR)
+
+
+def _lane_names(events: List[BaseEvent]) -> Dict[str, str]:
+    """subagent run id -> the name it was announced under."""
+    return {e.subagent_run_id: e.name for e in _announcements(events)}  # type: ignore[attr-defined]
+
+
+def _messages_in_order(events: List[BaseEvent]) -> List[Tuple[Optional[str], str]]:
+    """(name of the member that owns it, joined text) per message, in the order they opened.
+
+    Ordered, never keyed by the text: two members that happen to say the same
+    thing have to stay two entries.
+    """
+    names = _lane_names(events)
+    return [(names[lane] if lane is not None else None, text) for lane, text in joined_text_in_emitted_order(events)]
+
+
+def _tool_calls_in_order(events: List[BaseEvent]) -> List[Tuple[str, Optional[str]]]:
+    """(tool call id, name of the member that owns it) per TOOL_CALL_START, in order."""
+    names = _lane_names(events)
+    return [
+        (tool_call_id, names[lane] if lane is not None else None)
+        for tool_call_id, lane in in_emitted_order(events, EventType.TOOL_CALL_START, "tool_call_id", _lane)
+    ]
+
+
+def _tool_call_lanes_in_order(events: List[BaseEvent]) -> List[Tuple[str, Optional[str]]]:
+    """(tool call id, raw member lane) per TOOL_CALL_START, in order."""
+    return [
+        (tool_call_id, lane)
+        for tool_call_id, lane in in_emitted_order(events, EventType.TOOL_CALL_START, "tool_call_id", _lane)
+    ]
+
+
+def _reasoning_blocks_in_order(events: List[BaseEvent]) -> List[Tuple[Optional[str], str]]:
+    """(member lane, joined reasoning text) per reasoning message, in the order they opened."""
+    deltas: Dict[str, str] = {}
+    for event in _of_type(events, EventType.REASONING_MESSAGE_CONTENT):
+        message_id = event.message_id  # type: ignore[attr-defined]
+        deltas[message_id] = deltas.get(message_id, "") + event.delta  # type: ignore[attr-defined]
+    return [
+        (_lane(event), deltas.get(event.message_id, ""))  # type: ignore[attr-defined]
+        for event in _of_type(events, EventType.REASONING_MESSAGE_START)
+    ]
+
+
+def _lane_of_message_id(events: List[BaseEvent]) -> Dict[str, Optional[str]]:
+    """message id -> the member lane that opened it.
+
+    A mapping is the right shape here: this is looked up by id to answer "who
+    owns this message", never compared against an expected mapping. The stream
+    invariant helper is what refuses a message id opened twice.
+    """
+    return {e.message_id: _lane(e) for e in _of_type(events, EventType.TEXT_MESSAGE_START)}  # type: ignore[attr-defined]
+
+
+def _type_sequence(events: List[BaseEvent]) -> List[str]:
+    return [str(e.type) for e in events]
+
+
+def _lane_sequence(events: List[BaseEvent], lane: Optional[str]) -> List[str]:
+    return [str(e.type).removeprefix("EventType.") for e in events if _lane(e) == lane]
+
+
+def _span_pairs(events: List[BaseEvent], start: EventType, end: EventType) -> Tuple[List[str], List[str]]:
+    """The message ids a span type opened and the ones it closed, in order."""
+    return (
+        [e.message_id for e in _of_type(events, start)],  # type: ignore[attr-defined]
+        [e.message_id for e in _of_type(events, end)],  # type: ignore[attr-defined]
+    )
+
+
+def _normalized_payloads(events: List[BaseEvent]) -> List[Tuple[str, Dict[str, Any]]]:
+    """Event payloads with generated ids replaced by first-seen ordinals, so two runs compare."""
+    aliases: Dict[str, str] = {}
+
+    def alias(value: Any) -> Any:
+        if not isinstance(value, str) or len(value) != 36 or value.count("-") != 4:
+            return value
+        return aliases.setdefault(value, f"id-{len(aliases)}")
+
+    normalized = []
+    for event in events:
+        payload = event.model_dump(exclude_none=True, by_alias=True)
+        payload.pop("type", None)
+        payload.pop("timestamp", None)
+        if event.type == EventType.RAW:
+            # RAW carries the whole Agno chunk, including timings and token
+            # counts that differ between runs; its identity is the event name.
+            payload = {"event": payload.get("event", {}).get("event")}
+        normalized.append((str(event.type), {k: alias(v) for k, v in payload.items()}))
+    return normalized
+
+
+# The lineage fields a member's or a team's chunks carry, and the two content
+# chunks, come from the shared module: the failure and hostile suites build the
+# same chunks, and a member chunk only reads as one while its parent names the
+# same top-level run these do.
+_member_kwargs = member_chunk_kwargs
+_team_kwargs = team_chunk_kwargs
+_agent_said = agent_said
+_team_said = team_said
+
+_TOP_LEVEL = _team_kwargs("research-team", "Research Team", TOP_LEVEL_RUN)
+
+
+def _reasoning_step(title: str, reasoning: str, **kwargs: Any) -> ReasoningStepEvent:
+    chunk = ReasoningStepEvent(**kwargs)
+    chunk.content = ReasoningStep(title=title, reasoning=reasoning)
+    return chunk
+
+
+def _delegation(tool_call_id: str, member_id: str, task: str, result: Optional[str] = None) -> ToolExecution:
+    """The call a leader delegates to one member with, as the framework records it.
+
+    The name and the two arguments are what the interface reads to tie a member
+    to the call that spawned it, so they are written once here rather than at
+    every site that needs one.
+    """
+    return ToolExecution(
+        tool_call_id=tool_call_id,
+        tool_name="delegate_task_to_member",
+        tool_args={"member_id": member_id, "task": task},
+        result=result,
+    )
+
+
+def _requirement(
+    tool: ToolExecution,
+    member_id: Optional[str] = None,
+    run_id: Optional[str] = None,
+    name: Optional[str] = None,
+) -> RunRequirement:
+    """A pending call a paused run names the member waiting on it by.
+
+    The three member fields travel together, so they are written together: a
+    case that means to leave one out passes None and says so, rather than
+    omitting a line among three that reads as an oversight.
+    """
+    requirement = RunRequirement(tool)
+    requirement.member_agent_id = member_id
+    requirement.member_agent_name = name
+    requirement.member_run_id = run_id
+    return requirement
+
+
+def _nameless_tool() -> ToolExecution:
+    """A pending call with no tool name, which the client cannot be shown."""
+    return ToolExecution(tool_call_id="tc-nameless", tool_args={"to": "ops"}, requires_confirmation=True)
+
+
+def _idless_tool() -> ToolExecution:
+    """A pending call with no id, which a resume has nothing to resolve against."""
+    return ToolExecution(tool_name="send_invoice", tool_args={"to": "ops"}, requires_confirmation=True)
+
+
+def _enumerated_by_the_interface(table: Iterable[Any], *floor: Any, described: str) -> Set[Any]:
+    """One of the interface's own enumerations, refused when it has lost a member it must hold.
+
+    Several checks in this module scan the interface for what one of its
+    enumerations names and are handed that same enumeration to scan for. An
+    empty one folds such a check to nothing found against nothing expected, and
+    it then holds whatever the interface does. Naming a member that has to be
+    there is what keeps the comparison from being between two absences, so every
+    check of that shape states its floor through here.
+    """
+    names = set(table)
+    missing = sorted(str(entry) for entry in floor if entry not in names)
+    assert not missing, (
+        f"{described} no longer names {missing}, so what is keyed by it compares nothing: "
+        f"it holds {sorted(str(name) for name in names)}"
+    )
+    return names
+
+
+# --- Attribution ------------------------------------------------------------
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@entity_mappers
+async def test_team_attributes_each_message_to_its_member(collect_entity):
+    events = await collect_entity(_two_member_team(InMemoryDb()), attributed())
+
+    assert_stream_contains(events, EventType.TEXT_MESSAGE_CONTENT, 3)
+    # In order, so two lanes are never folded together by what they said. The
+    # empty entries are the assistant messages a tool call has to be parented to.
+    assert _messages_in_order(events) == [
+        (None, ""),
+        ("Researcher", ""),
+        ("Researcher", "Found three sources."),
+        ("Writer", ""),
+        ("Writer", "Here is the brief."),
+        # The team leader's own reply belongs to no subagent.
+        (None, "Final synthesis."),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@entity_mappers
+async def test_two_members_that_say_the_same_thing_stay_two_messages(collect_entity):
+    events = await collect_entity(_twins_team(InMemoryDb()), attributed())
+    names = _lane_names(events)
+
+    assert_stream_contains(events, EventType.TEXT_MESSAGE_CONTENT, 3)
+    assert_stream_contains(events, EventType.SUBAGENT_FINISHED, 2)
+    # In order, so the two identical messages stay two entries. The empty entry
+    # is the assistant message the delegation calls are parented to.
+    assert _messages_in_order(events) == [
+        (None, ""),
+        ("Alpha", "identical wording"),
+        ("Beta", "identical wording"),
+        (None, "Final synthesis."),
+    ]
+    terminals = in_emitted_order(events, EventType.SUBAGENT_FINISHED, "subagent_run_id", "result")
+    assert [(names[lane], result) for lane, result in terminals] == [
+        ("Alpha", "identical wording"),
+        ("Beta", "identical wording"),
+    ]
+    # The framework gives each delegation its own run id, which is what keeps
+    # two members saying one thing from sharing a lane.
+    first, second = [lane for lane, _ in terminals]
+    assert first != second, "both members were reported under one run id"
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@entity_mappers
+async def test_team_attributes_each_tool_call_to_its_member(collect_entity):
+    events = await collect_entity(_two_member_team(InMemoryDb()), attributed())
+
+    assert_stream_contains(events, EventType.TOOL_CALL_START, 4)
+    # In order, so a call emitted twice cannot hide behind its own id, and the
+    # delegations themselves stay the leader's own tool calls.
+    assert _tool_calls_in_order(events) == [
+        ("tc-delegate-researcher", None),
+        ("tc-search", "Researcher"),
+        ("tc-delegate-writer", None),
+        ("tc-spell", "Writer"),
+    ]
+
+
+def _reasoning_team_chunks() -> List[Any]:
+    """Two members reasoning at the same time, which a scripted model cannot drive.
+
+    Both spans open before any step arrives and the four steps then alternate
+    between the lanes, which is what tells per-lane step numbering apart from one
+    counter for the whole stream: reset at each reasoning span or never reset,
+    one counter numbers the alternating steps 1, 2, 3, 4, so the two blocks read
+    "Step 1" then "Step 3" and "Step 2" then "Step 4". Only a counter kept per
+    lane numbers both members 1 then 2.
+    """
+
+    def delegation(member_id: str, tool_call_id: str) -> ToolExecution:
+        return _delegation(tool_call_id, member_id, f"work for {member_id}", result=f"{member_id} finished")
+
+    researcher = _member_kwargs("researcher", "run-1")
+    writer = _member_kwargs("writer", "run-2")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=delegation("researcher", "tc-d1")),
+        RunStartedEvent(**researcher),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=delegation("writer", "tc-d2")),
+        RunStartedEvent(**writer),
+        ReasoningStartedEvent(**researcher),
+        ReasoningStartedEvent(**writer),
+        _reasoning_step("researcher plan", "researcher is thinking", **researcher),
+        _reasoning_step("writer plan", "writer is thinking", **writer),
+        _reasoning_step("researcher check", "researcher is checking", **researcher),
+        _reasoning_step("writer check", "writer is checking", **writer),
+        ReasoningCompletedEvent(**researcher),
+        ReasoningCompletedEvent(**writer),
+        _agent_said("researcher says hello", **researcher),
+        RunCompletedEvent(content="researcher says hello", **researcher),
+        TeamToolCallCompletedEvent(run_id=TOP_LEVEL_RUN, tool=delegation("researcher", "tc-d1")),
+        _agent_said("writer says hello", **writer),
+        RunCompletedEvent(content="writer says hello", **writer),
+        TeamToolCallCompletedEvent(run_id=TOP_LEVEL_RUN, tool=delegation("writer", "tc-d2")),
+        _team_said("Final synthesis.", **_TOP_LEVEL),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_team_attributes_each_reasoning_block_to_its_member(collect):
+    events = await collect(_reasoning_team_chunks(), attributed())
+    names = _lane_names(events)
+
+    assert_stream_contains(events, EventType.REASONING_MESSAGE_CONTENT, 4)
+    # Ordered, and the whole block text rather than a phrase inside it: a member's
+    # reasoning landing in another member's block stays visible, and so does the
+    # step numbering, which the two lanes count separately even while the steps
+    # they contribute alternate on the wire.
+    blocks = [(names[lane] if lane is not None else None, text) for lane, text in _reasoning_blocks_in_order(events)]
+    assert blocks == [
+        (
+            "Researcher",
+            "## Step 1: researcher plan\nresearcher is thinking\n\n"
+            "## Step 2: researcher check\nresearcher is checking\n\n",
+        ),
+        (
+            "Writer",
+            "## Step 1: writer plan\nwriter is thinking\n\n## Step 2: writer check\nwriter is checking\n\n",
+        ),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_two_members_reasoning_at_once_keep_a_reasoning_span_each(collect):
+    """Neither lane's reasoning span is closed by the other lane's steps arriving.
+
+    The two spans are open together and their steps alternate on the wire, so a
+    lane switch that ended whichever span was current would split each member's
+    reasoning into two blocks and interleave the pieces. The shared checker
+    holds every delta to the span it names, which such a stream still satisfies.
+    """
+    events = await collect(_reasoning_team_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.REASONING_MESSAGE_CONTENT, 4)
+    # One reasoning span per lane, holding both of that lane's steps, and the
+    # same shape on both lanes so neither is the other's leftovers.
+    for lane in ("run-1", "run-2"):
+        assert _lane_sequence(events, lane) == [
+            "SUBAGENT_STARTED",
+            "RAW",
+            "REASONING_START",
+            "REASONING_MESSAGE_START",
+            "REASONING_MESSAGE_CONTENT",
+            "REASONING_MESSAGE_CONTENT",
+            "REASONING_MESSAGE_END",
+            "REASONING_END",
+            "TEXT_MESSAGE_START",
+            "TEXT_MESSAGE_CONTENT",
+            "TEXT_MESSAGE_END",
+            "SUBAGENT_FINISHED",
+        ], lane
+
+
+def _streamed_reasoning_chunks() -> List[Any]:
+    """A member whose reasoning arrives as deltas rather than as whole steps.
+
+    A model that streams its reasoning takes this path instead of the step path,
+    and it opens the reasoning span itself rather than being told to.
+    """
+    member = _member_kwargs("scout", "run-scout")
+
+    def delta(text: str) -> ReasoningContentDeltaEvent:
+        chunk = ReasoningContentDeltaEvent(**member)
+        chunk.reasoning_content = text
+        return chunk
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**member),
+        delta("first I "),
+        delta("then I"),
+        RunCompletedEvent(content="scout done", **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_streamed_reasoning_deltas_are_attributed_to_the_member_that_streamed_them(collect):
+    events = await collect(_streamed_reasoning_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.REASONING_MESSAGE_CONTENT, 2)
+    # One span opened by the first delta, both deltas inside it, all on the
+    # member's lane, and ordered so a delta emitted twice stays visible.
+    assert in_emitted_order(events, EventType.REASONING_MESSAGE_CONTENT, "delta", _lane) == [
+        ("first I ", "run-scout"),
+        ("then I", "run-scout"),
+    ]
+    assert in_emitted_order(events, EventType.REASONING_START, _lane) == [("run-scout",)]
+    assert _lane_sequence(events, "run-scout") == [
+        "SUBAGENT_STARTED",
+        "RAW",
+        "REASONING_START",
+        "REASONING_MESSAGE_START",
+        "REASONING_MESSAGE_CONTENT",
+        "REASONING_MESSAGE_CONTENT",
+        "REASONING_MESSAGE_END",
+        "REASONING_END",
+        "SUBAGENT_FINISHED",
+    ]
+
+
+def _text_then_reasoning_and_tool_chunks() -> List[Any]:
+    """A member that is mid-sentence when it starts reasoning, and again when it calls a tool."""
+    member = _member_kwargs("scout", "run-scout")
+    scout_tool = ToolExecution(tool_call_id="tc-scout-lookup", tool_name="lookup", tool_args={"q": "x"}, result="found")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**member),
+        _agent_said("Let me think.", **member),
+        ReasoningStartedEvent(**member),
+        _reasoning_step("scout plan", "scout is thinking", **member),
+        ReasoningCompletedEvent(**member),
+        _agent_said("Now I will look it up.", **member),
+        ToolCallStartedEvent(tool=scout_tool, **member),
+        ToolCallCompletedEvent(tool=scout_tool, **member),
+        RunCompletedEvent(content="scout done", **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_lanes_open_text_message_is_closed_before_its_reasoning_or_tool_calls(collect):
+    events = await collect(_text_then_reasoning_and_tool_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.REASONING_MESSAGE_CONTENT)
+    assert_stream_contains(events, EventType.TOOL_CALL_START)
+    # The member lane in full: each open text message is ended by the reasoning
+    # or tool call that follows it, rather than staying open around it.
+    assert _lane_sequence(events, "run-scout") == [
+        "SUBAGENT_STARTED",
+        "RAW",
+        "TEXT_MESSAGE_START",
+        "TEXT_MESSAGE_CONTENT",
+        "TEXT_MESSAGE_END",
+        "REASONING_START",
+        "REASONING_MESSAGE_START",
+        "REASONING_MESSAGE_CONTENT",
+        "REASONING_MESSAGE_END",
+        "REASONING_END",
+        "TEXT_MESSAGE_START",
+        "TEXT_MESSAGE_CONTENT",
+        "TEXT_MESSAGE_END",
+        "TOOL_CALL_START",
+        "TOOL_CALL_ARGS",
+        "TOOL_CALL_END",
+        "TOOL_CALL_RESULT",
+        "SUBAGENT_FINISHED",
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "chunk_factory",
+    [_reasoning_team_chunks, _text_then_reasoning_and_tool_chunks],
+    ids=["two_members_reasoning", "one_member_interleaving"],
+)
+@chunk_mappers
+async def test_no_lane_ever_holds_a_reasoning_or_tool_event_inside_an_open_text_message(collect, chunk_factory):
+    events = await collect(chunk_factory(), attributed())
+
+    assert_stream_contains(events, EventType.REASONING_MESSAGE_START)
+    assert_stream_contains(events, EventType.TOOL_CALL_START)
+    open_in_lane: Dict[Optional[str], bool] = {}
+    for event in events:
+        lane = _lane(event)
+        if event.type == EventType.TEXT_MESSAGE_START:
+            open_in_lane[lane] = True
+        elif event.type == EventType.TEXT_MESSAGE_END:
+            open_in_lane[lane] = False
+        elif str(event.type).rsplit(".", 1)[-1].startswith(("REASONING_", "TOOL_CALL_")):
+            assert not open_in_lane.get(lane), f"{event.type} arrived inside an open text message in lane {lane}"
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@entity_mappers
+async def test_member_and_leader_text_never_share_a_message(collect_entity):
+    """Inline joins the leader's reply to the message the last member left open; attributed does not.
+
+    The shared checker holds every delta to the member its own span was opened
+    in, so the leader's words written into a member's message and stamped with
+    that member would satisfy it. What refuses that shape is the pair of
+    streams read together: inline really does put the two in one bubble, which
+    is what makes the split under attributed a change rather than a restatement.
+    """
+    inline = await collect_entity(_two_member_team(InMemoryDb()), SUBAGENT_VISIBILITY_INLINE)
+    events = await collect_entity(_two_member_team(InMemoryDb()), attributed())
+
+    assert_stream_contains(events, EventType.TEXT_MESSAGE_CONTENT, 3)
+    assert joined_text_in_emitted_order(inline)[-1] == (None, "Here is the brief.Final synthesis.")
+    assert _messages_in_order(events)[-2:] == [("Writer", "Here is the brief."), (None, "Final synthesis.")]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@entity_mappers
+async def test_subagent_started_links_back_to_its_delegation(collect_entity):
+    events = await collect_entity(_two_member_team(InMemoryDb()), attributed())
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED, 2)
+    started = _announcements(events)
+    parent_of_tool_call = {
+        e.tool_call_id: e.parent_message_id  # type: ignore[attr-defined]
+        for e in _of_type(events, EventType.TOOL_CALL_START)
+    }
+
+    # One announcement per delegation, in the order the leader delegated, and
+    # neither has a parent subagent because the top-level team delegated to both.
+    assert [
+        (e.name, e.description, e.parent_tool_call_id, e.parent_subagent_run_id)  # type: ignore[attr-defined]
+        for e in started
+    ] == [
+        ("Researcher", "research the topic", "tc-delegate-researcher", None),
+        ("Writer", "write the brief", "tc-delegate-writer", None),
+    ]
+    # The delegation's own parent message, which has to be a message this stream
+    # really opened: read back as None on both sides, this compares nothing.
+    parents = [parent_of_tool_call["tc-delegate-researcher"], parent_of_tool_call["tc-delegate-writer"]]
+    lane_of_message = _lane_of_message_id(events)
+    assert all(parent in lane_of_message for parent in parents), (parents, sorted(lane_of_message))
+    assert in_emitted_order(events, EventType.SUBAGENT_STARTED, "parent_message_id") == [
+        (parent,) for parent in parents
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@entity_mappers
+async def test_each_subagent_gets_exactly_one_terminal_carrying_its_result(collect_entity):
+    events = await collect_entity(_two_member_team(InMemoryDb()), attributed())
+    names = _lane_names(events)
+    assert_stream_contains(events, EventType.SUBAGENT_FINISHED, 2)
+    finished = _of_type(events, EventType.SUBAGENT_FINISHED)
+
+    assert [(names[e.subagent_run_id], e.result) for e in finished] == [  # type: ignore[attr-defined]
+        ("Researcher", "Found three sources."),
+        ("Writer", "Here is the brief."),
+    ]
+    assert not _of_type(events, EventType.SUBAGENT_ERROR)
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@entity_mappers
+async def test_a_members_terminal_goes_out_before_its_delegation_reports_a_result(collect_entity):
+    """The member's card resolves before the leader's delegation renders what it returned.
+
+    The shared checker orders a member's own events against its own terminal,
+    and a child's terminal against its parent's. Neither says where that
+    terminal sits relative to the leader's own tool call, which is what decides
+    whether a client sees the member close before the result reporting it
+    arrives, and before the next member is announced under the same leader.
+    """
+    events = await collect_entity(_two_member_team(InMemoryDb()), attributed())
+    assert_stream_contains(events, EventType.SUBAGENT_FINISHED, 2)
+    names = _lane_names(events)
+
+    def described(event: BaseEvent) -> Optional[str]:
+        lane = _lane(event)
+        return names[lane] if lane is not None else getattr(event, "tool_call_id", None)
+
+    lifecycle = [
+        (str(event.type).removeprefix("EventType."), described(event))
+        for event in events
+        if event.type == EventType.SUBAGENT_STARTED
+        or _is_terminal(event)
+        or (_lane(event) is None and event.type in (EventType.TOOL_CALL_END, EventType.TOOL_CALL_RESULT))
+    ]
+    assert lifecycle == [
+        ("SUBAGENT_STARTED", "Researcher"),
+        ("SUBAGENT_FINISHED", "Researcher"),
+        ("TOOL_CALL_END", "tc-delegate-researcher"),
+        ("TOOL_CALL_RESULT", "tc-delegate-researcher"),
+        ("SUBAGENT_STARTED", "Writer"),
+        ("SUBAGENT_FINISHED", "Writer"),
+        ("TOOL_CALL_END", "tc-delegate-writer"),
+        ("TOOL_CALL_RESULT", "tc-delegate-writer"),
+    ]
+
+
+# --- Nesting ----------------------------------------------------------------
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@entity_mappers
+async def test_nested_team_reports_the_full_parent_chain(collect_entity):
+    db = InMemoryDb()
+    scout = Agent(
+        name="Scout",
+        id="scout",
+        model=ScriptedModel(
+            "m-scout",
+            [("tool", "search_docs", {"query": "x"}, "tc-scout"), ("content", "Scout done.")],
+        ),
+        tools=[search_docs],
+        db=db,
+        telemetry=False,
+    )
+    inner = Team(
+        name="Inner Team",
+        id="inner-team",
+        model=ScriptedModel(
+            "m-inner",
+            [
+                ("tool", "delegate_task_to_member", {"member_id": "scout", "task": "scout it"}, "tc-inner"),
+                ("content", "Inner done."),
+            ],
+        ),
+        members=[scout],
+        db=db,
+        telemetry=False,
+    )
+    outer = _team(db, [inner], [({"member_id": "inner-team", "task": "run inner"}, "tc-outer")])
+
+    events = await collect_entity(outer, attributed())
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED, 2)
+    started = _announcements(events)
+    # A mapping is the right shape here: it resolves a member name to the run id
+    # the expected values below are written against, and the ordered assertions
+    # that follow are what would catch two members sharing a name.
+    lane_named = {e.name: e.subagent_run_id for e in started}  # type: ignore[attr-defined]
+
+    assert [
+        (e.name, e.parent_subagent_run_id, e.parent_tool_call_id, e.description)  # type: ignore[attr-defined]
+        for e in started
+    ] == [
+        ("Inner Team", None, "tc-outer", "run inner"),
+        ("Scout", lane_named["Inner Team"], "tc-inner", "scout it"),
+    ]
+
+    finished = [e.subagent_run_id for e in _of_type(events, EventType.SUBAGENT_FINISHED)]  # type: ignore[attr-defined]
+    assert finished == [lane_named["Scout"], lane_named["Inner Team"]]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@entity_mappers
+async def test_parallel_delegation_keeps_each_member_in_its_own_lane(collect_entity):
+    db = InMemoryDb()
+    team = Team(
+        name="Research Team",
+        id="research-team",
+        model=ScriptedModel(
+            "m-leader",
+            [
+                ("tool", "delegate_task_to_members", {"task": "both of you work"}, "tc-broadcast"),
+                ("content", "Final synthesis."),
+            ],
+        ),
+        members=[_researcher(db), _writer(db)],
+        delegate_to_all_members=True,
+        db=db,
+        telemetry=False,
+    )
+
+    events = await collect_entity(team, attributed())
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED, 2)
+    said = [entry for entry in _messages_in_order(events) if entry[1]]
+
+    # This path runs the members as concurrent tasks merged through one queue, so
+    # which of the two lanes reaches the wire first is the scheduler's and not a
+    # promise. What is promised holds per lane: each member's own words arrive
+    # whole in its own lane, and the leader's reply is the run's last word.
+    assert sorted(entry for entry in said if entry[0] is not None) == [
+        ("Researcher", "Found three sources."),
+        ("Writer", "Here is the brief."),
+    ]
+    assert [entry for entry in said if entry[0] is None] == [(None, "Final synthesis.")]
+    assert said[-1] == (None, "Final synthesis."), "the leader replied before both members had spoken"
+    # Each member gets its own announcement rather than one shared between them.
+    # The broadcast call names no member, so neither is linked to it: the link
+    # is only reported off a delegation that says which member it spawned.
+    assert sorted(
+        in_emitted_order(events, EventType.SUBAGENT_STARTED, "name", "parent_tool_call_id", "description")
+    ) == [
+        ("Researcher", None, None),
+        ("Writer", None, None),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@entity_mappers
+async def test_the_same_member_delegated_twice_occupies_two_lanes(collect_entity):
+    db = InMemoryDb()
+    scout = Agent(
+        name="Scout",
+        id="scout",
+        model=ScriptedModel("m-scout", [("content", "done: scout the north"), ("content", "done: scout the south")]),
+        db=db,
+        telemetry=False,
+    )
+    team = _team(
+        db,
+        [scout],
+        [
+            ({"member_id": "scout", "task": "scout the north"}, "tc-first"),
+            ({"member_id": "scout", "task": "scout the south"}, "tc-second"),
+        ],
+    )
+
+    events = await collect_entity(team, attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED, 2)
+    assert_stream_contains(events, EventType.SUBAGENT_FINISHED, 2)
+    # One invocation is one lane, and the framework mints a run id per
+    # delegation: keyed by name or by member id these would be one entry.
+    announced = in_emitted_order(
+        events, EventType.SUBAGENT_STARTED, "subagent_run_id", "name", "description", "parent_tool_call_id"
+    )
+    assert [row[1:] for row in announced] == [
+        ("Scout", "scout the north", "tc-first"),
+        ("Scout", "scout the south", "tc-second"),
+    ]
+    first, second = [row[0] for row in announced]
+    assert first != second, "both delegations to one member were reported under a single run id"
+    assert in_emitted_order(events, EventType.SUBAGENT_FINISHED, "subagent_run_id", "result") == [
+        (first, "done: scout the north"),
+        (second, "done: scout the south"),
+    ]
+
+
+# --- Failure paths ----------------------------------------------------------
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@entity_mappers
+async def test_a_failing_member_is_errored_and_the_team_run_still_finishes(collect_entity):
+    db = InMemoryDb()
+    broken = Agent(
+        name="Broken",
+        id="broken",
+        model=ScriptedModel("m-broken", [], fail_with="member exploded"),
+        db=db,
+        telemetry=False,
+    )
+    team = _team(db, [broken], [({"member_id": "broken", "task": "break"}, "tc-delegate-broken")])
+
+    events = await collect_entity(team, attributed())
+    names = _lane_names(events)
+    assert_stream_contains(events, EventType.SUBAGENT_ERROR)
+    errors = _of_type(events, EventType.SUBAGENT_ERROR)
+
+    assert [names[e.subagent_run_id] for e in errors] == ["Broken"]  # type: ignore[attr-defined]
+    assert "member exploded" in errors[0].message  # type: ignore[attr-defined]
+    # A lane that errored is not also reported as finished.
+    assert not _of_type(events, EventType.SUBAGENT_FINISHED)
+    # The leader recovered from its member's failure, so the run itself finished.
+    assert str(events[-1].type) == str(EventType.RUN_FINISHED)
+    assert (None, "Final synthesis.") in _messages_in_order(events)
+
+
+def _run_error_with_open_lanes_chunks(message: str) -> List[Any]:
+    """A nested team and its member are both mid-run when the top-level run fails."""
+    inner = _team_kwargs("inner-team", "Inner Team", "run-inner", parent=TOP_LEVEL_RUN)
+    member = _member_kwargs("scout", "run-scout", parent="run-inner")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamRunStartedEvent(**inner),
+        RunStartedEvent(**member),
+        _agent_said("half a sen", **member),
+        TeamRunErrorEvent(content=message, error_type="RuntimeError", **_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_run_that_errors_closes_every_open_member_lane_deepest_first(collect):
+    events = await collect(_run_error_with_open_lanes_chunks("team blew up"), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_ERROR, 2)
+    assert_stream_contains(events, EventType.RUN_ERROR)
+    # The member's own span closes, then the lanes error child before parent, and
+    # the run terminal is last with nothing after it.
+    assert [(str(e.type).removeprefix("EventType."), _lane(e), getattr(e, "message", None)) for e in events[-4:]] == [
+        ("TEXT_MESSAGE_END", "run-scout", None),
+        ("SUBAGENT_ERROR", "run-scout", "team blew up"),
+        ("SUBAGENT_ERROR", "run-inner", "team blew up"),
+        ("RUN_ERROR", None, "team blew up"),
+    ]
+    assert [e.code for e in _of_type(events, EventType.RUN_ERROR)] == ["RuntimeError"]  # type: ignore[attr-defined]
+    # Errored lanes are never also reported as finished.
+    assert not _of_type(events, EventType.SUBAGENT_FINISHED)
+
+
+_A_CHILD_RESOLVED_AFTER_ITS_PARENT = "terminated after its parent"
+
+
+def _assert_the_child_resolved_after_its_parent(violation: Optional[str]) -> None:
+    """The one thing a member's own terminal cannot put in order, stated once.
+
+    A member's terminal terminates that member and nothing else, so a run whose
+    source says a parent finished while its child was still streaming puts the
+    child's terminal after its parent's. The alternatives were both worse and
+    both reproduced defects: terminating the child from the parent's terminal
+    sent a terminal for a member that was still working, with no result, after
+    which the child's own completion was read as a repeat and dropped; holding
+    the parent's terminal back would report the parent as running after its own
+    run said otherwise.
+
+    Pinned as a violation rather than exempted: the shared checker still calls
+    such a stream malformed, which is the honest verdict on a source that
+    reported those two things in that order.
+    """
+    assert violation is not None, "a child resolving after its parent passed as a well-formed stream"
+    assert _A_CHILD_RESOLVED_AFTER_ITS_PARENT in violation, violation
+
+
+def _parent_lane_terminates_first_chunks(fail: bool) -> List[Any]:
+    """A sub-team reaches its own terminal with two generations still open below it.
+
+    Two, at different depths, because with a single open descendant the order
+    the run-end drain puts them in is whatever order one element comes in:
+    reversing it would still pass.
+    """
+    inner = _team_kwargs("inner-team", "Inner Team", "run-inner", parent=TOP_LEVEL_RUN)
+    middle = _team_kwargs("middle-team", "Middle Team", "run-middle", parent="run-inner")
+    member = _member_kwargs("scout", "run-scout", parent="run-middle")
+    parent_terminal = (
+        TeamRunErrorEvent(content="inner exploded", error_type="RuntimeError", **inner)
+        if fail
+        else TeamRunCompletedEvent(content="inner done", **inner)
+    )
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamRunStartedEvent(**inner),
+        TeamRunStartedEvent(**middle),
+        RunStartedEvent(**member),
+        _agent_said("scouting", **member),
+        parent_terminal,
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "fail,terminal",
+    [(False, "SUBAGENT_FINISHED"), (True, "SUBAGENT_ERROR")],
+    ids=["finished", "errored"],
+)
+@malformed_mappers
+async def test_a_members_own_terminal_terminates_only_that_member(collect_malformed, fail, terminal):
+    """The generations below it are still running, so the run end is what terminates them.
+
+    Neither of them is finished or errored here, which is what keeps a member
+    that never failed from carrying the failure above it and keeps a member that
+    is still working from being reported as done with nothing to show.
+    """
+    events, error, violation = await collect_malformed(
+        _parent_lane_terminates_first_chunks(fail),
+        attributed(),
+        thread_id=THREAD_ID,
+        run_id=TOP_LEVEL_RUN,
+    )
+
+    assert error is None, f"the source stream raised {error!r}"
+    terminals = [
+        (str(e.type).removeprefix("EventType."), e.subagent_run_id)  # type: ignore[attr-defined]
+        for e in events
+        if str(e.type).removeprefix("EventType.") in {"SUBAGENT_FINISHED", "SUBAGENT_ERROR"}
+    ]
+    # Only the lane whose run reported the terminal takes it. The two below it
+    # are drained by the run end, deepest first, as plain completions.
+    assert terminals == [
+        (terminal, "run-inner"),
+        ("SUBAGENT_FINISHED", "run-scout"),
+        ("SUBAGENT_FINISHED", "run-middle"),
+    ]
+    _assert_the_child_resolved_after_its_parent(violation)
+
+
+def _open_lanes_at_run_end_chunks() -> List[Any]:
+    """A nested team and its member never reach their own terminals."""
+    inner = _team_kwargs("inner-team", "Inner Team", "run-inner", parent=TOP_LEVEL_RUN)
+    member = _member_kwargs("scout", "run-scout", parent="run-inner")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamRunStartedEvent(**inner),
+        RunStartedEvent(**member),
+        _agent_said("scouting", **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_the_run_end_drain_terminates_open_member_lanes_deepest_first(collect):
+    events = await collect(_open_lanes_at_run_end_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_FINISHED, 2)
+    # The drain closes the child before its parent and the run terminal is last,
+    # with nothing after it.
+    assert [(str(e.type).removeprefix("EventType."), _lane(e)) for e in events[-3:]] == [
+        ("SUBAGENT_FINISHED", "run-scout"),
+        ("SUBAGENT_FINISHED", "run-inner"),
+        ("RUN_FINISHED", None),
+    ]
+    # A lane the run terminated carries no result: the member never reported one.
+    # Read as a declared field, so a renamed or removed result field is a failure
+    # here rather than two Nones comparing equal.
+    assert in_emitted_order(events, EventType.SUBAGENT_FINISHED, "subagent_run_id", "result") == [
+        ("run-scout", None),
+        ("run-inner", None),
+    ]
+    assert not _of_type(events, EventType.SUBAGENT_ERROR)
+
+
+def _two_lanes_holding_a_message_and_a_tool_call_chunks() -> List[Any]:
+    """A sub-team and its member each reach the run end mid-sentence with a call still open.
+
+    The tool call goes out before the words in each lane, and the lane has no
+    message open when it does: the call opens an empty parent message of its own
+    and closes it in the same breath, and the words that follow open a second
+    one. Given the other way round the call would close the message the words
+    opened, and only the call would still be open when the run ends, which is
+    not the two-spans-per-lane shape this run end is about.
+    """
+    inner = _team_kwargs("inner-team", "Inner Team", "run-inner", parent=TOP_LEVEL_RUN)
+    member = _member_kwargs("scout", "run-scout", parent="run-inner")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamRunStartedEvent(**inner),
+        RunStartedEvent(**member),
+        TeamToolCallStartedEvent(tool=ToolExecution(tool_call_id="tc-inner-plan", tool_name="plan"), **inner),
+        _team_said("inner speaking", **inner),
+        ToolCallStartedEvent(tool=ToolExecution(tool_call_id="tc-scout-look", tool_name="look"), **member),
+        _agent_said("scout speaking", **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_the_run_end_closes_every_lanes_messages_then_its_tool_calls_then_terminates_it(collect):
+    """One sweep per kind across all lanes, rather than one lane emptied at a time.
+
+    Emptying a lane at a time would put the deeper lane's terminal ahead of the
+    shallower lane's message end, which lands a terminal inside another lane's
+    open span, and would put a member's terminal ahead of the tool call end it
+    is still holding. Both orders are ones the shared checker accepts.
+    """
+    events = await collect(_two_lanes_holding_a_message_and_a_tool_call_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.TOOL_CALL_END, 2)
+    assert [(str(e.type).removeprefix("EventType."), _lane(e)) for e in events[-7:]] == [
+        ("TEXT_MESSAGE_END", "run-scout"),
+        ("TEXT_MESSAGE_END", "run-inner"),
+        ("TOOL_CALL_END", "run-scout"),
+        ("TOOL_CALL_END", "run-inner"),
+        ("SUBAGENT_FINISHED", "run-scout"),
+        ("SUBAGENT_FINISHED", "run-inner"),
+        ("RUN_FINISHED", None),
+    ]
+    # The ends name the calls each lane really opened, so the pairing above is
+    # not two ends of one lane's making.
+    assert in_emitted_order(events, EventType.TOOL_CALL_END, "tool_call_id", _lane) == [
+        ("tc-scout-look", "run-scout"),
+        ("tc-inner-plan", "run-inner"),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_tool_call_opened_after_its_members_terminal_is_still_closed(collect):
+    member = _member_kwargs("scout", "run-scout")
+    late = ToolExecution(tool_call_id="tc-late", tool_name="cleanup", tool_args={})
+
+    chunks = [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**member),
+        RunCompletedEvent(content="scout done", **member),
+        # Output trailing the member's own terminal: the lane is closed but the
+        # tool call it opens still has to be ended before the run terminal.
+        ToolCallStartedEvent(tool=late, **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+    events = await collect(chunks, attributed(), exempt=[TRAILING_OUTPUT_AFTER_A_MEMBER_TERMINAL])
+
+    assert_stream_contains(events, EventType.TOOL_CALL_END)
+    assert _tool_call_lanes_in_order(events) == [("tc-late", "run-scout")]
+    assert in_emitted_order(events, EventType.TOOL_CALL_END, "tool_call_id", _lane) == [("tc-late", "run-scout")]
+    # A terminal is final for the lane it names, so the trailing output does not
+    # earn the member a second one.
+    assert [e.subagent_run_id for e in _of_type(events, EventType.SUBAGENT_FINISHED)] == ["run-scout"]  # type: ignore[attr-defined]
+    assert str(events[-1].type) == str(EventType.RUN_FINISHED)
+
+
+def _member_content_after_its_terminal_chunks() -> List[Any]:
+    """A member says one more thing after its own terminal, while its delegation is still open."""
+    delegation = _delegation("tc-delegate-scout", "scout", "scout the topic", result="scout done")
+    member = _member_kwargs("scout", "run-scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=delegation),
+        RunStartedEvent(**member),
+        RunCompletedEvent(content="scout done", **member),
+        _agent_said("one more thing", **member),
+        TeamToolCallCompletedEvent(run_id=TOP_LEVEL_RUN, tool=delegation),
+        _team_said("Final synthesis.", **_TOP_LEVEL),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_content_trailing_a_members_terminal_stays_attributed_without_holding_a_span_open(collect):
+    events = await collect(
+        _member_content_after_its_terminal_chunks(),
+        attributed(),
+        exempt=[TRAILING_OUTPUT_AFTER_A_MEMBER_TERMINAL],
+    )
+
+    assert_stream_contains(events, EventType.TOOL_CALL_RESULT)
+    # The attribution is kept: the trailing text is still the member's.
+    assert _messages_in_order(events) == [(None, ""), ("Scout", "one more thing"), (None, "Final synthesis.")]
+    trailing = [e for e in _of_type(events, EventType.TEXT_MESSAGE_START) if _lane(e) == "run-scout"]
+    assert len(trailing) == 1
+    closed_at = [
+        index
+        for index, event in enumerate(events)
+        if event.type == EventType.TEXT_MESSAGE_END and event.message_id == trailing[0].message_id  # type: ignore[attr-defined]
+    ]
+    result_at = [index for index, event in enumerate(events) if event.type == EventType.TOOL_CALL_RESULT]
+    assert closed_at and result_at
+    assert closed_at[0] < result_at[0], (
+        "the member's trailing message was still open when the leader's tool result arrived, "
+        "so a client renders that result inside the member's bubble"
+    )
+
+
+def _closed_lane_trailing_spans_chunks() -> List[Any]:
+    """A member and its sub-team both emit new spans after their own run completed."""
+    inner = _team_kwargs("inner-team", "Inner Team", "run-inner", parent=TOP_LEVEL_RUN)
+    member = _member_kwargs("scout", "run-scout", parent="run-inner")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamRunStartedEvent(**inner),
+        RunStartedEvent(**member),
+        RunCompletedEvent(content="scout done", **member),
+        TeamRunCompletedEvent(content="inner done", **inner),
+        # Trailing output from lanes whose own terminal has already been emitted.
+        ReasoningStartedEvent(**member),
+        _agent_said("scout afterword", **member),
+        _team_said("inner afterword", **inner),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@entity_mappers
+async def test_no_lane_is_left_with_an_open_span_at_the_end_of_the_run(collect_entity):
+    events = await collect_entity(_two_member_team(InMemoryDb()), attributed())
+    assert_stream_contains(events, EventType.TEXT_MESSAGE_START, 3)
+    assert_stream_contains(events, EventType.TOOL_CALL_START, 4)
+    _assert_every_span_closed(events)
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "chunk_factory,reasoning_spans,exempt",
+    [
+        (_reasoning_team_chunks, 2, ()),
+        (_text_then_reasoning_and_tool_chunks, 1, ()),
+        (_open_lanes_at_run_end_chunks, 0, ()),
+        # This one streams chunks from members whose own runs already completed,
+        # so its stamped events deliberately outlive their member terminals.
+        (_closed_lane_trailing_spans_chunks, 1, (TRAILING_OUTPUT_AFTER_A_MEMBER_TERMINAL,)),
+    ],
+    ids=["two_members_reasoning", "one_member_interleaving", "open_lanes_at_run_end", "trailing_spans"],
+)
+@chunk_mappers
+async def test_every_reasoning_and_message_span_is_closed_before_the_run_ends(
+    collect, chunk_factory, reasoning_spans, exempt
+):
+    events = await collect(chunk_factory(), attributed(), exempt=exempt)
+    # How much reasoning this particular stream carries is stated per case, as a
+    # count, so the case that carries none says so rather than stating a bound
+    # that holds for every stream there is.
+    assert_stream_contains(events, EventType.TEXT_MESSAGE_START)
+    assert_stream_carries_exactly(events, EventType.REASONING_START, reasoning_spans)
+    _assert_every_span_closed(events)
+
+
+def _assert_every_span_closed(events: List[BaseEvent]) -> None:
+    """Every span the stream opened was closed, by id, before the run terminal."""
+    for start, end in (
+        (EventType.TEXT_MESSAGE_START, EventType.TEXT_MESSAGE_END),
+        (EventType.REASONING_START, EventType.REASONING_END),
+        (EventType.REASONING_MESSAGE_START, EventType.REASONING_MESSAGE_END),
+    ):
+        opened, closed = _span_pairs(events, start, end)
+        assert sorted(opened) == sorted(closed), f"{start} ids {opened} do not match {end} ids {closed}"
+
+    open_tool_calls = [e.tool_call_id for e in _of_type(events, EventType.TOOL_CALL_START)]  # type: ignore[attr-defined]
+    ended_tool_calls = [e.tool_call_id for e in _of_type(events, EventType.TOOL_CALL_END)]  # type: ignore[attr-defined]
+    assert sorted(open_tool_calls) == sorted(ended_tool_calls)
+
+    # A conforming client rejects a run that ends inside a span, so the terminal
+    # really is the last thing on the wire.
+    assert str(events[-1].type) in {str(EventType.RUN_FINISHED), str(EventType.RUN_ERROR)}
+
+
+# --- Visibility -------------------------------------------------------------
+
+# The stream a two-member Team produced before lineage existed. Under the default
+# inline visibility it must still be exactly this.
+_INLINE_TEAM_SEQUENCE = [
+    "EventType.RAW",  # TeamRunStarted
+    "EventType.RAW",  # TeamModelRequestStarted
+    "EventType.RAW",  # TeamModelRequestCompleted
+    "EventType.TEXT_MESSAGE_START",  # empty parent for the first delegation
+    "EventType.TEXT_MESSAGE_END",
+    "EventType.TOOL_CALL_START",  # delegate to Researcher
+    "EventType.TOOL_CALL_ARGS",
+    "EventType.RAW",  # Researcher RunStarted
+    "EventType.RAW",  # Researcher ModelRequestStarted
+    "EventType.RAW",  # Researcher ModelRequestCompleted
+    "EventType.TOOL_CALL_START",  # search_docs
+    "EventType.TOOL_CALL_ARGS",
+    "EventType.TOOL_CALL_END",
+    "EventType.TOOL_CALL_RESULT",
+    "EventType.RAW",  # Researcher ModelRequestStarted
+    "EventType.TEXT_MESSAGE_START",
+    "EventType.TEXT_MESSAGE_CONTENT",  # "Found three sources."
+    "EventType.RAW",  # Researcher ModelRequestCompleted
+    "EventType.RAW",  # Researcher RunContentCompleted
+    "EventType.TOOL_CALL_END",  # delegation to Researcher returns
+    "EventType.TOOL_CALL_RESULT",
+    "EventType.RAW",  # TeamModelRequestStarted
+    "EventType.RAW",  # TeamModelRequestCompleted
+    "EventType.TEXT_MESSAGE_END",
+    "EventType.TOOL_CALL_START",  # delegate to Writer
+    "EventType.TOOL_CALL_ARGS",
+    "EventType.RAW",  # Writer RunStarted
+    "EventType.RAW",  # Writer ModelRequestStarted
+    "EventType.RAW",  # Writer ModelRequestCompleted
+    "EventType.TOOL_CALL_START",  # spell_check
+    "EventType.TOOL_CALL_ARGS",
+    "EventType.TOOL_CALL_END",
+    "EventType.TOOL_CALL_RESULT",
+    "EventType.RAW",  # Writer ModelRequestStarted
+    "EventType.TEXT_MESSAGE_START",
+    "EventType.TEXT_MESSAGE_CONTENT",  # "Here is the brief."
+    "EventType.RAW",  # Writer ModelRequestCompleted
+    "EventType.RAW",  # Writer RunContentCompleted
+    "EventType.TOOL_CALL_END",  # delegation to Writer returns
+    "EventType.TOOL_CALL_RESULT",
+    "EventType.RAW",  # TeamModelRequestStarted
+    "EventType.TEXT_MESSAGE_CONTENT",  # the leader's reply joins the Writer's message
+    "EventType.RAW",  # TeamModelRequestCompleted
+    "EventType.RAW",  # TeamRunContentCompleted
+    "EventType.TEXT_MESSAGE_END",
+    "EventType.RUN_FINISHED",
+]
+
+
+@pytest.mark.asyncio
+@entity_mappers
+async def test_inline_is_the_default_and_leaves_the_team_stream_unchanged(collect_entity):
+    default_events = await collect_entity(_two_member_team(InMemoryDb()))
+    inline_events = await collect_entity(_two_member_team(InMemoryDb()), SUBAGENT_VISIBILITY_INLINE)
+
+    assert _type_sequence(default_events) == _INLINE_TEAM_SEQUENCE
+    assert _normalized_payloads(default_events) == _normalized_payloads(inline_events)
+    assert all(_lane(e) is None for e in default_events)
+    assert not [e for e in default_events if "SUBAGENT" in str(e.type)]
+
+
+@pytest.mark.asyncio
+@malformed_mappers
+async def test_the_default_keeps_the_duplicate_prompt_a_paused_tool_listed_twice_produced(collect_malformed):
+    """Part of the same claim: the default stream is what it was, defect and all.
+
+    The fixture has to carry a tool listed twice or the claim is vacuous: before
+    member attribution existed a paused tool was prompted once per listing,
+    duplicate tool call id and all. That duplicate is a defect the default keeps
+    rather than a stream the default is allowed to change, which is why it is
+    pinned here as the invariant violation it is.
+    """
+
+    async def paused(visibility):
+        return await collect_malformed(
+            _paused_tool_listed_in_both_places_chunks(),
+            visibility,
+            thread_id=THREAD_ID,
+            run_id=TOP_LEVEL_RUN,
+        )
+
+    default_paused, default_error, violation = await paused(None)
+    inline_paused, inline_error, inline_violation = await paused(SUBAGENT_VISIBILITY_INLINE)
+
+    assert default_error is None and inline_error is None
+    assert _normalized_payloads(default_paused) == _normalized_payloads(inline_paused)
+    assert in_emitted_order(default_paused, EventType.TOOL_CALL_START, "tool_call_id", _lane) == [
+        ("tc-shared-confirm", None),
+        ("tc-shared-confirm", None),
+    ]
+    # The duplicate itself is pinned above, in order. This states that the
+    # shared checker still calls such a stream malformed, without pinning the
+    # sentence it says so in.
+    assert violation is not None and "tc-shared-confirm" in violation
+    assert inline_violation == violation
+
+
+@pytest.mark.asyncio
+@entity_mappers
+async def test_hidden_withholds_member_internals_but_keeps_the_delegation(collect_entity):
+    events = await collect_entity(_two_member_team(InMemoryDb()), SUBAGENT_VISIBILITY_HIDDEN)
+
+    # Only the leader's own delegations, only the leader's own reply, and nothing
+    # a member produced: no member tool call, no member text, no lineage at all.
+    assert_stream_contains(events, EventType.TOOL_CALL_RESULT, 2)
+    assert _tool_call_lanes_in_order(events) == [("tc-delegate-researcher", None), ("tc-delegate-writer", None)]
+    # The empty entry is the assistant message the delegation calls are parented
+    # to; ordered, so it stays visible rather than being folded away by content.
+    assert _messages_in_order(events) == [(None, ""), (None, "Final synthesis.")]
+    assert in_emitted_order(events, EventType.TOOL_CALL_RESULT, "tool_call_id", lambda e: json.loads(e.content)) == [
+        ("tc-delegate-researcher", "Found three sources."),
+        ("tc-delegate-writer", "Here is the brief."),
+    ]
+    assert not [e for e in events if "SUBAGENT" in str(e.type)]
+    assert not [e for e in events if _lane(e) is not None]
+
+
+@pytest.mark.asyncio
+@entity_mappers
+async def test_hidden_keeps_the_delegation_calls_own_arguments_which_name_the_member(collect_entity):
+    """What hidden withholds is the member surface, not the team's own delegation call.
+
+    Those arguments are the team's own work, and the default puts exactly the
+    same ones on the wire, so no account of hidden may say nothing reaching the
+    client names a member.
+    """
+    events = await collect_entity(_two_member_team(InMemoryDb()), SUBAGENT_VISIBILITY_HIDDEN)
+
+    assert_stream_contains(events, EventType.TOOL_CALL_ARGS, 2)
+    assert in_emitted_order(events, EventType.TOOL_CALL_ARGS, "tool_call_id", lambda e: json.loads(e.delta)) == [
+        ("tc-delegate-researcher", {"member_id": "researcher", "task": "research the topic"}),
+        ("tc-delegate-writer", {"member_id": "writer", "task": "write the brief"}),
+    ]
+    # Withheld all the same: nothing tells the client which member produced what.
+    assert not [e for e in events if "SUBAGENT" in str(e.type)]
+    assert not [e for e in events if _lane(e) is not None]
+
+
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_hidden_withholds_a_nested_teams_members_too(collect):
+    inner = _team_kwargs("inner-team", "Inner Team", "run-inner", parent=TOP_LEVEL_RUN)
+    member = _member_kwargs("scout", "run-scout", parent="run-inner")
+    delegation = _delegation("tc-delegate-inner", "inner-team", "run inner", result="inner finished")
+    scout_tool = ToolExecution(tool_call_id="tc-scout-search", tool_name="search_docs", tool_args={"query": "x"})
+
+    chunks = [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=delegation),
+        TeamRunStartedEvent(**inner),
+        RunStartedEvent(**member),
+        ToolCallStartedEvent(tool=scout_tool, **member),
+        _agent_said("Scout says hello.", **member),
+        _team_said("Inner says hello.", **inner),
+        TeamToolCallCompletedEvent(run_id=TOP_LEVEL_RUN, tool=delegation),
+        _team_said("Final synthesis.", **_TOP_LEVEL),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+    events = await collect(chunks, SUBAGENT_VISIBILITY_HIDDEN)
+
+    # Nesting does not earn a grandchild any exposure the direct member lacks.
+    assert _tool_call_lanes_in_order(events) == [("tc-delegate-inner", None)]
+    # The empty entry is the assistant message the delegation calls are parented
+    # to; ordered, so it stays visible rather than being folded away by content.
+    assert _messages_in_order(events) == [(None, ""), (None, "Final synthesis.")]
+    assert not [e for e in events if _lane(e) is not None]
+    assert not [e for e in events if "SUBAGENT" in str(e.type)]
+    assert str(events[-1].type) == str(EventType.RUN_FINISHED)
+
+
+@pytest.mark.asyncio
+@entity_mappers
+@pytest.mark.parametrize(
+    # Resolved inside the test rather than at collection: naming the attributed
+    # setting is what skips on a release that cannot serve it.
+    "setting",
+    [
+        lambda: None,
+        lambda: SUBAGENT_VISIBILITY_INLINE,
+        attributed,
+        lambda: SUBAGENT_VISIBILITY_HIDDEN,
+    ],
+    ids=["default", "inline", "attributed", "hidden"],
+)
+async def test_a_single_agent_is_unaffected_by_the_visibility_setting(collect_entity, setting):
+    """Each setting against the unset default, which is the stream a released client reads.
+
+    The baseline is the setting left unset rather than any named one, so the
+    default arm compares that stream with a second run of itself. That arm is
+    the run-to-run determinism control the other three rest on rather than a
+    claim about the setting: without it a difference between two runs of the
+    same code would read as a difference the setting made.
+    """
+    visibility = setting()
+    baseline = await collect_entity(_researcher(InMemoryDb()), prompt="Research agno")
+    events = await collect_entity(_researcher(InMemoryDb()), visibility, prompt="Research agno")
+
+    assert _normalized_payloads(events) == _normalized_payloads(baseline)
+    assert all(_lane(e) is None for e in events)
+    assert not [e for e in events if "SUBAGENT" in str(e.type)]
+
+
+_SINGLE_AGENT: Dict[str, Any] = {"agent_id": "assistant", "agent_name": "Assistant", "run_id": TOP_LEVEL_RUN}
+
+
+def _pending(tool_call_id: str, **flags: Any) -> ToolExecution:
+    return ToolExecution(tool_call_id=tool_call_id, tool_name="send_email", tool_args={"to": "ops"}, **flags)
+
+
+def _paused_single_agent_chunks() -> List[Any]:
+    """One Agent, no inner agent, pausing on a tool call it already streamed a start for."""
+    return [
+        RunStartedEvent(**_SINGLE_AGENT),
+        ToolCallStartedEvent(tool=_pending("tc-confirm"), **_SINGLE_AGENT),
+        AgentRunPausedEvent(
+            tools=[_pending("tc-confirm", requires_confirmation=True)], content="Send it?", **_SINGLE_AGENT
+        ),
+    ]
+
+
+def _flags_that_list_a_pending_call() -> List[str]:
+    """Every ToolExecution flag that puts a pending call on a list the pause prompt reads.
+
+    Asked of the paused event itself, one candidate flag at a time, rather than
+    written out here. A flag added to the framework, or a list added to the ones
+    the prompt reads, is a new way for one pending call to be reported twice,
+    and the cases below are generated from whatever this finds so that such an
+    addition arrives already covered instead of quietly widening the gap this
+    test exists to close.
+    """
+    found: List[str] = []
+    for candidate in fields(ToolExecution):
+        probe = ToolExecution(tool_call_id="probe", tool_name="probe")
+        setattr(probe, candidate.name, True)
+        paused = AgentRunPausedEvent(tools=[probe])
+        if any(getattr(paused, list_name, None) for list_name in handlers._PAUSE_TOOL_LISTS):
+            found.append(candidate.name)
+    return found
+
+
+def _ways_one_pending_call_is_reported_twice() -> Dict[str, Callable[[], List[Any]]]:
+    """The shapes in which one paused Agent reports the same pending call more than once.
+
+    Two of them are hand-written: a call the run already streamed a start for,
+    and two separate pending records sharing one id. The rest are generated,
+    one per combination of the flags discovered above, because a call flagged
+    for several lists is listed by each of them. Generating that part is what
+    makes a flag added to the framework arrive covered; the two hand-written
+    shapes are the ones that were reported, and nothing here proves they are
+    the only two.
+    """
+    flags = _flags_that_list_a_pending_call()
+    ways: Dict[str, Callable[[], List[Any]]] = {
+        "already-streamed": _paused_single_agent_chunks,
+        "two-records-one-id": lambda: [
+            RunStartedEvent(**_SINGLE_AGENT),
+            AgentRunPausedEvent(
+                tools=[
+                    _pending("tc-twice", requires_confirmation=True),
+                    _pending("tc-twice", requires_confirmation=True),
+                ],
+                **_SINGLE_AGENT,
+            ),
+        ],
+    }
+    for size in range(2, len(flags) + 1):
+        for combination in combinations(flags, size):
+            ways["+".join(combination)] = partial(_paused_on_every_flag, combination)
+    return ways
+
+
+def _paused_on_every_flag(flags: Tuple[str, ...]) -> List[Any]:
+    """One Agent pausing on a single pending call carrying several pause flags at once."""
+    return [
+        RunStartedEvent(**_SINGLE_AGENT),
+        AgentRunPausedEvent(
+            tools=[_pending("tc-many-flags", **{flag: True for flag in flags})], content="Send it?", **_SINGLE_AGENT
+        ),
+    ]
+
+
+_WAYS_REPORTED_TWICE = _ways_one_pending_call_is_reported_twice()
+
+
+def test_the_pause_prompt_reads_more_than_one_list_of_pending_calls():
+    """Otherwise the generated cases below collapse to the two hand-written ones."""
+    assert len(_flags_that_list_a_pending_call()) >= 2, (
+        "the pause prompt reads one list of pending calls at most, so no generated case reports one twice"
+    )
+
+
+@pytest.mark.parametrize("paused", [AgentRunPausedEvent, TeamRunPausedEvent], ids=["agent", "team"])
+def test_every_list_the_pause_prompt_reads_is_one_the_paused_event_carries(paused):
+    """A name the event does not carry is read as an empty list, so it has to be checked here.
+
+    The prompt reaches these by name and treats a missing one as no pending
+    calls, because a paused run may not be told what the client cannot render
+    by raising at it. That tolerance is what makes a misnamed entry silently
+    drop everything on that list, which is what this refuses.
+    """
+    missing = [name for name in handlers._PAUSE_TOOL_LISTS if not hasattr(paused(tools=[]), name)]
+    assert not missing, f"{paused.__name__} carries no such list of pending calls: {missing}"
+
+
+@pytest.mark.asyncio
+@malformed_mappers
+@pytest.mark.parametrize(
+    "setting",
+    [lambda: None, attributed, lambda: SUBAGENT_VISIBILITY_HIDDEN],
+    ids=["default", "attributed", "hidden"],
+)
+@pytest.mark.parametrize("way", sorted(_WAYS_REPORTED_TWICE), ids=sorted(_WAYS_REPORTED_TWICE))
+async def test_a_paused_single_agent_is_unaffected_by_the_visibility_setting(collect_malformed, setting, way):
+    """A run with no member on the wire streams the same events whatever the setting.
+
+    A pause is where that is easiest to lose, and every way one pending call can
+    be reported twice is a way to lose it: the prompt de-duplicates by tool call
+    id, and a de-duplication the default does not do makes an Agent alone stream
+    one thing under the default and another under either lineage setting. So the
+    cases are the whole class rather than the one shape that was reported.
+
+    The default's stream here is the duplicate prompt it has always emitted, so
+    the shared checker calls it malformed. That is what these settings have to
+    match, defect and all, which is why it is driven through the collector that
+    records the violation instead of failing on it. The duplicate is asserted on
+    the baseline first, so a case that stopped producing one fails here rather
+    than passing on three identical well-formed streams.
+    """
+
+    async def paused(visibility):
+        return await collect_malformed(
+            _WAYS_REPORTED_TWICE[way](), visibility, thread_id=THREAD_ID, run_id=TOP_LEVEL_RUN
+        )
+
+    baseline, baseline_error, baseline_violation = await paused(SUBAGENT_VISIBILITY_INLINE)
+    events, error, violation = await paused(setting())
+
+    assert baseline_error is None and error is None
+    prompted = in_emitted_order(baseline, EventType.TOOL_CALL_START, "tool_call_id", _lane)
+    assert len(prompted) > len(set(prompted)), f"the {way} case prompts no call twice, so it tests nothing"
+    assert _normalized_payloads(events) == _normalized_payloads(baseline)
+    assert violation == baseline_violation
+    assert not [e for e in events if "SUBAGENT" in str(e.type)]
+
+
+def test_visibility_is_validated():
+    assert validate_subagent_visibility(None) == SUBAGENT_VISIBILITY_INLINE
+    assert validate_subagent_visibility(SUBAGENT_VISIBILITY_HIDDEN) == SUBAGENT_VISIBILITY_HIDDEN
+    with pytest.raises(ValueError, match="subagent_visibility must be one of"):
+        validate_subagent_visibility("loud")
+
+
+def test_attributed_is_refused_when_the_protocol_lacks_the_lineage_events(monkeypatch):
+    """Named without the usual skip: on such a release this is the behavior under test."""
+    monkeypatch.setattr(handlers, "SUBAGENT_EVENTS_AVAILABLE", False)
+    with pytest.raises(ValueError, match="ag-ui-protocol"):
+        validate_subagent_visibility(ATTRIBUTED_EVEN_WHEN_REFUSED)
+    # Every other setting keeps working on an older protocol.
+    assert validate_subagent_visibility(SUBAGENT_VISIBILITY_HIDDEN) == SUBAGENT_VISIBILITY_HIDDEN
+
+
+# --- A real member that pauses ----------------------------------------------
+
+
+@tool(requires_confirmation=True)
+def send_email(to: str) -> str:
+    return f"emailed {to}"
+
+
+def _emailer(db: InMemoryDb) -> Agent:
+    """A member whose only tool needs a confirmation, so its run really pauses."""
+    return Agent(
+        name="Emailer",
+        id="emailer",
+        model=ScriptedModel(
+            "m-emailer",
+            [("tool", "send_email", {"to": "ops"}, "tc-send"), ("content", "Email sent.")],
+        ),
+        tools=[send_email],
+        db=db,
+        telemetry=False,
+    )
+
+
+def _team_whose_member_pauses(db: InMemoryDb) -> Team:
+    return _team(db, [_emailer(db)], [({"member_id": "emailer", "task": "email ops"}, "tc-delegate-emailer")])
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@entity_mappers
+async def test_a_real_member_that_pauses_is_prompted_on_its_own_lane(collect_entity):
+    """A genuine member pause, from a real team run rather than a hand-built chunk list.
+
+    The framework decides the member's run id here, so the lane is read off the
+    announcement rather than written down. What the hand-built pauses still
+    cover is the shapes one scripted run cannot produce: a leader and a member
+    paused at once, a pause naming a member whose lane already terminated, a
+    paused grandchild, and a pause reported only through requirements.
+    """
+    events = await collect_entity(_team_whose_member_pauses(InMemoryDb()), attributed(), prompt="Email ops")
+
+    announced = _announcements(events)
+    assert [(e.name, e.parent_tool_call_id) for e in announced] == [("Emailer", "tc-delegate-emailer")]  # type: ignore[attr-defined]
+    lane = announced[0].subagent_run_id  # type: ignore[attr-defined]
+
+    assert_stream_contains(events, EventType.TOOL_CALL_ARGS, 2)
+    assert in_emitted_order(events, EventType.TOOL_CALL_ARGS, "tool_call_id", "delta", _lane) == [
+        ("tc-delegate-emailer", '{"member_id": "emailer", "task": "email ops"}', None),
+        ("tc-send", '{"to": "ops"}', lane),
+    ]
+    # The pending call is prompted before the lane's own terminal, and pausing
+    # is not finishing, so the terminal carries no result.
+    assert [(e.subagent_run_id, e.result) for e in _of_type(events, EventType.SUBAGENT_FINISHED)] == [(lane, None)]  # type: ignore[attr-defined]
+    assert str(events[-1].type) == str(EventType.RUN_FINISHED)
+
+
+# --- Over the wire ----------------------------------------------------------
+
+
+def _sse_events(body: str) -> List[Dict[str, Any]]:
+    return [json.loads(line[len("data: ") :]) for line in body.splitlines() if line.startswith("data: ")]
+
+
+@needs_lineage_events
+def test_lineage_reaches_the_wire_through_the_agui_interface():
+    """The AGUI constructor option must survive all the way to the SSE stream."""
+    from fastapi.testclient import TestClient
+
+    from agno.os import AgentOS
+    from agno.os.interfaces.agui import AGUI
+
+    team = _two_member_team(InMemoryDb())
+    agent_os = AgentOS(
+        id="lineage-os",
+        teams=[team],
+        interfaces=[AGUI(team=team, subagent_visibility=attributed())],
+        telemetry=False,
+    )
+    client = TestClient(agent_os.get_app())
+
+    response = client.post(
+        "/agui",
+        json={
+            "thread_id": "wire-thread",
+            "run_id": "wire-run",
+            "state": {"approved": False},
+            "messages": [{"id": "m1", "role": "user", "content": "Write a brief"}],
+            "tools": [],
+            "context": [],
+            "forwarded_props": {},
+        },
+    )
+    assert response.status_code == 200
+
+    events = _sse_events(response.text)
+    # The body is the whole deliverable here, so it has to end the way every
+    # other stream in this module ends. Without this the run terminal could go
+    # missing from the response and every payload assertion below would still
+    # hold on the truncated body.
+    types = [event["type"] for event in events]
+    assert types[-1] == "RUN_FINISHED", f"the response body does not end on the run terminal: {types[-3:]}"
+    assert "RUN_ERROR" not in types, (
+        f"the run reached the wire as a failure: {[e for e in events if e['type'] == 'RUN_ERROR']}"
+    )
+
+    started = [e for e in events if e["type"] == "SUBAGENT_STARTED"]
+    assert [(e["name"], e["parentToolCallId"]) for e in started] == [
+        ("Researcher", "tc-delegate-researcher"),
+        ("Writer", "tc-delegate-writer"),
+    ]
+
+    # A set is the right shape for this one claim: every lane that appears on
+    # the wire was announced. Which events carry it is asserted in order below.
+    lanes = {e["subagentRunId"] for e in events if e.get("subagentRunId")}
+    assert lanes == {e["subagentRunId"] for e in started}
+
+    name_of_lane = {e["subagentRunId"]: e["name"] for e in started}
+    deltas: Dict[str, str] = {}
+    for event in events:
+        if event["type"] == "TEXT_MESSAGE_CONTENT":
+            deltas[event["messageId"]] = deltas.get(event["messageId"], "") + event["delta"]
+    # Ordered over the message starts, so a member's message never disappears
+    # into another's key and an empty parent message stays visible.
+    said = [
+        (name_of_lane.get(event.get("subagentRunId")), deltas.get(event["messageId"], ""))
+        for event in events
+        if event["type"] == "TEXT_MESSAGE_START"
+    ]
+    assert said == [
+        (None, ""),
+        ("Researcher", ""),
+        ("Researcher", "Found three sources."),
+        ("Writer", ""),
+        ("Writer", "Here is the brief."),
+        (None, "Final synthesis."),
+    ]
+
+    # A team's session state is one shared document, so state events are left
+    # unattributed on purpose: a client filtering by member must not lose state
+    # written during a delegation.
+    state_events = [e for e in events if e["type"].startswith("STATE_")]
+    assert {e["type"] for e in state_events} == {"STATE_SNAPSHOT", "STATE_DELTA"}
+    assert [e.get("subagentRunId") for e in state_events] == [None] * len(state_events)
+    assert [e["snapshot"]["approved"] for e in state_events if e["type"] == "STATE_SNAPSHOT"] == [False, False]
+
+
+def test_the_agui_interface_defaults_to_inline():
+    from agno.os.interfaces.agui import AGUI
+
+    team = _two_member_team(InMemoryDb())
+    assert AGUI(team=team).subagent_visibility == SUBAGENT_VISIBILITY_INLINE
+    with pytest.raises(ValueError, match="subagent_visibility must be one of"):
+        AGUI(team=team, subagent_visibility="loud")
+
+
+# --- Lane lifecycle ---------------------------------------------------------
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_spans_opened_after_a_lane_terminated_are_still_closed_before_the_run_ends(collect):
+    events = await collect(
+        _closed_lane_trailing_spans_chunks(),
+        attributed(),
+        exempt=[TRAILING_OUTPUT_AFTER_A_MEMBER_TERMINAL],
+    )
+
+    assert_stream_contains(events, EventType.REASONING_END)
+    # Ordered on both sides, so a span opened or closed twice cannot hide behind
+    # a shared message id.
+    assert in_emitted_order(events, EventType.TEXT_MESSAGE_START, "message_id", _lane) == in_emitted_order(
+        events, EventType.TEXT_MESSAGE_END, "message_id", _lane
+    )
+    assert in_emitted_order(events, EventType.TEXT_MESSAGE_START, _lane) == [("run-scout",), ("run-inner",)]
+
+    assert in_emitted_order(events, EventType.REASONING_START, "message_id", _lane) == in_emitted_order(
+        events, EventType.REASONING_END, "message_id", _lane
+    )
+    assert in_emitted_order(events, EventType.REASONING_START, _lane) == [("run-scout",)]
+
+    # A child lane's spans close before its parent's.
+    ends = [_lane(e) for e in _of_type(events, EventType.TEXT_MESSAGE_END)]
+    assert ends.index("run-scout") < ends.index("run-inner")
+    assert str(events[-1].type) == str(EventType.RUN_FINISHED)
+
+
+def test_closing_the_root_lane_ignores_whichever_lane_is_current():
+    state = StreamState(subagent_visibility=attributed(), root_run_id=TOP_LEVEL_RUN)
+    state.current_lane = ROOT_LANE
+    root_message_id = state.open_text_message()
+    state.current_lane = "run-scout"
+    state.open_text_message()
+
+    closed = handlers._close_lane_spans(state, ROOT_LANE)
+
+    assert [(str(e.type), e.message_id, _lane(e)) for e in closed] == [  # type: ignore[attr-defined]
+        (str(EventType.TEXT_MESSAGE_END), root_message_id, None)
+    ]
+    # The subagent lane is untouched by a root-lane close.
+    assert state.lane("run-scout").text_message_open is True
+
+
+@needs_lineage_events
+def test_open_tool_calls_close_in_the_order_the_run_opened_them():
+    """The close order is part of the wire, so it may not be left to set iteration.
+
+    The 24 ids go out interleaved from both ends, lowest then highest then next
+    lowest, an order that is neither ascending nor descending and so is not the
+    output of sorting them either way. The three orders that would pass without
+    the run's own order being kept are refused below before the ids are opened.
+    """
+    state = StreamState(subagent_visibility=attributed(), root_run_id=TOP_LEVEL_RUN)
+    state.current_lane = ROOT_LANE
+    ends = [f"tc-{index:02d}" for index in range(24)]
+    opened = [ends[index // 2] if index % 2 == 0 else ends[-1 - index // 2] for index in range(24)]
+    assert sorted(opened) == ends, "the interleave dropped or repeated an id"
+    assert opened != ends, "an ascending sort reproduces this order"
+    assert opened != ends[::-1], "a descending sort reproduces this order"
+    for tool_call_id in opened:
+        state.start_tool_call(tool_call_id)
+    assert list(state.active_tool_call_ids) != opened, "this interpreter's set iteration reproduces this order"
+
+    closed = [e.tool_call_id for e in handlers._close_all_lane_spans(state)]  # type: ignore[attr-defined]
+
+    assert closed == opened
+
+
+@needs_lineage_events
+def test_an_open_tool_call_is_closed_even_when_its_lane_holds_no_other_span():
+    """The run-end close reaches a lane through the tool call it owns, not only through its spans."""
+    state = StreamState(subagent_visibility=attributed(), root_run_id=TOP_LEVEL_RUN)
+    state.current_lane = "run-scout"
+    state.start_tool_call("tc-only")
+    assert state.lanes == {}, "the lane must hold nothing else for this to test what it claims"
+
+    closed = handlers._close_all_lane_spans(state)
+
+    assert [(str(e.type), e.tool_call_id, _lane(e)) for e in closed] == [  # type: ignore[attr-defined]
+        (str(EventType.TOOL_CALL_END), "tc-only", "run-scout")
+    ]
+    assert "tc-only" not in state.active_tool_call_ids
+
+
+def _paused_member_chunks() -> List[Any]:
+    """A member pauses for a confirmation while the leader also has one of its own."""
+    member_tool = ToolExecution(
+        tool_call_id="tc-member-confirm",
+        tool_name="send_email",
+        tool_args={"to": "ops"},
+        requires_confirmation=True,
+    )
+    requirement = _requirement(member_tool, "scout", "run-scout")
+    leader_tool = ToolExecution(
+        tool_call_id="tc-leader-confirm",
+        tool_name="publish",
+        tool_args={"channel": "blog"},
+        requires_confirmation=True,
+    )
+    member = _member_kwargs("scout", "run-scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**member),
+        _agent_said("I need approval.", **member),
+        AgentRunPausedEvent(tools=[member_tool], **member),
+        TeamRunPausedEvent(tools=[leader_tool], requirements=[requirement], **_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_paused_member_gets_one_plain_terminal_after_all_of_its_events(collect):
+    events = await collect(_paused_member_chunks(), attributed())
+    assert_stream_contains(events, EventType.SUBAGENT_FINISHED)
+    finished = _of_type(events, EventType.SUBAGENT_FINISHED)
+
+    # Pausing is not finishing, so the lane stays open until the run-end drain
+    # closes it. No suspended outcome: this interface emits no run-level
+    # interrupt outcome to pair one with.
+    assert [(e.subagent_run_id, e.result, e.outcome) for e in finished] == [("run-scout", None, None)]  # type: ignore[attr-defined]
+    terminal_at = events.index(finished[0])
+    assert [str(e.type) for i, e in enumerate(events) if _lane(e) == "run-scout" and i > terminal_at] == []
+    assert str(events[-1].type) == str(EventType.RUN_FINISHED)
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_paused_tool_is_attributed_to_the_member_that_owns_it(collect):
+    events = await collect(_paused_member_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.TOOL_CALL_START, 2)
+    assert_stream_contains(events, EventType.TOOL_CALL_ARGS, 2)
+    assert _tool_call_lanes_in_order(events) == [("tc-leader-confirm", None), ("tc-member-confirm", "run-scout")]
+    assert in_emitted_order(events, EventType.TOOL_CALL_ARGS, "tool_call_id", lambda e: json.loads(e.delta)) == [
+        ("tc-leader-confirm", {"channel": "blog"}),
+        ("tc-member-confirm", {"to": "ops"}),
+    ]
+
+    # The confirmation prompt the client must render arrives inside the lane, so
+    # it precedes that member's terminal, and it opens a message of the member's
+    # own rather than borrowing the leader's.
+    lane_events = _lane_sequence(events, "run-scout")
+    assert lane_events[-6:] == [
+        "TEXT_MESSAGE_START",
+        "TEXT_MESSAGE_END",
+        "TOOL_CALL_START",
+        "TOOL_CALL_ARGS",
+        "TOOL_CALL_END",
+        "SUBAGENT_FINISHED",
+    ]
+
+    # A tool call and the message carrying it name the same member. One message
+    # cannot name two, so each lane's pending calls get a message of their own.
+    parent_of = {e.tool_call_id: e.parent_message_id for e in _of_type(events, EventType.TOOL_CALL_START)}  # type: ignore[attr-defined]
+    lane_of_message = _lane_of_message_id(events)
+    assert lane_of_message[parent_of["tc-member-confirm"]] == "run-scout"
+    assert lane_of_message[parent_of["tc-leader-confirm"]] is None
+    assert parent_of["tc-member-confirm"] != parent_of["tc-leader-confirm"]
+
+
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_hidden_does_not_attribute_a_paused_member_tool(collect):
+    events = await collect(_paused_member_chunks(), SUBAGENT_VISIBILITY_HIDDEN)
+
+    assert _tool_call_lanes_in_order(events) == [("tc-leader-confirm", None), ("tc-member-confirm", None)]
+    assert not [e for e in events if _lane(e) is not None]
+
+
+def _grandchild_announced_first_chunks() -> List[Any]:
+    """A grandchild whose first chunk precedes its parent sub-team's first chunk."""
+    inner = _team_kwargs("inner-team", "Inner Team", "run-inner", parent=TOP_LEVEL_RUN)
+    member = _member_kwargs("scout", "run-scout", parent="run-inner")
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        _agent_said("Scout first.", **member),
+        _team_said("Inner second.", **inner),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+def _grandchild_under_an_announced_parent_chunks() -> List[Any]:
+    """The same nesting, with the parent sub-team streaming before its member."""
+    inner = _team_kwargs("inner-team", "Inner Team", "run-inner", parent=TOP_LEVEL_RUN)
+    member = _member_kwargs("scout", "run-scout", parent="run-inner")
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        _team_said("Inner first.", **inner),
+        _agent_said("Scout second.", **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_grandchild_is_placed_under_a_parent_the_client_already_has(collect):
+    """A parent link resolves against an announcement the client has already read."""
+    events = await collect(_grandchild_under_an_announced_parent_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED, 2)
+    assert [(e.subagent_run_id, e.parent_subagent_run_id) for e in _announcements(events)] == [  # type: ignore[attr-defined]
+        ("run-inner", None),
+        ("run-scout", "run-inner"),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_grandchild_whose_parent_is_not_announced_yet_names_no_parent(collect):
+    """A forward reference is refused: no announcement names a lane the client lacks.
+
+    A grandchild's first event can outrun its parent's. Naming the parent anyway
+    hands the client a link it cannot resolve at the moment it reads it, which a
+    client validating the protocol rejects outright, so the lane is announced
+    with no parent and drawn directly under the run instead.
+    """
+    events = await collect(_grandchild_announced_first_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED, 2)
+    assert [(e.subagent_run_id, e.parent_subagent_run_id) for e in _announcements(events)] == [  # type: ignore[attr-defined]
+        ("run-scout", None),
+        ("run-inner", None),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_parent_this_stream_never_announces_is_not_well_formed(collect):
+    """A parent named but never announced is malformed, and the checker says so.
+
+    Driven by deleting one lane from a stream the interface really produced,
+    which is what a client would be left with if an announcement went missing:
+    the surviving child still names a parent, and nothing on the wire says what
+    that parent is.
+    """
+    events = await collect(_grandchild_under_an_announced_parent_chunks(), attributed())
+    without_the_parent = [event for event in events if _lane(event) != "run-inner"]
+
+    assert [e.subagent_run_id for e in _announcements(without_the_parent)] == ["run-scout"]  # type: ignore[attr-defined]
+    violation = stream_invariant_violation(without_the_parent)
+    assert violation is not None, "a parent no announcement names passed as a well-formed stream"
+    assert "names parent run-inner" in violation, violation
+    assert "never announces" in violation, violation
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_no_parent_is_reported_while_the_top_level_run_is_still_unknown(collect):
+    member = _member_kwargs("scout", "run-scout", parent="run-inner")
+
+    chunks = [
+        # No chunk reporting no parent has arrived yet, so the top-level run id
+        # is unknown and naming a parent would be a guess.
+        _agent_said("Scout first.", **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+    events = await collect(chunks, attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED)
+    assert [(e.subagent_run_id, e.parent_subagent_run_id) for e in _announcements(events)] == [("run-scout", None)]  # type: ignore[attr-defined]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_resumed_runs_member_is_not_mistaken_for_a_grandchild(collect):
+    """On resume the entity runs under the stored paused run's id, not the request's."""
+    stored = _team_kwargs("research-team", "Research Team", "stored-paused-run")
+    member = _member_kwargs("scout", "run-scout", parent="stored-paused-run")
+
+    chunks = [
+        TeamRunStartedEvent(**stored),
+        _agent_said("Scout resumed.", **member),
+        _team_said("Leader resumed.", **stored),
+        TeamRunCompletedEvent(**stored),
+    ]
+
+    # The request's run id differs from the stored paused run's on purpose.
+    events = await collect(chunks, attributed(), run_id="wire-run")
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED)
+    assert [(e.subagent_run_id, e.parent_subagent_run_id) for e in _announcements(events)] == [("run-scout", None)]  # type: ignore[attr-defined]
+    assert _messages_in_order(events) == [("Scout", "Scout resumed."), (None, "Leader resumed.")]
+
+
+def _grandchild_of_a_lane_announced_first_chunks() -> List[Any]:
+    """A sub-team's chunk opens the stream, and a member of that sub-team follows it.
+
+    No chunk reporting no parent has arrived, so the top-level run id is still
+    unknown when both lanes are announced.
+    """
+    inner = _team_kwargs("inner-team", "Inner Team", "run-inner", parent=TOP_LEVEL_RUN)
+    member = _member_kwargs("scout", "run-scout", parent="run-inner")
+
+    return [
+        TeamRunStartedEvent(**inner),
+        _agent_said("Scout first.", **member),
+        _team_said("Inner second.", **inner),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_lane_announced_before_the_top_level_run_is_known_still_parents_its_own_children(collect):
+    """An announced lane is one the top-level run cannot be confused with, known or not.
+
+    Reporting no parent for a member of it would flatten a grandchild into a
+    direct child of the top-level entity, which is a delegation tree the run
+    never had.
+    """
+    events = await collect(_grandchild_of_a_lane_announced_first_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED, 2)
+    assert [(e.subagent_run_id, e.parent_subagent_run_id) for e in _announcements(events)] == [  # type: ignore[attr-defined]
+        ("run-inner", None),
+        ("run-scout", "run-inner"),
+    ]
+    assert _messages_in_order(events) == [("Scout", "Scout first."), ("Inner Team", "Inner second.")]
+
+
+def _leader_tool_open_when_a_member_starts_chunks(tool: ToolExecution) -> List[Any]:
+    member = _member_kwargs("scout", "run-scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=tool),
+        RunStartedEvent(**member),
+        RunCompletedEvent(content="scout done", **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_leader_tool_that_is_not_a_delegation_is_never_reported_as_one(collect):
+    tool = ToolExecution(tool_call_id="tc-leader-search", tool_name="search_docs", tool_args={"query": "x"})
+
+    events = await collect(_leader_tool_open_when_a_member_starts_chunks(tool), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED)
+    assert [
+        (e.subagent_run_id, e.parent_tool_call_id, e.description, e.parent_message_id)  # type: ignore[attr-defined]
+        for e in _announcements(events)
+    ] == [("run-scout", None, None, None)]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_non_mapping_tool_arguments_do_not_break_the_announce_path(collect):
+    tool = ToolExecution(
+        tool_call_id="tc-weird",
+        tool_name="delegate_task_to_member",
+        tool_args="not a mapping",  # type: ignore[arg-type]
+    )
+
+    events = await collect(_leader_tool_open_when_a_member_starts_chunks(tool), attributed())
+
+    # Arguments that are not a mapping name no member, so the link is left out
+    # rather than guessed, and the run finishes either way.
+    assert [
+        (e.subagent_run_id, e.parent_tool_call_id, e.description)  # type: ignore[attr-defined]
+        for e in _announcements(events)
+    ] == [("run-scout", None, None)]
+    assert str(events[-1].type) == str(EventType.RUN_FINISHED)
+
+
+def _two_open_delegations_chunks(member_id: str, member_run: str) -> List[Any]:
+    """Two delegation calls open at once, then one member's first event arrives."""
+
+    def delegation(tool_call_id: str, target: str) -> ToolExecution:
+        return _delegation(tool_call_id, target, f"work for {target}")
+
+    member = _member_kwargs(member_id, member_run)
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=delegation("tc-alpha", "alpha")),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=delegation("tc-beta", "beta")),
+        RunStartedEvent(**member),
+        RunCompletedEvent(content=f"{member_id} done", **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_the_delegation_that_names_the_member_wins_when_several_are_open(collect):
+    events = await collect(_two_open_delegations_chunks("beta", "run-beta"), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED)
+    assert [
+        (e.subagent_run_id, e.parent_tool_call_id, e.description)  # type: ignore[attr-defined]
+        for e in _announcements(events)
+    ] == [("run-beta", "tc-beta", "work for beta")]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_the_delegation_link_is_omitted_rather_than_guessed_when_no_open_call_names_the_member(collect):
+    events = await collect(_two_open_delegations_chunks("gamma", "run-gamma"), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED)
+    # Two candidates, neither naming this member: the link is left out, not
+    # picked at random, and the description that would come with it goes too.
+    assert [
+        (e.subagent_run_id, e.parent_tool_call_id, e.description, e.parent_message_id)  # type: ignore[attr-defined]
+        for e in _announcements(events)
+    ] == [("run-gamma", None, None, None)]
+
+
+def _member_tool_changes_state_chunks(session_state: Dict[str, Any], member: Dict[str, Any]) -> List[Any]:
+    """A member runs two tools, each writing the team's shared session state.
+
+    The writes are side effects driven by iteration: the mapper snapshots the
+    state when the stream opens, so a write that happened while the chunk list
+    was being built would produce no delta at all. Two writes rather than one,
+    because one delta is the same whether or not the mapper banked the state it
+    just reported: only the second says the baseline moved with it.
+    """
+    approve = ToolExecution(tool_call_id="tc-member-approve", tool_name="approve", tool_args={}, result="ok")
+    notify = ToolExecution(tool_call_id="tc-member-notify", tool_name="notify", tool_args={}, result="sent")
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**member),
+        ToolCallStartedEvent(tool=approve, **member),
+        SideEffect(lambda: session_state.__setitem__("approved", True)),
+        ToolCallCompletedEvent(tool=approve, **member),
+        ToolCallStartedEvent(tool=notify, **member),
+        SideEffect(lambda: session_state.__setitem__("notified", True)),
+        ToolCallCompletedEvent(tool=notify, **member),
+        RunCompletedEvent(content="scout done", **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+# The two deltas that fixture produces, in order. The second is what shows the
+# mapper reports a change against the state it last sent rather than against the
+# state the stream opened on, which would repeat the first change inside it.
+_STATE_DELTAS_IN_ORDER = [
+    ([{"op": "replace", "path": "/approved", "value": True}],),
+    ([{"op": "add", "path": "/notified", "value": True}],),
+]
+
+
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_hidden_still_delivers_a_state_change_a_member_tool_made(collect):
+    session_state: Dict[str, Any] = {"approved": False}
+    member = _member_kwargs("scout", "run-scout")
+
+    events = await collect(
+        _member_tool_changes_state_chunks(session_state, member),
+        SUBAGENT_VISIBILITY_HIDDEN,
+        run_state=session_state,
+    )
+
+    assert_stream_contains(events, EventType.STATE_DELTA, 2)
+    assert in_emitted_order(events, EventType.STATE_DELTA, "delta") == _STATE_DELTAS_IN_ORDER
+    # The member's own tool call is withheld: this fixture holds no delegation
+    # call of the leader's, so nothing at all here is attributed or attributable.
+    assert not [e for e in events if "TOOL_CALL" in str(e.type)]
+    assert not [e for e in events if _lane(e) is not None]
+    assert not _messages_in_order(events)
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_state_events_are_never_attributed_to_the_member_that_changed_them(collect):
+    session_state: Dict[str, Any] = {"approved": False}
+    member = _member_kwargs("scout", "run-scout")
+
+    events = await collect(
+        _member_tool_changes_state_chunks(session_state, member),
+        attributed(),
+        run_state=session_state,
+    )
+
+    assert_stream_contains(events, EventType.STATE_DELTA, 2)
+    assert_stream_contains(events, EventType.STATE_SNAPSHOT)
+    # The changes were made inside a member lane, yet the state events carry no
+    # member: a team's session state is one shared document.
+    state_events = [e for e in events if str(e.type).removeprefix("EventType.").startswith("STATE_")]
+    assert [(str(e.type).removeprefix("EventType."), _lane(e)) for e in state_events] == [
+        ("STATE_DELTA", None),
+        ("STATE_DELTA", None),
+        ("STATE_SNAPSHOT", None),
+    ]
+    assert in_emitted_order(events, EventType.STATE_DELTA, "delta") == _STATE_DELTAS_IN_ORDER
+
+
+def _member_result_chunks(content: Any) -> List[Any]:
+    """One member whose run reports ``content`` as its result."""
+    member = _member_kwargs("scout", "run-scout")
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**member),
+        RunCompletedEvent(content=content, **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    # Built per case rather than at collection time, so the two mappers cannot
+    # hand each other a result one of them has already been through.
+    "content_factory,expected",
+    [
+        (lambda: {"headline": "found it", "sources": 3}, {"headline": "found it", "sources": 3}),
+        (lambda: ["a", "b"], ["a", "b"]),
+    ],
+    ids=["mapping", "sequence"],
+)
+@chunk_mappers
+async def test_a_non_text_member_result_is_serialized_rather_than_dropped(collect, content_factory, expected):
+    events = await collect(_member_result_chunks(content_factory()), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_FINISHED)
+    finished = _of_type(events, EventType.SUBAGENT_FINISHED)
+    assert [e.subagent_run_id for e in finished] == ["run-scout"]  # type: ignore[attr-defined]
+    assert json.loads(finished[0].result) == expected  # type: ignore[attr-defined]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_structured_member_result_is_serialized_rather_than_dropped(collect):
+    class Brief(BaseModel):
+        headline: str
+        sources: int
+
+    events = await collect(_member_result_chunks(Brief(headline="found it", sources=3)), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_FINISHED)
+    finished = _of_type(events, EventType.SUBAGENT_FINISHED)
+    assert json.loads(finished[0].result) == {"headline": "found it", "sources": 3}  # type: ignore[attr-defined]
+
+
+# --- Optional dependency diagnostics ----------------------------------------
+
+
+def _probe(script: str) -> str:
+    """Run a snippet in a fresh interpreter that can see this checkout."""
+    import os
+    import subprocess
+    import sys
+
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(path for path in sys.path if path)
+    result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True, env=env)
+    assert result.returncode == 0, result.stderr
+    return result.stdout
+
+
+def test_the_handlers_module_names_the_missing_optional_dependency():
+    output = _probe(
+        "import sys\n"
+        "sys.modules['ag_ui'] = None\n"
+        "sys.modules['ag_ui.core'] = None\n"
+        "try:\n"
+        "    import agno.os.interfaces.agui.handlers\n"
+        "except ImportError as error:\n"
+        "    print(error)\n"
+    )
+    assert "ag-ui-protocol" in output
+
+
+def test_missing_subagent_lineage_events_are_reported_at_debug_level():
+    output = _probe(
+        "import logging, sys\n"
+        "import agno.utils.log as agno_log\n"
+        "probe = logging.getLogger('probe')\n"
+        "probe.setLevel(logging.DEBUG)\n"
+        "handler = logging.StreamHandler(sys.stdout)\n"
+        # The level is written into the line, so the level itself is read back
+        # below rather than only the text, which any log helper would produce.
+        "handler.setFormatter(logging.Formatter('%(levelname)s %(message)s'))\n"
+        "probe.addHandler(handler)\n"
+        "agno_log.logger = probe\n"
+        "agno_log.debug_on = True\n"
+        "agno_log.debug_level = 1\n"
+        "import ag_ui.core as core\n"
+        "for name in ('SubagentStartedEvent', 'SubagentFinishedEvent', 'SubagentErrorEvent'):\n"
+        # Conditional, because the install this probe describes is exactly the
+        # one where these are already absent.
+        "    if hasattr(core, name):\n"
+        "        delattr(core, name)\n"
+        "import agno.os.interfaces.agui.handlers as probed\n"
+        "print('AVAILABLE', probed.SUBAGENT_EVENTS_AVAILABLE)\n"
+    )
+    assert "AVAILABLE False" in output
+    reported = [line for line in output.splitlines() if "ag-ui-protocol" in line]
+    assert reported, f"the missing lineage events were reported nowhere: {output}"
+    assert all(line.startswith("DEBUG ") for line in reported), reported
+
+
+# --- Which tool call is the delegation --------------------------------------
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_leader_tool_that_merely_takes_a_task_is_not_read_as_the_delegation(collect):
+    """Agno's own ``update_user_memory`` takes a ``task``, and is not a delegation."""
+    tool = ToolExecution(
+        tool_call_id="tc-memory",
+        tool_name="update_user_memory",
+        tool_args={"task": "the user likes brevity"},
+    )
+
+    events = await collect(_leader_tool_open_when_a_member_starts_chunks(tool), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED)
+    assert [
+        (e.subagent_run_id, e.parent_tool_call_id, e.description, e.parent_message_id)  # type: ignore[attr-defined]
+        for e in _announcements(events)
+    ] == [("run-scout", None, None, None)]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    # The two tasks-mode delegation tools differ in what they name: one takes
+    # the member it hands the task to, the other takes only task ids, so only
+    # the first can be shown to have spawned this member.
+    "tool_name,tool_args,links",
+    [
+        ("execute_task", {"task_id": "t-1", "member_id": "scout"}, True),
+        ("execute_tasks_parallel", {"task_ids": ["t-1"]}, False),
+    ],
+    ids=["execute_task", "execute_tasks_parallel"],
+)
+@chunk_mappers
+async def test_a_tasks_mode_delegation_links_the_member_it_names(collect, tool_name, tool_args, links):
+    tool = ToolExecution(tool_call_id="tc-task", tool_name=tool_name, tool_args=tool_args)
+
+    events = await collect(_leader_tool_open_when_a_member_starts_chunks(tool), attributed())
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED)
+    parent_of_tool_call = {
+        e.tool_call_id: e.parent_message_id  # type: ignore[attr-defined]
+        for e in _of_type(events, EventType.TOOL_CALL_START)
+    }
+
+    # A tasks-mode delegation carries no task text, so a link it does report
+    # comes without a description rather than with an invented one. The parent
+    # message it names has to be one this stream really opened: read back as
+    # None on both sides, that field compares nothing.
+    parent_message = parent_of_tool_call["tc-task"]
+    if links:
+        assert parent_message in _lane_of_message_id(events), parent_message
+    expected = ("tc-task", None, parent_message) if links else (None, None, None)
+    assert [
+        (e.subagent_run_id, e.parent_tool_call_id, e.description, e.parent_message_id)  # type: ignore[attr-defined]
+        for e in _announcements(events)
+    ] == [("run-scout", *expected)]
+
+
+def test_an_open_tool_call_is_recorded_under_its_tool_name():
+    """The name is a required part of the record, so a reader cannot fall back to argument shape."""
+    delegating = StreamState(subagent_visibility=attributed())
+    delegating.record_open_tool_call("tc-1", "delegate_task_to_member", {"member_id": "scout", "task": "go"}, "m-1")
+    assert delegating.find_delegation_call(ROOT_LANE, "scout") == "tc-1"
+    assert delegating.delegation_task(ROOT_LANE, "tc-1") == "go"
+
+    # The unrelated call names a member, so the lookup is asked for that member
+    # rather than for nothing: given a falsy member id it answers None without
+    # ever reading the record, which is true of any tool at all.
+    unrelated = StreamState(subagent_visibility=attributed())
+    unrelated.record_open_tool_call("tc-2", "update_user_memory", {"member_id": "scout", "task": "remember"}, "m-1")
+    assert unrelated.find_delegation_call(ROOT_LANE, "scout") is None
+    assert unrelated.delegation_task(ROOT_LANE, "tc-2") is None
+
+
+def _delegation_args(member: str) -> Dict[str, Any]:
+    return {"member_id": member, "task": f"{member}, do the leader's task"}
+
+
+def _state_with_a_delegation_in_every_kind_of_lane() -> StreamState:
+    """A state where the root lane and two member lanes each hold a delegation to ``scout``.
+
+    Three lanes, so a lookup that reaches past the lane it was asked about lands
+    on somebody else's call rather than on nothing.
+    """
+    state = StreamState(subagent_visibility=attributed())
+    state.resolve_lane(TOP_LEVEL_RUN, None)
+    state.record_open_tool_call("tc-root", "delegate_task_to_member", _delegation_args("scout"), "m-root")
+
+    for run_id, tool_call_id in (("run-open", "tc-open"), ("run-closed", "tc-closed")):
+        state.open_subagent(run_id, name=run_id, parent_lane=ROOT_LANE)
+        state.current_lane = run_id
+        state.record_open_tool_call(tool_call_id, "delegate_task_to_member", _delegation_args("scout"), f"m-{run_id}")
+    state.close_subagent("run-closed")
+    state.current_lane = ROOT_LANE
+    return state
+
+
+# "No lane can be named" is spelled with a marker of its own rather than with
+# None, which is what the root lane is spelled with: written as None the two
+# expectations would be one, and a case expecting no lane would pass on an
+# answer of the root lane's own delegation call.
+_UNNAMEABLE = "<no lane can be named>"
+
+# The parent kinds this module drives, one per state a named run can be in as
+# far as the lane table is concerned, and the lane each resolves to. Written out
+# rather than derived from anything, so it is what is covered rather than a
+# proof that nothing else exists: the property below is stated over all of them
+# so that a new reason a lane cannot be named inherits the check, but a kind
+# nobody adds here still goes undriven.
+_PARENTS_A_CHUNK_CAN_NAME: Dict[str, Tuple[Optional[str], Optional[str]]] = {
+    "no parent at all": (None, ROOT_LANE),
+    "the top-level run": (TOP_LEVEL_RUN, ROOT_LANE),
+    "an announced lane still open": ("run-open", "run-open"),
+    "an announced lane already terminated": ("run-closed", _UNNAMEABLE),
+    "a lane this stream has never announced": ("run-unheard-of", _UNNAMEABLE),
+}
+
+
+@needs_lineage_events
+@pytest.mark.parametrize("parent", sorted(_PARENTS_A_CHUNK_CAN_NAME), ids=sorted(_PARENTS_A_CHUNK_CAN_NAME))
+def test_a_delegation_link_is_only_ever_read_from_the_parents_own_lane(parent):
+    """Whatever lane comes back, the call beside it belongs to that lane and to that parent.
+
+    Stated over each of the parent kinds above rather than over the one that was
+    reported, and as a property rather than as an expected pair, so a new reason
+    a lane cannot be named inherits the check instead of needing a case of its
+    own. What it forbids is the reach: answering with the top-level
+    entity's own open call for a parent that is not the top-level entity, which
+    hands a grandchild the leader's call, the leader's parent message and the
+    leader's task text as its own description.
+    """
+    parent_run_id, resolves_to = _PARENTS_A_CHUNK_CAN_NAME[parent]
+    state = _state_with_a_delegation_in_every_kind_of_lane()
+
+    lane, delegation_call_id = state.delegating_lane_for(parent_run_id, "scout")
+
+    if resolves_to == _UNNAMEABLE:
+        assert (lane, delegation_call_id) == (None, None)
+        assert state.delegation_task(lane, delegation_call_id) is None
+        assert state.delegation_parent_message_id(lane, delegation_call_id) is None
+        return
+    assert lane == resolves_to
+    assert delegation_call_id in (state.open_tool_calls.get(lane) or {}), (
+        f"the call reported for {parent} belongs to some other lane"
+    )
+
+
+def _grandchild_whose_parent_was_never_announced_chunks() -> List[Any]:
+    """A member appears under an inner team's run that this stream never saw start.
+
+    The leader's own delegation names the same member id, which is what makes
+    the reach visible: reaching past for it hands this member the leader's call.
+    """
+    delegation = _delegation("tc-delegate-scout", **_delegation_args("scout"))
+    grandchild = _member_kwargs("scout", "run-grandchild", parent="run-inner-team")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamToolCallStartedEvent(tool=delegation, **_TOP_LEVEL),
+        _agent_said("Reporting in.", **grandchild),
+        RunCompletedEvent(content="done", **grandchild),
+        _team_said("Final synthesis.", **_TOP_LEVEL),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_member_under_an_unannounced_parent_carries_no_part_of_the_leaders_delegation(collect):
+    """No parent means no parent call, no parent message and no description either.
+
+    All three are read off the delegating lane's own open calls, so a lane that
+    cannot be named leaves the announcement with none of them. Asserted on the
+    payload, because the reported symptom was an announcement reporting no
+    parent lane while carrying the leader's call id, the leader's parent message
+    and the leader's task text.
+    """
+    events = await collect(_grandchild_whose_parent_was_never_announced_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED)
+    assert [
+        (
+            e.subagent_run_id,  # type: ignore[attr-defined]
+            e.parent_subagent_run_id,  # type: ignore[attr-defined]
+            e.parent_tool_call_id,  # type: ignore[attr-defined]
+            e.parent_message_id,  # type: ignore[attr-defined]
+            e.description,  # type: ignore[attr-defined]
+        )
+        for e in _announcements(events)
+    ] == [("run-grandchild", None, None, None, None)]
+    # The leader's own delegation call is still on the wire as the leader's.
+    assert _tool_call_lanes_in_order(events) == [("tc-delegate-scout", None)]
+
+
+# --- Paused members ---------------------------------------------------------
+
+
+def _paused_on_two_members_chunks() -> List[Any]:
+    """One pause waiting on a pending call from each of two different members."""
+
+    def requirement(member: str, run: str, tool_call_id: str, tool_name: str) -> RunRequirement:
+        return _requirement(
+            ToolExecution(
+                tool_call_id=tool_call_id,
+                tool_name=tool_name,
+                tool_args={"for": member},
+                requires_confirmation=True,
+            ),
+            member,
+            run,
+            member.capitalize(),
+        )
+
+    def delegation(member: str) -> ToolExecution:
+        return _delegation(f"tc-delegate-{member}", member, f"{member} it")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamToolCallStartedEvent(tool=delegation("scout"), **_TOP_LEVEL),
+        TeamToolCallStartedEvent(tool=delegation("writer"), **_TOP_LEVEL),
+        TeamRunPausedEvent(
+            tools=[],
+            requirements=[
+                requirement("scout", "run-scout", "tc-scout-confirm", "send_email"),
+                requirement("writer", "run-writer", "tc-writer-confirm", "publish"),
+            ],
+            **_TOP_LEVEL,
+        ),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_pause_waiting_on_two_members_gives_each_a_message_of_its_own(collect):
+    """One message cannot name two members, so the prompt is split per member.
+
+    A tool call belongs to the message that carries it, so the two have to agree
+    about whose call it is. With pending calls from two members under one
+    message they cannot, whichever member that message were stamped with.
+    """
+    events = await collect(_paused_on_two_members_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.TEXT_MESSAGE_START, 2)
+    assert _tool_call_lanes_in_order(events) == [
+        ("tc-delegate-scout", None),
+        ("tc-delegate-writer", None),
+        ("tc-scout-confirm", "run-scout"),
+        ("tc-writer-confirm", "run-writer"),
+    ]
+
+    lane_of_message = _lane_of_message_id(events)
+    assert [
+        (e.tool_call_id, _lane(e), lane_of_message[e.parent_message_id])  # type: ignore[attr-defined]
+        for e in _of_type(events, EventType.TOOL_CALL_START)
+        if _lane(e) is not None
+    ] == [
+        ("tc-scout-confirm", "run-scout", "run-scout"),
+        ("tc-writer-confirm", "run-writer", "run-writer"),
+    ]
+
+
+# The events that open or close a message or a tool call. One of these landing
+# inside somebody else's open span is a nesting a validating client rejects.
+#
+# Nothing else is read. RAW and CUSTOM are opaque passthroughs the source stream
+# interleaves wherever it likes, and a delegation stays open for as long as the
+# member it spawned is producing them. A member's announcement belongs inside
+# that delegation too: the call it names in ``parentToolCallId`` is exactly the
+# one still open around it.
+_SPAN_LIFECYCLE_EVENTS = frozenset({"TEXT_MESSAGE_START", "TEXT_MESSAGE_END", "TOOL_CALL_START", "TOOL_CALL_END"})
+
+
+def _spans_a_prompt_opens_inside(events: List[BaseEvent]) -> List[Tuple[str, str]]:
+    """(what was emitted, what it landed inside) for every span event nested in another."""
+    nested: List[Tuple[str, str]] = []
+    open_messages: Set[str] = set()
+    open_tool_calls: Set[str] = set()
+    for event in events:
+        kind = str(event.type).removeprefix("EventType.")
+        own_message = getattr(event, "message_id", None)
+        own_call = getattr(event, "tool_call_id", None)
+        if kind in _SPAN_LIFECYCLE_EVENTS:
+            nested.extend(
+                (kind, f"TOOL_CALL {tool_call_id}") for tool_call_id in open_tool_calls if tool_call_id != own_call
+            )
+            nested.extend(
+                (kind, f"TEXT_MESSAGE {message_id}") for message_id in open_messages if message_id != own_message
+            )
+        if kind == "TEXT_MESSAGE_START":
+            open_messages.add(event.message_id)  # type: ignore[attr-defined]
+        elif kind == "TEXT_MESSAGE_END":
+            open_messages.discard(event.message_id)  # type: ignore[attr-defined]
+        elif kind == "TOOL_CALL_START":
+            open_tool_calls.add(event.tool_call_id)  # type: ignore[attr-defined]
+        elif kind == "TOOL_CALL_END":
+            open_tool_calls.discard(event.tool_call_id)  # type: ignore[attr-defined]
+    return nested
+
+
+def _paused_inside_one_open_delegation_chunks() -> List[Any]:
+    """The run pauses on a member's call with the delegation that spawned it still open."""
+    delegation = _delegation("tc-delegate-scout", "scout", "scout it")
+    requirement = _requirement(
+        ToolExecution(
+            tool_call_id="tc-scout-confirm",
+            tool_name="send_email",
+            tool_args={"to": "ops"},
+            requires_confirmation=True,
+        ),
+        "scout",
+        "run-scout",
+        "Scout",
+    )
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamToolCallStartedEvent(tool=delegation, **_TOP_LEVEL),
+        RunStartedEvent(**_member_kwargs("scout", "run-scout")),
+        TeamRunPausedEvent(tools=[], requirements=[requirement], **_TOP_LEVEL),
+    ]
+
+
+@pytest.mark.asyncio
+@chunk_mappers
+@pytest.mark.parametrize(
+    "setting",
+    [lambda: SUBAGENT_VISIBILITY_INLINE, attributed, lambda: SUBAGENT_VISIBILITY_HIDDEN],
+    ids=["inline", "attributed", "hidden"],
+)
+async def test_a_pause_prompt_never_lands_inside_a_span_whichever_setting_is_set(collect, setting):
+    """The three settings agree about nesting: the prompt goes out with nothing open.
+
+    The leader's delegation call is open when the run pauses, and the prompt
+    opens a message and a tool call of its own. A tool call carries only its own
+    arguments and its end between start and end, so those have to follow the
+    delegation's close, and they have to follow it under every setting: a client
+    reading one stream correctly and another not is the same defect twice.
+    """
+    events = await collect(_paused_inside_one_open_delegation_chunks(), setting())
+
+    assert_stream_contains(events, EventType.TOOL_CALL_START, 2)
+    assert _spans_a_prompt_opens_inside(events) == []
+
+
+def _paused_member_that_never_streamed_chunks() -> List[Any]:
+    """A member pauses without ever having emitted an event of its own."""
+    member_tool = ToolExecution(
+        tool_call_id="tc-ghost-confirm",
+        tool_name="send_email",
+        tool_args={"to": "ops"},
+        requires_confirmation=True,
+    )
+    requirement = _requirement(member_tool, "ghost", "run-ghost", "Ghost")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamRunPausedEvent(tools=[], requirements=[requirement], **_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_paused_members_lane_is_announced_before_anything_carries_it(collect):
+    events = await collect(_paused_member_that_never_streamed_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.TOOL_CALL_START)
+    assert _tool_call_lanes_in_order(events) == [("tc-ghost-confirm", "run-ghost")]
+    assert [(e.subagent_run_id, e.name) for e in _announcements(events)] == [("run-ghost", "Ghost")]  # type: ignore[attr-defined]
+    # A start and a terminal around the message and the tool call the client has
+    # to render, both on the member's own lane so the two agree about whose call
+    # it is.
+    assert _lane_sequence(events, "run-ghost") == [
+        "SUBAGENT_STARTED",
+        "TEXT_MESSAGE_START",
+        "TEXT_MESSAGE_END",
+        "TOOL_CALL_START",
+        "TOOL_CALL_ARGS",
+        "TOOL_CALL_END",
+        "SUBAGENT_FINISHED",
+    ]
+    carrying = [e.parent_message_id for e in _of_type(events, EventType.TOOL_CALL_START)]  # type: ignore[attr-defined]
+    assert [_lane_of_message_id(events)[message_id] for message_id in carrying] == ["run-ghost"]
+
+
+def _paused_tool_listed_in_both_places_chunks() -> List[Any]:
+    """One paused tool call reported both on the terminal event and in a member's requirement."""
+    shared = ToolExecution(
+        tool_call_id="tc-shared-confirm",
+        tool_name="send_email",
+        tool_args={"to": "ops"},
+        requires_confirmation=True,
+    )
+    requirement = _requirement(shared, "scout", "run-scout", "Scout")
+    member = _member_kwargs("scout", "run-scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**member),
+        TeamRunPausedEvent(tools=[shared], requirements=[requirement], **_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_paused_tool_listed_twice_is_prompted_once_on_its_members_lane(collect):
+    events = await collect(_paused_tool_listed_in_both_places_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.TOOL_CALL_START)
+    assert _tool_call_lanes_in_order(events) == [("tc-shared-confirm", "run-scout")]
+    assert in_emitted_order(events, EventType.TOOL_CALL_END, "tool_call_id", _lane) == [
+        ("tc-shared-confirm", "run-scout")
+    ]
+
+
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_hidden_prompts_a_paused_tool_listed_twice_once_and_names_no_member(collect):
+    """Hidden de-duplicates the prompt as attributed does, without attributing it.
+
+    Only the default keeps the duplicate, because only the default's stream has
+    to be what it was before member attribution existed.
+    """
+    events = await collect(_paused_tool_listed_in_both_places_chunks(), SUBAGENT_VISIBILITY_HIDDEN)
+
+    assert_stream_contains(events, EventType.TOOL_CALL_START)
+    assert _tool_call_lanes_in_order(events) == [("tc-shared-confirm", None)]
+    assert in_emitted_order(events, EventType.TOOL_CALL_END, "tool_call_id", _lane) == [("tc-shared-confirm", None)]
+    assert not [e for e in events if "SUBAGENT" in str(e.type)]
+    assert not [e for e in events if _lane(e) is not None]
+
+
+def _pause_while_a_member_tool_is_still_running_chunks() -> List[Any]:
+    """A member's own tool call is open, and the run pauses on the leader's instead."""
+    member = _member_kwargs("scout", "run-scout")
+    working = ToolExecution(tool_call_id="tc-scout-work", tool_name="search_docs", tool_args={"query": "agno"})
+    leader_tool = ToolExecution(
+        tool_call_id="tc-leader-confirm", tool_name="publish", tool_args={"channel": "blog"}, requires_confirmation=True
+    )
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**member),
+        ToolCallStartedEvent(tool=working, **member),
+        TeamRunPausedEvent(tools=[leader_tool], **_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_pause_still_closes_a_member_tool_call_left_running(collect):
+    """A pause ends the run's stream, so a member call nobody is waiting on still needs an end.
+
+    A member's terminal ends no tool call, so the end is written by the run's
+    final sweep. The sweep runs before that member's terminal, so the call is
+    put away while its lane is still open, and it is still the member's call,
+    which is what the client needs to put it away.
+    """
+    events = await collect(_pause_while_a_member_tool_is_still_running_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_FINISHED)
+    assert _tool_call_lanes_in_order(events) == [("tc-scout-work", "run-scout"), ("tc-leader-confirm", None)]
+    assert in_emitted_order(events, EventType.TOOL_CALL_END, "tool_call_id", _lane) == [
+        ("tc-scout-work", "run-scout"),
+        ("tc-leader-confirm", None),
+    ]
+    # The member's own call carries no result: it never reported one.
+    assert not _of_type(events, EventType.TOOL_CALL_RESULT)
+    assert str(events[-1].type) == str(EventType.RUN_FINISHED)
+
+
+def _pause_naming_a_member_that_already_terminated_chunks() -> List[Any]:
+    """The paused requirement names a member whose own terminal has already gone out."""
+    member = _member_kwargs("scout", "run-scout")
+    late = ToolExecution(
+        tool_call_id="tc-late-confirm", tool_name="send_email", tool_args={"to": "ops"}, requires_confirmation=True
+    )
+    requirement = _requirement(late, "scout", "run-scout", "Scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**member),
+        RunCompletedEvent(content="scout done", **member),
+        TeamRunPausedEvent(tools=[], requirements=[requirement], **_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_pause_naming_a_closed_member_prompts_on_the_root_lane(collect):
+    """A terminal is final for the id it names, so the prompt cannot be put in that lane.
+
+    Stamping it there would hand the client a tool call inside a member it has
+    already closed, and announcing the lane again would give one invocation two
+    lifecycles. The prompt goes out unattributed instead, which is a call the
+    client can still render and answer.
+    """
+    events = await collect(_pause_naming_a_member_that_already_terminated_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.TOOL_CALL_START)
+    assert _tool_call_lanes_in_order(events) == [("tc-late-confirm", None)]
+    assert [e.subagent_run_id for e in _announcements(events)] == ["run-scout"]  # type: ignore[attr-defined]
+    assert in_emitted_order(events, EventType.SUBAGENT_FINISHED, "subagent_run_id") == [("run-scout",)]
+    assert str(events[-1].type) == str(EventType.RUN_FINISHED)
+
+
+def _paused_member_with_nothing_to_show_chunks() -> List[Any]:
+    """A member pauses on a tool the client cannot be shown: it carries no name.
+
+    The pause carries the run's own words, as a real one does, so what the client
+    is left with when the call is dropped is a message that says why the run
+    stopped rather than an empty bubble.
+    """
+    nameless = _nameless_tool()
+    requirement = _requirement(nameless, "ghost", "run-ghost", "Ghost")
+    paused = TeamRunPausedEvent(tools=[], requirements=[requirement], **_TOP_LEVEL)
+    paused.content = "Waiting on an approval."
+
+    return [TeamRunStartedEvent(**_TOP_LEVEL), paused]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_lane_is_not_announced_when_the_prompt_it_was_for_is_dropped(collect):
+    """A dropped prompt must not leave the client a terminal for a member it never saw start."""
+    events = await collect(_paused_member_with_nothing_to_show_chunks(), attributed())
+
+    assert not [e for e in events if "SUBAGENT" in str(e.type)]
+    assert not [e for e in events if _lane(e) is not None]
+    assert not _of_type(events, EventType.TOOL_CALL_START)
+    assert str(events[-1].type) == str(EventType.RUN_FINISHED)
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_pause_the_client_cannot_act_on_is_recorded(collect, caplog):
+    """A pause prompting nothing has to be logged, and as the kind of pause it is.
+
+    Here the terminal listed a pending call and the client cannot be shown it,
+    so the client is told the run is waiting and given nothing to answer with.
+    That is not the same as a terminal that listed nothing, which is the case
+    below, so the two do not share a line.
+    """
+    with captured_agno_logs(caplog, "WARNING"):
+        events = await collect(_paused_member_with_nothing_to_show_chunks(), attributed())
+
+    assert not _of_type(events, EventType.TOOL_CALL_START)
+    assert_stream_contains(events, EventType.TEXT_MESSAGE_CONTENT)
+    # The joined text, not merely that a message opened: an empty bubble tells
+    # the client nothing about why the run stopped. Unattributed, because the
+    # lane the prompt was for is not announced when its call is dropped.
+    assert joined_text_in_emitted_order(events) == [(None, "Waiting on an approval.")]
+    # Matched on a phrase the line about the dropped call itself does not carry,
+    # so this cannot pass on that one instead.
+    assert [r.message for r in caplog.records if "the run is waiting" in r.message], (
+        "a pause the client was told about but cannot answer left no trace at all"
+    )
+
+
+def _paused_listing_no_pending_call_chunks() -> List[Any]:
+    """A run pauses without listing a pending tool call at all."""
+    paused = AgentRunPausedEvent(agent_id="solo", agent_name="Solo", run_id=TOP_LEVEL_RUN, tools=[])
+    paused.content = "Confirm before I send this."
+
+    return [RunStartedEvent(agent_id="solo", agent_name="Solo", run_id=TOP_LEVEL_RUN), paused]
+
+
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_pause_that_lists_nothing_reaches_the_client_as_a_finished_run_and_says_so(collect, caplog):
+    """Nothing announces this pause, so the log is the only place it exists.
+
+    The prompt turns on the terminal having listed a pending call at all, which
+    this one did not, so the pause's own content goes out nowhere either. A
+    terminal that listed a call the client cannot be shown still carries the
+    content, which is the pre-change stream and is pinned separately.
+
+    Driven on the default visibility: no member is involved, so this is a run
+    any supported protocol release serves.
+    """
+    chunks = _paused_listing_no_pending_call_chunks()
+    # The pause does carry content, so the silence below is that content being
+    # dropped rather than a fixture with nothing to say.
+    assert any(getattr(chunk, "content", None) for chunk in chunks)
+    with captured_agno_logs(caplog, "WARNING"):
+        events = await collect(chunks)
+
+    assert_stream_carries_exactly(events, EventType.TEXT_MESSAGE_START, 0)
+    assert not _of_type(events, EventType.TOOL_CALL_START)
+    assert str(events[-1].type) == str(EventType.RUN_FINISHED)
+    assert [r.message for r in caplog.records if "plain finished run" in r.message], (
+        "a pause the client cannot tell from a completion left no trace at all"
+    )
+
+
+def _paused_member_carrying_one_unusable_tool_chunks(unusable: ToolExecution) -> List[Any]:
+    """Two members pause, and one of them waits on a tool the client cannot be shown."""
+    ghost = _requirement(unusable, "ghost", "run-ghost", "Ghost")
+
+    usable = ToolExecution(
+        tool_call_id="tc-scout-confirm", tool_name="send_email", tool_args={"to": "ops"}, requires_confirmation=True
+    )
+    scout = _requirement(usable, "scout", "run-scout", "Scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamRunPausedEvent(tools=[], requirements=[ghost, scout], **_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_only_the_members_the_prompt_names_are_announced(collect):
+    """A lane the prompt carries nothing for tells the client about a member it never hears from."""
+    events = await collect(_paused_member_carrying_one_unusable_tool_chunks(_nameless_tool()), attributed())
+
+    assert_stream_contains(events, EventType.TOOL_CALL_START)
+    assert [(e.subagent_run_id, e.name) for e in _announcements(events)] == [("run-scout", "Scout")]  # type: ignore[attr-defined]
+    assert _tool_call_lanes_in_order(events) == [("tc-scout-confirm", "run-scout")]
+
+
+def _paused_tool_that_already_completed_chunks() -> List[Any]:
+    """The paused requirement repeats a member tool call that already streamed to its end."""
+    member = _member_kwargs("scout", "run-scout")
+    streamed = ToolExecution(tool_call_id="tc-member-search", tool_name="search_docs", tool_args={"query": "agno"})
+    completed = ToolExecution(
+        tool_call_id="tc-member-search", tool_name="search_docs", tool_args={"query": "agno"}, result="three sources"
+    )
+    repeated = ToolExecution(
+        tool_call_id="tc-member-search",
+        tool_name="search_docs",
+        tool_args={"query": "agno"},
+        requires_confirmation=True,
+    )
+    requirement = _requirement(repeated, "scout", "run-scout", "Scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**member),
+        ToolCallStartedEvent(tool=streamed, **member),
+        ToolCallCompletedEvent(tool=completed, **member),
+        TeamRunPausedEvent(tools=[], requirements=[requirement], **_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_paused_tool_that_already_ended_is_not_given_a_second_lifecycle(collect):
+    events = await collect(_paused_tool_that_already_completed_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.TOOL_CALL_RESULT)
+    assert in_emitted_order(events, EventType.TOOL_CALL_START, "tool_call_id", _lane) == [
+        ("tc-member-search", "run-scout")
+    ]
+    assert in_emitted_order(events, EventType.TOOL_CALL_END, "tool_call_id", _lane) == [
+        ("tc-member-search", "run-scout")
+    ]
+
+
+def _paused_grandchild_chunks() -> List[Any]:
+    """A sub-team's member pauses, and the requirement reaches the top-level terminal."""
+    inner = _team_kwargs("inner-team", "Inner Team", "run-inner", parent=TOP_LEVEL_RUN)
+    outer_delegation = _delegation("tc-delegate-inner", "inner-team", "run the inner team")
+    inner_delegation = _delegation("tc-delegate-scout", "scout", "scout the topic")
+    member_tool = ToolExecution(
+        tool_call_id="tc-scout-confirm",
+        tool_name="send_email",
+        tool_args={"to": "ops"},
+        requires_confirmation=True,
+    )
+    requirement = _requirement(member_tool, "scout", "run-scout", "Scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=outer_delegation),
+        TeamRunStartedEvent(**inner),
+        TeamToolCallStartedEvent(tool=inner_delegation, **inner),
+        TeamRunPausedEvent(tools=[], requirements=[requirement], **_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_paused_grandchild_is_announced_under_the_member_that_delegated_to_it(collect):
+    events = await collect(_paused_grandchild_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED, 2)
+    assert [
+        (e.subagent_run_id, e.parent_subagent_run_id, e.parent_tool_call_id, e.description)  # type: ignore[attr-defined]
+        for e in _announcements(events)
+    ] == [
+        ("run-inner", None, "tc-delegate-inner", "run the inner team"),
+        ("run-scout", "run-inner", "tc-delegate-scout", "scout the topic"),
+    ]
+    # The grandchild resolves inside its real parent, so its terminal comes first.
+    assert in_emitted_order(events, EventType.SUBAGENT_FINISHED, "subagent_run_id") == [("run-scout",), ("run-inner",)]
+
+
+def _paused_inner_agent_chunks() -> List[Any]:
+    """A single Agent pauses on a tool call its own inner agent is waiting on.
+
+    An agent that runs an inner agent reports what that run is waiting on the
+    way a team reports a member's: on the paused event's requirements, which
+    name the run waiting and carry the pending call itself.
+    """
+    outer = {"agent_id": "assistant", "agent_name": "Assistant", "run_id": TOP_LEVEL_RUN}
+    inner_tool = ToolExecution(
+        tool_call_id="tc-inner-confirm",
+        tool_name="send_email",
+        tool_args={"to": "ops"},
+        requires_confirmation=True,
+    )
+    requirement = _requirement(inner_tool, "memory-agent", "run-inner-agent", "Memory")
+
+    return [
+        RunStartedEvent(**outer),
+        AgentRunPausedEvent(tools=[], requirements=[requirement], **outer),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_paused_inner_agents_pending_tool_call_is_prompted_on_its_own_lane(collect):
+    """The run cannot be resumed past a call the client was never shown."""
+    events = await collect(_paused_inner_agent_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED)
+    assert [(e.subagent_run_id, e.name) for e in _announcements(events)] == [("run-inner-agent", "Memory")]  # type: ignore[attr-defined]
+    assert _tool_call_lanes_in_order(events) == [("tc-inner-confirm", "run-inner-agent")]
+    assert in_emitted_order(events, EventType.TOOL_CALL_ARGS, "tool_call_id", lambda e: json.loads(e.delta)) == [
+        ("tc-inner-confirm", {"to": "ops"})
+    ]
+    assert str(events[-1].type) == str(EventType.RUN_FINISHED)
+
+
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_paused_inner_agents_pending_tool_call_reaches_the_client_unattributed_too(collect):
+    """Hidden does not name the inner run and still has to render the call it is waiting on."""
+    events = await collect(_paused_inner_agent_chunks(), SUBAGENT_VISIBILITY_HIDDEN)
+
+    assert_stream_contains(events, EventType.TOOL_CALL_START)
+    assert _tool_call_lanes_in_order(events) == [("tc-inner-confirm", None)]
+    assert in_emitted_order(events, EventType.TOOL_CALL_ARGS, "tool_call_id", lambda e: json.loads(e.delta)) == [
+        ("tc-inner-confirm", {"to": "ops"})
+    ]
+    assert not [e for e in events if "SUBAGENT" in str(e.type)]
+
+
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_the_default_prompts_nothing_for_an_agent_pause_reported_only_through_requirements(collect):
+    """The default stream is the pre-change one, which read requirements on a team's pause only.
+
+    Losing the call is a real defect, and it is the pre-change default's, not
+    this one's: the default is defined as that stream, so the pending call
+    reaching the wire here would be a tool call a released client never
+    received, and one it may auto-execute.
+    """
+    expected = [
+        (str(EventType.RAW), {"event": "RunStarted"}),
+        (str(EventType.RUN_FINISHED), {"threadId": THREAD_ID, "runId": TOP_LEVEL_RUN}),
+    ]
+
+    assert _normalized_payloads(await collect(_paused_inner_agent_chunks())) == expected
+    assert _normalized_payloads(await collect(_paused_inner_agent_chunks(), SUBAGENT_VISIBILITY_INLINE)) == expected
+
+
+# --- A lane whose terminal has already gone out -----------------------------
+
+_INNER_TEAM = _team_kwargs("inner-team", "Inner Team", "run-inner", parent=TOP_LEVEL_RUN)
+
+
+def _sub_team_that_finished_holding_its_delegation_chunks(*tail: Any) -> List[Any]:
+    """A sub-team reaches its own terminal with the delegation it made still open.
+
+    A lane's terminal ends none of its tool calls, so that delegation outlives
+    the lane, and it is the only open call naming the member below it.
+    """
+    delegation = _delegation("tc-delegate-scout", "scout", "scout the topic")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamRunStartedEvent(**_INNER_TEAM),
+        TeamToolCallStartedEvent(tool=delegation, **_INNER_TEAM),
+        TeamRunCompletedEvent(content="inner done", **_INNER_TEAM),
+        *tail,
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_member_that_starts_after_its_parent_lane_terminated_is_not_announced_under_it(collect):
+    """A lane the client has already closed can neither gain a child nor resolve after one."""
+    member = _member_kwargs("scout", "run-scout", parent="run-inner")
+    chunks = _sub_team_that_finished_holding_its_delegation_chunks(
+        _agent_said("Scout speaking.", **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    )
+
+    # The delegation the sub-team left open is ended by the run-end sweep, which
+    # is after that lane's own terminal: a lane's terminal ends no tool call.
+    events = await collect(chunks, attributed(), exempt=[TRAILING_OUTPUT_AFTER_A_MEMBER_TERMINAL])
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED, 2)
+    assert [
+        (e.subagent_run_id, e.parent_subagent_run_id, e.parent_tool_call_id, e.description)  # type: ignore[attr-defined]
+        for e in _announcements(events)
+    ] == [("run-inner", None, None, None), ("run-scout", None, None, None)]
+    # The empty entry is the sub-team's own parent message for its delegation.
+    assert _messages_in_order(events) == [("Inner Team", ""), ("Scout", "Scout speaking.")]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_paused_member_is_not_announced_under_a_parent_lane_that_terminated(collect):
+    """The delegation that named the member outlives the lane that made it, and cannot speak for it."""
+    tool = ToolExecution(
+        tool_call_id="tc-scout-confirm",
+        tool_name="send_email",
+        tool_args={"to": "ops"},
+        requires_confirmation=True,
+    )
+    requirement = _requirement(tool, "scout", "run-scout", "Scout")
+    chunks = _sub_team_that_finished_holding_its_delegation_chunks(
+        TeamRunPausedEvent(tools=[], requirements=[requirement], **_TOP_LEVEL),
+    )
+
+    events = await collect(chunks, attributed(), exempt=[TRAILING_OUTPUT_AFTER_A_MEMBER_TERMINAL])
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED, 2)
+    assert [
+        (e.subagent_run_id, e.parent_subagent_run_id, e.parent_tool_call_id, e.description)  # type: ignore[attr-defined]
+        for e in _announcements(events)
+    ] == [("run-inner", None, None, None), ("run-scout", None, None, None)]
+    # The prompt itself is still the member's, on the member's own lane.
+    assert _tool_call_lanes_in_order(events) == [
+        ("tc-delegate-scout", "run-inner"),
+        ("tc-scout-confirm", "run-scout"),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_paused_member_is_still_linked_to_a_delegation_its_parent_lane_is_still_running(collect):
+    """The other half of that rule: a live lane's open delegation is the link it always was."""
+    tool = ToolExecution(
+        tool_call_id="tc-scout-confirm",
+        tool_name="send_email",
+        tool_args={"to": "ops"},
+        requires_confirmation=True,
+    )
+    requirement = _requirement(tool, "scout", "run-scout", "Scout")
+    delegation = _delegation("tc-delegate-scout", "scout", "scout the topic")
+
+    chunks = [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamRunStartedEvent(**_INNER_TEAM),
+        TeamToolCallStartedEvent(tool=delegation, **_INNER_TEAM),
+        TeamRunPausedEvent(tools=[], requirements=[requirement], **_TOP_LEVEL),
+    ]
+
+    events = await collect(chunks, attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED, 2)
+    assert [
+        (e.subagent_run_id, e.parent_subagent_run_id, e.parent_tool_call_id, e.description)  # type: ignore[attr-defined]
+        for e in _announcements(events)
+    ] == [("run-inner", None, None, None), ("run-scout", "run-inner", "tc-delegate-scout", "scout the topic")]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_members_own_pause_is_not_dumped_to_the_wire(collect):
+    events = await collect(_paused_member_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.RAW)
+    assert_stream_contains(events, EventType.TOOL_CALL_START, 2)
+    # The member's other chunks do reach the wire as RAW, on its own lane, so
+    # the absence below is this one event being withheld rather than the whole
+    # lane going unmapped. The name is the framework's own rather than a literal.
+    raw = in_emitted_order(events, EventType.RAW, lambda e: e.event.get("event"), _lane)  # type: ignore[attr-defined]
+    assert (RunEvent.run_started.value, "run-scout") in raw, raw
+    assert RunEvent.run_paused.value not in [name for name, _ in raw]
+    # The pending call still reaches the client once, from the team's requirement.
+    assert [e.tool_call_id for e in _of_type(events, EventType.TOOL_CALL_START)] == [  # type: ignore[attr-defined]
+        "tc-leader-confirm",
+        "tc-member-confirm",
+    ]
+
+
+def _pause_reported_by_a_member_whose_lane_closed_chunks() -> List[Any]:
+    """A member finishes, and then its own pause is the last thing the stream carries.
+
+    The pause is reported from the member's run, so the run terminal is built
+    out of a chunk whose lane the wire has already terminated.
+    """
+    member = _member_kwargs("scout", "run-scout")
+    pending = ToolExecution(
+        tool_call_id="tc-member-confirm", tool_name="send_email", tool_args={"to": "ops"}, requires_confirmation=True
+    )
+    paused = AgentRunPausedEvent(tools=[pending], **member)
+    paused.content = "I need approval to email ops."
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=_delegation("tc-delegate-scout", "scout", "scout it")),
+        RunStartedEvent(**member),
+        _agent_said("half a sen", **member),
+        RunCompletedEvent(content="scout done", **member),
+        paused,
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_pause_a_member_reports_after_its_own_terminal_is_prompted_on_the_root_lane(collect):
+    """A terminal is final for the lane it names, and this prompt is what would break that.
+
+    The pause is the run terminal here, so the prompt is built out of a chunk of
+    the member's. Named after it, every event of the prompt would carry that
+    member: the message, the words on it, and the three the pending call takes,
+    all of them after the lane's own terminal.
+    """
+    events = await collect(_pause_reported_by_a_member_whose_lane_closed_chunks(), attributed())
+
+    finished = _of_type(events, EventType.SUBAGENT_FINISHED)
+    assert [event.subagent_run_id for event in finished] == ["run-scout"]  # type: ignore[attr-defined]
+    after = events[events.index(finished[0]) + 1 :]
+    assert [(str(event.type), _lane(event)) for event in after if _lane(event) is not None] == []
+    # The pending call still reaches the client, unattributed, because no resume
+    # gets past a call nobody was shown.
+    assert _tool_call_lanes_in_order(events) == [("tc-delegate-scout", None), ("tc-member-confirm", None)]
+    # The member's own words are not relabeled as the leader's on the way out.
+    assert "I need approval to email ops." not in [
+        event.delta  # type: ignore[attr-defined]
+        for event in _of_type(events, EventType.TEXT_MESSAGE_CONTENT)
+    ]
+
+
+def _paused_member_the_run_names_by_id_alone_chunks() -> List[Any]:
+    """A pause whose requirement carries the member's id and no name of its own."""
+    pending = ToolExecution(
+        tool_call_id="tc-scout-confirm", tool_name="send_email", tool_args={"to": "ops"}, requires_confirmation=True
+    )
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamRunPausedEvent(tools=[], requirements=[_requirement(pending, "scout", "run-scout")], **_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_paused_member_with_no_name_is_announced_under_its_id(collect):
+    """The id is what the framework always has, and a lane announced under nothing is unreadable.
+
+    The streamed announcement falls back the same way and is pinned elsewhere.
+    This is the pause path's own copy of that fallback, which nothing reached.
+    """
+    events = await collect(_paused_member_the_run_names_by_id_alone_chunks(), attributed())
+
+    assert [(e.subagent_run_id, e.name) for e in _announcements(events)] == [("run-scout", "scout")]  # type: ignore[attr-defined]
+    assert _tool_call_lanes_in_order(events) == [("tc-scout-confirm", "run-scout")]
+
+
+# --- Run-end ordering -------------------------------------------------------
+
+
+def _member_open_inside_a_delegation_chunks(fail: bool) -> List[Any]:
+    """The leader is mid-sentence with a delegation open and its member still running."""
+    delegation = _delegation("tc-delegate-scout", "scout", "scout it")
+    member = _member_kwargs("scout", "run-scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=delegation),
+        _team_said("Delegating now.", **_TOP_LEVEL),
+        RunStartedEvent(**member),
+        _agent_said("scouting", **member),
+        TeamRunErrorEvent(content="team blew up", error_type="RuntimeError", **_TOP_LEVEL)
+        if fail
+        else TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+def _member_terminal_index(events: List[BaseEvent]) -> int:
+    terminals = [index for index, event in enumerate(events) if _is_terminal(event)]
+    assert len(terminals) == 1, f"expected one member terminal, got {len(terminals)}"
+    return terminals[0]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fail", [False, True], ids=["run_completed", "run_errored"])
+@chunk_mappers
+async def test_a_member_terminal_lands_outside_every_span_the_stream_had_open(collect, fail):
+    """The run end closes what is open first, so no terminal is nested in anything.
+
+    A tool call admits only its own arguments and its end between the two, and a
+    message admits only its own content, so a member terminal landing inside
+    either is a stream a validating client rejects. That covers the delegation
+    call the member was running inside, which closes before the terminal rather
+    than after it.
+    """
+    events = await collect(_member_open_inside_a_delegation_chunks(fail), attributed())
+    terminal_at = _member_terminal_index(events)
+
+    delegation_close_at = [
+        index
+        for index, event in enumerate(events)
+        if event.type == EventType.TOOL_CALL_END and getattr(event, "tool_call_id", None) == "tc-delegate-scout"  # type: ignore[attr-defined]
+    ]
+    assert delegation_close_at, "the delegation tool call was never closed"
+    assert delegation_close_at[0] < terminal_at
+
+    open_messages: Set[str] = set()
+    open_tool_calls: Set[str] = set()
+    for index, event in enumerate(events):
+        if index == terminal_at:
+            assert not open_messages, f"a member terminal landed inside open messages {sorted(open_messages)}"
+            assert not open_tool_calls, f"a member terminal landed inside open tool calls {sorted(open_tool_calls)}"
+        if event.type == EventType.TEXT_MESSAGE_START:
+            open_messages.add(event.message_id)  # type: ignore[attr-defined]
+        elif event.type == EventType.TEXT_MESSAGE_END:
+            open_messages.discard(event.message_id)  # type: ignore[attr-defined]
+        elif event.type == EventType.TOOL_CALL_START:
+            open_tool_calls.add(event.tool_call_id)  # type: ignore[attr-defined]
+        elif event.type == EventType.TOOL_CALL_END:
+            open_tool_calls.discard(event.tool_call_id)  # type: ignore[attr-defined]
+
+
+# --- Cancellation -----------------------------------------------------------
+
+
+def _cancelled_member_chunks() -> List[Any]:
+    member = _member_kwargs("scout", "run-scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**member),
+        RunCancelledEvent(reason="user cancelled the run", **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_cancelled_member_is_not_reported_as_a_success(collect):
+    events = await collect(_cancelled_member_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_ERROR)
+    assert not _of_type(events, EventType.SUBAGENT_FINISHED)
+    assert [(e.subagent_run_id, e.message, e.code) for e in _of_type(events, EventType.SUBAGENT_ERROR)] == [  # type: ignore[attr-defined]
+        ("run-scout", "user cancelled the run", "cancelled")
+    ]
+    # The member's other chunks do reach the wire as RAW, on its own lane, so
+    # the absence below is this one event being withheld rather than the whole
+    # lane going unmapped. The name is the framework's own rather than a literal.
+    assert_stream_contains(events, EventType.RAW)
+    raw = in_emitted_order(events, EventType.RAW, lambda e: e.event.get("event"), _lane)  # type: ignore[attr-defined]
+    assert (RunEvent.run_started.value, "run-scout") in raw, raw
+    assert RunEvent.run_cancelled.value not in [name for name, _ in raw]
+
+
+# --- Withheld failures are still recorded -----------------------------------
+
+
+def _failing_member_chunks() -> List[Any]:
+    member = _member_kwargs("scout", "run-scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**member),
+        RunErrorEvent(
+            content="member exploded",
+            error_type="RuntimeError",
+            error_id="err-42",
+            additional_data={"attempt": 2},
+            **member,
+        ),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "chunk_factory,expected",
+    [
+        (_failing_member_chunks, "member exploded"),
+        (_cancelled_member_chunks, "user cancelled the run"),
+    ],
+    ids=["error", "cancellation"],
+)
+@chunk_mappers
+async def test_hidden_records_a_member_failure_it_withholds(collect, caplog, chunk_factory, expected):
+    with captured_agno_logs(caplog, "WARNING"):
+        events = await collect(chunk_factory(), SUBAGENT_VISIBILITY_HIDDEN)
+
+    # Hidden withholds what identifies the member, not the fact that it failed.
+    assert not [e for e in events if "SUBAGENT" in str(e.type)]
+    assert not [e for e in events if _lane(e) is not None]
+    assert [r.message for r in caplog.records if expected in r.message]
+
+
+_SCOUT = _member_kwargs("scout", "run-scout")
+_WRITER = _member_kwargs("writer", "run-writer")
+
+# One chunk per way a member's run stops, with the text that member carried.
+# Keyed by the normalized event name so the coverage check below can compare
+# them with the events the interface itself treats as ending a member: a
+# terminal kind added there without a case here fails that check rather than
+# going unexamined by everything generated from this table.
+_MEMBER_RUN_TERMINALS: Dict[str, Tuple[Callable[[], Any], str]] = {
+    RunEvent.run_completed.value: (lambda: RunCompletedEvent(content="scout finished", **_SCOUT), "scout finished"),
+    RunEvent.run_error.value: (lambda: RunErrorEvent(content="scout exploded", **_SCOUT), "scout exploded"),
+    RunEvent.run_cancelled.value: (
+        lambda: RunCancelledEvent(reason="operator stopped scout", **_SCOUT),
+        "operator stopped scout",
+    ),
+    RunEvent.run_paused.value: (
+        lambda: AgentRunPausedEvent(
+            tools=[_pending("tc-scout-confirm", requires_confirmation=True)], content="scout is waiting", **_SCOUT
+        ),
+        "scout is waiting",
+    ),
+}
+
+
+def test_every_way_a_member_run_stops_has_a_case():
+    """The cases generated from the table are the class, checked against the interface's list."""
+    missing = sorted(handlers._SUBAGENT_RUN_ENDING_EVENTS.difference(_MEMBER_RUN_TERMINALS))
+    assert not missing, f"these member terminals have no case: {missing}"
+
+
+def _member_run_ending_chunks(terminal: Any) -> List[Any]:
+    """A run whose last chunk is one member terminal, so that terminal is the run's."""
+    return [TeamRunStartedEvent(**_TOP_LEVEL), RunStartedEvent(**_SCOUT), terminal]
+
+
+_WAYS_A_MEMBER_STOPS_UNDER_HIDDEN: Dict[str, Tuple[Callable[[], List[Any]], str]] = {
+    name: (lambda build=build: _member_run_ending_chunks(build()), text)  # type: ignore[misc]
+    for name, (build, text) in _MEMBER_RUN_TERMINALS.items()
+}
+# Not a way a member's run stops, and here for the contrast: a tool call
+# failure ends no run, so nothing of it can reach the client and its record
+# must not say otherwise.
+_WAYS_A_MEMBER_STOPS_UNDER_HIDDEN[RunEvent.tool_call_error.value] = (
+    lambda: _member_run_ending_chunks(
+        ToolCallErrorEvent(
+            tool=ToolExecution(tool_call_id="tc-boom", tool_name="search_docs"),
+            error="scout's tool exploded",
+            **_SCOUT,
+        )
+    ),
+    "scout's tool exploded",
+)
+
+
+@pytest.mark.asyncio
+@chunk_mappers
+@pytest.mark.parametrize(
+    "way", sorted(_WAYS_A_MEMBER_STOPS_UNDER_HIDDEN), ids=sorted(_WAYS_A_MEMBER_STOPS_UNDER_HIDDEN)
+)
+async def test_a_hidden_record_claims_the_reason_reached_the_client_exactly_when_it_did(collect, caplog, way):
+    """``hidden`` withholds the member's identity, and its record may not overstate that.
+
+    A member's terminal can be the only account the stream carries of how the
+    run ended, and is then read as the run's, so the text that member carried
+    reaches the client as the reason the run stopped even though nothing on the
+    wire names the member. Whether the record says so is checked against
+    whether the terminal really carries that text, over every way a member's
+    run can stop rather than over the one that was reported, so a terminal kind
+    added later cannot arrive with a record that claims the client was told
+    nothing while the client is reading the member's own words.
+    """
+    build, text = _WAYS_A_MEMBER_STOPS_UNDER_HIDDEN[way]
+    with captured_agno_logs(caplog, "WARNING"):
+        events = await collect(build(), SUBAGENT_VISIBILITY_HIDDEN)
+
+    assert not [e for e in events if "SUBAGENT" in str(e.type)]
+    assert not [e for e in events if _lane(e) is not None]
+    reason_on_the_wire = getattr(events[-1], "message", None)
+    claims = [r.message for r in caplog.records if handlers._REASON_STILL_REACHES_THE_CLIENT in r.message]
+
+    if reason_on_the_wire == text:
+        assert claims, f"the {way} record does not say the client is reading this member's own words"
+        assert all(text in claim for claim in claims)
+    else:
+        assert not claims, f"the {way} record claims a reason reached the client, and {reason_on_the_wire!r} did"
+
+
+@pytest.mark.asyncio
+@malformed_mappers
+@pytest.mark.parametrize(
+    "setting",
+    [lambda: None, lambda: SUBAGENT_VISIBILITY_INLINE, attributed, lambda: SUBAGENT_VISIBILITY_HIDDEN],
+    ids=["default", "inline", "attributed", "hidden"],
+)
+@pytest.mark.parametrize("stopped", sorted(_MEMBER_RUN_TERMINALS), ids=sorted(_MEMBER_RUN_TERMINALS))
+async def test_the_last_member_terminal_is_the_one_the_run_terminal_is_built_from(collect_malformed, setting, stopped):
+    """No member terminal outranks a later one, whichever way the earlier member stopped.
+
+    A run that reported no terminal of its own is described by the last member
+    terminal the stream carried and by nothing else. So a member that fails, and
+    then another member that completes, ends the run as a completion, and a
+    member that pauses followed by another member completing loses the pending
+    call the pause was waiting on: a completion carries none to prompt with.
+    Both hold under every setting, the default included, which is why the whole
+    class runs against all four rather than being described as a lineage
+    difference.
+
+    Driven through the collector that records violations, because the paused
+    arm leaves the member's own pending call opened by the stream and never
+    prompted, which the shared checker has an opinion about.
+    """
+    build, _ = _MEMBER_RUN_TERMINALS[stopped]
+    chunks = [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**_SCOUT),
+        build(),
+        RunStartedEvent(**_WRITER),
+        RunCompletedEvent(content="writer finished", **_WRITER),
+    ]
+
+    events, error, _ = await collect_malformed(chunks, setting(), thread_id=THREAD_ID, run_id=TOP_LEVEL_RUN)
+
+    assert error is None
+    assert str(events[-1].type) == str(EventType.RUN_FINISHED)
+    assert getattr(events[-1], "message", None) is None
+    # Nothing the run stopped for is prompted: the completion the terminal is
+    # built from asks the client to resolve nothing.
+    assert not _of_type(events, EventType.TOOL_CALL_START)
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_member_failure_is_logged_once_and_that_line_carries_the_ids(collect, caplog):
+    """One line, carrying everything an operator needs to find the failure again.
+
+    Read off the single record rather than off every record joined together: an
+    operator reads one line at a time, so identifiers scattered across separate
+    lines are identifiers that line does not have.
+    """
+    with captured_agno_logs(caplog, "ERROR"):
+        events = await collect(_failing_member_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_ERROR)
+    assert [(e.subagent_run_id, e.message, e.code) for e in _of_type(events, EventType.SUBAGENT_ERROR)] == [  # type: ignore[attr-defined]
+        ("run-scout", "member exploded", "RuntimeError")
+    ]
+    failures = [r.message for r in caplog.records if "member exploded" in r.message]
+    assert len(failures) == 1, f"one failure was recorded {len(failures)} times: {failures}"
+    assert "err-42" in failures[0], failures[0]
+    assert "attempt" in failures[0], failures[0]
+
+
+def _member_error_after_its_terminal_chunks() -> List[Any]:
+    """A member reports a failure after its own terminal has already gone out."""
+    member = _member_kwargs("scout", "run-scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**member),
+        RunCompletedEvent(content="scout done", **member),
+        RunErrorEvent(content="too late", error_type="RuntimeError", error_id="err-99", **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_failure_arriving_after_its_members_terminal_is_recorded_and_sends_no_second_terminal(collect, caplog):
+    """A terminal is final for the lane it names, so the late failure is recorded instead.
+
+    A second terminal for the same id would be a protocol violation, so the log
+    line is the only account of this failure and has to carry what an operator
+    needs from it: which lane failed, that the lane had already terminated so
+    the client was told nothing, and the identifiers the failure was reported
+    with.
+    """
+    with captured_agno_logs(caplog, "ERROR"):
+        events = await collect(_member_error_after_its_terminal_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_FINISHED)
+    # The one terminal the lane owns is its own, carrying what its run reported
+    # before the failure, and no error terminal joins it.
+    assert in_emitted_order(events, EventType.SUBAGENT_FINISHED, "subagent_run_id", "result") == [
+        ("run-scout", "scout done")
+    ]
+    assert in_emitted_order(events, EventType.SUBAGENT_ERROR, "subagent_run_id", "message") == []
+
+    recorded = [r.message for r in caplog.records if "too late" in r.message]
+    assert len(recorded) == 1, f"the late failure was recorded {len(recorded)} times: {recorded}"
+    assert "run-scout" in recorded[0], recorded[0]
+    assert "already terminated" in recorded[0], recorded[0]
+    assert "RuntimeError" in recorded[0], recorded[0]
+    assert "err-99" in recorded[0], recorded[0]
+
+
+# --- Serializing a member's result ------------------------------------------
+
+
+class _ExplodingDump:
+    """A result whose model dump raises, as a partly-built pydantic object can."""
+
+    def model_dump_json(self) -> str:
+        raise RuntimeError("dump exploded")
+
+    def __str__(self) -> str:
+        return "exploding result"
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    # Built per case rather than at collection time, so the two mappers cannot
+    # hand each other a result one of them has already mutated. What each falls
+    # back to is stated: an expectation of "some string" holds for every result
+    # the interface could possibly report. Every route that gave way on the way
+    # there is stated too, because a fallback nobody is told about is a member
+    # result quietly replaced by something else.
+    "content_factory,expected,recorded",
+    [
+        (
+            _ExplodingDump,
+            "exploding result",
+            ("could not dump a subagent result", "could not serialize a subagent result"),
+        ),
+        (circular, "{'self': {...}}", ("could not serialize a subagent result",)),
+    ],
+    ids=["model_dump_raises", "cyclic_content"],
+)
+@chunk_mappers
+async def test_an_unserializable_member_result_never_fails_the_run(
+    collect, caplog, content_factory, expected, recorded
+):
+    with captured_agno_logs(caplog, "WARNING"):
+        events = await collect(_member_result_chunks(content_factory()), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_FINISHED)
+    finished = _of_type(events, EventType.SUBAGENT_FINISHED)
+
+    assert [e.subagent_run_id for e in finished] == ["run-scout"]  # type: ignore[attr-defined]
+    assert finished[0].result == expected  # type: ignore[attr-defined]
+    assert str(events[-1].type) == str(EventType.RUN_FINISHED)
+    assert not _of_type(events, EventType.RUN_ERROR)
+    logged = [record.message for record in caplog.records]
+    for fragment in recorded:
+        assert [message for message in logged if fragment in message], (
+            f"the result the interface could not serialize left no trace of {fragment!r}: {logged}"
+        )
+
+
+# --- The lane stamp ---------------------------------------------------------
+
+_SCOUT_LANE = "run-scout"
+
+
+def _member_alone_chunks(*inner: Any) -> List[Any]:
+    """A team whose only speaker is one member, with no delegation call of the leader's.
+
+    The leader stays silent so that every event of a given type on the stream is
+    the member's, which is what lets the lanes below be stated as an exact list
+    rather than as a set with the leader's copies filtered out.
+    """
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**_SCOUT),
+        *inner,
+        RunCompletedEvent(content="scout done", **_SCOUT),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+def _a_member_spoke() -> List[Any]:
+    return _member_alone_chunks(_agent_said("scouting", **_SCOUT))
+
+
+def _a_member_called_a_tool() -> List[Any]:
+    tool = ToolExecution(tool_call_id="tc-scout", tool_name="search_docs", tool_args={"query": "agno"}, result="three")
+    return _member_alone_chunks(ToolCallStartedEvent(tool=tool, **_SCOUT), ToolCallCompletedEvent(tool=tool, **_SCOUT))
+
+
+def _a_member_reasoned() -> List[Any]:
+    delta = ReasoningContentDeltaEvent(**_SCOUT)
+    delta.reasoning_content = "first I "
+    return _member_alone_chunks(ReasoningStartedEvent(**_SCOUT), delta, ReasoningCompletedEvent(**_SCOUT))
+
+
+def _a_member_emitted_a_custom_event() -> List[Any]:
+    chunk = CustomEvent(**_SCOUT)
+    chunk.to_dict = lambda: {"event": "Custom", "payload": {"progress": 1}}  # type: ignore[method-assign]
+    return _member_alone_chunks(chunk)
+
+
+# One stream per attributable event type, with the lanes that type's events
+# carry on it, in order. Keyed by event name and checked against the stamp's own
+# set below, so an event type added to that set is driven here or named.
+_ATTRIBUTED_ON_A_MEMBER_LANE: Dict[str, Tuple[Callable[[], List[Any]], Tuple[Optional[str], ...]]] = {
+    # The team's own run-started chunk is unmapped too, and it is the leading
+    # unstamped RAW here; the member's is the stamped one.
+    "RAW": (_member_alone_chunks, (None, _SCOUT_LANE)),
+    "TEXT_MESSAGE_START": (_a_member_spoke, (_SCOUT_LANE,)),
+    "TEXT_MESSAGE_CONTENT": (_a_member_spoke, (_SCOUT_LANE,)),
+    "TEXT_MESSAGE_END": (_a_member_spoke, (_SCOUT_LANE,)),
+    # A tool call opens a message of the member's own to hang itself off, which
+    # is why this stream carries a text span with no content in it.
+    "TOOL_CALL_START": (_a_member_called_a_tool, (_SCOUT_LANE,)),
+    "TOOL_CALL_ARGS": (_a_member_called_a_tool, (_SCOUT_LANE,)),
+    "TOOL_CALL_END": (_a_member_called_a_tool, (_SCOUT_LANE,)),
+    "TOOL_CALL_RESULT": (_a_member_called_a_tool, (_SCOUT_LANE,)),
+    "REASONING_START": (_a_member_reasoned, (_SCOUT_LANE,)),
+    "REASONING_MESSAGE_START": (_a_member_reasoned, (_SCOUT_LANE,)),
+    "REASONING_MESSAGE_CONTENT": (_a_member_reasoned, (_SCOUT_LANE,)),
+    "REASONING_MESSAGE_END": (_a_member_reasoned, (_SCOUT_LANE,)),
+    "REASONING_END": (_a_member_reasoned, (_SCOUT_LANE,)),
+    "CUSTOM": (_a_member_emitted_a_custom_event, (_SCOUT_LANE,)),
+}
+
+
+def test_every_event_type_the_stamp_attributes_is_driven_onto_a_member_lane():
+    """The coverage is derived from the stamp's own set, so a type added to it lands here.
+
+    Named per event type rather than counted: a type nothing here puts on a
+    member's lane is one the stamp could skip with every test in this folder
+    still green, which is exactly what CUSTOM was.
+    """
+    attributable = _enumerated_by_the_interface(
+        {event_type.value for event_type in handlers._SUBAGENT_ATTRIBUTABLE_EVENT_TYPES},
+        EventType.CUSTOM.value,
+        described="the event types the lane stamp attributes",
+    )
+    assert set(_ATTRIBUTED_ON_A_MEMBER_LANE) == attributable, (
+        "these event types are attributable and no stream here puts one on a member's lane: "
+        f"{sorted(attributable - set(_ATTRIBUTED_ON_A_MEMBER_LANE))}; and these are driven here and no "
+        f"longer attributable: {sorted(set(_ATTRIBUTED_ON_A_MEMBER_LANE) - attributable)}"
+    )
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+@pytest.mark.parametrize("event_name", sorted(_ATTRIBUTED_ON_A_MEMBER_LANE))
+async def test_an_attributable_event_a_member_produced_carries_that_member(collect, event_name):
+    """Every attributable type, on the member that produced it, by payload and in order."""
+    chunks, expected = _ATTRIBUTED_ON_A_MEMBER_LANE[event_name]
+    event_type = event_type_named(event_name)
+    events = await collect(chunks(), attributed())
+
+    assert_stream_contains(events, event_type)
+    assert [lane for (lane,) in in_emitted_order(events, event_type, _lane)] == list(expected)
+
+
+class _EventWithoutLineage(BaseModel):
+    """An attributable event from a protocol release that cannot express a lane."""
+
+    model_config = {"extra": "allow"}
+
+    type: EventType = EventType.TEXT_MESSAGE_START
+
+
+@needs_lineage_events
+def test_a_protocol_that_cannot_carry_a_lane_is_refused_before_the_run_starts(monkeypatch):
+    """The refusal belongs at startup: mid-stream it would abort a run a client is already reading.
+
+    Gated, because this is the refusal for a release that HAS the lineage events
+    and not the field. A release with neither is refused for the missing events,
+    which is the test above.
+    """
+    visibility = attributed()
+    monkeypatch.setitem(handlers._ATTRIBUTABLE_EVENT_CLASSES, EventType.TEXT_MESSAGE_START, _EventWithoutLineage)
+
+    with pytest.raises(ValueError, match="subagent_run_id"):
+        validate_subagent_visibility(visibility)
+    # The settings that never stamp an event keep working on such a release.
+    assert validate_subagent_visibility(SUBAGENT_VISIBILITY_INLINE) == SUBAGENT_VISIBILITY_INLINE
+    assert validate_subagent_visibility(SUBAGENT_VISIBILITY_HIDDEN) == SUBAGENT_VISIBILITY_HIDDEN
+
+
+class _AnnouncementWithoutADescription(BaseModel):
+    """An announcement from a protocol release that declares no description field."""
+
+    model_config = {"extra": "allow"}
+
+    subagent_run_id: str = ""
+    name: str = ""
+    parent_subagent_run_id: Optional[str] = None
+    parent_tool_call_id: Optional[str] = None
+    parent_message_id: Optional[str] = None
+
+
+def _lineage_fields_the_interface_writes(event_class_names: Set[str]) -> Dict[str, Set[str]]:
+    """The arguments the interface really passes to each lineage event class.
+
+    Every module of the interface package is read, not just the one that happens
+    to construct these today, and the call sites are matched against the exact
+    class names the startup check enumerates rather than against a name prefix:
+    the state module declares its own ``Subagent`` record, which a prefix match
+    would count as a protocol event and compare its fields against the wire's.
+
+    Positional and starred arguments are refused rather than skipped. This scan
+    can put no name to either, so a field written that way would be missing from
+    what it returns and read as a field the interface does not write at all.
+    """
+    package = Path(handlers.__file__).parent
+    written: Dict[str, Set[str]] = {}
+    for path in sorted(package.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
+                continue
+            if node.func.id not in event_class_names:
+                continue
+            assert not node.args, (
+                f"{path.name} builds a {node.func.id} with positional arguments, which this scan cannot name"
+            )
+            assert all(keyword.arg is not None for keyword in node.keywords), (
+                f"{path.name} builds a {node.func.id} from a starred mapping, which this scan cannot read"
+            )
+            # ``type`` is the protocol's own discriminator, which every event
+            # declares by definition, so it is not one of the fields at issue.
+            written.setdefault(node.func.id, set()).update(
+                keyword.arg for keyword in node.keywords if keyword.arg is not None and keyword.arg != "type"
+            )
+    return written
+
+
+@needs_lineage_events
+def test_the_startup_check_feature_detects_every_lineage_field_the_interface_writes():
+    """A field nothing detects is one an older protocol takes as an undeclared attribute.
+
+    The protocol models accept what they do not declare, so a release missing
+    one of these does not raise: the value rides out under the name written
+    here instead of the one the wire format defines, and the client reads a lane
+    with no description, no parent or no result.
+    """
+    detected = {event_class.__name__: set(fields) for event_class, fields in handlers._lineage_event_fields().items()}
+    # The scan below is handed the very names this table is keyed by, so an
+    # empty table leaves it scanning for nothing and the comparison is between
+    # two empty mappings. The three classes the interface builds are the floor.
+    scanned_for = _enumerated_by_the_interface(
+        detected,
+        "SubagentStartedEvent",
+        "SubagentFinishedEvent",
+        "SubagentErrorEvent",
+        described="the lineage classes the startup check feature-detects fields on",
+    )
+
+    assert _lineage_fields_the_interface_writes(scanned_for) == detected
+
+
+@needs_lineage_events
+def test_a_protocol_missing_a_field_an_announcement_carries_is_refused_before_the_run_starts(monkeypatch):
+    visibility = attributed()
+    # The release accepts the write and keeps it as an undeclared attribute,
+    # which is why the field has to be detected rather than trusted.
+    silently_accepted = _AnnouncementWithoutADescription(description="scout the topic")
+    assert silently_accepted.description == "scout the topic"  # type: ignore[attr-defined]
+
+    monkeypatch.setattr(handlers, "SubagentStartedEvent", _AnnouncementWithoutADescription)
+
+    # The refusal names the class this install really carries, not the one the
+    # protocol would have provided.
+    with pytest.raises(ValueError, match=rf"{_AnnouncementWithoutADescription.__name__}\.description"):
+        validate_subagent_visibility(visibility)
+    # The settings that emit no lineage event keep working on such a release.
+    assert validate_subagent_visibility(SUBAGENT_VISIBILITY_INLINE) == SUBAGENT_VISIBILITY_INLINE
+    assert validate_subagent_visibility(SUBAGENT_VISIBILITY_HIDDEN) == SUBAGENT_VISIBILITY_HIDDEN
+
+
+def test_the_lane_stamp_cannot_fail_a_run_that_has_already_started():
+    stamped = handlers._stamp_lane([_EventWithoutLineage()], "run-scout")  # type: ignore[list-item]
+
+    assert [_lane(e) for e in stamped] == [None]
+
+
+def test_the_startup_check_covers_every_event_type_the_stamp_attributes():
+    """Feature-detecting a class the stamp never writes to would leave the mid-stream path exposed.
+
+    The set the stamp tests against is derived from the classes the startup
+    check reads, so the two cannot disagree and nothing here compares them.
+    What can drift is a class registered under an event type it does not carry:
+    the stamp would then skip an event the startup check cleared.
+    """
+    attributable = handlers._ATTRIBUTABLE_EVENT_CLASSES
+    # A registry that lost its entries stamps nothing and leaves the startup
+    # check nothing to feature-detect, and the assertion below holds for it, so
+    # the floor is stated first.
+    _enumerated_by_the_interface(
+        attributable, EventType.TEXT_MESSAGE_START, described="the event classes the lane stamp attributes"
+    )
+    mismatched = {
+        event_type: event_class.__name__
+        for event_type, event_class in attributable.items()
+        if event_class.model_fields["type"].default is not event_type
+    }
+    assert not mismatched, f"these classes do not carry the event type they are registered under: {mismatched}"
+
+
+@needs_lineage_events
+def test_the_lane_stamp_writes_the_declared_field_and_keeps_an_explicit_one():
+    from ag_ui.core import TextMessageStartEvent
+
+    plain = TextMessageStartEvent(type=EventType.TEXT_MESSAGE_START, message_id="m-1", role="assistant")
+    (stamped,) = handlers._stamp_lane([plain], "run-scout")
+    assert stamped.subagent_run_id == "run-scout"  # type: ignore[attr-defined]
+
+    explicit = TextMessageStartEvent(
+        type=EventType.TEXT_MESSAGE_START, message_id="m-2", role="assistant", subagent_run_id="run-other"
+    )
+    (kept,) = handlers._stamp_lane([explicit], "run-scout")
+    assert kept.subagent_run_id == "run-other"  # type: ignore[attr-defined]
+
+
+# --- Where the setting is validated -----------------------------------------
+
+
+def test_the_routes_refuse_an_invalid_visibility_when_they_are_mounted():
+    from fastapi import APIRouter
+
+    from agno.os.interfaces.agui.router import attach_routes
+
+    with pytest.raises(ValueError, match="subagent_visibility must be one of"):
+        attach_routes(APIRouter(), team=_two_member_team(InMemoryDb()), subagent_visibility="loud")
+
+
+def test_the_stream_state_refuses_an_invalid_visibility():
+    with pytest.raises(ValueError, match="subagent_visibility must be one of"):
+        StreamState(subagent_visibility="loud")
+
+
+def test_a_missing_agent_or_team_is_reported_before_the_visibility():
+    from agno.os.interfaces.agui import AGUI
+
+    with pytest.raises(ValueError, match="requires an agent or a team"):
+        AGUI(subagent_visibility="loud")
+
+
+# --- What the docs claim ----------------------------------------------------
+
+
+def _inner_agent_of_a_single_agent_chunks() -> List[Any]:
+    """A context provider runs an agent inside the outer run and stamps the outer run as its parent."""
+    outer = {"agent_id": "assistant", "agent_name": "Assistant", "run_id": TOP_LEVEL_RUN}
+    inner = {
+        "agent_id": "memory-agent",
+        "agent_name": "Memory",
+        "run_id": "run-inner-agent",
+        "parent_run_id": TOP_LEVEL_RUN,
+    }
+
+    return [
+        RunStartedEvent(**outer),
+        _agent_said("inner agent speaking", **inner),
+        _agent_said("outer agent speaking", **outer),
+        RunCompletedEvent(**outer),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_single_agents_inner_agent_becomes_a_lane_under_attributed(collect):
+    events = await collect(_inner_agent_of_a_single_agent_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED)
+    assert [(e.subagent_run_id, e.name) for e in _announcements(events)] == [("run-inner-agent", "Memory")]  # type: ignore[attr-defined]
+    assert _messages_in_order(events) == [("Memory", "inner agent speaking"), (None, "outer agent speaking")]
+
+
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_single_agents_inner_agent_is_withheld_under_hidden(collect):
+    events = await collect(_inner_agent_of_a_single_agent_chunks(), SUBAGENT_VISIBILITY_HIDDEN)
+
+    assert _messages_in_order(events) == [(None, "outer agent speaking")]
+
+
+def test_a_direct_child_lane_reports_the_same_depth_as_the_root():
+    state = StreamState(subagent_visibility=attributed(), root_run_id=TOP_LEVEL_RUN)
+    state.open_subagent("run-child", name="Child", parent_lane=None)
+    state.open_subagent("run-grandchild", name="Grandchild", parent_lane="run-child")
+
+    assert (state.lane_depth(ROOT_LANE), state.lane_depth("run-child"), state.lane_depth("run-grandchild")) == (0, 0, 1)
+
+
+def _within(seconds: float, described: str, call: Callable[[], Any]) -> Any:
+    """The call's result, failing rather than hanging when it does not return.
+
+    A parent chain that closes on itself is walked by the ordering helpers
+    below, and a walk that looped would wedge a run with no output and no
+    failure anywhere. The wait is therefore bounded, and the thread is a
+    daemon so a wedged walk cannot hold the suite open either.
+
+    Whatever the call raised is re-raised here rather than left in the worker:
+    reading the result by index instead would turn every exception inside the
+    walk into a bare IndexError on an empty list, which names neither the walk
+    nor what went wrong in it.
+    """
+    outcome: Dict[str, Any] = {}
+
+    def run() -> None:
+        try:
+            outcome["returned"] = call()
+        except BaseException as raised:  # noqa: BLE001 - re-raised below, in the calling thread
+            outcome["raised"] = raised
+
+    worker = threading.Thread(target=run, daemon=True)
+    worker.start()
+    worker.join(seconds)
+    assert not worker.is_alive(), (
+        f"{described} did not return within {seconds}s, so a parent chain that closes on itself is walked forever"
+    )
+    if "raised" in outcome:
+        raise AssertionError(f"{described} raised {outcome['raised']!r}") from outcome["raised"]
+    return outcome["returned"]
+
+
+def test_a_parent_chain_that_closes_on_itself_is_walked_once_and_stops():
+    """No run produces this, and every ordering helper has to survive one that did.
+
+    Each of these walks the parent chain, so a guard that stops guarding turns a
+    run into a hang, which is a failure no assertion about its output can catch.
+    """
+    state = StreamState(subagent_visibility=attributed(), root_run_id=TOP_LEVEL_RUN)
+    state.open_subagent("run-a", name="A", parent_lane="run-c")
+    state.open_subagent("run-b", name="B", parent_lane="run-a")
+    state.open_subagent("run-c", name="C", parent_lane="run-b")
+    state.open_subagent("run-self", name="Self", parent_lane="run-self")
+    for lane in ("run-a", "run-b", "run-c", "run-self"):
+        state.lane(lane)
+
+    # The walk stops on the first lane it has already passed, so each chain
+    # reports the lanes above it once and the lane itself never again.
+    assert _within(5, "the ancestor walk", lambda: state.ancestor_lanes("run-a")) == ["run-c", "run-b"]
+    assert _within(5, "the ancestor walk", lambda: state.ancestor_lanes("run-self")) == []
+    assert _within(5, "the lane depth", lambda: (state.lane_depth("run-a"), state.lane_depth("run-self"))) == (2, 0)
+    assert _within(5, "the member terminal order", lambda: state.subagents_deepest_first()) == [
+        "run-a",
+        "run-b",
+        "run-c",
+        "run-self",
+    ]
+    assert _within(5, "the lane sweep", lambda: state.lanes_deepest_first()) == [
+        "run-a",
+        "run-b",
+        "run-c",
+        "run-self",
+        ROOT_LANE,
+    ]
+
+
+def _docstring(owner: Any, described: str) -> str:
+    """The docstring, refusing an absent one.
+
+    Falling back to an empty string makes every claim below trivially absent the
+    moment a docstring is deleted, which leaves these assertions pinning the
+    absence of prose in a docstring that no longer exists.
+    """
+    text = owner.__doc__
+    assert text, f"{described} carries no docstring, so nothing here can check what it claims"
+    return text
+
+
+# --- What a lane terminal must not take with it -----------------------------
+
+
+def _live_descendant_tool_when_its_parent_terminates_chunks(session_state: Dict[str, Any]) -> List[Any]:
+    """A sub-team reaches its own terminal while its member's tool call is still running."""
+    inner = _team_kwargs("inner-team", "Inner Team", "run-inner", parent=TOP_LEVEL_RUN)
+    member = _member_kwargs("scout", "run-scout", parent="run-inner")
+    tool = ToolExecution(tool_call_id="tc-scout-approve", tool_name="approve", tool_args={}, result="approved")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamRunStartedEvent(**inner),
+        RunStartedEvent(**member),
+        ToolCallStartedEvent(tool=tool, **member),
+        TeamRunCompletedEvent(content="inner done", **inner),
+        SideEffect(lambda: session_state.__setitem__("approved", True)),
+        ToolCallCompletedEvent(tool=tool, **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@malformed_mappers
+async def test_a_lane_terminal_leaves_a_live_descendants_tool_call_to_its_own_completion(collect_malformed):
+    """The tool goes on running, so its call keeps its own end, result and state change.
+
+    Closing that call from the ancestor's terminal would mark it ended, which
+    makes the completion that follows read as a repeat and be dropped whole,
+    taking the result and the session state the tool wrote with it.
+    """
+    session_state: Dict[str, Any] = {"approved": False}
+
+    events, error, violation = await collect_malformed(
+        _live_descendant_tool_when_its_parent_terminates_chunks(session_state),
+        attributed(),
+        thread_id=THREAD_ID,
+        run_id=TOP_LEVEL_RUN,
+        run_state=session_state,
+    )
+
+    assert error is None, f"the source stream raised {error!r}"
+    assert_stream_contains(events, EventType.TOOL_CALL_RESULT)
+    assert in_emitted_order(events, EventType.TOOL_CALL_RESULT, "tool_call_id", "content") == [
+        ("tc-scout-approve", '"approved"')
+    ]
+    # Closed once, by the completion, and still attributed to the member.
+    assert in_emitted_order(events, EventType.TOOL_CALL_END, "tool_call_id", _lane) == [
+        ("tc-scout-approve", "run-scout")
+    ]
+    assert_stream_contains(events, EventType.STATE_DELTA)
+    assert in_emitted_order(events, EventType.STATE_DELTA, "delta") == [
+        ([{"op": "replace", "path": "/approved", "value": True}],)
+    ]
+    _assert_the_child_resolved_after_its_parent(violation)
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@malformed_mappers
+async def test_a_live_descendants_tool_call_that_never_completes_is_still_closed(collect_malformed):
+    """Left open for its own completion, and closed by the run end if that never comes.
+
+    The run end closes every open tool call before it terminates the members
+    that still hold one, so the end goes out while the lane is still open and the
+    member's terminal is the last thing that lane carries.
+    """
+    session_state: Dict[str, Any] = {"approved": False}
+    chunks = [
+        chunk
+        for chunk in _live_descendant_tool_when_its_parent_terminates_chunks(session_state)
+        if not isinstance(chunk, (ToolCallCompletedEvent, SideEffect))
+    ]
+
+    events, error, violation = await collect_malformed(
+        chunks,
+        attributed(),
+        thread_id=THREAD_ID,
+        run_id=TOP_LEVEL_RUN,
+        run_state=session_state,
+    )
+
+    assert error is None, f"the source stream raised {error!r}"
+    assert_stream_contains(events, EventType.TOOL_CALL_END)
+    assert in_emitted_order(events, EventType.TOOL_CALL_END, "tool_call_id", _lane) == [
+        ("tc-scout-approve", "run-scout")
+    ]
+    assert not _of_type(events, EventType.TOOL_CALL_RESULT)
+    # The member's terminal, read off the two terminal types: a substring match
+    # on SUBAGENT takes the announcement instead, which precedes everything the
+    # lane carries, and the ordering below then holds whatever the sweep does.
+    terminal_at = [index for index, event in enumerate(events) if _lane(event) == "run-scout" and _is_terminal(event)]
+    closed_at = [index for index, event in enumerate(events) if event.type == EventType.TOOL_CALL_END]
+    assert terminal_at and closed_at and closed_at[0] < terminal_at[0], (closed_at, terminal_at)
+    _assert_the_child_resolved_after_its_parent(violation)
+
+
+def _member_tool_completes_after_its_own_terminal_chunks(session_state: Dict[str, Any]) -> List[Any]:
+    """A member's own tool call completes after that member's run already ended."""
+    member = _member_kwargs("scout", "run-scout")
+    tool = ToolExecution(tool_call_id="tc-scout-approve", tool_name="approve", tool_args={}, result="approved")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**member),
+        ToolCallStartedEvent(tool=tool, **member),
+        RunCompletedEvent(content="scout done", **member),
+        SideEffect(lambda: session_state.__setitem__("approved", True)),
+        ToolCallCompletedEvent(tool=tool, **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_tool_result_arriving_after_its_members_terminal_still_reaches_the_client(collect):
+    """A member's terminal ends no tool call, so the one it left open keeps its own lifecycle.
+
+    Ending that call with the terminal would mark it ended, which makes the
+    completion that follows read as a repeat and be dropped whole, taking the
+    result and the session state the tool wrote with it.
+    """
+    session_state: Dict[str, Any] = {"approved": False}
+
+    events = await collect(
+        _member_tool_completes_after_its_own_terminal_chunks(session_state),
+        attributed(),
+        run_state=session_state,
+        exempt=[TRAILING_OUTPUT_AFTER_A_MEMBER_TERMINAL],
+    )
+
+    assert_stream_contains(events, EventType.TOOL_CALL_RESULT)
+    assert in_emitted_order(events, EventType.TOOL_CALL_RESULT, "tool_call_id", "content", _lane) == [
+        ("tc-scout-approve", '"approved"', "run-scout")
+    ]
+    # Closed once, by the completion, and still the member's.
+    assert in_emitted_order(events, EventType.TOOL_CALL_END, "tool_call_id", _lane) == [
+        ("tc-scout-approve", "run-scout")
+    ]
+    assert_stream_contains(events, EventType.STATE_DELTA)
+    assert in_emitted_order(events, EventType.STATE_DELTA, "delta") == [
+        ([{"op": "replace", "path": "/approved", "value": True}],)
+    ]
+    # The member's own terminal still carries what its run reported.
+    assert in_emitted_order(events, EventType.SUBAGENT_FINISHED, "subagent_run_id", "result") == [
+        ("run-scout", "scout done")
+    ]
+
+
+def _descendant_still_open_when_its_parent_terminates_chunks(fail: bool) -> List[Any]:
+    """A sub-team reaches its own terminal with its member still running."""
+    inner = _team_kwargs("inner-team", "Inner Team", "run-inner", parent=TOP_LEVEL_RUN)
+    member = _member_kwargs("scout", "run-scout", parent="run-inner")
+    parent_terminal = (
+        TeamRunErrorEvent(content="inner exploded", error_type="RuntimeError", **inner)
+        if fail
+        else TeamRunCompletedEvent(content="inner done", **inner)
+    )
+
+    chunks: List[Any] = [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamRunStartedEvent(**inner),
+        RunStartedEvent(**member),
+        _agent_said("scouting", **member),
+        parent_terminal,
+    ]
+    if not fail:
+        # The member goes on working and reports its own result afterwards.
+        chunks.append(RunCompletedEvent(content="scout done", **member))
+    chunks.append(TeamRunCompletedEvent(**_TOP_LEVEL))
+    return chunks
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@malformed_mappers
+async def test_a_member_still_running_reports_its_own_result_when_the_member_above_it_finishes(collect_malformed):
+    """A parent's terminal terminates the parent, so the child still delivers what it produced.
+
+    Terminating the child here instead would send a terminal with no result,
+    after which the child's own completion is read as a second terminal and
+    dropped, so the member's real content reaches nobody.
+    """
+    events, error, violation = await collect_malformed(
+        _descendant_still_open_when_its_parent_terminates_chunks(fail=False),
+        attributed(),
+        thread_id=THREAD_ID,
+        run_id=TOP_LEVEL_RUN,
+        exempt=[TRAILING_OUTPUT_AFTER_A_MEMBER_TERMINAL],
+    )
+
+    assert error is None, f"the source stream raised {error!r}"
+    assert_stream_contains(events, EventType.SUBAGENT_FINISHED, 2)
+    assert in_emitted_order(events, EventType.SUBAGENT_FINISHED, "subagent_run_id", "result") == [
+        ("run-inner", "inner done"),
+        ("run-scout", "scout done"),
+    ]
+    # The member's own words still reached the client, in its own lane.
+    assert joined_text_in_emitted_order(events) == [("run-scout", "scouting")]
+    _assert_the_child_resolved_after_its_parent(violation)
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@malformed_mappers
+async def test_a_member_that_never_failed_carries_no_error_from_the_member_above_it(collect_malformed, caplog):
+    """The failure belongs to the run that reported it, and to no lane below it."""
+    with captured_agno_logs(caplog, "ERROR"):
+        events, error, violation = await collect_malformed(
+            _descendant_still_open_when_its_parent_terminates_chunks(fail=True),
+            attributed(),
+            thread_id=THREAD_ID,
+            run_id=TOP_LEVEL_RUN,
+            exempt=[TRAILING_OUTPUT_AFTER_A_MEMBER_TERMINAL],
+        )
+
+    assert error is None, f"the source stream raised {error!r}"
+    assert_stream_contains(events, EventType.SUBAGENT_ERROR)
+    assert in_emitted_order(events, EventType.SUBAGENT_ERROR, "subagent_run_id", "message", "code") == [
+        ("run-inner", "inner exploded", "RuntimeError")
+    ]
+    # The member never failed, so the run end finishes it, without a code and
+    # without the message of the failure above it.
+    assert in_emitted_order(events, EventType.SUBAGENT_FINISHED, "subagent_run_id", "result") == [("run-scout", None)]
+    assert [record.message for record in caplog.records if "run-scout" in record.message] == []
+    _assert_the_child_resolved_after_its_parent(violation)
+
+
+def _pause_repeating_a_members_open_tool_call_chunks() -> List[Any]:
+    """The paused requirement repeats a member tool call that is still open."""
+    member = _member_kwargs("scout", "run-scout")
+    streaming = ToolExecution(tool_call_id="tc-member-confirm", tool_name="send_email", tool_args={"to": "ops"})
+    repeated = ToolExecution(
+        tool_call_id="tc-member-confirm",
+        tool_name="send_email",
+        tool_args={"to": "ops"},
+        requires_confirmation=True,
+    )
+    requirement = _requirement(repeated, "scout", "run-scout", "Scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**member),
+        ToolCallStartedEvent(tool=streaming, **member),
+        TeamRunPausedEvent(tools=[], requirements=[requirement], **_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_pause_does_not_open_a_second_start_for_a_call_the_client_already_has(collect):
+    """A call still open has had its start: prompting it again opens one span twice."""
+    events = await collect(_pause_repeating_a_members_open_tool_call_chunks(), attributed())
+
+    assert in_emitted_order(events, EventType.TOOL_CALL_START, "tool_call_id", _lane) == [
+        ("tc-member-confirm", "run-scout")
+    ]
+    assert in_emitted_order(events, EventType.TOOL_CALL_END, "tool_call_id", _lane) == [
+        ("tc-member-confirm", "run-scout")
+    ]
+
+    # Nothing survived the prompt, and every call it would have carried is
+    # already on the wire, so the prompt says nothing rather than adding an
+    # assistant message with neither words nor a call under it. Every message
+    # here is one a tool call is parented to.
+    carrying = {e.parent_message_id for e in _of_type(events, EventType.TOOL_CALL_START)}  # type: ignore[attr-defined]
+    assert [
+        (_lane(e), e.message_id in carrying)  # type: ignore[attr-defined]
+        for e in _of_type(events, EventType.TEXT_MESSAGE_START)
+    ] == [("run-scout", True)]
+    assert not _of_type(events, EventType.TEXT_MESSAGE_CONTENT)
+
+
+# --- A member name the interface cannot read --------------------------------
+
+
+class _UnreadableName:
+    """A name whose stringification raises, as a proxy object's can."""
+
+    def __str__(self) -> str:
+        raise RuntimeError("name exploded")
+
+
+def _member_with_an_unreadable_name_chunks() -> List[Any]:
+    member = {"agent_name": _UnreadableName(), "run_id": "run-scout", "parent_run_id": TOP_LEVEL_RUN}
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        _agent_said("scouting", **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_member_name_the_interface_cannot_read_does_not_end_the_run(collect, caplog):
+    with captured_agno_logs(caplog, "WARNING"):
+        events = await collect(_member_with_an_unreadable_name_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED)
+    # Nameable or not, the lane is announced, under the only name left: its run id.
+    assert [(e.subagent_run_id, e.name) for e in _announcements(events)] == [("run-scout", "run-scout")]  # type: ignore[attr-defined]
+    assert str(events[-1].type) == str(EventType.RUN_FINISHED)
+    # The client is shown a run id where a name belongs, so the raise that cost
+    # it the name has to reach the operator.
+    assert [record.message for record in caplog.records if "name exploded" in record.message], (
+        "the member name the interface could not read left no trace at all"
+    )
+
+
+@pytest.mark.parametrize(
+    "value",
+    [None, "", 0, 0.0, False, [], {}, ()],
+    ids=["none", "empty_text", "zero", "zero_float", "false", "empty_list", "empty_mapping", "empty_tuple"],
+)
+def test_a_falsy_label_is_read_as_no_label_at_all(value):
+    """Every falsy value is absent, not a label, which is what each caller falls back on.
+
+    Stated over the falsy values a chunk can carry rather than over None alone,
+    because the guard tests truthiness: a caller reading ``""`` or ``"0"`` off
+    this would put it on the wire as a member's name or its id, and the next
+    fallback would never be tried.
+    """
+    assert handlers._readable(value, "a label under test") is None
+
+
+def test_a_label_that_is_present_is_read_as_its_text():
+    """Otherwise the case above passes on a guard that discards everything."""
+    assert handlers._readable("Scout", "a label under test") == "Scout"
+    assert handlers._readable(7, "a label under test") == "7"
+
+
+# --- The member id the framework delegates by -------------------------------
+
+
+def _parallel_delegations_to_named_members_chunks() -> List[Any]:
+    """Two delegations open at once, to members named but never given ids."""
+    scout = {"agent_name": "Scout", "run_id": "run-scout", "parent_run_id": TOP_LEVEL_RUN}
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=_delegation("tc-scout", "scout", "scout the north")),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=_delegation("tc-ranger", "ranger", "range the south")),
+        _agent_said("scouting", **scout),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_named_member_without_an_id_is_still_linked_to_its_delegation(collect):
+    """The delegation argument carries the framework's derived member id, not the run's.
+
+    A member given no id of its own is delegated to by the url-safe form of its
+    name. Initializing a Team then assigns that same derived id to the member,
+    so a locally built Team's chunks carry it and this branch never runs for
+    one. It is there for the chunks that assignment does not stand behind, a
+    remote entity's among them, which are rebuilt from what its stream sent:
+    reading the run's own agent id alone would leave a member arriving with a
+    name and no id unmatched, and a parallel delegation then has no single
+    candidate to fall back on.
+    """
+    from agno.utils.team import get_member_id
+
+    named = Agent(name="Scout", telemetry=False)
+    assert named.id is None, "this fixture is about a member given no id of its own"
+    assert get_member_id(named) == "scout", "the framework no longer derives a member id from the name"
+    Team(name="Owner", members=[named], telemetry=False)._initialize_member(named)
+    assert named.id == "scout", "a Team no longer assigns its members the id it delegates to them by"
+
+    events = await collect(_parallel_delegations_to_named_members_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED)
+    announcement = _announcements(events)[0]
+    assert (
+        announcement.subagent_run_id,  # type: ignore[attr-defined]
+        announcement.name,  # type: ignore[attr-defined]
+        announcement.description,  # type: ignore[attr-defined]
+        announcement.parent_tool_call_id,  # type: ignore[attr-defined]
+    ) == ("run-scout", "Scout", "scout the north", "tc-scout")
+    # The delegation's own parent message, resolved against the messages this
+    # stream really opened: read back as None on both sides, that field compares
+    # nothing, and an id no start ever carried is one a client cannot place.
+    assert announcement.parent_message_id in _lane_of_message_id(events), (  # type: ignore[attr-defined]
+        "the delegation's own parent message names no message this stream opened"
+    )
+
+
+def _two_delegations_naming_one_member_chunks() -> List[Any]:
+    """Two open delegations name the same member, so neither can be shown to have spawned it."""
+    member = _member_kwargs("scout", "run-scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=_delegation("tc-first", "scout", "scout the north")),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=_delegation("tc-second", "scout", "scout the south")),
+        _agent_said("scouting", **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_two_open_delegations_naming_one_member_report_no_link_rather_than_a_guess(collect):
+    events = await collect(_two_delegations_naming_one_member_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED)
+    assert [
+        (e.subagent_run_id, e.description, e.parent_tool_call_id, e.parent_message_id)  # type: ignore[attr-defined]
+        for e in _announcements(events)
+    ] == [("run-scout", None, None, None)]
+
+
+def _broadcast_delegation(tool_call_id: str, task: str) -> ToolExecution:
+    """One of the delegation tools that names no member, because it targets them all."""
+    return ToolExecution(
+        tool_call_id=tool_call_id,
+        tool_name="delegate_task_to_members",
+        tool_args={"task": task},
+    )
+
+
+def _member_spawned_by_a_broadcast_chunks() -> List[Any]:
+    """The only open delegation is a broadcast, so nothing on it names the member."""
+    member = _member_kwargs("scout", "run-scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=_broadcast_delegation("tc-broadcast", "everyone work")),
+        RunStartedEvent(**member),
+        RunCompletedEvent(content="scout done", **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_broadcast_delegation_names_no_member_so_no_link_is_reported(collect):
+    """A lone open delegation is not evidence that it spawned this member.
+
+    Returning it because it is the only candidate hands an unrelated lane, such
+    as the inner run of a context provider, another member's parent call, task
+    text and parent message.
+    """
+    events = await collect(_member_spawned_by_a_broadcast_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED)
+    assert [
+        (e.subagent_run_id, e.parent_tool_call_id, e.description, e.parent_message_id)  # type: ignore[attr-defined]
+        for e in _announcements(events)
+    ] == [("run-scout", None, None, None)]
+
+
+def _paused_member_spawned_by_a_broadcast_chunks() -> List[Any]:
+    """A member pauses, and the only open delegation is a broadcast that names nobody."""
+    tool = ToolExecution(
+        tool_call_id="tc-scout-confirm", tool_name="send_email", tool_args={"to": "ops"}, requires_confirmation=True
+    )
+    requirement = _requirement(tool, "scout", "run-scout", "Scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=_broadcast_delegation("tc-broadcast", "everyone work")),
+        TeamRunPausedEvent(tools=[], requirements=[requirement], **_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_paused_member_a_broadcast_spawned_reports_no_link(collect):
+    """The paused path resolves the parent the same way, so it borrows nothing either."""
+    events = await collect(_paused_member_spawned_by_a_broadcast_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.TOOL_CALL_START, 2)
+    assert [
+        (e.subagent_run_id, e.parent_subagent_run_id, e.parent_tool_call_id, e.description, e.parent_message_id)  # type: ignore[attr-defined]
+        for e in _announcements(events)
+    ] == [("run-scout", None, None, None, None)]
+
+
+def _paused_grandchild_a_broadcast_delegated_chunks() -> List[Any]:
+    """A sub-team broadcasts to its members, and one of them pauses."""
+    inner = _team_kwargs("inner-team", "Inner Team", "run-inner", parent=TOP_LEVEL_RUN)
+    outer_delegation = _delegation("tc-delegate-inner", "inner-team", "run the inner team")
+    member_tool = ToolExecution(
+        tool_call_id="tc-scout-confirm", tool_name="send_email", tool_args={"to": "ops"}, requires_confirmation=True
+    )
+    requirement = _requirement(member_tool, "scout", "run-scout", "Scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=outer_delegation),
+        TeamRunStartedEvent(**inner),
+        TeamToolCallStartedEvent(tool=_broadcast_delegation("tc-inner-broadcast", "everyone scout"), **inner),
+        TeamRunPausedEvent(tools=[], requirements=[requirement], **_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_paused_grandchild_whose_parent_cannot_be_identified_reports_no_parent(collect):
+    """No parent beats the leader: the sub-team's task and the leader's message are not this member's.
+
+    Reaching past the sub-team for the leader's own open delegation also flattens
+    the tree, which puts the grandchild at the same depth as the member that
+    really delegated to it and reverses the order their terminals go out in.
+    """
+    events = await collect(_paused_grandchild_a_broadcast_delegated_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED, 2)
+    parent_of_tool_call = {
+        e.tool_call_id: e.parent_message_id  # type: ignore[attr-defined]
+        for e in _of_type(events, EventType.TOOL_CALL_START)
+    }
+    # The sub-team's own link names a message this stream really opened: read
+    # back as None on both sides, that field compares nothing.
+    assert parent_of_tool_call["tc-delegate-inner"] in _lane_of_message_id(events), parent_of_tool_call
+    assert [
+        (e.subagent_run_id, e.parent_subagent_run_id, e.parent_tool_call_id, e.description, e.parent_message_id)  # type: ignore[attr-defined]
+        for e in _announcements(events)
+    ] == [
+        ("run-inner", None, "tc-delegate-inner", "run the inner team", parent_of_tool_call["tc-delegate-inner"]),
+        ("run-scout", None, None, None, None),
+    ]
+
+
+def _paused_member_named_by_two_delegations_chunks() -> List[Any]:
+    """One lane holds two open delegations naming the member that then pauses."""
+    tool = ToolExecution(
+        tool_call_id="tc-scout-confirm", tool_name="send_email", tool_args={"to": "ops"}, requires_confirmation=True
+    )
+    requirement = _requirement(tool, "scout", "run-scout", "Scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=_delegation("tc-first", "scout", "scout the north")),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=_delegation("tc-second", "scout", "scout the south")),
+        TeamRunPausedEvent(tools=[], requirements=[requirement], **_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_paused_member_named_by_two_delegations_reports_no_link(collect):
+    """The paused path resolves the parent the same way, so it omits the same links."""
+    events = await collect(_paused_member_named_by_two_delegations_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED)
+    assert [
+        (e.subagent_run_id, e.description, e.parent_subagent_run_id, e.parent_tool_call_id)  # type: ignore[attr-defined]
+        for e in _announcements(events)
+    ] == [("run-scout", None, None, None)]
+
+
+# --- Failures that have to reach somebody -----------------------------------
+
+
+def _member_tool_call_fails_chunks() -> List[Any]:
+    member = _member_kwargs("scout", "run-scout")
+    tool = ToolExecution(tool_call_id="tc-member-search", tool_name="search_docs", tool_args={"query": "agno"})
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**member),
+        ToolCallStartedEvent(tool=tool, **member),
+        ToolCallErrorEvent(tool=tool, error="tool exploded", **member),
+        RunCompletedEvent(content="scout done", **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_hidden_records_a_member_tool_call_failure_it_withholds(collect, caplog):
+    """Hidden withholds what identifies a member, never the fact that something failed."""
+    with captured_agno_logs(caplog, "WARNING"):
+        events = await collect(_member_tool_call_fails_chunks(), SUBAGENT_VISIBILITY_HIDDEN)
+
+    assert not [e for e in events if _lane(e) is not None]
+    assert not [e for e in events if "TOOL_CALL" in str(e.type)]
+    assert [r.message for r in caplog.records if "tool exploded" in r.message], (
+        "a member's tool call failed and neither the client nor the log was told"
+    )
+
+
+def _plain_member_failure_chunks() -> List[Any]:
+    """A member failure carrying nothing beyond its message and type."""
+    member = _member_kwargs("scout", "run-scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**member),
+        RunErrorEvent(content="member exploded", error_type="RuntimeError", **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+async def _assert_the_failure_line_names_only_what_it_has(collect, caplog, visibility: Optional[str]) -> None:
+    with captured_agno_logs(caplog, "ERROR"):
+        await collect(_plain_member_failure_chunks(), visibility)
+
+    failures = [r.message for r in caplog.records if "member exploded" in r.message]
+    assert len(failures) == 1, f"one failure was recorded {len(failures)} times: {failures}"
+    assert "None" not in failures[0], f"the failure line reports fields it does not have: {failures[0]}"
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_plain_member_failure_on_the_wire_is_recorded_without_empty_detail_fields(collect, caplog):
+    await _assert_the_failure_line_names_only_what_it_has(collect, caplog, attributed())
+
+
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_plain_member_failure_hidden_from_the_wire_is_recorded_without_empty_detail_fields(collect, caplog):
+    await _assert_the_failure_line_names_only_what_it_has(collect, caplog, SUBAGENT_VISIBILITY_HIDDEN)
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    # Built per case rather than at collection time, so the two mappers cannot
+    # hand each other a pending call one of them has already been through.
+    "unusable_factory,named",
+    [(_nameless_tool, "tc-nameless"), (_idless_tool, "send_invoice")],
+    ids=["no_name", "no_id"],
+)
+@chunk_mappers
+async def test_a_paused_tool_the_client_cannot_be_shown_is_recorded_even_when_another_survives(
+    collect, caplog, unusable_factory, named
+):
+    """A dropped pending call hangs the resume, so a partial drop cannot be silent."""
+    with captured_agno_logs(caplog, "WARNING"):
+        events = await collect(_paused_member_carrying_one_unusable_tool_chunks(unusable_factory()), attributed())
+
+    assert_stream_contains(events, EventType.TOOL_CALL_START)
+    assert [r.message for r in caplog.records if named in r.message], (
+        f"the dropped pending call {named} left no trace in the log"
+    )
+
+
+# --- The default pause prompt -----------------------------------------------
+
+
+def _paused_on_nothing_renderable_chunks() -> List[Any]:
+    """A run pauses on a single tool the client cannot be shown: it carries no name."""
+    nameless = _nameless_tool()
+    paused = AgentRunPausedEvent(agent_id="solo", agent_name="Solo", run_id=TOP_LEVEL_RUN, tools=[nameless])
+    paused.content = "Confirm before I send this."
+
+    return [RunStartedEvent(agent_id="solo", agent_name="Solo", run_id=TOP_LEVEL_RUN), paused]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    # Resolved inside the test rather than at collection: naming the attributed
+    # setting is what skips on a release that cannot serve it. It belongs here
+    # because it is the setting this behavior was reworked for, and because the
+    # prompt is now split one message per subagent, so a run with no subagent on
+    # it has to come out as the single unattributed message the others produce.
+    "setting",
+    [lambda: None, lambda: SUBAGENT_VISIBILITY_INLINE, attributed, lambda: SUBAGENT_VISIBILITY_HIDDEN],
+    ids=["default", "inline", "attributed", "hidden"],
+)
+@chunk_mappers
+async def test_a_pause_carrying_only_unrenderable_tools_still_says_so(collect, setting):
+    """The prompt message goes out whenever the terminal carries paused tools at all.
+
+    Before member attribution existed the renderability of a pending call
+    decided only whether that call was prompted, never whether the pause was
+    announced, so a run that paused on nothing renderable still told the client
+    why it stopped. It is the listing that decides: a terminal that listed no
+    pending call at all carries no prompt and no content with it, which is that
+    same stream and is pinned separately.
+    """
+    events = await collect(_paused_on_nothing_renderable_chunks(), setting())
+
+    assert_stream_contains(events, EventType.TEXT_MESSAGE_CONTENT)
+    # One message, unattributed, under every setting: no subagent is involved,
+    # so the per-subagent split has nothing to split and nothing to announce.
+    assert joined_text_in_emitted_order(events) == [(None, "Confirm before I send this.")]
+    assert not [e for e in events if "SUBAGENT" in str(e.type)]
+    assert not _of_type(events, EventType.TOOL_CALL_START)
+    assert str(events[-1].type) == str(EventType.RUN_FINISHED)
+
+
+# --- The interface's own shape ----------------------------------------------
+
+
+def _stream_state_attributes_read_outside(module_name: str) -> Set[str]:
+    """Every attribute the rest of the interface reads off a ``StreamState``.
+
+    Read off the syntax rather than by searching the source text for a bare
+    ``.name``: the per-lane ``Lane`` object declares fields under the same names
+    as the properties that front them, so a text search counts
+    ``lane.text_message_id`` as a read of the property and goes on reporting one
+    after every ``state.text_message_id`` is gone.
+    """
+    package = Path(handlers.__file__).parent
+    read: Set[str] = set()
+    for path in sorted(package.glob("*.py")):
+        if path.name == module_name:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        holders = {
+            argument.arg
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            for argument in node.args.args
+            if isinstance(argument.annotation, ast.Name) and argument.annotation.id == StreamState.__name__
+        }
+        holders.update(
+            target.id
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Assign)
+            and isinstance(node.value, ast.Call)
+            and isinstance(node.value.func, ast.Name)
+            and node.value.func.id == StreamState.__name__
+            for target in node.targets
+            if isinstance(target, ast.Name)
+        )
+        read.update(
+            node.attr
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Attribute)
+            and isinstance(node.ctx, ast.Load)
+            and isinstance(node.value, ast.Name)
+            and node.value.id in holders
+        )
+    return read
+
+
+def test_every_stream_state_property_is_read_somewhere_in_the_interface():
+    """A property nothing reads is a second home for state with one truth.
+
+    Each of these reads whichever lane is current, so one left unread outlives
+    the reader that justified it and answers for the wrong lane if anything
+    picks it up again.
+    """
+    # A walk that found no StreamState at all would report every property as
+    # unread rather than pass, so what it did find is stated first.
+    read = _enumerated_by_the_interface(
+        _stream_state_attributes_read_outside("state.py"),
+        "lane",
+        described="the StreamState attributes the rest of the interface reads",
+    )
+    unread = sorted(
+        name for name, member in vars(StreamState).items() if isinstance(member, property) if name not in read
+    )
+    assert not unread, f"nothing outside the state module reads these StreamState properties: {unread}"
+
+
+def test_the_terminal_check_requires_the_state_it_classifies_against():
+    """Its default is unreachable, and would read a member's terminal as the run's."""
+    state_parameter = inspect.signature(handlers.is_completion_event).parameters["state"]
+    assert state_parameter.default is inspect.Parameter.empty
+
+
+def test_the_hidden_visibility_says_what_still_reaches_the_client():
+    """Two things do, so neither the option nor the branch may claim it withholds all."""
+    from agno.os.interfaces.agui import AGUI
+
+    constructor_doc = _docstring(AGUI.__init__, "the AGUI constructor")
+    for claim in ("session state", "pending tool call"):
+        assert claim in constructor_doc, f"the documented hidden option does not mention the {claim} it delivers"
+        assert claim in inspect.getsource(handlers.process_event), (
+            f"the hidden branch does not mention the {claim} it delivers"
+        )
+
+
+def test_the_announcement_says_it_never_names_a_parent_the_stream_has_not_reached():
+    """A refusal a reader has to be told about: the parent link is dropped, not deferred."""
+    said = _docstring(handlers._announce_subagent, "the member announcement")
+    assert "already announced" in said
+    assert "forward reference" in said


### PR DESCRIPTION
## Summary

When a team hands work to its sub-agents, everything they produce arrives at the UI as one undifferentiated stream: you can't tell which one said what, or which one made a given tool call. Agno already knows; the interface was just throwing it away.

This tags each message and tool call with the sub-agent that produced it, using labels the protocol already has for exactly this. It's off by default, so nothing changes for anyone until they ask for it.

- `subagent_visibility` on the AGUI interface: `inline` (default, byte-identical to today's stream), `attributed` (delegations announced and finished, each event stamped with its sub-agent), `hidden` (lifecycle, stamps and the failing sub-agent's identity withheld; a paused run's pending call and the reason a run stopped still get through).
- Single-Agent runs are unchanged under every setting.
- Needs `ag-ui-protocol` 0.1.21+ for the two lineage settings. On older releases the default works as before and the others refuse with a clear error.

## Type of change

- [x] New feature

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts — `./scripts/validate.sh` passes. `./scripts/format.sh` was **not** run because it reformats 15+ files unrelated to this change; `ruff format` and `ruff check` were run on the touched files instead.
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: cookbook example added
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated
