### PR TITLE
feat: add optional documentation Markdown source transform

### DIFF
--- a/cookbook/05_agent_os/27_public_pages/README.md
+++ b/cookbook/05_agent_os/27_public_pages/README.md
@@ -277,3 +277,34 @@ normalizer that leaves code unchanged; run it without a database or provider key
 
 Component-specific MDX transformations, prompt rendering, citations and query
 alternatives remain application-owned.
+
+
+### Documentation Markdown
+
+Run `python cookbook/05_agent_os/27_public_pages/documentation_markdown.py` for a
+local transform/chunking example with no provider calls. `DocumentationMarkdown`
+is a callable for `Knowledge.sync_pages(..., transform=...)` and
+`async_sync_pages`. Its default `markdown` profile returns text verbatim.
+
+- `fumadocs` converts whole-line components and the leading Documentation Index
+  preamble, then decodes serializer escapes/entities outside fences. This includes
+  inline code, preserving the existing documentation application's behavior.
+- `mintlify` handles the shared steps/tabs/callouts/cards/fields/media vocabulary
+  and preamble, keeping escapes and entities unless `unescape_serializer=True`.
+- `component_aliases={"Aside": "Warning"}` selects a built-in rendering.
+  `component_renderers={"Panel": renderer}` overrides a component with a trusted
+  Python callback receiving literal attributes and normalized inner Markdown.
+  No JSX expressions, imports or JavaScript execute. Unknown wrappers keep text.
+
+This deliberately supports a bounded component vocabulary, not arbitrary MDX
+execution. Inline components and multiline attributes are not evaluated. Escaped
+HTML examples can become component text after decoding; apply the transform once
+to source, not repeatedly to already normalized pages. Use
+`unescape_serializer=False` for literal authored Markdown. Code fences preserve
+content and relative indentation. Site profiles reject empty pages and emit a
+final LF; the default profile leaves even empty input unchanged.
+
+No reader or index changes automatically on upgrade. Compare normalized bytes and
+chunks before adopting a profile on an existing corpus. Keep the same
+`index_version` only for byte-compatible extraction; bump it for intentional
+normalization changes and rerun retrieval evaluations before release.

--- a/cookbook/05_agent_os/27_public_pages/TEST_LOG.md
+++ b/cookbook/05_agent_os/27_public_pages/TEST_LOG.md
@@ -147,3 +147,14 @@ neither shared environment was modified. Live database/provider modes were not
 run. The focused public-configuration and MCP suites passed all 204 tests.
 
 ---
+
+
+## 2026-09-09 documentation Markdown transform
+
+- PASS: `documentation_markdown.py` ran with the demo Python and candidate source. Produces labeled Markdown and one chunk without network/model calls.
+- PASS: 30 normalization and chunking tests, including the existing application fixtures, nested/mismatched fences, serializer escapes, Unicode and callback isolation.
+- PASS: two disposable PostgreSQL publication tests cover sync and async transforms and repeat-sync embedding reuse.
+- PASS: full format and validation scripts.
+- Compatibility comparison: all 3,909 local published pages yield identical old/new transformed bytes and chunks, and are unchanged on repeat normalization. This is a published-text corpus comparison, not a full raw-source crawl.
+- Raw-source sample: 24 of 40 public Markdown pages fetched successfully (18 contained sampled component types); all 24 match old/new bytes and chunks. The other 16 URLs returned HTTP 500 and were excluded from equivalence claims.
+- No index mutation, re-embedding, reader default change or production deployment. Generic repeated entity decoding is not guaranteed idempotent; the documented transform operates on source once.

--- a/cookbook/05_agent_os/27_public_pages/documentation_markdown.py
+++ b/cookbook/05_agent_os/27_public_pages/documentation_markdown.py
@@ -1,0 +1,25 @@
+"""Normalize documentation Markdown before indexing, without network or model calls."""
+
+from agno.knowledge.chunking.page import PageMarkdownChunking
+from agno.knowledge.reader.utils.mdx import DocumentationMarkdown
+
+source = r"""# Setup
+
+<Steps>
+  <Step title="Configure">
+    Set API\_KEY, then call the agent.
+    <Note>Keep the key in your environment.</Note>
+  </Step>
+</Steps>
+"""
+
+transform = DocumentationMarkdown(profile="fumadocs")
+normalized = transform(source, path="/setup.md")
+print(normalized)
+chunks = PageMarkdownChunking().chunk_texts(normalized)
+assert "API_KEY" in normalized and "<Step" not in normalized
+assert chunks
+print(f"Prepared {len(chunks)} chunks without embedding calls.")
+
+# Pass the same pure transform to Knowledge.sync_pages or async_sync_pages:
+# knowledge.sync_pages(url=site_url, transform=transform, index_version="docs-v1")

--- a/libs/agno/agno/knowledge/reader/utils/mdx.py
+++ b/libs/agno/agno/knowledge/reader/utils/mdx.py
@@ -4,6 +4,8 @@ Preserve code fences, prose placeholders and relative indentation.
 Unwrap unknown components while retaining their content.
 """
 
+from __future__ import annotations
+
 import html
 import re
 from dataclasses import dataclass, field

--- a/libs/agno/agno/knowledge/reader/utils/mdx.py
+++ b/libs/agno/agno/knowledge/reader/utils/mdx.py
@@ -1,0 +1,322 @@
+"""Convert MDX components to Markdown for indexing and page reads.
+
+Preserve code fences, prose placeholders and relative indentation.
+Unwrap unknown components while retaining their content.
+"""
+
+import html
+import re
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Callable, Literal, Mapping, Optional
+
+from agno.utils.markdown import FenceState, advance_code_fence
+
+HTML_BLOCK = r"div|h[1-6]|video"
+HTML_VOID = r"img|br|source|video"
+BLOCK_OPEN = re.compile(rf"^\s*<(?P<name>[A-Z][A-Za-z]*|{HTML_BLOCK})(?P<attrs>\s[^<>]*?)?(?<!/)>\s*$")
+BLOCK_CLOSE = re.compile(rf"^\s*</(?P<name>[A-Z][A-Za-z]*|{HTML_BLOCK})>\s*$")
+SELF_CLOSING = re.compile(rf"^\s*<(?P<name>[A-Z][A-Za-z]*|{HTML_VOID})(?P<attrs>\s[^<>]*?)?\s*/>\s*$")
+ONE_LINER = re.compile(r"^\s*<(?P<name>[A-Z][A-Za-z]*|h[1-6])(?P<attrs>\s[^<>]*?)?>(?P<body>.*)</(?P=name)>\s*$")
+ATTR = re.compile(r"""([A-Za-z][\w-]*)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|\{([^}]*)\}|([^\s"'<>]+)))?""")
+CALLOUTS = {"Note": "Note", "Warning": "Warning", "Tip": "Tip", "Info": "Info", "Check": "Check", "Callout": ""}
+LABELLED = {"CodeBlockTab": "value", "Tab": "title", "Accordion": "title"}  # tag -> attribute that names it
+_PLAIN_BLOCK_START = re.compile(r"^(?:[-*+]\s|\d+[.)]\s|#{1,6}\s|>|\||```|~~~)")
+
+
+ComponentRenderer = Callable[[Mapping[str, str], str], str]
+
+
+@dataclass
+class _Context:
+    step: int = 0
+    aliases: Mapping[str, str] = field(default_factory=dict)
+    renderers: Mapping[str, ComponentRenderer] = field(default_factory=dict)
+
+
+def _attrs(raw: str | None) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for match in ATTR.finditer(raw or ""):
+        key = match.group(1)
+        value = next((g for g in match.groups()[1:] if g is not None), "")
+        out[key] = value.strip()
+    return out
+
+
+def _dedent(lines: list[str]) -> list[str]:
+    """Remove the indentation the JSX nesting added: the smallest indent of the block's non-blank lines."""
+    indents = [len(line) - len(line.lstrip(" ")) for line in lines if line.strip()]
+    if not indents:
+        return ["" for _ in lines]
+    depth = min(indents)
+    return [line[depth:] if line.strip() else "" for line in lines]
+
+
+def _find_close(lines: list[str], start: int, name: str) -> int | None:
+    """Index of the closing tag matching an opening tag of `name` at start-1, fence-aware; None if unmatched."""
+    depth = 1
+    fence: FenceState | None = None
+    for index in range(start, len(lines)):
+        line = lines[index]
+        was_code = fence is not None
+        fence, delimiter = advance_code_fence(line, fence)
+        if was_code or delimiter:
+            continue
+        opened = BLOCK_OPEN.match(line)
+        if opened and opened.group("name") == name:
+            depth += 1
+            continue
+        closed = BLOCK_CLOSE.match(line)
+        if closed and closed.group("name") == name:
+            depth -= 1
+            if depth == 0:
+                return index
+    return None
+
+
+def _joined_text(lines: list[str]) -> str | None:
+    """The block's content as one line when it is plain prose, else None."""
+    text = [line.strip() for line in lines if line.strip()]
+    if not text or any(_PLAIN_BLOCK_START.match(line) or line.startswith("<") for line in text):
+        return None
+    return " ".join(text)
+
+
+def _bullet(head: str, inner: list[str], ctx: _Context) -> list[str]:
+    body = _walk(inner, ctx)
+    if not head:
+        return body
+    text = _joined_text(body)
+    if text is not None:
+        return [f"- {head}: {text}"]
+    if not any(line.strip() for line in body):
+        return [f"- {head}"]
+    return [f"- {head}"] + [f"  {line}" if line.strip() else "" for line in body]
+
+
+def _render(name: str, attrs: dict[str, str], inner: list[str], ctx: _Context) -> list[str]:
+    original_name = name
+    name = ctx.aliases.get(name, name)
+    renderer = ctx.renderers.get(original_name) or ctx.renderers.get(name)
+    if renderer is not None:
+        return renderer(MappingProxyType(attrs), "\n".join(_walk(inner, ctx))).split("\n")
+    if name == "Steps":
+        saved = ctx.step
+        ctx.step = 0
+        try:
+            return [""] + _walk(inner, ctx) + [""]
+        finally:
+            ctx.step = saved
+    if name == "Step":
+        ctx.step = ctx.step + 1
+        title = attrs.get("title", "")
+        label = f"**Step {ctx.step}: {title}**" if title else f"**Step {ctx.step}**"
+        return ["", label, ""] + _walk(inner, ctx) + [""]
+    if name == "CodeBlockTabsTrigger":
+        return []  # the tab's label; <CodeBlockTab value=...> carries it again
+    if name in LABELLED:
+        label = attrs.get(LABELLED[name], "")
+        return ([""] + [f"**{label}**", ""] if label else [""]) + _walk(inner, ctx) + [""]
+    if name in CALLOUTS:
+        label = CALLOUTS[name] or (attrs.get("type", "note").capitalize() or "Note")
+        body = _walk(inner, ctx)
+        text = _joined_text(body)
+        if text is not None:
+            return ["", f"**{label}:** {text}", ""]
+        return ["", f"**{label}:**"] + body + [""]
+    if name == "Card":
+        title, href = attrs.get("title", ""), attrs.get("href", "")
+        head = f"[{title}]({href})" if title and href else f"**{title}**" if title else f"<{href}>" if href else ""
+        return _bullet(head, inner, ctx)
+    if name in ("ResponseField", "ParamField"):
+        head = f"`{attrs['name']}`" if attrs.get("name") else ""
+        details = [attrs["type"]] if attrs.get("type") else []
+        if "required" in attrs:
+            details.append("required")
+        if attrs.get("default"):
+            details.append(f"default {attrs['default']}")
+        if head and details:
+            head += f" ({', '.join(details)})"
+        return _bullet(head, inner, ctx)
+    if name == "Frame":
+        caption = attrs.get("caption", "")
+        return [""] + _walk(inner, ctx) + ([f"*{caption}*", ""] if caption else [""])
+    if name in ("ImageZoom", "Image", "img"):
+        src = attrs.get("src", "")
+        return [f"![{attrs.get('alt', '')}]({src})"] if src else []
+    if name in ("video", "Video", "source"):
+        src = attrs.get("src", "")
+        return [f"[Video]({src})"] if src else _walk(inner, ctx)
+    if name == "br":
+        return [""]
+    if name == "Tooltip":
+        tip = attrs.get("tip", "")
+        text = _joined_text(_walk(inner, ctx)) or ""
+        return [f"*{tip}*" if tip else text]
+    if re.fullmatch(r"h[1-6]", name):
+        text = " ".join(line.strip() for line in inner if line.strip())
+        return ["", f"{'#' * int(name[1])} {text}", ""] if text else []
+    return [""] + _walk(inner, ctx) + [""]  # unknown component: unwrap
+
+
+def _walk(lines: list[str], ctx: _Context) -> list[str]:
+    out: list[str] = []
+    index = 0
+    fence: FenceState | None = None
+    while index < len(lines):
+        line = lines[index]
+        was_code = fence is not None
+        fence, delimiter = advance_code_fence(line, fence)
+        if was_code or delimiter:
+            out.append(line)
+            index += 1
+            continue
+        opened = BLOCK_OPEN.match(line)
+        if opened:
+            name = opened.group("name")
+            end = _find_close(lines, index + 1, name)
+            if end is None:
+                out.extend(_render(name, _attrs(opened.group("attrs")), [], ctx))
+                index += 1
+                continue
+            out.extend(_render(name, _attrs(opened.group("attrs")), _dedent(lines[index + 1 : end]), ctx))
+            index = end + 1
+            continue
+        one = ONE_LINER.match(line)
+        if one:
+            out.extend(_render(one.group("name"), _attrs(one.group("attrs")), [one.group("body").strip()], ctx))
+            index += 1
+            continue
+        closed = SELF_CLOSING.match(line)
+        if closed:
+            out.extend(_render(closed.group("name"), _attrs(closed.group("attrs")), [], ctx))
+            index += 1
+            continue
+        if BLOCK_CLOSE.match(line):
+            index += 1  # a stray closing tag
+            continue
+        out.append(line)
+        index += 1
+    return out
+
+
+def _collapse_blank_lines(lines: list[str]) -> list[str]:
+    """At most one blank line between blocks outside fences; fences keep their blank lines."""
+    out: list[str] = []
+    fence: FenceState | None = None
+    for line in lines:
+        was_code = fence is not None
+        fence, delimiter = advance_code_fence(line, fence)
+        if not (was_code or delimiter) and not line.strip() and out and not out[-1].strip():
+            continue
+        out.append(line)
+    while out and not out[0].strip():
+        out.pop(0)
+    while out and not out[-1].strip():
+        out.pop()
+    return out
+
+
+def normalize_mdx(
+    markdown: str,
+    *,
+    component_aliases: Optional[Mapping[str, str]] = None,
+    component_renderers: Optional[Mapping[str, ComponentRenderer]] = None,
+) -> str:
+    """Convert whole-line documentation components, preserving fenced code.
+
+    Supports steps, tabs, callouts, cards, fields, media and transparent wrappers.
+    Unknown components are unwrapped. Inline JSX and multiline attributes are not
+    evaluated. Attribute expressions are literal strings, never Python/JavaScript.
+    Aliases select a built-in component; renderers receive parsed attributes and
+    normalized inner Markdown. Call this once on source text before chunking.
+    """
+    if "<" not in markdown:
+        return markdown
+    ctx = _Context(aliases=dict(component_aliases or {}), renderers=dict(component_renderers or {}))
+    lines = _collapse_blank_lines(_walk(markdown.split("\n"), ctx))
+    return "\n".join(lines) + ("\n" if markdown.endswith("\n") and lines else "")
+
+
+PREAMBLE_HEADER = "> ## Documentation Index"
+
+
+def _strip_preamble(markdown: str) -> str:
+    """Drop the site's '> ## Documentation Index' blockquote that precedes every page."""
+    if not markdown.startswith(PREAMBLE_HEADER):
+        return markdown
+    lines = markdown.splitlines()
+    i = 0
+    while i < len(lines) and lines[i].startswith(">"):
+        i += 1
+    while i < len(lines) and not lines[i].strip():
+        i += 1
+    return "\n".join(lines[i:]) + ("\n" if markdown.endswith("\n") else "")
+
+
+# The serializer escapes markdown punctuation in text nodes (`QWEN\_API\_KEY`, `List\[Message]`).
+# Not `|` (table cells) and not backticks: a code span may hold a literal backslash.
+MD_ESCAPE = re.compile(r"\\([_\[\]*~<>&])")
+
+
+def _unescape_prose(markdown: str) -> str:
+    """Decode the HTML entities and drop the markdown backslash escapes the site's serializer
+    emits in prose (never inside code fences), so identifiers read and search as written."""
+    out = []
+    fence: FenceState | None = None
+    for line in markdown.splitlines():
+        was_code = fence is not None
+        fence, delimiter = advance_code_fence(line, fence)
+        if not (was_code or delimiter):
+            if "&" in line:
+                line = html.unescape(line)
+            if "\\" in line:
+                line = MD_ESCAPE.sub(r"\1", line)
+        out.append(line)
+    return "\n".join(out) + ("\n" if markdown.endswith("\n") else "")
+
+
+@dataclass(frozen=True)
+class DocumentationMarkdown:
+    """Optional pure source transform for Knowledge.sync_pages/async_sync_pages.
+
+    ``markdown`` returns input verbatim. ``fumadocs`` normalizes components,
+    removes the leading Documentation Index blockquote and decodes serializer
+    escapes outside fences, including inline code. ``mintlify`` normalizes the
+    same component vocabulary and preamble but keeps escapes/entities by default.
+    Fumadocs decoding deliberately preserves its existing html.unescape semantics;
+    use unescape_serializer=False for authored Markdown or literal HTML examples.
+    Profiles normalize CRLF, trim surrounding whitespace and add a final LF.
+    They reject empty pages. No reader changes behavior unless explicitly called.
+
+    This is a source transform, not an MDX runtime or an HTML sanitizer. Repeated
+    decoding of escaped tags/entities is not guaranteed idempotent. Keep the
+    original source and version the transform when changing an existing index.
+    """
+
+    profile: Literal["markdown", "fumadocs", "mintlify"] = "markdown"
+    strip_index_preamble: bool = True
+    unescape_serializer: Optional[bool] = None
+    component_aliases: Mapping[str, str] = field(default_factory=dict)
+    component_renderers: Mapping[str, ComponentRenderer] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.profile not in ("markdown", "fumadocs", "mintlify"):
+            raise ValueError("Unknown documentation Markdown profile")
+        object.__setattr__(self, "component_aliases", MappingProxyType(dict(self.component_aliases)))
+        object.__setattr__(self, "component_renderers", MappingProxyType(dict(self.component_renderers)))
+
+    def __call__(self, text: str, *, path: str) -> str:
+        if self.profile == "markdown":
+            return text
+        if self.strip_index_preamble:
+            text = _strip_preamble(text)
+        text = normalize_mdx(
+            text, component_aliases=self.component_aliases, component_renderers=self.component_renderers
+        )
+        if self.unescape_serializer is True or (self.unescape_serializer is None and self.profile == "fumadocs"):
+            text = _unescape_prose(text)
+        content = text.replace("\r\n", "\n").strip()
+        if not content:
+            raise ValueError("empty page")
+        return content + "\n"

--- a/libs/agno/tests/integration/knowledge/test_page_storage.py
+++ b/libs/agno/tests/integration/knowledge/test_page_storage.py
@@ -88,6 +88,31 @@ def warm_search_pool(knowledge, count):
             stack.enter_context(knowledge._page_engine.connect())
 
 
+@pytest.mark.parametrize("asynchronous", [False, True])
+def test_documentation_transform_publishes_normalized_text_and_reuses_embeddings(corpus, asynchronous):
+    import asyncio
+
+    from agno.knowledge.reader.utils.mdx import DocumentationMarkdown
+
+    knowledge, embedder, site = corpus
+    raw = '# Agent\n\n<Steps>\n<Step title="Configure">\nSet API\\_KEY &amp; tools.\n</Step>\n</Steps>\n'
+    site["https://docs.example.com/agent.md"] = raw
+    transform = DocumentationMarkdown(profile="fumadocs")
+    kwargs = dict(url="https://docs.example.com/llms.txt", transform=transform, index_version="docs-v1")
+
+    def sync():
+        return asyncio.run(knowledge.async_sync_pages(**kwargs)) if asynchronous else knowledge.sync_pages(**kwargs)
+
+    assert sync().updated == 1
+    page = knowledge.read_full_page("/agent.md")
+    assert page == transform(raw, path="/agent.md")
+    assert "API_KEY & tools" in page and "<Step" not in page
+    calls = list(embedder.calls)
+    assert calls and all("<Step" not in text for text in calls)
+    assert sync().updated == 0
+    assert embedder.calls == calls
+
+
 @pytest.mark.parametrize("tuned", [False, True])
 @pytest.mark.parametrize("plan_mode", [None, "force_custom_plan"])
 def test_search_tuning_honors_hnsw_and_operator_defaults_without_leaking(corpus, tuned, plan_mode):

--- a/libs/agno/tests/unit/reader/test_mdx_normalize.py
+++ b/libs/agno/tests/unit/reader/test_mdx_normalize.py
@@ -1,0 +1,246 @@
+import pytest
+
+from agno.knowledge.reader.utils.mdx import DocumentationMarkdown, normalize_mdx
+
+normalize_page = DocumentationMarkdown(profile="fumadocs")
+
+STEPS = r"""# Agent with Memory (/docs/models/x/usage/memory)
+
+## Usage [#usage]
+
+<Steps>
+    <Step title="Set up your virtual environment">
+      <CodeBlockTabs defaultValue="Mac">
+        <CodeBlockTabsList>
+          <CodeBlockTabsTrigger value="Mac">
+            Mac
+          </CodeBlockTabsTrigger>
+
+          <CodeBlockTabsTrigger value="Windows">
+            Windows
+          </CodeBlockTabsTrigger>
+        </CodeBlockTabsList>
+
+        <CodeBlockTab value="Mac">
+          ```bash
+          uv venv --python 3.12
+          source .venv/bin/activate
+          ```
+        </CodeBlockTab>
+
+        <CodeBlockTab value="Windows">
+          ```bash
+          uv venv --python 3.12
+          .venv\Scripts\activate
+          ```
+        </CodeBlockTab>
+      </CodeBlockTabs>
+    </Step>
+
+  <Step title="Run Agent">
+    Save the code above as `memory.py`, then run:
+
+    ```bash
+    python memory.py
+    ```
+  </Step>
+</Steps>
+"""
+
+STEPS_EXPECTED = r"""# Agent with Memory (/docs/models/x/usage/memory)
+
+## Usage [#usage]
+
+**Step 1: Set up your virtual environment**
+
+**Mac**
+
+```bash
+uv venv --python 3.12
+source .venv/bin/activate
+```
+
+**Windows**
+
+```bash
+uv venv --python 3.12
+.venv\Scripts\activate
+```
+
+**Step 2: Run Agent**
+
+Save the code above as `memory.py`, then run:
+
+```bash
+python memory.py
+```
+"""
+
+
+def test_steps_and_code_tabs_become_labelled_markdown():
+    assert normalize_mdx(STEPS) == STEPS_EXPECTED
+
+
+def test_normalisation_is_idempotent_and_leaves_plain_pages_alone():
+    assert normalize_mdx(STEPS_EXPECTED) == STEPS_EXPECTED
+    plain = "# T\n\nText with `<your-api-key>` and <id> placeholders.\n\n<topic>\n"
+    assert normalize_mdx(plain) == plain
+
+
+def test_callouts():
+    single = "<Note>\n  With `x=True`, hooks run in the background.\n</Note>\n"
+    assert normalize_mdx(single) == "**Note:** With `x=True`, hooks run in the background.\n"
+    assert normalize_mdx("<Tip>Short.</Tip>\n") == "**Tip:** Short.\n"
+    assert normalize_mdx('<Callout type="warning">\n  Careful.\n</Callout>\n') == "**Warning:** Careful.\n"
+    multi = "<Warning>\n  Run:\n\n  ```bash\n  rm -rf tmp\n  ```\n</Warning>\n\nAfter.\n"
+    assert normalize_mdx(multi) == "**Warning:**\nRun:\n\n```bash\nrm -rf tmp\n```\n\nAfter.\n"
+
+
+def test_cards_accordions_fields_and_tooltips():
+    cards = (
+        '<CardGroup cols="2">\n'
+        '  <Card title="Setup Guide" icon="rocket" href="/slack/setup">\n'
+        "    Create a Slack App from scratch\n  </Card>\n\n"
+        '  <Card title="Features" href="/slack/features" />\n'
+        "</CardGroup>\n"
+    )
+    assert normalize_mdx(cards) == (
+        "- [Setup Guide](/slack/setup): Create a Slack App from scratch\n\n- [Features](/slack/features)\n"
+    )
+    accordion = (
+        '<AccordionGroup>\n  <Accordion title="MissingGreenlet exception">\n    Use the async engine.\n  </Accordion>\n'
+        "</AccordionGroup>\n"
+    )
+    assert normalize_mdx(accordion) == "**MissingGreenlet exception**\n\nUse the async engine.\n"
+    field = '<ResponseField name="name" type="str" required>\n  Name of the directory. `--name`\n</ResponseField>\n'
+    assert normalize_mdx(field) == "- `name` (str, required): Name of the directory. `--name`\n"
+    badge = (
+        '<Badge icon="code-branch" color="orange">\n'
+        '  <Tooltip tip="Introduced in v2.2.1" cta="View release notes" href="https://x">\n    v2.2.1\n  </Tooltip>\n'
+        "</Badge>\n"
+    )
+    assert normalize_mdx(badge) == "*Introduced in v2.2.1*\n"
+
+
+def test_media_html_and_unknown_components():
+    frame = (
+        '<Frame caption="AgentOS API">\n'
+        '  <ImageZoom src="/docs/videos/first-agent-api.gif" alt="AgentOS API" width="800" height="524" />\n'
+        "</Frame>\n"
+    )
+    assert normalize_mdx(frame) == "![AgentOS API](/docs/videos/first-agent-api.gif)\n*AgentOS API*\n"
+    assert (
+        normalize_mdx('<video className="w-full" src="/docs/videos/demo.mp4" />\n')
+        == "[Video](/docs/videos/demo.mp4)\n"
+    )
+    heading = '<h2 id="get-started" style="{ marginTop: "1.5rem" }">\n  Get started\n</h2>\n\n* [Build](/first-agent)\n'
+    assert normalize_mdx(heading) == "## Get started\n\n* [Build](/first-agent)\n"
+    assert normalize_mdx("a\n\n<br />\n\n<div style=\"{ marginTop: '2rem' }\">\n  inside\n</div>\n") == "a\n\ninside\n"
+    assert normalize_mdx("<Whatever prop={1}>\n  kept\n</Whatever>\n") == "kept\n"
+    # unclosed tags: the tag line goes, the rest is kept as written
+    assert normalize_mdx('<Steps>\n  <Step title="Only">\n    one\n') == "**Step 1: Only**\n\n    one\n"
+
+
+def test_fences_and_nested_lists_are_preserved():
+    fenced = '```mdx\n<Steps>\n  <Step title="x">\n</Steps>\n```\n'
+    assert normalize_mdx(fenced) == fenced
+    nested = '<Steps>\n  <Step title="A">\n    - one\n      - nested\n    - two\n  </Step>\n</Steps>\n'
+    assert normalize_mdx(nested) == "**Step 1: A**\n\n- one\n  - nested\n- two\n"
+    numbered = '<Steps>\n<Step title="A">\na\n</Step>\n</Steps>\n\n<Steps>\n<Step title="B">\nb\n</Step>\n</Steps>\n'
+    assert normalize_mdx(numbered) == "**Step 1: A**\n\na\n\n**Step 1: B**\n\nb\n"
+    # inner list has two steps so the outer counter resuming at 2 (not 3) is observable
+    nested_steps = (
+        '<Steps>\n<Step title="A">\n<Steps>\n<Step title="i1">\nx\n</Step>\n<Step title="i2">\ny\n</Step>\n</Steps>\n'
+        '</Step>\n<Step title="B">\nb\n</Step>\n</Steps>\n'
+    )
+    assert normalize_mdx(nested_steps) == (
+        "**Step 1: A**\n\n**Step 1: i1**\n\nx\n\n**Step 2: i2**\n\ny\n\n**Step 2: B**\n\nb\n"
+    )
+
+
+@pytest.mark.parametrize(
+    "opening,inner,closing",
+    [("````markdown", "```python", "````"), ("~~~markdown", "```", "~~~~"), ("```mdx", "```not-a-close", "```")],
+)
+@pytest.mark.parametrize("wrapped", [False, True])
+def test_normalization_preserves_literal_content_inside_nested_fences(opening, inner, closing, wrapped):
+    code = f'{opening}\n{inner}\n</Note>\n<Note>literal example</Note>\n\n\nTOKEN = "A\\_B &amp; C"\n{closing}\n'
+    after = "\n<Note>Outside &amp; prose\\_identifier.</Note>\n"
+    raw = f"<Note>\n{code}</Note>\n{after}" if wrapped else code + after
+    expected = ("**Note:**\n" if wrapped else "") + code + "\n**Note:** Outside & prose_identifier.\n"
+    assert normalize_page(raw, path="/example.md") == expected
+
+
+def test_unescape_prose_strips_markdown_escapes_outside_fences():
+    raw = (
+        "Set QWEN\\_API\\_KEY and pass List\\[Message] or a \\*star\\*\n\n```\nkeep \\_ this\n```\n\n"
+        "| a \\| b |\n\nRun `%APPDATA%\\Claude\\` and `\\[literal]`\n"
+    )
+    assert normalize_page(raw, path="/page.md") == (
+        "Set QWEN_API_KEY and pass List[Message] or a *star*\n\n```\nkeep \\_ this\n```\n\n"
+        "| a \\| b |\n\nRun `%APPDATA%\\Claude\\` and `[literal]`\n"
+    )
+
+
+def test_unescape_prose_leaves_fences_alone():
+    raw = "Say &#x22;hi&#x22;\n\n```\n&#x2A; kept\n```\n"
+    assert normalize_page(raw, path="/page.md") == 'Say "hi"\n\n```\n&#x2A; kept\n```\n'
+
+
+def test_default_profile_preserves_authored_markdown_verbatim():
+    raw = "\r\n<Note>Literal</Note>\r\n\r\n\r\n    code &amp; \\_\r\n\r\n"
+    assert DocumentationMarkdown()(raw, path="/plain.md") == raw
+
+
+def test_profiles_and_serializer_override():
+    raw = "> ## Documentation Index\n> See /llms.txt\n\n<Note>Use API\\_KEY &amp; tokens.</Note>\n"
+    assert DocumentationMarkdown(profile="fumadocs")(raw, path="/x.md") == "**Note:** Use API_KEY & tokens.\n"
+    expected = "**Note:** Use API\\_KEY &amp; tokens.\n"
+    assert DocumentationMarkdown(profile="mintlify")(raw, path="/x.md") == expected
+    assert DocumentationMarkdown(profile="fumadocs", unescape_serializer=False)(raw, path="/x.md") == expected
+    assert DocumentationMarkdown(profile="mintlify", unescape_serializer=True)(raw, path="/x.md") == normalize_page(
+        raw, path="/x.md"
+    )
+
+
+def test_only_leading_preamble_is_removed_and_can_be_disabled():
+    text = "> ## Documentation Index\n> See /llms.txt\n\n# T\n\n> ## Documentation Index\n> Keep this.\n"
+    assert normalize_page(text, path="/x.md") == "# T\n\n> ## Documentation Index\n> Keep this.\n"
+    assert DocumentationMarkdown(profile="fumadocs", strip_index_preamble=False)(text, path="/x.md") == text
+
+
+def test_component_overrides_are_isolated_and_receive_normalized_children():
+    aliases = {"Aside": "Warning"}
+    seen = []
+
+    def render(attrs, content):
+        seen.append((dict(attrs), content))
+        return f"{attrs['title']}: {content.strip()}"
+
+    transform = DocumentationMarkdown(
+        profile="mintlify", component_aliases=aliases, component_renderers={"Panel": render}
+    )
+    aliases["Aside"] = "Tip"
+    raw = '<Panel title="安全" expression={never_execute()}>\n<Aside>慎重に。</Aside>\n</Panel>\n'
+    assert transform(raw, path="/x.md") == "安全: **Warning:** 慎重に。\n"
+    assert seen[0][0] == {"title": "安全", "expression": "never_execute()"}
+    assert normalize_mdx("<Aside>text</Aside>\n") == "text\n"
+
+
+def test_empty_profile_output_and_invalid_profile():
+    with pytest.raises(ValueError, match="empty page"):
+        normalize_page("> ## Documentation Index\n> index only\n", path="/x.md")
+    with pytest.raises(ValueError, match="Unknown"):
+        DocumentationMarkdown(profile="unknown")
+
+
+def test_serializer_order_and_non_idempotent_entity_limit_are_explicit():
+    # Decode after component rendering so escaped examples remain literal this pass.
+    assert normalize_page("&lt;Note&gt;example&lt;/Note&gt;\n", path="/x.md") == "<Note>example</Note>\n"
+    assert normalize_page("&amp;amp;\n", path="/x.md") == "&amp;\n"
+    assert normalize_page("&amp;\n", path="/x.md") == "&\n"
+
+
+@pytest.mark.parametrize("profile", ["fumadocs", "mintlify"])
+def test_unicode_and_line_endings(profile):
+    assert DocumentationMarkdown(profile=profile)("<Note>説明 🙂</Note>\r\n", path="/x.md") == "**Note:** 説明 🙂\n"


### PR DESCRIPTION
## Summary

Documentation sites expose Markdown containing steps, tabs, callouts and other MDX wrappers. Add an optional `DocumentationMarkdown` callable for the existing `Knowledge.sync_pages` and `async_sync_pages` transform hook, plus `normalize_mdx` for standalone component conversion. This replaces the documentation application's MDX walker and serializer normalization with a public API.

The default `markdown` profile is verbatim. `fumadocs` preserves the application's current component/preamble/serializer behavior; `mintlify` handles the shared component vocabulary without decoding authored escapes by default. Profiles support trusted component aliases/renderers. Fences, nested steps, relative indentation and Unicode are preserved. No JavaScript executes and no reader defaults, extension routing or stored indexes change automatically.

Apply once to raw source: repeated entity decoding is not universally idempotent. Keep literal authored Markdown on the default profile or disable serializer decoding explicitly. Inline JSX and multiline attributes are not evaluated. Intentional normalization changes require a versioned index and retrieval validation.

## Type of change

- [x] New feature
- [x] Improvement

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated
- [ ] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated

## Additional Notes

30 unit normalization/chunking tests and two disposable PostgreSQL sync/async publication tests passed. The cookbook ran without provider calls; full format/validation passed. All 3,909 local published pages have identical old/new normalized bytes and chunks. Of 40 sampled raw-source URLs, 24 fetched successfully and all matched; 16 returned HTTP 500 and are excluded from equivalence claims. No re-embedding or production change occurred.
