### PR TITLE
feat: serve A2UI generated interfaces over AG-UI

### DIFF
--- a/cookbook/05_agent_os/16_agui/README.md
+++ b/cookbook/05_agent_os/16_agui/README.md
@@ -22,6 +22,8 @@ default empty prefix those routes are `POST /agui` and `GET /status`.
 | `shared_state.py` | Send state snapshots and JSON Patch deltas as session state changes. |
 | `human_in_the_loop.py` | Pause and resume a real backend tool that uses `requires_confirmation`. |
 | `research_team.py` | Stream a coordinated Team and its member activity over AG-UI. |
+| `a2ui_generated_ui.py` | Let the agent design its own interface, painted as it streams. |
+| `a2ui_fixed_schema.py` | Return a hand-authored interface from an ordinary tool. |
 | `multiple_instances.py` | Mount two independent AG-UI interfaces on one AgentOS. |
 | `openui/` | Render an Agent as streaming charts, follow-ups, and validated forms with OpenUI. |
 
@@ -33,6 +35,7 @@ Install the demo environment, then export the provider key used by the file:
 ./scripts/demo_setup.sh
 export OPENAI_API_KEY=...
 export GOOGLE_API_KEY=...  # agent_with_media.py only
+.venvs/demo/bin/pip install -U ag-ui-a2ui-toolkit  # a2ui_generated_ui.py only
 ```
 
 `research_team.py` also needs internet access for `WebSearchTools`.
@@ -50,6 +53,8 @@ Start one example at a time; every standalone server uses port 7777:
 .venvs/demo/bin/python cookbook/05_agent_os/16_agui/shared_state.py
 .venvs/demo/bin/python cookbook/05_agent_os/16_agui/human_in_the_loop.py
 .venvs/demo/bin/python cookbook/05_agent_os/16_agui/research_team.py
+.venvs/demo/bin/python cookbook/05_agent_os/16_agui/a2ui_generated_ui.py
+.venvs/demo/bin/python cookbook/05_agent_os/16_agui/a2ui_fixed_schema.py
 .venvs/demo/bin/python cookbook/05_agent_os/16_agui/multiple_instances.py
 ```
 
@@ -70,6 +75,8 @@ endpoint:
 | `shared_state.py` | `http://localhost:7777/shared-state/agui` | `http://localhost:7777/shared-state/status` |
 | `human_in_the_loop.py` | `http://localhost:7777/human-in-the-loop/agui` | `http://localhost:7777/human-in-the-loop/status` |
 | `research_team.py` | `http://localhost:7777/research-team/agui` | `http://localhost:7777/research-team/status` |
+| `a2ui_generated_ui.py` | `http://localhost:7777/generated-ui/agui` | `http://localhost:7777/generated-ui/status` |
+| `a2ui_fixed_schema.py` | `http://localhost:7777/fixed-schema/agui` | `http://localhost:7777/fixed-schema/status` |
 | `multiple_instances.py` | `http://localhost:7777/chat/agui` and `http://localhost:7777/analyst/agui` | `/chat/status` and `/analyst/status` |
 | `openui/server.py` | `http://localhost:7777/agui` | `http://localhost:7777/status` |
 
@@ -149,3 +156,183 @@ snapshot.
 Media belongs in the latest user message as an AG-UI image, audio, video, or
 document content part. The adapter converts URL or base64 data sources into
 Agno media objects before calling the Gemini agent in `agent_with_media.py`.
+
+## Agent-generated interface
+
+An agent can answer with a rendered surface rather than prose. AG-UI carries
+that as A2UI: a declarative component tree in a tool result, which the client
+draws using components it already knows how to render. There are two ways to
+produce one, and they cost very different things.
+
+| | `a2ui_generated_ui.py` | `a2ui_fixed_schema.py` |
+|---|---|---|
+| Who designs the layout | A render subagent, per question | You, once, in Python |
+| Extra model calls | One per attempt | None |
+| Component tree | Decided per question | Fixed; only the data changes |
+| Needs `ag-ui-a2ui-toolkit` | Yes | No |
+| Use when | The shape of the answer varies | You know what the card looks like |
+
+### Asking for generation
+
+Generation is off unless the run asks for it. A client asks by forwarding
+`injectA2UITool`. The interface then adds the generation tool for that run and
+removes the render tool the client injected, which it replaces.
+
+Alongside that, the client sends the catalog of components it can draw as a
+context entry. That entry is what tells the subagent which components exist,
+and, unless you pin one with `a2ui={"default_catalog_id": ...}`, it names the
+catalog the surface is stamped with. A run that asks for generation without it
+still generates, but the subagent designs with no component list and the surface
+is stamped with the A2UI basic catalog, which is rarely what the client
+registered.
+
+```bash
+curl -N http://localhost:7777/generated-ui/agui \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "threadId": "a2ui-readme-thread",
+    "runId": "a2ui-readme-run",
+    "state": {},
+    "messages": [
+      {"id": "message-1", "role": "user", "content": "Show me the quarter"}
+    ],
+    "tools": [],
+    "context": [
+      {
+        "description": "A2UI Component Schema — available components for generating UI surfaces. Use these component names and properties when creating A2UI operations.",
+        "value": "{\"catalogId\": \"my-catalog\", \"components\": [{\"name\": \"Column\"}, {\"name\": \"Text\"}]}"
+      }
+    ],
+    "forwardedProps": {"injectA2UITool": true}
+  }'
+```
+
+That `description` is matched by exact text, so it has to read exactly as
+above; an AG-UI client library sends it for you.
+
+To generate for clients that do not ask, pass
+`AGUI(agent=..., a2ui={"inject_a2ui_tool": True})`. A client forwarding
+`injectA2UITool: false` still turns generation off for its own run.
+
+A tool you wired yourself with `get_a2ui_tools` is never injected over. The
+interface reads the `tools` list of the agent or team it was given once per run
+and asks two questions of that single reading: whether the entity already
+generates surfaces, and whether the generation tool's name is taken.
+
+Every shape a tool reaches that list in answers both. The returned `Function`,
+and a `Toolkit` wrapping it, are recognized as generating: injection is skipped,
+and the run gets the render channel that paints a surface as it is written. A
+plain callable, an OpenAI-style `{"type": "function", ...}` dict, and a flat
+`{"name": ...}` dict are read for their names, so a tool of the generation
+tool's name is not injected over even when nothing about it generates; a run
+against one of those gets no render channel, because nothing server-side is
+going to push fragments into it.
+
+One shape cannot be read: a `tools` that is itself a callable the agent resolves
+when it runs. Reading it would mean running your code an extra time per request
+and handing back tool objects the agent then never sees, so it answers neither
+question, and the interface declines instead of guessing. Injection is skipped
+with a warning saying why, because a second tool of the same name would leave
+the model choosing between duplicates and take the client's render tool away.
+Painting is not skipped: the render channel is prepared for any run that might
+generate, since an unused channel costs nothing while a missing one loses
+progressive painting with nothing to show that it did.
+
+Declining, for any of those reasons, leaves the run exactly as the client
+arranged it, and that includes the render tool the client injected: it is not
+dropped, so the model is offered both. The client's render tool is an ordinary
+frontend tool, so a call to it pauses the run until the browser sends a result
+back, the same way `change_background` does in `agent_with_tools.py`. Either
+have the client stop injecting it, or expect that pause. The same hands-off path is taken when
+generation is asked for and `ag-ui-a2ui-toolkit` is not installed: the interface
+logs an error and serves the run with whatever the client sent. A file that
+imports from `agno.os.interfaces.agui.a2ui` itself, as `a2ui_generated_ui.py`
+does for the tool choice below, does need the toolkit to start at all.
+
+### What the stream looks like
+
+The generation call arrives as an ordinary `TOOL_CALL_*` sequence. Nested inside
+it is a second call carrying the design as it is written, one `TOOL_CALL_ARGS`
+frame at a time, which is what lets the client show a surface filling in rather
+than appearing whole several seconds later. The generation call's result is the
+finished surface.
+
+How progressive that is depends on the provider. `OpenAIChat` streams partial
+tool arguments; `OpenAIResponses` hands them over in one piece, so the surface
+still renders correctly but arrives all at once. That is why
+`a2ui_generated_ui.py` uses `OpenAIChat`.
+
+### When the design is wrong
+
+Each attempt is validated against the same rules the client applies, and a tree
+that fails is never committed: the errors go back to the subagent and it tries
+again, up to three times by default (`a2ui={"recovery": {"maxAttempts": 5}}` to
+change that; those keys are camelCase, and a snake_case one is ignored with a
+warning). Only a tree that validated becomes the tool result, so a rejected
+design never enters the conversation.
+
+A design that never arrives costs an attempt too. One render turn is given 180
+seconds by default, and a turn that goes over it, or fails on a provider or
+transport error, is recorded as a failed attempt and retried like an invalid
+tree. Change that bound with `a2ui={"subagent_timeout": 300}`, or `None` for no
+bound at all, remembering that a generation which retries can take a multiple of
+whatever you set.
+
+Streaming means a rejected design does reach the client, though. Every attempt's
+render call is pushed frame by frame while it is being written, which is before
+there is a finished tree to validate. What keeps it off the screen is the client:
+the validator the recovery loop retries on is the same one the renderer uses as
+its paint gate, so the tree the tool rejects is the tree the renderer refuses to
+draw.
+
+If every attempt fails, the tool result is a structured failure carrying no
+operations at all, so a surface already on screen is left alone and the
+conversation stays usable. When the attempts failed for a reason other than a
+bad design, that failure also carries the provider errors under
+`subagentErrors`, so a run that died on an expired key does not read as a model
+that could not lay out a card.
+
+### Forcing the render call
+
+An attempt that produces no render call at all costs exactly what an invalid
+design costs: the loop records that the subagent did not call `render_a2ui` and
+spends one of its three attempts. So a subagent that answers in prose burns a
+third of the budget before a single tree has been validated.
+
+Forcing the render tool removes that failure mode, and nothing is forced by
+default, because no spelling of `tool_choice` works everywhere. Agno hands
+`tool_choice` to the provider as it was given: an OpenAI-compatible provider
+takes the forced-function object, Gemini reads the same value as a
+`function_calling_config.mode` and rejects it, which fails every attempt, and
+Anthropic drops `tool_choice` and carries on. Forcing belongs with the model you
+picked rather than in a default, which is why the module exports the OpenAI
+shape instead of applying it.
+
+`a2ui_generated_ui.py` runs an OpenAI model, so it forces:
+
+```python
+from agno.os.interfaces.agui.a2ui import OPENAI_RENDER_TOOL_CHOICE
+
+AGUI(agent=sales_agent, a2ui={"tool_choice": OPENAI_RENDER_TOOL_CHOICE})
+```
+
+Wiring the tool yourself puts the same value in the second argument of
+`get_a2ui_tools`, which is where the Agno-specific options live rather than in
+the cross-framework parameters of the first:
+
+```python
+get_a2ui_tools({"model": model}, {"tool_choice": OPENAI_RENDER_TOOL_CHOICE})
+```
+
+`subagent_timeout` is passed the same way on either path. A provider that
+rejects the object may still accept a plain string: Gemini maps `"any"`,
+`"auto"`, `"none"`, and `"validated"` onto its own function-calling modes, and
+`"any"` is the one that forces a call.
+
+### A2UI and OpenUI
+
+Both put generated interface on screen, from opposite directions. A2UI is part
+of AG-UI: the agent emits components from a catalog the client registered, so
+any AG-UI client can draw them. [`openui/`](openui/) is a complete client that
+renders an agent's text as components of its own. Use A2UI when the frontend
+owns the component library; use OpenUI when you want its client and renderer.

--- a/cookbook/05_agent_os/16_agui/TEST_LOG.md
+++ b/cookbook/05_agent_os/16_agui/TEST_LOG.md
@@ -1,10 +1,12 @@
 # Test Log: 16_agui
 
-Tested on 2026-07-24 against Agno source commit
-`a463d3be3563d30d11d32d4f0f9dc23ccefdb4d2`.
+Runs are identified by their date, what was exercised, and the pinned
+dependency versions, never by commit hash: this work rebases onto new upstream
+releases, and each rebase rewrites every hash on the branch. The branch's
+current upstream base is Agno v3.0.8.
 
-The OpenUI addition was tested on 2026-08-18 against Agno source commit
-`32e5fb9c2203fa98de19ca72750133a57a075899`.
+The AG-UI examples were tested on 2026-07-24 and the OpenUI addition on
+2026-08-18, each against the branch as it stood then.
 
 Each checked-in server was first booted on its default port 7777. The sweep
 asserted `GET /health`, `GET /config`, every mounted AG-UI status route, and a
@@ -188,13 +190,109 @@ TypeScript compilation, and the Vite production build passed.
 
 ---
 
-## Validation
+## A2UI addition, 2026-09-08
 
-- All 9 standalone files booted, exposed their expected `/status` route, and
-  shut down cleanly.
-- All 9 files completed a real capability-specific AG-UI POST flow.
-- Recursive pattern validation checked exactly 9 Python files with 0
-  violations.
+Tested against the A2UI addition on this branch, with `ag-ui-protocol 0.1.22`
+and `ag-ui-a2ui-toolkit 0.0.4`.
+
+**Test mode:** SCRIPTED MODEL. This environment has no provider key, so each
+model turn is scripted at the provider's HTTP boundary. Everything downstream of
+that is real: uvicorn, chunked SSE over a real socket, Agno's own streaming
+delta parser and tool executor, the AG-UI interface, and the shared A2UI
+toolkit's validation and retry loop. A live-model pass is still owed.
+
+### a2ui_generated_ui.py
+
+**Status:** PASS
+
+**Test mode:** SCRIPTED MODEL
+
+**Description:** Booted the server, checked `/health`, `/config`, and
+`/generated-ui/status`, then drove four flows over real HTTP: a surface
+generated from scratch, an edit whose first design was invalid, an edit whose
+every design was invalid, and a run that refused generation.
+
+**Result:** Health returned `ok`; config returned OS `agui-a2ui-os`, agent
+`agui-a2ui-agent`, and one AG-UI interface at `/generated-ui`.
+
+Generation streamed: the design arrived as six incremental `TOOL_CALL_ARGS`
+frames on a call nested inside `generate_a2ui`, the first naming the catalog the
+request forwarded, and the nested call closed before the generation call
+reported. The committed surface was the design the model produced, bound to the
+forwarded catalog. Ordinary text and tool events were unaffected.
+
+The flow was checked to be genuinely incremental rather than merely ordered: the
+render subagent stopped after its first fragment and waited for the client to
+confirm that fragment had arrived. Held-back fragments would deadlock instead of
+passing.
+
+Recovery held: an invalid design was rejected, its errors were fed back, and the
+retry was what got committed. The rejected design never appeared in any tool
+result. An edit reconciled the existing surface rather than recreating it.
+
+Exhaustion was clean and bounded: three attempts, then a structured
+`a2ui_recovery_exhausted` result carrying no operations at all, so a surface
+already on screen was left alone. The run still finished with an ordinary text
+answer.
+
+Opting out was clean: with `injectA2UITool: false` the generation tool was never
+offered to the model, the client's own render tool was passed through untouched,
+no surface was produced, and the answer came back as text. The next request on
+the same server, asking for generation, got it.
+
+The README's `curl` example was then run verbatim against the same server and
+produced the nested render call, five incremental argument frames, and a surface
+bound to the catalog id in the example.
+
+---
+
+### a2ui_fixed_schema.py
+
+**Status:** PASS
+
+**Test mode:** SCRIPTED MODEL
+
+**Description:** Booted the server, checked `/health`, `/config`, and
+`/fixed-schema/status`, then asked for a flight over real HTTP.
+
+**Result:** Config returned OS `agui-a2ui-fixed-os`, agent
+`agui-a2ui-fixed-agent`, and one AG-UI interface at `/fixed-schema`. The
+`show_flight` result was the surface itself: the authored component tree
+returned unchanged, the catalog id as written in the file, and only the data
+model carrying the call's arguments. Exactly two model turns ran, so no second
+model was involved in producing the surface.
+
+---
+
+### Interface tests
+
+**Status:** PASS
+
+**Description:** `libs/agno/tests/unit/os/interfaces/` and
+`libs/agno/tests/unit/app/`.
+
+**Result:** green, and green again on every round since.
+`./scripts/format.sh` and `./scripts/validate.sh` both clean.
+
+This entry used to carry a count and an inventory of the strict
+expected-failures the suites held at the time. Every gap those pinned has since
+been closed, each as an ordinary passing assertion, so there is no inventory
+left to keep and no reason to record a count here that a later round will
+outgrow. The current one is measured in each round's own validation block, most
+recently 2026-09-09.
+
+---
+
+## Validation, AG-UI and A2UI addition
+
+- All 11 standalone files booted and exposed their expected `/status` route.
+  The 9 that predate the A2UI addition were also checked for a clean shutdown.
+- All 11 files completed a capability-specific AG-UI POST flow: the 9 that
+  predate the A2UI addition against live models, and `a2ui_generated_ui.py` and
+  `a2ui_fixed_schema.py` against a scripted model. A live-model pass for those
+  two is still owed.
+- Pattern validation checked the folder's 11 top-level Python files with 0
+  violations, and 12 with `--recursive`, which adds `openui/server.py`.
 - Targeted Ruff format and check passed.
 - Python compilation, banned-model, stale-route, scope, Unicode/emoji,
   non-PASS status, and `git diff --check` gates passed.
@@ -206,3 +304,206 @@ TypeScript compilation, and the Vite production build passed.
 - Repository-wide Ruff, agnoctl mypy, and cookbook pattern checks passed. The
   core Agno mypy step reported 27 existing errors in six files outside this
   integration's diff.
+
+---
+
+## A2UI docs refresh, 2026-09-08
+
+The render subagent's default tool choice was removed from
+`agno/os/interfaces/agui/a2ui.py` after the A2UI addition above was documented:
+nothing is forced now, and the OpenAI forced-function shape is exported as
+`OPENAI_RENDER_TOOL_CHOICE` for hosts that want it. `README.md` and
+`a2ui_generated_ui.py` were brought back in line with that, and the rest of the
+A2UI section was re-checked against the current module.
+
+### a2ui_generated_ui.py
+
+**Status:** PASS
+
+**Test mode:** SCRIPTED MODEL. The file now sets
+`a2ui={"tool_choice": OPENAI_RENDER_TOOL_CHOICE}`, so what needed checking was
+the wiring, not another generation flow. The model was a stand-in driven
+in-process rather than scripted at the HTTP boundary. The full generation flows
+recorded above were not re-run, and the live-model pass they owe is still
+owed.
+
+**Description:** Booted the file's own `app` over real HTTP and asked for
+`/generated-ui/status`. Then drove the generation tool on a stand-in model that
+records what it is called with: once through `prepare_a2ui_run` with and without
+the interface config, and once through `get_a2ui_tools` with and without its
+options argument.
+
+**Result:** Status returned `available` with the new interface config in place,
+and a run forwarding `injectA2UITool` still injected `generate_a2ui` and dropped
+the client's `render_a2ui`. Both wiring paths passed the tool choice to the model
+call unchanged, and both defaulted to no tool choice at all when nothing was
+given. Exhausting the attempts produced an `a2ui_recovery_exhausted` result
+carrying `error`, `code`, and `attempts` and no operations, which is what the
+README claims about a failed generation.
+
+---
+
+## Validation, A2UI docs refresh
+
+- `./scripts/format.sh` and `./scripts/validate.sh` clean.
+- `check_cookbook_pattern.py --base-dir cookbook/05_agent_os/16_agui`: 11 files,
+  0 violations.
+
+---
+
+## A2UI docs re-verification, 2026-09-08
+
+A second review round found claims in `README.md` that the module no longer
+supports. Every claim in the README's A2UI section, and every claim in the two
+A2UI example files, was re-read against the current
+`agno/os/interfaces/agui/a2ui.py`, `a2ui_stream.py`, `router.py`, `handlers.py`,
+`agui.py`, the `Agent.tools` signature, the OpenAI Responses, Gemini, and
+Anthropic model modules, and the installed `ag-ui-a2ui-toolkit 0.0.4`. No code
+was changed.
+
+**Status:** PASS
+
+**Test mode:** SOURCE AND TEST SUITE. No server was booted for this pass; the
+runs recorded above stand, and the live-model pass the two A2UI files owe is
+still owed.
+
+**Corrected:**
+
+- The README claimed a tool the developer wired with `get_a2ui_tools` is never
+  injected over. The two tool detectors of the time each read `entity.tools`
+  only when it is a list, so a `tools` given as a callable factory was
+  invisible to both and a second tool of the same name was injected; a flat
+  `{"name": ...}` dict was missed by the name detector for the same reason. The
+  README stated which shapes were seen, which were not, and what happened to a
+  run against one that was not. Both detectors were later replaced by the
+  single `resolve_entity_tools`, which closed those gaps; see the 2026-09-09
+  round below.
+- The README said the missing-toolkit path logs a warning. `_plan_a2ui_run` in
+  `router.py` calls `log_error`, and a unit test pins the emitted level, so the
+  README now says error.
+- The README's list of Gemini tool-choice strings omitted `"validated"`, which
+  `Gemini.get_request_params` maps like `"auto"`, `"none"`, and `"any"`.
+- This log cited four commit hashes, three of which are no longer ancestors of
+  the branch after a rebase onto a new upstream release. Runs are now identified
+  by date, scope, and pinned dependency versions.
+- This log reported 281 passing interface tests, which the suite had already
+  grown past. Counts now live in each round's own validation block.
+- A `FAKE MODEL` label, two missing entry separators, and a `Validation`
+  heading at two different levels were brought in line with the rest of the
+  file.
+- The addition's validation list recorded 27 pre-existing core mypy errors in
+  six files outside this integration's diff. `./scripts/validate.sh` now
+  reports no issues across 1050 source files, so that note is superseded.
+
+**Re-verified and left standing:** the two-way comparison table; the exact-text
+match on the schema context entry, byte-identical to the toolkit's own
+`A2UI_SCHEMA_CONTEXT_DESCRIPTION`; the basic-catalog fallback when no catalog is
+forwarded and no `default_catalog_id` is pinned; the hands-off path leaving the
+client's render tool in place; nesting of render progress inside the generation
+call as `TOOL_CALL_START`, `TOOL_CALL_ARGS`, `TOOL_CALL_END`; three recovery
+attempts by default with camelCase `maxAttempts` and a warning on a snake_case
+key; the 180-second default render-turn bound; the `a2ui_recovery_exhausted`
+envelope carrying `error`, `code`, `attempts`, no operations, and
+`subagentErrors` on a provider failure; `OpenAIResponses` accumulating tool
+arguments internally and publishing them only at `response.output_item.done`,
+which is why `a2ui_generated_ui.py` uses `OpenAIChat`; Gemini rejecting the
+forced-function object and Anthropic accepting `tool_choice` and never
+forwarding it; and `a2ui_fixed_schema.py`'s authored tree, which the toolkit's
+own validator accepts against the data model the tool supplies.
+
+---
+
+## Validation, A2UI docs re-verification
+
+- `libs/agno/tests/unit/os/interfaces/` and `libs/agno/tests/unit/app/` were
+  green at the time, with the strict expected-failures then in place. For the
+  counts as they stand, see the 2026-09-09 round below.
+- `./scripts/format.sh` and `./scripts/validate.sh` clean.
+- `check_cookbook_pattern.py --base-dir cookbook/05_agent_os/16_agui`: 11 files,
+  0 violations.
+
+---
+
+## A2UI docs re-verification, 2026-09-09
+
+A third review round found the README describing tool-shape blind spots that the
+tool detectors no longer have, and this log describing expected-failures the
+suite no longer contains. `resolve_entity_tools` in
+`agno/os/interfaces/agui/a2ui_stream.py` and `prepare_a2ui_run` in
+`agno/os/interfaces/agui/a2ui.py` were read as they stand on this branch, along
+with the tests that parametrize every tool shape in
+`libs/agno/tests/unit/os/interfaces/test_agui_a2ui_injection.py`.
+
+**Status:** PASS
+
+**Test mode:** SOURCE AND TEST SUITE. No server was booted for this pass; the
+runs recorded above stand, and the live-model pass the two A2UI files owe is
+still owed. Both A2UI example files were imported and their apps built.
+
+**Corrected:**
+
+- The README said a generation tool inside a `Toolkit` stops injection without
+  being recognized as generating, so its surface arrives whole. One walk of the
+  tools list now answers both questions from the same reading, and a `Toolkit`
+  is walked for its functions, so such a run is recognized and does get the
+  render channel.
+- The README said a flat `{"name": ...}` tool dict carries no name to read.
+  `_tool_dict_name` reads a name from the flat spelling as well as the nested
+  one, so that shape now holds the generation tool's name against injection.
+- The README said a run against a `tools` callable, or against a flat dict, has
+  a second tool of the same name injected over it. An unreadable tools list is
+  now reported as an explicit third answer rather than as absence, and
+  injection is declined with a warning saying why. The render channel is still
+  prepared for such a run, so a generation tool the callable builds paints as
+  it streams.
+- This log recorded 395 passed and 18 xfailed and inventoried six groups of
+  strict expected-failure. There are none left: 487 passed, no expected
+  failures, and the inventory was removed rather than updated, since the thing
+  it described no longer exists.
+- This log named `entity_generates_a2ui` and `entity_tool_names`. Both are gone,
+  replaced by the single `resolve_entity_tools`.
+- Comments in `router.py` and `handlers.py` said a retried render attempt reuses
+  the tool-call id its rejected predecessor was closed under. `A2UIRenderAttempt`
+  mints a wire id per attempt precisely so that cannot happen, and its own
+  docstring says a reused id would leave the healed surface unpainted. Both
+  comments now describe what the branch actually guards, a start arriving for an
+  id already closed, and the test docstring that made the same claim was
+  corrected with them.
+- A test comment said the README describes the missing-toolkit path as logging a
+  warning. The README was corrected to say error in the round above, so the
+  comment now records the two as pinned to each other.
+- `a2ui_fixed_schema.py` gave its agent a `db` and invited a multi-turn
+  conversation without `add_history_to_context`, so every follow-up arrived with
+  no memory of the card just shown and the stored history was never read. The
+  option is set now, with the reason in the file, as `a2ui_generated_ui.py`
+  already had it.
+- `a2ui_generated_ui.py`'s use of `OpenAIChat` against the cookbook rule was
+  explained in its module docstring only. The exemption is now recorded at the
+  import and the model call, which is where a sweep for the name lands.
+
+**Re-verified and left standing:** injection being off unless asked for, with a
+client's `injectA2UITool: false` overriding a backend `inject_a2ui_tool`; the
+catalog moving into run state only on a run that is injected into; the exact
+text of the schema context entry, still byte-identical to the toolkit's own
+`A2UI_SCHEMA_CONTEXT_DESCRIPTION`; the declined run keeping the client's render
+tool and the pause a call to it costs; `log_error` on the missing-toolkit path;
+`DEFAULT_RENDER_TOOL_CHOICE` being `None` with `OPENAI_RENDER_TOOL_CHOICE`
+exported for hosts that want forcing; the 180-second
+`DEFAULT_RENDER_SUBAGENT_TIMEOUT`; three recovery attempts with camelCase
+`maxAttempts`; and the `a2ui_recovery_exhausted` envelope.
+
+**Not covered by any test at this version:** `resolve_entity_tools` reads the
+entity's own `tools` only, so a generation tool held by a team member is not
+seen when the interface is given the team. The README claims nothing either way
+about members.
+
+---
+
+## Validation, A2UI docs re-verification 2026-09-09
+
+- `libs/agno/tests/unit/os/interfaces/` and `libs/agno/tests/unit/app/`:
+  487 passed, no expected failures.
+- `./scripts/format.sh` and `./scripts/validate.sh` clean.
+- `check_cookbook_pattern.py --base-dir cookbook/05_agent_os/16_agui`: 11 files,
+  0 violations.
+- Both A2UI example files imported and built their `app`.

--- a/cookbook/05_agent_os/16_agui/a2ui_fixed_schema.py
+++ b/cookbook/05_agent_os/16_agui/a2ui_fixed_schema.py
@@ -1,0 +1,127 @@
+"""
+Return a Hand-Authored A2UI Surface over AG-UI
+==============================================
+
+The other way to put a rendered surface on screen: an ordinary backend tool
+whose result is the surface itself. The component tree is written here, once, so
+only the data changes per call. No second model designs anything, so there is
+nothing to validate, retry, or stream, and no extra tokens are spent.
+
+Reach for this when you know what the card looks like and the agent only chooses
+when to show it and what to put in it. Reach for `a2ui_generated_ui.py` when the
+layout itself has to be decided per question.
+
+The client renders whatever it finds under `a2ui_operations` in a tool result, so
+the component names below have to exist in the catalog the client registered,
+and `CATALOG_ID` has to be that catalog's id.
+
+Prerequisites: OPENAI_API_KEY
+Run: .venvs/demo/bin/python cookbook/05_agent_os/16_agui/a2ui_fixed_schema.py
+Try: ask for a flight at http://localhost:7777/fixed-schema/agui
+"""
+
+import json
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIResponses
+from agno.os import AgentOS
+from agno.os.interfaces.agui import AGUI
+from agno.tools import tool
+
+# ---------------------------------------------------------------------------
+# Author the Surface
+# ---------------------------------------------------------------------------
+
+# Must match the catalog id the client registered with its renderer.
+CATALOG_ID = "flight-card-catalog"
+SURFACE_ID = "flight-card"
+
+# Values are bound to data paths rather than written in, so one tree serves
+# every flight and only the data model changes per call.
+FLIGHT_CARD = [
+    {"id": "root", "component": "Card", "child": "body"},
+    {"id": "body", "component": "Column", "children": ["route", "times", "price"]},
+    {"id": "route", "component": "Text", "text": {"path": "/route"}},
+    {"id": "times", "component": "Text", "text": {"path": "/times"}},
+    {"id": "price", "component": "Text", "text": {"path": "/price"}},
+]
+
+db = SqliteDb(
+    id="agui-a2ui-fixed-db",
+    db_file="tmp/agui_a2ui_fixed.db",
+)
+
+
+@tool
+def show_flight(route: str, times: str, price: str) -> str:
+    """Show a flight to the user as a card.
+
+    Args:
+        route: Origin and destination, for example "SFO to JFK".
+        times: Departure and arrival, for example "08:15 to 16:40".
+        price: Fare including currency, for example "USD 412".
+    """
+    return json.dumps(
+        {
+            "a2ui_operations": [
+                {
+                    "version": "v0.9",
+                    "createSurface": {"surfaceId": SURFACE_ID, "catalogId": CATALOG_ID},
+                },
+                {
+                    "version": "v0.9",
+                    "updateComponents": {
+                        "surfaceId": SURFACE_ID,
+                        "components": FLIGHT_CARD,
+                    },
+                },
+                {
+                    "version": "v0.9",
+                    "updateDataModel": {
+                        "surfaceId": SURFACE_ID,
+                        "path": "/",
+                        "value": {"route": route, "times": times, "price": price},
+                    },
+                },
+            ]
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Create Flight Agent
+# ---------------------------------------------------------------------------
+
+flight_agent = Agent(
+    id="agui-a2ui-fixed-agent",
+    name="AG-UI Flight Agent",
+    model=OpenAIResponses(id="gpt-5.6-luna"),
+    db=db,
+    # The AG-UI interface passes only the latest user message as input, so this
+    # is what gives the agent its earlier turns. Without it a follow-up such as
+    # "what about the morning flight" arrives with no memory of the card that
+    # was just shown, and the db above stores a history nothing reads.
+    add_history_to_context=True,
+    tools=[show_flight],
+    instructions=[
+        "Help the user find a flight.",
+        "Call show_flight to present a specific flight rather than describing it.",
+        "Invent plausible times and fares; this example has no booking backend.",
+    ],
+)
+
+agent_os = AgentOS(
+    id="agui-a2ui-fixed-os",
+    description="AgentOS returning a hand-authored A2UI surface over AG-UI.",
+    agents=[flight_agent],
+    interfaces=[AGUI(agent=flight_agent, prefix="/fixed-schema")],
+)
+app = agent_os.get_app()
+
+# ---------------------------------------------------------------------------
+# Run Fixed-Schema Server
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    agent_os.serve(app=app)

--- a/cookbook/05_agent_os/16_agui/a2ui_generated_ui.py
+++ b/cookbook/05_agent_os/16_agui/a2ui_generated_ui.py
@@ -1,0 +1,126 @@
+"""
+Let an Agent Generate its Own Interface over AG-UI
+==================================================
+
+Serve an agent that can answer with a rendered surface instead of prose. A
+client that renders A2UI asks for generation per run and forwards the catalog of
+components it knows how to draw; a render subagent designs a surface from that
+catalog, and the client paints it as the design streams in.
+
+Nothing below turns generation on. The agent has one ordinary tool and no A2UI
+setup of its own: the AG-UI interface adds the generation tool for any run whose
+`forwardedProps` carry `injectA2UITool`, and adds nothing to a run that does
+not ask. The instructions below do talk about surfaces, intents, and surface
+ids, because knowing when a surface is the better answer is the agent's job.
+They say it conditionally, because a run that did not ask has no generation tool
+for the model to call.
+
+The one A2UI setting made here is the render subagent's tool choice, which is a
+reliability measure rather than wiring: with the render call forced, a subagent
+that would have replied in prose cannot spend one of its three attempts doing
+so. Nothing is forced by default because the forced shape is provider specific,
+and this file has picked its provider.
+
+The model here is OpenAIChat rather than OpenAIResponses because the Responses
+API hands over tool arguments in one piece. Generation works either way, but on
+Responses the surface appears all at once instead of building as it is written.
+Chat completions asks for something back: this model takes function tools there
+only with its reasoning turned off, so the model below sets that explicitly.
+
+Prerequisites: OPENAI_API_KEY, .venvs/demo/bin/pip install -U ag-ui-a2ui-toolkit
+Run: .venvs/demo/bin/python cookbook/05_agent_os/16_agui/a2ui_generated_ui.py
+Try: POST with forwardedProps.injectA2UITool at http://localhost:7777/generated-ui/agui
+"""
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat  # deliberate: see the model below
+from agno.os import AgentOS
+from agno.os.interfaces.agui import AGUI
+from agno.os.interfaces.agui.a2ui import OPENAI_RENDER_TOOL_CHOICE
+from agno.tools import tool
+
+# ---------------------------------------------------------------------------
+# Create Generating Agent
+# ---------------------------------------------------------------------------
+
+db = SqliteDb(
+    id="agui-a2ui-db",
+    db_file="tmp/agui_a2ui.db",
+)
+
+
+@tool
+def quarterly_sales() -> dict:
+    """Return sales figures for the last four quarters."""
+    return {
+        "currency": "USD",
+        "quarters": [
+            {"quarter": "Q1", "revenue": 1_240_000, "growth": 0.04},
+            {"quarter": "Q2", "revenue": 1_385_000, "growth": 0.12},
+            {"quarter": "Q3", "revenue": 1_301_000, "growth": -0.06},
+            {"quarter": "Q4", "revenue": 1_702_000, "growth": 0.31},
+        ],
+    }
+
+
+sales_agent = Agent(
+    id="agui-a2ui-agent",
+    name="AG-UI Sales Agent",
+    # OpenAIChat rather than the OpenAIResponses the cookbook otherwise calls
+    # for, and the exception is the lesson: Responses hands tool arguments over in one
+    # piece, which leaves a generated surface appearing whole instead of painting
+    # as it is written, and progressive painting is what this file exists to show.
+    # The reasoning effort is off because chat completions refuses function tools
+    # for this model otherwise, which is the price of painting progressively.
+    model=OpenAIChat(id="gpt-5.6-luna", reasoning_effort="none"),
+    db=db,
+    # The AG-UI interface passes only the latest user message as input, so this
+    # is what gives the agent its earlier turns. Finding a surface to edit does
+    # not depend on it: that search reads the message history the client
+    # forwards with every request.
+    add_history_to_context=True,
+    tools=[quarterly_sales],
+    instructions=[
+        "Answer questions about sales using the quarterly_sales tool.",
+        (
+            "When you have a tool for generating a surface and the user asks to "
+            "see, show, compare, or lay something out, generate a surface for "
+            "it instead of describing it in prose. Without that tool, answer in "
+            "prose."
+        ),
+        (
+            "To change a surface you already rendered, generate again with "
+            "intent set to update and the surface id you used, so the client "
+            "reconciles what is on screen instead of replacing it."
+        ),
+        "Keep any prose alongside a surface to a single sentence.",
+    ],
+)
+
+agent_os = AgentOS(
+    id="agui-a2ui-os",
+    description="AgentOS whose agent renders its own interface over AG-UI.",
+    agents=[sales_agent],
+    # Generation itself needs no configuration here: the client asks per run.
+    # The tool choice is the OpenAI forced-function shape, which the model above
+    # accepts and Gemini would reject, so it is set per file rather than as a
+    # default. Also available: a2ui={"inject_a2ui_tool": True} to generate for
+    # clients that do not ask, or a2ui={"default_catalog_id": ...} to pin the
+    # catalog yourself.
+    interfaces=[
+        AGUI(
+            agent=sales_agent,
+            prefix="/generated-ui",
+            a2ui={"tool_choice": OPENAI_RENDER_TOOL_CHOICE},
+        )
+    ],
+)
+app = agent_os.get_app()
+
+# ---------------------------------------------------------------------------
+# Run Generated-UI Server
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    agent_os.serve(app=app)

--- a/libs/agno/agno/os/interfaces/agui/a2ui.py
+++ b/libs/agno/agno/os/interfaces/agui/a2ui.py
@@ -1,0 +1,1685 @@
+"""A2UI surface generation for Agno agents served over AG-UI.
+
+A2UI lets an agent generate its own interface: instead of returning prose, a
+tool returns a declarative component tree the AG-UI client renders. Generation
+is delegated to a subagent, one ``render_a2ui`` turn on the agent's own model,
+and only a tree that passes validation becomes the tool result. Every attempt
+streams to the client while it is being written, so what keeps a rejected tree
+off the screen is the client's own paint gate, which applies the same
+validation.
+
+``ag-ui-a2ui-toolkit`` owns everything framework-agnostic: the operation
+builders, prompt assembly, the history walk that finds a surface to edit, the
+operations envelope, semantic validation, and the validate/retry recovery loop.
+This module owns only the Agno-specific glue.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import json
+import threading
+import time
+import uuid
+from inspect import currentframe
+from typing import Any, Callable, Dict, List, NamedTuple, Optional, Set, Tuple, TypedDict, Union
+
+from agno.os.interfaces.agui.a2ui_stream import (
+    NO_ENTITY_TOOLS,
+    A2UIConfig,
+    A2UIGenerationFunction,
+    A2UIRenderStream,
+    A2UIRun,
+    ToolPresence,
+    current_a2ui_run,
+    is_remote_entity,
+    requested_a2ui_injection,
+    resolve_entity_tools,
+    validate_a2ui_config,
+)
+from agno.run.base import RunContext
+from agno.utils.log import log_debug, log_error, log_warning
+
+
+def _toolkit_import_message(err: ImportError) -> str:
+    """Say which way the toolkit import failed.
+
+    Three ways, each with a different fix, and naming the wrong one sends
+    someone to reinstall what they already have. The package can be absent.
+    It can be installed while a package it imports in turn is not, which is an
+    environment to complete rather than a version to upgrade. Or it can be
+    installed and no longer provide a name this module imports, which is a
+    version to upgrade. The original error is carried through for the last
+    two: it names the module or the symbol that was not found.
+    """
+    missing = err.name if isinstance(err, ModuleNotFoundError) else None
+    if (missing or "").split(".")[0] == "ag_ui_a2ui_toolkit":
+        return "`ag_ui_a2ui_toolkit` not installed. Please install it with `pip install -U ag-ui-a2ui-toolkit`"
+    if missing:
+        return (
+            f"`ag_ui_a2ui_toolkit` is installed but imports `{missing}`, which this environment does not have "
+            f"({err}). Please install the toolkit's dependencies with `pip install -U ag-ui-a2ui-toolkit`"
+        )
+    return (
+        "`ag_ui_a2ui_toolkit` is installed but does not provide what the A2UI interface needs, which usually "
+        f"means it is out of date ({err}). Please upgrade it with `pip install -U ag-ui-a2ui-toolkit`"
+    )
+
+
+try:
+    from ag_ui_a2ui_toolkit import (
+        A2UI_OPERATIONS_KEY,
+        A2UI_SCHEMA_CONTEXT_DESCRIPTION,
+        BASIC_CATALOG_ID,
+        GENERATE_A2UI_ARG_DESCRIPTIONS,
+        GENERATE_A2UI_TOOL_NAME,
+        RENDER_A2UI_TOOL_DEF,
+        A2UIGuidelines,
+        A2UIToolParams,
+        build_a2ui_envelope,
+        prepare_a2ui_request,
+        resolve_a2ui_catalog,
+        resolve_a2ui_tool_params,
+        run_a2ui_generation_with_recovery,
+        split_a2ui_schema_context,
+        wrap_error_envelope,
+    )
+except ImportError as e:
+    raise ImportError(_toolkit_import_message(e)) from e
+
+__all__ = [
+    # Wiring generation, by hand or per request.
+    "get_a2ui_tools",
+    "prepare_a2ui_run",
+    "A2UIAdapterOptions",
+    "A2UIConfig",
+    "A2UIRunPlan",
+    "A2UIGenerationFunction",
+    "A2UIRun",
+    "A2UIGuidelines",
+    "A2UIToolParams",
+    "A2UIRenderAttempt",
+    "A2UIRenderArgumentsError",
+    # Names, defaults and keys a caller configures or recognizes a run by.
+    "A2UI_OPERATIONS_KEY",
+    "A2UI_SCHEMA_CONTEXT_DESCRIPTION",
+    "BASIC_CATALOG_ID",
+    "GENERATE_A2UI_TOOL_NAME",
+    "RENDER_A2UI_TOOL_NAME",
+    "OPENAI_RENDER_TOOL_CHOICE",
+    "DEFAULT_RENDER_TOOL_CHOICE",
+    "DEFAULT_RENDER_SUBAGENT_TIMEOUT",
+    # The glue a custom wiring or another adapter reuses.
+    "agui_state_from_dependencies",
+    "build_agui_state",
+    "classify_a2ui_subagent_error",
+    "forwarded_a2ui_catalog",
+    "render_guide_description",
+    "stream_render_subagent",
+    "strip_host_system_messages",
+    "strip_in_flight_tool_call",
+]
+
+#: Name of the inner render tool the generation subagent is asked to call.
+RENDER_A2UI_TOOL_NAME: str = RENDER_A2UI_TOOL_DEF["function"]["name"]
+
+#: Tool choice for the render subagent. Nothing is forced by default. Agno
+#: hands ``tool_choice`` to each provider unchanged rather than normalizing it,
+#: and no spelling is accepted everywhere: the OpenAI function shape reaches
+#: Gemini's ``function_calling_config.mode``, where pydantic rejects it and
+#: every attempt fails, while Anthropic drops ``tool_choice`` entirely. Forcing
+#: is only a reliability measure, since a subagent that answers with prose
+#: instead of a tool call is already recorded as a failed attempt and retried,
+#: so a default that breaks a provider outright buys nothing. Force it per
+#: provider with ``A2UIAdapterOptions["tool_choice"]`` or
+#: ``A2UIConfig["tool_choice"]``.
+DEFAULT_RENDER_TOOL_CHOICE: Optional[Union[str, Dict[str, Any]]] = None
+
+#: The OpenAI forced-function shape, ready to pass as ``tool_choice`` for an
+#: OpenAI-compatible provider.
+OPENAI_RENDER_TOOL_CHOICE: Dict[str, Any] = {
+    "type": "function",
+    "function": {"name": RENDER_A2UI_TOOL_NAME},
+}
+
+#: How long one render turn may take before it is given up on and recorded as
+#: a failed attempt. Generous, because a large surface on a slow provider is a
+#: legitimately long call; bounded, because a provider that never answers would
+#: otherwise hold the tool call, and the client's whole run, open forever. It
+#: bounds one turn, so a generation that retries can take a multiple of it.
+#: Override per tool with ``A2UIAdapterOptions["subagent_timeout"]``, or
+#: ``None`` for no bound at all.
+DEFAULT_RENDER_SUBAGENT_TIMEOUT: Optional[float] = 180.0
+
+#: How often the thread blocked on a render turn wakes to check whether the
+#: caller is still there. Sets how quickly a disconnect is noticed mid-call.
+_DISCONNECT_POLL_SECONDS = 0.1
+
+#: This module's own source file, matched against the frame an exception was
+#: raised in to tell a bug here from a failure the model layer or the provider
+#: SDK produced.
+_THIS_MODULE_FILE = __file__
+
+
+class A2UIAdapterOptions(TypedDict, total=False):
+    """Agno-side wiring that the shared ``A2UIToolParams`` cannot express.
+
+    ``A2UIToolParams`` is owned by the toolkit and is identical across every
+    framework adapter. Anything Agno-specific belongs here instead.
+    """
+
+    tool_choice: Optional[Union[str, Dict[str, Any]]]
+    subagent_timeout: Optional[float]
+
+
+class A2UIRenderArgumentsError(ValueError):
+    """A render call whose arguments cannot be validated or committed.
+
+    Raised rather than returned as an empty mapping so the reason travels with
+    the failure. The shared recovery loop cannot tell an empty mapping from a
+    missing one, and reports both as a sub-agent that never called the render
+    tool, which is the only account of the failure the model and the client
+    get. Raised, it is recorded as this attempt's cause instead.
+    """
+
+
+#: The classes this module raises on purpose to end one attempt. They come
+#: from its own frames and are still worth another try, so the origin rule
+#: below must not read them as bugs: a render call whose arguments cannot be
+#: used, and a render turn that outran its deadline.
+_A2UI_ATTEMPT_FAILURES: Tuple[type, ...] = (A2UIRenderArgumentsError, TimeoutError)
+
+#: How an exception carrying no traceback is read, since it says nothing about
+#: where it came from. These are the classes a mistake in this module produces:
+#: reading a provider delta shape that is not there (``AttributeError``,
+#: ``KeyError``, ``IndexError``), calling something the wrong way
+#: (``TypeError``), a missing name or optional dependency (``NameError``,
+#: ``ImportError``), or a broken invariant (``AssertionError``). The model
+#: layer and the provider SDK raise every one of them too, which is why an
+#: exception that does carry a traceback is judged by its origin instead.
+_A2UI_ADAPTER_BUG_ERRORS: Tuple[type, ...] = (
+    TypeError,
+    NameError,
+    AttributeError,
+    KeyError,
+    IndexError,
+    ImportError,
+    AssertionError,
+)
+
+
+def _is_a2ui_cancellation(err: BaseException) -> bool:
+    """Whether ``err`` is a cancellation, whichever package's class it arrives as.
+
+    The recovery loop runs on a thread and waits on a ``concurrent.futures``
+    future, so cancelling the wait raises that package's own
+    ``CancelledError``. It is a plain ``Exception`` and no relation of
+    ``asyncio.CancelledError``, so recognizing only asyncio's reads a
+    cancelled render call as a model failure and retries it after the caller
+    has already gone.
+    """
+    return isinstance(err, (asyncio.CancelledError, concurrent.futures.CancelledError))
+
+
+def _raised_in_this_module(err: BaseException) -> Optional[bool]:
+    """Whether ``err`` was raised by this module's own code, or ``None`` if unknown.
+
+    The innermost frame of a traceback is the raise site: every frame the
+    exception travels through on the way out is prepended as it unwinds, and
+    the future the recovery thread waits on re-raises the original object with
+    its traceback intact. So the deepest frame still names where the failure
+    began, however many layers it crossed to get here.
+
+    ``None`` when there is no traceback to read, which is every exception that
+    was constructed rather than raised.
+    """
+    tb = err.__traceback__
+    if tb is None:
+        return None
+    while tb.tb_next is not None:
+        tb = tb.tb_next
+    return tb.tb_frame.f_code.co_filename == _THIS_MODULE_FILE
+
+
+def classify_a2ui_subagent_error(err: BaseException) -> str:
+    """Classify a subagent failure as ``"rethrow"`` or ``"recoverable"``.
+
+    ``"rethrow"`` unwinds the tool call without consuming retries. Two kinds of
+    failure earn it: cancellation, where retrying would defeat the cancel and
+    spend more tokens; and this module's own mistakes, which must surface
+    loudly instead of masquerading as a model that produced a bad surface.
+    Everything else is a genuine model or transport failure the recovery loop
+    should record as a failed attempt.
+
+    Which of the two a failure is cannot be read off its class. ``KeyError``,
+    ``AttributeError`` and friends arise as readily inside the model layer and
+    the provider SDK as they do here, and killing a run over a provider-side
+    one costs the caller every remaining attempt as well. So the question
+    asked is where the exception was raised, not what it is called.
+    """
+    if _is_a2ui_cancellation(err):
+        return "rethrow"
+    # SystemExit and KeyboardInterrupt signal shutdown; further attempts would
+    # fire model calls during interpreter teardown.
+    if not isinstance(err, Exception):
+        return "rethrow"
+    if isinstance(err, _A2UI_ATTEMPT_FAILURES):
+        return "recoverable"
+    raised_here = _raised_in_this_module(err)
+    if raised_here is None:
+        return "rethrow" if isinstance(err, _A2UI_ADAPTER_BUG_ERRORS) else "recoverable"
+    return "rethrow" if raised_here else "recoverable"
+
+
+def _read_tool_call_delta(entry: Any) -> Tuple[Optional[str], Optional[str], Optional[str], Optional[int]]:
+    """Read ``(tool_name, argument_fragment, call_id, index)`` from one delta.
+
+    Providers disagree on the shape. OpenAI-compatible models stream objects
+    where only the first frame carries the tool name and later frames carry
+    argument fragments; Anthropic and Gemini emit a single dict carrying the
+    whole call. Both are read the same way here, and any part may be absent.
+    """
+    if isinstance(entry, dict):
+        function: Any = entry.get("function") or {}
+        call_id = entry.get("id")
+        index = entry.get("index")
+    else:
+        function = getattr(entry, "function", None)
+        call_id = getattr(entry, "id", None)
+        index = getattr(entry, "index", None)
+
+    if isinstance(function, dict):
+        return function.get("name"), function.get("arguments"), call_id, index
+    return getattr(function, "name", None), getattr(function, "arguments", None), call_id, index
+
+
+#: How one delta names the tool call it belongs to: every dimension it carries,
+#: as ``(dimension, value)`` pairs, and nothing for the ones it omits.
+_DeltaKey = Tuple[Tuple[str, Any], ...]
+
+
+def _delta_call_key(call_id: Optional[str], index: Optional[int]) -> _DeltaKey:
+    """Every dimension one delta names its tool call by.
+
+    Providers disagree about which dimension they stamp where.
+    OpenAI-compatible streams put the id on the opening frame and the index on
+    all of them; others do the mirror image, an id on the opener and an index
+    on the continuations; some carry neither. Preferring one dimension over the
+    other reads every continuation frame of one of those families as a
+    different call and drops the whole surface, so a frame is keyed by what it
+    actually carries and calls are matched dimension by dimension.
+    """
+    dimensions: List[Tuple[str, Any]] = []
+    if call_id:
+        dimensions.append(("id", call_id))
+    if index is not None:
+        dimensions.append(("index", index))
+    return tuple(dimensions)
+
+
+def _key_conflicts(known: Dict[str, Any], key: _DeltaKey) -> bool:
+    """Whether a frame names a dimension differently from what is known of a call.
+
+    A dimension the frame omits says nothing about it and so cannot conflict,
+    which is what lets a continuation frame carrying only an index continue a
+    call that opened carrying only an id.
+    """
+    return any(dimension in known and known[dimension] != value for dimension, value in key)
+
+
+class _PartialToolNames:
+    """Tool names still arriving in fragments, one per call being named.
+
+    Matched dimension by dimension like the call itself, so a provider that
+    names one frame by id and the next by index accumulates one name rather
+    than two halves neither of which is recognizable.
+    """
+
+    def __init__(self) -> None:
+        self._entries: List[Tuple[Dict[str, Any], str]] = []
+
+    def _find(self, key: _DeltaKey) -> Optional[int]:
+        for position, (known, _) in enumerate(self._entries):
+            if not _key_conflicts(known, key):
+                return position
+        return None
+
+    def so_far(self, key: _DeltaKey) -> str:
+        found = self._find(key)
+        return "" if found is None else self._entries[found][1]
+
+    def remember(self, key: _DeltaKey, named: str) -> None:
+        found = self._find(key)
+        if found is None:
+            self._entries.append((dict(key), named))
+            return
+        known = self._entries[found][0]
+        known.update(key)
+        self._entries[found] = (known, named)
+
+    def forget(self, key: _DeltaKey) -> None:
+        found = self._find(key)
+        if found is not None:
+            self._entries.pop(found)
+
+
+def strip_in_flight_tool_call(messages: List[Any], tool_name: str) -> List[Any]:
+    """Drop the trailing assistant turn that is calling ``tool_name`` right now.
+
+    When the model invokes the generation tool, that assistant turn is the last
+    message and has no result yet. The subagent is not offered that tool, so
+    handing it an unanswered call is malformed input for providers that check
+    the pairing. Only a trailing match is stripped, so a normal user turn at the
+    tail survives.
+    """
+    if not messages:
+        return []
+
+    last = messages[-1]
+    role = last.get("role") if isinstance(last, dict) else getattr(last, "role", None)
+    if role != "assistant":
+        return list(messages)
+
+    tool_calls = last.get("tool_calls") if isinstance(last, dict) else getattr(last, "tool_calls", None)
+    for call in tool_calls or []:
+        name = _read_tool_call_delta(call)[0]
+        if name == tool_name:
+            return list(messages[:-1])
+    return list(messages)
+
+
+def _agui_context_entries(context: List[Any]) -> List[Dict[str, Any]]:
+    """Forwarded context entries as the shared toolkit needs to read them.
+
+    A served run forwards these as request models, and the toolkit's catalog
+    lookup passes over every entry that is not a dict. Left as models, the
+    catalog it finds is none, and a surface is bound to the basic catalog
+    rather than the one the client registered and can draw.
+    """
+    entries: List[Dict[str, Any]] = []
+    for entry in context:
+        if isinstance(entry, dict):
+            entries.append(entry)
+        else:
+            entries.append({"description": getattr(entry, "description", None), "value": getattr(entry, "value", None)})
+    return entries
+
+
+def build_agui_state(schema: Any, context: List[Any]) -> Dict[str, Any]:
+    """Assemble the run state the shared toolkit reads the catalog and context from.
+
+    The catalog arrives already parsed, so it is rendered back as JSON: left as
+    a dict, the subagent prompt would carry a Python repr of it instead.
+    """
+    ag_ui: Dict[str, Any] = {"context": _agui_context_entries(context)}
+    if schema is not None:
+        ag_ui["a2ui_schema"] = json.dumps(schema) if isinstance(schema, (dict, list)) else schema
+    return {"ag-ui": ag_ui}
+
+
+def agui_state_from_dependencies(dependencies: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Rebuild the ``state["ag-ui"]`` shape the toolkit reads from run dependencies.
+
+    The AG-UI router turns every ``RunAgentInput.context`` entry into a
+    dependency keyed by the entry's description, which puts the A2UI component
+    schema at a known key. Split it back out from the ordinary context entries:
+    the toolkit renders the schema as an available-components block and the rest
+    as plain context.
+    """
+    context: List[Dict[str, Any]] = []
+    schema: Any = None
+
+    for description, value in (dependencies or {}).items():
+        if description == A2UI_SCHEMA_CONTEXT_DESCRIPTION:
+            schema = value
+        else:
+            context.append({"description": description, "value": value})
+
+    return build_agui_state(schema, context)
+
+
+def _structural_gate_only(reason: str) -> Optional[Dict[str, Any]]:
+    """Report that the retry gate just lost the client's rule, and why.
+
+    Said out loud every time, because the gate carrying on with fewer checks
+    looks from the outside exactly like the gate that is checking everything.
+    """
+    log_warning(
+        f"A2UI component schema was forwarded but {reason}, so generated surfaces are checked for structure "
+        "only and a component the client cannot draw will reach it unchallenged."
+    )
+    return None
+
+
+def _flattened_component_schema(entry: Any) -> Optional[Dict[str, Any]]:
+    """One component's schema, with any ``allOf`` composition folded into it.
+
+    The client composes each component against a shared component base, so what
+    the component takes and what it requires arrive nested inside ``allOf``
+    members. The shared validator reads ``properties`` and ``required`` off the
+    top of the entry, so left nested every component reads as one that requires
+    nothing and declares no property: catalog membership would still be checked
+    and required properties never would. Members are merged in the order they
+    are composed, which is the order the client's own resolution follows.
+    """
+    if not isinstance(entry, dict):
+        return None
+
+    schema: Dict[str, Any] = {}
+    properties: Dict[str, Any] = {}
+    required: List[str] = []
+
+    def absorb(member: Any) -> None:
+        if not isinstance(member, dict):
+            return
+        for key, value in member.items():
+            if key == "allOf":
+                for nested in value if isinstance(value, list) else []:
+                    absorb(nested)
+            elif key == "properties" and isinstance(value, dict):
+                properties.update(value)
+            elif key == "required" and isinstance(value, list):
+                required.extend(name for name in value if isinstance(name, str) and name not in required)
+            else:
+                schema.setdefault(key, value)
+
+    absorb(entry)
+    if properties:
+        schema["properties"] = properties
+    if required:
+        schema["required"] = required
+    return schema
+
+
+def forwarded_a2ui_catalog(state: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """The catalog the client registered, in the shape the shared validator reads.
+
+    The two ends of this feature have to apply one rule. The client's renderer
+    validates a tree against the catalog it registered, so it also refuses a
+    component that catalog does not define and one that is missing a property
+    that catalog requires. The server's retry gate is handed a catalog only
+    when the host hard-coded one, so without this a tree that is structurally
+    fine but names components the client cannot draw passes validation, is
+    committed as the tool result, and is then silently refused by the browser:
+    no attempt is left to heal it and nobody is told.
+
+    The wire sends ``{"catalogId": ..., "components": {<name>: <schema>}}``,
+    each schema composed with ``allOf`` against a shared component base, and
+    the validator wants component schemas keyed by name with their properties
+    and required lists at the top. Only that keyed shape yields a catalog,
+    which is the same line the client's own middleware draws: it builds no
+    validation catalog from the legacy array forms either and falls back to
+    structural checks, so reading an array here would leave this gate the
+    stricter of the two.
+
+    Returns ``None`` when the run forwarded no schema, or forwarded one that
+    names no components: the structural gate alone is what this had before, and
+    it is a better answer than declining to generate at all.
+    """
+    ag_ui = state.get("ag-ui") if isinstance(state, dict) else None
+    raw = ag_ui.get("a2ui_schema") if isinstance(ag_ui, dict) else None
+    if not raw:
+        return None
+
+    parsed: Any = raw
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            return _structural_gate_only("it is not valid JSON")
+
+    components = parsed.get("components") if isinstance(parsed, dict) else None
+    if not isinstance(components, dict) or not components:
+        return _structural_gate_only("it does not key component schemas by name")
+
+    by_name: Dict[str, Any] = {}
+    for name, entry in components.items():
+        schema = _flattened_component_schema(entry)
+        if isinstance(name, str) and name and schema is not None:
+            by_name[name] = schema
+
+    if not by_name:
+        return _structural_gate_only("none of its component schemas can be read")
+    return {"components": by_name}
+
+
+class A2UIRenderAttempt(NamedTuple):
+    """The identity of one render attempt: what it is called, and what it names.
+
+    Decided once, before the attempt emits anything, and read by both sites
+    that would otherwise each choose for themselves: the fragments a client
+    paints the surface from, and the envelope committed as the tool's result.
+    Anything either site decides on its own can disagree with the other, and
+    every such disagreement looks the same from the server, which logs a
+    generated surface and a client that shows none.
+
+    A retry gets a new identity. An attempt that reuses a rejected attempt's
+    wire id has its arguments appended to the buffer the client is still
+    holding for that id, so the two attempts parse as one malformed object and
+    the healed surface never paints.
+    """
+
+    #: The tool-call id every event of this attempt is emitted under. Host
+    #: chosen rather than the provider's, which is reused across attempts.
+    call_id: str
+    #: The surface this attempt commits to, or ``None`` when the model names
+    #: it, which is every create.
+    surface_id: Optional[str] = None
+    #: The catalog the surface is resolved in. Never the model's to choose.
+    catalog_id: Optional[str] = None
+
+    @classmethod
+    def new(cls, surface_id: Optional[str] = None, catalog_id: Optional[str] = None) -> "A2UIRenderAttempt":
+        """Mint an identity for one attempt, with a wire id belonging to it alone."""
+        return cls(call_id=f"a2ui-render-{uuid.uuid4().hex[:8]}", surface_id=surface_id, catalog_id=catalog_id)
+
+    @property
+    def host_fields(self) -> Dict[str, str]:
+        """The argument members the host owns, in the order they are written."""
+        fields: Dict[str, str] = {}
+        if self.surface_id:
+            fields["surfaceId"] = self.surface_id
+        if self.catalog_id:
+            fields["catalogId"] = self.catalog_id
+        return fields
+
+    def confirm(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """The arguments of an attempt that streamed under this identity, or a refusal.
+
+        On an update every id is this identity's and is imposed on the stream
+        and the envelope alike, so the two cannot part. On a create the model
+        names the surface and the client paints the name it was sent, while the
+        envelope commits that name only when it is a non-empty string and
+        narrows anything else to the configured default. Left to narrow, such
+        an attempt paints one surface and commits another: the skeleton the
+        client mounted is never filled, and the surface that was committed was
+        never painted. The attempt is ended here instead, which costs a retry
+        and tells the model what to name.
+
+        A name the model never wrote is left alone: nothing was painted under
+        a competing id, so the default disagrees with nothing.
+        """
+        if self.surface_id is not None or "surfaceId" not in arguments:
+            return arguments
+        named = arguments["surfaceId"]
+        if isinstance(named, str) and named:
+            return arguments
+        raise A2UIRenderArgumentsError(
+            f"the render call named surfaceId {named!r}, which cannot be committed as written: name the "
+            "surface with a non-empty string"
+        )
+
+
+class _EmittedRenderArguments:
+    """One render call's argument stream, rewritten so the host owns its ids.
+
+    A client mounts and paints the surface from these fragments while they
+    arrive, so the ids it reads have to be the ids the committed envelope will
+    carry. Two things follow. The host's members are written as the object's
+    first, because a surface cannot be mounted before it is named. And a
+    member of the model's own under a host-owned name is dropped, because a
+    JSON parser keeps the last of two identical keys: left in, the id the
+    model guessed at would take the surface back at the end of the stream.
+
+    Separators between the remaining members are rewritten with them, since
+    their order changed. Arguments that own no field, and arguments that are
+    not a JSON object and so have nowhere to carry an id, go out exactly as
+    the model wrote them.
+
+    Every way out of the object closes it. A client reads these fragments with
+    an incremental parser, so a member emitted without the separator or the
+    colon that was swallowed for it paints no surface at all, and this exists
+    to keep unparseable arguments off the wire rather than to make new ones.
+    Whatever follows the close belonged to a member that cannot be placed in an
+    object already ended, so it is dropped.
+    """
+
+    def __init__(self, host_fields: Dict[str, str]) -> None:
+        self._host_fields = host_fields
+        # Two terminal phases: "verbatim" passes the model's own bytes through
+        # untouched, "done" emits nothing more.
+        self._phase = "before-object" if host_fields else "verbatim"
+        self._key = ""
+        self._depth = 0
+        self._in_string = False
+        self._escaped = False
+        self._wrote_member = False
+
+    def feed(self, fragment: str) -> str:
+        """What to emit for one fragment of the model's arguments."""
+        if self._phase == "verbatim":
+            return fragment
+        if self._phase == "done":
+            return ""
+        out: List[str] = []
+        for char in fragment:
+            self._consume(char, out)
+        return "".join(out)
+
+    def _finish(self, out: List[str]) -> None:
+        """Close the object this opened, and rewrite nothing further."""
+        out.append("}")
+        self._phase = "done"
+
+    def _consume(self, char: str, out: List[str]) -> None:
+        if self._phase == "done":
+            return
+        if self._phase == "verbatim":
+            out.append(char)
+        elif self._phase == "before-object":
+            self._before_object(char, out)
+        elif self._phase == "member-start":
+            self._member_start(char, out)
+        elif self._phase == "key":
+            self._key_char(char)
+        elif self._phase == "after-key":
+            self._after_key(char, out)
+        else:
+            self._value_char(char, out, keep=self._phase == "value")
+
+    def _before_object(self, char: str, out: List[str]) -> None:
+        if char.isspace():
+            out.append(char)
+            return
+        if char != "{":
+            self._phase = "verbatim"
+            out.append(char)
+            return
+        members = ", ".join(f'"{name}": {json.dumps(value)}' for name, value in self._host_fields.items())
+        out.append("{" + members)
+        self._wrote_member = bool(members)
+        self._phase = "member-start"
+
+    def _member_start(self, char: str, out: List[str]) -> None:
+        if char.isspace() or char == ",":
+            return
+        if char == '"':
+            self._key = '"'
+            self._phase = "key"
+            return
+        # The object ends, or the model wrote something no object may contain,
+        # which cannot be emitted as a member of one either way.
+        self._finish(out)
+
+    def _key_char(self, char: str) -> None:
+        self._key += char
+        if self._escaped:
+            self._escaped = False
+        elif char == "\\":
+            self._escaped = True
+        elif char == '"':
+            self._phase = "after-key"
+
+    def _after_key(self, char: str, out: List[str]) -> None:
+        if char.isspace():
+            return
+        if char != ":":
+            # A key with no value is no member, and emitting it would leave the
+            # host's own members separated from it by nothing at all.
+            self._finish(out)
+            return
+        try:
+            owned = json.loads(self._key) in self._host_fields
+        except json.JSONDecodeError:
+            owned = False
+        self._depth = 0
+        if owned:
+            self._phase = "skipped-value"
+            return
+        if self._wrote_member:
+            out.append(", ")
+        out.append(self._key + ":")
+        self._wrote_member = True
+        self._phase = "value"
+
+    def _value_char(self, char: str, out: List[str], keep: bool) -> None:
+        if self._in_string:
+            if keep:
+                out.append(char)
+            if self._escaped:
+                self._escaped = False
+            elif char == "\\":
+                self._escaped = True
+            elif char == '"':
+                self._in_string = False
+            return
+        if char == '"':
+            self._in_string = True
+        elif char in "{[":
+            self._depth += 1
+        elif char in "}]" and self._depth > 0:
+            self._depth -= 1
+        elif self._depth == 0 and char == ",":
+            self._phase = "member-start"
+            return
+        elif self._depth == 0 and char == "}":
+            self._finish(out)
+            return
+        if keep:
+            out.append(char)
+
+
+def strip_host_system_messages(messages: List[Any]) -> List[Any]:
+    """Drop the host agent's instruction turns from the subagent's input.
+
+    The subagent runs under its own render prompt. The outer agent's system
+    message rides along in the run history, and handing both over sets two
+    instructions against each other: the render prompt says to call the render
+    tool, the host persona says to answer as that persona, and the persona
+    tends to win. ``developer`` is stripped with ``system`` because providers
+    that accept it treat it the same way.
+    """
+    kept: List[Any] = []
+    for message in messages:
+        role = message.get("role") if isinstance(message, dict) else getattr(message, "role", None)
+        if role in ("system", "developer"):
+            continue
+        kept.append(message)
+    return kept
+
+
+class _RenderCall:
+    """The one render call a turn may produce, and every transition it allows.
+
+    Three phases and no more. ``pending`` until the render tool has been named
+    in full, ``open`` while its arguments accumulate and stream, ``closed``
+    once it has been ended. ``closed`` is terminal: a turn commits one
+    surface, so a second render call would paint one with nothing behind it,
+    and reopening the call would append to a buffer the client already holds.
+
+    Every event goes out under the attempt's own id rather than the
+    provider's, which providers reuse across attempts.
+    """
+
+    def __init__(self, attempt: A2UIRenderAttempt, emit: Callable[[Dict[str, Any]], None]) -> None:
+        self._attempt = attempt
+        self._emit = emit
+        self._phase = "pending"
+        #: Every dimension this call has been named by so far, learned as its
+        #: frames arrive: a provider that stamps the id on the opening frame
+        #: and the index on the continuations tells it the index only once the
+        #: first continuation is here.
+        self._named_by: Dict[str, Any] = {}
+        self._emitted = _EmittedRenderArguments(attempt.host_fields)
+        #: Exactly what the model wrote, which is what validation reads.
+        self.arguments = ""
+        #: Whether a render call was ever seen, which is a different fact from
+        #: whether one is open: conflating them throws away a surface that
+        #: streamed in full just because the provider named another tool after
+        #: it.
+        self.seen = False
+
+    def start(self, key: _DeltaKey) -> bool:
+        """Open the turn's render call, or refuse a later one."""
+        if self._phase != "pending":
+            return False
+        self._phase = "open"
+        self._named_by = dict(key)
+        self.seen = True
+        self._emit(
+            {
+                "kind": "start",
+                "tool_call_id": self._attempt.call_id,
+                "tool_call_name": RENDER_A2UI_TOOL_NAME,
+            }
+        )
+        return True
+
+    def accepts(self, key: _DeltaKey) -> bool:
+        """Whether a frame keyed this way belongs to the call in progress.
+
+        Only a frame that names a dimension differently from this call is
+        another call's. A dimension it omits says nothing, which is how
+        providers stream argument fragments after the opening frame, how
+        providers such as ollama repeat the tool name on every frame of a
+        single call, and how a stream keyed by id on its opener and by index
+        thereafter stays one call.
+        """
+        return self._phase == "open" and not _key_conflicts(self._named_by, key)
+
+    def absorb(self, key: _DeltaKey) -> None:
+        """Learn the dimensions a frame of this call names it by."""
+        self._named_by.update(key)
+
+    def dropped_from(self, key: _DeltaKey) -> bool:
+        """Whether a fragment arriving now was part of this call, already closed.
+
+        What separates a fragment of the committed surface arriving too late
+        to be part of it from a fragment of some other call the provider
+        happened to echo. A frame that names no call at all is this one's:
+        there is no other call for it to belong to, and the surface it was
+        meant to finish is the one that truncated.
+        """
+        return self._phase == "closed" and not _key_conflicts(self._named_by, key)
+
+    def is_identified_by(self, key: _DeltaKey) -> bool:
+        """Whether a frame names the call in progress, rather than continuing it.
+
+        Only such a frame can take the call's place, which is what separates a
+        provider echoing another tool over this call from one echoing it
+        beside a call it cannot name.
+        """
+        return self._phase == "open" and any(self._named_by.get(dimension) == value for dimension, value in key)
+
+    def extend(self, fragment: str) -> None:
+        if self._phase != "open":
+            return
+        self.arguments += fragment
+        emitted = self._emitted.feed(fragment)
+        if emitted:
+            self._emit({"kind": "args", "tool_call_id": self._attempt.call_id, "delta": emitted})
+
+    def close(self) -> None:
+        if self._phase != "open":
+            return
+        self._phase = "closed"
+        self._emit({"kind": "end", "tool_call_id": self._attempt.call_id})
+
+
+def _parse_render_arguments(raw: str) -> Dict[str, Any]:
+    """Read what a render call streamed, or say why it cannot be used.
+
+    Every shape refused here costs one attempt and is retried rather than
+    committing an unrenderable surface, and the reason reaches the model in
+    the failure envelope instead of being flattened into "did not call
+    render_a2ui".
+    """
+    if not raw.strip():
+        raise A2UIRenderArgumentsError("the render call carried no arguments")
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, TypeError) as err:
+        raise A2UIRenderArgumentsError(f"the render arguments were not valid JSON: {err}") from err
+    if not isinstance(parsed, dict):
+        # The shared toolkit reads these as a mapping; a list or a scalar would
+        # raise there and take the whole run down with it.
+        raise A2UIRenderArgumentsError(f"the render arguments were {type(parsed).__name__}, not an object")
+    if not parsed:
+        raise A2UIRenderArgumentsError("the render arguments were an empty object")
+    return parsed
+
+
+async def stream_render_subagent(
+    model: Any,
+    prompt: str,
+    messages: List[Any],
+    tool_choice: Optional[Union[str, Dict[str, Any]]],
+    push: Optional[Callable[[Dict[str, Any]], None]] = None,
+    attempt: Optional[A2UIRenderAttempt] = None,
+) -> Optional[Dict[str, Any]]:
+    """Run one ``render_a2ui`` turn and return the arguments it produced.
+
+    Returns ``None`` when the subagent produced no render call at all, and
+    raises ``A2UIRenderArgumentsError`` when it produced one whose arguments
+    cannot be used. The recovery loop records either as a failed attempt.
+
+    ``attempt`` is the identity this turn is painted and committed under, and
+    the caller decides it before the turn starts so that both can be the same.
+    An attempt of its own is minted when there is none, since every emitted
+    event needs an id whatever the provider does.
+
+    This is a single model turn rather than a nested agent run. An agent loop
+    would execute the bound render tool and fire a second call to continue the
+    turn, and under a "render this surface" system prompt that continuation
+    tends to render again instead of settling — the surface paints but the
+    outer tool call never returns.
+
+    ``push`` receives the render call's progress as it streams, so a client can
+    paint the surface while it is still being written. How progressive that is
+    depends on the provider: models that stream partial tool arguments give a
+    fragment at a time, while a provider that hands over the whole call at once
+    yields a single fragment.
+    """
+    from agno.models.base import MessageData
+    from agno.models.message import Message
+
+    subagent_messages = [Message(role="system", content=prompt), *strip_host_system_messages(messages)]
+    assistant_message = Message(role=model.assistant_message_role)
+    stream_data = MessageData()
+
+    def emit(payload: Dict[str, Any]) -> None:
+        if push is not None:
+            push(payload)
+
+    identity = attempt or A2UIRenderAttempt.new()
+    call = _RenderCall(identity, emit)
+    # The tool name as each call has spelled it so far, because some providers
+    # stream the name itself in fragments.
+    names = _PartialToolNames()
+    reported: set = set()
+
+    def report_once(reason: str, message: str, level: Callable[[str], None] = log_debug) -> None:
+        """Account for one branch this turn took, the first time it takes it.
+
+        Every branch that declines to do what the stream asked owes the
+        caller an explanation, and none of them can afford to give it per
+        fragment: a provider sends hundreds, and each one can take the same
+        branch.
+        """
+        if reason in reported:
+            return
+        reported.add(reason)
+        level(message)
+
+    try:
+        async for delta in model.aprocess_response_stream(
+            messages=subagent_messages,
+            assistant_message=assistant_message,
+            stream_data=stream_data,
+            tools=[RENDER_A2UI_TOOL_DEF],
+            tool_choice=tool_choice,
+        ):
+            for entry in delta.tool_calls or []:
+                name, fragment, call_id, index = _read_tool_call_delta(entry)
+                key = _delta_call_key(call_id, index)
+
+                if name:
+                    # Empty rather than absent on continuation frames for some
+                    # providers, which is why this is a truthiness test: read
+                    # as a name it would start a bogus call and the real
+                    # arguments would be dropped.
+                    # A whole name stands on its own, so a foreign tool whose
+                    # name merely begins like the render tool's cannot leave a
+                    # fragment behind that spoils the next name read.
+                    named = name if name == RENDER_A2UI_TOOL_NAME else names.so_far(key) + name
+                    if named != RENDER_A2UI_TOOL_NAME and RENDER_A2UI_TOOL_NAME.startswith(named):
+                        # A provider streaming the name in pieces. The call
+                        # cannot start until the name is whole, and blaming
+                        # the model for not calling the tool would be wrong.
+                        names.remember(key, named)
+                        report_once(
+                            "partial-name",
+                            f"A2UI render turn is receiving the tool name in fragments ({named!r} so far). "
+                            "Nothing is emitted until it is whole.",
+                        )
+                        continue
+                    names.forget(key)
+                    if named != RENDER_A2UI_TOOL_NAME:
+                        # Only one tool is offered, so this is a provider echo
+                        # of some other call. It ends the render call only when
+                        # it takes its place, which a frame that identifies no
+                        # call cannot do; whatever streamed is kept either way.
+                        report_once(
+                            "foreign-name",
+                            f"A2UI render turn saw a call to {named!r}, which is not the render tool and is not "
+                            "offered to the sub-agent. Whatever the render call streamed is kept.",
+                        )
+                        if call.is_identified_by(key):
+                            call.close()
+                        continue
+                    if call.accepts(key):
+                        call.absorb(key)
+                    elif not call.start(key):
+                        report_once(
+                            "second-render-call",
+                            "A2UI render turn produced more than one render call. Keeping the first: the "
+                            "client has already painted it, and only one surface is committed, so a later "
+                            "call would leave a surface on screen that nothing backs.",
+                            log_warning,
+                        )
+                        continue
+
+                if fragment:
+                    if call.accepts(key):
+                        call.absorb(key)
+                        call.extend(fragment)
+                    elif call.dropped_from(key):
+                        report_once(
+                            "fragment-after-close",
+                            "A2UI render call received argument fragments after it was closed. They are not "
+                            "part of the committed surface, which may therefore be truncated.",
+                            log_warning,
+                        )
+                    else:
+                        report_once(
+                            "foreign-fragment",
+                            "A2UI render turn carried argument fragments for a call that is not the render "
+                            "call, and dropped them.",
+                        )
+    except BaseException:
+        # The provider stream died mid-call. Close the emitted call before
+        # unwinding: leaving one open breaks the protocol, and the next attempt
+        # would open another on top of it.
+        call.close()
+        raise
+
+    call.close()
+
+    if not call.seen:
+        log_debug("A2UI render turn produced no render call, which the recovery loop records as a failed attempt.")
+        return None
+    return identity.confirm(_parse_render_arguments(call.arguments))
+
+
+def _log_abandoned_recovery(future: "concurrent.futures.Future") -> None:
+    """Report a recovery failure nobody is waiting for any more.
+
+    Attached only once the caller has gone, and to the worker's own future
+    rather than the awaitable wrapped around it: cancelling the await cancels
+    that wrapper, and a cancelled wrapper never receives the worker's result at
+    all, so the error this exists to report would be dropped there.
+    """
+    if future.cancelled():
+        return
+    error = future.exception()
+    if error is None or _is_a2ui_cancellation(error):
+        return
+    log_warning(f"A2UI recovery loop failed after its caller disconnected: {type(error).__name__}: {error}")
+
+
+def _start_recovery_thread(work: Callable[[], Any]) -> "concurrent.futures.Future":
+    """Run the synchronous recovery loop on a thread of its own.
+
+    Not on the loop's default executor. An attempt spends nearly all its time
+    blocked on a model call, and a generation can make three, so parking one
+    there holds a thread the whole process shares for as long as the provider
+    takes: enough concurrent generations and nothing else in the process can
+    reach the pool at all.
+    """
+    worker: "concurrent.futures.Future" = concurrent.futures.Future()
+
+    def run() -> None:
+        if not worker.set_running_or_notify_cancel():
+            return
+        try:
+            worker.set_result(work())
+        except BaseException as err:
+            worker.set_exception(err)
+
+    threading.Thread(target=run, name="a2ui-recovery", daemon=True).start()
+    return worker
+
+
+def _wait_for_a2ui_subagent(
+    pending: "concurrent.futures.Future",
+    abandoned: threading.Event,
+    loop: asyncio.AbstractEventLoop,
+    timeout: Optional[float],
+) -> Optional[Dict[str, Any]]:
+    """Block on one scheduled render turn without becoming unresponsive.
+
+    The recovery loop is synchronous, so this thread has to block somewhere.
+    Blocking outright would mean a disconnect is noticed only between attempts
+    and a provider that never answers is waited on forever, so the wait is
+    broken into polls: an abandoned run gives up at once and cancels the call,
+    and a call past its deadline is cancelled and raised as a failed attempt.
+    """
+    deadline = None if timeout is None else time.monotonic() + timeout
+    while True:
+        wait_for = _DISCONNECT_POLL_SECONDS
+        if deadline is not None:
+            wait_for = min(wait_for, max(deadline - time.monotonic(), 0.0))
+        # Waiting on the future rather than ``result(timeout=...)``: a wait that
+        # timed out and a ``TimeoutError`` raised by the call itself are the
+        # same class, and telling them apart matters here.
+        concurrent.futures.wait([pending], timeout=wait_for)
+        if pending.done():
+            return pending.result()
+        if abandoned.is_set() or loop.is_closed():
+            pending.cancel()
+            raise asyncio.CancelledError("caller disconnected; abandoning A2UI generation")
+        if deadline is not None and time.monotonic() >= deadline:
+            pending.cancel()
+            raise TimeoutError(f"A2UI render subagent did not answer within {timeout}s")
+
+
+def _with_subagent_causes(envelope: str, causes: List[str]) -> str:
+    """Keep why attempts really failed in the envelope the model reads.
+
+    The shared loop only ever learns that an attempt yielded no surface, so its
+    failure envelope says the sub-agent did not call the render tool. When the
+    real cause was a provider or transport error, an expired key say, that
+    wording is not merely vague but wrong, and it is the only account of the
+    failure the model and the client get.
+    """
+    try:
+        payload = json.loads(envelope)
+    except (json.JSONDecodeError, TypeError):
+        return envelope
+    if not isinstance(payload, dict):
+        return envelope
+    payload["subagentErrors"] = causes
+    return json.dumps(payload)
+
+
+def _on_the_awaiting_tool_path() -> bool:
+    """Whether this hook is running under the tool path that awaits the entrypoint.
+
+    A running event loop does not answer that: a synchronous run driven from
+    inside one, a notebook cell or a sync call in an async handler, still
+    takes the synchronous path. Agno runs a synchronous pre-hook from both
+    ``FunctionCall.execute`` and ``FunctionCall.aexecute``, so the nearer of
+    the two on the stack is what says which path this call is on.
+
+    With neither on the stack the tool is being driven by something else, and
+    a running loop is then the only evidence there is.
+    """
+    from agno.tools.function import FunctionCall
+
+    awaiting = FunctionCall.aexecute.__code__
+    keeping = FunctionCall.execute.__code__
+    frame = currentframe()
+    while frame is not None:
+        if frame.f_code is awaiting:
+            return True
+        if frame.f_code is keeping:
+            return False
+        frame = frame.f_back
+    try:
+        asyncio.get_running_loop()
+        return True
+    except RuntimeError:
+        return False
+
+
+def _synchronous_path_guard(tool_name: str) -> Callable[[], None]:
+    """Refuse the synchronous tool path instead of handing a model a coroutine.
+
+    Generation is asynchronous: it streams a subagent turn and waits on the
+    caller's own event loop. Agno's synchronous tool path calls the entrypoint
+    and keeps whatever comes back, so the call "succeeds" with a coroutine
+    nobody awaited and the model is sent its repr, with only a stray "never
+    awaited" warning to go on.
+
+    A team run is what reaches here. An agent collecting its tools for a
+    synchronous run refuses an async tool of its own accord, with a message
+    that says as much; the team path has no such check, so the tool is called
+    and its coroutine kept.
+
+    Wired as the tool's pre-hook, which both paths run before the entrypoint.
+    """
+
+    def refuse_a_synchronous_call() -> None:
+        if _on_the_awaiting_tool_path():
+            return
+        from agno.exceptions import AgentRunException
+
+        message = (
+            f"'{tool_name}' generates A2UI asynchronously and cannot run on Agno's synchronous tool path. "
+            "Drive the agent or team with arun() or aprint_response(), or serve it over AG-UI."
+        )
+        log_error(message)
+        raise AgentRunException(message) from None
+
+    return refuse_a_synchronous_call
+
+
+def get_a2ui_tools(params: A2UIToolParams, options: Optional[A2UIAdapterOptions] = None) -> A2UIGenerationFunction:
+    """Build the A2UI generation tool for an Agno agent.
+
+    Add the returned tool to an agent's ``tools`` and the model can generate
+    interface surfaces on demand::
+
+        from agno.os.interfaces.agui.a2ui import get_a2ui_tools
+
+        model = OpenAIChat(id="gpt-5.6-luna")
+        agent = Agent(model=model, tools=[get_a2ui_tools({"model": model})])
+
+    Args:
+        params: The shared cross-framework parameters. ``model`` is the model
+            the render subagent runs on and is required; the rest are behavior
+            knobs the toolkit fills with canonical defaults.
+        options: Agno-specific wiring, currently the ``tool_choice`` to run
+            the render subagent with.
+
+    Returns:
+        An Agno ``Function`` whose result is an A2UI operations envelope.
+    """
+    if params.get("model") is None:
+        # Left implicit, the subagent would bind whatever default model the
+        # provider supplies, so a surface would be generated by a model the
+        # caller never chose.
+        raise ValueError("get_a2ui_tools requires a 'model' — the Agno model the render subagent runs on.")
+
+    recovery = params.get("recovery")
+    if isinstance(recovery, dict):
+        for key in recovery:
+            if isinstance(key, str) and "_" in key:
+                log_warning(
+                    f"A2UI recovery option {key!r} is ignored: the shared toolkit reads "
+                    "camelCase keys such as 'maxAttempts'."
+                )
+
+    cfg = resolve_a2ui_tool_params(params)
+    # ``resolve_a2ui_tool_params`` substitutes the basic catalog when no id was
+    # given, which would hide the catalog the client registered for this run.
+    # Keep the caller's own choice separate so it still wins.
+    caller_catalog_id = params.get("default_catalog_id")
+    tool_choice = (options or {}).get("tool_choice", DEFAULT_RENDER_TOOL_CHOICE)
+    subagent_timeout = (options or {}).get("subagent_timeout", DEFAULT_RENDER_SUBAGENT_TIMEOUT)
+    tool_name = cfg["tool_name"]
+
+    async def generate_a2ui(
+        intent: str = "create",
+        target_surface_id: Optional[str] = None,
+        changes: Optional[str] = None,
+        run_context: Optional[RunContext] = None,
+    ) -> str:
+        run = current_a2ui_run.get()
+        render_stream = run.render_stream if run is not None else None
+
+        # The agent's own history for the subagent to read.
+        messages = strip_in_flight_tool_call(list(getattr(run_context, "messages", None) or []), tool_name)
+
+        # Where to look for a surface the model asked to edit. The agent's run
+        # history covers only the turn in progress, so a surface rendered in an
+        # earlier turn is found in what the client sent. The run's own messages
+        # come last because the search works backwards, so a surface created
+        # earlier in this same turn wins.
+        history: List[Any] = [*(run.messages if run is not None else []), *messages]
+
+        state = (
+            run.state
+            if run is not None and run.state is not None
+            else agui_state_from_dependencies(getattr(run_context, "dependencies", None))
+        )
+
+        resolved = resolve_a2ui_catalog(state)
+        runtime_catalog_id = resolved[1] if resolved else None
+        catalog_id = caller_catalog_id or runtime_catalog_id or cfg["default_catalog_id"]
+
+        # The catalog the retry gate validates against. A host that hard-coded
+        # one has said which components it will draw; otherwise the client's
+        # own forwarded schema is the answer, so that the gate here refuses
+        # what the renderer there would refuse.
+        validation_catalog = cfg["catalog"] or forwarded_a2ui_catalog(state)
+
+        prep = prepare_a2ui_request(
+            intent=intent,
+            target_surface_id=target_surface_id,
+            changes=changes,
+            messages=history,
+            state=state,
+            guidelines=cfg["guidelines"],
+        )
+        if prep.get("error"):
+            # The model reads the envelope and can correct itself, but leave a
+            # server-side breadcrumb so these stay countable.
+            log_warning(f"A2UI request preparation failed: {prep['error']}")
+            return wrap_error_envelope(prep["error"])
+
+        # One identity per attempt, decided here and read by both the stream
+        # that paints the surface and the envelope that commits it. An update
+        # is committed to the surface the caller named and the catalog that
+        # surface was created in, whatever the model writes; a create leaves
+        # the surface id to the model, which is the only field it owns.
+        prior = prep.get("prior")
+        committed_surface_id = target_surface_id if prep["is_update"] else None
+        committed_catalog_id = (prior or {}).get("catalogId") or catalog_id
+
+        def next_attempt() -> A2UIRenderAttempt:
+            return A2UIRenderAttempt.new(surface_id=committed_surface_id, catalog_id=committed_catalog_id)
+
+        identity = next_attempt()
+
+        def build_envelope(render_args: Dict[str, Any]) -> str:
+            # Called with the arguments of the attempt that just produced them,
+            # so ``identity`` is that attempt's.
+            args = render_args if identity.surface_id is None else {**render_args, "surfaceId": identity.surface_id}
+            return build_a2ui_envelope(
+                args=args,
+                is_update=prep["is_update"],
+                target_surface_id=identity.surface_id,
+                prior=prior,
+                default_surface_id=cfg["default_surface_id"],
+                default_catalog_id=identity.catalog_id,
+            )
+
+        loop = asyncio.get_running_loop()
+        # Set when the caller goes away, so the loop stops before spending
+        # another subagent call on a surface nobody will see.
+        abandoned = threading.Event()
+        # Written by the recovery thread and read by this one when it unwinds.
+        in_flight_lock = threading.Lock()
+        in_flight: Optional["concurrent.futures.Future"] = None
+        # Why attempts failed, per attempt, for a failure envelope and a retry
+        # prompt that would otherwise blame the model for a provider error.
+        causes: Dict[int, str] = {}
+
+        def cancel_in_flight() -> None:
+            with in_flight_lock:
+                pending = in_flight
+            if pending is not None:
+                pending.cancel()
+
+        def invoke_subagent(prompt: str, attempt_number: int) -> Optional[Dict[str, Any]]:
+            nonlocal in_flight, identity
+            if abandoned.is_set() or loop.is_closed():
+                raise asyncio.CancelledError("caller disconnected; abandoning A2UI generation")
+            # Before anything is emitted, so nothing this attempt paints can
+            # be buffered against a rejected attempt's wire id.
+            identity = next_attempt()
+            # The shared loop only ever learns that an attempt yielded no
+            # surface, so the prompt it built for this one says the sub-agent
+            # did not call the render tool. Where the attempt before actually
+            # failed on a provider or transport error, or wrote arguments that
+            # could not be used, that is the account this attempt needs.
+            previous_cause = causes.get(attempt_number - 1)
+            if previous_cause is not None:
+                prompt = f"{prompt}\n\nThe previous attempt did not finish: {previous_cause}"
+            # The recovery loop is synchronous, so it runs on a thread of its
+            # own, but the subagent itself is scheduled back onto the request's
+            # event loop. Running it on a fresh loop inside the thread instead
+            # would use the model's HTTP client from a loop it was not bound to,
+            # and the subagent shares its model with the agent that called it.
+            pending = asyncio.run_coroutine_threadsafe(
+                stream_render_subagent(
+                    cfg["model"],
+                    prompt,
+                    messages,
+                    tool_choice,
+                    push=render_stream.push if render_stream is not None else None,
+                    attempt=identity,
+                ),
+                loop,
+            )
+            with in_flight_lock:
+                in_flight = pending
+            try:
+                return _wait_for_a2ui_subagent(pending, abandoned, loop, subagent_timeout)
+            except BaseException as err:
+                if classify_a2ui_subagent_error(err) == "rethrow":
+                    raise
+                cause = f"{type(err).__name__}: {err}"
+                causes[attempt_number] = cause
+                log_warning(f"A2UI subagent failed on attempt {attempt_number}, recording a failed attempt: {cause}")
+                return None
+            finally:
+                with in_flight_lock:
+                    in_flight = None
+
+        worker = _start_recovery_thread(
+            lambda: run_a2ui_generation_with_recovery(
+                base_prompt=prep["prompt"],
+                catalog=validation_catalog,
+                config=cfg["recovery"],
+                on_attempt=cfg["on_a2ui_attempt"],
+                invoke_subagent=invoke_subagent,
+                build_envelope=build_envelope,
+            )
+        )
+
+        try:
+            result = await asyncio.wrap_future(worker, loop=loop)
+        except BaseException:
+            abandoned.set()
+            cancel_in_flight()
+            if not worker.done():
+                # Still running, so nobody is left to see how it ends. An
+                # already finished worker needs no such report: its outcome is
+                # the exception being raised here.
+                worker.add_done_callback(_log_abandoned_recovery)
+            raise
+
+        log_debug(f"A2UI generation finished after {len(result['attempts'])} attempt(s), ok={result['ok']}")
+        if not result["ok"] and causes:
+            return _with_subagent_causes(result["envelope"], [causes[at] for at in sorted(causes)])
+        return result["envelope"]
+
+    return A2UIGenerationFunction(
+        name=tool_name,
+        description=cfg["tool_description"],
+        # This tool writes its own schema, in which two of the three arguments
+        # describe an edit and only ``intent`` is asked of every call. Strict
+        # mode cannot say that: it requires every property. Declared not
+        # strict, the schema the provider receives is the one written here,
+        # and the provider is promised no adherence this schema does not ask
+        # for.
+        strict=False,
+        parameters={
+            "type": "object",
+            "properties": {
+                "intent": {
+                    "type": "string",
+                    "enum": ["create", "update"],
+                    "description": GENERATE_A2UI_ARG_DESCRIPTIONS["intent"],
+                },
+                "target_surface_id": {
+                    "type": "string",
+                    "description": GENERATE_A2UI_ARG_DESCRIPTIONS["target_surface_id"],
+                },
+                "changes": {
+                    "type": "string",
+                    "description": GENERATE_A2UI_ARG_DESCRIPTIONS["changes"],
+                },
+            },
+            # Stated, because a provider reads a missing ``required`` as every
+            # property being required, and the other two describe an edit:
+            # demanding them would make creating a first surface impossible.
+            "required": ["intent"],
+        },
+        entrypoint=generate_a2ui,
+        skip_entrypoint_processing=True,
+        pre_hook=_synchronous_path_guard(tool_name),
+    )
+
+
+class A2UIRunPlan(TypedDict):
+    """What the router needs to serve one request's A2UI arrangements."""
+
+    #: Context to forward to the agent, with the component catalog taken out
+    #: when this run's generation happens server-side and reads it from state.
+    context: List[Any]
+    #: The generation tool to add for this run, if one is being injected.
+    tool: Optional[A2UIGenerationFunction]
+    #: Client tools to discard, namely the render tool this replaces.
+    drop_tool_names: List[str]
+    #: The per-request inputs the generation tool reads.
+    run: A2UIRun
+
+
+def render_guide_description(tool_name: str) -> str:
+    """The context entry the A2UI middleware attaches to explain the render tool.
+
+    Matched by exact text against what the middleware sends, so this must stay
+    byte for byte what it emits.
+    """
+    return f"A2UI render tool usage guide — how to call {tool_name} with valid arguments."
+
+
+def _client_tool_names(run_input: Any) -> Set[str]:
+    """The names of the tools the client forwarded for this run."""
+    names: Set[str] = set()
+    for tool in getattr(run_input, "tools", None) or []:
+        name = tool.get("name") if isinstance(tool, dict) else getattr(tool, "name", None)
+        if isinstance(name, str):
+            names.add(name)
+    return names
+
+
+def _client_renders_a2ui(client_tools: Set[str], requested: Union[bool, str]) -> bool:
+    """Whether a render tool of the client's own is standing on this run.
+
+    Such a tool draws the surface in the browser, which works only if the
+    model read the component list, so on such a run the catalog has to stay in
+    the context the model reads. A client that renamed its render tool named
+    it in the request.
+    """
+    wanted = {RENDER_A2UI_TOOL_NAME}
+    if isinstance(requested, str):
+        wanted.add(requested)
+    return bool(wanted & client_tools)
+
+
+def _without_render_guides(context: List[Any], tool_names: List[str]) -> List[Any]:
+    """Drop the usage guides for render tools this run replaces.
+
+    The guide teaches the model to call a tool that is no longer there, so
+    leaving it in invites a call to nothing.
+    """
+    unwanted = {render_guide_description(name) for name in tool_names}
+    kept = []
+    for entry in context:
+        description = entry.get("description") if isinstance(entry, dict) else getattr(entry, "description", None)
+        if description not in unwanted:
+            kept.append(entry)
+    return kept
+
+
+def prepare_a2ui_run(
+    *,
+    entity: Any,
+    run_input: Any,
+    config: Optional[A2UIConfig] = None,
+) -> A2UIRunPlan:
+    """Work out this request's A2UI arrangements.
+
+    Injection is off unless asked for. The client asks by forwarding
+    ``injectA2UITool``; a backend can opt in with ``inject_a2ui_tool`` instead,
+    which an explicit ``injectA2UITool: false`` still overrides. A tool the
+    developer wired themselves is never injected over, and a tools list the
+    agent builds from a callable cannot be read without running it, so such a
+    run is declined rather than risking a second tool of the same name.
+
+    The component catalog is taken out of the forwarded context on every run
+    whose generation happens here, whether this injected the tool or the
+    developer wired it. There it reaches generation through run state instead,
+    so a catalog that can run to thousands of tokens is not also pasted into
+    every prompt the planner sees. It is left where the client put it on a run
+    that carries a render tool of the client's own, which draws in the browser
+    and works only if the model read the component list.
+    """
+    config = validate_a2ui_config(config) or {}
+
+    forwarded_context: List[Any] = list(getattr(run_input, "context", None) or [])
+    schema, regular_context = split_a2ui_schema_context(forwarded_context)
+    state = build_agui_state(schema, regular_context)
+    ag_ui = state["ag-ui"]
+
+    # A remote entity's tools run in the remote deployment, so nothing here can
+    # write render progress whatever they are, and listing them would be an
+    # HTTP round trip per request.
+    remote = is_remote_entity(entity)
+    tools = NO_ENTITY_TOOLS if remote else resolve_entity_tools(entity)
+    generates = tools.generates_a2ui()
+    plan: A2UIRunPlan = {
+        "context": forwarded_context,
+        "tool": None,
+        "drop_tool_names": [],
+        "run": A2UIRun(
+            # Prepared on a maybe: the channel is a list and an event, unread
+            # if nothing ever writes to it, while a run that turns out to
+            # generate without one loses progressive painting invisibly.
+            render_stream=A2UIRenderStream() if generates is not ToolPresence.ABSENT else None,
+            state=state,
+            messages=list(getattr(run_input, "messages", None) or []),
+        ),
+    }
+
+    requested = requested_a2ui_injection(getattr(run_input, "forwarded_props", None), config)
+    client_tools = _client_tool_names(run_input)
+
+    def lift_the_catalog_out_of_the_prompt() -> None:
+        plan["context"] = regular_context
+        # The plan's own entries stay as the router forwarded them; state gets
+        # the shape the toolkit can read.
+        ag_ui["context"] = _agui_context_entries(regular_context)
+
+    if generates is ToolPresence.PRESENT and not _client_renders_a2ui(client_tools, requested):
+        # Generation is wired on the entity itself and reads the catalog from
+        # run state, so nothing needs it in the context either.
+        lift_the_catalog_out_of_the_prompt()
+
+    if not requested:
+        return plan
+
+    if remote:
+        # Per-run tools are not forwarded to a remote agent or team at all, so
+        # injecting would take the client's render tool away and hand the
+        # remote entity nothing in its place, leaving the run with no way to
+        # produce a surface. Leave the client's own arrangement standing.
+        log_warning(
+            "A2UI generation was requested but this run targets a remote agent or team, and per-run tools are "
+            "not forwarded to one. Leaving the client's render tool in place; wire get_a2ui_tools() into the "
+            "agent in the remote deployment instead."
+        )
+        return plan
+
+    # Nothing below is injected over what is already there, and each of the
+    # three answers is declined differently. Every one leaves the run exactly
+    # as the client arranged it, the render tool it injected included.
+    tool_name = config.get("tool_name") or GENERATE_A2UI_TOOL_NAME
+    carries = tools.carries(tool_name)
+    if generates is ToolPresence.PRESENT:
+        # The documented way to have generation, so this is the arrangement
+        # working rather than a problem to report once per request.
+        log_debug(f"A2UI generation is already wired on this agent, so no '{tool_name}' is being added")
+        return plan
+    if carries is ToolPresence.PRESENT:
+        log_warning(
+            f"A2UI generation was requested but this agent already has a tool named '{tool_name}', which this "
+            "interface knows nothing about. Skipping injection; rename it, or set a2ui={'tool_name': ...} to "
+            "inject under another name."
+        )
+        return plan
+    if ToolPresence.UNKNOWN in (generates, carries):
+        unreadable = "this entity's own tools are" if not tools.fully_read else "a team member's tools are"
+        log_warning(
+            f"A2UI generation was requested but {unreadable} a callable resolved when the run starts, so "
+            f"whether generation is already wired, or a '{tool_name}' already taken, cannot be known without "
+            "running it. Skipping injection, because a second tool of that name would leave the model choosing "
+            "between duplicates and take the client's render tool away. Pass the tools as a list, or wire "
+            "get_a2ui_tools() into the list the callable returns."
+        )
+        return plan
+
+    model = getattr(entity, "model", None)
+    if model is None:
+        log_warning(
+            "A2UI generation was requested but this agent has no model to run the render "
+            "subagent on. Skipping injection; wire get_a2ui_tools() explicitly instead."
+        )
+        return plan
+
+    # A truthy string names the render tool the client injected, so a client
+    # using a custom name still gets it replaced.
+    render_tool_name = requested if isinstance(requested, str) else RENDER_A2UI_TOOL_NAME
+
+    resolved = resolve_a2ui_catalog(state)
+    runtime_catalog_id = resolved[1] if resolved else None
+
+    try:
+        tool = get_a2ui_tools(
+            {
+                "model": model,
+                "tool_name": tool_name,
+                "tool_description": config.get("tool_description"),
+                "default_surface_id": config.get("default_surface_id"),
+                "default_catalog_id": config.get("default_catalog_id") or runtime_catalog_id,
+                "catalog": config.get("catalog"),
+                "guidelines": config.get("guidelines"),
+                "recovery": config.get("recovery"),
+                "on_a2ui_attempt": config.get("on_a2ui_attempt"),
+            },
+            {
+                "tool_choice": config.get("tool_choice", DEFAULT_RENDER_TOOL_CHOICE),
+                "subagent_timeout": config.get("subagent_timeout", DEFAULT_RENDER_SUBAGENT_TIMEOUT),
+            },
+        )
+    except Exception as e:
+        # Generation was asked for and cannot be given, but the turn itself is
+        # still answerable, so run it without A2UI rather than failing outright.
+        log_error(f"A2UI generation was requested but the tool could not be built: {e}")
+        return plan
+
+    drop_tool_names = [render_tool_name]
+    if tool_name != render_tool_name and tool_name in client_tools:
+        # Agno keeps the first tool of a name and skips every later one, and a
+        # run's client tools are registered ahead of the tool added for it, so
+        # left in this one would win and nothing would generate here.
+        drop_tool_names.append(tool_name)
+        log_warning(
+            f"A2UI generation was requested and the client forwarded a tool named '{tool_name}', the name "
+            "generation is injected under. Dropping the client's tool for this run, because leaving it in "
+            "would disable generation here instead; set a2ui={'tool_name': ...} to inject under another name "
+            "and keep it."
+        )
+
+    plan["tool"] = tool
+    plan["drop_tool_names"] = drop_tool_names
+    lift_the_catalog_out_of_the_prompt()
+    plan["context"] = _without_render_guides(plan["context"], drop_tool_names)
+    plan["run"].render_stream = A2UIRenderStream()
+    ag_ui["context"] = _agui_context_entries(plan["context"])
+    return plan

--- a/libs/agno/agno/os/interfaces/agui/a2ui_stream.py
+++ b/libs/agno/agno/os/interfaces/agui/a2ui_stream.py
@@ -1,0 +1,337 @@
+"""What an A2UI generation tool needs from the request it is serving, and
+what can be known about the agent serving it.
+
+A generation tool is built once, when the agent is defined, but everything it
+needs is per-request: the catalog the client registered, the conversation to
+look through for a surface to edit, and somewhere to send render progress. A
+context variable carries them, because there is no argument the tool could take
+that the model would not also see.
+
+Nothing here depends on ``ag-ui-a2ui-toolkit``: the router and the stream mapper
+are imported on every AG-UI request, whether or not A2UI is installed or used.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextvars import ContextVar
+from dataclasses import dataclass, field, replace
+from difflib import get_close_matches
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Dict, FrozenSet, List, Mapping, Optional, Set, TypedDict, Union, cast
+
+from agno.tools.function import Function
+from agno.tools.toolkit import Toolkit
+from agno.utils.log import log_warning
+
+if TYPE_CHECKING:
+    from ag_ui_a2ui_toolkit import A2UIGuidelines
+
+
+class A2UIGenerationFunction(Function):
+    """An A2UI generation tool.
+
+    A distinct type so the router can tell that a run may generate surfaces and
+    arrange to interleave their render progress, and so a tool the developer
+    wired themselves is never injected over. It lives here rather than beside
+    the generation code so that recognizing one costs no toolkit import.
+    """
+
+
+class A2UIRenderStream:
+    """A buffer of render fragments plus a signal that some are waiting.
+
+    Deliberately not an ``asyncio.Queue``: the stream mapper has to wait on
+    this and on the agent's next event at the same time, and cancelling a
+    pending ``Queue.get`` can consume an item as it goes. Waiting on a signal
+    consumes nothing, so no fragment can be lost in the race.
+    """
+
+    def __init__(self) -> None:
+        self._pending: List[Dict[str, Any]] = []
+        self._signal = asyncio.Event()
+
+    def push(self, payload: Dict[str, Any]) -> None:
+        self._pending.append(payload)
+        self._signal.set()
+
+    def drain(self) -> List[Dict[str, Any]]:
+        pending, self._pending = self._pending, []
+        self._signal.clear()
+        return pending
+
+    async def wait(self) -> None:
+        await self._signal.wait()
+
+
+@dataclass
+class A2UIRun:
+    """The A2UI half of one AG-UI request.
+
+    ``state`` holds the component catalog the client forwarded, in the shape the
+    shared toolkit reads. ``messages`` is the conversation as the client sent
+    it, which is where an earlier surface is found when the model asks to edit
+    one; the agent's own run history covers only the turn in progress.
+    """
+
+    render_stream: Optional[A2UIRenderStream] = None
+    state: Optional[Dict[str, Any]] = None
+    messages: List[Any] = field(default_factory=list)
+
+
+#: The A2UI inputs for the request being served, read by the generation tool.
+current_a2ui_run: ContextVar[Optional[A2UIRun]] = ContextVar("agno_agui_a2ui_run", default=None)
+
+
+class ToolPresence(Enum):
+    """Whether a tool is on an entity, where "cannot tell" is a real answer.
+
+    A tools list can be a callable the agent resolves when it runs, and what
+    that will build cannot be read without running it. Reported as ABSENT, one
+    unknowable case had two callers take two different wrong turns from the
+    same wrong answer, so it is a value of its own and every caller has to say
+    what it does about not knowing.
+    """
+
+    PRESENT = "present"
+    ABSENT = "absent"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class EntityTools:
+    """One reading of the tools an agent or team was defined with.
+
+    Both questions the A2UI interface asks are answered from this single walk:
+    whether the entity already generates surfaces, and whether a name is
+    taken. They were two functions with independently written cases, which is
+    how a tool shape one could read and the other could not came to give a
+    caller a confidently wrong answer.
+    """
+
+    names: FrozenSet[str] = frozenset()
+    generation_tool_found: bool = False
+    #: False when part of the list could not be read, which is what makes
+    #: ABSENT unsayable: nothing was ruled out, it was only not seen.
+    fully_read: bool = True
+    #: The same for a team member's own tools, kept apart because it answers
+    #: only one of the two questions: a member's generation is this team's
+    #: generation, while what a member calls its tools cannot collide with a
+    #: tool added to the leader.
+    members_fully_read: bool = True
+
+    def generates_a2ui(self) -> ToolPresence:
+        """Whether a run on this entity may produce an A2UI surface itself."""
+        if self.generation_tool_found:
+            return ToolPresence.PRESENT
+        if self.fully_read and self.members_fully_read:
+            return ToolPresence.ABSENT
+        return ToolPresence.UNKNOWN
+
+    def carries(self, tool_name: str) -> ToolPresence:
+        """Whether a tool of this name is already there."""
+        if tool_name in self.names:
+            return ToolPresence.PRESENT
+        return ToolPresence.ABSENT if self.fully_read else ToolPresence.UNKNOWN
+
+
+#: An entity whose tools cannot serve A2UI here whatever they are, so there is
+#: nothing to read: a remote agent or team, whose tools run in the remote
+#: deployment and could only be listed with an HTTP round trip per request.
+NO_ENTITY_TOOLS = EntityTools()
+
+
+def _tool_dict_name(tool: Dict[str, Any]) -> Optional[str]:
+    """The name of a provider-executed tool passed as a dict.
+
+    Two spellings arrive: the OpenAI nesting under ``function``, and a flat
+    dict. A dict that names nothing is a provider builtin identified by its
+    type alone, which cannot collide with a tool added here.
+    """
+    nested = tool.get("function")
+    name = nested.get("name") if isinstance(nested, dict) else tool.get("name")
+    return name if isinstance(name, str) else None
+
+
+def is_remote_entity(entity: Any) -> bool:
+    """Whether this entity's tools live in another process.
+
+    Its tools run in the remote deployment, so they cannot serve a surface
+    here whatever they are, and reading them is an HTTP round trip per
+    request: the attribute itself fetches the remote configuration.
+    """
+    from agno.agent.remote import RemoteAgent
+    from agno.team.remote import RemoteTeam
+
+    return isinstance(entity, (RemoteAgent, RemoteTeam))
+
+
+def resolve_entity_tools(entity: Any) -> EntityTools:
+    """Read the tools an agent or team was defined with, once.
+
+    A team is read through its members as well as its own list. A member's
+    generation tool is how that team generates, and a leader told otherwise
+    loses the render channel for the run and has a second generation tool
+    injected on top of the one already there. Each member is read exactly as
+    the entity itself is, so a member whose tools are a callable makes the
+    answer unknowable rather than absent; a remote member is not asked.
+
+    A tools list given as a callable is resolved by the agent at run time.
+    Calling it here to look inside would run the developer's code an extra
+    time per request, and hand back objects the agent then never sees, so it
+    is reported as unread instead.
+    """
+    return _resolve_entity_tools(entity, {id(entity)})
+
+
+def _resolve_entity_tools(entity: Any, seen: Set[int]) -> EntityTools:
+    """One entity's own tools, plus what its members add to the answer.
+
+    ``seen`` is what keeps a team listed among its own members, however
+    indirectly, from being walked forever.
+    """
+    reading = _resolve_own_tools(entity)
+    members = getattr(entity, "members", None)
+    if members is None:
+        return reading
+
+    generates = reading.generation_tool_found
+    members_read = isinstance(members, list)
+    for member in members if isinstance(members, list) else []:
+        if id(member) in seen or is_remote_entity(member):
+            continue
+        seen.add(id(member))
+        member_tools = _resolve_entity_tools(member, seen)
+        generates = generates or member_tools.generation_tool_found
+        members_read = members_read and member_tools.fully_read and member_tools.members_fully_read
+    return replace(reading, generation_tool_found=generates, members_fully_read=members_read)
+
+
+def _resolve_own_tools(entity: Any) -> EntityTools:
+    tools = getattr(entity, "tools", None)
+    if tools is None:
+        return EntityTools()
+    if not isinstance(tools, list):
+        return EntityTools(fully_read=False)
+
+    names: Set[str] = set()
+    generates = False
+    for tool in tools:
+        if isinstance(tool, Toolkit):
+            names.update(tool.functions.keys())
+            generates = generates or any(
+                isinstance(function, A2UIGenerationFunction) for function in tool.functions.values()
+            )
+        elif isinstance(tool, Function):
+            names.add(tool.name)
+            generates = generates or isinstance(tool, A2UIGenerationFunction)
+        elif isinstance(tool, dict) or callable(tool):
+            # A dict is a tool the provider runs and a bare callable is one
+            # Agno wraps; from here both are just a name that is taken.
+            name = _tool_dict_name(tool) if isinstance(tool, dict) else getattr(tool, "__name__", None)
+            if isinstance(name, str):
+                names.add(name)
+    return EntityTools(names=frozenset(names), generation_tool_found=generates)
+
+
+class A2UIConfig(TypedDict, total=False):
+    """Backend A2UI settings for an AG-UI interface.
+
+    ``inject_a2ui_tool`` opts a backend in when the client does not ask. An
+    explicit ``injectA2UITool: false`` from the client still wins, so a client
+    can always turn generation off for a run.
+
+    Declared here rather than beside the generation code so that the interface
+    can name the type it accepts without importing the toolkit.
+    """
+
+    inject_a2ui_tool: Optional[Union[bool, str]]
+    tool_name: Optional[str]
+    tool_description: Optional[str]
+    default_surface_id: Optional[str]
+    default_catalog_id: Optional[str]
+    catalog: Optional[Dict[str, Any]]
+    guidelines: Optional["A2UIGuidelines"]
+    recovery: Optional[Dict[str, Any]]
+    on_a2ui_attempt: Optional[Any]
+    tool_choice: Optional[Union[str, Dict[str, Any]]]
+    subagent_timeout: Optional[float]
+
+
+#: Every setting ``a2ui=`` accepts, read off the type so the two cannot drift.
+A2UI_CONFIG_KEYS: FrozenSet[str] = frozenset(A2UIConfig.__annotations__)
+
+
+def validate_a2ui_config(config: Optional[Mapping[str, Any]]) -> Optional[A2UIConfig]:
+    """Refuse a setting that would otherwise be ignored.
+
+    ``A2UIConfig`` is a TypedDict, so a misspelled key is caught wherever the
+    annotation is in scope and nowhere at all once a plain dict has crossed a
+    boundary. Every one of these settings turns something on or changes what it
+    does, so ignoring one leaves the feature off with the configuration
+    apparently in place, which is indistinguishable from the feature not
+    working.
+    """
+    if config is None:
+        return None
+    if not isinstance(config, Mapping):
+        raise ValueError(f"A2UI settings must be a mapping of A2UIConfig keys, not {type(config).__name__}")
+
+    known = sorted(A2UI_CONFIG_KEYS)
+    unknown = []
+    for key in config:
+        if key in A2UI_CONFIG_KEYS:
+            continue
+        nearest = get_close_matches(str(key), known, n=1)
+        unknown.append(f"{key!r}{f' (did you mean {nearest[0]!r}?)' if nearest else ''}")
+    if unknown:
+        raise ValueError(f"Unknown A2UI setting(s): {', '.join(unknown)}. Valid settings are: {', '.join(known)}")
+
+    return cast("A2UIConfig", dict(config))
+
+
+#: How a stringified boolean reaches here from a client or a config file that
+#: has no boolean of its own to send.
+_NO_SPELLINGS = frozenset({"false", "0", "no", "off"})
+_YES_SPELLINGS = frozenset({"true", "1", "yes", "on"})
+
+
+def _as_injection_request(value: Any, setting: str) -> Optional[Union[bool, str]]:
+    """One asker's answer: True, False, a render tool name, or nothing said.
+
+    A truthy string names the render tool the client injected, which is why a
+    stringified ``"false"`` cannot be left as one: it would turn generation on
+    and take away a client tool called ``"false"``.
+    """
+    if value is None or isinstance(value, bool):
+        return value
+    if not value:
+        # Present and false: a client with no boolean of its own to send says
+        # no with a 0, and the opt-out is a promise. Discarded as unreadable
+        # instead, a backend opt-in would apply and the refusal would be gone.
+        return False
+    if isinstance(value, str):
+        spelling = value.strip().lower()
+        if spelling in _NO_SPELLINGS:
+            return False
+        if spelling in _YES_SPELLINGS:
+            return True
+        if spelling:
+            return value
+    log_warning(f"Ignoring {setting}={value!r}: expected a boolean, or the name of the render tool to replace")
+    return None
+
+
+def requested_a2ui_injection(forwarded_props: Any, config: Optional[Mapping[str, Any]]) -> Union[bool, str]:
+    """What this run was asked to do about injecting the generation tool.
+
+    False for no, True for yes, and a tool name for a client that named the
+    render tool it wants replaced. The client is asked first: a backend opt-in
+    applies only where the client said nothing, and an explicit refusal from
+    the client is never overridden.
+    """
+    forwarded = forwarded_props if isinstance(forwarded_props, Mapping) else {}
+    requested = _as_injection_request(forwarded.get("injectA2UITool"), "injectA2UITool")
+    if requested is None:
+        requested = _as_injection_request((config or {}).get("inject_a2ui_tool"), "inject_a2ui_tool")
+    return False if requested is None else requested

--- a/libs/agno/agno/os/interfaces/agui/agui.py
+++ b/libs/agno/agno/os/interfaces/agui/agui.py
@@ -6,6 +6,7 @@ from fastapi.routing import APIRouter
 
 from agno.agent import Agent
 from agno.agent.remote import RemoteAgent
+from agno.os.interfaces.agui.a2ui_stream import A2UIConfig, is_remote_entity, validate_a2ui_config
 from agno.os.interfaces.agui.router import attach_routes
 from agno.os.interfaces.base import BaseInterface
 from agno.team import Team
@@ -23,6 +24,7 @@ class AGUI(BaseInterface):
         team: Optional[Union[Team, RemoteTeam]] = None,
         prefix: str = "",
         tags: Optional[List[str]] = None,
+        a2ui: Optional[A2UIConfig] = None,
     ):
         """
         Initialize the AGUI interface.
@@ -32,19 +34,41 @@ class AGUI(BaseInterface):
             team: The team to expose via AG-UI
             prefix: Custom prefix for the router (e.g., "/agui/v1", "/chat/public")
             tags: Custom tags for the router (e.g., ["AGUI", "Chat"], defaults to ["AGUI"])
+            a2ui: A2UI generation settings, as `A2UIConfig`. Set `inject_a2ui_tool`
+                to let this agent generate its own interface even when the client
+                does not ask for it; the rest are behavior knobs (catalog, prompt
+                guidelines, retry cap). A client forwarding `injectA2UITool: false`
+                still turns generation off for that run.
+
+        Raises:
+            ValueError: if `a2ui` holds a setting this interface does not have.
+                Every one of them turns something on, so ignoring a misspelled
+                key would leave generation off with the configuration
+                apparently in place.
+            ValueError: if `a2ui` is given for a remote agent or team. Per-run
+                tools are not forwarded to a remote deployment, so no setting
+                here can reach one; wire `get_a2ui_tools()` into the agent in
+                that deployment instead.
         """
         self.agent = agent
         self.team = team
         self.prefix = prefix
         self.tags = tags or ["AGUI"]
+        self.a2ui = validate_a2ui_config(a2ui)
 
         if not (self.agent or self.team):
             raise ValueError("AGUI requires an agent or a team")
 
+        if self.a2ui is not None and is_remote_entity(self.agent or self.team):
+            raise ValueError(
+                "A2UI settings cannot apply to a remote agent or team: per-run tools are not forwarded to a "
+                "remote deployment. Wire get_a2ui_tools() into the agent there instead."
+            )
+
     def get_router(self) -> APIRouter:
         self.router = APIRouter(prefix=self.prefix, tags=self.tags)  # type: ignore
 
-        self.router = attach_routes(router=self.router, agent=self.agent, team=self.team)
+        self.router = attach_routes(router=self.router, agent=self.agent, team=self.team, a2ui=self.a2ui)
 
         return self.router
 

--- a/libs/agno/agno/os/interfaces/agui/handlers.py
+++ b/libs/agno/agno/os/interfaces/agui/handlers.py
@@ -42,6 +42,12 @@ from agno.utils.message import get_text_from_message
 
 EventHandler = Callable[[BaseRunOutputEvent, StreamState], List[BaseEvent]]
 
+#: Name for a render call whose fragment carries none. Mirrors the render tool
+#: name the shared A2UI toolkit owns, spelled out because this module loads on
+#: every AG-UI request and that toolkit is optional. A test pins the two
+#: together, so drift fails the suite.
+RENDER_A2UI_TOOL_NAME_FALLBACK = "render_a2ui"
+
 
 def _extract_response_chunk_content(response: RunContentEvent) -> str:
     # RunContentEvent can carry text in .messages (list) or .content (direct)
@@ -102,8 +108,13 @@ def _emit_state_delta(state: StreamState) -> List[BaseEvent]:
     return [StateDeltaEvent(type=EventType.STATE_DELTA, delta=ops)]
 
 
-def _close_open_spans(state: StreamState) -> List[BaseEvent]:
-    """End any reasoning, tool call, or text message still open, so a terminal event never leaves a dangling span."""
+def close_open_spans(state: StreamState) -> List[BaseEvent]:
+    """End any reasoning, tool call, or text message still open, so a terminal event never leaves a dangling span.
+
+    Part of this module's interface: a run that fails outside the stream mapper
+    still has to close whatever it opened, because a terminal event is the last
+    thing the client will ever see for that run.
+    """
     events: List[BaseEvent] = []
 
     # Close orphaned reasoning session
@@ -321,6 +332,70 @@ def on_reasoning_completed(chunk: BaseRunOutputEvent, state: StreamState) -> Lis
     return events
 
 
+def on_a2ui_render_stream(payload: Dict[str, Any], state: StreamState) -> List[BaseEvent]:
+    """Translate one A2UI render fragment into AG-UI tool-call events.
+
+    A client paints a generated surface from the render call's argument
+    fragments as they arrive, so the fragments have to reach the wire as a tool
+    call of their own, nested inside the generation call that produced them.
+    """
+    tool_call_id = payload.get("tool_call_id") or ""
+    if not tool_call_id:
+        return []
+
+    kind = payload.get("kind")
+    events: List[BaseEvent] = []
+
+    if kind == "start":
+        # A wire id belongs to one render call, and the client buffers that
+        # call's arguments under it. A second start under a spent id appends
+        # this surface to the buffer still held for the other, so the two parse
+        # as one malformed object and neither paints.
+        if tool_call_id in state.active_tool_call_ids or tool_call_id in state.ended_tool_call_ids:
+            return []
+        # A tool call may not open inside an unfinished text message.
+        if state.text_message_open:
+            events.append(TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=state.text_message_id))
+            state.set_pending_tool_calls_parent_id(state.text_message_id)
+            state.close_text_message()
+        events.append(
+            ToolCallStartEvent(
+                type=EventType.TOOL_CALL_START,
+                tool_call_id=tool_call_id,
+                tool_call_name=payload.get("tool_call_name") or RENDER_A2UI_TOOL_NAME_FALLBACK,
+                # The generation call hangs off this message too, which is
+                # what groups the surface into the turn that produced it. No
+                # empty parent is invented when there is none, unlike the path
+                # for the agent's own tool calls: the field is optional, and a
+                # message the run never produced is worse than an absent id.
+                parent_message_id=state.get_parent_message_id_for_tool_call() or None,
+            )
+        )
+        # Tracked like any other call, so a run that dies mid-generation still
+        # closes it.
+        state.start_tool_call(tool_call_id)
+
+    elif kind == "args":
+        # A fragment for a call that was never opened, or that has already been
+        # closed, has nothing on the wire to attach to: the client would be
+        # given arguments for a tool call it does not know about.
+        if tool_call_id not in state.active_tool_call_ids:
+            return []
+        delta = payload.get("delta")
+        if delta:
+            events.append(ToolCallArgsEvent(type=EventType.TOOL_CALL_ARGS, tool_call_id=tool_call_id, delta=delta))
+
+    elif kind == "end":
+        # Only a call the client was told about can be ended. An end for one it
+        # never saw opened, or has already finished with, is an event its
+        # verifier rejects fatally, which costs the run every event after it.
+        if tool_call_id in state.active_tool_call_ids:
+            events.append(ToolCallEndEvent(type=EventType.TOOL_CALL_END, tool_call_id=tool_call_id))
+            state.end_tool_call(tool_call_id)
+
+    return events
+
+
 def on_custom_event(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
     try:
         custom_event_name = chunk.__class__.__name__
@@ -353,7 +428,7 @@ def on_run_error(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEven
     message = getattr(chunk, "content", None) or "Run failed"
     error_type = getattr(chunk, "error_type", None)
 
-    events = _close_open_spans(state)
+    events = close_open_spans(state)
     events.append(
         AGUIRunErrorEvent(
             type=EventType.RUN_ERROR,
@@ -366,7 +441,7 @@ def on_run_error(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEven
 
 
 def on_run_completed(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
-    events = _close_open_spans(state)
+    events = close_open_spans(state)
 
     # 1. Collect paused tools for frontend rendering
     paused_tools: List[ToolExecution] = []

--- a/libs/agno/agno/os/interfaces/agui/input.py
+++ b/libs/agno/agno/os/interfaces/agui/input.py
@@ -167,6 +167,35 @@ def extract_tool_messages(messages: List[AGUIMessage]) -> List[AGUIToolMessage]:
     return list(reversed(tool_msgs))
 
 
+def describe_tool_results(messages: List[AGUIMessage], tool_messages: List[AGUIToolMessage]) -> str:
+    """Render trailing tool results as the input for a turn.
+
+    A tool result no paused run is waiting on is still the newest thing the
+    client has to say, and this request is the only place it exists: an
+    interactive surface reports a click as a result for a tool call it minted
+    itself, and nothing wrote it into the session. Left out, the turn runs on
+    the last user message, which is a turn already answered, and the click is
+    answered with a repeat of it.
+
+    Each result is named from the assistant call carrying its id, because the
+    content alone need not say what produced it.
+    """
+    tool_names: Dict[str, str] = {}
+    for msg in messages:
+        for call in getattr(msg, "tool_calls", None) or []:
+            call_id = getattr(call, "id", None)
+            name = getattr(getattr(call, "function", None), "name", None)
+            if call_id and name:
+                tool_names[call_id] = name
+
+    lines: List[str] = []
+    for msg in tool_messages:
+        content = msg.error or msg.content or ""
+        name = tool_names.get(msg.tool_call_id)
+        lines.append(f"Result of the {name} tool call: {content}" if name else f"Tool result: {content}")
+    return "\n".join(lines)
+
+
 def parse_client_tools(agui_tools: Optional[List[AGUITool]]) -> List[Function]:
     # Frontend tools run in the browser; external_execution=True pauses the run
     if not agui_tools:

--- a/libs/agno/agno/os/interfaces/agui/resume.py
+++ b/libs/agno/agno/os/interfaces/agui/resume.py
@@ -113,6 +113,35 @@ def _find_paused_run(
     return None
 
 
+async def afind_paused_run(
+    entity: Union[Agent, Team],
+    session_id: str,
+    tool_messages: List[AGUIToolMessage],
+):
+    """The paused run these tool results answer, or None if there is none.
+
+    A trailing tool result is not by itself proof of a resume. Clients append
+    one for a tool call this backend never emitted and never offered: that is
+    how an interactive surface reports a click. What separates the two cases is
+    whether a paused run in this session is actually waiting on one of these
+    tool call ids, so that is the only thing consulted here.
+
+    Every "no" is a None rather than a raise, including the ones that say this
+    entity could never resume at all. A remote entity, an entity with no
+    database, and a session that no longer exists all mean the same thing to
+    the caller: there is no paused run here, so the results belong to a new
+    turn.
+    """
+    if not isinstance(entity, (Agent, Team)) or not entity.db:
+        return None
+
+    session = await entity.aget_session(session_id=session_id)
+    if not isinstance(session, (AgentSession, TeamSession)):
+        return None
+
+    return _find_paused_run(session, tool_messages, is_team=isinstance(entity, Team))
+
+
 async def resume_paused_run(
     entity: Union[Agent, Team],
     session_id: str,
@@ -120,20 +149,10 @@ async def resume_paused_run(
     run_context: RunContext,
     run_kwargs: dict,
 ):
-    if not isinstance(entity, (Agent, Team)):
-        raise ValueError("Frontend tool resume requires a local Agent or Team")
-    if not entity.db:
-        raise ValueError("Frontend tool resume requires a database")
-
-    session = await entity.aget_session(session_id=session_id)
-    if not session:
-        raise ValueError(f"Session {session_id} not found")
-    if not isinstance(session, (AgentSession, TeamSession)):
-        raise ValueError(f"Session {session_id} is not a valid session type")
-
-    paused_run = _find_paused_run(session, tool_messages, is_team=isinstance(entity, Team))
-    if not paused_run:
-        raise ValueError(f"No paused run matching the provided tool results found in session {session_id}")
+    """Continue the paused run these tool results answer, or None if there is none."""
+    paused_run = await afind_paused_run(entity, session_id, tool_messages)
+    if paused_run is None:
+        return None
     if not paused_run.requirements:
         raise ValueError(f"Run {paused_run.run_id} has no requirements to resume")
 

--- a/libs/agno/agno/os/interfaces/agui/router.py
+++ b/libs/agno/agno/os/interfaces/agui/router.py
@@ -1,17 +1,26 @@
+import asyncio
 import copy
 import uuid
-from typing import AsyncIterator, Optional, Union
+from contextvars import Token
+from typing import Any, AsyncGenerator, AsyncIterator, Mapping, Optional, Union
 
-from agno.utils.log import log_error, log_warning
+from agno.utils.log import log_debug, log_error, log_warning
 
 try:
     from ag_ui.core import (
         BaseEvent,
         EventType,
+        ReasoningEndEvent,
+        ReasoningMessageEndEvent,
+        ReasoningMessageStartEvent,
         RunAgentInput,
         RunErrorEvent,
         RunStartedEvent,
         StateSnapshotEvent,
+        TextMessageEndEvent,
+        TextMessageStartEvent,
+        ToolCallEndEvent,
+        ToolCallStartEvent,
     )
     from ag_ui.encoder import EventEncoder
 except ImportError as e:
@@ -21,7 +30,10 @@ from fastapi import APIRouter, Request
 from fastapi.responses import StreamingResponse
 
 from agno.agent import Agent, RemoteAgent
+from agno.os.interfaces.agui.a2ui_stream import A2UIConfig, A2UIRun, current_a2ui_run, requested_a2ui_injection
+from agno.os.interfaces.agui.handlers import close_open_spans
 from agno.os.interfaces.agui.input import (
+    describe_tool_results,
     extract_context,
     extract_media,
     extract_tool_messages,
@@ -30,6 +42,7 @@ from agno.os.interfaces.agui.input import (
     validate_state,
 )
 from agno.os.interfaces.agui.resume import resume_paused_run
+from agno.os.interfaces.agui.state import StreamState
 from agno.os.interfaces.agui.stream import async_stream_agno_response_as_agui_events
 from agno.os.middleware.user_scope import assert_session_writable, caller_is_admin, resolve_run_user_id
 from agno.run.base import RunContext
@@ -37,10 +50,65 @@ from agno.team.remote import RemoteTeam
 from agno.team.team import Team
 
 
+def _plan_a2ui_run(entity: Any, run_input: RunAgentInput, config: Optional[A2UIConfig]) -> Mapping[str, Any]:
+    """Work out this request's A2UI arrangements, or leave the run untouched.
+
+    A2UI generation needs ``ag-ui-a2ui-toolkit``, which the AG-UI interface does
+    not otherwise require. Without it a run behaves exactly as it did before,
+    except that asking for generation says so instead of quietly doing nothing.
+
+    Every failure of that import is caught, not only ``ImportError``. This runs
+    on the path of every AG-UI request, and almost none of them want
+    generation: a module body that raises anything else would otherwise fail
+    runs that never asked whether A2UI works.
+    """
+    try:
+        from agno.os.interfaces.agui.a2ui import prepare_a2ui_run
+    except Exception as e:
+        if requested_a2ui_injection(run_input.forwarded_props, config):
+            # Relayed rather than restated: a toolkit that is missing, one too
+            # old to import from, and one that fails while loading need
+            # different fixes, and only the error itself says which this was.
+            log_error(f"A2UI generation was requested but its support could not be imported: {e}")
+        elif not isinstance(e, ImportError):
+            # An absent optional extra is the ordinary case and says nothing.
+            # Anything else means the support is installed and broken, which
+            # the operator has to hear even from a run that lost nothing by it.
+            log_warning(f"A2UI support failed to load: {e}")
+        # Nothing can generate a surface without the toolkit, so there is no
+        # render progress to carry.
+        return {"context": run_input.context, "tool": None, "drop_tool_names": [], "run": A2UIRun()}
+
+    return prepare_a2ui_run(entity=entity, run_input=run_input, config=config)  # type: ignore[arg-type]
+
+
+def _track_spans(event: BaseEvent, spans: StreamState) -> None:
+    """Record what this event opens or closes on the wire.
+
+    The stream mapper keeps this tally for the events it emits, but its copy
+    goes out of scope with it when a run raises, so anything still open at that
+    point can no longer be ended from there.
+    """
+    if isinstance(event, TextMessageStartEvent):
+        spans.text_message_id = event.message_id
+        spans.text_message_open = True
+    elif isinstance(event, TextMessageEndEvent):
+        spans.close_text_message()
+    elif isinstance(event, ToolCallStartEvent):
+        spans.start_tool_call(event.tool_call_id)
+    elif isinstance(event, ToolCallEndEvent):
+        spans.end_tool_call(event.tool_call_id)
+    elif isinstance(event, ReasoningMessageStartEvent):
+        spans.reasoning_message_id = event.message_id
+    elif isinstance(event, (ReasoningMessageEndEvent, ReasoningEndEvent)):
+        spans.end_reasoning()
+
+
 async def run_entity(
     entity: Union[Agent, RemoteAgent, Team, RemoteTeam],
     run_input: RunAgentInput,
     user_id: Optional[str] = None,
+    a2ui_config: Optional[A2UIConfig] = None,
 ) -> AsyncIterator[BaseEvent]:
     """Shared handler for running an Agent or Team with AG-UI input/output mapping.
 
@@ -49,8 +117,25 @@ async def run_entity(
     caller must not attribute runs, sessions, or memory writes to an arbitrary user.
     """
     run_id = run_input.run_id or str(uuid.uuid4())
+    spans = StreamState()
+    a2ui_token: Optional["Token[Optional[A2UIRun]]"] = None
+    agui_events: Optional[AsyncGenerator[BaseEvent, None]] = None
 
     try:
+        # First, so that everything which can fail is reportable: an error
+        # emitted before this one has no run for the client to attach it to.
+        yield RunStartedEvent(type=EventType.RUN_STARTED, thread_id=run_input.thread_id, run_id=run_id)
+
+        # Inside the try: a malformed catalog or context entry from the client
+        # raises here, and the client is owed a RUN_ERROR rather than a stream
+        # that simply stops.
+        a2ui = _plan_a2ui_run(entity, run_input, a2ui_config)
+        # A generation tool blocks this stream while its render subagent works, so
+        # its progress needs a channel of its own to reach the client while the
+        # surface is still being written.
+        render_stream = a2ui["run"].render_stream
+        a2ui_token = current_a2ui_run.set(a2ui["run"])
+
         messages = run_input.messages or []
 
         # 1. Extract inputs from AG-UI message history
@@ -59,16 +144,22 @@ async def run_entity(
         tool_messages = extract_tool_messages(messages)
 
         # 2. Convert frontend tool definitions to Agno Functions
-        client_tools = parse_client_tools(run_input.tools) or None
-
-        yield RunStartedEvent(type=EventType.RUN_STARTED, thread_id=run_input.thread_id, run_id=run_id)
+        run_tools = [
+            tool for tool in parse_client_tools(run_input.tools) or [] if tool.name not in a2ui["drop_tool_names"]
+        ]
+        if a2ui["tool"] is not None:
+            # A2UI generation runs on the server, so it joins this run's tools
+            # rather than the agent's own: the agent is shared across requests
+            # and the tool is bound to this one.
+            run_tools.append(a2ui["tool"])
+        client_tools = run_tools or None
 
         session_state = validate_state(run_input.state, run_input.thread_id)
 
         if session_state is not None:
             yield StateSnapshotEvent(type=EventType.STATE_SNAPSHOT, snapshot=copy.deepcopy(session_state))
 
-        ui_deps = extract_context(run_input.context)
+        ui_deps = extract_context(a2ui["context"])
 
         # 3. Build RunContext with client_tools and session_state
         run_context = RunContext(
@@ -84,9 +175,12 @@ async def run_entity(
         if ui_deps:
             run_kwargs["add_dependencies_to_context"] = True
 
-        # 4. Determine if this is a resume (trailing ToolMessages) or fresh run
+        # 4. Trailing tool results are a resume only when a paused run in this
+        #    session is waiting on one of their tool call ids. A client is free
+        #    to send a result for a tool call this backend never emitted, and an
+        #    interactive surface reports a click that way, which is a new turn.
+        response_stream = None
         if tool_messages:
-            # Resume: frontend executed external tools and sent results back
             response_stream = await resume_paused_run(
                 entity=entity,  # type: ignore[arg-type]
                 session_id=run_input.thread_id,
@@ -94,8 +188,16 @@ async def run_entity(
                 run_context=run_context,
                 run_kwargs=run_kwargs,
             )
-        else:
-            # Fresh run: new user input
+
+        if response_stream is None:
+            if tool_messages:
+                # These results answer no paused run, so they are what is new in
+                # the turn. Kept as the input over the last user message, which
+                # is a turn the agent already answered and whose media is
+                # already in the session history.
+                log_debug("AG-UI tool results match no paused run; running them as a new turn")
+                user_input = describe_tool_results(messages, tool_messages)
+                images, audio, videos, files = [], [], [], []
             if isinstance(entity, (RemoteAgent, RemoteTeam)):
                 # A RunContext is an in-process object: RemoteAgent/RemoteTeam forward every
                 # unknown kwarg as a form field, and the remote AgentOS would hand the
@@ -121,21 +223,69 @@ async def run_entity(
                 **run_kwargs,
             )
 
-        async for event in async_stream_agno_response_as_agui_events(
+        agui_events = async_stream_agno_response_as_agui_events(
             response_stream=response_stream,  # type: ignore
             thread_id=run_input.thread_id,
             run_id=run_id,
             run_state=session_state,
-        ):
+            a2ui_render_stream=render_stream,
+        )
+        async for event in agui_events:
+            _track_spans(event, spans)
             yield event
 
+    except asyncio.CancelledError as e:
+        # Cancellation is not an ``Exception``, so the handler below never sees
+        # one. The A2UI generation tool raises it on purpose, for a caller that
+        # has gone and for a render turn past its deadline, and unhandled it
+        # unwinds the run with no terminal event at all: the client is left
+        # holding whatever was open on a stream that simply stops.
+        reason = str(e) or "Run cancelled"
+        log_warning(f"AG-UI run cancelled: {reason}")
+        for closing in close_open_spans(spans):
+            yield closing
+        yield RunErrorEvent(type=EventType.RUN_ERROR, message=reason)
+        # Cancellation belongs to whoever asked for it.
+        raise
     except Exception as e:
         log_error(f"Error running entity: {str(e)}")
+        # RUN_ERROR is terminal, so a message, tool call, or reasoning session
+        # left open here never ends: the client keeps it in flight for good.
+        for closing in close_open_spans(spans):
+            yield closing
         yield RunErrorEvent(type=EventType.RUN_ERROR, message=str(e))
+    finally:
+        # Iterating does not close, so a client that leaves mid-run would leave
+        # the mapper suspended and everything below it unfinalized. Closed
+        # before the token is reset: the close is what drives the rest of the
+        # run, and the run reads its A2UI inputs off the context variable.
+        try:
+            if agui_events is not None:
+                await agui_events.aclose()
+        except Exception as e:
+            # The response is already sent by the time this runs, so raising
+            # here only hands ASGI an error nobody can be told about.
+            log_error(f"Error finalizing AG-UI run: {e}")
+        finally:
+            # Reached however the close went, cancellation included: leaving
+            # the token unreset leaves this run's A2UI inputs readable in a
+            # context the server goes on to reuse.
+            if a2ui_token is not None:
+                try:
+                    current_a2ui_run.reset(a2ui_token)
+                except ValueError:
+                    # An async generator borrows whatever context drives it, so
+                    # a stream finalized elsewhere than it started cannot reset
+                    # the token. There is nothing to undo: the value was never
+                    # visible in this context.
+                    pass
 
 
 def attach_routes(
-    router: APIRouter, agent: Optional[Union[Agent, RemoteAgent]] = None, team: Optional[Union[Team, RemoteTeam]] = None
+    router: APIRouter,
+    agent: Optional[Union[Agent, RemoteAgent]] = None,
+    team: Optional[Union[Team, RemoteTeam]] = None,
+    a2ui: Optional[A2UIConfig] = None,
 ) -> APIRouter:
     if agent is None and team is None:
         raise ValueError("Either agent or team must be provided.")
@@ -160,7 +310,7 @@ def attach_routes(
         )
 
         async def event_generator():
-            async for event in run_entity(entity, run_input, user_id=user_id):  # type: ignore
+            async for event in run_entity(entity, run_input, user_id=user_id, a2ui_config=a2ui):  # type: ignore
                 yield encoder.encode(event)
 
         return StreamingResponse(

--- a/libs/agno/agno/os/interfaces/agui/stream.py
+++ b/libs/agno/agno/os/interfaces/agui/stream.py
@@ -1,12 +1,24 @@
+import asyncio
 from collections.abc import Iterator
-from typing import Any, AsyncIterator, Dict, Optional, Union
+from typing import Any, AsyncGenerator, AsyncIterator, Dict, List, Optional, Tuple, Union
 
 from ag_ui.core import BaseEvent
 
-from agno.os.interfaces.agui.handlers import is_completion_event, process_completion, process_event
+from agno.os.interfaces.agui.a2ui_stream import A2UIRenderStream
+from agno.os.interfaces.agui.handlers import (
+    is_completion_event,
+    on_a2ui_render_stream,
+    process_completion,
+    process_event,
+)
 from agno.os.interfaces.agui.state import StreamState
 from agno.run.agent import RunCompletedEvent, RunOutputEvent
 from agno.run.team import TeamRunOutputEvent
+
+#: What produced an item the mapper is about to translate: the agent's own run,
+#: or the side channel carrying A2UI render progress.
+_AGENT = "agent"
+_A2UI = "a2ui"
 
 
 def stream_agno_response_as_agui_events(
@@ -36,13 +48,163 @@ def stream_agno_response_as_agui_events(
         yield event
 
 
+async def _close_stream(events: Any) -> None:
+    """Close the agent's stream, if it is the kind that can be closed.
+
+    Closing is what reaches the run's own cleanup. A plain async iterator has
+    none to reach, so there is nothing to do for one.
+    """
+    aclose = getattr(events, "aclose", None)
+    if aclose is not None:
+        await aclose()
+
+
+async def _agent_events_only(
+    response_stream: AsyncIterator[Union[RunOutputEvent, TeamRunOutputEvent]],
+) -> AsyncGenerator[Tuple[str, Any], None]:
+    """Pass the agent's events through, and close its stream on the way out.
+
+    Iterating never closes what it iterates, so closing this wrapper would
+    otherwise stop here and leave the run behind it suspended.
+    """
+    events = response_stream.__aiter__()
+    try:
+        async for chunk in events:
+            yield _AGENT, chunk
+    finally:
+        await _close_stream(events)
+
+
+async def _drive_agent_stream(
+    events: AsyncIterator[Union[RunOutputEvent, TeamRunOutputEvent]],
+    chunks: List[Any],
+    ready: asyncio.Event,
+    taken: asyncio.Event,
+) -> None:
+    """Advance the agent's stream from one task, handing each event over in turn.
+
+    The merge loop cannot await the next agent event itself: it has to stay free
+    to emit a render fragment while that event is still being produced. Driving
+    the whole stream from a single task, rather than a task per event, is what
+    keeps the run in one context: a task copies the context it was created in
+    and drops whatever the coroutine wrote to it, so a context variable the run
+    set while producing one event would be gone by the next one.
+
+    ``taken`` makes each handoff a rendezvous, so the run is never advanced past
+    an event the merge loop has not emitted yet.
+    """
+    try:
+        async for chunk in events:
+            chunks.append(chunk)
+            ready.set()
+            await taken.wait()
+            taken.clear()
+    finally:
+        # Exhausted, failed or cancelled: stop the merge loop from waiting for
+        # an event that is never coming.
+        ready.set()
+
+
+async def _stop_agent_stream(
+    events: AsyncIterator[Union[RunOutputEvent, TeamRunOutputEvent]],
+    driver: "asyncio.Future",
+) -> None:
+    """Stop driving the agent's stream and let the run finalize.
+
+    Cancelling is not enough on its own: closing an async generator raises
+    while one of its steps is still in flight, so the cancellation has to have
+    landed before the close. Awaiting it does not mean the run has finished
+    finalizing, though, because a cancelled run is persisted on a task of its
+    own that outlives this one. Closing is not enough either: a run suspended
+    at one of its own events has nothing in flight to cancel, so only the close
+    reaches its cleanup.
+    """
+    driver.cancel()
+    await asyncio.wait({driver})
+    if not driver.cancelled():
+        # The consumer has gone away, so a failure here has nowhere left to be
+        # reported. Take it off the task so asyncio does not log it as
+        # unretrieved.
+        driver.exception()
+
+    await _close_stream(events)
+
+
+async def _interleaved_with_a2ui(
+    response_stream: AsyncIterator[Union[RunOutputEvent, TeamRunOutputEvent]],
+    render_stream: A2UIRenderStream,
+) -> AsyncGenerator[Tuple[str, Any], None]:
+    """Merge the agent's events with A2UI render progress as each arrives.
+
+    A generation tool holds the agent's event stream open while its render
+    subagent works, so waiting only on the agent would hold every fragment back
+    until the tool returned and the surface would appear all at once.
+    """
+    events = response_stream.__aiter__()
+    chunks: List[Any] = []
+    ready = asyncio.Event()
+    taken = asyncio.Event()
+    driver = asyncio.ensure_future(_drive_agent_stream(events, chunks, ready, taken))
+
+    try:
+        while True:
+            waiters = [
+                asyncio.ensure_future(ready.wait()),
+                asyncio.ensure_future(render_stream.wait()),
+            ]
+            try:
+                await asyncio.wait(waiters, return_when=asyncio.FIRST_COMPLETED)
+            finally:
+                # Both are waits on a signal, and waiting on one consumes
+                # nothing, so cancelling them cannot drop a fragment or an
+                # agent event.
+                for waiter in waiters:
+                    waiter.cancel()
+
+            # Fragments first: they were produced while the tool was running, so
+            # they precede whatever the agent emitted once it returned.
+            for payload in render_stream.drain():
+                yield _A2UI, payload
+
+            if chunks:
+                chunk = chunks.pop(0)
+                ready.clear()
+                yield _AGENT, chunk
+                taken.set()
+                continue
+
+            if driver.done():
+                # Raises whatever ended the run; a clean end returns None.
+                driver.result()
+                break
+    except Exception:
+        # The run is over either way, so whatever of the surface was drawn
+        # before the failure is all the client will ever get: hand the buffered
+        # fragments over ahead of the error rather than dropping them.
+        for payload in render_stream.drain():
+            yield _A2UI, payload
+        raise
+    finally:
+        await _stop_agent_stream(events, driver)
+
+    for payload in render_stream.drain():
+        yield _A2UI, payload
+
+
 async def async_stream_agno_response_as_agui_events(
     response_stream: AsyncIterator[Union[RunOutputEvent, TeamRunOutputEvent]],
     thread_id: str,
     run_id: str,
     run_state: Optional[Dict[str, Any]] = None,
-) -> AsyncIterator[BaseEvent]:
-    """Map the Agno response stream to AG-UI format."""
+    a2ui_render_stream: Optional[A2UIRenderStream] = None,
+) -> AsyncGenerator[BaseEvent, None]:
+    """Map the Agno response stream to AG-UI format.
+
+    ``a2ui_render_stream`` is supplied only for a run that can generate an A2UI
+    surface. Interleaving costs a wait on every streamed event, so a run that
+    cannot generate one does not pay it. There is no equivalent on the
+    synchronous mapper above: A2UI generation is asynchronous throughout.
+    """
     state = StreamState(thread_id=thread_id, run_id=run_id, run_state=run_state)
 
     if run_state is not None:
@@ -50,12 +212,25 @@ async def async_stream_agno_response_as_agui_events(
 
     terminal_chunk = None
 
-    async for chunk in response_stream:
-        if is_completion_event(chunk):
-            terminal_chunk = chunk
-        else:
-            for event in process_event(chunk, state):
-                yield event
+    if a2ui_render_stream is None:
+        source = _agent_events_only(response_stream)
+    else:
+        source = _interleaved_with_a2ui(response_stream, a2ui_render_stream)
+
+    try:
+        async for origin, item in source:
+            if origin == _A2UI:
+                for event in on_a2ui_render_stream(item, state):
+                    yield event
+            elif is_completion_event(item):
+                terminal_chunk = item
+            else:
+                for event in process_event(item, state):
+                    yield event
+    finally:
+        # Iterating does not close, so a client that leaves mid-run would leave
+        # the source suspended and the run behind it unfinalized.
+        await source.aclose()
 
     # Process completion (or synthesize one if stream ended naturally)
     final_chunk = terminal_chunk or RunCompletedEvent()

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -241,7 +241,11 @@ markdown-chunking = ["unstructured<0.18.31", "nltk!=3.10.1", "markdown"]
 pdf-ocr = ["rapidocr_onnxruntime"]
 
 # Dependencies for AG-UI integration
-agui = ["ag-ui-protocol>=0.1.15", "jsonpatch>=1.33"]
+# ag-ui-a2ui-toolkit requires Python >= 3.10; the marker keeps `pip install
+# agno[agui]` (and the dev/tests chains) resolvable on 3.9, where importing
+# agno.os.interfaces.agui.a2ui then raises its readable ImportError. A2UI is
+# the only part of the interface that needs it, and it is imported lazily.
+agui = ["ag-ui-protocol>=0.1.15", "jsonpatch>=1.33", "ag-ui-a2ui-toolkit>=0.0.4; python_version >= '3.10'"]
 
 # Dependencies for A2A integration
 a2a = ["a2a-sdk>=0.3.0,<1.0"]
@@ -537,6 +541,7 @@ exclude = ["tests*"]
 module = [
   "a2a.*",
   "ag_ui.*",
+  "ag_ui_a2ui_toolkit.*",
   "agentql.*",
   "aioboto3.*",
   "aiohttp.*",

--- a/libs/agno/tests/unit/app/test_agui_client_tools.py
+++ b/libs/agno/tests/unit/app/test_agui_client_tools.py
@@ -1,8 +1,9 @@
+from ag_ui.core.types import AssistantMessage, FunctionCall, ToolCall, ToolMessage, UserMessage
 from ag_ui.core.types import Tool as AGUITool
-from ag_ui.core.types import ToolMessage, UserMessage
 
 from agno.models.response import ToolExecution
 from agno.os.interfaces.agui.input import (
+    describe_tool_results,
     extract_tool_messages,
     parse_client_tools,
 )
@@ -88,6 +89,55 @@ def test_extract_tool_messages_empty_content():
     result = extract_tool_messages(messages)
     assert len(result) == 1
     assert result[0].content == ""
+
+
+# describe_tool_results tests
+
+
+def _assistant_call(call_id: str, name: str, arguments: str = "{}") -> AssistantMessage:
+    return AssistantMessage(
+        id="a-" + call_id,
+        tool_calls=[ToolCall(id=call_id, type="function", function=FunctionCall(name=name, arguments=arguments))],
+    )
+
+
+def test_describe_tool_results_names_the_tool_from_the_call():
+    messages = [
+        UserMessage(id="u1", content="show me hotels"),
+        _assistant_call("call_click", "log_a2ui_event"),
+        ToolMessage(id="t1", tool_call_id="call_click", content='User performed action "bookHotel"'),
+    ]
+    described = describe_tool_results(messages, extract_tool_messages(messages))
+    assert described == 'Result of the log_a2ui_event tool call: User performed action "bookHotel"'
+
+
+def test_describe_tool_results_without_the_call_still_carries_the_content():
+    """A client may send a result with no assistant call beside it; the content is the point."""
+    messages = [ToolMessage(id="t1", tool_call_id="call_orphan", content="done")]
+    assert describe_tool_results(messages, extract_tool_messages(messages)) == "Tool result: done"
+
+
+def test_describe_tool_results_carries_an_error_in_place_of_content():
+    messages = [
+        _assistant_call("call_1", "change_background"),
+        ToolMessage(id="t1", tool_call_id="call_1", content="", error="the browser refused"),
+    ]
+    described = describe_tool_results(messages, extract_tool_messages(messages))
+    assert described == "Result of the change_background tool call: the browser refused"
+
+
+def test_describe_tool_results_keeps_every_result_in_order():
+    messages = [
+        _assistant_call("call_1", "first_tool"),
+        _assistant_call("call_2", "second_tool"),
+        ToolMessage(id="t1", tool_call_id="call_1", content="one"),
+        ToolMessage(id="t2", tool_call_id="call_2", content="two"),
+    ]
+    described = describe_tool_results(messages, extract_tool_messages(messages))
+    assert described.splitlines() == [
+        "Result of the first_tool tool call: one",
+        "Result of the second_tool tool call: two",
+    ]
 
 
 # parse_client_tools tests

--- a/libs/agno/tests/unit/app/test_agui_resume.py
+++ b/libs/agno/tests/unit/app/test_agui_resume.py
@@ -42,73 +42,79 @@ def _make_session_with_paused_run() -> AgentSession:
     return session
 
 
-class TestResumePausedRunErrorPaths:
+class TestNothingToResume:
+    """A trailing tool result no paused run is waiting on is not a resume.
+
+    Each case here says the same thing to the caller: this session holds no
+    paused run these results answer, so the router owes them a new turn rather
+    than a failed one. A client mints tool call ids the backend never emitted
+    (an interactive surface reports a click that way), so this is ordinary
+    traffic, not a broken resume.
+    """
+
+    async def _resume(self, entity, session_id: str):
+        return await resume_paused_run(
+            entity=entity,
+            session_id=session_id,
+            tool_messages=[FakeToolMessage("call_1", "result")],
+            run_context=RunContext(run_id="new-run", session_id=session_id),
+            run_kwargs={},
+        )
+
     @pytest.mark.asyncio
-    async def test_raises_when_no_db(self):
+    async def test_no_db_cannot_hold_a_paused_run(self):
         # spec=Agent needed for isinstance() check in resume_paused_run
         entity = MagicMock(spec=Agent)
         entity.db = None
 
-        with pytest.raises(ValueError, match="requires a database"):
-            await resume_paused_run(
-                entity=entity,
-                session_id="test-session",
-                tool_messages=[FakeToolMessage("call_1", "result")],
-                run_context=RunContext(run_id="new-run", session_id="test-session"),
-                run_kwargs={},
-            )
+        assert await self._resume(entity, "test-session") is None
 
     @pytest.mark.asyncio
-    async def test_raises_when_session_not_found(self):
+    async def test_a_session_that_is_gone_holds_no_paused_run(self):
         entity = MagicMock(spec=Agent)
         entity.db = MagicMock()
         entity.aget_session = AsyncMock(return_value=None)
 
-        with pytest.raises(ValueError, match="Session .* not found"):
-            await resume_paused_run(
-                entity=entity,
-                session_id="missing-session",
-                tool_messages=[FakeToolMessage("call_1", "result")],
-                run_context=RunContext(run_id="new-run", session_id="missing-session"),
-                run_kwargs={},
-            )
+        assert await self._resume(entity, "missing-session") is None
 
     @pytest.mark.asyncio
-    async def test_raises_when_no_paused_run(self):
+    async def test_a_session_of_completed_runs_holds_no_paused_run(self):
         entity = MagicMock(spec=Agent)
         entity.db = MagicMock()
         session = AgentSession(session_id="test-session")
         session.runs = [RunOutput(run_id="completed-run", status=RunStatus.completed)]
         entity.aget_session = AsyncMock(return_value=session)
 
-        with pytest.raises(ValueError, match="No paused run matching"):
-            await resume_paused_run(
-                entity=entity,
-                session_id="test-session",
-                tool_messages=[FakeToolMessage("call_1", "result")],
-                run_context=RunContext(run_id="new-run", session_id="test-session"),
-                run_kwargs={},
-            )
+        assert await self._resume(entity, "test-session") is None
 
     @pytest.mark.asyncio
-    async def test_raises_when_paused_run_has_no_requirements(self):
-        """Paused run with no requirements won't match any tool_call_ids."""
+    async def test_a_paused_run_with_no_requirements_waits_on_nothing(self):
         entity = MagicMock(spec=Agent)
         entity.db = MagicMock()
         session = AgentSession(session_id="test-session")
-        paused_run = RunOutput(run_id="paused-run", status=RunStatus.paused, requirements=None)
-        session.runs = [paused_run]
+        session.runs = [RunOutput(run_id="paused-run", status=RunStatus.paused, requirements=None)]
         entity.aget_session = AsyncMock(return_value=session)
 
-        # Run has no requirements, so no tool_call_ids to match
-        with pytest.raises(ValueError, match="No paused run matching"):
-            await resume_paused_run(
-                entity=entity,
-                session_id="test-session",
-                tool_messages=[FakeToolMessage("call_1", "result")],
-                run_context=RunContext(run_id="new-run", session_id="test-session"),
-                run_kwargs={},
-            )
+        assert await self._resume(entity, "test-session") is None
+
+    @pytest.mark.asyncio
+    async def test_an_unmatched_tool_call_id_leaves_a_paused_run_alone(self):
+        """The paused run waits on call_1; these results answer something else."""
+        entity = MagicMock(spec=Agent)
+        entity.db = MagicMock()
+        entity.aget_session = AsyncMock(return_value=_make_session_with_paused_run())
+        entity.acontinue_run = MagicMock(return_value=AsyncMock())
+
+        resumed = await resume_paused_run(
+            entity=entity,
+            session_id="test-session",
+            tool_messages=[FakeToolMessage("767065f4-7cc3-42d4", 'User performed action "bookHotel"')],
+            run_context=RunContext(run_id="new-run", session_id="test-session"),
+            run_kwargs={},
+        )
+
+        assert resumed is None
+        entity.acontinue_run.assert_not_called()
 
 
 class TestResumePausedRunHappyPath:

--- a/libs/agno/tests/unit/os/interfaces/test_agui_a2ui.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_a2ui.py
@@ -1,0 +1,2572 @@
+"""A2UI surface generation over the AG-UI interface."""
+
+import asyncio
+import concurrent.futures
+import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, AsyncIterator, Dict, List, Optional, Tuple
+
+import pytest
+
+pytest.importorskip("ag_ui", reason="ag_ui not installed")
+pytest.importorskip("ag_ui_a2ui_toolkit", reason="ag_ui_a2ui_toolkit not installed")
+
+from ag_ui_a2ui_toolkit import (  # noqa: E402
+    A2UI_SCHEMA_CONTEXT_DESCRIPTION,
+    BASIC_CATALOG_ID,
+    GENERATE_A2UI_TOOL_NAME,
+)
+from fastapi.testclient import TestClient  # noqa: E402
+
+from agno.agent import Agent  # noqa: E402
+from agno.os.app import AgentOS  # noqa: E402
+from agno.os.interfaces.agui import AGUI  # noqa: E402
+from agno.os.interfaces.agui import a2ui as a2ui_module  # noqa: E402
+from agno.os.interfaces.agui.a2ui import (  # noqa: E402
+    OPENAI_RENDER_TOOL_CHOICE,
+    RENDER_A2UI_TOOL_NAME,
+    A2UIRenderArgumentsError,
+    A2UIRenderAttempt,
+    agui_state_from_dependencies,
+    classify_a2ui_subagent_error,
+    get_a2ui_tools,
+    stream_render_subagent,
+    strip_in_flight_tool_call,
+)
+from agno.os.interfaces.agui.a2ui_stream import A2UIRenderStream, A2UIRun, current_a2ui_run  # noqa: E402
+
+CATALOG_ID = "declarative-gen-ui-catalog"
+
+VALID_COMPONENTS = [
+    {"id": "root", "component": "Column", "children": ["title"]},
+    {"id": "title", "component": "Text", "text": "Quarterly sales"},
+]
+
+# No component has id "root", so the toolkit's semantic gate rejects the tree.
+INVALID_COMPONENTS = [{"id": "orphan", "component": "Text", "text": "nowhere"}]
+
+
+# =============================================================================
+# Test doubles
+# =============================================================================
+
+
+class FakeDelta:
+    """One streamed model response carrying tool-call deltas."""
+
+    def __init__(self, tool_calls: Optional[List[Any]] = None) -> None:
+        self.tool_calls = tool_calls
+
+
+class FakeFunctionDelta:
+    """A provider tool-call delta in object form (the OpenAI-compatible shape)."""
+
+    def __init__(
+        self,
+        name: Optional[str] = None,
+        arguments: Optional[str] = None,
+        index: Optional[int] = None,
+        id: Optional[str] = None,
+    ) -> None:
+        self.function = type("Fn", (), {"name": name, "arguments": arguments})()
+        self.index = index
+        self.id = id
+
+
+class ScriptedModel:
+    """A model whose render turns are scripted per attempt.
+
+    Each entry in ``script`` is the outcome of one subagent turn: a dict of
+    render arguments, ``None`` for "answered without calling the tool", or an
+    exception instance to raise.
+    """
+
+    assistant_message_role = "assistant"
+
+    def __init__(self, script: List[Any]) -> None:
+        self.script = list(script)
+        self.calls: List[str] = []
+        self.tool_choices: List[Any] = []
+        self.seen_messages: List[Any] = []
+        self.offered_tools: List[Any] = []
+
+    async def aprocess_response_stream(self, **kwargs: Any) -> AsyncIterator[FakeDelta]:
+        prompt = kwargs["messages"][0].content
+        self.calls.append(prompt)
+        self.seen_messages = list(kwargs["messages"])
+        self.offered_tools = list(kwargs.get("tools") or [])
+        self.tool_choices.append(kwargs.get("tool_choice"))
+        outcome = self.script.pop(0) if self.script else None
+
+        if isinstance(outcome, BaseException):
+            raise outcome
+        if outcome is None:
+            yield FakeDelta()
+            return
+
+        # Stream the arguments the way an OpenAI-compatible provider does: a
+        # named opening frame, then argument fragments with no name.
+        yield FakeDelta([FakeFunctionDelta(name=RENDER_A2UI_TOOL_NAME, arguments="")])
+        payload = json.dumps(outcome)
+        for start in range(0, len(payload), 16):
+            yield FakeDelta([FakeFunctionDelta(arguments=payload[start : start + 16])])
+
+
+class MisreadDeltaModel:
+    """A provider whose argument fragments are not strings.
+
+    Nothing the model did: reading this shape is this module's own job, so the
+    failure is raised in a frame of its own rather than in the model layer.
+    """
+
+    assistant_message_role = "assistant"
+
+    def __init__(self) -> None:
+        self.calls: List[str] = []
+
+    async def aprocess_response_stream(self, **kwargs: Any) -> AsyncIterator[FakeDelta]:
+        self.calls.append(kwargs["messages"][0].content)
+        yield FakeDelta([FakeFunctionDelta(name=RENDER_A2UI_TOOL_NAME, arguments="")])
+        yield FakeDelta([FakeFunctionDelta(arguments=17)])  # type: ignore[arg-type]
+
+
+class HangingModel:
+    """A model whose render turn never answers until the call is cancelled."""
+
+    assistant_message_role = "assistant"
+
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+        self.cancelled = asyncio.Event()
+        self.calls: List[str] = []
+
+    async def aprocess_response_stream(self, **kwargs: Any) -> AsyncIterator[FakeDelta]:
+        self.calls.append(kwargs["messages"][0].content)
+        self.started.set()
+        try:
+            await asyncio.sleep(30)
+        except asyncio.CancelledError:
+            self.cancelled.set()
+            raise
+        yield FakeDelta()
+
+
+class FakeRunContext:
+    def __init__(
+        self,
+        messages: Optional[List[Any]] = None,
+        dependencies: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.messages = messages or []
+        self.dependencies = dependencies
+
+
+def levels_logging(caplog: Any, needle: str) -> set:
+    """The levels the records mentioning ``needle`` were logged at.
+
+    A substring match on the text says a line was emitted but not how loudly,
+    and a downgrade nobody is told about at the level they watch is the same as
+    no downgrade being reported at all.
+    """
+    return {record.levelname for record in caplog.records if needle in record.getMessage()}
+
+
+def catalog_component(name: str, *requires: str) -> Dict[str, Any]:
+    """One component's schema, in the shape the client's catalog extractor sends.
+
+    Every component is composed with ``allOf`` against the shared component
+    base, so the properties it takes and the ones it requires sit a level below
+    the entry itself. Written out that way here rather than flattened by hand,
+    because a gate that only reads the flattened shape is a gate that never
+    runs on a real run.
+    """
+    return {
+        "allOf": [
+            {"$ref": "common_types.json#/$defs/ComponentCommon"},
+            {
+                "properties": {"component": {"const": name}, **{prop: {} for prop in requires}},
+                "required": ["component", *requires],
+            },
+        ]
+    }
+
+
+def forwarded_catalog(**components: Dict[str, Any]) -> Dict[str, Any]:
+    """The catalog value the client forwards: component schemas keyed by name."""
+    return {"catalogId": CATALOG_ID, "components": components}
+
+
+def schema_dependencies(catalog_id: str = CATALOG_ID) -> Dict[str, Any]:
+    """Dependencies as the AG-UI router builds them from forwarded context."""
+    return {
+        A2UI_SCHEMA_CONTEXT_DESCRIPTION: {
+            "catalogId": catalog_id,
+            "components": {"Column": catalog_component("Column"), "Text": catalog_component("Text")},
+        },
+        "User preferences": {"currency": "USD"},
+    }
+
+
+def prior_surface_envelope(surface_id: str, catalog_id: str = CATALOG_ID) -> str:
+    """The tool result an already-rendered surface left behind."""
+    return json.dumps(
+        {
+            "a2ui_operations": [
+                {"version": "v0.9", "createSurface": {"surfaceId": surface_id, "catalogId": catalog_id}},
+                {
+                    "version": "v0.9",
+                    "updateComponents": {"surfaceId": surface_id, "components": VALID_COMPONENTS},
+                },
+            ]
+        }
+    )
+
+
+def prior_surface_message(surface_id: str, catalog_id: str = CATALOG_ID) -> Any:
+    """A tool result carrying an already-rendered surface, as history replays it."""
+    envelope = prior_surface_envelope(surface_id, catalog_id)
+    return type("Msg", (), {"role": "tool", "content": envelope, "tool_calls": None})()
+
+
+def client_surface_message(surface_id: str, catalog_id: str = CATALOG_ID) -> Any:
+    """The same surface as the client replays it: a real AG-UI tool message.
+
+    This is the type the router hands the generation tool for a cross-turn
+    edit, so the history walk has to read it and not merely something shaped
+    like it.
+    """
+    from ag_ui.core import ToolMessage
+
+    return ToolMessage(
+        id=f"msg-{surface_id}",
+        role="tool",
+        tool_call_id=f"call-{surface_id}",
+        content=prior_surface_envelope(surface_id, catalog_id),
+    )
+
+
+async def call_tool(tool: Any, run_context: Any = None, **kwargs: Any) -> Dict[str, Any]:
+    """Call a generation tool the way a served run does.
+
+    A real render channel is attached whether or not the caller asked for one,
+    because a run that generates a surface always has one: with the channel
+    left off, every recovery case here exercised the tool with nothing to push
+    to, which is the reason a whole class of streaming defect went unseen.
+    """
+    existing = current_a2ui_run.get()
+    run = A2UIRun(
+        render_stream=(existing.render_stream if existing is not None else None) or A2UIRenderStream(),
+        state=existing.state if existing is not None else None,
+        messages=existing.messages if existing is not None else [],
+    )
+    token = current_a2ui_run.set(run)
+    try:
+        raw = await tool.entrypoint(run_context=run_context or FakeRunContext(), **kwargs)
+    finally:
+        current_a2ui_run.reset(token)
+    return json.loads(raw)
+
+
+async def call_tool_over_the_channel(tool: Any, run_context: Any = None, **kwargs: Any) -> Any:
+    """Call a generation tool and collect what it painted as well as what it committed.
+
+    The two are chosen at different sites from different inputs, and a server
+    that logs a generated surface while the client shows none is what every
+    disagreement between them looks like.
+    """
+    render_stream = A2UIRenderStream()
+    existing = current_a2ui_run.get()
+    run = A2UIRun(
+        render_stream=render_stream,
+        state=existing.state if existing is not None else None,
+        messages=existing.messages if existing is not None else [],
+    )
+    token = current_a2ui_run.set(run)
+    try:
+        raw = await tool.entrypoint(run_context=run_context or FakeRunContext(), **kwargs)
+    finally:
+        current_a2ui_run.reset(token)
+    return json.loads(raw), render_stream.drain()
+
+
+def painted_calls(pushed: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Each painted render call as a progressively painting client buffers it.
+
+    Buffered per wire id, because that is the key the AG-UI client's reducer
+    buffers argument fragments on: two attempts sharing an id are one buffer
+    holding both sets of arguments, which parses as nothing and paints
+    nothing.
+    """
+    order: List[str] = []
+    starts: Dict[str, int] = {}
+    buffers: Dict[str, str] = {}
+    for event in pushed:
+        call_id = event["tool_call_id"]
+        if event["kind"] == "start":
+            if call_id not in order:
+                order.append(call_id)
+                buffers[call_id] = ""
+            starts[call_id] = starts.get(call_id, 0) + 1
+        elif event["kind"] == "args":
+            buffers[call_id] += event["delta"]
+    return [{"call_id": call_id, "starts": starts[call_id], "args": buffers[call_id]} for call_id in order]
+
+
+async def wait_until(predicate: Any, timeout: float = 5.0) -> None:
+    """Poll a cross-thread condition without blocking the event loop."""
+    deadline = asyncio.get_running_loop().time() + timeout
+    while not predicate():
+        if asyncio.get_running_loop().time() > deadline:
+            raise AssertionError("condition never became true")
+        await asyncio.sleep(0.01)
+
+
+def operation_kinds(envelope: Dict[str, Any]) -> List[str]:
+    """The operation names in an envelope, in order."""
+    kinds = []
+    for operation in envelope.get("a2ui_operations", []):
+        kinds.extend(key for key in operation if key != "version")
+    return kinds
+
+
+def operation(envelope: Dict[str, Any], kind: str) -> Dict[str, Any]:
+    for entry in envelope["a2ui_operations"]:
+        if kind in entry:
+            return entry[kind]
+    raise AssertionError(f"envelope has no {kind} operation: {envelope}")
+
+
+# =============================================================================
+# Tool construction
+# =============================================================================
+
+
+def test_requires_a_model():
+    with pytest.raises(ValueError, match="requires a 'model'"):
+        get_a2ui_tools({})
+
+
+def test_advertises_the_shared_tool_contract():
+    tool = get_a2ui_tools({"model": ScriptedModel([])})
+
+    assert tool.name == GENERATE_A2UI_TOOL_NAME
+    assert tool.description
+    assert set(tool.parameters["properties"]) == {"intent", "target_surface_id", "changes"}
+    assert tool.parameters["properties"]["intent"]["enum"] == ["create", "update"]
+    for spec in tool.parameters["properties"].values():
+        assert spec["description"]
+
+
+def test_honours_a_custom_tool_name():
+    tool = get_a2ui_tools({"model": ScriptedModel([]), "tool_name": "draw_ui"})
+
+    assert tool.name == "draw_ui"
+
+
+def test_warns_on_snake_case_recovery_options(caplog):
+    get_a2ui_tools({"model": ScriptedModel([]), "recovery": {"max_attempts": 2}})
+
+    assert "maxAttempts" in caplog.text
+
+
+def test_nothing_is_forced_by_default():
+    """Agno hands ``tool_choice`` to each provider unchanged, and no single
+    spelling is accepted everywhere, so the default forces nothing."""
+    model = ScriptedModel([{"surfaceId": "s", "components": VALID_COMPONENTS}])
+    tool = get_a2ui_tools({"model": model})
+
+    asyncio.run(call_tool(tool))
+
+    assert model.tool_choices == [None]
+
+
+def test_a_provider_specific_tool_choice_overrides_the_default():
+    model = ScriptedModel([{"surfaceId": "s", "components": VALID_COMPONENTS}])
+    tool = get_a2ui_tools({"model": model}, {"tool_choice": "any"})
+
+    asyncio.run(call_tool(tool))
+
+    assert model.tool_choices == ["any"]
+
+
+def test_the_openai_forced_shape_is_available_to_opt_in_to():
+    model = ScriptedModel([{"surfaceId": "s", "components": VALID_COMPONENTS}])
+    tool = get_a2ui_tools({"model": model}, {"tool_choice": OPENAI_RENDER_TOOL_CHOICE})
+
+    asyncio.run(call_tool(tool))
+
+    assert model.tool_choices == [{"type": "function", "function": {"name": RENDER_A2UI_TOOL_NAME}}]
+
+
+def test_agnos_synchronous_tool_path_is_refused_rather_than_answered_with_a_coroutine():
+    """An async-only entrypoint on the sync path "succeeds" with a coroutine.
+
+    Agno's synchronous tool path calls the entrypoint and keeps what comes
+    back, so a developer who wires this onto an agent they drive with run() or
+    print_response() has the repr of an un-awaited coroutine sent to their
+    model as the tool result.
+    """
+    from agno.exceptions import AgentRunException
+    from agno.tools.function import FunctionCall
+
+    model = ScriptedModel([{"surfaceId": "s", "components": VALID_COMPONENTS}])
+    call = FunctionCall(function=get_a2ui_tools({"model": model}), arguments={})
+
+    with pytest.raises(AgentRunException, match="asynchronous"):
+        call.execute()
+
+    # The model is told the tool failed, and why, rather than being handed a
+    # successful result it cannot read.
+    assert "aprint_response" in (call.error or "")
+    assert model.calls == []
+
+
+@pytest.mark.asyncio
+async def test_the_asynchronous_tool_path_still_runs_the_whole_call():
+    """The same guard runs on both paths, and must only refuse the one."""
+    from agno.tools.function import FunctionCall
+
+    model = ScriptedModel([{"surfaceId": "sales", "components": VALID_COMPONENTS}])
+    call = FunctionCall(function=get_a2ui_tools({"model": model}), arguments={})
+
+    result = await call.aexecute()
+
+    assert result.status == "success"
+    assert operation(json.loads(result.result), "createSurface")["surfaceId"] == "sales"
+
+
+@pytest.mark.parametrize(
+    ("err", "phrase"),
+    [
+        (ModuleNotFoundError("No module named 'ag_ui_a2ui_toolkit'", name="ag_ui_a2ui_toolkit"), "not installed"),
+        (ModuleNotFoundError("No module named 'jsonschema'", name="jsonschema"), "does not have"),
+        (ImportError("cannot import name 'resolve_a2ui_catalog'"), "out of date"),
+    ],
+    ids=["toolkit-absent", "dependency-absent", "symbol-absent"],
+)
+def test_a_failed_toolkit_import_names_the_fix_it_needs(err, phrase):
+    """Three failures, three fixes. A dependency of the toolkit that this
+    environment lacks is not the toolkit being out of date, and sending
+    someone to upgrade a package that is already current leaves them stuck."""
+    message = a2ui_module._toolkit_import_message(err)
+
+    assert phrase in message
+    if isinstance(err, ModuleNotFoundError) and err.name != "ag_ui_a2ui_toolkit":
+        assert err.name in message
+
+
+# =============================================================================
+# Generation
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_creates_a_surface_from_the_subagent_output():
+    model = ScriptedModel([{"surfaceId": "sales", "components": VALID_COMPONENTS, "data": {"n": 1}}])
+    tool = get_a2ui_tools({"model": model})
+
+    envelope = await call_tool(tool, FakeRunContext(dependencies=schema_dependencies()))
+
+    assert operation_kinds(envelope) == ["createSurface", "updateComponents", "updateDataModel"]
+    assert operation(envelope, "createSurface")["surfaceId"] == "sales"
+    assert operation(envelope, "updateComponents")["components"] == VALID_COMPONENTS
+    assert operation(envelope, "updateDataModel")["value"] == {"n": 1}
+
+
+@pytest.mark.asyncio
+async def test_the_subagent_is_offered_the_render_tool():
+    """The one tool the render turn exists to have called.
+
+    Offered nothing, a real provider has no tool to call and every attempt
+    ends as a sub-agent that produced no surface, while a scripted model
+    streams a render call regardless and the whole suite stays green.
+    """
+    model = ScriptedModel([{"surfaceId": "s", "components": VALID_COMPONENTS}])
+    tool = get_a2ui_tools({"model": model})
+
+    await call_tool(tool)
+
+    assert [offered["function"]["name"] for offered in model.offered_tools] == [RENDER_A2UI_TOOL_NAME]
+
+
+@pytest.mark.asyncio
+async def test_the_in_flight_generation_call_never_reaches_the_subagent():
+    """The assistant turn calling the generation tool has no result yet.
+
+    The sub-agent is not offered that tool, so an unanswered call to it is
+    malformed input for every provider that checks the pairing, and the render
+    turn fails on the provider rather than on anything the model wrote.
+    """
+    history = [
+        {"role": "user", "content": "make a card"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{"function": {"name": GENERATE_A2UI_TOOL_NAME}}],
+        },
+    ]
+    model = ScriptedModel([{"surfaceId": "s", "components": VALID_COMPONENTS}])
+    tool = get_a2ui_tools({"model": model})
+
+    await call_tool(tool, FakeRunContext(messages=history))
+
+    assert [message for message in model.seen_messages if isinstance(message, dict)] == history[:1]
+
+
+@pytest.mark.asyncio
+async def test_binds_the_surface_to_the_catalog_the_client_registered():
+    model = ScriptedModel([{"surfaceId": "s", "components": VALID_COMPONENTS}])
+    tool = get_a2ui_tools({"model": model})
+
+    envelope = await call_tool(tool, FakeRunContext(dependencies=schema_dependencies()))
+
+    assert operation(envelope, "createSurface")["catalogId"] == CATALOG_ID
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_the_basic_catalog_without_forwarded_context():
+    model = ScriptedModel([{"surfaceId": "s", "components": VALID_COMPONENTS}])
+    tool = get_a2ui_tools({"model": model})
+
+    envelope = await call_tool(tool)
+
+    assert operation(envelope, "createSurface")["catalogId"] == BASIC_CATALOG_ID
+
+
+@pytest.mark.asyncio
+async def test_a_configured_catalog_beats_the_forwarded_one():
+    model = ScriptedModel([{"surfaceId": "s", "components": VALID_COMPONENTS}])
+    tool = get_a2ui_tools({"model": model, "default_catalog_id": "chosen-by-the-host"})
+
+    envelope = await call_tool(tool, FakeRunContext(dependencies=schema_dependencies()))
+
+    assert operation(envelope, "createSurface")["catalogId"] == "chosen-by-the-host"
+
+
+@pytest.mark.asyncio
+async def test_the_subagent_prompt_carries_the_catalog_and_the_context():
+    model = ScriptedModel([{"surfaceId": "s", "components": VALID_COMPONENTS}])
+    tool = get_a2ui_tools({"model": model})
+
+    await call_tool(tool, FakeRunContext(dependencies=schema_dependencies()))
+
+    prompt = model.calls[0]
+    assert "## Available Components" in prompt
+    assert '"Column"' in prompt
+    assert "## User preferences" in prompt
+
+
+@pytest.mark.asyncio
+async def test_updating_a_prior_surface_reuses_it_in_place():
+    model = ScriptedModel([{"surfaceId": "ignored", "components": VALID_COMPONENTS}])
+    tool = get_a2ui_tools({"model": model})
+    context = FakeRunContext(messages=[prior_surface_message("sales")])
+
+    envelope = await call_tool(tool, context, intent="update", target_surface_id="sales", changes="make it red")
+
+    # No createSurface: the client reconciles the surface it already has.
+    assert operation_kinds(envelope) == ["updateComponents"]
+    assert operation(envelope, "updateComponents")["surfaceId"] == "sales"
+    prompt = model.calls[0]
+    assert "Editing an existing surface" in prompt
+    assert "make it red" in prompt
+
+
+@pytest.mark.asyncio
+async def test_a_surface_from_an_earlier_turn_is_edited_in_place():
+    """The cross-turn edit, against the message type the client really sends.
+
+    The agent's own run history covers only the turn in progress, so a surface
+    from an earlier turn is found in what the client replayed, and those are
+    AG-UI messages rather than anything this package built.
+    """
+    model = ScriptedModel([{"surfaceId": "ignored", "components": VALID_COMPONENTS}])
+    tool = get_a2ui_tools({"model": model})
+    run = A2UIRun(messages=[client_surface_message("sales")])
+
+    token = current_a2ui_run.set(run)
+    try:
+        envelope = await call_tool(tool, intent="update", target_surface_id="sales", changes="make it red")
+    finally:
+        current_a2ui_run.reset(token)
+
+    assert operation_kinds(envelope) == ["updateComponents"]
+    assert operation(envelope, "updateComponents")["surfaceId"] == "sales"
+    assert "Editing an existing surface" in model.calls[0]
+
+
+@pytest.mark.asyncio
+async def test_updating_an_unknown_surface_fails_without_calling_the_model():
+    model = ScriptedModel([{"surfaceId": "s", "components": VALID_COMPONENTS}])
+    tool = get_a2ui_tools({"model": model})
+
+    envelope = await call_tool(tool, intent="update", target_surface_id="never-rendered")
+
+    assert "no prior render" in envelope["error"]
+    assert model.calls == []
+
+
+@pytest.mark.asyncio
+async def test_an_update_that_names_no_surface_creates_one():
+    """An edit with nothing to edit is served as a fresh surface.
+
+    ``target_surface_id`` is optional because it has to be: a provider in
+    strict mode reads a missing ``required`` as "all of them" and could not
+    create a surface at all. So a model can ask to update and name nothing,
+    and the useful answer is the surface it was asked for rather than an error
+    the user sees as a turn that produced nothing.
+    """
+    # Deliberately not the prior surface's id: "created from the model's own id"
+    # and "silently reused the prior surface" are otherwise the same assertion.
+    model = ScriptedModel([{"surfaceId": "fresh", "components": VALID_COMPONENTS}])
+    tool = get_a2ui_tools({"model": model})
+    context = FakeRunContext(messages=[prior_surface_message("sales")])
+
+    envelope = await call_tool(tool, context, intent="update", changes="make it red")
+
+    assert operation_kinds(envelope) == ["createSurface", "updateComponents"]
+    assert operation(envelope, "createSurface")["surfaceId"] == "fresh"
+    assert operation(envelope, "updateComponents")["surfaceId"] == "fresh"
+    assert len(model.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_an_intent_outside_the_enum_creates_a_surface():
+    """The tool advertises create and update, and a provider that ignores the
+    enum still gets a renderable answer instead of taking the run down. Only
+    an update names a surface to reuse, so anything else creates one."""
+    model = ScriptedModel([{"surfaceId": "fresh", "components": VALID_COMPONENTS}])
+    tool = get_a2ui_tools({"model": model})
+    context = FakeRunContext(messages=[prior_surface_message("sales")])
+
+    envelope = await call_tool(tool, context, intent="destroy", target_surface_id="sales")
+
+    assert operation_kinds(envelope) == ["createSurface", "updateComponents"]
+    assert operation(envelope, "createSurface")["surfaceId"] == "fresh"
+    assert operation(envelope, "updateComponents")["surfaceId"] == "fresh"
+
+
+# =============================================================================
+# Recovery
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_an_invalid_surface_is_retried_and_only_the_valid_one_is_committed():
+    model = ScriptedModel(
+        [
+            {"surfaceId": "s", "components": INVALID_COMPONENTS},
+            {"surfaceId": "s", "components": VALID_COMPONENTS},
+        ]
+    )
+    attempts: List[Dict[str, Any]] = []
+    tool = get_a2ui_tools({"model": model, "on_a2ui_attempt": attempts.append})
+
+    envelope = await call_tool(tool)
+
+    assert operation(envelope, "updateComponents")["components"] == VALID_COMPONENTS
+    assert [entry["ok"] for entry in attempts] == [False, True]
+
+
+@pytest.mark.asyncio
+async def test_a_retry_tells_the_subagent_what_was_wrong():
+    model = ScriptedModel(
+        [
+            {"surfaceId": "s", "components": INVALID_COMPONENTS},
+            {"surfaceId": "s", "components": VALID_COMPONENTS},
+        ]
+    )
+    tool = get_a2ui_tools({"model": model})
+
+    await call_tool(tool)
+
+    assert "Previous attempt was invalid" not in model.calls[0]
+    assert "Previous attempt was invalid" in model.calls[1]
+
+
+@pytest.mark.asyncio
+async def test_a_component_the_client_cannot_draw_is_retried_rather_than_committed():
+    """The retry gate applies the rule the client's paint gate applies.
+
+    The renderer validates against the catalog it registered, so it refuses a
+    component that catalog does not define. Checked for structure only, such a
+    tree passes here, is committed, and is then refused by the browser with no
+    attempt left to heal it and nothing said on either side.
+    """
+    unknown = [{"id": "root", "component": "Sparkline", "series": [1, 2]}]
+    model = ScriptedModel(
+        [
+            {"surfaceId": "s", "components": unknown},
+            {"surfaceId": "s", "components": VALID_COMPONENTS},
+        ]
+    )
+    attempts: List[Dict[str, Any]] = []
+    tool = get_a2ui_tools({"model": model, "on_a2ui_attempt": attempts.append})
+
+    envelope = await call_tool(tool, FakeRunContext(dependencies=schema_dependencies()))
+
+    assert [entry["ok"] for entry in attempts] == [False, True]
+    assert [error["code"] for error in attempts[0]["errors"]] == ["unknown_component"]
+    assert operation(envelope, "updateComponents")["components"] == VALID_COMPONENTS
+
+
+@pytest.mark.asyncio
+async def test_a_component_missing_a_property_its_catalog_requires_is_retried():
+    """The second half of the client's rule: required props, per component.
+
+    What each component requires is stated inside its ``allOf`` composition, so
+    a gate that reads the entry only at its top level finds every component
+    requiring nothing and this half of the rule never fires.
+    """
+    dependencies = {
+        A2UI_SCHEMA_CONTEXT_DESCRIPTION: forwarded_catalog(
+            Column=catalog_component("Column"),
+            Text=catalog_component("Text", "text"),
+        )
+    }
+    model = ScriptedModel(
+        [
+            {"surfaceId": "s", "components": [{"id": "root", "component": "Text"}]},
+            {"surfaceId": "s", "components": VALID_COMPONENTS},
+        ]
+    )
+    attempts: List[Dict[str, Any]] = []
+    tool = get_a2ui_tools({"model": model, "on_a2ui_attempt": attempts.append})
+
+    envelope = await call_tool(tool, FakeRunContext(dependencies=dependencies))
+
+    assert [error["code"] for error in attempts[0]["errors"]] == ["missing_required_prop"]
+    assert operation(envelope, "updateComponents")["components"] == VALID_COMPONENTS
+
+
+@pytest.mark.asyncio
+async def test_a_catalog_the_host_pinned_beats_the_forwarded_one_at_the_gate():
+    """A host that hard-coded a catalog has said what it will draw.
+
+    Its own components are the ones to validate against, so a run whose client
+    forwarded a different schema is still gated on the host's choice.
+    """
+    model = ScriptedModel([{"surfaceId": "s", "components": [{"id": "root", "component": "Sparkline"}]}])
+    tool = get_a2ui_tools({"model": model, "catalog": {"components": {"Sparkline": {}}}})
+
+    envelope = await call_tool(tool, FakeRunContext(dependencies=schema_dependencies()))
+
+    assert operation(envelope, "updateComponents")["components"][0]["component"] == "Sparkline"
+
+
+@pytest.mark.parametrize(
+    "state",
+    [None, {}, {"ag-ui": {}}, {"ag-ui": {"a2ui_schema": ""}}],
+    ids=["no-state", "no-ag-ui", "no-schema", "empty-schema"],
+)
+def test_a_run_that_forwarded_no_schema_says_nothing_about_it(state, caplog):
+    """Nothing was forwarded, so there is nothing to report about it.
+
+    A host that never wired a catalog is not running a degraded gate, it is
+    running the only gate available, and warning per generation about it would
+    train an operator to read past the warnings that do mean something.
+    """
+    assert a2ui_module.forwarded_a2ui_catalog(state) is None
+    assert levels_logging(caplog, "A2UI component schema") == set()
+
+
+@pytest.mark.parametrize(
+    "schema",
+    [
+        "{not json",
+        json.dumps({"catalogId": "c"}),
+        json.dumps({"components": "Column, Text"}),
+        json.dumps({"components": {}}),
+        json.dumps({"components": {"Text": "not a schema"}}),
+        json.dumps([{"name": "Column"}, {"name": "Text"}]),
+        json.dumps({"components": [{"name": "Column"}, {"name": "Text"}]}),
+    ],
+    ids=[
+        "not-json",
+        "no-components",
+        "components-a-string",
+        "no-components-at-all",
+        "no-readable-component",
+        "legacy-array",
+        "legacy-list",
+    ],
+)
+def test_a_schema_that_names_no_components_leaves_the_structural_gate_standing(schema, caplog):
+    """A gate weaker than the client's still beats no generation at all.
+
+    None of these shapes keys component schemas by name, which is the only
+    shape the client's own middleware builds a validation catalog from: the
+    legacy array forms degrade to structural checks there too, so degrading
+    here is parity and converting them would make this gate the stricter of
+    the two. Every one of them is said out loud, because a silent downgrade is
+    how a gate comes to look like it is running when it is not.
+    """
+    assert a2ui_module.forwarded_a2ui_catalog({"ag-ui": {"a2ui_schema": schema}}) is None
+    assert levels_logging(caplog, "A2UI component schema") == {"WARNING"}
+
+
+def test_the_forwarded_catalog_is_read_with_its_composition_flattened(caplog):
+    """The client keys components by name and composes each one with ``allOf``.
+
+    The shared validator reads ``required`` and ``properties`` off the top of
+    an entry, so the composition has to be flattened into it or a component
+    that requires a property is indistinguishable from one that requires none.
+    A catalog this can read is also the ordinary case, and says nothing.
+    """
+    state = {"ag-ui": {"a2ui_schema": json.dumps(forwarded_catalog(Text=catalog_component("Text", "text")))}}
+
+    catalog = a2ui_module.forwarded_a2ui_catalog(state)
+
+    assert catalog is not None
+    assert catalog["components"]["Text"]["required"] == ["component", "text"]
+    assert set(catalog["components"]["Text"]["properties"]) == {"component", "text"}
+    assert levels_logging(caplog, "A2UI component schema") == set()
+
+
+def test_a_catalog_already_flat_is_left_as_it_is():
+    """A host or client that sends a plain JSON Schema per component is read too."""
+    flat = {"Text": {"type": "object", "properties": {"text": {}}, "required": ["text"]}}
+    state = {"ag-ui": {"a2ui_schema": {"catalogId": CATALOG_ID, "components": flat}}}
+
+    assert a2ui_module.forwarded_a2ui_catalog(state) == {"components": flat}
+
+
+def test_a_schema_forwarded_as_a_mapping_is_read_without_a_round_trip():
+    """The router hands state a JSON string, a hand-wired run a dict."""
+    schema = forwarded_catalog(Text=catalog_component("Text"))
+
+    catalog = a2ui_module.forwarded_a2ui_catalog({"ag-ui": {"a2ui_schema": schema}})
+
+    assert catalog is not None
+    assert list(catalog["components"]) == ["Text"]
+
+
+@pytest.mark.asyncio
+async def test_a_failing_update_leaves_the_prior_surface_untouched():
+    model = ScriptedModel([{"surfaceId": "s", "components": INVALID_COMPONENTS}] * 3)
+    tool = get_a2ui_tools({"model": model})
+    context = FakeRunContext(messages=[prior_surface_message("sales")])
+
+    envelope = await call_tool(tool, context, intent="update", target_surface_id="sales")
+
+    # A hard failure carries no operations at all, so nothing overwrites what
+    # is already on screen.
+    assert envelope["code"] == "a2ui_recovery_exhausted"
+    assert "a2ui_operations" not in envelope
+
+
+@pytest.mark.asyncio
+async def test_repeated_invalid_surfaces_fail_cleanly_within_the_attempt_cap():
+    model = ScriptedModel([{"surfaceId": "s", "components": INVALID_COMPONENTS}] * 5)
+    tool = get_a2ui_tools({"model": model})
+
+    envelope = await call_tool(tool)
+
+    assert envelope["code"] == "a2ui_recovery_exhausted"
+    assert len(envelope["attempts"]) == 3
+    assert len(model.calls) == 3
+
+
+@pytest.mark.asyncio
+async def test_the_attempt_cap_is_configurable():
+    model = ScriptedModel([{"surfaceId": "s", "components": INVALID_COMPONENTS}] * 5)
+    tool = get_a2ui_tools({"model": model, "recovery": {"maxAttempts": 2}})
+
+    envelope = await call_tool(tool)
+
+    assert len(envelope["attempts"]) == 2
+    assert len(model.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_a_subagent_that_never_calls_the_render_tool_counts_as_a_failed_attempt():
+    model = ScriptedModel([None, {"surfaceId": "s", "components": VALID_COMPONENTS}])
+    tool = get_a2ui_tools({"model": model})
+
+    envelope = await call_tool(tool)
+
+    assert operation(envelope, "updateComponents")["components"] == VALID_COMPONENTS
+    assert len(model.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_a_model_failure_is_retried_rather_than_surfaced():
+    model = ScriptedModel([RuntimeError("429 rate limited"), {"surfaceId": "s", "components": VALID_COMPONENTS}])
+    tool = get_a2ui_tools({"model": model})
+
+    envelope = await call_tool(tool)
+
+    assert operation(envelope, "updateComponents")["components"] == VALID_COMPONENTS
+
+
+@pytest.mark.asyncio
+async def test_a_mistake_in_this_adapter_is_not_swallowed_as_a_bad_surface():
+    """A delta shape this module misreads comes out of a frame of its own.
+
+    Retried as if the model had produced a bad surface it would burn every
+    attempt and then be reported to the model as a sub-agent that never called
+    the render tool, which hides the real bug entirely.
+    """
+    model = MisreadDeltaModel()
+    tool = get_a2ui_tools({"model": model})
+
+    with pytest.raises(TypeError):
+        await call_tool(tool)
+
+    assert len(model.calls) == 1
+
+
+def test_cancellation_is_recognized_whichever_packages_class_it_arrives_as():
+    """Why the cancellation guard names two classes rather than one.
+
+    The recovery loop runs on a thread and waits on a ``concurrent.futures``
+    future, so a cancelled render call arrives as that package's own
+    ``CancelledError``. The two library facts below are what make the second
+    entry load-bearing, and both would go unnoticed: an ``except
+    asyncio.CancelledError`` never sees a cross-thread cancel, and a bare
+    ``except Exception`` swallows one as if it were a model failure and retries
+    it after the caller has already gone.
+    """
+    assert a2ui_module._is_a2ui_cancellation(asyncio.CancelledError())
+    assert a2ui_module._is_a2ui_cancellation(concurrent.futures.CancelledError())
+
+    assert not issubclass(concurrent.futures.CancelledError, asyncio.CancelledError)
+    assert issubclass(concurrent.futures.CancelledError, Exception)
+
+
+def test_the_classes_that_mean_this_adapter_is_wrong_are_enumerated():
+    """Named exactly, so adding or removing one is a diff rather than a judgement.
+
+    These decide an exception that carries no traceback to read an origin
+    from. Each unwinds the tool call without consuming a retry, which is the
+    right answer only for a failure this module itself caused; every one of
+    them also arises in the model layer and the provider SDK, which is why an
+    exception raised for real is judged by where it came from instead.
+    """
+    assert a2ui_module._A2UI_ADAPTER_BUG_ERRORS == (
+        TypeError,
+        NameError,
+        AttributeError,
+        KeyError,
+        IndexError,
+        ImportError,
+        AssertionError,
+    )
+
+
+@pytest.mark.parametrize(
+    ("err", "verdict"),
+    [
+        (asyncio.CancelledError(), "rethrow"),
+        (concurrent.futures.CancelledError(), "rethrow"),
+        (KeyboardInterrupt(), "rethrow"),
+        (SystemExit(), "rethrow"),
+        (TypeError(), "rethrow"),
+        (NameError(), "rethrow"),
+        (AttributeError(), "rethrow"),
+        (KeyError(), "rethrow"),
+        (IndexError(), "rethrow"),
+        (ImportError(), "rethrow"),
+        (AssertionError(), "rethrow"),
+        (RuntimeError(), "recoverable"),
+        (ValueError(), "recoverable"),
+        (TimeoutError(), "recoverable"),
+        (asyncio.TimeoutError(), "recoverable"),
+        (json.JSONDecodeError("bad", "{", 0), "recoverable"),
+    ],
+    ids=[
+        "asyncio-cancelled",
+        "cross-thread-cancelled",
+        "keyboard-interrupt",
+        "system-exit",
+        "type",
+        "name",
+        "attribute",
+        "key",
+        "index",
+        "import",
+        "assertion",
+        "runtime",
+        "value",
+        "timeout",
+        "asyncio-timeout",
+        "json-decode",
+    ],
+)
+def test_every_class_the_classifier_can_see_has_a_pinned_verdict(err, verdict):
+    """One row per class this module raises, names, or receives across a thread.
+
+    Constructed rather than raised, so none of them carries a traceback: these
+    are the verdicts the fallback earns when there is no origin to read. Where
+    each class comes from when it is raised for real is pinned below.
+    """
+    assert classify_a2ui_subagent_error(err) == verdict
+
+
+def test_where_an_exception_was_raised_decides_it_when_the_traceback_says():
+    """The same class earns opposite verdicts depending on where it came from.
+
+    ``AttributeError`` is as much a provider-SDK failure as an adapter bug.
+    Read by class alone, a provider-side one kills the run without even
+    costing an attempt, and an adapter-side one is retried three times and
+    then blamed on the model.
+    """
+    # Through ``pytest.raises`` rather than caught by hand: a call that stops
+    # raising is then reported as exactly that, instead of as a NameError from
+    # the name below never being bound.
+    with pytest.raises(AttributeError) as from_elsewhere:
+        raise AttributeError("raised where the model layer lives")
+
+    with pytest.raises(AttributeError) as from_this_module:
+        a2ui_module._parse_render_arguments(None)  # type: ignore[arg-type]
+
+    assert classify_a2ui_subagent_error(from_elsewhere.value) == "recoverable"
+    assert a2ui_module._raised_in_this_module(from_elsewhere.value) is False
+    assert a2ui_module._raised_in_this_module(from_this_module.value) is True
+    assert a2ui_module._raised_in_this_module(AttributeError()) is None
+
+
+def test_the_failures_this_module_raises_on_purpose_still_cost_only_an_attempt():
+    """Origin alone would read these as bugs; they are attempt outcomes.
+
+    Unusable arguments and a render turn past its deadline are both raised
+    from this module's own frames in order to end one attempt and be tried
+    again, so they have to outrank the origin rule that would kill the run.
+    """
+    with pytest.raises(A2UIRenderArgumentsError) as unusable_arguments:
+        a2ui_module._parse_render_arguments("   ")
+
+    pending: "concurrent.futures.Future" = concurrent.futures.Future()
+    loop = asyncio.new_event_loop()
+    try:
+        with pytest.raises(TimeoutError) as outran_its_deadline:
+            a2ui_module._wait_for_a2ui_subagent(pending, threading.Event(), loop, timeout=0.0)
+    finally:
+        loop.close()
+
+    for raised in (unusable_arguments.value, outran_its_deadline.value):
+        assert a2ui_module._raised_in_this_module(raised) is True
+        assert classify_a2ui_subagent_error(raised) == "recoverable"
+
+
+def test_a_cross_thread_cancellation_is_not_reported_as_a_recovery_failure(caplog):
+    """The abandoned-recovery report reads cancellation by the same twin.
+
+    Cancelling the wait cancels the worker's future, so the error the callback
+    finds there is the caller's own cancellation. Reported as a failure it puts
+    a warning in the log for every ordinary disconnect.
+    """
+    worker: "concurrent.futures.Future" = concurrent.futures.Future()
+    worker.set_running_or_notify_cancel()
+    worker.set_exception(concurrent.futures.CancelledError())
+
+    a2ui_module._log_abandoned_recovery(worker)
+
+    assert "recovery loop failed" not in caplog.text
+
+
+@pytest.mark.parametrize(
+    "err",
+    [
+        AttributeError("'Fn' object has no attribute 'name'"),
+        KeyError("choices"),
+        ImportError("no module named 'httpx'"),
+    ],
+    ids=["attribute", "key", "import"],
+)
+async def test_a_provider_side_shape_error_costs_one_attempt_rather_than_the_run(err):
+    """The model layer and the provider SDK raise these too.
+
+    Treated as this adapter's own bug, a transient one inside the provider
+    call unwinds the whole tool call without even trying again, so a run that
+    a second attempt would have completed produces nothing at all.
+    """
+    model = ScriptedModel([err, {"surfaceId": "s", "components": VALID_COMPONENTS}])
+    tool = get_a2ui_tools({"model": model})
+
+    envelope = await call_tool(tool)
+
+    assert operation(envelope, "updateComponents")["components"] == VALID_COMPONENTS
+    assert len(model.calls) == 2
+
+
+@pytest.mark.parametrize(
+    "err",
+    [
+        AttributeError("'Fn' object has no attribute 'name'"),
+        RuntimeError("401 invalid api key"),
+        A2UIRenderArgumentsError("the render arguments were not valid JSON"),
+    ],
+    ids=["shape", "auth", "arguments"],
+)
+async def test_the_next_attempt_is_told_what_really_went_wrong(err):
+    """The shared loop can only say the sub-agent did not call the render tool.
+
+    That is the whole account the next attempt gets, and for a transport
+    failure or arguments that could not be read it is not vague but wrong.
+    """
+    model = ScriptedModel([err, {"surfaceId": "s", "components": VALID_COMPONENTS}])
+    tool = get_a2ui_tools({"model": model})
+
+    await call_tool(tool)
+
+    assert str(err) not in model.calls[0]
+    assert str(err) in model.calls[1]
+
+
+async def test_a_provider_failure_reaches_the_tool_result():
+    """A 401 is not a bad surface, and must not be reported as one."""
+    # One instance per attempt, as a provider raises them. Re-raising a single
+    # object accumulates a traceback and an exception context across attempts,
+    # which is state the origin rule reads.
+    model = ScriptedModel([RuntimeError("401 invalid api key") for _ in range(3)])
+    tool = get_a2ui_tools({"model": model})
+
+    envelope = await call_tool(tool)
+
+    assert envelope["code"] == "a2ui_recovery_exhausted"
+    assert any("401 invalid api key" in cause for cause in envelope["subagentErrors"])
+
+
+# =============================================================================
+# Concurrency, hangs and disconnects
+# =============================================================================
+
+
+def test_generation_does_not_compete_for_the_shared_thread_pool():
+    """A generation waits on model calls, so it must not park in the pool the
+    rest of the process shares.
+
+    On a loop of its own, because there is no way to give a loop its default
+    executor back: leaving a shut-down pool installed on a loop anything else
+    reaches would break every later ``run_in_executor`` on it.
+    """
+
+    async def occupy_the_default_pool_and_generate() -> None:
+        loop = asyncio.get_running_loop()
+        shared_pool = ThreadPoolExecutor(max_workers=1)
+        loop.set_default_executor(shared_pool)
+        release = threading.Event()
+        occupied = loop.run_in_executor(None, release.wait)
+
+        try:
+            model = ScriptedModel([{"surfaceId": "s", "components": VALID_COMPONENTS}])
+            tool = get_a2ui_tools({"model": model})
+
+            envelope = await asyncio.wait_for(call_tool(tool), timeout=5)
+
+            assert operation(envelope, "updateComponents")["components"] == VALID_COMPONENTS
+        finally:
+            release.set()
+            await occupied
+            shared_pool.shutdown(wait=True)
+
+    asyncio.run(occupy_the_default_pool_and_generate())
+
+
+async def test_a_hung_subagent_call_is_given_up_on():
+    model = HangingModel()
+    tool = get_a2ui_tools({"model": model, "recovery": {"maxAttempts": 1}}, {"subagent_timeout": 0.2})
+
+    envelope = await asyncio.wait_for(call_tool(tool), timeout=10)
+
+    assert envelope["code"] == "a2ui_recovery_exhausted"
+    assert any("did not answer" in cause for cause in envelope["subagentErrors"])
+    # The abandoned call is cancelled, not left streaming into nothing.
+    await asyncio.wait_for(model.cancelled.wait(), timeout=5)
+
+
+async def test_a_hang_is_bounded_without_any_configuration(monkeypatch):
+    monkeypatch.setattr(a2ui_module, "DEFAULT_RENDER_SUBAGENT_TIMEOUT", 0.2)
+    model = HangingModel()
+    tool = get_a2ui_tools({"model": model, "recovery": {"maxAttempts": 1}})
+
+    envelope = await asyncio.wait_for(call_tool(tool), timeout=10)
+
+    assert envelope["code"] == "a2ui_recovery_exhausted"
+
+
+async def test_a_disconnect_mid_call_cancels_the_call_and_stops_the_loop():
+    model = HangingModel()
+    tool = get_a2ui_tools({"model": model})
+    task = asyncio.create_task(call_tool(tool))
+    await asyncio.wait_for(model.started.wait(), timeout=5)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    await asyncio.wait_for(model.cancelled.wait(), timeout=5)
+    assert len(model.calls) == 1
+
+
+def never_answers() -> "concurrent.futures.Future":
+    """A scheduled render turn that neither completes nor can be cancelled promptly."""
+    return concurrent.futures.Future()
+
+
+def wait_for_render_turn(
+    pending: "concurrent.futures.Future",
+    abandoned: threading.Event,
+    loop: asyncio.AbstractEventLoop,
+    timeout: Optional[float],
+) -> Dict[str, Any]:
+    """Run the blocking wait on a thread and report how it ended.
+
+    On a thread rather than inline because every way out of that wait is a
+    branch under test: a wait that stops ending has to fail this suite rather
+    than wedge it.
+    """
+    outcome: Dict[str, Any] = {}
+
+    def run() -> None:
+        try:
+            outcome["result"] = a2ui_module._wait_for_a2ui_subagent(pending, abandoned, loop, timeout)
+        except BaseException as err:  # noqa: BLE001 - how it ended is the outcome
+            outcome["error"] = err
+
+    worker = threading.Thread(target=run, name="a2ui-wait-probe", daemon=True)
+    worker.start()
+    worker.join(5)
+
+    assert not worker.is_alive(), "the wait on the render turn never ended"
+    return outcome
+
+
+def test_a_disconnect_is_noticed_while_the_render_turn_is_still_running():
+    """The mid-call poll, on its own.
+
+    The wait is broken into polls precisely so a disconnect does not have to
+    wait for the provider, and this branch is the only mechanism that can
+    notice one mid-call: the caller's own cancel races the bookkeeping that
+    would let it reach the call in flight, and the next attempt's check comes a
+    whole model turn too late.
+    """
+    pending = never_answers()
+    abandoned = threading.Event()
+    abandoned.set()
+    loop = asyncio.new_event_loop()
+
+    try:
+        outcome = wait_for_render_turn(pending, abandoned, loop, timeout=2.0)
+    finally:
+        loop.close()
+
+    assert isinstance(outcome.get("error"), asyncio.CancelledError)
+    assert "disconnected" in str(outcome["error"])
+    # Left running it would stream a surface nobody will ever see.
+    assert pending.cancelled()
+
+
+def test_a_closed_loop_ends_the_wait_the_same_way():
+    """Nothing can be scheduled back onto a closed loop, so the turn in flight
+    will never answer and the next attempt cannot even start."""
+    pending = never_answers()
+    loop = asyncio.new_event_loop()
+    loop.close()
+
+    outcome = wait_for_render_turn(pending, threading.Event(), loop, timeout=2.0)
+
+    assert isinstance(outcome.get("error"), asyncio.CancelledError)
+    assert pending.cancelled()
+
+
+def test_a_render_turn_past_its_deadline_is_cancelled_and_reported():
+    """A provider that never answers would otherwise hold the tool call, and
+    the client's whole run, open forever."""
+    pending = never_answers()
+    loop = asyncio.new_event_loop()
+
+    try:
+        outcome = wait_for_render_turn(pending, threading.Event(), loop, timeout=0.2)
+    finally:
+        loop.close()
+
+    assert isinstance(outcome.get("error"), TimeoutError)
+    assert "did not answer within" in str(outcome["error"])
+    assert pending.cancelled()
+
+
+async def test_an_ordinary_failure_is_not_reported_as_a_disconnect(caplog):
+    model = MisreadDeltaModel()
+    tool = get_a2ui_tools({"model": model})
+
+    with pytest.raises(TypeError):
+        await call_tool(tool)
+    for _ in range(5):
+        await asyncio.sleep(0.01)
+
+    assert "disconnected" not in caplog.text
+
+
+async def test_a_worker_failure_after_a_disconnect_is_still_logged(caplog):
+    """The abandoned loop's own error is the one thing nobody else can report."""
+    entered = threading.Event()
+    release = threading.Event()
+
+    def record_attempt(_: Dict[str, Any]) -> None:
+        entered.set()
+        release.wait(5)
+        raise RuntimeError("attempt bookkeeping exploded")
+
+    model = ScriptedModel([{"surfaceId": "s", "components": INVALID_COMPONENTS}] * 3)
+    tool = get_a2ui_tools({"model": model, "on_a2ui_attempt": record_attempt})
+    task = asyncio.create_task(call_tool(tool))
+    await wait_until(entered.is_set)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    release.set()
+
+    await wait_until(lambda: "attempt bookkeeping exploded" in caplog.text)
+
+
+# =============================================================================
+# Provider delta shapes
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_reads_a_whole_call_delivered_in_one_frame():
+    """Anthropic and Gemini emit the complete call as a single dict."""
+
+    class SingleFrameModel(ScriptedModel):
+        async def aprocess_response_stream(self, **kwargs: Any) -> AsyncIterator[FakeDelta]:
+            self.calls.append(kwargs["messages"][0].content)
+            yield FakeDelta(
+                [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": RENDER_A2UI_TOOL_NAME,
+                            "arguments": json.dumps({"surfaceId": "s", "components": VALID_COMPONENTS}),
+                        },
+                    }
+                ]
+            )
+
+    tool = get_a2ui_tools({"model": SingleFrameModel([])})
+
+    envelope = await call_tool(tool)
+
+    assert operation(envelope, "updateComponents")["components"] == VALID_COMPONENTS
+
+
+@pytest.mark.asyncio
+async def test_ignores_fragments_belonging_to_another_tool():
+    class NoisyModel(ScriptedModel):
+        async def aprocess_response_stream(self, **kwargs: Any) -> AsyncIterator[FakeDelta]:
+            self.calls.append(kwargs["messages"][0].content)
+            yield FakeDelta([FakeFunctionDelta(name="something_else", arguments='{"junk":')])
+            yield FakeDelta([FakeFunctionDelta(arguments="1}")])
+            yield FakeDelta(
+                [
+                    FakeFunctionDelta(
+                        name=RENDER_A2UI_TOOL_NAME,
+                        arguments=json.dumps({"surfaceId": "s", "components": VALID_COMPONENTS}),
+                    )
+                ]
+            )
+
+    tool = get_a2ui_tools({"model": NoisyModel([])})
+
+    envelope = await call_tool(tool)
+
+    assert operation(envelope, "updateComponents")["components"] == VALID_COMPONENTS
+
+
+@pytest.mark.asyncio
+async def test_truncated_arguments_do_not_commit_a_surface():
+    class TruncatingModel(ScriptedModel):
+        async def aprocess_response_stream(self, **kwargs: Any) -> AsyncIterator[FakeDelta]:
+            self.calls.append(kwargs["messages"][0].content)
+            yield FakeDelta([FakeFunctionDelta(name=RENDER_A2UI_TOOL_NAME, arguments='{"surfaceId": "s", "comp')])
+
+    tool = get_a2ui_tools({"model": TruncatingModel([]), "recovery": {"maxAttempts": 1}})
+
+    envelope = await call_tool(tool)
+
+    assert envelope["code"] == "a2ui_recovery_exhausted"
+    # The shared loop cannot tell arguments it could not read from a
+    # sub-agent that never called the render tool, and reports both the
+    # second way, so the real cause has to travel separately.
+    assert any("not valid JSON" in cause for cause in envelope["subagentErrors"])
+
+
+@pytest.mark.asyncio
+async def test_reads_argument_fragments_from_a_real_provider_stream():
+    """Pins the contract this adapter depends on: an OpenAI-compatible model
+    surfaces partial render arguments as separate deltas."""
+    pytest.importorskip("openai")
+    from openai.types.chat import ChatCompletionChunk
+
+    from agno.models.openai import OpenAIChat
+
+    fragments = ['{"surfaceId": "s", "compo', 'nents": ', json.dumps(VALID_COMPONENTS), "}"]
+
+    def chunk(tool_calls):
+        return ChatCompletionChunk.model_validate(
+            {
+                "id": "c",
+                "object": "chat.completion.chunk",
+                "created": 0,
+                "model": "m",
+                "choices": [{"index": 0, "delta": {"tool_calls": tool_calls}, "finish_reason": None}],
+            }
+        )
+
+    class StreamingProvider(OpenAIChat):
+        async def ainvoke_stream(self, *args: Any, **kwargs: Any) -> AsyncIterator[Any]:  # type: ignore[override]
+            yield self._parse_provider_response_delta(
+                chunk(
+                    [
+                        {
+                            "index": 0,
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": RENDER_A2UI_TOOL_NAME, "arguments": ""},
+                        }
+                    ]
+                )
+            )
+            for fragment in fragments:
+                yield self._parse_provider_response_delta(chunk([{"index": 0, "function": {"arguments": fragment}}]))
+
+    tool = get_a2ui_tools({"model": StreamingProvider(id="m", api_key="x")})
+
+    envelope = await call_tool(tool)
+
+    assert operation(envelope, "updateComponents")["components"] == VALID_COMPONENTS
+
+
+@pytest.mark.asyncio
+async def test_a_trailing_delta_for_another_tool_keeps_the_finished_surface():
+    """A finished surface must survive a provider naming another tool after it."""
+
+    class TrailingEchoModel(ScriptedModel):
+        async def aprocess_response_stream(self, **kwargs: Any) -> AsyncIterator[FakeDelta]:
+            self.calls.append(kwargs["messages"][0].content)
+            yield FakeDelta(
+                [
+                    FakeFunctionDelta(
+                        name=RENDER_A2UI_TOOL_NAME,
+                        index=0,
+                        id="call_1",
+                        arguments=json.dumps({"surfaceId": "s", "components": VALID_COMPONENTS}),
+                    )
+                ]
+            )
+            yield FakeDelta([FakeFunctionDelta(name="search_web", index=1, id="call_2", arguments="{}")])
+
+    model = TrailingEchoModel([])
+    tool = get_a2ui_tools({"model": model, "recovery": {"maxAttempts": 1}})
+
+    envelope = await call_tool(tool)
+
+    assert operation(envelope, "updateComponents")["components"] == VALID_COMPONENTS
+    assert len(model.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_provider_that_repeats_the_tool_name_on_every_frame():
+    """ollama and mistral name the tool on every frame of one call, so a name
+    alone cannot mean a new call has started."""
+
+    class RepeatsNameModel(ScriptedModel):
+        async def aprocess_response_stream(self, **kwargs: Any) -> AsyncIterator[FakeDelta]:
+            self.calls.append(kwargs["messages"][0].content)
+            payload = json.dumps({"surfaceId": "s", "components": VALID_COMPONENTS})
+            for start in range(0, len(payload), 16):
+                yield FakeDelta(
+                    [
+                        FakeFunctionDelta(
+                            name=RENDER_A2UI_TOOL_NAME,
+                            index=0,
+                            arguments=payload[start : start + 16],
+                        )
+                    ]
+                )
+
+    tool = get_a2ui_tools({"model": RepeatsNameModel([]), "recovery": {"maxAttempts": 1}})
+
+    envelope = await call_tool(tool)
+
+    assert operation(envelope, "updateComponents")["components"] == VALID_COMPONENTS
+
+
+@pytest.mark.asyncio
+async def test_an_empty_tool_name_on_a_continuation_frame_is_ignored():
+    """Some providers echo an empty name on continuation frames."""
+
+    class EmptyNameModel(ScriptedModel):
+        async def aprocess_response_stream(self, **kwargs: Any) -> AsyncIterator[FakeDelta]:
+            self.calls.append(kwargs["messages"][0].content)
+            payload = json.dumps({"surfaceId": "s", "components": VALID_COMPONENTS})
+            yield FakeDelta([FakeFunctionDelta(name=RENDER_A2UI_TOOL_NAME, index=0, arguments=payload[:16])])
+            yield FakeDelta([FakeFunctionDelta(name="", index=0, arguments=payload[16:])])
+
+    tool = get_a2ui_tools({"model": EmptyNameModel([]), "recovery": {"maxAttempts": 1}})
+
+    envelope = await call_tool(tool)
+
+    assert operation(envelope, "updateComponents")["components"] == VALID_COMPONENTS
+
+
+@pytest.mark.asyncio
+async def test_a_provider_that_repeats_the_name_and_identifies_no_call():
+    """Same repetition, but with neither an index nor an id to key on."""
+
+    class BareRepeatsNameModel(ScriptedModel):
+        async def aprocess_response_stream(self, **kwargs: Any) -> AsyncIterator[FakeDelta]:
+            self.calls.append(kwargs["messages"][0].content)
+            payload = json.dumps({"surfaceId": "s", "components": VALID_COMPONENTS})
+            for start in range(0, len(payload), 16):
+                yield FakeDelta([FakeFunctionDelta(name=RENDER_A2UI_TOOL_NAME, arguments=payload[start : start + 16])])
+
+    tool = get_a2ui_tools({"model": BareRepeatsNameModel([]), "recovery": {"maxAttempts": 1}})
+
+    envelope = await call_tool(tool)
+
+    assert operation(envelope, "updateComponents")["components"] == VALID_COMPONENTS
+
+
+@pytest.mark.asyncio
+async def test_an_unkeyed_trailing_echo_keeps_the_finished_surface():
+    """The same trailing echo from a provider that identifies no call."""
+
+    class BareTrailingEchoModel(ScriptedModel):
+        async def aprocess_response_stream(self, **kwargs: Any) -> AsyncIterator[FakeDelta]:
+            self.calls.append(kwargs["messages"][0].content)
+            yield FakeDelta(
+                [
+                    FakeFunctionDelta(
+                        name=RENDER_A2UI_TOOL_NAME,
+                        arguments=json.dumps({"surfaceId": "s", "components": VALID_COMPONENTS}),
+                    )
+                ]
+            )
+            yield FakeDelta([FakeFunctionDelta(name="search_web", arguments='{"q": "sales"}')])
+
+    tool = get_a2ui_tools({"model": BareTrailingEchoModel([]), "recovery": {"maxAttempts": 1}})
+
+    envelope = await call_tool(tool)
+
+    assert operation(envelope, "updateComponents")["components"] == VALID_COMPONENTS
+
+
+@pytest.mark.asyncio
+async def test_only_the_first_render_call_of_a_turn_is_painted_and_committed():
+    """One turn, one surface, and the same one on screen as in the result.
+
+    Neither call's arguments may be folded into the other's, and by the time a
+    second call arrives the client has already painted the first, so the first
+    is the turn's: committing the second would leave the first on screen with
+    nothing behind it.
+    """
+
+    class TwoCallsModel(ScriptedModel):
+        async def aprocess_response_stream(self, **kwargs: Any) -> AsyncIterator[FakeDelta]:
+            self.calls.append(kwargs["messages"][0].content)
+            for index, surface_id in enumerate(("first", "second")):
+                yield FakeDelta(
+                    [
+                        FakeFunctionDelta(
+                            name=RENDER_A2UI_TOOL_NAME,
+                            index=index,
+                            id=f"call_{index}",
+                            arguments=json.dumps({"surfaceId": surface_id, "components": VALID_COMPONENTS}),
+                        )
+                    ]
+                )
+
+    tool = get_a2ui_tools({"model": TwoCallsModel([]), "recovery": {"maxAttempts": 1}})
+
+    envelope, pushed = await call_tool_over_the_channel(tool)
+
+    painted = painted_calls(pushed)
+    assert len(painted) == 1
+    assert json.loads(painted[0]["args"])["surfaceId"] == "first"
+    assert operation(envelope, "createSurface")["surfaceId"] == "first"
+
+
+@pytest.mark.asyncio
+async def test_each_attempt_paints_under_a_wire_id_of_its_own():
+    """The retry that a shared wire id makes invisible.
+
+    A client buffers argument fragments per tool-call id and treats a repeated
+    start on one as the same call, so an attempt that reuses a rejected
+    attempt's id has its arguments appended to the buffer already holding the
+    rejected ones. The buffer then parses as nothing and the healed surface
+    never paints, while the server records a successful generation.
+    """
+    model = ScriptedModel(
+        [
+            {"surfaceId": "sales", "components": INVALID_COMPONENTS},
+            {"surfaceId": "sales", "components": VALID_COMPONENTS},
+        ]
+    )
+    tool = get_a2ui_tools({"model": model})
+
+    envelope, pushed = await call_tool_over_the_channel(tool)
+
+    painted = painted_calls(pushed)
+    assert len(painted) == 2
+    assert len({call["call_id"] for call in painted}) == 2
+    assert all(call["call_id"] and call["starts"] == 1 for call in painted)
+    # Each attempt's arguments parse on their own, and the last painted
+    # surface is the one committed.
+    assert [json.loads(call["args"])["components"] for call in painted] == [INVALID_COMPONENTS, VALID_COMPONENTS]
+    assert operation(envelope, "updateComponents")["components"] == VALID_COMPONENTS
+
+
+@pytest.mark.asyncio
+async def test_an_update_paints_the_surface_and_catalog_it_commits():
+    """The ids an edit is committed under are the caller's and the prior
+    surface's, so a stream carrying the model's own would mount the skeleton
+    under an id the real surface never uses and the edit would look
+    unapplied."""
+    model = ScriptedModel([{"surfaceId": "invented", "components": VALID_COMPONENTS}])
+    tool = get_a2ui_tools({"model": model})
+    context = FakeRunContext(
+        messages=[prior_surface_message("sales", catalog_id="a-catalog-of-its-own")],
+        dependencies=schema_dependencies(),
+    )
+
+    envelope, pushed = await call_tool_over_the_channel(
+        tool, context, intent="update", target_surface_id="sales", changes="make it red"
+    )
+
+    painted = painted_calls(pushed)
+    assert len(painted) == 1
+    surface = json.loads(painted[0]["args"])
+    assert (surface["surfaceId"], surface["catalogId"]) == ("sales", "a-catalog-of-its-own")
+    assert operation(envelope, "updateComponents")["surfaceId"] == "sales"
+
+
+@pytest.mark.parametrize("named", ["", None, 7, ["s"]], ids=["empty", "null", "number", "list"])
+@pytest.mark.asyncio
+async def test_a_create_naming_a_surface_that_cannot_be_committed_is_retried(named):
+    """A create names its own surface, and the client paints the name it was sent.
+
+    The envelope builder commits that name only when it is a non-empty string
+    and narrows anything else to the configured default, so a model that
+    answers with ``""``, ``null`` or a number paints one surface and commits
+    another: the skeleton the client mounted is never filled and the surface
+    that was committed is never painted. The attempt is refused instead, and
+    the model is told what to name.
+    """
+    model = ScriptedModel(
+        [
+            {"surfaceId": named, "components": VALID_COMPONENTS},
+            {"surfaceId": "sales", "components": VALID_COMPONENTS},
+        ]
+    )
+    tool = get_a2ui_tools({"model": model})
+
+    envelope, pushed = await call_tool_over_the_channel(tool)
+
+    committed = operation(envelope, "createSurface")["surfaceId"]
+    assert committed == "sales"
+    assert json.loads(painted_calls(pushed)[-1]["args"])["surfaceId"] == committed
+    assert len(model.calls) == 2
+    # Reported as a sub-agent that never called the render tool, the model has
+    # nothing to correct and answers the same way again.
+    assert "surfaceId" in model.calls[1]
+
+
+@pytest.mark.asyncio
+async def test_a_create_that_names_no_surface_at_all_still_gets_the_default():
+    """Nothing was painted under a competing id, so nothing disagrees.
+
+    A name the model never wrote leaves the client no skeleton to orphan, and
+    the configured default is a renderable answer. Costing an attempt here
+    would spend a retry on a surface that was already fine.
+    """
+    model = ScriptedModel([{"components": VALID_COMPONENTS}])
+    tool = get_a2ui_tools({"model": model, "default_surface_id": "host-default"})
+
+    envelope, pushed = await call_tool_over_the_channel(tool)
+
+    assert operation(envelope, "createSurface")["surfaceId"] == "host-default"
+    assert "surfaceId" not in json.loads(painted_calls(pushed)[-1]["args"])
+    assert len(model.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_render_arguments_that_are_not_an_object_count_as_a_failed_attempt():
+    """The shared toolkit reads the arguments as a mapping. A list reaching it
+    would raise there and abort the whole run instead of costing one attempt."""
+
+    class ListArgsModel(ScriptedModel):
+        async def aprocess_response_stream(self, **kwargs: Any) -> AsyncIterator[FakeDelta]:
+            self.calls.append(kwargs["messages"][0].content)
+            yield FakeDelta(
+                [
+                    FakeFunctionDelta(
+                        name=RENDER_A2UI_TOOL_NAME,
+                        index=0,
+                        arguments=json.dumps([{"surfaceId": "s", "components": VALID_COMPONENTS}]),
+                    )
+                ]
+            )
+
+    tool = get_a2ui_tools({"model": ListArgsModel([]), "recovery": {"maxAttempts": 1}})
+
+    envelope = await call_tool(tool)
+
+    assert envelope["code"] == "a2ui_recovery_exhausted"
+    assert any("not an object" in cause for cause in envelope["subagentErrors"])
+
+
+# =============================================================================
+# The render turn in isolation
+# =============================================================================
+
+
+def host_identity(surface_id: Optional[str] = None, catalog_id: Optional[str] = None) -> A2UIRenderAttempt:
+    """The identity a served run decides for one attempt before it streams."""
+    return A2UIRenderAttempt.new(surface_id=surface_id, catalog_id=catalog_id)
+
+
+def render_once(
+    frames: List[List[Any]],
+    attempt: Optional[A2UIRenderAttempt] = None,
+    messages: Optional[List[Any]] = None,
+) -> Any:
+    """Run one render turn over scripted frames, collecting what it pushed.
+
+    Arguments the turn cannot use are raised rather than returned, and what it
+    painted before that is part of what has to be asserted, so the error comes
+    back as the outcome instead of ending the test.
+    """
+
+    class FrameModel:
+        assistant_message_role = "assistant"
+
+        def __init__(self) -> None:
+            self.seen_messages: List[Any] = []
+
+        async def aprocess_response_stream(self, **kwargs: Any) -> AsyncIterator[FakeDelta]:
+            self.seen_messages = list(kwargs["messages"])
+            for frame in frames:
+                yield FakeDelta(frame)
+
+    model = FrameModel()
+    pushed: List[Dict[str, Any]] = []
+    try:
+        outcome: Any = asyncio.run(
+            stream_render_subagent(
+                model,
+                "RENDER PROMPT",
+                messages or [],
+                None,
+                push=pushed.append,
+                attempt=attempt,
+            )
+        )
+    except A2UIRenderArgumentsError as err:
+        outcome = err
+    return model, outcome, pushed
+
+
+def emitted_args(pushed: List[Dict[str, Any]]) -> str:
+    """The argument stream a progressively painting client would have seen."""
+    return "".join(event["delta"] for event in pushed if event["kind"] == "args")
+
+
+def render_frame(arguments: str, **kwargs: Any) -> List[Any]:
+    return [FakeFunctionDelta(name=RENDER_A2UI_TOOL_NAME, arguments=arguments, index=0, **kwargs)]
+
+
+def continuation_frame(arguments: str) -> List[Any]:
+    return [FakeFunctionDelta(arguments=arguments, index=0)]
+
+
+def test_the_host_ids_lead_the_argument_stream():
+    """A client mounts the surface as soon as it can read which one it is, so
+    the host's ids have to reach the stream before the model's own members."""
+    _, _, pushed = render_once(
+        [render_frame('{"components": []}')],
+        attempt=host_identity(surface_id="sales", catalog_id="cat"),
+    )
+
+    first = next(event["delta"] for event in pushed if event["kind"] == "args")
+    assert first.startswith('{"surfaceId": "sales", "catalogId": "cat"')
+
+
+def test_an_id_the_model_wrote_itself_never_wins_the_surface_back():
+    """Two identical keys leave a parser holding the last one.
+
+    On an update the surface the caller named is the one committed, so a
+    member the model wrote under the same name has to be gone from the stream
+    rather than merely preceded by the host's: left in, it would take the
+    painted surface back at the end of the stream and orphan the skeleton the
+    client had already mounted.
+    """
+    payload = json.dumps(
+        {"surfaceId": "invented", "catalogId": "invented-too", "components": VALID_COMPONENTS},
+    )
+
+    _, args, pushed = render_once([render_frame(payload)], attempt=host_identity("sales", "cat"))
+
+    emitted = json.loads(emitted_args(pushed))
+    assert (emitted["surfaceId"], emitted["catalogId"]) == ("sales", "cat")
+    assert emitted["components"] == VALID_COMPONENTS
+    # What validation reads is still exactly what the model wrote.
+    assert args["surfaceId"] == "invented"
+
+
+def test_a_create_leaves_the_surface_id_to_the_model():
+    """Only an update has a surface to impose. Imposing one on a create would
+    rename every surface the model makes, and the envelope keeps the model's."""
+    _, _, pushed = render_once([render_frame('{"surfaceId": "s"}')], attempt=host_identity(catalog_id="cat"))
+
+    assert json.loads(emitted_args(pushed)) == {"catalogId": "cat", "surfaceId": "s"}
+
+
+def test_an_empty_argument_object_is_not_a_usable_surface():
+    _, args, pushed = render_once([render_frame("{}")], attempt=host_identity(catalog_id="cat"))
+
+    assert json.loads(emitted_args(pushed)) == {"catalogId": "cat"}
+    assert isinstance(args, A2UIRenderArgumentsError)
+    assert "empty object" in str(args)
+
+
+def test_the_host_ids_survive_a_brace_only_first_fragment():
+    _, _, pushed = render_once(
+        [render_frame("{"), continuation_frame('"surfaceId": "s"}')],
+        attempt=host_identity(catalog_id="cat"),
+    )
+
+    assert json.loads(emitted_args(pushed)) == {"catalogId": "cat", "surfaceId": "s"}
+
+
+def test_the_host_ids_survive_an_object_closed_in_a_later_fragment():
+    _, _, pushed = render_once(
+        [render_frame("{"), continuation_frame("}")],
+        attempt=host_identity(catalog_id="cat"),
+    )
+
+    assert json.loads(emitted_args(pushed)) == {"catalogId": "cat"}
+
+
+def test_leading_whitespace_does_not_displace_the_host_ids():
+    _, _, pushed = render_once(
+        [render_frame("  "), continuation_frame('{"surfaceId": "s"}')],
+        attempt=host_identity(catalog_id="cat"),
+    )
+
+    assert json.loads(emitted_args(pushed)) == {"catalogId": "cat", "surfaceId": "s"}
+
+
+@pytest.mark.parametrize("width", [1, 3, 7, 4096], ids=["char", "tiny", "small", "whole"])
+def test_a_member_split_across_fragments_survives_the_rewrite(width):
+    """The rewrite reads the stream a character at a time, and a provider
+    breaks it wherever it likes: mid-key, mid-string, and inside a nested
+    object whose braces and quotes are not the object's own."""
+    text = 'a } {" b'
+    payload = {"surfaceId": "invented", "components": [{"id": "root", "component": "Text", "text": text}]}
+    raw = json.dumps(payload)
+    frames = [render_frame(raw[:width])] + [
+        continuation_frame(raw[start : start + width]) for start in range(width, len(raw), width)
+    ]
+
+    _, args, pushed = render_once(frames, attempt=host_identity("sales", "cat"))
+
+    assert json.loads(emitted_args(pushed)) == {
+        "surfaceId": "sales",
+        "catalogId": "cat",
+        "components": payload["components"],
+    }
+    assert args == payload
+
+
+def test_the_host_ids_are_never_written_into_a_nested_object():
+    """Arguments that are not an object have no place to carry an id, so the
+    stream must go out exactly as the model wrote it."""
+    fragments = ["[", '{"surfaceId": "s"}', "]"]
+    frames = [render_frame(fragments[0])] + [continuation_frame(fragment) for fragment in fragments[1:]]
+
+    _, args, pushed = render_once(frames, attempt=host_identity("sales", "cat"))
+
+    assert emitted_args(pushed) == "".join(fragments)
+    assert isinstance(args, A2UIRenderArgumentsError)
+    assert "not an object" in str(args)
+
+
+def test_the_arguments_kept_for_validation_are_never_rewritten():
+    payload = {"surfaceId": "s", "components": VALID_COMPONENTS}
+    _, args, pushed = render_once([render_frame(json.dumps(payload))], attempt=host_identity(catalog_id="cat"))
+
+    assert args == payload
+    assert json.loads(emitted_args(pushed))["catalogId"] == "cat"
+
+
+def test_a_stream_that_owns_no_ids_is_passed_through_untouched():
+    """Nothing to impose means nothing to rewrite: a caller with no ids of its
+    own gets the model's bytes, separators and whitespace included."""
+    raw = '{ "surfaceId" : "s" ,  "components" : [] }'
+
+    _, _, pushed = render_once([render_frame(raw)])
+
+    assert emitted_args(pushed) == raw
+
+
+#: One row per way out of the argument rewrite: what the model wrote, and the
+#: object a progressively painting client is left holding. A client reads these
+#: fragments with an incremental JSON parser, so an exit that omits the comma
+#: or the colon it swallowed does not paint a surface late, it paints none at
+#: all, and the rewrite exists to keep invalid JSON off the wire rather than to
+#: make new ones.
+REWRITE_EXITS: Dict[str, Any] = {
+    "the-object-ends": ('{"components": []}', {"catalogId": "cat", "components": []}),
+    "a-host-owned-member-ends-it": (
+        '{"components": [], "catalogId": "guessed"}',
+        {"catalogId": "cat", "components": []},
+    ),
+    "nothing-an-object-may-contain": ('{"components": [], 5}', {"catalogId": "cat", "components": []}),
+    "a-key-with-no-colon": ('{"surfaceId" "s"}', {"catalogId": "cat"}),
+    "a-key-with-no-colon-after-a-member": (
+        '{"components": [], "surfaceId" "s"}',
+        {"catalogId": "cat", "components": []},
+    ),
+    "bytes-after-the-object": ('{"components": []} and then some', {"catalogId": "cat", "components": []}),
+    "arguments-that-are-not-an-object": ('[{"surfaceId": "s"}]', [{"surfaceId": "s"}]),
+    "arguments-that-are-a-bare-string": ('"a surface, honest"', "a surface, honest"),
+}
+
+
+@pytest.mark.parametrize("exit_name", list(REWRITE_EXITS), ids=list(REWRITE_EXITS))
+def test_every_way_out_of_the_rewrite_leaves_the_client_parseable_json(exit_name):
+    raw, expected = REWRITE_EXITS[exit_name]
+
+    _, _, pushed = render_once([render_frame(raw)], attempt=host_identity(catalog_id="cat"))
+
+    assert json.loads(emitted_args(pushed)) == expected
+
+
+@pytest.mark.parametrize("exit_name", list(REWRITE_EXITS), ids=list(REWRITE_EXITS))
+def test_the_rewrite_leaves_parseable_json_however_the_fragments_fall(exit_name):
+    """The same exits, reached a character at a time.
+
+    The rewrite keeps its state across fragments, so a provider that breaks
+    the arguments mid-key or mid-string must not reach a different exit from
+    one that hands them over whole.
+    """
+    raw, expected = REWRITE_EXITS[exit_name]
+    frames = [render_frame(raw[:1])] + [continuation_frame(char) for char in raw[1:]]
+
+    _, _, pushed = render_once(frames, attempt=host_identity(catalog_id="cat"))
+
+    assert json.loads(emitted_args(pushed)) == expected
+
+
+def test_arguments_that_are_not_valid_json_say_what_went_wrong():
+    _, args, _ = render_once([render_frame('{"surfaceId": "s", "comp')])
+
+    assert isinstance(args, A2UIRenderArgumentsError)
+    assert "not valid JSON" in str(args)
+
+
+def test_a_turn_with_no_render_call_at_all_returns_none():
+    _, args, _ = render_once([[FakeFunctionDelta(name="search_web", index=0, arguments="{}")]])
+
+    assert args is None
+
+
+def test_the_emitted_call_is_always_terminated():
+    _, _, pushed = render_once([render_frame('{"surfaceId": "s"}')])
+
+    assert [event["kind"] for event in pushed] == ["start", "args", "end"]
+    # An id is mandatory on every tool-call event, so a fragment carrying an
+    # empty one is dropped whole and the surface never paints. This frame has
+    # no id of its own, which is the case a minted identity exists for.
+    assert {event["tool_call_id"] for event in pushed} == {pushed[0]["tool_call_id"]}
+    assert pushed[0]["tool_call_id"]
+
+
+def test_every_event_is_emitted_under_the_attempts_own_id():
+    """Not the provider's, which it reuses across attempts: the client buffers
+    argument fragments per wire id, so a reused id holds two attempts at once."""
+    attempt = host_identity()
+    frames = [render_frame('{"surfaceId": "s"}', id="provider-1")]
+
+    _, _, pushed = render_once(frames, attempt=attempt)
+
+    assert {event["tool_call_id"] for event in pushed} == {attempt.call_id}
+    assert attempt.call_id != "provider-1"
+
+
+# =============================================================================
+# One render call, as each provider spells it out
+# =============================================================================
+
+RENDER_ARGS = {"surfaceId": "s", "components": VALID_COMPONENTS}
+RENDER_PAYLOAD = json.dumps(RENDER_ARGS)
+FIRST_HALF = RENDER_PAYLOAD[: len(RENDER_PAYLOAD) // 2]
+SECOND_HALF = RENDER_PAYLOAD[len(RENDER_PAYLOAD) // 2 :]
+
+#: One row per provider shape: the frames the model streams, the arguments the
+#: turn must return, and the fragment sequence a progressively painting client
+#: must see. The second half is what nothing observed before: the state of the
+#: call in progress is five mutable locals with no closed transition set, and
+#: every guard over them is otherwise assertable only through the committed
+#: envelope.
+FRAME_SEQUENCES: Dict[str, Any] = {
+    "openai-index-only": (
+        [
+            [FakeFunctionDelta(name=RENDER_A2UI_TOOL_NAME, index=0, arguments=FIRST_HALF)],
+            [FakeFunctionDelta(index=0, arguments=SECOND_HALF)],
+        ],
+        RENDER_ARGS,
+        [("start", 0), ("args", 0), ("args", 0), ("end", 0)],
+    ),
+    "id-and-index-on-every-frame": (
+        [
+            [FakeFunctionDelta(name=RENDER_A2UI_TOOL_NAME, index=0, id="c1", arguments=FIRST_HALF)],
+            [FakeFunctionDelta(index=0, id="c1", arguments=SECOND_HALF)],
+        ],
+        RENDER_ARGS,
+        [("start", 0), ("args", 0), ("args", 0), ("end", 0)],
+    ),
+    "anthropic-single-dict": (
+        [[{"id": "c1", "type": "function", "function": {"name": RENDER_A2UI_TOOL_NAME, "arguments": RENDER_PAYLOAD}}]],
+        RENDER_ARGS,
+        [("start", 0), ("args", 0), ("end", 0)],
+    ),
+    "gemini-identifies-no-call": (
+        [[{"type": "function", "function": {"name": RENDER_A2UI_TOOL_NAME, "arguments": RENDER_PAYLOAD}}]],
+        RENDER_ARGS,
+        [("start", 0), ("args", 0), ("end", 0)],
+    ),
+    "ollama-repeats-the-name-unkeyed": (
+        [
+            [FakeFunctionDelta(name=RENDER_A2UI_TOOL_NAME, arguments=FIRST_HALF)],
+            [FakeFunctionDelta(name=RENDER_A2UI_TOOL_NAME, arguments=SECOND_HALF)],
+        ],
+        RENDER_ARGS,
+        [("start", 0), ("args", 0), ("args", 0), ("end", 0)],
+    ),
+    "unkeyed-continuation-fragments": (
+        [
+            [FakeFunctionDelta(name=RENDER_A2UI_TOOL_NAME, arguments=FIRST_HALF)],
+            [FakeFunctionDelta(arguments=SECOND_HALF)],
+        ],
+        RENDER_ARGS,
+        [("start", 0), ("args", 0), ("args", 0), ("end", 0)],
+    ),
+    "only-the-opening-frame-is-keyed": (
+        [
+            [FakeFunctionDelta(name=RENDER_A2UI_TOOL_NAME, index=0, id="c1", arguments=FIRST_HALF)],
+            [FakeFunctionDelta(arguments=SECOND_HALF)],
+        ],
+        RENDER_ARGS,
+        [("start", 0), ("args", 0), ("args", 0), ("end", 0)],
+    ),
+    # The mirror image of the OpenAI shape: the id is stamped on the opening
+    # frame and the index on the continuations. Keyed by a fixed preference for
+    # one dimension, every continuation of one of the two families reads as a
+    # different call and the whole surface is dropped.
+    "only-continuations-are-keyed": (
+        [
+            [FakeFunctionDelta(name=RENDER_A2UI_TOOL_NAME, id="c1", arguments=FIRST_HALF)],
+            [FakeFunctionDelta(index=0, arguments=SECOND_HALF)],
+        ],
+        RENDER_ARGS,
+        [("start", 0), ("args", 0), ("args", 0), ("end", 0)],
+    ),
+    "another-call-s-fragments-after-an-id-keyed-opener": (
+        [
+            [FakeFunctionDelta(name=RENDER_A2UI_TOOL_NAME, id="c1", arguments=FIRST_HALF)],
+            [FakeFunctionDelta(index=0, arguments=SECOND_HALF)],
+            [FakeFunctionDelta(index=1, arguments='{"query": "sales"}')],
+        ],
+        RENDER_ARGS,
+        [("start", 0), ("args", 0), ("args", 0), ("end", 0)],
+    ),
+    "a-fragment-for-another-id-after-an-id-keyed-opener": (
+        [
+            [FakeFunctionDelta(name=RENDER_A2UI_TOOL_NAME, id="c1", arguments=RENDER_PAYLOAD)],
+            [FakeFunctionDelta(id="c2", arguments='{"query": "sales"}')],
+        ],
+        RENDER_ARGS,
+        [("start", 0), ("args", 0), ("end", 0)],
+    ),
+    "the-tool-name-arrives-in-fragments": (
+        [
+            [FakeFunctionDelta(name="render", index=0, arguments="")],
+            [FakeFunctionDelta(name="_a2ui", index=0, arguments="")],
+            [FakeFunctionDelta(index=0, arguments=RENDER_PAYLOAD)],
+        ],
+        RENDER_ARGS,
+        [("start", 0), ("args", 0), ("end", 0)],
+    ),
+    "the-tool-name-arrives-in-fragments-keyed-two-ways": (
+        [
+            [FakeFunctionDelta(name="render", id="c1", arguments="")],
+            [FakeFunctionDelta(name="_a2ui", index=0, arguments="")],
+            [FakeFunctionDelta(index=0, arguments=RENDER_PAYLOAD)],
+        ],
+        RENDER_ARGS,
+        [("start", 0), ("args", 0), ("end", 0)],
+    ),
+    "a-foreign-name-that-begins-like-the-render-tool-s": (
+        [
+            [FakeFunctionDelta(name="render", index=0, arguments="{}")],
+            [FakeFunctionDelta(name=RENDER_A2UI_TOOL_NAME, index=0, arguments=RENDER_PAYLOAD)],
+        ],
+        RENDER_ARGS,
+        [("start", 0), ("args", 0), ("end", 0)],
+    ),
+    "another-tool-takes-the-live-call-s-place": (
+        [
+            [FakeFunctionDelta(name=RENDER_A2UI_TOOL_NAME, index=0, arguments=FIRST_HALF)],
+            [FakeFunctionDelta(name="search_web", index=0, arguments="{}")],
+            [FakeFunctionDelta(index=0, arguments=SECOND_HALF)],
+        ],
+        # The render call is over, so its arguments are truncated and cost an
+        # attempt. What must not happen is a fragment after its end.
+        A2UIRenderArgumentsError,
+        [("start", 0), ("args", 0), ("end", 0)],
+    ),
+    "an-unkeyed-fragment-arrives-after-the-call-closed": (
+        [
+            [FakeFunctionDelta(name=RENDER_A2UI_TOOL_NAME, index=0, arguments=FIRST_HALF)],
+            [FakeFunctionDelta(name="search_web", index=0, arguments="{}")],
+            [FakeFunctionDelta(arguments=SECOND_HALF)],
+        ],
+        # The tail of the committed surface, arriving on a frame that names no
+        # call. Dropped either way, but an operator whose surfaces truncate is
+        # owed the reason.
+        A2UIRenderArgumentsError,
+        [("start", 0), ("args", 0), ("end", 0)],
+    ),
+    "another-tool-opens-beside-the-live-call": (
+        [
+            [FakeFunctionDelta(name=RENDER_A2UI_TOOL_NAME, index=0, arguments=FIRST_HALF)],
+            [FakeFunctionDelta(name="search_web", index=1, arguments="{}")],
+            [FakeFunctionDelta(index=0, arguments=SECOND_HALF)],
+        ],
+        RENDER_ARGS,
+        [("start", 0), ("args", 0), ("args", 0), ("end", 0)],
+    ),
+    "another-tool-echoed-with-nothing-to-key-on": (
+        [
+            [FakeFunctionDelta(name=RENDER_A2UI_TOOL_NAME, arguments=FIRST_HALF)],
+            [FakeFunctionDelta(name="search_web", arguments="{}")],
+            [FakeFunctionDelta(arguments=SECOND_HALF)],
+        ],
+        RENDER_ARGS,
+        [("start", 0), ("args", 0), ("args", 0), ("end", 0)],
+    ),
+    # A turn commits one surface, and the client has already painted the first
+    # call by the time a second arrives, so the first is the turn's and the
+    # rest are dropped: painting both would leave one on screen with nothing
+    # behind it.
+    "two-render-calls-keyed-by-index": (
+        [
+            [FakeFunctionDelta(name=RENDER_A2UI_TOOL_NAME, index=0, arguments='{"surfaceId": "first"}')],
+            [FakeFunctionDelta(name=RENDER_A2UI_TOOL_NAME, index=1, arguments=RENDER_PAYLOAD)],
+        ],
+        {"surfaceId": "first"},
+        [("start", 0), ("args", 0), ("end", 0)],
+    ),
+    "two-render-calls-keyed-by-id": (
+        [
+            [FakeFunctionDelta(name=RENDER_A2UI_TOOL_NAME, id="c1", arguments='{"surfaceId": "first"}')],
+            [FakeFunctionDelta(name=RENDER_A2UI_TOOL_NAME, id="c2", arguments=RENDER_PAYLOAD)],
+        ],
+        {"surfaceId": "first"},
+        [("start", 0), ("args", 0), ("end", 0)],
+    ),
+    "a-render-call-that-reopens-after-its-end": (
+        [
+            [FakeFunctionDelta(name=RENDER_A2UI_TOOL_NAME, index=0, arguments=FIRST_HALF)],
+            [FakeFunctionDelta(name="search_web", index=0, arguments="{}")],
+            [FakeFunctionDelta(name=RENDER_A2UI_TOOL_NAME, index=1, arguments=RENDER_PAYLOAD)],
+        ],
+        A2UIRenderArgumentsError,
+        [("start", 0), ("args", 0), ("end", 0)],
+    ),
+    "a-render-call-with-no-arguments": (
+        [[FakeFunctionDelta(name=RENDER_A2UI_TOOL_NAME, index=0, arguments="")]],
+        A2UIRenderArgumentsError,
+        [("start", 0), ("end", 0)],
+    ),
+    "no-render-call-at-all": (
+        [[FakeFunctionDelta(name="search_web", index=0, arguments="{}")]],
+        None,
+        [],
+    ),
+    "another-call-s-continuation-fragments": (
+        [
+            [FakeFunctionDelta(name=RENDER_A2UI_TOOL_NAME, index=0, arguments=RENDER_PAYLOAD)],
+            [FakeFunctionDelta(index=1, arguments='{"query": "sales"}')],
+        ],
+        RENDER_ARGS,
+        [("start", 0), ("args", 0), ("end", 0)],
+    ),
+}
+
+
+def pushed_shape(pushed: List[Dict[str, Any]]) -> List[Any]:
+    """Each fragment's kind and which call it belongs to.
+
+    Calls are numbered by first appearance rather than by id, because a
+    provider that identifies no call has one synthesized for it and the id is
+    not predictable.
+    """
+    calls: List[str] = []
+    for event in pushed:
+        if event["tool_call_id"] not in calls:
+            calls.append(event["tool_call_id"])
+    return [(event["kind"], calls.index(event["tool_call_id"])) for event in pushed]
+
+
+@pytest.mark.parametrize("shape", list(FRAME_SEQUENCES), ids=list(FRAME_SEQUENCES))
+def test_the_fragment_sequence_each_provider_shape_produces(shape):
+    """Both halves of one render turn: what it returns, and what it emitted.
+
+    A client paints from the emitted fragments alone, so a guard in this loop
+    that only the committed envelope observes can be deleted with the suite
+    green. Each row asserts the sequence too, and every fragment's id, since a
+    fragment with an empty id is dropped before it becomes an event.
+    """
+    frames, expected_args, expected_shape = FRAME_SEQUENCES[shape]
+
+    _, args, pushed = render_once(frames)
+
+    assert all(event["tool_call_id"] for event in pushed)
+    if expected_args is A2UIRenderArgumentsError:
+        assert isinstance(args, A2UIRenderArgumentsError)
+    else:
+        assert args == expected_args
+    assert pushed_shape(pushed) == expected_shape
+
+
+@pytest.fixture
+def diagnostics(monkeypatch):
+    """Every diagnostic this module emits during the test, with its level."""
+    collected: List[Tuple[str, str]] = []
+
+    def recorder(level: str):
+        def record(msg: Any, *args: Any, **kwargs: Any) -> None:
+            collected.append((level, str(msg)))
+
+        return record
+
+    for level in ("log_debug", "log_warning", "log_error"):
+        monkeypatch.setattr(a2ui_module, level, recorder(level))
+    return collected
+
+
+#: One row per branch of the render loop that declines to do what the stream
+#: asked: which provider shape takes it, what it has to say for itself, and
+#: how loudly. Lost arguments are a warning because the committed surface is
+#: not what the model wrote; the rest are ordinary provider behaviour.
+SILENT_BRANCHES: Dict[str, Any] = {
+    "the-tool-name-arrives-in-fragments": ("log_debug", "tool name in fragments"),
+    "another-tool-echoed-with-nothing-to-key-on": ("log_debug", "not the render tool"),
+    "another-call-s-continuation-fragments": ("log_debug", "not the render call"),
+    "no-render-call-at-all": ("log_debug", "produced no render call"),
+    "two-render-calls-keyed-by-index": ("log_warning", "more than one render call"),
+    "another-tool-takes-the-live-call-s-place": ("log_warning", "may therefore be truncated"),
+    # The same truncation, on a frame that names no call: a provider keyed only
+    # on its opening frame loses the tail of its surface exactly as quietly.
+    "an-unkeyed-fragment-arrives-after-the-call-closed": ("log_warning", "may therefore be truncated"),
+}
+
+
+@pytest.mark.parametrize("shape", list(SILENT_BRANCHES), ids=list(SILENT_BRANCHES))
+def test_a_branch_that_declines_says_so_exactly_once(shape, diagnostics):
+    """A turn that quietly drops what it was sent leaves nobody anything to read.
+
+    Every one of these ends with a surface the caller did not ask for, or with
+    an attempt reported to the model as a sub-agent that never called the
+    render tool, and none of them said which.
+    """
+    level, phrase = SILENT_BRANCHES[shape]
+    frames = FRAME_SEQUENCES[shape][0]
+
+    render_once(frames)
+
+    said = [record for record in diagnostics if phrase in record[1]]
+    assert len(said) == 1, f"expected one {phrase!r} diagnostic, got {said}"
+    assert said[0][0] == level
+
+
+def test_the_same_branch_taken_by_every_fragment_is_reported_once(diagnostics):
+    """A provider sends hundreds of fragments and each can take the same turn."""
+    frames = [[FakeFunctionDelta(name=RENDER_A2UI_TOOL_NAME, index=0, arguments=RENDER_PAYLOAD)]]
+    frames += [[FakeFunctionDelta(index=1, arguments="x")] for _ in range(50)]
+
+    render_once(frames)
+
+    assert len([record for record in diagnostics if "not the render call" in record[1]]) == 1
+
+
+def test_the_host_system_prompt_does_not_reach_the_subagent():
+    """Two system messages set the render prompt against the host persona, and
+    the persona tends to win: the subagent answers in prose."""
+    history = [
+        {"role": "system", "content": "You are a SALES ANALYST. Always answer in prose."},
+        {"role": "developer", "content": "Never call tools."},
+        {"role": "user", "content": "show me a card"},
+    ]
+
+    model, _, _ = render_once([render_frame('{"surfaceId": "s"}')], messages=history)
+
+    roles = [
+        message.get("role") if isinstance(message, dict) else getattr(message, "role", None)
+        for message in model.seen_messages
+    ]
+    assert roles == ["system", "user"]
+    assert model.seen_messages[0].content == "RENDER PROMPT"
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def test_state_is_rebuilt_from_forwarded_context():
+    state = agui_state_from_dependencies(schema_dependencies())
+
+    assert json.loads(state["ag-ui"]["a2ui_schema"])["catalogId"] == CATALOG_ID
+    assert state["ag-ui"]["context"] == [{"description": "User preferences", "value": {"currency": "USD"}}]
+
+
+def test_state_without_any_context():
+    assert agui_state_from_dependencies(None) == {"ag-ui": {"context": []}}
+
+
+def test_a_string_schema_is_left_alone():
+    raw = '{"catalogId": "already-json"}'
+    state = agui_state_from_dependencies({A2UI_SCHEMA_CONTEXT_DESCRIPTION: raw})
+
+    assert state["ag-ui"]["a2ui_schema"] == raw
+
+
+def test_forwarded_context_reaches_the_toolkit_as_plain_entries():
+    """The served route forwards context as request models, not as dicts.
+
+    The shared toolkit scans these entries for the catalog the client named and
+    skips anything that is not a dict, so left as models the catalog it finds
+    is none and the surface is bound to the basic catalog the client never
+    registered.
+    """
+    from ag_ui.core import Context
+    from ag_ui_a2ui_toolkit import resolve_a2ui_catalog
+
+    entry = Context(description="A2UI catalog and components", value=f"- {CATALOG_ID}\n")
+
+    state = a2ui_module.build_agui_state(None, [entry])
+
+    assert state["ag-ui"]["context"] == [{"description": entry.description, "value": entry.value}]
+    assert resolve_a2ui_catalog(state) == (entry.value, CATALOG_ID)
+
+
+def test_an_injected_run_leaves_the_toolkit_the_same_readable_entries():
+    """The run this injects into rebuilds its state context from the plan.
+
+    That assignment is the last word on what the toolkit reads, so a run that
+    generates would otherwise be the one run whose entries it cannot read.
+    """
+    pytest.importorskip("openai")
+    from ag_ui.core import RunAgentInput
+    from ag_ui_a2ui_toolkit import resolve_a2ui_catalog
+
+    from agno.models.openai import OpenAIChat
+
+    entry = {"description": "A2UI catalog and components", "value": f"- {CATALOG_ID}\n"}
+    run_input = RunAgentInput.model_validate(
+        {
+            "threadId": "t",
+            "runId": "r",
+            "state": None,
+            "messages": [{"id": "m1", "role": "user", "content": "show me a card"}],
+            "tools": [],
+            "context": [entry],
+            "forwardedProps": {"injectA2UITool": True},
+        }
+    )
+
+    plan = a2ui_module.prepare_a2ui_run(
+        entity=Agent(id="a", name="A", model=OpenAIChat(id="gpt-x", api_key="not-used")),
+        run_input=run_input,
+    )
+
+    assert plan["tool"] is not None
+    assert resolve_a2ui_catalog(plan["run"].state) == (entry["value"], CATALOG_ID)
+
+
+def test_the_in_flight_generation_call_is_stripped():
+    history = [
+        {"role": "user", "content": "make a card"},
+        {"role": "assistant", "content": None, "tool_calls": [{"function": {"name": GENERATE_A2UI_TOOL_NAME}}]},
+    ]
+
+    assert strip_in_flight_tool_call(history, GENERATE_A2UI_TOOL_NAME) == history[:1]
+
+
+def test_a_trailing_user_turn_is_kept():
+    history = [{"role": "user", "content": "make a card"}]
+
+    assert strip_in_flight_tool_call(history, GENERATE_A2UI_TOOL_NAME) == history
+
+
+def test_a_trailing_tool_result_carrying_the_generation_call_is_kept():
+    """Only an assistant turn can be the call in progress.
+
+    A trailing ``tool`` or ``user`` message naming the generation tool is a
+    result, not an unanswered call, and dropping it would take the surface the
+    model is being asked to edit out of the history it edits from.
+    """
+    history = [
+        {"role": "user", "content": "make a card"},
+        {
+            "role": "tool",
+            "content": "{}",
+            "tool_calls": [{"function": {"name": GENERATE_A2UI_TOOL_NAME}}],
+        },
+    ]
+
+    assert strip_in_flight_tool_call(history, GENERATE_A2UI_TOOL_NAME) == history
+
+
+def test_another_agents_trailing_tool_call_is_kept():
+    history = [
+        {"role": "assistant", "content": None, "tool_calls": [{"function": {"name": "search_web"}}]},
+    ]
+
+    assert strip_in_flight_tool_call(history, GENERATE_A2UI_TOOL_NAME) == history
+
+
+def test_empty_history():
+    assert strip_in_flight_tool_call([], GENERATE_A2UI_TOOL_NAME) == []
+
+
+# =============================================================================
+# Over the wire
+# =============================================================================
+
+
+def parse_sse_events(content: str) -> List[Dict[str, Any]]:
+    """Every ``data:`` frame the server sent, parsed.
+
+    Nothing is skipped: a frame that is not valid JSON is a broken event, and
+    swallowing it would take a RUN_ERROR or a truncated tool result out of the
+    stream before the assertions below ever counted it.
+    """
+    events = []
+    for line in content.split("\n"):
+        line = line.strip()
+        if line.startswith("data:"):
+            payload = line[5:].strip()
+            try:
+                events.append(json.loads(payload))
+            except json.JSONDecodeError as err:
+                raise AssertionError(f"the server sent a data frame that is not valid JSON: {payload!r}") from err
+    return events
+
+
+def test_the_generated_surface_reaches_the_wire():
+    """The envelope must arrive as the tool result, verbatim, or the client
+    renderer never sees a surface."""
+    pytest.importorskip("openai")
+    from openai.types.chat import ChatCompletionChunk
+
+    from agno.models.openai import OpenAIChat
+
+    turns = {"n": 0}
+
+    def chunk(delta):
+        return ChatCompletionChunk.model_validate(
+            {
+                "id": "c",
+                "object": "chat.completion.chunk",
+                "created": 0,
+                "model": "m",
+                "choices": [{"index": 0, "delta": delta, "finish_reason": None}],
+            }
+        )
+
+    class PlannerModel(OpenAIChat):
+        async def ainvoke_stream(self, *args: Any, **kwargs: Any) -> AsyncIterator[Any]:  # type: ignore[override]
+            turns["n"] += 1
+            if turns["n"] == 1:
+                yield self._parse_provider_response_delta(
+                    chunk(
+                        {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "outer",
+                                    "type": "function",
+                                    "function": {"name": GENERATE_A2UI_TOOL_NAME, "arguments": "{}"},
+                                }
+                            ]
+                        }
+                    )
+                )
+            elif turns["n"] == 2:
+                # The render subagent turn.
+                yield self._parse_provider_response_delta(
+                    chunk(
+                        {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "inner",
+                                    "type": "function",
+                                    "function": {
+                                        "name": RENDER_A2UI_TOOL_NAME,
+                                        "arguments": json.dumps({"surfaceId": "sales", "components": VALID_COMPONENTS}),
+                                    },
+                                }
+                            ]
+                        }
+                    )
+                )
+            else:
+                yield self._parse_provider_response_delta(chunk({"content": "Rendered."}))
+
+    model = PlannerModel(id="m", api_key="x")
+    agent = Agent(id="a2ui-agent", name="A2UI Agent", model=model, tools=[get_a2ui_tools({"model": model})])
+    app = AgentOS(id="a2ui-os", agents=[agent], interfaces=[AGUI(agent=agent)]).get_app()
+
+    body = {
+        "threadId": "thread-1",
+        "runId": "run-1",
+        "state": None,
+        "messages": [{"id": "m1", "role": "user", "content": "show me a sales card"}],
+        "tools": [],
+        "context": [
+            {
+                "description": A2UI_SCHEMA_CONTEXT_DESCRIPTION,
+                "value": json.dumps(
+                    forwarded_catalog(Column=catalog_component("Column"), Text=catalog_component("Text", "text"))
+                ),
+            }
+        ],
+        "forwardedProps": {},
+    }
+
+    with TestClient(app) as client:
+        response = client.post("/agui", json=body)
+
+    assert response.status_code == 200
+    events = parse_sse_events(response.text)
+    assert "RUN_ERROR" not in [event.get("type") for event in events]
+
+    results = [event for event in events if event.get("type") == "TOOL_CALL_RESULT"]
+    assert len(results) == 1
+    envelope = json.loads(results[0]["content"])
+    assert operation(envelope, "createSurface") == {"surfaceId": "sales", "catalogId": CATALOG_ID}
+    assert operation(envelope, "updateComponents")["components"] == VALID_COMPONENTS
+
+    starts = [event["toolCallName"] for event in events if event.get("type") == "TOOL_CALL_START"]
+    assert starts == [GENERATE_A2UI_TOOL_NAME, RENDER_A2UI_TOOL_NAME]

--- a/libs/agno/tests/unit/os/interfaces/test_agui_a2ui_injection.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_a2ui_injection.py
@@ -1,0 +1,1564 @@
+"""Giving an agent the A2UI generation tool for a single request.
+
+A client that can render A2UI asks for generation per run. The interface adds
+the tool for that run only, because the agent is shared across requests and the
+tool is bound to one. Asking is opt-in and refusing is always honoured.
+"""
+
+import asyncio
+import json
+import logging
+import sys
+import types
+from typing import Any, AsyncIterator, Callable, Dict, List, Optional
+
+import pytest
+
+pytest.importorskip("ag_ui", reason="ag_ui not installed")
+pytest.importorskip("ag_ui_a2ui_toolkit", reason="ag_ui_a2ui_toolkit not installed")
+
+from ag_ui.core import EventType, RunAgentInput, RunFinishedEvent, RunStartedEvent  # noqa: E402
+from ag_ui_a2ui_toolkit import (  # noqa: E402
+    A2UI_SCHEMA_CONTEXT_DESCRIPTION,
+    BASIC_CATALOG_ID,
+    GENERATE_A2UI_TOOL_NAME,
+)
+
+from agno.agent import Agent  # noqa: E402
+from agno.agent.remote import RemoteAgent  # noqa: E402
+from agno.models.response import ToolExecution  # noqa: E402
+from agno.os.app import AgentOS  # noqa: E402
+from agno.os.interfaces.agui import AGUI  # noqa: E402
+from agno.os.interfaces.agui import a2ui as a2ui_module  # noqa: E402
+from agno.os.interfaces.agui.a2ui import (  # noqa: E402
+    RENDER_A2UI_TOOL_NAME,
+    A2UIConfig,
+    get_a2ui_tools,
+    prepare_a2ui_run,
+    render_guide_description,
+)
+from agno.os.interfaces.agui.a2ui_stream import (  # noqa: E402
+    ToolPresence,
+    current_a2ui_run,
+    resolve_entity_tools,
+)
+from agno.os.interfaces.agui.router import run_entity  # noqa: E402
+from agno.run.agent import RunContentEvent, ToolCallStartedEvent  # noqa: E402
+from agno.team import Team  # noqa: E402
+from agno.team.remote import RemoteTeam  # noqa: E402
+from agno.tools.function import Function  # noqa: E402
+from agno.tools.toolkit import Toolkit  # noqa: E402
+from agno.utils import log as agno_log  # noqa: E402
+
+CATALOG_ID = "declarative-gen-ui-catalog"
+
+COMPONENTS = [
+    {"id": "root", "component": "Column", "children": ["title"]},
+    {"id": "title", "component": "Text", "text": "Quarterly sales"},
+]
+
+SCHEMA_ENTRY = {
+    "description": A2UI_SCHEMA_CONTEXT_DESCRIPTION,
+    "value": json.dumps({"catalogId": CATALOG_ID, "components": [{"name": "Column"}, {"name": "Text"}]}),
+}
+
+
+def a_model() -> Any:
+    """A real model instance; these tests never let it reach the network."""
+    pytest.importorskip("openai")
+    from agno.models.openai import OpenAIChat
+
+    return OpenAIChat(id="gpt-x", api_key="not-used")
+
+
+def run_input(
+    *,
+    forwarded_props: Optional[Dict[str, Any]] = None,
+    context: Optional[List[Dict[str, Any]]] = None,
+    tools: Optional[List[Dict[str, Any]]] = None,
+    messages: Optional[List[Dict[str, Any]]] = None,
+) -> RunAgentInput:
+    return RunAgentInput.model_validate(
+        {
+            "threadId": "thread-1",
+            "runId": "run-1",
+            "state": None,
+            "messages": messages or [{"id": "m1", "role": "user", "content": "show me a card"}],
+            "tools": tools or [],
+            "context": context if context is not None else [SCHEMA_ENTRY],
+            "forwardedProps": forwarded_props or {},
+        }
+    )
+
+
+def agent_with(*tools: Any, model: Any = None) -> Agent:
+    return Agent(id="a", name="A", model=model if model is not None else a_model(), tools=list(tools) or None)
+
+
+def a_rendering_model() -> Any:
+    """A model whose single turn is one complete render call.
+
+    Enough to run a generation tool's entrypoint offline, without the recovery
+    loop needing a second attempt.
+    """
+    pytest.importorskip("openai")
+    from agno.models.openai import OpenAIChat
+
+    payload = json.dumps({"surfaceId": "sales", "components": COMPONENTS})
+
+    class RenderingModel(OpenAIChat):
+        async def aprocess_response_stream(self, **kwargs: Any) -> AsyncIterator[Any]:  # type: ignore[override]
+            function = type("Fn", (), {"name": RENDER_A2UI_TOOL_NAME, "arguments": payload})()
+            entry = type("Entry", (), {"function": function, "index": 0, "id": "inner"})()
+            yield type("Delta", (), {"tool_calls": [entry]})()
+
+    return RenderingModel(id="m", api_key="not-used")
+
+
+def created_surface(envelope: Dict[str, Any]) -> Dict[str, Any]:
+    return next(entry["createSurface"] for entry in envelope["a2ui_operations"] if "createSurface" in entry)
+
+
+def levels_logging(caplog: Any, needle: str) -> set:
+    """The levels the records mentioning ``needle`` were logged at.
+
+    A substring match on ``caplog.text`` says a line was emitted but not how
+    loudly, and the level is part of what the cookbook README promises an
+    operator. Pinning it is what keeps the two from drifting apart unnoticed a
+    third time.
+    """
+    return {record.levelname for record in caplog.records if needle in record.getMessage()}
+
+
+#: Nothing listens there, so any attempt to reach the remote deployment fails
+#: rather than being quietly served.
+UNREACHABLE = "http://127.0.0.1:1"
+
+
+# =============================================================================
+# Whether the tool is added at all
+# =============================================================================
+
+
+def test_generation_is_off_unless_asked_for():
+    plan = prepare_a2ui_run(entity=agent_with(), run_input=run_input())
+
+    assert plan["tool"] is None
+
+
+def test_a_client_asking_for_generation_gets_it():
+    plan = prepare_a2ui_run(entity=agent_with(), run_input=run_input(forwarded_props={"injectA2UITool": True}))
+
+    assert plan["tool"] is not None
+    assert plan["tool"].name == GENERATE_A2UI_TOOL_NAME
+
+
+def test_a_backend_can_opt_in_for_clients_that_do_not_ask():
+    plan = prepare_a2ui_run(entity=agent_with(), run_input=run_input(), config={"inject_a2ui_tool": True})
+
+    assert plan["tool"] is not None
+
+
+def test_a_client_refusing_beats_a_backend_opt_in():
+    plan = prepare_a2ui_run(
+        entity=agent_with(),
+        run_input=run_input(forwarded_props={"injectA2UITool": False}),
+        config={"inject_a2ui_tool": True},
+    )
+
+    assert plan["tool"] is None
+
+
+def test_generation_needs_a_model_to_run_the_subagent_on(caplog):
+    entity = Agent(id="a", name="A")
+
+    plan = prepare_a2ui_run(entity=entity, run_input=run_input(forwarded_props={"injectA2UITool": True}))
+
+    assert plan["tool"] is None
+    assert "no model" in caplog.text
+    assert levels_logging(caplog, "no model") == {"WARNING"}
+
+
+def test_a_malformed_forwarded_props_payload_is_tolerated():
+    request = run_input()
+    request.forwarded_props = "not a mapping"  # type: ignore[assignment]
+
+    assert prepare_a2ui_run(entity=agent_with(), run_input=request)["tool"] is None
+
+
+# =============================================================================
+# The settings the interface is given
+# =============================================================================
+
+
+def test_a_misspelled_setting_is_refused():
+    """Every one of these settings turns something on, so one that is ignored
+    leaves the feature off with the configuration apparently in place."""
+    with pytest.raises(ValueError) as refusal:
+        AGUI(agent=agent_with(), a2ui={"inject_a2ui_tools": True})  # type: ignore[typeddict-unknown-key]
+
+    assert "inject_a2ui_tools" in str(refusal.value)
+    # The setting it was nearly spelled as, so the reader is not left to diff
+    # their key against the list themselves.
+    assert "inject_a2ui_tool'" in str(refusal.value)
+
+
+def test_a_misspelled_setting_is_refused_by_the_planner_too():
+    """The interface is not the only door in: the planner is what actually
+    reads these, and another adapter's wiring calls it directly."""
+    with pytest.raises(ValueError, match="default_catalog"):
+        prepare_a2ui_run(
+            entity=agent_with(),
+            run_input=run_input(forwarded_props={"injectA2UITool": True}),
+            config={"default_catalog": CATALOG_ID},  # type: ignore[typeddict-unknown-key]
+        )
+
+
+def test_settings_that_are_not_a_mapping_are_refused():
+    with pytest.raises(ValueError, match="mapping"):
+        AGUI(agent=agent_with(), a2ui=["inject_a2ui_tool"])  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "wiring",
+    [
+        {"agent": RemoteAgent(base_url=UNREACHABLE, agent_id="remote-agent")},
+        {"team": RemoteTeam(base_url=UNREACHABLE, team_id="remote-team")},
+    ],
+    ids=["remote-agent", "remote-team"],
+)
+def test_a2ui_settings_for_a_remote_entity_are_refused_where_they_are_written(wiring):
+    """Per-run tools are not forwarded to a remote deployment, so no setting
+    here can ever reach one. Refused at construction rather than warned about
+    once per request, which leaves the configuration apparently in place."""
+    with pytest.raises(ValueError, match="remote"):
+        AGUI(a2ui={"inject_a2ui_tool": True}, **wiring)
+
+
+def test_a_remote_entity_with_no_a2ui_settings_is_served_as_before():
+    assert AGUI(agent=RemoteAgent(base_url=UNREACHABLE, agent_id="remote-agent")).a2ui is None
+
+
+def test_every_documented_setting_is_accepted():
+    """Refusing the unknown is only safe if the known set is the whole one."""
+    documented: A2UIConfig = {
+        "inject_a2ui_tool": True,
+        "tool_name": "draw_ui",
+        "tool_description": "Draw.",
+        "default_surface_id": "sales",
+        "default_catalog_id": CATALOG_ID,
+        "catalog": {"components": []},
+        "guidelines": {},
+        "recovery": {"maxAttempts": 5},
+        "on_a2ui_attempt": None,
+        "tool_choice": "auto",
+        "subagent_timeout": 300,
+    }
+
+    assert set(documented) == set(A2UIConfig.__annotations__)
+    assert AGUI(agent=agent_with(), a2ui=documented).a2ui == documented
+
+
+# =============================================================================
+# Reading what was asked for
+# =============================================================================
+
+
+@pytest.mark.parametrize("spelling", ["false", "False", "FALSE", " false ", "0", "no", "off"])
+def test_a_stringified_refusal_is_read_as_one(spelling):
+    """A client that stringifies its booleans on the way out still means no.
+
+    Read as a tool name instead, a refusal turns generation on and takes away
+    a client tool called "false", which is neither what was asked for nor
+    something the client has.
+    """
+    plan = prepare_a2ui_run(
+        entity=agent_with(),
+        run_input=run_input(forwarded_props={"injectA2UITool": spelling}),
+        config={"inject_a2ui_tool": True},
+    )
+
+    assert plan["tool"] is None
+    assert plan["drop_tool_names"] == []
+
+
+@pytest.mark.parametrize("spelling", ["true", "True", "1", "yes", "on"])
+def test_a_stringified_yes_is_read_as_one(spelling):
+    """And the render tool replaced is the default one, not a tool named "true"."""
+    plan = prepare_a2ui_run(entity=agent_with(), run_input=run_input(forwarded_props={"injectA2UITool": spelling}))
+
+    assert plan["tool"] is not None
+    assert plan["drop_tool_names"] == [RENDER_A2UI_TOOL_NAME]
+
+
+@pytest.mark.parametrize("value", [0, 0.0, "", [], {}], ids=["zero", "float-zero", "empty", "list", "mapping"])
+def test_a_falsy_refusal_beats_a_backend_opt_in(value, caplog):
+    """The opt-out is a promise, so anything false the client sends is a no.
+
+    Discarded as unreadable instead, the backend opt-in below applies and the
+    client's refusal is gone: a client that has no boolean of its own and
+    sends 0 is refused as surely as one that sends false.
+    """
+    plan = prepare_a2ui_run(
+        entity=agent_with(),
+        run_input=run_input(forwarded_props={"injectA2UITool": value}),
+        config={"inject_a2ui_tool": True},
+    )
+
+    assert plan["tool"] is None
+    assert plan["drop_tool_names"] == []
+
+
+def test_a_stringified_refusal_in_the_backend_settings_is_read_as_one():
+    """Backend settings arrive from a config file as readily as from Python."""
+    plan = prepare_a2ui_run(entity=agent_with(), run_input=run_input(), config={"inject_a2ui_tool": "false"})
+
+    assert plan["tool"] is None
+
+
+@pytest.mark.parametrize("value", ["   ", 1, {"name": "render"}], ids=["blank", "int", "mapping"])
+def test_a_value_that_is_neither_a_boolean_nor_a_tool_name_is_reported(value, caplog):
+    """Not a choice to make quietly: read as a name it drops a tool nobody
+    has, and read as a yes it enables what the client may have meant to refuse."""
+    plan = prepare_a2ui_run(entity=agent_with(), run_input=run_input(forwarded_props={"injectA2UITool": value}))
+
+    assert plan["tool"] is None
+    assert levels_logging(caplog, "injectA2UITool") == {"WARNING"}
+
+
+# =============================================================================
+# Remote agents and teams
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "entity",
+    [
+        RemoteAgent(base_url=UNREACHABLE, agent_id="remote-agent"),
+        RemoteTeam(base_url=UNREACHABLE, team_id="remote-team"),
+    ],
+    ids=["remote-agent", "remote-team"],
+)
+def test_a_remote_entity_keeps_the_a2ui_it_already_had(entity, caplog):
+    """Per-run tools are not forwarded to a remote deployment, so injecting
+    would take the client's render tool away and put nothing in its place."""
+    plan = prepare_a2ui_run(entity=entity, run_input=run_input(forwarded_props={"injectA2UITool": True}))
+
+    assert plan["tool"] is None
+    assert plan["drop_tool_names"] == []
+    # The catalog the client's own render tool needs the model to have read.
+    assert [entry.description for entry in plan["context"]] == [A2UI_SCHEMA_CONTEXT_DESCRIPTION]
+    assert "remote" in caplog.text
+    assert levels_logging(caplog, "remote agent or team") == {"WARNING"}
+    # A remote entity does have a model; it just is not exposed locally.
+    assert "no model" not in caplog.text
+
+
+# =============================================================================
+# Never injecting over the developer's own wiring
+# =============================================================================
+
+
+def test_a_developer_wired_tool_is_not_duplicated():
+    wired = get_a2ui_tools({"model": a_model()})
+
+    plan = prepare_a2ui_run(entity=agent_with(wired), run_input=run_input(forwarded_props={"injectA2UITool": True}))
+
+    assert plan["tool"] is None
+
+
+def test_a_developer_wired_tool_under_another_name_is_still_recognized():
+    wired = get_a2ui_tools({"model": a_model(), "tool_name": "draw_ui"})
+
+    plan = prepare_a2ui_run(entity=agent_with(wired), run_input=run_input(forwarded_props={"injectA2UITool": True}))
+
+    assert plan["tool"] is None
+
+
+def test_a_hand_rolled_tool_of_the_same_name_is_respected():
+    hand_rolled = Function(name=GENERATE_A2UI_TOOL_NAME, entrypoint=lambda: "")
+
+    plan = prepare_a2ui_run(
+        entity=agent_with(hand_rolled), run_input=run_input(forwarded_props={"injectA2UITool": True})
+    )
+
+    assert plan["tool"] is None
+
+
+def test_a_developer_wired_tool_leaves_the_clients_render_tool_alone():
+    """Opting out of managed wiring opts out of all of it."""
+    wired = get_a2ui_tools({"model": a_model()})
+
+    plan = prepare_a2ui_run(entity=agent_with(wired), run_input=run_input(forwarded_props={"injectA2UITool": True}))
+
+    assert plan["drop_tool_names"] == []
+
+
+def test_the_tool_can_be_renamed_by_configuration():
+    plan = prepare_a2ui_run(
+        entity=agent_with(),
+        run_input=run_input(forwarded_props={"injectA2UITool": True}),
+        config={"tool_name": "draw_ui"},
+    )
+
+    assert plan["tool"] is not None
+    assert plan["tool"].name == "draw_ui"
+
+
+# =============================================================================
+# The two tool detectors, over every shape a tool can arrive in
+# =============================================================================
+
+
+def a_generation_function() -> Any:
+    return get_a2ui_tools({"model": a_model()})
+
+
+def a_toolkit_wrapping_the_generation_tool() -> Any:
+    """A toolkit exposing a generation tool it was handed.
+
+    Writing into ``functions`` is how a toolkit publishes a Function it did not
+    derive from one of its own methods, and it is the dict the name detector
+    reads.
+    """
+    toolkit = Toolkit(name="a2ui", auto_register=False)
+    toolkit.functions[GENERATE_A2UI_TOOL_NAME] = a_generation_function()
+    return toolkit
+
+
+def a_callable_named_like_the_generation_tool() -> Any:
+    def generate_a2ui() -> str:
+        return ""
+
+    generate_a2ui.__name__ = GENERATE_A2UI_TOOL_NAME
+    return generate_a2ui
+
+
+#: Every shape a tool reaches an entity in, and what one reading of the tools
+#: can establish about it: whether the entity generates surfaces, and whether
+#: the generation tool's name is taken. They are different questions -- three
+#: of these shapes carry a tool of that name that generates nothing -- and a
+#: factory answers neither, because reading it means running it.
+TOOL_SHAPES: Dict[str, Any] = {
+    "function": (lambda: agent_with(a_generation_function()), ToolPresence.PRESENT, ToolPresence.PRESENT),
+    "toolkit": (
+        lambda: agent_with(a_toolkit_wrapping_the_generation_tool()),
+        ToolPresence.PRESENT,
+        ToolPresence.PRESENT,
+    ),
+    "factory": (
+        lambda: Agent(id="a", name="A", model=a_model(), tools=lambda: [a_generation_function()]),
+        ToolPresence.UNKNOWN,
+        ToolPresence.UNKNOWN,
+    ),
+    "bare-callable": (
+        lambda: agent_with(a_callable_named_like_the_generation_tool()),
+        ToolPresence.ABSENT,
+        ToolPresence.PRESENT,
+    ),
+    "openai-nested-dict": (
+        lambda: agent_with(
+            {"type": "function", "function": {"name": GENERATE_A2UI_TOOL_NAME, "parameters": {"type": "object"}}}
+        ),
+        ToolPresence.ABSENT,
+        ToolPresence.PRESENT,
+    ),
+    "flat-dict": (
+        lambda: agent_with({"name": GENERATE_A2UI_TOOL_NAME, "parameters": {"type": "object"}}),
+        ToolPresence.ABSENT,
+        ToolPresence.PRESENT,
+    ),
+}
+
+EVERY_TOOL_SHAPE = list(TOOL_SHAPES)
+
+
+@pytest.mark.parametrize("shape", EVERY_TOOL_SHAPE)
+def test_one_reading_of_the_tools_answers_both_questions(shape):
+    """Both questions come off one walk of the tools list.
+
+    They were two functions with independently written cases, and nothing
+    required them to agree on one input: a shape one could read and the other
+    could not was reported as a tool that is absent rather than one that
+    cannot be seen, and each caller then made a different wrong decision from
+    the same wrong answer.
+    """
+    build, generates, carries = TOOL_SHAPES[shape]
+    tools = resolve_entity_tools(build())
+
+    assert tools.generates_a2ui() is generates
+    assert tools.carries(GENERATE_A2UI_TOOL_NAME) is carries
+
+
+def test_a_shape_that_cannot_be_read_is_not_reported_as_empty():
+    """The distinction the whole type exists for: nothing was ruled out, it was
+    only not seen, and "absent" is the answer that cannot be given."""
+    unreadable = resolve_entity_tools(Agent(id="a", name="A", model=a_model(), tools=lambda: []))
+    read = resolve_entity_tools(agent_with())
+
+    assert unreadable.generates_a2ui() is ToolPresence.UNKNOWN
+    assert unreadable.carries("anything_at_all") is ToolPresence.UNKNOWN
+    assert read.generates_a2ui() is ToolPresence.ABSENT
+    assert read.carries("anything_at_all") is ToolPresence.ABSENT
+
+
+@pytest.mark.parametrize("shape", EVERY_TOOL_SHAPE)
+def test_a_tool_the_developer_wired_is_never_injected_over_whatever_shape_it_has(shape):
+    """The promise the module docstring and the cookbook both make.
+
+    Injecting over one leaves the run with two tools of the same name and takes
+    the client's render tool away, so the model chooses between duplicates and
+    the browser has nothing of its own left to draw with. A shape that cannot
+    be read is declined for that reason: the duplicate is a run that cannot
+    work, while declining leaves the developer's own wiring standing and says
+    so in the log.
+    """
+    build, _, _ = TOOL_SHAPES[shape]
+
+    plan = prepare_a2ui_run(entity=build(), run_input=run_input(forwarded_props={"injectA2UITool": True}))
+
+    assert plan["tool"] is None
+    assert plan["drop_tool_names"] == []
+
+
+@pytest.mark.parametrize("shape", ["function", "toolkit", "factory"])
+def test_a_run_that_may_generate_gets_the_render_channel(shape):
+    """Recognizing the tool is what buys progressive painting.
+
+    A run that generates a surface without this channel still commits the
+    surface, so nothing fails: the surface simply appears whole, seconds later,
+    and the loss is invisible from the outside. Which is why a shape that
+    cannot be read gets one too, unlike injection: an unread channel costs a
+    run nothing.
+    """
+    build, _, _ = TOOL_SHAPES[shape]
+
+    plan = prepare_a2ui_run(entity=build(), run_input=run_input(forwarded_props={"injectA2UITool": True}))
+
+    assert plan["run"].render_stream is not None
+
+
+@pytest.mark.parametrize("shape", ["bare-callable", "openai-nested-dict", "flat-dict"])
+def test_a_run_that_cannot_generate_gets_no_channel(shape):
+    """A tool of that name which generates nothing is still only a name, and
+    the channel exists for fragments the generation tool pushes."""
+    build, _, _ = TOOL_SHAPES[shape]
+
+    plan = prepare_a2ui_run(entity=build(), run_input=run_input(forwarded_props={"injectA2UITool": True}))
+
+    assert plan["run"].render_stream is None
+
+
+# =============================================================================
+# Saying why generation was declined
+# =============================================================================
+
+
+def test_declining_because_a_tool_of_that_name_exists_says_so(caplog):
+    """The client asked for generation and is getting none, and the tool that
+    kept the name is not one this interface knows anything about."""
+    hand_rolled = Function(name=GENERATE_A2UI_TOOL_NAME, entrypoint=lambda: "")
+
+    plan = prepare_a2ui_run(
+        entity=agent_with(hand_rolled), run_input=run_input(forwarded_props={"injectA2UITool": True})
+    )
+
+    assert plan["tool"] is None
+    assert levels_logging(caplog, GENERATE_A2UI_TOOL_NAME) == {"WARNING"}
+
+
+def test_declining_because_the_tools_cannot_be_read_says_so(caplog):
+    """The one bail-out a developer can act on only if they are told: the
+    remedy is to hand the tools over as a list, or to wire generation in."""
+    entity = Agent(id="a", name="A", model=a_model(), tools=lambda: [])
+
+    plan = prepare_a2ui_run(entity=entity, run_input=run_input(forwarded_props={"injectA2UITool": True}))
+
+    assert plan["tool"] is None
+    assert levels_logging(caplog, "callable") == {"WARNING"}
+
+
+def test_leaving_the_developers_own_generation_tool_alone_is_not_a_warning(caplog, monkeypatch):
+    """Wiring one is the documented path, so warning about it once per request
+    would be noise. The record still exists for whoever reads a debug log."""
+    monkeypatch.setattr(agno_log, "debug_on", True)
+    caplog.set_level(logging.DEBUG, logger="agno")
+
+    plan = prepare_a2ui_run(
+        entity=agent_with(get_a2ui_tools({"model": a_model()})),
+        run_input=run_input(forwarded_props={"injectA2UITool": True}),
+    )
+
+    assert plan["tool"] is None
+    assert levels_logging(caplog, GENERATE_A2UI_TOOL_NAME) == {"DEBUG"}
+
+
+# =============================================================================
+# Replacing the render tool the client injected
+# =============================================================================
+
+
+def test_the_clients_render_tool_is_replaced():
+    plan = prepare_a2ui_run(entity=agent_with(), run_input=run_input(forwarded_props={"injectA2UITool": True}))
+
+    assert plan["drop_tool_names"] == [RENDER_A2UI_TOOL_NAME]
+
+
+def test_a_client_naming_its_render_tool_has_that_one_replaced():
+    plan = prepare_a2ui_run(
+        entity=agent_with(), run_input=run_input(forwarded_props={"injectA2UITool": "paint_surface"})
+    )
+
+    assert plan["tool"] is not None
+    assert plan["drop_tool_names"] == ["paint_surface"]
+
+
+def test_a_client_tool_of_the_generation_tools_name_is_taken_out(caplog):
+    """Agno keeps the first tool of a name and skips the rest, and this run's
+    client tools are registered ahead of the injected one, so such a tool
+    would leave the model calling the client and nothing generating here."""
+    client_tools = [
+        {
+            "name": GENERATE_A2UI_TOOL_NAME,
+            "description": "The client's own.",
+            "parameters": {"type": "object", "properties": {}},
+        }
+    ]
+
+    plan = prepare_a2ui_run(
+        entity=agent_with(), run_input=run_input(tools=client_tools, forwarded_props={"injectA2UITool": True})
+    )
+
+    assert plan["tool"] is not None
+    assert plan["drop_tool_names"] == [RENDER_A2UI_TOOL_NAME, GENERATE_A2UI_TOOL_NAME]
+    assert levels_logging(caplog, "forwarded a tool named") == {"WARNING"}
+
+
+def test_a_client_tool_that_collides_with_nothing_is_not_reported(caplog):
+    plan = prepare_a2ui_run(entity=agent_with(), run_input=run_input(forwarded_props={"injectA2UITool": True}))
+
+    assert plan["drop_tool_names"] == [RENDER_A2UI_TOOL_NAME]
+    assert "forwarded a tool named" not in caplog.text
+
+
+def test_the_guide_for_the_replaced_tool_is_dropped():
+    context = [
+        SCHEMA_ENTRY,
+        {"description": render_guide_description(RENDER_A2UI_TOOL_NAME), "value": "call it like this"},
+        {"description": "User preferences", "value": "USD"},
+    ]
+
+    plan = prepare_a2ui_run(
+        entity=agent_with(), run_input=run_input(forwarded_props={"injectA2UITool": True}, context=context)
+    )
+
+    kept = [entry.description for entry in plan["context"]]
+    assert kept == ["User preferences"]
+
+
+def test_an_unrelated_guide_is_kept():
+    context = [
+        {"description": render_guide_description("someone_elses_tool"), "value": "call it like this"},
+    ]
+
+    plan = prepare_a2ui_run(
+        entity=agent_with(), run_input=run_input(forwarded_props={"injectA2UITool": True}, context=context)
+    )
+
+    assert [entry.description for entry in plan["context"]] == [render_guide_description("someone_elses_tool")]
+
+
+# =============================================================================
+# The catalog
+# =============================================================================
+
+
+def test_the_catalog_is_taken_out_of_the_context_the_agent_sees():
+    """When generation is injected the catalog reaches the render subagent
+    through run state, and can run to thousands of tokens the planner cannot use."""
+    plan = prepare_a2ui_run(entity=agent_with(), run_input=run_input(forwarded_props={"injectA2UITool": True}))
+
+    assert [entry.description for entry in plan["context"]] == []
+    assert json.loads(plan["run"].state["ag-ui"]["a2ui_schema"])["catalogId"] == CATALOG_ID
+
+
+def test_the_catalog_stays_in_the_context_when_nothing_here_generates():
+    """The client renders A2UI through its own render tool on such a run, and
+    that tool only works if the component list reached the model."""
+    plan = prepare_a2ui_run(entity=agent_with(), run_input=run_input())
+
+    assert plan["tool"] is None
+    assert [entry.description for entry in plan["context"]] == [A2UI_SCHEMA_CONTEXT_DESCRIPTION]
+    assert json.loads(plan["run"].state["ag-ui"]["a2ui_schema"])["catalogId"] == CATALOG_ID
+
+
+def test_the_catalog_is_taken_out_for_a_developer_wired_tool_too():
+    """Whoever wired it, generation reads the catalog from run state, and the
+    planner pays for it in every prompt for nothing."""
+    wired = get_a2ui_tools({"model": a_model()})
+
+    plan = prepare_a2ui_run(entity=agent_with(wired), run_input=run_input(forwarded_props={"injectA2UITool": True}))
+
+    assert [entry.description for entry in plan["context"]] == []
+    assert json.loads(plan["run"].state["ag-ui"]["a2ui_schema"])["catalogId"] == CATALOG_ID
+
+
+def test_a_hand_wired_agent_is_spared_the_catalog_on_a_run_nobody_asked_about():
+    """The client asks for injection per run; a hand-wired agent generates on
+    every one of them, including the runs where nothing was asked."""
+    wired = get_a2ui_tools({"model": a_model()})
+
+    plan = prepare_a2ui_run(entity=agent_with(wired), run_input=run_input())
+
+    assert [entry.description for entry in plan["context"]] == []
+
+
+def test_the_catalog_stays_for_a_client_that_renders_a2ui_itself():
+    """A run carrying the client's own render tool draws in the browser, and
+    that only works if the component list reached the model."""
+    wired = get_a2ui_tools({"model": a_model()})
+    client_tools = [
+        {
+            "name": RENDER_A2UI_TOOL_NAME,
+            "description": "Render an A2UI surface.",
+            "parameters": {"type": "object", "properties": {}},
+        }
+    ]
+
+    plan = prepare_a2ui_run(entity=agent_with(wired), run_input=run_input(tools=client_tools))
+
+    assert [entry.description for entry in plan["context"]] == [A2UI_SCHEMA_CONTEXT_DESCRIPTION]
+
+
+def test_context_without_a_catalog_is_passed_through():
+    context = [{"description": "User preferences", "value": "USD"}]
+
+    plan = prepare_a2ui_run(entity=agent_with(), run_input=run_input(context=context))
+
+    assert [entry.description for entry in plan["context"]] == ["User preferences"]
+    assert "a2ui_schema" not in plan["run"].state["ag-ui"]
+
+
+async def test_the_forwarded_catalog_is_what_generated_surfaces_bind_to():
+    """The catalog is baked into the tool this run gets, not only left in state.
+
+    The tool is built per request precisely so it can carry this run's catalog,
+    and the surface it commits has to name that one rather than the built-in
+    default: a surface bound to a catalog the client never registered renders
+    as nothing.
+    """
+    plan = prepare_a2ui_run(
+        entity=agent_with(model=a_rendering_model()), run_input=run_input(forwarded_props={"injectA2UITool": True})
+    )
+
+    assert plan["tool"] is not None
+    assert json.loads(plan["run"].state["ag-ui"]["a2ui_schema"])["catalogId"] == CATALOG_ID
+
+    # Called with none of this run's inputs in scope, so what the planner put
+    # on the tool is the only place a catalog can come from.
+    envelope = json.loads(await plan["tool"].entrypoint(run_context=None))
+
+    assert created_surface(envelope)["catalogId"] == CATALOG_ID
+
+
+def test_the_client_history_travels_to_the_tool():
+    """An earlier surface is found in what the client sent, because the agent's
+    own run history only covers the turn in progress."""
+    messages = [
+        {"id": "m1", "role": "user", "content": "make a card"},
+        {"id": "m2", "role": "tool", "toolCallId": "prior", "content": "{}"},
+        {"id": "m3", "role": "user", "content": "make it red"},
+    ]
+
+    plan = prepare_a2ui_run(entity=agent_with(), run_input=run_input(messages=messages))
+
+    assert [message.id for message in plan["run"].messages] == ["m1", "m2", "m3"]
+
+
+# =============================================================================
+# What the tool tells the model about itself
+# =============================================================================
+
+
+def test_only_the_intent_is_a_required_argument():
+    """A provider in strict mode reads a missing 'required' as "all of them",
+    which would make creating a surface impossible without an update's arguments."""
+    tool = get_a2ui_tools({"model": a_model()})
+
+    assert tool.parameters["required"] == ["intent"]
+
+
+def test_the_arguments_an_update_needs_stay_optional():
+    tool = get_a2ui_tools({"model": a_model()})
+
+    optional = set(tool.parameters["properties"]) - set(tool.parameters["required"])
+    assert optional == {"target_surface_id", "changes"}
+
+
+def test_the_declaration_survives_the_processing_every_run_does():
+    """A run processes its own copy of the tool, honouring the tool's own
+    strict setting over the run's, which is what keeps this schema as written."""
+    tool = get_a2ui_tools({"model": a_model()})
+    per_run = tool._per_run_copy()
+
+    # What agno.agent._tools does with each tool of a run whose other tools go
+    # out strict: the tool's own setting wins where it has one.
+    per_run.process_entrypoint(strict=True if per_run.strict is None else per_run.strict)
+
+    assert per_run.parameters["required"] == ["intent"]
+
+
+def test_the_tool_is_not_declared_strict_to_the_provider():
+    """A strict schema must require every property, and this one cannot.
+
+    Two of the three arguments describe an edit, so a run whose other tools go
+    out strict must not carry this one's schema rebuilt to match: the model
+    would have to supply an edit's arguments to create a first surface. What
+    keeps the declaration is the tool saying it is not strict, so the run
+    never processes it that way to begin with.
+    """
+    tool = get_a2ui_tools({"model": a_model()})
+
+    assert tool.strict is False
+    assert tool.to_dict()["strict"] is False
+
+
+def test_processing_one_runs_schema_leaves_the_next_runs_alone():
+    """Runs share the tool's definition, never its schema.
+
+    Both the strict rewrite and one provider adapter assign ``required`` in
+    place, so a schema shared between runs would carry the first run's
+    processing into every later one for the life of the process, and a
+    declaration the tool makes once would be gone from the second request on.
+    """
+    tool = get_a2ui_tools({"model": a_model()})
+    per_run = tool._per_run_copy()
+
+    # What one provider adapter does to the schema it is handed: assign
+    # ``required`` from ``properties``, in place.
+    per_run.parameters["required"] = list(per_run.parameters["properties"])
+    per_run.process_entrypoint(strict=True)
+
+    assert tool.parameters["required"] == ["intent"]
+    assert tool._per_run_copy().parameters["required"] == ["intent"]
+    assert get_a2ui_tools({"model": a_model()}).parameters is not tool.parameters
+
+
+# =============================================================================
+# The module's own surface
+# =============================================================================
+
+
+def test_everything_this_module_is_imported_for_is_exported():
+    """``__all__`` is the module's contract, and importers of these names
+    include the router, the interface's own tests and any custom wiring."""
+    exported = set(a2ui_module.__all__)
+
+    for name in exported:
+        assert hasattr(a2ui_module, name), name
+
+    imported_elsewhere = {
+        "OPENAI_RENDER_TOOL_CHOICE",
+        "RENDER_A2UI_TOOL_NAME",
+        "agui_state_from_dependencies",
+        "classify_a2ui_subagent_error",
+        "get_a2ui_tools",
+        "prepare_a2ui_run",
+        "render_guide_description",
+        "stream_render_subagent",
+        "strip_in_flight_tool_call",
+    }
+    assert imported_elsewhere <= exported
+
+
+# =============================================================================
+# When the toolkit cannot be imported
+# =============================================================================
+
+
+def test_a_missing_toolkit_says_to_install_it():
+    message = a2ui_module._toolkit_import_message(
+        ModuleNotFoundError("No module named 'ag_ui_a2ui_toolkit'", name="ag_ui_a2ui_toolkit")
+    )
+
+    assert "not installed" in message
+    assert "pip install -U ag-ui-a2ui-toolkit" in message
+
+
+def test_a_toolkit_too_old_to_import_from_is_not_called_missing():
+    """Reporting this as "not installed" sends someone to reinstall a package
+    they already have, and throws away the name that could not be found."""
+    message = a2ui_module._toolkit_import_message(
+        ImportError("cannot import name 'run_a2ui_generation_with_recovery' from 'ag_ui_a2ui_toolkit'")
+    )
+
+    assert "not installed" not in message
+    assert "run_a2ui_generation_with_recovery" in message
+
+
+def without_the_toolkit(monkeypatch: Any) -> None:
+    """Make importing A2UI support fail the way an absent toolkit does.
+
+    The tests in this file need the toolkit to run at all, so the branch the
+    router takes without it is unreachable by uninstalling anything. Replacing
+    the module with one that has no ``prepare_a2ui_run`` reaches it: that
+    import is what fails, and it fails the same way for a toolkit that is
+    missing and one too old to import from.
+    """
+    monkeypatch.setitem(sys.modules, "agno.os.interfaces.agui.a2ui", types.ModuleType("agno.os.interfaces.agui.a2ui"))
+
+
+async def test_the_router_reports_why_the_toolkit_import_failed(caplog, monkeypatch):
+    """The fallback runs without A2UI either way, but the reason it took that
+    path is the only clue the operator gets."""
+    without_the_toolkit(monkeypatch)
+
+    events = await collect(StubEntity(one_text_chunk), run_input(forwarded_props={"injectA2UITool": True}))
+
+    assert [event.type for event in events][-1] == EventType.RUN_FINISHED
+    assert "prepare_a2ui_run" in caplog.text
+    # The level is part of what the README promises an operator, and the README
+    # now says error, so the two are pinned to each other here.
+    assert levels_logging(caplog, "could not be imported") == {"ERROR"}
+
+
+async def test_without_the_toolkit_the_clients_own_render_tool_is_left_standing(monkeypatch):
+    """Nothing server-side can generate a surface on such a run, so the render
+    tool the client injected is the only way one gets drawn. Replacing it here
+    would leave the run with no way to render at all, and the catalog has to
+    stay in the context the model reads for the same reason."""
+    without_the_toolkit(monkeypatch)
+    entity = RecordingEntity(one_text_chunk)
+
+    events = await collect(
+        entity,
+        run_input(
+            forwarded_props={"injectA2UITool": True},
+            tools=[{"name": RENDER_A2UI_TOOL_NAME, "description": "Render.", "parameters": {"type": "object"}}],
+        ),
+    )
+
+    assert [event.type for event in events][-1] == EventType.RUN_FINISHED
+    run_context = entity.kwargs["run_context"]
+    assert [tool.name for tool in run_context.client_tools or []] == [RENDER_A2UI_TOOL_NAME]
+    assert list(run_context.dependencies or {}) == [A2UI_SCHEMA_CONTEXT_DESCRIPTION]
+
+
+def with_a_broken_a2ui_module(monkeypatch: Any, error: BaseException) -> None:
+    """Make importing A2UI support fail the way a broken module body does.
+
+    Anything raised while the module runs reaches the importer, not just the
+    ``ImportError`` an absent toolkit raises: a toolkit whose import has a side
+    effect that fails, a syntax error in an installed build, a bad value in a
+    module-level constant. A module whose attribute access raises reproduces
+    every one of them at the same place: the ``from`` that reads the name.
+    """
+    module = types.ModuleType("agno.os.interfaces.agui.a2ui")
+
+    def raise_it(name: str) -> Any:
+        raise error
+
+    module.__getattr__ = raise_it  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "agno.os.interfaces.agui.a2ui", module)
+
+
+async def test_a_run_that_never_asked_for_a2ui_survives_a_broken_module(caplog, monkeypatch):
+    """A2UI is an optional extra, and this call sits on the path of every run.
+
+    Almost no AG-UI traffic asks for generation, so a failure that escapes here
+    fails every ordinary request: whatever the run was for, the client gets
+    RUN_ERROR and nothing else.
+    """
+    with_a_broken_a2ui_module(monkeypatch, RuntimeError("a2ui module body blew up"))
+
+    events = await collect(StubEntity(one_text_chunk), run_input())
+
+    assert [event.type for event in events][-1] == EventType.RUN_FINISHED
+    assert EventType.RUN_ERROR not in [event.type for event in events]
+    # Installed and broken is not the ordinary absent-extra case, so it is
+    # still reported, at the level of something this run did not need.
+    assert levels_logging(caplog, "a2ui module body blew up") == {"WARNING"}
+
+
+async def test_a_broken_a2ui_module_is_reported_to_the_run_that_wanted_it(caplog, monkeypatch):
+    """The run goes on without generation, so the log is the only account of
+    why the surface the client asked for never came."""
+    with_a_broken_a2ui_module(monkeypatch, RuntimeError("a2ui module body blew up"))
+
+    events = await collect(StubEntity(one_text_chunk), run_input(forwarded_props={"injectA2UITool": True}))
+
+    assert [event.type for event in events][-1] == EventType.RUN_FINISHED
+    assert "a2ui module body blew up" in caplog.text
+    assert levels_logging(caplog, "a2ui module body blew up") == {"ERROR"}
+
+
+async def test_a_run_that_never_asked_for_generation_says_nothing_about_the_toolkit(caplog, monkeypatch):
+    """The toolkit is an extra almost nobody installs, and a run that does not
+    want generation loses nothing by its absence: reporting it would put an
+    error in the log for every ordinary request."""
+    without_the_toolkit(monkeypatch)
+
+    events = await collect(StubEntity(one_text_chunk), run_input())
+
+    assert [event.type for event in events][-1] == EventType.RUN_FINISHED
+    assert "could not be imported" not in caplog.text
+
+
+# =============================================================================
+# Over the wire
+# =============================================================================
+
+
+def _chunk(delta: Dict[str, Any]) -> Any:
+    from openai.types.chat import ChatCompletionChunk
+
+    return ChatCompletionChunk.model_validate(
+        {
+            "id": "c",
+            "object": "chat.completion.chunk",
+            "created": 0,
+            "model": "m",
+            "choices": [{"index": 0, "delta": delta, "finish_reason": None}],
+        }
+    )
+
+
+def _call(name: Optional[str], arguments: str, call_id: Optional[str] = None) -> Dict[str, Any]:
+    function: Dict[str, Any] = {"arguments": arguments}
+    if name is not None:
+        function["name"] = name
+    frame: Dict[str, Any] = {"index": 0, "function": function}
+    if call_id is not None:
+        frame["id"] = call_id
+        frame["type"] = "function"
+    return {"tool_calls": [frame]}
+
+
+def build_app(
+    offered: List[List[str]],
+    a2ui: Optional[Dict[str, Any]] = None,
+    as_team: bool = False,
+    schemas: Optional[List[Dict[str, Any]]] = None,
+) -> Any:
+    """An AG-UI app whose model records the tools it was offered each turn.
+
+    ``schemas`` collects the tool definitions as the provider received them,
+    which is the only place the schema a run actually sends can be read.
+    """
+    pytest.importorskip("openai")
+    from agno.models.openai import OpenAIChat
+
+    turns = {"n": 0}
+
+    class PlannerModel(OpenAIChat):
+        async def ainvoke_stream(self, *args: Any, **kwargs: Any) -> AsyncIterator[Any]:  # type: ignore[override]
+            turns["n"] += 1
+            sent = kwargs.get("tools") or []
+            offered.append(sorted(tool["function"]["name"] for tool in sent))
+            if schemas is not None:
+                schemas.extend(sent)
+            if turns["n"] == 1 and GENERATE_A2UI_TOOL_NAME in offered[-1]:
+                yield self._parse_provider_response_delta(_chunk(_call(GENERATE_A2UI_TOOL_NAME, "{}", call_id="outer")))
+            elif turns["n"] == 2:
+                yield self._parse_provider_response_delta(
+                    _chunk(
+                        _call(
+                            RENDER_A2UI_TOOL_NAME,
+                            json.dumps({"surfaceId": "sales", "components": COMPONENTS}),
+                            call_id="inner",
+                        )
+                    )
+                )
+            else:
+                yield self._parse_provider_response_delta(_chunk({"content": "Here you go."}))
+
+    model = PlannerModel(id="m", api_key="x")
+    agent = Agent(id="a2ui-agent", name="A2UI Agent", model=model)
+    if as_team:
+        team = Team(id="a2ui-team", name="A2UI Team", members=[agent], model=model)
+        return AgentOS(id="a2ui-os", teams=[team], interfaces=[AGUI(team=team, a2ui=a2ui)]).get_app()
+    return AgentOS(id="a2ui-os", agents=[agent], interfaces=[AGUI(agent=agent, a2ui=a2ui)]).get_app()
+
+
+def post(app: Any, body: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """POST an AG-UI request and return the events the server sent.
+
+    A run reports its own failure in band, so the 200 says only that the
+    response started. The check belongs here rather than in each caller: a run
+    that produced the tool result and then blew up leaves a test that forgot it
+    green.
+    """
+    from fastapi.testclient import TestClient
+
+    with TestClient(app) as client:
+        response = client.post("/agui", json=body)
+
+    assert response.status_code == 200
+    events = []
+    for line in response.text.split("\n"):
+        line = line.strip()
+        if line.startswith("data:"):
+            events.append(json.loads(line[5:].strip()))
+
+    errors = [event for event in events if event.get("type") == "RUN_ERROR"]
+    assert not errors, f"the run failed in band: {errors}"
+    return events
+
+
+def wire_body(**forwarded_props: Any) -> Dict[str, Any]:
+    return {
+        "threadId": "thread-1",
+        "runId": "run-1",
+        "state": None,
+        "messages": [{"id": "m1", "role": "user", "content": "show me a sales card"}],
+        # The client injects its render tool alongside asking for generation.
+        "tools": [
+            {
+                "name": RENDER_A2UI_TOOL_NAME,
+                "description": "Render an A2UI surface.",
+                "parameters": {"type": "object", "properties": {}},
+            }
+        ],
+        "context": [
+            SCHEMA_ENTRY,
+            {"description": render_guide_description(RENDER_A2UI_TOOL_NAME), "value": "how to call it"},
+        ],
+        "forwardedProps": forwarded_props,
+    }
+
+
+def test_an_asking_client_gets_a_generated_surface():
+    offered: List[List[str]] = []
+    events = post(build_app(offered), wire_body(injectA2UITool=True))
+
+    types = [event.get("type") for event in events]
+    assert "RUN_ERROR" not in types
+
+    # The generation tool replaced the client's render tool, so the run never
+    # pauses waiting for the browser to draw anything.
+    assert offered[0] == [GENERATE_A2UI_TOOL_NAME]
+
+    results = [event for event in events if event.get("type") == "TOOL_CALL_RESULT"]
+    envelope = json.loads(results[0]["content"])
+    operations = {key: value for entry in envelope["a2ui_operations"] for key, value in entry.items()}
+    assert operations["createSurface"] == {"surfaceId": "sales", "catalogId": CATALOG_ID}
+    assert operations["updateComponents"]["components"] == COMPONENTS
+
+
+def test_a_client_cannot_take_server_generation_away_by_naming_a_tool_after_it():
+    """The whole run, with a client tool of the generation tool's own name."""
+    offered: List[List[str]] = []
+    body = wire_body(injectA2UITool=True)
+    body["tools"].append(
+        {
+            "name": GENERATE_A2UI_TOOL_NAME,
+            "description": "The client's own.",
+            "parameters": {"type": "object", "properties": {}},
+        }
+    )
+
+    events = post(build_app(offered), body)
+
+    assert offered[0] == [GENERATE_A2UI_TOOL_NAME]
+    results = [event for event in events if event.get("type") == "TOOL_CALL_RESULT"]
+    assert len(results) == 1, "the client's tool won and nothing generated here"
+    envelope = json.loads(results[0]["content"])
+    assert created_surface(envelope)["catalogId"] == CATALOG_ID
+
+
+def test_the_declared_arguments_are_what_a_real_run_sends():
+    """What the builder wrote is not by itself what a provider receives: every
+    run copies the tool and processes that copy. Losing the declaration makes
+    both edit arguments mandatory, and a model that has to supply them cannot
+    create a first surface at all."""
+    offered: List[List[str]] = []
+    schemas: List[Dict[str, Any]] = []
+
+    post(build_app(offered, schemas=schemas), wire_body(injectA2UITool=True))
+
+    generation = next(tool for tool in schemas if tool["function"]["name"] == GENERATE_A2UI_TOOL_NAME)
+    assert generation["function"]["parameters"]["required"] == ["intent"]
+    assert generation["function"].get("strict") is not True
+
+
+def test_a_refusing_client_gets_an_ordinary_answer():
+    offered: List[List[str]] = []
+    events = post(build_app(offered, a2ui={"inject_a2ui_tool": True}), wire_body(injectA2UITool=False))
+
+    assert GENERATE_A2UI_TOOL_NAME not in offered[0]
+    # The client's own render tool is left exactly as it sent it.
+    assert offered[0] == [RENDER_A2UI_TOOL_NAME]
+    assert [event.get("type") for event in events].count("TOOL_CALL_RESULT") == 0
+    contents = [event["delta"] for event in events if event.get("type") == "TEXT_MESSAGE_CONTENT"]
+    assert contents == ["Here you go."]
+
+
+def test_a_backend_opt_in_generates_without_the_client_asking():
+    offered: List[List[str]] = []
+    events = post(build_app(offered, a2ui={"inject_a2ui_tool": True}), wire_body())
+
+    assert offered[0] == [GENERATE_A2UI_TOOL_NAME]
+    assert [event.get("type") for event in events].count("TOOL_CALL_RESULT") == 1
+
+
+def test_a_configured_catalog_overrides_the_forwarded_one():
+    offered: List[List[str]] = []
+    events = post(
+        build_app(offered, a2ui={"default_catalog_id": "host-catalog"}),
+        wire_body(injectA2UITool=True),
+    )
+
+    # Choosing a catalog server-side changes nothing about the wiring: the
+    # generation tool still stands in for the client's render tool.
+    assert offered[0] == [GENERATE_A2UI_TOOL_NAME]
+
+    results = [event for event in events if event.get("type") == "TOOL_CALL_RESULT"]
+    envelope = json.loads(results[0]["content"])
+    operations = {key: value for entry in envelope["a2ui_operations"] for key, value in entry.items()}
+    assert operations["createSurface"]["catalogId"] == "host-catalog"
+
+
+def test_without_a_forwarded_catalog_the_basic_one_is_used():
+    offered: List[List[str]] = []
+    body = wire_body(injectA2UITool=True)
+    body["context"] = []
+    events = post(build_app(offered), body)
+
+    assert offered[0] == [GENERATE_A2UI_TOOL_NAME]
+
+    results = [event for event in events if event.get("type") == "TOOL_CALL_RESULT"]
+    envelope = json.loads(results[0]["content"])
+    operations = {key: value for entry in envelope["a2ui_operations"] for key, value in entry.items()}
+    assert operations["createSurface"]["catalogId"] == BASIC_CATALOG_ID
+
+
+# =============================================================================
+# Teams
+# =============================================================================
+
+
+def test_a_team_gets_the_generation_tool_too():
+    """Nothing about generation is agent-specific, and a team is the entity a
+    client is likeliest to be talking to when it asks for a surface."""
+    team = Team(id="t", name="T", members=[agent_with()], model=a_model())
+
+    plan = prepare_a2ui_run(entity=team, run_input=run_input(forwarded_props={"injectA2UITool": True}))
+
+    assert plan["tool"] is not None
+    assert plan["tool"].name == GENERATE_A2UI_TOOL_NAME
+    assert plan["drop_tool_names"] == [RENDER_A2UI_TOOL_NAME]
+    # The catalog moves into run state on a team run for the same reason as on
+    # an agent run: the planner cannot use it and pays for it in every prompt.
+    assert [entry.description for entry in plan["context"]] == []
+    assert json.loads(plan["run"].state["ag-ui"]["a2ui_schema"])["catalogId"] == CATALOG_ID
+
+
+def test_a_team_generates_a_surface_over_the_wire():
+    """The team's own model runs the render subagent, and its delegation tool
+    is left alone: only the client's render tool is taken away."""
+    offered: List[List[str]] = []
+    events = post(build_app(offered, as_team=True), wire_body(injectA2UITool=True))
+
+    types = [event.get("type") for event in events]
+    assert "RUN_ERROR" not in types
+    assert GENERATE_A2UI_TOOL_NAME in offered[0]
+    assert RENDER_A2UI_TOOL_NAME not in offered[0]
+
+    results = [event for event in events if event.get("type") == "TOOL_CALL_RESULT"]
+    envelope = json.loads(results[0]["content"])
+    operations = {key: value for entry in envelope["a2ui_operations"] for key, value in entry.items()}
+    assert operations["createSurface"] == {"surfaceId": "sales", "catalogId": CATALOG_ID}
+    assert operations["updateComponents"]["components"] == COMPONENTS
+
+
+def test_a_members_generation_tool_is_not_injected_over():
+    """A member's tool is this team's generation: a second one on the leader
+    leaves the model choosing between duplicates and takes the client's render
+    tool away for a run that now generates twice."""
+    member = agent_with(get_a2ui_tools({"model": a_model()}))
+    team = Team(id="t", name="T", members=[member], model=a_model())
+
+    plan = prepare_a2ui_run(entity=team, run_input=run_input(forwarded_props={"injectA2UITool": True}))
+
+    assert plan["tool"] is None
+    # A member's surface paints while it is written like any other, so the
+    # channel that carries the progress is prepared.
+    assert plan["run"].render_stream is not None
+
+
+def test_a_nested_teams_generation_tool_is_seen_too():
+    member = agent_with(get_a2ui_tools({"model": a_model()}))
+    inner = Team(id="i", name="I", members=[member], model=a_model())
+    team = Team(id="t", name="T", members=[inner], model=a_model())
+
+    assert resolve_entity_tools(team).generates_a2ui() is ToolPresence.PRESENT
+
+
+def test_a_member_whose_own_tools_cannot_be_read_is_not_reported_as_absent(caplog):
+    """A member's tools can be a callable it resolves when it runs, which is
+    as unreadable as the leader's own and rules nothing out."""
+    member = Agent(id="m", name="M", model=a_model(), tools=lambda: [])
+    team = Team(id="t", name="T", members=[member], model=a_model())
+
+    reading = resolve_entity_tools(team)
+    assert reading.generates_a2ui() is ToolPresence.UNKNOWN
+    # The leader's own list was read, so a name collision is still answerable.
+    assert reading.carries(GENERATE_A2UI_TOOL_NAME) is ToolPresence.ABSENT
+
+    plan = prepare_a2ui_run(entity=team, run_input=run_input(forwarded_props={"injectA2UITool": True}))
+
+    assert plan["tool"] is None
+    assert levels_logging(caplog, "cannot be known without running it") == {"WARNING"}
+
+
+def test_members_given_as_a_callable_cannot_be_read_either():
+    team = Team(id="t", name="T", members=lambda: [agent_with()], model=a_model())
+
+    assert resolve_entity_tools(team).generates_a2ui() is ToolPresence.UNKNOWN
+
+
+def test_a_members_tool_name_is_not_the_leaders():
+    """The injected tool goes to the leader, so what a member calls its own
+    tools cannot collide with it."""
+    member = agent_with(Function(name=GENERATE_A2UI_TOOL_NAME, entrypoint=lambda: ""))
+    team = Team(id="t", name="T", members=[member], model=a_model())
+
+    plan = prepare_a2ui_run(entity=team, run_input=run_input(forwarded_props={"injectA2UITool": True}))
+
+    assert plan["tool"] is not None
+
+
+def test_a_remote_member_is_never_asked_what_tools_it_has():
+    """Reading a remote member's tools is an HTTP round trip per request, to
+    learn about tools that run in the remote deployment and cannot serve this
+    run whatever they are."""
+    remote = RemoteAgent(base_url=UNREACHABLE, agent_id="remote-member")
+    team = Team(id="t", name="T", members=[remote], model=a_model())
+
+    plan = prepare_a2ui_run(entity=team, run_input=run_input(forwarded_props={"injectA2UITool": True}))
+
+    assert plan["tool"] is not None
+
+
+# =============================================================================
+# The path the tool is run on
+# =============================================================================
+
+
+def _a_generation_call() -> Any:
+    from agno.tools.function import FunctionCall
+
+    return FunctionCall(function=get_a2ui_tools({"model": a_rendering_model()}), arguments={"intent": "create"})
+
+
+def test_the_synchronous_tool_path_is_refused():
+    """Agno's synchronous path keeps whatever the entrypoint returns, so a
+    coroutine nobody awaited would be handed to the model as the result."""
+    from agno.exceptions import AgentRunException
+
+    with pytest.raises(AgentRunException, match="synchronous"):
+        _a_generation_call().execute()
+
+
+async def test_the_synchronous_tool_path_is_refused_from_inside_a_running_loop():
+    """A synchronous run driven from inside a loop still takes that path, so a
+    loop is running says nothing about which path the call is on."""
+    from agno.exceptions import AgentRunException
+
+    with pytest.raises(AgentRunException, match="synchronous"):
+        _a_generation_call().execute()
+
+
+async def test_the_asynchronous_tool_path_is_left_alone():
+    result = await _a_generation_call().aexecute()
+
+    assert result.status == "success"
+    assert created_surface(json.loads(result.result))["surfaceId"] == "sales"
+
+
+# =============================================================================
+# When the run fails
+# =============================================================================
+
+
+class StubEntity:
+    """The least an entity can be: ``run_entity`` only ever calls ``arun``."""
+
+    def __init__(self, chunks: Callable[[], AsyncIterator[Any]]) -> None:
+        self._chunks = chunks
+
+    def arun(self, **kwargs: Any) -> AsyncIterator[Any]:
+        return self._chunks()
+
+
+class RecordingEntity(StubEntity):
+    """The same, keeping what the router ran it with."""
+
+    def __init__(self, chunks: Callable[[], AsyncIterator[Any]]) -> None:
+        super().__init__(chunks)
+        self.kwargs: Dict[str, Any] = {}
+
+    def arun(self, **kwargs: Any) -> AsyncIterator[Any]:
+        self.kwargs = kwargs
+        return super().arun(**kwargs)
+
+
+async def one_text_chunk() -> AsyncIterator[Any]:
+    yield RunContentEvent(content="Here you go.")
+
+
+async def text_then_failure() -> AsyncIterator[Any]:
+    yield RunContentEvent(content="Working on it")
+    raise RuntimeError("model connection dropped")
+
+
+async def tool_call_then_failure() -> AsyncIterator[Any]:
+    yield ToolCallStartedEvent(tool=ToolExecution(tool_call_id="call_1", tool_name="lookup", tool_args={}))
+    raise RuntimeError("model connection dropped")
+
+
+async def collect(entity: Any, request: RunAgentInput, **kwargs: Any) -> List[Any]:
+    return [event async for event in run_entity(entity, request, **kwargs)]  # type: ignore[arg-type]
+
+
+async def test_a_failure_while_arranging_a2ui_reaches_the_client(monkeypatch):
+    """Otherwise the response body just stops: a 200 with no error in it."""
+
+    def explode(**kwargs: Any) -> Any:
+        raise ValueError("malformed catalog")
+
+    monkeypatch.setattr("agno.os.interfaces.agui.a2ui.prepare_a2ui_run", explode)
+
+    events = await collect(StubEntity(one_text_chunk), run_input())
+
+    assert [event.type for event in events] == [EventType.RUN_STARTED, EventType.RUN_ERROR]
+    assert "malformed catalog" in events[-1].message
+
+
+async def test_a_failure_mid_stream_closes_the_open_text_message():
+    events = await collect(StubEntity(text_then_failure), run_input())
+
+    types = [event.type for event in events]
+    assert types == [
+        EventType.RUN_STARTED,
+        EventType.TEXT_MESSAGE_START,
+        EventType.TEXT_MESSAGE_CONTENT,
+        EventType.TEXT_MESSAGE_END,
+        EventType.RUN_ERROR,
+    ]
+    assert events[-2].message_id == events[1].message_id
+
+
+async def test_a_failure_mid_stream_closes_the_open_tool_call():
+    events = await collect(StubEntity(tool_call_then_failure), run_input())
+
+    types = [event.type for event in events]
+    assert types[-2:] == [EventType.TOOL_CALL_END, EventType.RUN_ERROR]
+    assert events[-2].tool_call_id == "call_1"
+    assert types.count(EventType.TEXT_MESSAGE_START) == types.count(EventType.TEXT_MESSAGE_END)
+
+
+async def cancelled_mid_tool_call() -> AsyncIterator[Any]:
+    """A run cancelled with a tool call open, as an abandoned generation is.
+
+    The A2UI classifier raises cancellation deliberately, for a caller that has
+    gone and for a render turn that outran its deadline, and it reaches the
+    router through the stream like any other failure.
+    """
+    yield ToolCallStartedEvent(tool=ToolExecution(tool_call_id="call_1", tool_name="generate_a2ui", tool_args={}))
+    raise asyncio.CancelledError("caller disconnected; abandoning A2UI generation")
+
+
+async def collect_until(entity: Any, request: RunAgentInput, raises: type) -> List[Any]:
+    events: List[Any] = []
+    with pytest.raises(raises):
+        async for event in run_entity(entity, request):  # type: ignore[arg-type]
+            events.append(event)
+    return events
+
+
+async def test_a_cancelled_run_still_ends_what_it_opened():
+    """Cancellation is not an ``Exception``, so the error path cannot see it.
+
+    Unhandled, the run unwinds with no terminal event at all: the client is
+    left holding an open tool call on a stream that simply stops, and the
+    cancel is what the client asked for in the first place.
+    """
+    events = await collect_until(StubEntity(cancelled_mid_tool_call), run_input(), asyncio.CancelledError)
+
+    types = [event.type for event in events]
+    assert types[-2:] == [EventType.TOOL_CALL_END, EventType.RUN_ERROR]
+    assert events[-2].tool_call_id == "call_1"
+    assert "abandoning A2UI generation" in events[-1].message
+
+
+async def test_a_failure_finalizing_the_run_does_not_escape_or_skip_the_reset(caplog, monkeypatch):
+    """Cleanup runs on the way out of every run, including a healthy one.
+
+    Raising there hands ASGI an exception with the response already sent, and
+    it skips the rest of the block: the context variable stays set on a context
+    the server reuses, so the next run served on it reads this run's A2UI
+    inputs.
+    """
+
+    def a_stream_that_fails_to_close(**kwargs: Any) -> AsyncIterator[Any]:
+        async def events() -> AsyncIterator[Any]:
+            try:
+                yield RunStartedEvent(type=EventType.RUN_STARTED, thread_id="thread-1", run_id="run-1")
+                yield RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id="thread-1", run_id="run-1")
+            except GeneratorExit:
+                raise RuntimeError("finalizing the agent stream failed")
+
+        return events()
+
+    monkeypatch.setattr(
+        "agno.os.interfaces.agui.router.async_stream_agno_response_as_agui_events",
+        a_stream_that_fails_to_close,
+    )
+
+    stream = run_entity(StubEntity(one_text_chunk), run_input())  # type: ignore[arg-type]
+    # Far enough in that the stream is suspended and the token is set.
+    await stream.__anext__()
+    await stream.__anext__()
+
+    await stream.aclose()
+
+    assert current_a2ui_run.get() is None
+    assert "finalizing the agent stream failed" in caplog.text
+
+
+async def test_cleanup_survives_a_stream_finalized_in_another_context():
+    """An async generator borrows whatever context drives it, so the context the
+    A2UI inputs were set in is not always the one that finalizes the stream.
+
+    The token cannot be reset from here, and the reset raising would abandon
+    the rest of the cleanup. So the run still has to be finalized, which is
+    what a close that quietly gave up would also satisfy if nothing said what
+    finalizing means.
+    """
+    finalized = asyncio.Event()
+    run_seen_while_driving: List[Any] = []
+
+    async def one_text_chunk_then_finalize() -> AsyncIterator[Any]:
+        try:
+            run_seen_while_driving.append(current_a2ui_run.get())
+            yield RunContentEvent(content="Here you go.")
+        finally:
+            finalized.set()
+
+    stream = run_entity(StubEntity(one_text_chunk_then_finalize), run_input())  # type: ignore[arg-type]
+
+    async def start() -> None:
+        # Far enough in that the A2UI context variable has been set.
+        await stream.__anext__()
+        await stream.__anext__()
+
+    await asyncio.create_task(start())
+
+    await stream.aclose()
+
+    # The scenario, not just its outcome: the run was visible in the context
+    # that drove the stream and never in this one.
+    assert run_seen_while_driving and run_seen_while_driving[0] is not None
+    assert current_a2ui_run.get() is None
+    assert finalized.is_set()

--- a/libs/agno/tests/unit/os/interfaces/test_agui_a2ui_streaming.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_a2ui_streaming.py
@@ -1,0 +1,1440 @@
+"""Progressive painting of a generated A2UI surface.
+
+A client paints a generated surface from the render call's argument fragments as
+they arrive. The generation tool holds the agent's event stream open while its
+render subagent works, so those fragments need a channel of their own to get
+out; otherwise the surface only appears once generation has finished.
+"""
+
+import asyncio
+import json
+from contextvars import ContextVar
+from typing import Any, AsyncIterator, Dict, List, Optional
+
+import pytest
+
+pytest.importorskip("ag_ui", reason="ag_ui not installed")
+pytest.importorskip("ag_ui_a2ui_toolkit", reason="ag_ui_a2ui_toolkit not installed")
+
+from ag_ui_a2ui_toolkit import A2UI_SCHEMA_CONTEXT_DESCRIPTION, GENERATE_A2UI_TOOL_NAME  # noqa: E402
+
+from agno.agent import Agent  # noqa: E402
+from agno.models.response import ToolExecution  # noqa: E402
+from agno.os.app import AgentOS  # noqa: E402
+from agno.os.interfaces.agui import AGUI  # noqa: E402
+from agno.os.interfaces.agui.a2ui import (  # noqa: E402
+    RENDER_A2UI_TOOL_NAME,
+    A2UIRenderAttempt,
+    get_a2ui_tools,
+)
+from agno.os.interfaces.agui.a2ui_stream import (  # noqa: E402
+    A2UIRenderStream,
+    A2UIRun,
+    ToolPresence,
+    current_a2ui_run,
+    resolve_entity_tools,
+)
+from agno.os.interfaces.agui.handlers import (  # noqa: E402
+    RENDER_A2UI_TOOL_NAME_FALLBACK,
+    close_open_spans,
+    on_a2ui_render_stream,
+    process_event,
+)
+from agno.os.interfaces.agui.router import _track_spans, run_entity  # noqa: E402
+from agno.os.interfaces.agui.state import StreamState  # noqa: E402
+from agno.os.interfaces.agui.stream import async_stream_agno_response_as_agui_events  # noqa: E402
+from agno.run.agent import (  # noqa: E402
+    ReasoningStartedEvent,
+    RunCompletedEvent,
+    RunContentEvent,
+    RunEvent,
+    ToolCallStartedEvent,
+)
+from agno.tools.function import Function  # noqa: E402
+
+CATALOG_ID = "declarative-gen-ui-catalog"
+
+COMPONENTS = [
+    {"id": "root", "component": "Column", "children": ["title"]},
+    {"id": "title", "component": "Text", "text": "Quarterly sales"},
+]
+
+
+# =============================================================================
+# The channel itself
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_pushed_fragments_come_back_in_order():
+    stream = A2UIRenderStream()
+
+    stream.push({"kind": "start"})
+    stream.push({"kind": "args"})
+
+    assert stream.drain() == [{"kind": "start"}, {"kind": "args"}]
+    assert stream.drain() == []
+
+
+@pytest.mark.asyncio
+async def test_waiting_returns_as_soon_as_something_is_pushed():
+    stream = A2UIRenderStream()
+    waiter = asyncio.ensure_future(stream.wait())
+    await asyncio.sleep(0)
+
+    assert not waiter.done()
+
+    stream.push({"kind": "start"})
+    await asyncio.wait_for(waiter, 1)
+
+
+@pytest.mark.asyncio
+async def test_draining_rearms_the_wait():
+    stream = A2UIRenderStream()
+    stream.push({"kind": "start"})
+    stream.drain()
+
+    waiter = asyncio.ensure_future(stream.wait())
+    await asyncio.sleep(0)
+
+    assert not waiter.done()
+    waiter.cancel()
+
+
+# =============================================================================
+# Deciding whether a run needs the channel
+# =============================================================================
+
+
+def generation_answer(entity: Any) -> ToolPresence:
+    return resolve_entity_tools(entity).generates_a2ui()
+
+
+def test_an_agent_carrying_the_generation_tool_is_recognized():
+    class Stub:
+        assistant_message_role = "assistant"
+
+    agent = Agent(id="a", name="A", tools=[get_a2ui_tools({"model": Stub()})])
+
+    assert generation_answer(agent) is ToolPresence.PRESENT
+
+
+def test_an_agent_with_other_tools_is_not():
+    agent = Agent(id="a", name="A", tools=[Function(name="search_web", entrypoint=lambda: "")])
+
+    assert generation_answer(agent) is ToolPresence.ABSENT
+
+
+def test_an_agent_with_no_tools_is_not():
+    assert generation_answer(Agent(id="a", name="A")) is ToolPresence.ABSENT
+
+
+def test_tools_behind_a_factory_cannot_be_inspected():
+    """A callable is resolved by the agent later, so whether the run will
+    generate a surface is not knowable here.
+
+    Answered as "no", such a run painted its surface in one go with nothing
+    saying why, so the answer is its own value and this caller prepares a
+    channel on the maybe: an unread one costs the run nothing.
+    """
+
+    def build_tools():
+        return []
+
+    agent = Agent(id="a", name="A", tools=build_tools)
+
+    assert generation_answer(agent) is ToolPresence.UNKNOWN
+
+
+# =============================================================================
+# Translating fragments into events
+# =============================================================================
+
+
+def test_a_start_fragment_opens_a_nested_tool_call():
+    state = StreamState(thread_id="t", run_id="r")
+
+    events = on_a2ui_render_stream(
+        {"kind": "start", "tool_call_id": "inner", "tool_call_name": RENDER_A2UI_TOOL_NAME}, state
+    )
+
+    assert [event.type for event in events] == ["TOOL_CALL_START"]
+    assert events[0].tool_call_name == RENDER_A2UI_TOOL_NAME
+    assert "inner" in state.active_tool_call_ids
+
+
+def test_a_start_fragment_finishes_an_open_text_message_first():
+    state = StreamState(thread_id="t", run_id="r")
+    state.open_text_message()
+
+    events = on_a2ui_render_stream({"kind": "start", "tool_call_id": "inner"}, state)
+
+    assert [event.type for event in events] == ["TEXT_MESSAGE_END", "TOOL_CALL_START"]
+    assert state.text_message_open is False
+
+
+def test_argument_fragments_become_argument_events():
+    state = StreamState(thread_id="t", run_id="r")
+    on_a2ui_render_stream({"kind": "start", "tool_call_id": "inner"}, state)
+
+    events = on_a2ui_render_stream({"kind": "args", "tool_call_id": "inner", "delta": '{"a":'}, state)
+
+    assert [event.type for event in events] == ["TOOL_CALL_ARGS"]
+    assert events[0].delta == '{"a":'
+
+
+def test_an_empty_fragment_emits_nothing():
+    state = StreamState(thread_id="t", run_id="r")
+    on_a2ui_render_stream({"kind": "start", "tool_call_id": "inner"}, state)
+
+    assert on_a2ui_render_stream({"kind": "args", "tool_call_id": "inner", "delta": ""}, state) == []
+
+
+def test_arguments_for_a_call_that_was_never_started_are_dropped():
+    """Arguments only mean something for a call the client has been told about.
+
+    Every tool-call event names a call, and one the client never saw opened is
+    one it has nothing to attach the arguments to.
+    """
+    state = StreamState(thread_id="t", run_id="r")
+
+    assert on_a2ui_render_stream({"kind": "args", "tool_call_id": "inner", "delta": '{"a":'}, state) == []
+
+
+def test_arguments_arriving_after_the_call_ended_are_dropped():
+    """The end is the client's last word on that call.
+
+    A late fragment would reopen a call the client has already finished with,
+    which is the same hazard the end branch already guards against, from the
+    other side.
+    """
+    state = StreamState(thread_id="t", run_id="r")
+    on_a2ui_render_stream({"kind": "start", "tool_call_id": "inner"}, state)
+    on_a2ui_render_stream({"kind": "end", "tool_call_id": "inner"}, state)
+
+    assert on_a2ui_render_stream({"kind": "args", "tool_call_id": "inner", "delta": '{"late"'}, state) == []
+
+
+def test_an_end_fragment_closes_the_call_once():
+    state = StreamState(thread_id="t", run_id="r")
+    on_a2ui_render_stream({"kind": "start", "tool_call_id": "inner"}, state)
+
+    first = on_a2ui_render_stream({"kind": "end", "tool_call_id": "inner"}, state)
+    again = on_a2ui_render_stream({"kind": "end", "tool_call_id": "inner"}, state)
+
+    assert [event.type for event in first] == ["TOOL_CALL_END"]
+    assert again == []
+
+
+def test_an_end_for_a_call_that_never_started_is_dropped():
+    """An end names a call the client was told about.
+
+    One for a call it never saw opened is not merely useless: the client's
+    event verifier rejects it, and rejects it fatally, so the run loses every
+    event after it too.
+    """
+    state = StreamState(thread_id="t", run_id="r")
+
+    assert on_a2ui_render_stream({"kind": "end", "tool_call_id": "inner"}, state) == []
+    assert state.ended_tool_call_ids == set()
+
+
+@pytest.mark.parametrize("first_call_is", ["still open", "already ended"])
+def test_a_second_start_under_the_same_id_is_dropped(first_call_is):
+    """A wire id belongs to one call, and the client buffers arguments by it.
+
+    A second start under a spent id, whether a duplicate or an attempt reusing
+    a rejected one's id, appends this surface to the buffer the client still
+    holds for the other, so the two parse as one malformed object and neither
+    paints. Refused here, the first surface survives whole.
+    """
+    state = StreamState(thread_id="t", run_id="r")
+    on_a2ui_render_stream({"kind": "start", "tool_call_id": "inner"}, state)
+    if first_call_is == "already ended":
+        on_a2ui_render_stream({"kind": "end", "tool_call_id": "inner"}, state)
+
+    assert on_a2ui_render_stream({"kind": "start", "tool_call_id": "inner"}, state) == []
+
+    # The first call's own span is untouched, so it is still ended exactly once.
+    assert ("inner" in state.active_tool_call_ids) is (first_call_is == "still open")
+
+
+def test_a_fragment_without_a_call_id_is_dropped_without_touching_the_run():
+    """Dropped rather than raised, and dropped whole.
+
+    An id is mandatory on every tool-call event, so a fragment without one
+    cannot become an event at all: the choice is between dropping it and
+    tearing down a run whose generated surface still arrives as the tool
+    result, and dropping is the right one. What it must not do is half-apply
+    the fragment, so nothing is opened, closed or reparented on the way out.
+    """
+    state = StreamState(thread_id="t", run_id="r")
+    state.open_text_message()
+
+    assert on_a2ui_render_stream({"kind": "start", "delta": "x"}, state) == []
+    assert on_a2ui_render_stream({"kind": "args", "delta": "x"}, state) == []
+    assert on_a2ui_render_stream({"kind": "end"}, state) == []
+
+    assert state.active_tool_call_ids == set()
+    assert state.text_message_open is True
+
+
+def test_an_unknown_fragment_kind_is_ignored_and_the_call_still_works():
+    """The kinds are a closed set this package pushes to itself, so an unknown
+    one is a bug here rather than anything a client or a model sent. Ignoring
+    it keeps the rest of that call renderable, which is worth more than
+    refusing a whole surface over one fragment nobody can act on."""
+    state = StreamState(thread_id="t", run_id="r")
+    on_a2ui_render_stream({"kind": "start", "tool_call_id": "inner"}, state)
+
+    assert on_a2ui_render_stream({"kind": "something-new", "tool_call_id": "inner"}, state) == []
+
+    # The call it named is untouched, so the fragments around it still paint.
+    assert "inner" in state.active_tool_call_ids
+    assert [event.type for event in on_a2ui_render_stream({"kind": "end", "tool_call_id": "inner"}, state)] == [
+        "TOOL_CALL_END"
+    ]
+
+
+# =============================================================================
+# Interleaving with the agent's own events
+# =============================================================================
+
+
+async def _collect(stream: AsyncIterator[Any]) -> List[Any]:
+    return [event async for event in stream]
+
+
+@pytest.mark.asyncio
+async def test_a_run_without_generation_is_unaffected():
+    async def agent_events() -> AsyncIterator[Any]:
+        yield RunContentEvent(event=RunEvent.run_content.value, content="hello")
+        yield RunCompletedEvent()
+
+    events = await _collect(async_stream_agno_response_as_agui_events(agent_events(), thread_id="t", run_id="r"))
+
+    assert [event.type for event in events] == [
+        "TEXT_MESSAGE_START",
+        "TEXT_MESSAGE_CONTENT",
+        "TEXT_MESSAGE_END",
+        "RUN_FINISHED",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_fragments_pushed_while_the_agent_is_busy_are_emitted_before_it_resumes():
+    render_stream = A2UIRenderStream()
+    released = asyncio.Event()
+
+    async def agent_events() -> AsyncIterator[Any]:
+        yield RunContentEvent(event=RunEvent.run_content.value, content="working")
+        # Stand in for a generation tool: the agent produces nothing while its
+        # subagent streams.
+        render_stream.push({"kind": "start", "tool_call_id": "inner"})
+        render_stream.push({"kind": "args", "tool_call_id": "inner", "delta": "{"})
+        # Bounded: nothing releases this if the fragments are held back until
+        # the run moves on, and a suite that hangs reports nothing at all.
+        await asyncio.wait_for(released.wait(), 10)
+        render_stream.push({"kind": "end", "tool_call_id": "inner"})
+        yield RunCompletedEvent()
+
+    collected: List[Any] = []
+    source = async_stream_agno_response_as_agui_events(
+        agent_events(), thread_id="t", run_id="r", a2ui_render_stream=render_stream
+    )
+
+    async for event in source:
+        collected.append(event)
+        # The agent is blocked at this point, so seeing the fragment at all
+        # proves it did not have to wait for the run to move on.
+        if event.type == "TOOL_CALL_ARGS":
+            released.set()
+
+    assert [event.type for event in collected] == [
+        "TEXT_MESSAGE_START",
+        "TEXT_MESSAGE_CONTENT",
+        "TEXT_MESSAGE_END",
+        "TOOL_CALL_START",
+        "TOOL_CALL_ARGS",
+        "TOOL_CALL_END",
+        "RUN_FINISHED",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_fragments_pushed_at_the_very_end_are_not_lost():
+    render_stream = A2UIRenderStream()
+
+    async def agent_events() -> AsyncIterator[Any]:
+        yield RunCompletedEvent()
+        render_stream.push({"kind": "start", "tool_call_id": "inner"})
+
+    events = await _collect(
+        async_stream_agno_response_as_agui_events(
+            agent_events(), thread_id="t", run_id="r", a2ui_render_stream=render_stream
+        )
+    )
+
+    assert "TOOL_CALL_START" in [event.type for event in events]
+
+
+@pytest.mark.asyncio
+async def test_a_run_that_ends_mid_generation_closes_the_nested_call():
+    render_stream = A2UIRenderStream()
+
+    async def agent_events() -> AsyncIterator[Any]:
+        render_stream.push({"kind": "start", "tool_call_id": "inner"})
+        render_stream.push({"kind": "args", "tool_call_id": "inner", "delta": '{"partial"'})
+        yield RunCompletedEvent()
+
+    events = await _collect(
+        async_stream_agno_response_as_agui_events(
+            agent_events(), thread_id="t", run_id="r", a2ui_render_stream=render_stream
+        )
+    )
+
+    types = [event.type for event in events]
+    assert types == ["TOOL_CALL_START", "TOOL_CALL_ARGS", "TOOL_CALL_END", "RUN_FINISHED"]
+
+
+# =============================================================================
+# Carrying the run's context, and unwinding early
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_context_the_run_sets_survives_into_its_next_event():
+    """A run's context is its own: nothing about interleaving may discard it.
+
+    Every event of an A2UI-enabled run goes through the interleaving path, so a
+    context variable a tool sets while producing one event has to still be set
+    while producing the next, exactly as it is without interleaving.
+    """
+    marker: ContextVar[Optional[str]] = ContextVar("test_marker", default=None)
+    observed: List[Optional[str]] = []
+
+    async def agent_events() -> AsyncIterator[Any]:
+        marker.set("set-by-the-run")
+        yield RunContentEvent(event=RunEvent.run_content.value, content="working")
+        observed.append(marker.get())
+        yield RunCompletedEvent()
+
+    await _collect(
+        async_stream_agno_response_as_agui_events(
+            agent_events(), thread_id="t", run_id="r", a2ui_render_stream=A2UIRenderStream()
+        )
+    )
+
+    assert observed == ["set-by-the-run"]
+
+
+@pytest.mark.asyncio
+async def test_context_the_run_sets_survives_without_interleaving_too():
+    """The baseline the test above has to match."""
+    marker: ContextVar[Optional[str]] = ContextVar("test_marker_plain", default=None)
+    observed: List[Optional[str]] = []
+
+    async def agent_events() -> AsyncIterator[Any]:
+        marker.set("set-by-the-run")
+        yield RunContentEvent(event=RunEvent.run_content.value, content="working")
+        observed.append(marker.get())
+        yield RunCompletedEvent()
+
+    await _collect(async_stream_agno_response_as_agui_events(agent_events(), thread_id="t", run_id="r"))
+
+    assert observed == ["set-by-the-run"]
+
+
+@pytest.mark.asyncio
+async def test_a_client_leaving_mid_generation_finalizes_the_run():
+    """Closing the mapper has to leave the run finalized, not merely cancelled.
+
+    The response is abandoned while the generation tool still holds the run
+    open. Whatever the run does on the way out, such as recording that it was
+    cancelled, has to have happened by the time the mapper is closed: the
+    request is over and nothing else will drive it.
+    """
+    render_stream = A2UIRenderStream()
+    finalized = asyncio.Event()
+    tool_returns = asyncio.Event()
+
+    async def agent_events() -> AsyncIterator[Any]:
+        try:
+            render_stream.push({"kind": "start", "tool_call_id": "inner"})
+            await tool_returns.wait()
+            yield RunCompletedEvent()
+        finally:
+            finalized.set()
+
+    source = async_stream_agno_response_as_agui_events(
+        agent_events(), thread_id="t", run_id="r", a2ui_render_stream=render_stream
+    )
+
+    async for event in source:
+        if event.type == "TOOL_CALL_START":
+            break
+
+    await source.aclose()
+
+    assert finalized.is_set()
+
+
+@pytest.mark.asyncio
+async def test_a_client_leaving_between_events_closes_the_agent_stream():
+    """The same, with the run suspended at one of its own events.
+
+    Nothing is in flight here, so there is nothing to cancel: the agent's stream
+    has to be closed for its cleanup to run at all.
+    """
+    render_stream = A2UIRenderStream()
+    finalized = asyncio.Event()
+
+    async def agent_events() -> AsyncIterator[Any]:
+        try:
+            yield RunContentEvent(event=RunEvent.run_content.value, content="working")
+            yield RunCompletedEvent()
+        finally:
+            finalized.set()
+
+    source = async_stream_agno_response_as_agui_events(
+        agent_events(), thread_id="t", run_id="r", a2ui_render_stream=render_stream
+    )
+
+    async for event in source:
+        if event.type == "TEXT_MESSAGE_CONTENT":
+            break
+
+    await source.aclose()
+
+    assert finalized.is_set()
+
+
+@pytest.mark.asyncio
+async def test_fragments_are_flushed_when_the_run_fails():
+    """A failing run does not take the surface it already drew with it.
+
+    The run pushes its last fragment once the earlier one has reached the
+    client, so the fragment is buffered at the moment the failure surfaces.
+    """
+    render_stream = A2UIRenderStream()
+    first_fragment_arrived = asyncio.Event()
+
+    async def agent_events() -> AsyncIterator[Any]:
+        render_stream.push({"kind": "start", "tool_call_id": "inner"})
+        # Bounded for the same reason as the gate above.
+        await asyncio.wait_for(first_fragment_arrived.wait(), 10)
+        render_stream.push({"kind": "args", "tool_call_id": "inner", "delta": '{"partial"'})
+        raise RuntimeError("the run failed")
+        yield RunCompletedEvent()  # pragma: no cover
+
+    collected: List[Any] = []
+    source = async_stream_agno_response_as_agui_events(
+        agent_events(), thread_id="t", run_id="r", a2ui_render_stream=render_stream
+    )
+
+    with pytest.raises(RuntimeError, match="the run failed"):
+        async for event in source:
+            collected.append(event)
+            if event.type == "TOOL_CALL_START":
+                first_fragment_arrived.set()
+                # Hand the loop back so the run pushes its last fragment and fails.
+                await asyncio.sleep(0)
+
+    assert [event.type for event in collected] == ["TOOL_CALL_START", "TOOL_CALL_ARGS"]
+
+
+# =============================================================================
+# Over the wire, while the surface is still being generated
+# =============================================================================
+
+
+def _chunk(delta: Dict[str, Any]) -> Any:
+    from openai.types.chat import ChatCompletionChunk
+
+    return ChatCompletionChunk.model_validate(
+        {
+            "id": "c",
+            "object": "chat.completion.chunk",
+            "created": 0,
+            "model": "m",
+            "choices": [{"index": 0, "delta": delta, "finish_reason": None}],
+        }
+    )
+
+
+def _tool_call_frame(name: Optional[str], arguments: str, call_id: Optional[str] = None) -> Dict[str, Any]:
+    function: Dict[str, Any] = {"arguments": arguments}
+    if name is not None:
+        function["name"] = name
+    frame: Dict[str, Any] = {"index": 0, "function": function}
+    if call_id is not None:
+        frame["id"] = call_id
+        frame["type"] = "function"
+    return {"tool_calls": [frame]}
+
+
+async def post_agui(app: Any, body: Dict[str, Any], on_event: Any) -> Any:
+    """POST an AG-UI request and hand each event over as the server sends it.
+
+    The app is driven directly rather than through an HTTP client, because
+    httpx's ASGI transport runs the whole app before returning a response and
+    would hide the very thing under test.
+
+    A run reports its own failure in band, so the status code says only that
+    the response started. That check lives here rather than in each caller,
+    where it can be forgotten.
+    """
+    payload = json.dumps(body).encode()
+    request_sent = False
+    never = asyncio.Event()
+
+    async def receive() -> Dict[str, Any]:
+        nonlocal request_sent
+        if request_sent:
+            # The response watches this for a client disconnect and abandons the
+            # stream the moment one arrives, so stay silent instead.
+            await never.wait()
+        request_sent = True
+        return {"type": "http.request", "body": payload, "more_body": False}
+
+    received: List[Dict[str, Any]] = []
+    status: Dict[str, Any] = {}
+    buffered = b""
+
+    async def send(message: Dict[str, Any]) -> None:
+        nonlocal buffered
+        if message["type"] == "http.response.start":
+            status["code"] = message["status"]
+            return
+        if message["type"] != "http.response.body":
+            return
+        buffered += message.get("body", b"")
+        while b"\n\n" in buffered:
+            frame, buffered = buffered.split(b"\n\n", 1)
+            for line in frame.decode().split("\n"):
+                if line.startswith("data: "):
+                    event = json.loads(line[6:])
+                    received.append(event)
+                    on_event(event)
+
+    await app(
+        {
+            "type": "http",
+            "asgi": {"version": "3.0", "spec_version": "2.3"},
+            "http_version": "1.1",
+            "method": "POST",
+            "scheme": "http",
+            "path": "/agui",
+            "raw_path": b"/agui",
+            "query_string": b"",
+            "root_path": "",
+            "headers": [(b"host", b"test"), (b"content-type", b"application/json")],
+            "client": ("127.0.0.1", 1234),
+            "server": ("test", 80),
+        },
+        receive,
+        send,
+    )
+
+    errors = [event for event in received if event.get("type") == "RUN_ERROR"]
+    assert not errors, f"the run failed in band: {errors}"
+    return status.get("code"), received
+
+
+@pytest.mark.asyncio
+async def test_fragments_reach_the_client_before_generation_finishes():
+    """The regression net for progressive painting.
+
+    The render subagent stops after its first fragment and waits for the test to
+    confirm it arrived. If fragments were held back until the generation tool
+    returned, nothing would ever confirm it and the wait would time out.
+    """
+    pytest.importorskip("openai")
+    from agno.models.openai import OpenAIChat
+
+    first_fragment_arrived = asyncio.Event()
+    fragments = ['{"surfaceId": "sales", ', '"components": ', json.dumps(COMPONENTS), "}"]
+    turns = {"n": 0}
+
+    class PlannerModel(OpenAIChat):
+        async def ainvoke_stream(self, *args: Any, **kwargs: Any) -> AsyncIterator[Any]:  # type: ignore[override]
+            turns["n"] += 1
+            if turns["n"] == 1:
+                yield self._parse_provider_response_delta(
+                    _chunk(_tool_call_frame(GENERATE_A2UI_TOOL_NAME, "{}", call_id="outer"))
+                )
+            elif turns["n"] == 2:
+                yield self._parse_provider_response_delta(
+                    _chunk(_tool_call_frame(RENDER_A2UI_TOOL_NAME, "", call_id="inner"))
+                )
+                for index, fragment in enumerate(fragments):
+                    yield self._parse_provider_response_delta(_chunk(_tool_call_frame(None, fragment)))
+                    if index == 0:
+                        await asyncio.wait_for(first_fragment_arrived.wait(), 10)
+            else:
+                yield self._parse_provider_response_delta(_chunk({"content": "Rendered."}))
+
+    model = PlannerModel(id="m", api_key="x")
+    agent = Agent(
+        id="a2ui-agent",
+        name="A2UI Agent",
+        model=model,
+        tools=[get_a2ui_tools({"model": model})],
+    )
+    app = AgentOS(id="a2ui-os", agents=[agent], interfaces=[AGUI(agent=agent)]).get_app()
+
+    body = {
+        "threadId": "thread-1",
+        "runId": "run-1",
+        "state": None,
+        "messages": [{"id": "m1", "role": "user", "content": "show me a sales card"}],
+        "tools": [],
+        "context": [
+            {
+                "description": A2UI_SCHEMA_CONTEXT_DESCRIPTION,
+                "value": json.dumps({"catalogId": CATALOG_ID, "components": [{"name": "Column"}, {"name": "Text"}]}),
+            }
+        ],
+        "forwardedProps": {},
+    }
+
+    # The nested call is found by the tool it names, not by the provider's own
+    # id for it: every attempt is emitted under an id of its own, because a
+    # client buffers argument fragments per id and providers reuse theirs
+    # across attempts.
+    nested: Dict[str, str] = {}
+
+    def on_event(event: Dict[str, Any]) -> None:
+        if event.get("type") == "TOOL_CALL_START" and event.get("toolCallName") == RENDER_A2UI_TOOL_NAME:
+            nested["id"] = event["toolCallId"]
+        if event.get("type") == "TOOL_CALL_ARGS" and event.get("toolCallId") == nested.get("id"):
+            first_fragment_arrived.set()
+
+    status, received = await post_agui(app, body, on_event)
+
+    assert status == 200
+    types = [event.get("type") for event in received]
+    assert "RUN_ERROR" not in types
+
+    inner_id = nested["id"]
+    assert inner_id != "inner"
+    inner_args = [
+        event for event in received if event.get("type") == "TOOL_CALL_ARGS" and event.get("toolCallId") == inner_id
+    ]
+    assert len(inner_args) == len(fragments), "the surface must stream in pieces, not arrive whole"
+
+    # The client reads the catalog off the streamed arguments, so the first
+    # fragment has to name it.
+    streamed = [event["delta"] for event in inner_args]
+    assert f'"catalogId": "{CATALOG_ID}"' in streamed[0]
+    assert streamed[0].startswith("{")
+
+    # Named once here because this run renders once. The ids belong to the
+    # attempt rather than to the run, so a run that retries names them again
+    # on the next attempt; that is pinned by the retry test further down.
+    inner_starts = [
+        index
+        for index, event in enumerate(received)
+        if event.get("type") == "TOOL_CALL_START" and event.get("toolCallId") == inner_id
+    ]
+    assert len(inner_starts) == 1
+    assert sum("catalogId" in fragment for fragment in streamed) == 1
+
+    # The nested render call opens, and closes, while the generation call that
+    # produced it is still running: that is what progressive painting means,
+    # and the outer call's own ordering says nothing about it.
+    outer_start = next(
+        index
+        for index, event in enumerate(received)
+        if event.get("type") == "TOOL_CALL_START" and event.get("toolCallId") == "outer"
+    )
+    inner_end = next(
+        index
+        for index, event in enumerate(received)
+        if event.get("type") == "TOOL_CALL_END" and event.get("toolCallId") == inner_id
+    )
+    outer_result = next(index for index, event in enumerate(received) if event.get("type") == "TOOL_CALL_RESULT")
+    assert outer_start < inner_starts[0] < inner_end < outer_result
+
+    # The committed surface is the model's own, with the catalog stamped on.
+    envelope = json.loads(received[outer_result]["content"])
+    operations = {key: value for entry in envelope["a2ui_operations"] for key, value in entry.items()}
+    assert operations["createSurface"] == {"surfaceId": "sales", "catalogId": CATALOG_ID}
+    assert operations["updateComponents"]["components"] == COMPONENTS
+
+
+class _StubModel:
+    """Enough of a model to build a generation tool; never called."""
+
+    assistant_message_role = "assistant"
+
+
+class _EntityDrivenBy:
+    """The least an entity can be: ``run_entity`` only ever calls ``arun``.
+
+    ``tools`` carries a generation tool so the run takes the interleaving path,
+    which isolates the router's own drive site from the plain one above.
+    """
+
+    def __init__(self, stream: Any, tools: Optional[List[Any]] = None) -> None:
+        self._stream = stream
+        self.tools = tools
+
+    def arun(self, **kwargs: Any) -> Any:
+        return self._stream
+
+
+def _run_input() -> Any:
+    from ag_ui.core import RunAgentInput
+
+    return RunAgentInput.model_validate(
+        {
+            "threadId": "thread-1",
+            "runId": "run-1",
+            "state": None,
+            "messages": [{"id": "m1", "role": "user", "content": "show me a card"}],
+            "tools": [],
+            "context": [],
+            "forwardedProps": {},
+        }
+    )
+
+
+# =============================================================================
+# Closing what this package drives
+# =============================================================================
+
+
+class FinalizationProbe:
+    """An agent stream that records whether whoever drove it closed it.
+
+    Deliberately not an async generator: one left unreferenced is finalized by
+    the event loop's own hooks, which would make a source nobody closed
+    indistinguishable from a closed one. This object stays referenced by the
+    test for as long as the assertion needs it, and records only a close it was
+    actually asked for.
+    """
+
+    def __init__(self, chunks: List[Any], on_close: Optional[Any] = None) -> None:
+        self._chunks = list(chunks)
+        self._on_close = on_close
+        self.closed = False
+
+    def __aiter__(self) -> "FinalizationProbe":
+        return self
+
+    async def __anext__(self) -> Any:
+        if not self._chunks:
+            raise StopAsyncIteration
+        return self._chunks.pop(0)
+
+    async def aclose(self) -> None:
+        self.closed = True
+        if self._on_close is not None:
+            self._on_close()
+
+
+def two_events() -> List[Any]:
+    return [RunContentEvent(event=RunEvent.run_content.value, content="working"), RunCompletedEvent()]
+
+
+@pytest.mark.asyncio
+async def test_the_interleaving_path_closes_the_agent_stream_it_drove():
+    """The run's own cleanup runs only if whoever drove it closes it.
+
+    Iterating a stream never closes it, so a run left suspended is a run that
+    never finalized: a cancelled run goes unpersisted and whatever it held open
+    stays open.
+    """
+    probe = FinalizationProbe(two_events())
+
+    await _collect(
+        async_stream_agno_response_as_agui_events(
+            probe, thread_id="t", run_id="r", a2ui_render_stream=A2UIRenderStream()
+        )
+    )
+
+    assert probe.closed
+
+
+@pytest.mark.asyncio
+async def test_the_plain_path_closes_the_agent_stream_it_drove():
+    """The same, on the path a run without generation takes.
+
+    That is every ordinary AG-UI run, and it is the level whose own comment
+    promises the finalization.
+    """
+    probe = FinalizationProbe(two_events())
+
+    await _collect(async_stream_agno_response_as_agui_events(probe, thread_id="t", run_id="r"))
+
+    assert probe.closed
+
+
+@pytest.mark.asyncio
+async def test_a_client_leaving_closes_the_stream_the_router_drove():
+    """The outermost drive site, and the only one a real client reaches.
+
+    A client that goes away mid-run leaves the router's own generator to be
+    closed, and nothing passes that close on to the mapper, so neither the
+    mapper's cleanup nor the run's happens at all.
+    """
+    probe = FinalizationProbe(two_events())
+    entity = _EntityDrivenBy(probe, tools=[get_a2ui_tools({"model": _StubModel()})])
+    stream = run_entity(entity, _run_input())  # type: ignore[arg-type]
+
+    async for event in stream:
+        if event.type == "TEXT_MESSAGE_CONTENT":
+            break
+
+    await stream.aclose()
+
+    # Asserted with nothing awaited in between: an unreferenced generator is
+    # finalized by the loop, and that would answer the question for us.
+    assert probe.closed
+
+
+@pytest.mark.asyncio
+async def test_a_fragment_pushed_while_the_agent_stream_closes_is_not_lost():
+    """The last place a fragment can arrive from.
+
+    A source with cleanup of its own can push while it is being closed, which
+    is after the merge loop has already broken out. That is the only fragment
+    the drain past the loop can ever see.
+    """
+    render_stream = A2UIRenderStream()
+    probe = FinalizationProbe(
+        [RunCompletedEvent()],
+        on_close=lambda: render_stream.push({"kind": "start", "tool_call_id": "late"}),
+    )
+
+    events = await _collect(
+        async_stream_agno_response_as_agui_events(probe, thread_id="t", run_id="r", a2ui_render_stream=render_stream)
+    )
+
+    types = [event.type for event in events]
+    assert "TOOL_CALL_START" in types
+    assert types.index("TOOL_CALL_START") < types.index("RUN_FINISHED")
+
+
+# =============================================================================
+# Span lifecycle of the nested render call
+# =============================================================================
+
+
+def test_a_retry_paints_under_an_id_of_its_own():
+    """Each attempt mints its own wire id, so a retry never reopens a spent one.
+
+    The id is what a client buffers a surface under, which is why the identity
+    type owns it rather than the provider, whose call ids repeat across
+    attempts. Both spans are opened once and closed once.
+    """
+    state = StreamState(thread_id="t", run_id="r")
+
+    attempts = []
+    for call_id in (A2UIRenderAttempt.new().call_id, A2UIRenderAttempt.new().call_id):
+        collected = []
+        collected.extend(on_a2ui_render_stream({"kind": "start", "tool_call_id": call_id}, state))
+        collected.extend(on_a2ui_render_stream({"kind": "args", "tool_call_id": call_id, "delta": '{"bad"'}, state))
+        collected.extend(on_a2ui_render_stream({"kind": "end", "tool_call_id": call_id}, state))
+        attempts.append([event.type for event in collected])
+
+    assert attempts == [["TOOL_CALL_START", "TOOL_CALL_ARGS", "TOOL_CALL_END"]] * 2
+    assert state.active_tool_call_ids == set()
+    assert len(state.ended_tool_call_ids) == 2
+
+
+def test_the_nested_call_is_parented_to_the_message_the_generation_call_hangs_off():
+    """The render call belongs under the generation call that produced it.
+
+    Both hang off the same assistant message, which is the grouping a client
+    uses to show the surface as part of that turn rather than a turn of its own.
+    """
+    state = StreamState(thread_id="t", run_id="r")
+    state.open_text_message()
+    parent = state.text_message_id
+
+    events = on_a2ui_render_stream({"kind": "start", "tool_call_id": "inner"}, state)
+
+    start = next(event for event in events if event.type == "TOOL_CALL_START")
+    assert start.parent_message_id == parent
+
+
+def test_a_later_nested_call_still_parents_to_the_generation_call_s_message():
+    """The parent is recorded when the first nested call opens, not looked up.
+
+    The run goes on producing messages after the surface starts, and the id of
+    the message that is merely most recent is not the one the generation call
+    hangs off. Without the record the parent silently follows the newest
+    message, which regroups the surface under a turn that did not produce it.
+    """
+    state = StreamState(thread_id="t", run_id="r")
+    state.open_text_message()
+    generation_message = state.text_message_id
+
+    on_a2ui_render_stream({"kind": "start", "tool_call_id": "inner"}, state)
+    on_a2ui_render_stream({"kind": "end", "tool_call_id": "inner"}, state)
+    # A later message of the run's own, opened and closed.
+    state.open_text_message()
+    state.close_text_message()
+    assert state.text_message_id != generation_message
+
+    events = on_a2ui_render_stream({"kind": "start", "tool_call_id": "inner-2"}, state)
+
+    assert events[0].parent_message_id == generation_message
+
+
+def test_the_nested_call_reuses_the_parent_the_generation_call_was_given():
+    """The generation call's own parent is a message that is already closed."""
+    state = StreamState(thread_id="t", run_id="r")
+    state.set_pending_tool_calls_parent_id("outer-parent")
+
+    events = on_a2ui_render_stream({"kind": "start", "tool_call_id": "inner"}, state)
+
+    assert events[0].parent_message_id == "outer-parent"
+
+
+def test_a_nested_call_with_no_parent_invents_no_message():
+    """Nothing is fabricated when no parent is known: the field is optional, and
+    an assistant message the run never produced is worse than an absent id."""
+    state = StreamState(thread_id="t", run_id="r")
+
+    events = on_a2ui_render_stream({"kind": "start", "tool_call_id": "inner"}, state)
+
+    assert [event.type for event in events] == ["TOOL_CALL_START"]
+    assert events[0].parent_message_id is None
+
+
+def test_the_fallback_tool_name_is_the_toolkits_own():
+    """A fragment carrying no name still has to be named what the toolkit calls
+    the render tool, and this pins the literal to it."""
+    assert RENDER_A2UI_TOOL_NAME_FALLBACK == RENDER_A2UI_TOOL_NAME
+
+    state = StreamState(thread_id="t", run_id="r")
+    events = on_a2ui_render_stream({"kind": "start", "tool_call_id": "inner"}, state)
+
+    assert events[0].tool_call_name == RENDER_A2UI_TOOL_NAME
+
+
+def test_a_failed_run_closes_spans_through_the_public_surface():
+    """The router has to close what a failed run left open, so closing is part
+    of this module's interface rather than a private helper reached across it."""
+    from agno.os.interfaces.agui import router as agui_router
+
+    assert agui_router.close_open_spans is close_open_spans
+
+
+# =============================================================================
+# The two span tallies, side by side
+# =============================================================================
+
+
+def a_render_call_started_again_under_a_spent_id(state: StreamState) -> List[Any]:
+    """A render call, ended, then a start under the same id, which is refused."""
+    return (
+        on_a2ui_render_stream({"kind": "start", "tool_call_id": "inner"}, state)
+        + on_a2ui_render_stream({"kind": "end", "tool_call_id": "inner"}, state)
+        + on_a2ui_render_stream({"kind": "start", "tool_call_id": "inner"}, state)
+    )
+
+
+def a_reasoning_session_left_open(state: StreamState) -> List[Any]:
+    return process_event(ReasoningStartedEvent(event=RunEvent.reasoning_started.value), state)
+
+
+def a_render_call_inside_the_generation_call(state: StreamState) -> List[Any]:
+    return process_event(
+        ToolCallStartedEvent(
+            event=RunEvent.tool_call_started.value,
+            tool=ToolExecution(tool_call_id="outer", tool_name=GENERATE_A2UI_TOOL_NAME, tool_args={}),
+        ),
+        state,
+    ) + on_a2ui_render_stream({"kind": "start", "tool_call_id": "inner"}, state)
+
+
+def a_text_message_reopened_after_a_render_call(state: StreamState) -> List[Any]:
+    return (
+        process_event(RunContentEvent(event=RunEvent.run_content.value, content="working"), state)
+        + on_a2ui_render_stream({"kind": "start", "tool_call_id": "inner"}, state)
+        + process_event(RunContentEvent(event=RunEvent.run_content.value, content="more"), state)
+    )
+
+
+SPAN_SEQUENCES: Dict[str, Any] = {
+    "a-render-call-started-again-under-a-spent-id": a_render_call_started_again_under_a_spent_id,
+    "a-reasoning-session-left-open": a_reasoning_session_left_open,
+    "a-render-call-inside-the-generation-call": a_render_call_inside_the_generation_call,
+    "a-text-message-reopened-after-a-render-call": a_text_message_reopened_after_a_render_call,
+}
+
+
+def closing_shape(state: StreamState) -> List[Any]:
+    """What closing this tally's open spans would emit, by type and subject."""
+    return [
+        (
+            type(event).__name__,
+            getattr(event, "tool_call_id", None) or getattr(event, "message_id", None),
+        )
+        for event in close_open_spans(state)
+    ]
+
+
+@pytest.mark.parametrize("sequence", list(SPAN_SEQUENCES), ids=list(SPAN_SEQUENCES))
+def test_both_span_tallies_would_close_the_same_spans(sequence):
+    """There is one event-to-span transition function, and there are two.
+
+    The mapper keeps a tally for the events it emits, and the router keeps a
+    second one because the mapper's goes out of scope when a run raises. Only
+    the router's runs on the failure path, so a rule added to the mapper and
+    not mirrored costs the client a span that stays open past RUN_ERROR, which
+    is terminal.
+    """
+    drive = SPAN_SEQUENCES[sequence]
+
+    mapper_tally = StreamState(thread_id="t", run_id="r")
+    emitted = drive(mapper_tally)
+
+    router_tally = StreamState()
+    for event in emitted:
+        _track_spans(event, router_tally)
+
+    assert closing_shape(router_tally) == closing_shape(mapper_tally)
+
+
+# =============================================================================
+# A retried surface, over the channel
+# =============================================================================
+
+
+class _ScriptedRenderModel:
+    """A model whose render turns are scripted, streamed as a provider streams.
+
+    One entry per subagent turn, each a dict of render arguments. The call id is
+    reused across turns, which is what a provider that numbers its calls per
+    turn does, and what makes the second attempt indistinguishable from the
+    first to anything keying on the id alone.
+    """
+
+    assistant_message_role = "assistant"
+
+    def __init__(self, script: List[Dict[str, Any]]) -> None:
+        self.script = list(script)
+        self.calls: List[str] = []
+
+    async def aprocess_response_stream(self, **kwargs: Any) -> AsyncIterator[Any]:
+        self.calls.append(kwargs["messages"][0].content)
+        payload = json.dumps(self.script.pop(0))
+        yield _delta(name=RENDER_A2UI_TOOL_NAME, arguments="", call_id="inner")
+        for start in range(0, len(payload), 24):
+            yield _delta(arguments=payload[start : start + 24])
+
+
+def _delta(name: Optional[str] = None, arguments: str = "", call_id: Optional[str] = None, index: int = 0) -> Any:
+    function = type("Fn", (), {"name": name, "arguments": arguments})()
+    entry = type("Entry", (), {"function": function, "index": index, "id": call_id})()
+    return type("Delta", (), {"tool_calls": [entry]})()
+
+
+INVALID_COMPONENTS = [{"id": "orphan", "component": "Text", "text": "nowhere"}]
+
+
+@pytest.mark.asyncio
+async def test_a_rejected_surface_is_retried_as_a_second_call_on_the_channel():
+    """Recovery and interleaving together, which is the combination that hides
+    an unbalanced span: each attempt owes the client a call of its own, and the
+    run goes on emitting its own events afterwards, so an end left off the
+    first attempt shows up as a tool call still open under the next message.
+    """
+    model = _ScriptedRenderModel(
+        [
+            {"surfaceId": "sales", "components": INVALID_COMPONENTS},
+            {"surfaceId": "sales", "components": COMPONENTS},
+        ]
+    )
+    tool = get_a2ui_tools({"model": model, "default_catalog_id": CATALOG_ID})
+    render_stream = A2UIRenderStream()
+    run = A2UIRun(render_stream=render_stream)
+    committed: List[Dict[str, Any]] = []
+
+    async def agent_events() -> AsyncIterator[Any]:
+        token = current_a2ui_run.set(run)
+        try:
+            committed.append(json.loads(await tool.entrypoint(run_context=None)))
+        finally:
+            current_a2ui_run.reset(token)
+        yield RunContentEvent(event=RunEvent.run_content.value, content="Rendered.")
+        yield RunCompletedEvent()
+
+    events = await _collect(
+        async_stream_agno_response_as_agui_events(
+            agent_events(), thread_id="t", run_id="r", a2ui_render_stream=render_stream
+        )
+    )
+
+    types = [event.type for event in events]
+    assert len(model.calls) == 2
+    # Two calls, each opened and ended, and both finished before the run's own
+    # next message: no span outlives the attempt that opened it.
+    assert types.count("TOOL_CALL_START") == 2
+    assert types.count("TOOL_CALL_END") == 2
+    assert [kind for kind in types if kind != "TOOL_CALL_ARGS"] == [
+        "TOOL_CALL_START",
+        "TOOL_CALL_END",
+        "TOOL_CALL_START",
+        "TOOL_CALL_END",
+        "TEXT_MESSAGE_START",
+        "TEXT_MESSAGE_CONTENT",
+        "TEXT_MESSAGE_END",
+        "RUN_FINISHED",
+    ]
+
+    # Both attempts streamed to the client, each carrying the catalog once: the
+    # client paints from the arguments alone and has no other source for it.
+    streamed = [event.delta for event in events if event.type == "TOOL_CALL_ARGS"]
+    assert sum("catalogId" in fragment for fragment in streamed) == 2
+
+    # Only the surface that passed validation is committed as the result.
+    operations = {key: value for entry in committed[0]["a2ui_operations"] for key, value in entry.items()}
+    assert operations["updateComponents"]["components"] == COMPONENTS
+    assert operations["createSurface"] == {"surfaceId": "sales", "catalogId": CATALOG_ID}
+
+
+# =============================================================================
+# The identity of one render attempt, painted against committed
+# =============================================================================
+
+
+class _TurnScriptedModel:
+    """A model whose whole turns are scripted, streamed as a provider streams.
+
+    One entry per subagent turn, each already a list of frames, so a turn can
+    carry more than one render call.
+    """
+
+    assistant_message_role = "assistant"
+
+    def __init__(self, turns: List[List[Any]]) -> None:
+        self.turns = list(turns)
+        self.calls: List[str] = []
+
+    async def aprocess_response_stream(self, **kwargs: Any) -> AsyncIterator[Any]:
+        self.calls.append(kwargs["messages"][0].content)
+        for frame in self.turns.pop(0):
+            yield frame
+
+
+def render_call_frames(payload: Dict[str, Any], call_id: str, index: int = 0) -> List[Any]:
+    """One render call, streamed the way an OpenAI-compatible provider streams it."""
+    body = json.dumps(payload)
+    frames = [_delta(name=RENDER_A2UI_TOOL_NAME, arguments="", call_id=call_id, index=index)]
+    for start in range(0, len(body), 24):
+        frames.append(_delta(arguments=body[start : start + 24], index=index))
+    return frames
+
+
+def prior_surface_message(surface_id: str, catalog_id: str = CATALOG_ID) -> Any:
+    """A tool result carrying an already-rendered surface, as history replays it."""
+    envelope = json.dumps(
+        {
+            "a2ui_operations": [
+                {"version": "v0.9", "createSurface": {"surfaceId": surface_id, "catalogId": catalog_id}},
+                {"version": "v0.9", "updateComponents": {"surfaceId": surface_id, "components": COMPONENTS}},
+            ]
+        }
+    )
+    return type("Msg", (), {"role": "tool", "content": envelope, "tool_calls": None})()
+
+
+async def generate_over_the_channel(tool: Any, run: Any, **kwargs: Any) -> Any:
+    """Run one generation with a real channel attached.
+
+    Returns the AG-UI events the client would have received and the envelope
+    the run committed, which is the pair the identity of an attempt has to
+    agree across.
+    """
+    committed: Dict[str, Any] = {}
+
+    async def agent_events() -> AsyncIterator[Any]:
+        token = current_a2ui_run.set(run)
+        try:
+            committed["envelope"] = json.loads(await tool.entrypoint(run_context=None, **kwargs))
+        finally:
+            current_a2ui_run.reset(token)
+        yield RunCompletedEvent()
+
+    events = await _collect(
+        async_stream_agno_response_as_agui_events(
+            agent_events(), thread_id="t", run_id="r", a2ui_render_stream=run.render_stream
+        )
+    )
+    return events, committed["envelope"]
+
+
+def painted_attempts(events: List[Any]) -> List[Dict[str, Any]]:
+    """Each render attempt as a progressively painting client reassembles it.
+
+    Buffered per wire call id, because that is the key the AG-UI reducer
+    buffers on: two attempts sharing an id are one buffer holding both sets of
+    arguments, which parses as nothing and paints nothing.
+    """
+    order: List[str] = []
+    buffers: Dict[str, str] = {}
+    starts: Dict[str, int] = {}
+    for event in events:
+        if event.type == "TOOL_CALL_START":
+            if event.tool_call_id not in order:
+                order.append(event.tool_call_id)
+                buffers[event.tool_call_id] = ""
+            starts[event.tool_call_id] = starts.get(event.tool_call_id, 0) + 1
+        elif event.type == "TOOL_CALL_ARGS":
+            buffers[event.tool_call_id] += event.delta
+    return [{"call_id": call_id, "starts": starts[call_id], "args": buffers[call_id]} for call_id in order]
+
+
+def committed_operations(envelope: Dict[str, Any]) -> Dict[str, Any]:
+    return {key: value for entry in envelope["a2ui_operations"] for key, value in entry.items()}
+
+
+def client_catalog_state(catalog_id: str = CATALOG_ID) -> Dict[str, Any]:
+    """Run state carrying the catalog the client registered, as the router builds it.
+
+    Supplied through state rather than configured on the tool, because that is
+    where a served run's catalog comes from and it is the only arrangement in
+    which the precedence between the two is load-bearing.
+    """
+    return {
+        "ag-ui": {
+            "context": [],
+            "a2ui_schema": json.dumps({"catalogId": catalog_id, "components": [{"name": "Column"}, {"name": "Text"}]}),
+        }
+    }
+
+
+def a_create_case() -> Any:
+    model = _TurnScriptedModel([render_call_frames({"surfaceId": "sales", "components": COMPONENTS}, "inner")])
+    tool = get_a2ui_tools({"model": model})
+    run = A2UIRun(render_stream=A2UIRenderStream(), state=client_catalog_state())
+    return tool, run, {}, "sales", CATALOG_ID, 1
+
+
+def an_update_case() -> Any:
+    """The model names a surface of its own while editing another.
+
+    ``target_surface_id`` decides which surface is edited, so the id the model
+    happened to write is not the one the operation carries.
+    """
+    model = _TurnScriptedModel([render_call_frames({"surfaceId": "ignored", "components": COMPONENTS}, "inner")])
+    tool = get_a2ui_tools({"model": model})
+    run = A2UIRun(
+        render_stream=A2UIRenderStream(),
+        state=client_catalog_state(),
+        messages=[prior_surface_message("sales")],
+    )
+    return tool, run, {"intent": "update", "target_surface_id": "sales"}, "sales", CATALOG_ID, 1
+
+
+def a_prior_surface_in_another_catalog_case() -> Any:
+    """The surface being edited was registered in a catalog of its own.
+
+    A client resolves an update's components against the catalog the surface
+    was created under, so the fragments have to name that one and not the
+    catalog this run happens to resolve.
+    """
+    model = _TurnScriptedModel([render_call_frames({"surfaceId": "ignored", "components": COMPONENTS}, "inner")])
+    tool = get_a2ui_tools({"model": model})
+    run = A2UIRun(
+        render_stream=A2UIRenderStream(),
+        state=client_catalog_state(),
+        messages=[prior_surface_message("sales", catalog_id="a-catalog-of-its-own")],
+    )
+    return tool, run, {"intent": "update", "target_surface_id": "sales"}, "sales", "a-catalog-of-its-own", 1
+
+
+def a_retry_then_heal_case() -> Any:
+    """A rejected attempt and the one that healed it, under one provider id.
+
+    Both are painted, because painting an attempt while it is written is the
+    feature and what keeps the rejected one off the screen is the client's own
+    paint gate. What the two attempts may not share is a wire id.
+    """
+    model = _TurnScriptedModel(
+        [
+            render_call_frames({"surfaceId": "sales", "components": INVALID_COMPONENTS}, "inner"),
+            render_call_frames({"surfaceId": "sales", "components": COMPONENTS}, "inner"),
+        ]
+    )
+    tool = get_a2ui_tools({"model": model})
+    run = A2UIRun(render_stream=A2UIRenderStream(), state=client_catalog_state())
+    return tool, run, {}, "sales", CATALOG_ID, 2
+
+
+def two_render_calls_in_one_turn_case() -> Any:
+    """One turn, two render calls, and the turn keeps the first.
+
+    The client has painted the first by the time the second arrives and only
+    one surface is committed, so committing the second would leave the first
+    on screen with nothing behind it. The second is refused instead, which is
+    also the only order in which the painted surface and the committed one can
+    agree without unpainting anything.
+    """
+    model = _TurnScriptedModel(
+        [
+            render_call_frames({"surfaceId": "first", "components": COMPONENTS}, "c1", index=0)
+            + render_call_frames({"surfaceId": "second", "components": COMPONENTS}, "c2", index=1)
+        ]
+    )
+    tool = get_a2ui_tools({"model": model})
+    run = A2UIRun(render_stream=A2UIRenderStream(), state=client_catalog_state())
+    return tool, run, {}, "first", CATALOG_ID, 1
+
+
+IDENTITY_CASES: Dict[str, Any] = {
+    "create": a_create_case,
+    "update-with-a-prior-surface": an_update_case,
+    "the-prior-surface-is-in-another-catalog": a_prior_surface_in_another_catalog_case,
+    "retry-then-heal": a_retry_then_heal_case,
+    "two-render-calls-in-one-turn": two_render_calls_in_one_turn_case,
+}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", list(IDENTITY_CASES), ids=list(IDENTITY_CASES))
+async def test_the_surface_painted_is_the_surface_committed(case):
+    """The identity of a render attempt, asserted across the two sites that choose it.
+
+    Wire call id, surface id and catalog id are each computed once where the
+    fragments are emitted and again where the envelope is built, from different
+    precedence chains, and nothing requires the two to agree. Every
+    disagreement so far has looked the same from the server: the run logs
+    success and the client paints nothing, or paints a surface it then cannot
+    reconcile with the one it is told to keep.
+
+    A generation paints every attempt it makes, which is the whole point of
+    streaming one, and what keeps a rejected attempt off the screen is the
+    client's own paint gate. So the surface the run commits is the last one
+    painted, and the agreement asserted here is with that attempt: each has a
+    wire id of its own, opened once, because two attempts sharing one leave
+    the client holding both sets of arguments in a single buffer, which parses
+    as neither.
+    """
+    tool, run, kwargs, surface_id, catalog_id, painted_count = IDENTITY_CASES[case]()
+
+    events, envelope = await generate_over_the_channel(tool, run, **kwargs)
+    attempts = painted_attempts(events)
+
+    # One wire id per attempt, opened once.
+    assert [attempt["starts"] for attempt in attempts] == [1] * len(attempts)
+    assert len({attempt["call_id"] for attempt in attempts}) == len(attempts)
+
+    # The attempt the envelope commits is the last one painted, and it names
+    # the surface and catalog the envelope does.
+    assert len(attempts) == painted_count
+    painted = json.loads(attempts[-1]["args"])
+    assert (painted.get("surfaceId"), painted.get("catalogId")) == (surface_id, catalog_id)
+
+    operations = committed_operations(envelope)
+    created = operations.get("createSurface") or {}
+    updated = operations.get("updateComponents") or {}
+    assert (created.get("surfaceId") or updated.get("surfaceId")) == surface_id
+    if created:
+        assert created["catalogId"] == catalog_id

--- a/libs/agno/tests/unit/os/interfaces/test_agui_router.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_router.py
@@ -1,14 +1,20 @@
+import json
 import logging
+from typing import Any, List, Optional
 from unittest.mock import MagicMock
 
 import pytest
 
 pytest.importorskip("ag_ui", reason="ag_ui not installed")
 
-from ag_ui.core import EventType
+from ag_ui.core import EventType, RunAgentInput
 from ag_ui.core.types import Tool as AGUITool
 
+from agno.agent import Agent
 from agno.agent.remote import RemoteAgent
+from agno.db.sqlite import SqliteDb
+from agno.models.base import Model
+from agno.models.response import ModelResponse, ModelResponseEvent
 from agno.os.interfaces.agui.router import run_entity
 from agno.team.remote import RemoteTeam
 
@@ -218,3 +224,245 @@ async def test_run_entity_remote_agent_warns_and_drops_client_tools(caplog):
     assert "run_context" not in captured
     assert any("client tools are not forwarded" in record.message for record in caplog.records)
     assert events[-1].type == EventType.RUN_FINISHED
+
+
+# =============================================================================
+# Routing a trailing tool result: resume versus fresh turn
+# =============================================================================
+
+CLICK_TOOL_NAME = "log_a2ui_event"
+CLICK_RESULT = (
+    'User performed action "bookHotel" on surface "luxury-hotels" '
+    '(component: hotel-card). Context: {"hotelName":"The Ritz-Carlton"}'
+)
+STALE_USER_TURN = "Show me three luxury hotels as cards, each with a Book button."
+
+
+class ScriptedModel(Model):
+    """Offline model that records the messages each turn was handed.
+
+    Script entries are one turn each: ``("tool", name, args, call_id)`` or
+    ``("content", text)``. The recorded turns are where an input the interface
+    built for the model can be read back.
+    """
+
+    def __init__(self, script: List[tuple]):
+        super().__init__(id="m-scripted", name="m-scripted", provider="test")
+        self._script = list(script)
+        self._i = 0
+        self.turns: List[List[Any]] = []
+
+    def _next(self, kwargs: dict) -> ModelResponse:
+        self.turns.append(list(kwargs.get("messages") or []))
+        turn = self._script[min(self._i, len(self._script) - 1)]
+        self._i += 1
+        if turn[0] == "tool":
+            _, name, args, call_id = turn
+            response = ModelResponse(role="assistant")
+            response.tool_calls = [
+                {"id": call_id, "type": "function", "function": {"name": name, "arguments": json.dumps(args)}}
+            ]
+            return response
+        response = ModelResponse(content=turn[1], role="assistant")
+        response.event = ModelResponseEvent.assistant_response.value
+        return response
+
+    def invoke(self, *args: Any, **kwargs: Any):
+        return self._next(kwargs)
+
+    async def ainvoke(self, *args: Any, **kwargs: Any):
+        return self._next(kwargs)
+
+    def invoke_stream(self, *args: Any, **kwargs: Any):
+        yield self._next(kwargs)
+
+    async def ainvoke_stream(self, *args: Any, **kwargs: Any):
+        yield self._next(kwargs)
+
+    def parse_provider_response(self, response: Any, **kwargs: Any) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+    def parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+    def _parse_provider_response(self, response: Any, **kwargs: Any) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+
+def surface_action_input(session_id: str, tool_call_id: str = "767065f4-7cc3-42d4") -> Any:
+    """The request an A2UI surface-action click sends.
+
+    Shape taken from a captured click: no new user message, and a trailing tool
+    result for a tool call the client minted, which the backend never emitted
+    and was never offered in ``tools``.
+    """
+    return RunAgentInput.model_validate(
+        {
+            "threadId": session_id,
+            "runId": "click-run",
+            "state": None,
+            "messages": [
+                {"id": "u1", "role": "user", "content": STALE_USER_TURN},
+                {"id": "a1", "role": "assistant", "content": "Here are three luxury hotel options."},
+                {
+                    "id": "a2",
+                    "role": "assistant",
+                    "toolCalls": [
+                        {
+                            "id": tool_call_id,
+                            "type": "function",
+                            "function": {"name": CLICK_TOOL_NAME, "arguments": json.dumps({"name": "bookHotel"})},
+                        }
+                    ],
+                },
+                {"id": "t1", "role": "tool", "toolCallId": tool_call_id, "content": CLICK_RESULT},
+            ],
+            "tools": [
+                {
+                    "name": "render_a2ui",
+                    "description": "Render an A2UI surface.",
+                    "parameters": {"type": "object", "properties": {}},
+                }
+            ],
+            "context": [],
+            "forwardedProps": {"a2uiAction": {"userAction": {"name": "bookHotel"}}},
+        }
+    )
+
+
+def user_turn_input(session_id: str, content: str) -> Any:
+    return RunAgentInput.model_validate(
+        {
+            "threadId": session_id,
+            "runId": "turn-run",
+            "state": None,
+            "messages": [{"id": "u1", "role": "user", "content": content}],
+            "tools": [],
+            "context": [],
+            "forwardedProps": {},
+        }
+    )
+
+
+def echoed_confirmation_input(session_id: str, tool_call_id: str) -> Any:
+    """A HITL answer: the client echoes back the tool call id the backend paused on."""
+    return RunAgentInput.model_validate(
+        {
+            "threadId": session_id,
+            "runId": "resume-run",
+            "state": None,
+            "messages": [
+                {"id": "u1", "role": "user", "content": "Email a@example.com"},
+                {
+                    "id": "a1",
+                    "role": "assistant",
+                    "toolCalls": [
+                        {
+                            "id": tool_call_id,
+                            "type": "function",
+                            "function": {"name": "send_email", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {
+                    "id": "t1",
+                    "role": "tool",
+                    "toolCallId": tool_call_id,
+                    "content": json.dumps({"accepted": True}),
+                },
+            ],
+            "tools": [],
+            "context": [],
+            "forwardedProps": {},
+        }
+    )
+
+
+def build_agent(tmp_path: Any, script: List[tuple], tools: Optional[List[Any]] = None) -> Any:
+    db = SqliteDb(db_file=str(tmp_path / "agui_routing.db"))
+    return Agent(
+        id="routing-agent",
+        name="Routing Agent",
+        model=ScriptedModel(script),
+        db=db,
+        tools=tools,
+        telemetry=False,
+    )
+
+
+def turn_text(model: ScriptedModel) -> str:
+    """Everything the model was given on its last turn, flattened."""
+    return "\n".join(f"{getattr(m, 'role', '')}: {getattr(m, 'content', '') or ''}" for m in model.turns[-1])
+
+
+@pytest.mark.asyncio
+async def test_a_tool_result_nothing_paused_on_runs_a_fresh_turn(tmp_path):
+    """A surface-action click is not a resume, and must not be routed as one."""
+    agent = build_agent(tmp_path, [("content", "Booked.")])
+    session_id = "s-click"
+
+    async for _ in run_entity(agent, user_turn_input(session_id, STALE_USER_TURN)):
+        pass
+
+    events = [event async for event in run_entity(agent, surface_action_input(session_id))]
+    types = [event.type for event in events]
+
+    assert EventType.RUN_ERROR not in types, [event.message for event in events if event.type == EventType.RUN_ERROR]
+    assert types[-1] == EventType.RUN_FINISHED
+
+
+@pytest.mark.asyncio
+async def test_a_tool_result_nothing_paused_on_reaches_the_model(tmp_path):
+    """The click is what is new in the turn, so the stale user message must not stand in for it."""
+    agent = build_agent(tmp_path, [("content", "Booked.")])
+    session_id = "s-click-input"
+
+    async for _ in run_entity(agent, user_turn_input(session_id, STALE_USER_TURN)):
+        pass
+    async for _ in run_entity(agent, surface_action_input(session_id)):
+        pass
+
+    text = turn_text(agent.model)
+    assert "bookHotel" in text
+    assert "The Ritz-Carlton" in text
+    # The stale turn is already answered and belongs to history, not to this input.
+    assert f"user: {STALE_USER_TURN}" not in text
+
+
+@pytest.mark.asyncio
+async def test_an_echoed_pause_still_resumes_the_paused_run(tmp_path):
+    """HITL echoes an id the backend paused on, so a paused run does match and is continued."""
+    from agno.run.base import RunStatus
+    from agno.tools import tool as tool_decorator
+
+    @tool_decorator(requires_confirmation=True)
+    def send_email(to: str) -> str:
+        return f"Email sent to {to}"
+
+    agent = build_agent(
+        tmp_path,
+        [("tool", "send_email", {"to": "a@example.com"}, "tc-send"), ("content", "Email sent.")],
+        tools=[send_email],
+    )
+    session_id = "s-hitl"
+
+    async for _ in run_entity(agent, user_turn_input(session_id, "Email a@example.com")):
+        pass
+
+    session = agent.db.get_session(session_id=session_id, session_type="agent")
+    paused = [run for run in (session.runs or []) if run.status == RunStatus.paused]
+    assert len(paused) == 1, "expected the send_email confirmation to pause the run"
+    paused_run_id = paused[0].run_id
+
+    events = [event async for event in run_entity(agent, echoed_confirmation_input(session_id, "tc-send"))]
+    types = [event.type for event in events]
+
+    assert EventType.RUN_ERROR not in types, [event.message for event in events if event.type == EventType.RUN_ERROR]
+    session = agent.db.get_session(session_id=session_id, session_type="agent")
+    resumed = next(run for run in (session.runs or []) if run.run_id == paused_run_id)
+    assert resumed.status == RunStatus.completed
+    # A resume continues the paused run; it never fabricates a turn out of the answer.
+    assert "Result of the send_email tool call" not in turn_text(agent.model)


### PR DESCRIPTION
## What it is
- Agno's AG-UI interface can now serve A2UI: client publishes a component catalog, agent replies with a tree from it, client renders it
- One optional setting on the interface constructor: `a2ui={...}`
- Two cookbook examples: generated surface, hand-authored surface

## The four capabilities
- Auto-injected generation tool, per run, opt-out-able by the client
- Progressive streaming: as soon as a block of the interface is written, it is on screen
- Bad generations retried; when retries run out, a clean failure that leaves an already-good surface untouched
- Design happens in one forced model turn, not a nested agent run (an agent loop keeps rendering and never returns)

## Dependency
- Needs `ag-ui-a2ui-toolkit`, added to the existing `agui` extra, gated to Python 3.10+
- The gate is not cosmetic: toolkit needs 3.10, Agno supports 3.9, ungated makes `agno[agui]` uninstallable there
- Lazy import, so AG-UI without A2UI never pulls it in

## Also fixes a pre-existing bug
- A tool result from the client with nothing paused to receive it killed the run
- Resume was decided by "conversation ends with a tool result", which is exactly what a button on a rendered card sends, so every click errored
- Now decided by whether anything is actually waiting on that id; if not, the click is just the next user turn
- Human-in-the-loop unaffected, and the same condition is on `main` today

## Type of change
- [x] New feature
- [x] Bug fix

## Checklist
- [x] `./scripts/format.sh` and `./scripts/validate.sh` clean
- [x] Tests added, 557 passing
- [x] Cookbook examples added
- [ ] Tested in a clean environment
