### PR TITLE
fix: never overwrite an existing run, and scope lifecycle updates to their owner

### DIFF
--- a/libs/agno/agno/agent/_storage.py
+++ b/libs/agno/agno/agent/_storage.py
@@ -485,6 +485,19 @@ def upsert_run(
         # a zombie attempt's write is refused instead of clobbering the row
         if persist_worker_owned_run(agent.db, run, session_id=session_id, user_id=user_id):
             return
+        from agno.db.run_writes import persist_run_scoped
+
+        # Scoped update first, strict create when the row is not there yet:
+        # a lifecycle save can then only ever touch the row this run created
+        try:
+            handled = persist_run_scoped(agent.db, run, session_id=session_id, user_id=user_id, run_index=run_index)
+        except NotImplementedError:
+            # The adapter declares the scoped pair but has not implemented
+            # it; the legacy save below overwrites, so say so
+            log_warning(f"{type(agent.db).__name__} declares scoped run writes but does not implement them")
+            handled = False
+        if handled:
+            return
         agent.db.upsert_run(run=run, session_id=session_id, user_id=user_id, run_index=run_index)  # type: ignore[union-attr]
     except NotImplementedError:
         # Adapter has not been ported to v3 storage; runs are persisted inline
@@ -530,6 +543,20 @@ async def aupsert_run(
         # Queue-worker-owned runs save through the attempt-fenced primitive;
         # a zombie attempt's write is refused instead of clobbering the row
         if await apersist_worker_owned_run(agent.db, run, session_id=session_id, user_id=user_id):
+            return
+        from agno.db.run_writes import apersist_run_scoped
+
+        # See upsert_run
+        try:
+            handled = await apersist_run_scoped(
+                agent.db, run, session_id=session_id, user_id=user_id, run_index=run_index
+            )
+        except NotImplementedError:
+            # The adapter declares the scoped pair but has not implemented
+            # it; the legacy save below overwrites, so say so
+            log_warning(f"{type(agent.db).__name__} declares scoped run writes but does not implement them")
+            handled = False
+        if handled:
             return
         if _init.has_async_db(agent):
             await agent.db.upsert_run(run=run, session_id=session_id, user_id=user_id, run_index=run_index)  # type: ignore[union-attr,misc]

--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 if TYPE_CHECKING:
     from agno.tracing.schemas import Span, Trace
 
+from agno.db.run_writes import RunCreateOutcome, RunUpdateOutcome
 from agno.db.schemas import UserMemory
 from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
@@ -297,6 +298,13 @@ class BaseDb(ABC):
 
     # We assume the database to be up to date with the 2.0.0 release
     default_schema_version = "2.0.0"
+
+    # Whether this adapter refuses to overwrite an existing run when a run is
+    # created, i.e. implements the strict ``create_run`` / scoped ``update_run``
+    # pair rather than only the overwriting ``upsert_run``. Runtime capability
+    # probe for callers that must know whether a conflicting caller-supplied
+    # run_id is rejected by storage itself (see agno.db.run_writes).
+    supports_atomic_run_creation: bool = False
 
     def __init__(
         self,
@@ -644,6 +652,55 @@ class BaseDb(ABC):
         raise NotImplementedError(
             f"{type(self).__name__} does not implement upsert_run yet. Use upsert_session() to persist runs inline."
         )
+
+    def create_run(
+        self,
+        run: Union[RunOutput, TeamRunOutput, WorkflowRunOutput, Dict[str, Any]],
+        session_id: str,
+        user_id: Optional[str] = None,
+        run_index: Optional[int] = None,
+    ) -> RunCreateOutcome:
+        """Insert a run, never overwriting an existing row with the same run_id.
+
+        This is the creation half of the split ``upsert_run`` performs in one
+        statement. It must be atomic: two concurrent calls with the same fresh
+        run_id have to produce exactly one ``CREATED`` and one ``CONFLICT``, so
+        a preflight read cannot substitute for it.
+
+        An adapter that overrides this must also override ``update_run``, and
+        only then set ``supports_atomic_run_creation``: the probe advertises
+        both halves, and implementing one would advertise a guarantee the
+        adapter does not provide. Adapters that have not been ported return
+        ``UNSUPPORTED``, leaving their callers on ``upsert_run``.
+
+        The guarantee covers the runs storage. A session that predates v3 can
+        still hold runs inline in its legacy ``runs`` blob, and an id taken
+        only there is not seen here; migrating the session moves those runs
+        into the runs storage and back under the check.
+        """
+        return RunCreateOutcome.UNSUPPORTED
+
+    def update_run(
+        self,
+        run: Union[RunOutput, TeamRunOutput, WorkflowRunOutput, Dict[str, Any]],
+        session_id: str,
+        user_id: Optional[str] = None,
+        run_index: Optional[int] = None,
+    ) -> RunUpdateOutcome:
+        """Patch an existing run, scoped to its owner; never inserts.
+
+        ``run_index`` repairs a legacy row stored with a NULL index, using the
+        position the caller resolved. Never overwrites a stored index.
+
+        The scope is the run's own ``session_id``, effective ``user_id`` and
+        component identity (``agent_id`` / ``team_id`` / ``workflow_id``). A
+        write whose scope does not match the stored row is refused with
+        ``SCOPE_MISMATCH`` instead of replacing it, so a lifecycle transition
+        cannot cross a session or user boundary.
+
+        Adapters that have not been ported return ``UNSUPPORTED``.
+        """
+        return RunUpdateOutcome.UNSUPPORTED
 
     def delete_run(self, run_id: str) -> bool:
         """Delete a single run from the runs storage.
@@ -2100,6 +2157,9 @@ class BaseDb(ABC):
 class AsyncBaseDb(ABC):
     """Base abstract class for all our async database implementations."""
 
+    # See BaseDb.supports_atomic_run_creation.
+    supports_atomic_run_creation: bool = False
+
     def __init__(
         self,
         id: Optional[str] = None,
@@ -2333,6 +2393,26 @@ class AsyncBaseDb(ABC):
         raise NotImplementedError(
             f"{type(self).__name__} does not implement upsert_run yet. Use upsert_session() to persist runs inline."
         )
+
+    async def create_run(
+        self,
+        run: Union[RunOutput, TeamRunOutput, WorkflowRunOutput, Dict[str, Any]],
+        session_id: str,
+        user_id: Optional[str] = None,
+        run_index: Optional[int] = None,
+    ) -> RunCreateOutcome:
+        """Async strict run insert. See ``BaseDb.create_run``."""
+        return RunCreateOutcome.UNSUPPORTED
+
+    async def update_run(
+        self,
+        run: Union[RunOutput, TeamRunOutput, WorkflowRunOutput, Dict[str, Any]],
+        session_id: str,
+        user_id: Optional[str] = None,
+        run_index: Optional[int] = None,
+    ) -> RunUpdateOutcome:
+        """Async scoped run update. See ``BaseDb.update_run``."""
+        return RunUpdateOutcome.UNSUPPORTED
 
     async def delete_run(self, run_id: str) -> bool:
         """Async delete of a single run. Adapters ported to v3 storage override this."""

--- a/libs/agno/agno/db/in_memory/in_memory_db.py
+++ b/libs/agno/agno/db/in_memory/in_memory_db.py
@@ -1,3 +1,4 @@
+import threading
 import time
 from copy import deepcopy
 from datetime import date, datetime, timedelta, timezone
@@ -11,6 +12,7 @@ from agno.db.in_memory.utils import (
     fetch_all_sessions_data,
     get_dates_to_calculate_metrics_for,
 )
+from agno.db.run_writes import RunCreateOutcome, RunUpdateOutcome
 from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.schemas.memory import UserMemory
@@ -29,7 +31,15 @@ if TYPE_CHECKING:
     from agno.tracing.schemas import Span, Trace
 
 
+def _next_run_index(runs: List[Any]) -> int:
+    """One past the highest index currently stored for the session."""
+    indexes: List[int] = [r["run_index"] for r in runs if isinstance(r, dict) and isinstance(r.get("run_index"), int)]
+    return max(indexes) + 1 if indexes else 0
+
+
 class InMemoryDb(BaseDb):
+    supports_atomic_run_creation = True
+
     def __init__(self):
         """Interface for in-memory storage."""
         super().__init__()
@@ -47,6 +57,18 @@ class InMemoryDb(BaseDb):
         # dict. The cached objects are shared by every read and immutable by
         # contract; the stored dicts remain the canonical state.
         self._run_object_cache: Dict[str, Dict[str, Tuple[Dict[str, Any], Any]]] = {}
+        # run_id -> the identity that created the run. The SQL adapters get
+        # both halves from the runs table: run_id is its primary key, so a
+        # conflicting insert is refused by the database, and the row carries
+        # the owning user in its own column. Runs here live inline in their
+        # session, which has neither, so the ledger supplies both. It is the
+        # authority for "is this run_id taken" and for the owner an update is
+        # scoped against.
+        # Serializes the check-then-write in create_run against concurrent
+        # creations of the same run_id. Without it both callers read "absent"
+        # and both believe they created the run. Reentrant because the run
+        # write helpers call each other.
+        self._runs_lock = threading.RLock()
         self._memories: List[Dict[str, Any]] = []
         self._metrics: List[Dict[str, Any]] = []
         self._eval_runs: List[Dict[str, Any]] = []
@@ -84,15 +106,15 @@ class InMemoryDb(BaseDb):
             Exception: If an error occurs during deletion.
         """
         try:
-            session = self._sessions.get(session_id)
-            if session is not None and (user_id is None or session.get("user_id") == user_id):
-                del self._sessions[session_id]
-                self._run_object_cache.pop(session_id, None)
-                log_debug(f"Successfully deleted session with session_id: {session_id}")
-                return True
-            else:
-                log_debug(f"No session found to delete with session_id: {session_id}")
-                return False
+            with self._runs_lock:
+                session = self._sessions.get(session_id)
+                if session is not None and (user_id is None or session.get("user_id") == user_id):
+                    del self._sessions[session_id]
+                    self._run_object_cache.pop(session_id, None)
+                    log_debug(f"Successfully deleted session with session_id: {session_id}")
+                    return True
+            log_debug(f"No session found to delete with session_id: {session_id}")
+            return False
 
         except Exception as e:
             log_error(f"Error deleting session: {str(e)}")
@@ -109,11 +131,12 @@ class InMemoryDb(BaseDb):
             Exception: If an error occurs during deletion.
         """
         try:
-            for session_id in session_ids:
-                session = self._sessions.get(session_id)
-                if session is not None and (user_id is None or session.get("user_id") == user_id):
-                    del self._sessions[session_id]
-                    self._run_object_cache.pop(session_id, None)
+            with self._runs_lock:
+                for session_id in session_ids:
+                    session = self._sessions.get(session_id)
+                    if session is not None and (user_id is None or session.get("user_id") == user_id):
+                        del self._sessions[session_id]
+                        self._run_object_cache.pop(session_id, None)
             log_debug(f"Successfully deleted sessions with ids: {session_ids}")
 
         except Exception as e:
@@ -373,39 +396,45 @@ class InMemoryDb(BaseDb):
                 session_dict["session_type"] = SessionType.WORKFLOW.value
 
             session_id = session_dict["session_id"]
-            existing_session = self._sessions.get(session_id)
-            if existing_session is not None:
-                # Owner guard, mirroring the SQL adapters' ON CONFLICT ... WHERE
-                # clause: an owned session is only writable by its owner; an
-                # unowned session can be claimed by anyone.
-                existing_uid = existing_session.get("user_id")
-                if existing_uid is not None and existing_uid != session_dict.get("user_id"):
-                    return None
-                session_dict["updated_at"] = int(time.time())
-                # A session-row update must never drop runs written by
-                # upsert_run: carry the stored list forward. The list is
-                # already owned by the store, so it needs no copy.
-                runs_for_store = existing_session.get("runs")
-            else:
-                session_dict["created_at"] = session_dict.get("created_at", int(time.time()))
-                session_dict["updated_at"] = session_dict.get("created_at")
-                # A delete + re-insert under the same id must not serve the
-                # deleted session's cached run objects.
-                self._run_object_cache.pop(session_id, None)
-                # First insert: serialize whatever runs the incoming session
-                # carries, once (bulk import and restore callers never call
-                # upsert_run). to_dict output is freshly built, so it needs
-                # no defensive copy.
-                incoming_runs = session.runs
-                runs_for_store = (
-                    [run.to_dict() if hasattr(run, "to_dict") else deepcopy(run) for run in incoming_runs]
-                    if incoming_runs
-                    else None
-                )
+            # The whole read-modify-write runs under the run lock: it replaces
+            # the stored row (and carries its runs list forward), so a
+            # concurrent create_run / update_run must not be mid-write on it.
+            with self._runs_lock:
+                existing_session = self._sessions.get(session_id)
+                if existing_session is not None:
+                    # Owner guard, mirroring the SQL adapters' ON CONFLICT ... WHERE
+                    # clause: an owned session is only writable by its owner; an
+                    # unowned session can be claimed by anyone.
+                    existing_uid = existing_session.get("user_id")
+                    if existing_uid is not None and existing_uid != session_dict.get("user_id"):
+                        return None
+                    session_dict["updated_at"] = int(time.time())
+                    # A session-row update must never drop runs written by
+                    # upsert_run: carry the stored list forward. The list is
+                    # already owned by the store, so it needs no copy.
+                    runs_for_store = existing_session.get("runs")
+                else:
+                    session_dict["created_at"] = session_dict.get("created_at", int(time.time()))
+                    session_dict["updated_at"] = session_dict.get("created_at")
+                    # A delete + re-insert under the same id must not serve the
+                    # deleted session's cached run objects.
+                    self._run_object_cache.pop(session_id, None)
+                    # First insert: serialize whatever runs the incoming session
+                    # carries, once (bulk import and restore callers never call
+                    # upsert_run). to_dict output is freshly built, so it needs
+                    # no defensive copy.
+                    incoming_runs = session.runs
+                    runs_for_store = (
+                        [run.to_dict() if hasattr(run, "to_dict") else deepcopy(run) for run in incoming_runs]
+                        if incoming_runs
+                        else None
+                    )
 
-            stored_session = deepcopy(session_dict)
-            stored_session["runs"] = runs_for_store
-            self._sessions[session_id] = stored_session
+                stored_session = deepcopy(session_dict)
+                stored_session["runs"] = runs_for_store
+                self._sessions[session_id] = stored_session
+                if existing_session is None:
+                    self._stamp_session_runs(runs_for_store, session_id, session_dict.get("user_id"))
 
             # Match the SQL adapters' return contract (see SqliteDb.upsert_session):
             # a fresh copy of the session row with the caller's own runs attached
@@ -468,12 +497,18 @@ class InMemoryDb(BaseDb):
     # same behaviour as adapters that store runs in a dedicated table.
 
     def _iter_session_runs(self) -> List[Tuple[Dict[str, Any], Dict[str, Any]]]:
-        """Yield (session_dict, run_dict) pairs across all in-memory sessions."""
+        """(session_dict, run_dict) pairs across all in-memory sessions.
+
+        Materialized under the run lock: a concurrent write can insert a
+        session while this walks the store, and iterating the live dict then
+        raises rather than returning a stale-but-valid view.
+        """
         pairs: List[Tuple[Dict[str, Any], Dict[str, Any]]] = []
-        for session in self._sessions.values():
-            for run in session.get("runs") or []:
-                if isinstance(run, dict):
-                    pairs.append((session, run))
+        with self._runs_lock:
+            for session in list(self._sessions.values()):
+                for run in list(session.get("runs") or []):
+                    if isinstance(run, dict):
+                        pairs.append((session, run))
         return pairs
 
     def get_run(self, run_id: str, deserialize: Optional[bool] = True) -> Optional[Union[Any, Dict[str, Any]]]:
@@ -548,6 +583,181 @@ class InMemoryDb(BaseDb):
             log_error(f"Error reading runs: {str(e)}")
             raise e
 
+    def _stamp_session_runs(self, runs: Optional[List[Any]], session_id: str, user_id: Optional[str]) -> None:
+        """Stamp the owner onto runs that arrive with their session.
+
+        A session can be stored with its runs already attached, and those rows
+        need the same owner on them that ``create_run`` writes, or a later
+        scoped write cannot tell whose they are.
+        """
+        for run in runs or []:
+            if isinstance(run, dict) and run.get("run_id") is not None:
+                self._stamp_run_scope(run, session_id, user_id)
+
+    def _stamp_run_scope(self, run_dict: Dict[str, Any], session_id: str, user_id: Optional[str]) -> None:
+        """Write the resolved owner onto the stored run, as the SQL row has it.
+
+        A SQL adapter keeps session and user in columns of its own, resolved
+        by ``build_single_run_row``, and every ownership decision reads those.
+        Here the run dict IS the row, so the same facts have to live on it.
+        Keeping them anywhere else gives ownership two homes that can disagree.
+        """
+        scope = self._run_scope(run_dict, session_id, user_id)
+        run_dict["session_id"] = session_id
+        run_dict["user_id"] = scope["user_id"]
+
+    def _locate_run(
+        self, run_id: str, session_id: Optional[str] = None
+    ) -> Optional[Tuple[Dict[str, Any], List[Any], int]]:
+        """(session, its runs list, index) for ``run_id``, or None.
+
+        ``session_id`` confines the search to one session, which is what a
+        scoped write needs: the SQL update carries ``session_id`` in its WHERE
+        clause, so it can never reach a row filed under a different session
+        even when the id is stored twice.
+        """
+        sessions = self._sessions.values() if session_id is None else [self._sessions.get(session_id)]
+        for session in sessions:
+            if session is None:
+                continue
+            runs = session.get("runs") or []
+            for i, existing in enumerate(runs):
+                existing_id = (
+                    existing.get("run_id") if isinstance(existing, dict) else getattr(existing, "run_id", None)
+                )
+                if existing_id == run_id:
+                    return session, runs, i
+        return None
+
+    def _stored_run_scope(self, session: Dict[str, Any], existing: Dict[str, Any]) -> Dict[str, Optional[str]]:
+        """The owner of a stored run, read off the row that holds it."""
+        return self._run_scope(
+            existing, str(existing.get("session_id") or session.get("session_id")), existing.get("user_id")
+        )
+
+    @staticmethod
+    def _run_scope(run_dict: Dict[str, Any], session_id: str, user_id: Optional[str]) -> Dict[str, Optional[str]]:
+        """The ownership facts a SQL adapter keeps in the run row's columns."""
+        from agno.db.utils import resolve_run_scope
+
+        return resolve_run_scope(run_dict, session_id, user_id)
+
+    @staticmethod
+    def _scope_matches(stored: Dict[str, Optional[str]], incoming: Dict[str, Optional[str]]) -> bool:
+        """Whether a write may reach a row owned by ``stored``."""
+        from agno.db.utils import run_scope_allows
+
+        return run_scope_allows(stored, incoming)
+
+    def create_run(
+        self,
+        run: Any,
+        session_id: str,
+        user_id: Optional[str] = None,
+        run_index: Optional[int] = None,
+    ) -> RunCreateOutcome:
+        """Insert a run into its session, refusing to overwrite an existing
+        run_id. See ``BaseDb.create_run``."""
+        try:
+            run_dict = deepcopy(run if isinstance(run, dict) else run.to_dict())
+            run_id = run_dict.get("run_id")
+            if run_id is None:
+                raise ValueError("Run must have a run_id")
+
+            with self._runs_lock:
+                if self._locate_run(run_id) is not None:
+                    return RunCreateOutcome.CONFLICT
+
+                session = self._sessions.get(session_id)
+                if session is None:
+                    return RunCreateOutcome.SESSION_MISSING
+
+                runs = session.get("runs") or []
+                session["runs"] = runs
+                # build_single_run_row's precedence: the explicit argument
+                # first, then the run's own value. MAX+1, not len(runs): a
+                # deleted run leaves a hole, and reusing its position would
+                # give two runs one index.
+                if run_index is not None:
+                    run_dict["run_index"] = run_index
+                elif run_dict.get("run_index") is None:
+                    run_dict["run_index"] = _next_run_index(runs)
+                self._stamp_run_scope(run_dict, session_id, user_id)
+                runs.append(run_dict)
+                session["updated_at"] = int(time.time())
+                return RunCreateOutcome.CREATED
+
+        except Exception as e:
+            log_error(f"Error creating run: {str(e)}")
+            raise e
+
+    def update_run(
+        self,
+        run: Any,
+        session_id: str,
+        user_id: Optional[str] = None,
+        run_index: Optional[int] = None,
+    ) -> RunUpdateOutcome:
+        """Replace an existing run scoped to its owner. See ``BaseDb.update_run``."""
+        try:
+            run_dict = deepcopy(run if isinstance(run, dict) else run.to_dict())
+            run_id = run_dict.get("run_id")
+            if run_id is None:
+                raise ValueError("Run must have a run_id")
+
+            with self._runs_lock:
+                # Confined to the addressed session, the way the SQL update
+                # carries session_id in its WHERE clause. A row filed under a
+                # different session is out of this write's reach, so it is
+                # refused rather than found and overwritten.
+                located = self._locate_run(run_id, session_id=session_id)
+                if located is None:
+                    return (
+                        RunUpdateOutcome.SCOPE_MISMATCH
+                        if self._locate_run(run_id) is not None
+                        else RunUpdateOutcome.MISSING
+                    )
+                session, runs, i = located
+                existing: Dict[str, Any] = runs[i] if isinstance(runs[i], dict) else {}
+                stored = self._stored_run_scope(session, existing)
+                incoming = self._run_scope(run_dict, session_id, user_id)
+                if not self._scope_matches(stored, incoming):
+                    return RunUpdateOutcome.SCOPE_MISMATCH
+
+                # The SQL update writes named columns and leaves the rest of
+                # the row alone. Replacing the dict wholesale is this
+                # adapter's equivalent of writing every column, so the facts
+                # the incoming run does not carry are put back. The identity
+                # columns are never written at all, only carried forward: an
+                # update that changed which session or component a stored row
+                # belongs to would move it out of its owner's reach.
+                for field in ("agent_id", "team_id", "workflow_id", "session_id", "run_type"):
+                    if existing.get(field) is not None:
+                        run_dict[field] = existing[field]
+                    # A row stored without this fact adopts the one this write
+                    # knows, the COALESCE the SQL adapters apply to the same
+                    # columns. Never the other way round.
+                    elif run_dict.get(field) is None and field == "session_id":
+                        run_dict[field] = session_id
+                # COALESCE(stored, incoming), as the SQL adapters write it:
+                # a stored position always wins, so a save that carries a
+                # different index cannot renumber the row.
+                if existing.get("run_index") is not None:
+                    run_dict["run_index"] = existing["run_index"]
+                elif run_dict.get("run_index") is None and run_index is not None:
+                    run_dict["run_index"] = run_index
+                # Attribute a run created before its owner was resolved,
+                # never rewriting an owner the scope matched against. The SQL
+                # adapters COALESCE the run row's user column; same rule here.
+                run_dict["user_id"] = stored["user_id"] if stored["user_id"] is not None else incoming["user_id"]
+                runs[i] = run_dict
+                session["updated_at"] = int(time.time())
+                return RunUpdateOutcome.UPDATED
+
+        except Exception as e:
+            log_error(f"Error updating run: {str(e)}")
+            raise e
+
     def upsert_run(
         self,
         run: Any,
@@ -567,29 +777,33 @@ class InMemoryDb(BaseDb):
             if run_id is None:
                 raise ValueError("Run must have a run_id")
 
-            session = self._sessions.get(session_id)
-            if session is None:
-                log_debug(f"upsert_run: session {session_id} not found; skipping")
-                return
+            with self._runs_lock:
+                session = self._sessions.get(session_id)
+                if session is None:
+                    log_debug(f"upsert_run: session {session_id} not found; skipping")
+                    return
 
-            # The stored row holds "runs": None until the first run lands
-            runs = session.get("runs") or []
-            session["runs"] = runs
-            for i, existing in enumerate(runs):
-                existing_id = (
-                    existing.get("run_id") if isinstance(existing, dict) else getattr(existing, "run_id", None)
-                )
-                if existing_id == run_id:
-                    # Preserve original run_index on update (matches SQL adapters)
-                    if isinstance(existing, dict) and "run_index" in existing:
-                        run_dict["run_index"] = existing["run_index"]
-                    runs[i] = run_dict
-                    break
-            else:
-                if run_index is not None and "run_index" not in run_dict:
-                    run_dict["run_index"] = run_index
-                runs.append(run_dict)
-            session["updated_at"] = int(time.time())
+                # The stored row holds "runs": None until the first run lands
+                runs = session.get("runs") or []
+                session["runs"] = runs
+                for i, existing in enumerate(runs):
+                    existing_id = (
+                        existing.get("run_id") if isinstance(existing, dict) else getattr(existing, "run_id", None)
+                    )
+                    if existing_id == run_id:
+                        # Preserve original run_index on update (matches SQL adapters)
+                        if isinstance(existing, dict) and "run_index" in existing:
+                            run_dict["run_index"] = existing["run_index"]
+                        runs[i] = run_dict
+                        break
+                else:
+                    if run_index is not None and "run_index" not in run_dict:
+                        run_dict["run_index"] = run_index
+                    # Stamped like any other insert, so a run that reached the
+                    # store this way is scoped the same as one that was created
+                    self._stamp_run_scope(run_dict, session_id, user_id)
+                    runs.append(run_dict)
+                session["updated_at"] = int(time.time())
         except Exception as e:
             log_error(f"Error upserting run: {str(e)}")
             raise e
@@ -597,13 +811,14 @@ class InMemoryDb(BaseDb):
     def delete_run(self, run_id: str) -> bool:
         """Remove a run from its session by run_id."""
         try:
-            for session in self._sessions.values():
-                runs = session.get("runs") or []
-                new_runs = [r for r in runs if not (isinstance(r, dict) and r.get("run_id") == run_id)]
-                if len(new_runs) != len(runs):
-                    session["runs"] = new_runs
-                    session["updated_at"] = int(time.time())
-                    return True
+            with self._runs_lock:
+                for session in self._sessions.values():
+                    runs = session.get("runs") or []
+                    new_runs = [r for r in runs if not (isinstance(r, dict) and r.get("run_id") == run_id)]
+                    if len(new_runs) != len(runs):
+                        session["runs"] = new_runs
+                        session["updated_at"] = int(time.time())
+                        return True
             return False
         except Exception as e:
             log_error(f"Error deleting run {run_id}: {str(e)}")
@@ -615,12 +830,13 @@ class InMemoryDb(BaseDb):
             return
         wanted = set(run_ids)
         try:
-            for session in self._sessions.values():
-                runs = session.get("runs") or []
-                new_runs = [r for r in runs if not (isinstance(r, dict) and r.get("run_id") in wanted)]
-                if len(new_runs) != len(runs):
-                    session["runs"] = new_runs
-                    session["updated_at"] = int(time.time())
+            with self._runs_lock:
+                for session in self._sessions.values():
+                    runs = session.get("runs") or []
+                    new_runs = [r for r in runs if not (isinstance(r, dict) and r.get("run_id") in wanted)]
+                    if len(new_runs) != len(runs):
+                        session["runs"] = new_runs
+                        session["updated_at"] = int(time.time())
         except Exception as e:
             log_error(f"Error deleting runs: {str(e)}")
             raise e

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -21,6 +21,7 @@ from agno.db.postgres.utils import (
     fetch_all_sessions_data,
     get_dates_to_calculate_metrics_for,
 )
+from agno.db.run_writes import RunCreateOutcome, RunUpdateOutcome
 from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.schemas.memory import UserMemory
@@ -36,9 +37,11 @@ from agno.db.utils import (
     deserialize_session,
     deserialize_sessions,
     filter_context_runs,
+    is_foreign_key_violation,
     learning_search_patterns,
     merge_runs_table_with_legacy_blob,
     metrics_starting_date_from_days,
+    run_scope_clause,
     table_schema_mismatch_error,
     validate_pagination,
 )
@@ -94,6 +97,8 @@ def _db_epoch() -> Any:
 
 
 class AsyncPostgresDb(AsyncBaseDb):
+    supports_atomic_run_creation = True
+
     def __init__(
         self,
         id: Optional[str] = None,
@@ -899,6 +904,130 @@ class AsyncPostgresDb(AsyncBaseDb):
 
         except Exception as e:
             log_error(f"Exception upserting run to runs table: {str(e)}")
+            raise e
+
+    async def create_run(
+        self,
+        run: Union[RunOutput, TeamRunOutput, WorkflowRunOutput, Dict[str, Any]],
+        session_id: str,
+        user_id: Optional[str] = None,
+        run_index: Optional[int] = None,
+    ) -> RunCreateOutcome:
+        """Async twin of ``PostgresDb.create_run``; see ``BaseDb.create_run``."""
+        from sqlalchemy.exc import IntegrityError
+
+        try:
+            runs_table = await self._get_table(table_type="runs", create_table_if_not_found=True)
+            if runs_table is None:
+                # See the sync twin: ERROR, not UNSUPPORTED
+                log_error("Runs table could not be resolved; the run was not created")
+                return RunCreateOutcome.ERROR
+
+            row = build_single_run_row(run=run, session_id=session_id, user_id=user_id, run_index=run_index)
+            row["run_data"] = sanitize_postgres_strings(row["run_data"])
+
+            try:
+                async with self.async_session_factory() as sess, sess.begin():
+                    if row.get("run_index") is None:
+                        # Same-session backfill serialization - see upsert_run
+                        await sess.execute(
+                            text("SELECT pg_advisory_xact_lock(hashtext('agno_run_index'), hashtext(:sid))"),
+                            {"sid": session_id},
+                        )
+                        current_max = (
+                            await sess.execute(
+                                select(func.max(runs_table.c.run_index)).where(runs_table.c.session_id == session_id)
+                            )
+                        ).scalar()
+                        row["run_index"] = (current_max + 1) if current_max is not None else 0
+                    stmt = (
+                        postgresql.insert(runs_table)
+                        .values(**row)
+                        .on_conflict_do_nothing(index_elements=["run_id"])
+                        .returning(runs_table.c.run_id)
+                    )
+                    # RETURNING yields a row only when the insert landed;
+                    # psycopg3 reports rowcount -1 for this statement
+                    inserted = (await sess.execute(stmt)).fetchone()
+            except IntegrityError as e:
+                # See PostgresDb.create_run: only a missing session row is an
+                # expected integrity failure here
+                if not is_foreign_key_violation(e):
+                    log_error(f"Exception creating run in runs table: {str(e)}")
+                    return RunCreateOutcome.ERROR
+                return RunCreateOutcome.SESSION_MISSING
+
+            return RunCreateOutcome.CREATED if inserted is not None else RunCreateOutcome.CONFLICT
+
+        except Exception as e:
+            log_error(f"Exception creating run in runs table: {str(e)}")
+            raise e
+
+    async def update_run(
+        self,
+        run: Union[RunOutput, TeamRunOutput, WorkflowRunOutput, Dict[str, Any]],
+        session_id: str,
+        user_id: Optional[str] = None,
+        run_index: Optional[int] = None,
+    ) -> RunUpdateOutcome:
+        """Async twin of ``PostgresDb.update_run``; see ``BaseDb.update_run``."""
+        try:
+            runs_table = await self._get_table(table_type="runs")
+            if runs_table is None:
+                return RunUpdateOutcome.MISSING
+
+            row = build_single_run_row(run=run, session_id=session_id, user_id=user_id, run_index=run_index)
+            row["run_data"] = sanitize_postgres_strings(row["run_data"])
+
+            async with self.async_session_factory() as sess, sess.begin():
+                stmt = (
+                    update(runs_table)
+                    .where(runs_table.c.run_id == row["run_id"])
+                    .where(run_scope_clause(runs_table, row))
+                    .values(
+                        status=row["status"],
+                        run_data=row["run_data"],
+                        parent_run_id=row["parent_run_id"],
+                        updated_at=row["updated_at"],
+                        # Adopt a row created before its component or owner was known.
+                        # COALESCE, not assignment: a value already on the row is what
+                        # the scope matched against and must not be rewritten.
+                        agent_id=func.coalesce(runs_table.c.agent_id, row["agent_id"]),
+                        team_id=func.coalesce(runs_table.c.team_id, row["team_id"]),
+                        workflow_id=func.coalesce(runs_table.c.workflow_id, row["workflow_id"]),
+                        user_id=func.coalesce(runs_table.c.user_id, row["user_id"]),
+                        # Repair a legacy row stored with a NULL index, using
+                        # the position the caller resolved. COALESCE so a
+                        # stored index is never renumbered; omitted entirely
+                        # when the caller did not resolve one.
+                        **(
+                            {"run_index": func.coalesce(runs_table.c.run_index, row["run_index"])}
+                            if row.get("run_index") is not None
+                            else {}
+                        ),
+                    )
+                    .returning(runs_table.c.run_id)
+                )
+                if (await sess.execute(stmt)).fetchone() is not None:
+                    return RunUpdateOutcome.UPDATED
+                # See the sync twin for why this asks twice
+                owned = (
+                    await sess.execute(
+                        select(runs_table.c.run_id)
+                        .where(runs_table.c.run_id == row["run_id"])
+                        .where(run_scope_clause(runs_table, row))
+                    )
+                ).fetchone()
+                if owned is not None:
+                    return RunUpdateOutcome.MISSING
+                exists = (
+                    await sess.execute(select(runs_table.c.run_id).where(runs_table.c.run_id == row["run_id"]))
+                ).fetchone()
+
+            return RunUpdateOutcome.SCOPE_MISMATCH if exists is not None else RunUpdateOutcome.MISSING
+
+        except Exception as e:
+            log_error(f"Exception updating run in runs table: {str(e)}")
             raise e
 
     async def get_runs(
@@ -4690,7 +4819,8 @@ class AsyncPostgresDb(AsyncBaseDb):
             table = await self._get_table(table_type="sessions", create_table_if_not_found=True)
             if table is None:
                 return None
-            session_dict = session.to_dict()
+            session_dict = session.to_dict(include_runs=False)
+            created_at = session_dict.get("created_at") or int(time.time())
             for data_field in ("agent_data", "team_data", "workflow_data", "session_data", "summary", "metadata"):
                 if session_dict.get(data_field):
                     session_dict[data_field] = sanitize_postgres_strings(session_dict[data_field])
@@ -4700,8 +4830,11 @@ class AsyncPostgresDb(AsyncBaseDb):
                 session_data=session_dict.get("session_data"),
                 summary=session_dict.get("summary"),
                 metadata=session_dict.get("metadata"),
-                created_at=session_dict.get("created_at"),
-                updated_at=session_dict.get("created_at"),
+                # NOT NULL, and to_dict always emits the key, so a missing
+                # timestamp arrives as None rather than absent. One value for
+                # both, or a row can be born already updated.
+                created_at=created_at,
+                updated_at=created_at,
             )
             if isinstance(session, AgentSession):
                 values.update(

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -37,6 +37,7 @@ from agno.db.postgres.utils import (
     is_table_available,
     is_valid_table,
 )
+from agno.db.run_writes import RunCreateOutcome, RunUpdateOutcome
 from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.schemas.mcp_oauth import (
@@ -60,9 +61,11 @@ from agno.db.utils import (
     deserialize_session,
     deserialize_sessions,
     filter_context_runs,
+    is_foreign_key_violation,
     learning_search_patterns,
     merge_runs_table_with_legacy_blob,
     metrics_starting_date_from_days,
+    run_scope_clause,
     table_schema_mismatch_error,
     validate_pagination,
 )
@@ -121,6 +124,8 @@ def _db_epoch() -> Any:
 
 
 class PostgresDb(BaseDb):
+    supports_atomic_run_creation = True
+
     def __init__(
         self,
         db_url: Optional[str] = None,
@@ -1082,6 +1087,137 @@ class PostgresDb(BaseDb):
 
         except Exception as e:
             log_error(f"Exception upserting run to runs table: {str(e)}")
+            raise e
+
+    def create_run(
+        self,
+        run: Union[RunOutput, TeamRunOutput, WorkflowRunOutput, Dict[str, Any]],
+        session_id: str,
+        user_id: Optional[str] = None,
+        run_index: Optional[int] = None,
+    ) -> RunCreateOutcome:
+        """Insert a run row, refusing to overwrite an existing run_id.
+
+        ``ON CONFLICT DO NOTHING`` on the run_id primary key: the database
+        decides the winner, so two concurrent creations of the same fresh id
+        cannot both be told they created it. See ``BaseDb.create_run``.
+        """
+        try:
+            runs_table = self._get_table(table_type="runs", create_table_if_not_found=True)
+            if runs_table is None:
+                # ERROR, not UNSUPPORTED: this adapter does implement the
+                # strict create, and UNSUPPORTED is the one answer that sends
+                # the caller back to the overwriting upsert_run
+                log_error("Runs table could not be resolved; the run was not created")
+                return RunCreateOutcome.ERROR
+
+            row = build_single_run_row(run=run, session_id=session_id, user_id=user_id, run_index=run_index)
+            row["run_data"] = sanitize_postgres_strings(row["run_data"])
+
+            try:
+                with self.Session() as sess, sess.begin():
+                    if row.get("run_index") is None:
+                        # Same-session backfill serialization - see upsert_run
+                        sess.execute(
+                            text("SELECT pg_advisory_xact_lock(hashtext('agno_run_index'), hashtext(:sid))"),
+                            {"sid": session_id},
+                        )
+                        current_max = sess.execute(
+                            select(func.max(runs_table.c.run_index)).where(runs_table.c.session_id == session_id)
+                        ).scalar()
+                        row["run_index"] = (current_max + 1) if current_max is not None else 0
+                    stmt = (
+                        postgresql.insert(runs_table)
+                        .values(**row)
+                        .on_conflict_do_nothing(index_elements=["run_id"])
+                        .returning(runs_table.c.run_id)
+                    )
+                    # RETURNING yields a row only when the insert landed;
+                    # psycopg3 reports rowcount -1 for this statement
+                    inserted = sess.execute(stmt).fetchone()
+            except IntegrityError as e:
+                # The runs table foreign-keys to its session, so the expected
+                # failure here is a missing session row. Anything else (a NOT
+                # NULL or CHECK violation) would be misreported as "create the
+                # session and retry", and the retry would fail the same way.
+                if not is_foreign_key_violation(e):
+                    log_error(f"Exception creating run in runs table: {str(e)}")
+                    return RunCreateOutcome.ERROR
+                return RunCreateOutcome.SESSION_MISSING
+
+            return RunCreateOutcome.CREATED if inserted is not None else RunCreateOutcome.CONFLICT
+
+        except Exception as e:
+            log_error(f"Exception creating run in runs table: {str(e)}")
+            raise e
+
+    def update_run(
+        self,
+        run: Union[RunOutput, TeamRunOutput, WorkflowRunOutput, Dict[str, Any]],
+        session_id: str,
+        user_id: Optional[str] = None,
+        run_index: Optional[int] = None,
+    ) -> RunUpdateOutcome:
+        """Patch an existing run row scoped to its owner. See ``BaseDb.update_run``."""
+        try:
+            runs_table = self._get_table(table_type="runs")
+            if runs_table is None:
+                return RunUpdateOutcome.MISSING
+
+            row = build_single_run_row(run=run, session_id=session_id, user_id=user_id, run_index=run_index)
+            row["run_data"] = sanitize_postgres_strings(row["run_data"])
+
+            with self.Session() as sess, sess.begin():
+                stmt = (
+                    update(runs_table)
+                    .where(runs_table.c.run_id == row["run_id"])
+                    .where(run_scope_clause(runs_table, row))
+                    .values(
+                        status=row["status"],
+                        run_data=row["run_data"],
+                        parent_run_id=row["parent_run_id"],
+                        updated_at=row["updated_at"],
+                        # Adopt a row created before its component or owner was known.
+                        # COALESCE, not assignment: a value already on the row is what
+                        # the scope matched against and must not be rewritten.
+                        agent_id=func.coalesce(runs_table.c.agent_id, row["agent_id"]),
+                        team_id=func.coalesce(runs_table.c.team_id, row["team_id"]),
+                        workflow_id=func.coalesce(runs_table.c.workflow_id, row["workflow_id"]),
+                        user_id=func.coalesce(runs_table.c.user_id, row["user_id"]),
+                        # Repair a legacy row stored with a NULL index, using
+                        # the position the caller resolved. COALESCE so a
+                        # stored index is never renumbered; omitted entirely
+                        # when the caller did not resolve one.
+                        **(
+                            {"run_index": func.coalesce(runs_table.c.run_index, row["run_index"])}
+                            if row.get("run_index") is not None
+                            else {}
+                        ),
+                    )
+                    .returning(runs_table.c.run_id)
+                )
+                if sess.execute(stmt).fetchone() is not None:
+                    return RunUpdateOutcome.UPDATED
+                # The update matched nothing. Two very different reasons, and
+                # only one of them is final, so ask which: a row this writer
+                # DOES own means it landed between the update and here, and
+                # MISSING sends the caller round again. A row it does not own
+                # is the refusal the scope exists for.
+                owned = sess.execute(
+                    select(runs_table.c.run_id)
+                    .where(runs_table.c.run_id == row["run_id"])
+                    .where(run_scope_clause(runs_table, row))
+                ).fetchone()
+                if owned is not None:
+                    return RunUpdateOutcome.MISSING
+                exists = sess.execute(
+                    select(runs_table.c.run_id).where(runs_table.c.run_id == row["run_id"])
+                ).fetchone()
+
+            return RunUpdateOutcome.SCOPE_MISMATCH if exists is not None else RunUpdateOutcome.MISSING
+
+        except Exception as e:
+            log_error(f"Exception updating run in runs table: {str(e)}")
             raise e
 
     def get_runs(
@@ -7356,7 +7492,8 @@ class PostgresDb(BaseDb):
             table = self._get_table(table_type="sessions", create_table_if_not_found=True)
             if table is None:
                 return None
-            session_dict = session.to_dict()
+            session_dict = session.to_dict(include_runs=False)
+            created_at = session_dict.get("created_at") or int(time.time())
             for data_field in ("agent_data", "team_data", "workflow_data", "session_data", "summary", "metadata"):
                 if session_dict.get(data_field):
                     session_dict[data_field] = sanitize_postgres_strings(session_dict[data_field])
@@ -7366,8 +7503,11 @@ class PostgresDb(BaseDb):
                 session_data=session_dict.get("session_data"),
                 summary=session_dict.get("summary"),
                 metadata=session_dict.get("metadata"),
-                created_at=session_dict.get("created_at"),
-                updated_at=session_dict.get("created_at"),
+                # NOT NULL, and to_dict always emits the key, so a missing
+                # timestamp arrives as None rather than absent. One value for
+                # both, or a row can be born already updated.
+                created_at=created_at,
+                updated_at=created_at,
             )
             if isinstance(session, AgentSession):
                 values.update(

--- a/libs/agno/agno/db/run_writes.py
+++ b/libs/agno/agno/db/run_writes.py
@@ -1,0 +1,296 @@
+"""Strict run creation and scoped run updates.
+
+``upsert_run`` cannot tell "the framework is saving its own run again" from
+"a caller handed us a run_id that already belongs to somebody else". Both
+arrive as ``INSERT ... ON CONFLICT (run_id) DO UPDATE``, so a request that
+supplies an id already in the runs table silently replaces the stored run,
+across session and user boundaries.
+
+This module splits the two intents:
+
+* Creation is a strict insert. It reports a conflict instead of overwriting,
+  so a run whose id is already taken is refused rather than landing on the
+  stored run.
+* Every later write is an update scoped to the run's own session, effective
+  user and component. A lifecycle transition (pause, resume, background,
+  terminal write) can only ever touch the row the run itself created.
+
+The two together also close the window a preflight ``get_run`` check cannot:
+two creations racing on the same fresh id both see no row, but only one
+insert lands and the other is told ``CONFLICT``.
+
+Adapters that do not implement the pair report ``UNSUPPORTED`` and keep the
+legacy ``upsert_run`` path unchanged. ``supports_atomic_run_creation``
+reports which behaviour a given db object provides, so an integration can
+detect the guarantee at runtime instead of branching on a version string.
+"""
+
+import inspect
+from enum import Enum
+from typing import Any, Optional
+
+from agno.utils.log import log_warning
+
+
+class RunCreateOutcome(str, Enum):
+    """Result of a strict run creation."""
+
+    CREATED = "created"  # the row was inserted by this call
+    CONFLICT = "conflict"  # the run_id is already taken. FINAL, never overwritten
+    SESSION_MISSING = "session_missing"  # the run has no session row to attach to. FINAL
+    UNSUPPORTED = "unsupported"  # adapter has no strict-insert primitive
+    ERROR = "error"  # the primitive exists but the write failed
+
+
+class RunUpdateOutcome(str, Enum):
+    """Result of a scoped run update."""
+
+    UPDATED = "updated"  # the row was patched
+    MISSING = "missing"  # no row with this run_id; the caller may create it
+    SCOPE_MISMATCH = "scope_mismatch"  # the row belongs to another session/user/component. FINAL
+    UNSUPPORTED = "unsupported"  # adapter has no scoped-update primitive
+    ERROR = "error"  # the primitive exists and did not answer. FINAL
+
+
+__all__ = [
+    "CREATE_NEEDED_UPDATE",
+    "FALLBACK_ALLOWED_CREATE",
+    "FALLBACK_ALLOWED_UPDATE",
+    "FINAL_CREATE",
+    "FINAL_UPDATE",
+    "RunCreateOutcome",
+    "RunUpdateOutcome",
+    "apersist_run_scoped",
+    "persist_run_scoped",
+    "supports_atomic_run_creation",
+]
+
+# How each outcome is routed. Listed member by member rather than derived as
+# a complement, so a member added later belongs to no set and the
+# exhaustiveness test fails, instead of the new member defaulting into the
+# branch that reaches the overwriting ``upsert_run``.
+FALLBACK_ALLOWED_CREATE = frozenset({RunCreateOutcome.UNSUPPORTED})
+FINAL_CREATE = frozenset(
+    {
+        RunCreateOutcome.CREATED,
+        RunCreateOutcome.CONFLICT,
+        RunCreateOutcome.SESSION_MISSING,
+        RunCreateOutcome.ERROR,
+    }
+)
+FALLBACK_ALLOWED_UPDATE = frozenset({RunUpdateOutcome.UNSUPPORTED})
+CREATE_NEEDED_UPDATE = frozenset({RunUpdateOutcome.MISSING})
+FINAL_UPDATE = frozenset({RunUpdateOutcome.UPDATED, RunUpdateOutcome.SCOPE_MISMATCH, RunUpdateOutcome.ERROR})
+
+
+def supports_atomic_run_creation(db: Any) -> bool:
+    """Whether ``db`` provides the strict-create / scoped-update pair.
+
+    Runtime capability probe for downstream integrations. True means a
+    conflicting caller-supplied run_id is rejected by the storage layer
+    itself and later writes stay inside the run's own scope, so the caller
+    needs no preflight read of its own to be safe. Reads the
+    ``supports_atomic_run_creation`` attribute, which an adapter sets only
+    once it implements both halves. See ``BaseDb.create_run``.
+    """
+    return bool(getattr(db, "supports_atomic_run_creation", False))
+
+
+def _run_id_of(run: Any) -> Optional[str]:
+    return run.get("run_id") if isinstance(run, dict) else getattr(run, "run_id", None)
+
+
+def _coerce_create(result: Any) -> RunCreateOutcome:
+    """Map an adapter's create result onto the typed outcome.
+
+    A third-party adapter can return the bare string (the members are
+    ``str``-valued), and an identity comparison against it would fall through
+    to the overwriting ``upsert_run`` -- the exact clobber this module
+    exists to stop. Anything unrecognised is an error, never a success.
+    """
+    if isinstance(result, RunCreateOutcome):
+        return result
+    try:
+        return RunCreateOutcome(result)
+    except ValueError:
+        log_warning(f"Adapter returned an unrecognised run-creation result: {result!r}")
+        return RunCreateOutcome.ERROR
+
+
+def _coerce_update(result: Any) -> RunUpdateOutcome:
+    """Map an adapter's update result onto the typed outcome.
+
+    Unrecognised means ERROR, not UNSUPPORTED: UNSUPPORTED sends the caller
+    to the overwriting ``upsert_run``, so reading a garbled answer that way
+    would perform the clobber this module exists to stop.
+    """
+    if isinstance(result, RunUpdateOutcome):
+        return result
+    try:
+        return RunUpdateOutcome(result)
+    except ValueError:
+        log_warning(f"Adapter returned an unrecognised run-update result: {result!r}")
+        return RunUpdateOutcome.ERROR
+
+
+def _create_is_final(outcome: RunCreateOutcome, run_id: Optional[str]) -> bool:
+    """Whether a non-CREATED creation ends the write here.
+
+    Only UNSUPPORTED hands the write back to the legacy ``upsert_run``; every
+    other outcome means the strict insert answered, and its answer stands. The
+    update side has the same rule, and letting the two disagree is how an
+    error becomes an overwrite.
+    """
+    if outcome in FALLBACK_ALLOWED_CREATE:
+        return False
+    if outcome not in FINAL_CREATE:
+        log_warning(f"Run {run_id} was not saved: the storage create answered an unrecognised outcome")
+        return True
+    if outcome is RunCreateOutcome.CONFLICT:
+        log_warning(
+            f"Refused run save: run {run_id} is already stored under a different session, user or component. "
+            "The stored run was left unchanged."
+        )
+        return True
+    if outcome is RunCreateOutcome.SESSION_MISSING:
+        log_warning(f"Run {run_id} was not saved: there is no session row to attach it to")
+        return True
+    log_warning(f"Run {run_id} was not saved: the storage create answered {outcome.value}")
+    return True
+
+
+def _resolve_update(outcome: RunUpdateOutcome, run_id: Optional[str]) -> Optional[bool]:
+    """Map a scoped-update outcome onto handled (True), create-needed (None)
+    or not-ours-to-answer (False, the caller keeps its legacy save).
+
+    Only the two sets that change the routing are read here: CREATE_NEEDED
+    and FALLBACK_ALLOWED. Everything else is final, so a member added later
+    without a decision falls through to final rather than to the overwriting
+    save. FINAL_UPDATE exists to make that completeness assertable, and the
+    exhaustiveness test is what enforces it.
+    """
+    if outcome in CREATE_NEEDED_UPDATE:
+        return None
+    if outcome in FALLBACK_ALLOWED_UPDATE:
+        return False
+    if outcome is RunUpdateOutcome.UPDATED:
+        return True
+    if outcome is RunUpdateOutcome.SCOPE_MISMATCH:
+        # FINAL by design: the stored run belongs to another session, user or
+        # component, and the whole point of scoping is that this write does
+        # not reach it. Falling through to the unscoped upsert would perform
+        # exactly the overwrite the scope refused.
+        log_warning(
+            f"Refused run save: run {run_id} is stored under a different session, user or component. "
+            "The stored run was left unchanged."
+        )
+        return True
+    # ERROR, and anything a future member might be: final either way, because
+    # the only alternative is the overwriting save.
+    log_warning(f"Run {run_id} was not saved: the storage update did not answer")
+    return True
+
+
+def _conflict_is_final(resolved: Optional[bool], run_id: Optional[str]) -> bool:
+    """Close out a create that reported CONFLICT.
+
+    The row exists, so either the re-driven scoped update lands on it or this
+    write has no business there. Both of the other answers are final too: an
+    adapter that reports the pair UNSUPPORTED only after its own create said
+    CONFLICT is contradicting itself, and "no row" means the id belongs to a
+    run nobody this writer can name. Handing either to the unscoped save is
+    the overwrite the whole module exists to refuse.
+    """
+    if resolved is True:
+        return True
+    log_warning(f"Run {run_id} was not saved: its id is taken by a run this write cannot reach")
+    return True
+
+
+def persist_run_scoped(
+    db: Any,
+    run: Any,
+    session_id: str,
+    user_id: Optional[str] = None,
+    run_index: Optional[int] = None,
+) -> bool:
+    """Save a run through the scoped-update / strict-create pair.
+
+    Returns True when this handled the write: applied, or finally refused
+    because the row belongs to another owner. Returns False when the adapter
+    does not advertise the scoped pair and the caller keeps the legacy
+    ``upsert_run``.
+    """
+    if not supports_atomic_run_creation(db):
+        return False
+    update = getattr(db, "update_run", None) if db is not None else None
+    create = getattr(db, "create_run", None) if db is not None else None
+    if not callable(update) or not callable(create):
+        return False
+    if inspect.iscoroutinefunction(update) or inspect.iscoroutinefunction(create):
+        # A ported adapter reached through the sync door still advertises the
+        # guarantee, so the mismatch has to be visible rather than quietly
+        # handing the write to the overwriting save
+        log_warning(
+            f"Run {_run_id_of(run)}: the scoped save was skipped because its storage only "
+            "writes runs asynchronously, and this caller reached it synchronously"
+        )
+        return False
+
+    run_id = _run_id_of(run)
+    resolved = _resolve_update(
+        _coerce_update(update(run=run, session_id=session_id, user_id=user_id, run_index=run_index)), run_id
+    )
+    if resolved is not None:
+        return resolved
+
+    created = _coerce_create(create(run=run, session_id=session_id, user_id=user_id, run_index=run_index))
+    if created is RunCreateOutcome.CREATED:
+        return True
+    if created is not RunCreateOutcome.CONFLICT:
+        return _create_is_final(created, run_id)
+    # A concurrent writer landed the row between the update and the create;
+    # re-drive the scoped update against whatever is there now.
+    resolved = _resolve_update(
+        _coerce_update(update(run=run, session_id=session_id, user_id=user_id, run_index=run_index)), run_id
+    )
+    return _conflict_is_final(resolved, run_id)
+
+
+async def apersist_run_scoped(
+    db: Any,
+    run: Any,
+    session_id: str,
+    user_id: Optional[str] = None,
+    run_index: Optional[int] = None,
+) -> bool:
+    """Async twin of :func:`persist_run_scoped`; also drives a sync adapter."""
+    if not supports_atomic_run_creation(db):
+        return False
+    update = getattr(db, "update_run", None) if db is not None else None
+    create = getattr(db, "create_run", None) if db is not None else None
+    if not callable(update) or not callable(create):
+        return False
+    update_is_async = inspect.iscoroutinefunction(update)
+    create_is_async = inspect.iscoroutinefunction(create)
+
+    async def _update() -> RunUpdateOutcome:
+        if update_is_async:
+            return _coerce_update(await update(run=run, session_id=session_id, user_id=user_id, run_index=run_index))
+        return _coerce_update(update(run=run, session_id=session_id, user_id=user_id, run_index=run_index))
+
+    run_id = _run_id_of(run)
+    resolved = _resolve_update(await _update(), run_id)
+    if resolved is not None:
+        return resolved
+
+    if create_is_async:
+        created = _coerce_create(await create(run=run, session_id=session_id, user_id=user_id, run_index=run_index))
+    else:
+        created = _coerce_create(create(run=run, session_id=session_id, user_id=user_id, run_index=run_index))
+    if created is RunCreateOutcome.CREATED:
+        return True
+    if created is not RunCreateOutcome.CONFLICT:
+        return _create_is_final(created, run_id)
+    resolved = _resolve_update(await _update(), run_id)
+    return _conflict_is_final(resolved, run_id)

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 
 from agno.db.base import AsyncBaseDb, SessionType
 from agno.db.migrations.manager import MigrationManager
+from agno.db.run_writes import RunCreateOutcome, RunUpdateOutcome
 from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.schemas.memory import UserMemory
@@ -38,10 +39,12 @@ from agno.db.utils import (
     deserialize_session_json_fields,
     deserialize_sessions,
     filter_context_runs,
+    is_foreign_key_violation,
     json_serializer,
     merge_runs_table_with_legacy_blob,
     metrics_starting_date_from_days,
     owner_key,
+    run_scope_clause,
     table_schema_mismatch_error,
     validate_pagination,
 )
@@ -54,8 +57,9 @@ from agno.utils.log import log_debug, log_error, log_info, log_warning
 from agno.utils.string import generate_id
 
 try:
-    from sqlalchemy import Column, ForeignKey, MetaData, String, Table, func, select, text
+    from sqlalchemy import Column, CursorResult, ForeignKey, MetaData, String, Table, func, select, text, update
     from sqlalchemy.dialects import sqlite
+    from sqlalchemy.exc import IntegrityError
     from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker, create_async_engine
     from sqlalchemy.schema import Index, UniqueConstraint
 except ImportError:
@@ -63,6 +67,8 @@ except ImportError:
 
 
 class AsyncSqliteDb(AsyncBaseDb):
+    supports_atomic_run_creation = True
+
     def __init__(
         self,
         db_file: Optional[str] = None,
@@ -877,6 +883,113 @@ class AsyncSqliteDb(AsyncBaseDb):
 
         except Exception as e:
             log_error(f"Exception upserting run to runs table: {str(e)}")
+            raise e
+
+    async def create_run(
+        self,
+        run: Union[RunOutput, TeamRunOutput, WorkflowRunOutput, Dict[str, Any]],
+        session_id: str,
+        user_id: Optional[str] = None,
+        run_index: Optional[int] = None,
+    ) -> RunCreateOutcome:
+        """Async twin of ``SqliteDb.create_run``; see ``BaseDb.create_run``."""
+        try:
+            runs_table = await self._get_table(table_type="runs", create_table_if_not_found=True)
+            if runs_table is None:
+                # See the sync twin: ERROR, not UNSUPPORTED
+                log_error("Runs table could not be resolved; the run was not created")
+                return RunCreateOutcome.ERROR
+
+            row = build_single_run_row(run=run, session_id=session_id, user_id=user_id, run_index=run_index)
+
+            try:
+                async with self.async_session_factory() as sess, sess.begin():
+                    if row.get("run_index") is None:
+                        # Computed inside the insert, same as upsert_run
+                        row["run_index"] = (
+                            select(func.coalesce(func.max(runs_table.c.run_index) + 1, 0))
+                            .where(runs_table.c.session_id == session_id)
+                            .scalar_subquery()
+                        )
+                    stmt = sqlite.insert(runs_table).values(**row).on_conflict_do_nothing(index_elements=["run_id"])
+                    inserted = cast("CursorResult[Any]", await sess.execute(stmt)).rowcount
+            except IntegrityError as e:
+                # See SqliteDb.create_run: only a missing session row is an
+                # expected integrity failure here
+                if not is_foreign_key_violation(e):
+                    log_error(f"Exception creating run in runs table: {str(e)}")
+                    return RunCreateOutcome.ERROR
+                return RunCreateOutcome.SESSION_MISSING
+
+            return RunCreateOutcome.CREATED if inserted else RunCreateOutcome.CONFLICT
+
+        except Exception as e:
+            log_error(f"Exception creating run in runs table: {str(e)}")
+            raise e
+
+    async def update_run(
+        self,
+        run: Union[RunOutput, TeamRunOutput, WorkflowRunOutput, Dict[str, Any]],
+        session_id: str,
+        user_id: Optional[str] = None,
+        run_index: Optional[int] = None,
+    ) -> RunUpdateOutcome:
+        """Async twin of ``SqliteDb.update_run``; see ``BaseDb.update_run``."""
+        try:
+            runs_table = await self._get_table(table_type="runs")
+            if runs_table is None:
+                return RunUpdateOutcome.MISSING
+
+            row = build_single_run_row(run=run, session_id=session_id, user_id=user_id, run_index=run_index)
+
+            async with self.async_session_factory() as sess, sess.begin():
+                stmt = (
+                    update(runs_table)
+                    .where(runs_table.c.run_id == row["run_id"])
+                    .where(run_scope_clause(runs_table, row))
+                    .values(
+                        status=row["status"],
+                        run_data=row["run_data"],
+                        parent_run_id=row["parent_run_id"],
+                        updated_at=row["updated_at"],
+                        # Adopt a row created before its component or owner was known.
+                        # COALESCE, not assignment: a value already on the row is what
+                        # the scope matched against and must not be rewritten.
+                        agent_id=func.coalesce(runs_table.c.agent_id, row["agent_id"]),
+                        team_id=func.coalesce(runs_table.c.team_id, row["team_id"]),
+                        workflow_id=func.coalesce(runs_table.c.workflow_id, row["workflow_id"]),
+                        user_id=func.coalesce(runs_table.c.user_id, row["user_id"]),
+                        # Repair a legacy row stored with a NULL index, using
+                        # the position the caller resolved. COALESCE so a
+                        # stored index is never renumbered; omitted entirely
+                        # when the caller did not resolve one.
+                        **(
+                            {"run_index": func.coalesce(runs_table.c.run_index, row["run_index"])}
+                            if row.get("run_index") is not None
+                            else {}
+                        ),
+                    )
+                )
+                if cast("CursorResult[Any]", await sess.execute(stmt)).rowcount:
+                    return RunUpdateOutcome.UPDATED
+                # See the sync twin for why this asks twice
+                owned = (
+                    await sess.execute(
+                        select(runs_table.c.run_id)
+                        .where(runs_table.c.run_id == row["run_id"])
+                        .where(run_scope_clause(runs_table, row))
+                    )
+                ).fetchone()
+                if owned is not None:
+                    return RunUpdateOutcome.MISSING
+                exists = (
+                    await sess.execute(select(runs_table.c.run_id).where(runs_table.c.run_id == row["run_id"]))
+                ).fetchone()
+
+            return RunUpdateOutcome.SCOPE_MISMATCH if exists is not None else RunUpdateOutcome.MISSING
+
+        except Exception as e:
+            log_error(f"Exception updating run in runs table: {str(e)}")
             raise e
 
     async def get_runs(

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -26,6 +26,7 @@ from agno.db.base import (
     project_config_identity,
 )
 from agno.db.migrations.manager import MigrationManager
+from agno.db.run_writes import RunCreateOutcome, RunUpdateOutcome
 from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.schemas.mcp_oauth import (
@@ -60,11 +61,13 @@ from agno.db.utils import (
     deserialize_session_json_fields,
     deserialize_sessions,
     filter_context_runs,
+    is_foreign_key_violation,
     json_serializer,
     learning_search_patterns,
     merge_runs_table_with_legacy_blob,
     metrics_starting_date_from_days,
     owner_key,
+    run_scope_clause,
     table_schema_mismatch_error,
     validate_pagination,
 )
@@ -77,7 +80,7 @@ from agno.utils.log import log_debug, log_error, log_info, log_warning
 from agno.utils.string import generate_id
 
 try:
-    from sqlalchemy import Column, MetaData, String, Table, Text, and_, func, or_, select, text
+    from sqlalchemy import Column, MetaData, String, Table, Text, and_, func, or_, select, text, update
     from sqlalchemy.dialects import sqlite
     from sqlalchemy.engine import Engine, create_engine
     from sqlalchemy.exc import IntegrityError
@@ -88,6 +91,8 @@ except ImportError:
 
 
 class SqliteDb(BaseDb):
+    supports_atomic_run_creation = True
+
     def __init__(
         self,
         db_file: Optional[str] = None,
@@ -1090,6 +1095,124 @@ class SqliteDb(BaseDb):
 
         except Exception as e:
             log_error(f"Exception upserting run to runs table: {str(e)}")
+            raise e
+
+    def create_run(
+        self,
+        run: Union[RunOutput, TeamRunOutput, WorkflowRunOutput, Dict[str, Any]],
+        session_id: str,
+        user_id: Optional[str] = None,
+        run_index: Optional[int] = None,
+    ) -> RunCreateOutcome:
+        """Insert a run row, refusing to overwrite an existing run_id.
+
+        ``ON CONFLICT DO NOTHING`` on the run_id primary key: the database
+        decides the winner, so two concurrent creations of the same fresh id
+        cannot both be told they created it. See ``BaseDb.create_run``.
+        """
+        try:
+            runs_table = self._get_table(table_type="runs", create_table_if_not_found=True)
+            if runs_table is None:
+                # ERROR, not UNSUPPORTED: this adapter does implement the
+                # strict create, and UNSUPPORTED is the one answer that sends
+                # the caller back to the overwriting upsert_run
+                log_error("Runs table could not be resolved; the run was not created")
+                return RunCreateOutcome.ERROR
+
+            row = build_single_run_row(run=run, session_id=session_id, user_id=user_id, run_index=run_index)
+
+            try:
+                with self.Session() as sess, sess.begin():
+                    if row.get("run_index") is None:
+                        # Computed inside the insert, same as upsert_run
+                        row["run_index"] = (
+                            select(func.coalesce(func.max(runs_table.c.run_index) + 1, 0))
+                            .where(runs_table.c.session_id == session_id)
+                            .scalar_subquery()
+                        )
+                    stmt = sqlite.insert(runs_table).values(**row).on_conflict_do_nothing(index_elements=["run_id"])
+                    inserted = sess.execute(stmt).rowcount
+            except IntegrityError as e:
+                # The runs table foreign-keys to its session, so the expected
+                # failure here is a missing session row. Anything else (a NOT
+                # NULL or CHECK violation) would be misreported as "create the
+                # session and retry", and the retry would fail the same way.
+                if not is_foreign_key_violation(e):
+                    log_error(f"Exception creating run in runs table: {str(e)}")
+                    return RunCreateOutcome.ERROR
+                return RunCreateOutcome.SESSION_MISSING
+
+            return RunCreateOutcome.CREATED if inserted else RunCreateOutcome.CONFLICT
+
+        except Exception as e:
+            log_error(f"Exception creating run in runs table: {str(e)}")
+            raise e
+
+    def update_run(
+        self,
+        run: Union[RunOutput, TeamRunOutput, WorkflowRunOutput, Dict[str, Any]],
+        session_id: str,
+        user_id: Optional[str] = None,
+        run_index: Optional[int] = None,
+    ) -> RunUpdateOutcome:
+        """Patch an existing run row scoped to its owner. See ``BaseDb.update_run``."""
+        try:
+            runs_table = self._get_table(table_type="runs")
+            if runs_table is None:
+                return RunUpdateOutcome.MISSING
+
+            row = build_single_run_row(run=run, session_id=session_id, user_id=user_id, run_index=run_index)
+
+            with self.Session() as sess, sess.begin():
+                stmt = (
+                    update(runs_table)
+                    .where(runs_table.c.run_id == row["run_id"])
+                    .where(run_scope_clause(runs_table, row))
+                    .values(
+                        status=row["status"],
+                        run_data=row["run_data"],
+                        parent_run_id=row["parent_run_id"],
+                        updated_at=row["updated_at"],
+                        # Adopt a row created before its component or owner was known.
+                        # COALESCE, not assignment: a value already on the row is what
+                        # the scope matched against and must not be rewritten.
+                        agent_id=func.coalesce(runs_table.c.agent_id, row["agent_id"]),
+                        team_id=func.coalesce(runs_table.c.team_id, row["team_id"]),
+                        workflow_id=func.coalesce(runs_table.c.workflow_id, row["workflow_id"]),
+                        user_id=func.coalesce(runs_table.c.user_id, row["user_id"]),
+                        # Repair a legacy row stored with a NULL index, using
+                        # the position the caller resolved. COALESCE so a
+                        # stored index is never renumbered; omitted entirely
+                        # when the caller did not resolve one.
+                        **(
+                            {"run_index": func.coalesce(runs_table.c.run_index, row["run_index"])}
+                            if row.get("run_index") is not None
+                            else {}
+                        ),
+                    )
+                )
+                if sess.execute(stmt).rowcount:
+                    return RunUpdateOutcome.UPDATED
+                # The update matched nothing. Two very different reasons, and
+                # only one of them is final, so ask which: a row this writer
+                # DOES own means it landed between the update and here, and
+                # MISSING sends the caller round again. A row it does not own
+                # is the refusal the scope exists for.
+                owned = sess.execute(
+                    select(runs_table.c.run_id)
+                    .where(runs_table.c.run_id == row["run_id"])
+                    .where(run_scope_clause(runs_table, row))
+                ).fetchone()
+                if owned is not None:
+                    return RunUpdateOutcome.MISSING
+                exists = sess.execute(
+                    select(runs_table.c.run_id).where(runs_table.c.run_id == row["run_id"])
+                ).fetchone()
+
+            return RunUpdateOutcome.SCOPE_MISMATCH if exists is not None else RunUpdateOutcome.MISSING
+
+        except Exception as e:
+            log_error(f"Exception updating run in runs table: {str(e)}")
             raise e
 
     def get_runs(

--- a/libs/agno/agno/db/utils.py
+++ b/libs/agno/agno/db/utils.py
@@ -50,6 +50,28 @@ DB_TABLE_NAME_KEYS: frozenset = frozenset(
 )
 
 
+def is_foreign_key_violation(exc: Exception) -> bool:
+    """Whether ``exc`` is a DB foreign-key violation specifically.
+
+    ``IntegrityError`` covers NOT NULL and CHECK failures too, and a run
+    insert that maps every one of them to "the session row is missing" would
+    send the caller to create a session and retry a write that fails the same
+    way. The SQLSTATE is authoritative where the driver exposes one (23503);
+    SQLite has none, so its fixed wording is the fallback. Only ``orig`` is
+    inspected, never ``str(exc)``, which folds bound parameters in.
+    """
+    orig = getattr(exc, "orig", None)
+    if orig is None:
+        return False
+    sqlstate = getattr(orig, "sqlstate", None) or getattr(orig, "pgcode", None)
+    if sqlstate is not None and str(sqlstate) == "23503":
+        return True
+    # Not the standard code, which does not mean "not a foreign key": MySQL
+    # reports 23000 for the whole integrity-constraint family, and SQLite
+    # exposes no SQLSTATE at all. The wording is the fallback for both.
+    return "foreign key" in str(orig).lower()
+
+
 def is_unique_violation(exc: Exception) -> bool:
     """Whether ``exc`` is a DB unique-constraint / duplicate-key violation.
 
@@ -351,7 +373,10 @@ def build_single_run_row(
     Args:
         run: The run object (RunOutput, TeamRunOutput, WorkflowRunOutput) or dict.
         session_id: The session ID this run belongs to.
-        user_id: Optional user ID to associate with the run.
+        user_id: Optional user ID to associate with the run. When it is None
+            the run's own ``user_id`` is used, so the row is stored under the
+            same owner the scoped update later matches on. See
+            ``resolve_run_scope``.
         run_index: Explicit index within the session. Callers **must** supply
             this for INSERTS (any first-time save of a ``run_id``). For UPDATES
             to an existing row it may be ``None``; every adapter's
@@ -382,7 +407,8 @@ def build_single_run_row(
         "agent_id": run_data.get("agent_id"),
         "team_id": run_data.get("team_id"),
         "workflow_id": run_data.get("workflow_id"),
-        "user_id": user_id,
+        # One derivation for every writer; see resolve_run_scope
+        "user_id": resolve_run_scope(run_data, session_id, user_id)["user_id"],
         "parent_run_id": run_data.get("parent_run_id"),
         "status": run_data.get("status"),
         "run_index": effective_run_index,
@@ -390,6 +416,87 @@ def build_single_run_row(
         "created_at": run_data.get("created_at") or current_time,
         "updated_at": current_time,
     }
+
+
+# The ownership facts a run write is scoped by, and where each one comes from.
+# ``session_id`` is always the caller's argument; the rest are read off the run
+# when the caller did not resolve them, because the framework reaches the save
+# path from several places that know different amounts (the route's user, the
+# session's, the run's own).
+_RUN_SCOPE_COMPONENTS = ("agent_id", "team_id", "workflow_id")
+
+
+def resolve_run_scope(run_data: Dict[str, Any], session_id: str, user_id: Optional[str]) -> Dict[str, Optional[str]]:
+    """The identity a write presents for scoping.
+
+    One derivation for every writer. A value of None means "this writer does
+    not know", never "this value is empty" -- that distinction is what
+    ``run_scope_clause`` and ``InMemoryDb._scope_matches`` both act on.
+    """
+    scope: Dict[str, Optional[str]] = {
+        "session_id": session_id,
+        "user_id": user_id if user_id is not None else run_data.get("user_id"),
+    }
+    for field in _RUN_SCOPE_COMPONENTS:
+        scope[field] = run_data.get(field)
+    return scope
+
+
+def run_scope_allows(stored: Dict[str, Optional[str]], incoming: Dict[str, Optional[str]]) -> bool:
+    """Whether a write presenting ``incoming`` may reach a row owned by ``stored``.
+
+    The one rule, in Python. ``run_scope_clause`` is the same rule in SQL, and
+    a caller that needs it outside a query, such as the in-memory adapter,
+    goes through here rather than writing its own. Two statements of a rule
+    can drift; three is how one backend ends up with a hole the others do not.
+    """
+    if stored["session_id"] != incoming["session_id"]:
+        return False
+    # Component identity is one fact spread over three columns, so it is
+    # compared as a whole. A row that names a component belongs to that
+    # component and to no other; a row that names none is unattributed, and
+    # the first write that knows a component adopts it.
+    stored_component = tuple(stored[field] for field in _RUN_SCOPE_COMPONENTS)
+    incoming_component = tuple(incoming[field] for field in _RUN_SCOPE_COMPONENTS)
+    if any(stored_component) and any(incoming_component) and stored_component != incoming_component:
+        return False
+    if incoming["user_id"] is None:
+        return True
+    return stored["user_id"] is None or stored["user_id"] == incoming["user_id"]
+
+
+def run_scope_clause(runs_table: Any, row: Dict[str, Any]) -> Any:
+    """WHERE terms confining a run write to the row its own run created.
+
+    Three rules, one per kind of fact:
+
+    * ``session_id`` is always known and compared exactly.
+    * Component identity is compared as a whole, across all three columns. A
+      row that names a component belongs to it and to no other, so a team's
+      write never reaches an agent's row. A row that names none is not yet
+      attributed, and the first write that knows a component adopts it. Rows
+      like that are real: a cancellation rebuilds a run from its id alone,
+      and a v3 migration brings rows across without one, and refusing them
+      locked those runs out of their own later saves.
+    * The user follows the same adopt-if-unattributed rule, per column.
+
+    A fact the writer does not know constrains nothing. The framework rebuilds
+    a run from its id alone on some paths (a cancellation caught with no run
+    object in hand), and requiring those unknowns to be NULL would refuse the
+    run's own final write.
+    """
+    from sqlalchemy import and_, or_
+
+    terms = [runs_table.c.session_id == row["session_id"]]
+    named = [runs_table.c[field] == row[field] for field in _RUN_SCOPE_COMPONENTS if row[field] is not None]
+    if named:
+        # Either the row is unattributed, or it names exactly what this write
+        # names. See run_scope_allows: the three columns are one fact.
+        unattributed = and_(*[runs_table.c[field].is_(None) for field in _RUN_SCOPE_COMPONENTS])
+        terms.append(or_(unattributed, and_(*named)))
+    if row["user_id"] is not None:
+        terms.append(or_(runs_table.c.user_id.is_(None), runs_table.c.user_id == row["user_id"]))
+    return and_(*terms)
 
 
 # Run statuses (as stored string values) excluded from context/history reads.
@@ -402,7 +509,7 @@ HISTORY_SKIP_STATUSES: List[str] = [status.value for status in _RUN_HISTORY_SKIP
 def filter_context_runs(runs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Keep only top-level, context-relevant runs from a list of run dicts.
 
-    Drops member sub-runs (``parent_run_id`` set) and terminal-skip statuses,
+    Drops member sub-runs (``parent_run_id`` set) and history-skip statuses,
     mirroring the pre-slice filtering in ``get_messages``. Used on the
     un-migrated / legacy-blob read path so slicing to "most recent N" yields the
     same window as the fully-migrated (SQL-filtered) path.

--- a/libs/agno/agno/team/_storage.py
+++ b/libs/agno/agno/team/_storage.py
@@ -277,6 +277,19 @@ def _upsert_run(
         # registered - a zombie leg's member writes orphan, not clobber)
         if persist_worker_owned_run(team.db, run, session_id=session_id, user_id=user_id):
             return
+        from agno.db.run_writes import persist_run_scoped
+
+        # Scoped update first, strict create when the row is not there yet:
+        # a lifecycle save can then only ever touch the row this run created
+        try:
+            handled = persist_run_scoped(team.db, run, session_id=session_id, user_id=user_id, run_index=run_index)
+        except NotImplementedError:
+            # The adapter declares the scoped pair but has not implemented
+            # it; the legacy save below overwrites, so say so
+            log_warning(f"{type(team.db).__name__} declares scoped run writes but does not implement them")
+            handled = False
+        if handled:
+            return
         team.db.upsert_run(run=run, session_id=session_id, user_id=user_id, run_index=run_index)  # type: ignore[union-attr]
     except NotImplementedError:
         log_debug(f"{type(team.db).__name__} does not implement upsert_run; skipping per-run write")
@@ -302,6 +315,20 @@ async def _aupsert_run(
         # Queue-worker-owned runs save through the attempt-fenced primitive;
         # member-run saves pass through untouched (see _upsert_run)
         if await apersist_worker_owned_run(team.db, run, session_id=session_id, user_id=user_id):
+            return
+        from agno.db.run_writes import apersist_run_scoped
+
+        # See _upsert_run
+        try:
+            handled = await apersist_run_scoped(
+                team.db, run, session_id=session_id, user_id=user_id, run_index=run_index
+            )
+        except NotImplementedError:
+            # The adapter declares the scoped pair but has not implemented
+            # it; the legacy save below overwrites, so say so
+            log_warning(f"{type(team.db).__name__} declares scoped run writes but does not implement them")
+            handled = False
+        if handled:
             return
         if _has_async_db(team):
             await team.db.upsert_run(run=run, session_id=session_id, user_id=user_id, run_index=run_index)  # type: ignore[union-attr,misc]

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -2167,6 +2167,20 @@ class Workflow:
             # primitive; a zombie attempt's write is refused, not applied
             if persist_worker_owned_run(self.db, run, session_id=session_id, user_id=user_id):
                 return
+            from agno.db.run_writes import persist_run_scoped
+
+            # Scoped update first, strict create when the row is not there
+            # yet, so a workflow run cannot land on a row owned by another
+            # session, user or component either
+            try:
+                handled = persist_run_scoped(self.db, run, session_id=session_id, user_id=user_id, run_index=run_index)
+            except NotImplementedError:
+                # The adapter declares the scoped pair but has not implemented
+                # it; the legacy save below overwrites, so say so
+                log_warning(f"{type(self.db).__name__} declares scoped run writes but does not implement them")
+                handled = False
+            if handled:
+                return
             self.db.upsert_run(run=run, session_id=session_id, user_id=user_id, run_index=run_index)  # type: ignore[union-attr]
         except NotImplementedError:
             log_debug(f"{type(self.db).__name__} does not implement upsert_run; skipping per-run write")
@@ -2193,6 +2207,20 @@ class Workflow:
             # Queue-worker-owned runs save through the attempt-fenced
             # primitive; a zombie attempt's write is refused, not applied
             if await apersist_worker_owned_run(self.db, run, session_id=session_id, user_id=user_id):
+                return
+            from agno.db.run_writes import apersist_run_scoped
+
+            # See save_run
+            try:
+                handled = await apersist_run_scoped(
+                    self.db, run, session_id=session_id, user_id=user_id, run_index=run_index
+                )
+            except NotImplementedError:
+                # The adapter declares the scoped pair but has not implemented
+                # it; the legacy save below overwrites, so say so
+                log_warning(f"{type(self.db).__name__} declares scoped run writes but does not implement them")
+                handled = False
+            if handled:
                 return
             if self._has_async_db():
                 await self.db.upsert_run(run=run, session_id=session_id, user_id=user_id, run_index=run_index)  # type: ignore[union-attr,misc]

--- a/libs/agno/tests/unit/agent/test_run_id_conflicts.py
+++ b/libs/agno/tests/unit/agent/test_run_id_conflicts.py
@@ -1,0 +1,527 @@
+"""An agent run cannot overwrite a stored run that is not its own.
+
+``run_id`` can be supplied by the caller, and storage used to accept a
+conflicting one as an update, replacing a stored run that may belong to
+another session or user. Creation is now a strict insert, and every later
+write is scoped to the run's own session, effective user and component: a run
+handed an id that is already taken executes normally, and its save is refused
+rather than landing on the stored run.
+
+The boundaries that refusal draws are the session, the user and the component.
+A caller reusing an id inside the scope the stored row already holds presents
+exactly what the run's own second save would, so that write is allowed; see
+``TestReusingAStoredId``.
+"""
+
+import asyncio
+import time
+from typing import Any, AsyncIterator, Iterator, Optional
+
+import pytest
+
+from agno.agent._storage import upsert_run
+from agno.agent.agent import Agent
+from agno.db.in_memory import InMemoryDb
+from agno.db.sqlite import SqliteDb
+from agno.models.base import Model
+from agno.models.message import MessageMetrics
+from agno.models.response import ModelResponse
+from agno.run.agent import RunOutput
+from agno.run.base import RunStatus
+
+
+class MockModel(Model):
+    """Minimal offline model: returns a canned text response without any network call."""
+
+    def __init__(self):
+        super().__init__(id="test-model", name="test-model", provider="test")
+        self.instructions = None
+        self._mock_response = ModelResponse(content="ok", role="assistant", response_usage=MessageMetrics())
+
+    def get_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    def get_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    def parse_args(self, *args, **kwargs):
+        return {}
+
+    def invoke(self, *args, **kwargs) -> ModelResponse:
+        return self._mock_response
+
+    async def ainvoke(self, *args, **kwargs) -> ModelResponse:
+        return self._mock_response
+
+    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+        yield self._mock_response
+
+    async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+        yield self._mock_response
+        return
+
+    def _parse_provider_response(self, response: Any, **kwargs) -> ModelResponse:
+        return self._mock_response
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return self._mock_response
+
+
+def _make_agent(db: Any, **kwargs) -> Agent:
+    return Agent(name="test-agent", id="test-agent", model=MockModel(), db=db, telemetry=False, **kwargs)
+
+
+def _stored(db: Any, run_id: str) -> Optional[dict]:
+    row = db.get_run(run_id, deserialize=False)
+    if row is None:
+        return None
+    return row.get("run_data") or row
+
+
+def _owner(db: Any, run_id: str) -> Optional[str]:
+    """The user the stored run belongs to, whichever row shape came back."""
+    row = db.get_run(run_id, deserialize=False) or {}
+    return row.get("user_id") or (row.get("run_data") or {}).get("user_id")
+
+
+def _asked(db: Any, run_id: str) -> Any:
+    """What the stored run was asked, which is what tells two turns apart.
+
+    Every turn here answers "ok", so the input is the only field that says
+    which run the stored row belongs to.
+    """
+    value = (_stored(db, run_id) or {}).get("input")
+    return value.get("input_content") if isinstance(value, dict) else value
+
+
+@pytest.fixture(params=["in_memory", "sqlite"])
+def db(request, tmp_path):
+    if request.param == "in_memory":
+        return InMemoryDb()
+    return SqliteDb(db_file=str(tmp_path / "runs.db"))
+
+
+class TestNormalRuns:
+    def test_a_generated_id_still_persists(self, db):
+        agent = _make_agent(db)
+
+        result = agent.run("hi", session_id="s1")
+
+        assert _stored(db, result.run_id) is not None
+        assert _stored(db, result.run_id)["status"] == RunStatus.completed.value
+
+    def test_an_explicit_fresh_id_still_persists(self, db):
+        agent = _make_agent(db)
+
+        result = agent.run("hi", session_id="s1", run_id="chosen")
+
+        assert result.run_id == "chosen"
+        assert _stored(db, "chosen")["status"] == RunStatus.completed.value
+
+    def test_two_turns_in_one_session_both_persist(self, db):
+        agent = _make_agent(db)
+
+        first = agent.run("one", session_id="s1")
+        second = agent.run("two", session_id="s1")
+
+        assert first.run_id != second.run_id
+        assert _stored(db, first.run_id) is not None
+        assert _stored(db, second.run_id) is not None
+
+    @pytest.mark.asyncio
+    async def test_async_runs_still_persist(self, db):
+        agent = _make_agent(db)
+
+        result = await agent.arun("hi", session_id="s1")
+
+        assert _stored(db, result.run_id)["status"] == RunStatus.completed.value
+
+    @pytest.mark.asyncio
+    async def test_background_runs_still_reach_a_terminal_status(self, db):
+        agent = _make_agent(db)
+
+        result = await agent.arun("hi", session_id="s1", background=True)
+        # Poll to a TERMINAL status: the run passes through RUNNING on its way,
+        # and breaking on the first stored status raced that transition
+        terminal = {RunStatus.completed.value, RunStatus.error.value, RunStatus.cancelled.value}
+        deadline = time.monotonic() + 10
+        while True:
+            row = _stored(db, result.run_id)
+            assert row is not None, "the background run stored no row"
+            if row["status"] in terminal:
+                break
+            assert time.monotonic() < deadline, f"background run stuck at {row['status']}"
+            await asyncio.sleep(0.01)
+
+        assert row["status"] == RunStatus.completed.value
+        assert row["content"] == "ok"
+
+    def test_a_streaming_run_still_persists(self, db):
+        agent = _make_agent(db)
+
+        events = list(agent.run("hi", session_id="s1", run_id="streamed", stream=True))
+
+        assert events
+        assert _stored(db, "streamed")["status"] == RunStatus.completed.value
+        assert _stored(db, "streamed")["content"] == "ok"
+
+    @pytest.mark.asyncio
+    async def test_an_async_streaming_run_still_persists(self, db):
+        agent = _make_agent(db)
+
+        events = [event async for event in agent.arun("hi", session_id="s1", run_id="streamed", stream=True)]
+
+        assert events
+        assert _stored(db, "streamed")["status"] == RunStatus.completed.value
+
+
+class TestReusingAStoredId:
+    """A run handed a taken id executes, and its save cannot reach the stored run.
+
+    Each refusal asserts the whole stored row is byte-for-byte what it was,
+    and every case that names a user asserts the owner column too, since
+    leaving the run readable by the wrong user is the same loss as replacing
+    its content.
+    """
+
+    def test_a_reuse_inside_the_stored_scope_is_the_runs_own_write(self, db):
+        """Nothing distinguishes this from the run saving itself a second time.
+
+        The scope a write presents is its session, user and component. A
+        caller reusing an id within the same scope presents exactly what the
+        stored row holds, which is also what every lifecycle transition of the
+        run itself presents, so the write lands. The boundaries asserted below
+        are what the scope refuses.
+        """
+        agent = _make_agent(db)
+        agent.run("first", session_id="s1", user_id="u1", run_id="taken")
+
+        agent.run("second", session_id="s1", user_id="u1", run_id="taken")
+
+        assert _asked(db, "taken") == "second"
+        assert _owner(db, "taken") == "u1"
+
+    def test_another_session_cannot_overwrite_the_stored_run(self, db):
+        agent = _make_agent(db)
+        agent.run("victim turn", session_id="victim", run_id="taken")
+        original = _stored(db, "taken")
+
+        agent.run("attacker turn", session_id="attacker", run_id="taken")
+
+        assert _stored(db, "taken") == original
+        assert _asked(db, "taken") == "victim turn"
+
+    def test_another_user_cannot_overwrite_the_stored_run(self, db):
+        """Same session, so the user is the only fact that differs."""
+        agent = _make_agent(db)
+        agent.run("victim turn", session_id="s1", user_id="victim-user", run_id="taken")
+        original = _stored(db, "taken")
+
+        agent.run("attacker turn", session_id="s1", user_id="attacker-user", run_id="taken")
+
+        assert _stored(db, "taken") == original
+        assert _owner(db, "taken") == "victim-user"
+
+    def test_another_users_session_cannot_overwrite_the_stored_run(self, db):
+        agent = _make_agent(db)
+        agent.run("victim turn", session_id="victim", user_id="victim-user", run_id="taken")
+        original = _stored(db, "taken")
+
+        agent.run("attacker turn", session_id="attacker", user_id="attacker-user", run_id="taken")
+
+        assert _stored(db, "taken") == original
+        assert _owner(db, "taken") == "victim-user"
+
+    def test_another_session_cannot_claim_an_anonymous_stored_run(self, db):
+        """The session refuses this write; naming a user would not have.
+
+        An unowned row is adopted by the first write that knows a user, so in
+        the stored row's own session this caller would land and the row would
+        become theirs. Here the sessions differ, which is the fact the refusal
+        rests on, and being unowned does not soften it: an anonymous row is no
+        more reachable from another session than an owned one.
+        """
+        agent = _make_agent(db)
+        agent.run("victim turn", session_id="victim", run_id="taken")
+        original = _stored(db, "taken")
+
+        agent.run("attacker turn", session_id="attacker", user_id="attacker-user", run_id="taken")
+
+        assert _stored(db, "taken") == original
+        assert _owner(db, "taken") is None
+
+    def test_two_identity_less_callers_do_not_reach_each_others_runs(self, db):
+        """Neither caller names a user, so the session is all the scope has."""
+        agent = _make_agent(db)
+        agent.run("first", session_id="s1", run_id="taken")
+        original = _stored(db, "taken")
+
+        agent.run("second", session_id="s2", run_id="taken")
+
+        assert _stored(db, "taken") == original
+        assert _asked(db, "taken") == "first"
+
+    def test_the_refused_run_still_executes_and_returns_its_output(self, db):
+        """The refusal is a storage decision, not a rejected request."""
+        agent = _make_agent(db)
+        agent.run("first", session_id="s1", run_id="taken")
+        calls = {"count": 0}
+        original_invoke = agent.model.invoke
+
+        def counting_invoke(*args, **kwargs):
+            calls["count"] += 1
+            return original_invoke(*args, **kwargs)
+
+        agent.model.invoke = counting_invoke  # type: ignore[method-assign]
+
+        result = agent.run("second", session_id="s2", run_id="taken")
+
+        assert calls["count"] == 1
+        assert result.run_id == "taken"
+        assert result.status == RunStatus.completed
+        assert result.content == "ok"
+
+    def test_a_sync_streaming_run_does_not_overwrite_the_stored_run(self, db):
+        agent = _make_agent(db)
+        agent.run("first", session_id="s1", run_id="taken")
+        original = _stored(db, "taken")
+
+        events = list(agent.run("second", session_id="s2", run_id="taken", stream=True))
+
+        assert events
+        assert _stored(db, "taken") == original
+
+    @pytest.mark.asyncio
+    async def test_an_async_run_does_not_overwrite_the_stored_run(self, db):
+        agent = _make_agent(db)
+        await agent.arun("first", session_id="s1", run_id="taken")
+        original = _stored(db, "taken")
+
+        await agent.arun("second", session_id="s2", user_id="other", run_id="taken")
+
+        assert _stored(db, "taken") == original
+        assert _owner(db, "taken") is None
+
+    @pytest.mark.asyncio
+    async def test_an_async_streaming_run_does_not_overwrite_the_stored_run(self, db):
+        agent = _make_agent(db)
+        await agent.arun("first", session_id="s1", run_id="taken")
+        original = _stored(db, "taken")
+
+        events = [event async for event in agent.arun("second", session_id="s2", run_id="taken", stream=True)]
+
+        assert events
+        assert _stored(db, "taken") == original
+
+    def test_a_run_without_a_database_still_reuses_the_id(self):
+        agent = Agent(name="test-agent", id="test-agent", model=MockModel(), telemetry=False)
+
+        first = agent.run("first", session_id="s1", run_id="taken")
+        second = agent.run("second", session_id="s1", run_id="taken")
+
+        assert first.run_id == second.run_id == "taken"
+
+
+class TestLifecycleAfterTheFirstSave:
+    """Transitions written after the first save go through the scoped update.
+
+    These use the framework's own per-run save helper, which is what the HITL,
+    resume, background and terminal paths all call.
+    """
+
+    def _seeded(self, db: Any, session_id: str = "s1", user_id: Optional[str] = None) -> tuple:
+        """An agent whose session exists, and an unsaved run to drive through it.
+
+        The seed turn is what creates the session row; a run has nothing to
+        attach to without one, and its strict create reports the session
+        missing rather than inventing it.
+        """
+        agent = _make_agent(db)
+        agent.run("seed", session_id=session_id, user_id=user_id)
+        run = RunOutput(run_id="r1", session_id=session_id, agent_id=agent.id, user_id=user_id)
+        return agent, run
+
+    def test_pause_then_resume_then_completion_all_land(self, db):
+        agent, run = self._seeded(db, user_id="u1")
+
+        run.status = RunStatus.paused
+        upsert_run(agent, run=run, session_id="s1", user_id="u1", run_index=1)
+        assert _stored(db, "r1")["status"] == RunStatus.paused.value
+
+        run.status = RunStatus.running
+        upsert_run(agent, run=run, session_id="s1", user_id="u1")
+        assert _stored(db, "r1")["status"] == RunStatus.running.value
+
+        run.status = RunStatus.completed
+        run.content = "done"
+        upsert_run(agent, run=run, session_id="s1", user_id="u1")
+        assert _stored(db, "r1")["status"] == RunStatus.completed.value
+        assert _stored(db, "r1")["content"] == "done"
+
+    def test_a_resume_by_another_user_is_refused(self, db):
+        agent, run = self._seeded(db, user_id="u1")
+        run.status = RunStatus.paused
+        upsert_run(agent, run=run, session_id="s1", user_id="u1", run_index=1)
+        paused = _stored(db, "r1")
+
+        run.content = "attacker"
+        run.status = RunStatus.completed
+        upsert_run(agent, run=run, session_id="s1", user_id="attacker")
+
+        assert _stored(db, "r1") == paused
+        assert _owner(db, "r1") == "u1"
+
+    def test_a_resume_from_another_session_is_refused(self, db):
+        agent, run = self._seeded(db, user_id="u1")
+        run.status = RunStatus.paused
+        upsert_run(agent, run=run, session_id="s1", user_id="u1", run_index=1)
+        paused = _stored(db, "r1")
+
+        run.content = "attacker"
+        run.status = RunStatus.completed
+        upsert_run(agent, run=run, session_id="attacker-session", user_id="u1")
+
+        assert _stored(db, "r1") == paused
+
+    def test_a_save_for_a_run_that_was_never_stored_still_creates_it(self, db):
+        """Paths whose run has no row yet, such as a forked run, keep working."""
+        agent = _make_agent(db)
+        agent.run("seed", session_id="s1")
+        run = RunOutput(run_id="unstored", session_id="s1", agent_id=agent.id, content="forked")
+
+        upsert_run(agent, run=run, session_id="s1", run_index=1)
+
+        assert _stored(db, "unstored")["content"] == "forked"
+
+    @pytest.mark.asyncio
+    async def test_an_async_scoped_save_refuses_another_owner(self, db):
+        from agno.agent._storage import aupsert_run
+
+        agent = _make_agent(db)
+        await agent.arun("seed", session_id="s1", user_id="u1")
+        run = RunOutput(run_id="r1", session_id="s1", agent_id=agent.id, user_id="u1", content="original")
+        await aupsert_run(agent, run=run, session_id="s1", user_id="u1", run_index=1)
+
+        attacker = RunOutput(run_id="r1", session_id="s1", agent_id=agent.id, user_id="u2", content="attacker")
+        await aupsert_run(agent, run=attacker, session_id="s1", user_id="u2")
+
+        assert _stored(db, "r1")["content"] == "original"
+        assert _owner(db, "r1") == "u1"
+
+
+class TestMemberAndWorkflowRuns:
+    def test_a_member_agent_writes_no_run_row_of_its_own(self, db):
+        """A member's run row is owned by the team that saves it."""
+        agent = _make_agent(db)
+        agent.team_id = "some-team"
+
+        agent.run("hi", session_id="s1", run_id="member")
+
+        assert _stored(db, "member") is None
+
+    def test_a_workflow_leg_writes_no_run_row_of_its_own(self, db):
+        agent = _make_agent(db)
+        agent.workflow_id = "some-workflow"
+
+        agent.run("hi", session_id="s1", run_id="leg")
+
+        assert _stored(db, "leg") is None
+
+    def test_a_save_naming_another_workflow_is_refused(self, db):
+        """The component is scoped alongside the session and the user."""
+        agent = _make_agent(db)
+        agent.run("seed", session_id="s1")
+        leg = RunOutput(run_id="leg", session_id="s1", agent_id=agent.id, workflow_id="wf-a", content="leg output")
+        upsert_run(agent, run=leg, session_id="s1", run_index=1)
+
+        other = RunOutput(run_id="leg", session_id="s1", agent_id=agent.id, workflow_id="wf-b", content="stolen")
+        upsert_run(agent, run=other, session_id="s1")
+
+        assert _stored(db, "leg")["content"] == "leg output"
+
+    def test_an_adapter_without_the_pair_keeps_saving(self):
+        """The shipped adapters that report UNSUPPORTED must be unaffected.
+
+        Such an adapter has no strict create and no scoped update, so the save
+        stays on the legacy path: both writes reach it, the second one
+        included, and nothing here refuses either.
+        """
+
+        class UnportedDb:
+            supports_atomic_run_creation = False
+
+            def __init__(self):
+                self.saves: list = []
+
+            def upsert_run(self, run, session_id, user_id=None, run_index=None):
+                self.saves.append((run.run_id, session_id, run.content))
+                return True
+
+        agent = _make_agent(InMemoryDb())
+        unported = UnportedDb()
+        agent.db = unported  # type: ignore[assignment]
+
+        upsert_run(
+            agent,
+            run=RunOutput(run_id="r1", session_id="s1", agent_id=agent.id, content="first"),
+            session_id="s1",
+            run_index=0,
+        )
+        upsert_run(
+            agent,
+            run=RunOutput(run_id="r1", session_id="other", agent_id=agent.id, content="second"),
+            session_id="other",
+            run_index=0,
+        )
+
+        assert unported.saves == [("r1", "s1", "first"), ("r1", "other", "second")]
+
+
+class TestAttribution:
+    """A run stays findable by the user it belongs to.
+
+    The save paths resolve identity from different places -- the route's user,
+    the session's, the run's own -- so the owner column has to survive
+    whichever one wrote the row, and a run must not lose its output because
+    two of them disagree.
+    """
+
+    def test_a_run_keeps_the_owner_its_session_has(self, db):
+        agent = _make_agent(db)
+        agent.run("first", session_id="s1", user_id="alice")
+
+        second = agent.run("second", session_id="s1")
+
+        # Asserted on the stored row: the in-memory adapter's get_runs filters
+        # by the SESSION's user, so it would pass either way
+        assert _owner(db, second.run_id) == "alice"
+
+    def test_an_explicit_user_is_recorded(self, db):
+        agent = _make_agent(db)
+
+        result = agent.run("hi", session_id="s1", user_id="alice")
+
+        assert _owner(db, result.run_id) == "alice"
+
+    def test_a_run_issued_without_a_user_on_an_owned_session_still_persists(self, db):
+        agent = _make_agent(db)
+        agent.run("first", session_id="s1", user_id="u1")
+
+        result = agent.run("second", session_id="s1")
+
+        assert _stored(db, result.run_id)["status"] == RunStatus.completed.value
+        assert _stored(db, result.run_id)["content"] == "ok"
+
+    def test_a_run_issued_with_a_user_on_an_unowned_session_still_persists(self, db):
+        agent = _make_agent(db)
+        agent.run("first", session_id="s1")
+
+        result = agent.run("second", session_id="s1", user_id="u1")
+
+        assert _stored(db, result.run_id)["content"] == "ok"

--- a/libs/agno/tests/unit/db/test_run_creation_isolation.py
+++ b/libs/agno/tests/unit/db/test_run_creation_isolation.py
@@ -1,0 +1,1493 @@
+"""Run creation never overwrites, and lifecycle updates stay inside their owner.
+
+``upsert_run`` writes creations and updates with the same statement, so a
+caller-supplied ``run_id`` that already exists replaced the stored run, across
+sessions and users. ``create_run`` is a strict insert that reports a conflict,
+and ``update_run`` patches only a row whose session, effective user and
+component identity match the write.
+
+Covered here for the in-memory and SQLite adapters, sync and async. The
+PostgreSQL twin lives in test_run_creation_isolation_postgres.py.
+"""
+
+import asyncio
+import threading
+import time
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from agno.db.in_memory import InMemoryDb
+from agno.db.run_writes import (
+    CREATE_NEEDED_UPDATE,
+    FALLBACK_ALLOWED_CREATE,
+    FALLBACK_ALLOWED_UPDATE,
+    FINAL_CREATE,
+    FINAL_UPDATE,
+    RunCreateOutcome,
+    RunUpdateOutcome,
+    apersist_run_scoped,
+    persist_run_scoped,
+    supports_atomic_run_creation,
+)
+from agno.db.sqlite import SqliteDb
+from agno.db.sqlite.async_sqlite import AsyncSqliteDb
+from agno.db.utils import is_foreign_key_violation, run_scope_allows
+from agno.run.agent import RunOutput
+from agno.run.base import RunStatus
+from agno.run.team import TeamRunOutput
+from agno.run.workflow import WorkflowRunOutput
+from agno.session import AgentSession, TeamSession, WorkflowSession
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _agent_session(session_id: str = "s1", user_id: Optional[str] = None) -> AgentSession:
+    return AgentSession(session_id=session_id, agent_id="a1", user_id=user_id, created_at=1)
+
+
+def _team_session(session_id: str = "s1", user_id: Optional[str] = None) -> TeamSession:
+    return TeamSession(session_id=session_id, team_id="t1", user_id=user_id, created_at=1)
+
+
+def _agent_run(
+    run_id: str, session_id: str = "s1", user_id: Optional[str] = None, content: Optional[str] = None
+) -> RunOutput:
+    return RunOutput(run_id=run_id, session_id=session_id, agent_id="a1", user_id=user_id, content=content)
+
+
+def _team_run(
+    run_id: str, session_id: str = "s1", user_id: Optional[str] = None, content: Optional[str] = None
+) -> TeamRunOutput:
+    return TeamRunOutput(run_id=run_id, session_id=session_id, team_id="t1", user_id=user_id, content=content)
+
+
+def _payload(row: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """The stored run itself, whichever row shape the adapter returns.
+
+    SQL adapters return a runs-table row wrapping the run in ``run_data``; the
+    in-memory adapter stores runs inline and returns the run dict directly.
+    """
+    if row is None:
+        return {}
+    return row.get("run_data") or row
+
+
+def _stored_content(db: Any, run_id: str) -> Optional[str]:
+    return _payload(db.get_run(run_id, deserialize=False)).get("content")
+
+
+async def _astored_content(db: Any, run_id: str) -> Optional[str]:
+    return _payload(await db.get_run(run_id, deserialize=False)).get("content")
+
+
+def _stored_status(db: Any, run_id: str) -> Optional[str]:
+    return _payload(db.get_run(run_id, deserialize=False)).get("status")
+
+
+def _stored_index(db: Any, run_id: str) -> Optional[int]:
+    return (db.get_run(run_id, deserialize=False) or {}).get("run_index")
+
+
+def _stored_owner(db: Any, run_id: str, column: str) -> Optional[str]:
+    """An identity column as stored, read the way the row shapes allow.
+
+    ``get`` rather than indexing: the in-memory adapter leaves a column it has
+    no value for out of the dict entirely, and a KeyError there would read as
+    a test bug rather than as the None it means.
+    """
+    return (db.get_run(run_id, deserialize=False) or {}).get(column)
+
+
+def _store_and_write(db: Any, run_id: str, content: str, session_id: str = "s1", user_id: Optional[str] = None):
+    """Store a run and give it content, the way a real run does.
+
+    A run's row is created by its first save and patched by every save after,
+    so a test that needs stored content performs both.
+    """
+    from agno.db.base import SessionType
+
+    if db.get_session(session_id=session_id, session_type=SessionType.AGENT, deserialize=False) is None:
+        db.upsert_session(_agent_session(session_id, user_id=user_id))
+    db.create_run(
+        run=_agent_run(run_id, session_id=session_id, user_id=user_id),
+        session_id=session_id,
+        user_id=user_id,
+    )
+    db.update_run(
+        run=_agent_run(run_id, session_id=session_id, user_id=user_id, content=content),
+        session_id=session_id,
+        user_id=user_id,
+    )
+
+
+def _drive_the_caller(db: Any, run: Any, session_id: str = "s1") -> None:
+    """The per-run save as the framework itself performs it.
+
+    ``persist_run_scoped`` never calls ``upsert_run``: returning False is what
+    sends its caller to the overwriting save. So "the overwrite was not
+    reached" is only assertable through a caller, and the agent save helper is
+    the one every agent run goes through.
+    """
+    from types import SimpleNamespace
+
+    from agno.agent._storage import upsert_run
+
+    upsert_run(SimpleNamespace(db=db), run, session_id=session_id)  # type: ignore[arg-type]
+
+
+@pytest.fixture(params=["in_memory", "sqlite"])
+def db(request, tmp_path):
+    if request.param == "in_memory":
+        yield InMemoryDb()
+        return
+    database = SqliteDb(db_file=str(tmp_path / "runs.db"))
+    yield database
+
+
+@pytest.fixture
+def async_db(tmp_path):
+    return AsyncSqliteDb(db_file=str(tmp_path / "async_runs.db"))
+
+
+# ---------------------------------------------------------------------------
+# Capability
+# ---------------------------------------------------------------------------
+
+
+class TestCapability:
+    def test_supported_adapters_advertise_atomic_creation(self, db):
+        assert supports_atomic_run_creation(db) is True
+
+    def test_async_sqlite_advertises_atomic_creation(self, async_db):
+        assert supports_atomic_run_creation(async_db) is True
+
+    def test_probe_is_false_for_an_object_without_the_pair(self):
+        assert supports_atomic_run_creation(object()) is False
+
+    def test_a_half_ported_adapter_keeps_the_legacy_save(self):
+        """Advertising the guarantee is not implementing it.
+
+        The probe reports what the adapter claims, because that is the flag a
+        downstream integration branches on. The save path asks a second
+        question -- are both halves callable -- and a half-ported adapter has
+        to hand the write back rather than have the missing half raise
+        mid-save.
+        """
+
+        class HalfPortedDb:
+            supports_atomic_run_creation = True
+            upsert_calls = 0
+
+            def create_run(self, **kwargs):
+                raise AssertionError("the pair is incomplete; the strict create must not be driven")
+
+            def upsert_run(self, **kwargs):
+                HalfPortedDb.upsert_calls += 1
+
+        database = HalfPortedDb()
+
+        assert supports_atomic_run_creation(database) is True
+        assert persist_run_scoped(database, _agent_run("r1"), session_id="s1") is False
+
+        # Handing the write back is only safe if the caller then writes it
+        _drive_the_caller(database, _agent_run("r1"))
+        assert HalfPortedDb.upsert_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# Strict creation
+# ---------------------------------------------------------------------------
+
+
+class TestStrictCreation:
+    def test_fresh_id_is_created(self, db):
+        db.upsert_session(_agent_session())
+        assert db.create_run(run=_agent_run("r1"), session_id="s1") is RunCreateOutcome.CREATED
+        assert _stored_content(db, "r1") is None
+
+    def test_taken_id_conflicts_and_leaves_the_stored_run_untouched(self, db):
+        db.upsert_session(_agent_session())
+        db.create_run(run=_agent_run("r1", content="original"), session_id="s1")
+
+        outcome = db.create_run(run=_agent_run("r1", content="attacker"), session_id="s1")
+
+        assert outcome is RunCreateOutcome.CONFLICT
+        assert _stored_content(db, "r1") == "original"
+
+    def test_taken_id_conflicts_across_sessions(self, db):
+        db.upsert_session(_agent_session("victim", user_id="victim-user"))
+        db.upsert_session(_agent_session("attacker", user_id="attacker-user"))
+        db.create_run(
+            run=_agent_run("r1", session_id="victim", content="original"), session_id="victim", user_id="victim-user"
+        )
+
+        outcome = db.create_run(
+            run=_agent_run("r1", session_id="attacker", content="attacker"),
+            session_id="attacker",
+            user_id="attacker-user",
+        )
+
+        assert outcome is RunCreateOutcome.CONFLICT
+        assert _stored_content(db, "r1") == "original"
+
+    def test_creation_reports_a_missing_session(self, db):
+        assert db.create_run(run=_agent_run("r1"), session_id="s1") is RunCreateOutcome.SESSION_MISSING
+
+    def test_team_runs_get_the_same_refusal(self, db):
+        db.upsert_session(_team_session())
+        db.create_run(run=_team_run("r1", content="original"), session_id="s1")
+
+        outcome = db.create_run(run=_team_run("r1", content="attacker"), session_id="s1")
+
+        assert outcome is RunCreateOutcome.CONFLICT
+        assert _stored_content(db, "r1") == "original"
+
+    def test_distinct_ids_both_land(self, db):
+        db.upsert_session(_agent_session())
+        assert db.create_run(run=_agent_run("r1"), session_id="s1") is RunCreateOutcome.CREATED
+        assert db.create_run(run=_agent_run("r2"), session_id="s1") is RunCreateOutcome.CREATED
+        assert db.get_run("r1") is not None and db.get_run("r2") is not None
+
+    def test_creation_assigns_increasing_run_indexes(self, db):
+        db.upsert_session(_agent_session())
+        db.create_run(run=_agent_run("r1"), session_id="s1")
+        db.create_run(run=_agent_run("r2"), session_id="s1")
+
+        assert _stored_index(db, "r2") > _stored_index(db, "r1")
+
+
+class TestStrictCreationAsync:
+    @pytest.mark.asyncio
+    async def test_fresh_id_is_created(self, async_db):
+        await async_db.upsert_session(_agent_session())
+        assert await async_db.create_run(run=_agent_run("r1"), session_id="s1") is RunCreateOutcome.CREATED
+
+    @pytest.mark.asyncio
+    async def test_taken_id_conflicts_and_leaves_the_stored_run_untouched(self, async_db):
+        await async_db.upsert_session(_agent_session())
+        await async_db.create_run(run=_agent_run("r1", content="original"), session_id="s1")
+
+        outcome = await async_db.create_run(run=_agent_run("r1", content="attacker"), session_id="s1")
+
+        assert outcome is RunCreateOutcome.CONFLICT
+        assert await _astored_content(async_db, "r1") == "original"
+
+    @pytest.mark.asyncio
+    async def test_taken_id_conflicts_across_users(self, async_db):
+        await async_db.upsert_session(_agent_session("victim", user_id="victim-user"))
+        await async_db.upsert_session(_agent_session("attacker", user_id="attacker-user"))
+        await async_db.create_run(
+            run=_agent_run("r1", session_id="victim", content="original"), session_id="victim", user_id="victim-user"
+        )
+
+        outcome = await async_db.create_run(
+            run=_agent_run("r1", session_id="attacker", content="attacker"),
+            session_id="attacker",
+            user_id="attacker-user",
+        )
+
+        assert outcome is RunCreateOutcome.CONFLICT
+        assert await _astored_content(async_db, "r1") == "original"
+
+    @pytest.mark.asyncio
+    async def test_creation_reports_a_missing_session(self, async_db):
+        assert await async_db.create_run(run=_agent_run("r1"), session_id="s1") is RunCreateOutcome.SESSION_MISSING
+
+
+# ---------------------------------------------------------------------------
+# Concurrent creation
+# ---------------------------------------------------------------------------
+
+
+CONCURRENT_WRITERS = 8
+
+# Every wait a concurrency case performs is bounded by this, so a writer that
+# never arrives at the barrier or a write that never returns fails the test
+# instead of hanging the suite.
+THREAD_TIMEOUT_SECONDS = 10.0
+
+
+def _run_threads(attempt: Any) -> None:
+    """Run ``attempt`` on CONCURRENT_WRITERS threads and fail on any raise.
+
+    A worker that raises would otherwise just be absent from the collected
+    outcomes, and an assertion counting exactly one CREATED would pass while
+    every other writer crashed.
+    """
+    failures: List[BaseException] = []
+    failures_lock = threading.Lock()
+
+    def guarded(index: int) -> None:
+        try:
+            attempt(index)
+        except BaseException as error:
+            with failures_lock:
+                failures.append(error)
+
+    # Daemon threads joined against one shared deadline: a stuck writer cannot
+    # hold the interpreter open, and eight per-thread timeouts cannot add up to
+    # eight times the wait a reader of this constant expects.
+    threads = [threading.Thread(target=guarded, args=(i,), daemon=True) for i in range(CONCURRENT_WRITERS)]
+    for thread in threads:
+        thread.start()
+    deadline = time.monotonic() + THREAD_TIMEOUT_SECONDS
+    for thread in threads:
+        thread.join(max(0.0, deadline - time.monotonic()))
+    still_running = [thread for thread in threads if thread.is_alive()]
+    if still_running:
+        raise AssertionError(
+            f"{len(still_running)} of {CONCURRENT_WRITERS} writers were still running after {THREAD_TIMEOUT_SECONDS}s"
+        )
+    if failures:
+        raise AssertionError(f"{len(failures)} of {CONCURRENT_WRITERS} writers raised; first: {failures[0]!r}")
+
+
+class _SlowCheckInMemoryDb(InMemoryDb):
+    """In-memory store whose run-existence check takes measurable time.
+
+    ``calls`` lets the test assert the delay was actually applied: an
+    implementation that stopped going through ``_locate_run`` would otherwise
+    make the concurrency test pass for the wrong reason.
+    """
+
+    def __init__(self, delay: float):
+        super().__init__()
+        self._delay = delay
+        self.calls = 0
+
+    def _locate_run(self, run_id: str):
+        located = super()._locate_run(run_id)
+        self.calls += 1
+        time.sleep(self._delay)
+        return located
+
+
+class TestConcurrentCreation:
+    def test_barrier_started_creations_of_one_fresh_id_produce_one_winner(self, db):
+        """The window a preflight read cannot close: every writer sees no row."""
+        db.upsert_session(_agent_session())
+        barrier = threading.Barrier(CONCURRENT_WRITERS, timeout=THREAD_TIMEOUT_SECONDS)
+        outcomes: List[RunCreateOutcome] = []
+        lock = threading.Lock()
+
+        def attempt(index: int) -> None:
+            run = _agent_run("contested", content=f"writer-{index}")
+            barrier.wait()
+            outcome = db.create_run(run=run, session_id="s1")
+            with lock:
+                outcomes.append(outcome)
+
+        _run_threads(attempt)
+
+        assert outcomes.count(RunCreateOutcome.CREATED) == 1
+        assert outcomes.count(RunCreateOutcome.CONFLICT) == CONCURRENT_WRITERS - 1
+
+    def test_the_winner_is_the_run_that_stays_stored(self, db):
+        db.upsert_session(_agent_session())
+        barrier = threading.Barrier(CONCURRENT_WRITERS, timeout=THREAD_TIMEOUT_SECONDS)
+        winners: List[str] = []
+        lock = threading.Lock()
+
+        def attempt(index: int) -> None:
+            content = f"writer-{index}"
+            barrier.wait()
+            if db.create_run(run=_agent_run("contested", content=content), session_id="s1") is RunCreateOutcome.CREATED:
+                with lock:
+                    winners.append(content)
+
+        _run_threads(attempt)
+
+        assert len(winners) == 1
+        assert _stored_content(db, "contested") == winners[0]
+
+    def test_a_slow_existence_check_still_yields_one_winner(self):
+        """The lock, not the interpreter, is what makes the check-then-write safe.
+
+        Runs inline in the in-memory store rather than in a database, so
+        nothing outside the adapter serializes the writers. Delaying the
+        existence check widens the window between "no row" and "row written"
+        to something a scheduler will actually interleave; every writer then
+        sees no row unless the write is held under the lock.
+        """
+        database = _SlowCheckInMemoryDb(delay=0.02)
+        database.upsert_session(_agent_session())
+        barrier = threading.Barrier(CONCURRENT_WRITERS, timeout=THREAD_TIMEOUT_SECONDS)
+        outcomes: List[RunCreateOutcome] = []
+        lock = threading.Lock()
+
+        def attempt(index: int) -> None:
+            run = _agent_run("contested", content=f"writer-{index}")
+            barrier.wait()
+            outcome = database.create_run(run=run, session_id="s1")
+            with lock:
+                outcomes.append(outcome)
+
+        _run_threads(attempt)
+
+        # One call is the healthy signature: the winner takes the delay, and
+        # the writers behind it short-circuit on the ledger the lock let it
+        # write. Zero would mean the delay never applied and the test proved
+        # nothing; without the lock every writer reaches the check instead.
+        assert database.calls >= 1, "the delayed check was bypassed; the test proves nothing"
+        assert outcomes.count(RunCreateOutcome.CREATED) == 1
+        assert outcomes.count(RunCreateOutcome.CONFLICT) == CONCURRENT_WRITERS - 1
+        _, total = database.get_runs(session_id="s1", deserialize=False)
+        assert total == 1
+
+
+class TestConcurrentCreationAsync:
+    @pytest.mark.asyncio
+    async def test_barrier_started_creations_of_one_fresh_id_produce_one_winner(self, async_db):
+        await async_db.upsert_session(_agent_session())
+        started = asyncio.Event()
+
+        async def attempt(index: int) -> RunCreateOutcome:
+            await started.wait()
+            return await async_db.create_run(run=_agent_run("contested", content=f"writer-{index}"), session_id="s1")
+
+        tasks = [asyncio.create_task(attempt(i)) for i in range(CONCURRENT_WRITERS)]
+        await asyncio.sleep(0)
+        started.set()
+        outcomes = await asyncio.gather(*tasks)
+
+        assert list(outcomes).count(RunCreateOutcome.CREATED) == 1
+        assert list(outcomes).count(RunCreateOutcome.CONFLICT) == CONCURRENT_WRITERS - 1
+
+
+# ---------------------------------------------------------------------------
+# Scoped lifecycle updates
+# ---------------------------------------------------------------------------
+
+
+class TestScopedUpdates:
+    def test_the_owner_can_update(self, db):
+        db.upsert_session(_agent_session(user_id="u1"))
+        db.create_run(run=_agent_run("r1", user_id="u1"), session_id="s1", user_id="u1")
+
+        outcome = db.update_run(run=_agent_run("r1", user_id="u1", content="turn one"), session_id="s1", user_id="u1")
+
+        assert outcome is RunUpdateOutcome.UPDATED
+        assert _stored_content(db, "r1") == "turn one"
+
+    def test_an_anonymous_run_is_updatable_by_the_same_anonymous_caller(self, db):
+        _store_and_write(db, "r1", "reserved")
+
+        outcome = db.update_run(run=_agent_run("r1", content="turn one"), session_id="s1")
+
+        assert outcome is RunUpdateOutcome.UPDATED
+        assert _stored_content(db, "r1") == "turn one"
+
+    def test_another_user_cannot_update(self, db):
+        _store_and_write(db, "r1", "original", user_id="u1")
+
+        outcome = db.update_run(run=_agent_run("r1", user_id="u2", content="attacker"), session_id="s1", user_id="u2")
+
+        assert outcome is RunUpdateOutcome.SCOPE_MISMATCH
+        assert _stored_content(db, "r1") == "original"
+
+    def test_an_unowned_run_accepts_an_identified_writer(self, db):
+        """The user is compared only when both sides know one.
+
+        The framework reaches the save path from several places that resolve
+        identity differently, and a strict comparison turns those
+        disagreements into silently dropped runs. What stays refused is one
+        named user reaching another named user's row.
+        """
+        _store_and_write(db, "r1", "original")
+
+        outcome = db.update_run(run=_agent_run("r1", user_id="u2", content="turn one"), session_id="s1", user_id="u2")
+
+        assert outcome is RunUpdateOutcome.UPDATED
+        assert _stored_content(db, "r1") == "turn one"
+
+    def test_a_writer_given_no_user_still_lands_when_the_run_knows_its_owner(self, db):
+        """A run loaded from storage carries its owner even when the route does not."""
+        _store_and_write(db, "r1", "original", user_id="u1")
+
+        outcome = db.update_run(run=_agent_run("r1", user_id="u1", content="turn one"), session_id="s1")
+
+        assert outcome is RunUpdateOutcome.UPDATED
+        assert _stored_content(db, "r1") == "turn one"
+
+    def test_a_writer_that_knows_no_user_is_not_refused(self, db):
+        """A fact the writer does not know constrains nothing.
+
+        The framework rebuilds a run from its id alone on some paths -- a
+        cancellation caught with no run object in hand -- and requiring that
+        unknown to be NULL would refuse the run's own final write. What stays
+        refused is a writer presenting a DIFFERENT user; the session and the
+        component the writer does know are still compared.
+        """
+        _store_and_write(db, "r1", "original", user_id="u1")
+
+        outcome = db.update_run(run=_agent_run("r1", content="cancelled"), session_id="s1")
+
+        assert outcome is RunUpdateOutcome.UPDATED
+        assert _stored_content(db, "r1") == "cancelled"
+
+    def test_a_run_rebuilt_from_its_id_alone_can_still_record_its_end(self, db):
+        """The shape the cancellation path produces: only a run_id."""
+        _store_and_write(db, "r1", "original", user_id="u1")
+        bare = RunOutput(run_id="r1", content="cancelled")
+        bare.status = RunStatus.cancelled
+
+        outcome = db.update_run(run=bare, session_id="s1", user_id="u1")
+
+        assert outcome is RunUpdateOutcome.UPDATED
+        assert _stored_status(db, "r1") == RunStatus.cancelled.value
+
+    def test_a_run_stored_unowned_is_saved_under_the_session_user(self, db):
+        """The first save and the terminal save resolve identity differently.
+
+        A run issued with no user_id on a session that has one creates its row
+        unowned and is later saved with the session's user; the completed turn
+        has to land, not be refused.
+        """
+        db.upsert_session(_agent_session(user_id="u1"))
+        db.create_run(run=_agent_run("r1"), session_id="s1")
+
+        outcome = db.update_run(run=_agent_run("r1", content="done"), session_id="s1", user_id="u1")
+
+        assert outcome is RunUpdateOutcome.UPDATED
+        assert _stored_content(db, "r1") == "done"
+
+    def test_an_unowned_row_is_attributed_by_its_first_owner_write(self, db):
+        """Creation can precede identity resolution; the column must catch up.
+
+        Landing the write is not enough. A row left unowned stays adoptable by
+        the next writer that names any user, so the owner has to be written
+        onto it, and both backends have to write it.
+        """
+        db.upsert_session(_agent_session(user_id="u1"))
+        db.create_run(run=_agent_run("r1"), session_id="s1")
+        assert _stored_owner(db, "r1", "user_id") is None
+
+        outcome = db.update_run(run=_agent_run("r1", content="done"), session_id="s1", user_id="u1")
+
+        assert outcome is RunUpdateOutcome.UPDATED
+        assert _stored_owner(db, "r1", "user_id") == "u1"
+
+    def test_an_attributed_row_then_refuses_another_user(self, db):
+        """What attribution buys: the second writer is out."""
+        db.upsert_session(_agent_session(user_id="u1"))
+        db.create_run(run=_agent_run("r1"), session_id="s1")
+        db.update_run(run=_agent_run("r1", content="done"), session_id="s1", user_id="u1")
+
+        outcome = db.update_run(run=_agent_run("r1", content="attacker"), session_id="s1", user_id="u2")
+
+        assert outcome is RunUpdateOutcome.SCOPE_MISMATCH
+        assert _stored_content(db, "r1") == "done"
+
+    def test_a_component_less_row_is_attributed_by_the_first_write_that_names_one(self, db):
+        """The component columns adopt the same way the user column does."""
+        db.upsert_session(_agent_session())
+        db.create_run(run=RunOutput(run_id="r1", session_id="s1"), session_id="s1")
+        assert _stored_owner(db, "r1", "agent_id") is None
+
+        outcome = db.update_run(run=_agent_run("r1", content="done"), session_id="s1")
+
+        assert outcome is RunUpdateOutcome.UPDATED
+        assert _stored_owner(db, "r1", "agent_id") == "a1"
+        # And the row now belongs to that agent alone
+        assert (
+            db.update_run(run=_team_run("r1", content="attacker"), session_id="s1") is RunUpdateOutcome.SCOPE_MISMATCH
+        )
+
+    def test_a_resume_that_omits_the_user_still_lands(self, db):
+        """AgentOS takes user_id as an optional form field on the continue route."""
+        _store_and_write(db, "r1", "reserved", user_id="u1")
+        paused = _agent_run("r1", user_id="u1", content="paused")
+        paused.status = RunStatus.paused
+        db.update_run(run=paused, session_id="s1", user_id="u1")
+
+        # The route omits user_id; the run loaded from storage still carries it
+        resumed = _agent_run("r1", user_id="u1", content="resumed")
+        resumed.status = RunStatus.completed
+        outcome = db.update_run(run=resumed, session_id="s1")
+
+        assert outcome is RunUpdateOutcome.UPDATED
+        assert _stored_content(db, "r1") == "resumed"
+
+    def test_another_session_cannot_update(self, db):
+        _store_and_write(db, "r1", "original")
+        db.upsert_session(_agent_session("s2"))
+
+        outcome = db.update_run(run=_agent_run("r1", session_id="s2", content="attacker"), session_id="s2")
+
+        assert outcome is RunUpdateOutcome.SCOPE_MISMATCH
+        assert _stored_content(db, "r1") == "original"
+
+    def test_another_component_cannot_update(self, db):
+        _store_and_write(db, "r1", "original")
+
+        outcome = db.update_run(run=_team_run("r1", content="attacker"), session_id="s1")
+
+        assert outcome is RunUpdateOutcome.SCOPE_MISMATCH
+        assert _stored_content(db, "r1") == "original"
+
+    def test_an_unknown_run_reports_missing(self, db):
+        db.upsert_session(_agent_session())
+        assert db.update_run(run=_agent_run("nope"), session_id="s1") is RunUpdateOutcome.MISSING
+
+    def test_update_never_inserts(self, db):
+        db.upsert_session(_agent_session())
+        db.update_run(run=_agent_run("nope"), session_id="s1")
+        assert db.get_run("nope") is None
+
+    def test_update_preserves_the_run_index(self, db):
+        db.upsert_session(_agent_session())
+        db.create_run(run=_agent_run("r1"), session_id="s1")
+        db.create_run(run=_agent_run("r2"), session_id="s1")
+        first_index = _stored_index(db, "r1")
+
+        db.update_run(run=_agent_run("r1", content="turn one"), session_id="s1")
+
+        assert _stored_index(db, "r1") == first_index
+
+    def test_terminal_writes_land_through_the_scoped_update(self, db):
+        db.upsert_session(_agent_session(user_id="u1"))
+        db.create_run(run=_agent_run("r1", user_id="u1"), session_id="s1", user_id="u1")
+        final = _agent_run("r1", user_id="u1", content="done")
+        final.status = RunStatus.completed
+
+        assert db.update_run(run=final, session_id="s1", user_id="u1") is RunUpdateOutcome.UPDATED
+        assert _stored_status(db, "r1") == RunStatus.completed.value
+
+
+class TestScopedUpdatesAsync:
+    @pytest.mark.asyncio
+    async def test_the_owner_can_update(self, async_db):
+        await async_db.upsert_session(_agent_session(user_id="u1"))
+        await async_db.create_run(run=_agent_run("r1", user_id="u1"), session_id="s1", user_id="u1")
+
+        outcome = await async_db.update_run(
+            run=_agent_run("r1", user_id="u1", content="turn one"), session_id="s1", user_id="u1"
+        )
+
+        assert outcome is RunUpdateOutcome.UPDATED
+        assert await _astored_content(async_db, "r1") == "turn one"
+
+    @pytest.mark.asyncio
+    async def test_another_user_cannot_update(self, async_db):
+        await async_db.upsert_session(_agent_session(user_id="u1"))
+        await async_db.create_run(run=_agent_run("r1", user_id="u1", content="original"), session_id="s1", user_id="u1")
+
+        outcome = await async_db.update_run(
+            run=_agent_run("r1", user_id="u2", content="attacker"), session_id="s1", user_id="u2"
+        )
+
+        assert outcome is RunUpdateOutcome.SCOPE_MISMATCH
+        assert await _astored_content(async_db, "r1") == "original"
+
+    @pytest.mark.asyncio
+    async def test_another_session_cannot_update(self, async_db):
+        await async_db.upsert_session(_agent_session())
+        await async_db.upsert_session(_agent_session("s2"))
+        await async_db.create_run(run=_agent_run("r1", content="original"), session_id="s1")
+
+        outcome = await async_db.update_run(run=_agent_run("r1", session_id="s2", content="attacker"), session_id="s2")
+
+        assert outcome is RunUpdateOutcome.SCOPE_MISMATCH
+        assert await _astored_content(async_db, "r1") == "original"
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_run_reports_missing(self, async_db):
+        await async_db.upsert_session(_agent_session())
+        assert await async_db.update_run(run=_agent_run("nope"), session_id="s1") is RunUpdateOutcome.MISSING
+
+
+# ---------------------------------------------------------------------------
+# Session insert-if-absent
+# ---------------------------------------------------------------------------
+
+
+class TestTheStoredRowIsTheRecord:
+    """Ownership lives on the row, and a write reaches only its own session.
+
+    The SQL adapters keep session and user in columns and scope every write by
+    them. The in-memory adapter's run dict IS its row, so it has to carry the
+    same facts: any second place to keep them is a place they can disagree,
+    and the ownership check reads the row.
+    """
+
+    def test_the_owner_is_stamped_onto_the_stored_run(self, db):
+        """The caller's user reaches the row even when the run does not carry it."""
+        db.upsert_session(_agent_session(user_id="u1"))
+        db.create_run(run=_agent_run("r1"), session_id="s1", user_id="u1")
+
+        row = db.get_run("r1", deserialize=False)
+
+        assert row["user_id"] == "u1"
+        assert row["session_id"] == "s1"
+
+    def test_a_write_cannot_reach_a_run_filed_under_another_session(self):
+        """The SQL update carries session_id in its WHERE clause; so does this.
+
+        A session imported carrying a run id that is already stored used to
+        re-point the ownership record, and the write then landed on the other
+        session's row. In-memory only: a SQL runs table cannot hold the same
+        run_id twice, so only this adapter can reach the state at all.
+        """
+        db = InMemoryDb()
+        db.upsert_session(_agent_session())
+        db.create_run(run=_agent_run("r1", content="s1 content"), session_id="s1")
+        db.upsert_session(
+            AgentSession(
+                session_id="s2",
+                agent_id="a1",
+                created_at=1,
+                runs=[RunOutput(run_id="r1", session_id="s2", agent_id="a1", content="imported")],
+            )
+        )
+
+        outcome = db.update_run(
+            run=RunOutput(run_id="r1", session_id="s2", agent_id="a1", content="s2 content"), session_id="s2"
+        )
+
+        assert outcome is RunUpdateOutcome.UPDATED
+        assert [row.get("content") for row in db.get_runs(session_id="s1", deserialize=False)[0]] == ["s1 content"]
+        assert [row.get("content") for row in db.get_runs(session_id="s2", deserialize=False)[0]] == ["s2 content"]
+
+    def test_a_run_stored_in_another_session_is_refused_not_missing(self, db):
+        """Out of this write's reach is a refusal, not an invitation to create."""
+        db.upsert_session(_agent_session())
+        db.upsert_session(_agent_session("s2"))
+        db.create_run(run=_agent_run("r1", content="original"), session_id="s1")
+
+        outcome = db.update_run(run=RunOutput(run_id="r1", session_id="s2", agent_id="a1"), session_id="s2")
+
+        assert outcome is RunUpdateOutcome.SCOPE_MISMATCH
+
+    def test_a_stored_position_is_never_renumbered(self, db):
+        """COALESCE(stored, incoming): the SQL update never moves a row."""
+        db.upsert_session(_agent_session())
+        db.create_run(run=_agent_run("r1"), session_id="s1")
+        first = _stored_index(db, "r1")
+
+        db.update_run(run=_agent_run("r1", content="later"), session_id="s1", run_index=99)
+
+        assert _stored_index(db, "r1") == first
+
+
+class TestAdapterContract:
+    """What the pair owes callers beyond the happy path."""
+
+    def test_a_string_result_is_read_as_the_outcome_it_names(self):
+        """A third-party adapter can return the bare value.
+
+        The outcome members are ``str``-valued, so an identity check against a
+        returned "conflict" would fall through to the overwriting upsert. The
+        sequence here is the create/update race: the update finds no row, the
+        create loses to a concurrent writer, and the update is re-driven.
+        """
+        calls: List[str] = []
+
+        class StringReturningDb:
+            supports_atomic_run_creation = True
+            upsert_called = False
+
+            def update_run(self, **kwargs):
+                calls.append("update")
+                return "missing" if len(calls) == 1 else "updated"
+
+            def create_run(self, **kwargs):
+                calls.append("create")
+                return "conflict"
+
+            def upsert_run(self, **kwargs):
+                StringReturningDb.upsert_called = True
+
+        handled = persist_run_scoped(StringReturningDb(), _agent_run("r1"), session_id="s1")
+
+        assert calls == ["update", "create", "update"]
+        assert handled is True
+        assert StringReturningDb.upsert_called is False
+
+    def test_a_conflicting_create_re_drives_the_scoped_update(self):
+        """The row a concurrent writer landed is still written under its scope."""
+        seen: List[Dict[str, Any]] = []
+
+        class RacingDb:
+            supports_atomic_run_creation = True
+
+            def update_run(self, **kwargs):
+                seen.append(kwargs)
+                return RunUpdateOutcome.MISSING if len(seen) == 1 else RunUpdateOutcome.SCOPE_MISMATCH
+
+            def create_run(self, **kwargs):
+                return RunCreateOutcome.CONFLICT
+
+            def upsert_run(self, **kwargs):
+                raise AssertionError("the legacy upsert must not run after a refused scope")
+
+        assert persist_run_scoped(RacingDb(), _agent_run("r1"), session_id="s1") is True
+        assert len(seen) == 2
+
+    def test_an_unrecognised_update_result_never_falls_back_to_the_upsert(self):
+        """UNSUPPORTED sends the caller to the overwriting upsert; a garbled
+        answer must not be read as UNSUPPORTED."""
+
+        class GarbledDb:
+            supports_atomic_run_creation = True
+            upsert_calls = 0
+
+            def create_run(self, **kwargs):
+                return RunCreateOutcome.CONFLICT
+
+            def update_run(self, **kwargs):
+                return "not-an-outcome"
+
+            def upsert_run(self, **kwargs):
+                GarbledDb.upsert_calls += 1
+
+        database = GarbledDb()
+
+        assert persist_run_scoped(database, _agent_run("r1", content="attacker"), session_id="s1") is True
+
+        _drive_the_caller(database, _agent_run("r1", content="attacker"))
+        assert GarbledDb.upsert_calls == 0
+
+    def test_an_adapter_without_the_pair_hands_the_write_back(self):
+        class UnportedDb:
+            supports_atomic_run_creation = False
+
+        assert persist_run_scoped(UnportedDb(), _agent_run("r1"), session_id="s1") is False
+
+    def test_a_run_written_by_the_legacy_upsert_is_still_scoped(self, db):
+        """upsert_run is the path unported callers and older code still use."""
+        db.upsert_session(_agent_session(user_id="u1"))
+        db.upsert_session(_agent_session("s2", user_id="u2"))
+        db.upsert_run(
+            run=_agent_run("r1", user_id="u1", content="original"), session_id="s1", user_id="u1", run_index=0
+        )
+
+        outcome = db.update_run(run=_agent_run("r1", user_id="u2", content="attacker"), session_id="s2", user_id="u2")
+
+        assert outcome is RunUpdateOutcome.SCOPE_MISMATCH
+        assert _stored_content(db, "r1") == "original"
+
+    def test_a_deleted_run_does_not_hand_its_index_to_a_survivor(self, db):
+        """Deleting the LAST run is the case a len()-based index survives.
+
+        With three runs and the first deleted, len() gives the next run the
+        index the third already holds; MAX+1 does not.
+        """
+        db.upsert_session(_agent_session())
+        for run_id in ("r1", "r2", "r3"):
+            db.create_run(run=_agent_run(run_id), session_id="s1")
+        db.delete_run("r1")
+
+        db.create_run(run=_agent_run("r4"), session_id="s1")
+
+        assert _stored_index(db, "r4") not in (_stored_index(db, "r2"), _stored_index(db, "r3"))
+
+    def test_a_deleted_run_frees_its_id(self, db):
+        db.upsert_session(_agent_session())
+        db.create_run(run=_agent_run("r1"), session_id="s1")
+        db.delete_run("r1")
+
+        assert db.create_run(run=_agent_run("r1"), session_id="s1") is RunCreateOutcome.CREATED
+
+    def test_a_deleted_session_frees_the_ids_of_its_runs(self, db):
+        db.upsert_session(_agent_session())
+        db.create_run(run=_agent_run("r1"), session_id="s1")
+        db.delete_session("s1")
+        db.upsert_session(_agent_session("s2"))
+
+        assert db.create_run(run=_agent_run("r1", session_id="s2"), session_id="s2") is RunCreateOutcome.CREATED
+
+
+class TestAsyncPathsOffline:
+    """The async twins, without needing a live PostgreSQL."""
+
+    @pytest.mark.asyncio
+    async def test_the_async_scoped_save_refuses_another_user(self, async_db):
+        await async_db.upsert_session(_agent_session(user_id="u1"))
+        await async_db.create_run(run=_agent_run("r1", user_id="u1", content="original"), session_id="s1", user_id="u1")
+
+        handled = await apersist_run_scoped(
+            async_db, _agent_run("r1", user_id="u2", content="attacker"), session_id="s1", user_id="u2"
+        )
+
+        assert handled is True
+        assert await _astored_content(async_db, "r1") == "original"
+
+    @pytest.mark.asyncio
+    async def test_the_async_scoped_save_creates_a_run_that_was_never_reserved(self, async_db):
+        await async_db.upsert_session(_agent_session())
+
+        handled = await apersist_run_scoped(
+            async_db, _agent_run("forked", content="forked"), session_id="s1", run_index=0
+        )
+
+        assert handled is True
+        assert await _astored_content(async_db, "forked") == "forked"
+
+
+# The ownership matrix. One row per (what the writer knows, what the row
+# holds), so a writer whose identity resolves differently from the one that
+# created the row is a table entry rather than a bug found a round later.
+# stored -> incoming -> may the write land
+OWNERSHIP_MATRIX = [
+    # session
+    ("same session", {"session_id": "s1"}, {"session_id": "s1"}, True),
+    ("other session", {"session_id": "s1"}, {"session_id": "s2"}, False),
+    # user
+    ("same user", {"user_id": "u1"}, {"user_id": "u1"}, True),
+    ("other user", {"user_id": "u1"}, {"user_id": "u2"}, False),
+    ("unowned row, identified writer", {"user_id": None}, {"user_id": "u1"}, True),
+    ("owned row, writer knows no user", {"user_id": "u1"}, {"user_id": None}, True),
+    ("neither knows a user", {"user_id": None}, {"user_id": None}, True),
+    # component
+    ("same agent", {"agent_id": "a1"}, {"agent_id": "a1"}, True),
+    ("other agent", {"agent_id": "a1"}, {"agent_id": "a2"}, False),
+    ("team writing an agent row", {"agent_id": "a1"}, {"team_id": "t1"}, False),
+    ("agent writing a team row", {"team_id": "t1"}, {"agent_id": "a1"}, False),
+    ("same workflow", {"workflow_id": "w1"}, {"workflow_id": "w1"}, True),
+    ("other workflow", {"workflow_id": "w1"}, {"workflow_id": "w2"}, False),
+    ("workflow writing an agent row", {"agent_id": "a1"}, {"workflow_id": "w1"}, False),
+    ("agent writing a workflow row", {"workflow_id": "w1"}, {"agent_id": "a1"}, False),
+    ("writer knows no component", {"agent_id": "a1"}, {}, True),
+    # The mirror of the unowned-user row, and adopted for the same reason.
+    # Rows without a component id are real: a cancellation rebuilds a run
+    # from its id alone, and a v3 migration brings rows across without one.
+    # Refusing them locked those runs out of their own later saves.
+    ("component-less row, writer knows one", {"agent_id": None}, {"agent_id": "a1"}, True),
+    ("component-less row, workflow knows one", {"workflow_id": None}, {"workflow_id": "w1"}, True),
+]
+
+
+def _scope(**overrides):
+    base = {"session_id": "s1", "user_id": None, "agent_id": None, "team_id": None, "workflow_id": None}
+    base.update(overrides)
+    return base
+
+
+def _allowed_by_rule(stored, incoming, tmp_path):
+    """The rule as the one Python function every non-SQL caller reaches."""
+    return run_scope_allows(stored, incoming)
+
+
+def _allowed_by_in_memory(stored, incoming, tmp_path):
+    """The rule as the in-memory adapter applies it to its own rows."""
+    return InMemoryDb._scope_matches(stored, incoming)
+
+
+def _allowed_by_sql(stored, incoming, tmp_path):
+    """The rule as the SQL predicate applies it, driven through a real update."""
+    database = SqliteDb(db_file=str(tmp_path / "matrix.db"))
+    for session_id in {stored["session_id"], incoming["session_id"]}:
+        database.upsert_session(AgentSession(session_id=session_id, agent_id="a1", created_at=1))
+    database.create_run(
+        run=run_for_scope(stored, "r1", content="original"),
+        session_id=stored["session_id"],
+        user_id=stored["user_id"],
+    )
+
+    outcome = database.update_run(
+        run=run_for_scope(incoming, "r1", content="written"),
+        session_id=incoming["session_id"],
+        user_id=incoming["user_id"],
+    )
+
+    return outcome is RunUpdateOutcome.UPDATED
+
+
+# Three independent statements of the rule: the shared Python function that
+# the reservation check reads through, the in-memory adapter's own predicate,
+# and the SQL WHERE clause. Any of them drifting is a hole in exactly one
+# backend, which is what makes them worth asserting separately. They take one
+# signature so the table drives all three; only the SQL arm needs tmp_path.
+OWNERSHIP_IMPLEMENTATIONS = [
+    ("rule", _allowed_by_rule),
+    ("in_memory", _allowed_by_in_memory),
+    ("sql", _allowed_by_sql),
+]
+
+
+@pytest.mark.parametrize(
+    "implementation",
+    [impl for _, impl in OWNERSHIP_IMPLEMENTATIONS],
+    ids=[name for name, _ in OWNERSHIP_IMPLEMENTATIONS],
+)
+@pytest.mark.parametrize("label,stored,incoming,allowed", OWNERSHIP_MATRIX, ids=[row[0] for row in OWNERSHIP_MATRIX])
+def test_the_ownership_rule_is_one_table(label, stored, incoming, allowed, implementation, tmp_path):
+    """One derivation, one rule, one place to change it.
+
+    Every round of review has found a writer that resolved identity
+    differently from the one that created the row. The rule lives in
+    ``resolve_run_scope`` plus this table; a new writer is a row here, and
+    every implementation of the rule answers the whole table the same way.
+    """
+    del label  # the row's label reaches the report as the parametrize id
+    assert implementation(_scope(**stored), _scope(**incoming), tmp_path) is allowed
+
+
+def run_for_scope(scope, run_id: str, content: str):
+    """A run object presenting the identity a matrix row names.
+
+    Public because the PostgreSQL twin drives the same table and each of the
+    three component columns needs its own run class; a copy of this that knows
+    only two silently turns those rows into component-less ones, which the
+    rule then allows.
+    """
+    if scope["team_id"] is not None:
+        return TeamRunOutput(
+            run_id=run_id,
+            session_id=scope["session_id"],
+            team_id=scope["team_id"],
+            user_id=scope["user_id"],
+            content=content,
+        )
+    if scope["workflow_id"] is not None:
+        return WorkflowRunOutput(
+            run_id=run_id,
+            session_id=scope["session_id"],
+            workflow_id=scope["workflow_id"],
+            user_id=scope["user_id"],
+            content=content,
+        )
+    return RunOutput(
+        run_id=run_id,
+        session_id=scope["session_id"],
+        agent_id=scope["agent_id"],
+        user_id=scope["user_id"],
+        content=content,
+    )
+
+
+class TestTheUpdateNeverMovesARow:
+    """A scoped update writes content, never identity.
+
+    The legacy ``upsert_run`` keeps the identity columns out of its conflict
+    set on purpose. An update that rewrote them could move a stored row into
+    a session or a type its owner never sees, and the owner is then locked
+    out of its own run by the very scope that protects it.
+    """
+
+    def test_a_save_naming_a_foreign_session_does_not_move_the_row(self, db):
+        db.upsert_session(_agent_session())
+        db.upsert_session(_agent_session("s2"))
+        db.create_run(run=_agent_run("r1", content="one"), session_id="s1")
+
+        # The write is addressed at s1; the run object it carries says s2
+        db.update_run(run=RunOutput(run_id="r1", session_id="s2", agent_id="a1", content="two"), session_id="s1")
+
+        assert db.get_run("r1", deserialize=False)["session_id"] == "s1"
+        assert db.update_run(run=_agent_run("r1", content="three"), session_id="s1") is RunUpdateOutcome.UPDATED
+
+    def test_a_dict_shaped_save_does_not_relabel_the_run(self, db):
+        """A dict with no component id would otherwise be read as a workflow."""
+        db.upsert_session(_agent_session())
+        db.create_run(run=_agent_run("r1", content="one"), session_id="s1")
+        before = _run_type_of(db, "r1")
+
+        db.update_run(run={"run_id": "r1", "content": "two"}, session_id="s1")
+
+        assert _run_type_of(db, "r1") == before
+
+    def test_a_team_shaped_save_does_not_relabel_an_agent_run(self, db):
+        db.upsert_session(_agent_session())
+        db.create_run(run=_agent_run("r1", content="one"), session_id="s1")
+        before = _run_type_of(db, "r1")
+
+        db.update_run(
+            run=TeamRunOutput(run_id="r1", session_id="s1", team_id="t1", content="two"),
+            session_id="s1",
+        )
+
+        assert _run_type_of(db, "r1") == before
+
+
+def _run_type_of(db: Any, run_id: str) -> Optional[str]:
+    """The class a reader actually gets back for a stored run.
+
+    Not ``get_run_type`` on the row: that recovers the type from the
+    component id, so it answers correctly even when the stored type column is
+    wrong. What a caller sees is the deserialized class, so that is the
+    assertion.
+    """
+    run = db.get_run(run_id)
+    return None if run is None else type(run).__name__
+
+
+class TestUnrecognisedAdapterAnswers:
+    """A garbled answer must never be the one that reaches the overwrite.
+
+    Both coercions turn an answer they cannot read into a FINAL outcome, so
+    an adapter returning nonsense drops the write loudly instead of handing
+    it to the unscoped save.
+    """
+
+    def test_an_unreadable_create_answer_is_not_a_success(self):
+        """UNSUPPORTED is the only create answer that reaches the legacy save."""
+
+        class GarbledCreateDb:
+            supports_atomic_run_creation = True
+            upsert_calls = 0
+
+            def update_run(self, **kwargs):
+                return RunUpdateOutcome.MISSING
+
+            def create_run(self, **kwargs):
+                return "not an outcome"
+
+            def upsert_run(self, **kwargs):
+                GarbledCreateDb.upsert_calls += 1
+
+        database = GarbledCreateDb()
+
+        assert persist_run_scoped(database, _agent_run("r1"), session_id="s1") is True
+
+        _drive_the_caller(database, _agent_run("r1"))
+        assert GarbledCreateDb.upsert_calls == 0
+
+    def test_an_unreadable_update_answer_is_not_a_success(self):
+        class GarbledUpdateDb:
+            supports_atomic_run_creation = True
+
+            def update_run(self, **kwargs):
+                return object()
+
+            def create_run(self, **kwargs):
+                raise AssertionError("the update answer was final; the create must not run")
+
+        assert persist_run_scoped(GarbledUpdateDb(), _agent_run("r1"), session_id="s1") is True
+
+    def test_a_create_conflict_never_reaches_the_legacy_save(self):
+        """The conflict is the refusal; falling through would overwrite."""
+
+        class ConflictingDb:
+            supports_atomic_run_creation = True
+            upsert_calls = 0
+
+            def update_run(self, **kwargs):
+                return RunUpdateOutcome.MISSING
+
+            def create_run(self, **kwargs):
+                return RunCreateOutcome.CONFLICT
+
+            def upsert_run(self, **kwargs):
+                ConflictingDb.upsert_calls += 1
+
+        database = ConflictingDb()
+
+        assert persist_run_scoped(database, _agent_run("r1"), session_id="s1") is True
+
+        _drive_the_caller(database, _agent_run("r1"))
+        assert ConflictingDb.upsert_calls == 0
+
+
+# How each outcome the pair can answer with is routed. Every row states the
+# same three things: whether the save reports itself handled, whether the
+# strict create was reached at all, and whether the write ended up at the
+# overwriting ``upsert_run``. Only UNSUPPORTED may end up there.
+# label -> update answers -> create answer -> handled, creates, overwrite
+ROUTING_CASES = [
+    (
+        "the create finds no session row",
+        [RunUpdateOutcome.MISSING],
+        RunCreateOutcome.SESSION_MISSING,
+        True,
+        1,
+        False,
+    ),
+    ("the create errors", [RunUpdateOutcome.MISSING], RunCreateOutcome.ERROR, True, 1, False),
+    ("the create is unsupported", [RunUpdateOutcome.MISSING], RunCreateOutcome.UNSUPPORTED, False, 1, True),
+    # The update answered, so the create is never asked. The placeholder
+    # answer is CREATED so a routing that wrongly asked would report handled
+    # and be caught by the flag as well as by the call count.
+    ("the update is unsupported", [RunUpdateOutcome.UNSUPPORTED], RunCreateOutcome.CREATED, False, 0, True),
+    ("the update errors", [RunUpdateOutcome.ERROR], RunCreateOutcome.CREATED, True, 0, False),
+]
+
+ROUTING_IDS = [row[0] for row in ROUTING_CASES]
+ROUTING_ARGS = [row[1:] for row in ROUTING_CASES]
+
+
+class _RoutingDb:
+    """An adapter answering with the outcomes a routing case names.
+
+    Counts every call, so "the create was never asked" and "the overwrite was
+    never reached" are assertions rather than assumptions.
+    """
+
+    supports_atomic_run_creation = True
+
+    def __init__(self, update_answers, create_answer):
+        self._update_answers = list(update_answers)
+        self._create_answer = create_answer
+        self.update_calls = 0
+        self.create_calls = 0
+        self.upsert_calls = 0
+
+    def update_run(self, **kwargs):
+        self.update_calls += 1
+        return self._update_answers[min(self.update_calls - 1, len(self._update_answers) - 1)]
+
+    def create_run(self, **kwargs):
+        self.create_calls += 1
+        return self._create_answer
+
+    def upsert_run(self, **kwargs):
+        self.upsert_calls += 1
+
+
+class TestOutcomeRouting:
+    """Each outcome the pair can answer with, and where the write ends up.
+
+    The refusals are the cases with teeth: SESSION_MISSING and ERROR mean the
+    run was not stored, and reading either as "not ours to answer" hands the
+    write to the unscoped save the module exists to keep it away from.
+    """
+
+    @pytest.mark.parametrize("update_answers,create_answer,handled,creates,overwrite", ROUTING_ARGS, ids=ROUTING_IDS)
+    def test_the_save_reports_what_it_did(self, update_answers, create_answer, handled, creates, overwrite):
+        del overwrite  # the caller-driven test below is what observes it
+        database = _RoutingDb(update_answers, create_answer)
+
+        assert persist_run_scoped(database, _agent_run("r1"), session_id="s1") is handled
+        assert database.create_calls == creates
+        # Only a CONFLICT re-drives the update, and no case here reports one
+        assert database.update_calls == 1
+
+    @pytest.mark.parametrize("update_answers,create_answer,handled,creates,overwrite", ROUTING_ARGS, ids=ROUTING_IDS)
+    def test_only_unsupported_reaches_the_overwriting_save(
+        self, update_answers, create_answer, handled, creates, overwrite
+    ):
+        del handled, creates
+        database = _RoutingDb(update_answers, create_answer)
+
+        _drive_the_caller(database, _agent_run("r1"))
+
+        assert (database.upsert_calls == 1) is overwrite
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("update_answers,create_answer,handled,creates,overwrite", ROUTING_ARGS, ids=ROUTING_IDS)
+    async def test_the_async_save_routes_them_the_same_way(
+        self, update_answers, create_answer, handled, creates, overwrite
+    ):
+        """The async twin repeats the routing, so it can drift from it."""
+        del overwrite
+        database = _RoutingDb(update_answers, create_answer)
+
+        assert await apersist_run_scoped(database, _agent_run("r1"), session_id="s1") is handled
+        assert database.create_calls == creates
+
+
+class TestForeignKeyClassification:
+    """A missing session row has to be told apart from every other
+    integrity failure, and drivers disagree about how they report it."""
+
+    def test_the_standard_sqlstate_is_a_foreign_key(self):
+        assert is_foreign_key_violation(_integrity_error(sqlstate="23503")) is True
+
+    def test_a_non_foreign_key_sqlstate_is_not(self):
+        assert is_foreign_key_violation(_integrity_error(sqlstate="23502", message="null value")) is False
+
+    def test_a_family_sqlstate_still_reads_the_message(self):
+        """MySQL reports 23000 for the whole integrity family."""
+        assert (
+            is_foreign_key_violation(_integrity_error(sqlstate="23000", message="FOREIGN KEY constraint fails")) is True
+        )
+
+    def test_no_sqlstate_falls_back_to_the_message(self):
+        """SQLite exposes none."""
+        assert is_foreign_key_violation(_integrity_error(message="FOREIGN KEY constraint failed")) is True
+        assert is_foreign_key_violation(_integrity_error(message="NOT NULL constraint failed")) is False
+
+    def test_an_error_with_no_driver_exception_is_not_one(self):
+        assert is_foreign_key_violation(Exception("boom")) is False
+
+
+def _integrity_error(sqlstate: Optional[str] = None, message: str = "constraint failed") -> Exception:
+    """An IntegrityError shaped like the driver ones the check inspects."""
+
+    class _Orig(Exception):
+        pass
+
+    orig = _Orig(message)
+    if sqlstate is not None:
+        orig.sqlstate = sqlstate  # type: ignore[attr-defined]
+    error = Exception(message)
+    error.orig = orig  # type: ignore[attr-defined]
+    return error
+
+
+class TestOutcomeClassification:
+    """Every outcome is classified once, so none defaults to the overwrite."""
+
+    def test_every_create_outcome_is_classified_exactly_once(self):
+        """Both sets are written out, so a new member lands in neither."""
+        assert FALLBACK_ALLOWED_CREATE | FINAL_CREATE == frozenset(RunCreateOutcome)
+        assert len(FALLBACK_ALLOWED_CREATE) + len(FINAL_CREATE) == len(RunCreateOutcome)
+
+    def test_every_update_outcome_is_classified_exactly_once(self):
+        classified = [FALLBACK_ALLOWED_UPDATE, CREATE_NEEDED_UPDATE, FINAL_UPDATE]
+        assert set().union(*classified) == frozenset(RunUpdateOutcome)
+        assert sum(len(one) for one in classified) == len(RunUpdateOutcome)
+
+    def test_only_unsupported_lets_a_creation_reach_the_legacy_save(self):
+        """Any other create outcome reaching upsert_run is an overwrite."""
+        assert FALLBACK_ALLOWED_CREATE == frozenset({RunCreateOutcome.UNSUPPORTED})
+
+
+# The row fields both adapters are expected to agree on. Timestamps are left
+# out because they are wall-clock, and run_type because the in-memory adapter
+# derives it on read instead of storing it. Everything the scoped write sets
+# or deliberately preserves is in.
+_COMPARED_COLUMNS = (
+    "run_id",
+    "session_id",
+    "user_id",
+    "agent_id",
+    "team_id",
+    "workflow_id",
+    "parent_run_id",
+    "status",
+    "run_index",
+)
+
+
+def _comparable_row(db: Any, run_id: str):
+    row = db.get_run(run_id, deserialize=False)
+    if row is None:
+        return None
+    return ({column: row.get(column) for column in _COMPARED_COLUMNS}, _payload(row).get("content"))
+
+
+def _reads(db: Any):
+    """What the read filters return, which is how the rows are actually seen.
+
+    ``user_id`` is not among them: the in-memory adapter scopes run reads by
+    the session's owner while the SQL adapters scope them by the run row's
+    own, which predates the scoped write path and is not its to change.
+    """
+    # Every filter here selects at least one row of the sequence that drives
+    # it; one that matches nothing compares two empty lists and asserts that
+    # neither backend has any rows, which is not the claim.
+    filters = [
+        {"session_id": "s1"},
+        {"session_id": "s2"},
+        {"agent_id": "a1"},
+        {"team_id": "t1"},
+        {"status": RunStatus.running},
+        {"session_id": "s1", "agent_id": "a1"},
+        {"session_id": "s2", "team_id": "t1"},
+    ]
+    seen = []
+    for one in filters:
+        rows, total = db.get_runs(deserialize=False, **one)
+        seen.append((tuple(sorted(one.items())), sorted(row["run_id"] for row in rows), total))
+    return seen
+
+
+class TestBackendsAgree:
+    """The in-memory adapter hand-writes the SQL predicates; they must match.
+
+    Each round of review found another way the twin diverged, so the two are
+    driven through the same sequence and compared rather than described twice.
+    """
+
+    def test_the_same_sequence_produces_the_same_outcomes_and_rows(self, tmp_path):
+        # A team run in the second session, so the reads compared below
+        # actually select something through every filter they apply
+        sequence = [
+            ("create", "r1", "s1", "u1", "first", "agent"),
+            ("update", "r1", "s1", "u1", "second", "agent"),
+            ("update", "r1", "s1", "u2", "attacker", "agent"),
+            ("update", "r1", "s2", "u1", "other session", "agent"),
+            ("create", "r1", "s1", "u1", "again", "agent"),
+            ("create", "r2", "s1", None, "anonymous", "agent"),
+            ("update", "r2", "s1", "u1", "attributed", "agent"),
+            ("update", "missing", "s1", "u1", "nothing", "agent"),
+            ("create", "r3", "s2", None, "team run", "team"),
+            ("update", "r3", "s2", None, "team turn", "team"),
+            ("update", "r3", "s2", None, "agent reaching a team row", "agent"),
+        ]
+        results = {}
+        for name, database in (
+            ("memory", InMemoryDb()),
+            ("sqlite", SqliteDb(db_file=str(tmp_path / "differential.db"))),
+        ):
+            for session_id in ("s1", "s2"):
+                database.upsert_session(AgentSession(session_id=session_id, agent_id="a1", user_id=None, created_at=1))
+            outcomes = []
+            for op, run_id, session_id, user_id, content, kind in sequence:
+                if kind == "team":
+                    run: Any = TeamRunOutput(
+                        run_id=run_id, session_id=session_id, team_id="t1", user_id=user_id, content=content
+                    )
+                else:
+                    run = RunOutput(
+                        run_id=run_id, session_id=session_id, agent_id="a1", user_id=user_id, content=content
+                    )
+                call = database.create_run if op == "create" else database.update_run
+                outcomes.append((op, run_id, call(run=run, session_id=session_id, user_id=user_id).value))
+            results[name] = (
+                outcomes,
+                [_comparable_row(database, rid) for rid in ("r1", "r2", "r3", "missing")],
+                _reads(database),
+            )
+
+        # A filter that selects nothing would compare two empty lists and
+        # assert only that neither backend has rows
+        assert all(run_ids for _, run_ids, _ in results["memory"][2])
+        assert results["memory"] == results["sqlite"]
+
+
+class TestWorkflowRunsAreScopedToo:
+    """Workflow runs go through the same save path as agents and teams.
+
+    They make no reservation -- the ticket scopes that to Agent and Team --
+    but their lifecycle writes must not be able to land on another session's
+    run either.
+    """
+
+    def _workflow(self, db):
+        from agno.workflow.workflow import Workflow
+
+        return Workflow(name="w", id="w1", db=db, steps=[], telemetry=False)
+
+    def test_a_workflow_run_cannot_overwrite_another_sessions_run(self, db):
+        db.upsert_session(_agent_session("victim", user_id="victim-user"))
+        db.upsert_session(WorkflowSession(session_id="attacker", workflow_id="w1", created_at=1))
+        db.create_run(
+            run=_agent_run("r1", session_id="victim", user_id="victim-user", content="original"),
+            session_id="victim",
+            user_id="victim-user",
+        )
+        workflow = self._workflow(db)
+        colliding = WorkflowRunOutput(run_id="r1", session_id="attacker", workflow_id="w1", content="attacker")
+
+        workflow.save_run(run=colliding, session_id="attacker", run_index=0)
+
+        assert _stored_content(db, "r1") == "original"
+
+    @pytest.mark.asyncio
+    async def test_the_async_workflow_save_is_scoped_too(self, db):
+        db.upsert_session(_agent_session("victim", user_id="victim-user"))
+        db.upsert_session(WorkflowSession(session_id="attacker", workflow_id="w1", created_at=1))
+        db.create_run(
+            run=_agent_run("r1", session_id="victim", user_id="victim-user", content="original"),
+            session_id="victim",
+            user_id="victim-user",
+        )
+        workflow = self._workflow(db)
+        colliding = WorkflowRunOutput(run_id="r1", session_id="attacker", workflow_id="w1", content="attacker")
+
+        await workflow.asave_run(run=colliding, session_id="attacker", run_index=0)
+
+        assert _stored_content(db, "r1") == "original"
+
+    def test_a_workflow_run_of_its_own_still_saves(self, db):
+        db.upsert_session(WorkflowSession(session_id="s1", workflow_id="w1", created_at=1))
+        workflow = self._workflow(db)
+        run = WorkflowRunOutput(run_id="own", session_id="s1", workflow_id="w1", content="written")
+
+        workflow.save_run(run=run, session_id="s1", run_index=0)
+
+        assert _stored_content(db, "own") == "written"

--- a/libs/agno/tests/unit/db/test_run_creation_isolation_postgres.py
+++ b/libs/agno/tests/unit/db/test_run_creation_isolation_postgres.py
@@ -1,0 +1,570 @@
+"""Run creation and scoped updates on the PostgreSQL adapters.
+
+Mirror of test_run_creation_isolation.py (in-memory + SQLite) against a live
+Postgres (cookbook/scripts/run_pgvector.sh, port 5532), sync and async. The
+concurrency cases matter most here: the winner is picked by the database's own
+primary key, not by any check the process performs.
+
+Each test runs in its own schema, dropped on teardown. The whole module skips
+when psycopg is missing or the server is unreachable.
+"""
+
+import asyncio
+import threading
+import time
+import uuid
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+pytest.importorskip("psycopg")
+
+from sqlalchemy import create_engine, text  # noqa: E402
+
+from agno.db.postgres import PostgresDb  # noqa: E402
+from agno.db.postgres.async_postgres import AsyncPostgresDb  # noqa: E402
+from agno.db.run_writes import (  # noqa: E402
+    RunCreateOutcome,
+    RunUpdateOutcome,
+    supports_atomic_run_creation,
+)
+from agno.run.agent import RunOutput  # noqa: E402
+from agno.run.base import RunStatus  # noqa: E402
+from agno.run.team import TeamRunOutput  # noqa: E402
+from agno.session import AgentSession, TeamSession  # noqa: E402
+from tests.unit.db.test_run_creation_isolation import OWNERSHIP_MATRIX, run_for_scope  # noqa: E402
+
+DB_URL = "postgresql+psycopg://ai:ai@localhost:5532/ai"
+
+CONCURRENT_WRITERS = 8
+
+# Every wait a concurrency case performs is bounded by this, so a writer that
+# never arrives at the barrier or a statement that never returns fails the test
+# instead of hanging the suite.
+CONCURRENCY_TIMEOUT_SECONDS = 10.0
+
+
+def _writer_barrier() -> threading.Barrier:
+    return threading.Barrier(CONCURRENT_WRITERS, timeout=CONCURRENCY_TIMEOUT_SECONDS)
+
+
+def _run_threads(attempt: Any) -> None:
+    """Run ``attempt`` on CONCURRENT_WRITERS threads and fail on any raise.
+
+    A worker that raises would otherwise just be absent from the collected
+    outcomes, and an assertion counting exactly one CREATED would pass while
+    every other writer crashed.
+    """
+    failures: List[BaseException] = []
+    failures_lock = threading.Lock()
+
+    def guarded(index: int) -> None:
+        try:
+            attempt(index)
+        except BaseException as error:
+            with failures_lock:
+                failures.append(error)
+
+    threads = [threading.Thread(target=guarded, args=(i,), daemon=True) for i in range(CONCURRENT_WRITERS)]
+    for thread in threads:
+        thread.start()
+    deadline = time.monotonic() + CONCURRENCY_TIMEOUT_SECONDS
+    for thread in threads:
+        thread.join(max(0.0, deadline - time.monotonic()))
+    still_running = [thread for thread in threads if thread.is_alive()]
+    if still_running:
+        raise AssertionError(
+            f"{len(still_running)} of {CONCURRENT_WRITERS} writers were still running after "
+            f"{CONCURRENCY_TIMEOUT_SECONDS}s"
+        )
+    if failures:
+        raise AssertionError(f"{len(failures)} of {CONCURRENT_WRITERS} writers raised; first: {failures[0]!r}")
+
+
+def _server_reachable() -> bool:
+    engine = create_engine(DB_URL)
+    try:
+        with engine.connect() as conn:
+            conn.execute(text("select 1"))
+        return True
+    except Exception:
+        return False
+    finally:
+        engine.dispose()
+
+
+@pytest.fixture(scope="module")
+def _postgres_server():
+    if not _server_reachable():
+        pytest.skip(f"Postgres server not reachable at {DB_URL}")
+
+
+def _drop_schema(schema: str) -> None:
+    engine = create_engine(DB_URL)
+    try:
+        with engine.begin() as conn:
+            conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+    finally:
+        engine.dispose()
+
+
+@pytest.fixture
+def db(_postgres_server):
+    schema = f"run_write_{uuid.uuid4().hex[:8]}"
+    database = PostgresDb(db_url=DB_URL, db_schema=schema, id=f"run-write-{schema}")
+    try:
+        yield database
+    finally:
+        # The adapter's own pool holds connections into this schema; DROP
+        # SCHEMA CASCADE blocks behind them, and every test would leak a pool.
+        database.db_engine.dispose()
+        _drop_schema(schema)
+
+
+@pytest.fixture
+async def async_db(_postgres_server):
+    schema = f"run_write_async_{uuid.uuid4().hex[:8]}"
+    database = AsyncPostgresDb(db_url=DB_URL, db_schema=schema, id=f"run-write-async-{schema}")
+    try:
+        yield database
+    finally:
+        await database.db_engine.dispose()
+        _drop_schema(schema)
+
+
+def _agent_session(session_id: str = "s1", user_id: Optional[str] = None) -> AgentSession:
+    return AgentSession(session_id=session_id, agent_id="a1", user_id=user_id, created_at=1)
+
+
+def _team_session(session_id: str = "s1", user_id: Optional[str] = None) -> TeamSession:
+    return TeamSession(session_id=session_id, team_id="t1", user_id=user_id, created_at=1)
+
+
+def _agent_run(
+    run_id: str, session_id: str = "s1", user_id: Optional[str] = None, content: Optional[str] = None
+) -> RunOutput:
+    return RunOutput(run_id=run_id, session_id=session_id, agent_id="a1", user_id=user_id, content=content)
+
+
+def _team_run(
+    run_id: str, session_id: str = "s1", user_id: Optional[str] = None, content: Optional[str] = None
+) -> TeamRunOutput:
+    return TeamRunOutput(run_id=run_id, session_id=session_id, team_id="t1", user_id=user_id, content=content)
+
+
+def _stored_content(db: Any, run_id: str) -> Optional[str]:
+    row: Optional[Dict[str, Any]] = db.get_run(run_id, deserialize=False)
+    return None if row is None else (row["run_data"] or {}).get("content")
+
+
+async def _astored_content(db: Any, run_id: str) -> Optional[str]:
+    row = await db.get_run(run_id, deserialize=False)
+    return None if row is None else (row["run_data"] or {}).get("content")
+
+
+def _stored_status(db: Any, run_id: str) -> Optional[str]:
+    row: Optional[Dict[str, Any]] = db.get_run(run_id, deserialize=False)
+    return None if row is None else (row["run_data"] or {}).get("status")
+
+
+def _stored_index(db: Any, run_id: str) -> Optional[int]:
+    row: Optional[Dict[str, Any]] = db.get_run(run_id, deserialize=False)
+    return None if row is None else row["run_index"]
+
+
+class TestPostgresStrictCreation:
+    def test_adapter_advertises_atomic_creation(self, db):
+        assert supports_atomic_run_creation(db) is True
+
+    def test_fresh_id_is_created(self, db):
+        db.upsert_session(_agent_session())
+        assert db.create_run(run=_agent_run("r1"), session_id="s1") is RunCreateOutcome.CREATED
+
+    def test_taken_id_conflicts_and_leaves_the_stored_run_untouched(self, db):
+        db.upsert_session(_agent_session())
+        db.create_run(run=_agent_run("r1", content="original"), session_id="s1")
+
+        outcome = db.create_run(run=_agent_run("r1", content="attacker"), session_id="s1")
+
+        assert outcome is RunCreateOutcome.CONFLICT
+        assert _stored_content(db, "r1") == "original"
+
+    def test_taken_id_conflicts_across_sessions_and_users(self, db):
+        db.upsert_session(_agent_session("victim", user_id="victim-user"))
+        db.upsert_session(_agent_session("attacker", user_id="attacker-user"))
+        db.create_run(
+            run=_agent_run("r1", session_id="victim", content="original"), session_id="victim", user_id="victim-user"
+        )
+
+        outcome = db.create_run(
+            run=_agent_run("r1", session_id="attacker", content="attacker"),
+            session_id="attacker",
+            user_id="attacker-user",
+        )
+
+        assert outcome is RunCreateOutcome.CONFLICT
+        assert _stored_content(db, "r1") == "original"
+
+    def test_creation_reports_a_missing_session_and_inserts_nothing(self, db):
+        assert db.create_run(run=_agent_run("r1"), session_id="s1") is RunCreateOutcome.SESSION_MISSING
+        assert db.get_run("r1") is None
+
+    def test_team_runs_get_the_same_refusal(self, db):
+        db.upsert_session(_team_session())
+        db.create_run(run=_team_run("r1", content="original"), session_id="s1")
+
+        assert db.create_run(run=_team_run("r1", content="attacker"), session_id="s1") is RunCreateOutcome.CONFLICT
+        assert _stored_content(db, "r1") == "original"
+
+    def test_a_deleted_run_frees_its_id(self, db):
+        db.upsert_session(_agent_session())
+        db.create_run(run=_agent_run("r1"), session_id="s1")
+        db.delete_run("r1")
+
+        assert db.create_run(run=_agent_run("r1"), session_id="s1") is RunCreateOutcome.CREATED
+
+    def test_a_deleted_session_frees_the_ids_of_its_runs(self, db):
+        db.upsert_session(_agent_session())
+        db.create_run(run=_agent_run("r1"), session_id="s1")
+        db.delete_session("s1")
+        db.upsert_session(_agent_session("s2"))
+
+        assert db.create_run(run=_agent_run("r1", session_id="s2"), session_id="s2") is RunCreateOutcome.CREATED
+
+
+class TestPostgresConcurrentCreation:
+    def test_barrier_started_creations_of_one_fresh_id_produce_one_winner(self, db):
+        db.upsert_session(_agent_session())
+        barrier = _writer_barrier()
+        outcomes: List[RunCreateOutcome] = []
+        lock = threading.Lock()
+
+        def attempt(index: int) -> None:
+            run = _agent_run("contested", content=f"writer-{index}")
+            barrier.wait()
+            outcome = db.create_run(run=run, session_id="s1")
+            with lock:
+                outcomes.append(outcome)
+
+        _run_threads(attempt)
+
+        assert outcomes.count(RunCreateOutcome.CREATED) == 1
+        assert outcomes.count(RunCreateOutcome.CONFLICT) == CONCURRENT_WRITERS - 1
+
+    def test_the_winner_is_the_run_that_stays_stored(self, db):
+        db.upsert_session(_agent_session())
+        barrier = _writer_barrier()
+        winners: List[str] = []
+        lock = threading.Lock()
+
+        def attempt(index: int) -> None:
+            content = f"writer-{index}"
+            barrier.wait()
+            if db.create_run(run=_agent_run("contested", content=content), session_id="s1") is RunCreateOutcome.CREATED:
+                with lock:
+                    winners.append(content)
+
+        _run_threads(attempt)
+
+        assert len(winners) == 1
+        assert _stored_content(db, "contested") == winners[0]
+
+    def test_barrier_started_creations_of_distinct_ids_each_take_their_own_position(self, db):
+        """Contention over the position, not over the id.
+
+        Each writer creates an id of its own, so none of them conflict; what
+        they contend for is the next run_index in the shared session. Two
+        writers reading the same maximum would hand out the same position.
+        """
+        db.upsert_session(_agent_session())
+        barrier = _writer_barrier()
+        outcomes: List[RunCreateOutcome] = []
+        lock = threading.Lock()
+
+        def attempt(index: int) -> None:
+            run = _agent_run(f"r{index}", content=f"writer-{index}")
+            barrier.wait()
+            outcome = db.create_run(run=run, session_id="s1")
+            with lock:
+                outcomes.append(outcome)
+
+        _run_threads(attempt)
+
+        assert outcomes.count(RunCreateOutcome.CREATED) == CONCURRENT_WRITERS
+        positions = [_stored_index(db, f"r{index}") for index in range(CONCURRENT_WRITERS)]
+        assert None not in positions
+        assert sorted(positions) == list(range(CONCURRENT_WRITERS))
+
+
+class TestPostgresScopedUpdates:
+    def test_the_owner_can_update(self, db):
+        db.upsert_session(_agent_session(user_id="u1"))
+        db.create_run(run=_agent_run("r1", user_id="u1"), session_id="s1", user_id="u1")
+
+        outcome = db.update_run(run=_agent_run("r1", user_id="u1", content="turn one"), session_id="s1", user_id="u1")
+
+        assert outcome is RunUpdateOutcome.UPDATED
+        assert _stored_content(db, "r1") == "turn one"
+
+    def test_an_anonymous_run_is_updatable_by_the_same_anonymous_caller(self, db):
+        db.upsert_session(_agent_session())
+        db.create_run(run=_agent_run("r1"), session_id="s1")
+
+        assert db.update_run(run=_agent_run("r1", content="turn one"), session_id="s1") is RunUpdateOutcome.UPDATED
+        assert _stored_content(db, "r1") == "turn one"
+
+    def test_another_user_cannot_update(self, db):
+        db.upsert_session(_agent_session(user_id="u1"))
+        db.create_run(run=_agent_run("r1", user_id="u1", content="original"), session_id="s1", user_id="u1")
+
+        outcome = db.update_run(run=_agent_run("r1", user_id="u2", content="attacker"), session_id="s1", user_id="u2")
+
+        assert outcome is RunUpdateOutcome.SCOPE_MISMATCH
+        assert _stored_content(db, "r1") == "original"
+
+    def test_an_unowned_run_accepts_an_identified_writer(self, db):
+        db.upsert_session(_agent_session())
+        db.create_run(run=_agent_run("r1", content="original"), session_id="s1")
+
+        outcome = db.update_run(run=_agent_run("r1", user_id="u2", content="turn one"), session_id="s1", user_id="u2")
+
+        assert outcome is RunUpdateOutcome.UPDATED
+        assert _stored_content(db, "r1") == "turn one"
+
+    def test_a_writer_given_no_user_still_lands_when_the_run_knows_its_owner(self, db):
+        """NULL semantics differ per dialect, so both directions are checked here."""
+        db.upsert_session(_agent_session(user_id="u1"))
+        db.create_run(run=_agent_run("r1", user_id="u1", content="original"), session_id="s1", user_id="u1")
+
+        outcome = db.update_run(run=_agent_run("r1", user_id="u1", content="turn one"), session_id="s1")
+
+        assert outcome is RunUpdateOutcome.UPDATED
+        assert _stored_content(db, "r1") == "turn one"
+
+    def test_a_run_rebuilt_from_its_id_alone_can_still_record_its_end(self, db):
+        """The shape the cancellation path produces: only a run_id."""
+        db.upsert_session(_agent_session(user_id="u1"))
+        db.create_run(run=_agent_run("r1", user_id="u1", content="original"), session_id="s1", user_id="u1")
+        bare = RunOutput(run_id="r1", content="cancelled")
+        bare.status = RunStatus.cancelled
+
+        outcome = db.update_run(run=bare, session_id="s1", user_id="u1")
+
+        assert outcome is RunUpdateOutcome.UPDATED
+        assert _stored_content(db, "r1") == "cancelled"
+        assert _stored_status(db, "r1") == RunStatus.cancelled.value
+
+    def test_terminal_writes_land_through_the_scoped_update(self, db):
+        db.upsert_session(_agent_session(user_id="u1"))
+        db.create_run(run=_agent_run("r1", user_id="u1"), session_id="s1", user_id="u1")
+        final = _agent_run("r1", user_id="u1", content="done")
+        final.status = RunStatus.completed
+
+        assert db.update_run(run=final, session_id="s1", user_id="u1") is RunUpdateOutcome.UPDATED
+        assert _stored_status(db, "r1") == RunStatus.completed.value
+
+    def test_update_preserves_the_run_index(self, db):
+        db.upsert_session(_agent_session())
+        db.create_run(run=_agent_run("r1"), session_id="s1")
+        db.create_run(run=_agent_run("r2"), session_id="s1")
+        first_index = _stored_index(db, "r1")
+
+        db.update_run(run=_agent_run("r1", content="turn one"), session_id="s1")
+
+        assert _stored_index(db, "r1") == first_index
+
+    def test_a_stored_position_is_never_renumbered(self, db):
+        """COALESCE(stored, incoming): the update never moves a row."""
+        db.upsert_session(_agent_session())
+        db.create_run(run=_agent_run("r1"), session_id="s1")
+        first_index = _stored_index(db, "r1")
+
+        db.update_run(run=_agent_run("r1", content="later"), session_id="s1", run_index=99)
+
+        assert _stored_index(db, "r1") == first_index
+
+    def test_an_unowned_row_is_attributed_by_its_first_owner_write(self, db):
+        """Creation can precede identity resolution; the column must catch up."""
+        db.upsert_session(_agent_session(user_id="u1"))
+        db.create_run(run=_agent_run("r1"), session_id="s1")
+
+        db.update_run(run=_agent_run("r1", content="done"), session_id="s1", user_id="u1")
+
+        assert db.get_run("r1", deserialize=False)["user_id"] == "u1"
+
+    def test_another_session_cannot_update(self, db):
+        db.upsert_session(_agent_session())
+        db.upsert_session(_agent_session("s2"))
+        db.create_run(run=_agent_run("r1", content="original"), session_id="s1")
+
+        outcome = db.update_run(run=_agent_run("r1", session_id="s2", content="attacker"), session_id="s2")
+
+        assert outcome is RunUpdateOutcome.SCOPE_MISMATCH
+        assert _stored_content(db, "r1") == "original"
+
+    def test_another_component_cannot_update(self, db):
+        db.upsert_session(_agent_session())
+        db.create_run(run=_agent_run("r1", content="original"), session_id="s1")
+
+        assert (
+            db.update_run(run=_team_run("r1", content="attacker"), session_id="s1") is RunUpdateOutcome.SCOPE_MISMATCH
+        )
+        assert _stored_content(db, "r1") == "original"
+
+    def test_an_unknown_run_reports_missing_and_inserts_nothing(self, db):
+        db.upsert_session(_agent_session())
+
+        assert db.update_run(run=_agent_run("nope"), session_id="s1") is RunUpdateOutcome.MISSING
+        assert db.get_run("nope") is None
+
+
+class TestAsyncPostgres:
+    @pytest.mark.asyncio
+    async def test_adapter_advertises_atomic_creation(self, async_db):
+        assert supports_atomic_run_creation(async_db) is True
+
+    @pytest.mark.asyncio
+    async def test_taken_id_conflicts_and_leaves_the_stored_run_untouched(self, async_db):
+        await async_db.upsert_session(_agent_session())
+        await async_db.create_run(run=_agent_run("r1", content="original"), session_id="s1")
+
+        outcome = await async_db.create_run(run=_agent_run("r1", content="attacker"), session_id="s1")
+
+        assert outcome is RunCreateOutcome.CONFLICT
+        assert await _astored_content(async_db, "r1") == "original"
+
+    @pytest.mark.asyncio
+    async def test_creation_reports_a_missing_session_and_inserts_nothing(self, async_db):
+        assert await async_db.create_run(run=_agent_run("r1"), session_id="s1") is RunCreateOutcome.SESSION_MISSING
+        assert await async_db.get_run("r1") is None
+
+    @pytest.mark.asyncio
+    async def test_fresh_id_is_created(self, async_db):
+        await async_db.upsert_session(_agent_session())
+
+        assert await async_db.create_run(run=_agent_run("r1"), session_id="s1") is RunCreateOutcome.CREATED
+        assert await async_db.get_run("r1") is not None
+
+    @pytest.mark.asyncio
+    async def test_barrier_started_creations_of_one_fresh_id_produce_one_winner(self, async_db):
+        await async_db.upsert_session(_agent_session())
+        started = asyncio.Event()
+
+        async def attempt(index: int) -> RunCreateOutcome:
+            await started.wait()
+            return await async_db.create_run(run=_agent_run("contested", content=f"writer-{index}"), session_id="s1")
+
+        tasks = [asyncio.create_task(attempt(i)) for i in range(CONCURRENT_WRITERS)]
+        await asyncio.sleep(0)
+        started.set()
+        outcomes = list(await asyncio.wait_for(asyncio.gather(*tasks), CONCURRENCY_TIMEOUT_SECONDS))
+
+        assert outcomes.count(RunCreateOutcome.CREATED) == 1
+        assert outcomes.count(RunCreateOutcome.CONFLICT) == CONCURRENT_WRITERS - 1
+
+    @pytest.mark.asyncio
+    async def test_another_user_cannot_update(self, async_db):
+        await async_db.upsert_session(_agent_session(user_id="u1"))
+        await async_db.create_run(run=_agent_run("r1", user_id="u1", content="original"), session_id="s1", user_id="u1")
+
+        outcome = await async_db.update_run(
+            run=_agent_run("r1", user_id="u2", content="attacker"), session_id="s1", user_id="u2"
+        )
+
+        assert outcome is RunUpdateOutcome.SCOPE_MISMATCH
+        assert await _astored_content(async_db, "r1") == "original"
+
+    @pytest.mark.asyncio
+    async def test_another_session_cannot_update(self, async_db):
+        await async_db.upsert_session(_agent_session())
+        await async_db.upsert_session(_agent_session("s2"))
+        await async_db.create_run(run=_agent_run("r1", content="original"), session_id="s1")
+
+        outcome = await async_db.update_run(run=_agent_run("r1", session_id="s2", content="attacker"), session_id="s2")
+
+        assert outcome is RunUpdateOutcome.SCOPE_MISMATCH
+        assert await _astored_content(async_db, "r1") == "original"
+
+    @pytest.mark.asyncio
+    async def test_the_owner_can_update(self, async_db):
+        await async_db.upsert_session(_agent_session(user_id="u1"))
+        await async_db.create_run(run=_agent_run("r1", user_id="u1"), session_id="s1", user_id="u1")
+
+        outcome = await async_db.update_run(
+            run=_agent_run("r1", user_id="u1", content="turn one"), session_id="s1", user_id="u1"
+        )
+
+        assert outcome is RunUpdateOutcome.UPDATED
+        assert await _astored_content(async_db, "r1") == "turn one"
+
+
+# The ownership matrix is stated once, in the in-memory and SQLite suite, and
+# read from there. Postgres is the dialect whose NULL comparisons can disagree
+# with the others, so it answers the same table rather than a copy of it.
+OWNERSHIP_IDS = [row[0] for row in OWNERSHIP_MATRIX]
+OWNERSHIP_CASES = [row[1:] for row in OWNERSHIP_MATRIX]
+
+
+def _scope(**overrides: Optional[str]) -> Dict[str, Optional[str]]:
+    base: Dict[str, Optional[str]] = {
+        "session_id": "s1",
+        "user_id": None,
+        "agent_id": None,
+        "team_id": None,
+        "workflow_id": None,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestPostgresOwnershipMatrix:
+    """One derivation of the rule, and Postgres answers the whole table.
+
+    A writer whose identity resolves differently from the one that created the
+    row is a row in this table rather than a bug found a round later.
+    """
+
+    @pytest.mark.parametrize("stored,incoming,allowed", OWNERSHIP_CASES, ids=OWNERSHIP_IDS)
+    def test_the_scoped_update_lands_exactly_where_the_rule_allows(self, db, stored, incoming, allowed):
+        stored_scope = _scope(**stored)
+        incoming_scope = _scope(**incoming)
+        for session_id in {stored_scope["session_id"], incoming_scope["session_id"]}:
+            db.upsert_session(_agent_session(session_id))
+        db.create_run(
+            run=run_for_scope(stored_scope, "r1", "original"),
+            session_id=stored_scope["session_id"],
+            user_id=stored_scope["user_id"],
+        )
+
+        outcome = db.update_run(
+            run=run_for_scope(incoming_scope, "r1", "written"),
+            session_id=incoming_scope["session_id"],
+            user_id=incoming_scope["user_id"],
+        )
+
+        assert (outcome is RunUpdateOutcome.UPDATED) is allowed
+        assert _stored_content(db, "r1") == ("written" if allowed else "original")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("stored,incoming,allowed", OWNERSHIP_CASES, ids=OWNERSHIP_IDS)
+    async def test_the_async_scoped_update_lands_exactly_where_the_rule_allows(
+        self, async_db, stored, incoming, allowed
+    ):
+        stored_scope = _scope(**stored)
+        incoming_scope = _scope(**incoming)
+        for session_id in {stored_scope["session_id"], incoming_scope["session_id"]}:
+            await async_db.upsert_session(_agent_session(session_id))
+        await async_db.create_run(
+            run=run_for_scope(stored_scope, "r1", "original"),
+            session_id=stored_scope["session_id"],
+            user_id=stored_scope["user_id"],
+        )
+
+        outcome = await async_db.update_run(
+            run=run_for_scope(incoming_scope, "r1", "written"),
+            session_id=incoming_scope["session_id"],
+            user_id=incoming_scope["user_id"],
+        )
+
+        assert (outcome is RunUpdateOutcome.UPDATED) is allowed
+        assert await _astored_content(async_db, "r1") == ("written" if allowed else "original")

--- a/libs/agno/tests/unit/run/test_worker_owned_save_fencing.py
+++ b/libs/agno/tests/unit/run/test_worker_owned_save_fencing.py
@@ -15,6 +15,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from agno.db.base import AsyncBaseDb, BaseDb
 from agno.run.agent import RunOutput
 from agno.run.base import RunStatus
 from agno.run.concurrency import mark_worker_managed, unmark_worker_managed
@@ -35,16 +36,40 @@ def make_run() -> RunOutput:
 
 
 def make_sync_db(outcome=RunPersistOutcome.UPDATED):
-    db = MagicMock(name="sync_db")
+    db = MagicMock(spec=BaseDb, name="sync_db")
     db.update_run_in_session = MagicMock(return_value=outcome)
+    db.upsert_run = MagicMock()
+    # A bare MagicMock answers every attribute, so it would otherwise
+    # advertise the strict create/scoped update pair it does not implement
+    db.supports_atomic_run_creation = False
     return db
 
 
 def make_async_db(outcome=RunPersistOutcome.UPDATED):
-    db = MagicMock(name="async_db")
+    # spec'd to AsyncBaseDb because the save helpers pick their sync/async
+    # branch with isinstance: a bare MagicMock is not an async adapter, so
+    # the async upsert_run fallback would never be reached and its coroutine
+    # would be created and dropped unawaited instead of exercised
+    db = MagicMock(spec=AsyncBaseDb, name="async_db")
     db.update_run_in_session = AsyncMock(return_value=outcome)
     db.upsert_run = AsyncMock()
+    # A bare MagicMock answers every attribute, so it would otherwise
+    # advertise the strict create/scoped update pair it does not implement
+    db.supports_atomic_run_creation = False
     return db
+
+
+def assert_saved_through_fence(db, attempt: int, calls: int = 1) -> None:
+    """The save reached the attempt-fenced primitive for this run.
+
+    Asserting only that bare ``upsert_run`` went uncalled passes even when
+    the fenced helper raises, because every choke point swallows exceptions.
+    """
+    assert db.update_run_in_session.call_count == calls
+    fenced = db.update_run_in_session.call_args.kwargs
+    assert fenced["run_id"] == RUN_ID
+    assert fenced["expected_attempt"] == attempt
+    db.upsert_run.assert_not_called()
 
 
 class TestFenceHelperCore:
@@ -80,19 +105,6 @@ class TestFenceHelperCore:
         assert await apersist_worker_owned_run(db, make_run(), session_id=SESSION_ID) is True
 
     @pytest.mark.asyncio
-    async def test_missing_row_appends_with_attempt_stamp(self):
-        from agno.run.status_persist import apersist_worker_owned_run
-
-        mark_worker_managed(RUN_ID, worker_id="w1", attempt=2)
-        db = make_async_db(RunPersistOutcome.MISSING)
-        db.append_run_to_session_if_absent = AsyncMock(return_value=True)
-        assert await apersist_worker_owned_run(db, make_run(), session_id=SESSION_ID) is True
-        appended = db.append_run_to_session_if_absent.call_args.kwargs
-        assert appended["run_dict"]["queue_attempt"] == 2, (
-            "a fresh row without the attempt stamp lets the next fence compare pass vacuously"
-        )
-
-    @pytest.mark.asyncio
     async def test_adapter_without_primitive_falls_through(self):
         from agno.run.status_persist import apersist_worker_owned_run
 
@@ -117,9 +129,111 @@ class TestFenceHelperCore:
         assert persist_worker_owned_run(db, make_run(), session_id=SESSION_ID) is False
 
 
+class TestMissingRowAppendPath:
+    """MISSING means the row is not there yet: the fenced save appends it,
+    and every answer the append can give has to be routed."""
+
+    @pytest.mark.asyncio
+    async def test_append_stamps_the_attempt(self):
+        from agno.run.status_persist import apersist_worker_owned_run
+
+        mark_worker_managed(RUN_ID, worker_id="w1", attempt=2)
+        db = make_async_db(RunPersistOutcome.MISSING)
+        db.append_run_to_session_if_absent = AsyncMock(return_value=True)
+        assert await apersist_worker_owned_run(db, make_run(), session_id=SESSION_ID) is True
+        appended = db.append_run_to_session_if_absent.call_args.kwargs
+        assert appended["run_dict"]["queue_attempt"] == 2, (
+            "a fresh row without the attempt stamp lets the next fence compare pass vacuously"
+        )
+
+    @pytest.mark.asyncio
+    async def test_append_returning_none_falls_through(self):
+        """No session row to append to: the legacy path decides, so the
+        caller must NOT be told the save was handled."""
+        from agno.run.status_persist import apersist_worker_owned_run
+
+        mark_worker_managed(RUN_ID, worker_id="w1", attempt=2)
+        db = make_async_db(RunPersistOutcome.MISSING)
+        db.append_run_to_session_if_absent = AsyncMock(return_value=None)
+        assert await apersist_worker_owned_run(db, make_run(), session_id=SESSION_ID) is False
+
+    @pytest.mark.asyncio
+    async def test_append_returning_false_redrives_the_fence(self):
+        """A concurrent writer landed the row between check and append, so
+        the fenced update is re-driven against it rather than skipped."""
+        from agno.run.status_persist import apersist_worker_owned_run
+
+        mark_worker_managed(RUN_ID, worker_id="w1", attempt=2)
+        db = make_async_db()
+        db.update_run_in_session = AsyncMock(
+            side_effect=[RunPersistOutcome.MISSING, RunPersistOutcome.UPDATED],
+        )
+        db.append_run_to_session_if_absent = AsyncMock(return_value=False)
+        assert await apersist_worker_owned_run(db, make_run(), session_id=SESSION_ID) is True
+        assert db.update_run_in_session.call_count == 2
+        assert db.update_run_in_session.call_args.kwargs["expected_attempt"] == 2
+
+    @pytest.mark.asyncio
+    async def test_append_returning_false_with_row_still_gone_falls_through(self):
+        from agno.run.status_persist import apersist_worker_owned_run
+
+        mark_worker_managed(RUN_ID, worker_id="w1", attempt=2)
+        db = make_async_db(RunPersistOutcome.MISSING)
+        db.append_run_to_session_if_absent = AsyncMock(return_value=False)
+        assert await apersist_worker_owned_run(db, make_run(), session_id=SESSION_ID) is False
+        assert db.update_run_in_session.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_adapter_without_append_falls_through(self):
+        from agno.run.status_persist import apersist_worker_owned_run
+
+        mark_worker_managed(RUN_ID, worker_id="w1", attempt=2)
+        db = make_async_db(RunPersistOutcome.MISSING)
+        assert await apersist_worker_owned_run(db, make_run(), session_id=SESSION_ID) is False
+
+    def test_sync_append_stamps_the_attempt(self):
+        from agno.run.status_persist import persist_worker_owned_run
+
+        mark_worker_managed(RUN_ID, worker_id="w1", attempt=5)
+        db = make_sync_db(RunPersistOutcome.MISSING)
+        db.append_run_to_session_if_absent = MagicMock(return_value=True)
+        assert persist_worker_owned_run(db, make_run(), session_id=SESSION_ID) is True
+        appended = db.append_run_to_session_if_absent.call_args.kwargs
+        assert appended["run_dict"]["queue_attempt"] == 5
+
+    def test_sync_append_returning_none_falls_through(self):
+        from agno.run.status_persist import persist_worker_owned_run
+
+        mark_worker_managed(RUN_ID, worker_id="w1", attempt=5)
+        db = make_sync_db(RunPersistOutcome.MISSING)
+        db.append_run_to_session_if_absent = MagicMock(return_value=None)
+        assert persist_worker_owned_run(db, make_run(), session_id=SESSION_ID) is False
+
+    def test_sync_append_returning_false_redrives_the_fence(self):
+        from agno.run.status_persist import persist_worker_owned_run
+
+        mark_worker_managed(RUN_ID, worker_id="w1", attempt=5)
+        db = make_sync_db()
+        db.update_run_in_session = MagicMock(
+            side_effect=[RunPersistOutcome.MISSING, RunPersistOutcome.UPDATED],
+        )
+        db.append_run_to_session_if_absent = MagicMock(return_value=False)
+        assert persist_worker_owned_run(db, make_run(), session_id=SESSION_ID) is True
+        assert db.update_run_in_session.call_count == 2
+
+    def test_sync_twin_skips_async_only_append(self):
+        from agno.run.status_persist import persist_worker_owned_run
+
+        mark_worker_managed(RUN_ID, worker_id="w1", attempt=5)
+        db = make_sync_db(RunPersistOutcome.MISSING)
+        db.append_run_to_session_if_absent = AsyncMock(return_value=True)
+        assert persist_worker_owned_run(db, make_run(), session_id=SESSION_ID) is False
+
+
 class TestChokePointWiring:
     """The three components' save helpers actually consult the fence: a
-    managed run's save must NOT reach bare upsert_run."""
+    managed run's save goes through the attempt-fenced primitive and never
+    reaches bare upsert_run."""
 
     @pytest.mark.asyncio
     async def test_agent_async_save_is_fenced(self):
@@ -129,7 +243,7 @@ class TestChokePointWiring:
         db = make_async_db(RunPersistOutcome.STALE_ATTEMPT)
         agent = SimpleNamespace(db=db)
         await aupsert_run(agent, make_run(), session_id=SESSION_ID)
-        db.upsert_run.assert_not_called()
+        assert_saved_through_fence(db, attempt=2)
 
     @pytest.mark.asyncio
     async def test_agent_async_save_unmanaged_uses_upsert(self):
@@ -138,7 +252,7 @@ class TestChokePointWiring:
         db = make_async_db()
         agent = SimpleNamespace(db=db)
         await aupsert_run(agent, make_run(), session_id=SESSION_ID)
-        db.upsert_run.assert_called_once()
+        db.upsert_run.assert_awaited_once()
         db.update_run_in_session.assert_not_called()
 
     @pytest.mark.asyncio
@@ -151,7 +265,7 @@ class TestChokePointWiring:
         team = SimpleNamespace(db=db)
         run = TeamRunOutput(run_id=RUN_ID, session_id=SESSION_ID, status=RunStatus.completed)
         await _aupsert_run(team, run, session_id=SESSION_ID)
-        db.upsert_run.assert_not_called()
+        assert_saved_through_fence(db, attempt=2)
 
     @pytest.mark.asyncio
     async def test_workflow_async_save_is_fenced(self):
@@ -160,17 +274,16 @@ class TestChokePointWiring:
 
         mark_worker_managed(RUN_ID, worker_id="w1", attempt=2)
         db = make_async_db(RunPersistOutcome.STALE_ATTEMPT)
-        workflow = Workflow(id="wf-fence", name="WF", db=db, steps=[])
+        workflow = Workflow(id="wf-fence", name="WF", db=db, steps=[], telemetry=False)
         run = WorkflowRunOutput(run_id=RUN_ID, session_id=SESSION_ID, status=RunStatus.completed)
         await workflow.asave_run(run=run, session_id=SESSION_ID)
-        db.upsert_run.assert_not_called()
+        assert_saved_through_fence(db, attempt=2)
 
     def test_agent_sync_save_is_fenced(self):
         from agno.agent._storage import upsert_run as sync_upsert_run
 
         mark_worker_managed(RUN_ID, worker_id="w1", attempt=2)
         db = make_sync_db(RunPersistOutcome.STALE_ATTEMPT)
-        db.upsert_run = MagicMock()
         agent = SimpleNamespace(db=db)
         sync_upsert_run(agent, make_run(), session_id=SESSION_ID)
-        db.upsert_run.assert_not_called()
+        assert_saved_through_fence(db, attempt=2)

--- a/libs/agno/tests/unit/team/test_run_id_conflicts.py
+++ b/libs/agno/tests/unit/team/test_run_id_conflicts.py
@@ -1,0 +1,500 @@
+"""A team run cannot write over a stored run that is not its own.
+
+``run_id`` can be supplied by the caller, and storage used to accept a
+conflicting one as an update, replacing a stored run that may belong to
+another session or user. Creation is now a strict insert, and every write
+after it is scoped to the run's own session, effective user and component:
+a run handed an id that is already taken executes and returns normally, and
+its save is refused instead of landing on the stored run.
+"""
+
+import asyncio
+import time
+from typing import Any, AsyncIterator, Iterator, Optional
+
+import pytest
+
+from agno.db.in_memory import InMemoryDb
+from agno.db.sqlite import SqliteDb
+from agno.models.base import Model
+from agno.models.message import MessageMetrics
+from agno.models.response import ModelResponse
+from agno.run.agent import RunOutput
+from agno.run.base import RunStatus
+from agno.run.team import TeamRunOutput
+from agno.team._storage import _upsert_run
+from agno.team.team import Team
+
+
+class MockModel(Model):
+    """Minimal offline model: returns a canned text response without any network call."""
+
+    def __init__(self, content: str = "ok"):
+        super().__init__(id="test-model", name="test-model", provider="test")
+        self.instructions = None
+        self._mock_response = ModelResponse(content=content, role="assistant", response_usage=MessageMetrics())
+
+    def get_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    def get_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    def parse_args(self, *args, **kwargs):
+        return {}
+
+    def invoke(self, *args, **kwargs) -> ModelResponse:
+        return self._mock_response
+
+    async def ainvoke(self, *args, **kwargs) -> ModelResponse:
+        return self._mock_response
+
+    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+        yield self._mock_response
+
+    async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+        yield self._mock_response
+        return
+
+    def _parse_provider_response(self, response: Any, **kwargs) -> ModelResponse:
+        return self._mock_response
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return self._mock_response
+
+
+def _make_team(db: Any, response: str = "ok", **kwargs) -> Team:
+    """A team whose model answers ``response``, so a landed write is recognisable."""
+    return Team(
+        name="test-team",
+        id="test-team",
+        members=[],
+        model=MockModel(response),
+        db=db,
+        telemetry=False,
+        **kwargs,
+    )
+
+
+def _stored(db: Any, run_id: str) -> Optional[dict]:
+    row = db.get_run(run_id, deserialize=False)
+    if row is None:
+        return None
+    return row.get("run_data") or row
+
+
+def _owner(db: Any, run_id: str) -> Optional[str]:
+    """The user the stored run belongs to, whichever row shape came back."""
+    row = db.get_run(run_id, deserialize=False) or {}
+    return row.get("user_id") or (row.get("run_data") or {}).get("user_id")
+
+
+@pytest.fixture(params=["in_memory", "sqlite"])
+def db(request, tmp_path):
+    if request.param == "in_memory":
+        return InMemoryDb()
+    return SqliteDb(db_file=str(tmp_path / "runs.db"))
+
+
+class TestNormalRuns:
+    def test_a_generated_id_still_persists(self, db):
+        team = _make_team(db)
+
+        result = team.run("hi", session_id="s1")
+
+        assert _stored(db, result.run_id) is not None
+        assert _stored(db, result.run_id)["status"] == RunStatus.completed.value
+
+    def test_an_explicit_fresh_id_still_persists(self, db):
+        team = _make_team(db)
+
+        result = team.run("hi", session_id="s1", run_id="chosen")
+
+        assert result.run_id == "chosen"
+        assert _stored(db, "chosen")["status"] == RunStatus.completed.value
+
+    def test_two_turns_in_one_session_both_persist(self, db):
+        team = _make_team(db)
+
+        first = team.run("one", session_id="s1")
+        second = team.run("two", session_id="s1")
+
+        assert first.run_id != second.run_id
+        assert _stored(db, first.run_id) is not None
+        assert _stored(db, second.run_id) is not None
+
+    @pytest.mark.asyncio
+    async def test_async_runs_still_persist(self, db):
+        team = _make_team(db)
+
+        result = await team.arun("hi", session_id="s1")
+
+        assert _stored(db, result.run_id)["status"] == RunStatus.completed.value
+
+    @pytest.mark.asyncio
+    async def test_background_runs_still_reach_a_terminal_status(self, db):
+        team = _make_team(db)
+
+        result = await team.arun("hi", session_id="s1", background=True)
+        # Poll to a TERMINAL status: the run passes through RUNNING on its way,
+        # and breaking on the first non-initial status raced that transition
+        terminal = {RunStatus.completed.value, RunStatus.error.value, RunStatus.cancelled.value}
+        deadline = time.monotonic() + 10
+        while True:
+            row = _stored(db, result.run_id)
+            assert row is not None, "the background run stored no row"
+            if row["status"] in terminal:
+                break
+            assert time.monotonic() < deadline, f"background run stuck at {row['status']}"
+            await asyncio.sleep(0.01)
+
+        assert row["status"] == RunStatus.completed.value
+        assert row["content"] == "ok"
+
+    def test_a_streaming_run_still_persists(self, db):
+        team = _make_team(db)
+
+        events = list(team.run("hi", session_id="s1", run_id="streamed", stream=True))
+
+        assert events
+        assert _stored(db, "streamed")["status"] == RunStatus.completed.value
+        assert _stored(db, "streamed")["content"] == "ok"
+
+    @pytest.mark.asyncio
+    async def test_an_async_streaming_run_still_persists(self, db):
+        team = _make_team(db)
+
+        events = [event async for event in team.arun("hi", session_id="s1", run_id="streamed", stream=True)]
+
+        assert events
+        assert _stored(db, "streamed")["status"] == RunStatus.completed.value
+
+
+class TestConflictingIds:
+    """A run whose id is taken runs to completion; only its save is refused.
+
+    Each refusal asserts the STORED run: its content is still the victim's,
+    and every case that names a user asserts its owner is unchanged. That is
+    the property worth having -- whether the intruding run itself succeeded is
+    the caller's business, but the stored run belongs to somebody else. The
+    last case here is the deliberate exception, where the scope the write
+    presents is the stored row's own and the write lands.
+    """
+
+    def test_the_run_completes_even_though_its_save_is_refused(self, db):
+        _make_team(db).run("victim turn", session_id="victim", user_id="victim-user", run_id="taken")
+
+        result = _make_team(db, response="attacker").run(
+            "attacker turn", session_id="attacker", user_id="attacker-user", run_id="taken"
+        )
+
+        assert result.status == RunStatus.completed
+        assert result.content == "attacker"
+        assert _stored(db, "taken")["content"] == "ok"
+        assert _owner(db, "taken") == "victim-user"
+
+    def test_another_user_in_the_same_session_cannot_overwrite_the_stored_run(self, db):
+        _make_team(db).run("victim turn", session_id="s1", user_id="victim-user", run_id="taken")
+        original = _stored(db, "taken")
+
+        _make_team(db, response="attacker").run(
+            "attacker turn", session_id="s1", user_id="attacker-user", run_id="taken"
+        )
+
+        assert _stored(db, "taken") == original
+        assert _stored(db, "taken")["content"] == "ok"
+        assert _owner(db, "taken") == "victim-user"
+
+    def test_another_session_cannot_overwrite_the_stored_run(self, db):
+        _make_team(db).run("victim turn", session_id="victim", user_id="u1", run_id="taken")
+        original = _stored(db, "taken")
+
+        _make_team(db, response="attacker").run("attacker turn", session_id="attacker", user_id="u1", run_id="taken")
+
+        assert _stored(db, "taken") == original
+        assert _stored(db, "taken")["content"] == "ok"
+        assert _owner(db, "taken") == "u1"
+
+    def test_another_session_cannot_claim_an_anonymous_stored_run(self, db):
+        """The session refuses this write; naming a user would not have.
+
+        An unowned row is adopted by the first write that knows a user, so in
+        the stored row's own session this caller would land and the row would
+        become theirs. Here the sessions differ, which is the fact the refusal
+        rests on, and being unowned does not soften it: an anonymous row is no
+        more reachable from another session than an owned one.
+        """
+        _make_team(db).run("victim turn", session_id="victim", run_id="taken")
+        original = _stored(db, "taken")
+
+        _make_team(db, response="attacker").run(
+            "attacker turn", session_id="attacker", user_id="attacker-user", run_id="taken"
+        )
+
+        assert _stored(db, "taken") == original
+        assert _stored(db, "taken")["content"] == "ok"
+        assert _owner(db, "taken") is None
+
+    def test_two_identity_less_callers_cannot_overwrite_each_other(self, db):
+        _make_team(db).run("first", session_id="s1", run_id="taken")
+        original = _stored(db, "taken")
+
+        _make_team(db, response="attacker").run("second", session_id="s2", run_id="taken")
+
+        assert _stored(db, "taken") == original
+        assert _stored(db, "taken")["content"] == "ok"
+
+    def test_the_runs_own_owner_and_session_still_reach_its_row(self, db):
+        """The deliberate limit of the scope, and why the boundary is where it is.
+
+        A save presenting the row's own session and owner is exactly what a
+        pause, a resume and a terminal write present, so it has to land. A
+        reused id inside one owner's own session is therefore indistinguishable
+        from that run saving again, and lands too.
+        """
+        team = _make_team(db)
+        team.run("first", session_id="s1", user_id="u1", run_id="taken")
+
+        _make_team(db, response="second").run("second", session_id="s1", user_id="u1", run_id="taken")
+
+        assert _stored(db, "taken")["content"] == "second"
+        assert _owner(db, "taken") == "u1"
+
+
+class TestComponentIdentity:
+    """A team and an agent never share a run row, even inside one session.
+
+    The component ids are part of the scope, so neither one's save can reach
+    a row the other created. Both directions go through the team's own save
+    helper, which is the path every lifecycle write takes.
+    """
+
+    def test_a_team_run_cannot_overwrite_an_agents_row(self, db):
+        team = _make_team(db)
+        team.run("seed", session_id="s1")
+        agent_run = RunOutput(run_id="shared", session_id="s1", agent_id="member-agent", content="agent output")
+        _upsert_run(team, run=agent_run, session_id="s1", run_index=1)
+
+        team_run = TeamRunOutput(run_id="shared", session_id="s1", team_id=team.id, content="team output")
+        _upsert_run(team, run=team_run, session_id="s1")
+
+        assert _stored(db, "shared")["content"] == "agent output"
+
+    def test_an_agent_run_cannot_overwrite_a_teams_row(self, db):
+        team = _make_team(db)
+        parent = team.run("hi", session_id="s1")
+
+        agent_run = RunOutput(
+            run_id=parent.run_id,
+            session_id="s1",
+            agent_id="member-agent",
+            parent_run_id=parent.run_id,
+            content="agent output",
+        )
+        _upsert_run(team, run=agent_run, session_id="s1")
+
+        assert _stored(db, parent.run_id)["content"] == "ok"
+
+
+class TestLifecycleAfterTheFirstSave:
+    """Transitions written after the run's own row exists go through the
+    scoped update, which is what the HITL, resume, background and terminal
+    paths all reach."""
+
+    def _stored_run(self, db: Any, session_id: str = "s1", user_id: Optional[str] = None) -> tuple:
+        team = _make_team(db)
+        # A real turn first, so the run rows have the session row they attach to
+        team.run("seed", session_id=session_id, user_id=user_id)
+        run = TeamRunOutput(
+            run_id="r1",
+            session_id=session_id,
+            team_id=team.id,
+            user_id=user_id,
+            status=RunStatus.running,
+        )
+        _upsert_run(team, run=run, session_id=session_id, user_id=user_id, run_index=1)
+        return team, run
+
+    def test_pause_then_resume_then_completion_all_land(self, db):
+        team, run = self._stored_run(db, user_id="u1")
+
+        run.status = RunStatus.paused
+        _upsert_run(team, run=run, session_id="s1", user_id="u1")
+        assert _stored(db, "r1")["status"] == RunStatus.paused.value
+
+        run.status = RunStatus.running
+        _upsert_run(team, run=run, session_id="s1", user_id="u1")
+        assert _stored(db, "r1")["status"] == RunStatus.running.value
+
+        run.status = RunStatus.completed
+        run.content = "done"
+        _upsert_run(team, run=run, session_id="s1", user_id="u1")
+        assert _stored(db, "r1")["status"] == RunStatus.completed.value
+        assert _stored(db, "r1")["content"] == "done"
+
+    def test_a_resume_by_another_user_is_refused(self, db):
+        team, run = self._stored_run(db, user_id="u1")
+        run.status = RunStatus.paused
+        _upsert_run(team, run=run, session_id="s1", user_id="u1")
+        paused = _stored(db, "r1")
+
+        run.content = "attacker"
+        run.status = RunStatus.completed
+        _upsert_run(team, run=run, session_id="s1", user_id="attacker")
+
+        assert _stored(db, "r1") == paused
+
+    def test_a_resume_from_another_session_is_refused(self, db):
+        team, run = self._stored_run(db, user_id="u1")
+        run.status = RunStatus.paused
+        _upsert_run(team, run=run, session_id="s1", user_id="u1")
+        paused = _stored(db, "r1")
+
+        run.content = "attacker"
+        run.status = RunStatus.completed
+        _upsert_run(team, run=run, session_id="attacker-session", user_id="u1")
+
+        assert _stored(db, "r1") == paused
+
+    def test_a_save_for_a_run_that_was_never_stored_still_creates_it(self, db):
+        """A forked run, and every other path whose first write is its only one."""
+        team = _make_team(db)
+        team.run("seed", session_id="s1")
+        run = TeamRunOutput(run_id="unstored", session_id="s1", team_id=team.id, content="forked")
+
+        _upsert_run(team, run=run, session_id="s1", run_index=1)
+
+        assert _stored(db, "unstored")["content"] == "forked"
+
+    @pytest.mark.asyncio
+    async def test_the_async_save_refuses_another_owner_too(self, db):
+        from agno.team._storage import _aupsert_run
+
+        team = _make_team(db)
+        await team.arun("seed", session_id="s1", user_id="u1")
+        run = TeamRunOutput(run_id="r1", session_id="s1", team_id=team.id, user_id="u1", content="original")
+        await _aupsert_run(team, run=run, session_id="s1", user_id="u1", run_index=1)
+
+        attacker = TeamRunOutput(run_id="r1", session_id="s1", team_id=team.id, user_id="u2", content="attacker")
+        await _aupsert_run(team, run=attacker, session_id="s1", user_id="u2")
+
+        assert _stored(db, "r1")["content"] == "original"
+        assert _owner(db, "r1") == "u1"
+
+
+class TestIdentityIsResolvedConsistently:
+    """The saves that make up one run do not always agree on the user.
+
+    The first save uses the run's resolved user, the terminal save uses the
+    session's, and the AgentOS continue route takes it as an optional form
+    field. A run must not lose its output because two of those disagree.
+    """
+
+    def test_a_run_issued_without_a_user_on_an_owned_session_still_persists(self, db):
+        team = _make_team(db)
+        team.run("first", session_id="s1", user_id="u1")
+
+        result = team.run("second", session_id="s1")
+
+        assert _stored(db, result.run_id)["status"] == RunStatus.completed.value
+        assert _stored(db, result.run_id)["content"] == "ok"
+
+    def test_a_run_issued_with_a_user_on_an_unowned_session_still_persists(self, db):
+        team = _make_team(db)
+        team.run("first", session_id="s1")
+
+        result = team.run("second", session_id="s1", user_id="u1")
+
+        assert _stored(db, result.run_id)["content"] == "ok"
+
+
+class TestMemberRunsAndUnportedAdapters:
+    def test_a_member_run_is_stored_beside_its_parents_run(self, db):
+        """A member's row is written by the parent that owns the turn."""
+        team = _make_team(db)
+        parent = team.run("hi", session_id="s1")
+        member = RunOutput(
+            run_id="member",
+            session_id="s1",
+            agent_id="member-agent",
+            parent_run_id=parent.run_id,
+            content="member output",
+        )
+
+        _upsert_run(team, run=member, session_id="s1", run_index=1)
+
+        assert _stored(db, "member")["content"] == "member output"
+        assert _stored(db, parent.run_id)["content"] == "ok"
+
+    def test_a_workflow_leg_still_stores_its_own_run(self, db):
+        team = _make_team(db)
+        team.run("seed", session_id="s1")
+        team.workflow_id = "some-workflow"
+        leg = TeamRunOutput(
+            run_id="leg",
+            session_id="s1",
+            team_id=team.id,
+            parent_run_id="workflow-run",
+            workflow_step_id="step-1",
+            content="leg output",
+        )
+
+        _upsert_run(team, run=leg, session_id="s1", run_index=1)
+
+        assert _stored(db, "leg")["content"] == "leg output"
+
+    def test_an_adapter_without_the_scoped_pair_keeps_saving(self, db):
+        """The shipped adapters that report UNSUPPORTED still take the legacy save."""
+
+        class UnportedDb:
+            supports_atomic_run_creation = False
+
+            def __init__(self):
+                self.saved: list = []
+
+            def upsert_run(self, run, session_id, user_id=None, run_index=None):
+                self.saved.append((run.run_id, session_id))
+
+            def __getattr__(self, name):
+                raise AttributeError(name)
+
+        unported = UnportedDb()
+        team = _make_team(db)
+        team.db = unported  # type: ignore[assignment]
+        run = TeamRunOutput(run_id="r1", session_id="s1", team_id=team.id)
+
+        _upsert_run(team, run=run, session_id="s1")
+        _upsert_run(team, run=run, session_id="s1")
+
+        assert unported.saved == [("r1", "s1"), ("r1", "s1")]
+
+
+class TestAttribution:
+    """A run stays findable by the user it belongs to.
+
+    A run's saves resolve identity from different places, so the owner column
+    has to survive all of them.
+    """
+
+    def test_a_run_keeps_the_owner_its_session_has(self, db):
+        team = _make_team(db)
+        team.run("first", session_id="s1", user_id="alice")
+
+        second = team.run("second", session_id="s1")
+
+        # Asserted on the stored row: the in-memory adapter's get_runs filters
+        # by the SESSION's user, so it would pass either way
+        assert _owner(db, second.run_id) == "alice"
+
+    def test_an_explicit_user_is_recorded(self, db):
+        team = _make_team(db)
+
+        result = team.run("hi", session_id="s1", user_id="alice")
+
+        assert _owner(db, result.run_id) == "alice"


### PR DESCRIPTION
## Summary

**On the overlap with #9886:** that PR and this one are complementary, not competing. #9886 probes the three REST create routers and answers 409 when the id is taken, and its own description notes the probe cannot close the race between two concurrent creations of the same fresh id, naming a strict insert at the storage layer as the follow-up. This is that follow-up. It also covers callers that never touch those routers, since the check lives in storage rather than in the routes. The two compose: keep #9886 for the early 409, and this for the guarantee underneath. Happy to rebase on top of #9886 if you would rather land them in order.

Issue: #9884

Saving a run used one statement that means both create and overwrite:

```sql
INSERT INTO agno_runs (...) VALUES (...)
ON CONFLICT (run_id) DO UPDATE SET ...
```

The `run_id` comes from the caller, and that statement cannot tell "this run is saving itself again" from "this id already belongs to someone else". So a request carrying an id that was already stored replaced the existing run, even one in another session or another user's, and its owner was never told. Checking first with `get_run` does not help: two requests racing on the same fresh id both see nothing and both write.

The two intents are now separate.

**Creating a run refuses a taken id.** `create_run` inserts with `ON CONFLICT DO NOTHING` and reports back whether it created the row or found one. The database picks the winner, so concurrent creations of one id produce exactly one.

**Every later write names its owner.** `update_run` only touches a row whose session, user and component match the write. The rule lives in one place, `resolve_run_scope`, and is stated once in Python and once in SQL:

- The session must match exactly.
- A row that names a component belongs to that component alone, so a team's write never lands on an agent's row. A row that names none is adopted by the first write that knows one, because such rows are real: a cancellation rebuilds a run from just its id, and a v3 migration brings rows across without one.
- The user works the same way.

Facts the writer does not know constrain nothing, since the save path is reached from places that know different amounts.

Updates write content, never identity, so a save cannot move a row somewhere its owner will not look for it.

**Adapters advertise the guarantee.** `supports_atomic_run_creation` is `False` by default and `True` on in-memory, SQLite and PostgreSQL, sync and async, so callers can check for the behaviour instead of checking a version. Adapters without it keep the old path unchanged.

One gap on purpose: an id held only inside a pre-v3 session's inline `runs` blob is not seen. Migrating the session fixes that.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: n/a, no user-facing API change
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

A caller that reuses a stored `run_id` across a session, user or component boundary now gets its save refused and logged, where before it overwrote. Inside a run's own scope nothing changes, which is what keeps pause, resume and terminal writes working.
