### PR TITLE
test(authz): catch the gate tests up with the async variants

### DIFF
--- a/libs/agno/tests/unit/os/test_list_endpoints_rbac.py
+++ b/libs/agno/tests/unit/os/test_list_endpoints_rbac.py
@@ -38,11 +38,16 @@ def harness(tmp_path, monkeypatch):
         return await call_next(request)
 
     # The caller's scope: registry components visible, db-* components not
-    def scoped_filter(request, resources, resource_type):
+    # The list endpoints await the async twins (the provider's I/O runs off the loop), so those
+    # are what a scoped caller must be simulated on.
+    async def scoped_filter(request, resources, resource_type):
         return [r for r in resources if not str(getattr(r, "id", "")).startswith("db-")]
 
-    monkeypatch.setattr("agno.os.auth.filter_resources_by_access", scoped_filter)
-    monkeypatch.setattr("agno.os.auth.get_accessible_resources", lambda request, kind: {"reg"})
+    async def scoped_ids(request, kind):
+        return {"reg"}
+
+    monkeypatch.setattr("agno.os.auth.afilter_resources_by_access", scoped_filter)
+    monkeypatch.setattr("agno.os.auth.aget_accessible_resources", scoped_ids)
 
     # The DB hands back one out-of-scope component per type
     monkeypatch.setattr(

--- a/libs/agno/tests/unit/os/test_mcp_oauth.py
+++ b/libs/agno/tests/unit/os/test_mcp_oauth.py
@@ -710,7 +710,7 @@ def _fake_http_request(state: dict, mcp_auth_enabled: bool):
     return SimpleNamespace(state=SimpleNamespace(**state), app=SimpleNamespace(state=app_state))
 
 
-def test_scope_gate_fails_closed_when_bridge_absent(monkeypatch):
+async def test_scope_gate_fails_closed_when_bridge_absent(monkeypatch):
     """Under mcp_auth, a provider-verified request with no bridged identity means the
     bridge did not run (an ordering regression): the gate must deny, not skip."""
     import fastmcp.server.dependencies as deps
@@ -719,17 +719,17 @@ def test_scope_gate_fails_closed_when_bridge_absent(monkeypatch):
 
     monkeypatch.setattr(deps, "get_http_request", lambda: _fake_http_request({}, mcp_auth_enabled=True))
     with pytest.raises(Exception, match="identity bridge did not"):
-        mcp_mod._require_tool_scopes("GET", "/config")
+        await mcp_mod._require_tool_scopes("GET", "/config")
 
 
-def test_scope_gate_stays_open_without_mcp_auth(monkeypatch):
+async def test_scope_gate_stays_open_without_mcp_auth(monkeypatch):
     """Without mcp_auth the skip is the intended open/security-key behavior."""
     import fastmcp.server.dependencies as deps
 
     from agno.os import mcp as mcp_mod
 
     monkeypatch.setattr(deps, "get_http_request", lambda: _fake_http_request({}, mcp_auth_enabled=False))
-    mcp_mod._require_tool_scopes("GET", "/config")
+    await mcp_mod._require_tool_scopes("GET", "/config")
 
 
 async def test_continue_run_gate_fails_closed_when_bridge_absent(monkeypatch):
@@ -763,7 +763,7 @@ async def test_continue_run_gate_allows_authenticated_rbac_off(monkeypatch):
     await mcp_mod._enforce_run_continuation_allowed(db=None, run_id="run-1")
 
 
-def test_scope_gate_enforces_bridged_identity(monkeypatch):
+async def test_scope_gate_enforces_bridged_identity(monkeypatch):
     """A bridged identity with insufficient scopes is denied, sufficient passes."""
     import fastmcp.server.dependencies as deps
 
@@ -772,14 +772,14 @@ def test_scope_gate_enforces_bridged_identity(monkeypatch):
     insufficient = {"user_id": "u", "scopes": ["sessions:read"], "authorization_enabled": True}
     monkeypatch.setattr(deps, "get_http_request", lambda: _fake_http_request(insufficient, mcp_auth_enabled=True))
     with pytest.raises(Exception, match="[Ii]nsufficient"):
-        mcp_mod._require_tool_scopes("POST", "/agents/demo-agent/runs")
+        await mcp_mod._require_tool_scopes("POST", "/agents/demo-agent/runs")
 
     sufficient = {"user_id": "u", "scopes": ["agents:run"], "authorization_enabled": True}
     monkeypatch.setattr(deps, "get_http_request", lambda: _fake_http_request(sufficient, mcp_auth_enabled=True))
-    mcp_mod._require_tool_scopes("POST", "/agents/demo-agent/runs")
+    await mcp_mod._require_tool_scopes("POST", "/agents/demo-agent/runs")
 
 
-def test_scope_gate_allows_authenticated_rbac_off_caller(monkeypatch):
+async def test_scope_gate_allows_authenticated_rbac_off_caller(monkeypatch):
     """A caller the bridge DID authenticate but whose token carries no RBAC (an RBAC-off
     agno JWT, or an external Tier-2 token) is a legitimate unenforced caller -- the
     fail-closed gate must NOT deny it (that only fires when the bridge did not run)."""
@@ -790,7 +790,7 @@ def test_scope_gate_allows_authenticated_rbac_off_caller(monkeypatch):
     rbac_off = {"authenticated": True, "user_id": "alice", "scopes": ["agents:run"], "authorization_enabled": False}
     monkeypatch.setattr(deps, "get_http_request", lambda: _fake_http_request(rbac_off, mcp_auth_enabled=True))
     # No exception: enforcement is skipped exactly as on a non-mcp_auth RBAC-off deploy.
-    mcp_mod._require_tool_scopes("POST", "/agents/demo-agent/runs")
+    await mcp_mod._require_tool_scopes("POST", "/agents/demo-agent/runs")
 
 
 async def test_rbac_off_jwt_bearer_runs_tools_under_mcp_auth(tmp_path):


### PR DESCRIPTION
## Summary

Fixes the five failures that have kept `tests (3/5)` red on `feat/agentos-authz` since the async-variants commit (`5bb78754ed`). Both are stale tests, not library bugs:

- `test_list_endpoints_rbac.py` monkeypatched the sync `filter_resources_by_access` and `get_accessible_resources`, but the agents/teams/workflows list routers now await `afilter_resources_by_access` and `aget_accessible_resources`. The scoped caller was never simulated, so every list returned 403. The fixture now patches the async twins.
- The four MCP scope-gate tests in `test_mcp_oauth.py` called `_require_tool_scopes` without awaiting it. It is a coroutine now, so it never raised: the two fail-closed tests could not observe the denial and the two allow tests passed vacuously. They are `async` and `await` the gate.

Both files: 56 passed locally. No library changes.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Independent of #10121; either can merge first.