### PR TITLE
feat: add knowledge level retrieval pipeline and MMR reranker

### DIFF
--- a/cookbook/07_knowledge/02_building_blocks/04_knowledge_level_reranking.py
+++ b/cookbook/07_knowledge/02_building_blocks/04_knowledge_level_reranking.py
@@ -1,0 +1,68 @@
+"""
+Knowledge-Level Reranking
+=========================
+A reranker set on Knowledge runs after the vector db returns results, rather than
+inside the vector db itself. Two differences follow from that:
+
+1. It works with any vector db, so the same reranker moves between backends.
+2. Knowledge widens the fetch first, so the reranker chooses from a real pool.
+   Asking for 5 results with a reranker set retrieves rerank_multiplier * 5
+   candidates (capped by max_rerank_candidates) and returns the best 5.
+
+The widened fetch is what makes ordering strategies possible: a reranker can only
+surface a document that was retrieved in the first place.
+
+A reranker configured on the vector db still runs first. The knowledge-level one
+runs on its output.
+
+See also: 03_reranking.py for vector db level reranking.
+"""
+
+import asyncio
+
+from agno.agent import Agent
+from agno.knowledge.knowledge import Knowledge
+from agno.knowledge.reranker.cohere import CohereReranker
+from agno.models.openai import OpenAIResponses
+from agno.vectordb.qdrant import Qdrant
+
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
+
+qdrant_url = "http://localhost:6333"
+
+knowledge = Knowledge(
+    vector_db=Qdrant(collection="knowledge_reranking_demo", url=qdrant_url),
+    # Runs after the vector db returns candidates.
+    reranker=CohereReranker(),
+    # Retrieve 5x the requested results, so the reranker has candidates to compare.
+    rerank_multiplier=5,
+    # Ceiling on the widened fetch, whatever max_results is asked for.
+    max_rerank_candidates=100,
+)
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.6-luna"),
+    knowledge=knowledge,
+    search_knowledge=True,
+    markdown=True,
+)
+
+
+async def main():
+    await knowledge.add_content_async(
+        url="https://docs.agno.com/introduction/agents.md",
+    )
+
+    # Retrieves 25 candidates, reranks them, returns the top 5.
+    results = await knowledge.asearch("What is an agent?", max_results=5)
+    print("Reranked results:")
+    for document in results:
+        print(f"  {document.name}")
+
+    await agent.aprint_response("What is an agent?", stream=True)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/cookbook/07_knowledge/02_building_blocks/07_knowledge_level_reranking.py
+++ b/cookbook/07_knowledge/02_building_blocks/07_knowledge_level_reranking.py
@@ -51,17 +51,17 @@ agent = Agent(
 
 
 async def main():
-    await knowledge.add_content_async(
-        url="https://docs.agno.com/introduction/agents.md",
+    await knowledge.ainsert(
+        url="https://agno-public.s3.amazonaws.com/recipes/ThaiRecipes.pdf"
     )
 
     # Retrieves 25 candidates, reranks them, returns the top 5.
-    results = await knowledge.asearch("What is an agent?", max_results=5)
+    results = await knowledge.asearch("What are some Thai curry dishes?", max_results=5)
     print("Reranked results:")
     for document in results:
         print(f"  {document.name}")
 
-    await agent.aprint_response("What is an agent?", stream=True)
+    await agent.aprint_response("What are some Thai curry dishes?", stream=True)
 
 
 if __name__ == "__main__":

--- a/cookbook/07_knowledge/02_building_blocks/08_mmr_diverse_results.py
+++ b/cookbook/07_knowledge/02_building_blocks/08_mmr_diverse_results.py
@@ -16,7 +16,7 @@ knowledge-level reranker provides: rerank_multiplier widens the fetch, MMR selec
 from it, and max_results are returned.
 
 MMR reads the embedding on each search result. Not every vector db returns one:
-Milvus, MongoDB, Redis, Valkey and Elasticsearch do not, so MMR raises there rather
+Milvus, MongoDB, Redis and Valkey do not, so MMR raises there rather
 than silently returning unreranked results.
 
 Take the returned order as the result: reranking_score holds the MMR score at the
@@ -59,16 +59,32 @@ agent = Agent(
 )
 
 
+def show(results, candidates: int) -> None:
+    """Print a snippet per result: every chunk shares the source file name."""
+    print(f"Selected {len(results)} of {candidates} candidates:\n")
+    for document in results:
+        snippet = " ".join(document.content.split())[:100]
+        print(f"  - {snippet}...")
+    print()
+
+
 async def main():
     await knowledge.ainsert(
         url="https://agno-public.s3.amazonaws.com/recipes/ThaiRecipes.pdf"
     )
 
+    query = "What are some Thai curry dishes?"
+
+    # Same query without MMR, to compare against.
+    plain = Knowledge(vector_db=knowledge.vector_db)
+    candidates = len(await plain.asearch(query, max_results=25))
+
+    print("\nWithout MMR")
+    show(await plain.asearch(query, max_results=5), candidates)
+
     # Retrieves 25 candidates, selects 5 that are relevant but unlike each other.
-    results = await knowledge.asearch("What are some Thai curry dishes?", max_results=5)
-    print("Diverse results:")
-    for document in results:
-        print(f"  {document.name}")
+    print("With MMR")
+    show(await knowledge.asearch(query, max_results=5), candidates)
 
     await agent.aprint_response("What are some Thai curry dishes?", stream=True)
 

--- a/cookbook/07_knowledge/02_building_blocks/08_mmr_diverse_results.py
+++ b/cookbook/07_knowledge/02_building_blocks/08_mmr_diverse_results.py
@@ -1,0 +1,73 @@
+"""
+MMR: Diverse, Non-Redundant Results
+===================================
+Vector search returns the closest matches to a query, which are often near-duplicates
+of each other: five chunks that all say the same thing. MMR (Maximal Marginal
+Relevance) picks documents one at a time, discounting each candidate by how similar it
+already is to what has been selected.
+
+lambda_mult controls the tradeoff:
+- 1.0 ranks by relevance alone (equivalent to plain vector search)
+- 0.5 balances relevance against difference
+- 0.0 ranks by difference alone
+
+MMR needs a pool larger than the number of results requested, which is what the
+knowledge-level reranker provides: rerank_multiplier widens the fetch, MMR selects
+from it, and max_results are returned.
+
+MMR reads the embedding on each search result. Not every vector db returns one:
+Milvus, MongoDB, Redis, Valkey and Elasticsearch do not, so MMR raises there rather
+than silently returning unreranked results.
+
+A reranker set on the vector db still runs first, on the widened pool, and MMR then
+reorders its output. Scoring by relevance and then by embedding similarity rarely
+composes usefully, so prefer setting one or the other.
+
+See also: 07_knowledge_level_reranking.py for how the widened fetch works.
+"""
+
+import asyncio
+
+from agno.agent import Agent
+from agno.knowledge.knowledge import Knowledge
+from agno.knowledge.reranker.mmr import MMRReranker
+from agno.models.openai import OpenAIResponses
+from agno.vectordb.qdrant import Qdrant
+
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
+
+qdrant_url = "http://localhost:6333"
+
+knowledge = Knowledge(
+    vector_db=Qdrant(collection="mmr_demo", url=qdrant_url),
+    reranker=MMRReranker(lambda_mult=0.5),
+    # Retrieve 5x the requested results so MMR has candidates to choose between.
+    rerank_multiplier=5,
+)
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.6-luna"),
+    knowledge=knowledge,
+    search_knowledge=True,
+    markdown=True,
+)
+
+
+async def main():
+    await knowledge.ainsert(
+        url="https://agno-public.s3.amazonaws.com/recipes/ThaiRecipes.pdf"
+    )
+
+    # Retrieves 25 candidates, selects 5 that are relevant but unlike each other.
+    results = await knowledge.asearch("What are some Thai curry dishes?", max_results=5)
+    print("Diverse results:")
+    for document in results:
+        print(f"  {document.name}")
+
+    await agent.aprint_response("What are some Thai curry dishes?", stream=True)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/cookbook/07_knowledge/02_building_blocks/08_mmr_diverse_results.py
+++ b/cookbook/07_knowledge/02_building_blocks/08_mmr_diverse_results.py
@@ -19,6 +19,10 @@ MMR reads the embedding on each search result. Not every vector db returns one:
 Milvus, MongoDB, Redis, Valkey and Elasticsearch do not, so MMR raises there rather
 than silently returning unreranked results.
 
+Take the returned order as the result: reranking_score holds the MMR score at the
+moment each document was picked, which is not descending, so re-sorting by it discards
+the diversity ordering.
+
 A reranker set on the vector db still runs first, on the widened pool, and MMR then
 reorders its output. Scoring by relevance and then by embedding similarity rarely
 composes usefully, so prefer setting one or the other.

--- a/cookbook/07_knowledge/02_building_blocks/09_mmr_with_pgvector.py
+++ b/cookbook/07_knowledge/02_building_blocks/09_mmr_with_pgvector.py
@@ -1,0 +1,83 @@
+"""
+MMR with PgVector
+=================
+The same diversity selection as 08_mmr_diverse_results.py, against PgVector.
+
+MMR compares candidates to each other, so it needs the embedding of every search
+result. PgVector returns embeddings on search, so MMR works against it directly.
+
+Setup:
+    ./cookbook/scripts/run_pgvector.sh
+
+See also: 08_mmr_diverse_results.py for what lambda_mult controls.
+"""
+
+import asyncio
+
+from agno.agent import Agent
+from agno.knowledge.embedder.openai import OpenAIEmbedder
+from agno.knowledge.knowledge import Knowledge
+from agno.knowledge.reranker.mmr import MMRReranker
+from agno.models.openai import OpenAIResponses
+from agno.vectordb.pgvector import PgVector
+from agno.vectordb.search import SearchType
+
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
+
+db_url = "postgresql+psycopg://ai:ai@localhost:5532/ai"
+
+knowledge = Knowledge(
+    vector_db=PgVector(
+        table_name="mmr_demo",
+        db_url=db_url,
+        search_type=SearchType.hybrid,
+        embedder=OpenAIEmbedder(id="text-embedding-3-small"),
+    ),
+    # Runs after PgVector returns candidates.
+    reranker=MMRReranker(lambda_mult=0.5),
+    # Retrieve 5x the requested results so MMR has candidates to choose between.
+    rerank_multiplier=5,
+)
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.6-luna"),
+    knowledge=knowledge,
+    search_knowledge=True,
+    instructions=[
+        "Always search your knowledge base before answering.",
+        "Include sources in your response.",
+    ],
+    markdown=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Demo
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+
+    async def main():
+        await knowledge.ainsert(
+            url="https://agno-public.s3.amazonaws.com/recipes/ThaiRecipes.pdf"
+        )
+
+        print("\n" + "=" * 60)
+        print("PgVector hybrid search + MMR")
+        print("=" * 60 + "\n")
+
+        # Retrieves 25 candidates, selects 5 that are relevant but unlike each other.
+        results = await knowledge.asearch(
+            "What are some Thai curry dishes?", max_results=5
+        )
+        for document in results:
+            print(f"  {document.name}")
+
+        await agent.aprint_response("What are some Thai curry dishes?", stream=True)
+
+    asyncio.run(main())

--- a/cookbook/07_knowledge/02_building_blocks/10_mmr_with_elasticsearch.py
+++ b/cookbook/07_knowledge/02_building_blocks/10_mmr_with_elasticsearch.py
@@ -1,13 +1,13 @@
 """
-MMR with PgVector
-=================
-The same diversity selection as 08_mmr_diverse_results.py, against PgVector.
+MMR with Elasticsearch
+======================
+The same diversity selection as 08_mmr_diverse_results.py, against Elasticsearch.
 
 MMR compares candidates to each other, so it needs the embedding of every search
-result. PgVector returns embeddings on search, so MMR works against it directly.
+result. Elasticsearch returns embeddings on search, so MMR works against it directly.
 
 Setup:
-    ./cookbook/scripts/run_pgvector.sh
+    ./cookbook/scripts/run_elasticsearch.sh
 
 See also: 08_mmr_diverse_results.py for what lambda_mult controls.
 """
@@ -19,23 +19,25 @@ from agno.knowledge.embedder.openai import OpenAIEmbedder
 from agno.knowledge.knowledge import Knowledge
 from agno.knowledge.reranker.mmr import MMRReranker
 from agno.models.openai import OpenAIResponses
-from agno.vectordb.pgvector import PgVector
+from agno.vectordb.elasticsearch import Elasticsearch
 from agno.vectordb.search import SearchType
 
 # ---------------------------------------------------------------------------
 # Setup
 # ---------------------------------------------------------------------------
 
-db_url = "postgresql+psycopg://ai:ai@localhost:5532/ai"
+elasticsearch_url = "http://localhost:9200"
+
+vector_db = Elasticsearch(
+    index_name="mmr_demo",
+    url=elasticsearch_url,
+    search_type=SearchType.hybrid,
+    embedder=OpenAIEmbedder(id="text-embedding-3-small"),
+)
 
 knowledge = Knowledge(
-    vector_db=PgVector(
-        table_name="mmr_demo",
-        db_url=db_url,
-        search_type=SearchType.hybrid,
-        embedder=OpenAIEmbedder(id="text-embedding-3-small"),
-    ),
-    # Runs after PgVector returns candidates.
+    vector_db=vector_db,
+    # Runs after Elasticsearch returns candidates.
     reranker=MMRReranker(lambda_mult=0.5),
     # Retrieve 5x the requested results so MMR has candidates to choose between.
     rerank_multiplier=5,
@@ -78,7 +80,7 @@ if __name__ == "__main__":
         )
 
         print("\n" + "=" * 60)
-        print("PgVector hybrid search + MMR")
+        print("Elasticsearch hybrid search + MMR")
         print("=" * 60 + "\n")
 
         query = "What are some Thai curry dishes?"
@@ -95,5 +97,9 @@ if __name__ == "__main__":
         show(await knowledge.asearch(query, max_results=5), candidates)
 
         await agent.aprint_response("What are some Thai curry dishes?", stream=True)
+
+        # The async client holds an aiohttp session that Python will not close for
+        # you: skip this and the script exits with an unclosed connector warning.
+        await vector_db.async_close()
 
     asyncio.run(main())

--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -143,6 +143,11 @@ class Knowledge(RemoteKnowledge):
         self.reranker = reranker
         self.rerank_multiplier = rerank_multiplier
         self.max_rerank_candidates = max_rerank_candidates
+        if reranker is not None and getattr(vector_db, "reranker", None) is not None:
+            log_warning(
+                "A reranker is set on both Knowledge and the vector db. Both will run, the "
+                "vector db's first, which reorders the candidates the second one then sees."
+            )
         self.__post_init__()
 
     @property
@@ -195,7 +200,9 @@ class Knowledge(RemoteKnowledge):
         """Widen the vector db fetch so the reranker has candidates to choose between."""
         if self.reranker is None:
             return max_results
-        return min(max_results * self.rerank_multiplier, self.max_rerank_candidates)
+        # The ceiling caps the widening, never the caller's own request: clamping below
+        # max_results would return fewer documents than were asked for.
+        return max(min(max_results * self.rerank_multiplier, self.max_rerank_candidates), max_results)
 
     def _rerank_documents(self, query: str, documents: List[Document], max_results: int) -> List[Document]:
         """Apply the knowledge-level reranker, then trim to the caller's requested count."""
@@ -203,6 +210,9 @@ class Knowledge(RemoteKnowledge):
             return documents[:max_results]
         try:
             reranked = self.reranker.rerank(query=query, documents=documents)
+        except ValueError:
+            # A misconfigured reranker would otherwise look like it ran and changed nothing.
+            raise
         except Exception as e:
             # A reranker failure degrades ordering, not availability: keep the vector db order.
             log_error(f"Error reranking documents: {str(e)}")
@@ -215,6 +225,9 @@ class Knowledge(RemoteKnowledge):
             return documents[:max_results]
         try:
             reranked = await self.reranker.arerank(query=query, documents=documents)
+        except ValueError:
+            # See the matching comment in ``_rerank_documents``.
+            raise
         except Exception as e:
             log_error(f"Error reranking documents: {str(e)}")
             return documents[:max_results]
@@ -1003,9 +1016,9 @@ class Knowledge(RemoteKnowledge):
         if self.page_store is not None:
             if filters:
                 raise ValueError("Page knowledge does not support filters")
-            return self._page_documents(
-                self.search_pages(query, limit=max_results if max_results is not None else self.max_results)
-            )
+            page_limit = max_results if max_results is not None else self.max_results
+            page_documents = self._page_documents(self.search_pages(query, limit=self._search_limit(page_limit)))
+            return self._rerank_documents(query, page_documents, page_limit)
         from agno.vectordb import VectorDb
         from agno.vectordb.search import SearchType
 
@@ -1056,9 +1069,9 @@ class Knowledge(RemoteKnowledge):
         if self.page_store is not None:
             if filters:
                 raise ValueError("Page knowledge does not support filters")
-            return self._page_documents(
-                await self.asearch_pages(query, limit=max_results if max_results is not None else self.max_results)
-            )
+            page_limit = max_results if max_results is not None else self.max_results
+            page_documents = self._page_documents(await self.asearch_pages(query, limit=self._search_limit(page_limit)))
+            return await self._arerank_documents(query, page_documents, page_limit)
         from agno.vectordb import VectorDb
         from agno.vectordb.search import SearchType
 

--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -27,6 +27,7 @@ from agno.knowledge.remote_content.remote_content import (
     RemoteContent,
 )
 from agno.knowledge.remote_knowledge import RemoteKnowledge
+from agno.knowledge.reranker.base import Reranker
 from agno.knowledge.types import ContentType
 from agno.knowledge.utils import get_agno_metadata, merge_user_metadata, set_agno_metadata, strip_agno_metadata
 from agno.utils.http import async_fetch_with_retry
@@ -79,6 +80,17 @@ class Knowledge(RemoteKnowledge):
     page_store: Optional[Any] = None
     page_search: Optional[PageSearchConfig] = None
 
+    # Reorders results after the vector db returns them, so a strategy that needs to
+    # compare candidates against each other (diversity, recency) sees a real pool.
+    # Runs after any reranker configured on the vector db itself.
+    reranker: Optional[Reranker] = None
+    # Candidates fetched per requested result when a reranker is set. Reordering can
+    # only surface a document that was retrieved, so the pool has to exceed max_results.
+    rerank_multiplier: int = 5
+    # Ceiling on the widened fetch, so a large max_results cannot turn one search into
+    # an unbounded scan.
+    max_rerank_candidates: int = 100
+
     def __init__(
         self,
         *,
@@ -94,6 +106,9 @@ class Knowledge(RemoteKnowledge):
         page_search: Optional[PageSearchConfig] = None,
         max_embedding_retries: int = 0,
         embedding_retry_backoff: float = 1.0,
+        reranker: Optional[Reranker] = None,
+        rerank_multiplier: int = 5,
+        max_rerank_candidates: int = 100,
         contents_db: Optional[Union[BaseDb, AsyncBaseDb]] = cast(Any, _DATABASE_UNSET),
     ):
         """Configure Knowledge using keyword arguments.
@@ -117,6 +132,17 @@ class Knowledge(RemoteKnowledge):
         self.embedding_retry_backoff = embedding_retry_backoff
         self.page_store = page_store
         self.page_search = page_search
+        if isinstance(rerank_multiplier, bool) or not isinstance(rerank_multiplier, int) or rerank_multiplier < 1:
+            raise ValueError("rerank_multiplier must be an integer greater than or equal to 1")
+        if (
+            isinstance(max_rerank_candidates, bool)
+            or not isinstance(max_rerank_candidates, int)
+            or max_rerank_candidates < 1
+        ):
+            raise ValueError("max_rerank_candidates must be an integer greater than or equal to 1")
+        self.reranker = reranker
+        self.rerank_multiplier = rerank_multiplier
+        self.max_rerank_candidates = max_rerank_candidates
         self.__post_init__()
 
     @property
@@ -164,6 +190,35 @@ class Knowledge(RemoteKnowledge):
             )
             for hit in result.results
         ]
+
+    def _search_limit(self, max_results: int) -> int:
+        """Widen the vector db fetch so the reranker has candidates to choose between."""
+        if self.reranker is None:
+            return max_results
+        return min(max_results * self.rerank_multiplier, self.max_rerank_candidates)
+
+    def _rerank_documents(self, query: str, documents: List[Document], max_results: int) -> List[Document]:
+        """Apply the knowledge-level reranker, then trim to the caller's requested count."""
+        if self.reranker is None:
+            return documents[:max_results]
+        try:
+            reranked = self.reranker.rerank(query=query, documents=documents)
+        except Exception as e:
+            # A reranker failure degrades ordering, not availability: keep the vector db order.
+            log_error(f"Error reranking documents: {str(e)}")
+            return documents[:max_results]
+        return reranked[:max_results]
+
+    async def _arerank_documents(self, query: str, documents: List[Document], max_results: int) -> List[Document]:
+        """Async variant of ``_rerank_documents``."""
+        if self.reranker is None:
+            return documents[:max_results]
+        try:
+            reranked = await self.reranker.arerank(query=query, documents=documents)
+        except Exception as e:
+            log_error(f"Error reranking documents: {str(e)}")
+            return documents[:max_results]
+        return reranked[:max_results]
 
     def setup(self) -> None:
         """Prepare and validate coordinated page storage before query traffic."""
@@ -971,12 +1026,13 @@ class Knowledge(RemoteKnowledge):
 
             _max_results = max_results or self.max_results
             log_debug(f"Getting {_max_results} relevant documents for query: {query}")
-            return self.vector_db.search(
+            documents = self.vector_db.search(
                 query=query,
-                limit=_max_results,
+                limit=self._search_limit(_max_results),
                 filters=search_filters,
                 **strict_user_id_kwarg(self.vector_db.search, user_id),
             )
+            return self._rerank_documents(query, documents, _max_results)
         except ValueError:
             # The adapters raise these outside their own catch-alls on purpose.
             raise
@@ -1022,21 +1078,23 @@ class Knowledge(RemoteKnowledge):
 
             _max_results = max_results or self.max_results
             log_debug(f"Getting {_max_results} relevant documents for query: {query}")
+            search_limit = self._search_limit(_max_results)
             try:
-                return await self.vector_db.async_search(
+                documents = await self.vector_db.async_search(
                     query=query,
-                    limit=_max_results,
+                    limit=search_limit,
                     filters=search_filters,
                     **strict_user_id_kwarg(self.vector_db.async_search, user_id),
                 )
             except NotImplementedError:
                 log_info("Vector db does not support async search")
-                return self.vector_db.search(
+                documents = self.vector_db.search(
                     query=query,
-                    limit=_max_results,
+                    limit=search_limit,
                     filters=search_filters,
                     **strict_user_id_kwarg(self.vector_db.search, user_id),
                 )
+            return await self._arerank_documents(query, documents, _max_results)
         except ValueError:
             # See the matching comment in ``search``.
             raise

--- a/libs/agno/agno/knowledge/reranker/__init__.py
+++ b/libs/agno/agno/knowledge/reranker/__init__.py
@@ -1,3 +1,4 @@
 from agno.knowledge.reranker.base import Reranker
+from agno.knowledge.reranker.mmr import MMRReranker
 
-__all__ = ["Reranker"]
+__all__ = ["Reranker", "MMRReranker"]

--- a/libs/agno/agno/knowledge/reranker/base.py
+++ b/libs/agno/agno/knowledge/reranker/base.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import List
 
 from pydantic import BaseModel, ConfigDict
@@ -14,5 +15,6 @@ class Reranker(BaseModel):
         raise NotImplementedError
 
     async def arerank(self, query: str, documents: List[Document]) -> List[Document]:
-        """Async rerank. Defaults to the sync implementation so existing rerankers keep working."""
-        return self.rerank(query=query, documents=documents)
+        """Async rerank. Runs the sync implementation off the event loop, since a
+        reranker that calls a provider would otherwise block it."""
+        return await asyncio.to_thread(self.rerank, query, documents)

--- a/libs/agno/agno/knowledge/reranker/base.py
+++ b/libs/agno/agno/knowledge/reranker/base.py
@@ -12,3 +12,7 @@ class Reranker(BaseModel):
 
     def rerank(self, query: str, documents: List[Document]) -> List[Document]:
         raise NotImplementedError
+
+    async def arerank(self, query: str, documents: List[Document]) -> List[Document]:
+        """Async rerank. Defaults to the sync implementation so existing rerankers keep working."""
+        return self.rerank(query=query, documents=documents)

--- a/libs/agno/agno/knowledge/reranker/mmr.py
+++ b/libs/agno/agno/knowledge/reranker/mmr.py
@@ -1,0 +1,176 @@
+from dataclasses import replace
+from math import sqrt
+from typing import Any, List, Optional, Sequence, Tuple
+
+from pydantic import Field, field_validator
+
+from agno.knowledge.document import Document
+from agno.knowledge.reranker.base import Reranker
+
+
+def _cosine_similarity(left: Sequence[float], right: Sequence[float]) -> float:
+    """Cosine similarity without numpy, which is not a core dependency."""
+    dot = 0.0
+    left_norm = 0.0
+    right_norm = 0.0
+    for a, b in zip(left, right):
+        dot += a * b
+        left_norm += a * a
+        right_norm += b * b
+    if left_norm <= 0.0 or right_norm <= 0.0:
+        return 0.0
+    return dot / (sqrt(left_norm) * sqrt(right_norm))
+
+
+class MMRReranker(Reranker):
+    """Selects results that are relevant to the query but unlike each other.
+
+    Plain vector search returns the closest matches, which are often near-duplicates of
+    one another. MMR picks documents one at a time, discounting each candidate by how
+    similar it already is to what has been selected.
+
+    Requires an embedding on every candidate document. Verified against live backends:
+    pgvector, Qdrant (vector and hybrid), Chroma and LanceDB return them; Milvus,
+    MongoDB, Redis, Valkey, Elasticsearch and Qdrant keyword search do not, and MMR
+    raises there rather than returning an unreranked list. Pinecone omits vectors unless
+    the store is built with return_vectors=True.
+
+    It also needs an embedder to embed the query. Vector dbs that embed queries
+    themselves (Upstash hosted embeddings) expose none, so MMR cannot run there.
+
+    The query is embedded with the embedder attached to the search results, so it always
+    uses the same model the documents were indexed with.
+
+    Returned documents are shallow copies carrying the MMR score; meta_data and embedding
+    are shared with the inputs.
+    """
+
+    # Weight between relevance and diversity: 1.0 ranks by relevance alone, 0.0 by
+    # difference alone.
+    lambda_mult: float = Field(default=0.5, ge=0.0, le=1.0)
+    # Caps how many documents are selected. Leave unset on Knowledge.reranker, which
+    # trims to max_results anyway: a smaller top_n returns fewer documents than asked for.
+    top_n: Optional[int] = Field(default=None, gt=0)
+
+    @field_validator("lambda_mult", mode="before")
+    @classmethod
+    def _reject_bool_lambda(cls, value: Any) -> Any:
+        # bool is an int subclass, so True would otherwise coerce to 1.0.
+        if isinstance(value, bool):
+            raise ValueError("lambda_mult must be a number between 0.0 and 1.0")
+        return value
+
+    @field_validator("top_n", mode="before")
+    @classmethod
+    def _reject_bool_top_n(cls, value: Any) -> Any:
+        if isinstance(value, bool):
+            raise ValueError("top_n must be a positive integer")
+        return value
+
+    def _select(self, query_embedding: Optional[List[float]], documents: List[Document], limit: int) -> List[Document]:
+        # Vector dbs return embeddings as lists or as numpy arrays, whose truth value
+        # is ambiguous, so length is the portable emptiness check throughout.
+        if query_embedding is None or len(query_embedding) == 0:
+            raise ValueError("MMRReranker could not embed the query: the embedder returned no vector")
+
+        embeddings: List[List[float]] = [doc.embedding for doc in documents]  # type: ignore[misc]
+        # zip() would silently truncate to the shorter vector and score against a prefix.
+        dimensions = {len(embedding) for embedding in embeddings} | {len(query_embedding)}
+        if len(dimensions) > 1:
+            raise ValueError(
+                f"MMRReranker requires embeddings of one dimension, but got {sorted(dimensions)}. "
+                "The query embedder and the indexed documents likely use different models."
+            )
+
+        relevance = [_cosine_similarity(query_embedding, embedding) for embedding in embeddings]
+
+        selected: List[Tuple[int, float]] = []
+        remaining = list(range(len(documents)))
+
+        # Seed with the closest match to the query. Scoring the first pick with the MMR
+        # formula would tie every candidate at lambda_mult=0.0 and pick by input order.
+        first = max(remaining, key=lambda candidate: relevance[candidate])
+        selected.append((first, relevance[first]))
+        remaining.remove(first)
+
+        # Each candidate's similarity to the nearest selected document, extended as
+        # documents are picked. Recomputing it per iteration is quadratic in the number
+        # selected, which at the candidate ceiling dominates the search itself.
+        best_redundancy = [0.0] * len(documents)
+        for candidate in remaining:
+            best_redundancy[candidate] = _cosine_similarity(embeddings[candidate], embeddings[first])
+
+        while remaining and len(selected) < limit:
+            best_index = remaining[0]
+            best_score = float("-inf")
+            for candidate in remaining:
+                score = self.lambda_mult * relevance[candidate] - (1.0 - self.lambda_mult) * best_redundancy[candidate]
+                if score > best_score:
+                    best_score = score
+                    best_index = candidate
+            selected.append((best_index, best_score))
+            remaining.remove(best_index)
+            for candidate in remaining:
+                similarity = _cosine_similarity(embeddings[candidate], embeddings[best_index])
+                if similarity > best_redundancy[candidate]:
+                    best_redundancy[candidate] = similarity
+
+        results: List[Document] = []
+        for index, score in selected:
+            # A shallow copy, made only so reranking_score does not land on the caller's
+            # documents: meta_data and embedding stay shared with the originals.
+            document = replace(documents[index])
+            # The MMR score itself, which descends by construction as candidates are
+            # picked, so sorting by reranking_score preserves this order.
+            document.reranking_score = score
+            results.append(document)
+        return results
+
+    def _prepare(self, documents: List[Document]) -> Optional[int]:
+        """Validate inputs and return the number of documents to select."""
+        if not documents:
+            return None
+
+        # A zero vector is indistinguishable from a broken ingest and would otherwise be
+        # selected as maximally different from everything.
+        missing = [
+            doc.id for doc in documents if doc.embedding is None or len(doc.embedding) == 0 or not any(doc.embedding)
+        ]
+        if missing:
+            # Silently returning the input order would look like MMR ran and found
+            # nothing to diversify.
+            raise ValueError(
+                "MMRReranker requires embeddings on search results, but the vector db returned "
+                f"{len(missing)} document(s) without one. Some vector dbs (Milvus, MongoDB, "
+                "Redis, Valkey, Elasticsearch) do not return embeddings on search."
+            )
+
+        limit = self.top_n if self.top_n is not None else len(documents)
+        return min(limit, len(documents))
+
+    def _resolve_embedder(self, documents: List[Document]) -> Any:
+        """The embedder travels on the search results, so the query uses the indexing model."""
+        for document in documents:
+            if document.embedder is not None:
+                return document.embedder
+        raise ValueError(
+            "MMRReranker needs an embedder to embed the query, but the vector db did not "
+            "attach one to its search results. Vector dbs that embed queries themselves "
+            "(such as Upstash hosted embeddings) do not expose one, so MMR cannot run there."
+        )
+
+    def rerank(self, query: str, documents: List[Document]) -> List[Document]:
+        limit = self._prepare(documents)
+        if limit is None:
+            return documents
+
+        embedder = self._resolve_embedder(documents)
+        return self._select(embedder.get_embedding(query), documents, limit)
+
+    async def arerank(self, query: str, documents: List[Document]) -> List[Document]:
+        limit = self._prepare(documents)
+        if limit is None:
+            return documents
+
+        embedder = self._resolve_embedder(documents)
+        return self._select(await embedder.async_get_embedding(query), documents, limit)

--- a/libs/agno/agno/knowledge/reranker/mmr.py
+++ b/libs/agno/agno/knowledge/reranker/mmr.py
@@ -31,9 +31,9 @@ class MMRReranker(Reranker):
 
     Requires an embedding on every candidate document. Verified against live backends:
     pgvector, Qdrant (vector and hybrid), Chroma and LanceDB return them; Milvus,
-    MongoDB, Redis, Valkey, Elasticsearch and Qdrant keyword search do not, and MMR
-    raises there rather than returning an unreranked list. Pinecone omits vectors unless
-    the store is built with return_vectors=True.
+    MongoDB, Redis, Valkey and Qdrant keyword search do not, and MMR raises there rather
+    than returning an unreranked list. Pinecone omits vectors unless the store is built
+    with return_vectors=True.
 
     It also needs an embedder to embed the query. Vector dbs that embed queries
     themselves (Upstash hosted embeddings) expose none, so MMR cannot run there.
@@ -148,7 +148,7 @@ class MMRReranker(Reranker):
             raise ValueError(
                 "MMRReranker requires embeddings on search results, but the vector db returned "
                 f"{len(missing)} document(s) without one. Some vector dbs (Milvus, MongoDB, "
-                "Redis, Valkey, Elasticsearch) do not return embeddings on search."
+                "Redis, Valkey) do not return embeddings on search."
             )
 
         limit = self.top_n if self.top_n is not None else len(documents)

--- a/libs/agno/agno/knowledge/reranker/mmr.py
+++ b/libs/agno/agno/knowledge/reranker/mmr.py
@@ -43,6 +43,11 @@ class MMRReranker(Reranker):
 
     Returned documents are shallow copies carrying the MMR score; meta_data and embedding
     are shared with the inputs.
+
+    Do not re-sort the result by reranking_score. Other rerankers score each document
+    independently, so their order can be rebuilt from the scores; MMR chooses each
+    document against the ones already chosen, so its scores are not descending and
+    sorting by them discards the diversity ordering.
     """
 
     # Weight between relevance and diversity: 1.0 ranks by relevance alone, 0.0 by
@@ -120,8 +125,9 @@ class MMRReranker(Reranker):
             # A shallow copy, made only so reranking_score does not land on the caller's
             # documents: meta_data and embedding stay shared with the originals.
             document = replace(documents[index])
-            # The MMR score itself, which descends by construction as candidates are
-            # picked, so sorting by reranking_score preserves this order.
+            # The MMR score at the moment this document was picked. Unlike a relevance
+            # score it is not monotonic across the list, because the candidate pool
+            # shrinks as redundancy grows: the returned order is authoritative.
             document.reranking_score = score
             results.append(document)
         return results

--- a/libs/agno/agno/vectordb/cassandra/cassandra.py
+++ b/libs/agno/agno/vectordb/cassandra/cassandra.py
@@ -86,6 +86,7 @@ class Cassandra(VectorDb):
             id=row["row_id"],
             content=row["body_blob"],
             meta_data=metadata,
+            embedder=self.embedder,
             embedding=row["vector"],
             name=row["document_name"],
             content_id=metadata.get("content_id"),

--- a/libs/agno/agno/vectordb/chroma/chromadb.py
+++ b/libs/agno/agno/vectordb/chroma/chromadb.py
@@ -1202,6 +1202,7 @@ class ChromaDb(VectorDb):
                     name=name,
                     meta_data=doc_metadata,
                     content=content,
+                    embedder=self.embedder,
                     embedding=embedding,
                     content_id=content_id,
                 )
@@ -1297,6 +1298,7 @@ class ChromaDb(VectorDb):
                         name=name,
                         meta_data=doc_metadata,
                         content=content,
+                        embedder=self.embedder,
                         embedding=embedding,
                         content_id=content_id,
                     )
@@ -1384,6 +1386,7 @@ class ChromaDb(VectorDb):
                         name=name,
                         meta_data=doc_metadata,
                         content=content,
+                        embedder=self.embedder,
                         embedding=embedding,
                         content_id=content_id,
                     )

--- a/libs/agno/agno/vectordb/couchbase/couchbase.py
+++ b/libs/agno/agno/vectordb/couchbase/couchbase.py
@@ -624,6 +624,7 @@ class CouchbaseSearch(VectorDb):
                     id=doc_id,
                     name=value["name"],
                     content=value["content"],
+                    embedder=self.embedder,
                     meta_data=value["meta_data"],
                     embedding=value["embedding"],
                     content_id=value.get("content_id"),
@@ -1413,6 +1414,7 @@ class CouchbaseSearch(VectorDb):
                             id=doc_id,
                             name=value.get("name"),
                             content=value.get("content", ""),
+                            embedder=self.embedder,
                             meta_data=value.get("meta_data", {}),
                             embedding=value.get("embedding", []),
                         )

--- a/libs/agno/agno/vectordb/elasticsearch/elasticsearch.py
+++ b/libs/agno/agno/vectordb/elasticsearch/elasticsearch.py
@@ -988,6 +988,7 @@ class Elasticsearch(VectorDb):
             content=doc_data["content"],
             name=doc_data.get("name"),
             meta_data=meta_data,
+            embedder=self.embedder,
             embedding=doc_data.get("embedding"),
             usage=doc_data.get("usage"),
             reranking_score=doc_data.get("reranking_score"),

--- a/libs/agno/agno/vectordb/opensearch/opensearch.py
+++ b/libs/agno/agno/vectordb/opensearch/opensearch.py
@@ -909,6 +909,7 @@ class OpenSearch(VectorDb):
             content=doc_data["content"],
             name=doc_data.get("name"),
             meta_data=meta_data,
+            embedder=self.embedder,
             embedding=doc_data.get("embedding"),
             usage=doc_data.get("usage"),
             reranking_score=doc_data.get("reranking_score"),

--- a/libs/agno/agno/vectordb/pineconedb/pineconedb.py
+++ b/libs/agno/agno/vectordb/pineconedb/pineconedb.py
@@ -95,6 +95,7 @@ class PineconeDb(VectorDb):
         use_hybrid_search: bool = False,
         hybrid_alpha: float = 0.5,
         reranker: Optional[Reranker] = None,
+        return_vectors: bool = False,
         **kwargs,
     ):
         # Validate required parameters
@@ -149,6 +150,9 @@ class PineconeDb(VectorDb):
             log_debug("Embedder not provided, using OpenAIEmbedder as default.")
         self.embedder: Embedder = _embedder
         self.reranker: Optional[Reranker] = reranker
+        # Pinecone omits vectors unless asked. Fetching them enlarges every response, so
+        # this stays off until a reranker that scores on embeddings needs them.
+        self.return_vectors: bool = return_vectors
 
     @property
     def client(self) -> Pinecone:
@@ -497,6 +501,12 @@ class PineconeDb(VectorDb):
         hdense = [v * alpha for v in dense]
         return hdense, hsparse
 
+    def _include_values(self, include_values: Optional[bool]) -> bool:
+        """An explicit argument wins; otherwise follow the instance setting."""
+        if include_values is not None:
+            return include_values
+        return self.return_vectors
+
     def search(
         self,
         query: str,
@@ -513,7 +523,8 @@ class PineconeDb(VectorDb):
             limit (int, optional): The maximum number of results to return. Defaults to 5.
             filters (Optional[Dict[str, Union[str, float, int, bool, List, dict]]], optional): The filter for the search. Defaults to None.
             namespace (Optional[str], optional): The namespace to search in. Defaults to None.
-            include_values (Optional[bool], optional): Whether to include values in the search results. Defaults to None.
+            include_values (Optional[bool], optional): Whether to include vectors in the results.
+                Defaults to None, which follows the return_vectors setting on the instance.
             include_metadata (Optional[bool], optional): Whether to include metadata in the search results. Defaults to None.
             user_id (Optional[str], optional): Scope results to this user plus shared chunks.
                 Defaults to None, which applies no scope.
@@ -543,7 +554,7 @@ class PineconeDb(VectorDb):
                 top_k=limit,
                 namespace=namespace or self.namespace,
                 filter=filters,
-                include_values=include_values,
+                include_values=self._include_values(include_values),
                 include_metadata=True,
             )
         else:
@@ -552,7 +563,7 @@ class PineconeDb(VectorDb):
                 top_k=limit,
                 namespace=namespace or self.namespace,
                 filter=filters,
-                include_values=include_values,
+                include_values=self._include_values(include_values),
                 include_metadata=True,
             )
 
@@ -560,6 +571,7 @@ class PineconeDb(VectorDb):
             Document(
                 content=(result.metadata.get("text", "") if result.metadata is not None else ""),
                 id=result.id,
+                embedder=self.embedder,
                 embedding=result.values,
                 meta_data=result.metadata,
             )

--- a/libs/agno/agno/vectordb/qdrant/qdrant.py
+++ b/libs/agno/agno/vectordb/qdrant/qdrant.py
@@ -600,6 +600,13 @@ class Qdrant(VectorDb):
             await asyncio.to_thread(self._delete_by_content_hash, content_hash, user_id)
         await self.async_insert(content_hash=content_hash, documents=documents, filters=filters, user_id=user_id)
 
+    def _dense_vector(self, vector: Any) -> Optional[List[float]]:
+        """Named-vector searches return a mapping, so pull the dense vector out of it."""
+        if isinstance(vector, dict):
+            dense = vector.get(self.dense_vector_name)
+            return list(dense) if dense is not None else None
+        return vector
+
     def search(
         self,
         query: str,
@@ -821,7 +828,7 @@ class Qdrant(VectorDb):
                     meta_data=result.payload["meta_data"],
                     content=result.payload["content"],
                     embedder=self.embedder,
-                    embedding=result.vector,  # type: ignore
+                    embedding=self._dense_vector(result.vector),
                     usage=result.payload.get("usage"),
                     content_id=result.payload.get("content_id"),
                 )

--- a/libs/agno/agno/vectordb/upstashdb/upstashdb.py
+++ b/libs/agno/agno/vectordb/upstashdb/upstashdb.py
@@ -482,6 +482,7 @@ class UpstashVectorDb(VectorDb):
                         content=result.data,
                         id=result.id,
                         meta_data=result.metadata or {},
+                        embedder=self.embedder,
                         embedding=result.vector,
                     )
                 )

--- a/libs/agno/tests/unit/knowledge/test_knowledge_reranker.py
+++ b/libs/agno/tests/unit/knowledge/test_knowledge_reranker.py
@@ -1,0 +1,134 @@
+"""Knowledge-level reranking: over-fetch, trimming and failure handling."""
+
+from typing import List, Optional
+
+import pytest
+
+from agno.knowledge.document import Document
+from agno.knowledge.knowledge import Knowledge
+from agno.knowledge.reranker.base import Reranker
+
+
+class StubVectorDb:
+    """Records the limit it was asked for and returns that many documents."""
+
+    def __init__(self, available: int = 100):
+        self.available = available
+        self.requested_limit: Optional[int] = None
+
+    def exists(self) -> bool:
+        return True
+
+    def create(self) -> None:  # pragma: no cover - exists() is always True
+        raise AssertionError("create should not be called")
+
+    def search(self, query: str, limit: int = 5, filters=None) -> List[Document]:
+        self.requested_limit = limit
+        count = min(limit, self.available)
+        return [Document(id=str(i), content=f"doc {i}") for i in range(count)]
+
+    async def async_search(self, query: str, limit: int = 5, filters=None) -> List[Document]:
+        return self.search(query=query, limit=limit, filters=filters)
+
+
+class NoAsyncVectorDb(StubVectorDb):
+    """Exercises the asearch fallback for adapters without async support."""
+
+    async def async_search(self, query: str, limit: int = 5, filters=None) -> List[Document]:
+        raise NotImplementedError
+
+
+class ReverseReranker(Reranker):
+    """Reverses order so the effect of reranking is observable."""
+
+    def rerank(self, query: str, documents: List[Document]) -> List[Document]:
+        return list(reversed(documents))
+
+
+class FailingReranker(Reranker):
+    def rerank(self, query: str, documents: List[Document]) -> List[Document]:
+        raise RuntimeError("reranker unavailable")
+
+
+def test_search_without_reranker_is_unchanged():
+    db = StubVectorDb()
+    knowledge = Knowledge(vector_db=db)
+
+    results = knowledge.search("q", max_results=5)
+
+    assert db.requested_limit == 5
+    assert len(results) == 5
+
+
+def test_search_over_fetches_when_reranker_is_set():
+    db = StubVectorDb()
+    knowledge = Knowledge(vector_db=db, reranker=ReverseReranker(), rerank_multiplier=5)
+
+    results = knowledge.search("q", max_results=5)
+
+    assert db.requested_limit == 25
+    assert len(results) == 5
+    # Reversing 25 candidates surfaces the tail, which plain search would never return.
+    assert results[0].id == "24"
+
+
+def test_over_fetch_is_capped():
+    db = StubVectorDb()
+    knowledge = Knowledge(vector_db=db, reranker=ReverseReranker(), rerank_multiplier=5, max_rerank_candidates=30)
+
+    knowledge.search("q", max_results=10)
+
+    assert db.requested_limit == 30
+
+
+def test_reranker_failure_falls_back_to_vector_db_order():
+    db = StubVectorDb()
+    knowledge = Knowledge(vector_db=db, reranker=FailingReranker())
+
+    results = knowledge.search("q", max_results=5)
+
+    assert len(results) == 5
+    assert results[0].id == "0"
+
+
+def test_fewer_candidates_than_requested_is_not_padded():
+    db = StubVectorDb(available=3)
+    knowledge = Knowledge(vector_db=db, reranker=ReverseReranker())
+
+    results = knowledge.search("q", max_results=5)
+
+    assert len(results) == 3
+
+
+@pytest.mark.asyncio
+async def test_asearch_applies_reranker():
+    db = StubVectorDb()
+    knowledge = Knowledge(vector_db=db, reranker=ReverseReranker())
+
+    results = await knowledge.asearch("q", max_results=5)
+
+    assert db.requested_limit == 25
+    assert results[0].id == "24"
+
+
+@pytest.mark.asyncio
+async def test_asearch_applies_reranker_on_sync_fallback():
+    db = NoAsyncVectorDb()
+    knowledge = Knowledge(vector_db=db, reranker=ReverseReranker())
+
+    results = await knowledge.asearch("q", max_results=5)
+
+    assert db.requested_limit == 25
+    assert results[0].id == "24"
+
+
+@pytest.mark.parametrize("multiplier", [0, -1, True])
+def test_invalid_rerank_multiplier_is_rejected(multiplier):
+    with pytest.raises(ValueError, match="rerank_multiplier"):
+        Knowledge(vector_db=StubVectorDb(), rerank_multiplier=multiplier)
+
+
+@pytest.mark.parametrize("candidates", [0, -1, True])
+def test_invalid_max_rerank_candidates_is_rejected(candidates):
+    with pytest.raises(ValueError, match="max_rerank_candidates"):
+        Knowledge(vector_db=StubVectorDb(), max_rerank_candidates=candidates)

--- a/libs/agno/tests/unit/knowledge/test_knowledge_reranker.py
+++ b/libs/agno/tests/unit/knowledge/test_knowledge_reranker.py
@@ -1,6 +1,6 @@
 """Knowledge-level reranking: over-fetch, trimming and failure handling."""
 
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 import pytest
 
@@ -132,3 +132,104 @@ def test_invalid_rerank_multiplier_is_rejected(multiplier):
 def test_invalid_max_rerank_candidates_is_rejected(candidates):
     with pytest.raises(ValueError, match="max_rerank_candidates"):
         Knowledge(vector_db=StubVectorDb(), max_rerank_candidates=candidates)
+
+
+class ValueErrorReranker(Reranker):
+    def rerank(self, query: str, documents: List[Document]) -> List[Document]:
+        raise ValueError("misconfigured")
+
+
+def test_reranker_value_error_propagates():
+    # Misconfiguration must surface rather than degrade to unreranked results.
+    knowledge = Knowledge(vector_db=StubVectorDb(), reranker=ValueErrorReranker())
+
+    with pytest.raises(ValueError, match="misconfigured"):
+        knowledge.search("q", max_results=5)
+
+
+@pytest.mark.asyncio
+async def test_reranker_value_error_propagates_async():
+    knowledge = Knowledge(vector_db=StubVectorDb(), reranker=ValueErrorReranker())
+
+    with pytest.raises(ValueError, match="misconfigured"):
+        await knowledge.asearch("q", max_results=5)
+
+
+def test_search_limit_never_drops_below_requested_results():
+    # The ceiling caps the widening, not the caller's own request.
+    knowledge = Knowledge(
+        vector_db=StubVectorDb(), reranker=ReverseReranker(), rerank_multiplier=5, max_rerank_candidates=100
+    )
+
+    assert knowledge._search_limit(150) == 150
+
+
+def test_over_fetch_is_capped_between_requested_and_ceiling():
+    knowledge = Knowledge(
+        vector_db=StubVectorDb(), reranker=ReverseReranker(), rerank_multiplier=5, max_rerank_candidates=100
+    )
+
+    assert knowledge._search_limit(10) == 50
+    assert knowledge._search_limit(30) == 100
+
+
+def test_large_max_results_returns_everything_requested():
+    db = StubVectorDb(available=200)
+    knowledge = Knowledge(vector_db=db, reranker=ReverseReranker(), max_rerank_candidates=100)
+
+    results = knowledge.search("q", max_results=150)
+
+    assert db.requested_limit == 150
+    assert len(results) == 150
+
+
+@pytest.mark.asyncio
+async def test_async_rerank_does_not_block_the_event_loop():
+    import asyncio
+    import threading
+
+    main_thread = threading.get_ident()
+    seen: List[int] = []
+
+    class ThreadRecordingReranker(Reranker):
+        def rerank(self, query: str, documents: List[Document]) -> List[Document]:
+            seen.append(threading.get_ident())
+            return documents
+
+    knowledge = Knowledge(vector_db=StubVectorDb(), reranker=ThreadRecordingReranker())
+    await knowledge.asearch("q", max_results=5)
+
+    assert seen and seen[0] != main_thread
+    assert asyncio.get_running_loop().is_running()
+
+
+def test_page_store_results_are_reranked():
+    # Page-backed knowledge returns before the vector db, so it needs its own wiring.
+    from agno.knowledge.page import SearchResult
+
+    class StubPageStore:
+        pass
+
+    recorded: Dict[str, int] = {}
+
+    knowledge = Knowledge.__new__(Knowledge)
+    knowledge.page_store = StubPageStore()
+    knowledge.max_results = 10
+    knowledge.reranker = ReverseReranker()
+    knowledge.rerank_multiplier = 5
+    knowledge.max_rerank_candidates = 100
+
+    def fake_search_pages(query, *, limit=10, **kwargs):
+        recorded["limit"] = limit
+        return SearchResult(results=[], partial=False)
+
+    knowledge.search_pages = fake_search_pages  # type: ignore[method-assign]
+    knowledge._page_documents = staticmethod(  # type: ignore[method-assign]
+        lambda result: [Document(id=str(i), content=f"doc {i}") for i in range(25)]
+    )
+
+    results = knowledge.search("q", max_results=5)
+
+    assert recorded["limit"] == 25
+    assert len(results) == 5
+    assert results[0].id == "24"

--- a/libs/agno/tests/unit/knowledge/test_mmr_reranker.py
+++ b/libs/agno/tests/unit/knowledge/test_mmr_reranker.py
@@ -60,11 +60,21 @@ def test_pure_relevance_keeps_the_near_duplicate():
     assert [doc.id for doc in results] == ["a", "b"]
 
 
-def test_reranking_score_is_descending():
-    results = MMRReranker(top_n=3).rerank("q", _documents())
+def test_reranking_score_is_the_score_at_selection_time():
+    # MMR scores are not descending: the pool shrinks as redundancy grows, so a later
+    # pick can score above an earlier one. List order, not score order, is the result.
+    embedder = StubEmbedder()
+    documents = [
+        Document(id="a", content="a", embedding=[-1.0, 0.0], embedder=embedder),
+        Document(id="b", content="b", embedding=[-0.9, 0.44], embedder=embedder),
+        Document(id="c", content="c", embedding=[-0.9, -0.44], embedder=embedder),
+    ]
+
+    results = MMRReranker(lambda_mult=0.5).rerank("q", documents)
 
     scores = [doc.reranking_score for doc in results]
-    assert scores == sorted(scores, reverse=True)
+    assert scores != sorted(scores, reverse=True)
+    assert [doc.id for doc in results] == ["b", "c", "a"]
 
 
 def test_top_n_defaults_to_all_documents():
@@ -179,9 +189,8 @@ def test_named_vector_mapping_is_not_treated_as_an_embedding():
 def test_reranking_score_is_the_mmr_score_not_a_rank_ordinal():
     results = MMRReranker(lambda_mult=0.5, top_n=2).rerank("q", _documents())
 
-    scores = [doc.reranking_score for doc in results]
-    assert scores == sorted(scores, reverse=True)
     # Rank ordinals would be 2.0 and 1.0; real MMR scores are bounded by lambda_mult.
+    scores = [doc.reranking_score for doc in results]
     assert all(score <= 1.0 for score in scores)
 
 

--- a/libs/agno/tests/unit/knowledge/test_mmr_reranker.py
+++ b/libs/agno/tests/unit/knowledge/test_mmr_reranker.py
@@ -1,0 +1,273 @@
+"""MMR reranking: diversity selection, configuration and embedding requirements."""
+
+from typing import List, Optional
+
+import pytest
+
+from agno.knowledge.document import Document
+from agno.knowledge.reranker.mmr import MMRReranker, _cosine_similarity
+
+
+class StubEmbedder:
+    """Returns a fixed query embedding without calling a provider."""
+
+    def __init__(self, embedding: Optional[List[float]] = None):
+        self.embedding = [1.0, 0.0] if embedding is None else embedding
+
+    def get_embedding(self, text: str) -> List[float]:
+        return self.embedding
+
+    async def async_get_embedding(self, text: str) -> List[float]:
+        return self.embedding
+
+
+def _documents() -> List[Document]:
+    """Two near-duplicates, then a document that is less relevant but far from them.
+
+    Relevance alone ranks a > b > c. Selecting "a" first makes "b" redundant, so an
+    even relevance/diversity split prefers "c" despite its lower relevance.
+    """
+    embedder = StubEmbedder()
+    return [
+        Document(id="a", content="a", embedding=[1.0, 0.5], embedder=embedder),
+        Document(id="b", content="b", embedding=[1.0, 0.55], embedder=embedder),
+        Document(id="c", content="c", embedding=[1.0, -0.7], embedder=embedder),
+    ]
+
+
+def test_cosine_similarity_of_identical_vectors_is_one():
+    assert _cosine_similarity([1.0, 0.0], [1.0, 0.0]) == pytest.approx(1.0)
+
+
+def test_cosine_similarity_of_orthogonal_vectors_is_zero():
+    assert _cosine_similarity([1.0, 0.0], [0.0, 1.0]) == pytest.approx(0.0)
+
+
+def test_zero_vector_does_not_divide_by_zero():
+    assert _cosine_similarity([0.0, 0.0], [1.0, 0.0]) == 0.0
+
+
+def test_diversity_beats_the_near_duplicate():
+    results = MMRReranker(lambda_mult=0.5, top_n=2).rerank("q", _documents())
+
+    # "b" is the closer match, but it nearly duplicates "a", so the distinct doc wins.
+    assert [doc.id for doc in results] == ["a", "c"]
+
+
+def test_pure_relevance_keeps_the_near_duplicate():
+    results = MMRReranker(lambda_mult=1.0, top_n=2).rerank("q", _documents())
+
+    assert [doc.id for doc in results] == ["a", "b"]
+
+
+def test_reranking_score_is_descending():
+    results = MMRReranker(top_n=3).rerank("q", _documents())
+
+    scores = [doc.reranking_score for doc in results]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_top_n_defaults_to_all_documents():
+    results = MMRReranker().rerank("q", _documents())
+
+    assert len(results) == 3
+
+
+def test_top_n_larger_than_input_is_clamped():
+    results = MMRReranker(top_n=10).rerank("q", _documents())
+
+    assert len(results) == 3
+
+
+def test_empty_documents_returns_empty():
+    assert MMRReranker().rerank("q", []) == []
+
+
+def test_missing_embeddings_raise_rather_than_silently_passing_through():
+    documents = _documents()
+    documents[1].embedding = None
+
+    with pytest.raises(ValueError, match="requires embeddings"):
+        MMRReranker().rerank("q", documents)
+
+
+def test_missing_embedder_raises():
+    documents = _documents()
+    for document in documents:
+        document.embedder = None
+
+    with pytest.raises(ValueError, match="needs an embedder"):
+        MMRReranker().rerank("q", documents)
+
+
+def test_embedder_is_taken_from_any_result_that_has_one():
+    documents = _documents()
+    documents[0].embedder = None
+
+    results = MMRReranker(lambda_mult=0.5, top_n=2).rerank("q", documents)
+
+    assert [doc.id for doc in results] == ["a", "c"]
+
+
+@pytest.mark.asyncio
+async def test_arerank_matches_sync_selection():
+    results = await MMRReranker(lambda_mult=0.5, top_n=2).arerank("q", _documents())
+
+    assert [doc.id for doc in results] == ["a", "c"]
+
+
+def test_mismatched_embedding_dimensions_raise():
+    documents = _documents()
+    documents[1].embedding = [1.0, 0.5, 0.25]
+
+    with pytest.raises(ValueError, match="one dimension"):
+        MMRReranker().rerank("q", documents)
+
+
+def test_query_embedding_of_wrong_dimension_raises():
+    documents = _documents()
+    for document in documents:
+        document.embedder = StubEmbedder(embedding=[1.0, 0.0, 0.0])
+
+    with pytest.raises(ValueError, match="one dimension"):
+        MMRReranker().rerank("q", documents)
+
+
+def test_embedder_returning_no_vector_raises():
+    documents = _documents()
+    for document in documents:
+        document.embedder = StubEmbedder(embedding=[])
+
+    with pytest.raises(ValueError, match="could not embed the query"):
+        MMRReranker().rerank("q", documents)
+
+
+def test_numpy_embeddings_are_supported():
+    # PgVector returns embeddings as numpy arrays, whose truth value is ambiguous.
+    numpy = pytest.importorskip("numpy")
+
+    embedder = StubEmbedder(embedding=numpy.array([1.0, 0.0]))
+    documents = [
+        Document(id="a", content="a", embedding=numpy.array([1.0, 0.5]), embedder=embedder),
+        Document(id="b", content="b", embedding=numpy.array([1.0, 0.55]), embedder=embedder),
+        Document(id="c", content="c", embedding=numpy.array([1.0, -0.7]), embedder=embedder),
+    ]
+
+    results = MMRReranker(lambda_mult=0.5, top_n=2).rerank("q", documents)
+
+    assert [doc.id for doc in results] == ["a", "c"]
+
+
+@pytest.mark.parametrize("kwargs", [{"lambda_mult": True}, {"top_n": True}])
+def test_booleans_are_rejected_as_numeric_config(kwargs):
+    # bool is an int subclass, so True would otherwise coerce to 1.0 / 1.
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        MMRReranker(**kwargs)
+
+
+def test_named_vector_mapping_is_not_treated_as_an_embedding():
+    # Qdrant hybrid/keyword searches return a dict of named vectors.
+    documents = _documents()
+    documents[1].embedding = {"dense": [1.0, 0.55]}  # type: ignore[assignment]
+
+    with pytest.raises(ValueError, match="one dimension"):
+        MMRReranker().rerank("q", documents)
+
+
+def test_reranking_score_is_the_mmr_score_not_a_rank_ordinal():
+    results = MMRReranker(lambda_mult=0.5, top_n=2).rerank("q", _documents())
+
+    scores = [doc.reranking_score for doc in results]
+    assert scores == sorted(scores, reverse=True)
+    # Rank ordinals would be 2.0 and 1.0; real MMR scores are bounded by lambda_mult.
+    assert all(score <= 1.0 for score in scores)
+
+
+def test_input_documents_are_not_scored_in_place():
+    documents = _documents()
+
+    MMRReranker(lambda_mult=0.5, top_n=2).rerank("q", documents)
+
+    assert all(document.reranking_score is None for document in documents)
+
+
+def test_zero_vector_is_rejected_as_a_broken_embedding():
+    documents = _documents()
+    documents[1].embedding = [0.0, 0.0]
+
+    with pytest.raises(ValueError, match="requires embeddings"):
+        MMRReranker().rerank("q", documents)
+
+
+@pytest.mark.parametrize("kwargs", [{"lambda_mult": -0.1}, {"lambda_mult": 1.1}, {"top_n": 0}, {"top_n": -1}])
+def test_out_of_range_config_is_rejected_at_construction(kwargs):
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        MMRReranker(**kwargs)
+
+
+def test_pure_diversity_does_not_depend_on_input_order():
+    # At lambda_mult=0.0 every candidate ties on the first pick, so the seed cannot be
+    # scored with the MMR formula or the input order decides the whole selection.
+    import itertools
+
+    embeddings = {"a": [1.0, 0.1], "b": [1.0, 0.5], "c": [1.0, -0.9]}
+
+    def documents(order):
+        embedder = StubEmbedder()
+        return [Document(id=key, content=key, embedding=embeddings[key], embedder=embedder) for key in order]
+
+    selections = {
+        tuple(doc.id for doc in MMRReranker(lambda_mult=0.0, top_n=2).rerank("q", documents(list(order))))
+        for order in itertools.permutations("abc")
+    }
+
+    assert len(selections) == 1
+
+
+def test_selection_matches_the_unoptimised_formula():
+    # Pins the running-redundancy optimisation to the definition it replaced.
+    import random
+
+    from agno.knowledge.reranker.mmr import _cosine_similarity
+
+    def reference(query_embedding, documents, lambda_mult, limit):
+        embeddings = [doc.embedding for doc in documents]
+        relevance = [_cosine_similarity(query_embedding, embedding) for embedding in embeddings]
+        remaining = list(range(len(documents)))
+        first = max(remaining, key=lambda candidate: relevance[candidate])
+        selected = [first]
+        remaining.remove(first)
+        while remaining and len(selected) < limit:
+            best_index, best_score = remaining[0], float("-inf")
+            for candidate in remaining:
+                redundancy = max(_cosine_similarity(embeddings[candidate], embeddings[j]) for j in selected)
+                score = lambda_mult * relevance[candidate] - (1.0 - lambda_mult) * redundancy
+                if score > best_score:
+                    best_score, best_index = score, candidate
+            selected.append(best_index)
+            remaining.remove(best_index)
+        return [documents[i].id for i in selected]
+
+    query_embedding = [1.0] + [0.0] * 15
+
+    def build(seed):
+        rnd = random.Random(seed)
+        embedder = StubEmbedder(embedding=query_embedding)
+        return [
+            Document(
+                id=str(i),
+                content=str(i),
+                embedding=[rnd.uniform(-1, 1) for _ in range(16)],
+                embedder=embedder,
+            )
+            for i in range(30)
+        ]
+
+    for seed in range(5):
+        for lambda_mult in (0.0, 0.5, 1.0):
+            selected = [doc.id for doc in MMRReranker(lambda_mult=lambda_mult, top_n=8).rerank("q", build(seed))]
+            assert selected == reference(query_embedding, build(seed), lambda_mult, 8)

--- a/libs/agno/tests/unit/vectordb/test_pineconedb.py
+++ b/libs/agno/tests/unit/vectordb/test_pineconedb.py
@@ -263,7 +263,7 @@ def test_search(mock_pinecone_db, mock_embedder):
 
     # Check that index.query was called with the right arguments
     mock_pinecone_db.index.query.assert_called_with(
-        vector=[0.1] * 1024, top_k=2, namespace=TEST_NAMESPACE, filter=None, include_values=None, include_metadata=True
+        vector=[0.1] * 1024, top_k=2, namespace=TEST_NAMESPACE, filter=None, include_values=False, include_metadata=True
     )
 
     # Check the results


### PR DESCRIPTION
## Summary

Adds MMR (Maximal Marginal Relevance) as a retrieval strategy, along with the knowledge level pipeline it needs to work.  

`Knowledge.search()` returned the vector db's results directly, so anything that reorders results had to be implemented per adapter. Reordering also needs more candidates than the caller asked for: a document can only be surfaced if it was retrieved in the first place.   

 **Knowledge level reranking.** `Knowledge` takes an optional `reranker` that runs after the vector db returns candidates, with a widened fetch to give it something to choose between:  
                                                                                                                                                                          
  - `reranker`: applied to results before they are returned                                                                                                                         
  - `candidate_multiplier`: candidates fetched per requested result (default 5)                                                                                                        
  - `max_candidates`: ceiling on the widened fetch (default 100)                                                                                                             
                                                                                                                                                                                     
One implementation covers every adapter, including those that never implemented reranking. A reranker configured on the vector db still runs first; this runs on its output, and `Knowledge` warns when both are set.                                                                                                                               
                                                                                                                                                                                     
  **MMRReranker.** Selects results that are relevant to the query but unlike each other, so a search returns several distinct answers instead of one answer repeated. `lambda_mult` trades relevance against diversity (1.0 is pure relevance, 0.0 pure                                                                                                  
  difference).      

 Selection tracks each candidate's similarity to the nearest already selected document instead of recomputing it every iteration. 

**Vector db fixes.** MMR needs an embedding on every candidate and an embedder for the query, and neither was returned everywhere:                                                                                                                                    
                                                                                                                                                                                     
  - Cassandra, Chroma, Couchbase, Elasticsearch, OpenSearch, Pinecone and Upstash returned embeddings without the embedder that produced them. They now attach it, as the other adapters already did.                                                                                                                                                      
  - Qdrant named vector searches return a mapping of dense and sparse vectors, which was assigned to `Document.embedding` whole. Scoring raised `TypeError`, which `Knowledge` caught as a transient reranker failure, so MMR silently did nothing.                                                                                                                                          
  - Pinecone omits vectors unless asked. `PineconeDb` takes `return_vectors`, off by default so ordinary searches keep their current response size.                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                                          
  `Reranker.arerank` now runs the sync implementation in a worker thread, since a  reranker that calls a provider would otherwise block the event loop. Page backed  knowledge routes through the reranker instead of returning ahead of it.  

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
