### PR TITLE
[fix] Honor Azure Responses reasoning override in native routing

### DIFF
--- a/libs/agno/agno/reasoning/openai.py
+++ b/libs/agno/agno/reasoning/openai.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, AsyncIterator, Iterator, List, Optional, Tuple
 
+from agno.models.azure.openai_responses import AzureOpenAIResponses
 from agno.models.base import Model
 from agno.models.message import Message
 from agno.models.openai.like import OpenAILike
@@ -12,6 +13,9 @@ if TYPE_CHECKING:
 
 
 def is_openai_reasoning_model(reasoning_model: Model) -> bool:
+    # Azure deployment names are arbitrary; an explicit override takes precedence.
+    if isinstance(reasoning_model, AzureOpenAIResponses) and reasoning_model.is_reasoning_model is not None:
+        return reasoning_model.is_reasoning_model
     return (
         (
             reasoning_model.__class__.__name__ == "OpenAIChat"

--- a/libs/agno/tests/unit/models/azure/test_reasoning_routing.py
+++ b/libs/agno/tests/unit/models/azure/test_reasoning_routing.py
@@ -1,0 +1,29 @@
+import pytest
+
+from agno.models.azure import AzureOpenAIResponses
+from agno.reasoning.manager import ReasoningConfig, ReasoningManager
+from agno.reasoning.openai import is_openai_reasoning_model
+
+
+@pytest.mark.parametrize(
+    "deployment,override,expected",
+    [
+        ("prod-reasoner", True, True),
+        ("gpt-5-deployment", False, False),
+        ("prod-reasoner", None, False),
+        ("gpt-5-deployment", None, True),
+    ],
+)
+def test_azure_responses_reasoning_override(deployment, override, expected):
+    model = AzureOpenAIResponses(id=deployment, is_reasoning_model=override)
+    assert is_openai_reasoning_model(model) is expected
+    manager = ReasoningManager(ReasoningConfig(reasoning_model=model))
+    assert manager.is_native_reasoning_model() is expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("deployment,override", [("prod-reasoner", True), ("gpt-5-deployment", False)])
+async def test_azure_responses_async_reasoning_override(deployment, override):
+    model = AzureOpenAIResponses(id=deployment, is_reasoning_model=override)
+    manager = ReasoningManager(ReasoningConfig(reasoning_model=model))
+    assert await manager._adetect_model_type(model) == ("openai" if override else None)


### PR DESCRIPTION
## Summary

Follow-up to #9841 and the routing inconsistency reported in its discussion.

`AzureOpenAIResponses` already supports `is_reasoning_model`, but `is_openai_reasoning_model()` ignores it and infers reasoning support from the Azure deployment name. This makes request shaping and native reasoning routing disagree:

- `id="prod-reasoner", is_reasoning_model=True`: the global detector incorrectly returns `False`.
- `id="gpt-5-deployment", is_reasoning_model=False`: it incorrectly returns `True`.

Honor the explicit Azure Responses flag before the existing name-based checks. Leave those checks unchanged when the flag is `None`. No new provider option or network request is introduced.

Add six regression cases covering explicit True/False, the unset fallback, synchronous native detection, and asynchronous manager routing. Before the fix: four failed, two passed.

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts successfully in the development environment described below
- [ ] Human author has reviewed and understands the diff
- [x] Code comment explains the Azure deployment-name constraint
- [x] Tests added and executed in an isolated environment
- [ ] Cookbook changes (not applicable: existing flag, no new API)

### Duplicate and AI-Generated PR Check

- [x] Searched open and closed PRs; no separate matching fix found at preparation time
- [x] This patch and draft were prepared with AI assistance

## Additional Notes

This fixes initial model-type detection. It does not change the manager's existing caching policy or support mutating the model configuration after its type has been cached. It does not change the fallback heuristic for unset flags or other providers.

No live Azure request, credentials, model training, or billable inference was used. Full integration tests and CI have not been run.

Validation: in the development environment without the optional Anthropic SDK, the Azure Responses tests plus two reasoning checker suites passed (128 passed). `scripts/format.sh` succeeded. `scripts/validate.sh` succeeded, including mypy over 1053 agno and 21 agnoctl source files, Ruff checks, and the cookbook pattern check. On Windows, the script's `python3` command was mapped to the activated virtual environment's `python` in Git Bash; the repository scripts were not changed. `git diff --check` passed. This is not the full project test suite.

Environment note: an expanded environment with the optional `anthropic==1.5.0` SDK passed all 35 Azure unit tests, but exposed three mypy errors in unchanged Anthropic/AWS files. Removing that optional SDK restored successful development-environment validation. No unrelated provider code was modified to suppress those errors.
