### PR TITLE
fix: require confirmation for team delegation

### DIFF
--- a/libs/agno/agno/team/_default_tools.py
+++ b/libs/agno/agno/team/_default_tools.py
@@ -1512,6 +1512,8 @@ def _get_delegate_task_function(
 
         delegate_func = Function.from_callable(delegate_function, name="delegate_task_to_member")
 
+    delegate_func.requires_confirmation = True
+
     if team.respond_directly:
         delegate_func.stop_after_tool_call = True
         delegate_func.show_result = True

--- a/libs/agno/tests/unit/os/interfaces/test_agui_team_resume.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_team_resume.py
@@ -117,16 +117,32 @@ async def test_agui_resume_team_member_pause_resumes_team_run(tmp_path):
             paused = True
     assert paused, "expected a member send_email pause"
 
-    # Resume through the AG-UI bridge with the confirmation ToolMessage.
-    tm = AGUIToolMessage(id="m1", role="tool", content=json.dumps({"accepted": True}), tool_call_id="tc-send")
+    # Resume the leader's delegation confirmation first.
+    delegation_confirmation = AGUIToolMessage(
+        id="m-delegation", role="tool", content=json.dumps({"accepted": True}), tool_call_id="tc-deleg"
+    )
     gen = await resume_paused_run(
         entity=team,
         session_id=session_id,
-        tool_messages=[tm],
+        tool_messages=[delegation_confirmation],
         run_context=RunContext(run_id="new", session_id=session_id),
         run_kwargs={},
     )
     async for _ in gen:  # today: raises AttributeError('RunOutput'...team_id); after fix: completes
+        pass
+
+    # The member then pauses on its own confirmation-gated tool.
+    member_confirmation = AGUIToolMessage(
+        id="m-member", role="tool", content=json.dumps({"accepted": True}), tool_call_id="tc-send"
+    )
+    gen = await resume_paused_run(
+        entity=team,
+        session_id=session_id,
+        tool_messages=[member_confirmation],
+        run_context=RunContext(run_id="new", session_id=session_id),
+        run_kwargs={},
+    )
+    async for _ in gen:
         pass
 
     # The TEAM run (not the member run) was resumed and completed.

--- a/libs/agno/tests/unit/os/test_public_json_bounds.py
+++ b/libs/agno/tests/unit/os/test_public_json_bounds.py
@@ -256,7 +256,7 @@ def test_selected_team_has_reduced_roster_and_private_members():
         assert client.post("/teams/support/runs", data={"message": "hi", "user_id": "spoof"}).status_code == 400
 
 
-def test_recovered_public_team_preserves_native_member_results():
+def test_public_team_pauses_before_member_execution():
     import json
 
     class Delegate(ShortAnswerModel):
@@ -285,9 +285,9 @@ def test_recovered_public_team_preserves_native_member_results():
         response = client.post("/teams/support/runs", data={"message": "Hello", "stream": "false"})
     assert response.status_code == 200
     payload = response.json()
-    assert payload["status"] == "COMPLETED" and payload["content"] == "Short answer."
-    assert any("private-diagnostic-marker" in str(message) for message in payload["messages"])
-    assert any("private-diagnostic-marker" in str(tool) for tool in payload["tools"])
+    assert payload["status"] == "PAUSED"
+    assert payload["requirements"][0]["tool_execution"]["tool_name"] == "delegate_task_to_member"
+    assert "private-diagnostic-marker" not in str(payload)
 
 
 def test_selected_team_and_agent_share_active_run_capacity():

--- a/libs/agno/tests/unit/team/test_paused_member_persistence.py
+++ b/libs/agno/tests/unit/team/test_paused_member_persistence.py
@@ -29,6 +29,22 @@ from agno.run.team import TeamRunOutput
 from agno.team import Team
 from agno.tools import tool
 
+
+@pytest.fixture(autouse=True)
+def _disable_delegation_confirmation_for_member_persistence(monkeypatch):
+    """Keep these tests focused on member pause persistence after delegation."""
+    from agno.team import _default_tools
+
+    original = _default_tools._get_delegate_task_function
+
+    def without_confirmation(*args, **kwargs):
+        delegate_function = original(*args, **kwargs)
+        delegate_function.requires_confirmation = False
+        return delegate_function
+
+    monkeypatch.setattr(_default_tools, "_get_delegate_task_function", without_confirmation)
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/libs/agno/tests/unit/team/test_team_system_prompt.py
+++ b/libs/agno/tests/unit/team/test_team_system_prompt.py
@@ -109,6 +109,27 @@ def test_every_tool_named_in_the_prompt_is_attached(mode):
     assert named <= attached, f"{mode}: prompt names unattached tools/args {sorted(named - attached)}"
 
 
+@pytest.mark.parametrize("mode", [mode for mode in MODES if mode != TeamMode.tasks.value])
+def test_delegation_requires_confirmation(mode):
+    team = _team(mode=mode)
+    team.initialize_team()
+    run_context = RunContext(session_state={}, run_id="r1", session_id="s1")
+
+    tools = team._determine_tools_for_model(
+        model=team.model,
+        run_response=TeamRunOutput(run_id="r1"),
+        run_context=run_context,
+        team_run_context={},
+        session=_session(),
+    )
+
+    delegation_tools = [
+        tool for tool in tools if getattr(tool, "name", None) in {"delegate_task_to_member", "delegate_task_to_members"}
+    ]
+    assert len(delegation_tools) == 1
+    assert delegation_tools[0].requires_confirmation is True
+
+
 def test_get_member_information_is_named_only_where_it_is_attached():
     """Tasks mode takes the task-tool branch, which never attaches it."""
     for mode in MODES:


### PR DESCRIPTION
Fixes #10054

## Summary

Require explicit human confirmation before a `Team` executes either route or broadcast delegation..

This fixes the reported default path where prompt-influenced delegation could immediately execute a member's tools without an explicit human confirmation step.

The generated delegation `Function` is now marked with `requires_confirmation=True` for both:

* `delegate_task_to_member`
* `delegate_task_to_members`

This ensures that delegated tool execution is gated behind explicit confirmation.

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Improvement
* [ ] Model update
* [ ] Other:

## Changes

* Added confirmation requirements to route delegation.
* Added confirmation requirements to broadcast delegation.
* Preserved the existing member context and tool APIs.
* Added/updated regression tests covering the confirmation requirement.
* Tasks mode is unchanged because it does not attach a delegation tool.

## Security context

This changes delegation from implicit execution to an explicit confirmation-gated operation in coordinate, route, and broadcast modes.

Without this confirmation requirement, prompt-influenced delegation could result in a member's tools being executed without an explicit human approval step.

## Checklist

* [x] Code complies with style guidelines
* [x] Ran focused Ruff format and lint checks
* [x] Self-review completed
* [ ] Documentation updated (no user-facing API documentation required for this internal default)
* [ ] Examples and guides: Relevant cookbook examples have been included or updated (not applicable)
* [x] Tests added/updated
* [x] Tested in clean environment

### Duplicate and AI-Generated PR Check

* [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
* [ ] If a similar PR exists, I have explained below why this PR is a better approach
* [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Validation

* `pytest libs/agno/tests/unit/team/test_team_system_prompt.py -q` → 39 passed
* Ruff format check → passed
* Ruff lint check → passed
* `git diff --check` → passed

## Additional Notes

This patch intentionally keeps the existing member context and tool APIs unchanged.

A separate design discussion may still be appropriate for delegated-principal/audit propagation and task-level tool allow-listing.