### PR TITLE
[fix] Re-raise get_session read failures in the async Postgres and MySQL adapters

### DIFF
--- a/libs/agno/agno/db/mysql/async_mysql.py
+++ b/libs/agno/agno/db/mysql/async_mysql.py
@@ -1026,7 +1026,7 @@ class AsyncMySQLDb(AsyncBaseDb):
 
         except Exception as e:
             log_error(f"Exception reading from session table: {str(e)}")
-            return None
+            raise e
 
     async def get_sessions(
         self,

--- a/libs/agno/agno/db/mysql/mysql.py
+++ b/libs/agno/agno/db/mysql/mysql.py
@@ -1020,7 +1020,7 @@ class MySQLDb(BaseDb):
 
         except Exception as e:
             log_error(f"Exception reading from session table: {str(e)}")
-            return None
+            raise e
 
     def get_sessions(
         self,

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -1383,7 +1383,7 @@ class AsyncPostgresDb(AsyncBaseDb):
 
         except Exception as e:
             log_error(f"Exception reading from session table: {str(e)}")
-            return None
+            raise e
 
     async def get_sessions(
         self,

--- a/libs/agno/tests/unit/db/test_db_get_session_propagates_errors.py
+++ b/libs/agno/tests/unit/db/test_db_get_session_propagates_errors.py
@@ -1,0 +1,66 @@
+"""``get_session`` on the SQL adapters must re-raise a read failure.
+
+The agent, team and workflow read helpers let read errors propagate (see
+``test_read_session_propagates_errors.py``), because ``None`` is taken to mean
+"row does not exist" and the caller then creates a fresh session that overwrites
+the real row on the next write. That only works when the adapter underneath
+re-raises too. The sync Postgres and SQLite adapters do; the async Postgres and
+both MySQL adapters returned ``None`` from the same except block.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytest.importorskip("psycopg")
+pytest.importorskip("pymysql")
+pytest.importorskip("asyncmy")
+
+from agno.db.mysql.async_mysql import AsyncMySQLDb  # noqa: E402
+from agno.db.mysql.mysql import MySQLDb  # noqa: E402
+from agno.db.postgres.async_postgres import AsyncPostgresDb  # noqa: E402
+from agno.db.postgres.postgres import PostgresDb  # noqa: E402
+
+
+class _SimulatedFailover(Exception):
+    """Distinctive error to prove the exception surfaced unchanged."""
+
+
+def _bare(cls):
+    """An adapter without a database: only what get_session touches before the table lookup."""
+    db = object.__new__(cls)
+    db.db_schema = "ai"
+    db.session_table_name = "agno_sessions"
+    return db
+
+
+@pytest.mark.parametrize("cls", [PostgresDb, MySQLDb])
+def test_sync_get_session_reraises_a_read_failure(cls):
+    db = _bare(cls)
+    with patch.object(db, "_get_table", side_effect=_SimulatedFailover("simulated failover")):
+        with pytest.raises(_SimulatedFailover, match="simulated failover"):
+            db.get_session(session_id="s1")
+
+
+@pytest.mark.parametrize("cls", [PostgresDb, MySQLDb])
+def test_sync_get_session_returns_none_when_there_is_nothing_to_read(cls):
+    db = _bare(cls)
+    with patch.object(db, "_get_table", return_value=None):
+        assert db.get_session(session_id="s1") is None
+
+
+@pytest.mark.parametrize("cls", [AsyncPostgresDb, AsyncMySQLDb])
+async def test_async_get_session_reraises_a_read_failure(cls):
+    db = _bare(cls)
+    with patch.object(db, "_get_table", AsyncMock(side_effect=_SimulatedFailover("simulated failover"))):
+        with pytest.raises(_SimulatedFailover, match="simulated failover"):
+            await db.get_session(session_id="s1")
+
+
+@pytest.mark.parametrize("cls", [AsyncPostgresDb, AsyncMySQLDb])
+async def test_async_get_session_returns_none_when_there_is_nothing_to_read(cls):
+    db = _bare(cls)
+    with patch.object(db, "_get_table", AsyncMock(return_value=None)):
+        assert await db.get_session(session_id="s1") is None


### PR DESCRIPTION
Fixes #7879

## Summary

Since 3.0.5 the agent, team and workflow read helpers let a session read failure propagate (`agent/_storage.py`: "Do NOT coerce failures to None here"), and the sync Postgres and both SQLite adapters re-raise in `get_session`. Three adapters were left on the old shape and still returned `None` from the same `except Exception` block: `AsyncPostgresDb`, `MySQLDb` and `AsyncMySQLDb`. For them the helper change is dead code: the caller sees `None`, treats it as "row does not exist", creates a fresh session with the same id and overwrites the real row on the next write.

This PR changes `return None` to `raise e` in those three `get_session` methods, mirroring the sync Postgres adapter line for line. The log line stays. `None` is still returned when there is nothing to read (no table).

One concrete way this bit: on 2.8.5 two concurrent first reads on a fresh `AsyncPostgresDb` raced the table reflection, the second read hit `table.c.session_id` on a column-less Table, and the only trace was `Exception reading from session table: session_id` (details and repro in #7879). 3.0.x fixed that race, but the next failure of this kind would have been just as silent.

`get_sessions` in the same adapters still returns `[]` on failure. Left out on purpose: a wrong empty list does not trigger an overwrite. Happy to follow up if you want it aligned too.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

`tests/unit/db/test_db_get_session_propagates_errors.py` builds each adapter without a database and injects the failure at `_get_table`: `PostgresDb`, `MySQLDb`, `AsyncPostgresDb` and `AsyncMySQLDb` must re-raise it, and must still return `None` when there is no table. The three non-Postgres-sync raise cases fail on main; the `PostgresDb` case passes on main and is the control. #7951 attempted the helper layer in May and was closed by its author; the helper layer has since been fixed upstream, this covers the adapters underneath it.
