### PR TITLE
[cookbook] Add AntiBrow MCP example

### DIFF
--- a/cookbook/91_tools/mcp/antibrow.py
+++ b/cookbook/91_tools/mcp/antibrow.py
@@ -1,0 +1,87 @@
+"""
+AntiBrow MCP Agent - Browsing With a Persistent Identity
+
+This example shows how to drive AntiBrow's MCP server from an Agno agent, so the
+browser the agent uses keeps its cookies, storage, fingerprint and exit IP between
+runs instead of starting over in a fresh Chromium every session.
+
+Features:
+- A named profile: sign in once, still signed in on the next run
+- 19 MCP tools, including launch_browser, navigate, click, fill, get_content
+- The browser runs locally, so there are no browser-hours to buy
+
+Prerequisites:
+- Install dependencies: uv pip install agno mcp
+- Set environment variables: ANTI_DETECT_BROWSER_KEY, OPENAI_API_KEY
+- Run this example: python cookbook/91_tools/mcp/antibrow.py
+
+Note on the command below: the MCP protocol SDK is an optional peer dependency of
+the npm package, which is why both `-p` flags are needed. Without them the server
+exits with "MCP server mode needs @modelcontextprotocol/sdk".
+"""
+
+import asyncio
+from os import environ
+from textwrap import dedent
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+from agno.tools.mcp import MCPTools
+from mcp import StdioServerParameters
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+
+async def run_agent(message: str) -> None:
+    server_params = StdioServerParameters(
+        command="npx",
+        args=[
+            "-y",
+            "-p",
+            "anti-detect-browser",
+            "-p",
+            "@modelcontextprotocol/sdk",
+            "anti-detect-browser",
+            "--mcp",
+        ],
+        env=environ.copy(),
+    )
+
+    async with MCPTools(server_params=server_params, timeout_seconds=120) as mcp_tools:
+        agent = Agent(
+            model=OpenAIChat(id="gpt-5.6-luna"),
+            tools=[mcp_tools],
+            instructions=dedent("""\
+                You drive a real browser through the AntiBrow MCP server.
+
+                Order of operations:
+                1. launch_browser first, with a profile name. The profile is created if new,
+                   and reused if it already exists - that is what keeps the session alive
+                   between runs, so check what is already on screen before signing in again.
+                2. navigate, then get_content to read the page. Prefer get_content over
+                   screenshot: text costs far fewer tokens than an image.
+                3. click and fill take CSS selectors. evaluate is there for the cases a
+                   selector cannot express.
+                4. close_browser when you are done. An abandoned browser is a whole
+                   Chromium still running.
+
+                One profile is one identity. If a task needs two identities that must not
+                be linked, launch two profiles rather than two tabs.
+            """),
+            markdown=True,
+        )
+        await agent.aprint_response(message, stream=True)
+
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    asyncio.run(
+        run_agent(
+            "Using the profile 'research-01', open https://news.ycombinator.com and summarise the top three stories."
+        )
+    )


### PR DESCRIPTION
Closes #10120

## Summary

Adds a cookbook example for driving [AntiBrow](https://antibrow.com)'s MCP server from an Agno agent, in the same shape as `cookbook/91_tools/mcp/stagehand.py`.

What it demonstrates that the existing browser MCP examples do not: the unit of state is a *profile*. Cookies, storage, the engine-level fingerprint and the per-profile proxy persist, so an agent that signed in on an earlier run is still signed in on the next one - and the instructions in the example tell the model to check what is already on screen before signing in again.

Verified before opening this: the server was driven over stdio JSON-RPC directly, with no model in the loop. It answered `initialize` with `serverInfo: {"name": "anti-detect-browser", "version": "0.1.0"}` and then listed 19 tools - `launch_browser`, `close_browser`, `list_sessions`, `list_profiles`, `create_profile`, `delete_profile`, `list_proxies`, `claim_proxy`, `navigate`, `screenshot`, `evaluate`, `click`, `fill`, `get_content`, `start_live_view`, `stop_live_view`, `list_recipes`, `run_recipe`, `fanout_recipe`.

One detail the example documents because it cost a run: the MCP protocol SDK is an optional peer dependency of the npm package, so the command needs both `-p` flags. `npx anti-detect-browser --mcp` on its own exits with `MCP server mode needs @modelcontextprotocol/sdk`.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [x] Other: cookbook example

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`ruff format` / `ruff check` with `libs/agno/pyproject.toml`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable) - cookbook examples are not unit tested in this repo

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Disclosure per the contributing guide: written with Claude Code, and the MCP handshake above was run rather than assumed. I am affiliated with AntiBrow. Related: #10117 adds the `AntibrowTools` toolkit for the code path; this one is the MCP path, and the two are independent - either can be merged without the other.
