### PR TITLE
[fix] Use UTF-8 for infra file helpers

### DIFF
--- a/libs/agno_infra/agno/utilities/json_io.py
+++ b/libs/agno_infra/agno/utilities/json_io.py
@@ -20,11 +20,11 @@ class CustomJSONEncoder(json.JSONEncoder):
 def read_json_file(file_path: Optional[Path]) -> Optional[Union[Dict, List]]:
     if file_path is not None and file_path.exists() and file_path.is_file():
         # log_debug(f"Reading {file_path}")
-        return json.loads(file_path.read_text())
+        return json.loads(file_path.read_text(encoding="utf-8"))
     return None
 
 
 def write_json_file(file_path: Optional[Path], data: Optional[Union[Dict, List]], **kwargs) -> None:
     if file_path is not None and data is not None:
         log_debug(f"Writing {file_path}")
-        file_path.write_text(json.dumps(data, cls=CustomJSONEncoder, indent=4, **kwargs))
+        file_path.write_text(json.dumps(data, cls=CustomJSONEncoder, indent=4, **kwargs), encoding="utf-8")

--- a/libs/agno_infra/agno/utilities/pyproject.py
+++ b/libs/agno_infra/agno/utilities/pyproject.py
@@ -19,7 +19,7 @@ def read_pyproject_agno(pyproject_file: Path) -> Optional[Dict]:
         except ImportError:
             import tomli  # type: ignore
 
-            pyproject_dict = tomli.loads(pyproject_file.read_text())
+            pyproject_dict = tomli.loads(pyproject_file.read_text(encoding="utf-8"))
 
         agno_conf = pyproject_dict.get("tool", {}).get("agno", None)
         if agno_conf is not None and isinstance(agno_conf, dict):

--- a/libs/agno_infra/agno/utilities/yaml_io.py
+++ b/libs/agno_infra/agno/utilities/yaml_io.py
@@ -9,7 +9,7 @@ def read_yaml_file(file_path: Optional[Path]) -> Optional[Dict[str, Any]]:
         import yaml
 
         logger.debug(f"Reading {file_path}")
-        data_from_file = yaml.safe_load(file_path.read_text())
+        data_from_file = yaml.safe_load(file_path.read_text(encoding="utf-8"))
         if data_from_file is not None and isinstance(data_from_file, dict):
             return data_from_file
         else:
@@ -22,4 +22,4 @@ def write_yaml_file(file_path: Optional[Path], data: Optional[Dict[str, Any]], *
         import yaml
 
         logger.debug(f"Writing {file_path}")
-        file_path.write_text(yaml.safe_dump(data, **kwargs))
+        file_path.write_text(yaml.safe_dump(data, **kwargs), encoding="utf-8")

--- a/libs/agno_infra/tests/test_utilities_encoding.py
+++ b/libs/agno_infra/tests/test_utilities_encoding.py
@@ -1,0 +1,24 @@
+import json
+
+from agno.utilities.json_io import read_json_file, write_json_file
+from agno.utilities.yaml_io import read_yaml_file, write_yaml_file
+
+
+def test_json_helpers_round_trip_utf8(tmp_path):
+    path = tmp_path / "config.json"
+    data = {"message": "hello \u2603"}
+
+    write_json_file(path, data, ensure_ascii=False)
+
+    assert json.loads(path.read_text(encoding="utf-8")) == data
+    assert read_json_file(path) == data
+
+
+def test_yaml_helpers_round_trip_utf8(tmp_path):
+    path = tmp_path / "config.yaml"
+    data = {"message": "hello \u2603"}
+
+    write_yaml_file(path, data, allow_unicode=True)
+
+    assert "hello \u2603" in path.read_text(encoding="utf-8")
+    assert read_yaml_file(path) == data


### PR DESCRIPTION
## Summary

Closes #10114

This makes the `agno_infra` JSON/YAML/TOML helper file I/O explicitly use UTF-8.

The helpers already read and write structured text formats that are commonly UTF-8, but several `Path.read_text()` / `Path.write_text()` calls still relied on the platform default encoding. On non-UTF-8 locales, that can make config files with non-ASCII content fail to read or write consistently.

Issue number: #10114

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

This PR was prepared with AI assistance and manually reviewed before submission.

---

## Problem

`agno_infra` utility helpers for JSON/YAML config files and the Python <3.11 `pyproject.toml` fallback used platform-default text encoding.

## Before / after

Before, these helper reads/writes could depend on the user's local default codec.

After, JSON/YAML helper reads and writes and the TOML fallback read use `encoding="utf-8"` explicitly.

## Verification

From `libs/agno_infra`:

- `$env:PYTHONPATH = (Resolve-Path 'agno').Path; python -m pytest tests\test_utilities_encoding.py -q` (`2 passed`)
- `python -m py_compile agno\utilities\json_io.py agno\utilities\yaml_io.py agno\utilities\pyproject.py tests\test_utilities_encoding.py`

I did not run the full `./scripts/format.sh` / `./scripts/validate.sh` suite locally because this PR is limited to the `agno_infra` helper package and focused tests above.