### PR TITLE
feat: expose native page sync and function step progress

### DIFF
--- a/cookbook/05_agent_os/27_public_pages/README.md
+++ b/cookbook/05_agent_os/27_public_pages/README.md
@@ -277,3 +277,38 @@ normalizer that leaves code unchanged; run it without a database or provider key
 
 Component-specific MDX transformations, prompt rendering, citations and query
 alternatives remain application-owned.
+
+
+### Native sync and function progress
+
+`Knowledge.stream_sync_pages(...)` and `astream_sync_pages(...)` accept the
+normal sync arguments and yield typed `PageSyncProgress` snapshots followed by
+one final `SyncReport`. Errors propagate; a partial report stays partial.
+Snapshots carry absolute discovery/processed/update/delete/failure/uncertain
+counts. At most 32 pending observer updates are retained, so a slow consumer may
+skip intermediate snapshots without losing the terminal report. The same bounded
+sync worker pool owns the operation. Use `closing`/`aclosing` when stopping early;
+cancellation requests propagate and capacity remains held until worker cleanup.
+
+For callback consumers, `sync_pages`/`async_sync_pages` accept a synchronous
+`on_progress(PageSyncProgress)` observer. A failing observer is logged and disabled
+without failing publication. Keep observer work short. Intentional index-shrink
+validation still belongs in `validate_discovery` and retains its failure semantics.
+
+A function executor can yield `StepProgress(content=..., data=...)` followed by
+its normal `StepOutput`. With workflow event streaming enabled, Agno emits native
+`StepProgressEvent` values under the existing workflow run ID and step ID, with a
+one-based retry attempt. Progress never enters final function output and creates
+no synthetic AgentRun or executor history. Non-streaming execution ignores it.
+Existing step/workflow completion, failure and cancellation remain authoritative.
+
+Run `page_sync_progress.py --check` without storage/provider calls, or provide a
+docs source URL to sync the configured example namespace. The example shows the
+small application adapter: translate progress snapshots and the terminal report
+into StepProgress/StepOutput. Source selection and sync policy remain explicit.
+
+Consumers must support the new `StepProgress` event to render its content. Native
+SSE/event-stream delivery and durable queue execution are tested here; Control
+Plane visual rendering is a separate adoption gate. Existing AG-UI progress work
+can map this event into its presentation layer; no AG-UI/Control Plane renderer is
+changed by this PR. SSE transport keepalives remain separate from page milestones.

--- a/cookbook/05_agent_os/27_public_pages/TEST_LOG.md
+++ b/cookbook/05_agent_os/27_public_pages/TEST_LOG.md
@@ -147,3 +147,12 @@ neither shared environment was modified. Live database/provider modes were not
 run. The focused public-configuration and MCP suites passed all 204 tests.
 
 ---
+
+
+## 2026-09-09 native sync and function progress
+
+- PASS: 815 workflow/worker/page-contract tests; nine skips include unsupported sync-with-async executor combinations and existing skips. Covers function progress identity, attempt numbers, non-stream output isolation, event serialization, real QueueWorker execution/event delivery/run storage, bounded coalescing, early close/cancellation capacity retention and worker errors.
+- PASS: all 123 disposable PostgreSQL page-storage tests, including new sync/async progress counts, terminal partial status and observer failure isolation.
+- PASS: `page_sync_progress.py --check` with demo Python; emits native workflow/step progress and completion without storage/provider calls.
+- PASS: full format and validation scripts.
+- Control Plane visual rendering was not exercised and requires consumer support for StepProgress. Existing AG-UI PR8710 is related presentation work; no renderer or production deployment changed here.

--- a/cookbook/05_agent_os/27_public_pages/page_sync_progress.py
+++ b/cookbook/05_agent_os/27_public_pages/page_sync_progress.py
@@ -1,0 +1,66 @@
+"""Native progress from a function step, without a synthetic agent/executor run."""
+
+import argparse
+import asyncio
+from contextlib import aclosing
+
+from agno.knowledge.page import SyncReport
+from agno.workflow import Workflow
+from agno.workflow.step import Step
+from agno.workflow.types import StepOutput, StepProgress
+
+
+async def sync_pages(step_input):
+    from public_pages import knowledge
+
+    await knowledge.asetup()
+    async with aclosing(knowledge.astream_sync_pages(url=step_input.input)) as updates:
+        async for update in updates:
+            if isinstance(update, SyncReport):
+                yield StepOutput(
+                    content=update.model_dump(), success=update.status != "partial"
+                )
+            else:
+                yield StepProgress(content=update.stage, data=update.model_dump())
+
+
+async def check_step(step_input):
+    yield StepProgress(content="Checking one page", data={"processed": 1})
+    yield StepOutput(content="done")
+
+
+async def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("url", nargs="?", help="HTTPS documentation llms.txt URL")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Run a function-only workflow without storage/provider calls",
+    )
+    args = parser.parse_args()
+    if not args.check and not args.url:
+        parser.error("provide a source URL or --check")
+    workflow = Workflow(
+        id="page-sync",
+        steps=[
+            Step(
+                name="sync",
+                executor=check_step if args.check else sync_pages,
+                max_retries=0,
+            )
+        ],
+        telemetry=False,
+    )
+    events = []
+    async for event in workflow.arun(
+        args.url or "check", stream=True, stream_events=True
+    ):
+        events.append(event)
+        print(event.to_json())
+    if args.check:
+        assert any(event.event == "StepProgress" for event in events)
+        assert events[-1].event == "WorkflowCompleted"
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -9,7 +9,7 @@ from enum import Enum
 from io import BytesIO
 from os.path import basename
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union, cast, overload
+from typing import Any, AsyncIterator, Callable, Dict, Iterator, List, Optional, Set, Tuple, Union, cast, overload
 
 from httpx import AsyncClient
 
@@ -19,7 +19,15 @@ from agno.exceptions import EmbeddingError
 from agno.filters import EQ, FilterExpr
 from agno.knowledge.content import Content, ContentAuth, ContentStatus, FileData
 from agno.knowledge.document import Document
-from agno.knowledge.page import GrepResult, PageList, PageRead, PageSearchConfig, SearchResult, SyncReport
+from agno.knowledge.page import (
+    GrepResult,
+    PageList,
+    PageRead,
+    PageSearchConfig,
+    PageSyncProgress,
+    SearchResult,
+    SyncReport,
+)
 from agno.knowledge.reader import Reader, ReaderFactory
 from agno.knowledge.reader.utils.urls import canonical_page_name, is_sitemap_url
 from agno.knowledge.remote_content.base import BaseStorageConfig
@@ -190,12 +198,15 @@ class Knowledge(RemoteKnowledge):
         index_version: str = "1",
         reindex: bool = False,
         validate_discovery: Optional[Callable[[int, int], None]] = None,
+        on_progress: Optional[Callable[[PageSyncProgress], None]] = None,
     ) -> SyncReport:
         """Reconcile an llms.txt source, publishing each page atomically.
 
         validate_discovery receives (discovered_count, published_count) under the
         namespace sync lock, before fetching or publishing pages. Supply a fast,
         synchronous check that returns None to accept or raises ValueError to abort.
+        on_progress is a short synchronous observer; failures disable observation
+        without failing publication. Use stream_sync_pages for bounded iteration.
         """
         return self._pages().sync(
             url=url,
@@ -204,6 +215,7 @@ class Knowledge(RemoteKnowledge):
             index_version=index_version,
             reindex=reindex,
             validate_discovery=validate_discovery,
+            on_progress=on_progress,
         )
 
     async def async_sync_pages(
@@ -215,6 +227,7 @@ class Knowledge(RemoteKnowledge):
         index_version: str = "1",
         reindex: bool = False,
         validate_discovery: Optional[Callable[[int, int], None]] = None,
+        on_progress: Optional[Callable[[PageSyncProgress], None]] = None,
     ) -> SyncReport:
         """Reconcile pages off the event loop with retained capacity on cancellation.
 
@@ -231,8 +244,35 @@ class Knowledge(RemoteKnowledge):
             index_version=index_version,
             reindex=reindex,
             validate_discovery=validate_discovery,
+            on_progress=on_progress,
             seconds=3900,
         )
+
+    def stream_sync_pages(self, **kwargs: Any) -> Iterator[Union[PageSyncProgress, SyncReport]]:
+        """Sync pages yielding bounded observer snapshots, then one terminal SyncReport.
+
+        Accepts sync_pages arguments except on_progress. Slow consumers may skip
+        intermediate snapshots; absolute counts and the terminal result stay valid.
+        Errors propagate and never masquerade as successful reports. Close the
+        iterator to cancel; worker capacity remains held during resource cleanup.
+        """
+        from agno.knowledge.page._coordinator import SYNC_WORKERS
+
+        if "on_progress" in kwargs:
+            raise ValueError("stream_sync_pages manages its own progress observer")
+        yield from SYNC_WORKERS.stream(self._pages().sync, seconds=3900, **kwargs)
+
+    async def astream_sync_pages(self, **kwargs: Any) -> AsyncIterator[Union[PageSyncProgress, SyncReport]]:
+        """Async stream_sync_pages; use aclosing when stopping iteration early."""
+        from contextlib import aclosing
+
+        from agno.knowledge.page._coordinator import SYNC_WORKERS
+
+        if "on_progress" in kwargs:
+            raise ValueError("astream_sync_pages manages its own progress observer")
+        async with aclosing(SYNC_WORKERS.astream(self._pages().sync, seconds=3900, **kwargs)) as events:
+            async for event in events:
+                yield event
 
     def search_pages(
         self,

--- a/libs/agno/agno/knowledge/page/__init__.py
+++ b/libs/agno/agno/knowledge/page/__init__.py
@@ -12,6 +12,7 @@ from agno.knowledge.page.types import (
     PageRead,
     PageResult,
     PageSearchConfig,
+    PageSyncProgress,
     SearchHit,
     SearchResult,
     SearchUnavailable,
@@ -38,6 +39,7 @@ __all__ = [
     "SearchUnavailable",
     "SyncFailed",
     "SyncReport",
+    "PageSyncProgress",
     "encoded_size",
     "tool_error",
 ]

--- a/libs/agno/agno/knowledge/page/_coordinator.py
+++ b/libs/agno/agno/knowledge/page/_coordinator.py
@@ -55,6 +55,7 @@ from agno.knowledge.page.types import (
     PageNotFound,
     PageRead,
     PageSearchConfig,
+    PageSyncProgress,
     SearchHit,
     SearchResult,
     SearchUnavailable,
@@ -1339,14 +1340,44 @@ class PageCoordinator:
         index_version: str = "1",
         reindex: bool = False,
         validate_discovery: Optional[Callable[[int, int], None]] = None,
+        on_progress: Optional[Callable[[PageSyncProgress], None]] = None,
         budget: Optional[WorkBudget] = None,
     ) -> SyncReport:
+        if on_progress is not None and not callable(on_progress):
+            raise ValueError("on_progress must be a synchronous callable")
+
+        def progress(stage, *, path=None):
+            nonlocal on_progress
+            if on_progress is None:
+                return
+            try:
+                outcome = on_progress(
+                    PageSyncProgress(
+                        stage=stage,
+                        discovered=discovered,
+                        processed=processed,
+                        updated=updated,
+                        deleted=deleted,
+                        failed=failed,
+                        unknown=unknown,
+                        path=path,
+                    )
+                )
+                if inspect.isawaitable(outcome):
+                    if inspect.iscoroutine(outcome):
+                        outcome.close()
+                    raise ValueError("on_progress must be synchronous")
+            except Exception:
+                log_warning("Page sync progress observer failed; further updates are disabled")
+                on_progress = None
+
         if validate_discovery is not None and not callable(validate_discovery):
             raise ValueError("validate_discovery must be a synchronous callable")
         self._ready()
         budget = budget or WorkBudget(3900)
         source = PageSource(url, public_url, budget)
-        updated = deleted = failed = unknown = 0
+        updated = deleted = failed = unknown = processed = discovered = 0
+        progress("waiting")
         errors = []
         acquired = False
         with self.engine.connect() as conn:
@@ -1373,6 +1404,8 @@ class PageCoordinator:
                         raise ValueError("filesystem namespace is bound to another documentation source")
                     self._source_attempt(conn, source, "processing")
                 pages = source.discover()
+                discovered = len(pages)
+                progress("discovered")
                 if validate_discovery is not None:
                     with conn.begin():
                         self._settings(conn, budget)
@@ -1394,6 +1427,7 @@ class PageCoordinator:
                 ) as prepared_pages:
                     for page, content, prepared, fetch_error in prepared_pages:
                         budget.remaining()
+                        processed += 1
                         try:
                             if fetch_error is not None:
                                 raise fetch_error
@@ -1427,7 +1461,9 @@ class PageCoordinator:
                             with conn.begin():
                                 self._settings(conn, budget)
                                 self._attempt(conn, page, "failed")
+                        progress("publishing", path=page.path)
                 if source.complete and not errors and not failed and not unknown:
+                    progress("pruning")
                     with conn.begin():
                         paths = [
                             row.metadata["_agno"]["page"]["path"]
@@ -1450,6 +1486,7 @@ class PageCoordinator:
                                 )
                                 pending_delete = True
                             deleted += 1
+                            progress("pruning", path=path)
                         except Exception:
                             if conn.invalidated or conn.closed or pending_delete:
                                 conn.invalidate()

--- a/libs/agno/agno/knowledge/page/types.py
+++ b/libs/agno/agno/knowledge/page/types.py
@@ -120,6 +120,19 @@ class GrepResult(PageResult):
     stop_reason: Optional[Literal["limit", "output_limit", "deadline"]] = None
 
 
+class PageSyncProgress(PageResult):
+    """Observer snapshot; terminal success/partial status is carried by SyncReport."""
+
+    stage: Literal["waiting", "discovered", "publishing", "pruning"]
+    discovered: int = 0
+    processed: int = 0
+    updated: int = 0
+    deleted: int = 0
+    failed: int = 0
+    unknown: int = 0
+    path: Optional[str] = None
+
+
 class SyncReport(PageResult):
     status: Literal["unchanged", "completed", "partial"]
     discovered: int = 0

--- a/libs/agno/agno/run/workflow.py
+++ b/libs/agno/agno/run/workflow.py
@@ -50,6 +50,7 @@ class WorkflowRunEvent(str, Enum):
 
     step_started = "StepStarted"
     step_completed = "StepCompleted"
+    step_progress = "StepProgress"
     step_paused = "StepPaused"
     step_continued = "StepContinued"
     step_executor_paused = "StepExecutorPaused"
@@ -312,6 +313,18 @@ class StepStartedEvent(BaseWorkflowRunOutputEvent):
     event: str = WorkflowRunEvent.step_started.value
     step_name: Optional[str] = None
     step_index: Optional[Union[int, tuple]] = None
+
+
+@dataclass
+class StepProgressEvent(BaseWorkflowRunOutputEvent):
+    """Function progress attached to the existing workflow/step and retry attempt."""
+
+    event: str = WorkflowRunEvent.step_progress.value
+    step_name: Optional[str] = None
+    step_index: Optional[Union[int, tuple]] = None
+    attempt: int = 1
+    content: Optional[str] = None
+    data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
@@ -655,6 +668,7 @@ WorkflowRunOutputEvent = Union[
     WorkflowCancelledEvent,
     StepStartedEvent,
     StepCompletedEvent,
+    StepProgressEvent,
     StepPausedEvent,
     StepContinuedEvent,
     StepExecutorPausedEvent,
@@ -694,6 +708,7 @@ WORKFLOW_RUN_EVENT_TYPE_REGISTRY = {
     WorkflowRunEvent.workflow_error.value: WorkflowErrorEvent,
     WorkflowRunEvent.step_started.value: StepStartedEvent,
     WorkflowRunEvent.step_completed.value: StepCompletedEvent,
+    WorkflowRunEvent.step_progress.value: StepProgressEvent,
     WorkflowRunEvent.step_paused.value: StepPausedEvent,
     WorkflowRunEvent.step_continued.value: StepContinuedEvent,
     WorkflowRunEvent.step_executor_paused.value: StepExecutorPausedEvent,

--- a/libs/agno/agno/utils/bounded.py
+++ b/libs/agno/agno/utils/bounded.py
@@ -8,6 +8,7 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FutureTimeoutError
+from queue import Empty, Full, Queue
 from typing import Any, Callable
 
 
@@ -84,3 +85,66 @@ class BoundedWorkers:
         except (asyncio.CancelledError, TimeoutError):
             budget.cancelled.set()
             raise
+
+    def _stream_submission(self, fn, args, kwargs, seconds):
+        if not self._capacity.acquire(blocking=False):
+            raise TimeoutError("worker_capacity")
+        budget = WorkBudget(seconds)
+        updates: Queue[Any] = Queue(maxsize=32)
+        update_lock = threading.Lock()
+
+        def emit(value):
+            # Coalesce only observer updates; the terminal result comes from the
+            # future and cannot be dropped when the consumer is slower than work.
+            with update_lock:
+                try:
+                    updates.put_nowait(value)
+                except Full:
+                    try:
+                        updates.get_nowait()
+                    except Empty:
+                        pass
+                    updates.put_nowait(value)
+
+        try:
+            future = self._executor.submit(
+                self._execute, contextvars.copy_context(), fn, args, {**kwargs, "on_progress": emit}, budget
+            )
+        except BaseException:
+            self._capacity.release()
+            raise
+        future.add_done_callback(lambda done: self._capacity.release())
+        future.add_done_callback(lambda done: done.exception())
+        return future, budget, updates
+
+    def stream(self, fn: Callable[..., Any], *args: Any, seconds: float, **kwargs: Any):
+        """Yield coalesced on_progress updates followed by the function's final result.
+
+        Uses this pool's existing capacity. Closing the iterator requests cancellation;
+        capacity remains held until the worker and its resource cleanup actually end.
+        The function must accept on_progress and budget keyword arguments.
+        """
+        future, budget, updates = self._stream_submission(fn, args, kwargs, seconds)
+        try:
+            while not future.done() or not updates.empty():
+                try:
+                    yield updates.get(timeout=min(0.1, budget.remaining()))
+                except Empty:
+                    pass
+            yield future.result()
+        finally:
+            budget.cancelled.set()
+
+    async def astream(self, fn: Callable[..., Any], *args: Any, seconds: float, **kwargs: Any):
+        """Async stream without blocking the event loop or adding bridge threads."""
+        future, budget, updates = self._stream_submission(fn, args, kwargs, seconds)
+        try:
+            while not future.done() or not updates.empty():
+                budget.remaining()
+                try:
+                    yield updates.get_nowait()
+                except Empty:
+                    await asyncio.sleep(0.02)
+            yield future.result()
+        finally:
+            budget.cancelled.set()

--- a/libs/agno/agno/workflow/step.py
+++ b/libs/agno/agno/workflow/step.py
@@ -52,6 +52,7 @@ from agno.run.team import (
 )
 from agno.run.workflow import (
     StepCompletedEvent,
+    StepProgressEvent,
     StepStartedEvent,
     WorkflowRunOutput,
     WorkflowRunOutputEvent,
@@ -69,6 +70,7 @@ from agno.workflow.types import (
     OnReject,
     StepInput,
     StepOutput,
+    StepProgress,
     StepRequirement,
     StepType,
     UserInputField,
@@ -104,6 +106,7 @@ StepExecutor = Callable[
     [StepInput],
     Union[
         StepOutput,
+        StepProgress,
         Iterator[StepOutput],
         Iterator[Any],
         Awaitable[StepOutput],
@@ -1094,7 +1097,9 @@ class Step:
                                 step_input,
                                 run_context,
                             ):  # type: ignore
-                                if isinstance(chunk, (BaseRunOutputEvent)):
+                                if isinstance(chunk, StepProgress):
+                                    continue
+                                elif isinstance(chunk, (BaseRunOutputEvent)):
                                     if (
                                         isinstance(chunk, (RunContentEvent, TeamRunContentEvent))
                                         and chunk.content is not None
@@ -1435,7 +1440,22 @@ class Step:
                                 run_context,
                             )
                             for event in iterator:  # type: ignore
-                                if isinstance(event, (BaseRunOutputEvent)):
+                                if isinstance(event, StepProgress):
+                                    if stream_events and workflow_run_response:
+                                        yield StepProgressEvent(
+                                            run_id=workflow_run_response.run_id,
+                                            workflow_id=workflow_run_response.workflow_id,
+                                            workflow_name=workflow_run_response.workflow_name,
+                                            session_id=workflow_run_response.session_id,
+                                            step_name=self.name,
+                                            step_id=self.step_id,
+                                            parent_step_id=parent_step_id,
+                                            step_index=step_index,
+                                            attempt=attempt + 1,
+                                            content=event.content,
+                                            data=event.data,
+                                        )
+                                elif isinstance(event, (BaseRunOutputEvent)):
                                     if (
                                         isinstance(event, (RunContentEvent, TeamRunContentEvent))
                                         and event.content is not None
@@ -1761,7 +1781,9 @@ class Step:
                                     run_context,
                                 )
                                 for chunk in iterator:  # type: ignore
-                                    if isinstance(chunk, (BaseRunOutputEvent)):
+                                    if isinstance(chunk, StepProgress):
+                                        continue
+                                    elif isinstance(chunk, (BaseRunOutputEvent)):
                                         if (
                                             isinstance(chunk, (RunContentEvent, TeamRunContentEvent))
                                             and chunk.content is not None
@@ -1788,7 +1810,9 @@ class Step:
                                         run_context,
                                     )
                                     async for chunk in iterator:  # type: ignore
-                                        if isinstance(chunk, (BaseRunOutputEvent)):
+                                        if isinstance(chunk, StepProgress):
+                                            continue
+                                        elif isinstance(chunk, (BaseRunOutputEvent)):
                                             if (
                                                 isinstance(chunk, (RunContentEvent, TeamRunContentEvent))
                                                 and chunk.content is not None
@@ -2077,7 +2101,22 @@ class Step:
                             run_context,
                         )
                         async for event in iterator:  # type: ignore
-                            if isinstance(event, (BaseRunOutputEvent)):
+                            if isinstance(event, StepProgress):
+                                if stream_events and workflow_run_response:
+                                    yield StepProgressEvent(
+                                        run_id=workflow_run_response.run_id,
+                                        workflow_id=workflow_run_response.workflow_id,
+                                        workflow_name=workflow_run_response.workflow_name,
+                                        session_id=workflow_run_response.session_id,
+                                        step_name=self.name,
+                                        step_id=self.step_id,
+                                        parent_step_id=parent_step_id,
+                                        step_index=step_index,
+                                        attempt=attempt + 1,
+                                        content=event.content,
+                                        data=event.data,
+                                    )
+                            elif isinstance(event, (BaseRunOutputEvent)):
                                 if (
                                     isinstance(event, (RunContentEvent, TeamRunContentEvent))
                                     and event.content is not None
@@ -2126,7 +2165,22 @@ class Step:
                             run_context,
                         )
                         for event in iterator:  # type: ignore
-                            if isinstance(event, (BaseRunOutputEvent)):
+                            if isinstance(event, StepProgress):
+                                if stream_events and workflow_run_response:
+                                    yield StepProgressEvent(
+                                        run_id=workflow_run_response.run_id,
+                                        workflow_id=workflow_run_response.workflow_id,
+                                        workflow_name=workflow_run_response.workflow_name,
+                                        session_id=workflow_run_response.session_id,
+                                        step_name=self.name,
+                                        step_id=self.step_id,
+                                        parent_step_id=parent_step_id,
+                                        step_index=step_index,
+                                        attempt=attempt + 1,
+                                        content=event.content,
+                                        data=event.data,
+                                    )
+                            elif isinstance(event, (BaseRunOutputEvent)):
                                 if (
                                     isinstance(event, (RunContentEvent, TeamRunContentEvent))
                                     and event.content is not None

--- a/libs/agno/agno/workflow/types.py
+++ b/libs/agno/agno/workflow/types.py
@@ -535,6 +535,14 @@ class StepInput:
 
 
 @dataclass
+class StepProgress:
+    """A function executor's observer update; never a separate executor run."""
+
+    content: Optional[str] = None
+    data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
 class StepOutput:
     """Output data from a step execution"""
 

--- a/libs/agno/tests/integration/knowledge/test_page_storage.py
+++ b/libs/agno/tests/integration/knowledge/test_page_storage.py
@@ -2111,3 +2111,47 @@ async def test_full_page_database_deadline_recovers_after_lock(corpus, async_mod
         with pytest.raises(PageError):
             await read(0.05)
     assert await read(2) == site["https://docs.example.com/agent.md"]
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+def test_native_sync_progress_stream_counts_and_terminal_partial_status(corpus, asynchronous):
+    import asyncio
+
+    from agno.knowledge.page import PageSyncProgress, SyncReport
+
+    knowledge, embedder, site = corpus
+
+    def collect():
+        if not asynchronous:
+            return list(knowledge.stream_sync_pages(url="https://docs.example.com/llms.txt"))
+
+        async def events():
+            return [event async for event in knowledge.astream_sync_pages(url="https://docs.example.com/llms.txt")]
+
+        return asyncio.run(events())
+
+    events = collect()
+    assert isinstance(events[-1], SyncReport) and events[-1].updated == 1
+    progress = [event for event in events if isinstance(event, PageSyncProgress)]
+    assert progress[0].stage == "waiting"
+    assert any(event.stage == "discovered" and event.discovered == 1 for event in progress)
+    assert any(event.processed == 1 and event.updated == 1 for event in progress)
+    site["https://docs.example.com/agent.md"] += "\nChanged content.\n"
+    embedder.fail = True
+    events = collect()
+    assert isinstance(events[-1], SyncReport)
+    assert events[-1].status == "partial" and events[-1].failed == 1
+    assert any(isinstance(event, PageSyncProgress) and event.failed == 1 for event in events)
+
+
+def test_failed_progress_observer_does_not_fail_publication(corpus):
+    knowledge, _, _ = corpus
+    seen = []
+
+    def observer(event):
+        seen.append(event)
+        raise RuntimeError("observer failed")
+
+    report = knowledge.sync_pages(url="https://docs.example.com/llms.txt", on_progress=observer)
+    assert report.updated == 1 and report.status == "completed"
+    assert len(seen) == 1

--- a/libs/agno/tests/unit/knowledge/test_page_contract.py
+++ b/libs/agno/tests/unit/knowledge/test_page_contract.py
@@ -45,7 +45,7 @@ def test_page_public_imports_preserve_types_without_loading_storage():
                     "PageNotFound", "PageRead", "PageResult", "PageSearchConfig", "SearchHit", "SearchResult",
                     "SearchUnavailable", "SyncFailed", "SyncReport", "encoded_size", "tool_error",
                 }
-                assert set(page.__all__) == expected | {"PageFileSystem"}
+                assert expected | {"PageFileSystem"} <= set(page.__all__)
                 for name in expected:
                     assert getattr(page, name) is getattr(types, name)
                 assert page.SearchResult().model_dump() == {

--- a/libs/agno/tests/unit/knowledge/test_sync_progress_workers.py
+++ b/libs/agno/tests/unit/knowledge/test_sync_progress_workers.py
@@ -1,0 +1,85 @@
+import asyncio
+from contextlib import aclosing, closing
+from threading import Event
+
+import pytest
+
+from agno.utils.bounded import BoundedWorkers
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_slow_consumer_is_bounded_and_final_result_never_dropped(asynchronous):
+    workers = BoundedWorkers(1, "progress-test")
+    finished = Event()
+
+    def work(*, budget, on_progress):
+        for number in range(10000):
+            on_progress(number)
+        finished.set()
+        return {"done": True}
+
+    if asynchronous:
+        stream = workers.astream(work, seconds=5)
+        first = await stream.__anext__()
+        await asyncio.to_thread(finished.wait, 5)
+        rest = [event async for event in stream]
+    else:
+        stream = workers.stream(work, seconds=5)
+        first = next(stream)
+        assert finished.wait(5)
+        rest = list(stream)
+    assert first is not None and rest[-1] == {"done": True}
+    assert len(rest) <= 33
+    workers._executor.shutdown(wait=True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_early_close_requests_cancellation_and_retains_capacity_until_cleanup(asynchronous):
+    workers = BoundedWorkers(1, "progress-close")
+    cancelled, release, ended = Event(), Event(), Event()
+
+    def work(*, budget, on_progress):
+        try:
+            on_progress("started")
+            assert budget.cancelled.wait(5)
+            cancelled.set()
+            assert release.wait(5)
+        finally:
+            ended.set()
+
+    try:
+        if asynchronous:
+            async with aclosing(workers.astream(work, seconds=10)) as stream:
+                assert await stream.__anext__() == "started"
+        else:
+            with closing(workers.stream(work, seconds=10)) as stream:
+                assert next(stream) == "started"
+        assert await asyncio.to_thread(cancelled.wait, 5)
+        with pytest.raises(TimeoutError, match="worker_capacity"):
+            workers.run_sync(lambda **kwargs: None, seconds=1)
+    finally:
+        release.set()
+        assert await asyncio.to_thread(ended.wait, 5)
+        workers._executor.shutdown(wait=True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_worker_errors_propagate_without_terminal_success(asynchronous):
+    workers = BoundedWorkers(1, "progress-error")
+
+    def work(*, budget, on_progress):
+        on_progress("working")
+        raise ValueError("invalid source")
+
+    seen = []
+    with pytest.raises(ValueError, match="invalid source"):
+        if asynchronous:
+            async for event in workers.astream(work, seconds=5):
+                seen.append(event)
+        else:
+            seen.extend(workers.stream(work, seconds=5))
+    assert seen == ["working"]
+    workers._executor.shutdown(wait=True)

--- a/libs/agno/tests/unit/workflow/test_function_progress.py
+++ b/libs/agno/tests/unit/workflow/test_function_progress.py
@@ -1,0 +1,72 @@
+import pytest
+
+from agno.db.in_memory import InMemoryDb
+from agno.run.workflow import StepProgressEvent, WorkflowCompletedEvent, workflow_run_output_event_from_dict
+from agno.workflow import Workflow
+from agno.workflow.step import Step
+from agno.workflow.types import StepOutput, StepProgress
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize("async_executor", [False, True])
+@pytest.mark.parametrize("stream", [False, True])
+async def test_function_progress_has_native_identity_and_does_not_pollute_output(asynchronous, async_executor, stream):
+    if async_executor and not asynchronous:
+        pytest.skip("sync execution deliberately rejects async executors")
+    attempts = []
+
+    def work(step_input):
+        attempts.append(1)
+        yield StepProgress(content="Indexed one page", data={"processed": 1})
+        yield StepOutput(content="final result")
+
+    async def awork(step_input):
+        for event in work(step_input):
+            yield event
+
+    workflow = Workflow(
+        id="index",
+        steps=[Step(name="sync", executor=awork if async_executor else work)],
+        db=InMemoryDb(),
+        store_events=True,
+        telemetry=False,
+    )
+    if stream:
+        kwargs = dict(input="go", session_id="session", stream=True, stream_events=True, stream_executor_events=False)
+        events = [event async for event in workflow.arun(**kwargs)] if asynchronous else list(workflow.run(**kwargs))
+        progress = [event for event in events if isinstance(event, StepProgressEvent)]
+        assert len(progress) == 1
+        event = progress[0]
+        completed = next(event for event in events if isinstance(event, WorkflowCompletedEvent))
+        assert event.run_id == completed.run_id and event.workflow_id == "index" and event.session_id == "session"
+        assert event.step_id and event.step_name == "sync" and event.attempt == 1
+        assert workflow_run_output_event_from_dict(event.to_dict()) == event
+        assert len(completed.step_results) == 1 and completed.step_results[0].content == "final result"
+        assert all(type(event).__module__ != "agno.run.agent" for event in events)
+    else:
+        output = await workflow.arun("go") if asynchronous else workflow.run("go")
+        assert output.content == "final result" and "Indexed one page" not in str(output.content)
+    assert len(attempts) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_progress_identifies_retry_attempt_without_another_executor_run(asynchronous):
+    attempts = []
+
+    def work(step_input):
+        attempts.append(1)
+        yield StepProgress(content="working")
+        if len(attempts) == 1:
+            raise RuntimeError("temporary failure")
+        yield StepOutput(content="finished")
+
+    workflow = Workflow(id="retry", steps=[Step(name="sync", executor=work, max_retries=1)], telemetry=False)
+    kwargs = dict(input="go", stream=True, stream_events=True)
+    events = [e async for e in workflow.arun(**kwargs)] if asynchronous else list(workflow.run(**kwargs))
+    progress = [e for e in events if isinstance(e, StepProgressEvent)]
+    assert [e.attempt for e in progress] == [1, 2]
+    assert len({(e.run_id, e.step_id) for e in progress}) == 1
+    completed = next(e for e in events if isinstance(e, WorkflowCompletedEvent))
+    assert len(completed.step_results) == 1

--- a/libs/agno/tests/unit/workflow/test_workflow_event_stream.py
+++ b/libs/agno/tests/unit/workflow/test_workflow_event_stream.py
@@ -176,3 +176,55 @@ class TestWorkerStreamingWorkflowJob:
 
         received = [idx async for idx, _sse in fresh_stream.tail("wr1")]
         assert received == [0, 1]
+
+
+@pytest.mark.asyncio
+async def test_native_function_progress_survives_queue_stream_and_run_storage(fresh_stream):
+    import json
+
+    from agno.db.in_memory import InMemoryDb
+    from agno.job_queue.config import QueueConfig
+    from agno.job_queue.store import InMemoryQueueStore
+    from agno.os.job_queue import QueueWorker
+    from agno.workflow.step import Step
+    from agno.workflow.types import StepOutput, StepProgress
+
+    async def sync(step_input):
+        yield StepProgress(content="one page", data={"processed": 1})
+        yield StepOutput(content="done")
+
+    workflow = Workflow(
+        id="wf-progress", steps=[Step(name="sync", executor=sync)], db=InMemoryDb(), store_events=True, telemetry=False
+    )
+    store = InMemoryQueueStore()
+    await store.enqueue_job(
+        dict(
+            id="progress-job",
+            component_type="workflow",
+            component_id=workflow.id,
+            session_id="s1",
+            job_type="run",
+            payload={"input": "go", "kwargs": {}, "stream": True},
+            status="queued",
+            attempt=0,
+            max_attempts=1,
+            available_at=0,
+            created_at=0,
+        )
+    )
+    worker = QueueWorker(
+        store=store,
+        resolve_component=lambda kind, ident: workflow,
+        config=QueueConfig(durable=True, poll_interval=0.05, lock_grace_seconds=60),
+    )
+    await worker._execute_claimed(await store.claim_job(worker.worker_id))
+    assert (await store.get_job("progress-job"))["status"] == "completed"
+    received = [payload async for _, payload in fresh_stream.tail("progress-job")]
+    events = [
+        json.loads(line[6:]) for payload in received for line in payload.splitlines() if line.startswith("data: ")
+    ]
+    progress = [event for event in events if event["event"] == "StepProgress"]
+    assert len(progress) == 1 and progress[0]["run_id"] == "progress-job"
+    assert progress[0]["data"] == {"processed": 1}
+    stored = await workflow.aget_run_output(run_id="progress-job", session_id="s1")
+    assert stored.content == "done" and len(stored.step_results) == 1


### PR DESCRIPTION
## Summary

Function-based indexing workflows currently create synthetic agent runs and maintain a task/queue/heartbeat bridge just to show progress. Add native Knowledge progress snapshots/iterators and a function executor `StepProgress` value. Workflow streaming emits `StepProgressEvent` under the existing workflow run ID, step ID and retry attempt; no agent or extra executor history is invented. Non-streaming execution ignores progress and retains the final StepOutput.

`Knowledge.stream_sync_pages` / `astream_sync_pages` yield typed absolute progress counts and one terminal SyncReport. The existing bounded sync pool retains at most 32 pending observer updates, coalesces slow consumers, propagates errors, and retains worker capacity until cancellation cleanup finishes. Sync/async callback users can supply `on_progress`; observer failure disables observation without failing publication. Index validation and partial/error semantics remain separate.

This replaces application task/queue/synthetic-agent scaffolding with a small adapter from PageSyncProgress/SyncReport to StepProgress/StepOutput. Source selection, shrink policy and summary wording remain application code.

Related #8710 handles AG-UI presentation of workflow structure; it does not add a function progress event or Knowledge sync progress. This PR supplies those engine/source primitives without changing its renderer.

## Type of change

- [x] New feature
- [x] Improvement

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated
- [ ] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests
- [x] If a similar PR exists, I have explained above how the scope differs
- [x] Check if this PR was entirely AI-generated

## Additional Notes

815 workflow/worker/page-contract tests passed with nine skips; all 123 disposable PostgreSQL page-storage cases passed. Tests cover native event identity/serialization, retry attempts, QueueWorker delivery/run storage, bounded slow consumers, cancellation capacity retention, sync/async counts, partial reports and observer failures. Cookbook `--check` and full format/validation passed.

Control Plane visual rendering is an adoption gate: consumers must render the new StepProgress event before the application can remove its old display adapter. Native event-stream/queue delivery is tested; no Control Plane/AG-UI renderer or production deployment changed here. SSE transport keepalives remain separate from progress snapshots.
