### PR TITLE
refactor(authz): one owner per concern, directory on AgentOS, config frozen

### DIFF
--- a/cookbook/05_agent_os/26_authorization/00_quickstart_authorization.py
+++ b/cookbook/05_agent_os/26_authorization/00_quickstart_authorization.py
@@ -40,8 +40,8 @@ OS_ID = "authz-quickstart-os"
 os.makedirs("tmp", exist_ok=True)
 db = SqliteDb(db_file="tmp/authz_quickstart.db")
 
-# One object. It borrows the AgentOS db below (no db= here), turns on the audit trail,
-# and runs a token-scope plane next to the roles so an operator token works too.
+# One object for what callers may DO. It borrows the AgentOS db below (no db= here), turns on the
+# audit trail, and runs a token-scope plane next to the roles so an operator token works too.
 authz = Authorization(
     audit=True,
     trust_token_scopes=True,
@@ -49,7 +49,6 @@ authz = Authorization(
     algorithm="HS256",  # matches how the tokens below are signed
     audience=OS_ID,
     verify_audience=True,
-    auto_provision=True,  # first valid token from an unknown user creates them with the default role
 )
 
 # Define the roles. "default=True" is what a brand-new user gets on first sign-in.
@@ -57,14 +56,9 @@ authz.define_role("admin", ["agent_os:admin"])
 authz.define_role("viewer", ["agents:*:read"], default=True)
 authz.define_role("runner", ["agents:*:read", "agents:*:run"])
 
-# Bootstrap an admin and a couple of users. Safe to run on every start (idempotent).
-authz.seed(
-    admin="alice",
-    users=[
-        ("bob", {"email": "bob@example.com", "name": "Bob", "role": "viewer"}),
-        ("carol", {"email": "carol@example.com", "name": "Carol", "role": "runner"}),
-    ],
-)
+# Bootstrap an admin and hand a couple of people their roles. Safe to run on every start: an
+# assignment an admin changed later through the API is kept.
+authz.seed(admin="alice", assignments={"bob": "viewer", "carol": "runner"})
 
 agent_os = AgentOS(
     id=OS_ID,
@@ -81,6 +75,10 @@ agent_os = AgentOS(
         ),
     ],
     authorization=authz,
+    # Who the callers ARE is the user directory, a peer of authorization on AgentOS: a roster with a
+    # per-person off switch. True builds it on the OS db with JIT provisioning on, so the first
+    # valid token from an unknown user creates them with the default role. /users mounts with it.
+    user_directory=True,
 )
 app = agent_os.get_app()
 

--- a/cookbook/05_agent_os/26_authorization/02_managed_users.py
+++ b/cookbook/05_agent_os/26_authorization/02_managed_users.py
@@ -45,35 +45,25 @@ OS_ID = "managed-users-os"
 
 os.makedirs("tmp", exist_ok=True)
 
-# Authorization is one object for both the roles (what users may do) and the user directory
-# (who they are + the disabled off-switch). It verifies the token too, and persists roles and
-# users together.
+# One database for the OS, the roles and the people. Authorization owns what a caller may DO
+# (roles, verification); the user directory (who they are + the disabled off-switch) is a peer on
+# AgentOS, so it also works with no authorization at all.
+db = SqliteDb(db_file="tmp/managed_users.db")
 authz = Authorization(
-    db_url="sqlite:///tmp/managed_users.db",
+    db=db,
     verification_keys=[JWT_SECRET],
     algorithm="HS256",
     verify_audience=True,
     audience=OS_ID,
-    # auto_provision: a user we have never seen is created from their token claims on their first
-    # authenticated request and granted the default role (the one flagged default=True below), so
-    # they land usable, not inert.
-    auto_provision=True,
 )
 # Roles: what each role can do. default=True flags "viewer" as the role an auto-provisioned user
 # gets - single-role model, so exactly one role is the default (flagging another moves the flag).
 authz.define_role("viewer", ["agents:*:read"], default=True)
 authz.define_role("admin", ["agent_os:admin"])
+# Hand people their roles. Create-if-absent, so it is safe to re-run on every boot: a promotion an
+# admin made later through the API is kept.
+authz.seed(assignments={"alice": "admin", "bob": "viewer"})
 
-# Seed the directory: people (id + optional email/name, no passwords) with a role each. Adding
-# users turns the directory on. Seeding is create-if-absent, so it is safe to re-run on every boot.
-authz.seed(
-    users=[
-        ("alice", {"email": "alice@co", "name": "Alice", "role": "admin"}),
-        ("bob", {"email": "bob@co", "name": "Bob", "role": "viewer"}),
-    ]
-)
-
-db = SqliteDb(db_file="tmp/managed_users_agentos.db")
 research_agent = Agent(
     id="research-agent",
     name="Research Agent",
@@ -81,20 +71,28 @@ research_agent = Agent(
     db=db,
 )
 
-# Wire it in with the single Authorization object: it carries verification, the roles, and the
-# directory (with the kill-switch + auto-provision), so there is no separate authorization config
-# or user_directory to build.
+# Wire both in. user_directory=True builds the roster on the OS db with auto_provision on: a user we
+# have never seen is created from their token claims on their first authenticated request and
+# granted the default role, so they land usable, not inert. Pass a UserDirectoryConfig for control
+# (fail_closed, the claim names, auto_provision off).
 agent_os = AgentOS(
     id=OS_ID,
     description="Managed-users AgentOS",
+    db=db,
     agents=[research_agent],
     authorization=authz,
+    user_directory=True,
 )
 app = agent_os.get_app()
-# We inspect and manage the directory through authz.user_store (list / set_disabled / get) and
-# roles through authz.role_store, which is all this transcript needs. Because roles are configured,
-# AgentOS also auto-mounts the admin HTTP API (/users, /authz/roles) -- see
-# 06_manage_users_and_roles.py for a frontend that drives it.
+
+# The directory: people (id + optional email/name, no passwords). Seed a couple so the roster is
+# not empty; upsert is create-or-update, so re-running is harmless.
+users = agent_os.user_directory.user_store
+users.upsert("alice", email="alice@co", name="Alice")
+users.upsert("bob", email="bob@co", name="Bob")
+# We inspect and manage the directory through `users` (list / set_disabled / get) and roles through
+# authz.role_store, which is all this transcript needs. AgentOS also auto-mounts the admin HTTP API
+# (/users, /authz/roles) -- see 06_manage_users_and_roles.py for a frontend that drives it.
 
 
 if __name__ == "__main__":
@@ -126,7 +124,7 @@ if __name__ == "__main__":
 
     # Everyone in the directory, with the role each one was assigned.
     print("\n  the directory:")
-    for u in authz.user_store.list():
+    for u in users.list():
         role = (authz.role_store.roles_of(u["id"]) or [None])[0]
         print(
             f"    - {u['id']:8s} {str(u['email'] or ''):12s} role={role}  disabled={u['disabled']}"
@@ -140,7 +138,7 @@ if __name__ == "__main__":
     )
 
     print("\n  >> now an admin DISABLES bob (e.g. he left the company)...\n")
-    authz.user_store.set_disabled("bob", True, actor="alice")
+    users.set_disabled("bob", True, actor="alice")
     show(
         "bob asks to LOOK at the agent",
         client.get("/agents/research-agent", headers=auth("bob")),
@@ -148,7 +146,7 @@ if __name__ == "__main__":
     )
 
     print("\n  >> ...bob is back, re-enable him...\n")
-    authz.user_store.set_disabled("bob", False, actor="alice")
+    users.set_disabled("bob", False, actor="alice")
     show(
         "bob asks to LOOK at the agent",
         client.get("/agents/research-agent", headers=auth("bob")),
@@ -158,9 +156,7 @@ if __name__ == "__main__":
     print(
         "\n  >> a brand-new user (dave) we've NEVER seen makes his first request...\n"
     )
-    print(
-        f"    dave in the directory beforehand?  {authz.user_store.get('dave') is not None}"
-    )
+    print(f"    dave in the directory beforehand?  {users.get('dave') is not None}")
     show(
         "dave (unknown) asks to LOOK at the agent",
         client.get("/agents/research-agent", headers=auth("dave")),
@@ -168,7 +164,7 @@ if __name__ == "__main__":
     )
     dave_role = (authz.role_store.roles_of("dave") or [None])[0]
     print(
-        f"    dave in the directory now?         {authz.user_store.get('dave') is not None}  role={dave_role}"
+        f"    dave in the directory now?         {users.get('dave') is not None}  role={dave_role}"
     )
 
     print("=" * 80)

--- a/cookbook/05_agent_os/26_authorization/06_manage_users_and_roles.py
+++ b/cookbook/05_agent_os/26_authorization/06_manage_users_and_roles.py
@@ -162,18 +162,14 @@ authz = Authorization(
     trust_token_scopes=True,
 )
 
-# Seed roles + a couple of users so a freshly-connected frontend isn't empty. Bootstrap-safe: an
-# admin who later changes a role/assignment through the admin API keeps that change across restarts.
+# Seed roles + a couple of assignments so a freshly-connected frontend isn't empty. Bootstrap-safe:
+# an admin who later changes a role/assignment through the admin API keeps that change across
+# restarts. (If the bootstrap admin is ever demoted with nobody else holding admin, the next boot
+# re-grants it, so the admin API can always be reached.)
 authz.define_role("admin", ["agent_os:admin"])
 authz.define_role("viewer", ["agents:*:read"])
 authz.define_role("runner", ["agents:*:read", "agents:*:run"])
-authz.seed(
-    admin=ADMIN_SUBJECT,  # so the admin API is usable at all
-    users=[
-        ("bob", {"email": "bob@co", "name": "Bob", "role": "viewer"}),
-        ("carol", {"email": "carol@co", "name": "Carol", "role": "runner"}),
-    ],
-)
+authz.seed(admin=ADMIN_SUBJECT, assignments={"bob": "viewer", "carol": "runner"})
 
 research_agent = Agent(
     id="research-agent",
@@ -204,9 +200,17 @@ agent_os = AgentOS(
     db=db,  # same database the stores use
     agents=[research_agent, vault_agent],
     cors_allowed_origins=CORS_ORIGINS,
-    authorization=authz,  # one object; /authz and /users are mounted for you
+    authorization=authz,  # what callers may do; /authz is mounted for you
+    user_directory=True,  # who they are, a peer of authorization; /users is mounted for you
 )
 app = agent_os.get_app()
+
+# The directory: seed a couple of profiles so the Users tab isn't empty. upsert is create-or-update,
+# so re-running is harmless; roles were assigned above, this is just name + email.
+users = agent_os.user_directory.user_store
+users.upsert(ADMIN_SUBJECT, name="Bootstrap admin")
+users.upsert("bob", email="bob@co", name="Bob")
+users.upsert("carol", email="carol@co", name="Carol")
 
 # Dev-mode only: let the bundled console.html "become" an end user. An admin
 # trades their token for one minted as any subject (sub only — no scopes, so

--- a/cookbook/05_agent_os/26_authorization/07_manage_users.py
+++ b/cookbook/05_agent_os/26_authorization/07_manage_users.py
@@ -70,8 +70,9 @@ CORS_ORIGINS = [
 
 os.makedirs("tmp", exist_ok=True)
 
-# One database, one object, users-only. No define_role, so there is no role store and no /authz:
-# the default scope plane (the caller's token scopes) governs, and Authorization mounts just /users.
+# One database, users-only. Authorization here is verify-only: no define_role, so there is no role
+# store and no /authz; the default scope plane (the caller's token scopes) governs. The directory is
+# AgentOS's (user_directory=True below), and /users mounts from it because authorization is on.
 db = SqliteDb(db_file="tmp/manage_users.db")
 authz = Authorization(
     db=db,
@@ -81,17 +82,7 @@ authz = Authorization(
     verify_audience=True,
     audience=OS_ID,
     issuer=ISSUER,
-    audit=True,  # record every access decision
-)
-
-# Seed a couple of people so a freshly-connected frontend isn't empty. No roles here -- admin of
-# /users is the agent_os:admin scope on the caller's token.
-authz.seed(
-    users=[
-        (ADMIN_SUBJECT, {"name": "Bootstrap admin"}),
-        ("bob", {"email": "bob@co", "name": "Bob"}),
-        ("carol", {"email": "carol@co", "name": "Carol"}),
-    ]
+    audit=True,  # record every access decision (and every directory change)
 )
 
 research_agent = Agent(
@@ -107,9 +98,17 @@ agent_os = AgentOS(
     db=db,
     agents=[research_agent],
     cors_allowed_origins=CORS_ORIGINS,
-    authorization=authz,  # mounts /users only; no roles means no /authz surface
+    authorization=authz,  # verify-only; no roles means no /authz surface
+    user_directory=True,  # the roster; /users mounts from it (admin = agent_os:admin on the token)
 )
 app = agent_os.get_app()
+
+# Seed a couple of people so a freshly-connected frontend isn't empty. upsert is create-or-update,
+# so re-running on every start is harmless.
+users = agent_os.user_directory.user_store
+users.upsert(ADMIN_SUBJECT, name="Bootstrap admin")
+users.upsert("bob", email="bob@co", name="Bob")
+users.upsert("carol", email="carol@co", name="Carol")
 # Only /users is mounted (no roles were defined), so there is no /authz roles surface for a frontend
 # to render. That is the difference from 06_manage_users_and_roles.py.
 

--- a/cookbook/05_agent_os/26_authorization/README.md
+++ b/cookbook/05_agent_os/26_authorization/README.md
@@ -23,7 +23,7 @@ it runs offline against a simulated issuer.
 
 | File | Lesson |
 |---|---|
-| `00_quickstart_authorization.py` | Start here. The whole setup in one `Authorization` object: verification, roles, users, audit, and the admin API, borrowing the OS db |
+| `00_quickstart_authorization.py` | Start here. Verification, roles, audit and the admin API in one `Authorization` object, plus the user directory on `AgentOS(user_directory=True)`, all on the OS db |
 | `01_managed_roles.py` | Roles only: define what each role may do and hand people roles through `authz.role_store`, no directory |
 | `02_managed_users.py` | The credential-less user directory and the disabled-user kill switch that outlives a valid token |
 | `03_directory_without_auth.py` | `AgentOS(db=db, user_isolation=True, user_directory=True)` with NO auth: a roster + per-user isolation that key off the run's user_id (advisory without auth) |

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -379,7 +379,7 @@ class AgentOS:
                 UserDirectoryConfig for control.
             audit: One AuditSink for BOTH audit trails -- the change log (who edited roles/users)
                 and the decision log (every allow/deny). Turns audit on for the whole OS. A sink
-                passed to a store or to AuthorizationConfig(audit=...) still wins there.
+                passed to a store of your own still wins there.
             cors_allowed_origins: List of allowed CORS origins (will be merged with default Agno domains)
             media_storage: Backend the media routes read stored media from. Defaults to the first
                 one configured on an agent, team or workflow.
@@ -481,8 +481,11 @@ class AgentOS:
         # into the (authorization_config, audit, user_directory) the pipeline below already
         # understands, and record its stores so get_app mounts /authz and /users automatically. It
         # adopts this OS db so role/user definitions persist alongside agent data.
+        # What the Authorization object hands over: its role store (provisioning + the /authz API),
+        # the provider it composed, the pinned issuer, and its audit sink.
         self._facade_role_store: Any = None
-        self._facade_user_store: Any = None
+        self._facade_provider: Any = None
+        self._facade_issuer: Optional[str] = None
 
         # authorization= takes the switch or the object, never the low-level config: one spelling
         # for the deprecated type is enough, and it is the keyword that already exists.
@@ -502,15 +505,12 @@ class AgentOS:
         from agno.os.authz.facade import Authorization as _Authorization
 
         if isinstance(authorization, _Authorization):
-            # The facade owns these, so accepting them here too would silently pick one and drop the
-            # other (a data-split footgun if the facade points at a different db). Fail loudly.
+            # The object owns verification and audit, so accepting them here too would silently pick
+            # one and drop the other. Fail loudly. The user directory is NOT the object's: it stays on
+            # AgentOS(user_directory=...), a peer that works with or without authorization.
             conflicts = [
                 name
-                for name, value in (
-                    ("authorization_config", authorization_config),
-                    ("user_directory", user_directory),
-                    ("audit", audit),
-                )
+                for name, value in (("authorization_config", authorization_config), ("audit", audit))
                 if value is not None
             ]
             if conflicts:
@@ -523,9 +523,9 @@ class AgentOS:
             authorization._bind(self.db)
             authorization_config = authorization.authorization_config()
             audit = authorization.audit_sink
-            user_directory = authorization.user_directory_config()
             self._facade_role_store = authorization.role_store
-            self._facade_user_store = authorization.user_store
+            self._facade_provider = authorization.provider
+            self._facade_issuer = authorization.issuer
             authorization = True
 
         self.authorization = authorization
@@ -539,7 +539,7 @@ class AgentOS:
         # and the DECISION log (every allow/deny -> authz_decisions). Passing AgentOS(audit=sink)
         # wires the sink to the stores' change trail AND the decision recorder, so "audit on" means
         # everything is logged and "off" means nothing. A sink passed directly to a store or to
-        # AuthorizationConfig(audit=...) still wins there, for anyone who wants just one trail.
+        # a store of your own still wins there, for anyone who wants just one trail.
         self.audit = audit
         # The credential-less user directory is a PEER of authorization (who the users are +
         # the disabled kill-switch), configured separately from authorization_config.
@@ -806,7 +806,7 @@ class AgentOS:
             )
             updated_routers.append(get_approval_router(os_db=self.db, settings=self.settings))
             updated_routers.append(get_service_accounts_router(os_db=self.db, settings=self.settings))
-            updated_routers.extend(self._facade_admin_routers())
+            updated_routers.extend(self._admin_api_routers())
         else:
             for prefix, tag in [
                 ("/components", "Components"),
@@ -1590,7 +1590,7 @@ class AgentOS:
         # catch-all mount added just below: a router included after get_app() returns sits behind
         # that mount and 404s on any OS with mcp_server=True. Independent of the OS db, since the
         # object may carry its own.
-        routers.extend(self._facade_admin_routers())
+        routers.extend(self._admin_api_routers())
 
         for router in routers:
             self._add_router(fastapi_app, router)
@@ -1665,24 +1665,6 @@ class AgentOS:
         # the parent app), so the mounted sub-app carries no auth code of its own.
         security_key = self.settings.os_security_key if self.settings else None
         jwt_env_configured = bool(getenv("JWT_VERIFICATION_KEY") or getenv("JWT_JWKS_FILE"))
-        # An authz plane with the enforcement flag off is the most dangerous shape this
-        # config can take: the provider is seeded but nothing consults it, so an OS the
-        # author believes is governed by roles serves every route to anonymous callers.
-        # Fail at construction rather than shipping a silently open instance.
-        cfg = self.authorization_config
-        # A custom provider only takes effect through the auth middleware, so with authorization
-        # off it is a silently-open instance -- the author believes routes are governed by their
-        # provider, but nothing consults it. That still raises. A user directory is different: it
-        # is a roster, valid without auth (the guard below only warns), because it is data, not an
-        # enforcement point.
-        authz_plane_configured = cfg is not None and getattr(cfg, "authorization_provider", None) is not None
-        if not self.authorization and authz_plane_configured:
-            raise ValueError(
-                "AuthorizationConfig(authorization_provider=...) requires "
-                "AgentOS(authorization=True). Without enforcement the plane is never applied "
-                "(every route is served unauthenticated). Set authorization=True, or drop the "
-                "config if you intended an open instance."
-            )
         if not self.authorization and (self.user_directory is not None or self.user_isolation):
             # A user directory or per-user isolation without authorization is a valid, intentional
             # shape for local/demo use: a run's user_id registers the person (a roster fills in) and
@@ -1891,6 +1873,7 @@ class AgentOS:
             self.authorization_config,
             authorization=self.authorization,
             service_account_verifier=self._get_service_account_verifier(),
+            issuer=self._facade_issuer,
         )
         # The top-level user_isolation flag is the primary spelling; OR it with the legacy
         # AuthorizationConfig(user_isolation=...) so either turns per-user scoping on.
@@ -2025,45 +2008,40 @@ class AgentOS:
 
         fastapi_app.add_middleware(AuthMiddleware, **middleware_kwargs)
 
-    def _facade_admin_routers(self) -> List[Any]:
-        """The admin-API routers to mount from the Authorization object's stores.
-
-        Returns ``/authz`` (roles) when it uses roles and ``/users`` (directory) when it has a
-        directory, so there is never a manual ``include_router``. Empty when authorization is a
-        bare switch or provider (no stores, nothing to administer). The routers carry their own
-        admin gate, so mounting them is always safe."""
+    def _admin_api_routers(self) -> List[Any]:
+        """The admin-API routers: ``/authz`` (roles) when the Authorization object has a role store,
+        and ``/users`` (directory) when ``AgentOS(user_directory=...)`` configured one under
+        authorization. There is never a manual ``include_router``. Both routers gate on admin, so
+        mounting them is always safe; without authorization there is no admin to gate on, so the
+        directory is a roster only and ``/users`` stays unmounted."""
         routers: List[Any] = []
-        if self._facade_role_store is not None or self._facade_user_store is not None:
-            from agno.os.authz.role_router import get_roles_router, get_users_router
+        directory_store = self.user_directory.user_store if self.user_directory is not None else None
+        if self._facade_role_store is not None:
+            from agno.os.authz.role_router import get_roles_router
 
-            if self._facade_role_store is not None:
-                routers.append(get_roles_router(self._facade_role_store))
-            if self._facade_user_store is not None:
-                routers.append(get_users_router(self._facade_user_store, role_store=self._facade_role_store))
+            routers.append(get_roles_router(self._facade_role_store))
+        if directory_store is not None and self.authorization:
+            from agno.os.authz.role_router import get_users_router
+
+            routers.append(get_users_router(directory_store, role_store=self._facade_role_store))
         return routers
 
     def _seed_authorization_provider(self, fastapi_app: FastAPI) -> None:
-        """Seed ``app.state.authorization_provider`` (and ``authz_audit``) from the
-        AuthorizationConfig, so the four choke points resolve the right enforcer.
+        """Seed ``app.state.authorization_provider`` (and ``authz_audit``) from the Authorization
+        object, so the four choke points resolve the right enforcer.
 
-        - ``authorization_provider`` set (the Authorization object composes its own from the
-          role store and the scope plane; the primitive path passes one directly): use it.
-        - unset: leave the state unset; the resolver defaults to ScopeAuthorizationProvider
-          (v2.7 behaviour).
+        - the object composed a provider (its role store's, with the scope plane alongside under
+          ``trust_token_scopes``, or the caller's override): use it.
+        - none: leave the state unset; the resolver defaults to ScopeAuthorizationProvider
+          (v2.7 behaviour), which is also what ``authorization=True`` means.
         """
-        config = self.authorization_config
-        # Decision trail: AgentOS(audit=...) is a single switch that also feeds the decision log
-        # (authz_decisions). An explicit AuthorizationConfig(audit=...) wins; else fall back to the
-        # top-level sink. Seeded even without an AuthorizationConfig, since the default scope plane
-        # still records decisions.
-        decision_sink = getattr(config, "audit", None) or self.audit
-        if decision_sink is not None:
-            fastapi_app.state.authz_audit = decision_sink
+        # Decision trail: the audit switch (AgentOS(audit=...) or Authorization(audit=...)) also
+        # feeds the decision log (authz_decisions). Seeded even for plain scope RBAC, since the
+        # default scope plane still records decisions.
+        if self.audit is not None:
+            fastapi_app.state.authz_audit = self.audit
 
-        if config is None:
-            return
-
-        provider = getattr(config, "authorization_provider", None)
+        provider = self._facade_provider
 
         resolved_provider: Optional[AuthorizationProvider] = None
         if provider is not None:

--- a/libs/agno/agno/os/auth.py
+++ b/libs/agno/agno/os/auth.py
@@ -133,11 +133,16 @@ def provision_user_with_default_role(
     nothing is granted and nothing is warned. Granting happens only on first creation, so a
     later login never re-grants and never fights an admin who removed the role.
 
+    A subject can hold a role before they ever log in (seeded by ``Authorization.seed``, or
+    assigned through ``/authz`` ahead of their first token). Creating their directory row must
+    not touch that: the default is a floor for people nobody assigned, never a replacement, so
+    the bootstrap admin's first request cannot demote them to viewer.
+
     Returns the provisioned user row (so the caller can read ``disabled`` off it without a
     second query).
     """
     user, created = user_store.provision_from_claims(subject, claims, email_claim=email_claim, name_claim=name_claim)
-    if created and role_store is not None:
+    if created and role_store is not None and not _holds_a_role(role_store, subject):
         role = default_role or _store_default_role(role_store)
         if role:
             try:
@@ -151,6 +156,29 @@ def provision_user_with_default_role(
                 "they are denied until a role is assigned"
             )
     return user
+
+
+def _holds_a_role(role_store: Any, subject: str) -> bool:
+    """Whether ``subject`` already holds a stored role; False (grant the default) if the store
+    cannot say, matching the tolerance for custom stores elsewhere in provisioning."""
+    fn = getattr(role_store, "roles_of", None)
+    if not callable(fn):
+        return False
+    try:
+        return bool(fn(subject))
+    except Exception:
+        return False
+
+
+async def _aholds_a_role(role_store: Any, subject: str) -> bool:
+    """Async twin of :func:`_holds_a_role`."""
+    afn = getattr(role_store, "aroles_of", None)
+    if callable(afn):
+        try:
+            return bool(await afn(subject))
+        except Exception:
+            return False
+    return await asyncio.to_thread(_holds_a_role, role_store, subject)
 
 
 async def _astore_default_role(role_store: Any) -> Optional[str]:
@@ -181,7 +209,7 @@ async def aprovision_user_with_default_role(
     user, created = await user_store.aprovision_from_claims(
         subject, claims, email_claim=email_claim, name_claim=name_claim
     )
-    if created and role_store is not None:
+    if created and role_store is not None and not await _aholds_a_role(role_store, subject):
         role = default_role or await _astore_default_role(role_store)
         if role:
             try:

--- a/libs/agno/agno/os/authz/audit.py
+++ b/libs/agno/agno/os/authz/audit.py
@@ -5,7 +5,7 @@ tables (see :class:`DbAuditSink`) because they answer different questions:
 
 1. Decision audit ("was alice allowed to run agent X, and with which token?") —
    recorded by the JWT middleware on every protected request when an
-   :class:`AuditSink` is set on ``AuthorizationConfig(audit=...)``. Each row is an
+   :class:`AuditSink` is set via ``Authorization(audit=...)`` / ``AgentOS(audit=...)``. Each row is an
    ``access.allowed`` / ``access.denied`` event with the principal, the route, the
    required scopes, the caller's scopes, and a NON-secret token reference (the
    token's ``jti`` when present, otherwise a short hash — never the token itself).

--- a/libs/agno/agno/os/authz/facade.py
+++ b/libs/agno/agno/os/authz/facade.py
@@ -1,39 +1,41 @@
-"""One object for AgentOS authorization: verification, roles, users, audit, admin API.
+"""One object for AgentOS authorization: verification, roles, audit, and the ``/authz`` admin API.
 
-Standing up managed roles + a user directory + the admin API by hand means assembling a dozen
-objects (a ``DbAuditSink``, a ``ManagedRoleStore``, a ``ManagedUserStore``, an
-``AuthorizationConfig``, a ``UserDirectoryConfig``, a ``ScopeAuthorizationProvider``, the store's
-provider, two router factories, two ``include_router`` calls) and keeping four of them pointed at
-the same database. :class:`Authorization` owns all of that and wires itself into AgentOS:
+Standing up managed roles by hand means assembling a ``DbAuditSink``, a ``ManagedRoleStore``, an
+``AuthorizationConfig``, a ``ScopeAuthorizationProvider``, the store's provider, a router factory
+and an ``include_router`` call, and keeping them pointed at the same database.
+:class:`Authorization` owns all of that and wires itself into AgentOS:
 
     from agno.os.authz import Authorization
 
     authz = Authorization(db=db, audit=True, trust_token_scopes=True,
-                          verification_keys=KEYS, audience=OS_ID, user_directory=True)
+                          verification_keys=KEYS, audience=OS_ID)
     authz.define_role("admin", ["agent_os:admin"])
     authz.define_role("viewer", ["agents:*:read"], default=True)
     authz.define_role("runner", ["agents:*:read", "agents:*:run"])
-    authz.seed(admin=ADMIN_SUBJECT, users=[("bob", {"email": "bob@co", "role": "viewer"})])
+    authz.seed(admin=ADMIN_SUBJECT, assignments={"bob": "viewer"})
 
-    agent_os = AgentOS(id=OS_ID, db=db, agents=[...], authorization=authz)
+    agent_os = AgentOS(id=OS_ID, db=db, agents=[...], authorization=authz, user_directory=True)
 
-Roles are opt-in, and so is the user directory: nothing is inferred from the other settings.
-``define_role`` puts roles in play; ``user_directory=True`` (or seeding users, which names them
-explicitly) builds the roster and mounts ``/users``. Verification lives here because it already
-lives under authorization today (``authorization=True`` + ``AuthorizationConfig(...)``), and plenty
-of setups verify tokens with no roles at all (isolation, scope-based access, service accounts). So
-the verify-only case is a one-liner:
+It owns what a caller may DO. Who the callers ARE is the user directory, a peer configured on
+``AgentOS(user_directory=...)`` (it works with no authorization at all, as a roster), and AgentOS
+mounts ``/users`` from it whenever authorization is on. This object never writes a directory row:
+people arrive through JIT provisioning on their first valid token, or through
+``agent_os.user_directory.user_store.upsert(...)``.
 
-    Authorization(verification_keys=KEYS, audience=OS_ID)   # no roles, no directory, no ceremony
+Roles are opt-in. Verification lives here because it already lives under authorization today
+(``authorization=True`` + ``AuthorizationConfig(...)``), and plenty of setups verify tokens with
+no roles at all (isolation, scope-based access, service accounts). So the verify-only case is a
+one-liner:
+
+    Authorization(verification_keys=KEYS, audience=OS_ID)   # no roles, no ceremony
 
 Everything the facade builds is still reachable as a primitive: pass your own ``role_store=`` /
-``user_directory=<store>`` / ``engine=`` and the facade uses them instead of building its own.
-``authorization_provider=`` is the full override: your provider decides alone, no store, no
-``/authz``. Simplicity by default, full control when you need it.
+``engine=`` and the facade uses it instead of building its own. ``authorization_provider=`` is the
+full override: your provider decides alone, no store, no ``/authz``. Simplicity by default, full
+control when you need it.
 
 The database is borrowed from AgentOS when you don't pass one, so you never write ``db=`` twice --
-role and user definitions are buffered and applied once the db binds (the same way
-``AgentOS(user_directory=True)`` adopts the OS db).
+role definitions and seeds are buffered and applied once the db binds.
 """
 
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
@@ -46,8 +48,7 @@ if TYPE_CHECKING:
     from agno.os.authz.engine import PolicyEngine
     from agno.os.authz.provider import AuthorizationProvider
     from agno.os.authz.role_store import ManagedRoleStore
-    from agno.os.authz.user_store import ManagedUserStore
-    from agno.os.config import AuthorizationConfig, UserDirectoryConfig
+    from agno.os.config import AuthorizationConfig
 
 # The role name :meth:`Authorization.seed` grants to its ``admin=`` subject. Define a role with
 # this slug (and the ``agent_os:admin`` scope) for the grant to actually confer admin.
@@ -62,11 +63,11 @@ _NEEDS_DB = (
 # be driven from an event loop, and driving it from a throwaway loop here would bind its connection
 # pool to the wrong loop. So setup needs a sync db; async is for request-time enforcement.
 _ASYNC_SETUP_MSG = (
-    "Authorization.define_role()/seed() write roles and users at setup time and need a synchronous "
-    "database, but the bound database is async ({db_type}). Give AgentOS a sync db for setup, or "
-    "configure roles/users yourself through the async store API (ManagedRoleStore.aset_role_scopes / "
-    "ManagedUserStore.aupsert) and pass them via Authorization(role_store=..., user_directory=<store>). A "
-    "facade with pre-built stores and no define_role()/seed() calls works against an async db."
+    "Authorization.define_role()/seed() write roles at setup time and need a synchronous database, "
+    "but the bound database is async ({db_type}). Give AgentOS a sync db for setup, or configure "
+    "roles yourself through the async store API (ManagedRoleStore.aset_role_scopes / aassign) and "
+    "pass the store via Authorization(role_store=...). A facade with a pre-built store and no "
+    "define_role()/seed() calls works against an async db."
 )
 
 # A scope entry as accepted by ManagedRoleStore.set_role_scopes.
@@ -76,9 +77,9 @@ ScopeInput = Union[str, Tuple[str, str], Dict[str, str]]
 class Authorization:
     """The single AgentOS authorization object. Pass it as ``AgentOS(authorization=...)``.
 
-    Owns token verification, the optional managed-role store, the optional user directory, the
-    audit sink, and the admin API mount. Build the common case in a few lines; drop to the
-    underlying primitives (``role_store=``, ``authorization_provider=``, ...) for full control.
+    Owns token verification, the optional managed-role store, the audit sink, and the ``/authz``
+    admin API mount. Build the common case in a few lines; drop to the underlying primitives
+    (``role_store=``, ``engine=``, ``authorization_provider=``) for full control.
     """
 
     def __init__(
@@ -86,7 +87,7 @@ class Authorization:
         *,
         db: Optional[Any] = None,
         db_url: Optional[str] = None,
-        # --- token verification (carried into the AuthorizationConfig AgentOS builds) ---
+        # --- token verification ---
         verification_keys: Optional[List[str]] = None,
         jwks_file: Optional[str] = None,
         algorithm: Optional[str] = None,
@@ -99,8 +100,6 @@ class Authorization:
         audit: Union[bool, "AuditSink"] = False,
         trust_token_scopes: bool = False,
         roles_claim: Optional[str] = None,
-        user_directory: Union[bool, "ManagedUserStore"] = False,
-        auto_provision: bool = True,
         # --- escape hatches (bring your own) ---
         authorization_provider: Optional[Union["AuthorizationProvider", List["AuthorizationProvider"]]] = None,
         engine: Optional["PolicyEngine"] = None,
@@ -108,31 +107,26 @@ class Authorization:
     ):
         """
         Args:
-            db / db_url: the SQL database for roles/users/audit. Optional -- when omitted the
-                facade borrows ``AgentOS(db=...)`` at bind time, so you pass a db once.
+            db / db_url: the SQL database for roles and audit. Optional -- when omitted the facade
+                borrows ``AgentOS(db=...)`` at bind time, so you pass a db once.
             verification_keys, jwks_file, algorithm, verify_audience, audience, issuer,
                 admin_scope, excluded_route_paths: JWT verification settings. Used with or
                 without roles (verify-only / scope-based / isolation deployments set just these).
             audit: ``True`` builds a ``DbAuditSink`` from the bound db (feeds both the change and
-                decision trails); pass an ``AuditSink`` to use your own; ``False`` disables it.
+                decision trails, and the user directory's change trail); pass an ``AuditSink`` to
+                use your own; ``False`` disables it.
             trust_token_scopes: run a scope plane alongside managed roles, so operators authorized
                 by their token scopes and end users authorized by the role store both work
                 (composed with OR). No effect without roles.
             roles_claim: the external-IdP case -- read the caller's role(s) from this token claim
                 (e.g. WorkOS/Auth0 send a ``role`` claim) instead of from stored assignments. You
                 still ``define_role`` what each role may do; the token asserts which role the caller
-                has, so no per-user ``assign``. Turns managed roles on by itself.
-            user_directory: the directory, one knob (mirrors ``AgentOS(user_directory=bool | ...)``).
-                ``False`` (default) builds none; ``True`` builds a ``ManagedUserStore`` roster from the
-                db; a ``ManagedUserStore`` uses yours. Explicit on purpose: defining roles does not
-                imply a roster. ``seed(users=...)`` turns it on too, since listing people is explicit.
-            auto_provision: JIT-provision an unknown subject on first valid token. The role they get
-                is the one flagged ``define_role(..., default=True)``.
+                has, so no per-user assignment. Turns managed roles on by itself.
             authorization_provider: full override -- your provider decides alone, no store is built
                 and ``/authz`` is not mounted. Cannot be combined with ``role_store``/``engine``; to
                 keep the admin API on top of your own backend, pass ``engine=`` instead.
             engine / role_store: primitives. Supply either and the facade uses it instead of
-                building its own (bring your own directory store via ``user_directory=<store>``).
+                building its own.
         """
         if authorization_provider is not None and (role_store is not None or engine is not None):
             raise ValueError(
@@ -140,44 +134,33 @@ class Authorization:
                 "or engine=: the provider decides alone. To keep managed roles and the /authz admin API "
                 "on your own backend, pass engine=<PolicyEngine> instead of a provider."
             )
-        # Verification settings, splatted into the AuthorizationConfig at build time. Typed Any so
-        # the per-key kwarg splat type-checks against AuthorizationConfig's specific field types.
+        # Verification settings. ``issuer`` is handed to AgentOS separately: the released
+        # AuthorizationConfig has no such field and stays frozen at its released shape.
         self._verification: Dict[str, Any] = {
             "verification_keys": verification_keys,
             "jwks_file": jwks_file,
             "algorithm": algorithm,
             "verify_audience": verify_audience,
             "audience": audience,
-            "issuer": issuer,
             "admin_scope": admin_scope,
             "excluded_route_paths": excluded_route_paths,
         }
+        self._issuer = issuer
         self._audit_arg = audit
         self._trust_token_scopes = trust_token_scopes
         self._roles_claim = roles_claim
-        self._auto_provision = auto_provision
         self._provider_override = authorization_provider
         self._engine = engine
 
         self._role_store: Optional["ManagedRoleStore"] = role_store
         self._audit_sink: Optional["AuditSink"] = None
 
-        # Directory is one knob, user_directory: True/False, or a ManagedUserStore to bring your own.
-        # Off unless asked for: defining roles does not imply a roster, so a roles-only or verify-only
-        # Authorization builds NO directory and mounts no /users.
-        self._user_directory_arg = user_directory
-        self._user_store: Optional["ManagedUserStore"] = (
-            user_directory if not isinstance(user_directory, bool) else None
-        )
-
         # Roles are in play if any were defined, or a store/engine was supplied.
         self._roles_defined = role_store is not None or engine is not None or roles_claim is not None
-        # Whether seed(users=...) named people -- the one implicit way to ask for a directory.
-        self._users_seeded = False
 
         # Buffers applied at bind time (used when no db is available yet).
         self._role_defs: List[Tuple[str, List[ScopeInput], bool, Optional[str], Optional[str]]] = []
-        self._seed_calls: List[Tuple[Optional[str], str, Optional[List[Tuple[str, Dict[str, Any]]]]]] = []
+        self._seed_calls: List[Tuple[Optional[str], str, Optional[Dict[str, str]]]] = []
         # Admins seeded, checked once at finalize so a warning never depends on define_role/seed order.
         self._seeded_admins: List[Tuple[str, str]] = []
         self._admins_checked = False
@@ -217,51 +200,50 @@ class Authorization:
         *,
         admin: Optional[str] = None,
         admin_role: str = _ADMIN_ROLE,
-        users: Optional[List[Tuple[str, Dict[str, Any]]]] = None,
+        assignments: Optional[Dict[str, str]] = None,
     ) -> "Authorization":
-        """Bootstrap an admin and directory users, without ever clobbering runtime state.
+        """Bootstrap role assignments, without ever clobbering runtime state.
 
         ``admin=<subject>`` grants ``admin_role`` (default ``"admin"`` -- define it first) to that
-        subject if they hold no role yet. ``users=[(subject, {"email", "name", "role"})]`` adds each
-        to the directory and assigns its role, again only if the subject is new.
+        subject if they hold no role yet. ``assignments={subject: role}`` gives each subject its role,
+        again only if they hold none. Nothing here touches the user directory: people are created by
+        JIT provisioning on their first valid token, or by ``user_store.upsert`` on the directory
+        AgentOS owns.
 
         BOOTSTRAP semantics: anything that already exists is left as is, so seeding on every start is
-        safe -- an operator who promoted a user or edited a profile through the admin API keeps that
-        change across restarts. Manage users/assignments after first boot through the admin API."""
-        if users:
-            self._users_seeded = True
+        safe -- an operator who promoted a user through the admin API keeps that change across
+        restarts. The one exception is a lockout: if the seeded admin was demoted and nobody holds an
+        admin role any more, the next boot re-grants it (and says so), because the admin API cannot
+        repair itself."""
         if self._bound:
-            self._apply_seed(admin, admin_role, users)
+            self._apply_seed(admin, admin_role, assignments)
         else:
-            self._seed_calls.append((admin, admin_role, users))
+            self._seed_calls.append((admin, admin_role, assignments))
         return self
 
     # ------------------------------------------------------------------ binding
     def _bind(self, os_db: Optional[Any] = None) -> "Authorization":
-        """Resolve the database (own, else the OS db), build the requested stores, and flush any
-        buffered role/user definitions. Idempotent: a second call (e.g. AgentOS re-binding an
-        already-bound facade) is a no-op."""
+        """Resolve the database (own, else the OS db), build the role store if roles are in play, and
+        flush any buffered role definitions and seeds. Idempotent: a second call (e.g. AgentOS
+        re-binding an already-bound facade) is a no-op."""
         if self._bound:
             return self
         self._db = self._db or os_db
         # A database is only needed for things that PERSIST and are not already persisted: a role
-        # store or directory the facade has to build (or was handed unbound), or a DbAuditSink from
-        # audit=True. Verify-only / scope-based / custom-provider setups store nothing, and a store
-        # you built with its own db brings its persistence along, so neither needs a db here.
+        # store the facade has to build (or was handed unbound), or a DbAuditSink from audit=True.
+        # Verify-only / scope-based / custom-provider setups store nothing, and a store you built
+        # with its own db brings its persistence along, so neither needs a db here.
         if self._db is None and self._needs_own_db():
             raise ValueError(_NEEDS_DB)
         self._db_is_async = is_async_authz_db(self._db)
         self._audit_sink = self._resolve_audit()
         if self._roles_defined or self._role_defs:
             self._ensure_role_store()
-        if self._directory_wanted():
-            self._ensure_user_store()
         # A store that could not bind (its own db missing AND the OS db not SQL-capable) would run
-        # in memory: roles and the disabled kill switch silently lost on restart, never seen by
-        # another replica. Fail here, at construction, rather than serve that.
-        for store in (self._role_store, self._user_store):
-            if store is not None and getattr(store, "is_bound", True) is False:
-                raise ValueError(_NEEDS_DB)
+        # in memory: roles silently lost on restart, never seen by another replica. Fail here, at
+        # construction, rather than serve that.
+        if self._role_store is not None and getattr(self._role_store, "is_bound", True) is False:
+            raise ValueError(_NEEDS_DB)
         self._bound = True
         self._flush()
         return self
@@ -270,29 +252,19 @@ class Authorization:
         for slug, scopes, default, name, description in self._role_defs:
             self._apply_role_def(slug, scopes, default, name, description)
         self._role_defs.clear()
-        for admin, admin_role, users in self._seed_calls:
-            self._apply_seed(admin, admin_role, users)
+        for admin, admin_role, assignments in self._seed_calls:
+            self._apply_seed(admin, admin_role, assignments)
         self._seed_calls.clear()
 
     def _needs_own_db(self) -> bool:
-        """Whether binding has to have a database: something must be built or bound, and no store of
-        the caller's already carries its own."""
+        """Whether binding has to have a database: a store must be built or bound, or an audit sink
+        built, and no store of the caller's already carries its own."""
         if self._audit_arg is True:
             return True
         if self._roles_defined or self._role_defs:
             if self._role_store is None or getattr(self._role_store, "is_bound", True) is False:
                 return True
-        if self._directory_wanted():
-            if self._user_store is None or getattr(self._user_store, "is_bound", True) is False:
-                return True
         return False
-
-    def _directory_wanted(self) -> bool:
-        """Whether a user directory should exist: asked for explicitly (``user_directory=True`` or a
-        store of your own), or implied by ``seed(users=...)`` naming people. Never inferred from roles."""
-        if self._user_directory_arg is True or self._user_store is not None:
-            return True
-        return self._users_seeded
 
     def _resolve_audit(self) -> Optional["AuditSink"]:
         if self._audit_arg is False or self._audit_arg is None:
@@ -314,17 +286,6 @@ class Authorization:
             self._role_store.attach_audit(self._audit_sink)
         return self._role_store
 
-    def _ensure_user_store(self) -> "ManagedUserStore":
-        if self._user_store is None:
-            from agno.os.authz.user_store import ManagedUserStore
-
-            self._user_store = ManagedUserStore(db=self._db)
-        else:
-            self._user_store.attach_db(self._db)
-        if self._audit_sink is not None:
-            self._user_store.attach_audit(self._audit_sink)
-        return self._user_store
-
     def _apply_role_def(
         self,
         slug: str,
@@ -345,9 +306,7 @@ class Authorization:
             return
         store.set_role_scopes(slug, scopes, name=name, description=description, is_default=default)
 
-    def _apply_seed(
-        self, admin: Optional[str], admin_role: str, users: Optional[List[Tuple[str, Dict[str, Any]]]]
-    ) -> None:
+    def _apply_seed(self, admin: Optional[str], admin_role: str, assignments: Optional[Dict[str, str]]) -> None:
         self._require_sync_setup()
         role_store = self._ensure_role_store()
         if admin is not None:
@@ -364,21 +323,11 @@ class Authorization:
                     f"the admin API was unreachable. Re-granted {admin_role!r} to {admin!r}."
                 )
                 role_store.assign(admin, admin_role)
-            if self._directory_wanted():
-                users_store = self._ensure_user_store()
-                if users_store.get(admin) is None:
-                    users_store.upsert(admin, name="Bootstrap admin")
             # Checked once at finalize (authorization_config), so the warning never depends on whether
             # define_role ran before or after this seed.
             self._seeded_admins.append((admin, admin_role))
-        for subject, info in users or []:
-            info = dict(info)
-            role = info.pop("role", None)
-            if self._directory_wanted():
-                users_store = self._ensure_user_store()
-                if users_store.get(subject) is None:  # bootstrap: keep an admin's profile edits
-                    users_store.upsert(subject, email=info.get("email"), name=info.get("name"))
-            if role and not role_store.roles_of(subject):  # bootstrap: keep a runtime promotion
+        for subject, role in (assignments or {}).items():
+            if not role_store.roles_of(subject):  # bootstrap: keep a runtime promotion
                 role_store.assign(subject, role)
 
     @staticmethod
@@ -413,9 +362,12 @@ class Authorization:
                     "seed(admin_role=<your admin role>)."
                 )
 
-    # ------------------------------------------------------------------ provider
-    def _provider(self) -> Optional[Union["AuthorizationProvider", List["AuthorizationProvider"]]]:
-        """The provider AgentOS should enforce with, or None to fall back to scope RBAC."""
+    # ------------------------------------------------------------------ what AgentOS reads
+    @property
+    def provider(self) -> Optional[Union["AuthorizationProvider", List["AuthorizationProvider"]]]:
+        """The provider AgentOS should enforce with: your override, the role store's provider (with
+        the scope plane alongside under ``trust_token_scopes``), or None so AgentOS falls back to
+        scope RBAC. A list means several planes composed with OR."""
         if self._provider_override is not None:
             return self._provider_override
         store = self.role_store
@@ -428,25 +380,17 @@ class Authorization:
         return store.provider
 
     @property
-    def _uses_roles(self) -> bool:
-        return self._roles_defined
+    def issuer(self) -> Optional[str]:
+        """The pinned token issuer (the ``iss`` claim), or None when not pinned."""
+        return self._issuer
 
-    # ------------------------------------------------------------------ what AgentOS reads
     @property
     def role_store(self) -> Optional["ManagedRoleStore"]:
         """The role store, or None when the facade is verify-only. Mount the ``/authz`` admin API
         only when this is set. Built on demand once a db is bound."""
-        if not self._uses_roles:
+        if not self._roles_defined:
             return None
         return self._ensure_role_store() if self._bound else self._role_store
-
-    @property
-    def user_store(self) -> Optional["ManagedUserStore"]:
-        """The directory store, or None when no directory is wanted. Mount the ``/users`` admin API
-        only when this is set. Built on demand once a db is bound."""
-        if not self._directory_wanted():
-            return None
-        return self._ensure_user_store() if self._bound else self._user_store
 
     @property
     def audit_sink(self) -> Optional["AuditSink"]:
@@ -454,19 +398,10 @@ class Authorization:
         return self._audit_sink
 
     def authorization_config(self) -> "AuthorizationConfig":
-        """The ``AuthorizationConfig`` AgentOS enforces: verification settings plus the composed
-        provider (or none, so AgentOS uses scope RBAC). AgentOS calls this once after all setup, so it
-        is where a seeded admin whose role does not grant admin is finally validated."""
+        """The verification settings as the ``AuthorizationConfig`` the JWT middleware reads (its
+        released field set, nothing more). AgentOS calls this once after all setup, so it is where a
+        seeded admin whose role does not grant admin is finally validated."""
         from agno.os.config import AuthorizationConfig
 
         self._check_seeded_admins()
-        return AuthorizationConfig(authorization_provider=self._provider(), **self._verification)
-
-    def user_directory_config(self) -> Optional["UserDirectoryConfig"]:
-        """The ``UserDirectoryConfig`` for AgentOS, or None when no directory is configured."""
-        store = self.user_store
-        if store is None:
-            return None
-        from agno.os.config import UserDirectoryConfig
-
-        return UserDirectoryConfig(user_store=store, auto_provision=self._auto_provision)
+        return AuthorizationConfig(**self._verification)

--- a/libs/agno/agno/os/authz/role_router.py
+++ b/libs/agno/agno/os/authz/role_router.py
@@ -6,8 +6,8 @@ with allow/deny), and grant or revoke them at runtime.
 With ``AgentOS(authorization=Authorization(...))`` you do not mount this yourself: AgentOS
 registers it at ``/authz`` whenever the object has a role store. The credential-less user
 DIRECTORY (who the users are + the disabled kill-switch) is a PEER concern served by
-:func:`get_users_router` at ``/users`` -- mounted from ``Authorization(user_directory=...)``,
-not this router.
+:func:`get_users_router` at ``/users`` -- mounted from ``AgentOS(user_directory=...)``, not this
+router.
 
     from agno.os.authz import Authorization
 
@@ -448,7 +448,7 @@ def get_roles_router(
     ) -> PaginatedResponse:
         """*Decision* events (allow/deny per request), paginated ``{data, meta}``.
 
-        Decision audit is configured on ``AuthorizationConfig(audit=...)`` and lands
+        Decision audit is configured on ``Authorization(audit=...)`` and lands
         on ``app.state.authz_audit`` — a separate table from the change trail above,
         so a high-volume decision log never buries the change history. Empty unless a
         readable decision sink (e.g. DbAuditSink) is configured."""

--- a/libs/agno/agno/os/config.py
+++ b/libs/agno/agno/os/config.py
@@ -1,11 +1,8 @@
 """Schemas related to the AgentOS configuration"""
 
-from typing import Any, Callable, Dict, Generic, List, Literal, Optional, Set, TypeVar, Union
+from typing import Any, Callable, Dict, Generic, List, Literal, Optional, Set, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
-
-from agno.os.authz.audit import AuditSink
-from agno.os.authz.provider import AuthorizationProvider
 
 # Tags carried by the built-in MCP tools, exposed here so callers (and the IDE) can see
 # the valid values for ``MCPConfig.include_tags`` / ``exclude_tags`` without reading
@@ -359,14 +356,14 @@ MCPServerConfig = MCPConfig
 
 
 class AuthorizationConfig(BaseModel):
-    """Low-level authorization config for the JWT middleware. Deprecated as a public type.
+    """Low-level JWT verification config. Deprecated as a public type.
 
-    Superseded by :class:`agno.os.authz.Authorization`, which owns every field here (verification,
-    provider, audit, excluded routes) plus the higher-level surface (define_role, seed, the user
-    directory, the admin API). ``Authorization`` builds one of these internally to feed the
-    pipeline; ``AgentOS(authorization_config=...)`` still accepts one so deployments written against
-    the released field set keep booting, with a warning. Frozen: do NOT add fields here -- add them
-    to ``Authorization``.
+    Superseded by :class:`agno.os.authz.Authorization`, which owns every field here plus the
+    higher-level surface (roles, seeding, audit, the admin API). ``Authorization`` builds one of
+    these internally to feed the JWT middleware; ``AgentOS(authorization_config=...)`` still accepts
+    one so deployments written against the released field set keep booting, with a warning.
+    Frozen at exactly that released field set: do NOT add fields here -- add them to
+    ``Authorization``.
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -376,23 +373,7 @@ class AuthorizationConfig(BaseModel):
     algorithm: Optional[str] = None
     verify_audience: Optional[bool] = None
     audience: Optional[str] = None
-    # Expected token issuer (the ``iss`` claim). When set, a token minted by anyone
-    # else is rejected even if its signature verifies -- pin this whenever more than
-    # one IdP can produce tokens your verification keys accept.
-    issuer: Optional[str] = None
     admin_scope: Optional[str] = None
-    # Pluggable authorization strategy. When None, AgentOS uses scope-based RBAC
-    # (JWT/PAT scopes, no external dependency). Supply an AuthorizationProvider to
-    # swap in a richer model (managed roles, ReBAC/ABAC, OpenFGA, ...) enforced at
-    # the same points as scopes — the REST route gate, per-resource gate, WS gates,
-    # and MCP tool gate all resolve through it. Pass a LIST of them to run several
-    # authz planes at once (e.g. token scopes for operators + a managed role store
-    # for end users) — a request is allowed if any of them allows it.
-    authorization_provider: Optional[Union[AuthorizationProvider, List[AuthorizationProvider]]] = None
-    # Optional AuditSink. When set, AgentOS records each authorization decision
-    # (allow/deny) alongside the change trail, so you get an access audit, not just a
-    # change audit. Pass the same sink you give ManagedRoleStore to unify both.
-    audit: Optional[AuditSink] = None
     # Additional fnmatch path patterns that bypass all AgentOS authentication,
     # merged with the default public-route exclusions.
     excluded_route_paths: Optional[List[str]] = None

--- a/libs/agno/agno/os/mcp_auth.py
+++ b/libs/agno/agno/os/mcp_auth.py
@@ -360,6 +360,7 @@ def _build_jwt_token_verifier(os: "AgentOS") -> Optional[JWTBearerTokenVerifier]
     kwargs = build_jwt_middleware_kwargs(
         getattr(os, "authorization_config", None),
         authorization=bool(getattr(os, "authorization", False)),
+        issuer=getattr(os, "_facade_issuer", None),
     )
     jwt_configured = bool(
         kwargs["verification_keys"] or kwargs["jwks_file"] or getenv("JWT_VERIFICATION_KEY") or getenv("JWT_JWKS_FILE")

--- a/libs/agno/agno/os/middleware/jwt.py
+++ b/libs/agno/agno/os/middleware/jwt.py
@@ -433,8 +433,12 @@ def build_jwt_middleware_kwargs(
     authorization: bool,
     service_account_verifier: Optional[Any] = None,
     excluded_route_paths: Optional[List[str]] = None,
+    issuer: Optional[str] = None,
 ) -> Dict[str, Any]:
     """JWTMiddleware kwargs derived from an ``AuthorizationConfig``, in one place.
+
+    ``issuer`` is passed by the caller (it lives on the ``Authorization`` object, not on the
+    released config), so both surfaces pin the same one.
 
     Both the REST app wiring (``agno.os.app``) and the mounted MCP app
     (``agno.os.mcp.get_mcp_server``) construct their middleware from this builder, so
@@ -449,7 +453,6 @@ def build_jwt_middleware_kwargs(
     jwks_file = None
     verify_audience = False
     audience = None
-    issuer = None
     admin_scope: Optional[str] = None
     user_isolation = False
 
@@ -459,7 +462,6 @@ def build_jwt_middleware_kwargs(
         jwks_file = authorization_config.jwks_file
         verify_audience = authorization_config.verify_audience or False
         audience = authorization_config.audience
-        issuer = authorization_config.issuer
         admin_scope = authorization_config.admin_scope
         user_isolation = authorization_config.user_isolation
 
@@ -977,7 +979,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
         reason: Optional[str] = None,
     ) -> None:
         """Record one authorization decision to the audit sink, if one is configured
-        on ``app.state.authz_audit`` (seeded from ``AuthorizationConfig(audit=...)``).
+        on ``app.state.authz_audit`` (seeded from ``Authorization(audit=...)`` / ``AgentOS(audit=...)``).
 
         Captures the principal, route, required scopes, the caller's scopes, and a
         NON-secret token reference (see :meth:`_token_reference`). Never the token

--- a/libs/agno/tests/integration/os/test_audit_single_switch.py
+++ b/libs/agno/tests/integration/os/test_audit_single_switch.py
@@ -19,6 +19,7 @@ from agno.os.authz import Authorization  # noqa: E402
 from agno.os.authz.audit import DbAuditSink  # noqa: E402
 from agno.os.authz.role_store import ManagedRoleStore  # noqa: E402
 from agno.os.authz.user_store import ManagedUserStore  # noqa: E402
+from agno.os.config import UserDirectoryConfig  # noqa: E402
 
 SECRET = "audit-switch-secret-at-least-256-bits-xxxxxxxxxx"
 
@@ -32,9 +33,8 @@ def _os(db, roles, users, audit=False):
         id="audit-os",
         agents=[Agent(id="a", name="R", db=InMemoryDb())],
         db=db,
-        authorization=Authorization(
-            verification_keys=[SECRET], algorithm="HS256", role_store=roles, user_directory=users, audit=audit
-        ),
+        authorization=Authorization(verification_keys=[SECRET], algorithm="HS256", role_store=roles, audit=audit),
+        user_directory=UserDirectoryConfig(user_store=users),
     )
 
 

--- a/libs/agno/tests/integration/os/test_authorization_facade.py
+++ b/libs/agno/tests/integration/os/test_authorization_facade.py
@@ -57,54 +57,75 @@ def test_verify_only_facade_builds_no_stores(tmp_path):
     authz = Authorization(verification_keys=[SECRET], audience=OS_ID)  # the exact documented shape
     authz._bind(db)
     assert authz.role_store is None
-    assert authz.user_store is None  # auto directory stays OFF with no roles/users
+    assert authz.provider is None  # AgentOS defaults to ScopeAuthorizationProvider
     cfg = authz.authorization_config()
-    assert cfg.authorization_provider is None  # AgentOS defaults to ScopeAuthorizationProvider
     assert cfg.verification_keys == [SECRET] and cfg.audience == OS_ID
 
 
-def test_user_directory_is_one_knob(tmp_path):
-    """The directory has a single knob: user_directory=<store> brings your own (no separate
-    user_store= param), mirroring AgentOS(user_directory=bool | ...)."""
+def test_object_owns_no_directory(tmp_path):
+    """The user directory is AgentOS's, not the object's: Authorization has no directory knob and
+    seed() never writes a directory row. Served, the directory comes from AgentOS(user_directory=)
+    and /users mounts only when one is configured (a 404 means not mounted; a mounted router
+    answers 200/403)."""
     import inspect
 
-    from agno.os.authz.user_store import ManagedUserStore
-
     params = inspect.signature(Authorization.__init__).parameters
-    assert "user_directory" in params
-    assert "user_store" not in params  # collapsed to one way
+    assert "user_directory" not in params and "auto_provision" not in params
+    assert not hasattr(Authorization, "user_store")
 
-    db = SqliteDb(db_file=str(tmp_path / "onedir.db"))
-    store = ManagedUserStore(db=db)
-    authz = Authorization(db=db, user_directory=store)
-    authz.define_role("viewer", ["agents:*:read"])
-    assert authz.user_store is store  # your store is used, on by virtue of being passed
+    def authz():
+        a = Authorization(verification_keys=[SECRET], algorithm="HS256", verify_audience=True, audience=OS_ID)
+        a.define_role("admin", ["agent_os:admin"])
+        a.seed(admin="root")
+        return a
+
+    without = TestClient(
+        AgentOS(
+            id=OS_ID, db=SqliteDb(db_file=str(tmp_path / "no.db")), agents=_agents(), authorization=authz()
+        ).get_app()
+    )
+    assert without.get("/authz/roles", headers=_auth("root")).status_code == 200
+    assert without.get("/users", headers=_auth("root")).status_code == 404
+
+    os_ = AgentOS(
+        id=OS_ID,
+        db=SqliteDb(db_file=str(tmp_path / "yes.db")),
+        agents=_agents(),
+        authorization=authz(),
+        user_directory=True,
+    )
+    with_dir = TestClient(os_.get_app())
+    assert os_.user_directory.user_store.get("root") is None  # seed(admin=) wrote no directory row
+    assert with_dir.get("/users", headers=_auth("root")).status_code == 200
+    # That request JIT-provisioned root's row, and it did NOT replace the seeded admin role with the
+    # default: a pre-assigned subject keeps their role when their directory row is created.
+    assert os_.user_directory.user_store.get("root") is not None
+    assert with_dir.get("/authz/roles", headers=_auth("root")).status_code == 200
 
 
 def test_borrowed_db_applies_buffered_definitions(tmp_path):
-    """No db passed to Authorization: role/user definitions buffer, then apply when the OS db binds
-    (the 'never pass db twice' path)."""
+    """No db passed to Authorization: role definitions and seeds buffer, then apply when the OS db
+    binds (the 'never pass db twice' path)."""
     authz = Authorization(audit=True)
     authz.define_role("runner", ["agents:*:run"])
-    authz.seed(users=[("carol", {"email": "c@co", "role": "runner"})])
+    authz.seed(assignments={"carol": "runner"})
     assert authz._bound is False
 
     db = SqliteDb(db_file=str(tmp_path / "borrow.db"))
     authz._bind(db)
     assert authz.role_store.list_roles() == ["runner"]
     assert authz.role_store.roles_of("carol") == ["runner"]
-    assert authz.user_store.get("carol") is not None
 
 
 def test_seed_is_idempotent(tmp_path):
-    """Seeding on every start is safe: single-role assigns and directory upserts are no-ops when
-    unchanged, so a restart neither re-grants nor duplicates."""
+    """Seeding on every start is safe: single-role assigns are no-ops when unchanged, so a restart
+    neither re-grants nor duplicates."""
     db = SqliteDb(db_file=str(tmp_path / "seed.db"))
     authz = Authorization(db=db)
     authz.define_role("admin", ["agent_os:admin"])
     authz.define_role("viewer", ["agents:*:read"], default=True)
-    authz.seed(admin="root", users=[("bob", {"email": "bob@co", "role": "viewer"})])
-    authz.seed(admin="root", users=[("bob", {"email": "bob@co", "role": "viewer"})])  # again
+    authz.seed(admin="root", assignments={"bob": "viewer"})
+    authz.seed(admin="root", assignments={"bob": "viewer"})  # again
     assert authz.role_store.roles_of("root") == ["admin"]
     assert authz.role_store.roles_of("bob") == ["viewer"]
     assert authz.role_store.default_role() == "viewer"
@@ -120,7 +141,7 @@ def test_reboot_preserves_runtime_operator_edits(tmp_path):
         a = Authorization(db=SqliteDb(db_file=dbfile))
         a.define_role("viewer", ["agents:*:read"], default=True)
         a.define_role("runner", ["agents:*:read", "agents:*:run"])
-        a.seed(users=[("bob", {"role": "viewer"})])
+        a.seed(assignments={"bob": "viewer"})
         return a
 
     a1 = boot()
@@ -219,18 +240,21 @@ def test_facade_prebuilt_async_store_no_setup_ok(tmp_path):
     adb = AsyncSqliteDb(db_file=str(tmp_path / "a.db"))
     authz = Authorization(role_store=ManagedRoleStore(db=adb), verification_keys=[SECRET], audience=OS_ID)
     authz._bind(adb)
-    cfg = authz.authorization_config()  # no writes, just wires the provider
-    assert cfg.authorization_provider is not None
+    authz.authorization_config()  # no writes
+    assert authz.provider is not None  # just wires the provider
 
 
 def test_agentos_rejects_config_alongside_facade(tmp_path):
-    """Passing authorization_config / user_directory / audit alongside an Authorization facade is a
-    silent-preference footgun (a data split if the facade has its own db), so AgentOS rejects it."""
+    """Passing authorization_config / audit alongside an Authorization facade is a silent-preference
+    footgun, so AgentOS rejects it. user_directory is NOT a conflict: the directory is AgentOS's."""
+    from agno.os.authz.audit import LoggingAuditSink
+
     db = SqliteDb(db_file=str(tmp_path / "conflict.db"))
     authz = Authorization(db=db, verification_keys=[SECRET], audience=OS_ID)
     authz.define_role("admin", ["agent_os:admin"])
-    with pytest.raises(ValueError, match="already owns"):
-        AgentOS(id=OS_ID, db=db, agents=_agents(), authorization=authz, user_directory=True)
+    with pytest.raises(ValueError, match="already owns audit"):
+        AgentOS(id=OS_ID, db=db, agents=_agents(), authorization=authz, audit=LoggingAuditSink())
+    AgentOS(id=OS_ID, db=db, agents=_agents(), authorization=authz, user_directory=True)  # fine
 
 
 # --------------------------------------------------------------------------- served end to end
@@ -246,18 +270,14 @@ def _served(tmp_path, *, borrow_db, trust_token_scopes=False):
         algorithm="HS256",
         verify_audience=True,
         audience=OS_ID,
-        auto_provision=True,
     )
     authz = Authorization(**kwargs) if borrow_db else Authorization(db=db, **kwargs)
     authz.define_role("admin", ["agent_os:admin"])
     authz.define_role("viewer", ["agents:*:read"], default=True)
     authz.define_role("runner", ["agents:research:read", "agents:research:run"])
-    authz.seed(
-        admin="root",
-        users=[("bob", {"email": "bob@co", "name": "Bob", "role": "viewer"}), ("carol", {"role": "runner"})],
-    )
-    os_ = AgentOS(id=OS_ID, db=db, agents=_agents(), authorization=authz)
-    return os_
+    authz.seed(admin="root", assignments={"bob": "viewer", "carol": "runner"})
+    # The directory is AgentOS's: True builds a roster on the OS db with JIT provisioning on.
+    return AgentOS(id=OS_ID, db=db, agents=_agents(), authorization=authz, user_directory=True)
 
 
 @pytest.mark.parametrize("borrow_db", [True, False], ids=["borrowed-db", "own-db"])
@@ -316,44 +336,6 @@ def test_authorization_config_is_deprecated_not_a_second_spelling(tmp_path):
 
     with pytest.raises(TypeError, match="authorization_config="):
         AgentOS(id=OS_ID, db=SqliteDb(db_file=str(tmp_path / "cfg2.db")), agents=_agents(), authorization=cfg)
-
-
-def test_directory_is_explicit_never_inferred_from_roles(tmp_path):
-    """Defining roles (or reading them off a token claim) must not stand up a roster: a roles-only
-    deployment gets no ManagedUserStore, no JIT provisioning, and no /users. The directory exists
-    only when asked for -- user_directory=True, a store of your own, or seed(users=...) naming
-    people."""
-    db = SqliteDb(db_file=str(tmp_path / "explicit.db"))
-
-    roles_only = Authorization(db=db, verification_keys=[SECRET], audience=OS_ID)
-    roles_only.define_role("viewer", ["agents:*:read"])
-    assert roles_only.role_store is not None
-    assert roles_only.user_store is None
-    assert roles_only.user_directory_config() is None
-
-    idp = Authorization(db=db, verification_keys=[SECRET], audience=OS_ID, roles_claim="role")
-    assert idp.role_store is not None and idp.user_store is None
-
-    asked = Authorization(db=db, verification_keys=[SECRET], audience=OS_ID, user_directory=True)
-    assert asked.user_store is not None
-
-    seeded = Authorization(db=db, verification_keys=[SECRET], audience=OS_ID)
-    seeded.define_role("viewer", ["agents:*:read"])
-    seeded.seed(users=[("bob", {"role": "viewer"})])
-    assert seeded.user_store is not None and seeded.user_store.get("bob") is not None
-
-    # Served: roles only mounts /authz but not /users (routes exist only once the app serves, so
-    # ask over HTTP rather than reading app.routes).
-    served = Authorization(verification_keys=[SECRET], algorithm="HS256", verify_audience=True, audience=OS_ID)
-    served.define_role("admin", ["agent_os:admin"])
-    served.seed(admin="root")  # an admin, but no users= -> still no directory
-    client = TestClient(
-        AgentOS(
-            id=OS_ID, db=SqliteDb(db_file=str(tmp_path / "ro.db")), agents=_agents(), authorization=served
-        ).get_app()
-    )
-    assert client.get("/authz/roles", headers=_auth("root")).status_code == 200
-    assert client.get("/users", headers=_auth("root")).status_code == 404
 
 
 def test_seed_admin_heals_a_lockout_but_respects_a_handover(tmp_path):
@@ -509,4 +491,24 @@ def test_bring_your_own_provider_overrides(tmp_path):
 
     db = SqliteDb(db_file=str(tmp_path / "byo.db"))
     authz = Authorization(db=db, verification_keys=[SECRET], audience=OS_ID, authorization_provider=DenyAll())
-    assert isinstance(authz.authorization_config().authorization_provider, DenyAll)
+    assert isinstance(authz.provider, DenyAll)
+
+
+def test_issuer_on_the_object_is_enforced(tmp_path):
+    """Authorization(issuer=) pins the ``iss`` claim on the served OS even though the released
+    AuthorizationConfig has no such field: the object hands it to the middleware directly."""
+    authz = Authorization(
+        verification_keys=[SECRET], algorithm="HS256", verify_audience=True, audience=OS_ID, issuer="https://good/"
+    )
+    client = TestClient(
+        AgentOS(
+            id=OS_ID, db=SqliteDb(db_file=str(tmp_path / "iss.db")), agents=_agents(), authorization=authz
+        ).get_app()
+    )
+
+    def tok(iss):
+        payload = {"sub": "u", "aud": OS_ID, "iss": iss, "scopes": ["agents:read"], "exp": int(time.time()) + 3600}
+        return {"Authorization": f"Bearer {jwt.encode(payload, SECRET, algorithm='HS256')}"}
+
+    assert client.get("/agents", headers=tok("https://good/")).status_code == 200
+    assert client.get("/agents", headers=tok("https://evil/")).status_code == 401

--- a/libs/agno/tests/integration/os/test_authz_async_db.py
+++ b/libs/agno/tests/integration/os/test_authz_async_db.py
@@ -27,6 +27,7 @@ from agno.db.in_memory import InMemoryDb  # noqa: E402
 from agno.db.sqlite import SqliteDb  # noqa: E402
 from agno.db.sqlite.async_sqlite import AsyncSqliteDb  # noqa: E402
 from agno.os import AgentOS  # noqa: E402
+from agno.os.authz import Authorization  # noqa: E402
 from agno.os.authz.audit import DbAuditSink  # noqa: E402
 from agno.os.authz.native_engine import NativePolicyEngine  # noqa: E402
 from agno.os.authz.role_store import ManagedRoleStore  # noqa: E402
@@ -144,8 +145,7 @@ def _served_os(tmp_path):
         id=OS_ID,
         agents=[Agent(id="research", name="R", db=InMemoryDb()), Agent(id="secret", name="S", db=InMemoryDb())],
         db=adb,
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,

--- a/libs/agno/tests/integration/os/test_authz_planes.py
+++ b/libs/agno/tests/integration/os/test_authz_planes.py
@@ -11,12 +11,12 @@ pytest.importorskip("sqlalchemy")  # managed roles persist/enforce via the nativ
 from agno.agent import Agent  # noqa: E402
 from agno.db.in_memory import InMemoryDb  # noqa: E402
 from agno.os import AgentOS  # noqa: E402
+from agno.os.authz import Authorization  # noqa: E402
 from agno.os.authz._composite import CompositeAuthorizationProvider  # noqa: E402 (internal mechanism)
 from agno.os.authz.provider import AuthorizationContext  # noqa: E402
 from agno.os.authz.role_router import get_roles_router  # noqa: E402
 from agno.os.authz.role_store import ManagedRoleStore  # noqa: E402
 from agno.os.authz.scope_provider import ScopeAuthorizationProvider  # noqa: E402
-from agno.os.config import AuthorizationConfig  # noqa: E402
 
 SECRET = "composite-secret-at-least-256-bits-long-padding-xxxxxxxx"
 OS_ID = "composite-os"
@@ -95,8 +95,7 @@ def test_both_planes_enforce_on_one_os_end_to_end():
     agent_os = AgentOS(
         id=OS_ID,
         agents=[agent],
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,
@@ -124,8 +123,7 @@ def test_admin_gate_accepts_admin_from_token_scope():
     agent_os = AgentOS(
         id=OS_ID,
         agents=[agent],
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,
@@ -172,8 +170,7 @@ def test_custom_provider_does_not_fail_open_on_non_resource_routes():
     agent_os = AgentOS(
         id=OS_ID,
         agents=[agent],
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,
@@ -193,15 +190,18 @@ def test_custom_provider_does_not_fail_open_on_non_resource_routes():
 
 
 def test_authorization_provider_rejects_a_string():
-    """A list of providers is supported; a string is a mistake. The typed
-    AuthorizationConfig field rejects it at construction (pydantic ValidationError,
-    a ValueError), so it can never be mistaken for an iterable of characters."""
+    """A list of providers is supported; a string is a mistake. AgentOS rejects it when it seeds
+    the provider, so it can never be mistaken for an iterable of characters."""
+    from agno.agent import Agent
+    from agno.db.in_memory import InMemoryDb
+
+    authz = Authorization(
+        verification_keys=[SECRET],
+        algorithm="HS256",
+        authorization_provider="ScopeAuthorizationProvider",  # oops, a string
+    )
     with pytest.raises(ValueError, match="AuthorizationProvider"):
-        AuthorizationConfig(
-            verification_keys=[SECRET],
-            algorithm="HS256",
-            authorization_provider="ScopeAuthorizationProvider",  # oops, a string
-        )
+        AgentOS(id=OS_ID, agents=[Agent(id="a", name="A", db=InMemoryDb())], authorization=authz).get_app()
 
 
 def test_composite_filter_accessible_unions_and_respects_per_plane_deny():

--- a/libs/agno/tests/integration/os/test_directory_no_auth.py
+++ b/libs/agno/tests/integration/os/test_directory_no_auth.py
@@ -107,7 +107,6 @@ def test_user_isolation_top_level_flag_wires_through_under_auth(tmp_path):
     secret = "isolation-flag-secret-at-least-256-bits-xxxxxxxxx"
     os_ = _os(
         tmp_path,
-        authorization=True,
         authorization_config=AuthorizationConfig(verification_keys=[secret], algorithm="HS256"),
         user_isolation=True,
     )
@@ -267,14 +266,3 @@ def test_no_auth_run_refuses_a_reserved_principal(tmp_path):
     assert store.get("sa:backend") is None  # reserved -> refused
     assert store.get("__scheduler__") is None  # reserved -> refused
     assert store.get("realuser") is not None  # normal -> provisioned
-
-
-def test_authz_plane_still_requires_authorization(tmp_path):
-    """Unchanged by the directory/isolation relaxation: a provider (an authz plane) still needs
-    authorization=True, because an unenforced plane would serve every route unauthenticated."""
-    from agno.os.authz.role_store import ManagedRoleStore
-
-    db = SqliteDb(db_file=str(tmp_path / "plane.db"))
-    provider = ManagedRoleStore(db=db).provider
-    with pytest.raises(ValueError, match="authorization=True"):
-        _os(tmp_path, authorization_config=AuthorizationConfig(authorization_provider=provider)).get_app()

--- a/libs/agno/tests/integration/os/test_fga_provider.py
+++ b/libs/agno/tests/integration/os/test_fga_provider.py
@@ -16,8 +16,7 @@ from fastapi.testclient import TestClient
 from agno.agent.agent import Agent
 from agno.db.in_memory import InMemoryDb
 from agno.os import AgentOS
-from agno.os.authz import AuthorizationContext, FGAAuthorizationProvider, ScopeAuthorizationProvider
-from agno.os.config import AuthorizationConfig
+from agno.os.authz import Authorization, AuthorizationContext, FGAAuthorizationProvider, ScopeAuthorizationProvider
 
 SECRET = "fga-provider-test-secret-at-least-256-bits-long-xxxxxx"
 OS_ID = "fga-test-os"
@@ -128,8 +127,7 @@ def test_fga_gates_a_real_agentos_per_resource():
     agent_os = AgentOS(
         id=OS_ID,
         agents=[research, other],
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,
@@ -174,8 +172,7 @@ def test_fga_list_endpoint_returns_a_filtered_list_not_a_403():
             Agent(id="research-agent", name="Research Agent", db=InMemoryDb()),
             Agent(id="other-agent", name="Other Agent", db=InMemoryDb()),
         ],
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,

--- a/libs/agno/tests/integration/os/test_managed_roles.py
+++ b/libs/agno/tests/integration/os/test_managed_roles.py
@@ -19,7 +19,6 @@ from agno.db.in_memory import InMemoryDb  # noqa: E402
 from agno.os import AgentOS  # noqa: E402
 from agno.os.authz import Authorization  # noqa: E402
 from agno.os.authz.role_store import ManagedRoleStore  # noqa: E402
-from agno.os.config import AuthorizationConfig  # noqa: E402
 
 SECRET = "managed-roles-test-secret-at-least-256-bits-long-xxxxx"
 OS_ID = "managed-roles-test-os"
@@ -50,8 +49,7 @@ def _build(store: ManagedRoleStore) -> TestClient:
     agent_os = AgentOS(
         id=OS_ID,
         agents=[agent, other],
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,
@@ -165,8 +163,7 @@ def test_non_resource_routes_are_gated_sessions():
         id=OS_ID,
         agents=[agent],
         db=db,
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,
@@ -514,8 +511,7 @@ def test_db_registered_teams_are_filtered_like_configured_ones(tmp_path):
         id=OS_ID,
         agents=[Agent(id="a1", name="A", db=db)],
         db=db,
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,

--- a/libs/agno/tests/integration/os/test_managed_roles_api.py
+++ b/libs/agno/tests/integration/os/test_managed_roles_api.py
@@ -16,9 +16,9 @@ pytest.importorskip("sqlalchemy")  # managed roles persist/enforce via the nativ
 from agno.agent import Agent  # noqa: E402
 from agno.db.in_memory import InMemoryDb  # noqa: E402
 from agno.os import AgentOS  # noqa: E402
+from agno.os.authz import Authorization  # noqa: E402
 from agno.os.authz.role_router import get_roles_router  # noqa: E402
 from agno.os.authz.role_store import ManagedRoleStore  # noqa: E402
-from agno.os.config import AuthorizationConfig  # noqa: E402
 
 SECRET = "managed-roles-api-test-secret-at-least-256-bits-long-xx"
 OS_ID = "managed-roles-api-test-os"
@@ -59,8 +59,7 @@ def client_and_store():
     agent_os = AgentOS(
         id=OS_ID,
         agents=[agent],
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,
@@ -219,8 +218,7 @@ def test_admin_via_token_claim_can_manage():
     agent_os = AgentOS(
         id=OS_ID,
         agents=[agent],
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,

--- a/libs/agno/tests/integration/os/test_managed_roles_audit.py
+++ b/libs/agno/tests/integration/os/test_managed_roles_audit.py
@@ -17,10 +17,10 @@ pytest.importorskip("sqlalchemy")  # managed roles persist/enforce via the nativ
 from agno.agent import Agent  # noqa: E402
 from agno.db.in_memory import InMemoryDb  # noqa: E402
 from agno.os import AgentOS  # noqa: E402
+from agno.os.authz import Authorization  # noqa: E402
 from agno.os.authz.audit import AuditEvent, AuditSink, DbAuditSink  # noqa: E402
 from agno.os.authz.role_router import get_roles_router  # noqa: E402
 from agno.os.authz.role_store import ManagedRoleStore  # noqa: E402
-from agno.os.config import AuthorizationConfig  # noqa: E402
 
 SECRET = "managed-roles-audit-secret-at-least-256-bits-long-xxxx"
 OS_ID = "managed-roles-audit-os"
@@ -131,8 +131,7 @@ def test_http_api_records_actor_from_jwt():
     agent_os = AgentOS(
         id=OS_ID,
         agents=[agent],
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,
@@ -171,8 +170,7 @@ def _decision_os(sink):
         id=OS_ID,
         agents=[agent],
         db=db,
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,
@@ -274,8 +272,7 @@ def test_decisions_endpoint_returns_trail_for_admin(tmp_path):
     agent_os = AgentOS(
         id=OS_ID,
         agents=[agent],
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,
@@ -318,8 +315,7 @@ def test_audit_endpoint_returns_trail(tmp_path):
     agent_os = AgentOS(
         id=OS_ID,
         agents=[agent],
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,
@@ -421,8 +417,7 @@ def test_per_resource_deny_is_recorded_when_it_denies_independently():
         id=OS_ID,
         agents=[Agent(id="yours", name="Yours", db=db)],
         db=db,
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,
@@ -457,9 +452,8 @@ def test_audit_sink_is_mirrored_onto_the_mcp_subapp():
         id=OS_ID,
         agents=[Agent(id="research-agent", name="Research Agent", db=db)],
         db=db,
-        authorization=True,
         mcp_server=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             authorization_provider=store.provider,

--- a/libs/agno/tests/integration/os/test_managed_roles_internal_token.py
+++ b/libs/agno/tests/integration/os/test_managed_roles_internal_token.py
@@ -23,8 +23,8 @@ pytest.importorskip("sqlalchemy")  # managed roles persist/enforce via the nativ
 from agno.agent import Agent  # noqa: E402
 from agno.db.in_memory import InMemoryDb  # noqa: E402
 from agno.os import AgentOS  # noqa: E402
+from agno.os.authz import Authorization  # noqa: E402
 from agno.os.authz.role_store import ManagedRoleStore  # noqa: E402
-from agno.os.config import AuthorizationConfig  # noqa: E402
 
 SECRET = "managed-roles-internal-token-test-secret-at-least-256-bits-long"
 OS_ID = "managed-roles-internal-token-os"
@@ -56,9 +56,8 @@ def client_and_store():
     agent_os = AgentOS(
         id=OS_ID,
         agents=[agent],
-        authorization=True,
         internal_service_token=INTERNAL_TOKEN,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,

--- a/libs/agno/tests/integration/os/test_managed_users.py
+++ b/libs/agno/tests/integration/os/test_managed_users.py
@@ -118,6 +118,7 @@ pytest.importorskip("sqlalchemy")  # managed roles persist/enforce via the nativ
 from agno.agent import Agent  # noqa: E402
 from agno.db.in_memory import InMemoryDb  # noqa: E402
 from agno.os import AgentOS  # noqa: E402
+from agno.os.authz import Authorization  # noqa: E402
 from agno.os.authz.role_store import ManagedRoleStore  # noqa: E402
 from agno.os.config import AuthorizationConfig, UserDirectoryConfig  # noqa: E402
 
@@ -146,9 +147,8 @@ def _os(role_store, user_store, *, auto_provision=False):
             verify_audience=True,
             audience=OS_ID,
             role_store=role_store,  # mounts /authz (roles) ...
-            user_directory=user_store,  # ... and /users (directory)
-            auto_provision=auto_provision,
         ),
+        user_directory=UserDirectoryConfig(user_store=user_store, auto_provision=auto_provision),  # ... and /users
     )
 
 
@@ -432,9 +432,8 @@ def test_agentos_adopts_its_db_so_the_kill_switch_persists(tmp_path):
         id="user-adopt-os",
         agents=[Agent(id="a1", name="A", db=os_db)],
         db=os_db,
-        authorization=Authorization(
-            verification_keys=["k" * 40], algorithm="HS256", role_store=roles, user_directory=users
-        ),
+        authorization=Authorization(verification_keys=["k" * 40], algorithm="HS256", role_store=roles),
+        user_directory=UserDirectoryConfig(user_store=users),
     ).get_app()
 
     # adopted, and the revocation made before adoption came across
@@ -479,12 +478,8 @@ def test_user_store_without_a_persistable_db_fails_fast():
             id="unpersisted-users-os",
             agents=[Agent(id="a1", name="A", db=non_sql_db)],
             db=non_sql_db,
-            authorization=Authorization(
-                verification_keys=["k" * 40],
-                algorithm="HS256",
-                role_store=roles,
-                user_directory=ManagedUserStore(),  # bare: nothing to persist into
-            ),
+            authorization=Authorization(verification_keys=["k" * 40], algorithm="HS256", role_store=roles),
+            user_directory=UserDirectoryConfig(user_store=ManagedUserStore()),  # bare: nothing to persist into
         ).get_app()
 
 
@@ -594,8 +589,7 @@ def test_workflow_continue_over_ws_enforces_the_approval_gate(monkeypatch):
         id=OS_ID,
         agents=[agent],
         db=os_db,
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,
@@ -638,3 +632,32 @@ def test_workflow_continue_over_ws_enforces_the_approval_gate(monkeypatch):
                 break
         else:
             raise AssertionError("no error frame within 8 messages")
+
+
+def test_jit_provisioning_never_replaces_a_pre_assigned_role(tmp_path):
+    """A subject can hold a role before their first login (seeded, or assigned through /authz ahead
+    of time). Creating their directory row on that first token must not overwrite it with the
+    default: the default is a floor for people nobody assigned. Regression: the bootstrap admin's
+    first request used to demote them to viewer."""
+    import asyncio
+
+    from agno.db.sqlite import SqliteDb
+    from agno.os.auth import aprovision_user_with_default_role, provision_user_with_default_role
+    from agno.os.authz.role_store import ManagedRoleStore
+
+    db = SqliteDb(db_file=str(tmp_path / "jit.db"))
+    roles, users = ManagedRoleStore(db=db), ManagedUserStore(db=db)
+    roles.set_role_scopes("admin", ["agent_os:admin"])
+    roles.set_role_scopes("viewer", ["agents:*:read"], is_default=True)
+    roles.assign("root", "admin")  # pre-assigned, no directory row yet
+    roles.assign("ops", "admin")
+
+    provision_user_with_default_role(users, roles, None, "root", {"email": "root@co"})
+    assert users.get("root") is not None  # row created ...
+    assert roles.roles_of("root") == ["admin"]  # ... role untouched
+
+    asyncio.run(aprovision_user_with_default_role(users, roles, None, "ops", {}))
+    assert roles.roles_of("ops") == ["admin"]
+
+    provision_user_with_default_role(users, roles, None, "newbie", {})
+    assert roles.roles_of("newbie") == ["viewer"]  # nobody assigned newbie: the default applies

--- a/libs/agno/tests/unit/os/test_jwt_middleware_helpers.py
+++ b/libs/agno/tests/unit/os/test_jwt_middleware_helpers.py
@@ -853,7 +853,7 @@ async def test_dispatch_sets_private_marker_on_success():
 
 
 class TestIssuerPinning:
-    """``AuthorizationConfig(issuer=...)`` must actually reject foreign issuers.
+    """``Authorization(issuer=...)`` must actually reject foreign issuers.
 
     A valid signature says the token was minted by SOMEONE holding a trusted key, not
     by the issuer you meant to trust: a deployment verifying several keys (multi-IdP,
@@ -899,15 +899,19 @@ class TestIssuerPinning:
         payload = self._validator().validate_token(self._token(iss=self.EVIL))
         assert payload["sub"] == "u"
 
-    def test_config_issuer_reaches_middleware_kwargs(self):
-        """Regression: the field must EXIST on AuthorizationConfig -- pydantic silently
-        dropped the kwarg before, so the whole feature was a no-op from config."""
+    def test_issuer_reaches_middleware_kwargs(self):
+        """Regression: the pinned issuer must actually reach the middleware. It lives on the
+        Authorization object (the released AuthorizationConfig has no such field, and pydantic
+        would silently drop an unknown kwarg), so the builder takes it explicitly."""
+        from agno.os.authz import Authorization
         from agno.os.config import AuthorizationConfig
         from agno.os.middleware.jwt import build_jwt_middleware_kwargs
 
-        config = AuthorizationConfig(verification_keys=[JWT_SECRET], algorithm="HS256", issuer=self.GOOD)
-        assert config.issuer == self.GOOD
-        assert build_jwt_middleware_kwargs(config, authorization=True)["issuer"] == self.GOOD
+        authz = Authorization(verification_keys=[JWT_SECRET], algorithm="HS256", issuer=self.GOOD)
+        assert authz.issuer == self.GOOD
+        config = AuthorizationConfig(verification_keys=[JWT_SECRET], algorithm="HS256")
+        assert build_jwt_middleware_kwargs(config, authorization=True, issuer=authz.issuer)["issuer"] == self.GOOD
+        assert "issuer" not in build_jwt_middleware_kwargs(config, authorization=True)  # unpinned by default
 
 
 class TestCreateDevToken:

--- a/libs/agno/tests/unit/os/test_mcp_oauth.py
+++ b/libs/agno/tests/unit/os/test_mcp_oauth.py
@@ -39,6 +39,7 @@ from starlette.middleware.base import BaseHTTPMiddleware  # noqa: E402
 from agno.agent import Agent  # noqa: E402
 from agno.db.schemas.service_accounts import ServiceAccount  # noqa: E402
 from agno.os import AgentOS, MCPServerConfig  # noqa: E402
+from agno.os.authz import Authorization  # noqa: E402
 from agno.os.mcp import _mcp_server_is_open, get_mcp_server  # noqa: E402
 from agno.os.mcp_auth import (  # noqa: E402
     AUTHORIZATION_ENABLED_CLAIM,
@@ -542,13 +543,11 @@ async def test_issuer_pin_is_enforced_on_mcp(monkeypatch):
     JWT verifier must enforce it too -- not just REST. Before the fix the issuer kwarg was
     dropped when building the MCP verifier (audience was threaded, issuer was not), so a
     token from an untrusted issuer that REST rejects still verified on /mcp."""
-    from agno.os.config import AuthorizationConfig
 
     os = AgentOS(
         agents=[_agent()],
         mcp_auth=_oauth_provider(),
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=["test-jwt-secret"], algorithm="HS256", issuer="https://trusted.example"
         ),
         mcp_server=MCPServerConfig(tools=[_ok_tool], enable_builtin_tools=False),

--- a/libs/agno/tests/unit/os/test_mcp_server.py
+++ b/libs/agno/tests/unit/os/test_mcp_server.py
@@ -1297,16 +1297,14 @@ def test_mcp_identity_bridge_carries_the_role_store_for_first_provision():
     from agno.os.mcp import _identity_bridge_kwargs
 
     with tempfile.NamedTemporaryFile(suffix=".db") as f:
-        authz = Authorization(
-            db=SqliteDb(db_file=f.name),
-            verification_keys=["x" * 40],
-            algorithm="HS256",
-            user_directory=True,
-            auto_provision=True,
-        )
+        db = SqliteDb(db_file=f.name)
+        authz = Authorization(db=db, verification_keys=["x" * 40], algorithm="HS256")
         authz.define_role("viewer", ["agents:*:read"], default=True)
         authz.define_role("admin", ["agent_os:admin"])
-        os = AgentOS(id="mcp-provision", agents=[_agent()], mcp_server=True, authorization=authz)
+        # The directory is AgentOS's; True builds it with JIT provisioning on.
+        os = AgentOS(
+            id="mcp-provision", db=db, agents=[_agent()], mcp_server=True, authorization=authz, user_directory=True
+        )
         os.get_app()
 
         kw = _identity_bridge_kwargs(os)


### PR DESCRIPTION
## Summary

Follow-up on #10112 for the `Authorization` object in #9092. Commits to one owner per concern: authorization on `Authorization`, the user directory on `AgentOS`, and `AuthorizationConfig` cut back to exactly what shipped in v3.0.x. Targets `feat/agentos-authz`.

- **The user directory has one home: `AgentOS(user_directory=...)`.** `Authorization` no longer takes `user_directory` or `auto_provision`, builds no `ManagedUserStore`, and exposes no `user_store`. The `AgentOS` knob already existed, works with no authorization at all (cookbook 03), and carries the full `UserDirectoryConfig` (`fail_closed`, claim names, `auto_provision`), which the object's copy could not. `/users` mounts from it whenever authorization is on, with the roles router alongside when the object has a store. Passing `user_directory=` next to an `Authorization` is no longer a conflict.
- **`seed` writes authorization data only.** `seed(admin=..., admin_role=..., assignments={subject: role})`. The `users=` list is gone, so the object never writes a directory row. People arrive by JIT provisioning on their first valid token, or by `agent_os.user_directory.user_store.upsert(...)`. The lockout heal from #10112 is unchanged.
- **JIT provisioning no longer replaces a pre-assigned role.** Creating a subject's directory row on their first token used to `assign` the default role unconditionally, and in the single-role model that overwrote whatever they held. Seeding directory rows masked it; without that, the bootstrap admin's first request demoted them to viewer. Both `provision_user_with_default_role` and its async twin now grant the default only when the subject holds no role. Regression test on the helper covers sync, async, and the still-granted case.
- **`AuthorizationConfig` is back to its released field set.** `issuer`, `authorization_provider`, and `audit` are removed (none existed in any release). The object hands AgentOS its composed provider, its issuer, and its audit sink directly; `build_jwt_middleware_kwargs` takes `issuer=` from the caller, and both the REST and MCP surfaces pass it. The boot guard that only existed for a config-carried provider is gone with the field.
- Tests migrated off `AuthorizationConfig(authorization_provider=..., audit=...)` onto `Authorization(...)` across ten files; the issuer tests assert the object's issuer reaches the middleware and is enforced end to end.
- Cookbooks 00, 02, 06, 07 updated to the final shape: `seed(assignments=...)`, `user_directory=True` on `AgentOS`, and profiles seeded through the directory store where a cookbook wants a pre-populated roster.

## Type of change

- [x] Improvement
- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

The final shapes:

```python
# roles + directory
authz = Authorization(db=db, verification_keys=KEYS, audience=OS_ID, audit=True)
authz.define_role("admin", ["agent_os:admin"])
authz.define_role("viewer", ["agents:*:read"], default=True)
authz.seed(admin="alice", assignments={"bob": "viewer"})
AgentOS(db=db, agents=[...], authorization=authz, user_directory=True)

# verify only
AgentOS(db=db, authorization=Authorization(verification_keys=KEYS, audience=OS_ID))

# IdP roles on the token
AgentOS(db=db, authorization=Authorization(jwks_file="jwks.json", audience=OS_ID, roles_claim="role"))

# own provider
AgentOS(db=db, authorization=Authorization(verification_keys=KEYS, audience=OS_ID, authorization_provider=my_provider))
```

Verification: the authorization test files pass (537 passed). The full `tests/unit/os` + `tests/integration/os` run has failures, every one of which reproduces with the same count on the branch head before this PR: the five shard-3 CI failures from the async-variants commit (three list-endpoint RBAC tests, two MCP OAuth scope-gate tests), the workflow-continue planes test, the schedules router tests, the components user-isolation tests, and a set of MCP/stream/output-schema tests that depend on package versions. Cookbooks 00 and 02 run clean offline.
