### PR TITLE
refactor(authz): explicit directory, lockout heal, one deprecated config spelling

### DIFF
--- a/cookbook/05_agent_os/26_authorization/02_managed_users.py
+++ b/cookbook/05_agent_os/26_authorization/02_managed_users.py
@@ -55,8 +55,8 @@ authz = Authorization(
     verify_audience=True,
     audience=OS_ID,
     # auto_provision: a user we have never seen is created from their token claims on their first
-    # authenticated request and granted the default role, so they land usable, not inert. To pin
-    # the default in code instead of flagging a role, pass default_role="viewer".
+    # authenticated request and granted the default role (the one flagged default=True below), so
+    # they land usable, not inert.
     auto_provision=True,
 )
 # Roles: what each role can do. default=True flags "viewer" as the role an auto-provisioned user

--- a/cookbook/05_agent_os/26_authorization/README.md
+++ b/cookbook/05_agent_os/26_authorization/README.md
@@ -24,7 +24,7 @@ it runs offline against a simulated issuer.
 | File | Lesson |
 |---|---|
 | `00_quickstart_authorization.py` | Start here. The whole setup in one `Authorization` object: verification, roles, users, audit, and the admin API, borrowing the OS db |
-| `01_managed_roles.py` | The same model built from the primitives (`ManagedRoleStore` + `AuthorizationConfig`), for when you want full control |
+| `01_managed_roles.py` | Roles only: define what each role may do and hand people roles through `authz.role_store`, no directory |
 | `02_managed_users.py` | The credential-less user directory and the disabled-user kill switch that outlives a valid token |
 | `03_directory_without_auth.py` | `AgentOS(db=db, user_isolation=True, user_directory=True)` with NO auth: a roster + per-user isolation that key off the run's user_id (advisory without auth) |
 | `04_managed_roles_sessions.py` | Roles protecting real data: who may delete a chat session |
@@ -75,7 +75,7 @@ both claims that establish that, especially when more than one issuer can mint
 tokens your keys verify:
 
 ```python
-AuthorizationConfig(
+Authorization(
     verification_keys=[PUBLIC_KEY],
     verify_audience=True,
     audience=OS_ID,                          # this AgentOS, not another one

--- a/libs/agno/agno/db/authz_store.py
+++ b/libs/agno/agno/db/authz_store.py
@@ -141,6 +141,12 @@ def get_direct_roles(engine: Engine, table: Any, subject: str) -> List[str]:
         return [r[0] for r in conn.execute(select(table.c.role).where(table.c.subject == subject))]
 
 
+def get_role_subjects(engine: Engine, table: Any, role: str) -> List[str]:
+    """Names directly assigned ``role`` (served by the index on ``role``)."""
+    with engine.connect() as conn:
+        return [r[0] for r in conn.execute(select(table.c.subject).where(table.c.role == role))]
+
+
 def name_is_role(engine: Engine, policy_table: Any, grouping_table: Any, name: str) -> bool:
     """True if ``name`` is used as a ROLE: it carries policy, or something is assigned to it.
 
@@ -511,6 +517,12 @@ async def adelete_policy(
 async def aget_direct_roles(engine: "AsyncEngine", table: Any, subject: str) -> List[str]:
     async with engine.connect() as conn:
         rows = await conn.execute(select(table.c.role).where(table.c.subject == subject))
+        return [r[0] for r in rows]
+
+
+async def aget_role_subjects(engine: "AsyncEngine", table: Any, role: str) -> List[str]:
+    async with engine.connect() as conn:
+        rows = await conn.execute(select(table.c.subject).where(table.c.role == role))
         return [r[0] for r in rows]
 
 

--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -2088,6 +2088,10 @@ class BaseDb(ABC):
         """Roles directly assigned to ``subject``."""
         raise NotImplementedError
 
+    def list_authz_role_subjects(self, role: str) -> List[str]:
+        """Names directly assigned ``role`` (subjects, plus roles when nesting)."""
+        raise NotImplementedError
+
     def authz_name_is_role(self, name: str) -> bool:
         """True if ``name`` is used as a ROLE: it carries policy, or something is assigned
         to it. Used by the collision guard, so it runs on every subject decision."""
@@ -3591,6 +3595,10 @@ class AsyncBaseDb(ABC):
 
     async def get_authz_direct_roles(self, subject: str) -> List[str]:
         """Roles directly assigned to ``subject``."""
+        raise NotImplementedError
+
+    async def list_authz_role_subjects(self, role: str) -> List[str]:
+        """Names directly assigned ``role`` (subjects, plus roles when nesting)."""
         raise NotImplementedError
 
     async def authz_name_is_role(self, name: str) -> bool:

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -9,15 +9,6 @@ if TYPE_CHECKING:
 
 from agno.db import authz_store
 from agno.db.base import AsyncBaseDb, SessionType
-from agno.db.schemas.authz import (
-    AUTHZ_AUDIT,
-    AUTHZ_DECISIONS,
-    AUTHZ_GROUPING,
-    AUTHZ_POLICY,
-    AUTHZ_ROLES,
-    AUTHZ_TABLE_NAME_ATTRS,
-    AUTHZ_USERS,
-)
 from agno.db.migrations.manager import MigrationManager
 from agno.db.postgres.engine import _engine_options
 from agno.db.postgres.schemas import get_table_schema_definition
@@ -30,6 +21,15 @@ from agno.db.postgres.utils import (
     calculate_date_metrics,
     fetch_all_sessions_data,
     get_dates_to_calculate_metrics_for,
+)
+from agno.db.schemas.authz import (
+    AUTHZ_AUDIT,
+    AUTHZ_DECISIONS,
+    AUTHZ_GROUPING,
+    AUTHZ_POLICY,
+    AUTHZ_ROLES,
+    AUTHZ_TABLE_NAME_ATTRS,
+    AUTHZ_USERS,
 )
 from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
@@ -5749,6 +5749,10 @@ class AsyncPostgresDb(AsyncBaseDb):
     async def get_authz_direct_roles(self, subject: str) -> List[str]:
         table = await self._get_table(table_type=AUTHZ_GROUPING, create_table_if_not_found=True)
         return await authz_store.aget_direct_roles(self.db_engine, table, subject)
+
+    async def list_authz_role_subjects(self, role: str) -> List[str]:
+        table = await self._get_table(table_type=AUTHZ_GROUPING, create_table_if_not_found=True)
+        return await authz_store.aget_role_subjects(self.db_engine, table, role)
 
     async def authz_name_is_role(self, name: str) -> bool:
         policy = await self._get_table(table_type=AUTHZ_POLICY, create_table_if_not_found=True)

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -8472,6 +8472,10 @@ class PostgresDb(BaseDb):
         table = self._get_table(table_type=AUTHZ_GROUPING, create_table_if_not_found=True)
         return authz_store.get_direct_roles(self.db_engine, table, subject)
 
+    def list_authz_role_subjects(self, role: str) -> List[str]:
+        table = self._get_table(table_type=AUTHZ_GROUPING, create_table_if_not_found=True)
+        return authz_store.get_role_subjects(self.db_engine, table, role)
+
     def authz_name_is_role(self, name: str) -> bool:
         policy = self._get_table(table_type=AUTHZ_POLICY, create_table_if_not_found=True)
         grouping = self._get_table(table_type=AUTHZ_GROUPING, create_table_if_not_found=True)

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -5125,6 +5125,10 @@ class AsyncSqliteDb(AsyncBaseDb):
         table = await self._get_table(table_type=AUTHZ_GROUPING, create_table_if_not_found=True)
         return await authz_store.aget_direct_roles(self.db_engine, table, subject)
 
+    async def list_authz_role_subjects(self, role: str) -> List[str]:
+        table = await self._get_table(table_type=AUTHZ_GROUPING, create_table_if_not_found=True)
+        return await authz_store.aget_role_subjects(self.db_engine, table, role)
+
     async def authz_name_is_role(self, name: str) -> bool:
         policy = await self._get_table(table_type=AUTHZ_POLICY, create_table_if_not_found=True)
         grouping = await self._get_table(table_type=AUTHZ_GROUPING, create_table_if_not_found=True)

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -7590,6 +7590,10 @@ class SqliteDb(BaseDb):
         table = self._get_table(table_type=AUTHZ_GROUPING, create_table_if_not_found=True)
         return authz_store.get_direct_roles(self.db_engine, table, subject)
 
+    def list_authz_role_subjects(self, role: str) -> List[str]:
+        table = self._get_table(table_type=AUTHZ_GROUPING, create_table_if_not_found=True)
+        return authz_store.get_role_subjects(self.db_engine, table, role)
+
     def authz_name_is_role(self, name: str) -> bool:
         policy = self._get_table(table_type=AUTHZ_POLICY, create_table_if_not_found=True)
         grouping = self._get_table(table_type=AUTHZ_GROUPING, create_table_if_not_found=True)

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -294,7 +294,7 @@ class AgentOS:
         knowledge: Optional[List[Knowledge]] = None,
         interfaces: Optional[List[BaseInterface]] = None,
         a2a_interface: bool = False,
-        authorization: Union[bool, "Authorization", AuthorizationConfig] = False,
+        authorization: Union[bool, "Authorization"] = False,
         authorization_config: Optional[AuthorizationConfig] = None,
         user_isolation: bool = False,
         user_directory: Optional[Union[bool, UserDirectoryConfig]] = None,
@@ -367,11 +367,11 @@ class AgentOS:
             auto_provision_dbs: Whether to automatically provision databases
             authorization: The authorization setup. Prefer ``Authorization(...)`` -- one object for
                 verification, roles, the user directory, audit, and the admin API (see
-                ``agno.os.authz.Authorization``). Also accepts ``True`` (scope RBAC from token
-                scopes) or a raw ``AuthorizationConfig``.
-            authorization_config: Deprecated -- pass the config as ``authorization=...`` instead (or
-                move to ``authorization=Authorization(...)``). An ``AuthorizationConfig`` for the
-                authorization middleware; kept for back-compat during migration.
+                ``agno.os.authz.Authorization``). ``True`` keeps today's scope RBAC from token
+                scopes, verifying with ``authorization_config`` or the JWT_* environment variables.
+            authorization_config: Deprecated. Move its fields onto ``Authorization(...)`` and pass
+                that as ``authorization=``. Still honoured with ``authorization=True`` so existing
+                deployments keep booting; logs a warning once at construction.
             user_isolation: Opt in to per-user data isolation (each caller sees only their own
                 sessions/memories). Enforced under authorization=True; advisory without auth.
             user_directory: A credential-less user directory (roster + disabled kill switch).
@@ -484,16 +484,20 @@ class AgentOS:
         self._facade_role_store: Any = None
         self._facade_user_store: Any = None
 
-        # A raw AuthorizationConfig may be passed straight to authorization=, folding the two entry
-        # params into one (the separate authorization_config= is the older, now-discouraged spelling).
+        # authorization= takes the switch or the object, never the low-level config: one spelling
+        # for the deprecated type is enough, and it is the keyword that already exists.
         if isinstance(authorization, AuthorizationConfig):
-            if authorization_config is not None:
-                raise ValueError(
-                    "Pass the AuthorizationConfig once: authorization=AuthorizationConfig(...) "
-                    "(or, preferably, authorization=Authorization(...)), not also authorization_config=."
-                )
-            authorization_config = authorization
-            authorization = True
+            raise TypeError(
+                "AgentOS(authorization=) takes True/False or an Authorization object. Pass an "
+                "AuthorizationConfig as authorization_config= (deprecated), or move its fields onto "
+                "Authorization(...) and pass that as authorization=."
+            )
+        if authorization_config is not None:
+            log_warning(
+                "AgentOS(authorization_config=...) is deprecated: move its fields onto "
+                "Authorization(...) from agno.os.authz and pass it as AgentOS(authorization=...). "
+                "The config still works with authorization=True for now."
+            )
 
         from agno.os.authz.facade import Authorization as _Authorization
 
@@ -1561,7 +1565,6 @@ class AgentOS:
             )
             routers.append(get_approval_router(os_db=self.db, settings=self.settings))
             routers.append(get_service_accounts_router(os_db=self.db, settings=self.settings))
-            routers.extend(self._facade_admin_routers())
         else:
             log_debug(
                 "Components, Scheduler, Approval, and Service Account routers not enabled: "
@@ -1582,30 +1585,12 @@ class AgentOS:
             log_debug("Registry router not enabled: requires a registry to be provided to AgentOS")
             routers.append(_get_disabled_feature_router("/registry", "Registry", "registry"))
 
-        # Managed-roles admin API (/authz). Registered HERE, with the other built-in
-        # routers, so it lands ahead of the MCP catch-all mount added just below. A
-        # router included after get_app() returns sits behind that mount and 404s --
-        # which is what the previously documented "app.include_router(get_roles_router(...))"
-        # step did on any OS with mcp_server=True. Configuring a role store is already
-        # the deliberate opt-in (and, per the check in _add_auth_middleware, it cannot
-        # be set without authorization=True), so no extra flag gates this.
-        authz_config = self.authorization_config
-        role_store = getattr(authz_config, "role_store", None) if authz_config is not None else None
-        directory_store = self.user_directory.user_store if self.user_directory is not None else None
-        if role_store is not None:
-            from agno.os.authz.role_router import get_roles_router
-
-            routers.append(get_roles_router(role_store))
-            if directory_store is not None:
-                from agno.os.authz.role_router import get_users_router
-
-                # The user DIRECTORY admin API (/users) is a peer of the /authz roles API,
-                # configured via AgentOS(user_directory=...). Auto-mounted here alongside
-                # the roles router ONLY in the role_store shortcut, mirroring it: with a
-                # composite/custom provider (or a directory on plain scope RBAC) the operator
-                # mounts both routers themselves (get_roles_router + get_users_router), so we
-                # do not auto-mount a second, role-store-less /users that would shadow theirs.
-                routers.append(get_users_router(directory_store, role_store=role_store))
+        # Managed-roles / directory admin API (/authz, /users), mounted from the Authorization
+        # object. Registered HERE, with the other built-in routers, so it lands ahead of the MCP
+        # catch-all mount added just below: a router included after get_app() returns sits behind
+        # that mount and 404s on any OS with mcp_server=True. Independent of the OS db, since the
+        # object may carry its own.
+        routers.extend(self._facade_admin_routers())
 
         for router in routers:
             self._add_router(fastapi_app, router)
@@ -1685,17 +1670,15 @@ class AgentOS:
         # author believes is governed by roles serves every route to anonymous callers.
         # Fail at construction rather than shipping a silently open instance.
         cfg = self.authorization_config
-        # A plane (role_store / custom provider) only takes effect through the auth middleware,
-        # so with authorization off it is a silently-open instance -- the author believes routes
-        # are governed by roles, but nothing consults the provider. That still raises. A user
-        # directory is different: it is a roster, valid without auth (the guard below only warns),
-        # because it is data, not an enforcement point.
-        authz_plane_configured = cfg is not None and (
-            getattr(cfg, "role_store", None) is not None or getattr(cfg, "authorization_provider", None) is not None
-        )
+        # A custom provider only takes effect through the auth middleware, so with authorization
+        # off it is a silently-open instance -- the author believes routes are governed by their
+        # provider, but nothing consults it. That still raises. A user directory is different: it
+        # is a roster, valid without auth (the guard below only warns), because it is data, not an
+        # enforcement point.
+        authz_plane_configured = cfg is not None and getattr(cfg, "authorization_provider", None) is not None
         if not self.authorization and authz_plane_configured:
             raise ValueError(
-                "AuthorizationConfig(role_store=.../authorization_provider=...) requires "
+                "AuthorizationConfig(authorization_provider=...) requires "
                 "AgentOS(authorization=True). Without enforcement the plane is never applied "
                 "(every route is served unauthenticated). Set authorization=True, or drop the "
                 "config if you intended an open instance."
@@ -2043,11 +2026,11 @@ class AgentOS:
         fastapi_app.add_middleware(AuthMiddleware, **middleware_kwargs)
 
     def _facade_admin_routers(self) -> List[Any]:
-        """The admin-API routers to mount when an Authorization facade configured the stores.
+        """The admin-API routers to mount from the Authorization object's stores.
 
-        Returns ``/authz`` (roles) when the facade uses roles and ``/users`` (directory) when it
-        has a directory, so the facade path needs no manual ``include_router``. Empty for the
-        non-facade path, which keeps mounting the admin API itself. The routers carry their own
+        Returns ``/authz`` (roles) when it uses roles and ``/users`` (directory) when it has a
+        directory, so there is never a manual ``include_router``. Empty when authorization is a
+        bare switch or provider (no stores, nothing to administer). The routers carry their own
         admin gate, so mounting them is always safe."""
         routers: List[Any] = []
         if self._facade_role_store is not None or self._facade_user_store is not None:
@@ -2063,18 +2046,10 @@ class AgentOS:
         """Seed ``app.state.authorization_provider`` (and ``authz_audit``) from the
         AuthorizationConfig, so the four choke points resolve the right enforcer.
 
-        Precedence, matching AuthorizationConfig's ``role_store`` XOR
-        ``authorization_provider`` validator:
-
-        - ``role_store`` set: adopt the OS db into the store (``attach_db``) so managed
-          roles persist alongside agent data, then use the store's provider. A managed
-          store MUST have a DB — an in-memory store can't stay consistent across the
-          replicas an AgentOS deployment runs — so if it ends up unbound (no store db
-          and no SQL-capable OS db to adopt) we fail fast rather than silently enforce
-          an empty policy.
-        - ``authorization_provider`` set: use it directly.
-        - neither: leave the state unset; the resolver defaults to
-          ScopeAuthorizationProvider (v2.7 behaviour).
+        - ``authorization_provider`` set (the Authorization object composes its own from the
+          role store and the scope plane; the primitive path passes one directly): use it.
+        - unset: leave the state unset; the resolver defaults to ScopeAuthorizationProvider
+          (v2.7 behaviour).
         """
         config = self.authorization_config
         # Decision trail: AgentOS(audit=...) is a single switch that also feeds the decision log
@@ -2088,25 +2063,10 @@ class AgentOS:
         if config is None:
             return
 
-        role_store = getattr(config, "role_store", None)
         provider = getattr(config, "authorization_provider", None)
 
         resolved_provider: Optional[AuthorizationProvider] = None
-        if role_store is not None:
-            # Adopt the OS db so a store created without one persists to it (no-op if the
-            # store already has its own db or the OS db isn't SQL-capable).
-            role_store.attach_db(self.db)
-            # Change trail: adopt the top-level audit sink if the store has none of its own.
-            role_store.attach_audit(self.audit)
-            if not role_store.is_bound:
-                raise ValueError(
-                    "AuthorizationConfig(role_store=...) needs a SQL database: managed roles must be "
-                    "persisted (an in-memory store can't stay consistent across replicas). Give the "
-                    "store a db (ManagedRoleStore(db_url=...) / db=...) or pass a SQL-capable db to "
-                    "AgentOS(db=...) for it to adopt."
-                )
-            resolved_provider = role_store.provider
-        elif provider is not None:
+        if provider is not None:
             # A list/tuple of providers means "run several authz planes at once"
             # (e.g. token scopes for operators + a managed role store for end users):
             # compose them with an OR — a request is allowed if any plane allows it.
@@ -2204,33 +2164,30 @@ class AgentOS:
         fastapi_app.state.user_directory_fail_closed = directory.fail_closed if directory is not None else False
         # The role store + explicit default role, for granting a role on first auto-provision
         # (the provisioning choke points read these to call provision_user_with_default_role).
-        authz = self.authorization_config
-        # The Authorization facade wires roles as a provider (not AuthorizationConfig.role_store),
-        # so take its store directly; fall back to the config's role_store for the primitive path.
-        # This is what the provisioning choke points read to grant a default role on first login,
-        # and the signal for whether managed roles / the /authz API are active.
-        fastapi_app.state.role_store = self._facade_role_store or (
-            getattr(authz, "role_store", None) if authz is not None else None
-        )
+        # The managed role store comes only from the Authorization object (it wires roles as a
+        # provider, and hands the store over for provisioning and the /authz API). This is what the
+        # provisioning choke points read to grant a default role on first login, and the signal for
+        # whether managed roles / the /authz API are active.
+        fastapi_app.state.role_store = self._facade_role_store
         fastapi_app.state.user_default_role = directory.default_role if directory is not None else None
         if fastapi_app.state.user_default_role and fastapi_app.state.role_store is None:
-            # A default role is granted through the store; with roles passed as
-            # authorization_provider= (e.g. a composite) the OS has only the engine, not the
-            # store, so the grant would silently never happen. Say so at boot rather than
-            # leave every new user mysteriously inert.
+            # A default role is granted through the store; with roles passed as a bare
+            # authorization_provider= the OS has only the engine, not the store, so the grant
+            # would silently never happen. Say so at boot rather than leave every new user
+            # mysteriously inert.
             log_warning(
-                "UserDirectoryConfig(default_role=...) is set but no role_store is configured. "
+                "UserDirectoryConfig(default_role=...) is set but no managed role store is configured. "
                 "Default roles are granted through the role store, so configure managed roles via "
-                "AuthorizationConfig(role_store=...) (not authorization_provider=) for it to apply."
+                "Authorization(...).define_role(...) for it to apply."
             )
-        elif fastapi_app.state.role_store is None:
+        elif fastapi_app.state.role_store is None and directory is not None:
             # A directory with no role store is valid (a pure roster), but say so once at boot: no
             # roles apply, provisioned users get none, and the /authz roles API is not mounted. This
             # is the signal a UI uses to hide role management for this deployment.
             log_info(
-                "AgentOS(user_directory=...) is configured without managed roles (no role_store). "
-                "The directory works as a roster; roles are not available and provisioned users get "
-                "none. Add AuthorizationConfig(role_store=...) to enable roles and the /authz API."
+                "The user directory is configured without managed roles. It works as a roster; roles "
+                "are not available and provisioned users get none. Define roles on Authorization(...) "
+                "to enable roles and the /authz API."
             )
 
     def get_routes(self) -> List[Any]:

--- a/libs/agno/agno/os/authz/__init__.py
+++ b/libs/agno/agno/os/authz/__init__.py
@@ -8,7 +8,7 @@ behaviour is unchanged.
 
 Customers who need a richer model (relationship-based / ReBAC, attribute-based,
 or an external engine such as OpenFGA, SpiceDB or Cerbos) implement the same
-interface and pass it via ``AuthorizationConfig(authorization_provider=...)``.
+interface and pass it via ``Authorization(authorization_provider=...)``.
 
 Managed roles (runtime-editable RBAC) are backed by agno's own
 :class:`NativePolicyEngine` behind the swappable :class:`PolicyEngine` port — no

--- a/libs/agno/agno/os/authz/_db.py
+++ b/libs/agno/agno/os/authz/_db.py
@@ -28,7 +28,7 @@ NO_DB_MESSAGE = (
     "ManagedRoleStore requires a SQL database — managed roles must be persisted, "
     "and an in-memory store cannot stay consistent across multiple workers/replicas. "
     "Pass db=/db_url= to the store, or hand it to AgentOS via "
-    "AuthorizationConfig(role_store=...) together with a SQL db on AgentOS so the "
+    "Authorization(role_store=...) together with a SQL db on AgentOS so the "
     "store adopts it."
 )
 

--- a/libs/agno/agno/os/authz/engine.py
+++ b/libs/agno/agno/os/authz/engine.py
@@ -85,6 +85,12 @@ class PolicyEngine(ABC):
     @abstractmethod
     def roles_of(self, subject: str) -> List[str]: ...
 
+    def subjects_of(self, role: str) -> List[str]:
+        """Names directly assigned ``role``. Optional: the bootstrap's admin-lockout check uses it
+        to ask whether anyone still holds an admin role, and skips that check on an engine that
+        cannot enumerate assignments."""
+        raise NotImplementedError("subjects_of")
+
     # --- decisions ---
     @abstractmethod
     def check_resource(
@@ -160,6 +166,9 @@ class PolicyEngine(ABC):
 
     async def aroles_of(self, subject: str) -> List[str]:
         return await asyncio.to_thread(self.roles_of, subject)
+
+    async def asubjects_of(self, role: str) -> List[str]:
+        return await asyncio.to_thread(self.subjects_of, role)
 
     async def acheck_resource(
         self,

--- a/libs/agno/agno/os/authz/facade.py
+++ b/libs/agno/agno/os/authz/facade.py
@@ -9,7 +9,7 @@ the same database. :class:`Authorization` owns all of that and wires itself into
     from agno.os.authz import Authorization
 
     authz = Authorization(db=db, audit=True, trust_token_scopes=True,
-                          verification_keys=KEYS, audience=OS_ID)
+                          verification_keys=KEYS, audience=OS_ID, user_directory=True)
     authz.define_role("admin", ["agent_os:admin"])
     authz.define_role("viewer", ["agents:*:read"], default=True)
     authz.define_role("runner", ["agents:*:read", "agents:*:run"])
@@ -17,16 +17,19 @@ the same database. :class:`Authorization` owns all of that and wires itself into
 
     agent_os = AgentOS(id=OS_ID, db=db, agents=[...], authorization=authz)
 
-Roles are opt-in. Verification lives here because it already lives under authorization today
-(``authorization=True`` + ``AuthorizationConfig(verification_keys=...)``), and plenty of setups
-verify tokens with no roles at all (isolation, scope-based access, service accounts). So the
-verify-only case is a one-liner:
+Roles are opt-in, and so is the user directory: nothing is inferred from the other settings.
+``define_role`` puts roles in play; ``user_directory=True`` (or seeding users, which names them
+explicitly) builds the roster and mounts ``/users``. Verification lives here because it already
+lives under authorization today (``authorization=True`` + ``AuthorizationConfig(...)``), and plenty
+of setups verify tokens with no roles at all (isolation, scope-based access, service accounts). So
+the verify-only case is a one-liner:
 
-    Authorization(verification_keys=KEYS, audience=OS_ID)   # no roles, no ceremony
+    Authorization(verification_keys=KEYS, audience=OS_ID)   # no roles, no directory, no ceremony
 
 Everything the facade builds is still reachable as a primitive: pass your own ``role_store=`` /
-``user_directory=<store>`` / ``authorization_provider=`` / ``engine=`` and the facade uses them instead of
-building its own. Simplicity by default, full control when you need it.
+``user_directory=<store>`` / ``engine=`` and the facade uses them instead of building its own.
+``authorization_provider=`` is the full override: your provider decides alone, no store, no
+``/authz``. Simplicity by default, full control when you need it.
 
 The database is borrowed from AgentOS when you don't pass one, so you never write ``db=`` twice --
 role and user definitions are buffered and applied once the db binds (the same way
@@ -36,7 +39,7 @@ role and user definitions are buffered and applied once the db binds (the same w
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 from agno.os.authz._db import is_async_authz_db, resolve_authz_db
-from agno.utils.log import log_warning
+from agno.utils.log import log_debug, log_warning
 
 if TYPE_CHECKING:
     from agno.os.authz.audit import AuditSink
@@ -96,9 +99,8 @@ class Authorization:
         audit: Union[bool, "AuditSink"] = False,
         trust_token_scopes: bool = False,
         roles_claim: Optional[str] = None,
-        user_directory: Union[bool, "ManagedUserStore", None] = None,
+        user_directory: Union[bool, "ManagedUserStore"] = False,
         auto_provision: bool = True,
-        default_role: Optional[str] = None,
         # --- escape hatches (bring your own) ---
         authorization_provider: Optional[Union["AuthorizationProvider", List["AuthorizationProvider"]]] = None,
         engine: Optional["PolicyEngine"] = None,
@@ -121,15 +123,23 @@ class Authorization:
                 still ``define_role`` what each role may do; the token asserts which role the caller
                 has, so no per-user ``assign``. Turns managed roles on by itself.
             user_directory: the directory, one knob (mirrors ``AgentOS(user_directory=bool | ...)``).
-                ``None`` (default) is auto -- built only when roles are used or users are seeded, so a
-                pure verify-only ``Authorization`` builds none. ``True`` always builds one; ``False``
-                never; a ``ManagedUserStore`` uses yours.
-            auto_provision / default_role: JIT-provision an unknown subject on first valid token,
-                and the role to grant them (falls back to the role flagged ``default=True``).
-            authorization_provider / engine / role_store: primitives. Supply any and the facade uses
-                it instead of building its own (bring your own directory store via
-                ``user_directory=<ManagedUserStore>``).
+                ``False`` (default) builds none; ``True`` builds a ``ManagedUserStore`` roster from the
+                db; a ``ManagedUserStore`` uses yours. Explicit on purpose: defining roles does not
+                imply a roster. ``seed(users=...)`` turns it on too, since listing people is explicit.
+            auto_provision: JIT-provision an unknown subject on first valid token. The role they get
+                is the one flagged ``define_role(..., default=True)``.
+            authorization_provider: full override -- your provider decides alone, no store is built
+                and ``/authz`` is not mounted. Cannot be combined with ``role_store``/``engine``; to
+                keep the admin API on top of your own backend, pass ``engine=`` instead.
+            engine / role_store: primitives. Supply either and the facade uses it instead of
+                building its own (bring your own directory store via ``user_directory=<store>``).
         """
+        if authorization_provider is not None and (role_store is not None or engine is not None):
+            raise ValueError(
+                "Authorization(authorization_provider=...) is the full override and takes no role_store= "
+                "or engine=: the provider decides alone. To keep managed roles and the /authz admin API "
+                "on your own backend, pass engine=<PolicyEngine> instead of a provider."
+            )
         # Verification settings, splatted into the AuthorizationConfig at build time. Typed Any so
         # the per-key kwarg splat type-checks against AuthorizationConfig's specific field types.
         self._verification: Dict[str, Any] = {
@@ -146,24 +156,23 @@ class Authorization:
         self._trust_token_scopes = trust_token_scopes
         self._roles_claim = roles_claim
         self._auto_provision = auto_provision
-        self._default_role = default_role
         self._provider_override = authorization_provider
         self._engine = engine
 
         self._role_store: Optional["ManagedRoleStore"] = role_store
         self._audit_sink: Optional["AuditSink"] = None
 
-        # Directory is one knob, user_directory: True/False/None(auto), or a ManagedUserStore to bring
-        # your own. None = auto: built only when roles are used or users are seeded, so a pure
-        # verify-only Authorization(verification_keys=...) builds NO directory.
+        # Directory is one knob, user_directory: True/False, or a ManagedUserStore to bring your own.
+        # Off unless asked for: defining roles does not imply a roster, so a roles-only or verify-only
+        # Authorization builds NO directory and mounts no /users.
         self._user_directory_arg = user_directory
         self._user_store: Optional["ManagedUserStore"] = (
-            user_directory if user_directory is not None and not isinstance(user_directory, bool) else None
+            user_directory if not isinstance(user_directory, bool) else None
         )
 
         # Roles are in play if any were defined, or a store/engine was supplied.
         self._roles_defined = role_store is not None or engine is not None or roles_claim is not None
-        # Whether seed() has added directory users -- a signal that a directory is wanted under auto.
+        # Whether seed(users=...) named people -- the one implicit way to ask for a directory.
         self._users_seeded = False
 
         # Buffers applied at bind time (used when no db is available yet).
@@ -235,11 +244,11 @@ class Authorization:
         if self._bound:
             return self
         self._db = self._db or os_db
-        # A database is only needed for things that PERSIST -- managed roles, the user directory, or a
-        # DbAuditSink built from audit=True. Verify-only / scope-based / custom-provider setups store
-        # nothing, so they need no db.
-        needs_db = self._roles_defined or bool(self._role_defs) or self._directory_wanted() or self._audit_arg is True
-        if needs_db and self._db is None:
+        # A database is only needed for things that PERSIST and are not already persisted: a role
+        # store or directory the facade has to build (or was handed unbound), or a DbAuditSink from
+        # audit=True. Verify-only / scope-based / custom-provider setups store nothing, and a store
+        # you built with its own db brings its persistence along, so neither needs a db here.
+        if self._db is None and self._needs_own_db():
             raise ValueError(_NEEDS_DB)
         self._db_is_async = is_async_authz_db(self._db)
         self._audit_sink = self._resolve_audit()
@@ -247,6 +256,12 @@ class Authorization:
             self._ensure_role_store()
         if self._directory_wanted():
             self._ensure_user_store()
+        # A store that could not bind (its own db missing AND the OS db not SQL-capable) would run
+        # in memory: roles and the disabled kill switch silently lost on restart, never seen by
+        # another replica. Fail here, at construction, rather than serve that.
+        for store in (self._role_store, self._user_store):
+            if store is not None and getattr(store, "is_bound", True) is False:
+                raise ValueError(_NEEDS_DB)
         self._bound = True
         self._flush()
         return self
@@ -259,14 +274,25 @@ class Authorization:
             self._apply_seed(admin, admin_role, users)
         self._seed_calls.clear()
 
+    def _needs_own_db(self) -> bool:
+        """Whether binding has to have a database: something must be built or bound, and no store of
+        the caller's already carries its own."""
+        if self._audit_arg is True:
+            return True
+        if self._roles_defined or self._role_defs:
+            if self._role_store is None or getattr(self._role_store, "is_bound", True) is False:
+                return True
+        if self._directory_wanted():
+            if self._user_store is None or getattr(self._user_store, "is_bound", True) is False:
+                return True
+        return False
+
     def _directory_wanted(self) -> bool:
-        """Whether a user directory should exist. Auto (``None``) builds one only once roles are used
-        or users are seeded, so verify-only stays store-free."""
-        if self._user_directory_arg is False:
-            return False
+        """Whether a user directory should exist: asked for explicitly (``user_directory=True`` or a
+        store of your own), or implied by ``seed(users=...)`` naming people. Never inferred from roles."""
         if self._user_directory_arg is True or self._user_store is not None:
             return True
-        return self._roles_defined or self._users_seeded
+        return self._users_seeded
 
     def _resolve_audit(self) -> Optional["AuditSink"]:
         if self._audit_arg is False or self._audit_arg is None:
@@ -327,6 +353,17 @@ class Authorization:
         if admin is not None:
             if not role_store.roles_of(admin):  # bootstrap: never override an existing assignment
                 role_store.assign(admin, admin_role)
+            elif self._locked_out(role_store):
+                # The subject holds some other role (an operator demoted them) and NOBODY holds an
+                # admin role any more: the admin API is unreachable and cannot be repaired through
+                # itself. Re-grant the bootstrap admin. This is the only case that overrides an
+                # operator's assignment, and only because the alternative is a permanent lockout;
+                # a demotion that left another admin in place is respected.
+                log_warning(
+                    f"seed(admin={admin!r}): no subject holds a role that confers 'agent_os:admin', so "
+                    f"the admin API was unreachable. Re-granted {admin_role!r} to {admin!r}."
+                )
+                role_store.assign(admin, admin_role)
             if self._directory_wanted():
                 users_store = self._ensure_user_store()
                 if users_store.get(admin) is None:
@@ -343,6 +380,17 @@ class Authorization:
                     users_store.upsert(subject, email=info.get("email"), name=info.get("name"))
             if role and not role_store.roles_of(subject):  # bootstrap: keep a runtime promotion
                 role_store.assign(subject, role)
+
+    @staticmethod
+    def _locked_out(role_store: "ManagedRoleStore") -> bool:
+        """True when no stored assignment confers admin. False, never a guess, on an engine that cannot
+        enumerate a role's holders: healing on a guess could hand admin back to someone an operator
+        deliberately demoted."""
+        try:
+            return not role_store.admin_subjects()
+        except NotImplementedError:
+            log_debug("seed(admin=): the policy engine cannot list a role's holders; skipping the lockout check")
+            return False
 
     def _require_sync_setup(self) -> None:
         """Setup writes run synchronously; refuse an async db with a clear, facade-level message rather
@@ -421,8 +469,4 @@ class Authorization:
             return None
         from agno.os.config import UserDirectoryConfig
 
-        return UserDirectoryConfig(
-            user_store=store,
-            auto_provision=self._auto_provision,
-            default_role=self._default_role,
-        )
+        return UserDirectoryConfig(user_store=store, auto_provision=self._auto_provision)

--- a/libs/agno/agno/os/authz/native_engine.py
+++ b/libs/agno/agno/os/authz/native_engine.py
@@ -39,8 +39,8 @@ from agno.os.authz._db import (
     resolve_authz_db,
     supports_authz,
 )
-from agno.os.authz._request_scope import amemoize, invalidate as _invalidate_request_cache
-from agno.os.authz._request_scope import memoize
+from agno.os.authz._request_scope import amemoize, memoize
+from agno.os.authz._request_scope import invalidate as _invalidate_request_cache
 from agno.os.authz._scope_policy import resource_action_to_scope, resource_matches, scope_to_resource_action
 from agno.os.authz.engine import PolicyEngine, ScopeEntry
 
@@ -342,6 +342,10 @@ class NativePolicyEngine(PolicyEngine):
     def roles_of(self, subject: str) -> List[str]:
         return sorted(self._direct_roles(subject))
 
+    def subjects_of(self, role: str) -> List[str]:
+        self._require_engine()
+        return sorted(self._db.list_authz_role_subjects(role))
+
     # --- decisions -------------------------------------------------------
     def _allowed_for_root(
         self, root: str, request_resource: str, request_action: str, *, is_subject: bool = False
@@ -632,6 +636,9 @@ class NativePolicyEngine(PolicyEngine):
 
     async def aroles_of(self, subject: str) -> List[str]:
         return sorted(await self._adirect_roles(subject))
+
+    async def asubjects_of(self, role: str) -> List[str]:
+        return sorted(await self._acall("list_authz_role_subjects", role))
 
     # --- async decisions ---
     async def _aallowed_for_root(

--- a/libs/agno/agno/os/authz/role_router.py
+++ b/libs/agno/agno/os/authz/role_router.py
@@ -3,16 +3,17 @@
 Admin-only REST API to create roles, set their permissions (in agno scope terms,
 with allow/deny), and grant or revoke them at runtime.
 
-With ``AuthorizationConfig(role_store=...)`` you do not mount this yourself: AgentOS
-registers it at ``/authz`` for you. The credential-less user DIRECTORY (who the users are
-+ the disabled kill-switch) is a PEER concern served by :func:`get_users_router` at
-``/users`` -- configured via ``AgentOS(user_directory=...)``, not this router.
+With ``AgentOS(authorization=Authorization(...))`` you do not mount this yourself: AgentOS
+registers it at ``/authz`` whenever the object has a role store. The credential-less user
+DIRECTORY (who the users are + the disabled kill-switch) is a PEER concern served by
+:func:`get_users_router` at ``/users`` -- mounted from ``Authorization(user_directory=...)``,
+not this router.
 
-    from agno.os.authz.role_store import ManagedRoleStore
+    from agno.os.authz import Authorization
 
-    roles = ManagedRoleStore(db_url="postgresql+psycopg://...")
-    agent_os = AgentOS(agents=[...], authorization=True,
-                       authorization_config=AuthorizationConfig(role_store=roles, ...))
+    authz = Authorization(db_url="postgresql+psycopg://...", verification_keys=KEYS, audience=OS_ID)
+    authz.define_role("admin", ["agent_os:admin"])
+    agent_os = AgentOS(agents=[...], authorization=authz)
     app = agent_os.get_app()   # /authz is already served
 
 It is registered alongside the other built-in routers, which is what keeps it ahead

--- a/libs/agno/agno/os/authz/role_store.py
+++ b/libs/agno/agno/os/authz/role_store.py
@@ -12,8 +12,8 @@ stale).
 
 A DB is **required** — managed roles must be persisted, and an in-memory store
 can't stay consistent across the replicas an AgentOS deployment runs. Give the
-store a DB directly (``db=``/``db_url=``) or let AgentOS adopt the OS DB via
-``AuthorizationConfig(role_store=...)``; without one, every operation raises.
+store a DB directly (``db=``/``db_url=``) or let AgentOS lend the OS DB via
+``Authorization(role_store=...)``; without one, every operation raises.
 Persistence to a DB needs SQLAlchemy: ``pip install "agno[roles]"`` (or ``agno[os]``).
 
 Example::
@@ -440,6 +440,22 @@ class ManagedRoleStore:
     def roles_of(self, subject: str) -> List[str]:
         return self._engine.roles_of(subject)
 
+    def admin_subjects(self) -> List[str]:
+        """Subjects whose STORED role satisfies ``agent_os:admin`` -- everyone who can reach the admin
+        API without an admin claim on their token. Empty means the store has locked itself out.
+
+        Only stored assignments count: a role carried on a token (``roles_claim``) is per-request and
+        cannot be enumerated. Raises ``NotImplementedError`` on an engine that cannot list a role's
+        holders (``subjects_of``)."""
+        roles = self.list_roles()
+        admin_roles = [r for r in roles if self._engine.check_scope("agent_os:admin", roles=[r])]
+        holders: set = set()
+        for role in admin_roles:
+            # Assignments share one namespace with role-to-role inheritance, so drop names that are
+            # themselves roles: those are nested roles, not people.
+            holders.update(name for name in self._engine.subjects_of(role) if name not in roles)
+        return sorted(holders)
+
     @property
     def is_bound(self) -> bool:
         """True once the store has a DB for both its policy engine and its role
@@ -453,8 +469,8 @@ class ManagedRoleStore:
     def attach_db(self, db: Any) -> None:
         """Bind an agno ``Db`` to a store created without one, so managed roles
         persist in (and read fresh from) that DB. No-op if the store already has its
-        own DB, or the db isn't SQL-capable. AgentOS calls this to default a managed
-        store to the OS database when you pass ``AuthorizationConfig(role_store=...)``."""
+        own DB, or the db isn't SQL-capable. The Authorization object calls this to default a
+        managed store to the OS database when you pass ``Authorization(role_store=...)``."""
         attach = getattr(self._engine, "attach_db", None)
         if callable(attach):
             attach(db)
@@ -756,6 +772,15 @@ class ManagedRoleStore:
     async def aroles_of(self, subject: str) -> List[str]:
         """Async twin of :meth:`roles_of`."""
         return await self._engine.aroles_of(subject)
+
+    async def aadmin_subjects(self) -> List[str]:
+        """Async twin of :meth:`admin_subjects`."""
+        roles = await self.alist_roles()
+        holders: set = set()
+        for role in roles:
+            if await self._engine.acheck_scope("agent_os:admin", roles=[role]):
+                holders.update(name for name in await self._engine.asubjects_of(role) if name not in roles)
+        return sorted(holders)
 
     # --- async audit + gating ---
     async def aaudit_log(

--- a/libs/agno/agno/os/config.py
+++ b/libs/agno/agno/os/config.py
@@ -6,7 +6,6 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from agno.os.authz.audit import AuditSink
 from agno.os.authz.provider import AuthorizationProvider
-from agno.os.authz.role_store import ManagedRoleStore
 
 # Tags carried by the built-in MCP tools, exposed here so callers (and the IDE) can see
 # the valid values for ``MCPConfig.include_tags`` / ``exclude_tags`` without reading
@@ -360,13 +359,14 @@ MCPServerConfig = MCPConfig
 
 
 class AuthorizationConfig(BaseModel):
-    """Low-level authorization config for the JWT middleware.
+    """Low-level authorization config for the JWT middleware. Deprecated as a public type.
 
     Superseded by :class:`agno.os.authz.Authorization`, which owns every field here (verification,
-    provider, role store, audit, excluded routes) plus the higher-level surface (define_role, seed,
-    the user directory, the admin API). ``Authorization`` builds one of these internally to feed the
-    pipeline, so prefer ``AgentOS(authorization=Authorization(...))`` and treat this as an internal
-    type. Do NOT add new fields here that duplicate ``Authorization`` -- add them there.
+    provider, audit, excluded routes) plus the higher-level surface (define_role, seed, the user
+    directory, the admin API). ``Authorization`` builds one of these internally to feed the
+    pipeline; ``AgentOS(authorization_config=...)`` still accepts one so deployments written against
+    the released field set keep booting, with a warning. Frozen: do NOT add fields here -- add them
+    to ``Authorization``.
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -389,10 +389,6 @@ class AuthorizationConfig(BaseModel):
     # authz planes at once (e.g. token scopes for operators + a managed role store
     # for end users) — a request is allowed if any of them allows it.
     authorization_provider: Optional[Union[AuthorizationProvider, List[AuthorizationProvider]]] = None
-    # Managed-roles shortcut: pass a ManagedRoleStore and AgentOS uses its provider
-    # (mutually exclusive with authorization_provider). If the store has no DB, AgentOS
-    # binds the OS database to it so roles persist alongside agent data.
-    role_store: Optional[ManagedRoleStore] = None
     # Optional AuditSink. When set, AgentOS records each authorization decision
     # (allow/deny) alongside the change trail, so you get an access audit, not just a
     # change audit. Pass the same sink you give ManagedRoleStore to unify both.
@@ -413,15 +409,6 @@ class AuthorizationConfig(BaseModel):
     # When False (default) JWT/RBAC still apply, but routes operate on the
     # unscoped DB and don't add per-user ownership gates on top of RBAC.
     user_isolation: bool = False
-
-    @model_validator(mode="after")
-    def _provider_xor_role_store(self) -> "AuthorizationConfig":
-        if self.role_store is not None and self.authorization_provider is not None:
-            raise ValueError(
-                "Pass either authorization_provider or role_store on AuthorizationConfig, not both — "
-                "role_store is the shortcut that wires the store's provider for you."
-            )
-        return self
 
 
 class UserDirectoryConfig(BaseModel):
@@ -444,7 +431,7 @@ class UserDirectoryConfig(BaseModel):
     # have AgentOS build one from its own ``db`` -- the zero-ceremony path, equivalent to
     # ``AgentOS(user_directory=True)``. Needs a SQL database: AgentOS adopts the OS db if the
     # store was created without one (and requires ``AgentOS(db=...)`` when you pass ``True``).
-    # Named ``user_store`` to mirror ``AuthorizationConfig.role_store``.
+    # Named ``user_store`` to mirror ``Authorization(role_store=...)``.
     user_store: Any
     # Just-in-time provisioning: when True, the first valid token from a subject not yet in
     # the directory creates a row from the token claims below.

--- a/libs/agno/tests/integration/os/test_audit_single_switch.py
+++ b/libs/agno/tests/integration/os/test_audit_single_switch.py
@@ -1,13 +1,11 @@
-"""AgentOS(audit=...) is a single switch for BOTH audit trails.
+"""Authorization(audit=...) is a single switch for BOTH audit trails.
 
 There are two trails: the CHANGE log (who edited roles/users -> authz_audit), which the STORES emit
 to their own sink, and the DECISION log (every allow/deny -> authz_decisions), which the OS records
 via app.state.authz_audit. Wiring the same sink in two places is a footgun (QA turned off one and
-was surprised the other kept going). AgentOS(audit=sink) feeds both, while an explicit sink on a
-store or on AuthorizationConfig still wins there.
+was surprised the other kept going). Authorization(audit=sink) feeds both, while an explicit sink
+passed to a store of your own still wins there.
 """
-
-import tempfile
 
 import pytest
 
@@ -17,10 +15,10 @@ from agno.agent import Agent  # noqa: E402
 from agno.db.in_memory import InMemoryDb  # noqa: E402
 from agno.db.sqlite import SqliteDb  # noqa: E402
 from agno.os import AgentOS  # noqa: E402
+from agno.os.authz import Authorization  # noqa: E402
 from agno.os.authz.audit import DbAuditSink  # noqa: E402
 from agno.os.authz.role_store import ManagedRoleStore  # noqa: E402
 from agno.os.authz.user_store import ManagedUserStore  # noqa: E402
-from agno.os.config import AuthorizationConfig, UserDirectoryConfig  # noqa: E402
 
 SECRET = "audit-switch-secret-at-least-256-bits-xxxxxxxxxx"
 
@@ -29,17 +27,14 @@ def _db(tmp_path):
     return SqliteDb(db_file=str(tmp_path / "os.db"))
 
 
-def _os(db, roles, users, **kw):
+def _os(db, roles, users, audit=False):
     return AgentOS(
         id="audit-os",
         agents=[Agent(id="a", name="R", db=InMemoryDb())],
         db=db,
-        authorization=True,
-        authorization_config=AuthorizationConfig(
-            verification_keys=[SECRET], algorithm="HS256", role_store=roles, **kw.pop("config", {})
+        authorization=Authorization(
+            verification_keys=[SECRET], algorithm="HS256", role_store=roles, user_directory=users, audit=audit
         ),
-        user_directory=UserDirectoryConfig(user_store=users),
-        **kw,
     )
 
 
@@ -54,14 +49,14 @@ def test_single_audit_switch_feeds_change_and_decision_trails(tmp_path):
     assert users._audit is sink  # directory change trail
 
 
-def test_explicit_sink_wins_over_the_top_level_switch(tmp_path):
+def test_explicit_store_sink_wins_over_the_switch(tmp_path):
     db = _db(tmp_path)
     top, explicit = DbAuditSink(db=db), DbAuditSink(db=db)
     roles = ManagedRoleStore(db=db, audit=explicit)  # explicit on the store
-    users = ManagedUserStore(db=db)  # no explicit -> should adopt the top-level
-    app = _os(db, roles, users, audit=top, config={"audit": explicit}).get_app()
+    users = ManagedUserStore(db=db)  # no explicit -> should adopt the switch
+    app = _os(db, roles, users, audit=top).get_app()
 
-    assert getattr(app.state, "authz_audit", None) is explicit  # config's explicit sink wins
+    assert getattr(app.state, "authz_audit", None) is top  # the switch feeds the decision trail
     assert roles._audit is explicit  # store keeps its own
     assert users._audit is top  # the one without an explicit sink adopts the switch
 

--- a/libs/agno/tests/integration/os/test_authorization_facade.py
+++ b/libs/agno/tests/integration/os/test_authorization_facade.py
@@ -214,7 +214,6 @@ def test_facade_prebuilt_async_store_no_setup_ok(tmp_path):
     """A facade with a pre-configured async store and NO define_role/seed works against an async db:
     only the sync setup writes are refused, not the provider wiring / request-time path."""
     from agno.db.sqlite.async_sqlite import AsyncSqliteDb
-
     from agno.os.authz.role_store import ManagedRoleStore
 
     adb = AsyncSqliteDb(db_file=str(tmp_path / "a.db"))
@@ -270,9 +269,12 @@ def test_served_facade_enforces_roles(tmp_path, borrow_db):
     client = TestClient(_served(tmp_path, borrow_db=borrow_db).get_app())
     with patch.object(Agent, "arun", new_callable=AsyncMock) as m:
         m.return_value = _MockRunOutput()
-        run = lambda sub, agent: client.post(  # noqa: E731
-            f"/agents/{agent}/runs", headers=_auth(sub), data={"message": "hi", "stream": "false"}
-        ).status_code
+
+        def run(sub, agent):
+            return client.post(
+                f"/agents/{agent}/runs", headers=_auth(sub), data={"message": "hi", "stream": "false"}
+            ).status_code
+
         assert run("carol", "secret") == 403  # runner has no secret grant
         assert run("carol", "research") == 200  # runner may run research
         assert run("root", "secret") == 200  # admin role bypass
@@ -282,33 +284,139 @@ def test_served_facade_enforces_roles(tmp_path, borrow_db):
         assert client.get("/agents/research", headers=_auth("nobody")).status_code == 200
 
 
-def test_authorization_accepts_raw_config(tmp_path):
-    """The two entry params are folded into one: a raw AuthorizationConfig can be passed as
-    authorization=, and passing it both ways raises. (authorization_config= stays for back-compat.)"""
+def test_authorization_config_is_deprecated_not_a_second_spelling(tmp_path):
+    """AuthorizationConfig has one remaining job: keep deployments written against the released
+    field set booting. authorization_config= still works with authorization=True and warns once;
+    authorization=AuthorizationConfig(...) is refused rather than becoming a new spelling of a
+    deprecated type."""
     from agno.os.config import AuthorizationConfig
 
     cfg = AuthorizationConfig(verification_keys=[SECRET], algorithm="HS256", verify_audience=True, audience=OS_ID)
-    os_ = AgentOS(id=OS_ID, db=SqliteDb(db_file=str(tmp_path / "cfg.db")), agents=_agents(), authorization=cfg)
-    assert os_.authorization is True and os_.authorization_config is cfg
-    with pytest.raises(ValueError, match="once"):
-        AgentOS(
+    messages: list = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record):
+            messages.append(record.getMessage())
+
+    handler = _Capture()
+    handler.setLevel(logging.WARNING)
+    logging.getLogger("agno").addHandler(handler)
+    try:
+        os_ = AgentOS(
             id=OS_ID,
-            db=SqliteDb(db_file=str(tmp_path / "cfg2.db")),
+            db=SqliteDb(db_file=str(tmp_path / "cfg.db")),
             agents=_agents(),
-            authorization=cfg,
+            authorization=True,
             authorization_config=cfg,
         )
+    finally:
+        logging.getLogger("agno").removeHandler(handler)
+    assert os_.authorization is True and os_.authorization_config is cfg  # still honoured
+    assert any("authorization_config" in m and "deprecated" in m for m in messages)
+
+    with pytest.raises(TypeError, match="authorization_config="):
+        AgentOS(id=OS_ID, db=SqliteDb(db_file=str(tmp_path / "cfg2.db")), agents=_agents(), authorization=cfg)
+
+
+def test_directory_is_explicit_never_inferred_from_roles(tmp_path):
+    """Defining roles (or reading them off a token claim) must not stand up a roster: a roles-only
+    deployment gets no ManagedUserStore, no JIT provisioning, and no /users. The directory exists
+    only when asked for -- user_directory=True, a store of your own, or seed(users=...) naming
+    people."""
+    db = SqliteDb(db_file=str(tmp_path / "explicit.db"))
+
+    roles_only = Authorization(db=db, verification_keys=[SECRET], audience=OS_ID)
+    roles_only.define_role("viewer", ["agents:*:read"])
+    assert roles_only.role_store is not None
+    assert roles_only.user_store is None
+    assert roles_only.user_directory_config() is None
+
+    idp = Authorization(db=db, verification_keys=[SECRET], audience=OS_ID, roles_claim="role")
+    assert idp.role_store is not None and idp.user_store is None
+
+    asked = Authorization(db=db, verification_keys=[SECRET], audience=OS_ID, user_directory=True)
+    assert asked.user_store is not None
+
+    seeded = Authorization(db=db, verification_keys=[SECRET], audience=OS_ID)
+    seeded.define_role("viewer", ["agents:*:read"])
+    seeded.seed(users=[("bob", {"role": "viewer"})])
+    assert seeded.user_store is not None and seeded.user_store.get("bob") is not None
+
+    # Served: roles only mounts /authz but not /users (routes exist only once the app serves, so
+    # ask over HTTP rather than reading app.routes).
+    served = Authorization(verification_keys=[SECRET], algorithm="HS256", verify_audience=True, audience=OS_ID)
+    served.define_role("admin", ["agent_os:admin"])
+    served.seed(admin="root")  # an admin, but no users= -> still no directory
+    client = TestClient(
+        AgentOS(
+            id=OS_ID, db=SqliteDb(db_file=str(tmp_path / "ro.db")), agents=_agents(), authorization=served
+        ).get_app()
+    )
+    assert client.get("/authz/roles", headers=_auth("root")).status_code == 200
+    assert client.get("/users", headers=_auth("root")).status_code == 404
+
+
+def test_seed_admin_heals_a_lockout_but_respects_a_handover(tmp_path):
+    """seed(admin=) re-grants the bootstrap admin ONLY when nobody holds an admin role any more.
+    An operator who moved admin to someone else keeps that decision across restarts; an operator
+    who demoted the last admin (lockout: the admin API can no longer repair itself) gets the
+    bootstrap admin back on the next boot."""
+    dbfile = str(tmp_path / "heal.db")
+
+    def boot():
+        a = Authorization(db=SqliteDb(db_file=dbfile))
+        a.define_role("admin", ["agent_os:admin"])
+        a.define_role("viewer", ["agents:*:read"])
+        a.seed(admin="root")
+        return a
+
+    a1 = boot()
+    assert a1.role_store.admin_subjects() == ["root"]
+
+    # Handover: root demoted, carol promoted. A restart must not undo it.
+    a1.role_store.assign("carol", "admin")
+    a1.role_store.assign("root", "viewer")
+    a2 = boot()
+    assert a2.role_store.roles_of("root") == ["viewer"]
+    assert a2.role_store.admin_subjects() == ["carol"]
+
+    # Lockout: carol demoted too, nobody is admin. A restart heals it.
+    a2.role_store.assign("carol", "viewer")
+    assert a2.role_store.admin_subjects() == []
+    a3 = boot()
+    assert a3.role_store.roles_of("root") == ["admin"]
+    assert a3.role_store.roles_of("carol") == ["viewer"]  # only the bootstrap subject is touched
+
+
+def test_provider_override_takes_no_store(tmp_path):
+    """authorization_provider= is the full override: combining it with a role store or engine
+    would leave a store nothing enforces behind a mounted /authz, so it is refused."""
+    from agno.os.authz.provider import AuthorizationContext, AuthorizationProvider
+    from agno.os.authz.role_store import ManagedRoleStore
+
+    class AllowAll(AuthorizationProvider):
+        def check(self, ctx: AuthorizationContext) -> bool:
+            return True
+
+        def accessible_resource_ids(self, ctx: AuthorizationContext):
+            return {"*"}
+
+    db = SqliteDb(db_file=str(tmp_path / "xor.db"))
+    with pytest.raises(ValueError, match="engine="):
+        Authorization(db=db, authorization_provider=AllowAll(), role_store=ManagedRoleStore(db=db))
 
 
 def test_served_verify_only_mounts_no_admin_api(tmp_path):
     """A served verify-only facade (no roles) mounts neither /authz nor /users -- the directory stays
-    off, so an isolation / scope-based deployment gets a clean surface with no role machinery."""
+    off, so an isolation / scope-based deployment gets a clean surface with no role machinery. Asked
+    over HTTP with an admin-scoped token: 404 means not mounted (a mounted router answers 200/403)."""
     db = SqliteDb(db_file=str(tmp_path / "vo_served.db"))
     authz = Authorization(verification_keys=[SECRET], algorithm="HS256", verify_audience=True, audience=OS_ID)
-    app = AgentOS(id=OS_ID, db=db, agents=_agents(), authorization=authz).get_app()
-    paths = {getattr(r, "path", "") for r in app.routes}
-    assert not any(p.startswith("/authz") for p in paths)  # no roles -> no /authz
-    assert not any(p == "/users" or p.startswith("/users/") for p in paths)  # no directory -> no /users
+    client = TestClient(AgentOS(id=OS_ID, db=db, agents=_agents(), authorization=authz).get_app())
+    admin = _auth("op", scopes=["agent_os:admin"])
+    assert client.get("/agents", headers=admin).status_code == 200  # the OS itself serves
+    assert client.get("/authz/roles", headers=admin).status_code == 404  # no roles -> no /authz
+    assert client.get("/users", headers=admin).status_code == 404  # no directory -> no /users
 
 
 def test_served_facade_list_filtering(tmp_path):

--- a/libs/agno/tests/integration/os/test_directory_no_auth.py
+++ b/libs/agno/tests/integration/os/test_directory_no_auth.py
@@ -269,11 +269,12 @@ def test_no_auth_run_refuses_a_reserved_principal(tmp_path):
     assert store.get("realuser") is not None  # normal -> provisioned
 
 
-def test_role_store_still_requires_authorization(tmp_path):
-    """Unchanged by the directory/isolation relaxation: a role_store (an authz plane) still needs
+def test_authz_plane_still_requires_authorization(tmp_path):
+    """Unchanged by the directory/isolation relaxation: a provider (an authz plane) still needs
     authorization=True, because an unenforced plane would serve every route unauthenticated."""
     from agno.os.authz.role_store import ManagedRoleStore
 
     db = SqliteDb(db_file=str(tmp_path / "plane.db"))
+    provider = ManagedRoleStore(db=db).provider
     with pytest.raises(ValueError, match="authorization=True"):
-        _os(tmp_path, authorization_config=AuthorizationConfig(role_store=ManagedRoleStore(db=db))).get_app()
+        _os(tmp_path, authorization_config=AuthorizationConfig(authorization_provider=provider)).get_app()

--- a/libs/agno/tests/integration/os/test_managed_roles.py
+++ b/libs/agno/tests/integration/os/test_managed_roles.py
@@ -17,6 +17,7 @@ pytest.importorskip("sqlalchemy")  # managed roles persist/enforce via the nativ
 from agno.agent import Agent  # noqa: E402
 from agno.db.in_memory import InMemoryDb  # noqa: E402
 from agno.os import AgentOS  # noqa: E402
+from agno.os.authz import Authorization  # noqa: E402
 from agno.os.authz.role_store import ManagedRoleStore  # noqa: E402
 from agno.os.config import AuthorizationConfig  # noqa: E402
 
@@ -204,9 +205,9 @@ def test_management_helpers():
 
 
 def test_role_store_shortcut_wires_provider_and_defaults_os_db(tmp_path):
-    """#4: AuthorizationConfig(role_store=...) wires the store's provider (no manual
-    .provider). #3: a store with no DB of its own adopts the OS DB when AgentOS wires
-    it (a DB is required — there is no in-memory mode), and roles persist there."""
+    """#4: Authorization(role_store=...) wires the store's provider (no manual .provider).
+    #3: a store with no DB of its own adopts the OS DB when AgentOS binds the object (a DB is
+    required — there is no in-memory mode), and roles persist there."""
     from agno.db.sqlite import SqliteDb
 
     store = ManagedRoleStore()  # no DB yet -> AgentOS will adopt the OS DB
@@ -216,13 +217,12 @@ def test_role_store_shortcut_wires_provider_and_defaults_os_db(tmp_path):
         id=OS_ID,
         agents=[agent],
         db=db,
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,
             audience=OS_ID,
-            role_store=store,  # <- the shortcut; AgentOS adopts the OS db + uses store.provider
+            role_store=store,  # <- bring your own store; AgentOS lends the OS db + uses store.provider
         ),
     )
     client = TestClient(agent_os.get_app())  # adopts the OS DB -> store is now bound
@@ -241,8 +241,8 @@ def test_role_store_shortcut_wires_provider_and_defaults_os_db(tmp_path):
 
 
 def test_managed_roles_enforce_on_rest_gate_via_shortcut(tmp_path):
-    """The payoff, end to end on the v2.7 REST route gate: an AgentOS wired with the
-    ``role_store=`` shortcut (no manual .provider) enforces a managed role for a caller
+    """The payoff, end to end on the v2.7 REST route gate: an AgentOS wired with
+    ``Authorization(role_store=...)`` (no manual .provider) enforces a managed role for a caller
     whose JWT carries NO scopes at all — the ``viewer`` role (agents:*:read) is resolved
     from the store, not the token. Same viewer, same token: GET /agents/{id} is 200 but
     POST /agents/{id}/runs is 403, proving action granularity flows through the same gate
@@ -257,13 +257,12 @@ def test_managed_roles_enforce_on_rest_gate_via_shortcut(tmp_path):
         id=OS_ID,
         agents=[agent],
         db=db,
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,
             audience=OS_ID,
-            role_store=store,  # the shortcut: AgentOS binds the OS db + uses store.provider
+            role_store=store,  # AgentOS binds the OS db + uses store.provider
         ),
     )
     client = TestClient(agent_os.get_app())
@@ -281,10 +280,11 @@ def test_managed_roles_enforce_on_rest_gate_via_shortcut(tmp_path):
 
 
 def test_role_store_and_provider_are_mutually_exclusive():
+    """authorization_provider= is the full override, so it takes no store to leave unenforced."""
     from agno.os.authz.scope_provider import ScopeAuthorizationProvider
 
-    with pytest.raises(ValueError, match="not both"):
-        AuthorizationConfig(role_store=ManagedRoleStore(), authorization_provider=ScopeAuthorizationProvider())
+    with pytest.raises(ValueError, match="engine="):
+        Authorization(role_store=ManagedRoleStore(), authorization_provider=ScopeAuthorizationProvider())
 
 
 def test_role_store_without_any_db_fails_loud_at_wiring():
@@ -293,20 +293,18 @@ def test_role_store_without_any_db_fails_loud_at_wiring():
     consistent across replicas."""
     store = ManagedRoleStore()  # no DB
     agent = Agent(id="research-agent", name="R", db=InMemoryDb())  # not SQL-capable
-    agent_os = AgentOS(
-        id=OS_ID,
-        agents=[agent],
-        authorization=True,
-        authorization_config=AuthorizationConfig(
-            verification_keys=[SECRET],
-            algorithm="HS256",
-            verify_audience=True,
-            audience=OS_ID,
-            role_store=store,
-        ),
-    )
     with pytest.raises(ValueError, match="needs a SQL database"):
-        agent_os.get_app()
+        AgentOS(
+            id=OS_ID,
+            agents=[agent],
+            authorization=Authorization(
+                verification_keys=[SECRET],
+                algorithm="HS256",
+                verify_audience=True,
+                audience=OS_ID,
+                role_store=store,
+            ),
+        )
 
 
 def test_deny_override_is_not_leaked_by_the_list_endpoint():

--- a/libs/agno/tests/integration/os/test_managed_roles_api.py
+++ b/libs/agno/tests/integration/os/test_managed_roles_api.py
@@ -329,8 +329,8 @@ def test_authz_api_is_served_with_the_mcp_server_enabled(tmp_path):
     from agno.agent import Agent
     from agno.db.in_memory import InMemoryDb
     from agno.os import AgentOS
+    from agno.os.authz import Authorization
     from agno.os.authz.role_store import ManagedRoleStore
-    from agno.os.config import AuthorizationConfig
 
     store = ManagedRoleStore(db_url=f"sqlite:///{tmp_path / 'roles.db'}")
     store.set_role_scopes("admin", ["agent_os:admin"])
@@ -339,9 +339,8 @@ def test_authz_api_is_served_with_the_mcp_server_enabled(tmp_path):
     agent_os = AgentOS(
         id=OS_ID,
         agents=[Agent(id="a1", name="A", db=InMemoryDb())],
-        authorization=True,
         mcp_server=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,

--- a/libs/agno/tests/integration/os/test_managed_users.py
+++ b/libs/agno/tests/integration/os/test_managed_users.py
@@ -133,21 +133,22 @@ def _db_url() -> str:
     return f"sqlite:///{path}"
 
 
-def _os(role_store, user_store, *, auto_provision=False, **cfg):
+def _os(role_store, user_store, *, auto_provision=False):
+    from agno.os.authz import Authorization
+
     agent = Agent(id="research-agent", name="Research Agent", db=InMemoryDb())
     return AgentOS(
         id=OS_ID,
         agents=[agent],
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,
             audience=OS_ID,
-            role_store=role_store,  # auto-mounts /authz (roles) and /users (directory)
-            **cfg,
+            role_store=role_store,  # mounts /authz (roles) ...
+            user_directory=user_store,  # ... and /users (directory)
+            auto_provision=auto_provision,
         ),
-        user_directory=UserDirectoryConfig(user_store=user_store, auto_provision=auto_provision),
     )
 
 
@@ -414,8 +415,8 @@ def test_agentos_adopts_its_db_so_the_kill_switch_persists(tmp_path):
     from agno.agent import Agent
     from agno.db.sqlite import SqliteDb
     from agno.os import AgentOS
+    from agno.os.authz import Authorization
     from agno.os.authz.role_store import ManagedRoleStore
-    from agno.os.config import AuthorizationConfig
 
     db_file = str(tmp_path / "os.db")
     os_db = SqliteDb(db_file=db_file)
@@ -431,9 +432,9 @@ def test_agentos_adopts_its_db_so_the_kill_switch_persists(tmp_path):
         id="user-adopt-os",
         agents=[Agent(id="a1", name="A", db=os_db)],
         db=os_db,
-        authorization=True,
-        authorization_config=AuthorizationConfig(verification_keys=["k" * 40], algorithm="HS256", role_store=roles),
-        user_directory=UserDirectoryConfig(user_store=users),
+        authorization=Authorization(
+            verification_keys=["k" * 40], algorithm="HS256", role_store=roles, user_directory=users
+        ),
     ).get_app()
 
     # adopted, and the revocation made before adoption came across
@@ -466,8 +467,8 @@ def test_user_store_without_a_persistable_db_fails_fast():
     from agno.agent import Agent
     from agno.db.in_memory import InMemoryDb
     from agno.os import AgentOS
+    from agno.os.authz import Authorization
     from agno.os.authz.role_store import ManagedRoleStore
-    from agno.os.config import AuthorizationConfig, UserDirectoryConfig
 
     non_sql_db = InMemoryDb()  # stands in for any db with no SQLAlchemy engine (e.g. Mongo)
     roles = ManagedRoleStore(db_url="sqlite:///:memory:")
@@ -478,13 +479,12 @@ def test_user_store_without_a_persistable_db_fails_fast():
             id="unpersisted-users-os",
             agents=[Agent(id="a1", name="A", db=non_sql_db)],
             db=non_sql_db,
-            authorization=True,
-            authorization_config=AuthorizationConfig(
+            authorization=Authorization(
                 verification_keys=["k" * 40],
                 algorithm="HS256",
                 role_store=roles,
+                user_directory=ManagedUserStore(),  # bare: nothing to persist into
             ),
-            user_directory=UserDirectoryConfig(user_store=ManagedUserStore()),  # bare: nothing to persist into
         ).get_app()
 
 

--- a/libs/agno/tests/unit/os/test_authz_offloading.py
+++ b/libs/agno/tests/unit/os/test_authz_offloading.py
@@ -1,32 +1,75 @@
-"""The authorization callbacks must stay synchronous so FastAPI threadpools them.
+"""Authorization callbacks must keep a sync provider's blocking I/O off the event loop.
 
 Authorization providers are synchronous by design: a managed-role store issues DB
 round trips inside ``check``/``authorize_route``, and an FGA provider issues network
-calls. FastAPI runs a **sync** dependency or endpoint in its worker threadpool, so
-that I/O stays off the event loop; declaring the same callback ``async`` runs the
-blocking work directly on the loop and serialises every other in-flight request
-behind each authorization check.
+calls. Two things keep that work off the loop. A **sync** FastAPI dependency or
+endpoint runs in the worker threadpool. An **async** one must reach the provider
+through its ``a*`` twin, whose default runs the sync method in a worker thread
+(``asyncio.to_thread``) so a plain sync provider is still offloaded.
 
-That property is invisible in normal test runs and easy to destroy with a
-well-intentioned "make it async" sweep, so it is asserted here explicitly. If one of
-these ever needs to be a coroutine, it must ``await`` the provider through
-``run_in_threadpool`` first -- see the offload sites in ``agno/os/service_accounts.py``.
+Both properties are invisible in normal test runs and easy to destroy with a
+well-intentioned "make it async" sweep, so they are asserted here explicitly.
 """
 
+import asyncio
 from inspect import iscoroutinefunction
 
+import pytest
+from fastapi import FastAPI
+from starlette.requests import Request
+
 from agno.os.auth import require_resource_access
+from agno.os.authz.provider import AuthorizationContext, AuthorizationProvider
 
 
-def test_per_resource_dependency_is_sync():
+class _Probe(AuthorizationProvider):
+    """Records whether ``check`` ran on a thread that has a running event loop."""
+
+    def __init__(self):
+        self.ran_on_loop = None
+
+    def check(self, ctx: AuthorizationContext) -> bool:
+        try:
+            asyncio.get_running_loop()
+            self.ran_on_loop = True
+        except RuntimeError:
+            self.ran_on_loop = False
+        return True
+
+    def accessible_resource_ids(self, ctx: AuthorizationContext):
+        return {"*"}
+
+
+@pytest.mark.asyncio
+async def test_per_resource_dependency_keeps_a_sync_provider_off_the_loop():
     """``require_resource_access`` builds the per-resource gate used by every run,
-    continue, cancel, and read route. Measured on a provider with a 50ms decision:
-    ten concurrent requests took 1.10s as a coroutine and 0.61s as a plain def."""
+    continue, cancel, and read route. It is a coroutine so an async database is driven
+    natively, which is only safe because it awaits the provider's async path: a sync
+    provider's ``check`` must land in a worker thread, never on the loop. Measured on a
+    provider with a 50ms decision, ten concurrent requests took 1.10s with the check on
+    the loop and 0.61s offloaded."""
+    app = FastAPI()
+    probe = _Probe()
+    app.state.authorization_provider = probe
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/agents/a1/runs",
+        "headers": [],
+        "query_string": b"",
+        "path_params": {"agent_id": "a1"},
+        "app": app,
+    }
+    request = Request(scope)
+    request.state.authorization_enabled = True
+    request.state.user_id = "bob"
+
     dependency = require_resource_access("agents", "run", "agent_id")
-    assert not iscoroutinefunction(dependency), (
-        "require_resource_access's dependency must stay a plain `def`: it awaits nothing, "
-        "and the authorization provider it calls does blocking I/O. As `async def` that "
-        "I/O runs on the event loop instead of FastAPI's threadpool."
+    assert iscoroutinefunction(dependency)  # drives an async db natively ...
+    await dependency(request)
+    assert probe.ran_on_loop is False, (
+        "the per-resource gate ran a sync provider's check on the event loop; it must await the "
+        "provider's async twin, whose default offloads to a worker thread"
     )
 
 
@@ -36,8 +79,7 @@ def test_authz_admin_handlers_are_sync():
     Every one of them calls the role/user store (DB round trips) with no await, so
     making any of them ``async`` would move that I/O onto the loop.
     """
-    pytest_sqlalchemy = __import__("pytest").importorskip("sqlalchemy")
-    assert pytest_sqlalchemy  # managed roles need SQLAlchemy
+    pytest.importorskip("sqlalchemy")  # managed roles need SQLAlchemy
 
     from agno.os.authz.role_router import get_roles_router
     from agno.os.authz.role_store import ManagedRoleStore

--- a/libs/agno/tests/unit/os/test_mcp_server.py
+++ b/libs/agno/tests/unit/os/test_mcp_server.py
@@ -1221,8 +1221,8 @@ def test_managed_role_provider_is_mirrored_onto_mcp_subapp():
     import tempfile
 
     from agno.db.sqlite import SqliteDb
+    from agno.os.authz import Authorization
     from agno.os.authz.role_store import ManagedRoleStore
-    from agno.os.config import AuthorizationConfig
 
     with tempfile.NamedTemporaryFile(suffix=".db") as f:
         roles = ManagedRoleStore(db=SqliteDb(db_file=f.name))
@@ -1230,9 +1230,8 @@ def test_managed_role_provider_is_mirrored_onto_mcp_subapp():
         os = AgentOS(
             id="mcp-authz",
             agents=[_agent()],
-            authorization=True,
             mcp_server=True,
-            authorization_config=AuthorizationConfig(verification_keys=["x" * 40], algorithm="HS256", role_store=roles),
+            authorization=Authorization(verification_keys=["x" * 40], algorithm="HS256", role_store=roles),
         )
         app = os.get_app()
         main_provider = getattr(app.state, "authorization_provider", None)
@@ -1253,9 +1252,9 @@ def test_authz_mirror_survives_a_rebuilt_mcp_subapp():
     import tempfile
 
     from agno.db.sqlite import SqliteDb
+    from agno.os.authz import Authorization
     from agno.os.authz.audit import LoggingAuditSink
     from agno.os.authz.role_store import ManagedRoleStore
-    from agno.os.config import AuthorizationConfig
 
     with tempfile.NamedTemporaryFile(suffix=".db") as f:
         roles = ManagedRoleStore(db=SqliteDb(db_file=f.name))
@@ -1264,11 +1263,8 @@ def test_authz_mirror_survives_a_rebuilt_mcp_subapp():
         os = AgentOS(
             id="mcp-mirror",
             agents=[_agent()],
-            authorization=True,
             mcp_server=True,
-            authorization_config=AuthorizationConfig(
-                verification_keys=["x" * 40], algorithm="HS256", role_store=roles, audit=sink
-            ),
+            authorization=Authorization(verification_keys=["x" * 40], algorithm="HS256", role_store=roles, audit=sink),
         )
         app = os.get_app()
         provider = app.state.authorization_provider


### PR DESCRIPTION
## Summary

Follow-up on the `Authorization` facade in #9092, closing the three places it still diverged from the agreed surface, plus the small cleanups that fell out of that discussion. Targets `feat/agentos-authz`.

- **The user directory is explicit, never inferred.** `Authorization(user_directory=)` now defaults to `False`. Defining roles or reading them off a token claim (`roles_claim`) no longer stands up a `ManagedUserStore`, JIT provisioning, or `/users`. The directory exists when asked for: `user_directory=True`, a store of your own, or `seed(users=...)`, which names people and so counts as explicit.
- **`seed(admin=)` heals a lockout without undoing a handover.** The bootstrap admin is re-granted only when no stored assignment confers `agent_os:admin` any more. An operator who moved admin to someone else keeps that across restarts; an operator who demoted the last admin gets the bootstrap admin back on the next boot, with a warning saying so. Needed one new read on the contract: `list_authz_role_subjects(role)` on `BaseDb`/`AsyncBaseDb` (implemented for SQLite and Postgres, sync and async), `PolicyEngine.subjects_of` (optional, default `NotImplementedError`), and `ManagedRoleStore.admin_subjects()` with its async twin. An engine that cannot enumerate holders skips the check rather than guessing.
- **One deprecated spelling for `AuthorizationConfig`.** `AgentOS(authorization=AuthorizationConfig(...))` is refused with a `TypeError` pointing at the two supported forms. `authorization_config=` keeps working with `authorization=True` and now logs a deprecation warning naming the `Authorization(...)` equivalent. The class is documented as frozen; nothing new goes on it.
- **`AuthorizationConfig.role_store` is gone**, with its XOR validator, the `get_app` mount branch keyed on it, the `_seed_authorization_provider` branch, and the boot guards that only existed to catch it. The role store reaches AgentOS only through the `Authorization` object. `/authz` and `/users` mount from the object regardless of whether AgentOS has its own db, since the object may carry one.
- **`Authorization(authorization_provider=)` is the full override** and refuses `role_store=`/`engine=` alongside it, so a store nothing enforces can no longer sit behind a mounted `/authz`. `engine=` is the way to keep the admin API on your own backend.
- **`default_role` has one spelling**: `define_role(..., default=True)`. The constructor argument is removed.
- A facade handed stores that already carry their own db no longer demands a db of its own, and a store that ends up unbound after binding fails at construction instead of running in memory.
- CI fixes: the unused `tempfile` import in `test_audit_single_switch.py`, `ruff format` on the facade tests, and `test_authz_offloading.py` rewritten. The per-resource dependency became a coroutine in the async-variants commit, which the old test forbade; the property that matters is that a sync provider's `check` still runs off the event loop, so the test now asserts exactly that with a probe provider.

Tests migrated off the config shortcut onto the object in `test_managed_roles.py`, `test_managed_roles_api.py`, `test_managed_users.py`, `test_audit_single_switch.py`, `test_directory_no_auth.py`, `test_mcp_server.py`. New facade tests cover the explicit directory (unit and served), the lockout heal vs. handover, the provider-override rule, and the deprecation path. The two "mounts no admin API" assertions now go over HTTP; reading `app.routes` before the app serves was vacuous.

Not touched: `test_authz_planes.py::test_workflow_continue_route_carries_the_approval_gate` and the 30 failures across the three `routers/test_schedules_*.py` files fail on the branch head before this PR and are unrelated. Everything else under `tests/unit/os` and `tests/integration/os` passes.

## Type of change

- [x] Improvement
- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Cookbooks `00_quickstart_authorization.py` and `02_managed_users.py` run clean offline (they seed users, so their directory stays on). `01`, `04`, and `05` define roles only and now build no directory, which none of them used. The `07_security` cookbooks still pass `authorization_config=` and will log the deprecation warning at boot; moving them is a separate change.
