### PR TITLE
refactor(authz): freeze AuthorizationConfig at its released field set

### DIFF
--- a/cookbook/05_agent_os/rbac/drafts/custom_authorization_provider.py
+++ b/cookbook/05_agent_os/rbac/drafts/custom_authorization_provider.py
@@ -27,8 +27,8 @@ from agno.agent import Agent
 from agno.db.postgres import PostgresDb
 from agno.models.openai import OpenAIResponses
 from agno.os import AgentOS
+from agno.os.authz import Authorization
 from agno.os.authz.provider import AuthorizationContext, AuthorizationProvider
-from agno.os.config import AuthorizationConfig
 
 # ---------------------------------------------------------------------------
 # Create Example
@@ -86,8 +86,7 @@ agent_os = AgentOS(
     description="AgentOS protected by a custom authorization provider",
     agents=[research_agent],
     db=db,
-    authorization=True,
-    authorization_config=AuthorizationConfig(
+    authorization=Authorization(
         verification_keys=[JWT_SECRET],
         algorithm="HS256",
         authorization_provider=TierAuthorizationProvider(),

--- a/cookbook/05_agent_os/rbac/drafts/managed_roles.py
+++ b/cookbook/05_agent_os/rbac/drafts/managed_roles.py
@@ -29,8 +29,8 @@ from agno.agent import Agent
 from agno.db.postgres import PostgresDb
 from agno.models.openai import OpenAIResponses
 from agno.os import AgentOS
+from agno.os.authz import Authorization
 from agno.os.authz.role_store import ManagedRoleStore
-from agno.os.config import AuthorizationConfig
 
 # ---------------------------------------------------------------------------
 # Create Example
@@ -61,14 +61,13 @@ roles.assign("carol", "viewer")
 roles.assign("bob", "member")
 roles.assign("alice", "admin")
 
-# Wire the store into AgentOS. `role_store=` is the shortcut: AgentOS uses the
-# store's authorization provider for you.
+# Wire the store into AgentOS through the Authorization object: it uses the
+# store's authorization provider for you and mounts the /authz admin API.
 agent_os = AgentOS(
     description="AgentOS protected by managed roles",
     agents=[research_agent],
     db=db,
-    authorization=True,
-    authorization_config=AuthorizationConfig(
+    authorization=Authorization(
         verification_keys=[JWT_SECRET],
         algorithm="HS256",
         role_store=roles,

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -379,7 +379,7 @@ class AgentOS:
                 UserDirectoryConfig for control.
             audit: One AuditSink for BOTH audit trails -- the change log (who edited roles/users)
                 and the decision log (every allow/deny). Turns audit on for the whole OS. A sink
-                passed to a store or to AuthorizationConfig(audit=...) still wins there.
+                passed to a store of your own still wins there.
             cors_allowed_origins: List of allowed CORS origins (will be merged with default Agno domains)
             media_storage: Backend the media routes read stored media from. Defaults to the first
                 one configured on an agent, team or workflow.
@@ -481,7 +481,11 @@ class AgentOS:
         # into the (authorization_config, audit, user_directory) the pipeline below already
         # understands, and record its stores so get_app mounts /authz and /users automatically. It
         # adopts this OS db so role/user definitions persist alongside agent data.
+        # What the Authorization object hands over: its role store (provisioning + the /authz API),
+        # the provider it composed, and the pinned issuer. Its audit sink lands on self.audit.
         self._facade_role_store: Any = None
+        self._facade_provider: Any = None
+        self._facade_issuer: Optional[str] = None
         self._facade_user_store: Any = None
 
         # authorization= takes the switch or the object, never the low-level config: one spelling
@@ -526,6 +530,8 @@ class AgentOS:
             authorization_config = authorization.authorization_config()
             audit = authorization.audit_sink
             self._facade_role_store = authorization.role_store
+            self._facade_provider = authorization.provider
+            self._facade_issuer = authorization.issuer
             authorization = True
 
         self.authorization = authorization
@@ -539,7 +545,7 @@ class AgentOS:
         # and the DECISION log (every allow/deny -> authz_decisions). Passing AgentOS(audit=sink)
         # wires the sink to the stores' change trail AND the decision recorder, so "audit on" means
         # everything is logged and "off" means nothing. A sink passed directly to a store or to
-        # AuthorizationConfig(audit=...) still wins there, for anyone who wants just one trail.
+        # a store of your own still wins there, for anyone who wants just one trail.
         self.audit = audit
         # The credential-less user directory is a PEER of authorization (who the users are +
         # the disabled kill-switch), configured separately from authorization_config.
@@ -1670,24 +1676,6 @@ class AgentOS:
         # the parent app), so the mounted sub-app carries no auth code of its own.
         security_key = self.settings.os_security_key if self.settings else None
         jwt_env_configured = bool(getenv("JWT_VERIFICATION_KEY") or getenv("JWT_JWKS_FILE"))
-        # An authz plane with the enforcement flag off is the most dangerous shape this
-        # config can take: the provider is seeded but nothing consults it, so an OS the
-        # author believes is governed by roles serves every route to anonymous callers.
-        # Fail at construction rather than shipping a silently open instance.
-        cfg = self.authorization_config
-        # A custom provider only takes effect through the auth middleware, so with authorization
-        # off it is a silently-open instance -- the author believes routes are governed by their
-        # provider, but nothing consults it. That still raises. A user directory is different: it
-        # is a roster, valid without auth (the guard below only warns), because it is data, not an
-        # enforcement point.
-        authz_plane_configured = cfg is not None and getattr(cfg, "authorization_provider", None) is not None
-        if not self.authorization and authz_plane_configured:
-            raise ValueError(
-                "AuthorizationConfig(authorization_provider=...) requires "
-                "AgentOS(authorization=True). Without enforcement the plane is never applied "
-                "(every route is served unauthenticated). Set authorization=True, or drop the "
-                "config if you intended an open instance."
-            )
         if not self.authorization and (self.user_directory is not None or self.user_isolation):
             # A user directory or per-user isolation without authorization is a valid, intentional
             # shape for local/demo use: a run's user_id registers the person (a roster fills in) and
@@ -1896,6 +1884,7 @@ class AgentOS:
             self.authorization_config,
             authorization=self.authorization,
             service_account_verifier=self._get_service_account_verifier(),
+            issuer=self._facade_issuer,
         )
         # The top-level user_isolation flag is the primary spelling; OR it with the legacy
         # AuthorizationConfig(user_isolation=...) so either turns per-user scoping on.
@@ -2048,27 +2037,21 @@ class AgentOS:
         return routers
 
     def _seed_authorization_provider(self, fastapi_app: FastAPI) -> None:
-        """Seed ``app.state.authorization_provider`` (and ``authz_audit``) from the
-        AuthorizationConfig, so the four choke points resolve the right enforcer.
+        """Seed ``app.state.authorization_provider`` (and ``authz_audit``) from the Authorization
+        object, so the four choke points resolve the right enforcer.
 
-        - ``authorization_provider`` set (the Authorization object composes its own from the
-          role store and the scope plane; the primitive path passes one directly): use it.
-        - unset: leave the state unset; the resolver defaults to ScopeAuthorizationProvider
-          (v2.7 behaviour).
+        - the object composed a provider (its role store's, with the scope plane alongside under
+          ``trust_token_scopes``, or the caller's override): use it.
+        - none: leave the state unset; the resolver defaults to ScopeAuthorizationProvider
+          (v2.7 behaviour), which is also what ``authorization=True`` means.
         """
-        config = self.authorization_config
-        # Decision trail: AgentOS(audit=...) is a single switch that also feeds the decision log
-        # (authz_decisions). An explicit AuthorizationConfig(audit=...) wins; else fall back to the
-        # top-level sink. Seeded even without an AuthorizationConfig, since the default scope plane
-        # still records decisions.
-        decision_sink = getattr(config, "audit", None) or self.audit
-        if decision_sink is not None:
-            fastapi_app.state.authz_audit = decision_sink
+        # Decision trail: the audit switch (AgentOS(audit=...) or Authorization(audit=...)) also
+        # feeds the decision log (authz_decisions). Seeded even for plain scope RBAC, since the
+        # default scope plane still records decisions.
+        if self.audit is not None:
+            fastapi_app.state.authz_audit = self.audit
 
-        if config is None:
-            return
-
-        provider = getattr(config, "authorization_provider", None)
+        provider = self._facade_provider
 
         resolved_provider: Optional[AuthorizationProvider] = None
         if provider is not None:

--- a/libs/agno/agno/os/authz/_composite.py
+++ b/libs/agno/agno/os/authz/_composite.py
@@ -10,11 +10,11 @@ Real deployments often have two populations hitting the same OS:
   carries identity; the store decides.
 
 A single provider can't be both "trust the token's scopes" and "ignore the token,
-ask the store." The public way to run several planes is to pass a **list** of
-providers to ``AuthorizationConfig`` / ``AgentOS`` — a request is allowed if any
-of them allows it::
+ask the store." The public way to run several planes is ``Authorization(trust_token_scopes=True)``
+with managed roles, or a **list** of providers on ``Authorization(authorization_provider=[...])``
+for a bring-your-own setup — a request is allowed if any of them allows it::
 
-    AuthorizationConfig(authorization_provider=[
+    Authorization(verification_keys=KEYS, audience=OS_ID, authorization_provider=[
         ScopeAuthorizationProvider(),   # operators: scopes from the token
         roles.provider,                 # end users: the OS-local managed store
     ])

--- a/libs/agno/agno/os/authz/audit.py
+++ b/libs/agno/agno/os/authz/audit.py
@@ -5,7 +5,7 @@ tables (see :class:`DbAuditSink`) because they answer different questions:
 
 1. Decision audit ("was alice allowed to run agent X, and with which token?") —
    recorded by the JWT middleware on every protected request when an
-   :class:`AuditSink` is set on ``AuthorizationConfig(audit=...)``. Each row is an
+   :class:`AuditSink` is set via ``Authorization(audit=...)`` / ``AgentOS(audit=...)``. Each row is an
    ``access.allowed`` / ``access.denied`` event with the principal, the route, the
    required scopes, the caller's scopes, and a NON-secret token reference (the
    token's ``jti`` when present, otherwise a short hash — never the token itself).

--- a/libs/agno/agno/os/authz/facade.py
+++ b/libs/agno/agno/os/authz/facade.py
@@ -136,16 +136,18 @@ class Authorization:
             )
         # Verification settings, splatted into the AuthorizationConfig at build time. Typed Any so
         # the per-key kwarg splat type-checks against AuthorizationConfig's specific field types.
+        # ``issuer`` is handed to AgentOS separately: the released AuthorizationConfig has no such
+        # field and stays frozen at its released shape.
         self._verification: Dict[str, Any] = {
             "verification_keys": verification_keys,
             "jwks_file": jwks_file,
             "algorithm": algorithm,
             "verify_audience": verify_audience,
             "audience": audience,
-            "issuer": issuer,
             "admin_scope": admin_scope,
             "excluded_route_paths": excluded_route_paths,
         }
+        self._issuer = issuer
         self._audit_arg = audit
         self._trust_token_scopes = trust_token_scopes
         self._roles_claim = roles_claim
@@ -362,9 +364,12 @@ class Authorization:
                     "seed(admin_role=<your admin role>)."
                 )
 
-    # ------------------------------------------------------------------ provider
-    def _provider(self) -> Optional[Union["AuthorizationProvider", List["AuthorizationProvider"]]]:
-        """The provider AgentOS should enforce with, or None to fall back to scope RBAC."""
+    # ------------------------------------------------------------------ what AgentOS reads
+    @property
+    def provider(self) -> Optional[Union["AuthorizationProvider", List["AuthorizationProvider"]]]:
+        """The provider AgentOS should enforce with: your override, the role store's provider (with
+        the scope plane alongside under ``trust_token_scopes``), or None so AgentOS falls back to
+        scope RBAC. A list means several planes composed with OR."""
         if self._provider_override is not None:
             return self._provider_override
         store = self.role_store
@@ -377,10 +382,14 @@ class Authorization:
         return store.provider
 
     @property
+    def issuer(self) -> Optional[str]:
+        """The pinned token issuer (the ``iss`` claim), or None when not pinned."""
+        return self._issuer
+
+    @property
     def _uses_roles(self) -> bool:
         return self._roles_defined
 
-    # ------------------------------------------------------------------ what AgentOS reads
     @property
     def role_store(self) -> Optional["ManagedRoleStore"]:
         """The role store, or None when the facade is verify-only. Mount the ``/authz`` admin API
@@ -395,10 +404,11 @@ class Authorization:
         return self._audit_sink
 
     def authorization_config(self) -> "AuthorizationConfig":
-        """The ``AuthorizationConfig`` AgentOS enforces: verification settings plus the composed
-        provider (or none, so AgentOS uses scope RBAC). AgentOS calls this once after all setup, so it
-        is where a seeded admin whose role does not grant admin is finally validated."""
+        """The verification settings as the ``AuthorizationConfig`` the JWT middleware reads (its
+        released field set, nothing more; the provider, issuer and audit sink travel separately).
+        AgentOS calls this once after all setup, so it is where a seeded admin whose role does not
+        grant admin is finally validated."""
         from agno.os.config import AuthorizationConfig
 
         self._check_seeded_admins()
-        return AuthorizationConfig(authorization_provider=self._provider(), **self._verification)
+        return AuthorizationConfig(**self._verification)

--- a/libs/agno/agno/os/authz/facade.py
+++ b/libs/agno/agno/os/authz/facade.py
@@ -1,10 +1,9 @@
-"""One object for AgentOS authorization: verification, roles, users, audit, admin API.
+"""One object for AgentOS authorization: verification, roles, audit, and the ``/authz`` admin API.
 
-Standing up managed roles + a user directory + the admin API by hand means assembling a dozen
-objects (a ``DbAuditSink``, a ``ManagedRoleStore``, a ``ManagedUserStore``, an
-``AuthorizationConfig``, a ``UserDirectoryConfig``, a ``ScopeAuthorizationProvider``, the store's
-provider, two router factories, two ``include_router`` calls) and keeping four of them pointed at
-the same database. :class:`Authorization` owns all of that and wires itself into AgentOS:
+Standing up managed roles by hand means assembling a ``DbAuditSink``, a ``ManagedRoleStore``, an
+``AuthorizationConfig``, a ``ScopeAuthorizationProvider``, the store's provider, a router factory
+and an ``include_router`` call, and keeping them pointed at the same database.
+:class:`Authorization` owns all of that and wires itself into AgentOS:
 
     from agno.os.authz import Authorization
 

--- a/libs/agno/agno/os/authz/fga.py
+++ b/libs/agno/agno/os/authz/fga.py
@@ -27,7 +27,7 @@ other engine by writing an equally small client.
 Typical wiring composes FGA (per-resource ReBAC) with the scope provider (coarse
 route gating), since FGA has no notion of non-resource routes like ``/config``::
 
-    AuthorizationConfig(authorization_provider=[
+    Authorization(verification_keys=KEYS, audience=OS_ID, authorization_provider=[
         ScopeAuthorizationProvider(),          # gates /config, /sessions, ... by scope
         FGAAuthorizationProvider(fga_client),  # per-resource agents/teams/workflows by relationship
     ])

--- a/libs/agno/agno/os/authz/role_router.py
+++ b/libs/agno/agno/os/authz/role_router.py
@@ -453,7 +453,7 @@ def get_roles_router(
     ) -> PaginatedResponse:
         """*Decision* events (allow/deny per request), paginated ``{data, meta}``.
 
-        Decision audit is configured on ``AuthorizationConfig(audit=...)`` and lands
+        Decision audit is configured on ``Authorization(audit=...)`` and lands
         on ``app.state.authz_audit`` — a separate table from the change trail above,
         so a high-volume decision log never buries the change history.
 

--- a/libs/agno/agno/os/authz/role_router.py
+++ b/libs/agno/agno/os/authz/role_router.py
@@ -6,8 +6,8 @@ with allow/deny), and grant or revoke them at runtime.
 With ``AgentOS(authorization=Authorization(...))`` you do not mount this yourself: AgentOS
 registers it at ``/authz`` whenever the object has a role store. The credential-less user
 DIRECTORY (who the users are + the disabled kill-switch) is a PEER concern served by
-:func:`get_users_router` at ``/users`` -- mounted from ``Authorization(user_directory=...)``,
-not this router.
+:func:`get_users_router` at ``/users`` -- mounted from ``AgentOS(user_directory=...)``, not this
+router.
 
     from agno.os.authz import Authorization
 

--- a/libs/agno/agno/os/authz/role_store.py
+++ b/libs/agno/agno/os/authz/role_store.py
@@ -25,11 +25,7 @@ Example::
 
     agent_os = AgentOS(
         agents=[...],
-        authorization=True,
-        authorization_config=AuthorizationConfig(
-            verification_keys=[...],
-            authorization_provider=store.provider,   # plug it in
-        ),
+        authorization=Authorization(verification_keys=[...], role_store=store),  # plug it in
     )
 
     # later, live (no redeploy, same token):

--- a/libs/agno/agno/os/config.py
+++ b/libs/agno/agno/os/config.py
@@ -1,11 +1,8 @@
 """Schemas related to the AgentOS configuration"""
 
-from typing import Any, Callable, Dict, Generic, List, Literal, Optional, Set, TypeVar, Union
+from typing import Any, Callable, Dict, Generic, List, Literal, Optional, Set, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
-
-from agno.os.authz.audit import AuditSink
-from agno.os.authz.provider import AuthorizationProvider
 
 # Tags carried by the built-in MCP tools, exposed here so callers (and the IDE) can see
 # the valid values for ``MCPConfig.include_tags`` / ``exclude_tags`` without reading
@@ -359,14 +356,14 @@ MCPServerConfig = MCPConfig
 
 
 class AuthorizationConfig(BaseModel):
-    """Low-level authorization config for the JWT middleware. Deprecated as a public type.
+    """Low-level JWT verification config. Deprecated as a public type.
 
-    Superseded by :class:`agno.os.authz.Authorization`, which owns every field here (verification,
-    provider, audit, excluded routes) plus the higher-level surface (define_role, seed, the user
-    directory, the admin API). ``Authorization`` builds one of these internally to feed the
-    pipeline; ``AgentOS(authorization_config=...)`` still accepts one so deployments written against
-    the released field set keep booting, with a warning. Frozen: do NOT add fields here -- add them
-    to ``Authorization``.
+    Superseded by :class:`agno.os.authz.Authorization`, which owns every field here plus the
+    higher-level surface (roles, seeding, audit, the admin API). ``Authorization`` builds one of
+    these internally to feed the JWT middleware; ``AgentOS(authorization_config=...)`` still accepts
+    one so deployments written against the released field set keep booting, with a warning.
+    Frozen at exactly that released field set: do NOT add fields here -- add them to
+    ``Authorization``.
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -376,23 +373,7 @@ class AuthorizationConfig(BaseModel):
     algorithm: Optional[str] = None
     verify_audience: Optional[bool] = None
     audience: Optional[str] = None
-    # Expected token issuer (the ``iss`` claim). When set, a token minted by anyone
-    # else is rejected even if its signature verifies -- pin this whenever more than
-    # one IdP can produce tokens your verification keys accept.
-    issuer: Optional[str] = None
     admin_scope: Optional[str] = None
-    # Pluggable authorization strategy. When None, AgentOS uses scope-based RBAC
-    # (JWT/PAT scopes, no external dependency). Supply an AuthorizationProvider to
-    # swap in a richer model (managed roles, ReBAC/ABAC, OpenFGA, ...) enforced at
-    # the same points as scopes — the REST route gate, per-resource gate, WS gates,
-    # and MCP tool gate all resolve through it. Pass a LIST of them to run several
-    # authz planes at once (e.g. token scopes for operators + a managed role store
-    # for end users) — a request is allowed if any of them allows it.
-    authorization_provider: Optional[Union[AuthorizationProvider, List[AuthorizationProvider]]] = None
-    # Optional AuditSink. When set, AgentOS records each authorization decision
-    # (allow/deny) alongside the change trail, so you get an access audit, not just a
-    # change audit. Pass the same sink you give ManagedRoleStore to unify both.
-    audit: Optional[AuditSink] = None
     # Additional fnmatch path patterns that bypass all AgentOS authentication,
     # merged with the default public-route exclusions.
     excluded_route_paths: Optional[List[str]] = None

--- a/libs/agno/agno/os/config.py
+++ b/libs/agno/agno/os/config.py
@@ -355,6 +355,12 @@ class MCPConfig(BaseModel):
 MCPServerConfig = MCPConfig
 
 
+# Fields that briefly existed on AuthorizationConfig and now live on ``Authorization``. Named in
+# the rejection so the error says where they went instead of a bare "extra inputs are not
+# permitted".
+_AUTHZ_FIELDS_MOVED_TO_AUTHORIZATION = ("issuer", "authorization_provider", "audit", "role_store")
+
+
 class AuthorizationConfig(BaseModel):
     """Low-level JWT verification config. Deprecated as a public type.
 
@@ -363,10 +369,25 @@ class AuthorizationConfig(BaseModel):
     these internally to feed the JWT middleware; ``AgentOS(authorization_config=...)`` still accepts
     one so deployments written against the released field set keep booting, with a warning.
     Frozen at exactly that released field set: do NOT add fields here -- add them to
-    ``Authorization``.
+    ``Authorization``. Unknown fields are rejected rather than ignored: a config carrying a
+    field this class never had (or no longer has) must fail at construction, because silently
+    dropping, say, an authorization provider would boot an OS that enforces token scopes where
+    the author expected managed roles.
     """
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_fields_moved_to_authorization(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            moved = [name for name in _AUTHZ_FIELDS_MOVED_TO_AUTHORIZATION if name in data]
+            if moved:
+                raise ValueError(
+                    f"AuthorizationConfig no longer takes {', '.join(moved)}: configure "
+                    "Authorization(...) from agno.os.authz and pass it as AgentOS(authorization=...)."
+                )
+        return data
 
     verification_keys: Optional[List[str]] = None
     jwks_file: Optional[str] = None

--- a/libs/agno/agno/os/mcp_auth.py
+++ b/libs/agno/agno/os/mcp_auth.py
@@ -360,6 +360,7 @@ def _build_jwt_token_verifier(os: "AgentOS") -> Optional[JWTBearerTokenVerifier]
     kwargs = build_jwt_middleware_kwargs(
         getattr(os, "authorization_config", None),
         authorization=bool(getattr(os, "authorization", False)),
+        issuer=getattr(os, "_facade_issuer", None),
     )
     jwt_configured = bool(
         kwargs["verification_keys"] or kwargs["jwks_file"] or getenv("JWT_VERIFICATION_KEY") or getenv("JWT_JWKS_FILE")

--- a/libs/agno/agno/os/middleware/jwt.py
+++ b/libs/agno/agno/os/middleware/jwt.py
@@ -433,8 +433,12 @@ def build_jwt_middleware_kwargs(
     authorization: bool,
     service_account_verifier: Optional[Any] = None,
     excluded_route_paths: Optional[List[str]] = None,
+    issuer: Optional[str] = None,
 ) -> Dict[str, Any]:
     """JWTMiddleware kwargs derived from an ``AuthorizationConfig``, in one place.
+
+    ``issuer`` is passed by the caller (it lives on the ``Authorization`` object, not on the
+    released config), so both surfaces pin the same one.
 
     Both the REST app wiring (``agno.os.app``) and the mounted MCP app
     (``agno.os.mcp.get_mcp_server``) construct their middleware from this builder, so
@@ -449,7 +453,6 @@ def build_jwt_middleware_kwargs(
     jwks_file = None
     verify_audience = False
     audience = None
-    issuer = None
     admin_scope: Optional[str] = None
     user_isolation = False
 
@@ -459,7 +462,6 @@ def build_jwt_middleware_kwargs(
         jwks_file = authorization_config.jwks_file
         verify_audience = authorization_config.verify_audience or False
         audience = authorization_config.audience
-        issuer = authorization_config.issuer
         admin_scope = authorization_config.admin_scope
         user_isolation = authorization_config.user_isolation
 
@@ -977,7 +979,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
         reason: Optional[str] = None,
     ) -> None:
         """Record one authorization decision to the audit sink, if one is configured
-        on ``app.state.authz_audit`` (seeded from ``AuthorizationConfig(audit=...)``).
+        on ``app.state.authz_audit`` (seeded from ``Authorization(audit=...)`` / ``AgentOS(audit=...)``).
 
         Captures the principal, route, required scopes, the caller's scopes, and a
         NON-secret token reference (see :meth:`_token_reference`). Never the token

--- a/libs/agno/tests/integration/os/test_authorization_facade.py
+++ b/libs/agno/tests/integration/os/test_authorization_facade.py
@@ -173,11 +173,20 @@ def test_seed_admin_role_configurable_and_warns_when_missing(tmp_path):
 
     handler = _Capture()
     handler.setLevel(logging.WARNING)  # ignore INFO decision logs
-    logging.getLogger("agno").addHandler(handler)
+    # log_warning writes to whichever agno logger the last agent/team/workflow run selected
+    # (agno, agno-agent, agno-team, agno-workflow), and that run may have raised its level to
+    # ERROR. Capture on all four with the level pinned, so this test is order-independent.
+    _agno_loggers = [logging.getLogger(n) for n in ("agno", "agno-agent", "agno-team", "agno-workflow")]
+    _prev_levels = [lg.level for lg in _agno_loggers]
+    for lg in _agno_loggers:
+        lg.setLevel(logging.WARNING)
+        lg.addHandler(handler)
     try:
         authz.authorization_config()  # AgentOS calls this once, after all setup
     finally:
-        logging.getLogger("agno").removeHandler(handler)
+        for lg, lvl in zip(_agno_loggers, _prev_levels):
+            lg.removeHandler(handler)
+            lg.setLevel(lvl)
     assert any("agent_os:admin" in m and "bob" in m for m in messages)  # warned, not silent
     assert not any("alice" in m for m in messages)  # alice's real admin role is not flagged
 
@@ -197,11 +206,20 @@ def test_seed_admin_warning_survives_define_after_seed_order(tmp_path):
     authz.define_role("boss", ["agent_os:admin"])  # define after
     handler = _Capture()
     handler.setLevel(logging.WARNING)  # ignore INFO decision logs
-    logging.getLogger("agno").addHandler(handler)
+    # log_warning writes to whichever agno logger the last agent/team/workflow run selected
+    # (agno, agno-agent, agno-team, agno-workflow), and that run may have raised its level to
+    # ERROR. Capture on all four with the level pinned, so this test is order-independent.
+    _agno_loggers = [logging.getLogger(n) for n in ("agno", "agno-agent", "agno-team", "agno-workflow")]
+    _prev_levels = [lg.level for lg in _agno_loggers]
+    for lg in _agno_loggers:
+        lg.setLevel(logging.WARNING)
+        lg.addHandler(handler)
     try:
         authz.authorization_config()
     finally:
-        logging.getLogger("agno").removeHandler(handler)
+        for lg, lvl in zip(_agno_loggers, _prev_levels):
+            lg.removeHandler(handler)
+            lg.setLevel(lvl)
     assert authz.role_store.can_manage("alice") is True
     assert not messages  # no false-positive warning despite seed-before-define
 
@@ -330,7 +348,14 @@ def test_authorization_config_is_deprecated_not_a_second_spelling(tmp_path):
 
     handler = _Capture()
     handler.setLevel(logging.WARNING)
-    logging.getLogger("agno").addHandler(handler)
+    # log_warning writes to whichever agno logger the last agent/team/workflow run selected
+    # (agno, agno-agent, agno-team, agno-workflow), and that run may have raised its level to
+    # ERROR. Capture on all four with the level pinned, so this test is order-independent.
+    _agno_loggers = [logging.getLogger(n) for n in ("agno", "agno-agent", "agno-team", "agno-workflow")]
+    _prev_levels = [lg.level for lg in _agno_loggers]
+    for lg in _agno_loggers:
+        lg.setLevel(logging.WARNING)
+        lg.addHandler(handler)
     try:
         os_ = AgentOS(
             id=OS_ID,
@@ -340,7 +365,9 @@ def test_authorization_config_is_deprecated_not_a_second_spelling(tmp_path):
             authorization_config=cfg,
         )
     finally:
-        logging.getLogger("agno").removeHandler(handler)
+        for lg, lvl in zip(_agno_loggers, _prev_levels):
+            lg.removeHandler(handler)
+            lg.setLevel(lvl)
     assert os_.authorization is True and os_.authorization_config is cfg  # still honoured
     assert any("authorization_config" in m and "deprecated" in m for m in messages)
 
@@ -614,6 +641,20 @@ def test_bring_your_own_provider_overrides(tmp_path):
     db = SqliteDb(db_file=str(tmp_path / "byo.db"))
     authz = Authorization(db=db, verification_keys=[SECRET], audience=OS_ID, authorization_provider=DenyAll())
     assert isinstance(authz.provider, DenyAll)
+
+
+def test_config_rejects_fields_that_moved_to_the_object():
+    """The released AuthorizationConfig never had a provider, audit sink or issuer. A config carrying
+    one must fail at construction, not silently drop it: an ignored provider would boot an OS that
+    enforces token scopes where the author expected managed roles or FGA. The error names the
+    object the field moved to."""
+    from agno.os.config import AuthorizationConfig
+
+    for name, value in (("authorization_provider", object()), ("audit", object()), ("issuer", "https://idp/")):
+        with pytest.raises(ValueError, match=f"no longer takes {name}.*Authorization"):
+            AuthorizationConfig(verification_keys=[SECRET], **{name: value})
+    with pytest.raises(ValueError, match="[Ee]xtra"):
+        AuthorizationConfig(verification_keys=[SECRET], not_a_field=1)  # anything unknown, same rule
 
 
 def test_issuer_on_the_object_is_enforced(tmp_path):

--- a/libs/agno/tests/integration/os/test_authorization_facade.py
+++ b/libs/agno/tests/integration/os/test_authorization_facade.py
@@ -58,8 +58,8 @@ def test_verify_only_facade_builds_no_stores(tmp_path):
     authz = Authorization(verification_keys=[SECRET], audience=OS_ID)  # the exact documented shape
     authz._bind(db)
     assert authz.role_store is None
+    assert authz.provider is None  # AgentOS defaults to ScopeAuthorizationProvider
     cfg = authz.authorization_config()
-    assert cfg.authorization_provider is None  # AgentOS defaults to ScopeAuthorizationProvider
     assert cfg.verification_keys == [SECRET] and cfg.audience == OS_ID
 
 
@@ -236,8 +236,8 @@ def test_facade_prebuilt_async_store_no_setup_ok(tmp_path):
     adb = AsyncSqliteDb(db_file=str(tmp_path / "a.db"))
     authz = Authorization(role_store=ManagedRoleStore(db=adb), verification_keys=[SECRET], audience=OS_ID)
     authz._bind(adb)
-    cfg = authz.authorization_config()  # no writes, just wires the provider
-    assert cfg.authorization_provider is not None
+    authz.authorization_config()  # no writes
+    assert authz.provider is not None  # just wires the provider
 
 
 def test_agentos_rejects_config_alongside_facade(tmp_path):
@@ -613,7 +613,27 @@ def test_bring_your_own_provider_overrides(tmp_path):
 
     db = SqliteDb(db_file=str(tmp_path / "byo.db"))
     authz = Authorization(db=db, verification_keys=[SECRET], audience=OS_ID, authorization_provider=DenyAll())
-    assert isinstance(authz.authorization_config().authorization_provider, DenyAll)
+    assert isinstance(authz.provider, DenyAll)
+
+
+def test_issuer_on_the_object_is_enforced(tmp_path):
+    """Authorization(issuer=) pins the ``iss`` claim on the served OS even though the released
+    AuthorizationConfig has no such field: the object hands it to the middleware directly."""
+    authz = Authorization(
+        verification_keys=[SECRET], algorithm="HS256", verify_audience=True, audience=OS_ID, issuer="https://good/"
+    )
+    client = TestClient(
+        AgentOS(
+            id=OS_ID, db=SqliteDb(db_file=str(tmp_path / "iss.db")), agents=_agents(), authorization=authz
+        ).get_app()
+    )
+
+    def tok(iss):
+        payload = {"sub": "u", "aud": OS_ID, "iss": iss, "scopes": ["agents:read"], "exp": int(time.time()) + 3600}
+        return {"Authorization": f"Bearer {jwt.encode(payload, SECRET, algorithm='HS256')}"}
+
+    assert client.get("/agents", headers=tok("https://good/")).status_code == 200
+    assert client.get("/agents", headers=tok("https://evil/")).status_code == 401
 
 
 def test_audit_api_404s_when_audit_is_off(tmp_path):

--- a/libs/agno/tests/integration/os/test_authz_async_db.py
+++ b/libs/agno/tests/integration/os/test_authz_async_db.py
@@ -27,6 +27,7 @@ from agno.db.in_memory import InMemoryDb  # noqa: E402
 from agno.db.sqlite import SqliteDb  # noqa: E402
 from agno.db.sqlite.async_sqlite import AsyncSqliteDb  # noqa: E402
 from agno.os import AgentOS  # noqa: E402
+from agno.os.authz import Authorization  # noqa: E402
 from agno.os.authz.audit import DbAuditSink  # noqa: E402
 from agno.os.authz.native_engine import NativePolicyEngine  # noqa: E402
 from agno.os.authz.role_store import ManagedRoleStore  # noqa: E402
@@ -144,8 +145,7 @@ def _served_os(tmp_path):
         id=OS_ID,
         agents=[Agent(id="research", name="R", db=InMemoryDb()), Agent(id="secret", name="S", db=InMemoryDb())],
         db=adb,
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,

--- a/libs/agno/tests/integration/os/test_authz_planes.py
+++ b/libs/agno/tests/integration/os/test_authz_planes.py
@@ -11,12 +11,12 @@ pytest.importorskip("sqlalchemy")  # managed roles persist/enforce via the nativ
 from agno.agent import Agent  # noqa: E402
 from agno.db.in_memory import InMemoryDb  # noqa: E402
 from agno.os import AgentOS  # noqa: E402
+from agno.os.authz import Authorization  # noqa: E402
 from agno.os.authz._composite import CompositeAuthorizationProvider  # noqa: E402 (internal mechanism)
 from agno.os.authz.provider import AuthorizationContext  # noqa: E402
 from agno.os.authz.role_router import get_roles_router  # noqa: E402
 from agno.os.authz.role_store import ManagedRoleStore  # noqa: E402
 from agno.os.authz.scope_provider import ScopeAuthorizationProvider  # noqa: E402
-from agno.os.config import AuthorizationConfig  # noqa: E402
 
 SECRET = "composite-secret-at-least-256-bits-long-padding-xxxxxxxx"
 OS_ID = "composite-os"
@@ -95,8 +95,7 @@ def test_both_planes_enforce_on_one_os_end_to_end():
     agent_os = AgentOS(
         id=OS_ID,
         agents=[agent],
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,
@@ -124,8 +123,7 @@ def test_admin_gate_accepts_admin_from_token_scope():
     agent_os = AgentOS(
         id=OS_ID,
         agents=[agent],
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,
@@ -172,8 +170,7 @@ def test_custom_provider_does_not_fail_open_on_non_resource_routes():
     agent_os = AgentOS(
         id=OS_ID,
         agents=[agent],
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,
@@ -193,15 +190,18 @@ def test_custom_provider_does_not_fail_open_on_non_resource_routes():
 
 
 def test_authorization_provider_rejects_a_string():
-    """A list of providers is supported; a string is a mistake. The typed
-    AuthorizationConfig field rejects it at construction (pydantic ValidationError,
-    a ValueError), so it can never be mistaken for an iterable of characters."""
+    """A list of providers is supported; a string is a mistake. AgentOS rejects it when it seeds
+    the provider, so it can never be mistaken for an iterable of characters."""
+    from agno.agent import Agent
+    from agno.db.in_memory import InMemoryDb
+
+    authz = Authorization(
+        verification_keys=[SECRET],
+        algorithm="HS256",
+        authorization_provider="ScopeAuthorizationProvider",  # oops, a string
+    )
     with pytest.raises(ValueError, match="AuthorizationProvider"):
-        AuthorizationConfig(
-            verification_keys=[SECRET],
-            algorithm="HS256",
-            authorization_provider="ScopeAuthorizationProvider",  # oops, a string
-        )
+        AgentOS(id=OS_ID, agents=[Agent(id="a", name="A", db=InMemoryDb())], authorization=authz).get_app()
 
 
 def test_composite_filter_accessible_unions_and_respects_per_plane_deny():

--- a/libs/agno/tests/integration/os/test_directory_no_auth.py
+++ b/libs/agno/tests/integration/os/test_directory_no_auth.py
@@ -107,6 +107,7 @@ def test_user_isolation_top_level_flag_wires_through_under_auth(tmp_path):
     secret = "isolation-flag-secret-at-least-256-bits-xxxxxxxxx"
     os_ = _os(
         tmp_path,
+        authorization=True,
         authorization_config=AuthorizationConfig(verification_keys=[secret], algorithm="HS256"),
         user_isolation=True,
     )

--- a/libs/agno/tests/integration/os/test_directory_no_auth.py
+++ b/libs/agno/tests/integration/os/test_directory_no_auth.py
@@ -107,7 +107,6 @@ def test_user_isolation_top_level_flag_wires_through_under_auth(tmp_path):
     secret = "isolation-flag-secret-at-least-256-bits-xxxxxxxxx"
     os_ = _os(
         tmp_path,
-        authorization=True,
         authorization_config=AuthorizationConfig(verification_keys=[secret], algorithm="HS256"),
         user_isolation=True,
     )
@@ -267,14 +266,3 @@ def test_no_auth_run_refuses_a_reserved_principal(tmp_path):
     assert store.get("sa:backend") is None  # reserved -> refused
     assert store.get("__scheduler__") is None  # reserved -> refused
     assert store.get("realuser") is not None  # normal -> provisioned
-
-
-def test_authz_plane_still_requires_authorization(tmp_path):
-    """Unchanged by the directory/isolation relaxation: a provider (an authz plane) still needs
-    authorization=True, because an unenforced plane would serve every route unauthenticated."""
-    from agno.os.authz.role_store import ManagedRoleStore
-
-    db = SqliteDb(db_file=str(tmp_path / "plane.db"))
-    provider = ManagedRoleStore(db=db).provider
-    with pytest.raises(ValueError, match="authorization=True"):
-        _os(tmp_path, authorization_config=AuthorizationConfig(authorization_provider=provider)).get_app()

--- a/libs/agno/tests/integration/os/test_fga_provider.py
+++ b/libs/agno/tests/integration/os/test_fga_provider.py
@@ -16,8 +16,7 @@ from fastapi.testclient import TestClient
 from agno.agent.agent import Agent
 from agno.db.in_memory import InMemoryDb
 from agno.os import AgentOS
-from agno.os.authz import AuthorizationContext, FGAAuthorizationProvider, ScopeAuthorizationProvider
-from agno.os.config import AuthorizationConfig
+from agno.os.authz import Authorization, AuthorizationContext, FGAAuthorizationProvider, ScopeAuthorizationProvider
 
 SECRET = "fga-provider-test-secret-at-least-256-bits-long-xxxxxx"
 OS_ID = "fga-test-os"
@@ -128,8 +127,7 @@ def test_fga_gates_a_real_agentos_per_resource():
     agent_os = AgentOS(
         id=OS_ID,
         agents=[research, other],
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,
@@ -174,8 +172,7 @@ def test_fga_list_endpoint_returns_a_filtered_list_not_a_403():
             Agent(id="research-agent", name="Research Agent", db=InMemoryDb()),
             Agent(id="other-agent", name="Other Agent", db=InMemoryDb()),
         ],
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,

--- a/libs/agno/tests/integration/os/test_managed_roles.py
+++ b/libs/agno/tests/integration/os/test_managed_roles.py
@@ -19,7 +19,6 @@ from agno.db.in_memory import InMemoryDb  # noqa: E402
 from agno.os import AgentOS  # noqa: E402
 from agno.os.authz import Authorization  # noqa: E402
 from agno.os.authz.role_store import ManagedRoleStore  # noqa: E402
-from agno.os.config import AuthorizationConfig  # noqa: E402
 
 SECRET = "managed-roles-test-secret-at-least-256-bits-long-xxxxx"
 OS_ID = "managed-roles-test-os"
@@ -50,8 +49,7 @@ def _build(store: ManagedRoleStore) -> TestClient:
     agent_os = AgentOS(
         id=OS_ID,
         agents=[agent, other],
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,
@@ -165,8 +163,7 @@ def test_non_resource_routes_are_gated_sessions():
         id=OS_ID,
         agents=[agent],
         db=db,
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,
@@ -514,8 +511,7 @@ def test_db_registered_teams_are_filtered_like_configured_ones(tmp_path):
         id=OS_ID,
         agents=[Agent(id="a1", name="A", db=db)],
         db=db,
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,

--- a/libs/agno/tests/integration/os/test_managed_roles_api.py
+++ b/libs/agno/tests/integration/os/test_managed_roles_api.py
@@ -16,9 +16,9 @@ pytest.importorskip("sqlalchemy")  # managed roles persist/enforce via the nativ
 from agno.agent import Agent  # noqa: E402
 from agno.db.in_memory import InMemoryDb  # noqa: E402
 from agno.os import AgentOS  # noqa: E402
+from agno.os.authz import Authorization  # noqa: E402
 from agno.os.authz.role_router import get_roles_router  # noqa: E402
 from agno.os.authz.role_store import ManagedRoleStore  # noqa: E402
-from agno.os.config import AuthorizationConfig  # noqa: E402
 
 SECRET = "managed-roles-api-test-secret-at-least-256-bits-long-xx"
 OS_ID = "managed-roles-api-test-os"
@@ -59,8 +59,7 @@ def client_and_store():
     agent_os = AgentOS(
         id=OS_ID,
         agents=[agent],
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,
@@ -219,8 +218,7 @@ def test_admin_via_token_claim_can_manage():
     agent_os = AgentOS(
         id=OS_ID,
         agents=[agent],
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,

--- a/libs/agno/tests/integration/os/test_managed_roles_audit.py
+++ b/libs/agno/tests/integration/os/test_managed_roles_audit.py
@@ -17,10 +17,10 @@ pytest.importorskip("sqlalchemy")  # managed roles persist/enforce via the nativ
 from agno.agent import Agent  # noqa: E402
 from agno.db.in_memory import InMemoryDb  # noqa: E402
 from agno.os import AgentOS  # noqa: E402
+from agno.os.authz import Authorization  # noqa: E402
 from agno.os.authz.audit import AuditEvent, AuditSink, DbAuditSink  # noqa: E402
 from agno.os.authz.role_router import get_roles_router  # noqa: E402
 from agno.os.authz.role_store import ManagedRoleStore  # noqa: E402
-from agno.os.config import AuthorizationConfig  # noqa: E402
 
 SECRET = "managed-roles-audit-secret-at-least-256-bits-long-xxxx"
 OS_ID = "managed-roles-audit-os"
@@ -131,8 +131,7 @@ def test_http_api_records_actor_from_jwt():
     agent_os = AgentOS(
         id=OS_ID,
         agents=[agent],
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,
@@ -171,8 +170,7 @@ def _decision_os(sink):
         id=OS_ID,
         agents=[agent],
         db=db,
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,
@@ -274,8 +272,7 @@ def test_decisions_endpoint_returns_trail_for_admin(tmp_path):
     agent_os = AgentOS(
         id=OS_ID,
         agents=[agent],
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,
@@ -318,8 +315,7 @@ def test_audit_endpoint_returns_trail(tmp_path):
     agent_os = AgentOS(
         id=OS_ID,
         agents=[agent],
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,
@@ -421,8 +417,7 @@ def test_per_resource_deny_is_recorded_when_it_denies_independently():
         id=OS_ID,
         agents=[Agent(id="yours", name="Yours", db=db)],
         db=db,
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,
@@ -457,9 +452,8 @@ def test_audit_sink_is_mirrored_onto_the_mcp_subapp():
         id=OS_ID,
         agents=[Agent(id="research-agent", name="Research Agent", db=db)],
         db=db,
-        authorization=True,
         mcp_server=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             authorization_provider=store.provider,

--- a/libs/agno/tests/integration/os/test_managed_roles_internal_token.py
+++ b/libs/agno/tests/integration/os/test_managed_roles_internal_token.py
@@ -23,8 +23,8 @@ pytest.importorskip("sqlalchemy")  # managed roles persist/enforce via the nativ
 from agno.agent import Agent  # noqa: E402
 from agno.db.in_memory import InMemoryDb  # noqa: E402
 from agno.os import AgentOS  # noqa: E402
+from agno.os.authz import Authorization  # noqa: E402
 from agno.os.authz.role_store import ManagedRoleStore  # noqa: E402
-from agno.os.config import AuthorizationConfig  # noqa: E402
 
 SECRET = "managed-roles-internal-token-test-secret-at-least-256-bits-long"
 OS_ID = "managed-roles-internal-token-os"
@@ -56,9 +56,8 @@ def client_and_store():
     agent_os = AgentOS(
         id=OS_ID,
         agents=[agent],
-        authorization=True,
         internal_service_token=INTERNAL_TOKEN,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,

--- a/libs/agno/tests/integration/os/test_managed_users.py
+++ b/libs/agno/tests/integration/os/test_managed_users.py
@@ -118,6 +118,7 @@ pytest.importorskip("sqlalchemy")  # managed roles persist/enforce via the nativ
 from agno.agent import Agent  # noqa: E402
 from agno.db.in_memory import InMemoryDb  # noqa: E402
 from agno.os import AgentOS  # noqa: E402
+from agno.os.authz import Authorization  # noqa: E402
 from agno.os.authz.role_store import ManagedRoleStore  # noqa: E402
 from agno.os.config import AuthorizationConfig, UserDirectoryConfig  # noqa: E402
 
@@ -593,8 +594,7 @@ def test_workflow_continue_over_ws_enforces_the_approval_gate(monkeypatch):
         id=OS_ID,
         agents=[agent],
         db=os_db,
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=[SECRET],
             algorithm="HS256",
             verify_audience=True,

--- a/libs/agno/tests/unit/os/test_jwt_middleware_helpers.py
+++ b/libs/agno/tests/unit/os/test_jwt_middleware_helpers.py
@@ -853,7 +853,7 @@ async def test_dispatch_sets_private_marker_on_success():
 
 
 class TestIssuerPinning:
-    """``AuthorizationConfig(issuer=...)`` must actually reject foreign issuers.
+    """``Authorization(issuer=...)`` must actually reject foreign issuers.
 
     A valid signature says the token was minted by SOMEONE holding a trusted key, not
     by the issuer you meant to trust: a deployment verifying several keys (multi-IdP,
@@ -899,15 +899,19 @@ class TestIssuerPinning:
         payload = self._validator().validate_token(self._token(iss=self.EVIL))
         assert payload["sub"] == "u"
 
-    def test_config_issuer_reaches_middleware_kwargs(self):
-        """Regression: the field must EXIST on AuthorizationConfig -- pydantic silently
-        dropped the kwarg before, so the whole feature was a no-op from config."""
+    def test_issuer_reaches_middleware_kwargs(self):
+        """Regression: the pinned issuer must actually reach the middleware. It lives on the
+        Authorization object (the released AuthorizationConfig has no such field, and pydantic
+        would silently drop an unknown kwarg), so the builder takes it explicitly."""
+        from agno.os.authz import Authorization
         from agno.os.config import AuthorizationConfig
         from agno.os.middleware.jwt import build_jwt_middleware_kwargs
 
-        config = AuthorizationConfig(verification_keys=[JWT_SECRET], algorithm="HS256", issuer=self.GOOD)
-        assert config.issuer == self.GOOD
-        assert build_jwt_middleware_kwargs(config, authorization=True)["issuer"] == self.GOOD
+        authz = Authorization(verification_keys=[JWT_SECRET], algorithm="HS256", issuer=self.GOOD)
+        assert authz.issuer == self.GOOD
+        config = AuthorizationConfig(verification_keys=[JWT_SECRET], algorithm="HS256")
+        assert build_jwt_middleware_kwargs(config, authorization=True, issuer=authz.issuer)["issuer"] == self.GOOD
+        assert "issuer" not in build_jwt_middleware_kwargs(config, authorization=True)  # unpinned by default
 
 
 class TestCreateDevToken:

--- a/libs/agno/tests/unit/os/test_mcp_oauth.py
+++ b/libs/agno/tests/unit/os/test_mcp_oauth.py
@@ -39,6 +39,7 @@ from starlette.middleware.base import BaseHTTPMiddleware  # noqa: E402
 from agno.agent import Agent  # noqa: E402
 from agno.db.schemas.service_accounts import ServiceAccount  # noqa: E402
 from agno.os import AgentOS, MCPServerConfig  # noqa: E402
+from agno.os.authz import Authorization  # noqa: E402
 from agno.os.mcp import _mcp_server_is_open, get_mcp_server  # noqa: E402
 from agno.os.mcp_auth import (  # noqa: E402
     AUTHORIZATION_ENABLED_CLAIM,
@@ -542,13 +543,11 @@ async def test_issuer_pin_is_enforced_on_mcp(monkeypatch):
     JWT verifier must enforce it too -- not just REST. Before the fix the issuer kwarg was
     dropped when building the MCP verifier (audience was threaded, issuer was not), so a
     token from an untrusted issuer that REST rejects still verified on /mcp."""
-    from agno.os.config import AuthorizationConfig
 
     os = AgentOS(
         agents=[_agent()],
         mcp_auth=_oauth_provider(),
-        authorization=True,
-        authorization_config=AuthorizationConfig(
+        authorization=Authorization(
             verification_keys=["test-jwt-secret"], algorithm="HS256", issuer="https://trusted.example"
         ),
         mcp_server=MCPServerConfig(tools=[_ok_tool], enable_builtin_tools=False),


### PR DESCRIPTION
## Summary

Last piece of the `Authorization` surface work on #9092, on top of 59b32b84db and 1a4a997e02 (directory on `AgentOS`, `seed(users=)` removed, JIT demotion fix). Targets `feat/agentos-authz`.

`AuthorizationConfig` goes back to exactly the field set that shipped in v3.0.x, so every authorization setting has one home: the `Authorization` object.

- **Three fields removed from `AuthorizationConfig`:** `issuer`, `authorization_provider`, `audit`. All three were added by #9092; none exist in any release, so the deprecated `authorization_config=` path loses nothing. The class docstring now says it is frozen.
- **The object hands its pieces to AgentOS directly.** `Authorization.provider` (the composed provider: override, or the role store's with the scope plane alongside under `trust_token_scopes`) and `Authorization.issuer` are read by AgentOS at construction, and the audit sink already was. `_seed_authorization_provider` seeds `app.state` from those rather than from the config.
- **Issuer pinning on both surfaces.** `build_jwt_middleware_kwargs` takes `issuer=` from the caller; the REST middleware and the MCP token verifier both pass the object's issuer, so a foreign-issuer token is rejected on `/mcp` exactly as on REST. New end-to-end test on a served OS.
- **Boot guard removed.** The "provider configured without `authorization=True`" guard only existed for a config-carried provider. An `Authorization` object always turns enforcement on, so the shape it guarded can no longer be written.
- Tests migrated off `AuthorizationConfig(authorization_provider=..., audit=..., issuer=...)` onto `Authorization(...)` across ten files. The string-provider test now asserts the rejection at `get_app()`; the config-only "plane without auth" test is gone with the shape.

## Type of change

- [x] Improvement

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Replaces #10119, which was superseded by the author's own directory and seeding commits; this is the part of it that was still missing.

Verification: the authorization test files pass (588 passed). The eight failures in that run all reproduce on the branch head before this PR: the workflow-continue planes test, the two MCP OAuth scope-gate tests, and five `test_mcp_server` tests that depend on the installed `mcp` package version. No cookbook changes; `00_quickstart_authorization.py` runs clean offline against this branch.
