### PR TITLE
feat: stream tool call arguments, and fix AG-UI shared state

### DIFF
--- a/cookbook/05_agent_os/16_agui/README.md
+++ b/cookbook/05_agent_os/16_agui/README.md
@@ -19,7 +19,7 @@ default empty prefix those routes are `POST /agui` and `GET /status`.
 | `structured_output.py` | Stream a response constrained by a Pydantic output schema. |
 | `reasoning_agent.py` | Translate Agno reasoning lifecycle events into AG-UI reasoning events. |
 | `agent_with_media.py` | Pass AG-UI image, audio, video, and document parts to Gemini. |
-| `shared_state.py` | Send state snapshots and JSON Patch deltas as session state changes. |
+| `shared_state.py` | Let a tool change session state and watch the interface's snapshots and deltas. |
 | `human_in_the_loop.py` | Pause and resume a real backend tool that uses `requires_confirmation`. |
 | `research_team.py` | Stream a coordinated Team and its member activity over AG-UI. |
 | `multiple_instances.py` | Mount two independent AG-UI interfaces on one AgentOS. |
@@ -98,10 +98,55 @@ curl -N http://localhost:7777/agui \
 ```
 
 The stream begins with `RUN_STARTED`, emits message or capability-specific
-events, and ends with `RUN_FINISHED`. Tool calls use `TOOL_CALL_*`; reasoning
-uses `REASONING_*`; shared state uses `STATE_SNAPSHOT` and `STATE_DELTA`.
-`threadId` becomes the Agno session ID, so later requests can continue the same
-conversation.
+events, and ends with `RUN_FINISHED`, or with `RUN_ERROR` if the run fails.
+Tool calls use `TOOL_CALL_*`; reasoning uses `REASONING_*`; shared state uses
+`STATE_SNAPSHOT` and `STATE_DELTA`. `threadId` becomes the Agno session ID, so
+later requests can continue the same conversation.
+
+## Shared state on the wire
+
+State events only happen when the request's `state` reads as a dictionary: a
+request that omits it, sends `null`, or sends a value the server cannot coerce
+gets none of them. When it is there, the AG-UI interface, not the example,
+sends that dictionary back as an opening `STATE_SNAPSHOT`, a `STATE_DELTA` each
+time a completed tool call leaves state different from the last payload, and a
+closing `STATE_SNAPSHOT` unless the run ends in `RUN_ERROR`. Four things are
+worth knowing about those payloads:
+
+- The opening snapshot is the dictionary the client sent, but the run does not
+  start from it. The agent's own `session_state` seeds the session row when
+  that row is created, and each run merges the row in under the request's own
+  state, which wins; the row is created once per `threadId`, so an edit to the
+  example's initial recipe shows up in a new conversation and never in one
+  already under way. Each delta is measured against the previous payload, so
+  unless the request already sent all of it, the first delta adds what the
+  merge brought in and reports more than the tool call itself touched. Later
+  deltas in the same run carry only what changed since the one before.
+- The delta is computed when a tool call completes, so several changes inside
+  one tool call arrive as a single delta, and a change made outside a tool call
+  reaches the client only in the closing snapshot.
+- They carry only the keys your application put in state. Agno also keeps
+  `current_user_id`, `current_session_id`, and `current_run_id` in session
+  state at runtime so tools and instruction templates can read them, and the
+  filter removes all three from every payload. It covers only those payloads:
+  `update_session_state` returns the whole of state as its result text, so the
+  session and run ids still reach the client in that tool result, and the user
+  id with them when the server resolved one. Treat them as reserved at the top
+  level: a key of your own with one of those names is filtered out too, so
+  pick another. That filtering is outbound only, so a value the request sent
+  under one of those names does reach the run. The filter does not descend, so
+  one of those names nested inside a value of yours does reach the client.
+- `STATE_DELTA` needs the `jsonpatch` package. Agno's `agui` extra installs it
+  together with `ag-ui-protocol`, and the `os` extra ships neither, so the gap
+  to watch for is an install that added `ag-ui-protocol` by hand on top of `os`.
+  `pip install jsonpatch` closes it. When no patch can be built for a change, a
+  missing package being one cause of several, the mid-stream event is a full
+  `STATE_SNAPSHOT` rather than a delta, and the server logs which cause fired.
+  Note that `agui` is those two packages and nothing else, so it does not stand
+  in for `os`: outside this cookbook's environment a bare `agno` install needs
+  `pip install "agno[os,agui]"`, plus the model package each file imports and
+  `ddgs` for `research_team.py`, before these servers will start; the
+  [Prerequisites](#prerequisites) environment above has all of it.
 
 ## Frontend tools and backend HITL are different
 
@@ -141,10 +186,13 @@ server, but cannot run until its confirmation requirement is resolved.
 
 ## State and media
 
-AG-UI state is a dictionary sent with the request. `shared_state.py` snapshots
-that dictionary before the run, lets `update_session_state` mutate it, emits a
-JSON Patch delta after the tool call, and finishes with an authoritative
-snapshot.
+AG-UI state is a dictionary sent with the request. `shared_state.py` gives its
+agent an `update_session_state` tool; the AG-UI interface, not the example,
+echoes the request dictionary back as an opening `STATE_SNAPSHOT`, emits a JSON
+Patch delta each time a completed tool call leaves state different from the
+last payload, and closes with a snapshot unless the run ends in `RUN_ERROR`.
+The opening snapshot is not the state the run starts from;
+[Shared state on the wire](#shared-state-on-the-wire) has the payload rules.
 
 Media belongs in the latest user message as an AG-UI image, audio, video, or
 document content part. The adapter converts URL or base64 data sources into

--- a/cookbook/05_agent_os/16_agui/shared_state.py
+++ b/cookbook/05_agent_os/16_agui/shared_state.py
@@ -2,8 +2,15 @@
 Synchronize Shared State over AG-UI
 ===================================
 
-Give an AG-UI agent a recipe-shaped session state and let its
-update_session_state tool emit state snapshots and JSON Patch deltas.
+Give an AG-UI agent a recipe-shaped session state, let its
+update_session_state tool change it, and watch the interface emit state
+snapshots and JSON Patch deltas.
+
+A delta fires each time a completed tool call leaves state different from the
+last payload, and because this agent's session_state seeds the session row that
+each run merges in, the first delta of a run reports more than that tool call
+touched, unless the request already sent all the state the run starts from. The
+README's "Shared state on the wire" has the rest of the payload rules.
 
 Prerequisites: OPENAI_API_KEY
 Run: .venvs/demo/bin/python cookbook/05_agent_os/16_agui/shared_state.py

--- a/libs/agno/agno/agent/__init__.py
+++ b/libs/agno/agno/agent/__init__.py
@@ -38,6 +38,7 @@ from agno.run.agent import (
     RunOutputEvent,
     RunPausedEvent,
     RunStartedEvent,
+    ToolCallArgsDeltaEvent,
     ToolCallCompletedEvent,
     ToolCallStartedEvent,
 )
@@ -76,6 +77,7 @@ __all__ = [
     "ReasoningStartedEvent",
     "ReasoningStepEvent",
     "ReasoningCompletedEvent",
+    "ToolCallArgsDeltaEvent",
     "ToolCallStartedEvent",
     "ToolCallCompletedEvent",
     "get_agent_by_id",

--- a/libs/agno/agno/agent/_response.py
+++ b/libs/agno/agno/agent/_response.py
@@ -34,7 +34,7 @@ from agno.run import RunContext
 from agno.run.agent import RUN_OUTPUT_EVENT_TYPES, Followups, RunEvent, RunOutput, RunOutputEvent
 from agno.run.messages import RunMessages
 from agno.run.requirement import RunRequirement
-from agno.run.team import TEAM_RUN_OUTPUT_EVENT_TYPES, TeamRunOutputEvent
+from agno.run.team import TEAM_RUN_OUTPUT_EVENT_TYPES, TeamRunEvent, TeamRunOutputEvent
 from agno.session import AgentSession
 from agno.tools.function import Function
 from agno.utils.events import (
@@ -51,6 +51,7 @@ from agno.utils.events import (
     create_reasoning_started_event,
     create_reasoning_step_event,
     create_run_output_content_event,
+    create_tool_call_args_delta_event,
     create_tool_call_completed_event,
     create_tool_call_error_event,
     create_tool_call_started_event,
@@ -65,6 +66,41 @@ from agno.utils.reasoning import (
     update_run_output_with_reasoning,
 )
 from agno.utils.string import parse_response_dict_str, parse_response_model_str
+from agno.utils.tools import (
+    REFUSED_TOOL_CALL_ERROR,
+    ToolCallArgsStream,
+    answer_streamed_tool_calls,
+    take_refused_tool_calls,
+)
+
+# The fragment event under both the names it reaches an agent under: its own,
+# and the one a nested team sends it out as.
+_TOOL_CALL_ARGS_DELTA_EVENTS = frozenset({RunEvent.tool_call_args_delta.value, TeamRunEvent.tool_call_args_delta.value})
+
+
+###########################################################################
+# Tool call argument streaming
+###########################################################################
+
+
+def close_refused_tool_calls(
+    agent: Agent,
+    run_response: RunOutput,
+    tool_args_stream: Optional[ToolCallArgsStream],
+) -> Iterator[RunOutputEvent]:
+    """Report as failed each call a client was shown that the run refused."""
+    for tool in take_refused_tool_calls(tool_args_stream):
+        yield handle_event(  # type: ignore
+            create_tool_call_error_event(
+                from_run_response=run_response,
+                tool=tool,
+                error=REFUSED_TOOL_CALL_ERROR,
+            ),
+            run_response,
+            events_to_skip=agent.events_to_skip,  # type: ignore
+            store_events=agent.store_events,
+        )
+
 
 ###########################################################################
 # Reasoning
@@ -469,6 +505,10 @@ def parse_response_with_parser_model_stream(
             messages_for_parser_model = get_messages_for_parser_model_stream(
                 agent, run_response, parser_response_format, run_context=run_context
             )
+            # The parser model is asked for its answer in one piece rather than
+            # streamed, so no delta of its own ever carries a call's arguments a
+            # fragment at a time. Nothing here threads the record that would
+            # attribute such fragments.
             for model_response_event in agent.parser_model.response_stream(
                 messages=messages_for_parser_model,
                 response_format=parser_response_format,
@@ -543,6 +583,10 @@ async def aparse_response_with_parser_model_stream(
                 stream_model_response=False,
                 run_response=run_response,
             )
+            # The parser model is asked for its answer in one piece rather than
+            # streamed, so no delta of its own ever carries a call's arguments a
+            # fragment at a time. Nothing here threads the record that would
+            # attribute such fragments.
             async for model_response_event in model_response_stream:  # type: ignore
                 for event in handle_model_response_chunk(
                     agent,
@@ -633,17 +677,33 @@ def generate_response_with_output_model_stream(
 
     model_response = ModelResponse(content="")
 
-    for model_response_event in agent.output_model.response_stream(
-        messages=messages_for_output_model, run_response=run_response
-    ):
-        yield from handle_model_response_chunk(
-            agent,
-            session=session,
-            run_response=run_response,
-            model_response=model_response,
-            model_response_event=model_response_event,
-            stream_events=stream_events,
-        )
+    # The run hands the output model none of its own tools, but a provider can
+    # answer with a call to one of its built-in tools whatever it was passed, so
+    # the record that attributes a call's argument fragments is threaded here.
+    # A caller that asked for no events is sent no fragments, so it is given no
+    # stream. Which of the call's other events this path announces is settled
+    # elsewhere and left as it was.
+    tool_args_stream = ToolCallArgsStream(run_response.session_id, run_response.run_id) if stream_events else None
+    try:
+        for model_response_event in agent.output_model.response_stream(
+            messages=messages_for_output_model, run_response=run_response
+        ):
+            yield from handle_model_response_chunk(
+                agent,
+                session=session,
+                run_response=run_response,
+                model_response=model_response,
+                model_response_event=model_response_event,
+                stream_events=stream_events,
+                tool_args_stream=tool_args_stream,
+            )
+    except Exception:
+        # As in the agent's own model loop: a stream that raised can still be
+        # yielded into, a generator the consumer abandoned cannot.
+        yield from close_refused_tool_calls(agent, run_response, tool_args_stream)
+        raise
+
+    yield from close_refused_tool_calls(agent, run_response, tool_args_stream)
 
     if stream_events:
         yield handle_event(
@@ -718,16 +778,34 @@ async def agenerate_response_with_output_model_stream(
         messages=messages_for_output_model, run_response=run_response
     )
 
-    async for model_response_event in model_response_stream:
-        for event in handle_model_response_chunk(
-            agent,
-            session=session,
-            run_response=run_response,
-            model_response=model_response,
-            model_response_event=model_response_event,
-            stream_events=stream_events,
-        ):
-            yield event
+    # The run hands the output model none of its own tools, but a provider can
+    # answer with a call to one of its built-in tools whatever it was passed, so
+    # the record that attributes a call's argument fragments is threaded here.
+    # A caller that asked for no events is sent no fragments, so it is given no
+    # stream. Which of the call's other events this path announces is settled
+    # elsewhere and left as it was.
+    tool_args_stream = ToolCallArgsStream(run_response.session_id, run_response.run_id) if stream_events else None
+    try:
+        async for model_response_event in model_response_stream:
+            for event in handle_model_response_chunk(
+                agent,
+                session=session,
+                run_response=run_response,
+                model_response=model_response,
+                model_response_event=model_response_event,
+                stream_events=stream_events,
+                tool_args_stream=tool_args_stream,
+            ):
+                yield event
+    except Exception:
+        # As in the agent's own model loop: a stream that raised can still be
+        # yielded into, a generator the consumer abandoned cannot.
+        for refused in close_refused_tool_calls(agent, run_response, tool_args_stream):
+            yield refused
+        raise
+
+    for refused in close_refused_tool_calls(agent, run_response, tool_args_stream):
+        yield refused
 
     if stream_events:
         yield handle_event(
@@ -1042,6 +1120,7 @@ def handle_model_response_stream(
         "reasoning_started": False,
         "reasoning_time_taken": 0.0,
     }
+    tool_args_stream = ToolCallArgsStream(run_response.session_id, run_response.run_id) if stream_events else None
     model_response = ModelResponse(content="")
 
     # Get output_schema from run_context
@@ -1055,103 +1134,121 @@ def handle_model_response_stream(
 
     from agno.agent._run import build_after_tool_results_callback
 
-    for model_response_event in call_model_stream_with_fallback(
-        agent.model,
-        agent.fallback_config,
-        messages=run_messages.messages,
-        response_format=response_format,
-        tools=tools,
-        tool_choice=agent.tool_choice,
-        tool_call_limit=agent.tool_call_limit,
-        stream_model_response=stream_model_response,
-        run_response=run_response,
-        send_media_to_model=agent.send_media_to_model,
-        compression_manager=agent.compression_manager if agent.compress_tool_results else None,
-        **result_store_kwargs(agent),
-        after_tool_results=build_after_tool_results_callback(
-            agent,
+    try:
+        for model_response_event in call_model_stream_with_fallback(
+            agent.model,
+            agent.fallback_config,
+            messages=run_messages.messages,
+            response_format=response_format,
+            tools=tools,
+            tool_choice=agent.tool_choice,
+            tool_call_limit=agent.tool_call_limit,
+            stream_model_response=stream_model_response,
             run_response=run_response,
-            session=session,
-            run_messages=run_messages,
-            run_context=run_context,
-        ),
-    ):
-        # Handle LLM request events and compression events from ModelResponse
-        if isinstance(model_response_event, ModelResponse):
-            if model_response_event.event == ModelResponseEvent.model_request_started.value:
-                if stream_events:
-                    yield handle_event(  # type: ignore
-                        create_model_request_started_event(
-                            from_run_response=run_response,
-                            model=agent.model.id,
-                            model_provider=agent.model.provider,
-                        ),
-                        run_response,
-                        events_to_skip=agent.events_to_skip,  # type: ignore
-                        store_events=agent.store_events,
-                    )
-                continue
+            send_media_to_model=agent.send_media_to_model,
+            compression_manager=agent.compression_manager if agent.compress_tool_results else None,
+            **result_store_kwargs(agent),
+            after_tool_results=build_after_tool_results_callback(
+                agent,
+                run_response=run_response,
+                session=session,
+                run_messages=run_messages,
+                run_context=run_context,
+            ),
+        ):
+            # Handle LLM request events and compression events from ModelResponse
+            if isinstance(model_response_event, ModelResponse):
+                if model_response_event.event == ModelResponseEvent.model_request_started.value:
+                    # By now the run has decided what to do with every call the last
+                    # turn made, and its tool call identities do not carry forward
+                    yield from close_refused_tool_calls(agent, run_response, tool_args_stream)
+                    if tool_args_stream is not None:
+                        tool_args_stream.begin_turn()
+                    if stream_events:
+                        yield handle_event(  # type: ignore
+                            create_model_request_started_event(
+                                from_run_response=run_response,
+                                model=agent.model.id,
+                                model_provider=agent.model.provider,
+                            ),
+                            run_response,
+                            events_to_skip=agent.events_to_skip,  # type: ignore
+                            store_events=agent.store_events,
+                        )
+                    continue
 
-            if model_response_event.event == ModelResponseEvent.model_request_completed.value:
-                if stream_events:
-                    yield handle_event(  # type: ignore
-                        create_model_request_completed_event(
-                            from_run_response=run_response,
-                            model=agent.model.id,
-                            model_provider=agent.model.provider,
-                            input_tokens=model_response_event.input_tokens,
-                            output_tokens=model_response_event.output_tokens,
-                            total_tokens=model_response_event.total_tokens,
-                            time_to_first_token=model_response_event.time_to_first_token,
-                            reasoning_tokens=model_response_event.reasoning_tokens,
-                            cache_read_tokens=model_response_event.cache_read_tokens,
-                            cache_write_tokens=model_response_event.cache_write_tokens,
-                        ),
-                        run_response,
-                        events_to_skip=agent.events_to_skip,  # type: ignore
-                        store_events=agent.store_events,
-                    )
-                continue
+                if model_response_event.event == ModelResponseEvent.model_request_completed.value:
+                    if stream_events:
+                        yield handle_event(  # type: ignore
+                            create_model_request_completed_event(
+                                from_run_response=run_response,
+                                model=agent.model.id,
+                                model_provider=agent.model.provider,
+                                input_tokens=model_response_event.input_tokens,
+                                output_tokens=model_response_event.output_tokens,
+                                total_tokens=model_response_event.total_tokens,
+                                time_to_first_token=model_response_event.time_to_first_token,
+                                reasoning_tokens=model_response_event.reasoning_tokens,
+                                cache_read_tokens=model_response_event.cache_read_tokens,
+                                cache_write_tokens=model_response_event.cache_write_tokens,
+                            ),
+                            run_response,
+                            events_to_skip=agent.events_to_skip,  # type: ignore
+                            store_events=agent.store_events,
+                        )
+                    continue
 
-            # Handle compression events
-            if model_response_event.event == ModelResponseEvent.compression_started.value:
-                if stream_events:
-                    yield handle_event(  # type: ignore
-                        create_compression_started_event(from_run_response=run_response),
-                        run_response,
-                        events_to_skip=agent.events_to_skip,  # type: ignore
-                        store_events=agent.store_events,
-                    )
-                continue
+                # Handle compression events
+                if model_response_event.event == ModelResponseEvent.compression_started.value:
+                    if stream_events:
+                        yield handle_event(  # type: ignore
+                            create_compression_started_event(from_run_response=run_response),
+                            run_response,
+                            events_to_skip=agent.events_to_skip,  # type: ignore
+                            store_events=agent.store_events,
+                        )
+                    continue
 
-            if model_response_event.event == ModelResponseEvent.compression_completed.value:
-                if stream_events:
-                    stats = model_response_event.compression_stats or {}
-                    yield handle_event(  # type: ignore
-                        create_compression_completed_event(
-                            from_run_response=run_response,
-                            tool_results_compressed=stats.get("tool_results_compressed"),
-                            original_size=stats.get("original_size"),
-                            compressed_size=stats.get("compressed_size"),
-                        ),
-                        run_response,
-                        events_to_skip=agent.events_to_skip,  # type: ignore
-                        store_events=agent.store_events,
-                    )
-                continue
+                if model_response_event.event == ModelResponseEvent.compression_completed.value:
+                    if stream_events:
+                        stats = model_response_event.compression_stats or {}
+                        yield handle_event(  # type: ignore
+                            create_compression_completed_event(
+                                from_run_response=run_response,
+                                tool_results_compressed=stats.get("tool_results_compressed"),
+                                original_size=stats.get("original_size"),
+                                compressed_size=stats.get("compressed_size"),
+                            ),
+                            run_response,
+                            events_to_skip=agent.events_to_skip,  # type: ignore
+                            store_events=agent.store_events,
+                        )
+                    continue
 
-        yield from handle_model_response_chunk(
-            agent,
-            session=session,
-            run_response=run_response,
-            model_response=model_response,
-            model_response_event=model_response_event,
-            reasoning_state=reasoning_state,
-            parse_structured_output=should_parse_structured_output,
-            stream_events=stream_events,
-            session_state=session_state,
-            run_context=run_context,
-        )
+            yield from handle_model_response_chunk(
+                agent,
+                session=session,
+                run_response=run_response,
+                model_response=model_response,
+                model_response_event=model_response_event,
+                reasoning_state=reasoning_state,
+                parse_structured_output=should_parse_structured_output,
+                stream_events=stream_events,
+                session_state=session_state,
+                run_context=run_context,
+                tool_args_stream=tool_args_stream,
+            )
+    except Exception:
+        # A stream that raised is still being read, so this generator can
+        # yield the closures. A generator the consumer abandoned cannot:
+        # that arrives as GeneratorExit, which is no Exception and is left
+        # alone, as are a keyboard interrupt and a process exit.
+        yield from close_refused_tool_calls(agent, run_response, tool_args_stream)
+        raise
+
+    # The stream ends here whether the run completed or paused, and a call
+    # refused on its last turn gets no later turn to be closed out on.
+    yield from close_refused_tool_calls(agent, run_response, tool_args_stream)
 
     # Update RunOutput
     # Build a list of messages that should be added to the RunOutput
@@ -1203,6 +1300,7 @@ async def ahandle_model_response_stream(
         "reasoning_started": False,
         "reasoning_time_taken": 0.0,
     }
+    tool_args_stream = ToolCallArgsStream(run_response.session_id, run_response.run_id) if stream_events else None
     model_response = ModelResponse(content="")
 
     # Get output_schema from run_context
@@ -1238,84 +1336,105 @@ async def ahandle_model_response_stream(
         ),
     )  # type: ignore
 
-    async for model_response_event in model_response_stream:  # type: ignore
-        # Handle LLM request events and compression events from ModelResponse
-        if isinstance(model_response_event, ModelResponse):
-            if model_response_event.event == ModelResponseEvent.model_request_started.value:
-                if stream_events:
-                    yield handle_event(  # type: ignore
-                        create_model_request_started_event(
-                            from_run_response=run_response,
-                            model=agent.model.id,
-                            model_provider=agent.model.provider,
-                        ),
-                        run_response,
-                        events_to_skip=agent.events_to_skip,  # type: ignore
-                        store_events=agent.store_events,
-                    )
-                continue
+    try:
+        async for model_response_event in model_response_stream:  # type: ignore
+            # Handle LLM request events and compression events from ModelResponse
+            if isinstance(model_response_event, ModelResponse):
+                if model_response_event.event == ModelResponseEvent.model_request_started.value:
+                    # By now the run has decided what to do with every call the last
+                    # turn made, and its tool call identities do not carry forward
+                    for refused in close_refused_tool_calls(agent, run_response, tool_args_stream):
+                        yield refused
+                    if tool_args_stream is not None:
+                        tool_args_stream.begin_turn()
+                    if stream_events:
+                        yield handle_event(  # type: ignore
+                            create_model_request_started_event(
+                                from_run_response=run_response,
+                                model=agent.model.id,
+                                model_provider=agent.model.provider,
+                            ),
+                            run_response,
+                            events_to_skip=agent.events_to_skip,  # type: ignore
+                            store_events=agent.store_events,
+                        )
+                    continue
 
-            if model_response_event.event == ModelResponseEvent.model_request_completed.value:
-                if stream_events:
-                    yield handle_event(  # type: ignore
-                        create_model_request_completed_event(
-                            from_run_response=run_response,
-                            model=agent.model.id,
-                            model_provider=agent.model.provider,
-                            input_tokens=model_response_event.input_tokens,
-                            output_tokens=model_response_event.output_tokens,
-                            total_tokens=model_response_event.total_tokens,
-                            time_to_first_token=model_response_event.time_to_first_token,
-                            reasoning_tokens=model_response_event.reasoning_tokens,
-                            cache_read_tokens=model_response_event.cache_read_tokens,
-                            cache_write_tokens=model_response_event.cache_write_tokens,
-                        ),
-                        run_response,
-                        events_to_skip=agent.events_to_skip,  # type: ignore
-                        store_events=agent.store_events,
-                    )
-                continue
+                if model_response_event.event == ModelResponseEvent.model_request_completed.value:
+                    if stream_events:
+                        yield handle_event(  # type: ignore
+                            create_model_request_completed_event(
+                                from_run_response=run_response,
+                                model=agent.model.id,
+                                model_provider=agent.model.provider,
+                                input_tokens=model_response_event.input_tokens,
+                                output_tokens=model_response_event.output_tokens,
+                                total_tokens=model_response_event.total_tokens,
+                                time_to_first_token=model_response_event.time_to_first_token,
+                                reasoning_tokens=model_response_event.reasoning_tokens,
+                                cache_read_tokens=model_response_event.cache_read_tokens,
+                                cache_write_tokens=model_response_event.cache_write_tokens,
+                            ),
+                            run_response,
+                            events_to_skip=agent.events_to_skip,  # type: ignore
+                            store_events=agent.store_events,
+                        )
+                    continue
 
-            # Handle compression events
-            if model_response_event.event == ModelResponseEvent.compression_started.value:
-                if stream_events:
-                    yield handle_event(  # type: ignore
-                        create_compression_started_event(from_run_response=run_response),
-                        run_response,
-                        events_to_skip=agent.events_to_skip,  # type: ignore
-                        store_events=agent.store_events,
-                    )
-                continue
+                # Handle compression events
+                if model_response_event.event == ModelResponseEvent.compression_started.value:
+                    if stream_events:
+                        yield handle_event(  # type: ignore
+                            create_compression_started_event(from_run_response=run_response),
+                            run_response,
+                            events_to_skip=agent.events_to_skip,  # type: ignore
+                            store_events=agent.store_events,
+                        )
+                    continue
 
-            if model_response_event.event == ModelResponseEvent.compression_completed.value:
-                if stream_events:
-                    stats = model_response_event.compression_stats or {}
-                    yield handle_event(  # type: ignore
-                        create_compression_completed_event(
-                            from_run_response=run_response,
-                            tool_results_compressed=stats.get("tool_results_compressed"),
-                            original_size=stats.get("original_size"),
-                            compressed_size=stats.get("compressed_size"),
-                        ),
-                        run_response,
-                        events_to_skip=agent.events_to_skip,  # type: ignore
-                        store_events=agent.store_events,
-                    )
-                continue
+                if model_response_event.event == ModelResponseEvent.compression_completed.value:
+                    if stream_events:
+                        stats = model_response_event.compression_stats or {}
+                        yield handle_event(  # type: ignore
+                            create_compression_completed_event(
+                                from_run_response=run_response,
+                                tool_results_compressed=stats.get("tool_results_compressed"),
+                                original_size=stats.get("original_size"),
+                                compressed_size=stats.get("compressed_size"),
+                            ),
+                            run_response,
+                            events_to_skip=agent.events_to_skip,  # type: ignore
+                            store_events=agent.store_events,
+                        )
+                    continue
 
-        for event in handle_model_response_chunk(
-            agent,
-            session=session,
-            run_response=run_response,
-            model_response=model_response,
-            model_response_event=model_response_event,
-            reasoning_state=reasoning_state,
-            parse_structured_output=should_parse_structured_output,
-            stream_events=stream_events,
-            session_state=session_state,
-            run_context=run_context,
-        ):
-            yield event
+            for event in handle_model_response_chunk(
+                agent,
+                session=session,
+                run_response=run_response,
+                model_response=model_response,
+                model_response_event=model_response_event,
+                reasoning_state=reasoning_state,
+                parse_structured_output=should_parse_structured_output,
+                stream_events=stream_events,
+                session_state=session_state,
+                run_context=run_context,
+                tool_args_stream=tool_args_stream,
+            ):
+                yield event
+    except Exception:
+        # A stream that raised is still being read, so this generator can
+        # yield the closures. A generator the consumer abandoned cannot:
+        # that arrives as GeneratorExit, which is no Exception and is left
+        # alone, as are a keyboard interrupt and a process exit.
+        for refused in close_refused_tool_calls(agent, run_response, tool_args_stream):
+            yield refused
+        raise
+
+    # The stream ends here whether the run completed or paused, and a call
+    # refused on its last turn gets no later turn to be closed out on.
+    for refused in close_refused_tool_calls(agent, run_response, tool_args_stream):
+        yield refused
 
     # Update RunOutput
     # Build a list of messages that should be added to the RunOutput
@@ -1360,6 +1479,7 @@ def handle_model_response_chunk(
     stream_events: bool = False,
     session_state: Optional[Dict[str, Any]] = None,
     run_context: Optional[RunContext] = None,
+    tool_args_stream: Optional[ToolCallArgsStream] = None,
 ) -> Iterator[RunOutputEvent]:
     from agno.run.workflow import WORKFLOW_RUN_OUTPUT_EVENT_TYPES
 
@@ -1368,6 +1488,13 @@ def handle_model_response_chunk(
         or isinstance(model_response_event, TEAM_RUN_OUTPUT_EVENT_TYPES)
         or isinstance(model_response_event, WORKFLOW_RUN_OUTPUT_EVENT_TYPES)
     ):
+        # A run told not to stream events is told that about the runs it nests
+        # too. A nested run is run with events on so the tool running it can
+        # read them, so its argument fragments arrive here and stop here, as
+        # this run's own do.
+        if not stream_events and model_response_event.event in _TOOL_CALL_ARGS_DELTA_EVENTS:
+            return
+
         if model_response_event.event == RunEvent.custom_event:  # type: ignore
             model_response_event.agent_id = agent.id  # type: ignore
             model_response_event.agent_name = agent.name  # type: ignore
@@ -1389,6 +1516,18 @@ def handle_model_response_chunk(
             model_response.reasoning_content = None
             run_response.content = None
             run_response.reasoning_content = None
+            # A replaced stream's own calls will never be made under its own ids
+            yield from close_refused_tool_calls(agent, run_response, tool_args_stream)
+            if tool_args_stream is not None:
+                tool_args_stream.begin_turn()
+            return
+        if model_response_event.event == ModelResponseEvent.model_request_started.value:
+            # The agent's own loop reads this event before delegating here. The
+            # output model's stream does not, and this is where its turns end:
+            # a provider's numbering restarts with each request it answers.
+            yield from close_refused_tool_calls(agent, run_response, tool_args_stream)
+            if tool_args_stream is not None:
+                tool_args_stream.begin_turn()
             return
         # If the model response is an assistant_response, yield a RunOutput
         if model_response_event.event == ModelResponseEvent.assistant_response.value:
@@ -1548,11 +1687,32 @@ def handle_model_response_chunk(
                         run_response.images = []
                     run_response.images.append(image)
 
+            # A chunk can carry both what the model said and the call it went on
+            # to make, and the saying came first, so the fragments go out last.
+            # A path threads a stream exactly when its fragments are the
+            # client's to receive, so the stream's presence is the whole gate.
+            if model_response_event.tool_calls and tool_args_stream is not None:
+                for tool_call_id, tool_name, tool_args_delta in tool_args_stream.fragments(
+                    model_response_event.tool_calls
+                ):
+                    yield handle_event(  # type: ignore
+                        create_tool_call_args_delta_event(
+                            from_run_response=run_response,
+                            tool_call_id=tool_call_id,
+                            tool_args_delta=tool_args_delta,
+                            tool_name=tool_name,
+                        ),
+                        run_response,
+                        events_to_skip=agent.events_to_skip,  # type: ignore
+                        store_events=agent.store_events,
+                    )
+
         # Handle tool interruption events (HITL flow)
         elif model_response_event.event == ModelResponseEvent.tool_call_paused.value:
             # Add tool calls to the run_response
             tool_executions_list = model_response_event.tool_executions
             if tool_executions_list is not None:
+                answer_streamed_tool_calls(tool_args_stream, tool_executions_list)
                 # Add tool calls to the agent.run_response
                 if run_response.tools is None:
                     run_response.tools = tool_executions_list
@@ -1569,6 +1729,7 @@ def handle_model_response_chunk(
         ):  # Add tool calls to the run_response
             tool_executions_list = model_response_event.tool_executions
             if tool_executions_list is not None:
+                answer_streamed_tool_calls(tool_args_stream, tool_executions_list)
                 # Add tool calls to the agent.run_response
                 if run_response.tools is None:
                     run_response.tools = tool_executions_list
@@ -1625,6 +1786,7 @@ def handle_model_response_chunk(
 
             tool_executions_list = model_response_event.tool_executions
             if tool_executions_list is not None:
+                answer_streamed_tool_calls(tool_args_stream, tool_executions_list)
                 # Update the existing tool call in the run_response
                 if run_response.tools:
                     # Create a mapping of tool_call_id to index

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -665,10 +665,12 @@ class Agent:
 
         self.store_events = store_events
         self.role = role
-        # By default, we skip the run response content event
+        # By default we keep the high frequency events out of the stored run: one
+        # row per token or per argument fragment is not what a caller wants. They
+        # are still streamed to subscribers; this list only governs storage.
         self.events_to_skip = events_to_skip
         if self.events_to_skip is None:
-            self.events_to_skip = [RunEvent.run_content]
+            self.events_to_skip = [RunEvent.run_content, RunEvent.tool_call_args_delta]
 
         self.debug_mode = debug_mode
         if debug_level not in [1, 2]:

--- a/libs/agno/agno/os/interfaces/agui/handlers.py
+++ b/libs/agno/agno/os/interfaces/agui/handlers.py
@@ -1,4 +1,3 @@
-import copy
 import json
 import uuid
 from typing import Any, Callable, Dict, List, Optional
@@ -29,7 +28,7 @@ from ag_ui.core import (
 )
 
 from agno.models.response import ToolExecution
-from agno.os.interfaces.agui.state import StreamState
+from agno.os.interfaces.agui.state import StateDeltaUnavailable, StreamState, client_state
 from agno.os.interfaces.agui.utils import to_json_str
 from agno.reasoning.step import ReasoningStep
 from agno.run.agent import RunContentEvent, RunEvent
@@ -38,6 +37,7 @@ from agno.run.base import BaseRunOutputEvent
 from agno.run.team import RunContentEvent as TeamRunContentEvent
 from agno.run.team import RunPausedEvent as TeamRunPausedEvent
 from agno.run.team import TeamRunEvent
+from agno.utils.log import log_warning
 from agno.utils.message import get_text_from_message
 
 EventHandler = Callable[[BaseRunOutputEvent, StreamState], List[BaseEvent]]
@@ -95,7 +95,27 @@ def _format_reasoning_step(step: Optional[ReasoningStep], step_number: int = 0) 
 def _emit_state_delta(state: StreamState) -> List[BaseEvent]:
     if state.run_state is None:
         return []
-    ops = state.compute_state_delta(state.run_state)
+    try:
+        ops = state.compute_state_delta(state.run_state)
+    except StateDeltaUnavailable as e:
+        if e.reason == StateDeltaUnavailable.STATE_NOT_SENDABLE:
+            # A snapshot would carry the very state the encoder has just
+            # refused, and the encoder runs after this handler, on the way to
+            # the socket: the event would take the rest of the response with
+            # it, terminal event included. So nothing goes out, and the
+            # baseline stays where the client is, which is what lets a later
+            # change the encoder can render be described against what it holds.
+            if state.should_warn_delta_fallback(e.reason):
+                log_warning(f"{e} The client keeps the state it was last sent. {state.run_label()}")
+            return []
+        # State did change, so staying quiet would hide the mutation from the
+        # client for the rest of the run. A full snapshot carries everything
+        # the patch would have.
+        if state.should_warn_delta_fallback(e.reason):
+            log_warning(f"{e} Sending a full STATE_SNAPSHOT instead. {state.run_label()}")
+        snapshot = client_state(state.run_state)
+        state.set_state_snapshot(state.run_state)
+        return [StateSnapshotEvent(type=EventType.STATE_SNAPSHOT, snapshot=snapshot)]
     if ops is None:
         return []
     state.set_state_snapshot(state.run_state)
@@ -436,7 +456,7 @@ def on_run_completed(chunk: BaseRunOutputEvent, state: StreamState) -> List[Base
     if state.run_state is not None:
         authoritative_state = getattr(chunk, "session_state", None)
         final_state = authoritative_state if authoritative_state is not None else state.run_state
-        events.append(StateSnapshotEvent(type=EventType.STATE_SNAPSHOT, snapshot=copy.deepcopy(final_state)))
+        events.append(StateSnapshotEvent(type=EventType.STATE_SNAPSHOT, snapshot=client_state(final_state)))
 
     events.append(RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id=state.thread_id, run_id=state.run_id))
     return events

--- a/libs/agno/agno/os/interfaces/agui/handlers.py
+++ b/libs/agno/agno/os/interfaces/agui/handlers.py
@@ -136,9 +136,8 @@ def _close_open_spans(state: StreamState) -> List[BaseEvent]:
 
     # Close remaining active tool calls
     for tool_call_id in list(state.active_tool_call_ids):
-        if tool_call_id not in state.ended_tool_call_ids:
-            events.append(ToolCallEndEvent(type=EventType.TOOL_CALL_END, tool_call_id=tool_call_id))
-            state.end_tool_call(tool_call_id)
+        events.append(ToolCallEndEvent(type=EventType.TOOL_CALL_END, tool_call_id=tool_call_id))
+        state.end_tool_call(tool_call_id)
 
     # Close open text message
     if state.text_message_open:
@@ -182,11 +181,17 @@ def on_run_content(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEv
     return events
 
 
-def on_tool_call_started(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
+def _open_tool_call(
+    state: StreamState, tool_call_id: str, tool_call_name: str, args_streaming: bool = False
+) -> List[BaseEvent]:
+    """TOOL_CALL_START for one call, parented to the message open at this moment.
+
+    Shared by the events that can be the first sight of a call: an argument
+    fragment and Agno's own announcement. Every caller has to have found the
+    call closed first, because a second start for a call the client holds open
+    is where its verifier stops reading the run.
+    """
     events: List[BaseEvent] = []
-    tool = getattr(chunk, "tool", None)
-    if tool is None:
-        return events
 
     # Close open text message before tool call
     if state.text_message_open:
@@ -212,11 +217,73 @@ def on_tool_call_started(chunk: BaseRunOutputEvent, state: StreamState) -> List[
     events.append(
         ToolCallStartEvent(
             type=EventType.TOOL_CALL_START,
-            tool_call_id=tool.tool_call_id,
-            tool_call_name=tool.tool_name,
+            tool_call_id=tool_call_id,
+            tool_call_name=tool_call_name,
             parent_message_id=parent_message_id,
         )
     )
+
+    state.start_tool_call(tool_call_id, args_streaming=args_streaming)
+    return events
+
+
+def on_tool_call_args_delta(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
+    """Pass one fragment of a tool call's arguments straight through to the client.
+
+    A provider streams a call's arguments in pieces, and these usually arrive
+    before Agno has the finished call to announce, so a fragment carrying
+    argument text for a call nothing has opened yet is what opens it. That is
+    also why the fragment carries the tool name: there is nothing else to read
+    it off yet.
+    """
+    events: List[BaseEvent] = []
+    tool_call_id = getattr(chunk, "tool_call_id", None)
+    if not tool_call_id:
+        return events
+
+    delta = getattr(chunk, "tool_args_delta", None)
+    if not delta:
+        # A provider can name a call on a fragment carrying no argument text at
+        # all. Opening the call on that would leave the client a start and an
+        # end with nothing between them, so the call waits for something to be
+        # said about it.
+        return events
+
+    if state.tool_call_open(tool_call_id):
+        if state.streamed_tool_call_args(tool_call_id) is None:
+            # Agno's announcement opened this call and carried its whole
+            # argument string, so passing this fragment on would append to
+            # arguments the client already holds complete.
+            return events
+    else:
+        tool_name = getattr(chunk, "tool_name", None)
+        if not tool_name:
+            # A call is opened once and under one name, and the name is what a
+            # client renders it as. A fragment that names no tool cannot open
+            # one, so the call waits for Agno's announcement of the finished
+            # call, which names it and carries its whole argument string.
+            return events
+        events.extend(_open_tool_call(state, tool_call_id, tool_name, args_streaming=True))
+
+    events.append(ToolCallArgsEvent(type=EventType.TOOL_CALL_ARGS, tool_call_id=tool_call_id, delta=delta))
+    state.note_streamed_tool_call_args(tool_call_id, delta)
+    return events
+
+
+def on_tool_call_started(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
+    events: List[BaseEvent] = []
+    tool = getattr(chunk, "tool", None)
+    if tool is None:
+        return events
+
+    # The call is already open, which means a fragment opened it, so this
+    # announcement neither opens it again nor carries the arguments:
+    # TOOL_CALL_ARGS appends, so anything sent here would be added to the text
+    # the fragments carried, whether or not they carried all of it.
+    if state.tool_call_open(tool.tool_call_id):
+        return events
+
+    events.extend(_open_tool_call(state, tool.tool_call_id, tool.tool_name))
 
     events.append(
         ToolCallArgsEvent(
@@ -226,7 +293,33 @@ def on_tool_call_started(chunk: BaseRunOutputEvent, state: StreamState) -> List[
         )
     )
 
-    state.start_tool_call(tool.tool_call_id)
+    return events
+
+
+def _close_tool_call(state: StreamState, tool_call_id: str, result: Optional[str]) -> List[BaseEvent]:
+    """End an open call on the wire and report what it left behind.
+
+    Every call that ends with something to report ends here, so a call is
+    released from the open record and its result carried the same way however
+    it ended. ``result`` is what the call is to be shown as having produced,
+    an error text included, and ``None`` where it produced nothing to show.
+    """
+    events: List[BaseEvent] = [ToolCallEndEvent(type=EventType.TOOL_CALL_END, tool_call_id=tool_call_id)]
+    state.end_tool_call(tool_call_id)
+
+    if result is not None:
+        events.append(
+            ToolCallResultEvent(
+                type=EventType.TOOL_CALL_RESULT,
+                tool_call_id=tool_call_id,
+                content=to_json_str(result),
+                role="tool",
+                # Use tool_call_id as message_id so frontend can link result to the tool call
+                message_id=tool_call_id,
+            )
+        )
+
+    events.extend(_emit_state_delta(state))
     return events
 
 
@@ -236,27 +329,41 @@ def on_tool_call_completed(chunk: BaseRunOutputEvent, state: StreamState) -> Lis
     if tool is None:
         return events
 
-    if tool.tool_call_id in state.ended_tool_call_ids:
+    # Nothing to close, and nothing to report the result of: either the call
+    # was never opened on the wire, or a completion for it has already been
+    # handled. An end for a call the client does not hold open is where its
+    # verifier stops reading the run.
+    if not state.tool_call_open(tool.tool_call_id):
         return events
 
-    events.append(ToolCallEndEvent(type=EventType.TOOL_CALL_END, tool_call_id=tool.tool_call_id))
-    state.end_tool_call(tool.tool_call_id)
+    return _close_tool_call(state, tool.tool_call_id, tool.result)
 
-    if tool.result is not None:
-        content = to_json_str(tool.result)
-        events.append(
-            ToolCallResultEvent(
-                type=EventType.TOOL_CALL_RESULT,
-                tool_call_id=tool.tool_call_id,
-                content=content,
-                role="tool",
-                # Use tool_call_id as message_id so frontend can link result to the tool call
-                message_id=tool.tool_call_id,
-            )
-        )
 
-    events.extend(_emit_state_delta(state))
-    return events
+def on_tool_call_error(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
+    """Close a call that failed, with what went wrong as its result.
+
+    A call the run refuses once its arguments have gone out is never started
+    and never completed, so this is the only event that says anything about
+    it: unhandled, it reaches the client as an opaque passthrough and leaves
+    the call pending until the run ends. What the failure says is Agno's to
+    word, a refusal included, so it is carried rather than restated.
+
+    An error for a call that is not open closes nothing. An ordinary tool
+    failure is announced as a completion first, which has already closed the
+    call and carried the same text as its result, and an end for a call the
+    client does not hold open is where its verifier stops reading the run.
+    """
+    events: List[BaseEvent] = []
+    tool = getattr(chunk, "tool", None)
+    if tool is None:
+        return events
+
+    tool_call_id = tool.tool_call_id
+    if not tool_call_id or not state.tool_call_open(tool_call_id):
+        return events
+
+    error = getattr(chunk, "error", None)
+    return _close_tool_call(state, tool_call_id, error if error is not None else tool.result)
 
 
 def on_reasoning_started(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
@@ -385,10 +492,8 @@ def on_run_error(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEven
     return events
 
 
-def on_run_completed(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
-    events = _close_open_spans(state)
-
-    # 1. Collect paused tools for frontend rendering
+def _paused_tool_calls(chunk: BaseRunOutputEvent) -> List[ToolExecution]:
+    """The calls a paused run is waiting on the client for."""
     paused_tools: List[ToolExecution] = []
     if isinstance(chunk, AgentRunPausedEvent):
         paused_tools = (
@@ -406,8 +511,31 @@ def on_run_completed(chunk: BaseRunOutputEvent, state: StreamState) -> List[Base
         for req in chunk.active_requirements:
             if req.member_agent_id and req.tool_execution:
                 paused_tools.append(req.tool_execution)
+    return paused_tools
 
-    if paused_tools:
+
+def on_run_completed(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
+    paused_tools = _paused_tool_calls(chunk)
+    events = _close_open_spans(state)
+
+    # A paused call the stream already opened, whichever opener did it, has
+    # been carried and closed by now: its fragments carried its arguments and
+    # the close above ended it. Rendering it again would give the client a
+    # second call under the same id, and a second stand-in message to parent it
+    # to. A pause can also name the same call twice, once as a team leader's
+    # and once as its member's.
+    tools_to_render: List[ToolExecution] = []
+    for tool in paused_tools:
+        if tool.tool_call_id is None or tool.tool_name is None:
+            continue
+        if state.tool_call_ended(tool.tool_call_id) or any(
+            tool.tool_call_id == picked.tool_call_id for picked in tools_to_render
+        ):
+            continue
+        tools_to_render.append(tool)
+    paused_content = getattr(chunk, "content", None) if paused_tools else None
+
+    if tools_to_render or paused_content:
         assistant_message_id = str(uuid.uuid4())
         events.append(
             TextMessageStartEvent(
@@ -417,40 +545,39 @@ def on_run_completed(chunk: BaseRunOutputEvent, state: StreamState) -> List[Base
             )
         )
 
-        content = getattr(chunk, "content", None)
-        if content:
+        if paused_content:
             events.append(
                 TextMessageContentEvent(
                     type=EventType.TEXT_MESSAGE_CONTENT,
                     message_id=assistant_message_id,
-                    delta=str(content),
+                    delta=str(paused_content),
                 )
             )
 
         events.append(TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=assistant_message_id))
 
-        for tool in paused_tools:
-            if tool.tool_call_id is None or tool.tool_name is None:
-                continue
-
+        for tool in tools_to_render:
+            tool_call_id = str(tool.tool_call_id)
             events.append(
                 ToolCallStartEvent(
                     type=EventType.TOOL_CALL_START,
-                    tool_call_id=tool.tool_call_id,
+                    tool_call_id=tool_call_id,
                     tool_call_name=tool.tool_name,
                     parent_message_id=assistant_message_id,
                 )
             )
+            state.start_tool_call(tool_call_id)
 
             events.append(
                 ToolCallArgsEvent(
                     type=EventType.TOOL_CALL_ARGS,
-                    tool_call_id=tool.tool_call_id,
+                    tool_call_id=tool_call_id,
                     delta=json.dumps(tool.tool_args),
                 )
             )
 
-            events.append(ToolCallEndEvent(type=EventType.TOOL_CALL_END, tool_call_id=tool.tool_call_id))
+            events.append(ToolCallEndEvent(type=EventType.TOOL_CALL_END, tool_call_id=tool_call_id))
+            state.end_tool_call(tool_call_id)
 
     # Emit final state snapshot
     if state.run_state is not None:
@@ -471,7 +598,9 @@ def _normalize_event(event: str) -> str:
 HANDLERS: Dict[str, EventHandler] = {
     RunEvent.run_content.value: on_run_content,
     RunEvent.tool_call_started.value: on_tool_call_started,
+    RunEvent.tool_call_args_delta.value: on_tool_call_args_delta,
     RunEvent.tool_call_completed.value: on_tool_call_completed,
+    RunEvent.tool_call_error.value: on_tool_call_error,
     RunEvent.reasoning_started.value: on_reasoning_started,
     RunEvent.reasoning_content_delta.value: on_reasoning_content_delta,
     RunEvent.reasoning_step.value: on_reasoning_step,

--- a/libs/agno/agno/os/interfaces/agui/router.py
+++ b/libs/agno/agno/os/interfaces/agui/router.py
@@ -1,4 +1,3 @@
-import copy
 import uuid
 from typing import AsyncIterator, Optional, Union
 
@@ -30,6 +29,7 @@ from agno.os.interfaces.agui.input import (
     validate_state,
 )
 from agno.os.interfaces.agui.resume import resume_paused_run
+from agno.os.interfaces.agui.state import client_state
 from agno.os.interfaces.agui.stream import async_stream_agno_response_as_agui_events
 from agno.os.middleware.user_scope import assert_session_writable, caller_is_admin, resolve_run_user_id
 from agno.run.base import RunContext
@@ -66,7 +66,7 @@ async def run_entity(
         session_state = validate_state(run_input.state, run_input.thread_id)
 
         if session_state is not None:
-            yield StateSnapshotEvent(type=EventType.STATE_SNAPSHOT, snapshot=copy.deepcopy(session_state))
+            yield StateSnapshotEvent(type=EventType.STATE_SNAPSHOT, snapshot=client_state(session_state))
 
         ui_deps = extract_context(run_input.context)
 

--- a/libs/agno/agno/os/interfaces/agui/state.py
+++ b/libs/agno/agno/os/interfaces/agui/state.py
@@ -121,9 +121,23 @@ class StreamState:
     text_message_open: bool = False
 
     # Tool call tracking
+    # Calls open on the wire, meaning a TOOL_CALL_START went out for them and
+    # no TOOL_CALL_END has. The one record every opener asks, so a call is
+    # opened once however many of them see it, and released on end, so a
+    # stream that hands the same id to a later call opens a call of its own
+    # rather than adding to the one that closed.
     active_tool_call_ids: Set[str] = field(default_factory=set)
+    # Every id a call has ended under, kept for the whole stream: it is what
+    # says a call has already been carried in full, which the terminal handler
+    # needs before it renders a paused run's pending calls.
     ended_tool_call_ids: Set[str] = field(default_factory=set)
     pending_tool_calls_parent_id: str = ""
+    # Open calls whose arguments are arriving in fragments, against the
+    # argument text those fragments have sent. Their arguments reach the client
+    # a piece at a time, so Agno's announcement of the finished call has
+    # nothing left to send, and the text is what that announcement holds the
+    # client's copy against: the protocol only ever appends to it.
+    _streamed_tool_call_args: Dict[str, str] = field(default_factory=dict, repr=False)
 
     # Reasoning tracking
     reasoning_message_id: Optional[str] = None
@@ -148,11 +162,45 @@ class StreamState:
         # ID persists for tool call parenting — only flag changes
         self.text_message_open = False
 
-    def start_tool_call(self, tool_call_id: str) -> None:
+    def start_tool_call(self, tool_call_id: str, args_streaming: bool = False) -> None:
+        """Record a call as open on the wire.
+
+        ``args_streaming`` says its arguments are arriving in fragments rather
+        than whole from Agno's announcement of the finished call.
+        """
         self.active_tool_call_ids.add(tool_call_id)
+        if args_streaming:
+            self._streamed_tool_call_args[tool_call_id] = ""
+
+    def tool_call_open(self, tool_call_id: str) -> bool:
+        """Whether a start went out for this call and no end has."""
+        return tool_call_id in self.active_tool_call_ids
+
+    def note_streamed_tool_call_args(self, tool_call_id: str, delta: str) -> None:
+        """Record argument text sent to the client for a call being streamed."""
+        self._streamed_tool_call_args[tool_call_id] = self._streamed_tool_call_args.get(tool_call_id, "") + delta
+
+    def streamed_tool_call_args(self, tool_call_id: str) -> Optional[str]:
+        """The argument text this call's fragments have sent, or ``None``.
+
+        ``None`` says the call's arguments never streamed: it was opened by
+        Agno's announcement of the finished call, which carried them whole.
+        """
+        return self._streamed_tool_call_args.get(tool_call_id)
+
+    def tool_call_ended(self, tool_call_id: str) -> bool:
+        """Whether a call under this id has already been closed on the wire."""
+        return tool_call_id in self.ended_tool_call_ids
 
     def end_tool_call(self, tool_call_id: str) -> None:
+        """Release everything held for a call that has closed on the wire.
+
+        What is held describes a call in progress, so it goes with the call:
+        a later call handed the same id is a call of its own, and would
+        otherwise inherit an argument string that is already complete.
+        """
         self.active_tool_call_ids.discard(tool_call_id)
+        self._streamed_tool_call_args.pop(tool_call_id, None)
         self.ended_tool_call_ids.add(tool_call_id)
 
     def get_parent_message_id_for_tool_call(self) -> str:

--- a/libs/agno/agno/os/interfaces/agui/state.py
+++ b/libs/agno/agno/os/interfaces/agui/state.py
@@ -1,9 +1,104 @@
 import copy
+import json
 import uuid
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Set, Tuple
 
+from pydantic import TypeAdapter
+
 from agno.utils.log import log_warning
+
+# Agno's run loop injects these into session_state so tools and instruction
+# templates can read them, and strips them again before the session row is
+# persisted. They are Agno's own record keeping rather than application state,
+# so every state event drops them by name: a client that sent one of these keys
+# itself never gets it back, and holds no value under it at all.
+RUNTIME_STATE_KEYS = frozenset({"current_user_id", "current_session_id", "current_run_id"})
+
+
+class StateDeltaUnavailable(Exception):
+    """Raised when state changed but no JSON Patch could be produced for it.
+
+    ``reason`` names which cause fired. The causes need different fixes, so a
+    caller that suppresses repeats can still report each one, and they are not
+    all answerable the same way: every reason but ``STATE_NOT_SENDABLE`` leaves
+    a full snapshot as a way to carry the change, while that one says the state
+    cannot go out under any event at all.
+    """
+
+    NO_JSONPATCH = "no_jsonpatch"
+    PATCH_FAILED = "patch_failed"
+    EMPTY_PATCH = "empty_patch"
+    PATCH_NOT_REPLAYABLE = "patch_not_replayable"
+    PATCH_NOT_FAITHFUL = "patch_not_faithful"
+    STATE_NOT_SENDABLE = "state_not_sendable"
+
+    def __init__(self, reason: str, message: str) -> None:
+        super().__init__(message)
+        self.reason = reason
+
+
+def _visible_state(state: Any) -> Any:
+    """``state`` without Agno's runtime bookkeeping keys, sharing its values.
+
+    Anything that is not a dict holds no bookkeeping keys and is handed back
+    whole. Kept apart from the copy below because most of what reads this only
+    encodes it and drops it, and copying state a run holds open is the most
+    expensive thing on that path.
+    """
+    if not isinstance(state, dict):
+        return state
+    return {key: value for key, value in state.items() if key not in RUNTIME_STATE_KEYS}
+
+
+def client_state(state: Any) -> Any:
+    """Copy ``state`` with Agno's runtime bookkeeping keys removed.
+
+    The copy is what makes the result safe to hold while the run mutates state
+    on: an event already handed over would otherwise keep changing under the
+    client. Anything that is not a dict is copied whole rather than refused,
+    because the terminal handler passes the run's own session_state through
+    here and a refusal would cost the client its RUN_FINISHED. A value
+    ``copy.deepcopy`` cannot copy at all still raises from here, so a caller
+    that owes the client an event either way has to be ready for that.
+    """
+    return copy.deepcopy(_visible_state(state))
+
+
+# A client never holds the Python objects in session_state, only the JSON the
+# AG-UI event encoder makes of them, so both the no-change question and the
+# patch describing the change are put to that encoded form. Reading the objects
+# disagrees with the wire both ways: {1: "a"} and {True: "a"} are one Python key
+# but two different JSON objects, while a list and a tuple are two Python
+# objects but one JSON array.
+_STATE_SERIALIZER: TypeAdapter = TypeAdapter(Any)
+
+# Names the cause for the once-per-stream warning registry, alongside the
+# reasons ``StateDeltaUnavailable`` carries.
+_STATE_NOT_ENCODABLE = "state_not_encodable"
+
+
+def _json_state(state: Any) -> Any:
+    """The JSON document the AG-UI event encoder will make of ``state``.
+
+    ``TypeAdapter(Any)`` in JSON mode, by alias, is the same serializer the
+    encoder runs over a STATE_SNAPSHOT payload, so this is the document a
+    client ends up holding: its keys are the keys a JSON Pointer has to name.
+    Dropping ``by_alias`` would point a patch at a pydantic model's field name
+    where the client holds the alias.
+    """
+    return _STATE_SERIALIZER.dump_python(state, mode="json", by_alias=True)
+
+
+def _encoded_document(document: Any) -> str:
+    """``document`` as one comparable string.
+
+    Key order is normalised because the client reads the parsed JSON, so a
+    dict rebuilt holding the same entries in a different order is not
+    something the client can see. Takes the document rather than the state so
+    that a caller needing both pays for the serializer once.
+    """
+    return json.dumps(document, sort_keys=True)
 
 
 @dataclass
@@ -35,7 +130,9 @@ class StreamState:
     reasoning_step_count: int = 0
 
     # State delta tracking
-    _last_snapshot: Optional[Dict[str, Any]] = field(default=None, repr=False)
+    _last_snapshot: Any = field(default=None, repr=False)
+    _last_snapshot_encoding: Optional[Tuple[Any, str]] = field(default=None, repr=False)
+    _warned_delta_fallbacks: Set[str] = field(default_factory=set, repr=False)
 
     # Run context
     thread_id: str = ""
@@ -89,20 +186,172 @@ class StreamState:
         self.reasoning_message_id = None
         self.reasoning_step_count = 0
 
-    def set_state_snapshot(self, state: Dict[str, Any]) -> None:
-        self._last_snapshot = copy.deepcopy(state)
+    def run_label(self) -> str:
+        """Names the conversation and the run, for a warning to be traced by.
 
-    def compute_state_delta(self, current_state: Dict[str, Any]) -> Optional[List[Dict[str, Any]]]:
+        A server carries many conversations at once, so a warning that says
+        only that some run degraded cannot be tied back to the one it happened
+        in, nor to the state the client of that conversation is left holding.
+        """
+        return f"(thread_id={self.thread_id}, run_id={self.run_id})"
+
+    def should_warn_delta_fallback(self, reason: str) -> bool:
+        """Whether this fallback ``reason`` has yet to be reported on this stream.
+
+        Records the reason, so one cause is reported once however many state
+        changes it affects, while a second, different cause is still reported.
+        """
+        if reason in self._warned_delta_fallbacks:
+            return False
+        self._warned_delta_fallbacks.add(reason)
+        return True
+
+    def set_state_snapshot(self, state: Any) -> None:
+        self._last_snapshot = client_state(state)
+        self._last_snapshot_encoding = None
+
+    def _snapshot_encoding(self) -> Tuple[Any, str]:
+        """The baseline's JSON document and its comparable text, encoded once.
+
+        The baseline only moves when a new snapshot is recorded, so every
+        emission that follows one reads this rather than putting the same
+        state through the serializer again.
+        """
+        if self._last_snapshot_encoding is None:
+            document = _json_state(self._last_snapshot)
+            self._last_snapshot_encoding = (document, _encoded_document(document))
+        return self._last_snapshot_encoding
+
+    def _warn_state_has_no_json_form(self, error: Exception) -> None:
+        """Report state the no-change question cannot be put to.
+
+        Such state counts as changed, never as unchanged: a client can discard
+        an update it already held, but it cannot recover one that was never
+        sent. Reported once per stream, so it can be told apart from an
+        ordinary change.
+        """
+        if self.should_warn_delta_fallback(_STATE_NOT_ENCODABLE):
+            log_warning(
+                f"AG-UI state has no JSON form to compare against the last snapshot ({error}). "
+                f"Treating it as changed. {self.run_label()}"
+            )
+
+    def compute_state_delta(self, current_state: Any) -> Optional[List[Dict[str, Any]]]:
+        """JSON Patch ops taking the last snapshot to ``current_state``.
+
+        Returns ``None`` when no snapshot has been recorded yet, and when
+        nothing the client can see has changed. Raises
+        ``StateDeltaUnavailable``, for whichever cause fired, only when state
+        did change and no patch could be built for it, so the caller can decide
+        what the change is still worth sending as, rather than dropping it
+        unremarked.
+        """
         if self._last_snapshot is None:
             return None
+
+        # Not copied: nothing here outlives the call, and the run holds the
+        # only reference that has to survive it, in the baseline copy.
+        current = _visible_state(current_state)
+
+        try:
+            # Encoded at the boundary the client reads state at, once, so the
+            # no-change question below, the diff and the replay check all read
+            # the document the client would hold: every pointer then names a
+            # key of that document rather than a Python key that was never on
+            # the wire.
+            current_document = _json_state(current)
+            current_encoded = _encoded_document(current_document)
+        except Exception as e:
+            # State with no JSON form is not a patch that could not be built:
+            # it is state no event can carry, a full snapshot included, so this
+            # is raised ahead of every other cause, and reported ahead of the
+            # no-change question it cannot answer either. Whatever else is
+            # wrong, nothing about this state is sendable, and the fix is in
+            # the application code that put the value in session_state.
+            self._warn_state_has_no_json_form(e)
+            raise StateDeltaUnavailable(
+                StateDeltaUnavailable.STATE_NOT_SENDABLE,
+                f"AG-UI state has no JSON form, so no state event carrying it can be sent ({e}).",
+            ) from e
+
+        snapshot_document: Any = None
+        snapshot_has_no_json_form: Optional[Exception] = None
+        try:
+            snapshot_document, snapshot_encoded = self._snapshot_encoding()
+        except Exception as e:
+            # A baseline with no JSON form leaves nothing to diff against, so
+            # the change counts as one no patch could be built for. The cause
+            # is held rather than raised here so that a missing jsonpatch,
+            # which an operator can act on, is still the cause reported first.
+            snapshot_has_no_json_form = e
+            self._warn_state_has_no_json_form(e)
+        else:
+            # Asked before any cause of failure can fire, because a run that
+            # never changed state owes the client nothing either way. Asking
+            # inside one failure branch alone would make that branch answer
+            # every later call of the run with a full snapshot the client
+            # already holds.
+            if current_encoded == snapshot_encoded:
+                return None
+
         try:
             import jsonpatch
-
-            patch = jsonpatch.make_patch(self._last_snapshot, current_state)
-            ops = patch.patch
-            if not ops:
-                return None
-            return ops
         except Exception as e:
-            log_warning(f"Failed to compute state delta: {e}")
-            return None
+            raise StateDeltaUnavailable(
+                StateDeltaUnavailable.NO_JSONPATCH,
+                f"AG-UI STATE_DELTA events need the jsonpatch package, which is not importable ({e}). "
+                "Install it with `pip install jsonpatch`, or install Agno's agui extra.",
+            ) from e
+
+        if snapshot_has_no_json_form is not None:
+            raise StateDeltaUnavailable(
+                StateDeltaUnavailable.PATCH_FAILED,
+                f"AG-UI state delta could not be computed: {snapshot_has_no_json_form}.",
+            ) from snapshot_has_no_json_form
+
+        try:
+            ops = jsonpatch.make_patch(snapshot_document, current_document).patch
+        except Exception as e:
+            raise StateDeltaUnavailable(
+                StateDeltaUnavailable.PATCH_FAILED, f"AG-UI state delta could not be computed: {e}."
+            ) from e
+
+        if not ops:
+            # ``jsonpatch`` reads a list element by element with ``==``,
+            # which calls 0 and False the same element, so [0] becoming
+            # [false] is a change to the client and no change to it. Nothing
+            # failed, so this carries its own reason: a caller that reports one
+            # cause per run still reports a real failure that follows it.
+            raise StateDeltaUnavailable(
+                StateDeltaUnavailable.EMPTY_PATCH,
+                "AG-UI state encodes to different JSON than the last snapshot did, "
+                "but the difference is one JSON Patch has no operation to describe.",
+            )
+
+        # Ops are worth sending only once they are known to reproduce the
+        # document the client is owed. The same element-by-element ``==`` that
+        # can leave the patch empty can also leave it describing one half of a
+        # change, and a half-patch is not empty: it goes out, the baseline
+        # advances past the half it omitted, and the client holds state the run
+        # has permanently moved on from.
+        try:
+            replayed = jsonpatch.apply_patch(snapshot_document, ops)
+            reproduces_the_change = _encoded_document(replayed) == current_encoded
+        except Exception as e:
+            # A replay that cannot run at all and a replay that runs and lands
+            # somewhere else are two failures with two fixes, so they carry two
+            # reasons: sharing one would let whichever fired first silence the
+            # other for the rest of the stream.
+            raise StateDeltaUnavailable(
+                StateDeltaUnavailable.PATCH_NOT_REPLAYABLE,
+                f"AG-UI state delta could not be replayed onto the last snapshot to check it ({e}).",
+            ) from e
+
+        if not reproduces_the_change:
+            raise StateDeltaUnavailable(
+                StateDeltaUnavailable.PATCH_NOT_FAITHFUL,
+                "AG-UI state delta does not reproduce the state it was computed for, "
+                "so a client applying it would be left holding state the run has moved on from.",
+            )
+
+        return ops

--- a/libs/agno/agno/run/agent.py
+++ b/libs/agno/agno/run/agent.py
@@ -161,6 +161,7 @@ class RunEvent(str, Enum):
     post_hook_started = "PostHookStarted"
     post_hook_completed = "PostHookCompleted"
 
+    tool_call_args_delta = "ToolCallArgsDelta"
     tool_call_started = "ToolCallStarted"
     tool_call_completed = "ToolCallCompleted"
     tool_call_error = "ToolCallError"
@@ -414,6 +415,43 @@ class ReasoningCompletedEvent(BaseAgentRunEvent):
 
 
 @dataclass
+class ToolCallArgsDeltaEvent(BaseAgentRunEvent):
+    """Event for streaming a tool call's arguments as they arrive.
+
+    Each event carries one fragment of one call's arguments. Concatenating the
+    `tool_args_delta` values that share a `tool_call_id`, in the order they
+    arrive, reproduces that call's argument string. How many fragments a call
+    is split into is up to the model provider, and may be a single fragment
+    holding the whole string. `tool_name` may be None, so group fragments by
+    `tool_call_id` rather than by name.
+
+    Several cases break that concatenation, and none of them can be repaired
+    from here, because a subscriber can only ever append what it is sent. A
+    provider stream that restarts part way through a call re-sends the
+    fragments it already sent, so the concatenation holds the retraced text
+    twice. A provider that reuses a `tool_call_id` for a later turn's call
+    gives two calls one id, and nothing on this event marks where the first
+    call's arguments end, so the concatenation runs both calls' arguments
+    together. Either way it will not parse. Both come from the model layer
+    below this event, which passes a provider's ids and fragments on as the
+    provider wrote them, so Agno's own reassembly is affected identically: a
+    restart doubles the finished call's arguments too, and a reused id leaves
+    the run holding two calls under the one id.
+
+    Two kinds of fragment never go out at all, which leaves the concatenation
+    short of the call's arguments: one whose arguments the provider wrote as a
+    structure rather than as the text the model wrote, and one that no call of
+    the turn can be attributed to. Each is logged as a warning by the run,
+    once for the stream, and is marked nowhere on this event.
+    """
+
+    event: str = RunEvent.tool_call_args_delta.value
+    tool_call_id: Optional[str] = None
+    tool_name: Optional[str] = None
+    tool_args_delta: str = ""
+
+
+@dataclass
 class ToolCallStartedEvent(BaseAgentRunEvent):
     event: str = RunEvent.tool_call_started.value
     tool: Optional[ToolExecution] = None
@@ -544,6 +582,7 @@ RunOutputEvent = Union[
     MemoryUpdateCompletedEvent,
     SessionSummaryStartedEvent,
     SessionSummaryCompletedEvent,
+    ToolCallArgsDeltaEvent,
     ToolCallStartedEvent,
     ToolCallCompletedEvent,
     ToolCallErrorEvent,
@@ -589,6 +628,7 @@ RUN_EVENT_TYPE_REGISTRY = {
     RunEvent.memory_update_completed.value: MemoryUpdateCompletedEvent,
     RunEvent.session_summary_started.value: SessionSummaryStartedEvent,
     RunEvent.session_summary_completed.value: SessionSummaryCompletedEvent,
+    RunEvent.tool_call_args_delta.value: ToolCallArgsDeltaEvent,
     RunEvent.tool_call_started.value: ToolCallStartedEvent,
     RunEvent.tool_call_completed.value: ToolCallCompletedEvent,
     RunEvent.tool_call_error.value: ToolCallErrorEvent,

--- a/libs/agno/agno/run/team.py
+++ b/libs/agno/agno/run/team.py
@@ -145,6 +145,7 @@ class TeamRunEvent(str, Enum):
     post_hook_started = "TeamPostHookStarted"
     post_hook_completed = "TeamPostHookCompleted"
 
+    tool_call_args_delta = "TeamToolCallArgsDelta"
     tool_call_started = "TeamToolCallStarted"
     tool_call_completed = "TeamToolCallCompleted"
     tool_call_error = "TeamToolCallError"
@@ -426,6 +427,43 @@ class ReasoningCompletedEvent(BaseTeamRunEvent):
 
 
 @dataclass
+class ToolCallArgsDeltaEvent(BaseTeamRunEvent):
+    """Event for streaming a tool call's arguments as they arrive.
+
+    Each event carries one fragment of one call's arguments. Concatenating the
+    `tool_args_delta` values that share a `tool_call_id`, in the order they
+    arrive, reproduces that call's argument string. How many fragments a call
+    is split into is up to the model provider, and may be a single fragment
+    holding the whole string. `tool_name` may be None, so group fragments by
+    `tool_call_id` rather than by name.
+
+    Several cases break that concatenation, and none of them can be repaired
+    from here, because a subscriber can only ever append what it is sent. A
+    provider stream that restarts part way through a call re-sends the
+    fragments it already sent, so the concatenation holds the retraced text
+    twice. A provider that reuses a `tool_call_id` for a later turn's call
+    gives two calls one id, and nothing on this event marks where the first
+    call's arguments end, so the concatenation runs both calls' arguments
+    together. Either way it will not parse. Both come from the model layer
+    below this event, which passes a provider's ids and fragments on as the
+    provider wrote them, so Agno's own reassembly is affected identically: a
+    restart doubles the finished call's arguments too, and a reused id leaves
+    the run holding two calls under the one id.
+
+    Two kinds of fragment never go out at all, which leaves the concatenation
+    short of the call's arguments: one whose arguments the provider wrote as a
+    structure rather than as the text the model wrote, and one that no call of
+    the turn can be attributed to. Each is logged as a warning by the run,
+    once for the stream, and is marked nowhere on this event.
+    """
+
+    event: str = TeamRunEvent.tool_call_args_delta.value
+    tool_call_id: Optional[str] = None
+    tool_name: Optional[str] = None
+    tool_args_delta: str = ""
+
+
+@dataclass
 class ToolCallStartedEvent(BaseTeamRunEvent):
     event: str = TeamRunEvent.tool_call_started.value
     tool: Optional[ToolExecution] = None
@@ -660,6 +698,7 @@ TeamRunOutputEvent = Union[
     MemoryUpdateCompletedEvent,
     SessionSummaryStartedEvent,
     SessionSummaryCompletedEvent,
+    ToolCallArgsDeltaEvent,
     ToolCallStartedEvent,
     ToolCallCompletedEvent,
     ToolCallErrorEvent,
@@ -709,6 +748,7 @@ TEAM_RUN_EVENT_TYPE_REGISTRY = {
     TeamRunEvent.memory_update_completed.value: MemoryUpdateCompletedEvent,
     TeamRunEvent.session_summary_started.value: SessionSummaryStartedEvent,
     TeamRunEvent.session_summary_completed.value: SessionSummaryCompletedEvent,
+    TeamRunEvent.tool_call_args_delta.value: ToolCallArgsDeltaEvent,
     TeamRunEvent.tool_call_started.value: ToolCallStartedEvent,
     TeamRunEvent.tool_call_completed.value: ToolCallCompletedEvent,
     TeamRunEvent.tool_call_error.value: ToolCallErrorEvent,

--- a/libs/agno/agno/team/__init__.py
+++ b/libs/agno/agno/team/__init__.py
@@ -15,6 +15,7 @@ from agno.run.team import (
     TeamRunEvent,
     TeamRunOutput,
     TeamRunOutputEvent,
+    ToolCallArgsDeltaEvent,
     ToolCallCompletedEvent,
     ToolCallStartedEvent,
 )
@@ -48,6 +49,7 @@ __all__ = [
     "ReasoningStartedEvent",
     "ReasoningStepEvent",
     "ReasoningCompletedEvent",
+    "ToolCallArgsDeltaEvent",
     "ToolCallStartedEvent",
     "ToolCallCompletedEvent",
     "get_team_by_id",

--- a/libs/agno/agno/team/_init.py
+++ b/libs/agno/agno/team/_init.py
@@ -370,12 +370,17 @@ def __init__(
     team.store_events = store_events
     team.store_member_responses = store_member_responses
 
+    # By default we keep the high frequency events out of the stored run: one row
+    # per token or per argument fragment is not what a caller wants. They are
+    # still streamed to subscribers; this list only governs storage.
     team.events_to_skip = events_to_skip
     if team.events_to_skip is None:
         team.events_to_skip = [
             RunEvent.run_content,
+            RunEvent.tool_call_args_delta,
             TeamRunEvent.run_content,
             TeamRunEvent.run_intermediate_content,
+            TeamRunEvent.tool_call_args_delta,
         ]
     team.stream_member_events = stream_member_events
 

--- a/libs/agno/agno/team/_response.py
+++ b/libs/agno/agno/team/_response.py
@@ -28,7 +28,7 @@ from agno.models.message import Message
 from agno.models.response import ModelResponse, ModelResponseEvent
 from agno.reasoning.step import NextAction, ReasoningStep, ReasoningSteps
 from agno.run import RunContext
-from agno.run.agent import RUN_OUTPUT_EVENT_TYPES, RunOutput, RunOutputEvent
+from agno.run.agent import RUN_OUTPUT_EVENT_TYPES, RunEvent, RunOutput, RunOutputEvent
 from agno.run.messages import RunMessages
 from agno.run.requirement import RunRequirement
 from agno.run.team import (
@@ -53,6 +53,7 @@ from agno.utils.events import (
     create_team_reasoning_started_event,
     create_team_reasoning_step_event,
     create_team_run_output_content_event,
+    create_team_tool_call_args_delta_event,
     create_team_tool_call_completed_event,
     create_team_tool_call_error_event,
     create_team_tool_call_started_event,
@@ -67,15 +68,45 @@ from agno.utils.reasoning import (
     update_run_output_with_reasoning,
 )
 from agno.utils.string import parse_response_dict_str, parse_response_model_str
+from agno.utils.tools import (
+    REFUSED_TOOL_CALL_ERROR,
+    ToolCallArgsStream,
+    answer_streamed_tool_calls,
+    take_refused_tool_calls,
+)
 
 if TYPE_CHECKING:
     from agno.reasoning.manager import ReasoningEvent
     from agno.team.team import Team
 
 
+# The fragment event under both the names it reaches a team under: its own, and
+# the one a member agent or a nested team sends it out as.
+_TOOL_CALL_ARGS_DELTA_EVENTS = frozenset({RunEvent.tool_call_args_delta.value, TeamRunEvent.tool_call_args_delta.value})
+
+
 # ---------------------------------------------------------------------------
 # Response format
 # ---------------------------------------------------------------------------
+
+
+def _close_refused_tool_calls(
+    team: "Team",
+    run_response: TeamRunOutput,
+    tool_args_stream: Optional[ToolCallArgsStream],
+) -> Iterator[TeamRunOutputEvent]:
+    """Report as failed each call a client was shown that the run refused."""
+    for tool in take_refused_tool_calls(tool_args_stream):
+        yield handle_event(  # type: ignore
+            create_team_tool_call_error_event(
+                from_run_response=run_response,
+                tool=tool,
+                error=REFUSED_TOOL_CALL_ERROR,
+            ),
+            run_response,
+            events_to_skip=team.events_to_skip,
+            store_events=team.store_events,
+        )
 
 
 def get_response_format(
@@ -260,6 +291,10 @@ def parse_response_with_parser_model_stream(
             messages_for_parser_model = _get_messages_for_parser_model_stream(
                 team, run_response, parser_response_format, run_context=run_context
             )
+            # The parser model is asked for its answer in one piece rather than
+            # streamed, so no delta of its own ever carries a call's arguments a
+            # fragment at a time. Nothing here threads the record that would
+            # attribute such fragments.
             for model_response_event in team.parser_model.response_stream(
                 messages=messages_for_parser_model,
                 response_format=parser_response_format,
@@ -337,6 +372,10 @@ async def aparse_response_with_parser_model_stream(
                 stream_model_response=False,
                 run_response=run_response,
             )
+            # The parser model is asked for its answer in one piece rather than
+            # streamed, so no delta of its own ever carries a call's arguments a
+            # fragment at a time. Nothing here threads the record that would
+            # attribute such fragments.
             async for model_response_event in model_response_stream:  # type: ignore
                 for event in _handle_model_response_chunk(
                     team,
@@ -436,16 +475,32 @@ def generate_response_with_output_model_stream(
     messages_for_output_model = _get_messages_for_output_model(team, run_messages.messages)
     model_response = ModelResponse(content="")
 
-    for model_response_event in team.output_model.response_stream(
-        messages=messages_for_output_model, run_response=run_response
-    ):
-        yield from _handle_model_response_chunk(
-            team,
-            session=session,
-            run_response=run_response,
-            full_model_response=model_response,
-            model_response_event=model_response_event,
-        )
+    # The run hands the output model none of its own tools, but a provider can
+    # answer with a call to one of its built-in tools whatever it was passed, so
+    # the record that attributes a call's argument fragments is threaded here.
+    # A caller that asked for no events is sent no fragments, so it is given no
+    # stream. Which of the call's other events this path announces is settled
+    # elsewhere and left as it was.
+    tool_args_stream = ToolCallArgsStream(run_response.session_id, run_response.run_id) if stream_events else None
+    try:
+        for model_response_event in team.output_model.response_stream(
+            messages=messages_for_output_model, run_response=run_response
+        ):
+            yield from _handle_model_response_chunk(
+                team,
+                session=session,
+                run_response=run_response,
+                full_model_response=model_response,
+                model_response_event=model_response_event,
+                tool_args_stream=tool_args_stream,
+            )
+    except Exception:
+        # As in the team's own model loop: a stream that raised can still be
+        # yielded into, a generator the consumer abandoned cannot.
+        yield from _close_refused_tool_calls(team, run_response, tool_args_stream)
+        raise
+
+    yield from _close_refused_tool_calls(team, run_response, tool_args_stream)
 
     # Update the TeamRunResponse content
     run_response.content = model_response.content
@@ -521,17 +576,35 @@ async def agenerate_response_with_output_model_stream(
     messages_for_output_model = _get_messages_for_output_model(team, run_messages.messages)
     model_response = ModelResponse(content="")
 
-    async for model_response_event in team.output_model.aresponse_stream(
-        messages=messages_for_output_model, run_response=run_response
-    ):
-        for event in _handle_model_response_chunk(
-            team,
-            session=session,
-            run_response=run_response,
-            full_model_response=model_response,
-            model_response_event=model_response_event,
+    # The run hands the output model none of its own tools, but a provider can
+    # answer with a call to one of its built-in tools whatever it was passed, so
+    # the record that attributes a call's argument fragments is threaded here.
+    # A caller that asked for no events is sent no fragments, so it is given no
+    # stream. Which of the call's other events this path announces is settled
+    # elsewhere and left as it was.
+    tool_args_stream = ToolCallArgsStream(run_response.session_id, run_response.run_id) if stream_events else None
+    try:
+        async for model_response_event in team.output_model.aresponse_stream(
+            messages=messages_for_output_model, run_response=run_response
         ):
-            yield event
+            for event in _handle_model_response_chunk(
+                team,
+                session=session,
+                run_response=run_response,
+                full_model_response=model_response,
+                model_response_event=model_response_event,
+                tool_args_stream=tool_args_stream,
+            ):
+                yield event
+    except Exception:
+        # As in the team's own model loop: a stream that raised can still be
+        # yielded into, a generator the consumer abandoned cannot.
+        for refused in _close_refused_tool_calls(team, run_response, tool_args_stream):
+            yield refused
+        raise
+
+    for refused in _close_refused_tool_calls(team, run_response, tool_args_stream):
+        yield refused
 
     # Update the TeamRunResponse content
     run_response.content = model_response.content
@@ -1015,99 +1088,118 @@ def _handle_model_response_stream(
     from agno.team._run import build_team_after_tool_results_callback
 
     full_model_response = ModelResponse()
-    for model_response_event in call_model_stream_with_fallback(
-        team.model,
-        team.fallback_config,
-        messages=run_messages.messages,
-        response_format=response_format,
-        tools=tools,
-        tool_choice=team.tool_choice,
-        tool_call_limit=team.tool_call_limit,
-        stream_model_response=stream_model_response,
-        run_response=run_response,
-        send_media_to_model=team.send_media_to_model,
-        compression_manager=team.compression_manager if team.compress_tool_results else None,
-        **result_store_kwargs(team),
-        after_tool_results=build_team_after_tool_results_callback(
-            team, run_response, session, run_messages, run_context
-        ),
-    ):
-        # Handle LLM request events and compression events from ModelResponse
-        if isinstance(model_response_event, ModelResponse):
-            if model_response_event.event == ModelResponseEvent.model_request_started.value:
-                if stream_events:
-                    yield handle_event(  # type: ignore
-                        create_team_model_request_started_event(
-                            from_run_response=run_response,
-                            model=team.model.id,
-                            model_provider=team.model.provider,
-                        ),
-                        run_response,
-                        events_to_skip=team.events_to_skip,
-                        store_events=team.store_events,
-                    )
-                continue
-
-            if model_response_event.event == ModelResponseEvent.model_request_completed.value:
-                if stream_events:
-                    yield handle_event(  # type: ignore
-                        create_team_model_request_completed_event(
-                            from_run_response=run_response,
-                            model=team.model.id,
-                            model_provider=team.model.provider,
-                            input_tokens=model_response_event.input_tokens,
-                            output_tokens=model_response_event.output_tokens,
-                            total_tokens=model_response_event.total_tokens,
-                            time_to_first_token=model_response_event.time_to_first_token,
-                            reasoning_tokens=model_response_event.reasoning_tokens,
-                            cache_read_tokens=model_response_event.cache_read_tokens,
-                            cache_write_tokens=model_response_event.cache_write_tokens,
-                        ),
-                        run_response,
-                        events_to_skip=team.events_to_skip,
-                        store_events=team.store_events,
-                    )
-                continue
-
-            # Handle compression events
-            if model_response_event.event == ModelResponseEvent.compression_started.value:
-                if stream_events:
-                    yield handle_event(  # type: ignore
-                        create_team_compression_started_event(from_run_response=run_response),
-                        run_response,
-                        events_to_skip=team.events_to_skip,
-                        store_events=team.store_events,
-                    )
-                continue
-
-            if model_response_event.event == ModelResponseEvent.compression_completed.value:
-                if stream_events:
-                    stats = model_response_event.compression_stats or {}
-                    yield handle_event(  # type: ignore
-                        create_team_compression_completed_event(
-                            from_run_response=run_response,
-                            tool_results_compressed=stats.get("tool_results_compressed"),
-                            original_size=stats.get("original_size"),
-                            compressed_size=stats.get("compressed_size"),
-                        ),
-                        run_response,
-                        events_to_skip=team.events_to_skip,
-                        store_events=team.store_events,
-                    )
-                continue
-
-        yield from _handle_model_response_chunk(
-            team,
-            session=session,
+    tool_args_stream = ToolCallArgsStream(run_response.session_id, run_response.run_id) if stream_events else None
+    try:
+        for model_response_event in call_model_stream_with_fallback(
+            team.model,
+            team.fallback_config,
+            messages=run_messages.messages,
+            response_format=response_format,
+            tools=tools,
+            tool_choice=team.tool_choice,
+            tool_call_limit=team.tool_call_limit,
+            stream_model_response=stream_model_response,
             run_response=run_response,
-            full_model_response=full_model_response,
-            model_response_event=model_response_event,
-            reasoning_state=reasoning_state,
-            stream_events=stream_events,
-            parse_structured_output=should_parse_structured_output,
-            session_state=session_state,
-            run_context=run_context,
-        )
+            send_media_to_model=team.send_media_to_model,
+            compression_manager=team.compression_manager if team.compress_tool_results else None,
+            **result_store_kwargs(team),
+            after_tool_results=build_team_after_tool_results_callback(
+                team, run_response, session, run_messages, run_context
+            ),
+        ):
+            # Handle LLM request events and compression events from ModelResponse
+            if isinstance(model_response_event, ModelResponse):
+                if model_response_event.event == ModelResponseEvent.model_request_started.value:
+                    # By now the run has decided what to do with every call the last
+                    # turn made, and its tool call identities do not carry forward
+                    yield from _close_refused_tool_calls(team, run_response, tool_args_stream)
+                    if tool_args_stream is not None:
+                        tool_args_stream.begin_turn()
+                    if stream_events:
+                        yield handle_event(  # type: ignore
+                            create_team_model_request_started_event(
+                                from_run_response=run_response,
+                                model=team.model.id,
+                                model_provider=team.model.provider,
+                            ),
+                            run_response,
+                            events_to_skip=team.events_to_skip,
+                            store_events=team.store_events,
+                        )
+                    continue
+
+                if model_response_event.event == ModelResponseEvent.model_request_completed.value:
+                    if stream_events:
+                        yield handle_event(  # type: ignore
+                            create_team_model_request_completed_event(
+                                from_run_response=run_response,
+                                model=team.model.id,
+                                model_provider=team.model.provider,
+                                input_tokens=model_response_event.input_tokens,
+                                output_tokens=model_response_event.output_tokens,
+                                total_tokens=model_response_event.total_tokens,
+                                time_to_first_token=model_response_event.time_to_first_token,
+                                reasoning_tokens=model_response_event.reasoning_tokens,
+                                cache_read_tokens=model_response_event.cache_read_tokens,
+                                cache_write_tokens=model_response_event.cache_write_tokens,
+                            ),
+                            run_response,
+                            events_to_skip=team.events_to_skip,
+                            store_events=team.store_events,
+                        )
+                    continue
+
+                # Handle compression events
+                if model_response_event.event == ModelResponseEvent.compression_started.value:
+                    if stream_events:
+                        yield handle_event(  # type: ignore
+                            create_team_compression_started_event(from_run_response=run_response),
+                            run_response,
+                            events_to_skip=team.events_to_skip,
+                            store_events=team.store_events,
+                        )
+                    continue
+
+                if model_response_event.event == ModelResponseEvent.compression_completed.value:
+                    if stream_events:
+                        stats = model_response_event.compression_stats or {}
+                        yield handle_event(  # type: ignore
+                            create_team_compression_completed_event(
+                                from_run_response=run_response,
+                                tool_results_compressed=stats.get("tool_results_compressed"),
+                                original_size=stats.get("original_size"),
+                                compressed_size=stats.get("compressed_size"),
+                            ),
+                            run_response,
+                            events_to_skip=team.events_to_skip,
+                            store_events=team.store_events,
+                        )
+                    continue
+
+            yield from _handle_model_response_chunk(
+                team,
+                session=session,
+                run_response=run_response,
+                full_model_response=full_model_response,
+                model_response_event=model_response_event,
+                reasoning_state=reasoning_state,
+                stream_events=stream_events,
+                parse_structured_output=should_parse_structured_output,
+                session_state=session_state,
+                run_context=run_context,
+                tool_args_stream=tool_args_stream,
+            )
+    except Exception:
+        # A stream that raised is still being read, so this generator can
+        # yield the closures. A generator the consumer abandoned cannot:
+        # that arrives as GeneratorExit, which is no Exception and is left
+        # alone, as are a keyboard interrupt and a process exit.
+        yield from _close_refused_tool_calls(team, run_response, tool_args_stream)
+        raise
+
+    # The stream ends here whether the run completed or paused, and a call
+    # refused on its last turn gets no later turn to be closed out on.
+    yield from _close_refused_tool_calls(team, run_response, tool_args_stream)
 
     # 3. Update TeamRunOutput
     if full_model_response.content is not None:
@@ -1176,6 +1268,7 @@ async def _ahandle_model_response_stream(
     from agno.team._run import abuild_team_after_tool_results_callback
 
     full_model_response = ModelResponse()
+    tool_args_stream = ToolCallArgsStream(run_response.session_id, run_response.run_id) if stream_events else None
     model_stream = acall_model_stream_with_fallback(
         team.model,
         team.fallback_config,
@@ -1193,84 +1286,105 @@ async def _ahandle_model_response_stream(
             team, run_response, session, run_messages, run_context
         ),
     )  # type: ignore
-    async for model_response_event in model_stream:
-        # Handle LLM request events and compression events from ModelResponse
-        if isinstance(model_response_event, ModelResponse):
-            if model_response_event.event == ModelResponseEvent.model_request_started.value:
-                if stream_events:
-                    yield handle_event(  # type: ignore
-                        create_team_model_request_started_event(
-                            from_run_response=run_response,
-                            model=team.model.id,
-                            model_provider=team.model.provider,
-                        ),
-                        run_response,
-                        events_to_skip=team.events_to_skip,
-                        store_events=team.store_events,
-                    )
-                continue
+    try:
+        async for model_response_event in model_stream:
+            # Handle LLM request events and compression events from ModelResponse
+            if isinstance(model_response_event, ModelResponse):
+                if model_response_event.event == ModelResponseEvent.model_request_started.value:
+                    # By now the run has decided what to do with every call the last
+                    # turn made, and its tool call identities do not carry forward
+                    for refused in _close_refused_tool_calls(team, run_response, tool_args_stream):
+                        yield refused
+                    if tool_args_stream is not None:
+                        tool_args_stream.begin_turn()
+                    if stream_events:
+                        yield handle_event(  # type: ignore
+                            create_team_model_request_started_event(
+                                from_run_response=run_response,
+                                model=team.model.id,
+                                model_provider=team.model.provider,
+                            ),
+                            run_response,
+                            events_to_skip=team.events_to_skip,
+                            store_events=team.store_events,
+                        )
+                    continue
 
-            if model_response_event.event == ModelResponseEvent.model_request_completed.value:
-                if stream_events:
-                    yield handle_event(  # type: ignore
-                        create_team_model_request_completed_event(
-                            from_run_response=run_response,
-                            model=team.model.id,
-                            model_provider=team.model.provider,
-                            input_tokens=model_response_event.input_tokens,
-                            output_tokens=model_response_event.output_tokens,
-                            total_tokens=model_response_event.total_tokens,
-                            time_to_first_token=model_response_event.time_to_first_token,
-                            reasoning_tokens=model_response_event.reasoning_tokens,
-                            cache_read_tokens=model_response_event.cache_read_tokens,
-                            cache_write_tokens=model_response_event.cache_write_tokens,
-                        ),
-                        run_response,
-                        events_to_skip=team.events_to_skip,
-                        store_events=team.store_events,
-                    )
-                continue
+                if model_response_event.event == ModelResponseEvent.model_request_completed.value:
+                    if stream_events:
+                        yield handle_event(  # type: ignore
+                            create_team_model_request_completed_event(
+                                from_run_response=run_response,
+                                model=team.model.id,
+                                model_provider=team.model.provider,
+                                input_tokens=model_response_event.input_tokens,
+                                output_tokens=model_response_event.output_tokens,
+                                total_tokens=model_response_event.total_tokens,
+                                time_to_first_token=model_response_event.time_to_first_token,
+                                reasoning_tokens=model_response_event.reasoning_tokens,
+                                cache_read_tokens=model_response_event.cache_read_tokens,
+                                cache_write_tokens=model_response_event.cache_write_tokens,
+                            ),
+                            run_response,
+                            events_to_skip=team.events_to_skip,
+                            store_events=team.store_events,
+                        )
+                    continue
 
-            # Handle compression events
-            if model_response_event.event == ModelResponseEvent.compression_started.value:
-                if stream_events:
-                    yield handle_event(  # type: ignore
-                        create_team_compression_started_event(from_run_response=run_response),
-                        run_response,
-                        events_to_skip=team.events_to_skip,
-                        store_events=team.store_events,
-                    )
-                continue
+                # Handle compression events
+                if model_response_event.event == ModelResponseEvent.compression_started.value:
+                    if stream_events:
+                        yield handle_event(  # type: ignore
+                            create_team_compression_started_event(from_run_response=run_response),
+                            run_response,
+                            events_to_skip=team.events_to_skip,
+                            store_events=team.store_events,
+                        )
+                    continue
 
-            if model_response_event.event == ModelResponseEvent.compression_completed.value:
-                if stream_events:
-                    stats = model_response_event.compression_stats or {}
-                    yield handle_event(  # type: ignore
-                        create_team_compression_completed_event(
-                            from_run_response=run_response,
-                            tool_results_compressed=stats.get("tool_results_compressed"),
-                            original_size=stats.get("original_size"),
-                            compressed_size=stats.get("compressed_size"),
-                        ),
-                        run_response,
-                        events_to_skip=team.events_to_skip,
-                        store_events=team.store_events,
-                    )
-                continue
+                if model_response_event.event == ModelResponseEvent.compression_completed.value:
+                    if stream_events:
+                        stats = model_response_event.compression_stats or {}
+                        yield handle_event(  # type: ignore
+                            create_team_compression_completed_event(
+                                from_run_response=run_response,
+                                tool_results_compressed=stats.get("tool_results_compressed"),
+                                original_size=stats.get("original_size"),
+                                compressed_size=stats.get("compressed_size"),
+                            ),
+                            run_response,
+                            events_to_skip=team.events_to_skip,
+                            store_events=team.store_events,
+                        )
+                    continue
 
-        for event in _handle_model_response_chunk(
-            team,
-            session=session,
-            run_response=run_response,
-            full_model_response=full_model_response,
-            model_response_event=model_response_event,
-            reasoning_state=reasoning_state,
-            stream_events=stream_events,
-            parse_structured_output=should_parse_structured_output,
-            session_state=session_state,
-            run_context=run_context,
-        ):
-            yield event
+            for event in _handle_model_response_chunk(
+                team,
+                session=session,
+                run_response=run_response,
+                full_model_response=full_model_response,
+                model_response_event=model_response_event,
+                reasoning_state=reasoning_state,
+                stream_events=stream_events,
+                parse_structured_output=should_parse_structured_output,
+                session_state=session_state,
+                run_context=run_context,
+                tool_args_stream=tool_args_stream,
+            ):
+                yield event
+    except Exception:
+        # A stream that raised is still being read, so this generator can
+        # yield the closures. A generator the consumer abandoned cannot:
+        # that arrives as GeneratorExit, which is no Exception and is left
+        # alone, as are a keyboard interrupt and a process exit.
+        for refused in _close_refused_tool_calls(team, run_response, tool_args_stream):
+            yield refused
+        raise
+
+    # The stream ends here whether the run completed or paused, and a call
+    # refused on its last turn gets no later turn to be closed out on.
+    for refused in _close_refused_tool_calls(team, run_response, tool_args_stream):
+        yield refused
 
     # Update TeamRunOutput
     if full_model_response.content is not None:
@@ -1319,11 +1433,19 @@ def _handle_model_response_chunk(
     parse_structured_output: bool = False,
     session_state: Optional[Dict[str, Any]] = None,
     run_context: Optional[RunContext] = None,
+    tool_args_stream: Optional[ToolCallArgsStream] = None,
 ) -> Iterator[Union[TeamRunOutputEvent, RunOutputEvent]]:
     if isinstance(model_response_event, RUN_OUTPUT_EVENT_TYPES) or isinstance(
         model_response_event, TEAM_RUN_OUTPUT_EVENT_TYPES
     ):
         if team.stream_member_events:
+            # A run told not to stream events is told that about its members
+            # too. Members are run with events on so the leader can read them,
+            # so their argument fragments arrive here and stop here, as the
+            # leader's own do.
+            if not stream_events and model_response_event.event in _TOOL_CALL_ARGS_DELTA_EVENTS:
+                return
+
             if model_response_event.event == TeamRunEvent.custom_event:  # type: ignore
                 if hasattr(model_response_event, "team_id"):
                     model_response_event.team_id = team.id
@@ -1373,6 +1495,18 @@ def _handle_model_response_chunk(
             full_model_response.reasoning_content = None
             run_response.content = None
             run_response.reasoning_content = None
+            # A replaced stream's own calls will never be made under its own ids
+            yield from _close_refused_tool_calls(team, run_response, tool_args_stream)
+            if tool_args_stream is not None:
+                tool_args_stream.begin_turn()
+            return
+        if model_response_event.event == ModelResponseEvent.model_request_started.value:
+            # The team's own loop reads this event before delegating here. The
+            # output model's stream does not, and this is where its turns end:
+            # a provider's numbering restarts with each request it answers.
+            yield from _close_refused_tool_calls(team, run_response, tool_args_stream)
+            if tool_args_stream is not None:
+                tool_args_stream.begin_turn()
             return
         # If the model response is an assistant_response, yield a RunOutput
         if model_response_event.event == ModelResponseEvent.assistant_response.value:
@@ -1510,10 +1644,31 @@ def _handle_model_response_chunk(
                         store_events=team.store_events,
                     )
 
+            # A chunk can carry both what the model said and the call it went on
+            # to make, and the saying came first, so the fragments go out last.
+            # A path threads a stream exactly when its fragments are the
+            # client's to receive, so the stream's presence is the whole gate.
+            if model_response_event.tool_calls and tool_args_stream is not None:
+                for tool_call_id, tool_name, tool_args_delta in tool_args_stream.fragments(
+                    model_response_event.tool_calls
+                ):
+                    yield handle_event(  # type: ignore
+                        create_team_tool_call_args_delta_event(
+                            from_run_response=run_response,
+                            tool_call_id=tool_call_id,
+                            tool_args_delta=tool_args_delta,
+                            tool_name=tool_name,
+                        ),
+                        run_response,
+                        events_to_skip=team.events_to_skip,
+                        store_events=team.store_events,
+                    )
+
         # Handle tool interruption events (HITL flow)
         elif model_response_event.event == ModelResponseEvent.tool_call_paused.value:
             tool_executions_list = model_response_event.tool_executions
             if tool_executions_list is not None:
+                answer_streamed_tool_calls(tool_args_stream, tool_executions_list)
                 if run_response.tools is None:
                     run_response.tools = tool_executions_list
                 else:
@@ -1527,6 +1682,7 @@ def _handle_model_response_chunk(
             # Add tool calls to the run_response
             tool_executions_list = model_response_event.tool_executions
             if tool_executions_list is not None:
+                answer_streamed_tool_calls(tool_args_stream, tool_executions_list)
                 # Add tool calls to the agent.run_response
                 if run_response.tools is None:
                     run_response.tools = tool_executions_list
@@ -1584,6 +1740,7 @@ def _handle_model_response_chunk(
             reasoning_step: Optional[ReasoningStep] = None
             tool_executions_list = model_response_event.tool_executions
             if tool_executions_list is not None:
+                answer_streamed_tool_calls(tool_args_stream, tool_executions_list)
                 # Update the existing tool call in the run_response
                 if run_response.tools:
                     # Create a mapping of tool_call_id to index

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -45,6 +45,7 @@ from agno.models.response import ModelResponse
 
 if TYPE_CHECKING:
     from agno.offload.store import ResultStore
+    from agno.utils.tools import ToolCallArgsStream
 from agno.registry.registry import Registry
 from agno.run import RunContext, RunStatus
 from agno.run.agent import RunEvent, RunOutput, RunOutputEvent
@@ -385,7 +386,7 @@ class Team:
 
     # Store the events from the Team
     store_events: bool = False
-    # List of events to skip from the Team
+    # List of events the Team keeps out of the stored run. Emission is unaffected.
     events_to_skip: Optional[List[Union[RunEvent, TeamRunEvent]]] = None
     # Store member agent runs inside the team's RunOutput
     store_member_responses: bool = False
@@ -1257,6 +1258,7 @@ class Team:
         parse_structured_output: bool = False,
         session_state: Optional[Dict[str, Any]] = None,
         run_context: Optional[RunContext] = None,
+        tool_args_stream: Optional[ToolCallArgsStream] = None,
     ) -> Iterator[Union[TeamRunOutputEvent, RunOutputEvent]]:
         yield from _response._handle_model_response_chunk(
             self,
@@ -1269,6 +1271,7 @@ class Team:
             parse_structured_output=parse_structured_output,
             session_state=session_state,
             run_context=run_context,
+            tool_args_stream=tool_args_stream,
         )
 
     ###########################################################################

--- a/libs/agno/agno/utils/events.py
+++ b/libs/agno/agno/utils/events.py
@@ -39,6 +39,7 @@ from agno.run.agent import (
     RunStartedEvent,
     SessionSummaryCompletedEvent,
     SessionSummaryStartedEvent,
+    ToolCallArgsDeltaEvent,
     ToolCallCompletedEvent,
     ToolCallErrorEvent,
     ToolCallStartedEvent,
@@ -81,6 +82,7 @@ from agno.run.team import TaskIterationStartedEvent as TeamTaskIterationStartedE
 from agno.run.team import TaskStateUpdatedEvent as TeamTaskStateUpdatedEvent
 from agno.run.team import TaskUpdatedEvent as TeamTaskUpdatedEvent
 from agno.run.team import TeamRunEvent, TeamRunInput, TeamRunOutput, TeamRunOutputEvent
+from agno.run.team import ToolCallArgsDeltaEvent as TeamToolCallArgsDeltaEvent
 from agno.run.team import ToolCallCompletedEvent as TeamToolCallCompletedEvent
 from agno.run.team import ToolCallErrorEvent as TeamToolCallErrorEvent
 from agno.run.team import ToolCallStartedEvent as TeamToolCallStartedEvent
@@ -576,6 +578,40 @@ def create_team_reasoning_completed_event(
         run_id=from_run_response.run_id,
         content=content,
         content_type=content_type or "str",
+    )
+
+
+def create_tool_call_args_delta_event(
+    from_run_response: RunOutput,
+    tool_call_id: str,
+    tool_args_delta: str,
+    tool_name: Optional[str] = None,
+) -> ToolCallArgsDeltaEvent:
+    return ToolCallArgsDeltaEvent(
+        session_id=from_run_response.session_id,
+        agent_id=from_run_response.agent_id,  # type: ignore
+        agent_name=from_run_response.agent_name,  # type: ignore
+        run_id=from_run_response.run_id,
+        tool_call_id=tool_call_id,
+        tool_name=tool_name,
+        tool_args_delta=tool_args_delta,
+    )
+
+
+def create_team_tool_call_args_delta_event(
+    from_run_response: TeamRunOutput,
+    tool_call_id: str,
+    tool_args_delta: str,
+    tool_name: Optional[str] = None,
+) -> TeamToolCallArgsDeltaEvent:
+    return TeamToolCallArgsDeltaEvent(
+        session_id=from_run_response.session_id,
+        team_id=from_run_response.team_id,  # type: ignore
+        team_name=from_run_response.team_name,  # type: ignore
+        run_id=from_run_response.run_id,
+        tool_call_id=tool_call_id,
+        tool_name=tool_name,
+        tool_args_delta=tool_args_delta,
     )
 
 

--- a/libs/agno/agno/utils/functions.py
+++ b/libs/agno/agno/utils/functions.py
@@ -7,6 +7,35 @@ from agno.utils.log import log_debug, log_error
 T = TypeVar("T")
 
 
+def coerce_literal_argument_values(arguments: Dict[str, Any]) -> Dict[str, Any]:
+    """Read the literal strings models write for Python values as those values.
+
+    Models do send "true", "false", "none" and "null" as argument strings where
+    they mean the value, so a top-level string of any of those becomes ``True``,
+    ``False`` or ``None``, in whatever casing and surrounded by whatever
+    whitespace it arrived in. Every other string is left exactly as it arrived,
+    its own whitespace included, and so is anything nested inside a value.
+
+    Anything holding arguments against the ones a run made a call with reads
+    them this way too, or Agno's own tidying looks like a disagreement.
+    """
+    coerced: Dict[str, Any] = {}
+    for key, value in arguments.items():
+        if isinstance(value, str):
+            literal = value.strip().lower()
+            if literal in ("none", "null"):
+                coerced[key] = None
+            elif literal == "true":
+                coerced[key] = True
+            elif literal == "false":
+                coerced[key] = False
+            else:
+                coerced[key] = value
+        else:
+            coerced[key] = value
+    return coerced
+
+
 def get_function_call(
     name: str,
     arguments: Optional[str] = None,
@@ -52,22 +81,7 @@ def get_function_call(
             return function_call
 
         try:
-            clean_arguments: Dict[str, Any] = {}
-            for k, v in _arguments.items():
-                if isinstance(v, str):
-                    _v = v.strip().lower()
-                    if _v in ("none", "null"):
-                        clean_arguments[k] = None
-                    elif _v == "true":
-                        clean_arguments[k] = True
-                    elif _v == "false":
-                        clean_arguments[k] = False
-                    else:
-                        clean_arguments[k] = v
-                else:
-                    clean_arguments[k] = v
-
-            function_call.arguments = clean_arguments
+            function_call.arguments = coerce_literal_argument_values(_arguments)
         except Exception as e:
             log_error(f"Unable to parsing function arguments:\n{arguments}\nError: {str(e)}")
             function_call.error = f"Error while parsing function arguments: {e}\n\n Please fix and retry."

--- a/libs/agno/agno/utils/tools.py
+++ b/libs/agno/agno/utils/tools.py
@@ -1,8 +1,10 @@
-from typing import Any, Dict, Optional
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterator, List, Optional, Set, Tuple
 
 from agno.models.response import ToolExecution
 from agno.tools.function import Function, FunctionCall
 from agno.utils.functions import get_function_call
+from agno.utils.log import log_warning
 
 
 def get_function_call_for_tool_call(
@@ -100,3 +102,311 @@ def get_function_call_for_tool_execution(
         call_id=_tool_call_id,
         functions=functions,
     )
+
+
+def _tool_call_delta_parts(tool_call: Any) -> Tuple[int, Optional[str], Optional[str], Any]:
+    """Read (index, id, name, arguments) off one streamed tool call delta.
+
+    Providers hand these to the run loop either as plain dicts or as their own
+    SDK objects, so both shapes are read the same way. An index that is absent
+    or is not an integer reads as zero, which is what every one of Agno's own
+    aggregators makes of it: a delta modelled as a tuple, for instance, answers
+    an `index` read with its own `index` method rather than with a stream index.
+
+    The id and the arguments come back as the provider wrote them, whatever
+    their type. The finished call carries that same unnarrowed id on its own
+    ``Optional[str]`` field, so narrowing it here, and only here, would leave a
+    subscriber holding fragments it cannot match to the call the run made.
+    """
+    if isinstance(tool_call, dict):
+        function: Any = tool_call.get("function") or {}
+        index = tool_call.get("index")
+        tool_call_id = tool_call.get("id")
+    else:
+        function = getattr(tool_call, "function", None)
+        index = getattr(tool_call, "index", None)
+        tool_call_id = getattr(tool_call, "id", None)
+
+    if isinstance(function, dict):
+        name = function.get("name")
+        arguments = function.get("arguments")
+    else:
+        name = getattr(function, "name", None)
+        arguments = getattr(function, "arguments", None)
+
+    return (
+        index if isinstance(index, int) and not isinstance(index, bool) else 0,
+        tool_call_id if tool_call_id else None,
+        name if isinstance(name, str) and name else None,
+        arguments,
+    )
+
+
+@dataclass
+class TurnToolCalls:
+    """What one model turn's tool call deltas have said about its calls so far.
+
+    A provider puts a call's id and function name on one delta and ties the
+    rest back to it, either by repeating the id or by its own stream index.
+    An index is the provider's own numbering and restarts at zero every turn,
+    so a caller drops the whole record at each turn boundary and no index can
+    then resolve against a call an earlier turn made.
+    """
+
+    id_by_index: Dict[int, str] = field(default_factory=dict)
+    name_by_id: Dict[str, str] = field(default_factory=dict)
+
+    def clear(self) -> None:
+        self.id_by_index.clear()
+        self.name_by_id.clear()
+
+
+def extract_tool_call_arg_deltas(
+    tool_calls: Optional[List[Any]],
+    turn: TurnToolCalls,
+) -> Tuple[List[Tuple[str, Optional[str], str]], int, List[Tuple[Optional[str], Optional[str]]], Optional[str]]:
+    """Pull the argument fragments out of one streamed tool call delta.
+
+    A call's id and function name may arrive on its first delta only, and that
+    delta often carries no arguments at all; later deltas carry an argument
+    chunk plus something that ties them back to the call, either the id again
+    or the provider's stream index. ``turn`` remembers both and is updated in
+    place, so a fragment can be attributed without having seen the finished
+    call. A turn can hold several calls, so their fragments interleave.
+
+    Attribution is what Agno's own tool call aggregators do, exactly: one entry
+    per stream index, a missing index read as zero, and an entry's id taken
+    from whichever of its deltas last carried one. So where a provider is
+    ambiguous the run and a subscriber read it the same way and cannot
+    disagree, which is the property that matters: what a subscriber assembles
+    is what the call is made with.
+
+    Returns the (tool_call_id, tool_name, arguments_fragment) triples to pass
+    on, one per fragment carrying argument text; how many fragments no call of
+    the turn could be found for; the (id, name) of each fragment that carried
+    arguments the provider wrote as a structure rather than as the text the
+    model wrote, which has no fragment of that text to send and whose id is
+    unknown when no call of the turn could be found for it either; and the type
+    name of a whole batch that was not a list of deltas, out of which no delta
+    can be read at all. Those three are the only text not passed on. Nothing
+    else is held back, dropped or rewritten: a subscriber can only ever append
+    what it is sent.
+    """
+    deltas: List[Tuple[str, Optional[str], str]] = []
+    unattributable = 0
+    unwritten: List[Tuple[Optional[str], Optional[str]]] = []
+    # A provider that reports the turn's calls as one object rather than as a
+    # list of them iterates into that object's own contents, which read as
+    # deltas naming no call and carrying no argument text, so nothing about
+    # them is reportable once they are in the loop. A batch is therefore turned
+    # away by its own shape, and only a list is read delta by delta.
+    if tool_calls is not None and not isinstance(tool_calls, list):
+        return deltas, unattributable, unwritten, type(tool_calls).__name__
+    for tool_call in tool_calls or []:
+        index, tool_call_id, tool_name, arguments = _tool_call_delta_parts(tool_call)
+        # An empty structure withholds no text the model wrote, so it is not
+        # reported as though it had.
+        structured_arguments = bool(arguments) and not isinstance(arguments, str)
+        if not isinstance(arguments, str):
+            arguments = None
+
+        if tool_call_id is None:
+            tool_call_id = turn.id_by_index.get(index)
+        if tool_call_id is None:
+            if structured_arguments:
+                unwritten.append((None, tool_name))
+            elif arguments:
+                unattributable += 1
+            continue
+
+        turn.id_by_index[index] = tool_call_id
+        # Learned whether or not this fragment carries arguments: what a call
+        # is called outlives the fragment that named it.
+        if tool_name is None:
+            tool_name = turn.name_by_id.get(tool_call_id)
+        else:
+            turn.name_by_id[tool_call_id] = tool_name
+
+        if structured_arguments:
+            unwritten.append((tool_call_id, tool_name))
+        elif arguments:
+            deltas.append((tool_call_id, tool_name, arguments))
+    return deltas, unattributable, unwritten, None
+
+
+# Told to a client holding a call the run declined to make, for instance
+# because the tool call limit was reached or no such tool exists.
+REFUSED_TOOL_CALL_ERROR = "This tool call was not run."
+
+
+class ToolCallArgsStream:
+    """Turns a model stream's tool call deltas into argument fragments to send.
+
+    Fragments are passed on exactly as the provider wrote them. Nothing is held
+    back, dropped or rewritten, because a subscriber can only append what it is
+    sent and so cannot be corrected afterwards. Three kinds of fragment cannot
+    go out: one no call of the turn has been named for, one whose arguments the
+    provider wrote as a structure rather than as text, and every fragment of a
+    batch the provider did not report as a list of deltas, out of which no
+    delta can be read at all. Each is reported rather than placed by a guess,
+    once for the stream.
+
+    An identity holds for one model turn: a provider's stream indexes restart
+    at zero each turn, so the record is dropped at every turn boundary rather
+    than letting a later fragment that carries no id resolve against a call the
+    client has already seen finish.
+
+    Fragments go out while the model is still writing the arguments, which is
+    before the run can say whether the call will run at all. Every call the
+    client has been shown is therefore remembered until the run takes it up, so
+    a call the run refuses can be closed out rather than left open on the
+    client for good. A call the run has taken up is never remembered again,
+    which costs one thing knowingly: a provider that reuses that id for a
+    second call the run then refuses leaves the second call open on the client,
+    because nothing on a fragment marks where one call's arguments end and a
+    reuse of its id begins. That is the lesser harm, a wrong report about a
+    call the client watched succeed being the worse one.
+
+    A run told not to stream events is sent no fragments and so is given no
+    stream at all. A caller holds one exactly where the fragments it carries
+    are the client's to receive, which is why a path can hand a stream to the
+    chunk handler without also telling it to announce anything else.
+    """
+
+    def __init__(self, session_id: Optional[str], run_id: Optional[str]) -> None:
+        self._turn = TurnToolCalls()
+        # tool_call_id -> tool name, for streamed calls the run has neither
+        # started, paused, nor finished
+        self._unanswered: Dict[str, Optional[str]] = {}
+        # The calls of this stream the run has taken up
+        self._answered: Set[str] = set()
+        self._run_label = f"(session_id={session_id}, run_id={run_id})"
+        self._reported_unattributable = False
+        self._reported_unwritten = False
+        self._reported_unreadable = False
+
+    def begin_turn(self) -> None:
+        """Drop the identities of a turn that has ended, or of a replaced stream."""
+        self._turn.clear()
+
+    def fragments(self, tool_calls: Optional[List[Any]]) -> Iterator[Tuple[str, Optional[str], str]]:
+        """Yield the (id, name, fragment) triples that are the client's to receive."""
+        deltas, unattributable, unwritten, unreadable = extract_tool_call_arg_deltas(tool_calls, self._turn)
+        if unattributable:
+            self._report_unattributable()
+        if unwritten:
+            self._report_unwritten(*unwritten[0])
+        if unreadable:
+            self._report_unreadable(unreadable)
+        for tool_call_id, tool_name, fragment in deltas:
+            # The client has been shown a call the run took up both starting
+            # and finishing, so putting it back on the record could only ever
+            # report a call it watched succeed as never run.
+            if tool_call_id not in self._answered:
+                self._unanswered[tool_call_id] = tool_name or self._unanswered.get(tool_call_id)
+            yield tool_call_id, tool_name, fragment
+
+    def call_answered(self, tool_call_id: Optional[str]) -> None:
+        """Record that the run has taken up a call whose arguments it streamed.
+
+        The run takes a call up only once the model has finished writing every
+        call of the turn, so this is where the turn's own numbering ends too.
+        Keying that on the run taking a call up, rather than on the next model
+        request, is what a cached model response needs: it replays the calls a
+        run made without making a request of its own, so a later turn's
+        fragment would otherwise resolve against an earlier turn's call.
+        """
+        self._turn.clear()
+        if tool_call_id:
+            self._unanswered.pop(tool_call_id, None)
+            self._answered.add(tool_call_id)
+
+    def take_unanswered(self) -> List[Tuple[str, Optional[str]]]:
+        """The (id, name) pairs of streamed calls the run never took up, once each."""
+        unanswered = list(self._unanswered.items())
+        self._unanswered.clear()
+        return unanswered
+
+    def _report_unattributable(self) -> None:
+        """Say once for the stream that argument text arrived naming no call."""
+        if self._reported_unattributable:
+            return
+        self._reported_unattributable = True
+        log_warning(
+            "A streamed tool call argument fragment carried neither a tool call id nor a provider "
+            "stream index, so nothing places it and it is not streamed. The streamed arguments of the "
+            "affected call are therefore incomplete, and a subscriber that concatenates them cannot "
+            "parse the result. Agno's own record of the call is unaffected, because only the stream "
+            f"is short of that text. {self._run_label}"
+        )
+
+    def _report_unwritten(self, tool_call_id: Optional[str], tool_name: Optional[str]) -> None:
+        """Say once for the stream that a delta's arguments were not text."""
+        if self._reported_unwritten:
+            return
+        self._reported_unwritten = True
+        known = ", ".join(part for part in (tool_call_id, tool_name) if part)
+        affected = f" ({known})" if known else ""
+        log_warning(
+            f"A streamed tool call delta{affected} carried its arguments as a structure rather than as "
+            "the text the model wrote, so there is no fragment of that text to stream and none is sent. "
+            "The streamed arguments of the affected call are therefore incomplete, and a subscriber that "
+            "concatenates them cannot parse the result. Agno's own record of the call is unaffected, "
+            f"because only the stream is short of that text. {self._run_label}"
+        )
+
+    def _report_unreadable(self, shape: str) -> None:
+        """Say once for the stream that a batch of deltas could not be read at all."""
+        if self._reported_unreadable:
+            return
+        self._reported_unreadable = True
+        log_warning(
+            f"A model stream reported its tool calls as a single {shape} rather than as a list of tool "
+            "call deltas, which this cannot read, so no argument fragment is streamed for any call that "
+            "batch carries. The streamed arguments of those calls are therefore missing altogether, and "
+            "a subscriber is left with nothing to concatenate. Agno's own record of the calls is "
+            f"unaffected, because only the stream is short of that text. {self._run_label}"
+        )
+
+
+def answer_streamed_tool_calls(
+    tool_args_stream: Optional[ToolCallArgsStream],
+    tool_executions: Optional[List[ToolExecution]],
+) -> None:
+    """Strike off the calls the run has taken up, so they are not closed as refused."""
+    if tool_args_stream is None:
+        return
+    for tool_execution in tool_executions or []:
+        tool_args_stream.call_answered(tool_execution.tool_call_id)
+
+
+def take_refused_tool_calls(
+    tool_args_stream: Optional[ToolCallArgsStream],
+) -> List[ToolExecution]:
+    """The calls a client was shown that the run refused, to be told to it.
+
+    Arguments are streamed while the model is still writing them, so a call
+    reaches the client before the run has decided whether to make it. One the
+    run then declines, by the tool call limit or because the model named a tool
+    that does not exist, is never started and never completed, so it is
+    reported as having failed rather than left as a call the client waits on
+    for good.
+
+    That report is an event and nothing else. The run's own tool list is the
+    framework's record of the calls it made, and a call it declined to make is
+    not one of them.
+
+    Safe to call at any point a turn's calls have all been decided: a call the
+    run took up has already been struck off, and nothing is reported twice.
+    """
+    if tool_args_stream is None:
+        return []
+    return [
+        ToolExecution(
+            tool_call_id=tool_call_id,
+            tool_name=tool_name,
+            tool_call_error=True,
+            result=REFUSED_TOOL_CALL_ERROR,
+        )
+        for tool_call_id, tool_name in tool_args_stream.take_unanswered()
+    ]

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -735,7 +735,19 @@ class Workflow:
         self.store_events = store_events
         self.store_media = store_media
         self.media_storage = media_storage
-        self.events_to_skip = events_to_skip or []
+        # A step's agent or team emits one argument fragment event per handful
+        # of the characters a tool call's arguments are typed in, so storing
+        # them grows the run's own event list by hundreds of entries per call.
+        # They are still streamed to subscribers; this list only governs
+        # storage. Any list the caller gives, empty included, is taken as given,
+        # but no component serializes this setting, so a workflow loaded from a
+        # database gets this default rather than the list it was saved with.
+        # The per-token content event is as frequent, and an agent and a team
+        # both drop it from their own stored runs, but a workflow's stored run
+        # has always kept it, so it stays stored here.
+        self.events_to_skip = events_to_skip
+        if self.events_to_skip is None:
+            self.events_to_skip = [RunEvent.tool_call_args_delta, TeamRunEvent.tool_call_args_delta]
         self.stream = stream
         self.stream_executor_events = stream_executor_events
         self.store_executor_outputs = store_executor_outputs

--- a/libs/agno/tests/unit/agent/test_tool_call_args_delta_events.py
+++ b/libs/agno/tests/unit/agent/test_tool_call_args_delta_events.py
@@ -1,0 +1,1835 @@
+"""What an Agent does with a tool call's streamed argument fragments.
+
+A fragmenting provider emits one fragment event per handful of argument
+characters, so a single tool call can produce hundreds of them. A subscriber
+rendering a call while the model is still writing it needs every fragment,
+attributed to the call it belongs to and offered exactly once. The stored run
+needs none of them, which is why the default skip list keeps them out of
+storage without keeping them off the stream.
+
+A fragment is attributed exactly the way Agno's own tool call aggregators
+attribute it: one entry per provider stream index, a missing index read as
+zero, and an entry's id taken from whichever of its deltas last carried one.
+So where a provider is ambiguous the run and a subscriber read it the same way
+and cannot disagree, which is all a subscriber needs. Those indexes restart at
+zero every turn, and the turn ends when the run takes a call up, so a later
+turn's fragment that carries no id of its own must not land on an earlier
+turn's finished call. Nothing else is held back or rewritten. A fragment
+offered twice, by a provider stream that restarts, goes out twice, because a
+subscriber can only append what it is sent and the run's own reassembly is
+doubled in the same way.
+"""
+
+import asyncio
+import json
+import logging
+from contextlib import contextmanager
+from typing import Any, AsyncIterator, Dict, Iterator, List, Optional, Tuple
+
+import pytest
+from pydantic import BaseModel
+
+from agno.agent import Agent
+from agno.agent._response import handle_model_response_chunk
+from agno.db.sqlite import SqliteDb
+from agno.exceptions import ModelProviderError
+from agno.models.base import Model
+from agno.models.response import ModelResponse, ModelResponseEvent, ToolExecution
+from agno.run.agent import RunEvent, RunOutput
+from agno.session import AgentSession
+from agno.tools import tool
+from agno.utils import log as agno_log
+from agno.utils.tools import REFUSED_TOOL_CALL_ERROR, ToolCallArgsStream
+
+
+class _ScriptedStreamModel(Model):
+    """Replays a fixed script of provider deltas, one turn per model call.
+
+    A call's id and function name ride its first fragment, which often carries
+    no arguments; every later fragment carries only an argument chunk and the
+    index that ties it back to the call. Each entry in ``turns`` is the list of
+    deltas for one model turn.
+
+    The script is finite: a call past its end fails the test rather than
+    replaying a turn, so a run that loops longer than intended is visible.
+    """
+
+    def __init__(self, turns: List[List[ModelResponse]]):
+        super().__init__(id="scripted-stream", name="scripted-stream", provider="test")
+        self._turns = list(turns)
+        self._turn = 0
+
+    def _next_turn(self) -> List[ModelResponse]:
+        assert self._turn < len(self._turns), f"model called {self._turn + 1} times, script holds {len(self._turns)}"
+        turn = self._turns[self._turn]
+        self._turn += 1
+        return turn
+
+    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+        yield from self._next_turn()
+
+    async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+        for delta in self._next_turn():
+            yield delta
+
+    def invoke(self, *args, **kwargs) -> ModelResponse:
+        raise AssertionError("the streaming paths are the ones under test")
+
+    async def ainvoke(self, *args, **kwargs) -> ModelResponse:
+        raise AssertionError("the streaming paths are the ones under test")
+
+    def _parse_provider_response(self, response, **kwargs) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+    def _parse_provider_response_delta(self, response) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+    def parse_tool_calls(self, tool_calls_data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Reassemble the fragments by index, as OpenAI-compatible models do."""
+        calls: Dict[int, Dict[str, Any]] = {}
+        order: List[int] = []
+        for fragment in tool_calls_data:
+            index = fragment.get("index", 0)
+            if index not in calls:
+                calls[index] = {"id": None, "type": "function", "function": {"name": "", "arguments": ""}}
+                order.append(index)
+            entry = calls[index]
+            if fragment.get("id"):
+                entry["id"] = fragment["id"]
+            function = fragment.get("function") or {}
+            if function.get("name"):
+                entry["function"]["name"] = function["name"]
+            if function.get("arguments"):
+                entry["function"]["arguments"] += function["arguments"]
+        return [calls[index] for index in order]
+
+
+class _AggregatingStreamModel(_ScriptedStreamModel):
+    """Also answers the non-streaming paths, with the turn as one response."""
+
+    def _aggregate_turn(self) -> ModelResponse:
+        turn = self._next_turn()
+        aggregated = ModelResponse(role="assistant")
+        fragments = [call for delta in turn for call in (delta.tool_calls or [])]
+        if fragments:
+            aggregated.tool_calls = self.parse_tool_calls(fragments)
+        content = "".join(delta.content for delta in turn if isinstance(delta.content, str))
+        if content:
+            aggregated.content = content
+        return aggregated
+
+    def invoke(self, *args, **kwargs) -> ModelResponse:
+        return self._aggregate_turn()
+
+    async def ainvoke(self, *args, **kwargs) -> ModelResponse:
+        return self._aggregate_turn()
+
+
+class _NonStreamedCallModel(_AggregatingStreamModel):
+    """Remembers the tool calls it handed back on the non-streamed path.
+
+    The parser model is asked for a finished response inside its stream, so a
+    test that path streams no fragments is only worth something if the model
+    really did answer it with a call.
+    """
+
+    def __init__(self, turns: List[List[ModelResponse]]):
+        super().__init__(turns)
+        self.returned_tool_calls: List[Dict[str, Any]] = []
+
+    def _aggregate_turn(self) -> ModelResponse:
+        aggregated = super()._aggregate_turn()
+        self.returned_tool_calls.extend(aggregated.tool_calls or [])
+        return aggregated
+
+
+class _ToolRecordingModel(_AggregatingStreamModel):
+    """Remembers the tools it was handed, once per stream it was asked for.
+
+    A path that hands its model none of the run's tools can still be answered
+    with a call, because a provider can call a built-in tool of its own, so
+    what the path passed is worth pinning beside what came back.
+    """
+
+    def __init__(self, turns: List[List[ModelResponse]]):
+        super().__init__(turns)
+        self.tools_seen: List[Optional[List[Any]]] = []
+
+    def response_stream(self, *args, **kwargs):
+        self.tools_seen.append(kwargs.get("tools"))
+        return super().response_stream(*args, **kwargs)
+
+    def aresponse_stream(self, *args, **kwargs):
+        self.tools_seen.append(kwargs.get("tools"))
+        return super().aresponse_stream(*args, **kwargs)
+
+
+class _DroppedStreamModel(_ScriptedStreamModel):
+    """Dies part way through a turn, the way a provider stream that drops does.
+
+    ``Model.retries`` restarts the whole stream, so the next attempt replays the
+    turn from its first fragment, including the fragments the dead attempt had
+    already delivered.
+    """
+
+    def __init__(self, turns: List[List[ModelResponse]], fail_after: int):
+        super().__init__(turns)
+        self._fail_after = fail_after
+        self.attempts = 0
+        self._pending: Optional[List[ModelResponse]] = None
+
+    def _attempt_deltas(self) -> List[ModelResponse]:
+        """The deltas of the turn under way, taken once and replayed on retry."""
+        if self._pending is None:
+            self._pending = self._next_turn()
+        return self._pending
+
+    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+        deltas = self._attempt_deltas()
+        self.attempts += 1
+        if self.attempts == 1:
+            yield from deltas[: self._fail_after]
+            raise ModelProviderError(message="stream dropped", model_name=self.name, model_id=self.id)
+        self._pending = None
+        yield from deltas
+
+    async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+        deltas = self._attempt_deltas()
+        self.attempts += 1
+        if self.attempts == 1:
+            for delta in deltas[: self._fail_after]:
+                yield delta
+            raise ModelProviderError(message="stream dropped", model_name=self.name, model_id=self.id)
+        self._pending = None
+        for delta in deltas:
+            yield delta
+
+
+def _fragment(
+    index: int,
+    arguments: str = "",
+    tool_call_id: Optional[str] = None,
+    tool_name: Optional[str] = None,
+) -> ModelResponse:
+    function: Dict[str, Any] = {"arguments": arguments}
+    if tool_name is not None:
+        function["name"] = tool_name
+    tool_call: Dict[str, Any] = {"index": index, "type": "function", "function": function}
+    if tool_call_id is not None:
+        tool_call["id"] = tool_call_id
+    return ModelResponse(role="assistant", tool_calls=[tool_call])
+
+
+def _unnumbered_fragment(
+    arguments: str = "",
+    tool_call_id: Optional[str] = None,
+    tool_name: Optional[str] = None,
+) -> ModelResponse:
+    """One fragment from a provider that puts no stream index on its deltas."""
+    function: Dict[str, Any] = {"arguments": arguments}
+    if tool_name is not None:
+        function["name"] = tool_name
+    tool_call: Dict[str, Any] = {"type": "function", "function": function}
+    if tool_call_id is not None:
+        tool_call["id"] = tool_call_id
+    return ModelResponse(role="assistant", tool_calls=[tool_call])
+
+
+def _unidentified_fragment(arguments: str = "", tool_name: Optional[str] = None) -> ModelResponse:
+    """One fragment from a provider that puts neither an index nor an id on it.
+
+    Ollama hands tool calls over this way, and Agno gives a call with no id of
+    its own one only once the finished call is assembled, so while such a
+    provider's fragments are arriving there is nothing to send them under.
+    """
+    return _unnumbered_fragment(arguments, tool_name=tool_name)
+
+
+def _chunks(text: str, size: int) -> List[str]:
+    return [text[i : i + size] for i in range(0, len(text), size)]
+
+
+def save_note(note: str) -> str:
+    """Save a note.
+
+    Args:
+        note: the note to save
+    """
+    return "saved"
+
+
+def save_other(note: str) -> str:
+    """Save a note somewhere else.
+
+    Args:
+        note: the note to save
+    """
+    return "saved other"
+
+
+class _Note(BaseModel):
+    note: str
+
+
+CHUNK_SIZE = 5
+
+
+def _tool_call_turns() -> Tuple[List[List[ModelResponse]], str]:
+    """One turn streaming a single tool call in fragments, then a reply turn."""
+    arguments = json.dumps({"note": "the sea is wide and the boat is small"})
+    fragments = [_fragment(0, tool_call_id="call_a", tool_name="save_note")]
+    fragments += [_fragment(0, chunk) for chunk in _chunks(arguments, CHUNK_SIZE)]
+    return [fragments, [ModelResponse(role="assistant", content="the note is saved")]], arguments
+
+
+def _interleaved_call_turns() -> Tuple[List[List[ModelResponse]], str, str]:
+    """One turn that streams two calls at once, their fragments interleaved.
+
+    The two argument strings differ in length, so the shorter call runs out of
+    fragments while the longer one is still streaming.
+    """
+    first = json.dumps({"note": "first"})
+    second = json.dumps({"note": "second, and a good deal longer than the first"})
+    fragments = [
+        _fragment(0, tool_call_id="call_a", tool_name="save_note"),
+        _fragment(1, tool_call_id="call_b", tool_name="save_other"),
+    ]
+    first_chunks = _chunks(first, CHUNK_SIZE)
+    second_chunks = _chunks(second, CHUNK_SIZE)
+    for position in range(max(len(first_chunks), len(second_chunks))):
+        if position < len(first_chunks):
+            fragments.append(_fragment(0, first_chunks[position]))
+        if position < len(second_chunks):
+            fragments.append(_fragment(1, second_chunks[position]))
+    return [fragments, [ModelResponse(role="assistant", content="both are saved")]], first, second
+
+
+def _two_turn_calls() -> Tuple[List[List[ModelResponse]], str, str]:
+    """Two tool call turns, the second opening with a fragment that has no id.
+
+    A provider ties later fragments back to a call by an index that restarts at
+    zero on every turn, so the second turn's opening fragment carries index
+    zero and no id of its own. It belongs to the call the second turn goes on
+    to announce, never to the first turn's finished call.
+    """
+    first = json.dumps({"note": "first"})
+    second = json.dumps({"note": "second"})
+    first_fragments = [_fragment(0, tool_call_id="call_a", tool_name="save_note")]
+    first_fragments += [_fragment(0, chunk) for chunk in _chunks(first, CHUNK_SIZE)]
+    second_fragments = [
+        _fragment(0, second[:4]),
+        _fragment(0, second[4:], tool_call_id="call_b", tool_name="save_other"),
+    ]
+    reply = [ModelResponse(role="assistant", content="both are saved")]
+    return [first_fragments, second_fragments, reply], first, second
+
+
+def _quiet_model() -> _ScriptedStreamModel:
+    """A model whose single turn is plain content, so it streams no fragments."""
+    return _ScriptedStreamModel([[ModelResponse(role="assistant", content="draft")]])
+
+
+def _events_named(events, event_name: str):
+    return [event for event in events if event.event == event_name]
+
+
+def _assembled(events, tool_call_id: str) -> str:
+    deltas = _events_named(events, RunEvent.tool_call_args_delta.value)
+    return "".join(delta.tool_args_delta for delta in deltas if delta.tool_call_id == tool_call_id)
+
+
+def _stored(run_output) -> List[str]:
+    return [event.event for event in (run_output.events or [])]
+
+
+# ---------------------------------------------------------------------------
+# Streaming a call's arguments
+# ---------------------------------------------------------------------------
+
+
+def test_agent_streams_tool_call_arg_fragments():
+    turns, arguments = _tool_call_turns()
+    agent = Agent(model=_ScriptedStreamModel(turns), tools=[save_note])
+
+    events = list(agent.run("go", stream=True, stream_events=True))
+
+    deltas = _events_named(events, RunEvent.tool_call_args_delta.value)
+    assert len(deltas) == len(_chunks(arguments, CHUNK_SIZE))
+    assert "".join(delta.tool_args_delta for delta in deltas) == arguments
+    assert {delta.tool_call_id for delta in deltas} == {"call_a"}
+    assert {delta.tool_name for delta in deltas} == {"save_note"}
+
+    # The finished events still arrive unchanged, and agree with the fragments.
+    started = _events_named(events, RunEvent.tool_call_started.value)
+    completed = _events_named(events, RunEvent.tool_call_completed.value)
+    assert len(started) == 1
+    assert len(completed) == 1
+    assert started[0].tool.tool_args == json.loads(arguments)
+    assert started[0].tool.tool_call_id == "call_a"
+
+
+async def test_agent_streams_tool_call_arg_fragments_async():
+    turns, arguments = _tool_call_turns()
+    agent = Agent(model=_ScriptedStreamModel(turns), tools=[save_note])
+
+    events = [event async for event in agent.arun("go", stream=True, stream_events=True)]
+
+    deltas = _events_named(events, RunEvent.tool_call_args_delta.value)
+    assert "".join(delta.tool_args_delta for delta in deltas) == arguments
+    assert {delta.tool_call_id for delta in deltas} == {"call_a"}
+    assert _events_named(events, RunEvent.tool_call_started.value)[0].tool.tool_args == json.loads(arguments)
+
+
+def test_agent_resolves_tool_call_id_from_index_on_later_fragments():
+    """Only the first fragment carries the id, and it carries no arguments at
+    all; every emitted fragment must still name the call it belongs to."""
+    turns, _ = _tool_call_turns()
+    later_fragments = turns[0][1:]
+    assert all(call.get("id") is None for delta in later_fragments for call in delta.tool_calls)
+
+    agent = Agent(model=_ScriptedStreamModel(turns), tools=[save_note])
+
+    events = list(agent.run("go", stream=True, stream_events=True))
+
+    deltas = _events_named(events, RunEvent.tool_call_args_delta.value)
+    assert deltas
+    assert all(delta.tool_call_id == "call_a" for delta in deltas)
+    assert all(delta.tool_name == "save_note" for delta in deltas)
+
+
+def test_agent_keeps_interleaved_tool_calls_apart():
+    turns, first, second = _interleaved_call_turns()
+    agent = Agent(model=_ScriptedStreamModel(turns), tools=[save_note, save_other])
+
+    events = list(agent.run("go", stream=True, stream_events=True))
+
+    assembled: Dict[str, str] = {}
+    names: Dict[str, Optional[str]] = {}
+    for delta in _events_named(events, RunEvent.tool_call_args_delta.value):
+        assembled[delta.tool_call_id] = assembled.get(delta.tool_call_id, "") + delta.tool_args_delta
+        names[delta.tool_call_id] = delta.tool_name
+    assert assembled == {"call_a": first, "call_b": second}
+    assert names == {"call_a": "save_note", "call_b": "save_other"}
+
+
+def _unnumbered_call_turns() -> Tuple[List[List[ModelResponse]], str]:
+    """One call from a provider that numbers none of its deltas.
+
+    The opening delta carries the id and the name, and every later one carries
+    only argument text. Agno's own aggregators, the OpenAI chat, watsonx,
+    cerebras and litellm ones among them, read a missing index as zero, so all
+    of these deltas belong to the one call the turn made.
+    """
+    arguments = json.dumps({"note": "the sea is wide and the boat is small"})
+    fragments = [_unnumbered_fragment(tool_call_id="call_a", tool_name="save_note")]
+    fragments += [_unnumbered_fragment(chunk) for chunk in _chunks(arguments, CHUNK_SIZE)]
+    return [fragments, [ModelResponse(role="assistant", content="the note is saved")]], arguments
+
+
+def _assert_the_unnumbered_calls_arguments_streamed_whole(events, arguments: str) -> None:
+    """The client was sent what the run itself assembled, not a prefix of it."""
+    started = _events_named(events, RunEvent.tool_call_started.value)
+    assert [json.dumps(event.tool.tool_args) for event in started] == [arguments]
+    assert _assembled(events, "call_a") == arguments
+
+
+def test_agent_streams_the_whole_arguments_of_a_provider_that_numbers_no_call():
+    turns, arguments = _unnumbered_call_turns()
+    agent = Agent(model=_ScriptedStreamModel(turns), tools=[save_note])
+
+    events = list(agent.run("go", stream=True, stream_events=True))
+
+    _assert_the_unnumbered_calls_arguments_streamed_whole(events, arguments)
+
+
+async def test_agent_streams_the_whole_arguments_of_a_provider_that_numbers_no_call_async():
+    turns, arguments = _unnumbered_call_turns()
+    agent = Agent(model=_ScriptedStreamModel(turns), tools=[save_note])
+
+    events = [event async for event in agent.arun("go", stream=True, stream_events=True)]
+
+    _assert_the_unnumbered_calls_arguments_streamed_whole(events, arguments)
+
+
+# ---------------------------------------------------------------------------
+# Turn and stream boundaries
+# ---------------------------------------------------------------------------
+
+
+def test_agent_does_not_carry_tool_call_ids_across_turns():
+    turns, first, _ = _two_turn_calls()
+    agent = Agent(model=_ScriptedStreamModel(turns), tools=[save_note, save_other])
+
+    events = list(agent.run("go", stream=True, stream_events=True))
+
+    # One model request per scripted turn, so nothing here rides on the fake
+    # having a turn left to hand out twice.
+    assert len(_events_named(events, RunEvent.model_request_started.value)) == len(turns)
+    assert json.loads(_assembled(events, "call_a")) == json.loads(first)
+
+
+async def test_agent_does_not_carry_tool_call_ids_across_turns_async():
+    turns, first, _ = _two_turn_calls()
+    agent = Agent(model=_ScriptedStreamModel(turns), tools=[save_note, save_other])
+
+    events = [event async for event in agent.arun("go", stream=True, stream_events=True)]
+
+    assert len(_events_named(events, RunEvent.model_request_started.value)) == len(turns)
+    assert json.loads(_assembled(events, "call_a")) == json.loads(first)
+
+
+def _cached_model(turns: List[List[ModelResponse]], cache_dir) -> _ScriptedStreamModel:
+    """A scripted model that records its stream and replays it on the next run."""
+    model = _ScriptedStreamModel(turns)
+    model.cache_response = True
+    model.cache_dir = str(cache_dir)
+    return model
+
+
+def _assert_a_cached_response_keeps_its_turns_apart(live, cached, first: str) -> None:
+    """The replayed turns are held apart by what the run did, not by a request.
+
+    A cache hit yields the deltas the recorded run produced and asks the model
+    for nothing, so the event that says a model request has started never
+    arrives. A turn boundary keyed on that event would let the second turn's
+    opening fragment, which carries index zero and no id, land on the call the
+    first turn already finished.
+    """
+    assert not _events_named(cached, RunEvent.model_request_started.value)
+    assert _events_named(cached, RunEvent.tool_call_args_delta.value)
+    assert json.loads(_assembled(cached, "call_a")) == json.loads(first)
+    assert _assembled(cached, "call_a") == _assembled(live, "call_a")
+
+
+def test_agent_does_not_carry_tool_call_ids_across_the_turns_of_a_cached_response(tmp_path):
+    turns, first, _ = _two_turn_calls()
+    recording = Agent(model=_cached_model(turns, tmp_path), tools=[save_note, save_other])
+
+    live = list(recording.run("go", stream=True, stream_events=True))
+    # An empty script: a cache hit asks the model for nothing, so a miss fails
+    # the run rather than quietly streaming the turns a second time.
+    replaying = Agent(model=_cached_model([], tmp_path), tools=[save_note, save_other])
+    cached = list(replaying.run("go", stream=True, stream_events=True))
+
+    _assert_a_cached_response_keeps_its_turns_apart(live, cached, first)
+
+
+async def test_agent_does_not_carry_tool_call_ids_across_the_turns_of_a_cached_response_async(tmp_path):
+    turns, first, _ = _two_turn_calls()
+    recording = Agent(model=_cached_model(turns, tmp_path), tools=[save_note, save_other])
+
+    live = [event async for event in recording.arun("go", stream=True, stream_events=True)]
+    replaying = Agent(model=_cached_model([], tmp_path), tools=[save_note, save_other])
+    cached = [event async for event in replaying.arun("go", stream=True, stream_events=True)]
+
+    _assert_a_cached_response_keeps_its_turns_apart(live, cached, first)
+
+
+def _assert_a_restarted_stream_offers_its_fragments_again(
+    events, model, turns, arguments: str, warnings: List[logging.LogRecord]
+) -> None:
+    """Every fragment the restarted stream produced went out, retraced or not.
+
+    A subscriber can only append what it is sent, so text held back can never
+    be made up for and text sent can never be taken back. Holding a fragment
+    back on the guess that a client already has it is what dropped real
+    argument text, so the fragments are passed on as the provider wrote them
+    and the assembled string is checked where it can be: against the finished
+    call, by the subscriber that has to render it.
+    """
+    # The stream really did drop and restart, and it restarted inside the turn
+    # rather than costing the run a model request.
+    assert model.attempts > 1
+    assert len(_events_named(events, RunEvent.model_request_started.value)) == len(turns)
+    retraced = "".join(_chunks(arguments, CHUNK_SIZE)[:3])
+    assert _assembled(events, "call_a") == retraced + arguments
+    # A restart leaves the run's own reassembly of the arguments doubled too,
+    # so the call fails to decode and is never started. It is closed out all
+    # the same, rather than left open on a client for good.
+    assert not _events_named(events, RunEvent.tool_call_started.value)
+    reported = _events_named(events, RunEvent.tool_call_error.value)
+    assert [event.tool.tool_call_id for event in reported] == ["call_a"]
+    assert reported[0].error == REFUSED_TOOL_CALL_ERROR
+    # The run reports the request that dropped and the doubled arguments its
+    # own reassembly then could not decode, and nothing else: the fragments
+    # went out as they arrived, so there is nothing to say of them.
+    logged = [record.getMessage() for record in warnings]
+    assert len(logged) == 2, logged
+    assert any("Model provider error" in message for message in logged)
+    assert any("Unable to decode function arguments" in message for message in logged)
+
+
+def _restarting_agent(turns) -> Tuple[Agent, _DroppedStreamModel]:
+    # Four deltas in: the call's announcement and three argument fragments.
+    model = _DroppedStreamModel(turns, fail_after=4)
+    model.retries = 1
+    model.delay_between_retries = 0
+    return Agent(model=model, tools=[save_note]), model
+
+
+def test_agent_streams_a_restarted_streams_fragments_again(warnings_logged):
+    turns, arguments = _tool_call_turns()
+    agent, model = _restarting_agent(turns)
+
+    events = list(agent.run("go", stream=True, stream_events=True))
+
+    _assert_a_restarted_stream_offers_its_fragments_again(events, model, turns, arguments, warnings_logged)
+
+
+async def test_agent_streams_a_restarted_streams_fragments_again_async(warnings_logged):
+    turns, arguments = _tool_call_turns()
+    agent, model = _restarting_agent(turns)
+
+    events = [event async for event in agent.arun("go", stream=True, stream_events=True)]
+
+    _assert_a_restarted_stream_offers_its_fragments_again(events, model, turns, arguments, warnings_logged)
+
+
+# ---------------------------------------------------------------------------
+# When a fragment is safe to send
+# ---------------------------------------------------------------------------
+
+
+def _text_and_fragment_turns() -> Tuple[List[List[ModelResponse]], str, str]:
+    """A turn whose opening delta carries both a line of text and a tool call.
+
+    A provider sends both in one chunk when the model says what it is about to
+    do, and the saying comes before the call it announces.
+    """
+    text = "Saving that now. "
+    arguments = json.dumps({"note": "the sea is wide"})
+    opening = _fragment(0, arguments[:4], tool_call_id="call_a", tool_name="save_note")
+    opening.content = text
+    fragments = [opening]
+    fragments += [_fragment(0, chunk) for chunk in _chunks(arguments[4:], CHUNK_SIZE)]
+    return [fragments, [ModelResponse(role="assistant", content="the note is saved")]], text, arguments
+
+
+def test_agent_sends_a_chunks_text_before_the_tool_call_it_announces():
+    turns, text, arguments = _text_and_fragment_turns()
+    agent = Agent(model=_ScriptedStreamModel(turns), tools=[save_note])
+
+    events = list(agent.run("go", stream=True, stream_events=True))
+
+    first_fragment = next(
+        position for position, event in enumerate(events) if event.event == RunEvent.tool_call_args_delta.value
+    )
+    said = next(
+        position
+        for position, event in enumerate(events)
+        if event.event == RunEvent.run_content.value and event.content == text
+    )
+    assert said < first_fragment
+    # The whole argument string still reaches the client, opening chunk included.
+    assert _assembled(events, "call_a") == arguments
+
+
+async def test_agent_sends_a_chunks_text_before_the_tool_call_it_announces_async():
+    turns, text, arguments = _text_and_fragment_turns()
+    agent = Agent(model=_ScriptedStreamModel(turns), tools=[save_note])
+
+    events = [event async for event in agent.arun("go", stream=True, stream_events=True)]
+
+    first_fragment = next(
+        position for position, event in enumerate(events) if event.event == RunEvent.tool_call_args_delta.value
+    )
+    said = next(
+        position
+        for position, event in enumerate(events)
+        if event.event == RunEvent.run_content.value and event.content == text
+    )
+    assert said < first_fragment
+    assert _assembled(events, "call_a") == arguments
+
+
+@contextmanager
+def _records_logged_at(level: int) -> Iterator[List[logging.LogRecord]]:
+    """Everything Agno logs at ``level`` or above, whichever logger carried it.
+
+    ``log_warning`` and ``log_error`` write to a process-global logger that a
+    team run rebinds to the team logger and never rebinds back, so the same
+    line is carried by one logger or another depending on what else ran
+    earlier in the process. What these tests assert is what a run reported, so
+    they read every logger the helpers can be bound to and stay out of that.
+    """
+    records: List[logging.LogRecord] = []
+
+    class _Collector(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    handler = _Collector(level)
+    loggers = list(
+        {id(value): value for value in vars(agno_log).values() if isinstance(value, logging.Logger)}.values()
+    )
+    for agno_logger in loggers:
+        agno_logger.addHandler(handler)
+    try:
+        yield records
+    finally:
+        for agno_logger in loggers:
+            agno_logger.removeHandler(handler)
+
+
+@pytest.fixture
+def warnings_logged() -> Iterator[List[logging.LogRecord]]:
+    with _records_logged_at(logging.WARNING) as records:
+        yield records
+
+
+@pytest.fixture
+def errors_logged() -> Iterator[List[logging.LogRecord]]:
+    with _records_logged_at(logging.ERROR) as records:
+        yield records
+
+
+def _unnamed_call_turns() -> Tuple[List[List[ModelResponse]], str]:
+    """A turn whose fragments name no call at all, then a reply turn."""
+    arguments = json.dumps({"note": "the sea is wide and the boat is small"})
+    fragments = [_unidentified_fragment(tool_name="save_note")]
+    fragments += [_unidentified_fragment(chunk) for chunk in _chunks(arguments, CHUNK_SIZE)]
+    return [fragments, [ModelResponse(role="assistant", content="the note is saved")]], arguments
+
+
+def _agent_on_a_provider_that_names_no_call() -> Tuple[Agent, str]:
+    turns, arguments = _unnamed_call_turns()
+    return Agent(model=_ScriptedStreamModel(turns), tools=[save_note]), arguments
+
+
+def _assert_the_arguments_arrive_whole_with_the_finished_call(events, arguments: str) -> None:
+    """No fragment reached a subscriber, and the finished call carried it all.
+
+    Which is what a subscriber was handed before any of this streamed: one
+    complete set of arguments, once, with the call Agno announces.
+    """
+    assert [event for event in events if event.event == RunEvent.tool_call_args_delta.value] == []
+    announcements = [event for event in events if event.event == RunEvent.tool_call_started.value]
+    assert [json.dumps(event.tool.tool_args) for event in announcements] == [arguments]
+    assert announcements[0].tool.tool_call_id
+
+
+class TestAProviderThatNamesNoCallSendsItsArgumentsWithTheFinishedCall:
+    """A provider whose fragments carry neither a stream index nor a call id.
+
+    Nothing but a guess could tie such a fragment to a call, so none of them
+    go out. What a subscriber gets is the behaviour it had before arguments
+    streamed at all, and a warning naming the run it happened in, once for the
+    stream rather than once for each of the fragments.
+    """
+
+    def test_the_arguments_arrive_whole_with_the_finished_call(self, warnings_logged):
+        agent, arguments = _agent_on_a_provider_that_names_no_call()
+
+        events = list(agent.run("go", stream=True, stream_events=True))
+
+        _assert_the_arguments_arrive_whole_with_the_finished_call(events, arguments)
+        # One warning for the stream, though the provider split the arguments
+        # over as many fragments as the chunk size allows.
+        warnings = [record.getMessage() for record in warnings_logged if record.levelno >= logging.WARNING]
+        assert len(warnings) == 1, warnings
+        assert "neither a tool call id nor a provider stream index" in warnings[0]
+        # A server carries many conversations at once, so the warning has to
+        # say which run left a subscriber without the streamed arguments.
+        run_started = _events_named(events, RunEvent.run_started.value)[0]
+        assert f"session_id={run_started.session_id}" in warnings[0]
+        assert f"run_id={run_started.run_id}" in warnings[0]
+
+    async def test_the_arguments_arrive_whole_with_the_finished_call_async(self, warnings_logged):
+        agent, arguments = _agent_on_a_provider_that_names_no_call()
+
+        events = [event async for event in agent.arun("go", stream=True, stream_events=True)]
+
+        _assert_the_arguments_arrive_whole_with_the_finished_call(events, arguments)
+        warnings = [record.getMessage() for record in warnings_logged if record.levelno >= logging.WARNING]
+        assert len(warnings) == 1, warnings
+
+    def test_the_tool_still_runs_on_the_arguments_the_model_asked_for(self, warnings_logged):
+        agent, arguments = _agent_on_a_provider_that_names_no_call()
+
+        events = list(agent.run("go", stream=True, stream_events=True))
+
+        completions = [event for event in events if event.event == RunEvent.tool_call_completed.value]
+        assert [json.dumps(event.tool.tool_args) for event in completions] == [arguments]
+        assert [event.tool.result for event in completions] == ["saved"]
+        # The call itself went through, so the one thing said of this run is
+        # what a subscriber was short of, said once however many fragments
+        # arrived. Anything else would be a report about a healthy call.
+        reported = [record.getMessage() for record in warnings_logged if record.levelno >= logging.WARNING]
+        assert len(reported) == 1, reported
+        assert "neither a tool call id nor a provider stream index" in reported[0]
+
+
+class _StructuredArgumentsModel(_ScriptedStreamModel):
+    """A provider that hands its arguments over as a mapping, not as text.
+
+    Mistral's streamed deltas type them either way, and the adapters that meet
+    a mapping turn it into JSON text on the way to the finished call, so the
+    run makes the call the model asked for while no delta ever carried the
+    text a subscriber could be sent a piece of.
+    """
+
+    def parse_tool_calls(self, tool_calls_data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        as_text: List[Dict[str, Any]] = []
+        for fragment in tool_calls_data:
+            function = dict(fragment.get("function") or {})
+            if isinstance(function.get("arguments"), (dict, list)):
+                function["arguments"] = json.dumps(function["arguments"])
+            as_text.append({**fragment, "function": function})
+        return super().parse_tool_calls(as_text)
+
+
+def _agent_on_a_provider_that_writes_no_argument_text() -> Tuple[Agent, str]:
+    note = {"note": "the sea is wide and the boat is small"}
+    turns = [
+        [
+            _fragment(0, tool_call_id="call_a", tool_name="save_note"),
+            ModelResponse(role="assistant", tool_calls=[{"index": 0, "function": {"arguments": note}}]),
+        ],
+        [ModelResponse(role="assistant", content="the note is saved")],
+    ]
+    return Agent(model=_StructuredArgumentsModel(turns), tools=[save_note]), json.dumps(note)
+
+
+class TestAProviderThatWritesNoArgumentTextSendsItsArgumentsWithTheFinishedCall:
+    """A provider whose deltas carry the arguments as a structure.
+
+    There is no piece of the model's own text to pass on, and serialising the
+    structure here would put a subscriber on text this library wrote rather
+    than the model. So nothing goes out, the run is unaffected, and the reason
+    is said once for the stream.
+    """
+
+    def test_the_arguments_arrive_whole_with_the_finished_call(self, warnings_logged):
+        agent, arguments = _agent_on_a_provider_that_writes_no_argument_text()
+
+        events = list(agent.run("go", stream=True, stream_events=True))
+
+        _assert_the_arguments_arrive_whole_with_the_finished_call(events, arguments)
+        warnings = [record.getMessage() for record in warnings_logged if record.levelno >= logging.WARNING]
+        assert len(warnings) == 1, warnings
+        assert "as a structure rather than as the text" in warnings[0]
+        # Named, so the call can be found, and said of what the client holds
+        # rather than of a whole copy of the arguments it never receives.
+        assert "call_a" in warnings[0] and "save_note" in warnings[0]
+        assert "are therefore incomplete" in warnings[0]
+        assert "Agno's own record of the call is unaffected" in warnings[0]
+        run_started = _events_named(events, RunEvent.run_started.value)[0]
+        assert f"session_id={run_started.session_id}" in warnings[0]
+        assert f"run_id={run_started.run_id}" in warnings[0]
+
+    async def test_the_arguments_arrive_whole_with_the_finished_call_async(self, warnings_logged):
+        agent, arguments = _agent_on_a_provider_that_writes_no_argument_text()
+
+        events = [event async for event in agent.arun("go", stream=True, stream_events=True)]
+
+        _assert_the_arguments_arrive_whole_with_the_finished_call(events, arguments)
+        warnings = [record.getMessage() for record in warnings_logged if record.levelno >= logging.WARNING]
+        assert len(warnings) == 1, warnings
+
+    def test_the_tool_still_runs_on_the_arguments_the_model_asked_for(self, warnings_logged):
+        agent, arguments = _agent_on_a_provider_that_writes_no_argument_text()
+
+        events = list(agent.run("go", stream=True, stream_events=True))
+
+        completions = [event for event in events if event.event == RunEvent.tool_call_completed.value]
+        assert [json.dumps(event.tool.tool_args) for event in completions] == [arguments]
+        assert [event.tool.result for event in completions] == ["saved"]
+        # The call itself went through, so the one thing said of this run is
+        # what a subscriber was short of, said once for the stream. Anything
+        # else would be a report about a healthy call.
+        reported = [record.getMessage() for record in warnings_logged if record.levelno >= logging.WARNING]
+        assert len(reported) == 1, reported
+        assert "as a structure rather than as the text" in reported[0]
+
+
+def _refused_call_turns() -> Tuple[List[List[ModelResponse]], str]:
+    """A turn asking for two tools, of which a limit of one lets only the first run."""
+    first = json.dumps({"note": "first"})
+    second = json.dumps({"note": "second"})
+    fragments = [
+        _fragment(0, tool_call_id="call_a", tool_name="save_note"),
+        _fragment(1, tool_call_id="call_b", tool_name="save_other"),
+    ]
+    fragments += [_fragment(0, chunk) for chunk in _chunks(first, CHUNK_SIZE)]
+    fragments += [_fragment(1, chunk) for chunk in _chunks(second, CHUNK_SIZE)]
+    return [fragments, [ModelResponse(role="assistant", content="one of them is saved")]], second
+
+
+def _refused_agent(turns) -> Agent:
+    return Agent(model=_ScriptedStreamModel(turns), tools=[save_note, save_other], tool_call_limit=1)
+
+
+def _assert_refusal_is_closed_out(events, second: str) -> None:
+    # The client was shown the second call while it was still being written.
+    assert _assembled(events, "call_b") == second
+    # The limit let only the first of the two run.
+    started = {event.tool.tool_call_id for event in _events_named(events, RunEvent.tool_call_started.value)}
+    assert started == {"call_a"}
+    # So the call the client is holding is closed out rather than left open.
+    errors = _events_named(events, RunEvent.tool_call_error.value)
+    assert [event.tool.tool_call_id for event in errors] == ["call_b"]
+    assert errors[0].tool.tool_name == "save_other"
+    assert errors[0].error == REFUSED_TOOL_CALL_ERROR
+    assert errors[0].tool.tool_call_error
+
+
+def test_agent_closes_out_a_tool_call_the_run_refuses():
+    turns, second = _refused_call_turns()
+
+    events = list(_refused_agent(turns).run("go", stream=True, stream_events=True))
+
+    _assert_refusal_is_closed_out(events, second)
+
+
+async def test_agent_closes_out_a_tool_call_the_run_refuses_async():
+    turns, second = _refused_call_turns()
+
+    events = [event async for event in _refused_agent(turns).arun("go", stream=True, stream_events=True)]
+
+    _assert_refusal_is_closed_out(events, second)
+
+
+def _tool_calls_the_run_kept(run_output) -> List[Tuple[Optional[str], bool]]:
+    return [(tool.tool_call_id, bool(tool.tool_call_error)) for tool in run_output.tools]
+
+
+def _assert_the_runs_tool_list_holds_only_the_call_it_made(run_output) -> None:
+    """A refused call is told to the client and left out of the run's own list.
+
+    That list is the framework's account of the calls the run made, and a call
+    it declined to make is not one of them. Telling the client is the stream's
+    job and stops there.
+    """
+    assert run_output.events is None
+    assert _tool_calls_the_run_kept(run_output) == [("call_a", False)]
+
+
+def test_agent_leaves_a_refused_tool_call_out_of_the_runs_tool_list():
+    turns, _ = _refused_call_turns()
+    agent = _refused_agent(turns)
+    assert not agent.store_events
+
+    streamed = list(agent.run("go", stream=True, stream_events=True, yield_run_output=True))
+
+    _assert_the_runs_tool_list_holds_only_the_call_it_made(streamed[-1])
+
+
+async def test_agent_leaves_a_refused_tool_call_out_of_the_runs_tool_list_async():
+    turns, _ = _refused_call_turns()
+    agent = _refused_agent(turns)
+
+    streamed = [event async for event in agent.arun("go", stream=True, stream_events=True, yield_run_output=True)]
+
+    _assert_the_runs_tool_list_holds_only_the_call_it_made(streamed[-1])
+
+
+def test_agent_keeps_the_same_tool_calls_whether_or_not_its_events_stream():
+    """The same model behaviour ends on the same tool list either way.
+
+    Whether a caller subscribed to the events is no part of what the run did,
+    so it can be no part of what the run reports having done.
+    """
+    subscribed = list(
+        _refused_agent(_refused_call_turns()[0]).run("go", stream=True, stream_events=True, yield_run_output=True)
+    )
+    unsubscribed = list(
+        _refused_agent(_refused_call_turns()[0]).run("go", stream=True, stream_events=False, yield_run_output=True)
+    )
+
+    assert _tool_calls_the_run_kept(subscribed[-1]) == _tool_calls_the_run_kept(unsubscribed[-1])
+    assert _tool_calls_the_run_kept(unsubscribed[-1]) == [("call_a", False)]
+
+
+def test_agent_closes_out_a_call_naming_a_tool_it_does_not_have(errors_logged):
+    arguments = json.dumps({"note": "nowhere to put this"})
+    fragments = [_fragment(0, tool_call_id="call_ghost", tool_name="save_nowhere")]
+    fragments += [_fragment(0, chunk) for chunk in _chunks(arguments, CHUNK_SIZE)]
+    turns = [fragments, [ModelResponse(role="assistant", content="there is no such tool")]]
+    agent = Agent(model=_ScriptedStreamModel(turns), tools=[save_note])
+
+    events = list(agent.run("go", stream=True, stream_events=True))
+
+    assert _assembled(events, "call_ghost") == arguments
+    assert not _events_named(events, RunEvent.tool_call_started.value)
+    errors = _events_named(events, RunEvent.tool_call_error.value)
+    assert [event.tool.tool_call_id for event in errors] == ["call_ghost"]
+    # The run says which tool it could not find, once.
+    assert [record.getMessage() for record in errors_logged] == ["Function save_nowhere not found"]
+
+
+class _RaisingStreamModel(_ScriptedStreamModel):
+    """Streams part of a turn and then dies for good, without a retry."""
+
+    def __init__(self, turns: List[List[ModelResponse]], fail_after: int):
+        super().__init__(turns)
+        self._fail_after = fail_after
+        self.retries = 0
+
+    def _up_to_the_failure(self) -> List[ModelResponse]:
+        return self._next_turn()[: self._fail_after]
+
+    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+        yield from self._up_to_the_failure()
+        raise ModelProviderError(message="stream died", model_name=self.name, model_id=self.id)
+
+    async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+        for delta in self._up_to_the_failure():
+            yield delta
+        raise ModelProviderError(message="stream died", model_name=self.name, model_id=self.id)
+
+
+def _assert_a_raising_stream_closes_the_call_it_left_open(events) -> None:
+    """A stream that raised is still being read, so the closure can still go out.
+
+    The call the client was shown will never be started or completed, and the
+    turn it belonged to never reaches its end, so closing it out only after the
+    loop would leave the client waiting on it for good.
+    """
+    assert _events_named(events, RunEvent.tool_call_args_delta.value), "nothing streamed, so nothing to close"
+    assert not _events_named(events, RunEvent.tool_call_started.value)
+    reported = _events_named(events, RunEvent.tool_call_error.value)
+    assert [event.tool.tool_call_id for event in reported] == ["call_a"]
+    assert reported[0].error == REFUSED_TOOL_CALL_ERROR
+    # The error itself still reaches the caller, after the closure.
+    assert [event.event for event in events[-2:]] == [
+        RunEvent.tool_call_error.value,
+        RunEvent.run_error.value,
+    ]
+
+
+def test_agent_closes_out_a_call_a_raising_stream_left_open():
+    turns, _ = _tool_call_turns()
+    # Three deltas in: the call's announcement and two argument fragments.
+    agent = Agent(model=_RaisingStreamModel(turns, fail_after=3), tools=[save_note])
+
+    events = list(agent.run("go", stream=True, stream_events=True))
+
+    _assert_a_raising_stream_closes_the_call_it_left_open(events)
+
+
+async def test_agent_closes_out_a_call_a_raising_stream_left_open_async():
+    turns, _ = _tool_call_turns()
+    agent = Agent(model=_RaisingStreamModel(turns, fail_after=3), tools=[save_note])
+
+    events = [event async for event in agent.arun("go", stream=True, stream_events=True)]
+
+    _assert_a_raising_stream_closes_the_call_it_left_open(events)
+
+
+# ---------------------------------------------------------------------------
+# A call the run pauses for the caller to confirm
+# ---------------------------------------------------------------------------
+
+
+@tool(requires_confirmation=True)
+def save_on_confirmation(note: str) -> str:
+    """Save a note, once the caller has agreed to it.
+
+    Args:
+        note: the note to save
+    """
+    return "saved"
+
+
+def _agent_awaiting_confirmation() -> Tuple[Agent, str]:
+    arguments = json.dumps({"note": "the sea is wide"})
+    fragments = [_fragment(0, tool_call_id="call_a", tool_name="save_on_confirmation")]
+    fragments += [_fragment(0, chunk) for chunk in _chunks(arguments, CHUNK_SIZE)]
+    turns = [fragments, [ModelResponse(role="assistant", content="the note is saved")]]
+    return Agent(model=_ScriptedStreamModel(turns), tools=[save_on_confirmation]), arguments
+
+
+def _assert_a_paused_call_is_not_reported_as_never_run(events, arguments: str) -> None:
+    """A call waiting on the caller is neither refused nor finished.
+
+    Its arguments streamed before the run could know it would pause, and the
+    run holds it open on purpose: the caller has still to say yes. Reporting it
+    as a call that was not run would be a lie about a call that may yet be.
+    """
+    assert _assembled(events, "call_a") == arguments
+    assert _events_named(events, RunEvent.run_paused.value)
+    assert not _events_named(events, RunEvent.tool_call_error.value)
+
+
+def test_agent_does_not_report_a_call_awaiting_confirmation_as_never_run():
+    agent, arguments = _agent_awaiting_confirmation()
+
+    *events, paused = list(agent.run("go", stream=True, stream_events=True, yield_run_output=True))
+
+    _assert_a_paused_call_is_not_reported_as_never_run(events, arguments)
+    assert paused.is_paused
+    assert [(tool.tool_call_id, tool.requires_confirmation) for tool in paused.tools] == [("call_a", True)]
+
+
+async def test_agent_does_not_report_a_call_awaiting_confirmation_as_never_run_async():
+    agent, arguments = _agent_awaiting_confirmation()
+
+    *events, paused = [
+        event async for event in agent.arun("go", stream=True, stream_events=True, yield_run_output=True)
+    ]
+
+    _assert_a_paused_call_is_not_reported_as_never_run(events, arguments)
+    assert paused.is_paused
+    assert [(tool.tool_call_id, tool.requires_confirmation) for tool in paused.tools] == [("call_a", True)]
+
+
+# ---------------------------------------------------------------------------
+# Nothing is held back on a guess about what the client already has
+# ---------------------------------------------------------------------------
+
+
+def save_map(entry: Dict[str, Any]) -> str:
+    """Save a map.
+
+    Args:
+        entry: the map to save
+    """
+    return "mapped"
+
+
+def _nested_call_beside_an_announcement() -> Tuple[List[List[ModelResponse]], str, str]:
+    """A call whose arguments nest, with a second call announced part way through.
+
+    The nesting is the point: the second half of the argument string opens the
+    same way the first half did, so anything treating a call's later fragments
+    as a possible repeat of its earlier ones reads the second half as the
+    first and drops what lies between them.
+    """
+    nested = json.dumps({"entry": {"entry": 1}})
+    head, tail = nested[: len('{"entry": ')], nested[len('{"entry": ') :]
+    assert tail.startswith(head), "the fixture no longer has a second half that opens like the first"
+    second = json.dumps({"note": "beside it"})
+    fragments = [
+        _fragment(0, tool_call_id="call_a", tool_name="save_map"),
+        _fragment(0, head),
+        # A second call announced while the first is still being written. It
+        # carries a tool call and no argument text, which is exactly the shape
+        # of the first delta of a stream that has started over.
+        _fragment(1, tool_call_id="call_b", tool_name="save_note"),
+        _fragment(0, tail),
+        _fragment(1, second),
+    ]
+    return [fragments, [ModelResponse(role="assistant", content="both are saved")]], nested, second
+
+
+def test_agent_streams_the_whole_arguments_of_a_call_a_second_call_was_announced_beside():
+    turns, nested, second = _nested_call_beside_an_announcement()
+    agent = Agent(model=_ScriptedStreamModel(turns), tools=[save_map, save_note])
+
+    events = list(agent.run("go", stream=True, stream_events=True))
+
+    assert _assembled(events, "call_a") == nested
+    assert _assembled(events, "call_b") == second
+    # Both calls really were made on those arguments, so the fragments and the
+    # run agree about what the model asked for.
+    announced = {
+        event.tool.tool_call_id: event.tool.tool_args
+        for event in _events_named(events, RunEvent.tool_call_started.value)
+    }
+    assert announced == {"call_a": json.loads(nested), "call_b": json.loads(second)}
+
+
+async def test_agent_streams_the_whole_arguments_of_a_call_a_second_call_was_announced_beside_async():
+    turns, nested, second = _nested_call_beside_an_announcement()
+    agent = Agent(model=_ScriptedStreamModel(turns), tools=[save_map, save_note])
+
+    events = [event async for event in agent.arun("go", stream=True, stream_events=True)]
+
+    assert _assembled(events, "call_a") == nested
+    assert _assembled(events, "call_b") == second
+
+
+def _same_call_id_twice() -> Tuple[List[List[ModelResponse]], str]:
+    """Two turns calling the same tool, under one id, on the same arguments.
+
+    Which is every call a provider makes twice under a reused id, and every
+    call to a tool that takes no arguments at all.
+    """
+    arguments = json.dumps({"note": "again"})
+    turn = [_fragment(0, tool_call_id="call_a", tool_name="save_note")]
+    turn += [_fragment(0, chunk) for chunk in _chunks(arguments, CHUNK_SIZE)]
+    reply = [ModelResponse(role="assistant", content="saved twice")]
+    return [list(turn), list(turn), reply], arguments
+
+
+def test_agent_streams_a_call_id_a_later_turn_uses_again():
+    turns, arguments = _same_call_id_twice()
+    agent = Agent(model=_ScriptedStreamModel(turns), tools=[save_note])
+
+    events = list(agent.run("go", stream=True, stream_events=True))
+
+    # Both turns really ran, and each streamed the arguments in full: a turn
+    # whose call happens to repeat an earlier one is still a call of its own.
+    assert len(_events_named(events, RunEvent.model_request_started.value)) == len(turns)
+    deltas = _events_named(events, RunEvent.tool_call_args_delta.value)
+    assert len(deltas) == 2 * len(_chunks(arguments, CHUNK_SIZE))
+    assert _assembled(events, "call_a") == arguments * 2
+
+
+async def test_agent_streams_a_call_id_a_later_turn_uses_again_async():
+    turns, arguments = _same_call_id_twice()
+    agent = Agent(model=_ScriptedStreamModel(turns), tools=[save_note])
+
+    events = [event async for event in agent.arun("go", stream=True, stream_events=True)]
+
+    assert len(_events_named(events, RunEvent.model_request_started.value)) == len(turns)
+    assert _assembled(events, "call_a") == arguments * 2
+
+
+# ---------------------------------------------------------------------------
+# A run cancelled while a call's arguments are streaming
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _asyncio_errors_reported() -> Iterator[List[logging.LogRecord]]:
+    """What the event loop reports when it closes what a cancelled run left it.
+
+    A stream nobody is reading any more is closed by the loop that ran it,
+    when that loop is closed, and an error raised by that closing is reported
+    to the asyncio logger rather than to the caller.
+    """
+    records: List[logging.LogRecord] = []
+
+    class _Collector(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    handler = _Collector(logging.ERROR)
+    asyncio_logger = logging.getLogger("asyncio")
+    asyncio_logger.addHandler(handler)
+    try:
+        yield records
+    finally:
+        asyncio_logger.removeHandler(handler)
+
+
+def _arguments_are_part_written(events) -> bool:
+    """True once some of a call's arguments have gone out and the rest have not."""
+    return len(_events_named(events, RunEvent.tool_call_args_delta.value)) == 2
+
+
+def _assert_the_cancelled_run_ends_and_nothing_waits_on_it(events) -> None:
+    """The run ends on its terminal events with the call it streamed undecided.
+
+    A cancellation is raised where the run's events are consumed, so the
+    stream that was writing the arguments is closed rather than read to the
+    end. Nothing can be added to a stream nobody is reading, and the call a
+    client is holding is closed out by the terminal events the run does end
+    on.
+    """
+    assert _events_named(events, RunEvent.tool_call_args_delta.value), "nothing streamed, so nothing to cancel"
+    assert not _events_named(events, RunEvent.tool_call_started.value)
+    assert [event.event for event in events[-2:]] == [
+        RunEvent.run_cancelled.value,
+        RunEvent.run_completed.value,
+    ]
+
+
+class _InterruptedStreamModel(_ScriptedStreamModel):
+    """Streams part of a turn and is then interrupted at the keyboard."""
+
+    def __init__(self, turns: List[List[ModelResponse]], interrupt_after: int):
+        super().__init__(turns)
+        self._interrupt_after = interrupt_after
+
+    def _up_to_the_interruption(self) -> List[ModelResponse]:
+        return self._next_turn()[: self._interrupt_after]
+
+    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+        yield from self._up_to_the_interruption()
+        raise KeyboardInterrupt()
+
+    async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+        for delta in self._up_to_the_interruption():
+            yield delta
+        raise KeyboardInterrupt()
+
+
+def _assert_the_interruption_was_left_to_the_run(events) -> None:
+    """Nothing on the way out treats an interrupt as a call to report on.
+
+    A keyboard interrupt is not a provider saying a call will not be made, and
+    catching it to say so is catching it: what the caller sees is the run's own
+    interrupt handling, and no reported call among it.
+    """
+    assert _events_named(events, RunEvent.tool_call_args_delta.value), "nothing streamed, so nothing to report"
+    assert not _events_named(events, RunEvent.tool_call_error.value)
+    assert [event.event for event in events[-2:]] == [
+        RunEvent.run_cancelled.value,
+        RunEvent.run_completed.value,
+    ]
+
+
+def test_agent_leaves_a_keyboard_interrupt_to_the_run():
+    turns, _ = _tool_call_turns()
+    agent = Agent(model=_InterruptedStreamModel(turns, interrupt_after=3), tools=[save_note])
+
+    events = list(agent.run("go", stream=True, stream_events=True))
+
+    _assert_the_interruption_was_left_to_the_run(events)
+
+
+async def test_agent_leaves_a_keyboard_interrupt_to_the_run_async():
+    turns, _ = _tool_call_turns()
+    agent = Agent(model=_InterruptedStreamModel(turns, interrupt_after=3), tools=[save_note])
+
+    events = [event async for event in agent.arun("go", stream=True, stream_events=True)]
+
+    _assert_the_interruption_was_left_to_the_run(events)
+
+
+def test_agent_cancelled_while_a_calls_arguments_stream_ends_the_run():
+    turns, _ = _tool_call_turns()
+    agent = Agent(model=_ScriptedStreamModel(turns), tools=[save_note])
+
+    events: List[Any] = []
+    for event in agent.run("go", stream=True, stream_events=True):
+        events.append(event)
+        if _arguments_are_part_written(events):
+            Agent.cancel_run(event.run_id)
+
+    _assert_the_cancelled_run_ends_and_nothing_waits_on_it(events)
+
+
+def test_agent_cancelled_while_a_calls_arguments_stream_closes_its_stream_cleanly():
+    """The stream the cancelled run abandoned is closed without complaint.
+
+    A cancellation is raised where the events are consumed, so the stream
+    writing the arguments is closed rather than read to the end. An async
+    generator that yields while it is being closed makes that closing raise,
+    and the loop reports it where nothing asserting on the run would see it.
+    """
+    turns, _ = _tool_call_turns()
+    agent = Agent(model=_ScriptedStreamModel(turns), tools=[save_note])
+
+    async def consume() -> List[Any]:
+        events: List[Any] = []
+        async for event in agent.arun("go", stream=True, stream_events=True):
+            events.append(event)
+            if _arguments_are_part_written(events):
+                await Agent.acancel_run(event.run_id)
+        return events
+
+    with _asyncio_errors_reported() as reported:
+        # A loop of this test's own, because a stream a cancelled run
+        # abandoned is closed when the loop that ran it is closed.
+        events = asyncio.run(consume())
+
+    _assert_the_cancelled_run_ends_and_nothing_waits_on_it(events)
+    assert [record.getMessage() for record in reported] == []
+
+
+# ---------------------------------------------------------------------------
+# Output model
+# ---------------------------------------------------------------------------
+
+
+def _agent_with_a_recording_output_model() -> Tuple[Agent, _ToolRecordingModel, str]:
+    """An output model whose script calls a tool, over a quiet agent model."""
+    turns, arguments = _tool_call_turns()
+    output_model = _ToolRecordingModel(turns)
+    return Agent(model=_quiet_model(), output_model=output_model, tools=[save_note]), output_model, arguments
+
+
+def _assert_the_output_models_call_reached_the_client(
+    events, output_model: _ToolRecordingModel, arguments: str, errors: List[logging.LogRecord]
+) -> None:
+    """A call can arrive here even though the path hands the model no tools.
+
+    The output model is asked for the finished answer, never for work, so the
+    run passes it none of the agent's tools. A provider can still answer with
+    a call to a built-in tool of its own, and then its fragments have to be
+    attributed and its call closed out like any other. The script stands in for
+    that provider, and the run refuses to find the function, which is why the
+    call the client was shown ends as a reported failure rather than as one it
+    waits on for good.
+    """
+    assert output_model.tools_seen == [None]
+    assert _assembled(events, "call_a") == arguments
+    assert not _events_named(events, RunEvent.tool_call_started.value)
+    reported = _events_named(events, RunEvent.tool_call_error.value)
+    assert [event.tool.tool_call_id for event in reported] == ["call_a"]
+    assert reported[0].error == REFUSED_TOOL_CALL_ERROR
+    assert [record.getMessage() for record in errors] == ["Function save_note not found"]
+
+
+def test_agent_output_model_streams_and_closes_out_a_tool_call(errors_logged):
+    agent, output_model, arguments = _agent_with_a_recording_output_model()
+
+    events = list(agent.run("go", stream=True, stream_events=True))
+
+    _assert_the_output_models_call_reached_the_client(events, output_model, arguments, errors_logged)
+
+
+async def test_agent_output_model_streams_and_closes_out_a_tool_call_async(errors_logged):
+    agent, output_model, arguments = _agent_with_a_recording_output_model()
+
+    events = [event async for event in agent.arun("go", stream=True, stream_events=True)]
+
+    _assert_the_output_models_call_reached_the_client(events, output_model, arguments, errors_logged)
+
+
+def _agent_with_a_two_turn_output_model() -> Tuple[Agent, str, str]:
+    """An output model that calls a tool on each of two turns of its own."""
+    turns, first, second = _two_turn_calls()
+    return (
+        Agent(model=_quiet_model(), output_model=_ToolRecordingModel(turns), tools=[save_note, save_other]),
+        first,
+        second,
+    )
+
+
+def _assert_the_output_models_turns_are_held_apart(
+    events, first: str, second: str, warnings: List[logging.LogRecord]
+) -> None:
+    """This path's turn boundary is the request event the chunk handler sees.
+
+    The agent's own loop reads that event itself, so nothing but the chunk
+    handler bounds a turn here. Without it the second turn's opening fragment,
+    which carries index zero and no id, would be appended to the arguments the
+    first turn's call was already made with. Bounded, that fragment belongs to
+    no call yet, and the run says so instead of placing it.
+    """
+    assert _assembled(events, "call_a") == first
+    assert _assembled(events, "call_b") == second[4:]
+    reported = [record.getMessage() for record in warnings if record.levelno == logging.WARNING]
+    assert len(reported) == 1, reported
+    assert "neither a tool call id nor a provider stream index" in reported[0]
+
+
+def test_agent_output_model_does_not_carry_tool_call_ids_across_its_turns(warnings_logged):
+    agent, first, second = _agent_with_a_two_turn_output_model()
+
+    events = list(agent.run("go", stream=True, stream_events=True))
+
+    _assert_the_output_models_turns_are_held_apart(events, first, second, warnings_logged)
+
+
+async def test_agent_output_model_does_not_carry_tool_call_ids_across_its_turns_async(warnings_logged):
+    agent, first, second = _agent_with_a_two_turn_output_model()
+
+    events = [event async for event in agent.arun("go", stream=True, stream_events=True)]
+
+    _assert_the_output_models_turns_are_held_apart(events, first, second, warnings_logged)
+
+
+_ANNOUNCED_ARGUMENTS = json.dumps({"title": "the plan", "thought": "the sea is wide"})
+
+
+def _announced_call_chunks() -> List[ModelResponse]:
+    """The chunks a provider writes for a built-in tool it ran itself.
+
+    First the call's arguments a fragment at a time, then the two chunks the
+    provider announces the finished call with, then its closing reply. The
+    call is named ``think``, which is also how the run recognises a reasoning
+    step, so one script covers every announcement this path can carry.
+    """
+    execution = ToolExecution(
+        tool_call_id="call_builtin",
+        tool_name="think",
+        tool_args=json.loads(_ANNOUNCED_ARGUMENTS),
+        result="thought about it",
+    )
+    chunks = [_fragment(0, tool_call_id="call_builtin", tool_name="think")]
+    chunks += [_fragment(0, chunk) for chunk in _chunks(_ANNOUNCED_ARGUMENTS, CHUNK_SIZE)]
+    chunks.append(
+        ModelResponse(
+            content="think(...)",
+            tool_executions=[execution],
+            event=ModelResponseEvent.tool_call_started.value,
+        )
+    )
+    chunks.append(
+        ModelResponse(
+            content="thought about it",
+            tool_executions=[execution],
+            event=ModelResponseEvent.tool_call_completed.value,
+        )
+    )
+    chunks.append(ModelResponse(role="assistant", content="the note is saved"))
+    return chunks
+
+
+class _ProviderAnnouncingModel(_ScriptedStreamModel):
+    """A provider that ran a built-in tool of its own and announces the call.
+
+    This path hands its model none of the run's tools, so the shared function
+    call machinery has no function to find and never announces a call here. A
+    provider that ran a built-in tool is the only thing that can, and it does
+    so in its own stream, which is what this stands in for.
+    """
+
+    def __init__(self):
+        super().__init__([])
+        self._script = _announced_call_chunks()
+
+    def response_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+        return iter(self._script)
+
+    async def aresponse_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+        for chunk in self._script:
+            yield chunk
+
+
+def _assert_the_output_model_path_adds_only_the_fragments(events) -> None:
+    """The fragments are what this path gained; its announcements are as they were.
+
+    An agent's output model path announced a provider's own call, and read a
+    call to ``think`` as a reasoning step, before it carried any fragments,
+    and it still does. A team's output model path announces neither. That
+    difference between the two is older than the fragments and is left alone
+    here, because changing which lifecycle events a client sees is a decision
+    of its own and not something to thread a fragment stream into.
+    """
+    assert _assembled(events, "call_builtin") == _ANNOUNCED_ARGUMENTS
+    announced = _events_named(events, RunEvent.tool_call_started.value)
+    assert [event.tool.tool_call_id for event in announced] == ["call_builtin"]
+    finished = _events_named(events, RunEvent.tool_call_completed.value)
+    assert [event.tool.tool_call_id for event in finished] == ["call_builtin"]
+    assert [event.content.title for event in _events_named(events, RunEvent.reasoning_step.value)] == ["the plan"]
+    # The provider answered the call it announced, so nothing is left to close out.
+    assert not _events_named(events, RunEvent.tool_call_error.value)
+
+
+def test_agent_output_model_adds_only_the_argument_fragments():
+    agent = Agent(model=_quiet_model(), output_model=_ProviderAnnouncingModel())
+
+    events = list(agent.run("go", stream=True, stream_events=True))
+
+    _assert_the_output_model_path_adds_only_the_fragments(events)
+
+
+async def test_agent_output_model_adds_only_the_argument_fragments_async():
+    agent = Agent(model=_quiet_model(), output_model=_ProviderAnnouncingModel())
+
+    events = [event async for event in agent.arun("go", stream=True, stream_events=True)]
+
+    _assert_the_output_model_path_adds_only_the_fragments(events)
+
+
+# ---------------------------------------------------------------------------
+# Chunk handler
+# ---------------------------------------------------------------------------
+
+
+def _through_the_chunk_handler(agent: Agent, tool_args_stream: ToolCallArgsStream, chunks) -> List[Any]:
+    """Every event the handler yields for a run of chunks, in order."""
+    session = AgentSession(session_id="session_1")
+    run_response = RunOutput(run_id="run_1", agent_id="agent_1", agent_name="Agent")
+    events: List[Any] = []
+    for chunk in chunks:
+        events.extend(
+            handle_model_response_chunk(
+                agent,
+                session=session,
+                run_response=run_response,
+                model_response=ModelResponse(),
+                model_response_event=chunk,
+                stream_events=True,
+                tool_args_stream=tool_args_stream,
+            )
+        )
+    return events
+
+
+def test_agent_chunk_handler_drops_its_stream_indexes_when_a_fallback_is_activated(warnings_logged):
+    """A replaced model's numbering is not the numbering of the one taking over.
+
+    A fallback model answers the request the primary failed part way through,
+    and its stream indexes start again at zero. Without a boundary there, its
+    opening fragment, which carries index zero and no id, would be appended to
+    the arguments of the call the replaced model was still writing, and a
+    subscriber would render two models' text as one call's arguments.
+    """
+    agent = Agent(model=_quiet_model(), tools=[save_note])
+    tool_args_stream = ToolCallArgsStream("session_1", "run_1")
+    replaced = _fragment(0, '{"note":', tool_call_id="call_a", tool_name="save_note")
+    replaced.event = ModelResponseEvent.assistant_response.value
+    taking_over = _fragment(0, ' "the sea is wide"}')
+    taking_over.event = ModelResponseEvent.assistant_response.value
+
+    events = _through_the_chunk_handler(
+        agent,
+        tool_args_stream,
+        (
+            replaced,
+            ModelResponse(event=ModelResponseEvent.fallback_model_activated.value),
+            taking_over,
+        ),
+    )
+
+    deltas = _events_named(events, RunEvent.tool_call_args_delta.value)
+    assert [(delta.tool_call_id, delta.tool_args_delta) for delta in deltas] == [("call_a", '{"note":')]
+    # The fragment after the boundary belongs to no call yet, and the run says
+    # so rather than placing it on the replaced model's call.
+    reported = [record.getMessage() for record in warnings_logged if record.levelno >= logging.WARNING]
+    assert len(reported) == 1, reported
+    assert "neither a tool call id nor a provider stream index" in reported[0]
+    # The replaced model's call will never be made under its own id either, so
+    # the client is not left waiting on it.
+    closed = _events_named(events, RunEvent.tool_call_error.value)
+    assert [event.tool.tool_call_id for event in closed] == ["call_a"]
+    assert closed[0].error == REFUSED_TOOL_CALL_ERROR
+
+
+# ---------------------------------------------------------------------------
+# Parser model
+# ---------------------------------------------------------------------------
+
+
+def _parser_model_turns() -> List[List[ModelResponse]]:
+    """One turn calling a tool in fragments, then one answering the output schema."""
+    turns, _ = _tool_call_turns()
+    return [turns[0], [ModelResponse(role="assistant", content=json.dumps({"note": "parsed"}))]]
+
+
+def _agent_with_a_calling_parser_model() -> Tuple[Agent, _NonStreamedCallModel]:
+    parser = _NonStreamedCallModel(_parser_model_turns())
+    agent = Agent(
+        model=_ScriptedStreamModel([[ModelResponse(role="assistant", content=json.dumps({"note": "draft"}))]]),
+        parser_model=parser,
+        output_schema=_Note,
+    )
+    return agent, parser
+
+
+def _assert_the_parser_model_streamed_no_fragments(
+    events, parser: _NonStreamedCallModel, errors: List[logging.LogRecord]
+) -> None:
+    """The parser model answers inside its stream with one finished response.
+
+    A tool call therefore arrives already assembled and there are no fragments
+    to attribute, which is why this path carries no per-stream record. A change
+    that made the parser model stream its response would fail here rather than
+    quietly dropping the fragments it started producing.
+    """
+    # A call really did arrive, already assembled, so the absence of fragments
+    # is the path's doing and not an inert script.
+    assert parser.returned_tool_calls, "the parser model no longer answers with one finished response"
+    assert not _events_named(events, RunEvent.tool_call_args_delta.value)
+    # It is handed no tools either, so the run refuses to find the function it
+    # named and says so once.
+    assert [record.getMessage() for record in errors] == ["Function save_note not found"]
+
+
+def test_agent_parser_model_emits_no_tool_call_arg_fragments(errors_logged):
+    agent, parser = _agent_with_a_calling_parser_model()
+
+    events = list(agent.run("go", stream=True, stream_events=True))
+
+    _assert_the_parser_model_streamed_no_fragments(events, parser, errors_logged)
+
+
+async def test_agent_parser_model_emits_no_tool_call_arg_fragments_async(errors_logged):
+    agent, parser = _agent_with_a_calling_parser_model()
+
+    events = [event async for event in agent.arun("go", stream=True, stream_events=True)]
+
+    _assert_the_parser_model_streamed_no_fragments(events, parser, errors_logged)
+
+
+# ---------------------------------------------------------------------------
+# Event storage
+# ---------------------------------------------------------------------------
+
+
+def _agent_storing_events(tmp_path, db_name: str, **kwargs) -> Tuple[Agent, str]:
+    turns, arguments = _tool_call_turns()
+    agent = Agent(
+        model=_ScriptedStreamModel(turns),
+        tools=[save_note],
+        db=SqliteDb(db_file=str(tmp_path / db_name)),
+        store_events=True,
+        **kwargs,
+    )
+    return agent, arguments
+
+
+def test_agent_keeps_tool_call_arg_fragments_out_of_the_stored_run_by_default(tmp_path):
+    agent, arguments = _agent_storing_events(tmp_path, "default_agent.db")
+
+    events = list(agent.run("go", stream=True, stream_events=True))
+    run_output = agent.get_last_run_output()
+
+    # The subscriber still sees every fragment: the skip list governs storage.
+    deltas = [event for event in events if event.event == RunEvent.tool_call_args_delta.value]
+    assert "".join(delta.tool_args_delta for delta in deltas) == arguments
+
+    stored = _stored(run_output)
+    assert RunEvent.tool_call_args_delta.value not in stored
+    # Held to the same standard as the content delta it is being grouped with,
+    # and the low frequency events are stored as before.
+    assert RunEvent.run_content.value not in stored
+    assert RunEvent.tool_call_started.value in stored
+    assert RunEvent.tool_call_completed.value in stored
+
+
+async def test_agent_keeps_tool_call_arg_fragments_out_of_the_stored_run_by_default_async(tmp_path):
+    agent, arguments = _agent_storing_events(tmp_path, "default_agent_async.db")
+
+    events = [event async for event in agent.arun("go", stream=True, stream_events=True)]
+    run_output = await agent.aget_last_run_output()
+
+    deltas = [event for event in events if event.event == RunEvent.tool_call_args_delta.value]
+    assert "".join(delta.tool_args_delta for delta in deltas) == arguments
+
+    stored = _stored(run_output)
+    assert RunEvent.tool_call_args_delta.value not in stored
+    assert RunEvent.run_content.value not in stored
+    assert RunEvent.tool_call_started.value in stored
+
+
+def test_agent_stores_tool_call_arg_fragments_when_the_caller_asks_for_them(tmp_path, skips_but_the_argument_fragments):
+    # Asking for the fragments back re-enables nothing else the default keeps
+    # out of storage, the content delta included.
+    agent, arguments = _agent_storing_events(
+        tmp_path,
+        "opted_in_agent.db",
+        events_to_skip=skips_but_the_argument_fragments(Agent(model=_quiet_model())),
+    )
+
+    list(agent.run("go", stream=True, stream_events=True))
+    run_output = agent.get_last_run_output()
+
+    fragments = [event for event in (run_output.events or []) if event.event == RunEvent.tool_call_args_delta.value]
+    assert "".join(event.tool_args_delta for event in fragments) == arguments
+    assert RunEvent.run_content.value not in _stored(run_output)
+
+
+def test_agent_omits_tool_call_arg_fragments_without_events():
+    turns, arguments = _tool_call_turns()
+
+    streaming_agent = Agent(model=_ScriptedStreamModel(turns), tools=[save_note])
+    streamed = list(streaming_agent.run("go", stream=True, stream_events=False))
+
+    # The run did stream to the caller, so the absence of fragments is the
+    # flag's doing and not an empty stream.
+    assert _events_named(streamed, RunEvent.run_content.value)
+    assert not _events_named(streamed, RunEvent.tool_call_args_delta.value)
+
+    # Nothing is skipped by configuration here, so an empty store is this
+    # path's doing: a run that never streamed creates no events to store,
+    # fragments included.
+    non_streaming_agent = Agent(
+        model=_AggregatingStreamModel(_tool_call_turns()[0]),
+        tools=[save_note],
+        store_events=True,
+        events_to_skip=[],
+    )
+    run_output = non_streaming_agent.run("go")
+    assert run_output.events is None
+    # The run still made the call, so the absence is not a broken run.
+    assert run_output.tools[0].tool_args == json.loads(arguments)
+
+
+# ---------------------------------------------------------------------------
+# A run nested inside a tool call
+# ---------------------------------------------------------------------------
+
+
+def _inner_agent_making_a_call() -> Tuple[Agent, str, str]:
+    """A second agent whose own turn streams a tool call in fragments.
+
+    Returns the id that call streams under, so its fragments can be told
+    apart from the outer run's own.
+    """
+    turns, arguments = _tool_call_turns()
+    agent = Agent(name="inner", model=_ScriptedStreamModel(turns), tools=[save_note])
+    return agent, "call_a", arguments
+
+
+def _outer_agent_calling(nesting_tool) -> Agent:
+    """An agent whose one turn calls the tool that runs the other agent.
+
+    A tool's generator may yield run events, and the model's call handler
+    bubbles them up rather than folding them into the tool's result. Agno's
+    own team delegation and workflow tools have that shape, so a nested run's
+    events reach this run the same way whoever wrote the tool arranged it.
+    """
+    arguments = json.dumps({"question": "write the note"})
+    fragments = [_fragment(0, tool_call_id="call_outer", tool_name=nesting_tool.__name__)]
+    fragments += [_fragment(0, chunk) for chunk in _chunks(arguments, CHUNK_SIZE)]
+    turns = [fragments, [ModelResponse(role="assistant", content="the inner agent saved it")]]
+    return Agent(name="outer", model=_ScriptedStreamModel(turns), tools=[nesting_tool])
+
+
+def _agent_nesting_a_run() -> Tuple[Agent, str, str]:
+    inner, call_id, arguments = _inner_agent_making_a_call()
+
+    def ask_the_inner_agent(question: str):
+        """Ask the inner agent to write a note.
+
+        Args:
+            question: what to ask it
+        """
+        yield from inner.run(question, stream=True, stream_events=True)
+
+    return _outer_agent_calling(ask_the_inner_agent), call_id, arguments
+
+
+def _agent_nesting_an_async_run() -> Tuple[Agent, str, str]:
+    inner, call_id, arguments = _inner_agent_making_a_call()
+
+    async def ask_the_inner_agent(question: str):
+        """Ask the inner agent to write a note.
+
+        Args:
+            question: what to ask it
+        """
+        async for event in inner.arun(question, stream=True, stream_events=True):
+            yield event
+
+    return _outer_agent_calling(ask_the_inner_agent), call_id, arguments
+
+
+def _assert_the_nested_runs_call_streamed(events, call_id: str, arguments: str) -> None:
+    assert _assembled(events, call_id) == arguments
+
+
+def test_agent_streams_a_nested_runs_tool_call_arg_fragments():
+    agent, call_id, arguments = _agent_nesting_a_run()
+
+    events = list(agent.run("go", stream=True, stream_events=True))
+
+    _assert_the_nested_runs_call_streamed(events, call_id, arguments)
+
+
+async def test_agent_streams_a_nested_runs_tool_call_arg_fragments_async():
+    agent, call_id, arguments = _agent_nesting_an_async_run()
+
+    events = [event async for event in agent.arun("go", stream=True, stream_events=True)]
+
+    _assert_the_nested_runs_call_streamed(events, call_id, arguments)
+
+
+def _assert_a_run_told_not_to_stream_events_delivers_no_fragments(events, arguments: str) -> None:
+    """A run told not to stream events is told that of the runs it nests too.
+
+    A nested run is run with events on so the tool running it can read them,
+    and they reach the caller through this run. So a guard on this run's own
+    model alone leaves a caller that opted out holding the nested run's
+    fragments.
+    """
+    assert not _events_named(events, RunEvent.tool_call_args_delta.value)
+    # The nested run made its call, and its other events arrive as before, so
+    # the absence above is the flag's doing and not an empty stream.
+    completed = _events_named(events, RunEvent.tool_call_completed.value)
+    assert arguments in [json.dumps(event.tool.tool_args) for event in completed]
+    assert _events_named(events, RunEvent.run_started.value)
+
+
+def test_agent_delivers_no_nested_runs_fragments_without_stream_events():
+    agent, _call_id, arguments = _agent_nesting_a_run()
+
+    events = list(agent.run("go", stream=True, stream_events=False))
+
+    _assert_a_run_told_not_to_stream_events_delivers_no_fragments(events, arguments)
+
+
+async def test_agent_delivers_no_nested_runs_fragments_without_stream_events_async():
+    agent, _call_id, arguments = _agent_nesting_an_async_run()
+
+    events = [event async for event in agent.arun("go", stream=True, stream_events=False)]
+
+    _assert_a_run_told_not_to_stream_events_delivers_no_fragments(events, arguments)

--- a/libs/agno/tests/unit/agent/test_tool_error_events.py
+++ b/libs/agno/tests/unit/agent/test_tool_error_events.py
@@ -1,3 +1,5 @@
+"""A failed tool call is reported as an error event by an agent and by a team."""
+
 from agno.agent import Agent
 from agno.models.openai import OpenAIChat
 from agno.models.response import ModelResponse, ModelResponseEvent, ToolExecution

--- a/libs/agno/tests/unit/app/test_agui_app.py
+++ b/libs/agno/tests/unit/app/test_agui_app.py
@@ -1,4 +1,5 @@
 import base64
+import json
 from unittest.mock import MagicMock
 
 import pytest
@@ -26,134 +27,148 @@ from agno.run.team import RunErrorEvent as TeamRunErrorEvent
 from agno.run.team import ToolCallStartedEvent as TeamToolCallStartedEvent
 
 
-def test_event_buffer_initial_state():
+def test_stream_state_initial_state():
     """Test StreamState initial state"""
-    buffer = StreamState()
+    state = StreamState()
 
-    assert len(buffer.active_tool_call_ids) == 0
-    assert len(buffer.ended_tool_call_ids) == 0
+    assert len(state.active_tool_call_ids) == 0
+    assert len(state.ended_tool_call_ids) == 0
 
 
-def test_event_buffer_tool_call_lifecycle():
+def test_stream_state_tool_call_lifecycle():
     """Test complete tool call lifecycle in StreamState"""
-    buffer = StreamState()
+    state = StreamState()
 
     # Initial state
-    assert len(buffer.active_tool_call_ids) == 0
+    assert len(state.active_tool_call_ids) == 0
 
     # Start tool call
-    buffer.start_tool_call("tool_1")
-    assert "tool_1" in buffer.active_tool_call_ids
+    state.start_tool_call("tool_1")
+    assert "tool_1" in state.active_tool_call_ids
 
     # End tool call
-    buffer.end_tool_call("tool_1")
-    assert "tool_1" in buffer.ended_tool_call_ids
-    assert "tool_1" not in buffer.active_tool_call_ids
+    state.end_tool_call("tool_1")
+    assert "tool_1" in state.ended_tool_call_ids
+    assert "tool_1" not in state.active_tool_call_ids
 
 
-def test_event_buffer_multiple_tool_calls():
+def test_stream_state_multiple_tool_calls():
     """Test multiple concurrent tool calls"""
-    buffer = StreamState()
+    state = StreamState()
 
     # Start first tool call
-    buffer.start_tool_call("tool_1")
-    assert "tool_1" in buffer.active_tool_call_ids
+    state.start_tool_call("tool_1")
+    assert "tool_1" in state.active_tool_call_ids
 
     # Start second tool call
-    buffer.start_tool_call("tool_2")
-    assert len(buffer.active_tool_call_ids) == 2
-    assert "tool_1" in buffer.active_tool_call_ids
-    assert "tool_2" in buffer.active_tool_call_ids
+    state.start_tool_call("tool_2")
+    assert len(state.active_tool_call_ids) == 2
+    assert "tool_1" in state.active_tool_call_ids
+    assert "tool_2" in state.active_tool_call_ids
 
-    # End first tool call
-    buffer.end_tool_call("tool_2")
-    assert "tool_2" in buffer.ended_tool_call_ids
-    assert "tool_2" not in buffer.active_tool_call_ids
-    assert "tool_1" in buffer.active_tool_call_ids  # Still active
+    # End the second tool call, the one started last
+    state.end_tool_call("tool_2")
+    assert "tool_2" in state.ended_tool_call_ids
+    assert "tool_2" not in state.active_tool_call_ids
+    assert "tool_1" in state.active_tool_call_ids  # Still active
 
-    # End second tool call
-    buffer.end_tool_call("tool_1")
-    assert "tool_1" in buffer.ended_tool_call_ids
-    assert "tool_1" not in buffer.active_tool_call_ids
-    assert len(buffer.active_tool_call_ids) == 0
+    # End the first tool call, the one that outlived it
+    state.end_tool_call("tool_1")
+    assert "tool_1" in state.ended_tool_call_ids
+    assert "tool_1" not in state.active_tool_call_ids
+    assert len(state.active_tool_call_ids) == 0
 
 
-def test_event_buffer_end_nonexistent_tool_call():
+def test_stream_state_end_nonexistent_tool_call():
     """Test ending a tool call that was never started"""
-    buffer = StreamState()
+    state = StreamState()
 
     # End tool call that was never started
-    buffer.end_tool_call("nonexistent_tool")
-    assert "nonexistent_tool" in buffer.ended_tool_call_ids
+    state.end_tool_call("nonexistent_tool")
+    assert "nonexistent_tool" in state.ended_tool_call_ids
+    assert "nonexistent_tool" not in state.active_tool_call_ids
 
 
-def test_event_buffer_duplicate_start_tool_call():
+def test_stream_state_duplicate_start_tool_call():
     """Test starting the same tool call multiple times"""
-    buffer = StreamState()
+    state = StreamState()
 
     # Start same tool call twice
-    buffer.start_tool_call("tool_1")
-    buffer.start_tool_call("tool_1")  # Should not cause issues
+    state.start_tool_call("tool_1")
+    state.start_tool_call("tool_1")  # Should not cause issues
 
-    assert len(buffer.active_tool_call_ids) == 1  # Should still be 1
-    assert "tool_1" in buffer.active_tool_call_ids
+    assert len(state.active_tool_call_ids) == 1  # Should still be 1
+    assert "tool_1" in state.active_tool_call_ids
 
 
-def test_event_buffer_duplicate_end_tool_call():
+def test_stream_state_duplicate_end_tool_call():
     """Test ending the same tool call multiple times"""
-    buffer = StreamState()
+    state = StreamState()
 
-    buffer.start_tool_call("tool_1")
+    state.start_tool_call("tool_1")
 
     # End same tool call twice
-    buffer.end_tool_call("tool_1")
-    buffer.end_tool_call("tool_1")  # Second end should be no-op
+    state.end_tool_call("tool_1")
+    state.end_tool_call("tool_1")  # Second end should be no-op
 
-    assert "tool_1" in buffer.ended_tool_call_ids
-    assert "tool_1" not in buffer.active_tool_call_ids
+    assert state.ended_tool_call_ids == {"tool_1"}
+    assert len(state.active_tool_call_ids) == 0
 
 
-def test_event_buffer_complex_sequence():
+def test_stream_state_complex_sequence():
     """Test complex sequence of tool call operations"""
-    buffer = StreamState()
+    state = StreamState()
 
     # Start multiple tool calls
-    buffer.start_tool_call("tool_1")
-    buffer.start_tool_call("tool_2")
-    buffer.start_tool_call("tool_3")
+    state.start_tool_call("tool_1")
+    state.start_tool_call("tool_2")
+    state.start_tool_call("tool_3")
 
-    assert len(buffer.active_tool_call_ids) == 3
+    assert len(state.active_tool_call_ids) == 3
 
     # End middle tool call
-    buffer.end_tool_call("tool_2")
-    assert "tool_2" in buffer.ended_tool_call_ids
-    assert len(buffer.active_tool_call_ids) == 2
+    state.end_tool_call("tool_2")
+    assert "tool_2" in state.ended_tool_call_ids
+    assert len(state.active_tool_call_ids) == 2
 
     # End first tool call
-    buffer.end_tool_call("tool_1")
-    assert "tool_1" in buffer.ended_tool_call_ids
+    state.end_tool_call("tool_1")
+    assert "tool_1" in state.ended_tool_call_ids
 
     # End remaining tool call
-    buffer.end_tool_call("tool_3")
-    assert "tool_3" in buffer.ended_tool_call_ids
+    state.end_tool_call("tool_3")
+    assert "tool_3" in state.ended_tool_call_ids
 
     # Check final state
-    assert len(buffer.active_tool_call_ids) == 0
-    assert len(buffer.ended_tool_call_ids) == 3
+    assert len(state.active_tool_call_ids) == 0
+    assert len(state.ended_tool_call_ids) == 3
 
 
-def test_event_buffer_edge_cases():
-    """Test edge cases in tool call handling"""
-    buffer = StreamState()
+def test_stream_state_tells_a_call_with_no_arguments_yet_from_one_that_never_streamed():
+    """Test that empty argument text and no argument text are different answers.
 
-    # Test that empty string tool_call_id is handled gracefully
-    buffer.start_tool_call("")  # Empty string
-    assert "" in buffer.active_tool_call_ids
+    A call opened for streaming has sent empty argument text until its first
+    fragment arrives. A call whose arguments never streamed has sent none at
+    all, and is owed the whole string from Agno's announcement of it, so the
+    two cannot share an answer.
+    """
+    state = StreamState()
 
-    # End with empty string
-    buffer.end_tool_call("")
-    assert "" in buffer.ended_tool_call_ids
-    assert "" not in buffer.active_tool_call_ids
+    state.start_tool_call("streaming_call", args_streaming=True)
+    state.start_tool_call("announced_call")
+
+    assert state.streamed_tool_call_args("streaming_call") == ""
+    assert state.streamed_tool_call_args("announced_call") is None
+    assert state.streamed_tool_call_args("call_never_seen") is None
+
+    state.note_streamed_tool_call_args("streaming_call", '{"query": ')
+    state.note_streamed_tool_call_args("streaming_call", '"test"}')
+    assert state.streamed_tool_call_args("streaming_call") == '{"query": "test"}'
+
+    # The text describes a call in progress, so it goes when the call ends and
+    # an id handed to a later call starts from nothing again.
+    state.end_tool_call("streaming_call")
+    assert state.streamed_tool_call_args("streaming_call") is None
 
 
 @pytest.mark.asyncio
@@ -270,8 +285,14 @@ async def test_stream_error_closes_open_tool_call(tool_event, error_event):
 
 
 @pytest.mark.asyncio
-async def test_stream_with_tool_call_blocking():
-    """Test that events are properly buffered during tool calls"""
+async def test_text_arriving_during_an_open_tool_call_is_sent_straight_through():
+    """Nothing is held back while a tool call is open.
+
+    Text that arrives between a call's start and its end is passed on where it
+    arrived, in a second message of its own: the first message closes to let
+    the call open and parent to it, the second opens while the call is still
+    open, and the call closes after it rather than before it.
+    """
     from agno.run.agent import RunEvent
 
     async def mock_stream_with_tool_calls():
@@ -285,18 +306,14 @@ async def test_stream_with_tool_call_blocking():
         tool_start_response = ToolCallStartedEvent()
         tool_start_response.event = RunEvent.tool_call_started
         tool_start_response.content = ""
-        tool_call = MagicMock()
-        tool_call.tool_call_id = "tool_1"
-        tool_call.tool_name = "search"
-        tool_call.tool_args = {"query": "test"}
-        tool_call.result = None
+        tool_call = ToolExecution(tool_call_id="tool_1", tool_name="search", tool_args={"query": "test"})
         tool_start_response.tool = tool_call
         yield tool_start_response
 
-        buffered_text_response = RunContentEvent()
-        buffered_text_response.event = RunEvent.run_content
-        buffered_text_response.content = "Searching..."
-        yield buffered_text_response
+        mid_call_text_response = RunContentEvent()
+        mid_call_text_response.event = RunEvent.run_content
+        mid_call_text_response.content = "Searching..."
+        yield mid_call_text_response
         tool_end_response = ToolCallCompletedEvent()
         tool_end_response.event = RunEvent.tool_call_completed
         tool_end_response.content = ""
@@ -311,20 +328,33 @@ async def test_stream_with_tool_call_blocking():
     async for event in async_stream_agno_response_as_agui_events(mock_stream_with_tool_calls(), "thread_1", "run_1"):
         events.append(event)
 
-    # Asserting all expected events are present
-    event_types = [event.type for event in events]
-    assert EventType.TEXT_MESSAGE_START in event_types
-    assert EventType.TEXT_MESSAGE_CONTENT in event_types
-    assert EventType.TOOL_CALL_START in event_types
-    assert EventType.TOOL_CALL_ARGS in event_types
-    assert EventType.TOOL_CALL_END in event_types
-    assert EventType.TEXT_MESSAGE_END in event_types
-    assert EventType.RUN_FINISHED in event_types
+    assert [event.type for event in events] == [
+        EventType.TEXT_MESSAGE_START,
+        EventType.TEXT_MESSAGE_CONTENT,
+        EventType.TEXT_MESSAGE_END,
+        EventType.TOOL_CALL_START,
+        EventType.TOOL_CALL_ARGS,
+        EventType.TEXT_MESSAGE_START,
+        EventType.TEXT_MESSAGE_CONTENT,
+        EventType.TOOL_CALL_END,
+        EventType.TEXT_MESSAGE_END,
+        EventType.RUN_FINISHED,
+    ], [event.type for event in events]
 
-    # Verify tool call ordering
-    tool_start_idx = event_types.index(EventType.TOOL_CALL_START)
-    tool_end_idx = event_types.index(EventType.TOOL_CALL_END)
-    assert tool_start_idx < tool_end_idx
+    # The text on either side of the call is carried whole, in the order it
+    # arrived, and the mid-call text belongs to a message of its own.
+    assert events[1].delta == "I'll help you"
+    assert events[6].delta == "Searching..."
+    assert events[5].message_id != events[0].message_id
+    assert events[8].message_id == events[5].message_id
+
+    # The call parents to the message that closed for it, not to the one that
+    # opened while it was running.
+    assert events[3].tool_call_id == "tool_1"
+    assert events[3].parent_message_id == events[0].message_id
+    assert events[4].tool_call_id == "tool_1"
+    assert json.loads(events[4].delta) == {"query": "test"}
+    assert events[7].tool_call_id == "tool_1"
 
 
 @pytest.mark.asyncio
@@ -362,11 +392,11 @@ async def test_concurrent_tool_calls_no_infinite_loop():
         tool_start_3.tool = tool_call_3
         yield tool_start_3
 
-        # Some buffered content during tool calls
-        buffered_response = RunContentEvent()
-        buffered_response.event = RunEvent.run_content
-        buffered_response.content = "Fetching stock data..."
-        yield buffered_response
+        # Some content arriving while the tool calls are open
+        mid_call_response = RunContentEvent()
+        mid_call_response.event = RunEvent.run_content
+        mid_call_response.content = "Fetching stock data..."
+        yield mid_call_response
 
         # Complete all tool calls
         tool_call_1.result = {"price": 250.50, "symbol": "TSLA"}
@@ -637,10 +667,15 @@ async def test_empty_content_chunks_handling():
     async for event in async_stream_agno_response_as_agui_events(mock_stream_with_empty_content(), "thread_1", "run_1"):
         events.append(event)
 
-    # Should only have content events for non-empty content
-    content_events = [e for e in events if e.type == EventType.TEXT_MESSAGE_CONTENT]
-    assert len(content_events) == 1, f"Expected 1 content event for non-empty content, got {len(content_events)}"
-    assert content_events[0].delta == "Valid content"
+    # The empty and None chunks should leave nothing behind them at all: the
+    # wire is what it would have been had only the valid chunk arrived
+    assert [event.type for event in events] == [
+        EventType.TEXT_MESSAGE_START,
+        EventType.TEXT_MESSAGE_CONTENT,
+        EventType.TEXT_MESSAGE_END,
+        EventType.RUN_FINISHED,
+    ], [event.type for event in events]
+    assert events[1].delta == "Valid content"
 
 
 @pytest.mark.asyncio
@@ -705,6 +740,13 @@ async def test_reasoning_events_handling():
     assert EventType.REASONING_MESSAGE_START in event_types, "Should have REASONING_MESSAGE_START"
     assert EventType.REASONING_MESSAGE_END in event_types, "Should have REASONING_MESSAGE_END"
     assert EventType.REASONING_END in event_types, "Should have REASONING_END"
+
+    # The reasoning the stream carried should reach the client, under the
+    # message the reasoning phase opened
+    reasoning_content_events = [e for e in events if e.type == EventType.REASONING_MESSAGE_CONTENT]
+    assert [e.delta for e in reasoning_content_events] == ["Thinking about this problem..."]
+    reasoning_start_event = next(e for e in events if e.type == EventType.REASONING_MESSAGE_START)
+    assert reasoning_content_events[0].message_id == reasoning_start_event.message_id
 
     # Should have text content (the run_content event between reasoning phases)
     assert EventType.TEXT_MESSAGE_CONTENT in event_types
@@ -1233,22 +1275,30 @@ async def test_event_ordering_invariants():
 
     # Critical ordering invariants
 
-    # 1. TEXT_MESSAGE_START must come before any TEXT_MESSAGE_CONTENT
-    start_indices = [i for i, t in enumerate(event_types) if t == EventType.TEXT_MESSAGE_START]
-    content_indices = [i for i, t in enumerate(event_types) if t == EventType.TEXT_MESSAGE_CONTENT]
+    # 1. Every TEXT_MESSAGE_CONTENT arrives inside an open message and under
+    #    the message_id that message was opened with, and every message that
+    #    opens is closed once, under that same id.
+    assert EventType.TEXT_MESSAGE_CONTENT in event_types, "the run carried no text at all"
 
-    for start_idx in start_indices:
-        related_content_indices = [i for i in content_indices if i > start_idx]
-        if related_content_indices:
-            next_end_idx = next(
-                (i for i, t in enumerate(event_types[start_idx:], start_idx) if t == EventType.TEXT_MESSAGE_END),
-                len(event_types),
+    open_message_id = None
+    for index, event in enumerate(events):
+        if event.type == EventType.TEXT_MESSAGE_START:
+            assert open_message_id is None, (
+                f"TEXT_MESSAGE_START at {index} opens a message while {open_message_id} is still open"
             )
-            related_content_indices = [i for i in related_content_indices if i < next_end_idx]
-            for content_idx in related_content_indices:
-                assert start_idx < content_idx, (
-                    f"TEXT_MESSAGE_START at {start_idx} should come before TEXT_MESSAGE_CONTENT at {content_idx}"
-                )
+            open_message_id = event.message_id
+        elif event.type == EventType.TEXT_MESSAGE_CONTENT:
+            assert open_message_id is not None, f"TEXT_MESSAGE_CONTENT at {index} arrives with no message open"
+            assert event.message_id == open_message_id, (
+                f"TEXT_MESSAGE_CONTENT at {index} carries {event.message_id}, not the open {open_message_id}"
+            )
+        elif event.type == EventType.TEXT_MESSAGE_END:
+            assert event.message_id == open_message_id, (
+                f"TEXT_MESSAGE_END at {index} closes {event.message_id}, not the open {open_message_id}"
+            )
+            open_message_id = None
+
+    assert open_message_id is None, f"the run left message {open_message_id} open"
 
     # 2. TOOL_CALL_START must come before TOOL_CALL_ARGS for same tool
     tool_starts = [(i, e) for i, e in enumerate(events) if e.type == EventType.TOOL_CALL_START]
@@ -1743,33 +1793,36 @@ def test_validate_state_with_invalid_to_dict():
 # --- State Events Tests ---
 
 
-def test_event_buffer_state_snapshot_deep_copy():
+def test_stream_state_snapshot_is_a_deep_copy():
     """Test StreamState state snapshot stores a deep copy and computes deltas correctly."""
-    buffer = StreamState()
+    state = StreamState()
 
-    state = {"score": 0, "items": ["a"]}
-    buffer.set_state_snapshot(state)
+    session_state = {"score": 0, "items": ["a"]}
+    state.set_state_snapshot(session_state)
 
-    # Verify deep copy: mutating original dict should not affect snapshot
-    state["score"] = 10
-    state["items"].append("b")
+    # Verify deep copy: mutating the original, nested values included, should
+    # not affect the snapshot
+    session_state["score"] = 10
+    session_state["items"].append("b")
 
-    delta = buffer.compute_state_delta(state)
+    delta = state.compute_state_delta(session_state)
     assert delta is not None
-    # Should have ops for score change and items change
+    # Should have ops for score change and items change. A snapshot sharing
+    # the list would have grown with it and reported the append as nothing.
     ops_paths = [op["path"] for op in delta]
     assert "/score" in ops_paths
+    assert "/items/1" in ops_paths
 
     # No change should return None
-    buffer.set_state_snapshot(state)
-    delta = buffer.compute_state_delta(state)
+    state.set_state_snapshot(session_state)
+    delta = state.compute_state_delta(session_state)
     assert delta is None
 
 
-def test_event_buffer_compute_delta_no_snapshot():
+def test_stream_state_compute_delta_no_snapshot():
     """Test compute_state_delta returns None when no snapshot has been set."""
-    buffer = StreamState()
-    result = buffer.compute_state_delta({"key": "value"})
+    state = StreamState()
+    result = state.compute_state_delta({"key": "value"})
     assert result is None
 
 
@@ -1829,10 +1882,7 @@ async def test_state_delta_after_tool_call():
         tool_start = ToolCallStartedEvent()
         tool_start.event = RunEvent.tool_call_started
         tool_start.content = ""
-        tool = MagicMock()
-        tool.tool_call_id = "tool_1"
-        tool.tool_name = "increment"
-        tool.tool_args = {}
+        tool = ToolExecution(tool_call_id="tool_1", tool_name="increment", tool_args={})
         tool_start.tool = tool
         yield tool_start
 
@@ -1871,6 +1921,68 @@ async def test_state_delta_after_tool_call():
     delta_paths = [op["path"] for op in delta_event.delta]
     assert "/counter" in delta_paths
     assert "/status" in delta_paths
+
+
+@pytest.mark.parametrize(
+    ("tool_call_error", "result"),
+    [(None, "incremented"), (True, "increment() failed: the counter is closed")],
+    ids=["a call that succeeded", "a call that failed"],
+)
+@pytest.mark.asyncio
+async def test_a_completion_carries_its_calls_own_result_whether_it_succeeded_or_failed(tool_call_error, result):
+    """What a call did is what its result event says it did.
+
+    A real execution reports a failure on the completion it arrives with, and
+    reports none at all where the call succeeded, so the two are pinned side
+    by side: the events are the same shape either way, the result is the run's
+    own, and the state the call left behind goes out in both cases. A call
+    that succeeded is never reported to a client as one that failed, and a
+    call that failed carries what went wrong rather than nothing at all.
+    """
+    run_state = {"counter": 0}
+
+    async def mock_stream():
+        tool_start = ToolCallStartedEvent()
+        tool_start.event = RunEvent.tool_call_started
+        tool_start.content = ""
+        tool = ToolExecution(tool_call_id="tool_1", tool_name="increment", tool_args={})
+        tool_start.tool = tool
+        yield tool_start
+
+        run_state["counter"] = 1
+
+        tool_end = ToolCallCompletedEvent()
+        tool_end.event = RunEvent.tool_call_completed
+        tool_end.content = ""
+        tool.result = result
+        tool.tool_call_error = tool_call_error
+        tool_end.tool = tool
+        yield tool_end
+
+        completed = RunContentEvent()
+        completed.event = RunEvent.run_completed
+        completed.content = ""
+        yield completed
+
+    events = []
+    async for event in async_stream_agno_response_as_agui_events(
+        mock_stream(), "thread_1", "run_1", run_state=run_state
+    ):
+        events.append(event)
+
+    assert [event.type for event in events] == [
+        EventType.TEXT_MESSAGE_START,
+        EventType.TEXT_MESSAGE_END,
+        EventType.TOOL_CALL_START,
+        EventType.TOOL_CALL_ARGS,
+        EventType.TOOL_CALL_END,
+        EventType.TOOL_CALL_RESULT,
+        EventType.STATE_DELTA,
+        EventType.STATE_SNAPSHOT,
+        EventType.RUN_FINISHED,
+    ], [event.type for event in events]
+    assert json.loads(events[5].content) == result
+    assert [op["path"] for op in events[6].delta] == ["/counter"], events[6].delta
 
 
 @pytest.mark.asyncio
@@ -1914,10 +2026,7 @@ async def test_no_delta_when_state_unchanged():
         tool_start = ToolCallStartedEvent()
         tool_start.event = RunEvent.tool_call_started
         tool_start.content = ""
-        tool = MagicMock()
-        tool.tool_call_id = "tool_1"
-        tool.tool_name = "noop"
-        tool.tool_args = {}
+        tool = ToolExecution(tool_call_id="tool_1", tool_name="noop", tool_args={})
         tool_start.tool = tool
         yield tool_start
 

--- a/libs/agno/tests/unit/conftest.py
+++ b/libs/agno/tests/unit/conftest.py
@@ -1,9 +1,36 @@
-"""Shared isolation for the unit suite."""
+"""Shared isolation and shared readings of production defaults for the unit suite."""
+
+from typing import Any, Callable, List, Union
 
 import pytest
 
 import agno.run.cancel as cancel_module
+from agno.run.agent import RunEvent
 from agno.run.cancellation_management.in_memory_cancellation_manager import InMemoryRunCancellationManager
+from agno.run.team import TeamRunEvent
+
+_ARGUMENT_FRAGMENT_EVENTS = (RunEvent.tool_call_args_delta, TeamRunEvent.tool_call_args_delta)
+
+
+@pytest.fixture
+def skips_but_the_argument_fragments() -> Callable[[Any], List[Union[RunEvent, TeamRunEvent]]]:
+    """A component's own default skip list, less the argument fragment events.
+
+    An agent, a team and a workflow each have a suite asserting that asking for
+    the fragment events back re-enables nothing else the default keeps out of
+    storage. Reading the default off the component rather than writing it out
+    again in each of those suites is what keeps that assertion true when the
+    default changes.
+    """
+
+    def without_the_fragments(component: Any) -> List[Union[RunEvent, TeamRunEvent]]:
+        default = component.events_to_skip or []
+        assert any(event in _ARGUMENT_FRAGMENT_EVENTS for event in default), (
+            f"{type(component).__name__} no longer skips argument fragments by default"
+        )
+        return [event for event in default if event not in _ARGUMENT_FRAGMENT_EVENTS]
+
+    return without_the_fragments
 
 
 @pytest.fixture(autouse=True)

--- a/libs/agno/tests/unit/os/interfaces/test_agui_state_events.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_state_events.py
@@ -1,16 +1,28 @@
+import copy
 import json
-from typing import Any, AsyncIterator, Dict, List
+import logging
+import sys
+from typing import Any, AsyncIterator, Callable, Dict, Iterator, List, Optional, Tuple
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 pytest.importorskip("ag_ui", reason="ag_ui not installed")
 
+from ag_ui.core import EventType
 from fastapi.testclient import TestClient
+from pydantic import BaseModel, Field
 
 from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.base import Model
+from agno.models.response import ModelResponse, ModelResponseEvent
 from agno.os.app import AgentOS
 from agno.os.interfaces.agui import AGUI
+from agno.os.interfaces.agui import state as agui_state
+from agno.os.interfaces.agui.handlers import process_completion
+from agno.os.interfaces.agui.state import StateDeltaUnavailable, StreamState, client_state
+from agno.run import RunContext
 from agno.run.agent import (
     RunCompletedEvent,
     RunContentEvent,
@@ -19,6 +31,8 @@ from agno.run.agent import (
     ToolCallStartedEvent,
 )
 from agno.team import Team
+from agno.tools import tool
+from agno.utils import log as agno_log
 
 
 def parse_sse_events(content: str) -> List[Dict[str, Any]]:
@@ -198,6 +212,8 @@ class TestAgentStateSnapshot:
 
 class TestAgentStateDelta:
     def test_delta_emitted_after_tool_mutation(self, agent_client):
+        pytest.importorskip("jsonpatch", reason="jsonpatch not installed")
+
         client, agent = agent_client
 
         # Mutable state that will be modified during stream
@@ -321,6 +337,8 @@ class TestAgentStateEdgeCases:
         assert snapshot["snapshot"] == {}
 
     def test_nested_state_changes(self, agent_client):
+        pytest.importorskip("jsonpatch", reason="jsonpatch not installed")
+
         client, agent = agent_client
 
         mutable_state = {"recipe": {"title": "", "ingredients": []}}
@@ -460,3 +478,1789 @@ class TestTeamStateSnapshot:
 
         assert "STATE_SNAPSHOT" not in types
         assert "STATE_DELTA" not in types
+
+
+# =============================================================================
+# State payloads a client actually receives
+#
+# The tests above drive a mocked ``arun``, so Agno's run loop never runs and
+# never touches session state. These drive a real run over a scripted model so
+# the asserted snapshots and deltas are the payloads a client would decode.
+# =============================================================================
+
+
+class _ScriptedModel(Model):
+    """Emits scripted turns offline: ('tool', name, args, id) or ('content', text)."""
+
+    def __init__(self, script: List[tuple]):
+        super().__init__(id="scripted", name="scripted", provider="test")
+        self._script = list(script)
+        self._index = 0
+
+    def _next(self) -> ModelResponse:
+        from agno.metrics import MessageMetrics
+
+        # Repeating the last turn once the script runs out would let a run that
+        # takes more model turns than its script describes carry on quietly.
+        assert self._index < len(self._script), (
+            f"the run asked for model turn {self._index + 1} of a {len(self._script)}-turn script, "
+            f"whose last turn was {self._script[-1]!r}"
+        )
+        turn = self._script[self._index]
+        self._index += 1
+        if turn[0] == "tool":
+            _, name, args, tool_call_id = turn
+            response = ModelResponse(role="assistant")
+            response.tool_calls = [
+                {"id": tool_call_id, "type": "function", "function": {"name": name, "arguments": json.dumps(args)}}
+            ]
+        else:
+            response = ModelResponse(content=turn[1], role="assistant")
+            response.event = ModelResponseEvent.assistant_response.value
+        response.response_usage = MessageMetrics(input_tokens=1, output_tokens=1, total_tokens=2)
+        return response
+
+    def invoke(self, *args, **kwargs):
+        return self._next()
+
+    async def ainvoke(self, *args, **kwargs):
+        return self._next()
+
+    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+        yield self._next()
+
+    async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+        yield self._next()
+
+    def _parse_provider_response(self, response: Any, **kwargs) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+
+@tool
+def bump_counter(run_context: Optional[RunContext] = None) -> str:
+    """Increment the shared counter by one."""
+    session_state = run_context.session_state  # type: ignore[union-attr]
+    session_state["counter"] = session_state.get("counter", 0) + 1
+    return f"counter is now {session_state['counter']}"
+
+
+@tool
+def read_counter(run_context: Optional[RunContext] = None) -> str:
+    """Report the shared counter without changing it."""
+    return f"counter is {run_context.session_state.get('counter', 0)}"  # type: ignore[union-attr]
+
+
+def _client_running_tool(tool_fn, calls: int = 1):
+    """An AgentOS whose agent really runs, calling ``tool_fn`` then answering."""
+    script = [("tool", tool_fn.name, {}, f"tc_{index}") for index in range(1, calls + 1)]
+    agent = Agent(
+        name="state-payload-agent",
+        model=_ScriptedModel(script + [("content", "done")]),
+        tools=[tool_fn],
+    )
+    agent_os = AgentOS(agents=[agent], interfaces=[AGUI(agent=agent)])
+    return TestClient(agent_os.get_app())
+
+
+def _real_run_client(mutates: bool = True):
+    return _client_running_tool(bump_counter if mutates else read_counter)
+
+
+def _state_events(events: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    return [e for e in events if e.get("type") in ("STATE_SNAPSHOT", "STATE_DELTA")]
+
+
+def _same_state_value(left: Any, right: Any) -> bool:
+    """Whether two decoded state payloads match with no type coercion at all.
+
+    Deliberately a check of its own rather than a call into the comparison the
+    delta is computed behind, which answers the same question by encoding both
+    sides and comparing the JSON text: a test that reused that comparison would
+    agree with it wherever it is wrong, and what these tests exist to catch is
+    the client being sent 0 where False was expected, or 1 where 1.0 was.
+    """
+    if type(left) is not type(right):
+        return False
+    if isinstance(left, dict):
+        return len(left) == len(right) and all(
+            key in right and _same_state_value(value, right[key]) for key, value in left.items()
+        )
+    if isinstance(left, list):
+        return len(left) == len(right) and all(_same_state_value(a, b) for a, b in zip(left, right))
+    return bool(left == right)
+
+
+def _pointed_at(document: Any, pointer: str) -> Tuple[Any, str]:
+    """The (container, token) pair a JSON Pointer's last segment names.
+
+    Deliberately a walk of its own rather than a call into ``jsonpatch``:
+    resolving a pointer with the library that wrote it lets a pointer built by
+    the wrong rule be read back by the same wrong rule and agree with itself,
+    which is the defect these deltas exist to be checked against.
+    """
+    tokens = [token.replace("~1", "/").replace("~0", "~") for token in pointer.split("/")[1:]]
+    if not tokens:
+        raise AssertionError(f"the delta op reads or writes {pointer!r}, the whole document, which names no key of it")
+    container = document
+    for depth, token in enumerate(tokens[:-1]):
+        try:
+            container = container[int(token)] if isinstance(container, list) else container[token]
+        except (KeyError, IndexError, TypeError, ValueError):
+            raise AssertionError(
+                f"the delta points at {pointer}, whose {'/'.join(tokens[: depth + 1])} the client does not hold"
+            ) from None
+    return container, tokens[-1]
+
+
+def _child_key(container: Any, token: str, op: Dict[str, Any]) -> Any:
+    """The key ``token`` names inside ``container``, as a client reads it.
+
+    An array index is digits and nothing else: a token a JSON Patch
+    implementation refuses to read as an index is refused here too, rather
+    than reaching ``int`` and leaving a bare ValueError to be read.
+    """
+    if not isinstance(container, list) or token == "-":
+        return token
+    assert token.isascii() and token.isdigit() and (token == "0" or not token.startswith("0")), (
+        f"the delta op {op} names {token!r} where the client holds an array, which is no array index"
+    )
+    return int(token)
+
+
+def _holds(container: Any, key: Any) -> bool:
+    if isinstance(container, list):
+        return isinstance(key, int) and 0 <= key < len(container)
+    return isinstance(container, dict) and key in container
+
+
+def _client_document_after(document: Any, ops: List[Dict[str, Any]]) -> Any:
+    """``document`` with a delta's ops applied the way a client applies them.
+
+    A client hands the delta to a JSON Patch implementation, which refuses an
+    operation the specification does not allow rather than making sense of
+    it, so this refuses the same. ``list.insert`` in particular reads an index
+    past the end of a list as an append and a negative one as a position
+    counted back from the end: an ``add`` at index 9 of a two-element list,
+    which a conformant client rejects outright, would otherwise replay
+    cleanly here and be taken for a delta that carried the run to its closing
+    snapshot.
+    """
+    document = copy.deepcopy(document)
+    for op in ops:
+        if op["op"] in ("move", "copy"):
+            source, source_token = _pointed_at(document, op["from"])
+            source_key = _child_key(source, source_token, op)
+            assert _holds(source, source_key), f"the delta op {op} reads a location the client does not hold"
+            value = copy.deepcopy(source[source_key])
+            if op["op"] == "move":
+                del source[source_key]
+        else:
+            value = op.get("value")
+
+        if op["path"] == "":
+            document = value
+            continue
+
+        container, token = _pointed_at(document, op["path"])
+        key = _child_key(container, token, op)
+        if op["op"] in ("remove", "replace"):
+            assert _holds(container, key), f"the delta op {op} names a location the client does not hold"
+            if op["op"] == "remove":
+                del container[key]
+            else:
+                container[key] = value
+        elif isinstance(container, list):
+            index = len(container) if token == "-" else key
+            assert index <= len(container), (
+                f"the delta op {op} adds at index {index} of an array the client holds {len(container)} elements in"
+            )
+            container.insert(index, value)
+        else:
+            container[token] = value
+    return document
+
+
+def _assert_the_deltas_carry_the_run_to_its_closing_snapshot(events: List[Dict[str, Any]]) -> None:
+    """A client replaying the stream ends up holding the state the run ended with.
+
+    That is the whole promise of a delta stream, and the only check that reads
+    the ops as a client reads them: an op naming a key the client never held,
+    or a change the ops describe only half of, leaves the replay somewhere the
+    closing snapshot is not. Everything before the closing snapshot is
+    replayed, so the closing snapshot is the answer rather than the last step.
+    """
+    closing = max((index for index, e in enumerate(events) if e.get("type") == "STATE_SNAPSHOT"), default=None)
+    assert closing is not None and closing > 0, f"the run sent no state for a client to replay: {_state_events(events)}"
+
+    held: Any = None
+    for event in events[:closing]:
+        if event.get("type") == "STATE_SNAPSHOT":
+            held = copy.deepcopy(event["snapshot"])
+        elif event.get("type") == "STATE_DELTA":
+            held = _client_document_after(held, event["delta"])
+
+    assert _same_state_value(held, events[closing]["snapshot"]), (
+        f"replaying the stream leaves a client holding {held!r}, "
+        f"not the {events[closing]['snapshot']!r} the run closed with"
+    )
+
+
+def _client_document_when(events: List[Dict[str, Any]], state_event: Dict[str, Any]) -> Any:
+    """What a client holds once it has applied ``state_event`` and all before it.
+
+    Several patches describe one change, and which of them ``jsonpatch``
+    emits is its own business: a rekeyed map it spells as a single move,
+    another implementation spells as a remove beside an add. What the client
+    is owed is the document, so a test reading the document back holds for
+    whichever spelling arrives, and still catches a move whose destination
+    reads correctly while the key it moved from is left behind.
+    """
+    held: Any = None
+    for event in events:
+        if event.get("type") == "STATE_SNAPSHOT":
+            held = copy.deepcopy(event["snapshot"])
+        elif event.get("type") == "STATE_DELTA":
+            held = _client_document_after(held, event["delta"])
+        if event is state_event:
+            return held
+    raise AssertionError(f"{state_event} is not one of the events it was to be replayed through")
+
+
+def _state_event_per_tool_call(events: List[Dict[str, Any]]) -> List[Optional[Dict[str, Any]]]:
+    """The state event each tool call sent the client, ``None`` where it sent none.
+
+    A run opens with a snapshot of the request state and closes with one of the
+    final state whatever its tool calls did, so neither says anything about a
+    change reaching the client while the run was still going: a guard that took
+    everything but the last state event would be satisfied by the opening
+    snapshot alone, and the closing snapshot is left out here even where a
+    tool call's end is the last thing before it.
+
+    A tool call's own state event follows the end of the call, and the anchor
+    is that end rather than the result event between them: a tool that returns
+    nothing sends no result while the state event goes out all the same, so
+    anchoring on the result would move the positions a test asserts on out
+    from under it.
+
+    Keeping the calls that sent nothing, rather than dropping them, is what
+    lets a test say which call was told about and which was left alone.
+    """
+    closing = max((index for index, e in enumerate(events) if e.get("type") == "STATE_SNAPSHOT"), default=-1)
+    per_call: List[Optional[Dict[str, Any]]] = []
+    for index, event in enumerate(events):
+        if event.get("type") != "TOOL_CALL_END":
+            continue
+        following = index + 1
+        if following < len(events) and events[following].get("type") == "TOOL_CALL_RESULT":
+            following += 1
+        sent = events[following] if following < len(events) else None
+        if sent is None or following == closing or sent.get("type") not in ("STATE_SNAPSHOT", "STATE_DELTA"):
+            per_call.append(None)
+        else:
+            per_call.append(sent)
+    return per_call
+
+
+def _snapshots_emitted_for_tool_calls(events: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """The snapshots the router sent because a tool call changed state."""
+    return [
+        event for event in _state_event_per_tool_call(events) if event is not None and event["type"] == "STATE_SNAPSHOT"
+    ]
+
+
+def _events_of_completed_run(
+    response,
+    *,
+    ran: List[str],
+    reported: Optional[str] = None,
+    left_state: Any,
+) -> List[Dict[str, Any]]:
+    """Assert what the run did, then hand back its events for the rest of a test.
+
+    A check that holds on an absent event type, on an event count or on a
+    substring is satisfied just as well by a run whose model answered with
+    content and never called the tool, or by one that died before finishing, so
+    every test below says here what the run was supposed to do: the tools it
+    called in order, optionally what the last one reported, and the state the
+    client was left holding once the run finished.
+
+    The state is compared without type coercion, because ``==`` alone calls 0
+    and False equal and 1 and 1.0 equal, which is exactly the distinction some
+    of the tests below exist to prove reaches the client.
+    """
+    assert response.status_code == 200, response.text
+    events = parse_sse_events(response.text)
+    types = get_event_types(events)
+
+    called = [e["toolCallName"] for e in events if e.get("type") == "TOOL_CALL_START"]
+    assert called == ran, f"the run called {called}, not {ran}: {types}"
+    results = [e for e in events if e.get("type") == "TOOL_CALL_RESULT"]
+    assert len(results) == len(ran), f"{len(ran)} tool calls returned {len(results)} results: {types}"
+    if reported is not None:
+        assert reported in results[-1]["content"], results[-1]["content"]
+
+    assert "RUN_FINISHED" in types, types
+    assert "RUN_ERROR" not in types, [e for e in events if e.get("type") == "RUN_ERROR"]
+
+    snapshots = [e for e in events if e.get("type") == "STATE_SNAPSHOT"]
+    assert snapshots, f"the client was left holding no state at all: {types}"
+    assert _same_state_value(snapshots[-1]["snapshot"], left_state), (
+        f"the client was left holding {snapshots[-1]['snapshot']!r}, not {left_state!r}"
+    )
+    _assert_the_deltas_carry_the_run_to_its_closing_snapshot(events)
+
+    return events
+
+
+@pytest.fixture
+def warnings_logged() -> Iterator[List[logging.LogRecord]]:
+    """Every warning Agno logs while a test runs, whichever logger carried it.
+
+    ``log_warning`` writes to a process-global logger that a team run rebinds
+    to the team logger and never rebinds back, so the same AG-UI state warning
+    is carried by one logger or another depending on what else ran earlier in
+    the process. What these tests assert is that the state path warned and what
+    it said, so they read every logger the helper can be bound to and stay out
+    of that. The loggers are read off the module rather than named, so one
+    added to it later is covered too.
+    """
+    records: List[logging.LogRecord] = []
+
+    class _Collector(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    handler = _Collector(logging.WARNING)
+    loggers = list(
+        {id(value): value for value in vars(agno_log).values() if isinstance(value, logging.Logger)}.values()
+    )
+    for agno_logger in loggers:
+        agno_logger.addHandler(handler)
+    try:
+        yield records
+    finally:
+        for agno_logger in loggers:
+            agno_logger.removeHandler(handler)
+
+
+@tool
+def add_ingredient(run_context: Optional[RunContext] = None) -> str:
+    """Append an ingredient to the shared recipe, leaving the recipe in place."""
+    run_context.session_state["recipe"]["ingredients"].append("noodles")  # type: ignore[union-attr,index]
+    return "the recipe lists noodles"
+
+
+class TestAMutationInsideAContainerReachesTheClient:
+    """A tool that appends to a list already in session_state never rebinds the
+    key holding it, which is the ordinary shape of a tool that edits a document
+    or a cart. The snapshot the comparison is measured against has to be a copy
+    taken deep enough that the append cannot reach it: sharing the containers
+    leaves the mutation on both sides of the comparison, so the run reads as
+    unchanged and the client hears about the ingredient only once it is over."""
+
+    def test_a_delta_reports_a_list_appended_to_in_place(self):
+        pytest.importorskip("jsonpatch", reason="jsonpatch not installed")
+
+        client = _client_running_tool(add_ingredient)
+        response = client.post(
+            "/agui", json=make_request_body("add", state={"recipe": {"title": "", "ingredients": []}})
+        )
+
+        events = _events_of_completed_run(
+            response,
+            ran=[add_ingredient.name],
+            reported="the recipe lists noodles",
+            left_state={"recipe": {"title": "", "ingredients": ["noodles"]}},
+        )
+        told = _state_event_per_tool_call(events)
+        assert told[0] is not None, f"the append never reached the client: {_state_events(events)}"
+        assert told[0]["type"] == "STATE_DELTA", told[0]
+        assert [op["path"] for op in told[0]["delta"]] == ["/recipe/ingredients/0"], told[0]["delta"]
+
+    def test_a_snapshot_reports_a_list_appended_to_in_place_without_jsonpatch(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "jsonpatch", None)
+        client = _client_running_tool(add_ingredient)
+        response = client.post(
+            "/agui", json=make_request_body("add", state={"recipe": {"title": "", "ingredients": []}})
+        )
+
+        events = _events_of_completed_run(
+            response,
+            ran=[add_ingredient.name],
+            reported="the recipe lists noodles",
+            left_state={"recipe": {"title": "", "ingredients": ["noodles"]}},
+        )
+        mid_stream = _snapshots_emitted_for_tool_calls(events)
+        assert mid_stream, f"the append never reached the client: {_state_events(events)}"
+        assert mid_stream[-1]["snapshot"]["recipe"]["ingredients"] == ["noodles"], mid_stream[-1]["snapshot"]
+
+
+class TestClientStateExcludesAgnoBookkeeping:
+    """Agno injects current_user_id/current_session_id/current_run_id into
+    session_state at runtime and strips them again before persisting the
+    session row. They are Agno's record keeping, so a client must never see
+    them appear in state it did not write."""
+
+    def test_final_snapshot_carries_only_application_state(self):
+        client = _real_run_client()
+        response = client.post("/agui", json=make_request_body("bump", state={"counter": 0}))
+
+        _events_of_completed_run(
+            response,
+            ran=[bump_counter.name],
+            reported="counter is now 1",
+            left_state={"counter": 1},
+        )
+
+    def test_delta_ops_never_reference_bookkeeping_keys(self):
+        pytest.importorskip("jsonpatch", reason="jsonpatch not installed")
+
+        client = _real_run_client()
+        response = client.post("/agui", json=make_request_body("bump", state={"counter": 0}))
+
+        events = _events_of_completed_run(
+            response,
+            ran=[bump_counter.name],
+            reported="counter is now 1",
+            left_state={"counter": 1},
+        )
+        deltas = [e for e in events if e.get("type") == "STATE_DELTA"]
+        assert deltas, "expected a state delta for the counter mutation"
+        assert [op["path"] for delta in deltas for op in delta["delta"]] == ["/counter"]
+
+    def test_initial_snapshot_drops_bookkeeping_keys_sent_by_the_client(self):
+        client = _real_run_client()
+        response = client.post(
+            "/agui",
+            json=make_request_body("bump", state={"counter": 0, "current_run_id": "stale", "current_user_id": "stale"}),
+        )
+
+        events = _events_of_completed_run(
+            response,
+            ran=[bump_counter.name],
+            reported="counter is now 1",
+            left_state={"counter": 1},
+        )
+        first_snapshot = next(e for e in events if e.get("type") == "STATE_SNAPSHOT")
+        assert first_snapshot["snapshot"] == {"counter": 0}
+
+
+class TestStateStreamingWithoutJsonpatch:
+    """Agno's ``agui`` extra installs ``jsonpatch`` together with
+    ``ag-ui-protocol``, and the ``os`` extra ships neither, so the install these
+    tests stand in for is one that added ``ag-ui-protocol`` by hand on top of
+    ``os``. Without ``jsonpatch`` the delta cannot be computed, and dropping the
+    update would hide the mutation from the client entirely."""
+
+    def test_state_change_stays_visible_as_a_snapshot(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "jsonpatch", None)
+        client = _real_run_client()
+        response = client.post("/agui", json=make_request_body("bump", state={"counter": 0}))
+
+        events = _events_of_completed_run(
+            response,
+            ran=[bump_counter.name],
+            reported="counter is now 1",
+            left_state={"counter": 1},
+        )
+        assert "STATE_DELTA" not in get_event_types(events)
+
+        mid_stream = [
+            e for e in _snapshots_emitted_for_tool_calls(events) if _same_state_value(e["snapshot"], {"counter": 1})
+        ]
+        assert mid_stream, f"the counter mutation never reached the client: {_state_events(events)}"
+
+    def test_warning_names_the_missing_dependency_and_how_to_install_it(self, monkeypatch, warnings_logged):
+        monkeypatch.setitem(sys.modules, "jsonpatch", None)
+        client = _real_run_client()
+
+        response = client.post("/agui", json=make_request_body("bump", state={"counter": 0}))
+
+        events = _events_of_completed_run(
+            response,
+            ran=[bump_counter.name],
+            reported="counter is now 1",
+            left_state={"counter": 1},
+        )
+        types = get_event_types(events)
+        assert "STATE_DELTA" not in types, types
+        assert [
+            e for e in _snapshots_emitted_for_tool_calls(events) if _same_state_value(e["snapshot"], {"counter": 1})
+        ], f"the snapshot fallback never fired: {_state_events(events)}"
+
+        # The fallback warns once per run, so the run's only warning is that
+        # warning and the wording checks cannot land on an unrelated line.
+        warnings = [record for record in warnings_logged if record.levelno >= logging.WARNING]
+        assert len(warnings) == 1, [record.getMessage() for record in warnings]
+        fallback_warning = warnings[0].getMessage()
+        assert "jsonpatch" in fallback_warning
+        assert "pip install" in fallback_warning
+        assert "STATE_SNAPSHOT" in fallback_warning
+
+    def test_no_extra_snapshot_when_state_did_not_change(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "jsonpatch", None)
+        client = _real_run_client(mutates=False)
+        response = client.post("/agui", json=make_request_body("read", state={"counter": 0}))
+
+        events = _events_of_completed_run(
+            response,
+            ran=[read_counter.name],
+            reported="counter is 0",
+            left_state={"counter": 0},
+        )
+        assert get_event_types(events).count("STATE_SNAPSHOT") == 2
+
+
+@tool
+def disable_flag(run_context: Optional[RunContext] = None) -> str:
+    """Replace the shared flag's zero with the boolean False."""
+    run_context.session_state["flag"] = False  # type: ignore[union-attr,index]
+    return "flag is now False"
+
+
+@tool
+def widen_counter(run_context: Optional[RunContext] = None) -> str:
+    """Store the shared counter as a float of the same numeric value."""
+    run_context.session_state["counter"] = 1.0  # type: ignore[union-attr,index]
+    return "counter is now a float"
+
+
+@tool
+def disable_nested_flag(run_context: Optional[RunContext] = None) -> str:
+    """Replace the nested flag's zero with the boolean False."""
+    run_context.session_state["nested"] = {"flag": False}  # type: ignore[union-attr,index]
+    return "the nested flag is now False"
+
+
+@tool
+def disable_listed_flag(run_context: Optional[RunContext] = None) -> str:
+    """Replace the zero inside the shared list with the boolean False."""
+    run_context.session_state["flags"] = [False]  # type: ignore[union-attr,index]
+    return "the listed flag is now False"
+
+
+class TestStateValueTypeChangesReachTheClient:
+    """``0 == False`` and ``1 == 1.0`` in Python, so a value whose type flips
+    without its numeric value changing is easy to mistake for no change at
+    all. A client that renders a checkbox off a flag has to learn about it."""
+
+    def test_delta_reports_an_int_becoming_a_bool(self):
+        pytest.importorskip("jsonpatch", reason="jsonpatch not installed")
+
+        client = _client_running_tool(disable_flag)
+        response = client.post("/agui", json=make_request_body("disable", state={"flag": 0}))
+
+        events = _events_of_completed_run(
+            response,
+            ran=[disable_flag.name],
+            reported="flag is now False",
+            left_state={"flag": False},
+        )
+        ops = [op for e in events if e.get("type") == "STATE_DELTA" for op in e["delta"]]
+        assert ops, f"the flag change never reached the client: {_state_events(events)}"
+        assert ops[-1]["path"] == "/flag"
+        assert ops[-1]["value"] is False
+
+    def test_delta_reports_an_int_becoming_a_float(self):
+        pytest.importorskip("jsonpatch", reason="jsonpatch not installed")
+
+        client = _client_running_tool(widen_counter)
+        response = client.post("/agui", json=make_request_body("widen", state={"counter": 1}))
+
+        events = _events_of_completed_run(
+            response,
+            ran=[widen_counter.name],
+            reported="counter is now a float",
+            left_state={"counter": 1.0},
+        )
+        ops = [op for e in events if e.get("type") == "STATE_DELTA" for op in e["delta"]]
+        assert ops, f"the counter change never reached the client: {_state_events(events)}"
+        assert ops[-1]["path"] == "/counter"
+        assert isinstance(ops[-1]["value"], float)
+
+    def test_delta_reports_a_nested_int_becoming_a_bool(self):
+        pytest.importorskip("jsonpatch", reason="jsonpatch not installed")
+
+        client = _client_running_tool(disable_nested_flag)
+        response = client.post("/agui", json=make_request_body("disable", state={"nested": {"flag": 0}}))
+
+        events = _events_of_completed_run(
+            response,
+            ran=[disable_nested_flag.name],
+            reported="the nested flag is now False",
+            left_state={"nested": {"flag": False}},
+        )
+        ops = [op for e in events if e.get("type") == "STATE_DELTA" for op in e["delta"]]
+        assert ops, f"the nested flag change never reached the client: {_state_events(events)}"
+        assert ops[-1]["path"] == "/nested/flag"
+        assert ops[-1]["value"] is False
+
+    def test_snapshot_reports_an_int_becoming_a_bool_without_jsonpatch(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "jsonpatch", None)
+        client = _client_running_tool(disable_flag)
+        response = client.post("/agui", json=make_request_body("disable", state={"flag": 0}))
+
+        events = _events_of_completed_run(
+            response,
+            ran=[disable_flag.name],
+            reported="flag is now False",
+            left_state={"flag": False},
+        )
+        mid_stream = _snapshots_emitted_for_tool_calls(events)
+        assert mid_stream, f"the flag change never reached the client: {_state_events(events)}"
+        assert mid_stream[-1]["snapshot"]["flag"] is False
+
+    def test_snapshot_reports_an_int_becoming_a_float_without_jsonpatch(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "jsonpatch", None)
+        client = _client_running_tool(widen_counter)
+        response = client.post("/agui", json=make_request_body("widen", state={"counter": 1}))
+
+        events = _events_of_completed_run(
+            response,
+            ran=[widen_counter.name],
+            reported="counter is now a float",
+            left_state={"counter": 1.0},
+        )
+        mid_stream = _snapshots_emitted_for_tool_calls(events)
+        assert mid_stream, f"the counter change never reached the client: {_state_events(events)}"
+        assert isinstance(mid_stream[-1]["snapshot"]["counter"], float)
+
+    def test_snapshot_reports_a_listed_int_becoming_a_bool_without_jsonpatch(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "jsonpatch", None)
+        client = _client_running_tool(disable_listed_flag)
+        response = client.post("/agui", json=make_request_body("disable", state={"flags": [0]}))
+
+        events = _events_of_completed_run(
+            response,
+            ran=[disable_listed_flag.name],
+            reported="the listed flag is now False",
+            left_state={"flags": [False]},
+        )
+        mid_stream = _snapshots_emitted_for_tool_calls(events)
+        assert mid_stream, f"the listed flag change never reached the client: {_state_events(events)}"
+        flags = mid_stream[-1]["snapshot"]["flags"]
+        assert _same_state_value(flags, [False]), f"the client was sent {flags!r}"
+        assert flags[0] is False
+
+
+# =============================================================================
+# Changes only the encoded state shows
+# =============================================================================
+
+
+@tool
+def key_the_map_by_one(run_context: Optional[RunContext] = None) -> str:
+    """Key the shared map by the integer 1."""
+    run_context.session_state["by_flag"] = {1: "on"}  # type: ignore[union-attr,index]
+    return "the map is keyed by 1"
+
+
+@tool
+def key_the_map_by_true(run_context: Optional[RunContext] = None) -> str:
+    """Key the shared map by the boolean True."""
+    run_context.session_state["by_flag"] = {True: "on"}  # type: ignore[union-attr,index]
+    return "the map is keyed by True"
+
+
+@tool
+def hold_zero_in_a_set(run_context: Optional[RunContext] = None) -> str:
+    """Hold the integer 0 in the shared set."""
+    run_context.session_state["seen"] = {0}  # type: ignore[union-attr,index]
+    return "the set holds 0"
+
+
+@tool
+def hold_false_in_a_set(run_context: Optional[RunContext] = None) -> str:
+    """Hold the boolean False in the shared set."""
+    run_context.session_state["seen"] = {False}  # type: ignore[union-attr,index]
+    return "the set holds False"
+
+
+@tool
+def key_the_map_by_nothing(run_context: Optional[RunContext] = None) -> str:
+    """Key the shared map by None, holding off."""
+    run_context.session_state["by_nothing"] = {None: "off"}  # type: ignore[union-attr,index]
+    return "the map is keyed by None, off"
+
+
+@tool
+def flip_the_map_keyed_by_nothing(run_context: Optional[RunContext] = None) -> str:
+    """Key the shared map by None again, holding on."""
+    run_context.session_state["by_nothing"] = {None: "on"}  # type: ignore[union-attr,index]
+    return "the map is keyed by None, on"
+
+
+@tool
+def key_the_labels_by_one_and_count(run_context: Optional[RunContext] = None) -> str:
+    """Key the shared labels by the integer 1, and count one."""
+    run_context.session_state["labels"] = {1: "x"}  # type: ignore[union-attr,index]
+    run_context.session_state["counted"] = 1  # type: ignore[union-attr,index]
+    return "keyed by 1, counted 1"
+
+
+@tool
+def key_the_labels_by_true_and_count(run_context: Optional[RunContext] = None) -> str:
+    """Key the shared labels by the boolean True, and count two."""
+    run_context.session_state["labels"] = {True: "x"}  # type: ignore[union-attr,index]
+    run_context.session_state["counted"] = 2  # type: ignore[union-attr,index]
+    return "keyed by True, counted 2"
+
+
+class AliasedProfile(BaseModel):
+    """A state value whose JSON key is not its field name, the way a model
+    carrying an API's own spelling of a field is."""
+
+    user_name: str = Field(alias="user-name")
+
+
+@tool
+def store_the_aliased_profile(run_context: Optional[RunContext] = None) -> str:
+    """Store a model the encoder renders under a key that is not its field name."""
+    run_context.session_state["profile"] = AliasedProfile(**{"user-name": "ran"})  # type: ignore[union-attr,index]
+    return "the profile names ran"
+
+
+@tool
+def disable_the_listed_flag_and_count(run_context: Optional[RunContext] = None) -> str:
+    """Replace the zero inside the shared list with False, and bump the counter."""
+    run_context.session_state["flags"] = [False]  # type: ignore[union-attr,index]
+    run_context.session_state["counter"] = 2  # type: ignore[union-attr,index]
+    return "the listed flag is False, counted 2"
+
+
+@tool
+def rebuild_the_recipe_in_another_key_order(run_context: Optional[RunContext] = None) -> str:
+    """Rebuild the shared recipe dict holding the same entries, keyed in reverse."""
+    recipe = run_context.session_state["recipe"]  # type: ignore[union-attr,index]
+    run_context.session_state["recipe"] = {key: recipe[key] for key in reversed(list(recipe))}  # type: ignore[union-attr,index]
+    return "the recipe is rebuilt in another key order"
+
+
+@tool
+def hold_the_pair_as_a_tuple(run_context: Optional[RunContext] = None) -> str:
+    """Hold the shared pair as a tuple rather than a list."""
+    run_context.session_state["pair"] = (1, 2)  # type: ignore[union-attr,index]
+    return "the pair is a tuple"
+
+
+def _client_running_tools(tool_fns: List[Any]):
+    """An AgentOS whose agent calls each of ``tool_fns`` in order, then answers."""
+    script = [("tool", tool_fn.name, {}, f"tc_{index}") for index, tool_fn in enumerate(tool_fns, start=1)]
+    agent = Agent(
+        name="state-payload-agent",
+        model=_ScriptedModel(script + [("content", "done")]),
+        tools=list(tool_fns),
+    )
+    return TestClient(AgentOS(agents=[agent], interfaces=[AGUI(agent=agent)]).get_app())
+
+
+class TestChangesOnlyTheEncodedStateShowsReachTheClient:
+    """A client never holds the Python objects in session_state, only the JSON
+    the event encoder makes of them. Two states Python calls equal can encode
+    to different JSON: a dict looks its keys up by hash, so 1 and True are one
+    key to it and ``"1"`` and ``"true"`` to a client, and a set compares by
+    membership, so ``{0}`` and ``{False}`` are one value to it and ``[0]`` and
+    ``[false]`` to a client. Judging the objects leaves the client rendering
+    state the run has already moved on from."""
+
+    def test_a_map_rekeyed_from_one_to_true_reaches_the_client(self):
+        pytest.importorskip("jsonpatch", reason="jsonpatch not installed")
+
+        client = _client_running_tools([key_the_map_by_one, key_the_map_by_true])
+        response = client.post("/agui", json=make_request_body("rekey", state={"by_flag": {}}))
+
+        events = _events_of_completed_run(
+            response,
+            ran=[key_the_map_by_one.name, key_the_map_by_true.name],
+            reported="the map is keyed by True",
+            left_state={"by_flag": {"true": "on"}},
+        )
+        told = _state_event_per_tool_call(events)
+        assert told[1] is not None, f"the rekey never reached the client: {_state_events(events)}"
+        assert told[1]["type"] == "STATE_DELTA", told[1]
+        # The client is left holding the key it can see, "true", and neither
+        # the "True" Python spells the same key nor the "1" the map was keyed
+        # by before: a rekey that adds the new key and leaves the old one
+        # behind is a map the client renders with two entries.
+        assert _same_state_value(_client_document_when(events, told[1]), {"by_flag": {"true": "on"}}), told[1]
+
+    def test_a_set_holding_zero_becoming_one_holding_false_reaches_the_client(self, warnings_logged):
+        pytest.importorskip("jsonpatch", reason="jsonpatch not installed")
+
+        client = _client_running_tools([hold_zero_in_a_set, hold_false_in_a_set])
+        response = client.post("/agui", json=make_request_body("swap", state={"seen": []}))
+
+        events = _events_of_completed_run(
+            response,
+            ran=[hold_zero_in_a_set.name, hold_false_in_a_set.name],
+            reported="the set holds False",
+            left_state={"seen": [False]},
+        )
+        told = _state_event_per_tool_call(events)
+        # ``jsonpatch`` reads a list element by element with ``==``, so it calls
+        # 0 and False the same element and has no op to offer for [0] becoming
+        # [false]. The client is told with the whole state instead, and never
+        # told nothing.
+        assert told[1] is not None, f"the set change never reached the client: {_state_events(events)}"
+        assert told[1]["type"] == "STATE_SNAPSHOT", told[1]
+        # The fallback warns once per run, so the run's only warning is that
+        # warning and the wording checks cannot land on an unrelated line. What
+        # an operator reads has to say the change still went out whole, without
+        # reading as a defect in a library that behaved as documented.
+        warnings = [record.getMessage() for record in warnings_logged if record.levelno >= logging.WARNING]
+        assert len(warnings) == 1, warnings
+        assert "no operation to describe" in warnings[0], warnings[0]
+        assert "STATE_SNAPSHOT" in warnings[0], warnings[0]
+
+    def test_a_key_json_renames_is_pointed_at_by_the_name_the_client_holds(self):
+        pytest.importorskip("jsonpatch", reason="jsonpatch not installed")
+
+        client = _client_running_tools([key_the_map_by_nothing, flip_the_map_keyed_by_nothing])
+        response = client.post("/agui", json=make_request_body("flip", state={"by_nothing": {}}))
+
+        events = _events_of_completed_run(
+            response,
+            ran=[key_the_map_by_nothing.name, flip_the_map_keyed_by_nothing.name],
+            reported="the map is keyed by None, on",
+            left_state={"by_nothing": {"None": "on"}},
+        )
+        told = _state_event_per_tool_call(events)
+        assert told[1] is not None, f"the flip never reached the client: {_state_events(events)}"
+        assert told[1]["type"] == "STATE_DELTA", told[1]
+        # Pointed at the value under the key, never at the map holding it: a
+        # pointer built one level too shallow replaces the whole map with the
+        # scalar and leaves the client rendering a string where an object was.
+        assert [op["path"] for op in told[1]["delta"]] == ["/by_nothing/None"], told[1]["delta"]
+
+    def test_a_change_the_client_sees_only_half_of_is_not_reported_as_the_whole(self):
+        pytest.importorskip("jsonpatch", reason="jsonpatch not installed")
+
+        client = _client_running_tools([key_the_labels_by_one_and_count, key_the_labels_by_true_and_count])
+        response = client.post("/agui", json=make_request_body("rekey", state={}))
+
+        events = _events_of_completed_run(
+            response,
+            ran=[key_the_labels_by_one_and_count.name, key_the_labels_by_true_and_count.name],
+            reported="keyed by True, counted 2",
+            left_state={"labels": {"true": "x"}, "counted": 2},
+        )
+        told = _state_event_per_tool_call(events)
+        assert told[1] is not None, f"the rekey never reached the client: {_state_events(events)}"
+        # Both halves or neither, and the rekeyed map left holding one entry
+        # rather than two. A delta carrying the counter alone is not empty, so
+        # no snapshot fallback fires behind it and the rekey is lost.
+        left_holding = {"labels": {"true": "x"}, "counted": 2}
+        assert _same_state_value(_client_document_when(events, told[1]), left_holding), told[1]
+
+    def test_a_type_flip_inside_a_list_is_not_dropped_behind_a_change_beside_it(self, warnings_logged):
+        """The same demand as the test above, for the half ``jsonpatch`` cannot
+        see at all. It reads a list element by element with ``==``, so [0]
+        becoming [false] is no change to it and the ops it offers describe the
+        counter alone. Those ops are not empty, so nothing behind them fires on
+        their own: they go out, the baseline advances past the flag, and the
+        client renders a checkbox the run turned off for the rest of the run."""
+        pytest.importorskip("jsonpatch", reason="jsonpatch not installed")
+
+        client = _client_running_tools([disable_the_listed_flag_and_count])
+        response = client.post("/agui", json=make_request_body("disable", state={"flags": [0], "counter": 1}))
+
+        events = _events_of_completed_run(
+            response,
+            ran=[disable_the_listed_flag_and_count.name],
+            reported="the listed flag is False, counted 2",
+            left_state={"flags": [False], "counter": 2},
+        )
+        told = _state_event_per_tool_call(events)
+        assert told[0] is not None, f"the change never reached the client: {_state_events(events)}"
+        assert told[0]["type"] == "STATE_SNAPSHOT", told[0]
+        assert told[0]["snapshot"]["flags"][0] is False, told[0]["snapshot"]
+        warnings = [record.getMessage() for record in warnings_logged if record.levelno >= logging.WARNING]
+        assert len(warnings) == 1, warnings
+        assert "does not reproduce the state it was computed for" in warnings[0], warnings[0]
+        assert "STATE_SNAPSHOT" in warnings[0], warnings[0]
+
+    def test_an_aliased_field_is_pointed_at_by_the_alias_the_client_holds(self):
+        """The encoder renders a model by alias, so the client holds
+        ``user-name``, and a pointer naming ``user_name`` names nothing it can
+        find: the op adds a second key beside the one it was meant for, and the
+        field the client renders keeps the value it already held."""
+        pytest.importorskip("jsonpatch", reason="jsonpatch not installed")
+
+        client = _client_running_tools([store_the_aliased_profile])
+        response = client.post("/agui", json=make_request_body("store", state={"profile": {}}))
+
+        events = _events_of_completed_run(
+            response,
+            ran=[store_the_aliased_profile.name],
+            reported="the profile names ran",
+            left_state={"profile": {"user-name": "ran"}},
+        )
+        told = _state_event_per_tool_call(events)
+        assert told[0] is not None, f"the profile never reached the client: {_state_events(events)}"
+        assert told[0]["type"] == "STATE_DELTA", told[0]
+        assert [op["path"] for op in told[0]["delta"]] == ["/profile/user-name"], told[0]["delta"]
+
+
+class TestStateThatEncodesTheSameIsNotAChange:
+    """The mirror of the class above: two states Python calls different can
+    encode to the same JSON, and a list swapped for a tuple is the ordinary
+    case. Judging the objects ships the client a full snapshot it already
+    holds, and on an install without ``jsonpatch`` a warning telling the reader
+    to install a package that would have changed nothing."""
+
+    def test_a_list_becoming_a_tuple_ships_nothing(self):
+        pytest.importorskip("jsonpatch", reason="jsonpatch not installed")
+
+        client = _client_running_tools([hold_the_pair_as_a_tuple])
+        response = client.post("/agui", json=make_request_body("retype", state={"pair": [1, 2]}))
+
+        events = _events_of_completed_run(
+            response,
+            ran=[hold_the_pair_as_a_tuple.name],
+            reported="the pair is a tuple",
+            left_state={"pair": [1, 2]},
+        )
+        assert _state_event_per_tool_call(events) == [None], _state_events(events)
+        # Only the run's opening and closing snapshots.
+        assert get_event_types(events).count("STATE_SNAPSHOT") == 2, _state_events(events)
+
+    def test_a_dict_rebuilt_in_another_key_order_ships_nothing(self, warnings_logged):
+        """A JSON object is its entries, not the order they were written in, so
+        a client reading the parsed payload cannot see a rebuild. The
+        comparison reads a serialization, which can see one unless its keys are
+        sorted, and jsonpatch has no op to offer for a difference that is not
+        there: the run would fall back to a snapshot of state already held, and
+        warn about it."""
+        pytest.importorskip("jsonpatch", reason="jsonpatch not installed")
+
+        client = _client_running_tools([rebuild_the_recipe_in_another_key_order])
+        response = client.post(
+            "/agui", json=make_request_body("rebuild", state={"recipe": {"title": "soup", "servings": 2}})
+        )
+
+        events = _events_of_completed_run(
+            response,
+            ran=[rebuild_the_recipe_in_another_key_order.name],
+            reported="the recipe is rebuilt in another key order",
+            left_state={"recipe": {"title": "soup", "servings": 2}},
+        )
+        assert _state_event_per_tool_call(events) == [None], _state_events(events)
+        assert get_event_types(events).count("STATE_SNAPSHOT") == 2, _state_events(events)
+        warnings = [record.getMessage() for record in warnings_logged if record.levelno >= logging.WARNING]
+        assert warnings == [], warnings
+
+    def test_a_list_becoming_a_tuple_ships_nothing_and_warns_nothing_without_jsonpatch(
+        self, monkeypatch, warnings_logged
+    ):
+        monkeypatch.setitem(sys.modules, "jsonpatch", None)
+        client = _client_running_tools([hold_the_pair_as_a_tuple])
+
+        response = client.post("/agui", json=make_request_body("retype", state={"pair": [1, 2]}))
+
+        events = _events_of_completed_run(
+            response,
+            ran=[hold_the_pair_as_a_tuple.name],
+            reported="the pair is a tuple",
+            left_state={"pair": [1, 2]},
+        )
+        assert _state_event_per_tool_call(events) == [None], _state_events(events)
+        assert get_event_types(events).count("STATE_SNAPSHOT") == 2, _state_events(events)
+        warnings = [record.getMessage() for record in warnings_logged if record.levelno >= logging.WARNING]
+        assert warnings == [], warnings
+
+
+# =============================================================================
+# Every reason the delta fallback fires
+# =============================================================================
+
+
+class _BrokenJsonpatch:
+    """Stands in for ``jsonpatch`` when the patch computation itself fails."""
+
+    @staticmethod
+    def make_patch(*args: Any, **kwargs: Any) -> Any:
+        raise ValueError("value is not diffable")
+
+
+class _SilentJsonpatch:
+    """Stands in for ``jsonpatch`` when it describes a change with no ops."""
+
+    class _Empty:
+        patch: List[Dict[str, Any]] = []
+
+    @staticmethod
+    def make_patch(*args: Any, **kwargs: Any) -> Any:
+        return _SilentJsonpatch._Empty()
+
+
+class _UnfaithfulJsonpatch:
+    """Stands in for ``jsonpatch`` when it answers a change with ops that do
+    not reproduce it: neither empty, nor the change the client is owed."""
+
+    class _Patch:
+        patch: List[Dict[str, Any]] = [{"op": "add", "path": "/unrelated", "value": "noise"}]
+
+    @staticmethod
+    def make_patch(*args: Any, **kwargs: Any) -> Any:
+        return _UnfaithfulJsonpatch._Patch()
+
+    @staticmethod
+    def apply_patch(document: Any, ops: List[Dict[str, Any]]) -> Any:
+        replayed = copy.deepcopy(document)
+        for operation in ops:
+            replayed[operation["path"].lstrip("/")] = operation["value"]
+        return replayed
+
+
+class _UnreplayableJsonpatch:
+    """Stands in for ``jsonpatch`` when the replay that checks the ops raises
+    rather than answering: ops that cannot be applied at all are a different
+    failure from ops that apply and land somewhere else."""
+
+    @staticmethod
+    def make_patch(*args: Any, **kwargs: Any) -> Any:
+        return _UnfaithfulJsonpatch.make_patch()
+
+    @staticmethod
+    def apply_patch(document: Any, ops: List[Dict[str, Any]]) -> Any:
+        raise ValueError("the ops name a path this document has no place for")
+
+
+class _UnreplayableThenUnfaithfulJsonpatch:
+    """Stands in for ``jsonpatch`` when the replay check fails one way and then
+    the other, so a single run reaches both arms of it.
+
+    An instance rather than a class, because ``sys.modules`` entries are read
+    by attribute and an instance keeps its call count to the one test holding
+    it, where a class attribute would carry it across the suite.
+    """
+
+    def __init__(self) -> None:
+        self.replays = 0
+
+    def make_patch(self, *args: Any, **kwargs: Any) -> Any:
+        return _UnfaithfulJsonpatch.make_patch()
+
+    def apply_patch(self, document: Any, ops: List[Dict[str, Any]]) -> Any:
+        self.replays += 1
+        if self.replays == 1:
+            return _UnreplayableJsonpatch.apply_patch(document, ops)
+        return _UnfaithfulJsonpatch.apply_patch(document, ops)
+
+
+# Set by the ``breaking_jsonpatch_mid_run`` fixture for as long as a test that
+# asked for it is running, and cleared again afterwards.
+_break_jsonpatch_mid_run: Optional[Callable[[], None]] = None
+
+
+@pytest.fixture
+def breaking_jsonpatch_mid_run(monkeypatch):
+    """Owns ``sys.modules["jsonpatch"]`` for a test whose tool breaks it mid-run.
+
+    Reaching the patch computation failing after the missing dependency inside
+    a single run means changing the entry while the run is going, which only a
+    tool body can do. Both changes are made through ``monkeypatch`` here, so
+    pytest restores the entry when the test ends however the run went, rather
+    than the tool leaving the process holding a broken ``jsonpatch``.
+    """
+    global _break_jsonpatch_mid_run
+
+    monkeypatch.setitem(sys.modules, "jsonpatch", None)
+
+    def swap() -> None:
+        monkeypatch.setitem(sys.modules, "jsonpatch", _BrokenJsonpatch)
+
+    _break_jsonpatch_mid_run = swap
+    yield swap
+    _break_jsonpatch_mid_run = None
+
+
+@tool
+def bump_counter_and_break_jsonpatch(run_context: Optional[RunContext] = None) -> str:
+    """Increment the shared counter, leaving jsonpatch importable but failing."""
+    assert _break_jsonpatch_mid_run is not None, (
+        "this tool changes sys.modules['jsonpatch'], so the test calling it has to take the "
+        "breaking_jsonpatch_mid_run fixture and let pytest restore the entry"
+    )
+    _break_jsonpatch_mid_run()
+    assert sys.modules["jsonpatch"] is _BrokenJsonpatch
+    session_state = run_context.session_state  # type: ignore[union-attr]
+    session_state["counter"] = session_state.get("counter", 0) + 1
+    return f"counter is now {session_state['counter']}"
+
+
+class TestEveryDeltaFallbackReasonIsReported:
+    """The fallback to a full snapshot has several distinct causes, and each is
+    actionable in a different way: ``jsonpatch`` not being importable is fixed
+    by installing it, while the patch computation failing is not. Reporting
+    only whichever came first leaves an operator with no sign of the other."""
+
+    def test_both_reasons_are_reported_once_each_in_one_run(self, breaking_jsonpatch_mid_run, warnings_logged):
+        agent = Agent(
+            name="state-payload-agent",
+            model=_ScriptedModel(
+                [
+                    ("tool", bump_counter.name, {}, "tc_1"),
+                    ("tool", bump_counter.name, {}, "tc_2"),
+                    ("tool", bump_counter_and_break_jsonpatch.name, {}, "tc_3"),
+                    ("tool", bump_counter.name, {}, "tc_4"),
+                    ("content", "done"),
+                ]
+            ),
+            tools=[bump_counter, bump_counter_and_break_jsonpatch],
+        )
+        client = TestClient(AgentOS(agents=[agent], interfaces=[AGUI(agent=agent)]).get_app())
+
+        response = client.post("/agui", json=make_request_body("bump", state={"counter": 0}))
+
+        _events_of_completed_run(
+            response,
+            ran=[
+                bump_counter.name,
+                bump_counter.name,
+                bump_counter_and_break_jsonpatch.name,
+                bump_counter.name,
+            ],
+            reported="counter is now 4",
+            left_state={"counter": 4},
+        )
+
+        warnings = [record.getMessage() for record in warnings_logged if record.levelno >= logging.WARNING]
+        missing_dependency = [warning for warning in warnings if "not importable" in warning]
+        computation_failed = [warning for warning in warnings if "could not be computed" in warning]
+        assert len(missing_dependency) == 1, warnings
+        assert len(computation_failed) == 1, warnings
+
+    def test_a_replay_that_raises_and_one_that_lands_elsewhere_are_both_reported(self, monkeypatch, warnings_logged):
+        """The check that the ops reproduce the change fails for two distinct
+        reasons, and sharing one reason between them makes whichever fires
+        first silence the other for the rest of the run."""
+        monkeypatch.setitem(sys.modules, "jsonpatch", _UnreplayableThenUnfaithfulJsonpatch())
+        client = _client_running_tool(bump_counter, calls=2)
+
+        response = client.post("/agui", json=make_request_body("bump", state={"counter": 0}))
+
+        _events_of_completed_run(
+            response,
+            ran=[bump_counter.name, bump_counter.name],
+            reported="counter is now 2",
+            left_state={"counter": 2},
+        )
+
+        warnings = [record.getMessage() for record in warnings_logged if record.levelno >= logging.WARNING]
+        not_replayable = [warning for warning in warnings if "could not be replayed" in warning]
+        not_faithful = [warning for warning in warnings if "does not reproduce the state" in warning]
+        assert len(not_replayable) == 1, warnings
+        assert len(not_faithful) == 1, warnings
+
+    def test_the_warning_names_the_thread_and_the_run(self, monkeypatch, warnings_logged):
+        """A server carries many conversations at once, so a warning that says
+        only that some run degraded cannot be traced back to one."""
+        monkeypatch.setitem(sys.modules, "jsonpatch", _BrokenJsonpatch)
+        client = _client_running_tool(bump_counter)
+
+        response = client.post(
+            "/agui", json=make_request_body("bump", state={"counter": 0}, thread_id="thread-among-many")
+        )
+
+        _events_of_completed_run(
+            response,
+            ran=[bump_counter.name],
+            reported="counter is now 1",
+            left_state={"counter": 1},
+        )
+
+        computation_failed = [
+            record.getMessage()
+            for record in warnings_logged
+            if record.levelno >= logging.WARNING and "could not be computed" in record.getMessage()
+        ]
+        assert len(computation_failed) == 1, [record.getMessage() for record in warnings_logged]
+        assert "thread-among-many" in computation_failed[0], computation_failed[0]
+        assert "test-run" in computation_failed[0], computation_failed[0]
+
+
+# =============================================================================
+# The contract both fallback reasons owe the client
+# =============================================================================
+
+# A stand-in for the ``jsonpatch`` module that provokes each reason: absent for
+# the missing dependency, failing for the computation itself, and answering a
+# change with no ops for the empty patch.
+_JSONPATCH_STAND_IN: Dict[str, Any] = {
+    StateDeltaUnavailable.NO_JSONPATCH: None,
+    StateDeltaUnavailable.PATCH_FAILED: _BrokenJsonpatch,
+    StateDeltaUnavailable.EMPTY_PATCH: _SilentJsonpatch,
+    StateDeltaUnavailable.PATCH_NOT_REPLAYABLE: _UnreplayableJsonpatch,
+    StateDeltaUnavailable.PATCH_NOT_FAITHFUL: _UnfaithfulJsonpatch,
+}
+
+# The reasons a ``jsonpatch`` stand-in can provoke, which are the reasons whose
+# contract is the fallback to a full snapshot.
+_FALLBACK_REASONS = sorted(_JSONPATCH_STAND_IN)
+
+_DECLARED_REASONS = sorted(
+    value for name, value in vars(StateDeltaUnavailable).items() if name.isupper() and isinstance(value, str)
+)
+
+# Every reason the once-per-stream warning registry can be handed. The
+# exception carries most of them, but state with no JSON form is reported
+# without one to name the cause, so reading the exception alone drops a reason
+# out of any coverage check silently. Every string the state module declares
+# is read, rather than the ones named a particular way, because a reason added
+# under a name no rule here predicted is exactly what would be dropped.
+_REGISTRY_REASONS = sorted(
+    set(_DECLARED_REASONS)
+    | {value for name, value in vars(agui_state).items() if isinstance(value, str) and not name.startswith("__")}
+)
+
+
+class TestEveryDeltaFallbackReasonHonoursTheSameContract:
+    """``compute_state_delta`` owes the caller two answers, and every reason it
+    can fail for owes both: ``None`` when no event is needed, and the raise
+    only when state changed and no patch could be built for it. A reason that
+    answered the second where the first was due would ship a full snapshot on
+    every later tool call of a run that never touched state."""
+
+    def test_every_reason_the_registry_can_hold_is_covered(self):
+        assert sorted({*_JSONPATCH_STAND_IN, *_REASONS_COVERED_BY_ANOTHER_CLASS}) == _REGISTRY_REASONS
+        for reason, covering in _REASONS_COVERED_BY_ANOTHER_CLASS.items():
+            assert [name for name in vars(covering) if name.startswith("test_")], (
+                f"{covering.__name__} is named as covering {reason} and holds no test"
+            )
+
+    @pytest.mark.parametrize("reason", _FALLBACK_REASONS)
+    def test_unchanged_state_over_several_tool_calls_ships_nothing_extra(self, monkeypatch, reason):
+        monkeypatch.setitem(sys.modules, "jsonpatch", _JSONPATCH_STAND_IN[reason])
+        client = _client_running_tool(read_counter, calls=3)
+        response = client.post("/agui", json=make_request_body("read", state={"counter": 0}))
+
+        events = _events_of_completed_run(
+            response,
+            ran=[read_counter.name] * 3,
+            reported="counter is 0",
+            left_state={"counter": 0},
+        )
+        types = get_event_types(events)
+        assert "STATE_DELTA" not in types, types
+        # Only the run's opening and closing snapshots, never one per tool call.
+        assert types.count("STATE_SNAPSHOT") == 2, _state_events(events)
+
+    @pytest.mark.parametrize("reason", _FALLBACK_REASONS)
+    def test_changed_state_reaches_the_client_as_a_snapshot(self, monkeypatch, reason):
+        monkeypatch.setitem(sys.modules, "jsonpatch", _JSONPATCH_STAND_IN[reason])
+        client = _client_running_tool(bump_counter)
+        response = client.post("/agui", json=make_request_body("bump", state={"counter": 0}))
+
+        events = _events_of_completed_run(
+            response,
+            ran=[bump_counter.name],
+            reported="counter is now 1",
+            left_state={"counter": 1},
+        )
+        assert "STATE_DELTA" not in get_event_types(events)
+        mid_stream = _snapshots_emitted_for_tool_calls(events)
+        assert mid_stream, f"the counter mutation never reached the client: {_state_events(events)}"
+        assert _same_state_value(mid_stream[-1]["snapshot"], {"counter": 1}), mid_stream[-1]["snapshot"]
+
+
+class TestTheTwoArmsOfTheReplayCheckAreTwoReasons:
+    """Ops that cannot be applied at all and ops that apply and land somewhere
+    else are two failures with two fixes, and a shared reason would leave an
+    operator reading about the one that did not happen."""
+
+    @pytest.mark.parametrize(
+        ("stand_in", "reason"),
+        [
+            (_UnreplayableJsonpatch, StateDeltaUnavailable.PATCH_NOT_REPLAYABLE),
+            (_UnfaithfulJsonpatch, StateDeltaUnavailable.PATCH_NOT_FAITHFUL),
+        ],
+        ids=["the replay raises", "the replay lands elsewhere"],
+    )
+    def test_each_arm_carries_its_own_reason(self, monkeypatch, stand_in, reason):
+        monkeypatch.setitem(sys.modules, "jsonpatch", stand_in)
+        state = StreamState()
+        state.set_state_snapshot({"counter": 0})
+
+        with pytest.raises(StateDeltaUnavailable) as raised:
+            state.compute_state_delta({"counter": 1})
+
+        assert raised.value.reason == reason
+
+
+# =============================================================================
+# State values the comparison cannot judge
+# =============================================================================
+
+
+class _RefusesToCompare(str):
+    """A state value whose ``==`` raises instead of answering, the way a numpy
+    array's does. Subclasses ``str`` so a client can still be sent it."""
+
+    def __eq__(self, other: object) -> bool:
+        raise ValueError("truth value of an array is ambiguous")
+
+    def __ne__(self, other: object) -> bool:
+        raise ValueError("truth value of an array is ambiguous")
+
+    __hash__ = str.__hash__
+
+
+class _NeverReachesTheBottom(str):
+    """A state value whose ``==`` exhausts the recursion limit, the way a
+    structure containing itself does. Subclasses ``str`` so a client can still
+    be sent it, which a structure containing itself cannot be.
+
+    ``__ne__`` is spelled out alongside it because ``str`` already defines one:
+    left to inherit, ``!=`` would answer with plain string inequality and a
+    comparison reaching for it would pass this value untouched.
+    """
+
+    def __eq__(self, other: object) -> bool:
+        return self == other
+
+    def __ne__(self, other: object) -> bool:
+        return self != other
+
+    __hash__ = str.__hash__
+
+
+# Each builds a value that has a JSON form and so reaches a client intact, but
+# that no comparison reading it through ``==`` can survive.
+_VALUES_THAT_REFUSE_TO_BE_COMPARED: Dict[str, Callable[[], str]] = {
+    "raises instead of comparing": lambda: _RefusesToCompare("ambiguous"),
+    "never finishes comparing": lambda: _NeverReachesTheBottom("endless"),
+}
+
+
+class _HasNoJsonForm:
+    """A state value the event encoder cannot render at all, the way an open
+    file handle or a live database connection left in session_state cannot be."""
+
+
+@tool
+def store_uncomparable_value(kind: str, run_context: Optional[RunContext] = None) -> str:
+    """Store the named uncomparable value in the shared state."""
+    run_context.session_state["value"] = _VALUES_THAT_REFUSE_TO_BE_COMPARED[kind]()  # type: ignore[union-attr,index]
+    return f"stored a value that {kind}"
+
+
+def _client_storing_then_reading(kind: str, reads: int = 2):
+    """An AgentOS whose agent stores ``kind`` then reads state ``reads`` times.
+
+    The reads matter: they ask the comparison about the stored value again on
+    every later tool call of the run, which is where a value it judges wrongly
+    costs the client an event each time.
+    """
+    script: List[tuple] = [("tool", store_uncomparable_value.name, {"kind": kind}, "tc_1")]
+    script += [("tool", read_counter.name, {}, f"tc_{index + 2}") for index in range(reads)]
+    agent = Agent(
+        name="state-payload-agent",
+        model=_ScriptedModel(script + [("content", "done")]),
+        tools=[store_uncomparable_value, read_counter],
+    )
+    return TestClient(AgentOS(agents=[agent], interfaces=[AGUI(agent=agent)]).get_app())
+
+
+class TestAValueThatRefusesToBeComparedIsStillJudgedByItsJsonForm:
+    """Application tool code owns what lands in session state, so a value there
+    can carry an ``__eq__`` that raises or one that never terminates. Asking
+    such a value nothing, and reading its encoded form instead, is what makes
+    it ordinary: it is judged as exactly as any other value, and the run pays
+    nothing for holding it."""
+
+    @pytest.mark.parametrize("kind", sorted(_VALUES_THAT_REFUSE_TO_BE_COMPARED))
+    def test_two_of_them_encoding_alike_are_not_a_change(self, kind):
+        """Nothing here catches an exception, so a comparison that reached for
+        ``==`` could not return at all, and one that caught the exception and
+        called the pair changed would answer with ops rather than ``None``."""
+        state = StreamState()
+        state.set_state_snapshot({"value": _VALUES_THAT_REFUSE_TO_BE_COMPARED[kind]()})
+
+        assert state.compute_state_delta({"value": _VALUES_THAT_REFUSE_TO_BE_COMPARED[kind]()}) is None
+
+    @pytest.mark.parametrize("kind", sorted(_VALUES_THAT_REFUSE_TO_BE_COMPARED))
+    @pytest.mark.parametrize("has_jsonpatch", [True, False], ids=["with jsonpatch", "without jsonpatch"])
+    def test_the_run_finishes_and_the_later_reads_ship_nothing(self, monkeypatch, kind, has_jsonpatch):
+        """An escaping comparison error would reach the client as a RUN_ERROR
+        with no RUN_FINISHED and a tool span left open. Judging the value
+        changed on every later read would ship the client, on each of them,
+        state it was already holding."""
+        if has_jsonpatch:
+            pytest.importorskip("jsonpatch", reason="jsonpatch not installed")
+        else:
+            monkeypatch.setitem(sys.modules, "jsonpatch", None)
+
+        client = _client_storing_then_reading(kind)
+        response = client.post("/agui", json=make_request_body("store", state={"counter": 0}))
+
+        events = _events_of_completed_run(
+            response,
+            ran=[store_uncomparable_value.name, read_counter.name, read_counter.name],
+            reported="counter is 0",
+            left_state={"counter": 0, "value": str(_VALUES_THAT_REFUSE_TO_BE_COMPARED[kind]())},
+        )
+        told = _state_event_per_tool_call(events)
+        assert told[0] is not None, f"the stored value never reached the client: {_state_events(events)}"
+        assert told[1:] == [None, None], f"a read that changed nothing still shipped state: {_state_events(events)}"
+
+
+class TestStateWithNoJsonFormCountsAsChangedAndIsReported:
+    """A value the encoder cannot render leaves the comparison with nothing to
+    read, and the answer it owes then is ``changed``: a client can discard an
+    update it already held, but it cannot recover one that was never sent. An
+    unreadable state is not an ordinary change though, so it is also said out
+    loud, once, or a defect in the comparison degrades in silence."""
+
+    def _stream_state_handed(self, before: Any, after: Any):
+        state = StreamState()
+        state.set_state_snapshot({"value": before})
+        return state, {"value": after}
+
+    def test_the_caller_is_left_the_exception_it_handles_and_one_warning(self, warnings_logged):
+        state, current = self._stream_state_handed("plain", _HasNoJsonForm())
+
+        with pytest.raises(StateDeltaUnavailable) as raised:
+            state.compute_state_delta(current)
+
+        assert raised.value.reason in _DECLARED_REASONS
+        unreadable = [
+            record.getMessage()
+            for record in warnings_logged
+            if record.levelno >= logging.WARNING and "no JSON form" in record.getMessage()
+        ]
+        assert len(unreadable) == 1, [record.getMessage() for record in warnings_logged]
+        assert "Treating it as changed" in unreadable[0]
+
+    def test_the_same_unreadable_state_is_reported_once_however_many_times_it_is_asked_about(self, warnings_logged):
+        state, current = self._stream_state_handed("plain", _HasNoJsonForm())
+
+        for _ in range(3):
+            with pytest.raises(StateDeltaUnavailable):
+                state.compute_state_delta(current)
+
+        unreadable = [record.getMessage() for record in warnings_logged if "no JSON form" in record.getMessage()]
+        assert len(unreadable) == 1, unreadable
+
+    def test_a_self_referential_structure_leaves_only_the_dedicated_exception(self, warnings_logged):
+        """A structure that contains itself cannot be JSON-encoded to a client
+        at all, and Agno's run loop fails on one before AG-UI state handling is
+        reached, so it cannot be driven through a completed run. What the
+        comparison owes is asserted here directly: whatever it is handed, the
+        only thing leaving ``compute_state_delta`` is the exception the caller
+        already handles by sending a full snapshot."""
+        snapshot_cycle: Dict[str, Any] = {}
+        snapshot_cycle["self"] = snapshot_cycle
+        current_cycle: Dict[str, Any] = {}
+        current_cycle["self"] = current_cycle
+        state, current = self._stream_state_handed(snapshot_cycle, current_cycle)
+
+        with pytest.raises(StateDeltaUnavailable) as raised:
+            state.compute_state_delta(current)
+
+        assert raised.value.reason in _DECLARED_REASONS
+        assert [record for record in warnings_logged if "no JSON form" in record.getMessage()]
+
+
+@tool
+def store_a_value_with_no_json_form(run_context: Optional[RunContext] = None) -> str:
+    """Leave a value the event encoder cannot render in the shared state."""
+    run_context.session_state["handle"] = _HasNoJsonForm()  # type: ignore[union-attr,index]
+    return "stored a live handle"
+
+
+@tool
+def close_the_value_with_no_json_form(run_context: Optional[RunContext] = None) -> str:
+    """Replace the unrenderable value with one the encoder can render."""
+    run_context.session_state["handle"] = "closed"  # type: ignore[union-attr,index]
+    return "the handle is closed"
+
+
+def _client_storing_then_closing_an_unrenderable_value(reads: int = 2):
+    """An AgentOS whose agent stores an unrenderable value, reads state
+    ``reads`` times, then replaces the value with a renderable one.
+
+    The reads ask the state path about the unrenderable value again on every
+    later tool call, and the close is what a run holding a live handle in
+    session state does before it ends: it is also the point where the client is
+    owed the change it can be sent, computed against the state it really holds.
+    """
+    script: List[tuple] = [("tool", store_a_value_with_no_json_form.name, {}, "tc_1")]
+    script += [("tool", read_counter.name, {}, f"tc_{index + 2}") for index in range(reads)]
+    script.append(("tool", close_the_value_with_no_json_form.name, {}, f"tc_{reads + 2}"))
+    agent = Agent(
+        name="state-payload-agent",
+        model=_ScriptedModel(script + [("content", "done")]),
+        tools=[store_a_value_with_no_json_form, read_counter, close_the_value_with_no_json_form],
+    )
+    return TestClient(AgentOS(agents=[agent], interfaces=[AGUI(agent=agent)]).get_app())
+
+
+class TestStateWithNoJsonFormIsWithheldRatherThanSent:
+    """State the encoder cannot render cannot be sent by any event, a full
+    snapshot included, and the encoder runs on the way to the socket, after the
+    state path has handed the event over: an event carrying such state takes
+    the rest of the response with it, terminal event and all. So the client is
+    owed no state event here. It keeps the state it was last sent, the run goes
+    on to finish, and the log says what was withheld and for which run.
+    """
+
+    def test_the_run_finishes_with_no_unsendable_event_on_the_wire(self):
+        pytest.importorskip("jsonpatch", reason="jsonpatch not installed")
+        client = _client_storing_then_closing_an_unrenderable_value()
+
+        response = client.post("/agui", json=make_request_body("store", state={"counter": 0}))
+
+        events = _events_of_completed_run(
+            response,
+            ran=[
+                store_a_value_with_no_json_form.name,
+                read_counter.name,
+                read_counter.name,
+                close_the_value_with_no_json_form.name,
+            ],
+            reported="the handle is closed",
+            left_state={"counter": 0, "handle": "closed"},
+        )
+        told = _state_event_per_tool_call(events)
+        assert told[:3] == [None, None, None], f"state that cannot be encoded still went out: {_state_events(events)}"
+        # A delta rather than a snapshot: the baseline stayed where the client
+        # is, so the close is describable as a change against what it holds.
+        assert told[3] is not None and told[3]["type"] == "STATE_DELTA", _state_events(events)
+
+    def test_both_causes_are_reported_once_each_and_name_the_run(self, warnings_logged):
+        pytest.importorskip("jsonpatch", reason="jsonpatch not installed")
+        client = _client_storing_then_closing_an_unrenderable_value()
+
+        response = client.post(
+            "/agui", json=make_request_body("store", state={"counter": 0}, thread_id="thread-among-many")
+        )
+        assert response.status_code == 200, response.text
+
+        warnings = [record.getMessage() for record in warnings_logged if record.levelno >= logging.WARNING]
+        unreadable = [warning for warning in warnings if "to compare against the last snapshot" in warning]
+        withheld = [warning for warning in warnings if "no state event carrying it can be sent" in warning]
+        assert len(unreadable) == 1, warnings
+        assert len(withheld) == 1, warnings
+        for warning in unreadable + withheld:
+            assert "thread-among-many" in warning, warning
+            assert "test-run" in warning, warning
+
+
+# The reasons no ``jsonpatch`` stand-in can provoke, because nothing about
+# ``jsonpatch`` causes them, against the class that covers each instead. The
+# classes themselves rather than their names, and so defined below both of
+# them: a name is a string nothing resolves, so renaming or deleting the class
+# it spells would leave the coverage guard passing and pointing at nothing.
+_REASONS_COVERED_BY_ANOTHER_CLASS = {
+    agui_state._STATE_NOT_ENCODABLE: TestStateWithNoJsonFormCountsAsChangedAndIsReported,
+    StateDeltaUnavailable.STATE_NOT_SENDABLE: TestStateWithNoJsonFormIsWithheldRatherThanSent,
+}
+
+
+class TestANonDictFinalStateStillFinishesTheRun:
+    """The terminal handler hands the run's own ``session_state`` to
+    ``client_state``, and nothing constrains it to a dict. A run whose state
+    ended up as anything else still owes the client its RUN_FINISHED, so
+    ``client_state`` copies what it cannot strip keys from rather than
+    raising and taking the whole terminal handler with it."""
+
+    @pytest.mark.parametrize(
+        "final_state",
+        ["the run left a bare string here", ["a", "list"], 7],
+        ids=["string", "list", "int"],
+    )
+    def test_the_terminal_handler_still_emits_run_finished(self, final_state):
+        state = StreamState(thread_id="t", run_id="r", run_state={"counter": 0})
+        state.set_state_snapshot(state.run_state)
+        chunk = RunCompletedEvent()
+        chunk.session_state = final_state
+
+        events = process_completion(chunk, state)
+
+        assert [event.type for event in events][-1] == EventType.RUN_FINISHED, events
+
+    def test_a_non_dict_is_copied_rather_than_shared(self):
+        original = ["a", ["nested"]]
+
+        copied = client_state(original)
+
+        assert copied == original
+        original[1].append("added")  # type: ignore[union-attr]
+        assert copied == ["a", ["nested"]]
+
+
+# =============================================================================
+# A value that is not equal to itself
+# =============================================================================
+
+
+@tool
+def set_ratio_to_nan(run_context: Optional[RunContext] = None) -> str:
+    """Store a float NaN as the shared ratio."""
+    run_context.session_state["ratio"] = float("nan")  # type: ignore[union-attr,index]
+    return "ratio is now NaN"
+
+
+def _client_storing_nan_then_reading(reads: int = 2):
+    script: List[tuple] = [("tool", set_ratio_to_nan.name, {}, "tc_1")]
+    script += [("tool", read_counter.name, {}, f"tc_{index + 2}") for index in range(reads)]
+    agent = Agent(
+        name="state-payload-agent",
+        model=_ScriptedModel(script + [("content", "done")]),
+        tools=[set_ratio_to_nan, read_counter],
+    )
+    return TestClient(AgentOS(agents=[agent], interfaces=[AGUI(agent=agent)]).get_app())
+
+
+class TestAValueNotEqualToItselfIsNotAChange:
+    """A float NaN is not equal to itself, so a state holding one reads as
+    changed on every comparison however long the run goes on. That is the same
+    wrong outcome as asking the no-change question too late: the client is sent
+    state it already holds after every tool call, forever."""
+
+    def test_a_nan_ships_one_snapshot_not_one_per_tool_call(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "jsonpatch", None)
+        client = _client_storing_nan_then_reading()
+        response = client.post("/agui", json=make_request_body("set", state={"counter": 0}))
+
+        events = _events_of_completed_run(
+            response,
+            ran=[set_ratio_to_nan.name, read_counter.name, read_counter.name],
+            reported="counter is 0",
+            left_state={"counter": 0, "ratio": None},
+        )
+        # The run's opening snapshot, the one carrying the NaN, and the closing
+        # one, never a further snapshot for each read that changed nothing.
+        assert get_event_types(events).count("STATE_SNAPSHOT") == 3, _state_events(events)
+
+    def test_a_nan_ships_one_delta_not_one_per_tool_call(self, monkeypatch):
+        pytest.importorskip("jsonpatch", reason="jsonpatch not installed")
+
+        client = _client_storing_nan_then_reading()
+        response = client.post("/agui", json=make_request_body("set", state={"counter": 0}))
+
+        events = _events_of_completed_run(
+            response,
+            ran=[set_ratio_to_nan.name, read_counter.name, read_counter.name],
+            reported="counter is 0",
+            left_state={"counter": 0, "ratio": None},
+        )
+        deltas = [e for e in events if e.get("type") == "STATE_DELTA"]
+        assert len(deltas) == 1, _state_events(events)
+        assert [op["path"] for op in deltas[0]["delta"]] == ["/ratio"]
+
+
+# =============================================================================
+# The transcript the cookbook README describes
+# =============================================================================
+
+AGENT_DEFAULT_RECIPE = {"title": "Untitled recipe", "ingredients": []}
+
+
+def _cookbook_shaped_client(tmp_path, tool_fn):
+    """An AgentOS in the shape ``shared_state.py`` has: a db and a session_state."""
+    agent = Agent(
+        name="state-payload-agent",
+        model=_ScriptedModel([("tool", tool_fn.name, {}, "tc_1"), ("content", "done")]),
+        db=SqliteDb(id="agui-state-transcript-db", db_file=str(tmp_path / "agui_state.db")),
+        session_state={"recipe": dict(AGENT_DEFAULT_RECIPE)},
+        tools=[tool_fn],
+    )
+    return TestClient(AgentOS(agents=[agent], interfaces=[AGUI(agent=agent)]).get_app())
+
+
+def _ops_by_path(delta: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """The delta's ops in path order.
+
+    ``jsonpatch`` walks the changed keys as a set, so their order varies from
+    one process to the next. Sorting pins which ops a delta carries and what
+    each one says, without pinning an order the library never promised.
+    """
+    return sorted(delta["delta"], key=lambda op: op["path"])
+
+
+def _first_snapshot(events: List[Dict[str, Any]]) -> Dict[str, Any]:
+    return next(e for e in events if e.get("type") == "STATE_SNAPSHOT")["snapshot"]
+
+
+def _only_delta(events: List[Dict[str, Any]]) -> Dict[str, Any]:
+    deltas = [e for e in events if e.get("type") == "STATE_DELTA"]
+    assert len(deltas) == 1, _state_events(events)
+    return deltas[0]
+
+
+class TestTheFirstDeltaCarriesTheStateTheRunBeganWith:
+    """Pins the transcript the ``16_agui`` cookbook README documents, so an
+    edit to either the wire behaviour or the prose shows up against the other.
+    The README says of an agent with its own ``session_state``:
+
+        "The agent's own `session_state` seeds the session row when that row
+        is created, and each run merges the row in under the request's own
+        state, which wins; the row is created once per `threadId`, so an edit
+        to the example's initial recipe shows up in a new conversation and
+        never in one already under way. Each delta is measured against the
+        previous payload, so unless the request already sent all of it, the
+        first delta adds what the merge brought in and reports more than the
+        tool call itself touched."
+
+    The opening snapshot is the request state, while the run starts from that
+    merged with the session row, and the request's own state wins over what
+    the row holds. So the merge lands in the first delta alongside whatever
+    the tool did: the first test below creates the row, which is where the
+    agent's own state seeds it, and the second reads that same row back.
+    """
+
+    def test_the_first_delta_also_adds_the_agent_default_state(self, tmp_path):
+        pytest.importorskip("jsonpatch", reason="jsonpatch not installed")
+
+        client = _cookbook_shaped_client(tmp_path, bump_counter)
+        response = client.post("/agui", json=make_request_body("bump", state={"counter": 7}, thread_id="recipe-thread"))
+
+        events = _events_of_completed_run(
+            response,
+            ran=[bump_counter.name],
+            reported="counter is now 8",
+            left_state={"recipe": AGENT_DEFAULT_RECIPE, "counter": 8},
+        )
+        assert _first_snapshot(events) == {"counter": 7}
+        # The tool touched /counter only; /recipe is the agent default arriving
+        # with it because the delta's baseline is what the client sent.
+        assert _ops_by_path(_only_delta(events)) == [
+            {"op": "replace", "path": "/counter", "value": 8},
+            {"op": "add", "path": "/recipe", "value": AGENT_DEFAULT_RECIPE},
+        ]
+
+    def test_the_first_delta_also_adds_the_stored_session_row(self, tmp_path):
+        pytest.importorskip("jsonpatch", reason="jsonpatch not installed")
+
+        _events_of_completed_run(
+            _cookbook_shaped_client(tmp_path, bump_counter).post(
+                "/agui", json=make_request_body("bump", state={"counter": 7}, thread_id="recipe-thread")
+            ),
+            ran=[bump_counter.name],
+            reported="counter is now 8",
+            left_state={"recipe": AGENT_DEFAULT_RECIPE, "counter": 8},
+        )
+
+        response = _cookbook_shaped_client(tmp_path, read_counter).post(
+            "/agui", json=make_request_body("read", state={"client_only": "kept"}, thread_id="recipe-thread")
+        )
+
+        events = _events_of_completed_run(
+            response,
+            ran=[read_counter.name],
+            reported="counter is 8",
+            left_state={"recipe": AGENT_DEFAULT_RECIPE, "counter": 8, "client_only": "kept"},
+        )
+        assert _first_snapshot(events) == {"client_only": "kept"}
+        # read_counter changes nothing, so every op here is the merge: /counter
+        # off the session row the first run persisted, /recipe the agent
+        # default. A delta still fires, reporting keys no tool call touched.
+        assert _ops_by_path(_only_delta(events)) == [
+            {"op": "add", "path": "/counter", "value": 8},
+            {"op": "add", "path": "/recipe", "value": AGENT_DEFAULT_RECIPE},
+        ]

--- a/libs/agno/tests/unit/os/interfaces/test_agui_state_events.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_state_events.py
@@ -14,28 +14,44 @@ from fastapi.testclient import TestClient
 from pydantic import BaseModel, Field
 
 from agno.agent import Agent
+from agno.agent._response import REFUSED_TOOL_CALL_ERROR
 from agno.db.sqlite import SqliteDb
 from agno.models.base import Model
-from agno.models.response import ModelResponse, ModelResponseEvent
+from agno.models.response import ModelResponse, ModelResponseEvent, ToolExecution
 from agno.os.app import AgentOS
 from agno.os.interfaces.agui import AGUI
+from agno.os.interfaces.agui import handlers as agui_handlers
 from agno.os.interfaces.agui import state as agui_state
-from agno.os.interfaces.agui.handlers import process_completion
+from agno.os.interfaces.agui.handlers import _normalize_event, process_completion, process_event
 from agno.os.interfaces.agui.state import StateDeltaUnavailable, StreamState, client_state
 from agno.run import RunContext
 from agno.run.agent import (
     RunCompletedEvent,
     RunContentEvent,
+    RunErrorEvent,
+    RunEvent,
     RunOutputEvent,
+    RunPausedEvent,
+    ToolCallArgsDeltaEvent,
     ToolCallCompletedEvent,
+    ToolCallErrorEvent,
     ToolCallStartedEvent,
 )
+from agno.run.team import TeamRunEvent
+from agno.run.team import ToolCallErrorEvent as TeamToolCallErrorEvent
 from agno.team import Team
 from agno.tools import tool
 from agno.utils import log as agno_log
 
 
 def parse_sse_events(content: str) -> List[Dict[str, Any]]:
+    """The events one SSE response carried, refusing any line that is not one.
+
+    A data line that does not decode is a defect these tests exist to catch,
+    not noise to skip: read as no event at all it satisfies every assertion
+    below about something being absent, so a stream that broke half way
+    through would pass a test asking for no RUN_ERROR and no second call.
+    """
     events = []
     for line in content.split("\n"):
         line = line.strip()
@@ -44,8 +60,8 @@ def parse_sse_events(content: str) -> List[Dict[str, Any]]:
         data_str = line[5:].strip()
         try:
             events.append(json.loads(data_str))
-        except json.JSONDecodeError:
-            continue
+        except json.JSONDecodeError as e:
+            raise AssertionError(f"the stream carried a data line that is no event: {data_str!r} ({e})") from None
     return events
 
 
@@ -111,7 +127,7 @@ class TestAgentStateSnapshot:
 
         # Verify snapshot content
         snapshot_event = events[first_snapshot_idx]
-        assert snapshot_event["snapshot"] == {"counter": 0}
+        assert _same_state_value(snapshot_event["snapshot"], {"counter": 0}), snapshot_event["snapshot"]
 
     def test_final_snapshot_emitted_before_run_finished(self, agent_client):
         client, agent = agent_client
@@ -137,7 +153,7 @@ class TestAgentStateSnapshot:
 
         # Verify final snapshot has updated state
         final_snapshot = events[last_snapshot_idx]
-        assert final_snapshot["snapshot"] == {"counter": 5}
+        assert _same_state_value(final_snapshot["snapshot"], {"counter": 5}), final_snapshot["snapshot"]
 
     def test_no_state_events_when_state_is_none(self, agent_client):
         client, agent = agent_client
@@ -186,6 +202,9 @@ class TestAgentStateSnapshot:
         events = parse_sse_events(response.text)
         types = get_event_types(events)
 
+        # The run really answered, so what is absent is state and not the run.
+        assert "RUN_FINISHED" in types, types
+        assert [e["delta"] for e in events if e.get("type") == "TEXT_MESSAGE_CONTENT"] == ["Hello"], types
         assert "STATE_SNAPSHOT" not in types
         assert "STATE_DELTA" not in types
 
@@ -207,7 +226,8 @@ class TestAgentStateSnapshot:
         # Verify agent.arun received session_state via run_context
         mock_arun.assert_called_once()
         call_kwargs = mock_arun.call_args.kwargs
-        assert call_kwargs["run_context"].session_state == initial_state
+        passed = call_kwargs["run_context"].session_state
+        assert _same_state_value(passed, initial_state), passed
 
 
 class TestAgentStateDelta:
@@ -334,7 +354,7 @@ class TestAgentStateEdgeCases:
         # Empty dict is still valid state
         assert "STATE_SNAPSHOT" in types
         snapshot = next(e for e in events if e.get("type") == "STATE_SNAPSHOT")
-        assert snapshot["snapshot"] == {}
+        assert _same_state_value(snapshot["snapshot"], {}), snapshot["snapshot"]
 
     def test_nested_state_changes(self, agent_client):
         pytest.importorskip("jsonpatch", reason="jsonpatch not installed")
@@ -457,7 +477,7 @@ class TestTeamStateSnapshot:
         assert last_snapshot_idx == run_finished_idx - 1
 
         final_snapshot = events[last_snapshot_idx]
-        assert final_snapshot["snapshot"] == {"task": "completed"}
+        assert _same_state_value(final_snapshot["snapshot"], {"task": "completed"}), final_snapshot["snapshot"]
 
     def test_team_no_state_events_without_state(self, team_client):
         client, team = team_client
@@ -476,6 +496,9 @@ class TestTeamStateSnapshot:
         events = parse_sse_events(response.text)
         types = get_event_types(events)
 
+        # The run really answered, so what is absent is state and not the run.
+        assert "RUN_FINISHED" in types, types
+        assert [e["delta"] for e in events if e.get("type") == "TEXT_MESSAGE_CONTENT"] == ["Team response"], types
         assert "STATE_SNAPSHOT" not in types
         assert "STATE_DELTA" not in types
 
@@ -593,25 +616,27 @@ def _same_state_value(left: Any, right: Any) -> bool:
     return bool(left == right)
 
 
-def _pointed_at(document: Any, pointer: str) -> Tuple[Any, str]:
+def _pointed_at(document: Any, pointer: str, op: Dict[str, Any]) -> Tuple[Any, str]:
     """The (container, token) pair a JSON Pointer's last segment names.
 
     Deliberately a walk of its own rather than a call into ``jsonpatch``:
     resolving a pointer with the library that wrote it lets a pointer built by
     the wrong rule be read back by the same wrong rule and agree with itself,
-    which is the defect these deltas exist to be checked against.
+    which is the defect these deltas exist to be checked against. Every
+    segment is read by the same rule as the last one, so a pointer naming an
+    array by something that is no index is refused wherever it does it.
     """
     tokens = [token.replace("~1", "/").replace("~0", "~") for token in pointer.split("/")[1:]]
     if not tokens:
         raise AssertionError(f"the delta op reads or writes {pointer!r}, the whole document, which names no key of it")
     container = document
     for depth, token in enumerate(tokens[:-1]):
-        try:
-            container = container[int(token)] if isinstance(container, list) else container[token]
-        except (KeyError, IndexError, TypeError, ValueError):
+        key = _child_key(container, token, op)
+        if not _holds(container, key):
             raise AssertionError(
                 f"the delta points at {pointer}, whose {'/'.join(tokens[: depth + 1])} the client does not hold"
-            ) from None
+            )
+        container = container[key]
     return container, tokens[-1]
 
 
@@ -651,7 +676,7 @@ def _client_document_after(document: Any, ops: List[Dict[str, Any]]) -> Any:
     document = copy.deepcopy(document)
     for op in ops:
         if op["op"] in ("move", "copy"):
-            source, source_token = _pointed_at(document, op["from"])
+            source, source_token = _pointed_at(document, op["from"], op)
             source_key = _child_key(source, source_token, op)
             assert _holds(source, source_key), f"the delta op {op} reads a location the client does not hold"
             value = copy.deepcopy(source[source_key])
@@ -664,7 +689,7 @@ def _client_document_after(document: Any, ops: List[Dict[str, Any]]) -> Any:
             document = value
             continue
 
-        container, token = _pointed_at(document, op["path"])
+        container, token = _pointed_at(document, op["path"], op)
         key = _child_key(container, token, op)
         if op["op"] in ("remove", "replace"):
             assert _holds(container, key), f"the delta op {op} names a location the client does not hold"
@@ -679,6 +704,9 @@ def _client_document_after(document: Any, ops: List[Dict[str, Any]]) -> Any:
             )
             container.insert(index, value)
         else:
+            assert isinstance(container, dict), (
+                f"the delta op {op} adds under {container!r}, which is neither an object nor an array"
+            )
             container[token] = value
     return document
 
@@ -811,6 +839,7 @@ def _events_of_completed_run(
         f"the client was left holding {snapshots[-1]['snapshot']!r}, not {left_state!r}"
     )
     _assert_the_deltas_carry_the_run_to_its_closing_snapshot(events)
+    _assert_the_client_accepts_the_tool_call_spans(events)
 
     return events
 
@@ -895,7 +924,8 @@ class TestAMutationInsideAContainerReachesTheClient:
         )
         mid_stream = _snapshots_emitted_for_tool_calls(events)
         assert mid_stream, f"the append never reached the client: {_state_events(events)}"
-        assert mid_stream[-1]["snapshot"]["recipe"]["ingredients"] == ["noodles"], mid_stream[-1]["snapshot"]
+        snapshot = mid_stream[-1]["snapshot"]
+        assert _same_state_value(snapshot["recipe"]["ingredients"], ["noodles"]), snapshot
 
 
 class TestClientStateExcludesAgnoBookkeeping:
@@ -945,7 +975,7 @@ class TestClientStateExcludesAgnoBookkeeping:
             left_state={"counter": 1},
         )
         first_snapshot = next(e for e in events if e.get("type") == "STATE_SNAPSHOT")
-        assert first_snapshot["snapshot"] == {"counter": 0}
+        assert _same_state_value(first_snapshot["snapshot"], {"counter": 0}), first_snapshot["snapshot"]
 
 
 class TestStateStreamingWithoutJsonpatch:
@@ -1965,6 +1995,32 @@ class TestStateWithNoJsonFormCountsAsChangedAndIsReported:
         assert [record for record in warnings_logged if "no JSON form" in record.getMessage()]
 
 
+class TestWhatTheDeltaIsMeasuredAgainstIsAnsweredForToo:
+    """The baseline a change is described against can be missing and can be
+    unrenderable, and neither is the same answer as an unrenderable change: a
+    run that has published no state owes the client nothing, and a baseline
+    with no JSON form leaves a change that cannot be described rather than one
+    that cannot be sent."""
+
+    def test_a_run_that_has_published_no_state_has_no_change_to_describe(self):
+        assert StreamState(thread_id="t", run_id="r").compute_state_delta({"counter": 1}) is None
+
+    def test_a_baseline_with_no_json_form_is_a_patch_that_could_not_be_built(self, warnings_logged):
+        pytest.importorskip("jsonpatch", reason="jsonpatch not installed")
+        state = StreamState(thread_id="typed-thread", run_id="typed-run")
+        state.set_state_snapshot({"value": _HasNoJsonForm()})
+
+        with pytest.raises(StateDeltaUnavailable) as raised:
+            state.compute_state_delta({"value": "a value with a JSON form"})
+
+        # Not STATE_NOT_SENDABLE: what the run holds now can be sent, as the
+        # full snapshot the caller falls back to.
+        assert raised.value.reason == StateDeltaUnavailable.PATCH_FAILED
+        unreadable = [record.getMessage() for record in warnings_logged if "no JSON form" in record.getMessage()]
+        assert len(unreadable) == 1, [record.getMessage() for record in warnings_logged]
+        assert "typed-thread" in unreadable[0] and "typed-run" in unreadable[0], unreadable[0]
+
+
 @tool
 def store_a_value_with_no_json_form(run_context: Optional[RunContext] = None) -> str:
     """Leave a value the event encoder cannot render in the shared state."""
@@ -2184,7 +2240,9 @@ def _ops_by_path(delta: Dict[str, Any]) -> List[Dict[str, Any]]:
 
 
 def _first_snapshot(events: List[Dict[str, Any]]) -> Dict[str, Any]:
-    return next(e for e in events if e.get("type") == "STATE_SNAPSHOT")["snapshot"]
+    snapshots = [e for e in events if e.get("type") == "STATE_SNAPSHOT"]
+    assert snapshots, f"the run sent no snapshot for a client to open on: {get_event_types(events)}"
+    return snapshots[0]["snapshot"]
 
 
 def _only_delta(events: List[Dict[str, Any]]) -> Dict[str, Any]:
@@ -2226,13 +2284,18 @@ class TestTheFirstDeltaCarriesTheStateTheRunBeganWith:
             reported="counter is now 8",
             left_state={"recipe": AGENT_DEFAULT_RECIPE, "counter": 8},
         )
-        assert _first_snapshot(events) == {"counter": 7}
+        opened_on = _first_snapshot(events)
+        assert _same_state_value(opened_on, {"counter": 7}), opened_on
         # The tool touched /counter only; /recipe is the agent default arriving
         # with it because the delta's baseline is what the client sent.
-        assert _ops_by_path(_only_delta(events)) == [
-            {"op": "replace", "path": "/counter", "value": 8},
-            {"op": "add", "path": "/recipe", "value": AGENT_DEFAULT_RECIPE},
-        ]
+        ops = _ops_by_path(_only_delta(events))
+        assert _same_state_value(
+            ops,
+            [
+                {"op": "replace", "path": "/counter", "value": 8},
+                {"op": "add", "path": "/recipe", "value": AGENT_DEFAULT_RECIPE},
+            ],
+        ), ops
 
     def test_the_first_delta_also_adds_the_stored_session_row(self, tmp_path):
         pytest.importorskip("jsonpatch", reason="jsonpatch not installed")
@@ -2256,11 +2319,1138 @@ class TestTheFirstDeltaCarriesTheStateTheRunBeganWith:
             reported="counter is 8",
             left_state={"recipe": AGENT_DEFAULT_RECIPE, "counter": 8, "client_only": "kept"},
         )
-        assert _first_snapshot(events) == {"client_only": "kept"}
+        opened_on = _first_snapshot(events)
+        assert _same_state_value(opened_on, {"client_only": "kept"}), opened_on
         # read_counter changes nothing, so every op here is the merge: /counter
         # off the session row the first run persisted, /recipe the agent
         # default. A delta still fires, reporting keys no tool call touched.
-        assert _ops_by_path(_only_delta(events)) == [
-            {"op": "add", "path": "/counter", "value": 8},
-            {"op": "add", "path": "/recipe", "value": AGENT_DEFAULT_RECIPE},
+        ops = _ops_by_path(_only_delta(events))
+        assert _same_state_value(
+            ops,
+            [
+                {"op": "add", "path": "/counter", "value": 8},
+                {"op": "add", "path": "/recipe", "value": AGENT_DEFAULT_RECIPE},
+            ],
+        ), ops
+
+
+# =============================================================================
+# Tool call arguments streamed to the client as they are produced
+#
+# Providers hand the run loop one delta per fragment of a tool call's argument
+# string, and Agno now emits a run event for each. Those fragments arrive
+# before Agno announces the finished call, so the wire has to open the call
+# from the first fragment and add arguments from each one after it. These drive
+# a real run over a fragmenting offline model so what is asserted is the
+# sequence a client decodes.
+# =============================================================================
+
+
+class _FragmentingModel(Model):
+    """Streams a turn's tool calls in fragments, the way a provider does.
+
+    Each turn is ``("content", text)`` or ``("tools", [(name, args, id), ...],
+    chunk_size, preamble)``. A tool turn puts a call's id and function name on
+    its own first fragment, which carries no arguments at all, then interleaves
+    the calls' argument chunks so several calls in one turn arrive at once. A
+    preamble streams that text ahead of the fragments, the way a model that
+    talks before it calls does.
+    """
+
+    def __init__(self, script: List[tuple]):
+        super().__init__(id="fragmenting", name="fragmenting", provider="test")
+        self._script = list(script)
+        self._index = 0
+
+    def _next_turn(self) -> List[ModelResponse]:
+        assert self._index < len(self._script), (
+            f"the run asked for model turn {self._index + 1} of a {len(self._script)}-turn script"
+        )
+        turn = self._script[self._index]
+        self._index += 1
+        if turn[0] == "content":
+            reply = ModelResponse(content=turn[1], role="assistant")
+            reply.event = ModelResponseEvent.assistant_response.value
+            return [reply]
+
+        _, calls, chunk_size = turn[:3]
+        preamble = turn[3] if len(turn) > 3 else ""
+        deltas: List[ModelResponse] = []
+        if preamble:
+            deltas.append(ModelResponse(content=preamble, role="assistant"))
+        for position, (name, args, tool_call_id) in enumerate(calls):
+            deltas.append(_arg_fragment(position, "", tool_call_id=tool_call_id, tool_name=name))
+        chunked = [_chunked(json.dumps(args), chunk_size) for _, args, _ in calls]
+        for step in range(max(len(chunks) for chunks in chunked)):
+            for position, chunks in enumerate(chunked):
+                if step < len(chunks):
+                    deltas.append(_arg_fragment(position, chunks[step]))
+        return deltas
+
+    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+        yield from self._next_turn()
+
+    async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+        for delta in self._next_turn():
+            yield delta
+
+    def invoke(self, *args, **kwargs) -> ModelResponse:
+        raise AssertionError("this model exists to be streamed")
+
+    async def ainvoke(self, *args, **kwargs) -> ModelResponse:
+        raise AssertionError("this model exists to be streamed")
+
+    def _parse_provider_response(self, response: Any, **kwargs) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+    def parse_tool_calls(self, tool_calls_data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Reassemble the fragments by index, as OpenAI-compatible models do."""
+        calls: Dict[int, Dict[str, Any]] = {}
+        order: List[int] = []
+        for fragment in tool_calls_data:
+            index = fragment.get("index", 0)
+            if index not in calls:
+                calls[index] = {"id": None, "type": "function", "function": {"name": "", "arguments": ""}}
+                order.append(index)
+            entry = calls[index]
+            if fragment.get("id"):
+                entry["id"] = fragment["id"]
+            function = fragment.get("function") or {}
+            if function.get("name"):
+                entry["function"]["name"] = function["name"]
+            if function.get("arguments"):
+                entry["function"]["arguments"] += function["arguments"]
+        return [calls[index] for index in order]
+
+
+def _arg_fragment(
+    index: int,
+    arguments: str = "",
+    tool_call_id: Optional[str] = None,
+    tool_name: Optional[str] = None,
+) -> ModelResponse:
+    function: Dict[str, Any] = {"arguments": arguments}
+    if tool_name is not None:
+        function["name"] = tool_name
+    tool_call: Dict[str, Any] = {"index": index, "type": "function", "function": function}
+    if tool_call_id is not None:
+        tool_call["id"] = tool_call_id
+    return ModelResponse(role="assistant", tool_calls=[tool_call])
+
+
+def _chunked(text: str, size: int) -> List[str]:
+    return [text[position : position + size] for position in range(0, len(text), size)]
+
+
+@tool
+def save_line(line: str, run_context: Optional[RunContext] = None) -> str:
+    """Store one line of a document.
+
+    Args:
+        line: the line to store
+    """
+    session_state = run_context.session_state  # type: ignore[union-attr]
+    session_state["lines"] = session_state.get("lines", []) + [line]
+    return f"stored {len(session_state['lines'])} line(s)"
+
+
+@tool
+def save_title(title: str, run_context: Optional[RunContext] = None) -> str:
+    """Store the document title.
+
+    Args:
+        title: the title to store
+    """
+    run_context.session_state["title"] = title  # type: ignore[union-attr]
+    return f"titled {title}"
+
+
+def _fragmenting_client(script: List[tuple], tools: List[Any], tool_call_limit: Optional[int] = None):
+    agent = Agent(
+        name="fragmenting-agent",
+        model=_FragmentingModel(script),
+        tools=tools,
+        tool_call_limit=tool_call_limit,
+    )
+    agent_os = AgentOS(agents=[agent], interfaces=[AGUI(agent=agent)])
+    return TestClient(agent_os.get_app())
+
+
+def _tool_call_wire(events: List[Dict[str, Any]], tool_call_id: str) -> List[Dict[str, Any]]:
+    """Every event on the wire that names one tool call, in order."""
+    return [event for event in events if event.get("toolCallId") == tool_call_id]
+
+
+def _raw_passthroughs_of(events: List[Dict[str, Any]], agno_event: str) -> List[Dict[str, Any]]:
+    """Every RAW event carrying one Agno event straight through to the client.
+
+    A RAW event is what an Agno event with no handler becomes: the whole event
+    dict, for the client to make what it can of.
+    """
+    return [
+        event
+        for event in events
+        if event.get("type") == "RAW"
+        and isinstance(event.get("event"), dict)
+        and event["event"].get("event") == agno_event
+    ]
+
+
+def _results_for(events: List[Dict[str, Any]], tool_call_id: str) -> List[Any]:
+    """What the client was told each of one call's results was, decoded."""
+    return [
+        json.loads(event["content"])
+        for event in events
+        if event.get("type") == "TOOL_CALL_RESULT" and event.get("toolCallId") == tool_call_id
+    ]
+
+
+def _args_deltas(events: List[Dict[str, Any]], tool_call_id: str) -> List[str]:
+    return [
+        event["delta"]
+        for event in events
+        if event.get("type") == "TOOL_CALL_ARGS" and event.get("toolCallId") == tool_call_id
+    ]
+
+
+def _assert_the_client_accepts_the_tool_call_spans(events: List[Dict[str, Any]]) -> None:
+    """Replay the wire under the rules the AG-UI client's own verifier applies.
+
+    The client keeps one entry per tool call id, added by TOOL_CALL_START and
+    deleted by TOOL_CALL_END, and it throws rather than renders when a start
+    names an id that already has an entry, when arguments or an end name an id
+    that has none, or when a run finishes with an entry left. Deletion on end
+    is why the same id may open again afterwards: it is a second call, not a
+    second start of the one that closed.
+
+    A run that ends in error is a run that ended, so an entry left open at
+    RUN_ERROR is the same unclosed span as one left open at RUN_FINISHED: the
+    client throws for either.
+    """
+    open_calls: List[str] = []
+    for event in events:
+        kind = event.get("type")
+        tool_call_id = event.get("toolCallId")
+        if kind == "TOOL_CALL_START":
+            assert tool_call_id not in open_calls, f"a second TOOL_CALL_START for the open call {tool_call_id!r}"
+            open_calls.append(tool_call_id)
+        elif kind == "TOOL_CALL_ARGS":
+            assert tool_call_id in open_calls, f"TOOL_CALL_ARGS for {tool_call_id!r}, which is not open"
+        elif kind == "TOOL_CALL_END":
+            assert tool_call_id in open_calls, f"TOOL_CALL_END for {tool_call_id!r}, which is not open"
+            open_calls.remove(tool_call_id)
+        elif kind in ("RUN_FINISHED", "RUN_ERROR"):
+            assert not open_calls, f"{kind} left the calls {open_calls} open"
+
+
+class TestToolCallArgumentsReachTheClientAsTheyAreProduced:
+    """A client rendering a tool call while it is still running needs the
+    arguments in pieces, so one TOOL_CALL_ARGS per fragment is the point: a
+    single event carrying the finished blob is what the client used to get and
+    is what these tests exist to rule out.
+    """
+
+    def test_each_fragment_becomes_its_own_args_event_under_one_start(self):
+        line = "the sea is wide and the boat is small"
+        args = json.dumps({"line": line})
+        client = _fragmenting_client(
+            [("tools", [(save_line.name, {"line": line}, "call_line")], 5), ("content", "done")],
+            [save_line],
+        )
+
+        response = client.post("/agui", json=make_request_body("write", state={"lines": []}))
+        events = _events_of_completed_run(
+            response, ran=[save_line.name], reported="stored 1 line(s)", left_state={"lines": [line]}
+        )
+
+        deltas = _args_deltas(events, "call_line")
+        assert len(deltas) == len(_chunked(args, 5))
+        assert len(deltas) > 1, "the client got the arguments in one piece, so nothing was streamed"
+        assert "".join(deltas) == args
+        assert json.loads("".join(deltas)) == {"line": line}
+
+    def test_the_announcement_after_the_fragments_repeats_nothing(self):
+        line = "a second look at the same call"
+        args = json.dumps({"line": line})
+        client = _fragmenting_client(
+            [("tools", [(save_line.name, {"line": line}, "call_line")], 5), ("content", "done")],
+            [save_line],
+        )
+
+        response = client.post("/agui", json=make_request_body("write", state={"lines": []}))
+        events = _events_of_completed_run(
+            response, ran=[save_line.name], reported="stored 1 line(s)", left_state={"lines": [line]}
+        )
+
+        wire = [event["type"] for event in _tool_call_wire(events, "call_line")]
+        assert wire.count("TOOL_CALL_START") == 1, wire
+        assert wire.count("TOOL_CALL_END") == 1, wire
+        # Agno announces the finished call after the fragments; the whole
+        # argument string must not arrive again alongside them.
+        deltas = _args_deltas(events, "call_line")
+        assert len(deltas) > 1, "the arguments arrived in one piece, so the announcement carried them"
+        assert "".join(deltas) == args
+        assert args not in deltas, "the announcement resent the whole argument string"
+        # And the wire stays in protocol order: start, arguments, end.
+        assert wire[0] == "TOOL_CALL_START"
+        assert wire.index("TOOL_CALL_END") > max(
+            position for position, kind in enumerate(wire) if kind == "TOOL_CALL_ARGS"
+        )
+
+    def test_the_call_opens_from_its_first_fragment_not_from_the_announcement(self):
+        line = "opened early"
+        client = _fragmenting_client(
+            [("tools", [(save_line.name, {"line": line}, "call_line")], 4), ("content", "done")],
+            [save_line],
+        )
+
+        response = client.post("/agui", json=make_request_body("write", state={"lines": []}))
+        events = _events_of_completed_run(
+            response, ran=[save_line.name], reported="stored 1 line(s)", left_state={"lines": [line]}
+        )
+
+        start = next(event for event in events if event.get("type") == "TOOL_CALL_START")
+        assert start["toolCallName"] == save_line.name
+        # A start with no parent is a protocol violation, and the parent has to
+        # be a message the client has already been told about.
+        parent = start["parentMessageId"]
+        assert parent
+        # Unmapped, every fragment reached the client as a raw event it has no
+        # way to render, one per fragment.
+        raw = [event.get("event", {}).get("event") for event in events if event.get("type") == "RAW"]
+        assert "ToolCallArgsDelta" not in raw, raw
+        assert len(_args_deltas(events, "call_line")) > 1
+        opened = [
+            position
+            for position, event in enumerate(events)
+            if event.get("type") == "TEXT_MESSAGE_START" and event.get("messageId") == parent
         ]
+        assert opened and opened[0] < events.index(start)
+
+    def test_two_calls_in_one_turn_stay_apart_on_the_wire(self):
+        line = "the first of two"
+        title = "a longer title than the line, so it keeps streaming after the line runs out"
+        client = _fragmenting_client(
+            [
+                (
+                    "tools",
+                    [(save_line.name, {"line": line}, "call_line"), (save_title.name, {"title": title}, "call_title")],
+                    6,
+                ),
+                ("content", "done"),
+            ],
+            [save_line, save_title],
+        )
+
+        response = client.post("/agui", json=make_request_body("write", state={"lines": []}))
+        events = _events_of_completed_run(
+            response,
+            ran=[save_line.name, save_title.name],
+            left_state={"lines": [line], "title": title},
+        )
+
+        assert json.loads("".join(_args_deltas(events, "call_line"))) == {"line": line}
+        assert json.loads("".join(_args_deltas(events, "call_title"))) == {"title": title}
+        starts = {
+            event["toolCallId"]: event["toolCallName"] for event in events if event.get("type") == "TOOL_CALL_START"
+        }
+        assert starts == {"call_line": save_line.name, "call_title": save_title.name}
+        # Each call opens before any of its own arguments and closes after the
+        # last of them, whatever the other call was doing in between.
+        for tool_call_id in ("call_line", "call_title"):
+            wire = [event["type"] for event in _tool_call_wire(events, tool_call_id)]
+            assert wire[0] == "TOOL_CALL_START", wire
+            assert wire.count("TOOL_CALL_START") == 1, wire
+            assert wire.count("TOOL_CALL_ARGS") > 1, wire
+            assert wire.index("TOOL_CALL_END") > max(
+                position for position, kind in enumerate(wire) if kind == "TOOL_CALL_ARGS"
+            ), wire
+
+    def test_a_call_whose_arguments_never_streamed_still_carries_them_whole(self, agent_client):
+        """A provider that hands the run loop no argument text leaves the
+        announcement as the only thing that can carry the arguments, and it
+        still carries all of them in one event, exactly as before."""
+        client, agent = agent_client
+        tool_mock = MagicMock()
+        tool_mock.tool_call_id = "call_unstreamed"
+        tool_mock.tool_name = "save_line"
+        tool_mock.tool_args = {"line": "never fragmented"}
+        tool_mock.result = "stored"
+
+        async def mock_stream() -> AsyncIterator[RunOutputEvent]:
+            yield ToolCallStartedEvent(content="", tool=tool_mock)
+            yield ToolCallCompletedEvent(content="", tool=tool_mock)
+            yield RunCompletedEvent(content="")
+
+        with patch.object(agent, "arun") as mock_arun:
+            mock_arun.return_value = mock_stream()
+            response = client.post("/agui", json=make_request_body("write"))
+
+        events = parse_sse_events(response.text)
+        wire = [event["type"] for event in _tool_call_wire(events, "call_unstreamed")]
+        assert wire.count("TOOL_CALL_START") == 1, wire
+        assert _args_deltas(events, "call_unstreamed") == [json.dumps({"line": "never fragmented"})]
+
+    def test_a_provider_that_does_not_fragment_sends_the_arguments_once(self):
+        """A provider that hands over a finished call rather than fragments of
+        one leaves a single fragment carrying the whole argument string, and
+        the client gets a single TOOL_CALL_ARGS, exactly as before."""
+        client = _real_run_client(mutates=True)
+
+        response = client.post("/agui", json=make_request_body("bump", state={"counter": 0}))
+        events = _events_of_completed_run(
+            response, ran=[bump_counter.name], reported="counter is now 1", left_state={"counter": 1}
+        )
+
+        wire = [event["type"] for event in _tool_call_wire(events, "tc_1")]
+        assert wire.count("TOOL_CALL_START") == 1, wire
+        assert _args_deltas(events, "tc_1") == ["{}"]
+
+    def test_fragments_arriving_under_an_open_message_parent_to_it(self):
+        """The fragments arrive earlier than the announcement used to, so what
+        they close and parent to is whatever text message is open at that
+        moment, not a fresh empty one."""
+        line = "after a word of warning"
+        client = _fragmenting_client(
+            [
+                ("tools", [(save_line.name, {"line": line}, "call_line")], 5, "Let me write that down. "),
+                ("content", "done"),
+            ],
+            [save_line],
+        )
+
+        response = client.post("/agui", json=make_request_body("write", state={"lines": []}))
+        events = _events_of_completed_run(
+            response, ran=[save_line.name], reported="stored 1 line(s)", left_state={"lines": [line]}
+        )
+
+        types = get_event_types(events)
+        start = next(event for event in events if event.get("type") == "TOOL_CALL_START")
+        spoken = next(
+            event
+            for event in events
+            if event.get("type") == "TEXT_MESSAGE_CONTENT" and "Let me write that down." in event["delta"]
+        )
+        assert start["parentMessageId"] == spoken["messageId"], (
+            "the call was parented to a message the preamble was not spoken in"
+        )
+        # That message is closed before the call opens, and no empty stand-in
+        # was minted alongside it.
+        ended = [
+            position
+            for position, event in enumerate(events)
+            if event.get("type") == "TEXT_MESSAGE_END" and event.get("messageId") == spoken["messageId"]
+        ]
+        assert ended and ended[0] < events.index(start), types
+        opened = [event for event in events if event.get("type") == "TEXT_MESSAGE_START"]
+        assert [event["messageId"] for event in opened].count(spoken["messageId"]) == 1
+        assert len(opened) == 2, [event["messageId"] for event in opened]
+        assert len(_args_deltas(events, "call_line")) > 1
+
+    def test_a_paused_call_whose_arguments_streamed_is_not_rendered_twice(self, agent_client):
+        """A client tool pauses the run, and the terminal handler renders the
+        paused calls for the frontend to execute. A call the fragments already
+        opened, carried and closed must not be rendered again there."""
+        client, agent = agent_client
+        paused_tool = ToolExecution(
+            tool_call_id="call_client",
+            tool_name="generate_haiku",
+            tool_args={"line": "streamed"},
+            external_execution_required=True,
+        )
+
+        async def mock_stream() -> AsyncIterator[RunOutputEvent]:
+            yield ToolCallArgsDeltaEvent(
+                tool_call_id="call_client", tool_name="generate_haiku", tool_args_delta='{"line":'
+            )
+            yield ToolCallArgsDeltaEvent(
+                tool_call_id="call_client", tool_name="generate_haiku", tool_args_delta='"streamed"}'
+            )
+            yield RunPausedEvent(tools=[paused_tool])
+
+        with patch.object(agent, "arun") as mock_arun:
+            mock_arun.return_value = mock_stream()
+            response = client.post("/agui", json=make_request_body("write"))
+
+        events = parse_sse_events(response.text)
+        wire = [event["type"] for event in _tool_call_wire(events, "call_client")]
+        assert wire.count("TOOL_CALL_START") == 1, wire
+        assert wire.count("TOOL_CALL_END") == 1, wire
+        assert _args_deltas(events, "call_client") == ['{"line":', '"streamed"}']
+        # And no stand-in parent message was minted for a call that never
+        # needed rendering.
+        assert [event["type"] for event in events].count("TEXT_MESSAGE_START") == 1
+
+    def test_a_paused_call_that_never_streamed_is_still_rendered(self, agent_client):
+        """The same terminal handler, for a call with no fragments: it opens
+        the call, carries the whole argument string and closes it, as before."""
+        client, agent = agent_client
+        paused_tool = ToolExecution(
+            tool_call_id="call_client",
+            tool_name="generate_haiku",
+            tool_args={"line": "unstreamed"},
+            external_execution_required=True,
+        )
+
+        async def mock_stream() -> AsyncIterator[RunOutputEvent]:
+            yield RunPausedEvent(tools=[paused_tool])
+
+        with patch.object(agent, "arun") as mock_arun:
+            mock_arun.return_value = mock_stream()
+            response = client.post("/agui", json=make_request_body("write"))
+
+        events = parse_sse_events(response.text)
+        wire = [event["type"] for event in _tool_call_wire(events, "call_client")]
+        assert wire == ["TOOL_CALL_START", "TOOL_CALL_ARGS", "TOOL_CALL_END"], wire
+        assert _args_deltas(events, "call_client") == [json.dumps({"line": "unstreamed"})]
+
+
+# =============================================================================
+# One call id, one call on the wire
+#
+# Three things can be the first sight of a tool call: an argument fragment,
+# Agno's announcement of the finished call, and the terminal handler rendering
+# a paused run's pending calls. Whichever sees a call first is the one that
+# opens it, and the others have to recognise it as open, or already closed, and
+# stay quiet. A client cannot repair any of this: a second start for an open
+# call, or arguments for one that has ended, is where its verifier throws and
+# takes the rest of the run with it.
+# =============================================================================
+
+
+def _announced(tool_call_id: str, tool_name: str, tool_args: Dict[str, Any], result: str = "stored") -> Any:
+    """Agno's record of a finished call, as its announcement carries it."""
+    tool = MagicMock()
+    tool.tool_call_id = tool_call_id
+    tool.tool_name = tool_name
+    tool.tool_args = tool_args
+    tool.result = result
+    return tool
+
+
+class TestOneCallIdOpensOneCallWhicheverOpenerSeesItFirst:
+    def test_a_fragment_after_the_announcement_opens_no_second_call(self, agent_client):
+        """The announcement got there first and carried the whole argument
+        string, so a fragment behind it has nothing to add: opening the call
+        again would give the client two calls under one id, and passing the
+        fragment on would append to arguments that are already complete."""
+        client, agent = agent_client
+        args = {"line": "announced first"}
+        tool = _announced("call_late_fragment", "save_line", args)
+
+        async def mock_stream() -> AsyncIterator[RunOutputEvent]:
+            yield ToolCallStartedEvent(content="", tool=tool)
+            yield ToolCallArgsDeltaEvent(
+                tool_call_id="call_late_fragment", tool_name="save_line", tool_args_delta='{"line":'
+            )
+            yield ToolCallCompletedEvent(content="", tool=tool)
+            yield RunCompletedEvent(content="")
+
+        with patch.object(agent, "arun") as mock_arun:
+            mock_arun.return_value = mock_stream()
+            response = client.post("/agui", json=make_request_body("write"))
+
+        events = parse_sse_events(response.text)
+        _assert_the_client_accepts_the_tool_call_spans(events)
+        wire = [event["type"] for event in _tool_call_wire(events, "call_late_fragment")]
+        assert wire == ["TOOL_CALL_START", "TOOL_CALL_ARGS", "TOOL_CALL_END", "TOOL_CALL_RESULT"], wire
+        assert _args_deltas(events, "call_late_fragment") == [json.dumps(args)]
+
+    def test_an_announcement_behind_an_open_call_leaves_dropped_fragments_dropped(self, agent_client):
+        """A call some of whose fragments never went out, which is the case the
+        run warns about when it can place no call for a fragment or the
+        provider wrote the arguments as a structure. TOOL_CALL_ARGS only ever
+        appends, so the announcement behind an open call cannot carry the whole
+        string without doubling what the client already holds. What the client
+        is left with is the fragments that did go out, and nothing more."""
+        client, agent = agent_client
+        streamed = 'piece never went out"}'
+        tool = _announced("call_short", "save_line", {"line": "the opening piece never went out"})
+
+        async def mock_stream() -> AsyncIterator[RunOutputEvent]:
+            # The opening fragment is the one that never reached the client.
+            yield ToolCallArgsDeltaEvent(tool_call_id="call_short", tool_name="save_line", tool_args_delta=streamed)
+            yield ToolCallStartedEvent(content="", tool=tool)
+            yield ToolCallCompletedEvent(content="", tool=tool)
+            yield RunCompletedEvent(content="")
+
+        with patch.object(agent, "arun") as mock_arun:
+            mock_arun.return_value = mock_stream()
+            response = client.post("/agui", json=make_request_body("write"))
+
+        events = parse_sse_events(response.text)
+        _assert_the_client_accepts_the_tool_call_spans(events)
+        wire = [event["type"] for event in _tool_call_wire(events, "call_short")]
+        assert wire == ["TOOL_CALL_START", "TOOL_CALL_ARGS", "TOOL_CALL_END", "TOOL_CALL_RESULT"], wire
+        assert "".join(_args_deltas(events, "call_short")) == streamed
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(streamed)
+
+    def test_an_id_reused_after_its_call_ended_opens_a_new_call(self, agent_client):
+        """A provider is free to hand the same call id to a later call in the
+        same run, and by then the first call has ended. The fragments of the
+        second one open a call of their own: adding them to the one that closed
+        is arguments after an end, which the client refuses."""
+        client, agent = agent_client
+        first = _announced("call_reused", "save_line", {"line": "one"}, result="stored 1")
+        second = _announced("call_reused", "save_line", {"line": "two"}, result="stored 2")
+
+        async def mock_stream() -> AsyncIterator[RunOutputEvent]:
+            yield ToolCallArgsDeltaEvent(tool_call_id="call_reused", tool_name="save_line", tool_args_delta='{"line":')
+            yield ToolCallArgsDeltaEvent(tool_call_id="call_reused", tool_name="save_line", tool_args_delta='"one"}')
+            yield ToolCallCompletedEvent(content="", tool=first)
+            yield ToolCallArgsDeltaEvent(tool_call_id="call_reused", tool_name="save_line", tool_args_delta='{"line":')
+            yield ToolCallArgsDeltaEvent(tool_call_id="call_reused", tool_name="save_line", tool_args_delta='"two"}')
+            yield ToolCallCompletedEvent(content="", tool=second)
+            yield RunCompletedEvent(content="")
+
+        with patch.object(agent, "arun") as mock_arun:
+            mock_arun.return_value = mock_stream()
+            response = client.post("/agui", json=make_request_body("write"))
+
+        events = parse_sse_events(response.text)
+        _assert_the_client_accepts_the_tool_call_spans(events)
+        wire = [event["type"] for event in _tool_call_wire(events, "call_reused")]
+        assert wire == [
+            "TOOL_CALL_START",
+            "TOOL_CALL_ARGS",
+            "TOOL_CALL_ARGS",
+            "TOOL_CALL_END",
+            "TOOL_CALL_RESULT",
+            "TOOL_CALL_START",
+            "TOOL_CALL_ARGS",
+            "TOOL_CALL_ARGS",
+            "TOOL_CALL_END",
+            "TOOL_CALL_RESULT",
+        ], wire
+        assert _args_deltas(events, "call_reused") == ['{"line":', '"one"}', '{"line":', '"two"}']
+        results = [json.loads(event["content"]) for event in events if event.get("type") == "TOOL_CALL_RESULT"]
+        assert results == ["stored 1", "stored 2"], results
+
+    def test_a_first_fragment_carrying_no_arguments_opens_nothing(self, agent_client):
+        """A provider names a call on a fragment that carries no argument text
+        at all. There is nothing to say about the call yet, so nothing goes out
+        for it, and the announcement behind it is still the opener that carries
+        the arguments. Opening on that empty fragment instead leaves the client
+        a call that starts and ends with no arguments between."""
+        client, agent = agent_client
+        args = {"line": "arguments came later"}
+        tool = _announced("call_empty_first", "save_line", args)
+
+        async def mock_stream() -> AsyncIterator[RunOutputEvent]:
+            yield ToolCallArgsDeltaEvent(tool_call_id="call_empty_first", tool_name="save_line", tool_args_delta="")
+            yield ToolCallStartedEvent(content="", tool=tool)
+            yield ToolCallCompletedEvent(content="", tool=tool)
+            yield RunCompletedEvent(content="")
+
+        with patch.object(agent, "arun") as mock_arun:
+            mock_arun.return_value = mock_stream()
+            response = client.post("/agui", json=make_request_body("write"))
+
+        events = parse_sse_events(response.text)
+        _assert_the_client_accepts_the_tool_call_spans(events)
+        wire = [event["type"] for event in _tool_call_wire(events, "call_empty_first")]
+        assert wire == ["TOOL_CALL_START", "TOOL_CALL_ARGS", "TOOL_CALL_END", "TOOL_CALL_RESULT"], wire
+        assert _args_deltas(events, "call_empty_first") == [json.dumps(args)]
+
+    def test_a_call_only_an_empty_fragment_ever_named_reaches_the_client_at_all(self, agent_client):
+        """Nothing else ever mentions the call, so the run has said nothing
+        about it and neither does the wire, rather than an empty pair of
+        brackets around no arguments."""
+        client, agent = agent_client
+
+        async def mock_stream() -> AsyncIterator[RunOutputEvent]:
+            yield ToolCallArgsDeltaEvent(tool_call_id="call_named_only", tool_name="save_line", tool_args_delta="")
+            yield RunCompletedEvent(content="")
+
+        with patch.object(agent, "arun") as mock_arun:
+            mock_arun.return_value = mock_stream()
+            response = client.post("/agui", json=make_request_body("write"))
+
+        events = parse_sse_events(response.text)
+        _assert_the_client_accepts_the_tool_call_spans(events)
+        assert "RUN_FINISHED" in get_event_types(events), get_event_types(events)
+        assert _tool_call_wire(events, "call_named_only") == []
+
+    def test_a_call_only_the_announcement_ever_mentions_is_carried_as_before(self, agent_client):
+        """The case with no fragments in it at all: the announcement opens the
+        call and carries every argument in one event, and the completion closes
+        it. None of the reconciling above shows up here."""
+        client, agent = agent_client
+        args = {"line": "no fragments anywhere"}
+        tool = _announced("call_announced_only", "save_line", args)
+
+        async def mock_stream() -> AsyncIterator[RunOutputEvent]:
+            yield ToolCallStartedEvent(content="", tool=tool)
+            yield ToolCallCompletedEvent(content="", tool=tool)
+            yield RunCompletedEvent(content="")
+
+        with patch.object(agent, "arun") as mock_arun:
+            mock_arun.return_value = mock_stream()
+            response = client.post("/agui", json=make_request_body("write"))
+
+        events = parse_sse_events(response.text)
+        _assert_the_client_accepts_the_tool_call_spans(events)
+        wire = [event["type"] for event in _tool_call_wire(events, "call_announced_only")]
+        assert wire == ["TOOL_CALL_START", "TOOL_CALL_ARGS", "TOOL_CALL_END", "TOOL_CALL_RESULT"], wire
+        assert _args_deltas(events, "call_announced_only") == [json.dumps(args)]
+
+    def test_a_completion_for_a_call_nothing_opened_ends_nothing(self, agent_client):
+        """A run configured to skip the announcement leaves a completion as the
+        only sight of a call whose arguments never streamed. There is no open
+        call to close, and an end for one the client does not hold open is
+        where its verifier stops reading, so the completion passes in silence
+        and the rest of the run still reaches the client."""
+        client, agent = agent_client
+        tool = _announced("call_never_opened", "save_line", {"line": "unannounced"})
+
+        async def mock_stream() -> AsyncIterator[RunOutputEvent]:
+            yield ToolCallCompletedEvent(content="", tool=tool)
+            yield RunContentEvent(content="answered anyway")
+            yield RunCompletedEvent(content="")
+
+        with patch.object(agent, "arun") as mock_arun:
+            mock_arun.return_value = mock_stream()
+            response = client.post("/agui", json=make_request_body("write"))
+
+        events = parse_sse_events(response.text)
+        _assert_the_client_accepts_the_tool_call_spans(events)
+        assert _tool_call_wire(events, "call_never_opened") == []
+        spoken = [event["delta"] for event in events if event.get("type") == "TEXT_MESSAGE_CONTENT"]
+        assert spoken == ["answered anyway"], spoken
+        assert "RUN_FINISHED" in get_event_types(events)
+
+    def test_a_paused_call_the_announcement_opened_is_not_rendered_twice(self, agent_client):
+        """The terminal handler renders a paused run's pending calls so the
+        frontend can execute them. A call already opened, carried and closed on
+        the wire is not pending anything the client has not seen, whichever
+        opener put it there."""
+        client, agent = agent_client
+        args = {"line": "announced then paused"}
+        tool = _announced("call_paused", "generate_haiku", args)
+        paused_tool = ToolExecution(
+            tool_call_id="call_paused",
+            tool_name="generate_haiku",
+            tool_args=args,
+            external_execution_required=True,
+        )
+
+        async def mock_stream() -> AsyncIterator[RunOutputEvent]:
+            yield ToolCallStartedEvent(content="", tool=tool)
+            yield RunPausedEvent(tools=[paused_tool])
+
+        with patch.object(agent, "arun") as mock_arun:
+            mock_arun.return_value = mock_stream()
+            response = client.post("/agui", json=make_request_body("write"))
+
+        events = parse_sse_events(response.text)
+        _assert_the_client_accepts_the_tool_call_spans(events)
+        wire = [event["type"] for event in _tool_call_wire(events, "call_paused")]
+        assert wire == ["TOOL_CALL_START", "TOOL_CALL_ARGS", "TOOL_CALL_END"], wire
+        assert _args_deltas(events, "call_paused") == [json.dumps(args)]
+
+
+class TestTheFragmentsAreTheClientsCopyOfTheArguments:
+    """What the announcement of a finished call does about the fragments.
+
+    Nothing. A client's copy of a call's arguments is the text the provider
+    streamed, which is what a streaming client reads them out of, and the
+    announcement neither repeats that text nor sits in judgement on it: the
+    arguments the run ends up holding differ from the text a healthy provider
+    sent in more ways than any comparison can allow for, from a parameter the
+    run defaulted to a literal it read as a Python value, and a client told
+    such a call failed cannot act on it at all. What a call did is what its
+    result event says it did.
+    """
+
+    def _streamed_then_announced(self, agent_client, fragments: List[str], tool_args: Any):
+        client, agent = agent_client
+        tool = _announced("call_checked", "save_line", tool_args)
+
+        async def mock_stream() -> AsyncIterator[RunOutputEvent]:
+            for fragment in fragments:
+                yield ToolCallArgsDeltaEvent(
+                    tool_call_id="call_checked", tool_name="save_line", tool_args_delta=fragment
+                )
+            yield ToolCallStartedEvent(content="", tool=tool)
+            yield ToolCallCompletedEvent(content="", tool=tool)
+            yield RunCompletedEvent(content="")
+
+        with patch.object(agent, "arun") as mock_arun:
+            mock_arun.return_value = mock_stream()
+            response = client.post("/agui", json=make_request_body("write"))
+        return parse_sse_events(response.text)
+
+    def test_arguments_the_provider_spelled_differently_are_left_alone(self, agent_client):
+        """The check is on the JSON the client parses, not on its characters.
+
+        A provider writes its argument JSON with whatever spacing it likes,
+        none of which the client can see, so the fragments here spell the same
+        object Agno's own encoder would spell with spaces after its colons.
+        """
+        args = {"line": "spelled tight"}
+        fragments = ['{"line":', '"spelled tight"}']
+        assert "".join(fragments) != json.dumps(args), "the fixture no longer differs from the canonical spelling"
+
+        events = self._streamed_then_announced(agent_client, fragments, args)
+
+        _assert_the_client_accepts_the_tool_call_spans(events)
+        # Nothing was added: the fragments are all the arguments the client got,
+        # and the call ran its ordinary course to a result.
+        assert _args_deltas(events, "call_checked") == fragments
+        wire = [event["type"] for event in _tool_call_wire(events, "call_checked")]
+        assert wire == ["TOOL_CALL_START", "TOOL_CALL_ARGS", "TOOL_CALL_ARGS", "TOOL_CALL_END", "TOOL_CALL_RESULT"]
+        assert _results_for(events, "call_checked") == ["stored"]
+
+    def test_a_provider_that_offers_its_arguments_twice_still_carries_the_calls_result(
+        self, agent_client, warnings_logged
+    ):
+        """A provider stream that restarts offers argument text a second time.
+
+        TOOL_CALL_ARGS appends and no AG-UI event replaces, so the client's
+        copy is the text twice over and nothing can put it right. What the call
+        did is still reported: the result is the run's own, and a client told
+        the truth about the result can act on it, which one told the call
+        failed cannot.
+        """
+        args = {"line": "written once"}
+        whole = json.dumps(args)
+        events = self._streamed_then_announced(agent_client, [whole, whole], args)
+
+        _assert_the_client_accepts_the_tool_call_spans(events)
+        assert _args_deltas(events, "call_checked") == [whole, whole]
+        wire = [event["type"] for event in _tool_call_wire(events, "call_checked")]
+        assert wire == ["TOOL_CALL_START", "TOOL_CALL_ARGS", "TOOL_CALL_ARGS", "TOOL_CALL_END", "TOOL_CALL_RESULT"]
+        assert _results_for(events, "call_checked") == ["stored"]
+        assert wire.count("TOOL_CALL_END") == 1, wire
+        warnings = [record.getMessage() for record in warnings_logged if record.levelno >= logging.WARNING]
+        assert warnings == [], warnings
+
+    @pytest.mark.parametrize(
+        ("fragment", "tool_args"),
+        [
+            ('{"line": "hello"}', {"line": "hello"}),
+            ('{"flag": "true"}', {"flag": True}),
+            ('{"flag": " FALSE "}', {"flag": False}),
+            ('{"flag": "none"}', {"flag": None}),
+            ('{"flag": "yes"}', {"flag": True}),
+            ('{"count": 1}', {"count": True}),
+            ("[]", None),
+            ('{"line": "hello"}', {"line": "hello", "run_context": "<injected>"}),
+        ],
+        ids=[
+            "arguments the run holds as they were sent",
+            "a literal the run read as a Python value",
+            "the same literal in another casing",
+            "a literal the run read as nothing at all",
+            "a string the run coerced to something else",
+            "a whole number where the run holds a boolean",
+            "a call with no parameters the provider sent as an empty list",
+            "a parameter the run filled in for itself",
+        ],
+    )
+    def test_arguments_the_run_holds_differently_still_reach_the_client_as_the_calls_own(
+        self, agent_client, fragment, tool_args
+    ):
+        """Every one of these is a healthy call, and each leaves the run
+        holding arguments the fragments never spelled: Agno reads the strings
+        "true", "false" and "none" out of a provider's top-level arguments as
+        Python values, a provider names a no-parameter call with whatever it
+        likes, and the run fills parameters in for itself. The client is left
+        the text it was streamed and the call runs its ordinary course to its
+        own result.
+        """
+        events = self._streamed_then_announced(agent_client, [fragment], tool_args)
+
+        _assert_the_client_accepts_the_tool_call_spans(events)
+        assert _args_deltas(events, "call_checked") == [fragment]
+        wire = [event["type"] for event in _tool_call_wire(events, "call_checked")]
+        assert wire == ["TOOL_CALL_START", "TOOL_CALL_ARGS", "TOOL_CALL_END", "TOOL_CALL_RESULT"], wire
+        assert _results_for(events, "call_checked") == ["stored"]
+
+    def test_a_paused_call_whose_fragments_left_a_prefix_is_still_closed_once(self, agent_client):
+        """A paused call is never started and never completed, and the terminal
+        handler renders only the calls the stream never carried, so closing the
+        spans is all that is left to do for one the fragments opened. The
+        client is left holding the prefix that was streamed, which is as much
+        of the arguments as the provider ever sent, under a call it holds
+        closed rather than pending."""
+        client, agent = agent_client
+        paused_tool = ToolExecution(
+            tool_call_id="call_flight",
+            tool_name="book_flight",
+            tool_args={"dest": "Oslo"},
+            requires_confirmation=True,
+        )
+
+        async def mock_stream() -> AsyncIterator[RunOutputEvent]:
+            yield ToolCallArgsDeltaEvent(
+                tool_call_id="call_flight", tool_name="book_flight", tool_args_delta='{"dest": "Osl'
+            )
+            yield RunPausedEvent(tools=[paused_tool])
+
+        with patch.object(agent, "arun") as mock_arun:
+            mock_arun.return_value = mock_stream()
+            response = client.post("/agui", json=make_request_body("fly"))
+
+        events = parse_sse_events(response.text)
+        _assert_the_client_accepts_the_tool_call_spans(events)
+        wire = [event["type"] for event in _tool_call_wire(events, "call_flight")]
+        assert wire == ["TOOL_CALL_START", "TOOL_CALL_ARGS", "TOOL_CALL_END"], wire
+        assert _args_deltas(events, "call_flight") == ['{"dest": "Osl']
+        # And it is not rendered a second time: a second call under the same id
+        # is where a client's verifier stops reading the run.
+        assert wire.count("TOOL_CALL_START") == 1, wire
+
+    def test_a_paused_call_whose_fragments_carried_its_arguments_is_left_alone(self, agent_client):
+        """The same path for a call whose fragments did reassemble: nothing to
+        report, nothing to close early, and no second render."""
+        paused_tool = ToolExecution(
+            tool_call_id="call_flight",
+            tool_name="book_flight",
+            tool_args={"dest": "Oslo"},
+            requires_confirmation=True,
+        )
+        client, agent = agent_client
+
+        async def mock_stream() -> AsyncIterator[RunOutputEvent]:
+            yield ToolCallArgsDeltaEvent(
+                tool_call_id="call_flight", tool_name="book_flight", tool_args_delta='{"dest": '
+            )
+            yield ToolCallArgsDeltaEvent(tool_call_id="call_flight", tool_args_delta='"Oslo"}')
+            yield RunPausedEvent(tools=[paused_tool])
+
+        with patch.object(agent, "arun") as mock_arun:
+            mock_arun.return_value = mock_stream()
+            response = client.post("/agui", json=make_request_body("fly"))
+
+        events = parse_sse_events(response.text)
+        _assert_the_client_accepts_the_tool_call_spans(events)
+        wire = [event["type"] for event in _tool_call_wire(events, "call_flight")]
+        assert wire == ["TOOL_CALL_START", "TOOL_CALL_ARGS", "TOOL_CALL_ARGS", "TOOL_CALL_END"], wire
+        assert json.loads("".join(_args_deltas(events, "call_flight"))) == {"dest": "Oslo"}
+
+    def test_a_fragment_naming_no_tool_leaves_the_call_to_the_announcement(self):
+        """A call is opened once and under one name, and the name is what a
+        client renders it as and what says whether the arguments are the state
+        tool's: a call opened without one is nameless for the rest of the
+        stream and its state updates are never read. Waiting costs nothing,
+        because the announcement carries the whole argument string and
+        appending to nothing leaves the client holding exactly it."""
+        state = StreamState(thread_id="thread", run_id="run")
+        args = {"line": "never named"}
+
+        streamed = agui_handlers.on_tool_call_args_delta(
+            ToolCallArgsDeltaEvent(tool_call_id="call_unnamed", tool_args_delta='{"line": '), state
+        )
+
+        assert streamed == [], streamed
+        assert not state.tool_call_open("call_unnamed")
+
+        announced = agui_handlers.on_tool_call_started(
+            ToolCallStartedEvent(content="", tool=_announced("call_unnamed", "save_line", args)), state
+        )
+
+        started = [event for event in announced if event.type == EventType.TOOL_CALL_START]
+        assert [event.tool_call_name for event in started] == ["save_line"], announced
+        assert announced[-1].type == EventType.TOOL_CALL_ARGS, announced
+        assert announced[-1].delta == json.dumps(args), announced[-1]  # type: ignore[attr-defined]
+        assert state.tool_call_open("call_unnamed")
+
+
+class TestACallThatFailedIsClosedRatherThanLeftPending:
+    """A tool call the run refuses, or one that fails, is reported by an event
+    of its own, and a client holds the call open until something ends it. Left
+    unhandled that event reaches the client as an opaque passthrough carrying
+    no result, and the call renders as pending until the run ends.
+    """
+
+    def test_a_call_refused_after_its_arguments_streamed_closes_with_what_agno_said(self):
+        """A run declining a call it has already shown the client, here by the
+        tool call limit, never starts or completes it, so the failure is the
+        only event that can close it."""
+        line = "the first of two"
+        refused = "the second of two"
+        client = _fragmenting_client(
+            [
+                (
+                    "tools",
+                    [(save_line.name, {"line": line}, "call_a"), (save_line.name, {"line": refused}, "call_b")],
+                    5,
+                ),
+                ("content", "done"),
+            ],
+            [save_line],
+            tool_call_limit=1,
+        )
+
+        response = client.post("/agui", json=make_request_body("write", state={"lines": []}))
+        events = _events_of_completed_run(
+            response,
+            ran=[save_line.name, save_line.name],
+            left_state={"lines": [line]},
+        )
+        _assert_the_client_accepts_the_tool_call_spans(events)
+
+        # The whole argument string the client was shown, then a close of its
+        # own carrying Agno's own account of the refusal.
+        assert json.loads("".join(_args_deltas(events, "call_b"))) == {"line": refused}
+        wire = [event["type"] for event in _tool_call_wire(events, "call_b")]
+        assert wire[-2:] == ["TOOL_CALL_END", "TOOL_CALL_RESULT"], wire
+        assert wire.count("TOOL_CALL_END") == 1, wire
+        assert _results_for(events, "call_b") == [REFUSED_TOOL_CALL_ERROR]
+        assert _raw_passthroughs_of(events, RunEvent.tool_call_error.value) == []
+
+        # Closed where it was refused rather than at the end of the run, so
+        # nothing the run says afterwards renders under a pending call.
+        closed = next(
+            position
+            for position, event in enumerate(events)
+            if event.get("type") == "TOOL_CALL_END" and event.get("toolCallId") == "call_b"
+        )
+        spoke_again = next(
+            position for position, event in enumerate(events) if event.get("type") == "TEXT_MESSAGE_CONTENT"
+        )
+        assert events[spoke_again]["delta"] == "done"
+        assert closed < spoke_again, get_event_types(events)
+
+    def test_an_error_on_an_open_call_closes_it_with_what_went_wrong(self, agent_client):
+        """A call still open when its failure arrives is closed by it, and the
+        client is told what the failure said."""
+        client, agent = agent_client
+        tool = ToolExecution(tool_call_id="call_open", tool_name="save_line", tool_args={"line": "written"})
+
+        async def mock_stream() -> AsyncIterator[RunOutputEvent]:
+            yield ToolCallStartedEvent(content="", tool=tool)
+            yield ToolCallErrorEvent(tool=tool, error="the tool broke")
+            yield RunCompletedEvent(content="")
+
+        with patch.object(agent, "arun") as mock_arun:
+            mock_arun.return_value = mock_stream()
+            response = client.post("/agui", json=make_request_body("write"))
+
+        events = parse_sse_events(response.text)
+        _assert_the_client_accepts_the_tool_call_spans(events)
+        wire = [event["type"] for event in _tool_call_wire(events, "call_open")]
+        assert wire == ["TOOL_CALL_START", "TOOL_CALL_ARGS", "TOOL_CALL_END", "TOOL_CALL_RESULT"], wire
+        assert _results_for(events, "call_open") == ["the tool broke"]
+        assert _raw_passthroughs_of(events, RunEvent.tool_call_error.value) == []
+
+    def test_an_error_for_a_call_that_was_never_opened_says_nothing(self, agent_client):
+        """Nothing is open to close, and an end for a call the client does not
+        hold open is where its verifier stops reading the run."""
+        client, agent = agent_client
+        tool = ToolExecution(tool_call_id="call_ghost", tool_name="save_line", tool_args={"line": "never shown"})
+
+        async def mock_stream() -> AsyncIterator[RunOutputEvent]:
+            yield ToolCallErrorEvent(tool=tool, error="the tool broke")
+            yield RunContentEvent(content="answered anyway")
+            yield RunCompletedEvent(content="")
+
+        with patch.object(agent, "arun") as mock_arun:
+            mock_arun.return_value = mock_stream()
+            response = client.post("/agui", json=make_request_body("write"))
+
+        events = parse_sse_events(response.text)
+        _assert_the_client_accepts_the_tool_call_spans(events)
+        assert _tool_call_wire(events, "call_ghost") == []
+        assert _raw_passthroughs_of(events, RunEvent.tool_call_error.value) == []
+        spoken = [event["delta"] for event in events if event.get("type") == "TEXT_MESSAGE_CONTENT"]
+        assert spoken == ["answered anyway"], spoken
+        assert "RUN_FINISHED" in get_event_types(events)
+
+    def test_a_failure_the_completion_already_closed_is_carried_once(self, agent_client):
+        """An ordinary tool failure is announced as a completion first, which
+        closes the call and carries the same text as its result, so the failure
+        behind it has nothing left to add."""
+        client, agent = agent_client
+        tool = ToolExecution(
+            tool_call_id="call_broke",
+            tool_name="save_line",
+            tool_args={"line": "written"},
+            result="the tool broke",
+            tool_call_error=True,
+        )
+
+        async def mock_stream() -> AsyncIterator[RunOutputEvent]:
+            yield ToolCallStartedEvent(content="", tool=tool)
+            yield ToolCallCompletedEvent(content="", tool=tool)
+            yield ToolCallErrorEvent(tool=tool, error="the tool broke")
+            yield RunCompletedEvent(content="")
+
+        with patch.object(agent, "arun") as mock_arun:
+            mock_arun.return_value = mock_stream()
+            response = client.post("/agui", json=make_request_body("write"))
+
+        events = parse_sse_events(response.text)
+        _assert_the_client_accepts_the_tool_call_spans(events)
+        wire = [event["type"] for event in _tool_call_wire(events, "call_broke")]
+        assert wire == ["TOOL_CALL_START", "TOOL_CALL_ARGS", "TOOL_CALL_END", "TOOL_CALL_RESULT"], wire
+        assert _results_for(events, "call_broke") == ["the tool broke"]
+        assert _raw_passthroughs_of(events, RunEvent.tool_call_error.value) == []
+
+    def test_a_run_that_fails_mid_call_leaves_no_call_open_at_the_error(self, agent_client):
+        """A client keeps one entry per open call and throws when a run ends
+        with one left, whichever terminal event ended it. A run that fails
+        while a call's arguments are still streaming is such a run."""
+        client, agent = agent_client
+
+        async def mock_stream() -> AsyncIterator[RunOutputEvent]:
+            yield ToolCallArgsDeltaEvent(
+                tool_call_id="call_cut", tool_name="save_line", tool_args_delta='{"line": "half'
+            )
+            yield RunErrorEvent(content="the model went away")
+
+        with patch.object(agent, "arun") as mock_arun:
+            mock_arun.return_value = mock_stream()
+            response = client.post("/agui", json=make_request_body("write"))
+
+        events = parse_sse_events(response.text)
+        types = get_event_types(events)
+        assert types[-1] == "RUN_ERROR", types
+        _assert_the_client_accepts_the_tool_call_spans(events)
+
+    def test_a_teams_failed_call_is_closed_by_the_same_handler(self):
+        """A team's events are dispatched under the same names an agent's are,
+        so the one handler entry serves both."""
+        assert _normalize_event(TeamRunEvent.tool_call_error.value) == RunEvent.tool_call_error.value
+
+        state = StreamState(thread_id="thread", run_id="run")
+        state.start_tool_call("call_member")
+        tool = ToolExecution(tool_call_id="call_member", tool_name="save_line", tool_args={"line": "written"})
+
+        events = process_event(TeamToolCallErrorEvent(tool=tool, error="the tool broke"), state)
+
+        assert [event.type for event in events] == [EventType.TOOL_CALL_END, EventType.TOOL_CALL_RESULT]
+        assert json.loads(events[1].content) == "the tool broke"
+        assert not state.tool_call_open("call_member")
+
+
+class TestTheHelpersTheseTestsReadTheWireWith:
+    """The helpers above read the wire the way a client reads it, deliberately
+    not by calling the code they check, so a rule applied wrongly on both
+    sides cannot agree with itself. What they refuse matters as much as what
+    they accept: a helper that reads a frame it cannot parse as no frame at
+    all satisfies every assertion here about something being absent, and one
+    that reaches a library error says nothing about what the wire was
+    missing."""
+
+    def test_a_data_line_that_is_not_an_event_is_refused_rather_than_skipped(self):
+        with pytest.raises(AssertionError, match="no event"):
+            parse_sse_events('data: {"type": "RUN_STARTED"}\ndata: {oops\n')
+
+    def test_a_pointer_naming_an_array_by_something_that_is_no_index_is_refused(self):
+        """An array index is digits and nothing else, at every segment of a
+        pointer and not only at its last: a token a client refuses outright is
+        refused here rather than read as an index it never named."""
+        with pytest.raises(AssertionError, match="no array index"):
+            _client_document_after({"rows": [{"a": 1}]}, [{"op": "replace", "path": "/rows/01/a", "value": 2}])
+        with pytest.raises(AssertionError, match="does not hold"):
+            _client_document_after({"rows": [{"a": 1}]}, [{"op": "replace", "path": "/rows/-/a", "value": 2}])
+
+    def test_an_addition_under_a_scalar_says_what_the_wire_was_missing(self):
+        with pytest.raises(AssertionError, match="neither an object nor an array"):
+            _client_document_after({"title": "Soup"}, [{"op": "add", "path": "/title/deeper", "value": 1}])

--- a/libs/agno/tests/unit/team/test_tool_call_args_delta_events.py
+++ b/libs/agno/tests/unit/team/test_tool_call_args_delta_events.py
@@ -1,0 +1,1504 @@
+"""Teams emit a tool call's argument fragments where a call can be made.
+
+The team model, the team's output model and the chunk handler exposed on the
+Team class all sit on a stream of provider deltas, so a caller that renders a
+tool call while its arguments are still arriving must see fragments from each.
+A member agent's own calls reach the caller through the team as well, and a
+team run told not to stream events delivers neither its own nor its members'.
+
+A fragment is attributed exactly the way Agno's own tool call aggregators
+attribute it: one entry per provider stream index, a missing index read as
+zero, and an entry's id taken from whichever of its deltas last carried one.
+Those indexes restart at zero every turn, and the turn ends when the run takes
+a call up, so a later turn's fragment that carries no id of its own must not
+land on an earlier turn's finished call. Nothing else is held back or
+rewritten: a stream that restarts offers its fragments again and they go out
+again.
+"""
+
+import asyncio
+import json
+import logging
+from contextlib import contextmanager
+from typing import Any, AsyncIterator, Dict, Iterator, List, Optional, Tuple
+
+import pytest
+from pydantic import BaseModel
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.exceptions import ModelProviderError
+from agno.models.base import Model
+from agno.models.response import ModelResponse, ModelResponseEvent, ToolExecution
+from agno.run.agent import RunEvent
+from agno.run.team import TeamRunEvent, TeamRunOutput
+from agno.session import TeamSession
+from agno.team import Team
+from agno.tools import tool
+from agno.utils import log as agno_log
+from agno.utils.tools import REFUSED_TOOL_CALL_ERROR, ToolCallArgsStream
+
+
+class _ScriptedStreamModel(Model):
+    """Replays a fixed script of provider deltas, one turn per model call.
+
+    Each entry in ``turns`` is the list of deltas for one turn. The script is
+    finite: a call past its end fails the test rather than replaying a turn,
+    so a run that loops longer than intended is visible instead of silent.
+    """
+
+    def __init__(self, turns: List[List[ModelResponse]]):
+        super().__init__(id="scripted-stream", name="scripted-stream", provider="test")
+        self._turns = list(turns)
+        self._turn = 0
+
+    def _next_turn(self) -> List[ModelResponse]:
+        assert self._turn < len(self._turns), f"model called {self._turn + 1} times, script holds {len(self._turns)}"
+        turn = self._turns[self._turn]
+        self._turn += 1
+        return turn
+
+    @property
+    def turns_taken(self) -> int:
+        """Turns the run has asked for, so a test can say the run really ran."""
+        return self._turn
+
+    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+        yield from self._next_turn()
+
+    async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+        for delta in self._next_turn():
+            yield delta
+
+    def _aggregate_turn(self) -> ModelResponse:
+        """The same turn as one finished response, for the non-streaming path."""
+        turn = self._next_turn()
+        aggregated = ModelResponse(role="assistant")
+        fragments = [call for delta in turn for call in (delta.tool_calls or [])]
+        if fragments:
+            aggregated.tool_calls = self.parse_tool_calls(fragments)
+        content = "".join(delta.content for delta in turn if isinstance(delta.content, str))
+        if content:
+            aggregated.content = content
+        return aggregated
+
+    def invoke(self, *args, **kwargs) -> ModelResponse:
+        return self._aggregate_turn()
+
+    async def ainvoke(self, *args, **kwargs) -> ModelResponse:
+        return self._aggregate_turn()
+
+    def _parse_provider_response(self, response, **kwargs) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+    def _parse_provider_response_delta(self, response) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+    def parse_tool_calls(self, tool_calls_data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Reassemble the fragments by index, as OpenAI-compatible models do."""
+        calls: Dict[int, Dict[str, Any]] = {}
+        order: List[int] = []
+        for fragment in tool_calls_data:
+            index = fragment.get("index", 0)
+            if index not in calls:
+                calls[index] = {"id": None, "type": "function", "function": {"name": "", "arguments": ""}}
+                order.append(index)
+            entry = calls[index]
+            if fragment.get("id"):
+                entry["id"] = fragment["id"]
+            function = fragment.get("function") or {}
+            if function.get("name"):
+                entry["function"]["name"] = function["name"]
+            if function.get("arguments"):
+                entry["function"]["arguments"] += function["arguments"]
+        return [calls[index] for index in order]
+
+
+def _fragment(
+    index: int,
+    arguments: str = "",
+    tool_call_id: Optional[str] = None,
+    tool_name: Optional[str] = None,
+) -> ModelResponse:
+    function: Dict[str, Any] = {"arguments": arguments}
+    if tool_name is not None:
+        function["name"] = tool_name
+    tool_call: Dict[str, Any] = {"index": index, "type": "function", "function": function}
+    if tool_call_id is not None:
+        tool_call["id"] = tool_call_id
+    return ModelResponse(role="assistant", tool_calls=[tool_call])
+
+
+def _unnumbered_fragment(
+    arguments: str = "",
+    tool_call_id: Optional[str] = None,
+    tool_name: Optional[str] = None,
+) -> ModelResponse:
+    """One fragment from a provider that puts no stream index on its deltas."""
+    function: Dict[str, Any] = {"arguments": arguments}
+    if tool_name is not None:
+        function["name"] = tool_name
+    tool_call: Dict[str, Any] = {"type": "function", "function": function}
+    if tool_call_id is not None:
+        tool_call["id"] = tool_call_id
+    return ModelResponse(role="assistant", tool_calls=[tool_call])
+
+
+def _chunks(text: str, size: int) -> List[str]:
+    return [text[i : i + size] for i in range(0, len(text), size)]
+
+
+def save_note(note: str) -> str:
+    """Save a note.
+
+    Args:
+        note: the note to save
+    """
+    return "saved"
+
+
+def save_other(note: str) -> str:
+    """Save a note somewhere else.
+
+    Args:
+        note: the note to save
+    """
+    return "saved"
+
+
+class _Note(BaseModel):
+    note: str
+
+
+CHUNK_SIZE = 5
+
+
+def _tool_call_turns(tool_call_id: str, tool_name: str = "save_note") -> Tuple[List[List[ModelResponse]], str]:
+    """One turn streaming a single tool call in fragments, then a reply turn."""
+    arguments = json.dumps({"note": "the sea is wide and the boat is small"})
+    fragments = [_fragment(0, tool_call_id=tool_call_id, tool_name=tool_name)]
+    fragments += [_fragment(0, chunk) for chunk in _chunks(arguments, CHUNK_SIZE)]
+    return [fragments, [ModelResponse(role="assistant", content="done")]], arguments
+
+
+@contextmanager
+def _records_logged_at(level: int) -> Iterator[List[logging.LogRecord]]:
+    """Everything Agno logs at ``level`` or above, whichever logger carried it.
+
+    ``log_error`` writes to a process-global logger that a team run rebinds to
+    the team logger and never rebinds back, so the same line is carried by one
+    logger or another depending on what else ran earlier in the process. What
+    these tests assert is what a run reported, so they read every logger the
+    helper can be bound to and stay out of that.
+    """
+    records: List[logging.LogRecord] = []
+
+    class _Collector(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    handler = _Collector(level)
+    loggers = list(
+        {id(value): value for value in vars(agno_log).values() if isinstance(value, logging.Logger)}.values()
+    )
+    for agno_logger in loggers:
+        agno_logger.addHandler(handler)
+    try:
+        yield records
+    finally:
+        for agno_logger in loggers:
+            agno_logger.removeHandler(handler)
+
+
+@pytest.fixture
+def errors_logged() -> Iterator[List[logging.LogRecord]]:
+    with _records_logged_at(logging.ERROR) as records:
+        yield records
+
+
+@pytest.fixture
+def warnings_logged() -> Iterator[List[logging.LogRecord]]:
+    with _records_logged_at(logging.WARNING) as records:
+        yield records
+
+
+def _events_named(events, event_name: str):
+    return [event for event in events if event.event == event_name]
+
+
+def _content_of(events) -> str:
+    """The reply a caller assembles out of the run's content events."""
+    return "".join(event.content for event in _events_named(events, TeamRunEvent.run_content.value))
+
+
+def _assert_fragments_assemble(events, arguments: str, tool_call_id: str, tool_name: str) -> None:
+    deltas = _events_named(events, TeamRunEvent.tool_call_args_delta.value)
+    assert len(deltas) == len(_chunks(arguments, CHUNK_SIZE))
+    assert "".join(delta.tool_args_delta for delta in deltas) == arguments
+    assert {delta.tool_call_id for delta in deltas} == {tool_call_id}
+    assert {delta.tool_name for delta in deltas} == {tool_name}
+
+
+# ---------------------------------------------------------------------------
+# Team model
+# ---------------------------------------------------------------------------
+
+
+def test_team_streams_tool_call_arg_fragments():
+    turns, arguments = _tool_call_turns("call_team")
+    team = Team(members=[], model=_ScriptedStreamModel(turns), tools=[save_note])
+
+    events = list(team.run("go", stream=True, stream_events=True))
+
+    _assert_fragments_assemble(events, arguments, "call_team", "save_note")
+
+    # The finished events still arrive unchanged, and agree with the fragments.
+    started = _events_named(events, TeamRunEvent.tool_call_started.value)
+    assert len(started) == 1
+    assert started[0].tool.tool_call_id == "call_team"
+    assert started[0].tool.tool_args == json.loads(arguments)
+
+
+async def test_team_streams_tool_call_arg_fragments_async():
+    turns, arguments = _tool_call_turns("call_team")
+    team = Team(members=[], model=_ScriptedStreamModel(turns), tools=[save_note])
+
+    events = [event async for event in team.arun("go", stream=True, stream_events=True)]
+
+    _assert_fragments_assemble(events, arguments, "call_team", "save_note")
+
+
+def test_team_streams_the_whole_arguments_of_a_provider_that_numbers_no_call():
+    """A provider that puts no index on any delta still streams every fragment.
+
+    Agno's own aggregators, the OpenAI chat, watsonx, cerebras and litellm
+    ones among them, read a missing index as zero, so every one of these
+    deltas belongs to the one call the turn made.
+    """
+    arguments = json.dumps({"note": "the sea is wide and the boat is small"})
+    fragments = [_unnumbered_fragment(tool_call_id="call_team", tool_name="save_note")]
+    fragments += [_unnumbered_fragment(chunk) for chunk in _chunks(arguments, CHUNK_SIZE)]
+    turns = [fragments, [ModelResponse(role="assistant", content="done")]]
+    team = Team(members=[], model=_ScriptedStreamModel(turns), tools=[save_note])
+
+    events = list(team.run("go", stream=True, stream_events=True))
+
+    _assert_fragments_assemble(events, arguments, "call_team", "save_note")
+    # What the client was sent is what the run itself assembled.
+    started = _events_named(events, TeamRunEvent.tool_call_started.value)
+    assert [json.dumps(event.tool.tool_args) for event in started] == [arguments]
+
+
+def test_team_emits_no_fragments_without_stream_events():
+    turns, _ = _tool_call_turns("call_team")
+    model = _ScriptedStreamModel(turns)
+    team = Team(members=[], model=model, tools=[save_note])
+
+    events = list(team.run("go", stream=True, stream_events=False))
+
+    # The run took the tool call turn and the reply turn after it and answered,
+    # so what is absent below is fragments rather than the whole stream.
+    assert model.turns_taken == len(turns)
+    assert _content_of(events) == "done"
+    assert not _events_named(events, TeamRunEvent.tool_call_args_delta.value)
+
+
+# ---------------------------------------------------------------------------
+# Member agents
+# ---------------------------------------------------------------------------
+
+_DELEGATE_TOOL = "delegate_task_to_member"
+
+
+def _delegating_turns(member_id: str) -> Tuple[List[List[ModelResponse]], str]:
+    """A leader turn that streams its delegation call in fragments."""
+    arguments = json.dumps({"member_id": member_id, "task": "write the note"})
+    fragments = [_fragment(0, tool_call_id="call_lead", tool_name=_DELEGATE_TOOL)]
+    fragments += [_fragment(0, chunk) for chunk in _chunks(arguments, CHUNK_SIZE)]
+    return [fragments, [ModelResponse(role="assistant", content="done")]], arguments
+
+
+def _team_with_a_calling_member() -> Tuple[Team, str, str]:
+    """A leader that delegates to a member, and a member that calls a tool."""
+    member_turns, member_arguments = _tool_call_turns("call_member")
+    leader_turns, leader_arguments = _delegating_turns("writer")
+    member = Agent(name="writer", model=_ScriptedStreamModel(member_turns), tools=[save_note])
+    return Team(members=[member], model=_ScriptedStreamModel(leader_turns)), leader_arguments, member_arguments
+
+
+def _fragments_by_event(events) -> Dict[str, str]:
+    """What a caller assembles from each of the two fragment event names.
+
+    A member agent sends its fragments under its own name, the leader under
+    the team's, so a team run carries both.
+    """
+    return {
+        name: "".join(event.tool_args_delta for event in _events_named(events, name))
+        for name in (RunEvent.tool_call_args_delta.value, TeamRunEvent.tool_call_args_delta.value)
+    }
+
+
+def _assert_both_the_leaders_and_the_members_call_streamed(events, leader: str, member: str) -> None:
+    """Every fragment of both calls reached the caller, under its own call id."""
+    assert _fragments_by_event(events) == {
+        TeamRunEvent.tool_call_args_delta.value: leader,
+        RunEvent.tool_call_args_delta.value: member,
+    }
+    member_deltas = _events_named(events, RunEvent.tool_call_args_delta.value)
+    assert {delta.tool_call_id for delta in member_deltas} == {"call_member"}
+    assert {delta.tool_name for delta in member_deltas} == {"save_note"}
+    # The member made that call on those arguments, so the fragments and the
+    # run agree about what its model asked for.
+    completed = _events_named(events, RunEvent.tool_call_completed.value)
+    assert [json.dumps(event.tool.tool_args) for event in completed] == [member]
+
+
+def test_team_streams_a_members_tool_call_arg_fragments():
+    team, leader, member = _team_with_a_calling_member()
+
+    events = list(team.run("go", stream=True, stream_events=True))
+
+    _assert_both_the_leaders_and_the_members_call_streamed(events, leader, member)
+
+
+async def test_team_streams_a_members_tool_call_arg_fragments_async():
+    team, leader, member = _team_with_a_calling_member()
+
+    events = [event async for event in team.arun("go", stream=True, stream_events=True)]
+
+    _assert_both_the_leaders_and_the_members_call_streamed(events, leader, member)
+
+
+def _assert_a_run_told_not_to_stream_events_delivers_no_fragments(events, member_arguments: str) -> None:
+    """A team run told not to stream events is told that of its members too.
+
+    A member is run with events on whatever the caller asked for, so that the
+    leader can read them, and they reach the caller through the team. So a
+    guard on the team's own model alone leaves a caller that opted out holding
+    its members' fragments.
+    """
+    assert _fragments_by_event(events) == {
+        TeamRunEvent.tool_call_args_delta.value: "",
+        RunEvent.tool_call_args_delta.value: "",
+    }
+    # The member ran and made its call, and its other events arrive as before,
+    # so the absence above is the flag's doing and not an empty stream.
+    completed = _events_named(events, RunEvent.tool_call_completed.value)
+    assert [json.dumps(event.tool.tool_args) for event in completed] == [member_arguments]
+    assert _events_named(events, RunEvent.run_started.value)
+
+
+def test_team_delivers_no_members_fragments_without_stream_events():
+    team, _leader, member = _team_with_a_calling_member()
+
+    events = list(team.run("go", stream=True, stream_events=False))
+
+    _assert_a_run_told_not_to_stream_events_delivers_no_fragments(events, member)
+
+
+async def test_team_delivers_no_members_fragments_without_stream_events_async():
+    team, _leader, member = _team_with_a_calling_member()
+
+    events = [event async for event in team.arun("go", stream=True, stream_events=False)]
+
+    _assert_a_run_told_not_to_stream_events_delivers_no_fragments(events, member)
+
+
+# ---------------------------------------------------------------------------
+# Team output model
+# ---------------------------------------------------------------------------
+
+
+class _ToolRecordingModel(_ScriptedStreamModel):
+    """Remembers the tools it was handed, once per stream it was asked for.
+
+    A path that hands its model none of the run's tools can still be answered
+    with a call, because a provider can call a built-in tool of its own, so
+    what the path passed is worth pinning beside what came back.
+    """
+
+    def __init__(self, turns: List[List[ModelResponse]]):
+        super().__init__(turns)
+        self.tools_seen: List[Optional[List[Any]]] = []
+
+    def response_stream(self, *args, **kwargs):
+        self.tools_seen.append(kwargs.get("tools"))
+        return super().response_stream(*args, **kwargs)
+
+    def aresponse_stream(self, *args, **kwargs):
+        self.tools_seen.append(kwargs.get("tools"))
+        return super().aresponse_stream(*args, **kwargs)
+
+
+def _team_with_a_recording_output_model() -> Tuple[Team, _ToolRecordingModel, str]:
+    """An output model whose script calls a tool, over a quiet team model."""
+    output_turns, arguments = _tool_call_turns("call_output", tool_name="save_output")
+    output_model = _ToolRecordingModel(output_turns)
+    team = Team(
+        members=[Agent(name="member", model=_ScriptedStreamModel([]))],
+        model=_ScriptedStreamModel([[ModelResponse(role="assistant", content="draft")]]),
+        output_model=output_model,
+        tools=[save_note],
+    )
+    return team, output_model, arguments
+
+
+def _assert_the_output_models_call_reached_the_client(
+    events, output_model: _ToolRecordingModel, arguments: str, errors: List[logging.LogRecord]
+) -> None:
+    """A call can arrive here even though the path hands the model no tools.
+
+    The output model is asked for the finished answer, never for work, so the
+    run passes it none of the team's tools. A provider can still answer with a
+    call to a built-in tool of its own, and then its fragments have to be
+    attributed and its call closed out like any other. The script stands in for
+    that provider, and the run refuses to find the function, which is why the
+    call the client was shown ends as a reported failure rather than as one it
+    waits on for good.
+    """
+    assert output_model.tools_seen == [None]
+    assert output_model.turns_taken == 2, "the output model did not run its whole script"
+    assert _content_of(events) == "done"
+    _assert_fragments_assemble(events, arguments, "call_output", "save_output")
+    reported = _events_named(events, TeamRunEvent.tool_call_error.value)
+    assert [event.tool.tool_call_id for event in reported] == ["call_output"]
+    assert reported[0].error == REFUSED_TOOL_CALL_ERROR
+    assert [record.getMessage() for record in errors] == ["Function save_output not found"]
+
+
+def test_team_output_model_streams_and_closes_out_a_tool_call(errors_logged):
+    team, output_model, arguments = _team_with_a_recording_output_model()
+
+    events = list(team.run("go", stream=True, stream_events=True))
+
+    _assert_the_output_models_call_reached_the_client(events, output_model, arguments, errors_logged)
+
+
+async def test_team_output_model_streams_and_closes_out_a_tool_call_async(errors_logged):
+    team, output_model, arguments = _team_with_a_recording_output_model()
+
+    events = [event async for event in team.arun("go", stream=True, stream_events=True)]
+
+    _assert_the_output_models_call_reached_the_client(events, output_model, arguments, errors_logged)
+
+
+def _team_with_a_two_turn_output_model() -> Tuple[Team, str, str]:
+    """An output model that calls a tool on each of two turns of its own."""
+    turns, first, second = _two_turn_calls()
+    return (
+        Team(
+            members=[Agent(name="member", model=_ScriptedStreamModel([]))],
+            model=_ScriptedStreamModel([[ModelResponse(role="assistant", content="draft")]]),
+            output_model=_ToolRecordingModel(turns),
+            tools=[save_note, save_other],
+        ),
+        first,
+        second,
+    )
+
+
+def _assert_the_output_models_turns_are_held_apart(
+    events, first: str, second: str, warnings: List[logging.LogRecord]
+) -> None:
+    """This path's turn boundary is the request event the chunk handler sees.
+
+    The team's own loop reads that event itself, so nothing but the chunk
+    handler bounds a turn here. Without it the second turn's opening fragment,
+    which carries index zero and no id, would be appended to the arguments the
+    first turn's call was already made with. Bounded, that fragment belongs to
+    no call yet, and the run says so instead of placing it.
+    """
+    assert _assembled(events, "call_a") == first
+    assert _assembled(events, "call_b") == second[4:]
+    reported = [record.getMessage() for record in warnings if record.levelno == logging.WARNING]
+    assert len(reported) == 1, reported
+    assert "neither a tool call id nor a provider stream index" in reported[0]
+
+
+def test_team_output_model_does_not_carry_tool_call_ids_across_its_turns(warnings_logged):
+    team, first, second = _team_with_a_two_turn_output_model()
+
+    events = list(team.run("go", stream=True, stream_events=True))
+
+    _assert_the_output_models_turns_are_held_apart(events, first, second, warnings_logged)
+
+
+async def test_team_output_model_does_not_carry_tool_call_ids_across_its_turns_async(warnings_logged):
+    team, first, second = _team_with_a_two_turn_output_model()
+
+    events = [event async for event in team.arun("go", stream=True, stream_events=True)]
+
+    _assert_the_output_models_turns_are_held_apart(events, first, second, warnings_logged)
+
+
+_ANNOUNCED_ARGUMENTS = json.dumps({"title": "the plan", "thought": "the sea is wide"})
+
+
+def _announced_call_chunks() -> List[ModelResponse]:
+    """The chunks a provider writes for a built-in tool it ran itself.
+
+    First the call's arguments a fragment at a time, then the two chunks the
+    provider announces the finished call with, then its closing reply. The
+    call is named ``think``, which is also how the run recognises a reasoning
+    step, so one script covers every announcement this path can carry.
+    """
+    execution = ToolExecution(
+        tool_call_id="call_builtin",
+        tool_name="think",
+        tool_args=json.loads(_ANNOUNCED_ARGUMENTS),
+        result="thought about it",
+    )
+    chunks = [_fragment(0, tool_call_id="call_builtin", tool_name="think")]
+    chunks += [_fragment(0, chunk) for chunk in _chunks(_ANNOUNCED_ARGUMENTS, CHUNK_SIZE)]
+    chunks.append(
+        ModelResponse(
+            content="think(...)",
+            tool_executions=[execution],
+            event=ModelResponseEvent.tool_call_started.value,
+        )
+    )
+    chunks.append(
+        ModelResponse(
+            content="thought about it",
+            tool_executions=[execution],
+            event=ModelResponseEvent.tool_call_completed.value,
+        )
+    )
+    chunks.append(ModelResponse(role="assistant", content="done"))
+    return chunks
+
+
+class _ProviderAnnouncingModel(_ScriptedStreamModel):
+    """A provider that ran a built-in tool of its own and announces the call.
+
+    This path hands its model none of the run's tools, so the shared function
+    call machinery has no function to find and never announces a call here. A
+    provider that ran a built-in tool is the only thing that can, and it does
+    so in its own stream, which is what this stands in for.
+    """
+
+    def __init__(self):
+        super().__init__([])
+        self._script = _announced_call_chunks()
+
+    def response_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+        return iter(self._script)
+
+    async def aresponse_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+        for chunk in self._script:
+            yield chunk
+
+
+def _team_with_an_announcing_output_model() -> Team:
+    return Team(
+        members=[Agent(name="member", model=_ScriptedStreamModel([]))],
+        model=_ScriptedStreamModel([[ModelResponse(role="assistant", content="draft")]]),
+        output_model=_ProviderAnnouncingModel(),
+    )
+
+
+def _assert_the_output_model_path_adds_only_the_fragments(events) -> None:
+    """The fragments are what this path gained; its silence is as it was.
+
+    A team's output model path has never announced a call the output model
+    made, nor read one as a reasoning step, and threading it the record that
+    attributes a call's argument fragments does not change that. An agent's
+    output model path does announce both. That difference between the two is
+    older than the fragments and is left alone here, because changing which
+    lifecycle events a client sees is a decision of its own and not something
+    to thread a fragment stream into.
+    """
+    _assert_fragments_assemble(events, _ANNOUNCED_ARGUMENTS, "call_builtin", "think")
+    assert not _events_named(events, TeamRunEvent.tool_call_started.value)
+    assert not _events_named(events, TeamRunEvent.tool_call_completed.value)
+    assert not _events_named(events, TeamRunEvent.reasoning_step.value)
+    assert not _events_named(events, TeamRunEvent.tool_call_error.value)
+
+
+def test_team_output_model_adds_only_the_argument_fragments():
+    team = _team_with_an_announcing_output_model()
+
+    events = list(team.run("go", stream=True, stream_events=True))
+
+    _assert_the_output_model_path_adds_only_the_fragments(events)
+
+
+async def test_team_output_model_adds_only_the_argument_fragments_async():
+    team = _team_with_an_announcing_output_model()
+
+    events = [event async for event in team.arun("go", stream=True, stream_events=True)]
+
+    _assert_the_output_model_path_adds_only_the_fragments(events)
+
+
+# ---------------------------------------------------------------------------
+# Chunk handler on the Team class
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def chunk_handler_team() -> Team:
+    return Team(members=[], model=_ScriptedStreamModel([]))
+
+
+def test_team_chunk_handler_carries_tool_call_identities_across_chunks(chunk_handler_team: Team):
+    """A later fragment names its call only through the per-stream record.
+
+    The record reaches the handler through the wrapper on the Team class, so
+    this also holds the wrapper to forwarding it.
+    """
+    session = TeamSession(session_id="session_1")
+    run_response = TeamRunOutput(run_id="run_1", team_id="team_1", team_name="Team")
+    tool_args_stream = ToolCallArgsStream(session.session_id, run_response.run_id)
+
+    first = _fragment(0, tool_call_id="call_a", tool_name="save_note")
+    later = _fragment(0, '{"note":')
+    assert later.tool_calls[0].get("id") is None
+
+    events = []
+    for chunk in (first, later):
+        chunk.event = ModelResponseEvent.assistant_response.value
+        events.extend(
+            chunk_handler_team._handle_model_response_chunk(
+                session=session,
+                run_response=run_response,
+                full_model_response=ModelResponse(),
+                model_response_event=chunk,
+                stream_events=True,
+                tool_args_stream=tool_args_stream,
+            )
+        )
+
+    deltas = _events_named(events, TeamRunEvent.tool_call_args_delta.value)
+    assert len(deltas) == 1
+    assert deltas[0].tool_call_id == "call_a"
+    assert deltas[0].tool_name == "save_note"
+    assert deltas[0].tool_args_delta == '{"note":'
+
+
+def _through_the_chunk_handler(team: Team, tool_args_stream: ToolCallArgsStream, chunks) -> List[Any]:
+    """Every event the handler yields for a run of chunks, in order."""
+    session = TeamSession(session_id="session_1")
+    run_response = TeamRunOutput(run_id="run_1", team_id="team_1", team_name="Team")
+    events: List[Any] = []
+    for chunk in chunks:
+        events.extend(
+            team._handle_model_response_chunk(
+                session=session,
+                run_response=run_response,
+                full_model_response=ModelResponse(),
+                model_response_event=chunk,
+                stream_events=True,
+                tool_args_stream=tool_args_stream,
+            )
+        )
+    return events
+
+
+def test_team_chunk_handler_drops_its_stream_indexes_when_a_fallback_is_activated(
+    chunk_handler_team: Team, warnings_logged
+):
+    """A replaced model's numbering is not the numbering of the one taking over.
+
+    A fallback model answers the request the primary failed part way through,
+    and its stream indexes start again at zero. Without a boundary there, its
+    opening fragment, which carries index zero and no id, would be appended to
+    the arguments of the call the replaced model was still writing, and a
+    subscriber would render two models' text as one call's arguments.
+    """
+    tool_args_stream = ToolCallArgsStream("session_1", "run_1")
+    replaced = _fragment(0, '{"note":', tool_call_id="call_a", tool_name="save_note")
+    replaced.event = ModelResponseEvent.assistant_response.value
+    taking_over = _fragment(0, ' "the sea is wide"}')
+    taking_over.event = ModelResponseEvent.assistant_response.value
+
+    events = _through_the_chunk_handler(
+        chunk_handler_team,
+        tool_args_stream,
+        (
+            replaced,
+            ModelResponse(event=ModelResponseEvent.fallback_model_activated.value),
+            taking_over,
+        ),
+    )
+
+    deltas = _events_named(events, TeamRunEvent.tool_call_args_delta.value)
+    assert [(delta.tool_call_id, delta.tool_args_delta) for delta in deltas] == [("call_a", '{"note":')]
+    # The fragment after the boundary belongs to no call yet, and the run says
+    # so rather than placing it on the replaced model's call.
+    reported = [record.getMessage() for record in warnings_logged if record.levelno >= logging.WARNING]
+    assert len(reported) == 1, reported
+    assert "neither a tool call id nor a provider stream index" in reported[0]
+    # The replaced model's call will never be made under its own id either, so
+    # the client is not left waiting on it.
+    closed = _events_named(events, TeamRunEvent.tool_call_error.value)
+    assert [event.tool.tool_call_id for event in closed] == ["call_a"]
+    assert closed[0].error == REFUSED_TOOL_CALL_ERROR
+
+
+# ---------------------------------------------------------------------------
+# Parser model
+# ---------------------------------------------------------------------------
+
+
+class _NonStreamedCallModel(_ScriptedStreamModel):
+    """Remembers the tool calls it handed back on the non-streamed path.
+
+    The parser model is asked for a finished response inside its stream, so a
+    test that path streams no fragments is only worth something if the model
+    really did answer it with a call.
+    """
+
+    def __init__(self, turns: List[List[ModelResponse]]):
+        super().__init__(turns)
+        self.returned_tool_calls: List[Dict[str, Any]] = []
+
+    def _aggregate_turn(self) -> ModelResponse:
+        aggregated = super()._aggregate_turn()
+        self.returned_tool_calls.extend(aggregated.tool_calls or [])
+        return aggregated
+
+
+def _parser_model_turns() -> List[List[ModelResponse]]:
+    """One turn calling a tool in fragments, then one answering the output schema."""
+    turns, _ = _tool_call_turns("call_parser")
+    return [turns[0], [ModelResponse(role="assistant", content=json.dumps({"note": "parsed"}))]]
+
+
+def _team_with_a_calling_parser_model() -> Tuple[Team, _NonStreamedCallModel]:
+    parser = _NonStreamedCallModel(_parser_model_turns())
+    team = Team(
+        members=[Agent(name="member", model=_ScriptedStreamModel([]))],
+        model=_ScriptedStreamModel([[ModelResponse(role="assistant", content=json.dumps({"note": "draft"}))]]),
+        parser_model=parser,
+        output_schema=_Note,
+    )
+    return team, parser
+
+
+def _assert_the_parser_model_streamed_no_fragments(
+    events, parser: _NonStreamedCallModel, errors: List[logging.LogRecord]
+) -> None:
+    """The parser model answers inside its stream with one finished response.
+
+    A tool call therefore arrives already assembled and there are no fragments
+    to attribute, which is why this path carries no per-stream record. A change
+    that made the parser model stream its response would fail here rather than
+    quietly dropping the fragments it started producing.
+    """
+    # A call really did arrive, already assembled, so the absence of fragments
+    # is the path's doing and not an inert script.
+    assert parser.returned_tool_calls, "the parser model no longer answers with one finished response"
+    assert not _events_named(events, TeamRunEvent.tool_call_args_delta.value)
+    assert not _events_named(events, RunEvent.tool_call_args_delta.value)
+    # It is handed no tools either, so the run refuses to find the function it
+    # named and says so once.
+    assert [record.getMessage() for record in errors] == ["Function save_note not found"]
+
+
+def test_team_parser_model_emits_no_tool_call_arg_fragments(errors_logged):
+    team, parser = _team_with_a_calling_parser_model()
+
+    events = list(team.run("go", stream=True, stream_events=True))
+
+    _assert_the_parser_model_streamed_no_fragments(events, parser, errors_logged)
+
+
+async def test_team_parser_model_emits_no_tool_call_arg_fragments_async(errors_logged):
+    team, parser = _team_with_a_calling_parser_model()
+
+    events = [event async for event in team.arun("go", stream=True, stream_events=True)]
+
+    _assert_the_parser_model_streamed_no_fragments(events, parser, errors_logged)
+
+
+# ---------------------------------------------------------------------------
+# Event storage
+# ---------------------------------------------------------------------------
+
+
+def _team_storing_events(tmp_path, db_name: str, **kwargs) -> Tuple[Team, str]:
+    turns, arguments = _tool_call_turns("call_team")
+    team = Team(
+        members=[],
+        model=_ScriptedStreamModel(turns),
+        tools=[save_note],
+        db=SqliteDb(db_file=str(tmp_path / db_name)),
+        store_events=True,
+        **kwargs,
+    )
+    return team, arguments
+
+
+def _stored(run_output) -> List[str]:
+    return [event.event for event in (run_output.events or [])]
+
+
+def test_team_keeps_tool_call_arg_fragments_out_of_the_stored_run_by_default(tmp_path):
+    team, arguments = _team_storing_events(tmp_path, "default_team.db")
+
+    events = list(team.run("go", stream=True, stream_events=True))
+    run_output = team.get_last_run_output()
+
+    # The subscriber still sees every fragment: the skip list governs storage.
+    _assert_fragments_assemble(events, arguments, "call_team", "save_note")
+
+    stored = _stored(run_output)
+    assert TeamRunEvent.tool_call_args_delta.value not in stored
+    # Held to the same standard as the content delta it is being grouped with,
+    # and the low frequency events are stored as before.
+    assert TeamRunEvent.run_content.value not in stored
+    assert TeamRunEvent.tool_call_started.value in stored
+    assert TeamRunEvent.tool_call_completed.value in stored
+
+
+async def test_team_keeps_tool_call_arg_fragments_out_of_the_stored_run_by_default_async(tmp_path):
+    team, arguments = _team_storing_events(tmp_path, "default_team_async.db")
+
+    events = [event async for event in team.arun("go", stream=True, stream_events=True)]
+    run_output = await team.aget_last_run_output()
+
+    _assert_fragments_assemble(events, arguments, "call_team", "save_note")
+
+    stored = _stored(run_output)
+    assert TeamRunEvent.tool_call_args_delta.value not in stored
+    assert TeamRunEvent.run_content.value not in stored
+    assert TeamRunEvent.tool_call_started.value in stored
+
+
+def test_team_stores_tool_call_arg_fragments_when_the_caller_asks_for_them(tmp_path, skips_but_the_argument_fragments):
+    # Asking for the fragments back re-enables nothing else the default keeps
+    # out of storage, the content deltas included.
+    team, arguments = _team_storing_events(
+        tmp_path,
+        "opted_in_team.db",
+        events_to_skip=skips_but_the_argument_fragments(Team(members=[], model=_ScriptedStreamModel([]))),
+    )
+
+    list(team.run("go", stream=True, stream_events=True))
+    run_output = team.get_last_run_output()
+
+    fragments = [event for event in (run_output.events or []) if event.event == TeamRunEvent.tool_call_args_delta.value]
+    assert "".join(event.tool_args_delta for event in fragments) == arguments
+    assert TeamRunEvent.run_content.value not in _stored(run_output)
+
+
+def _team_storing_a_members_events(tmp_path, db_name: str, **kwargs) -> Tuple[Team, str, str]:
+    """A leader that delegates to a member, both streaming a call, both stored."""
+    member_turns, member_arguments = _tool_call_turns("call_member")
+    leader_turns, leader_arguments = _delegating_turns("writer")
+    team = Team(
+        members=[Agent(name="writer", model=_ScriptedStreamModel(member_turns), tools=[save_note])],
+        model=_ScriptedStreamModel(leader_turns),
+        db=SqliteDb(db_file=str(tmp_path / db_name)),
+        store_events=True,
+        **kwargs,
+    )
+    return team, leader_arguments, member_arguments
+
+
+def _stored_fragments(run_output, event_name: str) -> str:
+    return "".join(event.tool_args_delta for event in (run_output.events or []) if event.event == event_name)
+
+
+def test_team_keeps_its_members_tool_call_arg_fragments_out_of_the_stored_run_by_default(tmp_path):
+    """A member's fragments are the team's to store, and by default it stores none.
+
+    A member agent's calls reach the caller through the team, so the team's
+    own default has to keep them out of its stored run as well as its
+    leader's. A team run with real members would otherwise store every
+    fragment of every member's every call.
+    """
+    team, leader, member = _team_storing_a_members_events(tmp_path, "default_member_team.db")
+
+    events = list(team.run("go", stream=True, stream_events=True))
+    run_output = team.get_last_run_output()
+
+    # The caller still sees both calls stream: the skip list governs storage.
+    _assert_both_the_leaders_and_the_members_call_streamed(events, leader, member)
+
+    stored = _stored(run_output)
+    assert RunEvent.tool_call_args_delta.value not in stored
+    assert TeamRunEvent.tool_call_args_delta.value not in stored
+    # The member really did run under this team, so the absence above is the
+    # skip list's doing and not a run that never delegated.
+    assert RunEvent.tool_call_completed.value in stored
+
+
+def test_team_stores_its_members_tool_call_arg_fragments_when_the_caller_asks_for_them(
+    tmp_path, skips_but_the_argument_fragments
+):
+    """Asked for, a member's fragments are stored under the member's own event name."""
+    team, leader, member = _team_storing_a_members_events(
+        tmp_path,
+        "opted_in_member_team.db",
+        events_to_skip=skips_but_the_argument_fragments(Team(members=[], model=_ScriptedStreamModel([]))),
+    )
+
+    list(team.run("go", stream=True, stream_events=True))
+    run_output = team.get_last_run_output()
+
+    assert _stored_fragments(run_output, RunEvent.tool_call_args_delta.value) == member
+    assert _stored_fragments(run_output, TeamRunEvent.tool_call_args_delta.value) == leader
+    # Asking for the fragments back re-enables nothing else the default keeps
+    # out of storage, the content deltas of either name included.
+    assert RunEvent.run_content.value not in _stored(run_output)
+    assert TeamRunEvent.run_content.value not in _stored(run_output)
+
+
+# Stream boundaries
+# ---------------------------------------------------------------------------
+
+
+class _DroppedStreamModel(_ScriptedStreamModel):
+    """Dies part way through a turn, the way a provider stream that drops does.
+
+    ``Model.retries`` restarts the whole stream, so the next attempt replays the
+    turn from its first fragment, including the fragments the dead attempt had
+    already delivered.
+    """
+
+    def __init__(self, turns: List[List[ModelResponse]], fail_after: int):
+        super().__init__(turns)
+        self._fail_after = fail_after
+        self.attempts = 0
+        self._pending: Optional[List[ModelResponse]] = None
+
+    def _attempt_deltas(self) -> List[ModelResponse]:
+        """The deltas of the turn under way, taken once and replayed on retry."""
+        if self._pending is None:
+            self._pending = self._next_turn()
+        return self._pending
+
+    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+        deltas = self._attempt_deltas()
+        self.attempts += 1
+        if self.attempts == 1:
+            yield from deltas[: self._fail_after]
+            raise ModelProviderError(message="stream dropped", model_name=self.name, model_id=self.id)
+        self._pending = None
+        yield from deltas
+
+    async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+        deltas = self._attempt_deltas()
+        self.attempts += 1
+        if self.attempts == 1:
+            for delta in deltas[: self._fail_after]:
+                yield delta
+            raise ModelProviderError(message="stream dropped", model_name=self.name, model_id=self.id)
+        self._pending = None
+        for delta in deltas:
+            yield delta
+
+
+def _two_turn_calls() -> Tuple[List[List[ModelResponse]], str, str]:
+    """Two tool call turns, the second opening with a fragment that has no id.
+
+    A provider ties later fragments back to a call by an index that restarts at
+    zero on every turn, so the second turn's opening fragment carries index zero
+    and no id of its own. It belongs to the call the second turn goes on to
+    announce, never to the first turn's finished call.
+    """
+    first = json.dumps({"note": "first"})
+    second = json.dumps({"note": "second"})
+    first_fragments = [_fragment(0, tool_call_id="call_a", tool_name="save_note")]
+    first_fragments += [_fragment(0, chunk) for chunk in _chunks(first, CHUNK_SIZE)]
+    second_fragments = [
+        _fragment(0, second[:4]),
+        _fragment(0, second[4:], tool_call_id="call_b", tool_name="save_other"),
+    ]
+    reply = [ModelResponse(role="assistant", content="done")]
+    return [first_fragments, second_fragments, reply], first, second
+
+
+def _assembled(events, tool_call_id: str) -> str:
+    deltas = _events_named(events, TeamRunEvent.tool_call_args_delta.value)
+    return "".join(delta.tool_args_delta for delta in deltas if delta.tool_call_id == tool_call_id)
+
+
+def _assert_turns_stay_apart(events, first: str, second: str) -> None:
+    """No turn's call carries any of another turn's argument text."""
+    # The second turn's opening fragment carries index zero and no id, and the
+    # indexes of a finished turn are dropped, so nothing places it: it is not
+    # appended to the first turn's call.
+    assert _assembled(events, "call_a") == first
+    # What the provider does name of the second turn's call is streamed, head
+    # or no head. The subscriber that renders it checks the assembled string
+    # against the finished call rather than being handed a guess.
+    assert _assembled(events, "call_b") == second[4:]
+    announced = {
+        event.tool.tool_call_id: event.tool.tool_args
+        for event in _events_named(events, TeamRunEvent.tool_call_started.value)
+    }
+    assert announced["call_b"] == json.loads(second)
+
+
+def test_team_does_not_carry_tool_call_ids_across_turns():
+    turns, first, second = _two_turn_calls()
+    team = Team(members=[], model=_ScriptedStreamModel(turns), tools=[save_note, save_other])
+
+    events = list(team.run("go", stream=True, stream_events=True))
+
+    # One model request per scripted turn, so nothing here rides on the fake
+    # having a turn left to hand out twice.
+    assert len(_events_named(events, TeamRunEvent.model_request_started.value)) == len(turns)
+    _assert_turns_stay_apart(events, first, second)
+
+
+async def test_team_does_not_carry_tool_call_ids_across_turns_async():
+    turns, first, second = _two_turn_calls()
+    team = Team(members=[], model=_ScriptedStreamModel(turns), tools=[save_note, save_other])
+
+    events = [event async for event in team.arun("go", stream=True, stream_events=True)]
+
+    assert len(_events_named(events, TeamRunEvent.model_request_started.value)) == len(turns)
+    _assert_turns_stay_apart(events, first, second)
+
+
+def _cached_model(turns: List[List[ModelResponse]], cache_dir) -> _ScriptedStreamModel:
+    """A scripted model that records its stream and replays it on the next run."""
+    model = _ScriptedStreamModel(turns)
+    model.cache_response = True
+    model.cache_dir = str(cache_dir)
+    return model
+
+
+def test_team_does_not_carry_tool_call_ids_across_the_turns_of_a_cached_response(tmp_path):
+    """A cache hit replays the calls a run made and makes no request of its own.
+
+    The event that says a model request has started is the one thing a cached
+    response never emits, so a turn boundary keyed on it would let the second
+    turn's opening fragment, which carries index zero and no id, land on the
+    call the first turn already finished.
+    """
+    turns, first, second = _two_turn_calls()
+    recording = Team(members=[], model=_cached_model(turns, tmp_path), tools=[save_note, save_other])
+
+    live = list(recording.run("go", stream=True, stream_events=True))
+    # An empty script: a cache hit asks the model for nothing, so a miss fails
+    # the run rather than quietly streaming the turns a second time.
+    replaying = Team(members=[], model=_cached_model([], tmp_path), tools=[save_note, save_other])
+    cached = list(replaying.run("go", stream=True, stream_events=True))
+
+    assert not _events_named(cached, TeamRunEvent.model_request_started.value)
+    _assert_turns_stay_apart(cached, first, second)
+    assert _assembled(cached, "call_a") == _assembled(live, "call_a")
+
+
+def _assert_a_restarted_stream_offers_its_fragments_again(
+    events, model, turns, arguments: str, warnings: List[logging.LogRecord]
+) -> None:
+    """Every fragment the restarted stream produced went out, retraced or not.
+
+    A subscriber can only append what it is sent, so holding a fragment back
+    on the guess that it already has it is what dropped real argument text.
+    """
+    # The stream really did drop and restart, and it restarted inside the turn
+    # rather than costing the run a model request.
+    assert model.attempts > 1
+    assert len(_events_named(events, TeamRunEvent.model_request_started.value)) == len(turns)
+    retraced = "".join(_chunks(arguments, CHUNK_SIZE)[:3])
+    assert _assembled(events, "call_team") == retraced + arguments
+    # The run's own reassembly is doubled the same way, so the call fails to
+    # decode and is never started. It is closed out all the same.
+    assert not _events_named(events, TeamRunEvent.tool_call_started.value)
+    reported = _events_named(events, TeamRunEvent.tool_call_error.value)
+    assert [event.tool.tool_call_id for event in reported] == ["call_team"]
+    assert reported[0].error == REFUSED_TOOL_CALL_ERROR
+    # The run reports the request that dropped and the doubled arguments its
+    # own reassembly then could not decode, and nothing else: the fragments
+    # went out as they arrived, so there is nothing to say of them.
+    logged = [record.getMessage() for record in warnings]
+    assert len(logged) == 2, logged
+    assert any("Model provider error" in message for message in logged)
+    assert any("Unable to decode function arguments" in message for message in logged)
+
+
+def _restarting_team(turns) -> Tuple[Team, "_DroppedStreamModel"]:
+    # Four deltas in: the call's announcement and three argument fragments.
+    model = _DroppedStreamModel(turns, fail_after=4)
+    model.retries = 1
+    model.delay_between_retries = 0
+    return Team(members=[], model=model, tools=[save_note]), model
+
+
+def test_team_streams_a_restarted_streams_fragments_again(warnings_logged):
+    turns, arguments = _tool_call_turns("call_team")
+    team, model = _restarting_team(turns)
+
+    events = list(team.run("go", stream=True, stream_events=True))
+
+    _assert_a_restarted_stream_offers_its_fragments_again(events, model, turns, arguments, warnings_logged)
+
+
+async def test_team_streams_a_restarted_streams_fragments_again_async(warnings_logged):
+    turns, arguments = _tool_call_turns("call_team")
+    team, model = _restarting_team(turns)
+
+    events = [event async for event in team.arun("go", stream=True, stream_events=True)]
+
+    _assert_a_restarted_stream_offers_its_fragments_again(events, model, turns, arguments, warnings_logged)
+
+
+# ---------------------------------------------------------------------------
+# When a fragment is safe to send
+# ---------------------------------------------------------------------------
+
+
+def _text_and_fragment_turns() -> Tuple[List[List[ModelResponse]], str, str]:
+    """A turn whose opening delta carries both a line of text and a tool call.
+
+    A provider sends both in one chunk when the model says what it is about to
+    do, and the saying comes before the call it announces.
+    """
+    text = "Saving that now. "
+    arguments = json.dumps({"note": "the sea is wide"})
+    opening = _fragment(0, arguments[:4], tool_call_id="call_team", tool_name="save_note")
+    opening.content = text
+    fragments = [opening]
+    fragments += [_fragment(0, chunk) for chunk in _chunks(arguments[4:], CHUNK_SIZE)]
+    return [fragments, [ModelResponse(role="assistant", content="the note is saved")]], text, arguments
+
+
+def _assert_text_comes_first(events, text: str, arguments: str) -> None:
+    first_fragment = next(
+        position for position, event in enumerate(events) if event.event == TeamRunEvent.tool_call_args_delta.value
+    )
+    said = next(
+        position
+        for position, event in enumerate(events)
+        if event.event == TeamRunEvent.run_content.value and event.content == text
+    )
+    assert said < first_fragment
+    # The whole argument string still reaches the client, opening chunk included.
+    assert _assembled(events, "call_team") == arguments
+
+
+def test_team_sends_a_chunks_text_before_the_tool_call_it_announces():
+    turns, text, arguments = _text_and_fragment_turns()
+    team = Team(members=[], model=_ScriptedStreamModel(turns), tools=[save_note])
+
+    events = list(team.run("go", stream=True, stream_events=True))
+
+    _assert_text_comes_first(events, text, arguments)
+
+
+async def test_team_sends_a_chunks_text_before_the_tool_call_it_announces_async():
+    turns, text, arguments = _text_and_fragment_turns()
+    team = Team(members=[], model=_ScriptedStreamModel(turns), tools=[save_note])
+
+    events = [event async for event in team.arun("go", stream=True, stream_events=True)]
+
+    _assert_text_comes_first(events, text, arguments)
+
+
+def _refused_call_turns() -> Tuple[List[List[ModelResponse]], str]:
+    """A turn asking for two tools, of which a limit of one lets only the first run."""
+    first = json.dumps({"note": "first"})
+    second = json.dumps({"note": "second"})
+    fragments = [
+        _fragment(0, tool_call_id="call_a", tool_name="save_note"),
+        _fragment(1, tool_call_id="call_b", tool_name="save_other"),
+    ]
+    fragments += [_fragment(0, chunk) for chunk in _chunks(first, CHUNK_SIZE)]
+    fragments += [_fragment(1, chunk) for chunk in _chunks(second, CHUNK_SIZE)]
+    return [fragments, [ModelResponse(role="assistant", content="one of them is saved")]], second
+
+
+def _refused_team(turns) -> Team:
+    return Team(members=[], model=_ScriptedStreamModel(turns), tools=[save_note, save_other], tool_call_limit=1)
+
+
+def _assert_refusal_is_closed_out(events, second: str) -> None:
+    # The client was shown the second call while it was still being written.
+    assert _assembled(events, "call_b") == second
+    # The limit let only the first of the two run.
+    started = {event.tool.tool_call_id for event in _events_named(events, TeamRunEvent.tool_call_started.value)}
+    assert started == {"call_a"}
+    # So the call the client is holding is closed out rather than left open.
+    errors = _events_named(events, TeamRunEvent.tool_call_error.value)
+    assert [event.tool.tool_call_id for event in errors] == ["call_b"]
+    assert errors[0].tool.tool_name == "save_other"
+    assert errors[0].error == REFUSED_TOOL_CALL_ERROR
+    assert errors[0].tool.tool_call_error
+
+
+def test_team_closes_out_a_tool_call_the_run_refuses():
+    turns, second = _refused_call_turns()
+
+    events = list(_refused_team(turns).run("go", stream=True, stream_events=True))
+
+    _assert_refusal_is_closed_out(events, second)
+
+
+async def test_team_closes_out_a_tool_call_the_run_refuses_async():
+    turns, second = _refused_call_turns()
+
+    events = [event async for event in _refused_team(turns).arun("go", stream=True, stream_events=True)]
+
+    _assert_refusal_is_closed_out(events, second)
+
+
+def test_team_closes_out_a_call_naming_a_tool_it_does_not_have(errors_logged):
+    arguments = json.dumps({"note": "nowhere to put this"})
+    fragments = [_fragment(0, tool_call_id="call_ghost", tool_name="save_nowhere")]
+    fragments += [_fragment(0, chunk) for chunk in _chunks(arguments, CHUNK_SIZE)]
+    turns = [fragments, [ModelResponse(role="assistant", content="there is no such tool")]]
+    team = Team(members=[], model=_ScriptedStreamModel(turns), tools=[save_note])
+
+    events = list(team.run("go", stream=True, stream_events=True))
+
+    assert _assembled(events, "call_ghost") == arguments
+    assert not _events_named(events, TeamRunEvent.tool_call_started.value)
+    errors = _events_named(events, TeamRunEvent.tool_call_error.value)
+    assert [event.tool.tool_call_id for event in errors] == ["call_ghost"]
+    # The run says which tool it could not find, once.
+    assert [record.getMessage() for record in errors_logged] == ["Function save_nowhere not found"]
+
+
+class _RaisingStreamModel(_ScriptedStreamModel):
+    """Streams part of a turn and then dies for good, without a retry."""
+
+    def __init__(self, turns: List[List[ModelResponse]], fail_after: int):
+        super().__init__(turns)
+        self._fail_after = fail_after
+        self.retries = 0
+
+    def _up_to_the_failure(self) -> List[ModelResponse]:
+        return self._next_turn()[: self._fail_after]
+
+    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+        yield from self._up_to_the_failure()
+        raise ModelProviderError(message="stream died", model_name=self.name, model_id=self.id)
+
+    async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+        for delta in self._up_to_the_failure():
+            yield delta
+        raise ModelProviderError(message="stream died", model_name=self.name, model_id=self.id)
+
+
+def _assert_a_raising_stream_closes_the_call_it_left_open(events) -> None:
+    """A stream that raised is still being read, so the closure can still go out.
+
+    The call the client was shown will never be started or completed, and the
+    turn it belonged to never reaches its end, so closing it out only after the
+    loop would leave the client waiting on it for good.
+    """
+    assert _events_named(events, TeamRunEvent.tool_call_args_delta.value), "nothing streamed, so nothing to close"
+    assert not _events_named(events, TeamRunEvent.tool_call_started.value)
+    reported = _events_named(events, TeamRunEvent.tool_call_error.value)
+    assert [event.tool.tool_call_id for event in reported] == ["call_team"]
+    assert reported[0].error == REFUSED_TOOL_CALL_ERROR
+    # The error itself still reaches the caller, after the closure.
+    assert [event.event for event in events[-2:]] == [
+        TeamRunEvent.tool_call_error.value,
+        TeamRunEvent.run_error.value,
+    ]
+
+
+def test_team_closes_out_a_call_a_raising_stream_left_open():
+    turns, _ = _tool_call_turns("call_team")
+    # Three deltas in: the call's announcement and two argument fragments.
+    team = Team(members=[], model=_RaisingStreamModel(turns, fail_after=3), tools=[save_note])
+
+    events = list(team.run("go", stream=True, stream_events=True))
+
+    _assert_a_raising_stream_closes_the_call_it_left_open(events)
+
+
+async def test_team_closes_out_a_call_a_raising_stream_left_open_async():
+    turns, _ = _tool_call_turns("call_team")
+    team = Team(members=[], model=_RaisingStreamModel(turns, fail_after=3), tools=[save_note])
+
+    events = [event async for event in team.arun("go", stream=True, stream_events=True)]
+
+    _assert_a_raising_stream_closes_the_call_it_left_open(events)
+
+
+@tool(requires_confirmation=True)
+def save_on_confirmation(note: str) -> str:
+    """Save a note, once the caller has agreed to it.
+
+    Args:
+        note: the note to save
+    """
+    return "saved"
+
+
+def _team_awaiting_confirmation() -> Tuple[Team, str]:
+    turns, arguments = _tool_call_turns("call_team", tool_name="save_on_confirmation")
+    return Team(members=[], model=_ScriptedStreamModel(turns), tools=[save_on_confirmation]), arguments
+
+
+def _assert_a_paused_call_is_not_reported_as_never_run(events, arguments: str) -> None:
+    """A call waiting on the caller is neither refused nor finished.
+
+    Its arguments streamed before the run could know it would pause, and the
+    run holds it open on purpose: the caller has still to say yes. Reporting it
+    as a call that was not run would be a lie about a call that may yet be.
+    """
+    assert _assembled(events, "call_team") == arguments
+    assert _events_named(events, TeamRunEvent.run_paused.value)
+    assert not _events_named(events, TeamRunEvent.tool_call_error.value)
+
+
+def test_team_does_not_report_a_call_awaiting_confirmation_as_never_run():
+    team, arguments = _team_awaiting_confirmation()
+
+    *events, paused = list(team.run("go", stream=True, stream_events=True, yield_run_output=True))
+
+    _assert_a_paused_call_is_not_reported_as_never_run(events, arguments)
+    assert paused.is_paused
+    assert [(tool.tool_call_id, tool.requires_confirmation) for tool in paused.tools] == [("call_team", True)]
+
+
+async def test_team_does_not_report_a_call_awaiting_confirmation_as_never_run_async():
+    team, arguments = _team_awaiting_confirmation()
+
+    *events, paused = [event async for event in team.arun("go", stream=True, stream_events=True, yield_run_output=True)]
+
+    _assert_a_paused_call_is_not_reported_as_never_run(events, arguments)
+    assert paused.is_paused
+    assert [(tool.tool_call_id, tool.requires_confirmation) for tool in paused.tools] == [("call_team", True)]
+
+
+def _tool_calls_the_run_kept(run_output) -> List[Tuple[Optional[str], bool]]:
+    return [(tool.tool_call_id, bool(tool.tool_call_error)) for tool in run_output.tools]
+
+
+def _assert_the_runs_tool_list_holds_only_the_call_it_made(run_output) -> None:
+    """A refused call is told to the client and left out of the run's own list.
+
+    That list is the framework's account of the calls the run made, and a call
+    it declined to make is not one of them. Telling the client is the stream's
+    job and stops there.
+    """
+    assert run_output.events is None
+    assert _tool_calls_the_run_kept(run_output) == [("call_a", False)]
+
+
+def test_team_leaves_a_refused_tool_call_out_of_the_runs_tool_list():
+    turns, _ = _refused_call_turns()
+    team = _refused_team(turns)
+    assert not team.store_events
+
+    streamed = list(team.run("go", stream=True, stream_events=True, yield_run_output=True))
+
+    _assert_the_runs_tool_list_holds_only_the_call_it_made(streamed[-1])
+
+
+async def test_team_leaves_a_refused_tool_call_out_of_the_runs_tool_list_async():
+    turns, _ = _refused_call_turns()
+    team = _refused_team(turns)
+
+    streamed = [event async for event in team.arun("go", stream=True, stream_events=True, yield_run_output=True)]
+
+    _assert_the_runs_tool_list_holds_only_the_call_it_made(streamed[-1])
+
+
+def test_team_keeps_the_same_tool_calls_whether_or_not_its_events_stream():
+    """The same model behaviour ends on the same tool list either way.
+
+    Whether a caller subscribed to the events is no part of what the run did,
+    so it can be no part of what the run reports having done.
+    """
+    subscribed = list(
+        _refused_team(_refused_call_turns()[0]).run("go", stream=True, stream_events=True, yield_run_output=True)
+    )
+    unsubscribed = list(
+        _refused_team(_refused_call_turns()[0]).run("go", stream=True, stream_events=False, yield_run_output=True)
+    )
+
+    assert _tool_calls_the_run_kept(subscribed[-1]) == _tool_calls_the_run_kept(unsubscribed[-1])
+    assert _tool_calls_the_run_kept(unsubscribed[-1]) == [("call_a", False)]
+
+
+# ---------------------------------------------------------------------------
+# A run cancelled while a call's arguments are streaming
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _asyncio_errors_reported() -> Iterator[List[logging.LogRecord]]:
+    """What the event loop reports when it closes what a cancelled run left it.
+
+    A stream nobody is reading any more is closed by the loop that ran it,
+    when that loop is closed, and an error raised by that closing is reported
+    to the asyncio logger rather than to the caller.
+    """
+    records: List[logging.LogRecord] = []
+
+    class _Collector(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    handler = _Collector(logging.ERROR)
+    asyncio_logger = logging.getLogger("asyncio")
+    asyncio_logger.addHandler(handler)
+    try:
+        yield records
+    finally:
+        asyncio_logger.removeHandler(handler)
+
+
+def _arguments_are_part_written(events) -> bool:
+    """True once some of a call's arguments have gone out and the rest have not."""
+    return len(_events_named(events, TeamRunEvent.tool_call_args_delta.value)) == 2
+
+
+def _assert_the_cancelled_run_ends_and_nothing_waits_on_it(events) -> None:
+    """The run ends on its terminal events with the call it streamed undecided.
+
+    A cancellation is raised where the run's events are consumed, so the
+    stream that was writing the arguments is closed rather than read to the
+    end. Nothing can be added to a stream nobody is reading, and the call a
+    client is holding is closed out by the terminal events the run does end
+    on.
+    """
+    assert _events_named(events, TeamRunEvent.tool_call_args_delta.value), "nothing streamed, so nothing to cancel"
+    assert not _events_named(events, TeamRunEvent.tool_call_started.value)
+    assert [event.event for event in events[-2:]] == [
+        TeamRunEvent.run_cancelled.value,
+        TeamRunEvent.run_completed.value,
+    ]
+
+
+def test_team_cancelled_while_a_calls_arguments_stream_ends_the_run():
+    turns, _ = _tool_call_turns("call_team")
+    team = Team(members=[], model=_ScriptedStreamModel(turns), tools=[save_note])
+
+    events: List[Any] = []
+    for event in team.run("go", stream=True, stream_events=True):
+        events.append(event)
+        if _arguments_are_part_written(events):
+            Team.cancel_run(event.run_id)
+
+    _assert_the_cancelled_run_ends_and_nothing_waits_on_it(events)
+
+
+def test_team_cancelled_while_a_calls_arguments_stream_closes_its_stream_cleanly():
+    """The stream the cancelled run abandoned is closed without complaint.
+
+    A cancellation is raised where the events are consumed, so the stream
+    writing the arguments is closed rather than read to the end. An async
+    generator that yields while it is being closed makes that closing raise,
+    and the loop reports it where nothing asserting on the run would see it.
+    """
+    turns, _ = _tool_call_turns("call_team")
+    team = Team(members=[], model=_ScriptedStreamModel(turns), tools=[save_note])
+
+    async def consume() -> List[Any]:
+        events: List[Any] = []
+        async for event in team.arun("go", stream=True, stream_events=True):
+            events.append(event)
+            if _arguments_are_part_written(events):
+                await Team.acancel_run(event.run_id)
+        return events
+
+    with _asyncio_errors_reported() as reported:
+        # A loop of this test's own, because a stream a cancelled run
+        # abandoned is closed when the loop that ran it is closed.
+        events = asyncio.run(consume())
+
+    _assert_the_cancelled_run_ends_and_nothing_waits_on_it(events)
+    assert [record.getMessage() for record in reported] == []

--- a/libs/agno/tests/unit/utils/test_functions.py
+++ b/libs/agno/tests/unit/utils/test_functions.py
@@ -1,10 +1,28 @@
 import json
-from typing import Dict
+from typing import Any, Dict
 
 import pytest
 
 from agno.tools.function import Function, FunctionCall
-from agno.utils.functions import get_function_call
+from agno.utils.functions import coerce_literal_argument_values, get_function_call
+
+
+def _same_argument_value(left: Any, right: Any) -> bool:
+    """Whether two decoded argument values match with no type coercion at all.
+
+    Plain equality would let True stand in for 1 and 1 for 1.0, and what a
+    comparison of decoded arguments pins is the type a tool is called with as
+    much as the value.
+    """
+    if type(left) is not type(right):
+        return False
+    if isinstance(left, dict):
+        return len(left) == len(right) and all(
+            key in right and _same_argument_value(value, right[key]) for key, value in left.items()
+        )
+    if isinstance(left, list):
+        return len(left) == len(right) and all(_same_argument_value(a, b) for a, b in zip(left, right))
+    return bool(left == right)
 
 
 @pytest.fixture
@@ -162,6 +180,46 @@ def test_get_function_call_coercion_with_surrounding_whitespace(sample_functions
     assert result is not None
     assert result.error is None
     assert result.arguments == {"param1": None, "param2": True, "param3": False}
+
+
+def test_get_function_call_decodes_arguments_through_the_shared_coercion(sample_functions):
+    """The values a tool is called with come from the shared coercion.
+
+    Anything holding a copy of a call's arguments against the run's own has to
+    read them the way the run did, so the coercion has one definition and this
+    pins the decoding to it: the values below are the ones decoding has always
+    produced, and they are also exactly what that definition returns.
+    """
+    sent = {
+        "param1": "true",
+        "param2": " FALSE ",
+        "param3": "null",
+        "param4": "hello",
+        "param5": {"nested": "true"},
+        "param6": ["true"],
+        "param7": 1,
+    }
+
+    result = get_function_call(
+        name="test_function",
+        arguments=json.dumps(sent),
+        functions=sample_functions,
+    )
+
+    expected = {
+        "param1": True,
+        "param2": False,
+        "param3": None,
+        "param4": "hello",
+        "param5": {"nested": "true"},
+        "param6": ["true"],
+        "param7": 1,
+    }
+
+    assert result is not None
+    assert result.error is None
+    assert _same_argument_value(result.arguments, expected), result.arguments
+    assert _same_argument_value(result.arguments, coerce_literal_argument_values(sent)), result.arguments
 
 
 def test_get_function_call_argument_advanced(sample_functions):

--- a/libs/agno/tests/unit/utils/test_tools.py
+++ b/libs/agno/tests/unit/utils/test_tools.py
@@ -1,0 +1,739 @@
+"""Tests for the streamed tool call helpers in agno.utils.tools.
+
+A fragment is attributed the way Agno's own tool call aggregators attribute
+it, and these tests hold it to that by running one of those aggregators over
+the same deltas. The OpenAI chat, watsonx, cerebras and litellm aggregators
+are one rule written out four times: one entry per stream index, a missing
+index read as zero, an entry's id taken from whichever of its deltas last
+carried one, and each delta's argument text appended to the entry it landed
+on. Agreeing with that is the property that matters, because that entry is
+what the run makes the call with.
+"""
+
+import logging
+from contextlib import contextmanager
+from typing import Any, Dict, Iterator, List, NamedTuple, Optional, Tuple
+
+from openai.types.chat.chat_completion_chunk import ChoiceDeltaToolCall, ChoiceDeltaToolCallFunction
+from pydantic import BaseModel
+
+from agno.models.openai.chat import OpenAIChat
+from agno.models.response import ToolExecution
+from agno.utils import log as agno_log
+from agno.utils.tools import (
+    REFUSED_TOOL_CALL_ERROR,
+    ToolCallArgsStream,
+    TurnToolCalls,
+    answer_streamed_tool_calls,
+    extract_tool_call_arg_deltas,
+    take_refused_tool_calls,
+)
+
+
+class _NamedTupleDelta(NamedTuple):
+    """A tuple shaped delta, as SDKs that model deltas as records hand them over.
+
+    It has no stream index, but being a tuple it does have a built-in `index`
+    method, so a plain attribute read finds a callable instead of nothing.
+    """
+
+    id: Optional[str] = None
+    function: Optional[Dict[str, Any]] = None
+
+
+class _LoneDelta(BaseModel):
+    """One delta reported on its own, not inside a list, as one provider does.
+
+    That is how the Llama model class reports a streamed tool call: it assigns
+    the provider's own delta object where a list of deltas belongs. Iterating
+    a model like this one yields its (field, value) pairs rather than deltas,
+    so the batch reads as calls naming nothing and carrying no argument text.
+    """
+
+    id: Optional[str] = None
+    function: Optional[Dict[str, Any]] = None
+
+
+def _drain(
+    chunks: List[List[Any]],
+    turn: Optional[TurnToolCalls] = None,
+) -> Tuple[List[Tuple[str, Optional[str], str]], int, List[Tuple[Optional[str], Optional[str]]]]:
+    """Feed a whole stream of deltas through the extractor, one chunk at a time.
+
+    Returns the fragments to pass on, how many no call of the turn could be
+    found for, and the calls whose arguments were not written as text.
+    """
+    if turn is None:
+        turn = TurnToolCalls()
+    deltas: List[Tuple[str, Optional[str], str]] = []
+    unattributable = 0
+    unwritten: List[Tuple[Optional[str], Optional[str]]] = []
+    for chunk in chunks:
+        chunk_deltas, chunk_unattributable, chunk_unwritten, _ = extract_tool_call_arg_deltas(chunk, turn)
+        deltas.extend(chunk_deltas)
+        unattributable += chunk_unattributable
+        unwritten.extend(chunk_unwritten)
+    return deltas, unattributable, unwritten
+
+
+@contextmanager
+def _warnings_logged() -> Iterator[List[logging.LogRecord]]:
+    """Everything Agno logs at warning level, whichever logger carried it.
+
+    ``log_warning`` writes to a process-global logger that a team run rebinds
+    to the team logger and never rebinds back, so the same line is carried by
+    one logger or another depending on what else ran earlier in the process.
+    """
+    records: List[logging.LogRecord] = []
+
+    class _Collector(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    handler = _Collector(logging.WARNING)
+    loggers = list(
+        {id(value): value for value in vars(agno_log).values() if isinstance(value, logging.Logger)}.values()
+    )
+    for agno_logger in loggers:
+        agno_logger.addHandler(handler)
+    try:
+        yield records
+    finally:
+        for agno_logger in loggers:
+            agno_logger.removeHandler(handler)
+
+
+def _as_openai_deltas(chunks: List[List[Any]]) -> Iterator[ChoiceDeltaToolCall]:
+    """The same deltas as the OpenAI SDK models them, for its own aggregator.
+
+    Built without validation so that a delta can leave the index out, which is
+    what an OpenAI compatible gateway sends and what `parse_tool_calls` reads
+    as zero.
+    """
+    for chunk in chunks:
+        for delta in chunk:
+            function = delta.get("function") or {}
+            yield ChoiceDeltaToolCall.model_construct(
+                index=delta.get("index"),
+                id=delta.get("id"),
+                type="function",
+                function=ChoiceDeltaToolCallFunction.model_construct(
+                    name=function.get("name"), arguments=function.get("arguments")
+                ),
+            )
+
+
+def _aggregated_by_agno(chunks: List[List[Any]]) -> Dict[Optional[str], str]:
+    """What the run itself will call with, from Agno's own OpenAI aggregator."""
+    return {
+        call["id"]: call["function"]["arguments"]
+        for call in OpenAIChat.parse_tool_calls(list(_as_openai_deltas(chunks)))
+        if call
+    }
+
+
+def _streamed_by_call(deltas: List[Tuple[str, Optional[str], str]]) -> Dict[Optional[str], str]:
+    """What a subscriber holds per call once it has appended every fragment."""
+    assembled: Dict[Optional[str], str] = {}
+    for tool_call_id, _tool_name, fragment in deltas:
+        assembled[tool_call_id] = assembled.get(tool_call_id, "") + fragment
+    return assembled
+
+
+def test_indexed_provider_sends_id_and_name_once():
+    """The ordinary case: one opening delta, then argument text on the same index."""
+    deltas, unattributable, _ = _drain(
+        [
+            [{"index": 0, "id": "call_1", "function": {"name": "get_weather", "arguments": ""}}],
+            [{"index": 0, "function": {"arguments": '{"city":'}}],
+            [{"index": 0, "function": {"arguments": ' "Paris"}'}}],
+        ]
+    )
+
+    assert deltas == [
+        ("call_1", "get_weather", '{"city":'),
+        ("call_1", "get_weather", ' "Paris"}'),
+    ]
+    assert unattributable == 0
+
+
+def test_two_indexed_calls_stream_side_by_side():
+    """Interleaved fragments follow the provider's own index."""
+    deltas, unattributable, _ = _drain(
+        [
+            [
+                {"index": 0, "id": "call_1", "function": {"name": "get_weather"}},
+                {"index": 1, "id": "call_2", "function": {"name": "get_time"}},
+            ],
+            [
+                {"index": 1, "function": {"arguments": '{"tz":'}},
+                {"index": 0, "function": {"arguments": '{"city":'}},
+            ],
+            [{"index": 0, "function": {"arguments": ' "Paris"}'}}],
+            [{"index": 1, "function": {"arguments": ' "UTC"}'}}],
+        ]
+    )
+
+    assert deltas == [
+        ("call_2", "get_time", '{"tz":'),
+        ("call_1", "get_weather", '{"city":'),
+        ("call_1", "get_weather", ' "Paris"}'),
+        ("call_2", "get_time", ' "UTC"}'),
+    ]
+    assert unattributable == 0
+
+
+def test_repeated_id_without_name_keeps_the_learned_name():
+    """A provider that repeats the id on every fragment but the name only once."""
+    deltas, _, _ = _drain(
+        [
+            [{"id": "call_1", "function": {"name": "get_weather"}}],
+            [{"id": "call_1", "function": {"arguments": '{"city":'}}],
+            [{"id": "call_1", "function": {"arguments": ' "Paris"}'}}],
+        ]
+    )
+
+    assert deltas == [
+        ("call_1", "get_weather", '{"city":'),
+        ("call_1", "get_weather", ' "Paris"}'),
+    ]
+
+
+def test_name_arriving_after_the_id_attaches_to_the_call():
+    """A provider that opens the call with an id and names it on a later fragment."""
+    deltas, _, _ = _drain(
+        [
+            [{"index": 0, "id": "call_1"}],
+            [{"index": 0, "function": {"name": "get_weather", "arguments": '{"city":'}}],
+            [{"index": 0, "function": {"arguments": ' "Paris"}'}}],
+        ]
+    )
+
+    assert deltas == [
+        ("call_1", "get_weather", '{"city":'),
+        ("call_1", "get_weather", ' "Paris"}'),
+    ]
+
+
+def test_tuple_shaped_delta_falls_back_instead_of_reading_its_index_method():
+    """A tuple has an `index` method, which must not pass for a stream index."""
+    deltas, _, _ = _drain(
+        [
+            [_NamedTupleDelta(id="call_1", function={"name": "get_weather"})],
+            [_NamedTupleDelta(id="call_1", function={"arguments": '{"city": "Paris"}'})],
+        ]
+    )
+
+    assert deltas == [("call_1", "get_weather", '{"city": "Paris"}')]
+
+
+def test_a_call_id_the_provider_did_not_write_as_a_string_keeps_its_fragments():
+    """An id of another type is the id the run calls under, so it is used as is.
+
+    Nothing here narrows it: the finished call carries whatever the provider
+    sent, and a subscriber has to be able to match its fragments to that.
+    """
+    deltas, unattributable, _ = _drain(
+        [
+            [{"index": 0, "id": 7, "function": {"name": "get_weather"}}],
+            [{"index": 0, "function": {"arguments": '{"city": "Paris"}'}}],
+        ]
+    )
+
+    assert deltas == [(7, "get_weather", '{"city": "Paris"}')]
+    assert unattributable == 0
+
+
+def test_a_call_id_the_provider_wrote_as_a_falsy_value_places_by_the_stream_index():
+    """An id field filled in with a falsy placeholder says nothing about the call.
+
+    A zero or an empty string there is not an id the finished call could be
+    matched by, so it is read as no id at all and the provider's stream index
+    places the fragment. A truthy id of another type is passed through
+    unnarrowed instead, because the finished call carries it unnarrowed too.
+    """
+    for falsy_id in (0, ""):
+        deltas, unattributable, _ = _drain(
+            [
+                [{"index": 0, "id": "call_1", "function": {"name": "get_weather"}}],
+                [{"index": 0, "id": falsy_id, "function": {"arguments": '{"city": "Paris"}'}}],
+            ]
+        )
+
+        assert deltas == [("call_1", "get_weather", '{"city": "Paris"}')], falsy_id
+        assert unattributable == 0, falsy_id
+
+
+def test_a_falsy_call_id_at_an_index_holding_no_call_places_nothing():
+    """Read as no id, and its index names no call either, so nothing places it.
+
+    The turn's one call sits at index one, so index zero is a slot no delta
+    has named and there is no call of the turn to hand the fragment to.
+    Passing the falsy id through instead would put a subscriber on argument
+    text under an id no call was ever made under.
+    """
+    for falsy_id in (0, ""):
+        deltas, unattributable, _ = _drain(
+            [
+                [{"index": 1, "id": "call_1", "function": {"name": "get_weather"}}],
+                [{"index": 0, "id": falsy_id, "function": {"arguments": '{"city": "Paris"}'}}],
+            ]
+        )
+
+        assert deltas == [], falsy_id
+        assert unattributable == 1, falsy_id
+
+
+def test_a_provider_that_numbers_no_delta_streams_the_whole_arguments():
+    """The id rides the opening delta and nothing carries an index.
+
+    Read strictly, the later fragments name no call and none of the arguments
+    could be sent; read as Agno's own aggregators read them, they are the one
+    call's and all of them go out.
+    """
+    chunks: List[List[Any]] = [
+        [{"id": "call_1", "function": {"name": "get_weather", "arguments": ""}}],
+        [{"function": {"arguments": '{"city":'}}],
+        [{"function": {"arguments": ' "Paris"}'}}],
+    ]
+    deltas, unattributable, _ = _drain(chunks)
+
+    assert _streamed_by_call(deltas) == {"call_1": '{"city": "Paris"}'}
+    assert _streamed_by_call(deltas) == _aggregated_by_agno(chunks)
+    assert unattributable == 0
+
+
+def test_a_mixed_provider_streams_what_the_run_will_call_with():
+    """One call carries an index, the other only an id, in the same turn.
+
+    An index-less delta counts as index zero here as it does in the run
+    itself, so the second call's id takes over that slot in both places and
+    every fragment of the turn goes out under it. Streaming a reading of our
+    own instead would leave a subscriber holding arguments no call was ever
+    made with.
+    """
+    chunks: List[List[Any]] = [
+        [
+            {"index": 0, "id": "call_1", "function": {"name": "get_weather"}},
+            {"id": "call_2", "function": {"name": "get_time"}},
+        ],
+        [{"index": 0, "function": {"arguments": '{"city":'}}],
+        [{"id": "call_2", "function": {"arguments": '{"tz":'}}],
+        [{"index": 0, "function": {"arguments": ' "Paris"}'}}],
+        [{"id": "call_2", "function": {"arguments": ' "UTC"}'}}],
+    ]
+    deltas, unattributable, _ = _drain(chunks)
+
+    assert _streamed_by_call(deltas) == {"call_2": '{"city":{"tz": "Paris"} "UTC"}'}
+    assert _streamed_by_call(deltas) == _aggregated_by_agno(chunks)
+    assert unattributable == 0
+
+
+def test_two_index_less_calls_follow_the_id_each_delta_carries():
+    """A provider that numbers nothing and opens a second call under a new id.
+
+    Each fragment goes out under the id its own delta carried, which is the id
+    that slot holds at the time. The run's aggregator ends by labelling the
+    whole slot with the last id it saw, and no stream can go back and relabel
+    text a subscriber already has, so the finished call is what says which
+    arguments the call was made with.
+    """
+    chunks: List[List[Any]] = [
+        [{"id": "call_1", "function": {"name": "get_weather", "arguments": '{"city":'}}],
+        [{"id": "call_2", "function": {"name": "get_time", "arguments": '{"tz":'}}],
+        [{"id": "call_1", "function": {"arguments": ' "Paris"}'}}],
+        [{"id": "call_2", "function": {"arguments": ' "UTC"}'}}],
+    ]
+    deltas, _, _ = _drain(chunks)
+
+    assert deltas == [
+        ("call_1", "get_weather", '{"city":'),
+        ("call_2", "get_time", '{"tz":'),
+        ("call_1", "get_weather", ' "Paris"}'),
+        ("call_2", "get_time", ' "UTC"}'),
+    ]
+    # Every fragment the run put in that one slot went out, in that order.
+    assert "".join(fragment for _id, _name, fragment in deltas) == _aggregated_by_agno(chunks)["call_2"]
+
+
+def test_a_fragment_that_arrives_before_any_call_is_named_is_counted_and_not_placed():
+    """No id has been seen yet, so index zero resolves to no call at all.
+
+    Agno gives a call the provider never named an id of its own only once the
+    finished call is assembled, so there is nothing to send these under and
+    the text is counted for the caller to report once for its stream.
+    """
+    deltas, unattributable, _ = _drain(
+        [
+            [{"function": {"name": "get_weather", "arguments": '{"city":'}}],
+            [{"function": {"arguments": ' "Paris"}'}}],
+        ]
+    )
+
+    assert deltas == []
+    assert unattributable == 2
+
+
+def test_a_fragment_that_names_nothing_joins_the_call_holding_index_zero():
+    """One call is open, so index zero can only mean that one.
+
+    Which is where the run itself puts such a fragment, so a subscriber ends
+    on the arguments the call is made with.
+    """
+    chunks: List[List[Any]] = [
+        [{"index": 0, "id": "call_1", "function": {"name": "get_weather", "arguments": '{"city":'}}],
+        [{"function": {"arguments": "stray"}}],
+        [{"index": 0, "function": {"arguments": ' "Paris"}'}}],
+    ]
+    deltas, unattributable, _ = _drain(chunks)
+
+    assert _streamed_by_call(deltas) == {"call_1": '{"city":stray "Paris"}'}
+    assert _streamed_by_call(deltas) == _aggregated_by_agno(chunks)
+    assert unattributable == 0
+
+
+def test_a_fragment_that_names_nothing_still_joins_index_zero_with_two_calls_open():
+    """Two calls are open and a fragment names neither.
+
+    Index zero hands the text to whichever of them holds that slot, and so
+    does the run: reading it any other way would put a subscriber on arguments
+    no call was made with, which is worse than agreeing with an ambiguous
+    provider.
+    """
+    chunks: List[List[Any]] = [
+        [
+            {"index": 0, "id": "call_1", "function": {"name": "get_weather"}},
+            {"index": 1, "id": "call_2", "function": {"name": "get_time"}},
+        ],
+        [{"function": {"arguments": '{"city": "Paris"}'}}],
+    ]
+    deltas, unattributable, _ = _drain(chunks)
+
+    assert deltas == [("call_1", "get_weather", '{"city": "Paris"}')]
+    assert _streamed_by_call(deltas)["call_1"] == _aggregated_by_agno(chunks)["call_1"]
+    assert unattributable == 0
+
+
+def test_an_unnumbered_fragment_beside_a_call_numbered_above_zero_is_counted():
+    """The turn's one call sits at index one, and a fragment carries no index.
+
+    Index zero is a slot no delta has named, and the run makes that slot a
+    call of its own with no id and no name. There is nothing for a subscriber
+    to hold such a fragment under, so it is counted rather than handed to the
+    numbered call it does not belong to.
+    """
+    chunks: List[List[Any]] = [
+        [{"index": 1, "id": "call_1", "function": {"name": "get_weather"}}],
+        [{"function": {"arguments": '{"city": "Paris"}'}}],
+    ]
+    deltas, unattributable, _ = _drain(chunks)
+
+    assert deltas == []
+    assert unattributable == 1
+    # The run puts that text on a call it gives no id, so no id could have
+    # carried it to a subscriber.
+    assert _aggregated_by_agno(chunks) == {None: '{"city": "Paris"}', "call_1": ""}
+
+
+def test_a_numbered_fragment_follows_its_own_index_with_two_calls_open():
+    """A provider that numbered the fragment has said which call it belongs to."""
+    deltas, unattributable, _ = _drain(
+        [
+            [
+                {"index": 0, "id": "call_1", "function": {"name": "get_weather"}},
+                {"index": 1, "id": "call_2", "function": {"name": "get_time"}},
+            ],
+            [{"index": 1, "function": {"arguments": '{"tz": "UTC"}'}}],
+        ]
+    )
+
+    assert deltas == [("call_2", "get_time", '{"tz": "UTC"}')]
+    assert unattributable == 0
+
+
+def test_arguments_the_provider_did_not_write_as_text_are_reported_with_their_call():
+    """A delta whose arguments are a structure rather than the model's text.
+
+    Mistral's streamed deltas type them either way, and the adapters that meet
+    a mapping turn it into JSON text for the finished call. There is no
+    fragment of the text the model wrote to send, and writing one here would
+    put a subscriber on text of this library's making, so it is reported
+    instead, under the call it happened to.
+    """
+    deltas, unattributable, unwritten = _drain(
+        [[{"id": "call_1", "function": {"name": "get_weather", "arguments": {"city": "Paris"}}}]]
+    )
+
+    assert deltas == []
+    assert unattributable == 0
+    assert unwritten == [("call_1", "get_weather")]
+
+
+def test_an_empty_structure_withholds_no_text_and_is_not_reported():
+    """A call to a tool that takes no arguments, typed as a mapping.
+
+    Nothing the model wrote is being kept from a subscriber here, so reporting
+    it would be a false report of text withheld.
+    """
+    deltas, unattributable, unwritten = _drain(
+        [
+            [{"index": 0, "id": "call_1", "function": {"name": "get_time", "arguments": {}}}],
+            [{"index": 1, "id": "call_2", "function": {"name": "get_date", "arguments": []}}],
+        ]
+    )
+
+    assert deltas == []
+    assert (unattributable, unwritten) == (0, [])
+
+
+def test_a_delta_whose_arguments_are_not_text_still_names_its_call():
+    """What such a delta does say about the call is still learned from it."""
+    deltas, _, unwritten = _drain(
+        [
+            [{"index": 0, "id": "call_1", "function": {"name": "get_weather", "arguments": ["Paris"]}}],
+            [{"index": 0, "function": {"arguments": '{"city": "Paris"}'}}],
+        ]
+    )
+
+    assert deltas == [("call_1", "get_weather", '{"city": "Paris"}')]
+    assert unwritten == [("call_1", "get_weather")]
+
+
+def test_fragment_without_arguments_yields_nothing():
+    turn = TurnToolCalls()
+
+    assert extract_tool_call_arg_deltas([{"index": 0, "id": "call_1", "function": {"name": "f"}}], turn) == (
+        [],
+        0,
+        [],
+        None,
+    )
+    assert extract_tool_call_arg_deltas(None, turn) == ([], 0, [], None)
+    assert extract_tool_call_arg_deltas([], turn) == ([], 0, [], None)
+
+
+def test_a_batch_that_is_not_a_list_of_deltas_is_named_and_read_no_further():
+    """A batch out of which no delta can be read is turned away by its shape.
+
+    Iterating one yields whatever that object yields, and those contents name
+    no call and carry no argument text, so nothing about them is reportable
+    once they are in the loop. The turn learns nothing from such a batch, so a
+    later fragment cannot resolve against a call it appeared to open.
+    """
+    turn = TurnToolCalls()
+    lone = _LoneDelta(id="call_1", function={"name": "get_weather", "arguments": '{"city": "Paris"}'})
+
+    assert extract_tool_call_arg_deltas(lone, turn) == ([], 0, [], "_LoneDelta")  # type: ignore[arg-type]
+    assert (turn.id_by_index, turn.name_by_id) == ({}, {})
+    # Any other shape a provider might report, rather than this one type.
+    assert extract_tool_call_arg_deltas({"0": {"function": {"arguments": "{}"}}}, turn)[3] == "dict"  # type: ignore[arg-type]
+    assert extract_tool_call_arg_deltas('{"city": "Paris"}', turn)[3] == "str"  # type: ignore[arg-type]
+
+
+def test_a_restarted_stream_offers_its_retraced_fragments_again():
+    """A provider stream that drops replays the turn from its opening delta.
+
+    The retraced fragments go out again, because a subscriber can only append
+    what it is sent and the run's own reassembly is retraced the same way.
+    """
+    chunks: List[List[Any]] = [
+        [{"index": 0, "id": "call_1", "function": {"name": "get_weather", "arguments": ""}}],
+        [{"index": 0, "function": {"arguments": '{"city":'}}],
+        [{"index": 0, "id": "call_1", "function": {"name": "get_weather", "arguments": ""}}],
+        [{"index": 0, "function": {"arguments": '{"city":'}}],
+        [{"index": 0, "function": {"arguments": ' "Paris"}'}}],
+    ]
+    deltas, _, _ = _drain(chunks)
+
+    # Retraced and all, which is what the run holds too.
+    assert _streamed_by_call(deltas) == {"call_1": '{"city":{"city": "Paris"}'}
+    assert _streamed_by_call(deltas) == _aggregated_by_agno(chunks)
+
+
+def test_a_cleared_turn_resolves_no_index_of_the_turn_before_it():
+    """Indexes restart at zero each turn, so a caller drops them between turns.
+
+    Without that, the next turn's first fragment, which carries index zero and
+    no id, would land on the finished call the last turn made under index zero.
+    """
+    turn = TurnToolCalls()
+    _drain([[{"index": 0, "id": "call_1", "function": {"name": "get_weather", "arguments": '{"city":'}}]], turn)
+
+    turn.clear()
+    deltas, unattributable, _ = _drain([[{"index": 0, "function": {"arguments": ' "Paris"}'}}]], turn)
+
+    assert deltas == []
+    assert unattributable == 1
+
+
+def test_a_delta_repeating_a_calls_id_and_name_is_neither_warned_about_nor_streamed():
+    """Repeating a call's id and name on a later delta is a healthy stream.
+
+    Some providers restate both on every delta of a call. The repetition adds
+    no argument text, so there is nothing to pass on, and there is nothing
+    wrong to report either.
+    """
+    stream = ToolCallArgsStream("session_1", "run_1")
+
+    with _warnings_logged() as warnings:
+        fragments = [
+            triple
+            for chunk in (
+                [{"index": 0, "id": "call_1", "function": {"name": "get_weather", "arguments": '{"city":'}}],
+                [{"index": 0, "id": "call_1", "function": {"name": "get_weather", "arguments": ""}}],
+                [{"index": 0, "id": "call_1", "function": {"name": "get_weather", "arguments": ' "Paris"}'}}],
+            )
+            for triple in stream.fragments(chunk)
+        ]
+
+    assert _streamed_by_call(fragments) == {"call_1": '{"city": "Paris"}'}
+    assert [record.getMessage() for record in warnings] == []
+
+
+def test_tool_calls_reported_in_an_unreadable_shape_are_reported_once_and_not_streamed():
+    """A provider that reports a streamed call as one delta object, not a list.
+
+    No fragment of that call can be read, so an operator is told so instead of
+    the loss passing in silence. The call is left off the stream's own record
+    too, since a client shown no fragment of it has nothing left open.
+    """
+    lone = _LoneDelta(id="call_1", function={"name": "get_weather", "arguments": '{"city": "Paris"}'})
+    stream = ToolCallArgsStream("session_1", "run_1")
+
+    with _warnings_logged() as warnings:
+        fragments = [triple for batch in (lone, lone) for triple in stream.fragments(batch)]  # type: ignore[arg-type]
+
+    assert fragments == []
+    assert stream.take_unanswered() == []
+    assert len(warnings) == 1
+    message = warnings[0].getMessage()
+    assert "_LoneDelta" in message
+    assert "no argument fragment is streamed" in message
+    assert "session_id=session_1, run_id=run_1" in message
+
+
+def test_a_fragment_arriving_after_the_run_took_a_call_up_reports_no_refusal():
+    """A call the run has made is never reported to the client as never run.
+
+    Providers sometimes trail a last argument fragment behind the call the run
+    has already taken up, and some restate the id and name on every fragment.
+    By then the client has watched that call start and finish, so returning it
+    to the record of streamed calls the run has not answered could only ever
+    close out a call the client saw succeed.
+    """
+    stream = ToolCallArgsStream("session_1", "run_1")
+
+    streamed = list(
+        stream.fragments([{"index": 0, "id": "call_1", "function": {"name": "set_flag", "arguments": '{"flag"'}}])
+    )
+    answer_streamed_tool_calls(stream, [ToolExecution(tool_call_id="call_1", tool_name="set_flag")])
+    late = list(
+        stream.fragments([{"index": 0, "id": "call_1", "function": {"name": "set_flag", "arguments": ": true}"}}])
+    )
+
+    assert streamed == [("call_1", "set_flag", '{"flag"')]
+    assert late == [("call_1", "set_flag", ": true}")]
+    assert take_refused_tool_calls(stream) == []
+
+
+def test_a_reused_call_id_leaves_a_later_refused_call_open_on_the_client():
+    """The cost of never returning an answered call to the record, on the record.
+
+    A provider that reuses the id of a call the run has made for a genuinely
+    new call, which the run then refuses, leaves that second call open on the
+    client instead of closing it out. Nothing on a fragment marks where one
+    call's arguments end and a reuse of its id begins, so this cannot be told
+    apart from the trailing fragment of the first call, and a wrong report
+    about a call the client watched succeed is the worse of the two harms.
+    """
+    stream = ToolCallArgsStream("session_1", "run_1")
+
+    list(stream.fragments([{"index": 0, "id": "call_1", "function": {"name": "set_flag", "arguments": "{}"}}]))
+    answer_streamed_tool_calls(stream, [ToolExecution(tool_call_id="call_1", tool_name="set_flag")])
+
+    stream.begin_turn()
+    reused = list(
+        stream.fragments(
+            [{"index": 0, "id": "call_1", "function": {"name": "set_flag", "arguments": '{"flag": true}'}}]
+        )
+    )
+
+    assert reused == [("call_1", "set_flag", '{"flag": true}')]
+    assert take_refused_tool_calls(stream) == []
+
+
+def test_a_stream_drops_its_stream_indexes_at_a_turn_boundary():
+    """A turn boundary ends the provider's numbering, not the record of calls.
+
+    Indexes restart at zero each turn, so a fragment of the next turn that
+    carries no id resolves against no call and is reported rather than placed
+    on the call the last turn made under that index. The calls the run has not
+    yet answered are a separate record and outlive the boundary.
+    """
+    stream = ToolCallArgsStream("session_1", "run_1")
+
+    opening = list(
+        stream.fragments([{"index": 0, "id": "call_1", "function": {"name": "get_weather", "arguments": '{"city":'}}])
+    )
+    stream.begin_turn()
+    with _warnings_logged() as warnings:
+        after_boundary = list(stream.fragments([{"index": 0, "function": {"arguments": ' "Paris"}'}}]))
+
+    assert opening == [("call_1", "get_weather", '{"city":')]
+    assert after_boundary == []
+    assert len(warnings) == 1
+    assert "carried neither a tool call id nor a provider stream index" in warnings[0].getMessage()
+    assert stream.take_unanswered() == [("call_1", "get_weather")]
+
+
+def test_a_call_the_run_takes_up_is_struck_off_and_the_rest_are_kept():
+    """Taking one call up says nothing about the other calls of the same turn."""
+    stream = ToolCallArgsStream("session_1", "run_1")
+
+    list(
+        stream.fragments(
+            [
+                {"index": 0, "id": "call_1", "function": {"name": "get_weather", "arguments": "{}"}},
+                {"index": 1, "id": "call_2", "function": {"name": "set_flag", "arguments": "{}"}},
+            ]
+        )
+    )
+    stream.call_answered("call_1")
+
+    assert stream.take_unanswered() == [("call_2", "set_flag")]
+
+
+def test_the_unanswered_sweep_hands_each_call_over_once_and_once_only():
+    """Whatever sweeps the record closes each call out exactly once.
+
+    A run reaches the sweep more than once, at each turn boundary and again
+    when it ends, so a call handed over is gone from the record and cannot be
+    reported to the client a second time.
+    """
+    stream = ToolCallArgsStream("session_1", "run_1")
+
+    list(
+        stream.fragments(
+            [
+                {"index": 0, "id": "call_1", "function": {"name": "get_weather", "arguments": "{}"}},
+                {"index": 1, "id": "call_2", "function": {"name": "set_flag", "arguments": "{}"}},
+            ]
+        )
+    )
+
+    assert stream.take_unanswered() == [("call_1", "get_weather"), ("call_2", "set_flag")]
+    assert stream.take_unanswered() == []
+
+
+def test_a_call_the_run_never_took_up_is_reported_to_the_client_as_refused():
+    """The record exists to close out a streamed call the run declined to make."""
+    stream = ToolCallArgsStream("session_1", "run_1")
+
+    list(stream.fragments([{"index": 0, "id": "call_1", "function": {"name": "get_weather", "arguments": "{}"}}]))
+
+    refused = take_refused_tool_calls(stream)
+
+    assert [(tool.tool_call_id, tool.tool_name, tool.tool_call_error) for tool in refused] == [
+        ("call_1", "get_weather", True)
+    ]
+    assert [tool.result for tool in refused] == [REFUSED_TOOL_CALL_ERROR]

--- a/libs/agno/tests/unit/workflow/test_tool_call_args_delta_events.py
+++ b/libs/agno/tests/unit/workflow/test_tool_call_args_delta_events.py
@@ -1,0 +1,295 @@
+"""What a Workflow stores of a tool call's streamed argument fragments.
+
+A workflow's steps run agents and teams, and their fragment events pass through
+the workflow on the way to the caller. One fragment per handful of argument
+characters means a single call can produce hundreds of them, so a workflow with
+event storage on must not keep every one of them on the run it persists: the
+default skip list holds them out of storage without holding them off the
+stream. Everything a workflow stored before is stored still.
+"""
+
+import json
+from typing import Any, AsyncIterator, Dict, Iterator, List, Optional, Tuple
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.base import Model
+from agno.models.response import ModelResponse
+from agno.run.agent import RunEvent
+from agno.run.team import TeamRunEvent
+from agno.run.workflow import WorkflowRunEvent, WorkflowRunOutput
+from agno.team import Team
+from agno.workflow import Step, Workflow
+
+CHUNK_SIZE = 4
+SESSION_ID = "notes-session"
+WORKFLOW_ID = "notes"
+
+
+class _ScriptedStreamModel(Model):
+    """Replays a fixed script of provider deltas, one turn per model call.
+
+    A call's id and function name ride its first fragment; every later fragment
+    carries only an argument chunk and the index that ties it back to the call.
+
+    The script is finite: a call past its end fails the test rather than
+    replaying a turn, so a run that loops longer than intended is visible. The
+    non-streaming paths answer out of the same script, so they cost a turn too
+    and cannot quietly serve a run the script never provided for.
+    """
+
+    def __init__(self, turns: List[List[ModelResponse]]):
+        super().__init__(id="scripted-stream", name="scripted-stream", provider="test")
+        self._turns = list(turns)
+        self._turn = 0
+
+    def _next_turn(self) -> List[ModelResponse]:
+        assert self._turn < len(self._turns), f"model called {self._turn + 1} times, script holds {len(self._turns)}"
+        turn = self._turns[self._turn]
+        self._turn += 1
+        return turn
+
+    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+        yield from self._next_turn()
+
+    async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+        for delta in self._next_turn():
+            yield delta
+
+    def _aggregate_turn(self) -> ModelResponse:
+        """The same turn as one finished response, for the non-streaming path."""
+        turn = self._next_turn()
+        aggregated = ModelResponse(role="assistant")
+        fragments = [call for delta in turn for call in (delta.tool_calls or [])]
+        if fragments:
+            aggregated.tool_calls = self.parse_tool_calls(fragments)
+        content = "".join(delta.content for delta in turn if isinstance(delta.content, str))
+        if content:
+            aggregated.content = content
+        return aggregated
+
+    def invoke(self, *args, **kwargs) -> ModelResponse:
+        return self._aggregate_turn()
+
+    async def ainvoke(self, *args, **kwargs) -> ModelResponse:
+        return self._aggregate_turn()
+
+    def _parse_provider_response(self, response, **kwargs) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+    def _parse_provider_response_delta(self, response) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+    def parse_tool_calls(self, tool_calls_data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Reassemble the fragments by index, as OpenAI-compatible models do."""
+        calls: Dict[int, Dict[str, Any]] = {}
+        for fragment in tool_calls_data:
+            index = fragment.get("index", 0)
+            call = calls.setdefault(index, {"id": None, "type": "function", "function": {"name": "", "arguments": ""}})
+            if fragment.get("id"):
+                call["id"] = fragment["id"]
+            function = fragment.get("function") or {}
+            if function.get("name"):
+                call["function"]["name"] = function["name"]
+            if function.get("arguments"):
+                call["function"]["arguments"] += function["arguments"]
+        return list(calls.values())
+
+
+def save_note(note: str) -> str:
+    """Save a note.
+
+    Args:
+        note: the note to save
+    """
+    return "saved"
+
+
+def _fragment(
+    index: int,
+    arguments: str = "",
+    tool_call_id: Optional[str] = None,
+    tool_name: Optional[str] = None,
+) -> ModelResponse:
+    call: Dict[str, Any] = {"index": index, "type": "function", "function": {"arguments": arguments}}
+    if tool_call_id is not None:
+        call["id"] = tool_call_id
+    if tool_name is not None:
+        call["function"]["name"] = tool_name
+    return ModelResponse(role="assistant", tool_calls=[call])
+
+
+def _chunks(text: str, size: int) -> List[str]:
+    return [text[start : start + size] for start in range(0, len(text), size)]
+
+
+def _tool_call_turns() -> Tuple[List[List[ModelResponse]], str]:
+    """A turn calling a tool in many fragments, then a turn replying."""
+    arguments = json.dumps({"note": "a note long enough to arrive in many fragments"})
+    fragments = [_fragment(0, arguments[:CHUNK_SIZE], tool_call_id="call_a", tool_name="save_note")]
+    fragments += [_fragment(0, chunk) for chunk in _chunks(arguments[CHUNK_SIZE:], CHUNK_SIZE)]
+    return [fragments, [ModelResponse(role="assistant", content="the note is saved")]], arguments
+
+
+def _workflow(tmp_path, db_name: str, step: Step, **kwargs) -> Tuple[Workflow, str]:
+    db_file = str(tmp_path / db_name)
+    workflow = Workflow(
+        id=WORKFLOW_ID,
+        name="notes",
+        steps=[step],
+        db=SqliteDb(db_file=db_file),
+        store_events=True,
+        **kwargs,
+    )
+    return workflow, db_file
+
+
+def _agent_step_workflow(tmp_path, db_name: str, **kwargs) -> Tuple[Workflow, str, str]:
+    turns, arguments = _tool_call_turns()
+    agent = Agent(name="writer", model=_ScriptedStreamModel(turns), tools=[save_note])
+    workflow, db_file = _workflow(tmp_path, db_name, Step(name="write", agent=agent), **kwargs)
+    return workflow, db_file, arguments
+
+
+def _team_step_workflow(tmp_path, db_name: str, **kwargs) -> Tuple[Workflow, str, str]:
+    turns, arguments = _tool_call_turns()
+    team = Team(
+        name="writers",
+        members=[Agent(name="member", model=_ScriptedStreamModel([]))],
+        model=_ScriptedStreamModel(turns),
+        tools=[save_note],
+    )
+    workflow, db_file = _workflow(tmp_path, db_name, Step(name="write", team=team), **kwargs)
+    return workflow, db_file, arguments
+
+
+def _persisted_run(db_file: str) -> WorkflowRunOutput:
+    """The run as the database holds it, read back through a fresh workflow.
+
+    Asking the workflow that just ran answers out of its own in-memory session,
+    which says nothing about what reached the db these tests configure.
+    """
+    fresh = Workflow(id=WORKFLOW_ID, db=SqliteDb(db_file=db_file))
+    session = fresh.get_session(session_id=SESSION_ID)
+    assert session is not None and session.runs, "the run was never persisted"
+    return session.runs[-1]
+
+
+def _fragments_of(events, event_name: str) -> str:
+    return "".join(event.tool_args_delta for event in events if event.event == event_name)
+
+
+def _stored(run_output: WorkflowRunOutput) -> List[str]:
+    return [event.event for event in (run_output.events or [])]
+
+
+def _assert_the_stream_kept_its_fragments(events, arguments: str, event_name: str) -> None:
+    """The skip list governs storage, so a subscriber still sees every one."""
+    assert _fragments_of(events, event_name) == arguments
+
+
+def _assert_the_workflow_still_stores_what_it_stored(stored: List[str], step_events: List[str]) -> None:
+    """Everything but the fragment event is stored as before."""
+    for event_name in (
+        WorkflowRunEvent.workflow_started.value,
+        WorkflowRunEvent.step_started.value,
+        WorkflowRunEvent.step_completed.value,
+        WorkflowRunEvent.workflow_completed.value,
+        *step_events,
+    ):
+        assert event_name in stored, f"{event_name} is no longer stored"
+
+
+_AGENT_STEP_EVENTS = [
+    RunEvent.run_started.value,
+    RunEvent.tool_call_started.value,
+    RunEvent.tool_call_completed.value,
+    RunEvent.run_content.value,
+    RunEvent.run_completed.value,
+]
+
+_TEAM_STEP_EVENTS = [
+    TeamRunEvent.run_started.value,
+    TeamRunEvent.tool_call_started.value,
+    TeamRunEvent.tool_call_completed.value,
+    TeamRunEvent.run_content.value,
+    TeamRunEvent.run_completed.value,
+]
+
+
+def test_workflow_keeps_an_agent_steps_tool_call_arg_fragments_out_of_storage(tmp_path):
+    workflow, db_file, arguments = _agent_step_workflow(tmp_path, "agent_step.db")
+
+    events = list(workflow.run("go", session_id=SESSION_ID, stream=True, stream_events=True))
+    stored = _stored(_persisted_run(db_file))
+
+    _assert_the_stream_kept_its_fragments(events, arguments, RunEvent.tool_call_args_delta.value)
+    assert RunEvent.tool_call_args_delta.value not in stored
+    _assert_the_workflow_still_stores_what_it_stored(stored, _AGENT_STEP_EVENTS)
+
+
+async def test_workflow_keeps_an_agent_steps_tool_call_arg_fragments_out_of_storage_async(tmp_path):
+    workflow, db_file, arguments = _agent_step_workflow(tmp_path, "agent_step_async.db")
+
+    events = [event async for event in workflow.arun("go", session_id=SESSION_ID, stream=True, stream_events=True)]
+    stored = _stored(_persisted_run(db_file))
+
+    _assert_the_stream_kept_its_fragments(events, arguments, RunEvent.tool_call_args_delta.value)
+    assert RunEvent.tool_call_args_delta.value not in stored
+    _assert_the_workflow_still_stores_what_it_stored(stored, _AGENT_STEP_EVENTS)
+
+
+def test_workflow_keeps_a_team_steps_tool_call_arg_fragments_out_of_storage(tmp_path):
+    """A team step carries the team's own fragment event, which is its own name."""
+    workflow, db_file, arguments = _team_step_workflow(tmp_path, "team_step.db")
+
+    events = list(workflow.run("go", session_id=SESSION_ID, stream=True, stream_events=True))
+    stored = _stored(_persisted_run(db_file))
+
+    _assert_the_stream_kept_its_fragments(events, arguments, TeamRunEvent.tool_call_args_delta.value)
+    assert TeamRunEvent.tool_call_args_delta.value not in stored
+    _assert_the_workflow_still_stores_what_it_stored(stored, _TEAM_STEP_EVENTS)
+
+
+async def test_workflow_keeps_a_team_steps_tool_call_arg_fragments_out_of_storage_async(tmp_path):
+    workflow, db_file, arguments = _team_step_workflow(tmp_path, "team_step_async.db")
+
+    events = [event async for event in workflow.arun("go", session_id=SESSION_ID, stream=True, stream_events=True)]
+    stored = _stored(_persisted_run(db_file))
+
+    _assert_the_stream_kept_its_fragments(events, arguments, TeamRunEvent.tool_call_args_delta.value)
+    assert TeamRunEvent.tool_call_args_delta.value not in stored
+    _assert_the_workflow_still_stores_what_it_stored(stored, _TEAM_STEP_EVENTS)
+
+
+def _opted_in_skip_list(skips_but_the_argument_fragments) -> List[Any]:
+    """The workflow default with the fragment events taken out of it.
+
+    Which is a request for the fragments and for nothing else that was already
+    stored, whatever else that default comes to hold.
+    """
+    return skips_but_the_argument_fragments(Workflow(id=WORKFLOW_ID, steps=[]))
+
+
+def test_workflow_stores_tool_call_arg_fragments_when_the_caller_asks_for_them(
+    tmp_path, skips_but_the_argument_fragments
+):
+    workflow, db_file, arguments = _agent_step_workflow(
+        tmp_path, "opted_in.db", events_to_skip=_opted_in_skip_list(skips_but_the_argument_fragments)
+    )
+
+    list(workflow.run("go", session_id=SESSION_ID, stream=True, stream_events=True))
+
+    assert _fragments_of(_persisted_run(db_file).events or [], RunEvent.tool_call_args_delta.value) == arguments
+
+
+async def test_workflow_stores_tool_call_arg_fragments_when_the_caller_asks_for_them_async(
+    tmp_path, skips_but_the_argument_fragments
+):
+    workflow, db_file, arguments = _agent_step_workflow(
+        tmp_path, "opted_in_async.db", events_to_skip=_opted_in_skip_list(skips_but_the_argument_fragments)
+    )
+
+    [event async for event in workflow.arun("go", session_id=SESSION_ID, stream=True, stream_events=True)]
+
+    assert _fragments_of(_persisted_run(db_file).events or [], RunEvent.tool_call_args_delta.value) == arguments


### PR DESCRIPTION
## Summary

This PR fixes 2 things:

**1. Streaming arguments.** Tool call's arguments only reached an AG-UI client once the model finished the entire call and the full arguments were available, so once at the end. This PR streams each new piece as the model writes it, and the client appends them.

It's a new run event on agents, teams and workflows, not only the AG-UI interface, and it's in the default skip list so stored runs are unchanged. How many pieces arrive is the provider's: same prompt gives 133 through OpenAI chat completions and 1 through OpenAI Responses, and Anthropic sends none.

**2. Shared state.** State was already shared both ways. What was broken is that the payloads a client decodes could be wrong, incomplete, or missing:

- A state change vanished entirely when the patch library was absent. It ships in the `agui` extra, so an install with `ag-ui-protocol` and not that extra got zero state events and one terse warning. Now falls back to a full snapshot, with the reason reported once per run.
- Agno injects `current_user_id`, `current_session_id` and `current_run_id` into session state for tools to read. The interface emitted the live dict, so the client watched keys appear in its own state that it never wrote. Now filtered from every client-facing payload.
- Change detection compared Python objects, not the JSON the client reads. It missed `0` becoming `false` and `1` becoming `1.0`, and falsely reported a list swapped for a tuple. Now compares the encoded documents, so datetimes, UUIDs and Decimals also diff.
- A patch is no longer trusted on its own. The library compares list elements with Python equality, so it could describe only part of a change while the baseline advanced past it, leaving the client permanently wrong. Ops are now replayed and confirmed before being sent.
- State with no JSON form killed the response with no terminal event. Now withheld, baseline left where the client is.

Cookbook updated for what the wire carries.

One known limit, documented on the event: a provider that restarts its stream or reuses a `tool_call_id` across turns leaves the client's concatenation unparseable. The cause is a layer below, where Agno's own reassembly breaks identically.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)
