### PR TITLE
feat: adopt the AG-UI interrupt round trip

### DIFF
--- a/cookbook/05_agent_os/16_agui/README.md
+++ b/cookbook/05_agent_os/16_agui/README.md
@@ -21,6 +21,7 @@ default empty prefix those routes are `POST /agui` and `GET /status`.
 | `agent_with_media.py` | Pass AG-UI image, audio, video, and document parts to Gemini. |
 | `shared_state.py` | Send state snapshots and JSON Patch deltas as session state changes. |
 | `human_in_the_loop.py` | Pause and resume a real backend tool that uses `requires_confirmation`. |
+| `interrupt_round_trip.py` | Report a pause as a typed AG-UI interrupt and resume it through the protocol's own resume array. |
 | `research_team.py` | Stream a coordinated Team and its member activity over AG-UI. |
 | `team_subagent_lineage.py` | Serve one Team twice, attributing each message and tool call to the member that produced it and streaming the same run without attribution. |
 | `multiple_instances.py` | Mount two independent AG-UI interfaces on one AgentOS. |
@@ -39,12 +40,19 @@ export GOOGLE_API_KEY=...  # agent_with_media.py only
 `research_team.py` and `team_subagent_lineage.py` also need internet access for
 `WebSearchTools`.
 
-`team_subagent_lineage.py` asks for `subagent_visibility="attributed"`, which
-needs the AG-UI subagent lineage events from `ag-ui-protocol` 0.1.21 or newer.
-The `agui` extra allows older releases, so upgrade the demo environment if it
-resolved one; otherwise the interface refuses the setting at startup.
-`demo_setup.sh` builds that environment with `uv venv`, which seeds no `pip`, so
-upgrade it the same way the setup script installs into it:
+`interrupt_round_trip.py` asks for `emit_interrupt_outcome=True`. The run-level
+outcome that turns on needs the AG-UI interrupt-aware run lifecycle from
+`ag-ui-protocol` 0.1.19 or newer, and that is the whole floor for that example,
+which serves a single agent. Naming the Team member an interrupt was raised
+inside, and closing that member's own lane as suspended, needs the AG-UI
+subagent lineage events instead, so that half of the round trip has the same
+floor as `team_subagent_lineage.py`, which asks for
+`subagent_visibility="attributed"`: `ag-ui-protocol` 0.1.21 or newer. The `agui`
+extra allows older releases, so upgrade the demo environment if it resolved one;
+otherwise the interface refuses the setting it cannot serve at startup. The
+higher of the two floors is what the command below installs, so one upgrade
+serves both. `demo_setup.sh` builds that environment with `uv venv`, which seeds
+no `pip`, so upgrade it the same way the setup script installs into it:
 
 ```bash
 VIRTUAL_ENV=.venvs/demo uv pip install -U 'ag-ui-protocol>=0.1.21'
@@ -62,6 +70,7 @@ Start one example at a time; every standalone server uses port 7777:
 .venvs/demo/bin/python cookbook/05_agent_os/16_agui/agent_with_media.py
 .venvs/demo/bin/python cookbook/05_agent_os/16_agui/shared_state.py
 .venvs/demo/bin/python cookbook/05_agent_os/16_agui/human_in_the_loop.py
+.venvs/demo/bin/python cookbook/05_agent_os/16_agui/interrupt_round_trip.py
 .venvs/demo/bin/python cookbook/05_agent_os/16_agui/research_team.py
 .venvs/demo/bin/python cookbook/05_agent_os/16_agui/team_subagent_lineage.py
 .venvs/demo/bin/python cookbook/05_agent_os/16_agui/multiple_instances.py
@@ -83,6 +92,7 @@ endpoint:
 | `agent_with_media.py` | `http://localhost:7777/media/agui` | `http://localhost:7777/media/status` |
 | `shared_state.py` | `http://localhost:7777/shared-state/agui` | `http://localhost:7777/shared-state/status` |
 | `human_in_the_loop.py` | `http://localhost:7777/human-in-the-loop/agui` | `http://localhost:7777/human-in-the-loop/status` |
+| `interrupt_round_trip.py` | `http://localhost:7777/interrupts/agui` and `http://localhost:7777/interrupts-quiet/agui` | `/interrupts/status` and `/interrupts-quiet/status` |
 | `research_team.py` | `http://localhost:7777/research-team/agui` | `http://localhost:7777/research-team/status` |
 | `team_subagent_lineage.py` | `http://localhost:7777/lineage/agui` and `http://localhost:7777/lineage-inline/agui` | `/lineage/status` and `/lineage-inline/status` |
 | `multiple_instances.py` | `http://localhost:7777/chat/agui` and `http://localhost:7777/analyst/agui` | `/chat/status` and `/analyst/status` |
@@ -154,6 +164,317 @@ trailing tool message with that ID to resume the persisted run. By contrast,
 the email function in `human_in_the_loop.py` is present and executable on the
 server, but cannot run until its confirmation requirement is resolved.
 
+## The interrupt round trip
+
+A paused Agno run is an AG-UI interrupt. The pending tool call the client has to
+resolve comes from the pause itself, and what
+`AGUI(..., emit_interrupt_outcome=True)` decides is whether the run terminal also
+says the run is waiting. It is a boolean, and the two rows below are what it
+decides for a pause a client can answer. It decides two further things, each
+described where it belongs: a pause nothing can answer ends the run rather than
+waiting, under [A pause no client could answer](#a-pause-no-client-could-answer),
+and a Team member the run paused inside has its own lane closed as suspended,
+under [A member the run paused inside](#a-member-the-run-paused-inside).
+
+Three pauses reach the client with no call to act on, and each is logged rather
+than passed off silently. A pending call carrying no tool call id or no tool name
+cannot be rendered, so it is dropped and said so; a pause whose every pending call
+went that way prompts with an assistant message and no call under it, which says
+the run is waiting rather than finished. A pause no pending call is read from at
+all prompts nothing, the run's own words included, so with the outcome off it
+reaches the client as a plain finished run: under the default
+`subagent_visibility="inline"` that is a pause reported by an Agent whose only
+pending call arrives through the run's active requirements, which is what the
+visibility table below states. With the outcome on, that pause is still reported
+as one: the terminal is built from the run's own open requirements, which are
+read under every visibility, so the client is told the run is waiting even where
+the prompt shows it nothing to act on. The third needs the outcome on rather than
+off, and prompts nothing because the run does not wait at all: a pause nothing
+can answer ends as `RUN_ERROR` before any prompt is built.
+
+| Value | What the run terminal carries |
+|---|---|
+| `False` (default) | `RUN_FINISHED` with no `outcome`, which is what this interface sent before the interrupt-aware lifecycle existed. A pause and a completion are indistinguishable on it, so a client tells them apart by a pending tool call with no result, which is the pause's own prompt rather than anything this setting adds. |
+| `True` | `RUN_FINISHED` with `outcome: {"type": "interrupt", "interrupts": [...]}`, one entry per requirement the pause left open, and not one per pending call the prompt showed. Those two lists differ three ways, and the requirement is what the entries are counted by in each: a call the pause carries on two of its own lists at once is prompted once per listing and is still one requirement, so it is one entry; a call the client already has a start for is left out of the prompt and still gets its entry, because it is no less open for that; and a call that could not be rendered is dropped from the prompt and still gets its entry, carrying the tool call id where that call had an id of its own and none where it did not. A pause that reports no requirement at all has nothing else to key an entry by, so there the entries fall back to the pending calls the prompt read, one per call, keyed by the tool call; such a pause whose every pending call could not be rendered keeps the plain terminal, logged rather than dressed up as a completion. A completed run's terminal is unchanged: the setting speaks about pauses only. |
+
+`False` is the default because a client released before that lifecycle stops
+sending its own resume directive the moment it sees the structured outcome,
+which strands the run. Turn it on for a client that resumes through
+`RunAgentInput.resume`.
+
+Each interrupt maps one of Agno's four pause kinds onto the protocol:
+
+| Agno pause | `reason` | Companion fields |
+|---|---|---|
+| `@tool(requires_confirmation=True)`, a `confirmation` pause | `tool_call` | `toolCallId`, and a `responseSchema` of `{"accepted": boolean, "note": string}`, whose `required` names `accepted` alone. The `note` carries a `description` saying what it is for: Agno records one on a denial, where the model reads it as why the call was refused, and its approval path keeps none, so one sent with an approval is dropped and said so in the server log. No `editedArgs` is offered, because advertising that field is what tells a client it may offer edit UI, and this interface has no way to apply edited arguments. |
+| `@tool(external_execution=True)`, an `external_execution` pause, and every frontend-defined tool | `tool_call` | `toolCallId` only. The client runs the tool and hands back whatever it returned, so there is no answer shape to describe. Its `metadata.agno` also carries an `error_report_path`, described under [Resuming](#resuming), and it is the one of the four kinds that does; an entry with no kind behind it carries none either. |
+| `@tool(requires_user_input=True)`, a `user_input` pause | `input_required` | `toolCallId`, and a `responseSchema` of `{"values": {...}}` built from the tool's declared input fields, with `values` itself `required`. Each field carries the `type` Agno declared for it, where that is one of the JSON types this interface maps, and its `description` where it has one; a field whose declared type is not one of those is advertised with `not: {"type": "null"}` instead, because a schema an untyped field satisfies is one a null satisfies, and a null is not an answer. The inner `required` names only the fields still without a value: `requires_user_input` is that boolean and nothing more; the separate `user_input_fields` list names the fields withheld from the model, so a field the model was allowed to fill and did fill is described here but not required. |
+| `UserFeedbackTools`, the `ask_user` tool, a `user_feedback` pause | `input_required` | `toolCallId`, and a `responseSchema` of `{"selections": {question: [label]}}` built from the questions, with `selections` itself `required`. Each question is an `array` whose `items` are a `string`, carrying an `enum` of that question's own labels where it declares any and no `enum` at all where it declares none, since a client offered an empty list of labels is told nothing rather than told to pick from nothing. Every question carries `minItems` of 1, because an empty array satisfies a required question while telling the model nothing. A single-select question also carries `maxItems` of 1, so a client cannot offer a choice the agent would have to reject, and a question with a header carries it as the array's `title`. The inner `required` names only the questions still unanswered. |
+
+`reason` carries the protocol's own core values, which a client switches on to
+pick a surface. Two of the four share `tool_call` and ask for opposite things,
+approve this call or run it yourself, so the exact kind and the waiting tool's
+name travel beside it in `metadata.agno`. The kind is the one the requirement the
+entry was keyed by declares, and one case has no such requirement to read: a
+pause reporting none at all falls back to the pending calls, as the table above
+says, and for an entry keyed that way no `pause_type` is written and no
+`error_report_path` with it. Nothing in such a pause says which of the four kinds
+it is, and a kind picked for looking plausible is wrong three times out of four
+and acted on every time: an approval published as an external execution is a tool
+the client is told to run itself. What that entry carries is what the pause did
+report, the proposed call: the `tool_call` reason such a call is shown under, the
+call's own id as both the entry's id and its `toolCallId`, the tool's name as the
+whole of its `metadata.agno`, and no `responseSchema`, since there is no
+requirement behind it to describe an answer. A pause reporting even one
+requirement keys every entry by a requirement, so it is never affected. No
+`message` is set: the paused run's own words, where it had any, are already on
+the wire as the assistant message the pending call is parented to. Where a
+visibility withholds them, because they are a member's rather than the run's,
+the interrupt does not carry them either: a prompt is not licence to send a
+member's words as the run's own reply.
+
+An advertised schema is not decoration, and it is not a validator either. It
+describes the answer in full so a client can hold itself to it before it
+submits, while the resume side checks the narrow thing it must: that a value
+under a described key is of the kind that key was described as. Three keywords
+are read for that, `type`, `properties` and `items`, while three are
+deliberately left to somebody else: `required` is whether the answer fills the
+pause, which Agno answers across the whole requirement and the resume guard
+below reports, and `description` and `title` are there for a renderer to show.
+The last two of the three exist only so the first is reached wherever a schema
+states one: a declared type lives one envelope down under a field's name, and
+one more down under the entries of an array, which is where a question describes
+its labels. The rest describe
+the answer without refusing one, so a client that does not validate can resolve
+a pause with an empty selection array, with more labels than a single-select
+question offers, or with a label that question never listed. An answer of the
+wrong kind under a described key is refused, which is what keeps a client's
+object out of a field the run records a string in, and a number out of the
+selections the run hands back to the model as the options somebody chose.
+
+A resume that fills nothing still cannot continue the run: the values are
+written on, the requirement stays unanswered, and the guard below stops the
+resume. A null under a described key the pause does not require is not refused
+either. JSON has one way to say there is no value, so that key is read as
+unanswered and dropped, which is what keeps a resume possible for a field the
+model had already filled.
+
+Only the resume array is read this way. A client answering through a trailing
+tool message, which is the channel Agno served before any of this, is held to
+nothing it was never shown: the payloads that channel took, a value of another
+kind under a declared field among them, are the payloads it still takes, and a
+decision it cannot read declines the proposed call there rather than failing the
+run.
+
+The `id` of an interrupt is the id of the Agno requirement waiting on it, which
+is stored with the paused run and survives the reload the resume reads it back
+through. A release that stores no id with the requirement falls back to the tool
+call that requirement is waiting on, which is unique within the run for the same
+reason the tool call events can be keyed by it. That tool call is the key for the
+whole pause as well, and only for a pause reporting no requirement at all: there
+is then nothing else to key an entry by, and the entries are the pending calls
+the prompt read. A pause that reports even one requirement is keyed by its
+requirements throughout, so a listed call with nothing open behind it is not an
+entry at all.
+
+### A pause no client could answer
+
+A resume has to answer every requirement the pause left open, or the guard that
+reads them stops the run, so one requirement no answer could resolve makes the
+whole pause a dead end however answerable the rest of it looks. With the outcome
+on, such a pause ends the run rather than waiting: the terminal is `RUN_ERROR`
+under the code `pause_not_continuable`, which is this interface's own name in the
+field the protocol keeps for one, so a client can tell that case from a run that
+died while working without reading the message. The message names each stranded
+requirement, the tool it waits on, the interrupt id it would have carried where
+it had one, and why nothing resolves it.
+
+The answerable remainder is not advertised and the pending calls are not
+prompted, because advertising it is what stranded such a run before: the client
+answered everything it was told about and the resume was refused over a
+requirement it was never told about, with nothing on the wire having said why. A
+client that answers such a pause anyway is refused in those same words, appended
+to the partial-resume refusal.
+
+A requirement reaches that state by carrying no id an answer could be keyed to;
+by sharing its id with another open requirement of the same pause, where one
+answer could only ever resolve one of the two; by being answered through the one
+resolver its pause kind picks when that is not what it is waiting on, which is
+what a call flagged for two pause kinds at once reports; by having that
+resolver's answer leave another of its own answers open; or by asking for input
+or feedback with no field or question to put an answer in, or none an answer
+could be keyed to. With the outcome off this interface advertises nothing and
+makes no claim about what a resume must carry, so it prompts such a pause like
+any other. A client that then answers through the resume array is refused by the
+guard on it, in those same words. The older tool-message channel runs no such
+guard, because merging tool messages leaves a requirement the client sent no
+result for untouched and wiring it in would make that an error for every existing
+caller, so there an unanswered confirmation is declined at dispatch instead.
+
+### Resuming
+
+The pause arrives on the first request:
+
+```bash
+curl -N http://localhost:7777/interrupts/agui \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "threadId": "agui-readme-interrupt-thread",
+    "runId": "agui-readme-interrupt-run",
+    "state": {},
+    "messages": [
+      {"id": "message-1", "role": "user", "content": "Email ops@example.com about the outage."}
+    ],
+    "tools": [],
+    "context": [],
+    "forwardedProps": {}
+  }'
+```
+
+The next request carries the answers, on the same `threadId` as the request that
+paused. A `threadId` is the Agno session id, so a different one starts a fresh
+session rather than resuming the paused run:
+
+```bash
+curl -N http://localhost:7777/interrupts/agui \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "threadId": "agui-readme-interrupt-thread",
+    "runId": "agui-readme-interrupt-resume",
+    "state": {},
+    "messages": [
+      {"id": "message-1", "role": "user", "content": "Email ops@example.com about the outage."}
+    ],
+    "tools": [],
+    "context": [],
+    "forwardedProps": {},
+    "resume": [
+      {"interruptId": "<the id from RUN_FINISHED>", "status": "resolved", "payload": {"accepted": true}}
+    ]
+  }'
+```
+
+The paused run continues rather than restarting: the resumed stream carries
+`TOOL_CALL_RESULT` for the tool call the pause reported, not a fresh proposal of
+the same call under a new id.
+
+That array is read whether or not the outcome is emitted, so accepting it does
+not depend on the setting. Filling it does: no interrupt id reaches the wire
+unless the outcome carries it, so a client talking to a server with the outcome
+off has no id to key an entry by and resolves the pause through the trailing
+tool message of the older channel instead. A request carrying both the array and
+those tool messages is resumed from the array, because that is the one of the
+two that names the interrupts the run reported.
+
+Rules worth knowing before writing a client against it:
+
+- One array addresses every open interrupt of the interrupted run. Answering
+  some of them stops the run, because an unanswered confirmation reaching
+  dispatch is read there as a refusal the client never gave.
+- A trailing tool result is keyed by the tool call, so it answers every open
+  requirement waiting on that call. Where a request leaves two of them open
+  under one call and reports a result for it, the whole request is refused
+  naming both interrupt ids: one answer resolving two would read as a pause
+  fully answered. Answering each by its own id in the array is what such a pause
+  takes. A request carrying no array is not held to this, because that channel
+  answered by tool call before any interrupt id existed to answer by.
+- A denial is `status: "resolved"` with a negative payload, for example
+  `{"accepted": false, "note": "wrong recipient"}`. The protocol's own approval
+  example names that field `approved`, and a payload using either name resolves.
+  The note is the denial's: an approval keeps none, because Agno's approval path
+  stores none and nothing downstream could read one.
+- `status: "cancelled"` is a client that abandoned the question. A confirmation
+  is then declined and a client-run tool reports back as a failure, so the model
+  learns the tool did not run. A pause waiting on structured input cannot express
+  it at all, since there is no value that stands in for data the tool needs, and
+  the run stops with that reason instead. Those two are the only statuses the
+  protocol declares, and an entry carrying a third never reaches the run at all:
+  the route validates the whole body against `RunAgentInput` before it is
+  handled, and the protocol types that field as those two words, so the request
+  is refused as an HTTP 422 naming the entry and the field. No stream opens, so
+  a client that handles a stopped run in band sees nothing of this one, not even
+  a `RUN_STARTED`.
+- A cancelled entry can say why the client gave up, in the same `metadata`
+  envelope a failure report uses. The reason joins the cancellation in what the
+  run records, as the declined call's note or the failed call's result, rather
+  than replacing it, and the run still stops on a pause waiting on structured
+  input, naming the reason. The envelope is read the same way under either
+  status, so a report that is not a non-empty string stops the run on both.
+- A client whose own tool raised says so on a `resolved` entry, under
+  `metadata: {"agno": {"error": "why it failed"}}`. That is envelope data about
+  the response rather than the answer, which is why it is not in the payload:
+  there it would reach the model as the output of a tool that never ran. The
+  interrupt for a client-run tool advertises the path in its
+  `metadata.agno.error_report_path`, because nothing else on the wire says the
+  convention exists. A client-run tool then reaches the model as a failed call, a
+  confirmation is declined with the reason as its note, exactly as an errored
+  trailing tool message has always been read, and a pause waiting on structured
+  input has nowhere to put it, so the run stops with the reason as a cancelled
+  one does. The report has to be a non-empty string; anything else stops the run
+  rather than being dropped, which would store the payload beside it as a result
+  and tell the model the tool ran. The entry's `metadata` was declared by the
+  protocol in `ag-ui-protocol` 0.1.21, and the envelope works below that release
+  as well: a resume entry accepts keys it does not declare and keeps them as
+  extra data, and this side reads the report off the entry rather than off a
+  declared field, so a client on the floor the Prerequisites name reports a
+  failure the same way and the run records it the same way.
+- A `resolved` entry for a client-run tool has to carry what it resolves it
+  with. No payload and no reported failure is refused: a tool that returned
+  nothing says so with an empty payload, and a client that ran nothing cancels
+  instead.
+- An `interruptId` the run does not carry is logged as a warning and skipped, and
+  is never matched to some other pause. The protocol has a producer proceed
+  without an entry it does not recognise rather than fail a run over an answer it
+  never asked for, so the entries beside it still answer the interrupts they name
+  and the run continues. One for a requirement the run has already resolved is a
+  replay of an answer it holds, so it is left alone.
+- A whole array that answers no paused run in the session answers nothing: a
+  retry, a double submit, or a body replayed after its run was already continued.
+  Those entries are unrecognised too, so they are warned about and the request
+  runs as the fresh run it otherwise describes instead of failing.
+- An answer to an interrupt the run *is* waiting on is a different case. It is
+  held to the shape that interrupt advertised, and one this side cannot read
+  still stops the run: the pause stays open either way, and a client is owed the
+  reason its payload was refused.
+
+A resume request carries the same `context` array as any other, and it reaches
+the continued run: tools and instruction templates read it through the run's
+dependencies, so changing a value between the two requests changes what they
+read. What it does not do is put a context block in the conversation. That block
+is written while a user message is built, and a resume continues the paused run
+instead of starting a turn, so the model still sees the block the first request
+produced.
+
+### A member the run paused inside
+
+Under `subagent_visibility="attributed"`, an interrupt raised inside a Team
+member carries that member's `subagentRunId`, and the member's own
+`SUBAGENT_FINISHED.outcome` carries `{"type": "suspended", "interruptIds":
+[...]}`, so a client renders the member as waiting rather than as work that
+finished. A member suspended only because a member below it interrupted is
+closed as suspended too, with no interrupt ids of its own.
+
+Both halves are one setting. A lane closed as suspended beside a run terminal
+that reports a completion would tell a client the member is waiting on a run
+that says it finished, so the suspended outcome is emitted only alongside the
+run-level one. The visibilities that name no member attribute nothing here
+either: `"hidden"` must not let a confirmation prompt reveal which member asked.
+
+Those two halves also need a later release than the run-level outcome does.
+Naming the member on an interrupt is the interrupt's own `subagentRunId` field,
+which arrived with the AG-UI subagent lineage events in `ag-ui-protocol` 0.1.21,
+while the run-level outcome is served from the earlier release the Prerequisites
+name. Asking for `"attributed"` needs those lineage events anyway, so an install
+that can attribute an interrupt to a member is one that can name it.
+
+The suspended outcome reached the protocol in that same release as the lineage
+events, so an install that can attribute an interrupt to a member can close its
+lane as suspended too, and no released version serves one without the other. The
+interface still detects the two separately, because they are two things it
+writes: an install carrying the interrupt types and the lineage fields but not
+the suspended outcome would attribute the interrupt to the member, close its lane
+plainly, and say so at startup rather than doing it silently.
+
 ## Team member attribution
 
 A Team run mixes the leader's own output with the output of every member it
@@ -167,7 +488,7 @@ way a member's is.
 
 | Value | What the client receives |
 |---|---|
-| `"inline"` (default) | Member work streams as the team's own, exactly as it did before this option existed. No lineage events, no lineage fields. A paused run's own three pending-call lists are read whichever entity reported the pause, an Agent's as much as a Team's. What the default reads on a Team's pause only is the other place a pending call arrives, the run's active requirements, which is how a delegated run and an inner agent report one; so a pause reported by a single Agent whose pending call arrives only that way reaches the client as a plain finished run with nothing to confirm. The other two settings read the requirements on both pause shapes and prompt that call. |
+| `"inline"` (default) | Member work streams as the team's own, exactly as it did before this option existed. No lineage events, no lineage fields. A paused run's own three pending-call lists are read whichever entity reported the pause, an Agent's as much as a Team's. What the default reads on a Team's pause only is the other place a pending call arrives, the run's active requirements, which is how a delegated run and an inner agent report one; so a pause reported by a single Agent whose pending call arrives only that way is prompted with nothing to confirm, and with `emit_interrupt_outcome=False` that is a plain finished run. Turning the outcome on does not change what this setting prompts; the run terminal reports that pause as an interrupt anyway, because the terminal is built from the run's open requirements under every visibility. The other two settings read the requirements on both pause shapes and prompt that call. |
 | `"attributed"` | The full member surface: `SUBAGENT_STARTED`, `SUBAGENT_FINISHED` and `SUBAGENT_ERROR` per delegation, plus a `subagentRunId` on the events that carry a member's own output: its text messages, its tool calls and their results, its reasoning, and any custom or otherwise unrecognized event it emitted. |
 | `"hidden"` | The member surface is withheld: no `SUBAGENT_*` event, no `subagentRunId`, and nothing a member streamed. What the client receives is the leader's own work, its delegation tool call included, and that call's arguments name the member and carry the task text it was given, exactly as the default sends them, followed by the call's result and the leader's own reply. Two things a member caused also reach the client, neither attributed to it: a session-state change one of the member's tools made, because that state is one shared document, and the pending tool call of a member that paused, because the client has to render it to answer, parented to an unattributed assistant message. What that member said while pausing does not reach the client: a prompt is not licence to send a member's words as the run's own reply. A member's failure withholds that same identity: no `SUBAGENT_ERROR`, no stamp, and nothing on it names the member that failed, while the reason the run stopped still reaches the client, because a member's terminal can be the only account the stream carries of how the run ended and is then read as the run's own. The prompt is de-duplicated here, as it is under `"attributed"`, in one case only: a pending call reported both on the paused run's own lists and in a member's requirement is prompted once, carrying the member's attribution. A call the paused run's own lists report twice, by carrying it on two of them at once, is prompted once per listing under every setting, duplicate tool call id and all, because that is the default's stream and the default stream is what it was before this option existed. Under `"attributed"` one more call is left out, a member's own that the client already has a start for; the top-level entity's own pending call is prompted under every setting, so a run with no member on the wire streams what the default streams. |
 
@@ -246,10 +567,14 @@ by a member rather than by the leader, whatever that member said while pausing
 goes out on that member's own message too, and under `"hidden"`, which will not
 name the lane, it does not go out at all.
 
-No outcome is attached to that terminal. The protocol pairs a suspended member
-with a run-level interrupt outcome, which this interface does not emit, and
-sending only the member half would tell a client the member is waiting while
-the run reports plain completion.
+Whether that terminal carries an outcome is what `emit_interrupt_outcome`
+decides, which [A member the run paused inside](#a-member-the-run-paused-inside)
+covers: with the outcome on, a lane this visibility names closes as suspended
+and the run's own terminal reports the interrupt outcome beside it, and with it
+off neither half goes out. The protocol pairs the two, and a lane closed as
+suspended beside a run terminal that reports a completion would tell a client
+the member is waiting on a run that says it finished, which is why one setting
+owns both halves.
 
 These are the events that carry a `subagentRunId`:
 

--- a/cookbook/05_agent_os/16_agui/README.md
+++ b/cookbook/05_agent_os/16_agui/README.md
@@ -22,6 +22,7 @@ default empty prefix those routes are `POST /agui` and `GET /status`.
 | `shared_state.py` | Send state snapshots and JSON Patch deltas as session state changes. |
 | `human_in_the_loop.py` | Pause and resume a real backend tool that uses `requires_confirmation`. |
 | `research_team.py` | Stream a coordinated Team and its member activity over AG-UI. |
+| `team_subagent_lineage.py` | Serve one Team twice, attributing each message and tool call to the member that produced it and streaming the same run without attribution. |
 | `multiple_instances.py` | Mount two independent AG-UI interfaces on one AgentOS. |
 | `openui/` | Render an Agent as streaming charts, follow-ups, and validated forms with OpenUI. |
 
@@ -35,7 +36,19 @@ export OPENAI_API_KEY=...
 export GOOGLE_API_KEY=...  # agent_with_media.py only
 ```
 
-`research_team.py` also needs internet access for `WebSearchTools`.
+`research_team.py` and `team_subagent_lineage.py` also need internet access for
+`WebSearchTools`.
+
+`team_subagent_lineage.py` asks for `subagent_visibility="attributed"`, which
+needs the AG-UI subagent lineage events from `ag-ui-protocol` 0.1.21 or newer.
+The `agui` extra allows older releases, so upgrade the demo environment if it
+resolved one; otherwise the interface refuses the setting at startup.
+`demo_setup.sh` builds that environment with `uv venv`, which seeds no `pip`, so
+upgrade it the same way the setup script installs into it:
+
+```bash
+VIRTUAL_ENV=.venvs/demo uv pip install -U 'ag-ui-protocol>=0.1.21'
+```
 
 ## Run
 
@@ -50,6 +63,7 @@ Start one example at a time; every standalone server uses port 7777:
 .venvs/demo/bin/python cookbook/05_agent_os/16_agui/shared_state.py
 .venvs/demo/bin/python cookbook/05_agent_os/16_agui/human_in_the_loop.py
 .venvs/demo/bin/python cookbook/05_agent_os/16_agui/research_team.py
+.venvs/demo/bin/python cookbook/05_agent_os/16_agui/team_subagent_lineage.py
 .venvs/demo/bin/python cookbook/05_agent_os/16_agui/multiple_instances.py
 ```
 
@@ -70,6 +84,7 @@ endpoint:
 | `shared_state.py` | `http://localhost:7777/shared-state/agui` | `http://localhost:7777/shared-state/status` |
 | `human_in_the_loop.py` | `http://localhost:7777/human-in-the-loop/agui` | `http://localhost:7777/human-in-the-loop/status` |
 | `research_team.py` | `http://localhost:7777/research-team/agui` | `http://localhost:7777/research-team/status` |
+| `team_subagent_lineage.py` | `http://localhost:7777/lineage/agui` and `http://localhost:7777/lineage-inline/agui` | `/lineage/status` and `/lineage-inline/status` |
 | `multiple_instances.py` | `http://localhost:7777/chat/agui` and `http://localhost:7777/analyst/agui` | `/chat/status` and `/analyst/status` |
 | `openui/server.py` | `http://localhost:7777/agui` | `http://localhost:7777/status` |
 
@@ -138,6 +153,170 @@ returns its tool-call ID; after the browser performs the change, it sends a
 trailing tool message with that ID to resume the persisted run. By contrast,
 the email function in `human_in_the_loop.py` is present and executable on the
 server, but cannot run until its confirmation requirement is resolved.
+
+## Team member attribution
+
+A Team run mixes the leader's own output with the output of every member it
+delegated to. `AGUI(..., subagent_visibility=...)` decides how much of that
+distinction the client sees. The setting concerns delegated runs, and a Team's
+members are where they usually come from. A single Agent usually has none, but
+a context provider that runs an inner agent inside the outer run is one: that
+inner run reports the outer run as its parent, so under `"attributed"` it
+becomes a lane of its own, and under `"hidden"` its own output is withheld the
+way a member's is.
+
+| Value | What the client receives |
+|---|---|
+| `"inline"` (default) | Member work streams as the team's own, exactly as it did before this option existed. No lineage events, no lineage fields. A paused run's own three pending-call lists are read whichever entity reported the pause, an Agent's as much as a Team's. What the default reads on a Team's pause only is the other place a pending call arrives, the run's active requirements, which is how a delegated run and an inner agent report one; so a pause reported by a single Agent whose pending call arrives only that way reaches the client as a plain finished run with nothing to confirm. The other two settings read the requirements on both pause shapes and prompt that call. |
+| `"attributed"` | The full member surface: `SUBAGENT_STARTED`, `SUBAGENT_FINISHED` and `SUBAGENT_ERROR` per delegation, plus a `subagentRunId` on the events that carry a member's own output: its text messages, its tool calls and their results, its reasoning, and any custom or otherwise unrecognized event it emitted. |
+| `"hidden"` | The member surface is withheld: no `SUBAGENT_*` event, no `subagentRunId`, and nothing a member streamed. What the client receives is the leader's own work, its delegation tool call included, and that call's arguments name the member and carry the task text it was given, exactly as the default sends them, followed by the call's result and the leader's own reply. Two things a member caused also reach the client, neither attributed to it: a session-state change one of the member's tools made, because that state is one shared document, and the pending tool call of a member that paused, because the client has to render it to answer, parented to an unattributed assistant message. What that member said while pausing does not reach the client: a prompt is not licence to send a member's words as the run's own reply. A member's failure withholds that same identity: no `SUBAGENT_ERROR`, no stamp, and nothing on it names the member that failed, while the reason the run stopped still reaches the client, because a member's terminal can be the only account the stream carries of how the run ended and is then read as the run's own. The prompt is de-duplicated here, as it is under `"attributed"`, in one case only: a pending call reported both on the paused run's own lists and in a member's requirement is prompted once, carrying the member's attribution. A call the paused run's own lists report twice, by carrying it on two of them at once, is prompted once per listing under every setting, duplicate tool call id and all, because that is the default's stream and the default stream is what it was before this option existed. Under `"attributed"` one more call is left out, a member's own that the client already has a start for; the top-level entity's own pending call is prompted under every setting, so a run with no member on the wire streams what the default streams. |
+
+`"inline"` is the default because a client already in production cannot be
+protected after the fact from event types its transport rejects. Opting in is a
+deliberate choice by whoever owns the frontend.
+
+Under `"attributed"`, Agno's own run identity is what lineage is built from.
+Every streamed chunk reports the run it came from and, for a member, the run
+that delegated to it, which maps onto AG-UI as follows:
+
+| AG-UI field | Agno source |
+|---|---|
+| `subagentRunId` | The member run's own run ID. Agno mints one per delegation, so a member invoked twice occupies two lanes. |
+| `SUBAGENT_STARTED.name` | The member's name, or its ID when the chunk carries no name, or the member run ID itself when it carries neither. Each of those is read defensively: a value whose own text cannot be rendered is treated as absent and the next one is tried, so a member with an unreadable name is announced under its run ID instead of ending the run. |
+| `SUBAGENT_STARTED.description` | The `task` the delegation call in the `parentToolCallId` row carried, identified by exactly the rule that row states and so absent whenever that call is. Absent too when the call carried no task text: the tasks-mode delegation tools, `execute_task` and `execute_tasks_parallel`, take a task id instead, so a member a task list delegated to has no description rather than an invented one. |
+| `SUBAGENT_STARTED.parentSubagentRunId` | The delegating member's run ID for a nested Team. Absent means that no member is named as the parent, so the client places the lane directly under the run itself, and that is the one thing absence means here. It is what a delegation by the top-level team reports; it is also what a member gets when nothing identifies a deeper parent, which includes a member whose first appearance is a pause that no single delegation call can be matched to. It is absent as well when the delegating lane's own terminal has already gone out, because a child must not resolve inside a lane the client has closed, and when this stream has not announced that parent yet: a grandchild's first event can outrun its parent's, and a link to a lane the client has not been given is one it cannot resolve. |
+| `SUBAGENT_STARTED.parentToolCallId` | The delegation call the member was spawned inside, when exactly one call identifies it. A call qualifies when it is still open, its tool is one the framework delegates through, and its `member_id` argument names this member. Which calls are searched depends on where the member first appears. For a member that streams, only the delegating lane's own open calls are searched, and exactly one of them has to name the member. For a member whose first appearance is a pause, the open calls of every lane are searched instead, and the one match has to be unique across all of them: two lanes each delegating to the same member therefore yield a link, and a description with it, when that member streams, and neither when it pauses. A lane the announcement cannot name is searched in neither case, and then no link, no parent message and no description is reported at all: that covers a lane whose own terminal has already gone out, and a lane this stream has not announced yet. Falling back to the top-level entity's open calls would hand a grandchild the leader's call, the leader's parent message and the leader's task text as its own description. Absent otherwise: when no open delegation names this member, when more than one does, and when the delegation names no member at all. The broadcast tools, `delegate_task_to_members` and `execute_tasks_parallel`, are that last case, so a member one of them spawned carries no link rather than whichever of the leader's own calls happened to be open. |
+| `SUBAGENT_STARTED.parentMessageId` | The assistant message that delegation tool call was parented to. Absent whenever the delegation call is, since the message is read off that call, and absent when that call carried no parent message of its own. |
+| `SUBAGENT_FINISHED.result` | The member run's final content, serialized when it is not already text, and absent when the run reported no content at all. A value that neither serialization nor a plain text conversion can render becomes a short note naming its type, so a member that produced something unrenderable still finishes rather than failing the run. |
+| `SUBAGENT_ERROR.message` | The member run's error, or the reason it was cancelled, or the interface's own wording when the run reported neither, or reported one whose text cannot be rendered. A cancelled member terminates as an error too, because it produced no result to report, and a lane that errored is never also reported as finished. |
+| `SUBAGENT_ERROR.code` | The `error_type` the member run's failure carried, or `"cancelled"` when the member was cancelled rather than failing. Absent when the failure named no type, so a client should treat a missing code as an unclassified failure rather than a successful lane. |
+
+Those last three rows describe a member that reaches its own terminal event.
+That terminal is emitted for that member alone: it ends the member's own text
+and reasoning spans, so it never lands inside a message, and it ends nothing
+else. A member still open when the whole run ends is terminated by the run
+instead, deepest lane first. Those two are the only places a member's terminal
+comes from. If the run failed, every lane still open is closed with a
+`SUBAGENT_ERROR` whose message is the run's error, not the member's, so that
+message says why the run stopped rather than what that member did, and which
+carries no `code`, because the run's failure is not a diagnosis of that member.
+Where the stream itself died rather than the run reporting a failure of its own,
+that message is the text of whatever raised, or the name of its type when it
+raised without any text, so the lane never errors for no stated reason. If the
+run completed or paused, every lane still open is closed with a
+`SUBAGENT_FINISHED` that carries no `result`.
+
+A member's terminal can also become the run's own. When a member's failure or
+cancellation is the last thing the stream carries, the top-level entity reported
+no terminal of its own, so that member's is read as the run's: the run ends with
+a `RUN_ERROR` carrying the member's error text, or the reason it was cancelled
+under the code `"cancelled"`, rather than with a completion that would report a
+run stopped part-way as a success. Which member terminal that is, is simply the
+last one the stream carried: nothing ranks a failure above a later completion,
+so a member that fails and is then followed by another member completing ends
+the run as a completion, and a member that pauses followed by another member
+completing loses the pending call it was waiting on. Both hold under every
+setting, the default included. A failure ends the run that way under every
+setting. A cancellation does so only under `"attributed"` and `"hidden"`, which
+are the settings that recognise a member's terminal as a member's: cancellation
+is not one of the events that end a run in its own right, so under the default,
+where every chunk is the run's own, the same chunk streams as an unrecognized
+event and the run still finishes.
+
+A `RUN_ERROR` built from a reported failure also carries the failing Agno event
+verbatim in its `rawEvent` field, and which failures come with one depends on
+the setting. The top-level entity's own failure supplies it under all three. A
+member's does not under `"attributed"` or `"hidden"`: that chunk names the
+member, its run, and the run that delegated to it, which is the identity those
+two settings exist to attribute or to withhold, so the terminal goes out without
+it. Only the default embeds it, whose stream is what it was before this option
+existed. A run whose stream died rather than reporting a failure has no such
+chunk at all, so its terminal carries only the text of whatever raised.
+
+A member paused awaiting outside input is one of those lanes: pausing is not
+finishing, so the member's lane stays open, the confirmation tool calls the
+client must render are emitted inside it, and the run-end drain closes it
+afterwards. A tool call belongs to the message that carries it, so the two
+always name the same member: a member's pending calls are parented to an
+assistant message carrying that member's `subagentRunId`, and the leader's own
+to an unattributed one. One pause can be waiting on several members at once,
+and one message cannot name two, so the prompt is one message per member rather
+than one message with everybody's calls under it. Where the pause was reported
+by a member rather than by the leader, whatever that member said while pausing
+goes out on that member's own message too, and under `"hidden"`, which will not
+name the lane, it does not go out at all.
+
+No outcome is attached to that terminal. The protocol pairs a suspended member
+with a run-level interrupt outcome, which this interface does not emit, and
+sending only the member half would tell a client the member is waiting while
+the run reports plain completion.
+
+These are the events that carry a `subagentRunId`:
+
+```text
+TEXT_MESSAGE_START TEXT_MESSAGE_CONTENT TEXT_MESSAGE_END
+TOOL_CALL_START TOOL_CALL_ARGS TOOL_CALL_END TOOL_CALL_RESULT
+REASONING_START REASONING_MESSAGE_START REASONING_MESSAGE_CONTENT
+REASONING_MESSAGE_END REASONING_END
+CUSTOM RAW
+```
+
+Three kinds of event carry none. The `SUBAGENT_*` events name their member in a
+dedicated field instead. The `RUN_*` lifecycle events belong to the run as a
+whole. And `STATE_SNAPSHOT` and `STATE_DELTA` are left unattributed
+deliberately: a team's session state is one shared document, so a client
+filtering by member must not lose state written during a delegation.
+
+Message, reasoning, and tool-parent state is tracked per member, so a member's
+text never lands in the leader's bubble and two members streaming at once keep
+independent spans. Independent spans are interleaved spans: while two of them
+are open the wire carries both members' content events mixed together rather
+than one whole message and then the next, so a client has to route each event by
+the message it names rather than by arrival order. A member's terminal event is
+emitted once and is final for the id it names, but it is not a fence. Two things
+put events carrying a member after that member's terminal. One is output the
+source stream itself produces from a run that has already ended: it stays
+attributed to that member rather than being reparented, because giving one
+invocation a second lifecycle would be worse than a late event. The other is
+this interface's own run-end close, which writes the end of a tool call the
+member left open, since a member's terminal ends no tool call: only that call's
+own completion carries its result and whatever it wrote to the session state.
+Either way a client should keep resolving a member's id after its terminal.
+
+Ordering promises nesting as far as the runs themselves nest: a nested member's
+terminal precedes its parent's. A parent run that reports its own completion
+while a member it delegated to is still streaming is the exception, because each
+terminal goes out when its own run reports one and the member below it is left
+to the run end, so that child resolves after its parent. Agno delegates
+synchronously, so a run does not normally report the two in that order.
+
+The run end closes what is open before it emits anything of its own. Once the
+stream has announced a member lane, it does that in two passes: every reasoning
+span and text message still open, children before parents; then every tool call
+still open, children before parents; then the pause prompt, if the run paused;
+then a terminal for every member lane the run left open. A stream that announced
+no member lane has nothing to order across lanes and closes the single lane it
+has in one pass instead: its reasoning span, then its tool calls, then its text
+message, and then the pause prompt. That is every `"inline"` and `"hidden"` run,
+and an `"attributed"` run that never delegated. The difference is visible when a
+run ends with both a message and a tool call open: `TOOL_CALL_END` precedes
+`TEXT_MESSAGE_END` with no member on the wire, and follows it once there is one.
+
+Either way, nothing the run end emits is nested inside a span, and the pause
+prompt in particular opens its message and its tool calls with the delegation
+that spawned them already closed. A member whose first appearance is that pause
+is announced at the head of the prompt, since a client cannot resolve a call
+stamped with a lane it has not been told about. The prompt still precedes the
+member terminals, because its calls carry the `subagentRunId` of the members it
+is prompting for and nothing may carry a member after that member's terminal.
+During the run itself a member's announcement and its own events do sit inside
+the still open delegation call: that call is what
+`SUBAGENT_STARTED.parentToolCallId` names.
+
+Lineage needs the AG-UI subagent events, which arrived in `ag-ui-protocol`
+0.1.21. Asking for `"attributed"` on an older release fails at startup rather
+than silently dropping attribution; `"inline"` and `"hidden"` work on any
+supported release.
 
 ## State and media
 

--- a/cookbook/05_agent_os/16_agui/TEST_LOG.md
+++ b/cookbook/05_agent_os/16_agui/TEST_LOG.md
@@ -6,6 +6,19 @@ Tested on 2026-07-24 against Agno source commit
 The OpenUI addition was tested on 2026-08-18 against Agno source commit
 `32e5fb9c2203fa98de19ca72750133a57a075899`.
 
+The Team member attribution addition was tested on the attribution branch
+itself, across two dates that cover different things. The server boot sweep and
+the resolved-visibility checks for `team_subagent_lineage.py` were measured on
+2026-09-04. The unit suites named in that entry were re-run on 2026-09-08,
+after the review rounds that added
+`libs/agno/tests/unit/os/interfaces/test_agui_stream_invariants.py` and changed
+what a member's own terminal event closes; that later date is the one the suite
+results here describe. The branch is based on Agno source commit
+`d1a388446e1b44b20498c772e91303588e2734cf`, which is the base it was written
+against and does not contain the work: the results below were measured on the
+branch, not on that tree. The branch squashes into one commit whose id does not
+exist yet, so the base is the only commit this log can name.
+
 Each checked-in server was first booted on its default port 7777. The sweep
 asserted `GET /health`, `GET /config`, every mounted AG-UI status route, and a
 clean shutdown. Capability-specific POST tests then used
@@ -148,6 +161,74 @@ and a final two-fact brief before `RUN_FINISHED`.
 
 ---
 
+### team_subagent_lineage.py
+
+**Status:** PASS
+
+**Test mode:** AUTOMATED
+
+**Description:** Added on 2026-09-04. Booted the two-interface server, checked
+`/health`, `/config`, and both status routes, and asserted the visibility each
+mounted interface resolved to. No live model turn ran, because this environment
+has no provider key; the streamed payloads this file demonstrates are covered
+by the AG-UI attribution modules under
+`libs/agno/tests/unit/os/interfaces/` instead:
+`libs/agno/tests/unit/os/interfaces/test_agui_subagent_lineage.py` for the
+attribution surface,
+`libs/agno/tests/unit/os/interfaces/test_agui_stream_failure.py` for the
+failure path, where a source stream that raises mid-run still has to close
+every span and member lane it opened,
+`libs/agno/tests/unit/os/interfaces/test_agui_hostile_run_content.py` for run
+content no serializer handles cleanly, driven through every boundary that
+builds an AG-UI event out of run content,
+`libs/agno/tests/unit/os/interfaces/test_agui_documented_contract.py`, which
+reads the enumerable claims out of this folder's README and this log and
+compares them with the interface's own constants, and
+`libs/agno/tests/unit/os/interfaces/test_agui_stream_invariants.py`, which
+feeds the shared definition of a well-formed stream a stream that breaks each
+invariant in turn and asserts it is reported.
+
+The definition those suites share lives beside them in
+`libs/agno/tests/unit/os/interfaces/agui_stream_invariants.py`. It carries no
+tests of its own and pytest collects nothing from it; the collectors in the
+suites above run it on every stream they gather, and the module named just
+above is what proves each of its invariants bites.
+
+**Result:** Health returned `ok`; config returned OS `agui-lineage-os` with
+AG-UI routes `/lineage` and `/lineage-inline`. Both status routes returned
+`available`. The `/lineage` interface resolved to `attributed` and
+`/lineage-inline` to the default `inline`. Every suite named above passed,
+under `pytest libs/agno/tests/unit/os/interfaces -k agui`, which also runs the
+AG-UI suites that predate attribution. That selector is written instead of a
+list of paths on purpose: it names no count and picks the suites up by name, so
+it stays correct as suites are added to the folder or removed from it.
+Per-suite test counts are deliberately not recorded here either. Tests keep
+being added to these suites, so a count written down goes stale while the pass
+stays true; run the command above for the current tally.
+Wherever a scripted offline model can drive the behavior the assertions run
+against a real `Team.run` and `Team.arun` stream: per-member messages and tool
+calls, the delegation link, one terminal per member carrying its result, two
+members whose runs report identical content staying two lanes, the same member
+delegated twice taking a lane and a run id per delegation, the nested-team
+parent chain, parallel delegation, a member whose own run fails, the unchanged
+inline stream, and a single Agent with no inner run, whose stream the setting
+leaves unchanged, pauses included: a pending call one paused Agent reports
+twice, by carrying it on two of its lists at once, is prompted once per
+listing under all three settings, duplicate tool call id and all, because
+that is what the default sends. A team member that pauses is driven from a
+real run too: a member whose tool needs a confirmation pauses under a scripted
+model, and its announcement and the pending call prompted on its own lane are
+asserted against that stream. Reasoning inside a member, output trailing a
+member's terminal, a lane whose parent lane terminated before it and a run that
+fails with member lanes still open are not reachable from a scripted model, and
+neither are the pause shapes a single run cannot produce: a leader and a member
+paused at once, a pause naming a member whose lane already terminated, a paused
+grandchild, and a pause reported only through requirements. Those cases
+hand-build the chunk sequence from the same `run_id`, `parent_run_id`, and
+member-identity fields the framework stamps on a member's chunks.
+
+---
+
 ### multiple_instances.py
 
 **Status:** PASS
@@ -190,11 +271,20 @@ TypeScript compilation, and the Vite production build passed.
 
 ## Validation
 
-- All 9 standalone files booted, exposed their expected `/status` route, and
-  shut down cleanly.
-- All 9 files completed a real capability-specific AG-UI POST flow.
-- Recursive pattern validation checked exactly 9 Python files with 0
-  violations.
+- All 11 server files booted, exposed their expected `/status` route, and
+  shut down cleanly. The count is every Python file under this folder: the 10
+  in its root plus `openui/server.py`, which is the backend half of the nested
+  OpenUI example rather than a standalone one. `multiple_instances.py` and
+  `team_subagent_lineage.py` each mount two interfaces and exposed both of
+  their `/status` routes.
+- 10 of the 11 files completed a real capability-specific AG-UI POST flow.
+  `team_subagent_lineage.py` was verified without a provider key, so its POST
+  flow is covered by the unit suites instead.
+- Recursive pattern validation checked exactly 11 Python files, the same root 10
+  plus `openui/server.py`, with 0 violations, from
+  `python cookbook/scripts/check_cookbook_pattern.py --base-dir cookbook/05_agent_os/16_agui --recursive`.
+  Without `--recursive` that command sees 10 files, so the flag is what makes
+  the two counts above comparable.
 - Targeted Ruff format and check passed.
 - Python compilation, banned-model, stale-route, scope, Unicode/emoji,
   non-PASS status, and `git diff --check` gates passed.
@@ -203,6 +293,18 @@ TypeScript compilation, and the Vite production build passed.
 - The OpenUI server passed Python compilation, import, Ruff format, and Ruff
   check. Its frontend passed five tests, TypeScript compilation, and a
   production build.
-- Repository-wide Ruff, agnoctl mypy, and cookbook pattern checks passed. The
-  core Agno mypy step reported 27 existing errors in six files outside this
-  integration's diff.
+- Repository-wide Ruff, agnoctl mypy, and cookbook pattern checks passed. On
+  2026-07-24 the core Agno mypy step reported 27 existing errors in six files
+  outside this integration's diff; re-run on 2026-09-08 by `./scripts/validate.sh`
+  it reported none, across 1033 Agno source files and 21 agnoctl ones.
+- Re-measured on 2026-09-08 against the current tree: `./scripts/validate.sh`
+  passed every step it runs, the recursive pattern check saw 11 files and the
+  non-recursive one 10 with 0 violations either way, Ruff format and check
+  passed on this folder's 11 files, `python -m compileall` and
+  `git diff --check` passed, and
+  `pytest libs/agno/tests/unit/os/interfaces -k agui` passed on an install
+  whose `ag-ui-protocol` serves the lineage events.
+- Not re-run on 2026-09-08: the server boots, the per-file AG-UI POST flows and
+  the OpenUI frontend checks recorded above, which need the servers started and
+  a provider key. Those stand as measured on the dates given with them, and the
+  dated line above covers only the checks named in it.

--- a/cookbook/05_agent_os/16_agui/TEST_LOG.md
+++ b/cookbook/05_agent_os/16_agui/TEST_LOG.md
@@ -13,11 +13,33 @@ the resolved-visibility checks for `team_subagent_lineage.py` were measured on
 after the review rounds that added
 `libs/agno/tests/unit/os/interfaces/test_agui_stream_invariants.py` and changed
 what a member's own terminal event closes; that later date is the one the suite
-results here describe. The branch is based on Agno source commit
-`d1a388446e1b44b20498c772e91303588e2734cf`, which is the base it was written
-against and does not contain the work: the results below were measured on the
-branch, not on that tree. The branch squashes into one commit whose id does not
-exist yet, so the base is the only commit this log can name.
+results here describe. As of 2026-09-10 that branch sits on Agno source commit
+`4253dedc95250afddfcea05dfc28f26a4833a117`, which is on Agno's `main` and does
+not contain the work: the results below were measured on the branch, not on that
+tree. The branch's own commit is not on Agno's `main`, so that base is the only
+Agno source commit this log can name for it.
+
+The interrupt round trip addition was tested on 2026-09-10, on the branch that
+adds it. That branch is not based on an Agno source commit at all: it sits on top
+of the attribution branch above, which is itself unmerged, and only that
+branch's base is on Agno's `main`. So the tree these results were measured on is
+the Agno source commit named in the previous paragraph plus the commits of the
+two unmerged branches, none of which is on Agno's `main`, and the interrupt work
+itself is not pushed anywhere. How many commits that is stays unwritten: the
+branch grows one per review round, and the number said nothing about what was
+measured. As with the attribution entry, the results were measured on the branch
+rather than on either base.
+
+That entry is AUTOMATED, not LIVE, and the reason is worth stating plainly: no
+model API key was available in the environment the work was done in, so the one
+thing this addition most needs proving against a real model, that a client is
+told the run is waiting and that answering continues the same run rather than
+starting a new one, was proven against a scripted model over real HTTP instead.
+The scripted proof is real end to end below the model: a real AgentOS app, real
+`POST /agui` requests, real SSE, a real persisted pause, and the real tool body
+running on resume. What it does not cover is a real provider deciding to call
+the tool in the first place. Anyone with a key should run
+`interrupt_round_trip.py` and confirm that by hand.
 
 Each checked-in server was first booted on its default port 7777. The sweep
 asserted `GET /health`, `GET /config`, every mounted AG-UI status route, and a
@@ -142,6 +164,84 @@ tool call `fc_0555339da3dade57006a62d9a7a6388191a2c63cd5b0cebfd6` without
 executing it. Sending `{"accepted": true}` resumed the persisted run, emitted
 the tool result, and completed with the recipient `ops@example.com` and subject
 `Test Alert`.
+
+---
+
+### interrupt_round_trip.py
+
+**Status:** PASS
+
+**Test mode:** AUTOMATED
+
+**Description:** Added on 2026-09-10. Booted the two-interface server, checked
+`/health`, `/config`, and both status routes, and asserted the setting each
+mount resolved. The behaviour itself was measured by the unit suite rather than
+by a live provider, because no model API key was available; see the note at the
+top of this log for what that leaves uncovered.
+
+**Result:** Health returned `ok`; config returned OS `agui-interrupt-os`, agent
+`agui-interrupt-agent`, and the two AG-UI interfaces at `/interrupts` and
+`/interrupts-quiet`; both status routes returned `available`. The mounts
+resolved `emit_interrupt_outcome` to `True` and `False` respectively.
+
+`libs/agno/tests/unit/os/interfaces/test_agui_interrupts.py` covers the
+behaviour, all passing on `ag-ui-protocol` 0.1.22 as measured on 2026-09-10. It
+drives the resume half over a real `POST /agui` against a real Agent and a real
+Team with a scripted model: the first request pauses and reports the interrupt,
+the second answers it through `RunAgentInput.resume`, and the assertion is that
+the tool body ran and its result reached the wire under the tool call id the
+pause reported, which a restarted run could not produce.
+
+The wider AG-UI unit surface is green with it. Re-measured on 2026-09-10 by
+
+```bash
+pytest libs/agno/tests/unit/os/interfaces/ libs/agno/tests/unit/app/ -q \
+  --ignore=libs/agno/tests/unit/os/interfaces/test_a2a.py \
+  --ignore=libs/agno/tests/unit/os/interfaces/test_slack_bot_filtering.py
+```
+
+which passed. Both exclusions are required rather than tidying: those two files
+fail to collect in this environment on optional dependencies it does not have,
+`a2a-sdk` and `slack_sdk`, neither of which this change touches, and without them
+pytest stops on the two collection errors and runs nothing at all. So the pass
+holds only under those exclusions, and says nothing about whatever the two
+excluded files would have contributed.
+
+No test count is written here, for one suite or for the whole run. Every count
+this log wrote went stale within days, and one pair of them had gone
+arithmetically impossible: a suite total, and a difference from an earlier total
+said to be one suite's whole contribution, while that suite had grown to more
+tests than the difference. Those totals move with every commit to directories
+this folder does not own. Run the command above for a current tally.
+
+Five of the counts kept below are facts about this folder rather than about a
+run, and all five are recomputed from the folder itself by
+`libs/agno/tests/unit/os/interfaces/test_agui_documented_contract.py`, which
+fails when one of them drifts: the Python files in this folder's root, the
+server files booted, the Python files the pattern check scanned, the POST flows
+completed, and the status routes the examples mount. Every other number below is
+what one dated run measured, the events a stream carried and the files a sweep
+walked among them. Nothing recomputes those, and a later run will report its
+own.
+
+Existing suites did have their assertions rewritten by this addition. The
+documented-floor check in
+`libs/agno/tests/unit/os/interfaces/test_agui_documented_contract.py` went from
+one folder-wide protocol floor to a floor per example plus a set comparison
+against the README, because the folder now has two optional protocol features
+with different floors. That suite now also recomputes what this entry's own
+document claims about the round trip: the option's documented values and default
+against the constructor's signature, Agno's four pause kinds against the reasons
+the interface maps them to, every constraint the advertised answer schemas state
+against what the resume side enforces and what the README names, the
+failure-report path against the constants both directions read, the
+not-continuable code against the terminal a pause nothing can answer really
+sends, that the outcome is counted by open requirement rather than by prompted
+call, and every request body the README shows against the protocol's own input
+model. The startup-check test in
+`libs/agno/tests/unit/os/interfaces/test_agui_subagent_lineage.py` now asserts
+over the union of two feature-detection tables instead of one, because the
+suspended member outcome is feature-detected separately from the lineage fields.
 
 ---
 
@@ -271,19 +371,24 @@ TypeScript compilation, and the Vite production build passed.
 
 ## Validation
 
-- All 11 server files booted, exposed their expected `/status` route, and
-  shut down cleanly. The count is every Python file under this folder: the 10
-  in its root plus `openui/server.py`, which is the backend half of the nested
-  OpenUI example rather than a standalone one. `multiple_instances.py` and
-  `team_subagent_lineage.py` each mount two interfaces and exposed both of
-  their `/status` routes.
-- 10 of the 11 files completed a real capability-specific AG-UI POST flow.
-  `team_subagent_lineage.py` was verified without a provider key, so its POST
-  flow is covered by the unit suites instead.
-- Recursive pattern validation checked exactly 11 Python files, the same root 10
+- All 12 server files booted, exposed their expected `/status` route, and shut
+  down cleanly, each on the date recorded with it rather than all in one sweep.
+  The most recent sweep, on 2026-09-10, re-booted 11 of the 12; the dated bullet
+  below names the one it could not boot and why. So the 12 is the union of the
+  sweeps across the dates in this log, not a count any single run reached. The
+  count is every Python file under this folder: the 11 in its root plus
+  `openui/server.py`, which is the backend half of the nested OpenUI example
+  rather than a standalone one. `multiple_instances.py`,
+  `team_subagent_lineage.py` and `interrupt_round_trip.py` each mount two
+  interfaces and exposed both of their `/status` routes.
+- 10 of the 12 files completed a real capability-specific AG-UI POST flow, each
+  on the date recorded with it rather than all in one pass.
+  `team_subagent_lineage.py` and `interrupt_round_trip.py` were verified without
+  a provider key, so their POST flows are covered by the unit suites instead.
+- Recursive pattern validation checked exactly 12 Python files, the same root 11
   plus `openui/server.py`, with 0 violations, from
   `python cookbook/scripts/check_cookbook_pattern.py --base-dir cookbook/05_agent_os/16_agui --recursive`.
-  Without `--recursive` that command sees 10 files, so the flag is what makes
+  Without `--recursive` that command sees 11 files, so the flag is what makes
   the two counts above comparable.
 - Targeted Ruff format and check passed.
 - Python compilation, banned-model, stale-route, scope, Unicode/emoji,
@@ -293,10 +398,30 @@ TypeScript compilation, and the Vite production build passed.
 - The OpenUI server passed Python compilation, import, Ruff format, and Ruff
   check. Its frontend passed five tests, TypeScript compilation, and a
   production build.
-- Repository-wide Ruff, agnoctl mypy, and cookbook pattern checks passed. On
-  2026-07-24 the core Agno mypy step reported 27 existing errors in six files
-  outside this integration's diff; re-run on 2026-09-08 by `./scripts/validate.sh`
-  it reported none, across 1033 Agno source files and 21 agnoctl ones.
+- Repository-wide Ruff, agnoctl mypy, and cookbook pattern checks passed. The
+  core Agno mypy step reported errors outside this integration's diff on
+  2026-07-24 and none when it was re-run on 2026-09-08 by
+  `./scripts/validate.sh`. Neither an error count nor a count of the source
+  files either run walked is written down: both move with which optional model
+  packages the environment has installed, and neither says anything about this
+  folder.
+- Re-measured on 2026-09-10 for the interrupt round trip addition: the boot
+  sweep booted 11 of the 12 and asserted `/health` plus every mounted
+  `/status`, 14 status routes in all, one per AG-UI interface those 11 files
+  mount, which is the one number this sweep measured that something recomputes.
+  `openui/server.py` was the exception, and
+  it refused to boot for a reason unrelated to this change: its system prompt is
+  generated by `npm run generate:prompt`, which had not been run in this
+  environment. The recursive pattern check saw 12 files with 0 violations and
+  the non-recursive one 11, and targeted Ruff format and check passed on all 12.
+  The pytest command in the interrupt entry above passed, under the two
+  `--ignore` exclusions it names, and no count is recorded for it. `mypy`
+  reported no error in the AG-UI
+  interface and the same pre-existing ones elsewhere as it reports on the
+  attribution commit this one sits on top of.
+  How many pre-existing errors that is stays unquoted, because it moves with
+  which optional model packages the environment has installed and says nothing
+  about this change either way.
 - Re-measured on 2026-09-08 against the current tree: `./scripts/validate.sh`
   passed every step it runs, the recursive pattern check saw 11 files and the
   non-recursive one 10 with 0 violations either way, Ruff format and check
@@ -304,6 +429,17 @@ TypeScript compilation, and the Vite production build passed.
   `git diff --check` passed, and
   `pytest libs/agno/tests/unit/os/interfaces -k agui` passed on an install
   whose `ag-ui-protocol` serves the lineage events.
+- Re-measured on 2026-09-10 for the pass that corrected these documents against
+  the merged behaviour, which changed this folder's `README.md`, this log and
+  `interrupt_round_trip.py`, plus
+  `libs/agno/tests/unit/os/interfaces/test_agui_documented_contract.py`, and no
+  interface source at all. `interrupt_round_trip.py` was booted again: `/health`
+  answered `ok`, `/config` returned OS `agui-interrupt-os`, both
+  `/interrupts/status` and `/interrupts-quiet/status` returned `available`, the
+  two mounts resolved `emit_interrupt_outcome` to `True` and `False`, and the
+  server shut down cleanly. The recursive pattern check saw 12 files with 0
+  violations and the non-recursive one 11; `ruff format` and `ruff check` passed
+  on `cookbook` and on `libs/agno`; and the pytest command above passed.
 - Not re-run on 2026-09-08: the server boots, the per-file AG-UI POST flows and
   the OpenUI frontend checks recorded above, which need the servers started and
   a provider key. Those stand as measured on the dates given with them, and the

--- a/cookbook/05_agent_os/16_agui/interrupt_round_trip.py
+++ b/cookbook/05_agent_os/16_agui/interrupt_round_trip.py
@@ -1,0 +1,111 @@
+"""
+Interrupt and resume over AG-UI
+===============================
+
+A paused Agno run is an AG-UI interrupt. By default the pause reaches the client
+as the pending tool call the pause itself reported, and the run terminal says
+nothing about the run waiting, which is what released clients already expect: a
+pause and a completion look the same on it. Set emit_interrupt_outcome=True, the
+boolean this file turns on for one of its two mounts, and the same terminal
+carries outcome={"type": "interrupt", "interrupts": [...]}, one entry per
+requirement the pause left open rather than per pending call it showed, each
+naming the call it is bound to where that call had an id of its own and, where
+the pause has an answer shape to describe, the JSON Schema of the answer it
+wants. A requirement whose call carried no id is still open and still answerable
+under its own interrupt id, so it is advertised without one. An answer that
+comes back is held to that same schema. An external execution describes none:
+the client runs the tool and hands back whatever that tool returned.
+
+The answers come back in the resume array of the next request, keyed by
+interrupt id, and the paused run continues from them rather than restarting.
+That array is read whether or not the outcome is emitted, so accepting it does
+not depend on the setting. Filling it does: no interrupt id reaches the wire
+unless the outcome carries it, so a client on the quiet mount has no id to key
+an entry by and resolves the pause through the older channel's trailing tool
+message instead.
+
+Both settings serve the same agent, so the two terminals can be compared side by
+side. Give each mount its own threadId, because a threadId becomes the Agno
+session id and reusing one continues the other mount's session.
+
+Prerequisites: OPENAI_API_KEY, and ag-ui-protocol 0.1.19 or newer, the release
+     the interrupt-aware run lifecycle this file asks for arrived in. Naming the
+     Team member an interrupt was raised inside needs the later release the
+     README states; this file serves a single agent and needs no part of that.
+Run: .venvs/demo/bin/python cookbook/05_agent_os/16_agui/interrupt_round_trip.py
+Try: POST to http://localhost:7777/interrupts/agui, read the interrupt ids off
+     RUN_FINISHED, then POST the same body again on the same threadId with one
+     field added: "resume": [{"interruptId": "<id>", "status": "resolved",
+     "payload": {"accepted": true}}]. One array answers every interrupt the
+     outcome carried, so a request naming two recipients pauses on two calls and
+     takes two entries: answering one of them is refused as a partial resume,
+     naming the ids left open. Every field a RunAgentInput requires has to be
+     there in that second request too, or it is refused before the resume is
+     read at all. Those are threadId, runId, messages, tools, context and
+     forwardedProps on every release this file runs on, and state as well on the
+     releases that still required it, which a later one made optional, so
+     sending all seven is what works across the range; the README's Resuming
+     section shows both requests in full. A second threadId is a second Agno
+     session, so it starts a new run instead of resuming the paused one.
+"""
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIResponses
+from agno.os import AgentOS
+from agno.os.interfaces.agui import AGUI
+from agno.tools import tool
+
+# ---------------------------------------------------------------------------
+# Create Confirmation Tool and Agent
+# ---------------------------------------------------------------------------
+
+
+@tool(requires_confirmation=True)
+def send_email(to: str, subject: str, body: str) -> str:
+    """Simulate sending one email after a user confirms its contents."""
+    return f"Email sent to {to} with subject '{subject}'."
+
+
+db = SqliteDb(
+    id="agui-interrupt-db",
+    db_file="tmp/agui_interrupt_round_trip.db",
+)
+
+email_agent = Agent(
+    id="agui-interrupt-agent",
+    name="AG-UI Interrupt Agent",
+    model=OpenAIResponses(id="gpt-5.6-luna"),
+    db=db,
+    tools=[send_email],
+    instructions=[
+        (
+            "For every email request, call send_email immediately with the "
+            "recipient, subject, and body."
+        ),
+        (
+            "Do not ask for confirmation in prose. AgentOS pauses the tool call "
+            "and lets the AG-UI client collect the confirmation."
+        ),
+        "Never claim send_email ran before its tool result is available.",
+        "After a confirmed call, report the recipient and subject in one sentence.",
+    ],
+)
+
+agent_os = AgentOS(
+    id="agui-interrupt-os",
+    description="The AG-UI interrupt round trip, with and without the typed outcome.",
+    agents=[email_agent],
+    interfaces=[
+        AGUI(agent=email_agent, prefix="/interrupts", emit_interrupt_outcome=True),
+        AGUI(agent=email_agent, prefix="/interrupts-quiet"),
+    ],
+)
+app = agent_os.get_app()
+
+# ---------------------------------------------------------------------------
+# Run Interrupt Round Trip Server
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    agent_os.serve(app=app)

--- a/cookbook/05_agent_os/16_agui/team_subagent_lineage.py
+++ b/cookbook/05_agent_os/16_agui/team_subagent_lineage.py
@@ -1,0 +1,99 @@
+"""
+Attribute Team member work over AG-UI
+=====================================
+
+A Team run mixes the leader's own output with the output of every member it
+delegated to. By default AG-UI streams all of it as the team's work, which is
+what released clients already expect. Set subagent_visibility="attributed" and
+the same run also carries lineage: SUBAGENT_STARTED, then SUBAGENT_FINISHED or
+SUBAGENT_ERROR, per delegation, and a subagentRunId on the events that carry a
+member's own output, so a client can label its messages, tool calls and
+reasoning per member.
+Session state events are left unattributed on purpose: a team's session state is
+one shared document, so a client filtering by member must not lose a change a
+member's tool made.
+
+The same team is mounted twice so the two streams can be compared side by side.
+Send the same prompt to each mount, but give each request its own threadId, for
+example "lineage-attributed" for /lineage and "lineage-inline" for
+/lineage-inline. A threadId becomes the Agno session id, so reusing one across
+both mounts is guaranteed to do one thing: the second request continues the
+first request's session, that session's history included. Whether the leader
+delegates again from there is the model's decision, not something this file can
+promise, but the answer is already in the history it reads, so it will most
+likely reply straight from it and leave the second stream with little or no
+member work to compare.
+
+Prerequisites: OPENAI_API_KEY, internet access, and ag-ui-protocol 0.1.21 or newer
+Run: .venvs/demo/bin/python cookbook/05_agent_os/16_agui/team_subagent_lineage.py
+Try: POST one prompt per threadId to http://localhost:7777/lineage/agui, then /lineage-inline/agui
+"""
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIResponses
+from agno.os import AgentOS
+from agno.os.interfaces.agui import AGUI
+from agno.team import Team
+from agno.tools.websearch import WebSearchTools
+
+# ---------------------------------------------------------------------------
+# Create Team and Interface Mounts
+# ---------------------------------------------------------------------------
+
+db = SqliteDb(
+    id="agui-lineage-db",
+    db_file="tmp/agui_team_lineage.db",
+)
+
+researcher = Agent(
+    id="lineage-researcher",
+    name="Researcher",
+    role="Find current, relevant source material.",
+    model=OpenAIResponses(id="gpt-5.6-luna"),
+    db=db,
+    tools=[WebSearchTools()],
+    instructions="Search the web, prefer primary sources, and return concise findings with URLs.",
+)
+
+writer = Agent(
+    id="lineage-writer",
+    name="Writer",
+    role="Turn research into a short, readable brief.",
+    model=OpenAIResponses(id="gpt-5.6-luna"),
+    db=db,
+    instructions="Synthesize supplied research without inventing unsupported facts.",
+)
+
+research_team = Team(
+    id="lineage-research-team",
+    name="AG-UI Lineage Team",
+    model=OpenAIResponses(id="gpt-5.6-luna"),
+    db=db,
+    members=[researcher, writer],
+    instructions=[
+        "Delegate research to the Researcher and synthesis to the Writer.",
+        "Return a concise brief with source links.",
+    ],
+)
+
+agent_os = AgentOS(
+    id="agui-lineage-os",
+    description="One Team served twice, with and without member attribution.",
+    teams=[research_team],
+    interfaces=[
+        # Members are announced, and the events carrying a member's own output
+        # are tagged with its run id. Session state events are not, as above.
+        AGUI(team=research_team, prefix="/lineage", subagent_visibility="attributed"),
+        # The default: member work streams as the team's own.
+        AGUI(team=research_team, prefix="/lineage-inline"),
+    ],
+)
+app = agent_os.get_app()
+
+# ---------------------------------------------------------------------------
+# Run Multi-Interface Server
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    agent_os.serve(app=app)

--- a/libs/agno/agno/os/interfaces/agui/agui.py
+++ b/libs/agno/agno/os/interfaces/agui/agui.py
@@ -6,6 +6,7 @@ from fastapi.routing import APIRouter
 
 from agno.agent import Agent
 from agno.agent.remote import RemoteAgent
+from agno.os.interfaces.agui.handlers import validate_subagent_visibility
 from agno.os.interfaces.agui.router import attach_routes
 from agno.os.interfaces.base import BaseInterface
 from agno.team import Team
@@ -23,6 +24,7 @@ class AGUI(BaseInterface):
         team: Optional[Union[Team, RemoteTeam]] = None,
         prefix: str = "",
         tags: Optional[List[str]] = None,
+        subagent_visibility: Optional[str] = None,
     ):
         """
         Initialize the AGUI interface.
@@ -32,23 +34,70 @@ class AGUI(BaseInterface):
             team: The team to expose via AG-UI
             prefix: Custom prefix for the router (e.g., "/agui/v1", "/chat/public")
             tags: Custom tags for the router (e.g., ["AGUI", "Chat"], defaults to ["AGUI"])
+            subagent_visibility: How a Team's members appear on the wire.
+                "inline" (the default) streams their work as the team's own, exactly as
+                before this option existed. "attributed" adds SUBAGENT_STARTED /
+                SUBAGENT_FINISHED / SUBAGENT_ERROR and tags the messages, tool calls
+                and reasoning a member produced with its subagent run id, so a client
+                can tell them apart per member; state events stay unattributed,
+                because a team's session state is one shared document. "hidden"
+                withholds the member lifecycle events and the per-event member
+                stamps, and streams nothing a member produced as its own work;
+                what the client receives is the team's own work, which includes
+                the delegation tool call, whose arguments name the member and
+                carry the task it was given exactly as the default sends them,
+                that call's result, and the team's own reply. Two things a member
+                produced also reach the client, a change one of its tools made to
+                the session state and a pending tool call it paused on, because
+                the first is that shared document and the run cannot continue
+                without the second; neither is attributed to the member. A
+                member's failure withholds that same identity: the lineage
+                events and the per-event stamps stay off the wire and nothing on
+                it names the member that failed, while the reason the run
+                stopped still reaches the client, because a member's terminal
+                can be the run's only account of how it ended and is then read
+                as the run's own.
+                A single Agent that runs no agent of its own has one lane, and its
+                stream is the same under all three settings, a pause included. That
+                covers a pending call the pause reports more than once, by carrying
+                it on two of its lists at once: every setting prompts such a call
+                once per listing, duplicate tool call id and all, because that is
+                what the default sends. An agent a context provider runs inside the
+                outer run does report that run as its parent, and that inner run is
+                the one thing the setting changes here: under "attributed" it
+                becomes a lane of its own, under "hidden" its internals are
+                withheld, and both read a pending tool call it paused on off the
+                outer run's requirements, which the default leaves unread and so
+                does not prompt.
         """
         self.agent = agent
         self.team = team
         self.prefix = prefix
         self.tags = tags or ["AGUI"]
 
-        if not (self.agent or self.team):
+        # The missing entity is checked first: it is the more fundamental error,
+        # so it is the one reported when both are wrong. Presence, never
+        # truthiness, exactly as the routes and the scope mapping decide it.
+        if self.agent is None and self.team is None:
             raise ValueError("AGUI requires an agent or a team")
+
+        self.subagent_visibility = validate_subagent_visibility(subagent_visibility)
 
     def get_router(self) -> APIRouter:
         self.router = APIRouter(prefix=self.prefix, tags=self.tags)  # type: ignore
 
-        self.router = attach_routes(router=self.router, agent=self.agent, team=self.team)
+        self.router = attach_routes(
+            router=self.router,
+            agent=self.agent,
+            team=self.team,
+            subagent_visibility=self.subagent_visibility,
+        )
 
         return self.router
 
     def get_scope_mappings(self) -> dict:
-        # Agent-wins precedence must match router dispatch (entity = agent or team)
+        # An agent takes precedence over a team, on presence, which is how the
+        # routes pick the entity a request runs: a scope naming the other family
+        # would authorize something the route never dispatches to.
         family = "agents" if self.agent is not None else "teams"
         return {f"POST {self.prefix}/agui": [f"{family}:run"]}

--- a/libs/agno/agno/os/interfaces/agui/handlers.py
+++ b/libs/agno/agno/os/interfaces/agui/handlers.py
@@ -1,7 +1,15 @@
 import copy
 import json
 import uuid
-from typing import Any, Callable, Dict, List, Optional
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type
+
+try:
+    import ag_ui.core  # noqa: F401
+except ImportError as e:
+    # The AG-UI interface is an optional extra; say which package is missing
+    # rather than surfacing a bare ModuleNotFoundError from deep in the import.
+    raise ImportError("`ag_ui` not installed. Please install it with `pip install -U ag-ui-protocol`") from e
 
 from ag_ui.core import (
     BaseEvent,
@@ -28,19 +36,341 @@ from ag_ui.core import (
     RunErrorEvent as AGUIRunErrorEvent,
 )
 
+try:
+    from ag_ui.core import (
+        SubagentErrorEvent,
+        SubagentFinishedEvent,
+        SubagentStartedEvent,
+    )
+
+    SUBAGENT_EVENTS_AVAILABLE = True
+except ImportError:  # ag-ui-protocol older than the subagent lineage events
+    from agno.utils.log import log_debug
+
+    SUBAGENT_EVENTS_AVAILABLE = False
+    log_debug(
+        "AG-UI subagent lineage events (SUBAGENT_STARTED / SUBAGENT_FINISHED / SUBAGENT_ERROR) are "
+        "missing from the installed ag_ui.core, so Team member attribution is unavailable. "
+        "Please upgrade with `pip install -U ag-ui-protocol`."
+    )
+
 from agno.models.response import ToolExecution
-from agno.os.interfaces.agui.state import StreamState
+from agno.os.interfaces.agui.state import (
+    ROOT_LANE,
+    SUBAGENT_VISIBILITY_ATTRIBUTED,
+    SUBAGENT_VISIBILITY_INLINE,
+    SUBAGENT_VISIBILITY_VALUES,
+    StreamState,
+)
 from agno.os.interfaces.agui.utils import to_json_str
 from agno.reasoning.step import ReasoningStep
 from agno.run.agent import RunContentEvent, RunEvent
 from agno.run.agent import RunPausedEvent as AgentRunPausedEvent
 from agno.run.base import BaseRunOutputEvent
+from agno.run.requirement import RunRequirement
 from agno.run.team import RunContentEvent as TeamRunContentEvent
 from agno.run.team import RunPausedEvent as TeamRunPausedEvent
 from agno.run.team import TeamRunEvent
+from agno.utils.log import log_error, log_warning
 from agno.utils.message import get_text_from_message
+from agno.utils.string import url_safe_string
 
 EventHandler = Callable[[BaseRunOutputEvent, StreamState], List[BaseEvent]]
+
+# The events that carry a ``subagent_run_id`` and are stamped with the lane of
+# the chunk they were mapped from, so the stream is self-describing per event and
+# a client never has to reconstruct attribution from an earlier event. Each type
+# is kept against the class this interface builds it from, which is what lets
+# the startup check feature-detect the field on every one of them.
+# Run-lifecycle and SUBAGENT_* events are excluded: the former belong to the run
+# as a whole, the latter carry their subagent id in a dedicated field. STATE_* is
+# excluded too, because a team's session state is one shared document; a client
+# filtering by lane must not lose state written during a delegation.
+_ATTRIBUTABLE_EVENT_CLASSES: Dict[EventType, Type[BaseEvent]] = {
+    EventType.TEXT_MESSAGE_START: TextMessageStartEvent,
+    EventType.TEXT_MESSAGE_CONTENT: TextMessageContentEvent,
+    EventType.TEXT_MESSAGE_END: TextMessageEndEvent,
+    EventType.TOOL_CALL_START: ToolCallStartEvent,
+    EventType.TOOL_CALL_ARGS: ToolCallArgsEvent,
+    EventType.TOOL_CALL_END: ToolCallEndEvent,
+    EventType.TOOL_CALL_RESULT: ToolCallResultEvent,
+    EventType.REASONING_START: ReasoningStartEvent,
+    EventType.REASONING_MESSAGE_START: ReasoningMessageStartEvent,
+    EventType.REASONING_MESSAGE_CONTENT: ReasoningMessageContentEvent,
+    EventType.REASONING_MESSAGE_END: ReasoningMessageEndEvent,
+    EventType.REASONING_END: ReasoningEndEvent,
+    EventType.CUSTOM: CustomEvent,
+    EventType.RAW: RawEvent,
+}
+
+# Derived from the classes, so the set the stamp tests an event against and the
+# classes the startup check feature-detects cannot drift apart.
+_SUBAGENT_ATTRIBUTABLE_EVENT_TYPES = frozenset(_ATTRIBUTABLE_EVENT_CLASSES)
+
+# The field those events carry the lane in.
+_SUBAGENT_RUN_ID_FIELD = "subagent_run_id"
+
+# The code a cancelled subagent's terminal carries, so a client can tell a
+# cancellation from a failure.
+_SUBAGENT_CANCELLED_CODE = "cancelled"
+
+# The pending-call lists a paused run's terminal carries, in the order the pause
+# prompt reads them. One pending call can be flagged for several of these at
+# once, and is then listed by each of them; the prompt sends it once per
+# listing, whichever visibility is set, which is what this interface has always
+# done.
+_PAUSE_TOOL_LISTS: Tuple[str, ...] = (
+    "tools_awaiting_external_execution",
+    "tools_requiring_confirmation",
+    "tools_requiring_user_input",
+)
+
+# What the ``hidden`` record of a subagent terminal says about the text beside
+# it. Such a terminal can be the only account the stream carries of how the run
+# stopped, and is then read as the run's own, so the text is on the wire even
+# though nothing on the wire names the subagent it came from. Written once and
+# shared by every terminal that can end the run that way, so a record of one of
+# them cannot claim the client was told nothing.
+_REASON_STILL_REACHES_THE_CLIENT = "the run terminal still reports this reason if the run ends here"
+
+
+def _chunk_run_ids(chunk: BaseRunOutputEvent) -> Tuple[Optional[str], Optional[str]]:
+    """The chunk's own run id, and the run that delegated to it when there is one."""
+    return getattr(chunk, "run_id", None), getattr(chunk, "parent_run_id", None)
+
+
+def _readable(value: Any, described: str) -> Optional[str]:
+    """A value as display text, or None when it is falsy or reading it raises.
+
+    A name reaches the chunk straight off the caller's own Agent or Team, so
+    rendering one can raise. A label is never worth ending a run for, so a value
+    that cannot be read is recorded and treated as absent.
+
+    Falsy is absent too, and deliberately: every caller is choosing a label, and
+    the empty string, an empty mapping and zero are all nothing to show, so each
+    of them falls through to whatever the caller offers next rather than
+    reaching the wire as ``""`` or ``"0"``. A caller that has to tell an empty
+    value from a missing one cannot use this.
+    """
+    try:
+        return str(value) if value else None
+    except Exception as error:
+        log_warning(f"AG-UI could not read {described}: {error}")
+        return None
+
+
+def _member_id(chunk: BaseRunOutputEvent) -> Optional[str]:
+    """The member id the framework's delegation tools name this run's entity by.
+
+    Derived as ``agno.utils.team.get_member_id`` derives it: an explicit id
+    verbatim, and otherwise the url-safe form of the member's name. Initializing
+    a Team assigns an id to every Agent and Team member it holds, so a member of
+    a locally built Team is matched by its id and never reaches the name branch.
+    That branch is for the chunks that assignment does not stand behind: a
+    remote entity's are rebuilt from what its stream sent rather than stamped by
+    this process, and reading the id alone would leave a member arriving that
+    way unmatched against the call that spawned it.
+    """
+    for id_attribute, name_attribute in (("agent_id", "agent_name"), ("team_id", "team_name")):
+        explicit = _readable(getattr(chunk, id_attribute, None), f"a member id from {id_attribute}")
+        if explicit:
+            return explicit
+        name = _readable(getattr(chunk, name_attribute, None), f"a member name from {name_attribute}")
+        if name:
+            return url_safe_string(name)
+    return None
+
+
+def _subagent_name(chunk: BaseRunOutputEvent, subagent_run_id: str) -> str:
+    for attribute in ("agent_name", "team_name", "agent_id", "team_id"):
+        name = _readable(getattr(chunk, attribute, None), f"a subagent name from {attribute}")
+        if name:
+            return name
+    return subagent_run_id
+
+
+def _stamp_lane(events: List[BaseEvent], lane: Optional[str]) -> List[BaseEvent]:
+    """Attribute events to a subagent lane, leaving any explicit id in place.
+
+    The protocol models accept extra attributes, so a plain write would succeed on
+    an event type that does not declare the field and hand the client an
+    undeclared one instead. Only a declared field is ever written. A protocol
+    that declares none on an event this interface attributes is refused when the
+    routes are mounted, so nothing reaches the skip below; it is a skip rather
+    than a raise because this runs while a client is already reading the stream,
+    where nothing may abort the run.
+    """
+    if lane is None:
+        return events
+    for event in events:
+        if event.type not in _SUBAGENT_ATTRIBUTABLE_EVENT_TYPES:
+            continue
+        if _SUBAGENT_RUN_ID_FIELD not in type(event).model_fields:
+            continue
+        if getattr(event, _SUBAGENT_RUN_ID_FIELD, None) is None:
+            setattr(event, _SUBAGENT_RUN_ID_FIELD, lane)
+    return events
+
+
+def _announce_subagent(chunk: BaseRunOutputEvent, state: StreamState, lane: Optional[str]) -> List[BaseEvent]:
+    """Emit SUBAGENT_STARTED the first time a subagent's lane appears.
+
+    A terminal is final for the id it names, so a lane that already closed is
+    never announced again: trailing output from a finished subagent stays
+    attributed to it without giving one invocation two lifecycles.
+
+    The parent named here is always a member this stream has already announced.
+    A parent link the client cannot resolve against an announcement it has
+    already received is a forward reference, which a validating client rejects,
+    so a grandchild whose first event outruns its parent's is announced with no
+    parent and sits directly under the run. A parent whose own terminal has
+    already gone out is left out for a different reason: it can no longer
+    terminate after a child of its own, and its delegation call is no longer a
+    link a client can follow.
+
+    A parent left out takes the rest of the delegation with it: no parent tool
+    call, no parent message and no description. Those are read from the
+    delegating lane's own open calls, and a lane that cannot be named has none
+    to read; falling back to the top-level entity's would announce this
+    subagent with the leader's call, the leader's parent message and the
+    leader's task text as its own description.
+    """
+    if lane is None or lane in state.open_subagents or lane in state.closed_subagents:
+        return []
+
+    member_id = _member_id(chunk)
+    _, parent_run_id = _chunk_run_ids(chunk)
+    parent_lane, delegation_call_id = state.delegating_lane_for(parent_run_id, member_id)
+    name = _subagent_name(chunk, lane)
+
+    state.open_subagent(lane, name=name, parent_lane=parent_lane)
+    return [
+        SubagentStartedEvent(
+            type=EventType.SUBAGENT_STARTED,
+            subagent_run_id=lane,
+            name=name,
+            description=state.delegation_task(parent_lane, delegation_call_id),
+            parent_subagent_run_id=parent_lane,
+            parent_tool_call_id=delegation_call_id,
+            parent_message_id=state.delegation_parent_message_id(parent_lane, delegation_call_id),
+        )
+    ]
+
+
+def _correlation(details: Optional[Dict[str, Any]]) -> str:
+    """The identifiers that let an operator correlate a failure, absent ones omitted.
+
+    Every value comes off the run that failed, so rendering one can raise, and
+    each is read through the same guard every other label is: a value that
+    cannot be read is left out. Building the line an operator reads is never
+    worth ending a run for. That holds for both callers: the lane terminal,
+    which has already closed the lane, and the withheld-failure record under
+    ``hidden``, where the lane never reaches the wire at all and this line is
+    the only trace of the failure.
+    """
+    rendered: List[str] = []
+    for key, value in (details or {}).items():
+        if value is None:
+            continue
+        text = _readable(value, f"the {key} of a subagent failure")
+        if text is not None:
+            rendered.append(f", {key}={text}")
+    return "".join(rendered)
+
+
+def _lane_finished(state: StreamState, lane: Optional[str], result: Any = None) -> List[BaseEvent]:
+    """One lane's terminal event, and nothing at all when it already owns one.
+
+    Only this lane is terminated, and only its own message and reasoning spans
+    are closed, which is the same rule output trailing a terminal follows. A
+    lane below this one belongs to a run that has not stopped, and a tool call
+    still open here belongs to work that can still report its own end; ending
+    either from here sends a terminal for a member that is still going and
+    discards whatever it reports afterwards.
+
+    No outcome is ever attached. The protocol pairs a suspended subagent with a
+    run-level interrupt outcome, and this interface emits none, so a lone
+    suspended half would tell a client the subagent is waiting while the run says
+    it finished.
+    """
+    if lane is None:
+        return []
+    already_closed = lane in state.closed_subagents
+    state.close_subagent(lane)
+    if already_closed:
+        return []
+    return [
+        *_close_lane_messages(state, lane),
+        SubagentFinishedEvent(type=EventType.SUBAGENT_FINISHED, subagent_run_id=lane, result=result),
+    ]
+
+
+def _lane_errored(
+    state: StreamState,
+    lane: Optional[str],
+    message: str,
+    code: Optional[str] = None,
+    details: Optional[Dict[str, Any]] = None,
+) -> List[BaseEvent]:
+    """One lane's error terminal, or the record of a failure that arrives too late.
+
+    Closes and terminates exactly what the finish path does, for the same
+    reasons, and the failure belongs to this lane alone: a member below it never
+    failed and must not be made to report somebody else's error.
+
+    A lane that already terminated gets no second terminal: a terminal is final
+    for the id it names, and a second one would be a protocol violation. The
+    failure is still recorded, saying that the lane had already terminated and
+    that nothing about it reached the client, so a failure no client can be told
+    about is not a failure nobody is told about.
+
+    The failure is recorded here and nowhere else, once either way. The wire
+    event carries only a message and a code, so whatever identifiers would let
+    an operator correlate the failure travel in ``details``.
+    """
+    if lane is None:
+        return []
+    already_closed = lane in state.closed_subagents
+    state.close_subagent(lane)
+    correlation = _correlation(details)
+    if already_closed:
+        log_error(
+            f"AG-UI subagent lane {lane} reported a failure after it had already terminated, so no "
+            f"SUBAGENT_ERROR was sent for it (code={code}): {message}{correlation}"
+        )
+        return []
+    log_error(f"AG-UI subagent lane {lane} ended in failure (code={code}): {message}{correlation}")
+    return [
+        *_close_lane_messages(state, lane),
+        SubagentErrorEvent(type=EventType.SUBAGENT_ERROR, subagent_run_id=lane, message=message, code=code),
+    ]
+
+
+def _drain_subagents(state: StreamState) -> List[BaseEvent]:
+    """Terminate every subagent still open when the run ends.
+
+    A subagent's terminal comes from exactly two places: its own terminal event,
+    and this drain. The drain covers one whose own terminal never arrived, for
+    instance because the run paused inside it, or because it was still streaming
+    when the run ended. A run that failed goes down the error path instead, which
+    errors these lanes rather than finishing them. Deepest first, so a child's
+    terminal precedes its parent's.
+    """
+    events: List[BaseEvent] = []
+    for lane in state.subagents_deepest_first():
+        events.extend(_lane_finished(state, lane))
+    return events
+
+
+def _error_open_subagents(state: StreamState, error_message: str) -> List[BaseEvent]:
+    """Error every subagent still open when the run's stream failed.
+
+    Deepest first, so a child's terminal precedes its parent's.
+    """
+    events: List[BaseEvent] = []
+    for lane in state.subagents_deepest_first():
+        events.extend(_lane_errored(state, lane, error_message))
+    return events
 
 
 def _extract_response_chunk_content(response: RunContentEvent) -> str:
@@ -102,29 +432,115 @@ def _emit_state_delta(state: StreamState) -> List[BaseEvent]:
     return [StateDeltaEvent(type=EventType.STATE_DELTA, delta=ops)]
 
 
-def _close_open_spans(state: StreamState) -> List[BaseEvent]:
-    """End any reasoning, tool call, or text message still open, so a terminal event never leaves a dangling span."""
+def _end_lane_reasoning(state: StreamState, lane_key: Optional[str]) -> List[BaseEvent]:
+    lane = state.lane(lane_key)
+    if lane.reasoning_message_id is None:
+        return []
+    reasoning_id = lane.reasoning_message_id
+    lane.reasoning_message_id = None
+    lane.reasoning_step_count = 0
+    return [
+        ReasoningMessageEndEvent(type=EventType.REASONING_MESSAGE_END, message_id=reasoning_id),
+        ReasoningEndEvent(type=EventType.REASONING_END, message_id=reasoning_id),
+    ]
+
+
+def _end_lane_tool_calls(state: StreamState, lane_key: Optional[str]) -> List[BaseEvent]:
     events: List[BaseEvent] = []
-
-    # Close orphaned reasoning session
-    if state.reasoning_message_id is not None:
-        events.append(
-            ReasoningMessageEndEvent(type=EventType.REASONING_MESSAGE_END, message_id=state.reasoning_message_id)
-        )
-        events.append(ReasoningEndEvent(type=EventType.REASONING_END, message_id=state.reasoning_message_id))
-        state.end_reasoning()
-
-    # Close remaining active tool calls
-    for tool_call_id in list(state.active_tool_call_ids):
+    # In the order the run opened them: these ends are swept out of a set of
+    # open calls, whose iteration order would otherwise decide the wire order.
+    for tool_call_id in state.active_tool_calls_in_order():
+        if state.lane_of_tool_call(tool_call_id) != lane_key:
+            continue
         if tool_call_id not in state.ended_tool_call_ids:
             events.append(ToolCallEndEvent(type=EventType.TOOL_CALL_END, tool_call_id=tool_call_id))
             state.end_tool_call(tool_call_id)
+    return events
 
-    # Close open text message
-    if state.text_message_open:
-        events.append(TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=state.text_message_id))
-        state.close_text_message()
 
+def _end_lane_text_message(state: StreamState, lane_key: Optional[str]) -> List[BaseEvent]:
+    lane = state.lane(lane_key)
+    if not lane.text_message_open:
+        return []
+    lane.text_message_open = False
+    return [TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=lane.text_message_id)]
+
+
+def _close_lane_spans(state: StreamState, lane_key: Optional[str]) -> List[BaseEvent]:
+    """End every reasoning, tool call and text message still open in one lane."""
+    events = [
+        *_end_lane_reasoning(state, lane_key),
+        *_end_lane_tool_calls(state, lane_key),
+        *_end_lane_text_message(state, lane_key),
+    ]
+    return _stamp_lane(events, lane_key)
+
+
+def _close_lane_messages(state: StreamState, lane_key: Optional[str]) -> List[BaseEvent]:
+    """End the reasoning and text spans open in one lane, leaving its tool calls open."""
+    events = [*_end_lane_reasoning(state, lane_key), *_end_lane_text_message(state, lane_key)]
+    return _stamp_lane(events, lane_key)
+
+
+def _close_lane_tool_calls(state: StreamState, lane_key: Optional[str]) -> List[BaseEvent]:
+    """End every tool call still open in one lane."""
+    return _stamp_lane(_end_lane_tool_calls(state, lane_key), lane_key)
+
+
+def _close_all_lane_spans(state: StreamState) -> List[BaseEvent]:
+    """End every span still open in any lane, and every tool call still open.
+
+    Every lane, not only the root and the ones still being drained: a text or
+    reasoning span opened in a lane whose subagent already terminated would
+    otherwise still be open when the run terminal arrives, and a conforming
+    client rejects a run that ends inside a message. The lanes iterated include
+    every lane that owns an open tool call, so no tool call reaches the run
+    terminal without an end event. Children before parents.
+    """
+    events: List[BaseEvent] = []
+    for lane_key in state.lanes_deepest_first():
+        events.extend(_close_lane_spans(state, lane_key))
+    return events
+
+
+def _close_run_end_spans(
+    state: StreamState,
+    terminate_members: Callable[[], List[BaseEvent]],
+    interlude: Optional[Callable[[], List[BaseEvent]]] = None,
+) -> List[BaseEvent]:
+    """The single closing order both run-ending paths use.
+
+    Everything the run end emits after the sweep lands outside every span the
+    stream had open, which is the one position that holds for all three
+    visibilities. ``interlude`` is the pause prompt: it opens a message and tool
+    calls of its own, so it goes out once no message and no tool call is still
+    open, and before ``terminate_members``, because the calls it carries are
+    stamped with the members it is prompting for and nothing may carry a member
+    after that member's terminal. That leaves the member terminals last, outside
+    the delegation call that spawned them rather than inside it.
+
+    With member lanes on the wire the spans close in two passes, children before
+    parents in each, so a member's terminal never lands inside another lane's
+    message. With none there is no terminal to position, so one pass per lane
+    closes everything and the emitted stream is exactly what it was before member
+    attribution existed.
+    """
+    events: List[BaseEvent] = []
+    if not state.announced_subagents:
+        # No lane was ever announced, so no lane can be open and there is nothing
+        # for ``terminate_members`` to produce.
+        events.extend(_close_all_lane_spans(state))
+        if interlude is not None:
+            events.extend(interlude())
+        return events
+
+    for lane_key in state.lanes_deepest_first():
+        events.extend(_close_lane_messages(state, lane_key))
+    for lane_key in state.lanes_deepest_first():
+        events.extend(_close_lane_tool_calls(state, lane_key))
+    if interlude is not None:
+        events.extend(interlude())
+    events.extend(terminate_members())
     return events
 
 
@@ -207,6 +623,10 @@ def on_tool_call_started(chunk: BaseRunOutputEvent, state: StreamState) -> List[
     )
 
     state.start_tool_call(tool.tool_call_id)
+    # A delegation is one of these calls; remembering the arguments and the parent
+    # message lets a subagent be linked back to the exact call that spawned it
+    # once its first event arrives.
+    state.record_open_tool_call(tool.tool_call_id, tool.tool_name, tool.tool_args, parent_message_id)
     return events
 
 
@@ -343,21 +763,65 @@ def on_unknown_event(chunk: BaseRunOutputEvent, state: StreamState) -> List[Base
     return [RawEvent(type=EventType.RAW, event=raw_dict, source="agno")]
 
 
-def on_run_error(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
-    """Close open spans, then emit the terminal AG-UI error event. Nothing may follow RUN_ERROR."""
+def close_open_spans(state: StreamState, error_message: str) -> List[BaseEvent]:
+    """End every span and member lane the stream left open, without a run terminal.
+
+    The open member lanes terminate as errored rather than finished, since the
+    run they belonged to did not reach its own end. No run terminal is included:
+    the caller owns that, and nothing may follow one on the wire.
+    """
+    return _close_run_end_spans(state, lambda: _error_open_subagents(state, error_message))
+
+
+def _terminal_raw_event(chunk: BaseRunOutputEvent, state: StreamState) -> Optional[Dict[str, Any]]:
+    """The failing chunk, verbatim, when it is the run's own account of the failure.
+
+    A run that died inside a subagent has no terminal of its own, so the
+    subagent's is read as the run's. The chunk itself is not: it is a subagent's
+    record, and it names the subagent, its run and the run that delegated to it.
+    Under ``hidden`` that is the identity the whole visibility withholds, put
+    back on the wire by the event that follows the line recording the failure was
+    kept off it; under ``attributed`` it is a subagent's own event dressed as the
+    run's. Only the default embeds it, whose stream is what it was before member
+    attribution existed.
+    """
+    if state.lane_for(*_chunk_run_ids(chunk)) is not ROOT_LANE:
+        return None
     try:
-        raw_event: Any = chunk.to_dict()
+        return chunk.to_dict()
     except Exception:
-        raw_event = {"event": str(getattr(chunk, "event", "RunError"))}
+        return {"event": str(getattr(chunk, "event", "RunError"))}
 
-    message = getattr(chunk, "content", None) or "Run failed"
-    error_type = getattr(chunk, "error_type", None)
 
-    events = _close_open_spans(state)
+def _terminal_failure(chunk: BaseRunOutputEvent, normalized: str) -> Tuple[str, Optional[str]]:
+    """What a failed run terminal says, and the code it says it under.
+
+    A cancellation is not a failure of the run's own making, so it reports the
+    reason it was cancelled for under the same code a cancelled member's
+    terminal carries. Only a subagent's cancellation ever reaches here: the
+    top-level entity's is not read as a run terminal at all.
+    """
+    if normalized == RunEvent.run_cancelled.value:
+        reason = _readable(getattr(chunk, "reason", None), "a cancelled run reason")
+        return reason or "Run cancelled", _SUBAGENT_CANCELLED_CODE
+    return str(getattr(chunk, "content", None) or "Run failed"), getattr(chunk, "error_type", None)
+
+
+def on_run_error(chunk: BaseRunOutputEvent, state: StreamState, normalized: str) -> List[BaseEvent]:
+    """Close open spans, then emit the terminal AG-UI error event. Nothing may follow RUN_ERROR.
+
+    ``normalized`` is the chunk's event name, which says which kind of failed
+    terminal this is. It is required rather than defaulted: a default would read
+    every cancellation as a plain failure and report the wrong code for it.
+    """
+    raw_event = _terminal_raw_event(chunk, state)
+    message, error_type = _terminal_failure(chunk, normalized)
+
+    events: List[BaseEvent] = close_open_spans(state, message)
     events.append(
         AGUIRunErrorEvent(
             type=EventType.RUN_ERROR,
-            message=str(message),
+            message=message,
             code=error_type,
             rawEvent=raw_event,
         )
@@ -365,72 +829,415 @@ def on_run_error(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEven
     return events
 
 
-def on_run_completed(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
-    events = _close_open_spans(state)
+@dataclass
+class _PausedMemberLane:
+    """A member lane a paused run needs on the wire, resolved but not yet announced."""
 
-    # 1. Collect paused tools for frontend rendering
-    paused_tools: List[ToolExecution] = []
-    if isinstance(chunk, AgentRunPausedEvent):
-        paused_tools = (
-            chunk.tools_awaiting_external_execution
-            + chunk.tools_requiring_confirmation
-            + chunk.tools_requiring_user_input
-        )
-    elif isinstance(chunk, TeamRunPausedEvent):
-        # Leader tools from .tools, member tools from active_requirements
-        paused_tools = (
-            chunk.tools_awaiting_external_execution
-            + chunk.tools_requiring_confirmation
-            + chunk.tools_requiring_user_input
-        )
-        for req in chunk.active_requirements:
-            if req.member_agent_id and req.tool_execution:
-                paused_tools.append(req.tool_execution)
+    run_id: str
+    name: str
+    parent_lane: Optional[str]
+    delegation_call_id: Optional[str]
 
-    if paused_tools:
-        assistant_message_id = str(uuid.uuid4())
+
+@dataclass
+class _PausedToolCall:
+    """One pending tool call a paused run can prompt the client with.
+
+    The id and the name are both required rather than optional: an event cannot
+    be built without the id and nothing can be rendered without the name, so a
+    pending call missing either is dropped before it becomes one of these.
+    """
+
+    tool_call_id: str
+    tool_name: str
+    tool_args: Any
+    lane: Optional[str]
+
+
+@dataclass
+class _PausedPrompt:
+    """What a paused run's terminal asks the client to resolve.
+
+    ``carried`` counts the pending calls the terminal listed before any were
+    dropped or deduplicated, because whether the pause is announced at all
+    turns on the terminal having listed one, never on what survived. ``dropped``
+    counts the ones the client cannot be shown.
+
+    ``content`` is the paused run's own text and ``content_lane`` the lane that
+    text belongs to. A pause reported by a member carries the member's words, so
+    they go out on the member's lane or not at all; the leader's own pause
+    carries the leader's, on the root lane.
+    """
+
+    lanes: Dict[str, _PausedMemberLane]
+    tool_calls: List[_PausedToolCall]
+    carried: int
+    dropped: int
+    content: Optional[str]
+    content_lane: Optional[str]
+
+
+def _prompt_lane(state: StreamState, lane: Optional[str]) -> Optional[str]:
+    """The lane a pause prompt may stamp, or the root lane when none can be named.
+
+    Only ``attributed`` names members on the wire: ``inline`` has one lane, and
+    ``hidden`` must not let a confirmation prompt reveal which member asked. A
+    lane whose terminal has already gone out is not named either, since a
+    terminal is final for the id it names and nothing may carry a member after
+    it.
+    """
+    if lane is ROOT_LANE or state.subagent_visibility != SUBAGENT_VISIBILITY_ATTRIBUTED:
+        return ROOT_LANE
+    return lane if lane in state.open_subagents else ROOT_LANE
+
+
+def _paused_member_lane(
+    state: StreamState,
+    requirement: RunRequirement,
+    pending: Dict[str, _PausedMemberLane],
+) -> Optional[str]:
+    """The lane a paused member's tool call is stamped with, resolving a new one.
+
+    Only ``attributed`` names members on the wire: ``inline`` has one lane, and
+    ``hidden`` must not let a confirmation prompt reveal which member asked.
+
+    A lane the client was never given a start for is unreadable, so a lane this
+    is the first sight of is recorded in ``pending`` for the caller to announce.
+    Nothing is announced from here: whether the prompt these lanes are for is
+    emitted at all is not known until every paused tool has been read, and a
+    lane announced for a prompt that is then dropped leaves the client a
+    terminal for a member it never saw start.
+
+    When no lane can be named, because the member's run is unknown or because
+    its terminal has already gone out and a terminal is final for the id it
+    names, the tool call falls back to the root lane instead of carrying an id
+    the client cannot resolve.
+    """
+    member_run_id = requirement.member_run_id
+    if member_run_id is None or member_run_id == state.root_run_id:
+        return ROOT_LANE
+    if state.subagent_visibility != SUBAGENT_VISIBILITY_ATTRIBUTED:
+        return ROOT_LANE
+    if member_run_id in state.open_subagents or member_run_id in pending:
+        return member_run_id
+    if member_run_id in state.closed_subagents:
+        return ROOT_LANE
+
+    # A member pauses inside the call that delegated to it, so the lane holding
+    # that call is the parent, at whatever depth the pause was reported. Without
+    # an open delegation naming this member there is nothing that establishes
+    # either, so both are left out: reaching past for the leader's own open call
+    # gives the member a parent it never had, the task text of somebody else's
+    # delegation, and a depth that puts a grandchild level with the member that
+    # really delegated to it.
+    parent_lane: Optional[str] = ROOT_LANE
+    delegation_call_id: Optional[str] = None
+    delegation = state.find_member_delegation(requirement.member_agent_id)
+    if delegation is not None:
+        parent_lane, delegation_call_id = delegation
+
+    # The member's name and id come off the paused run, so both are read through
+    # the same guard every other label is: a lane whose name cannot be rendered
+    # is announced under its run id rather than ending a run that is only
+    # waiting for an answer.
+    name = (
+        _readable(requirement.member_agent_name, "a paused member name")
+        or _readable(requirement.member_agent_id, "a paused member id")
+        or member_run_id
+    )
+    pending[member_run_id] = _PausedMemberLane(
+        run_id=member_run_id,
+        name=name,
+        parent_lane=parent_lane,
+        delegation_call_id=delegation_call_id,
+    )
+    return member_run_id
+
+
+def _announce_paused_lanes(state: StreamState, pending: Dict[str, _PausedMemberLane]) -> List[BaseEvent]:
+    """Announce the member lanes a pause prompt is about to carry."""
+    events: List[BaseEvent] = []
+    for lane in pending.values():
+        state.open_subagent(lane.run_id, name=lane.name, parent_lane=lane.parent_lane)
         events.append(
-            TextMessageStartEvent(
-                type=EventType.TEXT_MESSAGE_START,
-                message_id=assistant_message_id,
-                role="assistant",
+            SubagentStartedEvent(
+                type=EventType.SUBAGENT_STARTED,
+                subagent_run_id=lane.run_id,
+                name=lane.name,
+                description=state.delegation_task(lane.parent_lane, lane.delegation_call_id),
+                parent_subagent_run_id=lane.parent_lane,
+                parent_tool_call_id=lane.delegation_call_id,
+                parent_message_id=state.delegation_parent_message_id(lane.parent_lane, lane.delegation_call_id),
             )
         )
+    return events
 
-        content = getattr(chunk, "content", None)
-        if content:
-            events.append(
-                TextMessageContentEvent(
-                    type=EventType.TEXT_MESSAGE_CONTENT,
-                    message_id=assistant_message_id,
-                    delta=str(content),
-                )
+
+def _active_requirements(chunk: BaseRunOutputEvent) -> List[RunRequirement]:
+    """The requirements a paused run still needs resolved, on a release that reports them.
+
+    Both paused event types declare the field, and one that does not is read as
+    reporting none: a pause is what the client has to be told about, so a
+    missing field withholds the attribution rather than the prompt.
+    """
+    requirements = getattr(chunk, "active_requirements", None)
+    return list(requirements) if requirements else []
+
+
+def _paused_tools_with_lanes(chunk: BaseRunOutputEvent, state: StreamState) -> _PausedPrompt:
+    """The tool calls a paused run is waiting on, each with the lane that owns it.
+
+    A tool can be reported twice, once on the terminal event's own lists, which
+    carry copies of what its members are waiting on as well as the leader's own
+    tools, and once on the requirement that names the member waiting on it. It
+    is one pending call, so it is prompted once, on the member's lane. A call
+    already on the wire under a member's lane is then not prompted at all: the
+    client has a start for it and a second one would be a duplicate id. A call
+    of the top-level entity's own is prompted whichever visibility is set, so a
+    run with no member on the wire streams exactly what the default streams.
+    Neither the merge nor the drop applies under the default itself, whose
+    stream stays what it was before member attribution existed.
+
+    Only a requirement's copy ever merges into one already recorded. The
+    terminal's own lists are read as they are, so a pending call flagged for
+    several of them, and therefore listed by each, is prompted once per listing
+    under every visibility: that duplicate is the default's stream, and the
+    default's stream is the one every setting has to match on a run with no
+    member on the wire.
+
+    The terminal's own lists belong to the run that reported the pause. That is
+    the leader's for a leader's pause, and a member's where a member's pause was
+    the last thing the stream carried and became the run terminal, so those
+    tools are stamped with the run that is really waiting on them.
+
+    A tool without both an id and a name is dropped and recorded: there is
+    nothing the client could render and nothing to tell a duplicate by, and the
+    resume then waits on a call nothing asked for. Lanes come back alongside,
+    unannounced and only for the members a surviving tool call is stamped with,
+    since a lane the prompt carries nothing for tells the client about a member
+    it will never hear from again.
+    """
+    pending: Dict[str, _PausedMemberLane] = {}
+    recorded: List[_PausedToolCall] = []
+    carried = 0
+    dropped = 0
+    lineage = state.subagent_visibility != SUBAGENT_VISIBILITY_INLINE
+    terminal_lane = state.lane_for(*_chunk_run_ids(chunk))
+    reporting_lane = _prompt_lane(state, terminal_lane)
+
+    def record(tool: ToolExecution, lane: Optional[str], merges: bool) -> None:
+        nonlocal carried, dropped
+        carried += 1
+        if tool.tool_call_id is None or tool.tool_name is None:
+            dropped += 1
+            log_warning(
+                f"AG-UI dropped a pending tool call from the pause of run {state.run_id} in session "
+                f"{state.thread_id}, because the client cannot be shown it: tool_call_id={tool.tool_call_id}, "
+                f"tool_name={tool.tool_name}. A resume waits on that call with nothing on the wire to resolve it."
             )
+            return
+        prompted = _PausedToolCall(
+            tool_call_id=tool.tool_call_id, tool_name=tool.tool_name, tool_args=tool.tool_args, lane=lane
+        )
+        if merges:
+            for index, already in enumerate(recorded):
+                if already.tool_call_id == prompted.tool_call_id:
+                    # The member's attribution wins over the unattributed copy,
+                    # in the position the call was first reported in.
+                    recorded[index] = prompted
+                    return
+        recorded.append(prompted)
 
-        events.append(TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=assistant_message_id))
+    if isinstance(chunk, (AgentRunPausedEvent, TeamRunPausedEvent)):
+        for list_name in _PAUSE_TOOL_LISTS:
+            for tool in getattr(chunk, list_name, None) or ():
+                record(tool, reporting_lane, merges=False)
+        # A subagent's tools live in the requirements, which name the run waiting
+        # on them, and that attribution wins over the unattributed copy above. An
+        # agent that ran an inner agent reports them exactly as a team reports a
+        # member's, so lineage reads both paused shapes: a pending call the client
+        # is not shown is one the run can never be resumed past.
+        # The default is the pre-change stream, which read this on a team's pause only: an agent's is lineage behavior.
+        if lineage or isinstance(chunk, TeamRunPausedEvent):
+            for requirement in _active_requirements(chunk):
+                if not (requirement.member_agent_id and requirement.tool_execution):
+                    continue
+                record(
+                    requirement.tool_execution,
+                    _paused_member_lane(state, requirement, pending),
+                    merges=lineage,
+                )
 
-        for tool in paused_tools:
-            if tool.tool_call_id is None or tool.tool_name is None:
-                continue
+    if lineage:
+        # Read once every copy of a call has been merged, so a call the wire
+        # already carries under its member's lane is dropped whichever of the two
+        # places reported it first.
+        recorded = [
+            tool_call
+            for tool_call in recorded
+            if tool_call.lane is ROOT_LANE or not state.tool_call_started(tool_call.tool_call_id)
+        ]
 
-            events.append(
+    stamped = {tool_call.lane for tool_call in recorded}
+    return _PausedPrompt(
+        lanes={run_id: lane for run_id, lane in pending.items() if run_id in stamped},
+        tool_calls=recorded,
+        carried=carried,
+        dropped=dropped,
+        content=_pause_content(chunk, terminal_lane, reporting_lane),
+        content_lane=reporting_lane,
+    )
+
+
+def _pause_content(
+    chunk: BaseRunOutputEvent,
+    terminal_lane: Optional[str],
+    reporting_lane: Optional[str],
+) -> Optional[str]:
+    """The paused run's own words, or None when there are none to send.
+
+    A member's pause carries the member's words, so they go out on the member's
+    lane. A visibility that will not name that lane withholds them instead of
+    passing a member's prose off as the run's own reply.
+    """
+    content = getattr(chunk, "content", None)
+    if not content:
+        return None
+    if terminal_lane is not ROOT_LANE and reporting_lane is ROOT_LANE:
+        return None
+    return str(content)
+
+
+def _pause_prompt(
+    state: StreamState,
+    announcements: List[BaseEvent],
+    prompt: _PausedPrompt,
+) -> List[BaseEvent]:
+    """The assistant messages and tool calls a paused run asks the client to resolve.
+
+    One message per lane, each carrying that lane's own pending calls. A tool
+    call belongs to the message that carries it, so the two must agree about
+    which member they are: one message stamped for two members is unreadable,
+    and an unstamped message carrying a member's call is a call a client cannot
+    place. One pause can be waiting on several members at once, so one message
+    is not enough and the split is per lane rather than one message with mixed
+    calls under it.
+
+    A pause with nothing left to show still says something when the client was
+    never shown what the run is waiting on: a bare message tells it the run is
+    waiting rather than finished. A call left out because the client already has
+    a start for it is the case that needs nothing, being already on the wire to
+    be acted on.
+    """
+    if not prompt.carried:
+        return []
+
+    events: List[BaseEvent] = list(announcements)
+    blocks = _prompt_blocks(prompt)
+    if not blocks:
+        if not prompt.dropped:
+            return events
+        blocks = [(prompt.content_lane, [])]
+
+    for lane, tool_calls in blocks:
+        events.extend(_prompt_block(state, lane, tool_calls, prompt.content if lane == prompt.content_lane else None))
+    return events
+
+
+def _prompt_blocks(prompt: _PausedPrompt) -> List[Tuple[Optional[str], List[_PausedToolCall]]]:
+    """The pause prompt split into one message per lane, in the order it was reported.
+
+    The lane the paused run's own words belong to leads, since that message is
+    the prompt's opening line whether or not any pending call is stamped with
+    the same lane.
+    """
+    grouped: Dict[Optional[str], List[_PausedToolCall]] = {}
+    if prompt.content is not None:
+        grouped[prompt.content_lane] = []
+    for tool_call in prompt.tool_calls:
+        grouped.setdefault(tool_call.lane, []).append(tool_call)
+    return list(grouped.items())
+
+
+def _prompt_block(
+    state: StreamState,
+    lane: Optional[str],
+    tool_calls: List[_PausedToolCall],
+    content: Optional[str],
+) -> List[BaseEvent]:
+    """One lane's share of a pause prompt: its message, and the calls parented to it."""
+    message_id = str(uuid.uuid4())
+    events: List[BaseEvent] = [
+        TextMessageStartEvent(
+            type=EventType.TEXT_MESSAGE_START,
+            message_id=message_id,
+            role="assistant",
+        )
+    ]
+    if content:
+        events.append(
+            TextMessageContentEvent(
+                type=EventType.TEXT_MESSAGE_CONTENT,
+                message_id=message_id,
+                delta=content,
+            )
+        )
+    events.append(TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=message_id))
+
+    for tool_call in tool_calls:
+        events.extend(
+            [
                 ToolCallStartEvent(
                     type=EventType.TOOL_CALL_START,
-                    tool_call_id=tool.tool_call_id,
-                    tool_call_name=tool.tool_name,
-                    parent_message_id=assistant_message_id,
-                )
-            )
-
-            events.append(
+                    tool_call_id=tool_call.tool_call_id,
+                    tool_call_name=tool_call.tool_name,
+                    parent_message_id=message_id,
+                ),
                 ToolCallArgsEvent(
                     type=EventType.TOOL_CALL_ARGS,
-                    tool_call_id=tool.tool_call_id,
-                    delta=json.dumps(tool.tool_args),
-                )
+                    tool_call_id=tool_call.tool_call_id,
+                    delta=json.dumps(tool_call.tool_args),
+                ),
+                ToolCallEndEvent(type=EventType.TOOL_CALL_END, tool_call_id=tool_call.tool_call_id),
+            ]
+        )
+        # The client has been given an end for this call, so the run-end sweep
+        # must not write a second one.
+        state.end_tool_call(tool_call.tool_call_id)
+
+    return _stamp_lane(events, lane)
+
+
+def on_run_completed(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
+    prompt = _paused_tools_with_lanes(chunk, state)
+    # Announced here, before the closing order is chosen, because it is only now
+    # certain which lanes the prompt really carries, and because a lane
+    # announced needs the run end to terminate it.
+    announcements = _announce_paused_lanes(state, prompt.lanes)
+    if isinstance(chunk, (AgentRunPausedEvent, TeamRunPausedEvent)) and prompt.dropped == prompt.carried:
+        # The run is waiting on something nobody can resolve, and the two ways
+        # that happens reach the client differently, so they are recorded
+        # differently. A call left out because the client already has a start
+        # for it is neither of them: that one is on the wire to be acted on.
+        if prompt.carried:
+            log_warning(
+                f"AG-UI run {state.run_id} in session {state.thread_id} paused on tool calls the client "
+                "cannot be shown, so it is told the run is waiting with nothing on the wire to act on"
+            )
+        else:
+            # No pending call was READ, which is not the same as none existing.
+            # Under the default an Agent's active requirements are left unread,
+            # so a pause whose only pending call arrives that way lands here.
+            log_warning(
+                f"AG-UI run {state.run_id} in session {state.thread_id} paused with no pending tool call "
+                "this visibility reads, so the pause reaches the client as a plain finished run"
             )
 
-            events.append(ToolCallEndEvent(type=EventType.TOOL_CALL_END, tool_call_id=tool.tool_call_id))
+    events = _close_run_end_spans(
+        state,
+        lambda: _drain_subagents(state),
+        lambda: _pause_prompt(state, announcements, prompt),
+    )
 
     # Emit final state snapshot
     if state.run_state is not None:
@@ -472,8 +1279,219 @@ _COMPLETION_EVENTS = frozenset(
 )
 
 
-def is_completion_event(chunk: BaseRunOutputEvent) -> bool:
-    """Check if this event is terminal for the stream (completed, paused, or error)."""
+def _subagent_result(content: Any) -> Optional[str]:
+    """A member's output as its terminal's result, serialized when it is not text.
+
+    A terminal event must never be the thing that fails a run that otherwise
+    succeeded, so every step here falls back rather than raising: a model dump
+    can raise on a partly-built object, and the JSON encoder raises on cyclic
+    content. The last resort is the object's own text, and failing that a note
+    naming its type.
+    """
+    if content is None or isinstance(content, str):
+        return content
+
+    model_dump_json = getattr(content, "model_dump_json", None)
+    if callable(model_dump_json):
+        try:
+            return str(model_dump_json())
+        except Exception as error:
+            log_warning(f"AG-UI could not dump a subagent result of type {type(content).__name__}: {error}")
+
+    try:
+        return to_json_str(content)
+    except Exception as error:
+        log_warning(f"AG-UI could not serialize a subagent result of type {type(content).__name__}: {error}")
+
+    try:
+        return str(content)
+    except Exception as error:
+        log_warning(f"AG-UI could not render a subagent result of type {type(content).__name__}: {error}")
+        return f"<unrenderable {type(content).__name__} result>"
+
+
+def on_subagent_completed(chunk: BaseRunOutputEvent, state: StreamState, lane: Optional[str]) -> List[BaseEvent]:
+    return _lane_finished(state, lane, result=_subagent_result(getattr(chunk, "content", None)))
+
+
+def on_subagent_error(chunk: BaseRunOutputEvent, state: StreamState, lane: Optional[str]) -> List[BaseEvent]:
+    # The failure text comes off the failing run, so it is read through the same
+    # guard every other label is: one that cannot be rendered leaves the lane
+    # reporting a failure without a message of its own, never a live run ended
+    # by the attempt to describe a dead one.
+    message = _readable(getattr(chunk, "content", None), "a subagent failure message") or "Subagent run failed"
+    return _lane_errored(
+        state,
+        lane,
+        message,
+        getattr(chunk, "error_type", None),
+        details={
+            "error_id": getattr(chunk, "error_id", None),
+            "additional_data": getattr(chunk, "additional_data", None),
+        },
+    )
+
+
+def on_subagent_cancelled(chunk: BaseRunOutputEvent, state: StreamState, lane: Optional[str]) -> List[BaseEvent]:
+    """A cancelled member is terminated as errored: it produced no result to report."""
+    reason = _readable(getattr(chunk, "reason", None), "a subagent cancellation reason") or "Subagent run cancelled"
+    return _lane_errored(state, lane, reason, _SUBAGENT_CANCELLED_CODE)
+
+
+# A subagent's own terminal, which ends that subagent rather than the stream.
+# A member's pause is deliberately absent: a paused member has not finished, so
+# its lane stays open and the run-end drain terminates it.
+_SUBAGENT_TERMINAL_HANDLERS: Dict[str, Callable[[BaseRunOutputEvent, StreamState, Optional[str]], List[BaseEvent]]] = {
+    RunEvent.run_completed.value: on_subagent_completed,
+    RunEvent.run_error.value: on_subagent_error,
+    RunEvent.run_cancelled.value: on_subagent_cancelled,
+}
+
+# A member's own pause carries nothing the client needs: the pending tool call
+# reaches it from the delegating run's requirements, so dumping the internal
+# payload would both leak it and duplicate that call.
+_SUBAGENT_WITHHELD_EVENTS = frozenset({RunEvent.run_paused.value})
+
+# Every chunk that stops a subagent, normalized. Derived from the terminal table
+# rather than listed beside it, so a terminal type this interface learns to
+# handle cannot be one the stream fails to recognize as ending a subagent: the
+# two would then disagree, and a stream whose last chunk was that terminal would
+# report the run finished after saying the subagent did not. A pause is here
+# too, and only here: it stops the subagent without terminating its lane, so it
+# has no entry in the table.
+_SUBAGENT_RUN_ENDING_EVENTS = frozenset(_SUBAGENT_TERMINAL_HANDLERS) | _SUBAGENT_WITHHELD_EVENTS
+
+
+def _events_missing_the_lane_field() -> List[str]:
+    """The event classes this interface attributes that cannot carry a lane."""
+    return sorted(
+        event_class.__name__
+        for event_class in _ATTRIBUTABLE_EVENT_CLASSES.values()
+        if _SUBAGENT_RUN_ID_FIELD not in event_class.model_fields
+    )
+
+
+def _lineage_event_fields() -> Dict[Type[BaseEvent], Tuple[str, ...]]:
+    """Every SUBAGENT_* field this interface writes, per class it writes it on.
+
+    Built here rather than at import, because on a protocol release without the
+    lineage events there are no classes to key it by.
+    """
+    return {
+        SubagentStartedEvent: (
+            _SUBAGENT_RUN_ID_FIELD,
+            "name",
+            "description",
+            "parent_subagent_run_id",
+            "parent_tool_call_id",
+            "parent_message_id",
+        ),
+        SubagentFinishedEvent: (_SUBAGENT_RUN_ID_FIELD, "result"),
+        SubagentErrorEvent: (_SUBAGENT_RUN_ID_FIELD, "message", "code"),
+    }
+
+
+def _lineage_fields_the_protocol_omits() -> List[str]:
+    """The SUBAGENT_* fields this interface writes that the installed protocol omits.
+
+    Named class by field, so the refusal says exactly what is missing. The
+    protocol models accept attributes they do not declare, so an omitted field
+    would otherwise leave the run: the value goes out under the name written
+    here instead of the one the wire format defines, and a client reads a lane
+    with no description, no parent and no result rather than a refusal.
+    """
+    if not SUBAGENT_EVENTS_AVAILABLE:
+        return []
+    return sorted(
+        f"{event_class.__name__}.{field}"
+        for event_class, fields in _lineage_event_fields().items()
+        for field in fields
+        if field not in event_class.model_fields
+    )
+
+
+def validate_subagent_visibility(visibility: Optional[str]) -> str:
+    """Normalize a subagent_visibility value, refusing one this install cannot serve.
+
+    Everything ``attributed`` needs is feature-detected here: the lineage event
+    types, every field this interface writes on one of them, and the per-event
+    field the lane is stamped in. They belong in this check rather than at the
+    events themselves, which are built with a client already reading the stream.
+    """
+    resolved = visibility or SUBAGENT_VISIBILITY_INLINE
+    if resolved not in SUBAGENT_VISIBILITY_VALUES:
+        raise ValueError(f"subagent_visibility must be one of {SUBAGENT_VISIBILITY_VALUES}, got {visibility!r}")
+    if resolved == SUBAGENT_VISIBILITY_ATTRIBUTED:
+        if not SUBAGENT_EVENTS_AVAILABLE:
+            raise ValueError(
+                "subagent_visibility='attributed' needs the AG-UI subagent lineage events. "
+                "Please upgrade with `pip install -U ag-ui-protocol`."
+            )
+        undeclared = _lineage_fields_the_protocol_omits()
+        if undeclared:
+            raise ValueError(
+                "subagent_visibility='attributed' needs every field it writes on the AG-UI subagent "
+                f"lineage events, which the installed ag_ui.core omits: {', '.join(undeclared)}. "
+                "Please upgrade with `pip install -U ag-ui-protocol`."
+            )
+        cannot_carry_a_lane = _events_missing_the_lane_field()
+        if cannot_carry_a_lane:
+            raise ValueError(
+                f"subagent_visibility='attributed' needs {_SUBAGENT_RUN_ID_FIELD} on every event it "
+                f"attributes, which the installed ag_ui.core omits on {', '.join(cannot_carry_a_lane)}. "
+                "Please upgrade with `pip install -U ag-ui-protocol`."
+            )
+    return resolved
+
+
+def _log_withheld_failure(chunk: BaseRunOutputEvent, lane: Optional[str], normalized: str) -> None:
+    """Record a member failure or cancellation that ``hidden`` keeps off the wire.
+
+    Every way a member can fail belongs here, its own run and any one of its
+    tool calls alike: with nothing on the wire naming the member, this line is
+    the only trace an operator gets of which member it was.
+
+    What ``hidden`` withholds is that identity, not always the text. A member's
+    own terminal can be the only account the stream carries of how the run
+    stopped, and is then read as the run terminal, so its failure text or its
+    cancellation reason reaches the client as the reason the run ended. Those
+    two lines say so rather than claiming the client was told nothing. A tool
+    call's failure ends no run, so nothing of it reaches the client and its line
+    says exactly that.
+    """
+    if normalized == RunEvent.run_error.value:
+        details = {
+            "error_type": getattr(chunk, "error_type", None),
+            "error_id": getattr(chunk, "error_id", None),
+            "additional_data": getattr(chunk, "additional_data", None),
+        }
+        message = _readable(getattr(chunk, "content", None), "a withheld subagent failure message")
+        log_error(
+            f"AG-UI withheld the identity of a subagent that failed in lane {lane}, so no SUBAGENT_ERROR "
+            f"named it; {_REASON_STILL_REACHES_THE_CLIENT}: "
+            f"{message or 'Subagent run failed'}{_correlation(details)}"
+        )
+    elif normalized == RunEvent.tool_call_error.value:
+        tool = getattr(chunk, "tool", None)
+        details = {
+            "tool_call_id": getattr(tool, "tool_call_id", None),
+            "tool_name": getattr(tool, "tool_name", None),
+        }
+        error = _readable(getattr(chunk, "error", None), "a withheld subagent tool call failure")
+        log_error(
+            f"AG-UI withheld a subagent tool call failure in lane {lane}: "
+            f"{error or 'Tool call failed'}{_correlation(details)}"
+        )
+    elif normalized == RunEvent.run_cancelled.value:
+        reason = _readable(getattr(chunk, "reason", None), "a withheld subagent cancellation reason")
+        log_warning(
+            f"AG-UI withheld the identity of a subagent cancelled in lane {lane}, so no SUBAGENT_ERROR "
+            f"named it; {_REASON_STILL_REACHES_THE_CLIENT}: {reason or 'Subagent run cancelled'}"
+        )
+
+
+def _ends_a_run(chunk: BaseRunOutputEvent) -> bool:
+    """Whether a chunk is one of the events that end a run: completed, paused or error."""
     event = getattr(chunk, "event", None)
     if event is None:
         return False
@@ -481,26 +1499,118 @@ def is_completion_event(chunk: BaseRunOutputEvent) -> bool:
     return event_value in _COMPLETION_EVENTS
 
 
-def process_event(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
-    """Process a single Agno event and return AG-UI events to emit."""
+def _ends_a_subagent(chunk: BaseRunOutputEvent) -> bool:
+    """Whether a chunk stops the subagent it came from."""
+    return _normalized_event_of(chunk) in _SUBAGENT_RUN_ENDING_EVENTS
+
+
+def _normalized_event_of(chunk: BaseRunOutputEvent) -> str:
+    """A chunk's event name with the Team prefix stripped, or empty when it has none."""
     event = getattr(chunk, "event", None)
     if event is None:
-        return on_unknown_event(chunk, state)
+        return ""
+    return _normalize_event(event.value if hasattr(event, "value") else str(event))
 
-    event_value = event.value if hasattr(event, "value") else str(event)
-    normalized = _normalize_event(event_value)
 
-    handler = HANDLERS.get(normalized)
-    if handler:
-        return handler(chunk, state)
+def is_completion_event(chunk: BaseRunOutputEvent, state: StreamState) -> bool:
+    """Check if this event is terminal for the stream (completed, paused, or error).
 
-    return on_unknown_event(chunk, state)
+    A subagent's own completion is terminal for that subagent only. It still
+    reads as a stream terminal under inline visibility, where the wire carries
+    no subagent lifecycle and the top-level terminal that follows supersedes it.
+    The state is what says which of the two a chunk is, so there is no answering
+    without it.
+    """
+    return _ends_a_run(chunk) and state.lane_for(*_chunk_run_ids(chunk)) is ROOT_LANE
+
+
+def is_subagent_completion_event(chunk: BaseRunOutputEvent, state: StreamState) -> bool:
+    """Whether a chunk ends one subagent rather than the run.
+
+    A stream whose last chunk is one of these ended on a subagent's terminal and
+    reported no terminal of its own, so that chunk is the only account of how the
+    run ended: read as anything else, a run that died inside a subagent is
+    reported to the client as a success. Under inline visibility every such chunk
+    is already the run's own terminal, so this is what makes the other
+    visibilities end that stream the same way.
+
+    What counts is read from the subagent terminal table rather than from the
+    run-terminal set, which a cancellation is deliberately absent from: the
+    top-level entity's cancellation is not a run terminal this interface builds
+    from, but a subagent's is a subagent terminal, and every one of those has to
+    be recognized here.
+    """
+    return _ends_a_subagent(chunk) and state.lane_for(*_chunk_run_ids(chunk)) is not ROOT_LANE
+
+
+def process_event(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
+    """Process a single Agno event and return AG-UI events to emit."""
+    lane = state.resolve_lane(*_chunk_run_ids(chunk))
+
+    event = getattr(chunk, "event", None)
+    event_value = event.value if event is not None and hasattr(event, "value") else str(event)
+    normalized = _normalize_event(event_value) if event is not None else ""
+
+    events: List[BaseEvent] = []
+    if lane is not ROOT_LANE:
+        if state.hides_subagents:
+            # Invisible delegation: nothing the subagent streamed is sent as its
+            # own work, and no lineage event or stamp goes out. The parent's own
+            # delegation tool call and its result still do, arguments included.
+            # Two things the subagent produced also reach the client. One is a
+            # change a tool of its own made to the session state, which is one
+            # shared document, delivered here. The other is a pending tool call
+            # it paused on, which the run cannot continue without and which
+            # reaches the client from the delegating run's requirements.
+            if normalized == RunEvent.tool_call_completed.value:
+                return _emit_state_delta(state)
+            # Hidden withholds what identifies a member, not the fact that one
+            # failed: nothing else would tell the operator it happened.
+            _log_withheld_failure(chunk, lane, normalized)
+            return []
+        events.extend(_announce_subagent(chunk, state, lane))
+        if normalized in _SUBAGENT_WITHHELD_EVENTS:
+            return events
+        subagent_terminal = _SUBAGENT_TERMINAL_HANDLERS.get(normalized)
+        if subagent_terminal:
+            events.extend(subagent_terminal(chunk, state, lane))
+            return events
+
+    handler = HANDLERS.get(normalized) if event is not None else None
+    mapped = handler(chunk, state) if handler else on_unknown_event(chunk, state)
+    events.extend(_stamp_lane(mapped, lane))
+    if lane is not ROOT_LANE and lane in state.closed_subagents:
+        # These events carry a member after that member's terminal, which the
+        # rest of this interface refuses to do: the run end orders the pause
+        # prompt before the member terminals, and the prompt itself declines to
+        # name a lane that has already terminated, both for that reason. This is
+        # the exemption, and it is the source stream's doing rather than a
+        # choice made here. A member whose own run already ended is still
+        # emitting, and the alternatives are worse: reparenting its output to
+        # the leader would report a member's words as somebody else's, and a
+        # second announcement would give one invocation two lifecycles.
+        #
+        # The span it opens does close with it. Left open, it swallows
+        # everything the rest of the run emits, starting with the parent's
+        # result for the delegation this member was running inside. Tool calls
+        # keep their own lifecycle, so a result still arrives for one opened
+        # here.
+        events.extend(_close_lane_messages(state, lane))
+    return events
+
+
+# The terminal chunks that end the run in failure rather than completion. A
+# cancellation is one of them: the run stopped without producing what it was
+# asked for, so telling the client it finished would report a success that never
+# happened. Only a subagent's cancellation can be the chunk the run terminal is
+# built from, since the top-level entity's is not read as a run terminal at all.
+_FAILED_RUN_TERMINALS = frozenset({RunEvent.run_error.value, RunEvent.run_cancelled.value})
 
 
 def process_completion(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
     """Process a terminal event and return the corresponding AG-UI events."""
-    event = getattr(chunk, "event", None)
-    event_value = event.value if event is not None and hasattr(event, "value") else str(event)
-    if _normalize_event(event_value) == RunEvent.run_error.value:
-        return on_run_error(chunk, state)
+    state.resolve_lane(*_chunk_run_ids(chunk))
+    normalized = _normalized_event_of(chunk)
+    if normalized in _FAILED_RUN_TERMINALS:
+        return on_run_error(chunk, state, normalized)
     return on_run_completed(chunk, state)

--- a/libs/agno/agno/os/interfaces/agui/interrupts.py
+++ b/libs/agno/agno/os/interfaces/agui/interrupts.py
@@ -1,0 +1,951 @@
+"""The AG-UI interrupt round trip for Agno's paused runs.
+
+A paused Agno run is an AG-UI interrupt: the run has ended, and it ends carrying
+what the client has to resolve before the work can go on. This module maps one
+side to the other, in both directions.
+
+Out: each requirement a pause still needs answered becomes one ``Interrupt``
+inside ``RUN_FINISHED.outcome``, so a client is told the run is waiting rather
+than reading a pause as a completion.
+
+In: the ``resume`` array of the next request answers those interrupts by id, and
+the answers are written onto the stored requirements the continue then runs from.
+
+What the two directions have to agree about is one computation, not two:
+``answers_a_pause_needs`` is the single answer to which of a paused run's
+requirements must be answered and what each one's correlation id is. The
+terminal advertises one interrupt per entry it returns and the resume guard
+demands one answer per entry, so neither side can ask for a set the other does
+not. Where an entry is one no answer could resolve, the pause cannot be
+continued at all, and the terminal says so as a failed run rather than
+advertising the rest: a resume has to answer every entry, so a client that
+answered only the advertised ones would be refused with nothing on the wire
+having said why.
+
+The outcome is opt-in. A client released before the interrupt-aware lifecycle
+stops sending its own resume directive the moment it sees a structured outcome,
+which would strand the run, so the emission is off unless it is asked for. With
+it off this interface emits exactly what it emitted before the outcome existed.
+"""
+
+import json
+from collections import Counter
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
+
+from agno.models.response import UserFeedbackQuestion, UserInputField
+from agno.os.interfaces.agui.utils import readable
+from agno.run.requirement import PauseType, RunRequirement
+from agno.utils.log import log_warning
+
+try:
+    from ag_ui.core import Interrupt, RunFinishedInterruptOutcome
+
+    INTERRUPT_OUTCOME_AVAILABLE = True
+except ImportError:  # ag-ui-protocol older than the interrupt-aware run lifecycle
+    INTERRUPT_OUTCOME_AVAILABLE = False
+
+try:
+    from ag_ui.core import SubagentFinishedSuspendedOutcome
+
+    SUBAGENT_SUSPENDED_OUTCOME_AVAILABLE = True
+except ImportError:  # ag-ui-protocol older than the suspended subagent outcome
+    SUBAGENT_SUSPENDED_OUTCOME_AVAILABLE = False
+
+
+def undeclared_fields(model: Any, fields: Iterable[str]) -> List[str]:
+    """Which of these fields the installed protocol model does not declare.
+
+    The one question this module asks about a protocol field, and it is asked of
+    the schema. Asking the object instead answers a different question: the
+    protocol's models accept a key they do not declare, keeping it as untyped
+    extra data, so an attribute lookup finds a value this interface wrote under
+    a name the wire format has no place for and reports it as present. Every
+    gate and every emit site here reads this, so what is detected and what is
+    written cannot come apart.
+    """
+    declared = getattr(model, "model_fields", {})
+    return [field for field in fields if field not in declared]
+
+
+def declares(model: Any, *fields: str) -> bool:
+    """Whether the installed protocol model declares every one of these fields."""
+    return not undeclared_fields(model, fields)
+
+
+# The field an interrupt names the member it was raised inside by. It reached the
+# protocol with the subagent lineage events, which is later than the run-level
+# outcome, so an install can serve every interrupt this module builds for a
+# single agent and still have no place to write this one.
+MEMBER_ATTRIBUTION_FIELD = "subagent_run_id"
+
+
+# The protocol's core reason values, which a client switches on to pick a
+# dedicated surface. Both are spec-defined names a client matches exactly.
+#
+# Agno pauses for four kinds of thing, and they answer to two questions. A
+# confirmation and an external execution are both a decision about one tool call
+# the model has already proposed: approve this, or run it yourself and hand back
+# the result. Either way the call is on the wire under the same id and the
+# interrupt binds to it. A user-input and a user-feedback pause instead ask for
+# structured data the model needs before it can carry on, and that shape travels
+# as the interrupt's response schema. The exact kind stays readable in the
+# metadata, so a client can tell "approve this" from "run this" when it wants to.
+REASON_TOOL_CALL = "tool_call"
+REASON_INPUT_REQUIRED = "input_required"
+
+# The code a run terminal carries when the pause it reports can never be
+# continued, so a client can tell that case from a run that failed while working
+# without reading the message. It is this interface's own name, in the field the
+# protocol keeps for one.
+PAUSE_NOT_CONTINUABLE_CODE = "pause_not_continuable"
+
+_PAUSE_TYPE_REASONS: Dict[PauseType, str] = {
+    "confirmation": REASON_TOOL_CALL,
+    "external_execution": REASON_TOOL_CALL,
+    "user_input": REASON_INPUT_REQUIRED,
+    "user_feedback": REASON_INPUT_REQUIRED,
+}
+
+# The key a confirmation payload carries its decision under. This is the name
+# Agno's existing tool-message resume already reads, so one payload shape works
+# on both channels. The interrupt spec's own approval example names the field
+# ``approved`` instead, and a payload using that name is read too, on the resume
+# array the interrupt advertising it is answered by.
+CONFIRMATION_ACCEPTED_KEY = "accepted"
+CONFIRMATION_ACCEPTED_ALIAS = "approved"
+CONFIRMATION_NOTE_KEY = "note"
+
+# What the note beside a decision is for, told to the client that sends it. Agno
+# keeps one on a denial, where it reaches the model as the reason the call was
+# refused, and its approval path takes none: ``confirm`` has nowhere to put one,
+# and a note written on the requirement beside an approval does not survive the
+# reload a stored run is read back through. One schema is advertised for both
+# decisions, so this is where the advertisement says which of them records it.
+CONFIRMATION_NOTE_DESCRIPTION = "Why the call was refused. Recorded on a denial; an approval keeps no note."
+
+# The envelopes the structured pause types answer in, matching the payloads
+# Agno's tool-message resume already accepts.
+USER_INPUT_VALUES_KEY = "values"
+USER_FEEDBACK_SELECTIONS_KEY = "selections"
+
+# How a resume entry says that answering failed. The protocol keeps ``payload``
+# for the answer the agent asked for and ``metadata`` for envelope data about
+# the response, and reserves the ``ag-ui`` key inside the metadata for its own
+# use, so the report travels under this interface's own key. Putting it in the
+# payload instead would reach the model as the output of a tool that never ran.
+# The resume channel reads them; an interrupt for a client-run tool advertises
+# the path they form, because nothing else on the wire says the convention
+# exists.
+RESUME_METADATA_NAMESPACE = "agno"
+RESUME_ERROR_KEY = "error"
+ERROR_REPORT_PATH_KEY = "error_report_path"
+
+# The path itself: the entry field the report is written on, then the keys
+# inside it. Public, and read off this module rather than bound into the resume
+# side at import, because the side that reads an incoming report walks exactly
+# this and nothing else. Written out there as its own nesting, the two shared
+# their last two keys and not their structure, so moving one moved nothing else.
+ERROR_REPORT_PATH: Tuple[str, ...] = ("metadata", RESUME_METADATA_NAMESPACE, RESUME_ERROR_KEY)
+
+# What the model is told when a client-run tool's result can be neither
+# serialized nor rendered. Stored as the tool's output, because the resume has
+# to write one: an empty result is what a tool that returned nothing says, and
+# handing that back for a tool that returned something is the misreport this
+# says out loud instead.
+UNREADABLE_RESULT_NOTE = "The tool returned a result this server could not read."
+
+_JSON_TYPES: Dict[type, str] = {
+    str: "string",
+    bool: "boolean",
+    int: "integer",
+    float: "number",
+    list: "array",
+    dict: "object",
+}
+
+
+def interrupt_id_of(requirement: RunRequirement) -> Optional[str]:
+    """The id an interrupt for this requirement is correlated by.
+
+    The requirement's own id is it: it is minted when the pause is recorded,
+    stored with the paused run, and survives the reload the resume reads the run
+    back through, which is what makes it usable as the key an answer comes back
+    under. A release that stores no id falls back to the tool call the
+    requirement is waiting on, which is unique within the run for the same
+    reason the tool call events can be keyed by it.
+    """
+    stored_id = getattr(requirement, "id", None)
+    if isinstance(stored_id, str) and stored_id:
+        return stored_id
+    tool_execution = requirement.tool_execution
+    return tool_execution.tool_call_id if tool_execution else None
+
+
+def _json_type_of(field_type: Any) -> Optional[str]:
+    """The JSON Schema type for one of Agno's declared input field types.
+
+    A type this does not recognise is left unconstrained rather than guessed at:
+    a wrong type in the schema makes a client reject an answer the agent would
+    have accepted.
+    """
+    return _JSON_TYPES.get(field_type) if isinstance(field_type, type) else None
+
+
+def _agreed_on(described: Dict[str, Any], also: Dict[str, Any]) -> Dict[str, Any]:
+    """The two descriptions of one payload key, reduced to what they agree on.
+
+    Two declarations under one name are one key in the answer, and Agno writes
+    that one value onto every declaration carrying the name, so the key is
+    described once. Where the two disagree the constraint is dropped rather than
+    resolved to one of them: a constraint one copy would fail is a client
+    refusing an answer Agno accepts, which is the same wrong the unrecognised
+    type above is left unconstrained for.
+    """
+    merged: Dict[str, Any] = {}
+    for key, value in described.items():
+        other = also.get(key)
+        if isinstance(value, dict) and isinstance(other, dict):
+            nested = _agreed_on(value, other)
+            if nested:
+                merged[key] = nested
+        elif key in also and other == value:
+            merged[key] = value
+    return merged
+
+
+def _that_cannot_be_null(described: Dict[str, Any]) -> Dict[str, Any]:
+    """One field's description, with the one value it must never carry ruled out.
+
+    A named type rules null out already. A field left with no type, because the
+    type it declares is not one this maps or because two declarations of the
+    name agree on nothing, is otherwise advertised as a schema a null satisfies,
+    and a null is not an answer: the resume writes it onto the field, the field
+    counts as unfilled, and the requirement fails the partial-resume guard as a
+    run error. So the constraint that is known is stated without naming the type
+    that is not.
+    """
+    if "type" in described:
+        return described
+    return {**described, "not": {"type": "null"}}
+
+
+def _addressable(name: Any) -> bool:
+    """Whether an answer can name this field or question at all.
+
+    The payload is a JSON object keyed by the name, so a name that is not a
+    non-empty string is one no client can send a value under.
+    """
+    return isinstance(name, str) and bool(name)
+
+
+def _user_input_schema(fields: List[UserInputField]) -> Optional[Dict[str, Any]]:
+    """The schema for the values a user-input pause is waiting on.
+
+    Every field is described, and only the ones still without a value are
+    required: the model can pre-fill some of them, and the run continues once
+    the rest arrive.
+
+    A name declared twice is advertised once, in both lists, because two keys of
+    one name in the payload are one key and two entries in ``required`` are not
+    a list a client can satisfy.
+    """
+    if not fields:
+        return None
+    properties: Dict[str, Any] = {}
+    required: List[str] = []
+    for input_field in fields:
+        name = input_field.name
+        if not _addressable(name):
+            continue
+        described: Dict[str, Any] = {}
+        json_type = _json_type_of(input_field.field_type)
+        if json_type is not None:
+            described["type"] = json_type
+        description = readable(input_field.description, f"the description of the paused input field {name!r}")
+        if description is not None:
+            described["description"] = description
+        if name in properties:
+            log_warning(
+                f"AG-UI advertises the paused input field {name!r} once: the pause declares it more than "
+                "once, and one value in the answer is written onto every declaration of it."
+            )
+            described = _agreed_on(properties[name], described)
+        properties[name] = _that_cannot_be_null(described)
+        if input_field.value is None and name not in required:
+            required.append(name)
+    if not properties:
+        return None
+    values_schema: Dict[str, Any] = {"type": "object", "properties": properties}
+    if required:
+        values_schema["required"] = required
+    return {
+        "type": "object",
+        "properties": {USER_INPUT_VALUES_KEY: values_schema},
+        "required": [USER_INPUT_VALUES_KEY],
+    }
+
+
+def _offered_labels(question: UserFeedbackQuestion, text: str) -> List[str]:
+    """The choices this question offers, as the answers an enum holds a client to.
+
+    The choices and each label in them are values a tool declared, so walking
+    the one and reading the other both run code this interface did not write.
+    The whole walk is guarded and not only the labels, because a sequence that
+    refuses to be walked gives up every label at once, and a question advertised
+    without its choices is still a question a client can answer in words.
+    """
+    try:
+        offered = [
+            readable(option.label, f"an option label of the paused question {text!r}")
+            for option in question.options or []
+        ]
+    except Exception as error:
+        log_warning(f"AG-UI could not read the options of the paused question {text!r}: {error}")
+        return []
+    labels = [label for label in offered if label]
+    if len(labels) != len(offered):
+        log_warning(
+            f"AG-UI advertises the paused question {text!r} without {len(offered) - len(labels)} of its "
+            "options: a label with no text to show is not a choice a client could pick out of a list."
+        )
+    return labels
+
+
+def _asks_for_several(question: UserFeedbackQuestion, text: str) -> bool:
+    """Whether this question takes more than one selection.
+
+    A flag a tool set, so reading it runs that value's own code. One that cannot
+    be read leaves the cap off rather than guessing at it: a schema capping an
+    answer Agno would have accepted is a client refusing an answer the agent
+    wanted, which is the wrong an unrecognised field type is left unconstrained
+    for.
+    """
+    try:
+        return bool(question.multi_select)
+    except Exception as error:
+        log_warning(f"AG-UI could not read whether the paused question {text!r} takes more than one selection: {error}")
+        return True
+
+
+def _user_feedback_schema(questions: List[UserFeedbackQuestion]) -> Optional[Dict[str, Any]]:
+    """The schema for the selections a user-feedback pause is waiting on.
+
+    One array per question, keyed by the question text, because that is the key
+    Agno matches an answer back to its question by. A single-select question
+    caps the array at one entry, so a client cannot offer a choice the agent
+    would then have to reject, and every array asks for at least one entry: an
+    empty array satisfies a required question while telling the model nothing,
+    and the run would go on to use the answer nobody gave.
+
+    A question asked twice under one text is advertised once, for the reason one
+    input field declared twice is.
+    """
+    if not questions:
+        return None
+    properties: Dict[str, Any] = {}
+    required: List[str] = []
+    for question in questions:
+        text = question.question
+        if not _addressable(text):
+            continue
+        labels = _offered_labels(question, text)
+        item: Dict[str, Any] = {"type": "string"}
+        if labels:
+            item["enum"] = labels
+        answered: Dict[str, Any] = {"type": "array", "items": item, "minItems": 1}
+        if not _asks_for_several(question, text):
+            answered["maxItems"] = 1
+        header = readable(question.header, f"the header of the paused question {text!r}")
+        if header is not None:
+            answered["title"] = header
+        if text in properties:
+            log_warning(
+                f"AG-UI advertises the paused question {text!r} once: the pause asks it more than once, "
+                "and one selection in the answer is written onto every copy of it."
+            )
+            answered = _agreed_on(properties[text], answered)
+        properties[text] = answered
+        if question.selected_options is None and text not in required:
+            required.append(text)
+    if not properties:
+        return None
+    selections_schema: Dict[str, Any] = {"type": "object", "properties": properties}
+    if required:
+        selections_schema["required"] = required
+    return {
+        "type": "object",
+        "properties": {USER_FEEDBACK_SELECTIONS_KEY: selections_schema},
+        "required": [USER_FEEDBACK_SELECTIONS_KEY],
+    }
+
+
+def _confirmation_schema() -> Dict[str, Any]:
+    """The schema for a decision about one proposed tool call.
+
+    A denial is a resolved interrupt carrying a negative decision, which is how
+    the protocol expresses one; the ``cancelled`` status is for a client that
+    abandoned the question instead of answering it. No edited-arguments field is
+    offered, because this interface has no way to apply one and advertising the
+    field is what tells a client it may offer that UI.
+
+    The note is described as the denial's, because that is the only decision
+    Agno records one on. Offered to both without a word, it was a field a client
+    was told to fill and the approve branch then dropped.
+    """
+    return {
+        "type": "object",
+        "properties": {
+            CONFIRMATION_ACCEPTED_KEY: {"type": "boolean"},
+            CONFIRMATION_NOTE_KEY: {"type": "string", "description": CONFIRMATION_NOTE_DESCRIPTION},
+        },
+        "required": [CONFIRMATION_ACCEPTED_KEY],
+    }
+
+
+def advertised_answer_schema(requirement: RunRequirement) -> Optional[Dict[str, Any]]:
+    """The shape of the answer this requirement is waiting for, when it has one.
+
+    An external execution has none: the client runs the tool and hands back
+    whatever that tool returns, which this interface cannot describe.
+
+    Public because the resume side holds an incoming answer to this same schema.
+    One description of the shape is the point: a second copy is the divergence
+    between what a pause advertises and what it accepts.
+    """
+    pause_type = requirement.pause_type
+    if pause_type == "confirmation":
+        return _confirmation_schema()
+    if pause_type == "user_input":
+        return _user_input_schema(requirement.user_input_schema or [])
+    if pause_type == "user_feedback":
+        return _user_feedback_schema(requirement.user_feedback_schema or [])
+    return None
+
+
+# What a requirement still has open, in the words a warning about it uses.
+_OPEN_ANSWERS: Dict[str, str] = {
+    "needs_confirmation": "a decision",
+    "needs_external_execution": "a result from a tool the client runs",
+    "needs_user_input": "input values",
+    "needs_user_feedback": "feedback selections",
+}
+
+# Per pause kind, the answer the resume channel applies: the requirement's own
+# predicate the resolver refuses to run without, and every predicate that
+# resolver's answer can clear. The two structured kinds share Agno's
+# ``answered`` flag, so either one's answer clears both; a decision and a
+# client-run tool clear only their own.
+_PAUSE_TYPE_ANSWERS: Dict[PauseType, Tuple[str, Tuple[str, ...]]] = {
+    "confirmation": ("needs_confirmation", ("needs_confirmation",)),
+    "external_execution": ("needs_external_execution", ("needs_external_execution",)),
+    "user_input": ("needs_user_input", ("needs_user_input", "needs_user_feedback")),
+    "user_feedback": ("needs_user_feedback", ("needs_user_input", "needs_user_feedback")),
+}
+
+
+def _unanswerable_reason(requirement: RunRequirement, advertised: Optional[Dict[str, Any]]) -> Optional[str]:
+    """Why no answer could resolve this requirement, when none could.
+
+    ``pause_type`` picks exactly one resolver per requirement on both resume
+    channels, that resolver refuses to run unless the pause kind it belongs to
+    is what the requirement is still waiting on, and a requirement with anything
+    left open afterwards fails the partial-resume guard, which stops the whole
+    resume rather than continuing the run. So a requirement whose one resolver
+    cannot clear everything it has open is one no payload resolves, and an
+    interrupt advertising it hands the client an id whose every answer strands
+    the run.
+
+    Clearing a predicate is not the same as filling what it stood for. Agno
+    marks a whole call answered once its questions are, and that one flag stands
+    for both structured kinds, so a feedback answer clears the input predicate
+    with the fields the tool needs still empty.
+
+    What a client would be shown is not censused here but taken as given:
+    ``advertised`` is what the builder produced for this requirement, and a
+    requirement it describes no shape for is one whose client is told to send
+    structured data and told nothing about what, which is the state this guard
+    exists to prevent. A census of the requirement's own fields answers a
+    different question, and building a second copy of the shape here would run
+    every guarded read of the run's own values twice for one terminal.
+    """
+    pause_type = requirement.pause_type
+    applied, clears = _PAUSE_TYPE_ANSWERS[pause_type]
+    still_open = [predicate for predicate in _OPEN_ANSWERS if getattr(requirement, predicate, False)]
+    if applied not in still_open:
+        return f"the resume channel answers it as a {pause_type} pause, which it is not waiting on"
+    unclearable = [_OPEN_ANSWERS[predicate] for predicate in still_open if predicate not in clears]
+    if unclearable:
+        return (
+            f"the resume channel answers it as a {pause_type} pause, "
+            f"which leaves {' and '.join(unclearable)} unresolved"
+        )
+    if pause_type == "user_feedback" and any(
+        input_field.value is None for input_field in requirement.user_input_schema or []
+    ):
+        return (
+            f"the resume channel answers it as a {pause_type} pause, which marks the whole call answered "
+            f"with {_OPEN_ANSWERS['needs_user_input']} still missing"
+        )
+    if pause_type == "user_input" and advertised is None:
+        return "it asks for input and declares no field to put an answer in"
+    if pause_type == "user_feedback" and advertised is None:
+        return "it asks for feedback and declares no question to answer"
+    # The one thing a produced schema cannot report: a field still empty that no
+    # payload could be keyed to is left out of it, so it is counted here.
+    unaddressable = [
+        input_field.name
+        for input_field in (requirement.user_input_schema or [])
+        if input_field.value is None and not _addressable(input_field.name)
+    ] + [
+        question.question
+        for question in (requirement.user_feedback_schema or [])
+        if question.selected_options is None and not _addressable(question.question)
+    ]
+    if unaddressable:
+        counted = (
+            "1 unnamed field or question"
+            if len(unaddressable) == 1
+            else f"{len(unaddressable)} unnamed fields or questions"
+        )
+        return f"it waits on {counted}, which no answer can be keyed to"
+    return None
+
+
+@dataclass(frozen=True)
+class NeededAnswer:
+    """One answer a paused run must have before it can continue.
+
+    ``interrupt_id`` is the key the answer comes back under, and it is the only
+    key either side of the round trip uses. ``unanswerable`` says why no answer
+    could resolve this requirement, and is None for the requirements a client
+    can actually answer.
+
+    ``answer_schema`` is the shape the interrupt advertises, built once here
+    because both the guard that decides whether to advertise the requirement at
+    all and the interrupt that carries the shape ask for it. The words in it come
+    off the run's own values through guards that record what they could not read,
+    so a second build is a second record of every one of those.
+    """
+
+    requirement: RunRequirement
+    interrupt_id: Optional[str]
+    unanswerable: Optional[str]
+    answer_schema: Optional[Dict[str, Any]]
+
+    @property
+    def tool_name(self) -> Optional[str]:
+        """The tool this answer is about, as far as the pause records one."""
+        tool_execution = self.requirement.tool_execution
+        return tool_execution.tool_name if tool_execution else None
+
+    @property
+    def tool_call_id(self) -> Optional[str]:
+        """The pending call this answer is about, as far as the pause records one.
+
+        The key the older channel addresses an answer by, where the interrupt id
+        is the key the resume array addresses it by. Read off the same entry as
+        the id, so a caller weighing one channel's answers against the other's
+        reads one population and not two.
+        """
+        tool_execution = self.requirement.tool_execution
+        return tool_execution.tool_call_id if tool_execution else None
+
+
+def _no_answer_resolves(
+    requirement: RunRequirement,
+    interrupt_id: Optional[str],
+    shared_ids: Set[str],
+    advertised: Optional[Dict[str, Any]],
+) -> Optional[str]:
+    """Why nothing a client sends could resolve this requirement, when nothing could.
+
+    An id is what an answer is keyed to on both channels, so a requirement with
+    none is one no entry can address. An id two of the pause's open requirements
+    share is worse than none: an answer under it lands on whichever the
+    correlation map kept, leaving the other open, which is the partial resume the
+    guard stops. Both are refused here rather than at the one side that noticed,
+    so the terminal and the guard read the same verdict.
+    """
+    if not interrupt_id:
+        return "it carries no id an answer could be keyed to"
+    if interrupt_id in shared_ids:
+        return (
+            f"another open requirement of this pause is keyed by {interrupt_id} too, "
+            "and one answer under that id can resolve only one of them"
+        )
+    return _unanswerable_reason(requirement, advertised)
+
+
+def answers_a_pause_needs(requirements: Iterable[RunRequirement]) -> List["NeededAnswer"]:
+    """Every answer this paused run must have before it can continue, in order.
+
+    The single answer to what a resume has to carry. The terminal builds one
+    interrupt per entry and the resume guard demands one answer per entry, so
+    the advertised set and the demanded set are the same set by construction
+    rather than by two sides happening to agree.
+
+    A resolved requirement is not one of them: the run already holds its answer,
+    and an interrupt for it is an id the resume channel would refuse. That is
+    the same filter ``active_requirements`` applies, so the terminal reading a
+    paused event's active list and the guard reading the stored run's whole list
+    come to the same entries.
+    """
+    open_requirements = [requirement for requirement in requirements if not requirement.is_resolved()]
+    interrupt_ids = [interrupt_id_of(requirement) for requirement in open_requirements]
+    advertised = [advertised_answer_schema(requirement) for requirement in open_requirements]
+    shared_ids = {
+        interrupt_id for interrupt_id, times in Counter(key for key in interrupt_ids if key).items() if times > 1
+    }
+    return [
+        NeededAnswer(
+            requirement=requirement,
+            interrupt_id=interrupt_id,
+            unanswerable=_no_answer_resolves(requirement, interrupt_id, shared_ids, answer_schema),
+            answer_schema=answer_schema,
+        )
+        for requirement, interrupt_id, answer_schema in zip(open_requirements, interrupt_ids, advertised)
+    ]
+
+
+def pause_not_continuable(needed: List["NeededAnswer"]) -> Optional[str]:
+    """Why this pause can never be continued, when it cannot be.
+
+    A resume must answer every open requirement or the guard stops it, so one
+    requirement no answer resolves makes the whole pause a dead end, whatever
+    else it is waiting on. Both directions report it in these words: the
+    terminal fails the run with them instead of advertising the answerable
+    remainder, and the resume refuses the array with them, before it writes an
+    answer onto anything, for a client that resumed the pause anyway.
+    """
+    stranded = [answer for answer in needed if answer.unanswerable]
+    if not stranded:
+        return None
+    return "; ".join(
+        f"the pause on tool {answer.tool_name!r}"
+        + (f" under interrupt {answer.interrupt_id}" if answer.interrupt_id else "")
+        + f" cannot be answered, because {answer.unanswerable}"
+        for answer in stranded
+    )
+
+
+def _attribution_that_reaches_the_client(interrupt_id: str, subagent_run_id: Optional[str]) -> Optional[str]:
+    """The member this interrupt can say it was raised inside, if it can say so.
+
+    Detected here rather than at startup because the run-level outcome is served
+    without it: the release that has the outcome and not this field serves the
+    whole single-agent round trip, and only a pause inside a member asks for
+    something it cannot write. Naming it anyway would put the value on the wire
+    under a name the wire format does not define, so the attribution is dropped
+    and the interrupt goes out answerable but unattributed.
+    """
+    if subagent_run_id is None or interrupt_attribution_available():
+        return subagent_run_id
+    log_warning(
+        f"AG-UI cannot name the subagent that interrupt {interrupt_id} was raised inside: the installed "
+        f"ag_ui.core omits Interrupt.{MEMBER_ATTRIBUTION_FIELD}, so it goes out unattributed. "
+        "Please upgrade with `pip install -U ag-ui-protocol`."
+    )
+    return None
+
+
+def build_interrupt(
+    needed: Optional["NeededAnswer"],
+    *,
+    tool_call_id: Optional[str],
+    tool_name: Optional[str],
+    subagent_run_id: Optional[str] = None,
+) -> Optional["Interrupt"]:
+    """One answer a paused run needs, as the interrupt a client resolves it through.
+
+    The id is the one ``answers_a_pause_needs`` gave it, which is the key the
+    resume channel looks an answer up by. Nothing is decided here: an answer no
+    client could send never reaches this, because the caller reads the same
+    computation and fails the run instead. A pause that reports no requirement
+    at all has no answer to be built from, so it passes none and is keyed by its
+    tool call, which is unique within the run and is all such a release gives to
+    key by.
+
+    The tool call is what the client renders and answers against, and it is
+    optional: a requirement whose pending call carries no id is still open and
+    still answerable under the requirement's id, so it is advertised without
+    one rather than withheld from a client that would then never be told the
+    run is waiting on it.
+
+    No message is set. The paused run's own words are already on the wire as the
+    assistant message the pending tool call is parented to, so a message here
+    would repeat the prompt rather than add one. What a renderer cannot read off
+    the tool call events travels in the metadata instead: which of Agno's four
+    pause kinds this is, and the name of the tool waiting on it.
+
+    A client-run tool is told where to report that the tool raised, because the
+    answer it hands back is a tool result and a failed one has to reach the model
+    as a failed call rather than as output. That report is envelope data about
+    the response and not the answer itself, so it is named in the metadata; the
+    pause still advertises no response schema, since what the client hands back
+    is whatever its tool returned.
+
+    Only what there is something to say is written. A pause recording no tool
+    name has none to give, a member this install has no field to name would be
+    named nowhere, and a pause reporting no requirement has nothing that says
+    which kind it is: all are left out rather than published as an explicit null
+    or as a kind picked for looking plausible. Naming one anyway is a claim a
+    client acts on, and every one of the four is wrong three times out of four:
+    an approval published as an external execution is a tool the client is told
+    to run itself, and the path for saying a client-run tool raised is a path no
+    other kind accepts an answer on.
+
+    The reason such a pause carries is ``tool_call``, which is the one thing the
+    terminal did report: a proposed call the client was shown, keyed by that
+    call's id and answered against it. ``input_required`` would claim the run is
+    waiting on data the model needs, and nothing here says that.
+    """
+    if not INTERRUPT_OUTCOME_AVAILABLE:
+        return None
+    requirement = needed.requirement if needed is not None else None
+    interrupt_id = needed.interrupt_id if needed is not None else tool_call_id
+    if not interrupt_id:
+        return None
+    pause_type = requirement.pause_type if requirement is not None else None
+    about_the_pause: Dict[str, Any] = {}
+    if pause_type is not None:
+        about_the_pause["pause_type"] = pause_type
+    if tool_name is not None:
+        about_the_pause["tool_name"] = tool_name
+    if pause_type == "external_execution":
+        about_the_pause[ERROR_REPORT_PATH_KEY] = list(ERROR_REPORT_PATH)
+    written: Dict[str, Any] = {
+        "id": interrupt_id,
+        "reason": REASON_TOOL_CALL if pause_type is None else _PAUSE_TYPE_REASONS.get(pause_type, REASON_TOOL_CALL),
+        "tool_call_id": tool_call_id,
+        "response_schema": needed.answer_schema if needed is not None else None,
+        "metadata": {RESUME_METADATA_NAMESPACE: about_the_pause},
+    }
+    attribution = _attribution_that_reaches_the_client(interrupt_id, subagent_run_id)
+    if attribution is not None:
+        written[MEMBER_ATTRIBUTION_FIELD] = attribution
+    return Interrupt(**written)
+
+
+def interrupt_outcome(interrupts: List["Interrupt"]) -> Optional["RunFinishedInterruptOutcome"]:
+    """The run outcome for a pause, or nothing when there is no interrupt to carry.
+
+    The protocol rejects an interrupt outcome with an empty list, so a pause this
+    interface could build no interrupt for keeps the plain terminal it has always
+    sent. The caller records that case.
+    """
+    if not INTERRUPT_OUTCOME_AVAILABLE or not interrupts:
+        return None
+    return RunFinishedInterruptOutcome(type="interrupt", interrupts=interrupts)
+
+
+def suspended_outcome(interrupt_ids: List[str]) -> Optional["SubagentFinishedSuspendedOutcome"]:
+    """A subagent's terminal outcome when the run paused inside it.
+
+    ``interrupt_ids`` names the interrupts this subagent owns directly, and is
+    empty for one suspended only because a subagent below it interrupted.
+
+    Gated on the same declaration check the caller reads, rather than on the
+    import alone: a release carrying the type without the field it is built
+    from, or without the member terminal's place to carry the outcome, would
+    otherwise be handed an outcome whose every part rides out undeclared.
+    """
+    if not subagent_suspension_available():
+        return None
+    return SubagentFinishedSuspendedOutcome(type="suspended", interrupt_ids=interrupt_ids or None)
+
+
+def _resume_entry_model() -> Any:
+    """The model one entry of the resume array arrives as, or a stand-in for it.
+
+    A release too old to declare the entry model declares none of the fields an
+    answer is read off, so the stand-in carries the name the protocol gives it
+    and no fields at all, and the census names every one of them as missing
+    rather than failing on the import.
+    """
+    try:
+        from ag_ui.core import ResumeEntry
+    except ImportError:  # ag-ui-protocol older than the resume array's entry model
+        return type("ResumeEntry", (), {})
+    return ResumeEntry
+
+
+def interrupt_round_trip_fields() -> Dict[Any, Tuple[str, ...]]:
+    """Every protocol field the run-level round trip writes or reads, per class.
+
+    Built here rather than at import, because on a release without the interrupt
+    types there is no class to key them by. The floor below reads this table, so
+    what is detected and what is written cannot drift.
+
+    Outgoing, that is every field the builders set, the discriminator the
+    outcome is read by included: it is written on every outcome this module
+    builds, and a release that renamed it would carry the old name as data it
+    never declared rather than as the tag a client switches on.
+
+    Incoming, it is the resume array and the entries inside it. The array is the
+    channel the answers arrive in, so a release that does not declare it drops a
+    client's answers as an unknown field. The fields of an entry are read as
+    plain attributes while the answer is applied, so a release declaring them
+    differently raises mid-run on a run this interface told the client to
+    answer. An entry's ``metadata`` is not here: it is read through a lookup
+    that answers a release without one with a default, and an entry carrying no
+    failure report answers normally.
+
+    Naming the member an interrupt was raised inside is not here either. That
+    field reached the protocol a release later than the rest of the lifecycle,
+    and a server exposing a single agent never writes it, so demanding it would
+    refuse the whole round trip over a field the install would never be asked
+    for. It is detected on its own below instead.
+    """
+    if not INTERRUPT_OUTCOME_AVAILABLE:
+        return {}
+
+    from ag_ui.core import RunAgentInput, RunFinishedEvent
+
+    return {
+        Interrupt: ("id", "reason", "tool_call_id", "response_schema", "metadata"),
+        RunFinishedInterruptOutcome: ("type", "interrupts"),
+        RunFinishedEvent: ("outcome",),
+        RunAgentInput: ("resume",),
+        _resume_entry_model(): ("interrupt_id", "status", "payload"),
+    }
+
+
+def _missing_interrupt_fields() -> List[str]:
+    """The fields every interrupt round trip needs that the installed protocol omits.
+
+    The protocol models accept attributes they do not declare, so an omitted
+    field would otherwise leave the run: the value goes out under the name
+    written here instead of the one the wire format defines, and a client reads
+    an interrupt with no tool call and no schema rather than a refusal. On the
+    incoming half an omitted field is worse than a wrong key: the answers are
+    dropped unread, or read off an entry that carries them under another name,
+    and the run this interface told the client to answer fails mid-continue
+    instead of being refused before it started.
+    """
+    return sorted(
+        f"{model.__name__}.{field}"
+        for model, fields in interrupt_round_trip_fields().items()
+        for field in undeclared_fields(model, fields)
+    )
+
+
+def interrupt_attribution_fields() -> Dict[Any, Tuple[str, ...]]:
+    """The member-attribution field this module writes, per class it writes it on.
+
+    Built here rather than at import, because on a release without the interrupt
+    types there is no class to key it by. The availability check below reads this
+    table, so what is detected and what is written cannot drift.
+    """
+    if not INTERRUPT_OUTCOME_AVAILABLE:
+        return {}
+    return {Interrupt: (MEMBER_ATTRIBUTION_FIELD,)}
+
+
+def interrupt_attribution_available() -> bool:
+    """Whether this install can name the member an interrupt was raised inside.
+
+    Checked separately from the run-level outcome, and beside the suspended
+    outcome below, because the protocol added all three at different times. An
+    install with the outcome and not this field serves every pause a single
+    agent reports; only a pause inside a member asks it for a field it has no
+    name for.
+    """
+    fields = interrupt_attribution_fields()
+    if not fields:
+        return False
+    return all(declares(model, *names) for model, names in fields.items())
+
+
+def validate_interrupt_outcome(emit_interrupt_outcome: bool) -> bool:
+    """Refuse the interrupt outcome on an install that cannot serve it.
+
+    Everything the emission needs is feature-detected here rather than at the
+    events themselves, which are built with a client already reading the stream.
+    What is checked is the run-level round trip, which is what asking for the
+    outcome asks for; the two things a Team's member adds to it arrived in later
+    releases and are detected where they are written.
+    """
+    if not emit_interrupt_outcome:
+        return False
+    if not INTERRUPT_OUTCOME_AVAILABLE:
+        raise ValueError(
+            "emit_interrupt_outcome=True needs the AG-UI interrupt-aware run lifecycle. "
+            "Please upgrade with `pip install -U ag-ui-protocol`."
+        )
+    undeclared = _missing_interrupt_fields()
+    if undeclared:
+        raise ValueError(
+            "emit_interrupt_outcome=True needs every field the interrupt round trip writes on the AG-UI "
+            "interrupt types, and the resume array the answers arrive in with the fields each answer is read off, "
+            f"which the installed ag_ui.core omits: {', '.join(undeclared)}. "
+            "Please upgrade with `pip install -U ag-ui-protocol`."
+        )
+    return True
+
+
+def subagent_suspension_fields() -> Dict[Any, Tuple[str, ...]]:
+    """The suspended-outcome fields this module writes, per class it writes them on.
+
+    Built here rather than at import, because on a protocol release without the
+    suspended outcome there are no classes to key it by. The availability check
+    below reads this table, so what is detected and what is written cannot drift.
+    """
+    if not SUBAGENT_SUSPENDED_OUTCOME_AVAILABLE:
+        return {}
+    from ag_ui.core import SubagentFinishedEvent
+
+    return {
+        SubagentFinishedEvent: ("outcome",),
+        SubagentFinishedSuspendedOutcome: ("type", "interrupt_ids"),
+    }
+
+
+def subagent_suspension_available() -> bool:
+    """Whether this install can close a subagent the run paused inside as suspended.
+
+    Checked separately from the interrupt outcome because the protocol added it
+    later: an install can carry the run-level outcome and still omit this, and
+    the interrupt is then attributed to the member without its lane saying it is
+    waiting.
+    """
+    fields = subagent_suspension_fields()
+    if not fields:
+        return False
+    return all(declares(model, *names) for model, names in fields.items())
+
+
+def external_execution_result(payload: Any) -> str:
+    """A client-run tool's return value as the result text Agno stores for it.
+
+    A string is the result already. Anything else is the JSON the tool returned,
+    so it is sent on as JSON rather than as a Python repr, which is what the
+    tool-message channel carries and what a frontend can parse back.
+
+    A value JSON has no spelling for falls back to its Python rendering, and the
+    fallback says so: the model then reads a repr as a tool's output, and an
+    operator reading the answer it gave has nothing else to trace that by.
+
+    Both steps run the payload's own code, so both are guarded and anything they
+    raise is caught: the payload arrives over the wire, the caller is resolving
+    a problem with a tool result already, and a raise from here would replace
+    that problem with a stringification error and fail the whole resume with it.
+    Neither error the serializers raise on a value nested deeper than they walk
+    is a ``TypeError`` or a ``ValueError``.
+    """
+    if isinstance(payload, str):
+        return payload
+    if payload is None:
+        return ""
+    try:
+        return json.dumps(payload)
+    except Exception as error:
+        log_warning(
+            f"AG-UI could not serialize a client-run tool's result as JSON, so the model is handed its "
+            f"Python rendering instead: {error}"
+        )
+    try:
+        return str(payload)
+    except Exception as error:
+        log_warning(f"AG-UI could not read a client-run tool's result at all: {error}")
+        return UNREADABLE_RESULT_NOTE

--- a/libs/agno/agno/os/interfaces/agui/resume.py
+++ b/libs/agno/agno/os/interfaces/agui/resume.py
@@ -1,35 +1,342 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 from ag_ui.core.types import ToolMessage as AGUIToolMessage
 
 from agno.agent import Agent
+from agno.os.interfaces.agui import interrupts
+from agno.os.interfaces.agui.interrupts import (
+    CONFIRMATION_ACCEPTED_ALIAS,
+    CONFIRMATION_ACCEPTED_KEY,
+    CONFIRMATION_NOTE_KEY,
+    USER_FEEDBACK_SELECTIONS_KEY,
+    USER_INPUT_VALUES_KEY,
+    NeededAnswer,
+    advertised_answer_schema,
+    answers_a_pause_needs,
+    external_execution_result,
+    interrupt_id_of,
+    pause_not_continuable,
+)
 from agno.run.base import RunContext, RunStatus
-from agno.run.requirement import RunRequirement
+from agno.run.requirement import PauseType, RunRequirement
 from agno.run.team import TeamRunOutput
 from agno.session.agent import AgentSession
 from agno.session.team import TeamSession
 from agno.team.team import Team
+from agno.utils.log import log_warning
 from agno.utils.string import parse_response_dict_str
 
+# What each pause kind is waiting for, in the words a client that sent something
+# else is refused in. One sentence per kind, shared by the envelope guards and
+# by the schema check below, so a payload refused for either reason is refused
+# in the same terms a client already matches on.
+_WHAT_A_PAUSE_EXPECTS: Dict[PauseType, str] = {
+    "confirmation": "confirmation expects {'accepted': true|false} (or the spec's 'approved')",
+    "user_input": "user_input expects {'values': {...}}",
+    "user_feedback": "user_feedback expects {'selections': {question: [labels]}}",
+}
 
-def _resolve_confirmation(requirement: RunRequirement, payload: Dict[str, Any], error: Optional[str]) -> None:
-    if error or payload.get("accepted") is not True:
-        requirement.reject(note=payload.get("note") or error)
-    else:
+
+def _is_an_integer(value: Any) -> bool:
+    """Whether this value is the integer an advertised field asked for.
+
+    An integral float is one. JSON has a single number type, so 42.0 is how a
+    client that has no integer of its own sends 42, and the keyword describes the
+    value rather than the spelling it arrived in. A bool is not, even though
+    Python counts it as an int.
+    """
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, int):
+        return True
+    return isinstance(value, float) and value.is_integer()
+
+
+# One JSON Schema type, as the check that a value carries it. Written out rather
+# than read back off the type map the schemas are built from, because what
+# matters here is the other direction: an integer satisfies "number", and a bool
+# satisfies neither of the numeric types even though Python counts it as one.
+_OF_JSON_TYPE: Dict[str, Callable[[Any], bool]] = {
+    "null": lambda value: value is None,
+    "boolean": lambda value: isinstance(value, bool),
+    "integer": _is_an_integer,
+    "number": lambda value: isinstance(value, (int, float)) and not isinstance(value, bool),
+    "string": lambda value: isinstance(value, str),
+    "array": lambda value: isinstance(value, list),
+    "object": lambda value: isinstance(value, dict),
+}
+
+# The keywords an advertised schema carries that state no constraint: they are
+# there for a renderer to show.
+SCHEMA_ANNOTATIONS: Tuple[str, ...] = ("description", "title")
+
+# The one constraint the schemas state that this check leaves to somebody else.
+# Whether an answer fills the pause is Agno's own question: ``is_resolved``
+# answers it across every field and question at once, and the resolved-set guard
+# is what refuses a resume that left one open, with the reason the terminal gave.
+# The top-level key of every schema advertised here is the envelope its resolver
+# refuses to run without, so an answer that omits one is refused there and not by
+# a second reading of the same keyword.
+SCHEMA_COMPLETENESS: Tuple[str, ...] = ("required",)
+
+# The constraints the advertised schemas state and this side describes without
+# holding a client to: the labels a question offers, how many of them it takes,
+# and the null an untyped field must not carry. Each of those says which values
+# of the right kind an answer may carry, which is the client's half of the round
+# trip: an agent MAY validate the payload it is sent and a client SHOULD
+# validate before submitting, so the schema is what the client holds itself to
+# while this side checks only what a value has to be to reach a tool at all.
+# Enforcing the rest is also what refused answers this interface used to take,
+# so the check stays at the narrowest shape that still keeps a payload of the
+# wrong kind out of a tool.
+SCHEMA_ADVERTISED_ONLY: Tuple[str, ...] = ("enum", "minItems", "maxItems", "not")
+
+
+def _type_unmet(constraint: Any, value: Any, at: str) -> Optional[str]:
+    carries_it = _OF_JSON_TYPE.get(constraint)
+    if carries_it is None:
+        log_warning(f"AG-UI cannot check the advertised type {constraint!r}, so {at} is taken unchecked")
+        return None
+    return None if carries_it(value) else f"{at} has to be {constraint}"
+
+
+def _properties_unmet(constraint: Any, value: Any, at: str) -> Optional[str]:
+    if not isinstance(value, dict):
+        return None
+    for name, described in constraint.items():
+        if name in value:
+            unmet = _unmet_constraint(described, value[name], f"{at}[{name!r}]")
+            if unmet:
+                return unmet
+    return None
+
+
+def _items_unmet(constraint: Any, value: Any, at: str) -> Optional[str]:
+    """Every entry of an array, held to the schema that array described entries by.
+
+    Read for the same reason ``properties`` is: a declared type is reached
+    wherever the schema states one, and a selections answer states its one level
+    deeper than a field's value does. A question's labels are the text of its
+    options, stored as text and handed to the model as the options somebody
+    chose, so an entry of another kind is a value of the wrong kind reaching a
+    tool rather than a client picking badly.
+
+    Which labels a question offers is the other claim, and stays advertised-only:
+    this recurses through the same table, so the ``enum`` beside the type is
+    passed over here exactly as it is at the top level.
+    """
+    if not isinstance(value, list):
+        return None
+    for index, entry in enumerate(value):
+        unmet = _unmet_constraint(constraint, entry, f"{at}[{index}]")
+        if unmet:
+            return unmet
+    return None
+
+
+# Every constraint this side holds an answer to, as the one check that reads it.
+# A table rather than a chain of branches, so what is enforced is a list the
+# suite can hold the emitted schemas to.
+_CONSTRAINT_CHECKS: Dict[str, Callable[[Any, Any, str], Optional[str]]] = {
+    "type": _type_unmet,
+    "properties": _properties_unmet,
+    "items": _items_unmet,
+}
+
+# Every keyword this side of the round trip knows what to do with: enforced,
+# annotation, or deliberately somebody else's. A schema keyword outside it and
+# outside the advertised-only list is one the interface advertises and nothing
+# accounts for.
+ADVERTISED_KEYWORDS_READ: Tuple[str, ...] = tuple(_CONSTRAINT_CHECKS) + SCHEMA_ANNOTATIONS + SCHEMA_COMPLETENESS
+
+# Where an answer is being read, in the words a refusal names it by.
+_THE_ANSWER = "the answer"
+
+
+def _unmet_constraint(described: Dict[str, Any], value: Any, at: str = _THE_ANSWER) -> Optional[str]:
+    """The first constraint of one advertised schema this value does not meet.
+
+    A keyword this does not know is reported and passed over rather than
+    refused: a client that sent what it was told to send must not be turned away
+    over a constraint nothing here can read, which is the same reason the schemas
+    leave an unrecognised field type unconstrained. The suite holds every schema
+    the interface advertises to the keywords above, so that case stays
+    hypothetical rather than becoming a constraint accounted for nowhere.
+    """
+    for keyword, constraint in described.items():
+        if keyword in SCHEMA_ANNOTATIONS or keyword in SCHEMA_COMPLETENESS or keyword in SCHEMA_ADVERTISED_ONLY:
+            continue
+        check = _CONSTRAINT_CHECKS.get(keyword)
+        if check is None:
+            log_warning(f"AG-UI cannot check the advertised constraint {keyword!r} on {at}, so it is not enforced")
+            continue
+        unmet = check(constraint, value, at)
+        if unmet:
+            return unmet
+    return None
+
+
+def _without_the_keys_it_left_empty(described: Dict[str, Any], payload: Any) -> Any:
+    """One answer with the described keys a client sent nothing under removed.
+
+    JSON has one way to say that there is no value, and a client that sends it
+    under a key the pause does not require has sent no value for that key rather
+    than a wrong one. Reading it as the key being there is what refuses a resume
+    that could have been answered, and for a field the model already filled it is
+    worse than a refusal: the null is written on, the field counts as unfilled
+    again, and the run the client was told to resume dies on the guard.
+
+    A required key keeps its null, because there a null really is an answer that
+    answers nothing: under a key the schema gave a type it is refused as a value
+    of the wrong kind, and under one it left untyped it reaches Agno, which
+    counts the field unfilled and refuses the resume through the guard.
+    """
+    properties = described.get("properties")
+    if not isinstance(payload, dict) or not isinstance(properties, dict):
+        return payload
+    required = described.get("required") or []
+    kept: Dict[str, Any] = {}
+    for key, value in payload.items():
+        describes_it = properties.get(key)
+        if not isinstance(describes_it, dict):
+            kept[key] = value
+        elif value is None and key not in required:
+            continue
+        else:
+            kept[key] = _without_the_keys_it_left_empty(describes_it, value)
+    return kept
+
+
+def _the_answer_the_pause_advertised(requirement: RunRequirement, payload: Any) -> Any:
+    """One incoming answer, held to the shape the interrupt for it advertised.
+
+    The interface tells a client the exact shape of the answer it wants, so a
+    value of another kind is not accepted under a described key: the schema is
+    rebuilt here by the same builder the terminal advertised from, which is what
+    keeps the advertised shape and the accepted one from being two descriptions
+    that drift apart. Rebuilt from the requirement rather than read off the
+    emitted interrupt, because the interrupt carries the schema only on a release
+    that has the interrupt types, and an answer has to be held to its shape on
+    every release.
+
+    Only the protocol's resume array runs this. The trailing-tool-message channel
+    took answers before this interface described any shape at all, and holding
+    those to a schema refuses resumes Agno accepted, so that channel keeps
+    reading a payload the way it always has.
+
+    A pause that advertises no schema has nothing stated to hold an answer to: a
+    client-run tool hands back whatever its tool returned.
+    """
+    schema = advertised_answer_schema(requirement)
+    if schema is None:
+        return payload
+    answer = _without_the_keys_it_left_empty(schema, payload)
+    unmet = _unmet_constraint(schema, answer)
+    if unmet is None:
+        return answer
+    expected = _WHAT_A_PAUSE_EXPECTS.get(requirement.pause_type)
+    raise ValueError(f"{expected}: {unmet}" if expected else unmet)
+
+
+def _payload_fields(payload: Any) -> Dict[str, Any]:
+    """A resume payload as the field map the requirement resolvers read.
+
+    Anything that is not a map of fields comes through as none of them, which
+    each resolver then reports in its own terms rather than raising an attribute
+    error from inside one.
+    """
+    return payload if isinstance(payload, dict) else {}
+
+
+def _confirmation_fields(payload: Any) -> Dict[str, Any]:
+    """A decision payload as the protocol's resume array reads it.
+
+    Agno's key is the one this interface advertises, and the interrupt spec's
+    approval example names the field differently, so a payload written against
+    either one resolves the call. The alias is read only where Agno's own key
+    carries no value at all: a client that sends both, carrying a null under the
+    one it had no value for, sent exactly one decision, and reading the empty key
+    instead would refuse a resume it could have answered. A value under Agno's
+    own key is the decision, readable or not, so a malformed one is refused for
+    what it is rather than answered off whatever sits beside it.
+
+    Only the resume array runs this, because the interrupt that array answers is
+    what advertised the alias. The trailing-tool-message channel declines a
+    decision it cannot read, so reading one more key there is not a refusal
+    turning into an answer but a declined tool call turning into one that runs,
+    for every caller that channel already had.
+    """
+    fields = _payload_fields(payload)
+    if fields.get(CONFIRMATION_ACCEPTED_KEY) is not None:
+        return fields
+    alias = fields.get(CONFIRMATION_ACCEPTED_ALIAS)
+    if not isinstance(alias, bool):
+        return fields
+    return {**fields, CONFIRMATION_ACCEPTED_KEY: alias}
+
+
+def _confirmation_decision(fields: Dict[str, Any]) -> Optional[bool]:
+    """The decision this payload about one proposed tool call carries, if it carries one."""
+    decision = fields.get(CONFIRMATION_ACCEPTED_KEY)
+    return decision if isinstance(decision, bool) else None
+
+
+def _resolve_confirmation(
+    requirement: RunRequirement,
+    fields: Dict[str, Any],
+    error: Optional[str],
+    *,
+    unreadable_declines: bool,
+) -> None:
+    """Write the decision about one proposed tool call onto the requirement.
+
+    A client reporting a failure is itself a denial: it says the question could
+    not be answered, and the note records why. Either way the note reaches the
+    model as the reason a call was refused.
+
+    An approval keeps none: Agno's own approval entry point takes no note, and
+    the interrupt for a decision says so where it advertises the field. One
+    arriving anyway is dropped out loud rather than in silence, because the run
+    records nothing a reader could learn it from afterwards.
+
+    ``unreadable_declines`` is the one thing the two channels differ on. On the
+    protocol's resume array a payload carrying no decision this interface can
+    read fails the run, because recording it as a denial would put a refusal
+    nobody gave into the run, on the wire and in its audit record, where nothing
+    tells it apart from a real one. A trailing tool message declines the call
+    instead, which is what that channel did before any of this and what its
+    callers were written against.
+    """
+    note = fields.get(CONFIRMATION_NOTE_KEY)
+    decision = _confirmation_decision(fields)
+    if error:
+        requirement.reject(note=note or error)
+    elif decision is True:
+        if note is not None:
+            tool_execution = requirement.tool_execution
+            approved = repr(tool_execution.tool_name) if tool_execution and tool_execution.tool_name else "a call"
+            log_warning(
+                f"AG-UI approved {approved} and dropped the note the approval carried, which nothing "
+                f"downstream can read: {note!r}. Agno records a note on a denial only."
+            )
         requirement.confirm()
+    elif decision is False or unreadable_declines:
+        requirement.reject(note=note)
+    else:
+        raise ValueError(_WHAT_A_PAUSE_EXPECTS["confirmation"])
 
 
-def _resolve_user_input(requirement: RunRequirement, payload: Dict[str, Any]) -> None:
-    values = payload.get("values")
+def _resolve_user_input(requirement: RunRequirement, fields: Dict[str, Any]) -> None:
+    values = fields.get(USER_INPUT_VALUES_KEY)
     if not isinstance(values, dict):
-        raise ValueError("user_input expects {'values': {...}}")
+        raise ValueError(_WHAT_A_PAUSE_EXPECTS["user_input"])
     requirement.provide_user_input(values)
 
 
-def _resolve_user_feedback(requirement: RunRequirement, payload: Dict[str, Any]) -> None:
-    selections = payload.get("selections")
+def _resolve_user_feedback(requirement: RunRequirement, fields: Dict[str, Any]) -> None:
+    selections = fields.get(USER_FEEDBACK_SELECTIONS_KEY)
     if not isinstance(selections, dict) or not all(isinstance(v, list) for v in selections.values()):
-        raise ValueError("user_feedback expects {'selections': {question: [labels]}}")
+        raise ValueError(_WHAT_A_PAUSE_EXPECTS["user_feedback"])
     requirement.provide_user_feedback(selections)
 
 
@@ -64,11 +371,21 @@ def resolve_requirements_from_tool_messages(
 
         # Structured pause types: parse JSON payload
         parsed = parse_response_dict_str(tool_message.content)
-        payload: Dict[str, Any] = parsed if isinstance(parsed, dict) else {}
 
+        # Nothing here is held to an advertised schema, and no key this channel
+        # did not already read is read for it. It took answers before the
+        # interface described any shape, so the payloads it answered then are the
+        # payloads it answers now: a decision it cannot read declines the call
+        # rather than failing the run, a value of a kind the pause did not
+        # describe is written on as it always was, and the spec's own spelling of
+        # a decision stays unread here, because reading it would run a proposed
+        # tool this channel refused to run for every caller written against it.
+        payload = _payload_fields(parsed)
         if requirement.pause_type == "confirmation":
-            _resolve_confirmation(requirement, payload, tool_message.error)
-        elif requirement.pause_type == "user_input":
+            _resolve_confirmation(requirement, payload, tool_message.error, unreadable_declines=True)
+            continue
+
+        if requirement.pause_type == "user_input":
             _resolve_user_input(requirement, payload)
         elif requirement.pause_type == "user_feedback":
             _resolve_user_feedback(requirement, payload)
@@ -76,32 +393,400 @@ def resolve_requirements_from_tool_messages(
     return requirements
 
 
-def ensure_requirements_resolved(requirements: List[RunRequirement]) -> None:
-    """Guard: raise if any requirement is still unresolved after merging tool messages.
+def ensure_pause_can_be_continued(needed: List[NeededAnswer]) -> None:
+    """Guard: raise if this pause is one no answer could have continued.
 
-    A partial resume (some tools answered, some not) must fail loud here rather than
-    reach dispatch where unanswered confirmation tools are silently rejected.
+    Run before any answer is written, because a requirement whose one resolver
+    cannot clear what it has open raises Agno's own internal refusal from inside
+    that resolver, which says nothing about why the pause is a dead end. The
+    reason is the one the terminal computed and failed the run with, so a client
+    that resumed a pause it was never offered is told what the terminal said.
+
+    It is handed the answers the pause needs rather than the requirements,
+    because the caller keys the client's entries off that same list. Computing
+    it here as well would let the two read different populations, which is the
+    disagreement this whole round trip keeps having.
     """
-    unresolved = [r for r in requirements if not r.is_resolved()]
-    if unresolved:
-        ids = [r.tool_execution.tool_call_id for r in unresolved if r.tool_execution]
-        raise ValueError(f"Partial resume: requirements {ids} still unresolved")
+    unanswerable = pause_not_continuable(needed)
+    if unanswerable:
+        raise ValueError(f"This run cannot be continued: {unanswerable}")
+
+
+def ensure_no_result_answers_two_interrupts(
+    needed: List[NeededAnswer], resume_entries: List[Any], tool_messages: List[AGUIToolMessage]
+) -> None:
+    """Guard: raise where one trailing tool result would answer two interrupts.
+
+    The two channels address an answer by different keys. An entry names the
+    interrupt it answers, so two requirements with ids of their own are two
+    answers; a trailing tool result names the tool call, and every open
+    requirement waiting on that call takes it. Where a request leaves two of them
+    open under one call and reports a result for it, one answer the client sent
+    once resolves both, and the completeness guard then reads a pause as answered
+    that nobody answered twice.
+
+    Refused here rather than on the older channel, which keyed answers by the
+    tool call before this interface advertised an id to answer by and whose
+    callers were written against that, and rather than at the terminal, which
+    cannot tell the two shapes apart: a pause can hold two requirements for one
+    real call, where one result really does answer both, and once the run has
+    been stored and read back those are indistinguishable from two calls a model
+    numbered alike. What tells them apart is what the client did, which is known
+    only here.
+
+    Asked of what the array is about to answer, so a request that answers one of
+    the two by id leaves one open requirement on that call and the result it sent
+    beside it has one place to go. Asked before anything is written, for the
+    reason the pause guard above is: the refusal is about the request as a whole.
+    """
+    answered_by_id = {entry.interrupt_id for entry in resume_entries}
+    reported_calls = {message.tool_call_id for message in tool_messages}
+    left_to_the_result: Dict[str, List[str]] = {}
+    for answer in needed:
+        call_id = answer.tool_call_id
+        if call_id is None or call_id not in reported_calls:
+            continue
+        # A requirement with no id of its own is keyed by this very call, so the
+        # pause guard above has already refused the whole pause over it.
+        if answer.interrupt_id is None or answer.interrupt_id in answered_by_id:
+            continue
+        left_to_the_result.setdefault(call_id, []).append(answer.interrupt_id)
+    shared = {call_id: ids for call_id, ids in left_to_the_result.items() if len(ids) > 1}
+    if not shared:
+        return
+    raise ValueError(
+        "This resume cannot be applied: "
+        + "; ".join(
+            f"the result for tool call {call_id} answers interrupts {', '.join(ids)}, which are "
+            f"{len(ids)} requirements this pause left open on that one call, and a trailing tool result is "
+            "keyed by the call rather than by the interrupt it answers"
+            for call_id, ids in shared.items()
+        )
+        + ". Answer them by interrupt id in the resume array."
+    )
+
+
+def ensure_requirements_resolved(requirements: List[RunRequirement]) -> None:
+    """Guard: raise if a resume array left one of the run's requirements open.
+
+    What it demands is what ``answers_a_pause_needs`` says the run needs, which
+    is the same computation the terminal advertised from, so the set a client is
+    told to answer and the set it is held to are one set. The interrupt id is
+    what names each of them, because that is the key this channel addresses an
+    answer by; naming the tool call named something the client never sent, and a
+    requirement carrying no id has no name to give at all.
+
+    The resume-array channel is what runs this, because the protocol has one
+    array address every open interrupt of the interrupted run. The tool-message
+    channel does not: merging tool messages leaves a requirement the client sent
+    no result for untouched, and wiring the guard into it would decide for every
+    existing caller that such a request is now an error. A partial resume must
+    fail loud here rather than reach dispatch, where an unanswered confirmation
+    tool is silently rejected.
+    """
+    outstanding = answers_a_pause_needs(requirements)
+    if not outstanding:
+        return
+    addressed = [needed.interrupt_id for needed in outstanding if needed.interrupt_id]
+    named = ", ".join(addressed) if addressed else f"{len(outstanding)} carrying no id to name them by"
+    raise ValueError(f"Partial resume: interrupts {named} still unresolved")
+
+
+# What a requirement waiting on a decision is told when the client abandoned the
+# question instead of answering it. A tool call nobody decided about is one the
+# agent must not run, so it is declined, and the note is what the run records as
+# the reason.
+CANCELLED_NOTE = "The client cancelled this interrupt without answering it"
+
+
+def _cancellation_note(reported_error: Optional[str]) -> str:
+    """What a cancelled interrupt records, carrying the reason it came with.
+
+    A client that gave up can also say why, in the envelope a resolved entry
+    reports a failed answer in, and the reason belongs where a resolved entry's
+    goes: into what the run records about the call, which is the only place
+    anything downstream can read it. It rides with the cancellation rather than
+    replacing it, because the entry is still a cancellation, and a note carrying
+    only the client's reason would read as a decision somebody made.
+    """
+    return f"{CANCELLED_NOTE}: {reported_error}" if reported_error else CANCELLED_NOTE
+
+
+# The two statuses the protocol declares an entry can carry. The protocol's own
+# model validates the field as a literal of exactly these, so this is about an
+# entry that did not come through it: the resume array is read loosely typed,
+# because the model exists only on a release that declares it, and a third value
+# taking the resolved path would be answered from a payload that means something
+# else.
+RESUME_RESOLVED = "resolved"
+RESUME_CANCELLED = "cancelled"
+
+
+def _carried_at(envelope: Any, keys: Sequence[str]) -> Any:
+    """What this envelope carries at these keys, stopping where the nesting ends.
+
+    A client that wrote the reason where the advertised path nests further put
+    it one level short of the leaf, which is a report all the same, so the walk
+    hands back what it found rather than nothing. A key the envelope does not
+    carry at all is no report.
+    """
+    found = envelope
+    for key in keys:
+        if not isinstance(found, dict):
+            return found
+        if key not in found:
+            return None
+        found = found[key]
+    return found
+
+
+def _where_a_failure_is_reported() -> str:
+    """The advertised report path, spelled the way a refusal about it names it.
+
+    Built from the path the interrupt advertises rather than written out, for
+    the reason the walk below reads that path: a message naming somewhere else
+    sends a client to a place nothing reads.
+    """
+    field, *keys = interrupts.ERROR_REPORT_PATH
+    return field + "".join(f"[{key!r}]" for key in keys)
+
+
+def _reported_error(entry: Any) -> Optional[str]:
+    """The failure one resume entry reports, when it reports one.
+
+    Read at the path the interrupt for a client-run tool advertises, walked out
+    of that one constant: written out here as a nesting of its own, the two
+    shared their last keys and not their structure, and a client following the
+    advertisement would have had its report read as the result its tool returned.
+
+    Every lookup is optional: a protocol release without ``metadata`` carries no
+    envelope to read, and an entry that answers normally carries no error in the
+    one it has. What is present is read wherever a client plausibly put it,
+    inside the namespace the interrupt advertised or directly on the envelope,
+    and anything present that is not a reason the run can record is refused
+    rather than dropped, because dropping it stores the payload beside it as the
+    result and tells the model the tool ran.
+    """
+    envelope_field, *nested = interrupts.ERROR_REPORT_PATH
+    envelope = getattr(entry, envelope_field, None)
+    if not isinstance(envelope, dict):
+        return None
+    reported = _carried_at(envelope, nested)
+    if reported is None and len(nested) > 1:
+        reported = _carried_at(envelope, nested[-1:])
+    if reported is None:
+        return None
+    if not isinstance(reported, str) or not reported.strip():
+        raise ValueError(
+            f"Resume entry for interrupt {entry.interrupt_id!r} reports a failure under "
+            f"{_where_a_failure_is_reported()}, "
+            "which has to carry the reason as a non-empty string"
+        )
+    return reported
+
+
+def _the_answer_it_carries(payload: Any) -> Any:
+    """One resume entry's payload as the resolvers for the structured pauses read it.
+
+    A client that sent the JSON as a string sent the answer the tool-message
+    channel parses out of exactly that, so it goes through the same parser and
+    the two channels read one payload the same way. A client-run tool's result
+    is not parsed, because there a string is the result rather than an envelope
+    around one.
+    """
+    return parse_response_dict_str(payload) if isinstance(payload, str) else payload
+
+
+def _apply_resume_entry(requirement: RunRequirement, entry: Any) -> None:
+    """Write one interrupt's answer onto the requirement waiting for it.
+
+    A cancelled entry is a client that gave up on the question rather than
+    answering it, and only the two decision-shaped pauses can express that: a
+    declined tool call, and a client-run tool that reports back an error. A pause
+    waiting on structured data has no such value to stand in for the data, and
+    continuing without it would run the tool on whatever the model guessed, so
+    the run stops with the reason instead.
+
+    Either status can carry the failure its metadata reports, so the envelope is
+    read once and held to the same shape on both: a report nothing can read is
+    refused rather than passed over for what the status says, and a reason a
+    cancellation gave joins the note, which is what carries it into the run and
+    on to the model.
+
+    An entry that answers can still report that answering failed, through the
+    error its metadata carries. That is a resolved interrupt: the client did
+    respond, and what it responded is that the tool raised. A client-run tool
+    then reaches the model as a failed call rather than as output it never
+    produced, and a decision reported the same way is declined with the reason,
+    which is what an errored tool message has always done on the other channel.
+    The structured pauses have nowhere to put it, so a reported failure stops one
+    exactly as a cancellation does.
+
+    An entry that resolves an interrupt has to carry the answer it resolves it
+    with. One with no payload at all resolved a client-run tool as an empty
+    success, storing a result nobody returned and telling the model the tool ran,
+    while the same entry against a decision was refused; a client that ran
+    nothing cancels, and one whose tool returned nothing says so with an empty
+    payload rather than none.
+    """
+    if entry.status not in (RESUME_RESOLVED, RESUME_CANCELLED):
+        raise ValueError(
+            f"Resume entry for interrupt {entry.interrupt_id!r} carries status {entry.status!r}, "
+            f"and the protocol declares only {RESUME_RESOLVED!r} and {RESUME_CANCELLED!r}"
+        )
+
+    pause_type = requirement.pause_type
+    cancelled = entry.status == RESUME_CANCELLED
+    reported_error = _reported_error(entry)
+
+    if pause_type == "external_execution":
+        if cancelled:
+            _resolve_external_execution(requirement, "", _cancellation_note(reported_error))
+        elif reported_error is None and entry.payload is None:
+            raise ValueError(
+                f"Resume entry for interrupt {entry.interrupt_id!r} resolves a tool the client runs and "
+                "carries no result to resolve it with. A tool that returned nothing says so with an empty "
+                f"payload; one that failed reports it under {_where_a_failure_is_reported()}"
+            )
+        else:
+            _resolve_external_execution(requirement, external_execution_result(entry.payload), reported_error)
+        return
+
+    if pause_type == "confirmation":
+        if cancelled:
+            requirement.reject(note=_cancellation_note(reported_error))
+        else:
+            decision = _confirmation_fields(_the_answer_it_carries(entry.payload))
+            _resolve_confirmation(
+                requirement,
+                _payload_fields(_the_answer_the_pause_advertised(requirement, decision)),
+                reported_error,
+                unreadable_declines=False,
+            )
+        return
+
+    if cancelled or reported_error:
+        unanswered = "was cancelled" if cancelled else f"reports the failure {reported_error!r}"
+        alongside = f", reporting the failure {reported_error!r}" if cancelled and reported_error else ""
+        raise ValueError(
+            f"Resume entry for interrupt {entry.interrupt_id!r} {unanswered}{alongside}, and a {pause_type} pause "
+            "cannot be resumed without the input it is waiting for"
+        )
+
+    answer = _the_answer_the_pause_advertised(requirement, _the_answer_it_carries(entry.payload))
+    payload = _payload_fields(answer)
+    if pause_type == "user_input":
+        _resolve_user_input(requirement, payload)
+    elif pause_type == "user_feedback":
+        _resolve_user_feedback(requirement, payload)
+
+
+def _apply_resume_entries(
+    requirements: List[RunRequirement],
+    needed: List[NeededAnswer],
+    resume_entries: List[Any],
+) -> None:
+    """Write every entry's answer onto the open requirement it names.
+
+    The lookup is keyed off the answers the pause needs, which is the list the
+    terminal advertised its interrupts from, so an id a client was handed is the
+    id its answer is written under. Keyed off every requirement instead, one
+    already carrying the run's answer shadows an open one sharing its id, the
+    client's answer lands on the resolved twin, and the open one is reported
+    unresolved under the very id the client was told to send.
+
+    An entry naming an interrupt the run does not carry is warned about and
+    passed over rather than failing the resume: the protocol has a producer
+    proceed without an entry it does not recognise and surface a warning rather
+    than fail a run over an answer it never asked for, and failing here threw
+    away every real answer sent beside it. It is never matched to some other
+    pause, because guessing which one it meant would answer the wrong question.
+    An entry for a requirement the run has already answered is a replay, so it
+    is left alone in silence rather than reported as naming nothing.
+
+    No guard runs here. A request can carry answers on both channels, and what
+    the run still needs is a question about the two of them together, asked once
+    by the caller after both have been applied.
+    """
+    open_by_interrupt_id = {answer.interrupt_id: answer.requirement for answer in needed if answer.interrupt_id}
+    already_answered = {interrupt_id_of(requirement) for requirement in requirements if requirement.is_resolved()}
+
+    for entry in resume_entries:
+        addressed = open_by_interrupt_id.get(entry.interrupt_id)
+        if addressed is not None:
+            if not addressed.is_resolved():
+                _apply_resume_entry(addressed, entry)
+            continue
+        if entry.interrupt_id in already_answered:
+            continue
+        log_warning(
+            f"AG-UI resume entry addresses interrupt {entry.interrupt_id!r}, which this paused run does not "
+            "carry; it is skipped and the run continues on the entries that answer it"
+        )
+
+
+def resolve_requirements_from_resume_entries(
+    requirements: List[RunRequirement],
+    resume_entries: List[Any],
+    tool_messages: Optional[List[AGUIToolMessage]] = None,
+) -> List[RunRequirement]:
+    """Resolve a paused run's requirements from the answers the request carries.
+
+    Each entry names an interrupt this run reported, and an answer to one the run
+    is waiting on is held to the shape that interrupt advertised. An unreadable
+    one still fails the run: the pause it was sent for stays open either way, and
+    the client is owed the reason its payload was refused rather than the guard's
+    report that something went unanswered.
+
+    ``tool_messages`` are the answers the same request carried on the older
+    channel, and they are applied after the array rather than dropped for it. The
+    two channels address different things: the array names interrupts by id,
+    while a trailing tool message is how a frontend-executed tool's result enters
+    the conversation, keyed by tool call. One assistant turn can pause on both
+    kinds at once, so a client running frontend tools sends exactly this mixture,
+    and a channel dropped here is a pause reported unresolved that the request
+    answered. The array wins where both answer one requirement, because applying
+    it first leaves that requirement resolved and the tool-message pass skips
+    what is already answered.
+
+    Every open requirement must be answered before the run continues, because a
+    partial resume reaches dispatch as an unanswered confirmation and is silently
+    declined there. That is asked once, of what both channels together resolved.
+    A pause holding one requirement no answer resolves is refused before any
+    answer is written, so a client that resumed it reads the reason the terminal
+    gave rather than whatever the first resolver raised. So is a request whose
+    tool result would land on two interrupts at once, which the completeness
+    guard cannot see afterwards: both of them come back resolved.
+    """
+    needed = answers_a_pause_needs(requirements)
+    ensure_pause_can_be_continued(needed)
+    ensure_no_result_answers_two_interrupts(needed, resume_entries, tool_messages or [])
+
+    _apply_resume_entries(requirements, needed, resume_entries)
+    if tool_messages:
+        resolve_requirements_from_tool_messages(requirements, tool_messages)
+
+    ensure_requirements_resolved(requirements)
+    return requirements
 
 
 def _find_paused_run(
     session: Union[AgentSession, TeamSession],
-    tool_messages: List[AGUIToolMessage],
     is_team: bool,
+    addresses: Callable[[RunRequirement], bool],
 ):
-    incoming_call_ids = {msg.tool_call_id for msg in tool_messages}
+    """The paused run in this session that the incoming answers are for.
 
+    ``addresses`` is what each channel matches a requirement by: the tool call a
+    tool message names, or the interrupt id a resume entry names.
+    """
     for run in session.runs or []:
         if is_team and not isinstance(run, TeamRunOutput):
             continue
         if run.status != RunStatus.paused:
             continue
         for req in run.requirements or []:
-            if req.tool_execution and req.tool_execution.tool_call_id in incoming_call_ids:
+            if addresses(req):
                 # The resume flow writes the user's answers into this run's
                 # requirements before continuing it. History run objects are
                 # shared between session reads, so the resume works on a copy
@@ -120,6 +805,100 @@ async def resume_paused_run(
     run_context: RunContext,
     run_kwargs: dict,
 ):
+    """Continue the paused run the incoming tool results belong to.
+
+    The tool-message channel: a frontend that executed a tool, or answered a
+    prompt, sends the answer back as a trailing tool message keyed by the tool
+    call it is for.
+    """
+    incoming_call_ids = {msg.tool_call_id for msg in tool_messages}
+    return await _continue_paused_run(
+        entity=entity,
+        session_id=session_id,
+        run_context=run_context,
+        run_kwargs=run_kwargs,
+        addresses=lambda req: bool(req.tool_execution and req.tool_execution.tool_call_id in incoming_call_ids),
+        resolve=lambda requirements: resolve_requirements_from_tool_messages(requirements, tool_messages),
+        nothing_matched="No paused run matching the provided tool results found in session",
+    )
+
+
+async def resume_paused_run_from_entries(
+    entity: Union[Agent, Team],
+    session_id: str,
+    resume_entries: List[Any],
+    run_context: RunContext,
+    run_kwargs: dict,
+    tool_messages: Optional[List[AGUIToolMessage]] = None,
+):
+    """Continue the paused run the incoming resume entries answer, if one is waiting.
+
+    The protocol's own channel: each entry names an interrupt the run reported
+    when it paused, which is the id of the requirement waiting on it.
+
+    ``tool_messages`` are the answers the same request carried on the older
+    channel, for the pauses the array does not address. The paused run is matched
+    on either key, because a request answering a client-run tool and a decision
+    at once holds both, and matching on one alone found no run for a request that
+    named it twice.
+
+    Nothing is returned when no paused run in the session carries any of them,
+    because then the whole array answers nothing: the protocol reads a resume
+    list that continues no interrupted run as entries the producer does not
+    recognise, which it proceeds without rather than failing over. A client that
+    retried a request, double-submitted one, or replayed a body whose run has
+    already been continued gets there, and failing it turned an answer the run
+    already holds into a run error. The caller is handed nothing so the request
+    can go on as the fresh run it otherwise describes.
+    """
+    addressed = {entry.interrupt_id for entry in resume_entries}
+    answered_calls = {message.tool_call_id for message in tool_messages or []}
+    resumed = await _continue_paused_run(
+        entity=entity,
+        session_id=session_id,
+        run_context=run_context,
+        run_kwargs=run_kwargs,
+        addresses=lambda req: (
+            interrupt_id_of(req) in addressed
+            or bool(req.tool_execution and req.tool_execution.tool_call_id in answered_calls)
+        ),
+        resolve=lambda requirements: resolve_requirements_from_resume_entries(
+            requirements, resume_entries, tool_messages
+        ),
+        nothing_matched=None,
+    )
+    if resumed is None:
+        named = ", ".join(sorted(repr(interrupt_id) for interrupt_id in addressed))
+        also_dropped = (
+            ". The results sent beside them, for tool calls "
+            f"{', '.join(sorted(repr(call) for call in answered_calls))}, answer nothing either"
+            if answered_calls
+            else ""
+        )
+        log_warning(
+            f"AG-UI resume entries address interrupts {named}, which no paused run in session {session_id} "
+            f"carries; they answer nothing and the request runs without them{also_dropped}"
+        )
+    return resumed
+
+
+async def _continue_paused_run(
+    *,
+    entity: Union[Agent, Team],
+    session_id: str,
+    run_context: RunContext,
+    run_kwargs: dict,
+    addresses: Callable[[RunRequirement], bool],
+    resolve: Callable[[List[RunRequirement]], List[RunRequirement]],
+    nothing_matched: Optional[str],
+):
+    """Continue the paused run these answers are for.
+
+    ``nothing_matched`` is the refusal when the session holds no paused run they
+    address, or None from a channel whose answers are dropped rather than
+    refused, which is handed nothing back instead. A session that was never
+    written is the same condition: it holds no paused run either.
+    """
     if not isinstance(entity, (Agent, Team)):
         raise ValueError("Frontend tool resume requires a local Agent or Team")
     if not entity.db:
@@ -127,25 +906,31 @@ async def resume_paused_run(
 
     session = await entity.aget_session(session_id=session_id)
     if not session:
+        if nothing_matched is None:
+            return None
         raise ValueError(f"Session {session_id} not found")
     if not isinstance(session, (AgentSession, TeamSession)):
         raise ValueError(f"Session {session_id} is not a valid session type")
 
-    paused_run = _find_paused_run(session, tool_messages, is_team=isinstance(entity, Team))
+    paused_run = _find_paused_run(session, is_team=isinstance(entity, Team), addresses=addresses)
     if not paused_run:
-        raise ValueError(f"No paused run matching the provided tool results found in session {session_id}")
+        if nothing_matched is None:
+            return None
+        raise ValueError(f"{nothing_matched} {session_id}")
     if not paused_run.requirements:
         raise ValueError(f"Run {paused_run.run_id} has no requirements to resume")
 
-    requirements = resolve_requirements_from_tool_messages(paused_run.requirements, tool_messages)
+    requirements = resolve(paused_run.requirements)
 
     if paused_run.run_id:
         run_context.run_id = paused_run.run_id
 
     # Inline-door admission gate (see agno.os.job_queue): a durable ticket
     # owns this run's continuation - AG-UI must not execute it inline while
-    # an HTTP durable continue CASes the ticket. 409/503 HTTPException raises
-    # into the AG-UI route.
+    # an HTTP durable continue CASes the ticket. The gate's refusal never
+    # reaches the client as its 409/503: the route has already begun a 200
+    # stream, and run_entity turns any exception from here into an in-band run
+    # error carrying the status and detail as its message.
     from agno.os.job_queue import araise_if_ticket_owns_continue, get_active_queue_worker
 
     await araise_if_ticket_owns_continue(

--- a/libs/agno/agno/os/interfaces/agui/router.py
+++ b/libs/agno/agno/os/interfaces/agui/router.py
@@ -21,6 +21,7 @@ from fastapi import APIRouter, Request
 from fastapi.responses import StreamingResponse
 
 from agno.agent import Agent, RemoteAgent
+from agno.os.interfaces.agui.handlers import validate_subagent_visibility
 from agno.os.interfaces.agui.input import (
     extract_context,
     extract_media,
@@ -41,6 +42,7 @@ async def run_entity(
     entity: Union[Agent, RemoteAgent, Team, RemoteTeam],
     run_input: RunAgentInput,
     user_id: Optional[str] = None,
+    subagent_visibility: Optional[str] = None,
 ) -> AsyncIterator[BaseEvent]:
     """Shared handler for running an Agent or Team with AG-UI input/output mapping.
 
@@ -126,6 +128,7 @@ async def run_entity(
             thread_id=run_input.thread_id,
             run_id=run_id,
             run_state=session_state,
+            subagent_visibility=subagent_visibility,
         ):
             yield event
 
@@ -135,12 +138,21 @@ async def run_entity(
 
 
 def attach_routes(
-    router: APIRouter, agent: Optional[Union[Agent, RemoteAgent]] = None, team: Optional[Union[Team, RemoteTeam]] = None
+    router: APIRouter,
+    agent: Optional[Union[Agent, RemoteAgent]] = None,
+    team: Optional[Union[Team, RemoteTeam]] = None,
+    subagent_visibility: Optional[str] = None,
 ) -> APIRouter:
     if agent is None and team is None:
         raise ValueError("Either agent or team must be provided.")
 
-    entity = agent or team
+    # Validated at mount time, not per request: an unserveable setting is a
+    # startup failure, never an in-band error after a run has already begun.
+    subagent_visibility = validate_subagent_visibility(subagent_visibility)
+
+    # An agent takes precedence over a team, decided on presence, so the entity a
+    # request runs is the one the interface's scope mapping named.
+    entity = agent if agent is not None else team
     encoder = EventEncoder()
 
     @router.post("/agui", name="run_agent")
@@ -160,7 +172,12 @@ def attach_routes(
         )
 
         async def event_generator():
-            async for event in run_entity(entity, run_input, user_id=user_id):  # type: ignore
+            async for event in run_entity(
+                entity,  # type: ignore[arg-type]
+                run_input,
+                user_id=user_id,
+                subagent_visibility=subagent_visibility,
+            ):
                 yield encoder.encode(event)
 
         return StreamingResponse(

--- a/libs/agno/agno/os/interfaces/agui/state.py
+++ b/libs/agno/agno/os/interfaces/agui/state.py
@@ -1,17 +1,92 @@
 import copy
 import uuid
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from agno.utils.log import log_warning
 
+# The three client-facing presentations of a delegation to a subagent. Values
+# name what the CLIENT SEES, not an internal switch:
+#   "inline"     - the subagent's output streams as the parent's own work,
+#                  byte-identical to the pre-lineage behavior. The safe default:
+#                  a client already in production cannot be protected after the
+#                  fact from event types its transport rejects.
+#   "attributed" - the full subagent surface: SUBAGENT_* lifecycle events, and a
+#                  subagent_run_id on the message, tool call and reasoning events
+#                  a subagent produced. State events stay unstamped, because a
+#                  team's session state is one shared document.
+#   "hidden"     - invisible delegation: no SUBAGENT_* lifecycle event and no
+#                  per-event subagent stamp reaches the wire, and nothing a
+#                  subagent streamed is sent as its own work. What the client
+#                  sees is the parent's: the delegation tool call, whose
+#                  arguments name the member and carry the task text just as the
+#                  default sends them, that call's result, and the parent's own
+#                  reply. Two things a subagent produced also arrive: a change
+#                  its tool made to the session state, which is one shared
+#                  document, and a pending tool call it paused on, which the run
+#                  cannot continue without. Neither is attributed to it. What a
+#                  subagent's failure withholds is that same identity: the
+#                  lineage events and the per-event stamps stay off the wire and
+#                  nothing on it names the subagent that failed, while the
+#                  reason the run stopped still reaches the client, because a
+#                  subagent's terminal can be the run's only account of how it
+#                  ended and is then read as the run's own.
+SUBAGENT_VISIBILITY_INLINE = "inline"
+SUBAGENT_VISIBILITY_ATTRIBUTED = "attributed"
+SUBAGENT_VISIBILITY_HIDDEN = "hidden"
+SUBAGENT_VISIBILITY_VALUES = (
+    SUBAGENT_VISIBILITY_INLINE,
+    SUBAGENT_VISIBILITY_ATTRIBUTED,
+    SUBAGENT_VISIBILITY_HIDDEN,
+)
+
+# Lane key for the top-level entity's own streaming state. Subagent lanes are
+# keyed by the subagent's run id.
+ROOT_LANE: Optional[str] = None
+
+
+# The tools a Team delegates through, named exactly as the framework registers
+# them: two for member delegation, and two more when the team works a task list.
+# The decision keys on the name because argument shape does not identify a
+# delegation: Agno's own ``update_user_memory`` also takes a ``task``, and the
+# tasks-mode tools take none.
+DELEGATION_TOOL_NAMES = frozenset(
+    {
+        "delegate_task_to_member",
+        "delegate_task_to_members",
+        "execute_task",
+        "execute_tasks_parallel",
+    }
+)
+
 
 @dataclass
-class StreamState:
-    """Per-stream state for AG-UI event translation.
+class OpenToolCall:
+    """One tool call still open in a lane.
 
-    Tracks message lifecycle, tool calls, reasoning sessions, and state deltas.
-    All handlers receive this object and mutate it as events flow through.
+    The tool name is a required part of the record: it is what identifies a
+    delegation, and without it a reader is left inferring intent from the
+    arguments, which mistakes any tool taking a ``task`` for a delegation.
+    """
+
+    name: str
+    args: Dict[str, Any]
+    parent_message_id: str
+
+    @property
+    def is_delegation(self) -> bool:
+        return self.name in DELEGATION_TOOL_NAMES
+
+
+@dataclass
+class Lane:
+    """Streaming state for one attribution lane.
+
+    A lane is the top-level entity or a single subagent invocation. Message,
+    reasoning and tool-parent state is per-lane so a subagent's text never
+    lands in the parent's bubble and two subagents streaming at once keep
+    independent spans.
 
     Text Message Lifecycle:
         CLOSED (initial)      OPEN                   CLOSED
@@ -21,18 +96,42 @@ class StreamState:
     The text_message_id persists after close so tool calls can parent to it.
     """
 
-    # Text message tracking
     text_message_id: str = ""
     text_message_open: bool = False
-
-    # Tool call tracking
-    active_tool_call_ids: Set[str] = field(default_factory=set)
-    ended_tool_call_ids: Set[str] = field(default_factory=set)
     pending_tool_calls_parent_id: str = ""
-
-    # Reasoning tracking
     reasoning_message_id: Optional[str] = None
     reasoning_step_count: int = 0
+
+
+@dataclass
+class Subagent:
+    """A subagent invocation announced on the wire."""
+
+    name: str
+    parent_lane: Optional[str] = None
+
+
+@dataclass
+class StreamState:
+    """Per-stream state for AG-UI event translation.
+
+    Tracks message lifecycle, tool calls, reasoning sessions, state deltas and
+    subagent lineage. All handlers receive this object and mutate it as events
+    flow through.
+
+    Lane-scoped state lives in ``lanes``; the message, reasoning and tool-parent
+    properties below read whichever lane the chunk being mapped belongs to, and
+    the methods beside them are what writes it. Under ``inline`` visibility every
+    chunk resolves to ROOT_LANE, so there is exactly one lane and the emitted
+    stream is unchanged.
+    """
+
+    # Tool call tracking. Tool call ids are unique across the run, so these stay
+    # flat; ``tool_call_lanes`` remembers which lane each one belongs to so a
+    # tool call closed at run end is still attributed to its own subagent.
+    active_tool_call_ids: Set[str] = field(default_factory=set)
+    ended_tool_call_ids: Set[str] = field(default_factory=set)
+    tool_call_lanes: Dict[str, Optional[str]] = field(default_factory=dict)
 
     # State delta tracking
     _last_snapshot: Optional[Dict[str, Any]] = field(default=None, repr=False)
@@ -42,52 +141,354 @@ class StreamState:
     run_id: str = ""
     run_state: Optional[Dict[str, Any]] = None
 
+    # Lineage
+    subagent_visibility: str = SUBAGENT_VISIBILITY_INLINE
+    lanes: Dict[Optional[str], Lane] = field(default_factory=dict)
+    current_lane: Optional[str] = ROOT_LANE
+    # Run id of the top-level entity, learned from the first chunk that reports
+    # no parent, so a subagent whose parent IS the top-level run reports no parent
+    # subagent. It is deliberately not seeded from ``run_id``: a resumed run
+    # executes under the stored paused run's id, not the request's, and seeding
+    # would read every chunk of it as a subagent's.
+    root_run_id: Optional[str] = None
+    open_subagents: Dict[str, Subagent] = field(default_factory=dict)
+    # Every subagent ever announced, kept after its terminal so a lane drained at
+    # run end still knows where it sits in the delegation tree.
+    announced_subagents: Dict[str, Subagent] = field(default_factory=dict)
+    # SUBAGENT_FINISHED / SUBAGENT_ERROR are terminal for the id they name, so a
+    # closed subagent may neither be re-announced nor own a second terminal.
+    closed_subagents: Set[str] = field(default_factory=set)
+    # Open tool calls per lane, each holding its name, its arguments and the
+    # message it was parented to. A delegation is one of these calls, so this is
+    # what links a subagent back to the exact call that spawned it.
+    open_tool_calls: Dict[Optional[str], Dict[str, OpenToolCall]] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        # Validated here as well as at the interface boundary, so a value that
+        # reached this object by any other route cannot become a silent fourth
+        # mode that behaves like none of the three.
+        if self.subagent_visibility not in SUBAGENT_VISIBILITY_VALUES:
+            raise ValueError(
+                f"subagent_visibility must be one of {SUBAGENT_VISIBILITY_VALUES}, got {self.subagent_visibility!r}"
+            )
+
+    @property
+    def hides_subagents(self) -> bool:
+        return self.subagent_visibility == SUBAGENT_VISIBILITY_HIDDEN
+
+    def lane(self, key: Optional[str]) -> Lane:
+        """The state of one named lane, created on first use.
+
+        The key is always explicit: ROOT_LANE is ``None``, so a "current lane"
+        default here would make a root-lane lookup indistinguishable from one.
+        """
+        existing = self.lanes.get(key)
+        if existing is None:
+            existing = Lane()
+            self.lanes[key] = existing
+        return existing
+
+    def active_lane(self) -> Lane:
+        """The state of the lane the chunk being mapped belongs to."""
+        return self.lane(self.current_lane)
+
+    # --- Lane-scoped message state -------------------------------------------
+
+    @property
+    def text_message_id(self) -> str:
+        return self.active_lane().text_message_id
+
+    @property
+    def text_message_open(self) -> bool:
+        return self.active_lane().text_message_open
+
+    @property
+    def reasoning_message_id(self) -> Optional[str]:
+        return self.active_lane().reasoning_message_id
+
     def open_text_message(self) -> str:
-        self.text_message_id = str(uuid.uuid4())
-        self.text_message_open = True
-        return self.text_message_id
+        lane = self.active_lane()
+        lane.text_message_id = str(uuid.uuid4())
+        lane.text_message_open = True
+        return lane.text_message_id
 
     def close_text_message(self) -> None:
         # ID persists for tool call parenting — only flag changes
-        self.text_message_open = False
+        self.active_lane().text_message_open = False
 
     def start_tool_call(self, tool_call_id: str) -> None:
         self.active_tool_call_ids.add(tool_call_id)
+        self.tool_call_lanes[tool_call_id] = self.current_lane
 
     def end_tool_call(self, tool_call_id: str) -> None:
         self.active_tool_call_ids.discard(tool_call_id)
         self.ended_tool_call_ids.add(tool_call_id)
+        self.open_tool_calls.get(self.lane_of_tool_call(tool_call_id), {}).pop(tool_call_id, None)
+
+    def lane_of_tool_call(self, tool_call_id: str) -> Optional[str]:
+        return self.tool_call_lanes.get(tool_call_id, ROOT_LANE)
+
+    def tool_call_started(self, tool_call_id: str) -> bool:
+        """Whether a start has gone out for a call the run itself opened.
+
+        Every call opened from the run's own tool-call event is recorded in
+        ``tool_call_lanes`` and stays there once it ends, so this holds whatever
+        state such a call is in now, and a call the client already has a start
+        for is never given a second one. The starts a pause prompt writes are
+        not recorded here: one terminal produces one prompt, which dedupes
+        against the calls it is building rather than against this.
+        """
+        return tool_call_id in self.tool_call_lanes
+
+    def active_tool_calls_in_order(self) -> List[str]:
+        """Tool calls still open, in the order the run opened them.
+
+        The close order reaches the client, so it is read from
+        ``tool_call_lanes``, which records every call as it starts, rather than
+        from the unordered active set. A call that somehow never reached that
+        record still has to be closed, so any such id follows, sorted.
+        """
+        ordered = [tool_call_id for tool_call_id in self.tool_call_lanes if tool_call_id in self.active_tool_call_ids]
+        ordered.extend(sorted(self.active_tool_call_ids.difference(ordered)))
+        return ordered
 
     def get_parent_message_id_for_tool_call(self) -> str:
+        lane = self.active_lane()
         # pending_tool_calls_parent_id used for sequential tools after message close
-        if self.pending_tool_calls_parent_id:
-            return self.pending_tool_calls_parent_id
+        if lane.pending_tool_calls_parent_id:
+            return lane.pending_tool_calls_parent_id
         # text_message_id persists after close
-        return self.text_message_id
+        return lane.text_message_id
 
     def set_pending_tool_calls_parent_id(self, parent_id: str) -> None:
-        self.pending_tool_calls_parent_id = parent_id
+        self.active_lane().pending_tool_calls_parent_id = parent_id
 
     def clear_pending_tool_calls_parent_id(self) -> None:
-        self.pending_tool_calls_parent_id = ""
+        self.active_lane().pending_tool_calls_parent_id = ""
 
     def start_reasoning(self) -> str:
-        self.reasoning_message_id = str(uuid.uuid4())
-        self.reasoning_step_count = 0
-        return self.reasoning_message_id
+        lane = self.active_lane()
+        lane.reasoning_message_id = str(uuid.uuid4())
+        lane.reasoning_step_count = 0
+        return lane.reasoning_message_id
 
     def ensure_reasoning_started(self) -> Tuple[str, bool]:
-        if self.reasoning_message_id is not None:
-            return self.reasoning_message_id, False
+        lane = self.active_lane()
+        if lane.reasoning_message_id is not None:
+            return lane.reasoning_message_id, False
         return self.start_reasoning(), True
 
     def next_reasoning_step(self) -> int:
-        self.reasoning_step_count += 1
-        return self.reasoning_step_count
+        lane = self.active_lane()
+        lane.reasoning_step_count += 1
+        return lane.reasoning_step_count
 
     def end_reasoning(self) -> None:
-        self.reasoning_message_id = None
-        self.reasoning_step_count = 0
+        lane = self.active_lane()
+        lane.reasoning_message_id = None
+        lane.reasoning_step_count = 0
+
+    # --- Lineage -------------------------------------------------------------
+
+    def lane_for(self, run_id: Optional[str], parent_run_id: Optional[str]) -> Optional[str]:
+        """The lane a chunk belongs to, without changing any state.
+
+        Agno stamps every chunk with its own ``run_id`` and, for a subagent, the
+        ``parent_run_id`` of the run that delegated to it. A chunk that reports
+        no parent is the top-level entity's own work. Under ``inline`` visibility
+        every chunk is the top-level entity's work as far as the wire is
+        concerned, which is what keeps that stream unchanged.
+        """
+        if self.subagent_visibility == SUBAGENT_VISIBILITY_INLINE:
+            return ROOT_LANE
+        if parent_run_id is None or run_id is None or run_id == self.root_run_id:
+            return ROOT_LANE
+        return run_id
+
+    def resolve_lane(self, run_id: Optional[str], parent_run_id: Optional[str]) -> Optional[str]:
+        """Make the chunk's lane current, learning the top-level run id on the way."""
+        if parent_run_id is None and run_id is not None and self.root_run_id is None:
+            self.root_run_id = run_id
+        self.current_lane = self.lane_for(run_id, parent_run_id)
+        return self.current_lane
+
+    def delegating_lane_for(
+        self, parent_run_id: Optional[str], member_id: Optional[str]
+    ) -> Tuple[Optional[str], Optional[str]]:
+        """The lane that delegated to a subagent, and the call it delegated through.
+
+        The call is only ever looked for in the lane reported beside it, so what
+        a subagent is announced with comes from the run that really delegated to
+        it and from nowhere else. When the delegating lane cannot be named, no
+        call is reported either: the delegating run's own open calls are not
+        this run's, and searching the top-level entity's instead would hand a
+        grandchild the leader's call, the leader's parent message, and the
+        leader's task text as its own description.
+
+        A lane goes unnamed for two reasons, and neither leaves a link behind.
+        One is a lane this stream has not announced: a parent link is resolved
+        by the client against a lane it was told about, so a grandchild whose
+        first event outruns its parent's is placed directly under the run rather
+        than pointed at a lane the client cannot follow. The other is a lane
+        whose terminal has already gone out, which delegates nothing more:
+        naming it would hand the client a child that resolves inside a lane it
+        has already closed.
+        """
+        # A chunk reporting no parent at all, and one whose parent is the run
+        # this stream learned as the root, are both the top-level entity's work.
+        if parent_run_id is None or parent_run_id == self.root_run_id:
+            return ROOT_LANE, self.find_delegation_call(ROOT_LANE, member_id)
+        if parent_run_id in self.closed_subagents or parent_run_id not in self.announced_subagents:
+            return None, None
+        return parent_run_id, self.find_delegation_call(parent_run_id, member_id)
+
+    def record_open_tool_call(
+        self, tool_call_id: str, tool_name: Optional[str], tool_args: Any, parent_message_id: str
+    ) -> None:
+        # Name and arguments reach here straight off the model, so anything at all
+        # can arrive. Only a mapping of arguments is kept, which is all a
+        # delegation lookup reads.
+        self.open_tool_calls.setdefault(self.current_lane, {})[tool_call_id] = OpenToolCall(
+            name=str(tool_name) if tool_name else "",
+            args=dict(tool_args) if isinstance(tool_args, Mapping) else {},
+            parent_message_id=parent_message_id,
+        )
+
+    def find_delegation_call(self, parent_lane: Optional[str], member_id: Optional[str]) -> Optional[str]:
+        """Tool call id of the delegation that spawned a subagent, when identifiable.
+
+        Only a call still open in the delegating lane, whose tool name is one the
+        framework delegates through, and whose ``member_id`` argument names this
+        member. Naming the member is what makes such a call evidence: an open
+        delegation to somebody else would otherwise hand this lane another
+        member's parent call, task text and parent message. Two open delegations
+        naming the same member point at no single call, so nothing is reported
+        rather than one of them picked. The broadcast tools name no member at
+        all, so a member one of those spawned gets no link rather than the
+        leader's own call.
+        """
+        if not member_id:
+            return None
+        named = [
+            tool_call_id
+            for tool_call_id, entry in (self.open_tool_calls.get(parent_lane) or {}).items()
+            if entry.is_delegation and entry.args.get("member_id") == member_id
+        ]
+        return named[0] if len(named) == 1 else None
+
+    def find_member_delegation(self, member_id: Optional[str]) -> Optional[Tuple[Optional[str], str]]:
+        """The lane that delegated to a member and the call it delegated through.
+
+        A member run pauses inside the call that spawned it, so that call is
+        still open and the lane holding it is the member's parent, however deep
+        the run that reported the pause sits. Only a delegation naming this
+        member counts, and only while exactly one is open: two delegations
+        naming the same member, in one lane or in two, point at no single
+        parent, so nothing is reported rather than guessed.
+
+        A lane whose own terminal has already gone out is not searched. Whatever
+        it still holds open, that lane can no longer be named as a parent: its
+        terminal would then precede a child's, which is a lane the client has
+        already closed.
+        """
+        if not member_id:
+            return None
+        matches = [
+            (lane, tool_call_id)
+            for lane, calls in self.open_tool_calls.items()
+            if lane not in self.closed_subagents
+            for tool_call_id, entry in calls.items()
+            if entry.is_delegation and entry.args.get("member_id") == member_id
+        ]
+        if len(matches) != 1:
+            return None
+        return matches[0]
+
+    def _delegation_entry(self, parent_lane: Optional[str], tool_call_id: Optional[str]) -> Optional[OpenToolCall]:
+        if tool_call_id is None:
+            return None
+        return (self.open_tool_calls.get(parent_lane) or {}).get(tool_call_id)
+
+    def delegation_task(self, parent_lane: Optional[str], tool_call_id: Optional[str]) -> Optional[str]:
+        """The task text the delegation call carried, which describes the subagent's work.
+
+        Only a delegation's own arguments are read, so a ``task`` belonging to
+        some other tool can never become a subagent's description. The tasks-mode
+        delegations carry a task id instead of task text, so a subagent spawned by
+        one has no description rather than an invented one.
+        """
+        entry = self._delegation_entry(parent_lane, tool_call_id)
+        task = entry.args.get("task") if entry is not None and entry.is_delegation else None
+        return task if isinstance(task, str) and task else None
+
+    def delegation_parent_message_id(self, parent_lane: Optional[str], tool_call_id: Optional[str]) -> Optional[str]:
+        entry = self._delegation_entry(parent_lane, tool_call_id)
+        if entry is None or not entry.is_delegation:
+            return None
+        return entry.parent_message_id or None
+
+    def open_subagent(self, subagent_run_id: str, name: str, parent_lane: Optional[str]) -> None:
+        subagent = Subagent(name=name, parent_lane=parent_lane)
+        self.open_subagents[subagent_run_id] = subagent
+        self.announced_subagents[subagent_run_id] = subagent
+
+    def close_subagent(self, subagent_run_id: str) -> None:
+        self.open_subagents.pop(subagent_run_id, None)
+        self.closed_subagents.add(subagent_run_id)
+
+    def ancestor_lanes(self, lane_key: Optional[str]) -> List[str]:
+        """The announced subagent lanes above a lane, nearest first.
+
+        The walk stops on a lane it has already passed, so a parent chain that
+        somehow closes on itself ends the walk instead of looping.
+        """
+        ancestors: List[str] = []
+        seen = {lane_key}
+        entry = self.announced_subagents.get(lane_key) if lane_key is not None else None
+        parent = entry.parent_lane if entry else None
+        while parent is not None and parent not in seen:
+            ancestors.append(parent)
+            seen.add(parent)
+            entry = self.announced_subagents.get(parent)
+            parent = entry.parent_lane if entry else None
+        return ancestors
+
+    def lane_depth(self, lane_key: Optional[str]) -> int:
+        """How many announced subagent lanes sit above a lane.
+
+        A direct child of the top-level entity has none above it, so it reports 0,
+        the same as the root lane. The value exists to order children before
+        parents, not to measure how deep a delegation went.
+        """
+        return len(self.ancestor_lanes(lane_key))
+
+    def subagents_deepest_first(self) -> List[str]:
+        """Open subagents ordered so a child's terminal precedes its parent's."""
+        return sorted(self.open_subagents, key=self.lane_depth, reverse=True)
+
+    def lanes_deepest_first(self) -> List[Optional[str]]:
+        """Every lane the stream created, children before parents, then the root.
+
+        The root lane is always last whether or not it holds anything, so a
+        caller sweeping these closes nothing there rather than skipping it.
+
+        Every lane the mapper opens a tool call through already has a record here,
+        so the sweep over open tool calls adds nothing in practice; it is kept so
+        that the guarantee no tool call reaches the run terminal unended does not
+        rest on its lane happening to hold a span of its own. Ordering is taken
+        from insertion order rather than from the tool call sets, so lanes of equal
+        depth keep the order the stream created them in.
+        """
+        keys: List[Optional[str]] = list(self.lanes)
+        seen = set(keys)
+        for tool_call_id, lane_key in self.tool_call_lanes.items():
+            if tool_call_id in self.active_tool_call_ids and lane_key not in seen:
+                seen.add(lane_key)
+                keys.append(lane_key)
+        subagent_lanes = [key for key in keys if key is not ROOT_LANE]
+        return [*sorted(subagent_lanes, key=self.lane_depth, reverse=True), ROOT_LANE]
+
+    # --- State deltas --------------------------------------------------------
 
     def set_state_snapshot(self, state: Dict[str, Any]) -> None:
         self._last_snapshot = copy.deepcopy(state)

--- a/libs/agno/agno/os/interfaces/agui/stream.py
+++ b/libs/agno/agno/os/interfaces/agui/stream.py
@@ -1,12 +1,87 @@
 from collections.abc import Iterator
-from typing import Any, AsyncIterator, Dict, Optional, Union
+from typing import Any, AsyncIterator, Dict, List, Optional, Union
 
 from ag_ui.core import BaseEvent
 
-from agno.os.interfaces.agui.handlers import is_completion_event, process_completion, process_event
+from agno.os.interfaces.agui.handlers import (
+    close_open_spans,
+    is_completion_event,
+    is_subagent_completion_event,
+    process_completion,
+    process_event,
+    validate_subagent_visibility,
+)
+from agno.os.interfaces.agui.handlers import (
+    _readable as readable_value,
+)
 from agno.os.interfaces.agui.state import StreamState
 from agno.run.agent import RunCompletedEvent, RunOutputEvent
+from agno.run.base import BaseRunOutputEvent
 from agno.run.team import TeamRunOutputEvent
+from agno.utils.log import log_exception
+
+
+def _failure_message(error: Exception) -> str:
+    """What a failed stream tells the client: the exception's text, or its type name.
+
+    The text is read through the same guard every other label is. Rendering an
+    exception runs its own ``__str__``, which can raise, and this runs before the
+    cleanup's try: unguarded, an exception that cannot describe itself would
+    close no span and no subagent lane, and would replace the run's real failure
+    with the one raised while naming it.
+    """
+    return readable_value(error, "a stream failure message") or type(error).__name__
+
+
+def _failure_detail(error: Exception) -> str:
+    """The failure as an operator needs it: what raised, and its text when it has any.
+
+    Guarded exactly as the message above is, and for the same reason: this is
+    what the failure is recorded with, so raising here would lose the record too.
+    """
+    message = readable_value(error, "a stream failure detail")
+    return f"{type(error).__name__}: {message}" if message else type(error).__name__
+
+
+def _run_terminal(
+    root_terminal: Optional[BaseRunOutputEvent], subagent_terminal: Optional[BaseRunOutputEvent]
+) -> BaseRunOutputEvent:
+    """The chunk the run terminal is built from.
+
+    The top-level entity's own terminal is it whenever the stream carried one. A
+    stream that ended on a subagent's terminal instead reported no other account
+    of how the run ended, so that one is read as the run's: a run that died
+    inside a subagent must not reach the client as a success. A stream that
+    reported no terminal at all completed, which is what it was before subagent
+    lineage existed.
+
+    Which subagent terminal, when the stream carried more than one, is simply
+    the last of them: nothing here ranks a failure above a later completion. A
+    subagent that fails and is then followed by another subagent completing
+    therefore ends the run as a completion, the failure surviving as that
+    subagent's own ``SUBAGENT_ERROR`` and the line recording it. The pause
+    variant is the same shape: a subagent pause followed by another subagent's
+    completion loses the pending call, because the completion is what the run
+    terminal is then built from and a completion has no pending call to prompt
+    with. Both hold under every visibility, the default included, which has no
+    other account of how the run ended either.
+    """
+    return root_terminal or subagent_terminal or RunCompletedEvent()
+
+
+def _cleanup_events(state: StreamState, run_id: str, error_message: str) -> List[BaseEvent]:
+    """The spans a failed stream still has to close, for a cleanup that cannot fail.
+
+    The caller re-raises the run's own failure straight after this, and that
+    failure is what the run terminal is built from. A raise from in here would
+    replace it with one from the cleanup and skip the re-raise, so a cleanup
+    that fails is recorded and yields what it can.
+    """
+    try:
+        return close_open_spans(state, error_message)
+    except Exception as error:
+        log_exception(f"AG-UI stream for run {run_id} could not close its open spans: {_failure_detail(error)}")
+        return []
 
 
 def stream_agno_response_as_agui_events(
@@ -14,25 +89,47 @@ def stream_agno_response_as_agui_events(
     thread_id: str,
     run_id: str,
     run_state: Optional[Dict[str, Any]] = None,
+    subagent_visibility: Optional[str] = None,
 ) -> Iterator[BaseEvent]:
     """Map the Agno response stream to AG-UI format."""
-    state = StreamState(thread_id=thread_id, run_id=run_id, run_state=run_state)
+    state = StreamState(
+        thread_id=thread_id,
+        run_id=run_id,
+        run_state=run_state,
+        subagent_visibility=validate_subagent_visibility(subagent_visibility),
+    )
 
     if run_state is not None:
         state.set_state_snapshot(run_state)
 
-    terminal_chunk = None
+    terminal_chunk: Optional[BaseRunOutputEvent] = None
+    subagent_terminal_chunk: Optional[BaseRunOutputEvent] = None
 
-    for chunk in response_stream:
-        if is_completion_event(chunk):
-            terminal_chunk = chunk
-        else:
-            for event in process_event(chunk, state):
-                yield event
+    try:
+        for chunk in response_stream:
+            if is_completion_event(chunk, state):
+                terminal_chunk = chunk
+            else:
+                for event in process_event(chunk, state):
+                    yield event
+                # Read after the chunk was mapped, so the lane it decides
+                # against is the one the mapper settled on for that chunk.
+                if is_subagent_completion_event(chunk, state):
+                    subagent_terminal_chunk = chunk
+    except Exception as error:
+        # A source stream that dies mid-run leaves every span this mapper opened
+        # unclosed, so a client would keep spinning on a message, a tool call or
+        # a member that never resolves. Close them and re-raise: the caller turns
+        # the propagated failure into the run terminal, and nothing may follow a
+        # terminal event. The failure is recorded first, with what raised and
+        # where, because the cleanup that follows it is otherwise the only trace
+        # that anything went wrong.
+        log_exception(f"AG-UI stream for run {run_id} failed mid-run, closing open spans: {_failure_detail(error)}")
+        for event in _cleanup_events(state, run_id, _failure_message(error)):
+            yield event
+        raise
 
-    # Process completion (or synthesize one if stream ended naturally)
-    final_chunk = terminal_chunk or RunCompletedEvent()
-    for event in process_completion(final_chunk, state):
+    for event in process_completion(_run_terminal(terminal_chunk, subagent_terminal_chunk), state):
         yield event
 
 
@@ -41,23 +138,45 @@ async def async_stream_agno_response_as_agui_events(
     thread_id: str,
     run_id: str,
     run_state: Optional[Dict[str, Any]] = None,
+    subagent_visibility: Optional[str] = None,
 ) -> AsyncIterator[BaseEvent]:
     """Map the Agno response stream to AG-UI format."""
-    state = StreamState(thread_id=thread_id, run_id=run_id, run_state=run_state)
+    state = StreamState(
+        thread_id=thread_id,
+        run_id=run_id,
+        run_state=run_state,
+        subagent_visibility=validate_subagent_visibility(subagent_visibility),
+    )
 
     if run_state is not None:
         state.set_state_snapshot(run_state)
 
-    terminal_chunk = None
+    terminal_chunk: Optional[BaseRunOutputEvent] = None
+    subagent_terminal_chunk: Optional[BaseRunOutputEvent] = None
 
-    async for chunk in response_stream:
-        if is_completion_event(chunk):
-            terminal_chunk = chunk
-        else:
-            for event in process_event(chunk, state):
-                yield event
+    try:
+        async for chunk in response_stream:
+            if is_completion_event(chunk, state):
+                terminal_chunk = chunk
+            else:
+                for event in process_event(chunk, state):
+                    yield event
+                # Read after the chunk was mapped, so the lane it decides
+                # against is the one the mapper settled on for that chunk.
+                if is_subagent_completion_event(chunk, state):
+                    subagent_terminal_chunk = chunk
+    except Exception as error:
+        # A source stream that dies mid-run leaves every span this mapper opened
+        # unclosed, so a client would keep spinning on a message, a tool call or
+        # a member that never resolves. Close them and re-raise: the caller turns
+        # the propagated failure into the run terminal, and nothing may follow a
+        # terminal event. The failure is recorded first, with what raised and
+        # where, because the cleanup that follows it is otherwise the only trace
+        # that anything went wrong.
+        log_exception(f"AG-UI stream for run {run_id} failed mid-run, closing open spans: {_failure_detail(error)}")
+        for event in _cleanup_events(state, run_id, _failure_message(error)):
+            yield event
+        raise
 
-    # Process completion (or synthesize one if stream ended naturally)
-    final_chunk = terminal_chunk or RunCompletedEvent()
-    for event in process_completion(final_chunk, state):
+    for event in process_completion(_run_terminal(terminal_chunk, subagent_terminal_chunk), state):
         yield event

--- a/libs/agno/agno/os/interfaces/agui/utils.py
+++ b/libs/agno/agno/os/interfaces/agui/utils.py
@@ -1,6 +1,38 @@
 import ast
 import json
-from typing import Optional
+from typing import Any, Optional
+
+from agno.utils.log import log_warning
+
+
+def readable(value: Any, described: str) -> Optional[str]:
+    """A value as display text, or None when it is falsy or reading it raises.
+
+    A name reaches the chunk straight off the caller's own Agent or Team, and
+    the words a pause advertises its answer shape in come off whatever a tool
+    declared, so rendering one can raise. A label is never worth ending a run
+    for, so a value that cannot be read is recorded and treated as absent.
+
+    Falsy is absent too, and deliberately: every caller is choosing a label, and
+    the empty string, an empty mapping and zero are all nothing to show, so each
+    of them falls through to whatever the caller offers next rather than
+    reaching the wire as ``""`` or ``"0"``. A caller that has to tell an empty
+    value from a missing one cannot use this.
+
+    Shared by the stream's labels and the interrupt round trip's schema text,
+    because one guard is what keeps the two from disagreeing about which values
+    a run may not put on the wire.
+    """
+    try:
+        return str(value) if value else None
+    except Exception as error:
+        # The record names the failure's type and renders none of it: the value
+        # that could not be read is what raised, so the exception's own text can
+        # raise as readily as the read did. Interpolated, the guard raises from
+        # inside its own recovery, which ends a run over a label and takes with
+        # it whichever terminal was being built around the read.
+        log_warning(f"AG-UI could not read {described}: {type(error).__name__}")
+        return None
 
 
 def to_json_str(value: Optional[str]) -> str:

--- a/libs/agno/tests/unit/os/interfaces/agui_baseline/__init__.py.snapshot
+++ b/libs/agno/tests/unit/os/interfaces/agui_baseline/__init__.py.snapshot
@@ -1,0 +1,3 @@
+from agno.os.interfaces.agui.agui import AGUI
+
+__all__ = ["AGUI"]

--- a/libs/agno/tests/unit/os/interfaces/agui_baseline/agui.py.snapshot
+++ b/libs/agno/tests/unit/os/interfaces/agui_baseline/agui.py.snapshot
@@ -7,13 +7,10 @@ from fastapi.routing import APIRouter
 from agno.agent import Agent
 from agno.agent.remote import RemoteAgent
 from agno.os.interfaces.agui.handlers import validate_subagent_visibility
-from agno.os.interfaces.agui.interrupts import subagent_suspension_available, validate_interrupt_outcome
 from agno.os.interfaces.agui.router import attach_routes
-from agno.os.interfaces.agui.state import SUBAGENT_VISIBILITY_ATTRIBUTED
 from agno.os.interfaces.base import BaseInterface
 from agno.team import Team
 from agno.team.remote import RemoteTeam
-from agno.utils.log import log_warning
 
 
 class AGUI(BaseInterface):
@@ -28,7 +25,6 @@ class AGUI(BaseInterface):
         prefix: str = "",
         tags: Optional[List[str]] = None,
         subagent_visibility: Optional[str] = None,
-        emit_interrupt_outcome: bool = False,
     ):
         """
         Initialize the AGUI interface.
@@ -73,34 +69,6 @@ class AGUI(BaseInterface):
                 withheld, and both read a pending tool call it paused on off the
                 outer run's requirements, which the default leaves unread and so
                 does not prompt.
-            emit_interrupt_outcome: Whether a paused run's terminal says the run
-                is waiting. Off by default, which is the stream this interface
-                sent before the interrupt-aware lifecycle existed: the pause
-                reaches the client as the pending tool calls this interface can
-                show it, and the run terminal carries no outcome, so a pause and
-                a completion look the same on it. Two pauses reach it with no
-                call to act on, and both are logged rather than passed off
-                silently: one whose every pending call carries no tool call id
-                or no tool name, none of which can be rendered, and, under the
-                default ``subagent_visibility="inline"``, one reported by an
-                Agent whose only pending call arrives through the run's active
-                requirements, which is not read at all. On, that terminal carries
-                ``outcome: {"type": "interrupt", ...}``, one interrupt per
-                requirement the run still needs answered, each naming the tool
-                call it is bound to where that call had an id of its own, and
-                the shape of the answer it wants. Every open requirement is
-                carried whichever visibility is set, including one the prompt
-                above leaves unread: a client that answered only what it was
-                shown would leave the run unresumable. On is also what turns a
-                pause no answer could resolve into a failed run rather than a
-                prompt, and what closes the lane of a member the run paused
-                inside as suspended.
-                It is off by default because a client released before that
-                lifecycle stops sending its own resume directive the moment it
-                sees the structured outcome, which strands the run: turn it on
-                for a client that resumes through ``RunAgentInput.resume``.
-                Accepting that resume array does not depend on this setting; the
-                interface reads it either way.
         """
         self.agent = agent
         self.team = team
@@ -114,23 +82,6 @@ class AGUI(BaseInterface):
             raise ValueError("AGUI requires an agent or a team")
 
         self.subagent_visibility = validate_subagent_visibility(subagent_visibility)
-        self.emit_interrupt_outcome = validate_interrupt_outcome(emit_interrupt_outcome)
-
-        # A member the run paused inside is closed as suspended, so a client
-        # renders it as waiting rather than done. That outcome came to the
-        # protocol later than the interrupt one, so an install with the interrupt
-        # types but not this one attributes the interrupt to the member and
-        # closes its lane plainly, and says so rather than doing it silently.
-        if (
-            self.emit_interrupt_outcome
-            and self.subagent_visibility == SUBAGENT_VISIBILITY_ATTRIBUTED
-            and not subagent_suspension_available()
-        ):
-            log_warning(
-                "AG-UI cannot close a subagent the run paused inside as suspended: the installed "
-                "ag_ui.core omits the suspended subagent outcome, so such a member finishes like one "
-                "whose work completed. Please upgrade with `pip install -U ag-ui-protocol`."
-            )
 
     def get_router(self) -> APIRouter:
         self.router = APIRouter(prefix=self.prefix, tags=self.tags)  # type: ignore
@@ -140,7 +91,6 @@ class AGUI(BaseInterface):
             agent=self.agent,
             team=self.team,
             subagent_visibility=self.subagent_visibility,
-            emit_interrupt_outcome=self.emit_interrupt_outcome,
         )
 
         return self.router

--- a/libs/agno/tests/unit/os/interfaces/agui_baseline/handlers.py.snapshot
+++ b/libs/agno/tests/unit/os/interfaces/agui_baseline/handlers.py.snapshot
@@ -1,9 +1,8 @@
 import copy
 import json
 import uuid
-from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Type
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
 try:
     import ag_ui.core  # noqa: F401
@@ -56,16 +55,6 @@ except ImportError:  # ag-ui-protocol older than the subagent lineage events
     )
 
 from agno.models.response import ToolExecution
-from agno.os.interfaces.agui.interrupts import (
-    PAUSE_NOT_CONTINUABLE_CODE,
-    NeededAnswer,
-    answers_a_pause_needs,
-    build_interrupt,
-    interrupt_outcome,
-    pause_not_continuable,
-    subagent_suspension_available,
-    suspended_outcome,
-)
 from agno.os.interfaces.agui.state import (
     ROOT_LANE,
     SUBAGENT_VISIBILITY_ATTRIBUTED,
@@ -73,7 +62,6 @@ from agno.os.interfaces.agui.state import (
     SUBAGENT_VISIBILITY_VALUES,
     StreamState,
 )
-from agno.os.interfaces.agui.utils import readable as _readable
 from agno.os.interfaces.agui.utils import to_json_str
 from agno.reasoning.step import ReasoningStep
 from agno.run.agent import RunContentEvent, RunEvent
@@ -83,12 +71,9 @@ from agno.run.requirement import RunRequirement
 from agno.run.team import RunContentEvent as TeamRunContentEvent
 from agno.run.team import RunPausedEvent as TeamRunPausedEvent
 from agno.run.team import TeamRunEvent
-from agno.utils.log import log_error, log_exception, log_warning
+from agno.utils.log import log_error, log_warning
 from agno.utils.message import get_text_from_message
 from agno.utils.string import url_safe_string
-
-if TYPE_CHECKING:  # the interrupt types are an optional part of the protocol
-    from ag_ui.core import Interrupt
 
 EventHandler = Callable[[BaseRunOutputEvent, StreamState], List[BaseEvent]]
 
@@ -152,6 +137,26 @@ _REASON_STILL_REACHES_THE_CLIENT = "the run terminal still reports this reason i
 def _chunk_run_ids(chunk: BaseRunOutputEvent) -> Tuple[Optional[str], Optional[str]]:
     """The chunk's own run id, and the run that delegated to it when there is one."""
     return getattr(chunk, "run_id", None), getattr(chunk, "parent_run_id", None)
+
+
+def _readable(value: Any, described: str) -> Optional[str]:
+    """A value as display text, or None when it is falsy or reading it raises.
+
+    A name reaches the chunk straight off the caller's own Agent or Team, so
+    rendering one can raise. A label is never worth ending a run for, so a value
+    that cannot be read is recorded and treated as absent.
+
+    Falsy is absent too, and deliberately: every caller is choosing a label, and
+    the empty string, an empty mapping and zero are all nothing to show, so each
+    of them falls through to whatever the caller offers next rather than
+    reaching the wire as ``""`` or ``"0"``. A caller that has to tell an empty
+    value from a missing one cannot use this.
+    """
+    try:
+        return str(value) if value else None
+    except Exception as error:
+        log_warning(f"AG-UI could not read {described}: {error}")
+        return None
 
 
 def _member_id(chunk: BaseRunOutputEvent) -> Optional[str]:
@@ -283,40 +288,21 @@ def _lane_finished(state: StreamState, lane: Optional[str], result: Any = None) 
     either from here sends a terminal for a member that is still going and
     discards whatever it reports afterwards.
 
-    A lane the run paused inside closes as suspended, carrying the interrupts it
-    owns, so a client renders it as waiting rather than as work that finished.
-    Every other lane closes with no outcome at all, which the protocol reads as
-    success. The suspended outcome only ever pairs with a run-level interrupt
-    outcome, because the pause terminal records the lanes at the same time as it
-    builds that one: a lone suspended half would tell a client the subagent is
-    waiting while the run says it finished.
+    No outcome is ever attached. The protocol pairs a suspended subagent with a
+    run-level interrupt outcome, and this interface emits none, so a lone
+    suspended half would tell a client the subagent is waiting while the run says
+    it finished.
     """
     if lane is None:
         return []
     already_closed = lane in state.closed_subagents
-    owned_interrupts = state.suspended_lane_interrupts.get(lane)
-    suspended = suspended_outcome(owned_interrupts) if owned_interrupts is not None else None
     state.close_subagent(lane)
     if already_closed:
         return []
-    # The outcome is named only when there is one to name. An omitted outcome is
-    # the protocol's reading of a subagent whose work completed, and passing the
-    # field to say so would put it on the wire as an explicit null on a release
-    # that does not declare it.
-    if suspended is not None:
-        terminal = SubagentFinishedEvent(
-            type=EventType.SUBAGENT_FINISHED,
-            subagent_run_id=lane,
-            result=result,
-            outcome=suspended,
-        )
-    else:
-        terminal = SubagentFinishedEvent(
-            type=EventType.SUBAGENT_FINISHED,
-            subagent_run_id=lane,
-            result=result,
-        )
-    return [*_close_lane_messages(state, lane), terminal]
+    return [
+        *_close_lane_messages(state, lane),
+        SubagentFinishedEvent(type=EventType.SUBAGENT_FINISHED, subagent_run_id=lane, result=result),
+    ]
 
 
 def _lane_errored(
@@ -787,75 +773,6 @@ def close_open_spans(state: StreamState, error_message: str) -> List[BaseEvent]:
     return _close_run_end_spans(state, lambda: _error_open_subagents(state, error_message))
 
 
-# The keys a dumped chunk can name a subagent by, matched at any depth. A
-# fragment rather than a list of field names, because the identity travels on
-# several of the framework's models at once: a pause requirement carries the
-# member's id, its name and its run id, and a delegation's tool execution
-# carries the run it started. A list of names is what a model that later gains
-# another such field walks straight past. ``child_run_id`` is the one key
-# holding a subagent's run id without saying so in its name, so it is named.
-_SUBAGENT_NAMING_KEY_FRAGMENT = "member"
-_SUBAGENT_NAMING_KEYS = frozenset({"child_run_id"})
-
-
-def _names_a_subagent(dumped: Any) -> bool:
-    """Whether anything inside a dumped chunk names a subagent.
-
-    The question a verbatim dump has to answer before it goes out under a
-    visibility that withholds which member did something. Asking whose lane the
-    chunk came from answers a different one and is what let this through: a
-    leader's pause event is the leader's own, and carries the id, the name and
-    the run id of every member the run is waiting on inside it.
-
-    A key holding nothing names nobody, so a value that is absent or empty does
-    not withhold a dump: every requirement a pause reports carries the member
-    fields whether or not a member is involved, and a run with no members at all
-    would otherwise lose its dump to the fields that say so.
-
-    Reading the dump walks whatever a model or a tool put in the run's content,
-    which can nest arbitrarily and refer to itself. An unanswerable question is
-    answered yes: this decides whether identity reaches a client, so a walk that
-    cannot finish withholds rather than publishes.
-    """
-    try:
-        return _walk_for_a_subagent_name(dumped)
-    except Exception as error:
-        log_warning(
-            f"AG-UI could not read whether a failed run terminal's chunk names a member: {type(error).__name__}"
-        )
-        return True
-
-
-def _walk_for_a_subagent_name(dumped: Any) -> bool:
-    """The unguarded walk behind the question above. Text is a leaf, not a sequence."""
-    if isinstance(dumped, Mapping):
-        for key, value in dumped.items():
-            names_it = isinstance(key, str) and (
-                _SUBAGENT_NAMING_KEY_FRAGMENT in key.lower() or key in _SUBAGENT_NAMING_KEYS
-            )
-            if names_it and value not in (None, "", [], {}, ()):
-                return True
-            if _walk_for_a_subagent_name(value):
-                return True
-        return False
-    if isinstance(dumped, (list, tuple, set, frozenset)):
-        return any(_walk_for_a_subagent_name(item) for item in dumped)
-    return False
-
-
-def _recorded_verbatim(dumped: Dict[str, Any]) -> str:
-    """A withheld dump as the one line an operator reads it off instead.
-
-    Rendering it runs the same content the wire would have carried, so it falls
-    back rather than raising: this is the only place the withheld payload exists,
-    and a record that ends the run reports nothing at all.
-    """
-    try:
-        return json.dumps(dumped, default=str)
-    except Exception as error:
-        return f"<unrenderable {type(dumped).__name__}: {type(error).__name__}>"
-
-
 def _terminal_raw_event(chunk: BaseRunOutputEvent, state: StreamState) -> Optional[Dict[str, Any]]:
     """The failing chunk, verbatim, when it is the run's own account of the failure.
 
@@ -867,97 +784,38 @@ def _terminal_raw_event(chunk: BaseRunOutputEvent, state: StreamState) -> Option
     kept off it; under ``attributed`` it is a subagent's own event dressed as the
     run's. Only the default embeds it, whose stream is what it was before member
     attribution existed.
-
-    Whose chunk it is decides none of that on its own. A leader's own terminal
-    is the run's and still carries member identity inside it: a pause reports
-    one requirement per thing it waits on, each naming the member that asked, its
-    id and its run. So under ``hidden`` the dump goes out only when nothing in it
-    names a member, and is recorded for the operator when it does. The
-    visibilities that name members keep it, since withholding there withholds
-    nothing a client is not already told.
     """
     if state.lane_for(*_chunk_run_ids(chunk)) is not ROOT_LANE:
         return None
     try:
-        dumped = chunk.to_dict()
-    except Exception as error:
-        # Recorded, because this runs before the run terminal's own cleanup: a
-        # dump that fails silently here leaves nothing at all saying why the
-        # client got a terminal naming the event instead of the chunk. The
-        # record names the type and renders nothing, since an exception's text
-        # can raise as readily as the dump did, and the fallback reads the event
-        # name through the same guard: unguarded, both of them end the run from
-        # inside the terminal that reports why it stopped.
-        log_warning(f"AG-UI could not dump the chunk a failed run terminal reports verbatim: {type(error).__name__}")
-        return {"event": _readable(getattr(chunk, "event", None), "a failed run event name") or "RunError"}
-
-    if state.hides_subagents and _names_a_subagent(dumped):
-        # The only place the withheld payload survives, so it is recorded whole:
-        # the terminal tells the client why the run stopped and nothing else,
-        # and an operator diagnosing that has this line and no other copy.
-        log_warning(
-            "AG-UI withheld the chunk a failed run terminal reports verbatim, because it names a member and "
-            f"this visibility names none; it is recorded here instead: {_recorded_verbatim(dumped)}"
-        )
-        return None
-    return dumped
+        return chunk.to_dict()
+    except Exception:
+        return {"event": str(getattr(chunk, "event", "RunError"))}
 
 
-def _terminal_failure(
-    chunk: BaseRunOutputEvent,
-    normalized: str,
-    pause_not_continuable_because: Optional[str] = None,
-) -> Tuple[str, Optional[str]]:
+def _terminal_failure(chunk: BaseRunOutputEvent, normalized: str) -> Tuple[str, Optional[str]]:
     """What a failed run terminal says, and the code it says it under.
-
-    A pause no client can answer is a run that has ended for good, and the
-    reason for it is the caller's rather than the chunk's: the chunk is a pause,
-    which carries no failure to read. It says so under a code of its own, so a
-    client can tell a run that cannot be continued from one that died working.
 
     A cancellation is not a failure of the run's own making, so it reports the
     reason it was cancelled for under the same code a cancelled member's
     terminal carries. Only a subagent's cancellation ever reaches here: the
     top-level entity's is not read as a run terminal at all.
     """
-    if pause_not_continuable_because is not None:
-        return (
-            f"The paused run cannot be continued: {pause_not_continuable_because}. A resume has to answer "
-            "every requirement the pause left open, so nothing was advertised for a client to answer.",
-            PAUSE_NOT_CONTINUABLE_CODE,
-        )
     if normalized == RunEvent.run_cancelled.value:
         reason = _readable(getattr(chunk, "reason", None), "a cancelled run reason")
         return reason or "Run cancelled", _SUBAGENT_CANCELLED_CODE
-    # Read through the same guard the reason above is, and for a stronger
-    # reason: this message is built before the terminal's cleanup runs and is
-    # also what every open member lane terminates under, so a failure whose text
-    # cannot be rendered would close no span, terminate no lane and write no
-    # terminal, leaving the client an open message and the run's real failure
-    # replaced by the one raised while naming it.
-    message = _readable(getattr(chunk, "content", None), "a failed run message")
-    return message or "Run failed", getattr(chunk, "error_type", None)
+    return str(getattr(chunk, "content", None) or "Run failed"), getattr(chunk, "error_type", None)
 
 
-def on_run_error(
-    chunk: BaseRunOutputEvent,
-    state: StreamState,
-    normalized: str,
-    pause_not_continuable_because: Optional[str] = None,
-) -> List[BaseEvent]:
+def on_run_error(chunk: BaseRunOutputEvent, state: StreamState, normalized: str) -> List[BaseEvent]:
     """Close open spans, then emit the terminal AG-UI error event. Nothing may follow RUN_ERROR.
 
     ``normalized`` is the chunk's event name, which says which kind of failed
     terminal this is. It is required rather than defaulted: a default would read
     every cancellation as a plain failure and report the wrong code for it.
-
-    ``pause_not_continuable_because`` is how a pause reaches this path at all. A
-    paused chunk is not a failed terminal, so nothing routes it here on the
-    chunk's own account; the pause handler does, once it has read that no client
-    could answer what the run is waiting on.
     """
     raw_event = _terminal_raw_event(chunk, state)
-    message, error_type = _terminal_failure(chunk, normalized, pause_not_continuable_because)
+    message, error_type = _terminal_failure(chunk, normalized)
 
     events: List[BaseEvent] = close_open_spans(state, message)
     events.append(
@@ -997,22 +855,6 @@ class _PausedToolCall:
 
 
 @dataclass
-class _PausedRequirement:
-    """One answer a paused run still needs, and the lane that owns it.
-
-    ``needed`` is the entry ``answers_a_pause_needs`` returned for it, which
-    carries the id the resume channel looks an answer up by and whether any
-    answer could resolve it at all. The terminal is built from these rather than
-    from the calls the prompt shows, because those are a different list: one call
-    can be listed by several of the terminal's pause lists, and a listed call can
-    have no open requirement behind it at all.
-    """
-
-    needed: NeededAnswer
-    lane: Optional[str]
-
-
-@dataclass
 class _PausedPrompt:
     """What a paused run's terminal asks the client to resolve.
 
@@ -1025,32 +867,10 @@ class _PausedPrompt:
     text belongs to. A pause reported by a member carries the member's words, so
     they go out on the member's lane or not at all; the leader's own pause
     carries the leader's, on the root lane.
-
-    ``blocks`` is what the prompt shows, grouped into the one message per lane
-    it sends them in, and ``pending`` is what the run is actually waiting on.
-    They differ by the calls the client already has a start for, which the prompt
-    leaves out and the run still cannot continue without: an interrupt outcome
-    that named only the prompted ones would tell a client it had answered
-    everything while a requirement was still open.
-
-    The grouping is settled here rather than where the events are built, because
-    ``open_requirements`` is ordered against it. One grouping read by both is
-    what keeps the calls the client sees and the interrupts it reads beside them
-    from disagreeing about their order.
-
-    ``open_requirements`` is what the run has to have answered, which is neither
-    of those two lists: it is read from the run's own requirements under every
-    visibility, one entry per requirement the pause left open, and it is what
-    the terminal is built from. Each entry carries whether any answer could
-    resolve it, because one that none could ends the run instead of prompting.
-    It is empty for a pause that reports no requirement, and the terminal then
-    falls back to ``pending``.
     """
 
     lanes: Dict[str, _PausedMemberLane]
-    blocks: List[Tuple[Optional[str], List[_PausedToolCall]]]
-    pending: List[_PausedToolCall]
-    open_requirements: List[_PausedRequirement]
+    tool_calls: List[_PausedToolCall]
     carried: int
     dropped: int
     content: Optional[str]
@@ -1196,16 +1016,9 @@ def _paused_tools_with_lanes(chunk: BaseRunOutputEvent, state: StreamState) -> _
     unannounced and only for the members a surviving tool call is stamped with,
     since a lane the prompt carries nothing for tells the client about a member
     it will never hear from again.
-
-    The run's open requirements come back too, read under every visibility,
-    because they are what has to be answered rather than what is shown, and
-    the terminal's interrupts are built from them. Reading them changes nothing
-    the prompt sends: the calls above are read from the same lists, under the
-    same rules, as they always were.
     """
     pending: Dict[str, _PausedMemberLane] = {}
     recorded: List[_PausedToolCall] = []
-    open_requirements: List[_PausedRequirement] = []
     carried = 0
     dropped = 0
     lineage = state.subagent_visibility != SUBAGENT_VISIBILITY_INLINE
@@ -1224,10 +1037,7 @@ def _paused_tools_with_lanes(chunk: BaseRunOutputEvent, state: StreamState) -> _
             )
             return
         prompted = _PausedToolCall(
-            tool_call_id=tool.tool_call_id,
-            tool_name=tool.tool_name,
-            tool_args=tool.tool_args,
-            lane=lane,
+            tool_call_id=tool.tool_call_id, tool_name=tool.tool_name, tool_args=tool.tool_args, lane=lane
         )
         if merges:
             for index, already in enumerate(recorded):
@@ -1242,83 +1052,41 @@ def _paused_tools_with_lanes(chunk: BaseRunOutputEvent, state: StreamState) -> _
         for list_name in _PAUSE_TOOL_LISTS:
             for tool in getattr(chunk, list_name, None) or ():
                 record(tool, reporting_lane, merges=False)
-        # Every open requirement, which is what the run has to have answered and
-        # therefore what the terminal's interrupts are built from. A subagent's
-        # tools live here rather than on the lists above, and the requirement
-        # names the run waiting on them, so this is also where a member's
-        # attribution comes from; an agent that ran an inner agent reports one
-        # exactly as a team reports a member's.
-        for needed in answers_a_pause_needs(_active_requirements(chunk)):
-            requirement = needed.requirement
-            member_tool = requirement.tool_execution if requirement.member_agent_id else None
-            # The prompt's own lane rules, so an interrupt names a member only
-            # under a visibility that names members at all. Under the other two
-            # this resolves to the root and announces nothing.
-            lane = _paused_member_lane(state, requirement, pending) if member_tool else reporting_lane
-            open_requirements.append(_PausedRequirement(needed, lane))
-            # What the prompt shows is unchanged by any of the above: a member's
-            # attributed copy wins over the unattributed one, and the default is
-            # the pre-change stream, which read this on a team's pause only.
-            if member_tool is not None and (lineage or isinstance(chunk, TeamRunPausedEvent)):
-                record(member_tool, lane, merges=lineage)
+        # A subagent's tools live in the requirements, which name the run waiting
+        # on them, and that attribution wins over the unattributed copy above. An
+        # agent that ran an inner agent reports them exactly as a team reports a
+        # member's, so lineage reads both paused shapes: a pending call the client
+        # is not shown is one the run can never be resumed past.
+        # The default is the pre-change stream, which read this on a team's pause only: an agent's is lineage behavior.
+        if lineage or isinstance(chunk, TeamRunPausedEvent):
+            for requirement in _active_requirements(chunk):
+                if not (requirement.member_agent_id and requirement.tool_execution):
+                    continue
+                record(
+                    requirement.tool_execution,
+                    _paused_member_lane(state, requirement, pending),
+                    merges=lineage,
+                )
 
-    prompted = recorded
     if lineage:
         # Read once every copy of a call has been merged, so a call the wire
         # already carries under its member's lane is dropped whichever of the two
         # places reported it first.
-        prompted = [
+        recorded = [
             tool_call
             for tool_call in recorded
             if tool_call.lane is ROOT_LANE or not state.tool_call_started(tool_call.tool_call_id)
         ]
 
-    stamped = {tool_call.lane for tool_call in prompted}
-    content = _pause_content(chunk, terminal_lane, reporting_lane)
-    blocks = _prompt_blocks(prompted, reporting_lane, content is not None)
+    stamped = {tool_call.lane for tool_call in recorded}
     return _PausedPrompt(
         lanes={run_id: lane for run_id, lane in pending.items() if run_id in stamped},
-        blocks=blocks,
-        pending=recorded,
-        open_requirements=_in_prompt_order(open_requirements, blocks),
+        tool_calls=recorded,
         carried=carried,
         dropped=dropped,
-        content=content,
+        content=_pause_content(chunk, terminal_lane, reporting_lane),
         content_lane=reporting_lane,
     )
-
-
-def _in_prompt_order(
-    open_requirements: List[_PausedRequirement],
-    blocks: List[Tuple[Optional[str], List[_PausedToolCall]]],
-) -> List[_PausedRequirement]:
-    """The open requirements, ordered as the prompt sends the calls they wait on.
-
-    A client renders the pending calls in the order the prompt sent them and
-    reads the terminal's interrupts beside them, so the two name them in the
-    same order. The prompt sends one message per lane, so a lane's calls arrive
-    together whatever order the pause reported them in, and that order is read
-    off the blocks the prompt is built from rather than worked out a second way.
-
-    Keyed by the tool call, which is what a requirement and a prompted call have
-    in common. Several requirements can name one call, and those keep the order
-    the pause reported them in at the place that call is prompted. A requirement
-    the prompt sends no call for keeps its own place, after every requirement
-    that has one.
-    """
-    positions: Dict[str, int] = {}
-    for _, tool_calls in blocks:
-        for tool_call in tool_calls:
-            positions.setdefault(tool_call.tool_call_id, len(positions))
-
-    def prompted_at(open_requirement: _PausedRequirement) -> int:
-        tool_execution = open_requirement.needed.requirement.tool_execution
-        tool_call_id = tool_execution.tool_call_id if tool_execution else None
-        if tool_call_id is None:
-            return len(positions)
-        return positions.get(tool_call_id, len(positions))
-
-    return sorted(open_requirements, key=prompted_at)
 
 
 def _pause_content(
@@ -1331,15 +1099,13 @@ def _pause_content(
     A member's pause carries the member's words, so they go out on the member's
     lane. A visibility that will not name that lane withholds them instead of
     passing a member's prose off as the run's own reply.
-
-    The words are read through the same guard every other label is. Rendering a
-    run's content runs whatever the model or a tool put there, which can raise,
-    and this is the run terminal: prose is never worth ending a run for, so a
-    value that cannot be read is recorded and the prompt sends no words.
     """
+    content = getattr(chunk, "content", None)
+    if not content:
+        return None
     if terminal_lane is not ROOT_LANE and reporting_lane is ROOT_LANE:
         return None
-    return _readable(getattr(chunk, "content", None), "a paused run's own words")
+    return str(content)
 
 
 def _pause_prompt(
@@ -1367,7 +1133,7 @@ def _pause_prompt(
         return []
 
     events: List[BaseEvent] = list(announcements)
-    blocks = prompt.blocks
+    blocks = _prompt_blocks(prompt)
     if not blocks:
         if not prompt.dropped:
             return events
@@ -1378,11 +1144,7 @@ def _pause_prompt(
     return events
 
 
-def _prompt_blocks(
-    tool_calls: List[_PausedToolCall],
-    content_lane: Optional[str],
-    has_content: bool,
-) -> List[Tuple[Optional[str], List[_PausedToolCall]]]:
+def _prompt_blocks(prompt: _PausedPrompt) -> List[Tuple[Optional[str], List[_PausedToolCall]]]:
     """The pause prompt split into one message per lane, in the order it was reported.
 
     The lane the paused run's own words belong to leads, since that message is
@@ -1390,38 +1152,11 @@ def _prompt_blocks(
     the same lane.
     """
     grouped: Dict[Optional[str], List[_PausedToolCall]] = {}
-    if has_content:
-        grouped[content_lane] = []
-    for tool_call in tool_calls:
+    if prompt.content is not None:
+        grouped[prompt.content_lane] = []
+    for tool_call in prompt.tool_calls:
         grouped.setdefault(tool_call.lane, []).append(tool_call)
     return list(grouped.items())
-
-
-# What a pending call is prompted with when its own arguments cannot be sent.
-# An empty object, because the client parses this field as JSON and a call it
-# cannot parse is one it cannot render an approval for at all.
-_NO_PROMPTED_ARGUMENTS = "{}"
-
-
-def _prompted_arguments(tool_call: _PausedToolCall) -> str:
-    """One pending call's arguments as the prompt sends them, or an empty object.
-
-    Serializing them runs whatever a tool was called with through the JSON
-    encoder, which refuses a cycle, a set, and anything with no encoding at all.
-    This is the run terminal, and it is built after the closing sweep: a raise
-    here discards every span end the sweep produced along with the terminal
-    itself, leaving the client a message and a tool call nothing ever closes. So
-    the arguments are dropped with a record instead, and the call still reaches
-    the client under the id a resume answers it by.
-    """
-    try:
-        return json.dumps(tool_call.tool_args)
-    except Exception as error:
-        log_warning(
-            f"AG-UI could not serialize the arguments of paused tool call {tool_call.tool_call_id}, so it "
-            f"is prompted with none: {type(error).__name__}"
-        )
-        return _NO_PROMPTED_ARGUMENTS
 
 
 def _prompt_block(
@@ -1461,7 +1196,7 @@ def _prompt_block(
                 ToolCallArgsEvent(
                     type=EventType.TOOL_CALL_ARGS,
                     tool_call_id=tool_call.tool_call_id,
-                    delta=_prompted_arguments(tool_call),
+                    delta=json.dumps(tool_call.tool_args),
                 ),
                 ToolCallEndEvent(type=EventType.TOOL_CALL_END, tool_call_id=tool_call.tool_call_id),
             ]
@@ -1473,185 +1208,17 @@ def _prompt_block(
     return _stamp_lane(events, lane)
 
 
-def _pause_interrupts(state: StreamState, prompt: _PausedPrompt) -> List["Interrupt"]:
-    """The interrupts a paused run's terminal carries, and the lanes they suspend.
-
-    One interrupt per answer ``answers_a_pause_needs`` said the run needs, keyed
-    by the id that computation gave it, which is the id the resume channel looks
-    an answer up by. Nothing sits between the two lists: every entry becomes an
-    interrupt, because an entry with no id and two entries sharing one are both
-    answers no client could send, which makes the pause not continuable and the
-    caller emits the failed terminal instead of reaching here. The calls the
-    prompt shows are a different list again, and neither of the two ways they
-    differ is a thing to be answered: one call flagged for several pause kinds is
-    listed once per kind, and a listed call can have no open requirement behind
-    it at all.
-
-    A pause that reports no requirement has nothing to key by but the calls the
-    prompt read, so it falls back to those, keyed by the tool call, which is
-    unique within the run. There the dedup below earns its place: the prompt can
-    list one call more than once, and one correlation key standing for two
-    interrupts is one answer that could land on either.
-
-    A requirement stamped with a member's lane makes that interrupt the member's
-    request, and the lane it names is recorded so the drain closes it as
-    suspended instead of finished. The lanes above it are recorded too, with no
-    interrupts of their own: a delegation whose member is waiting has not
-    finished either, and the protocol says so with a suspended outcome carrying
-    nothing. Under a visibility that names no member every lane resolves to the
-    root, so nothing is stamped and nothing is suspended.
-
-    Called after the pause prompt's own lanes are announced, so a lane the state
-    now holds open is one the client has been told about, and a lane it does not
-    is one the client will never hear of: the announcement is withheld for a
-    member whose every pending call was dropped, and its requirement is still
-    open. Such an interrupt goes out unattributed rather than naming a member
-    the client never saw start.
-    """
-    interrupts: List["Interrupt"] = []
-    owned: Dict[str, List[str]] = {}
-
-    def carry(
-        needed: Optional[NeededAnswer],
-        tool_call_id: Optional[str],
-        tool_name: Optional[str],
-        lane: Optional[str],
-    ) -> None:
-        named = lane if lane in state.open_subagents else ROOT_LANE
-        # The member the interrupt names and the lane recorded as owning it are
-        # one value, read once: a lane suspended for an interrupt that went out
-        # naming another member is an outcome no client can reconcile.
-        attributed_to = named if named is not ROOT_LANE else None
-        interrupt = build_interrupt(
-            needed,
-            tool_call_id=tool_call_id,
-            tool_name=tool_name,
-            subagent_run_id=attributed_to,
-        )
-        if interrupt is None or any(already.id == interrupt.id for already in interrupts):
-            return
-        interrupts.append(interrupt)
-        if attributed_to is not None:
-            owned.setdefault(attributed_to, []).append(interrupt.id)
-
-    if prompt.open_requirements:
-        for open_requirement in prompt.open_requirements:
-            tool_execution = open_requirement.needed.requirement.tool_execution
-            carry(
-                open_requirement.needed,
-                tool_execution.tool_call_id if tool_execution else None,
-                tool_execution.tool_name if tool_execution else None,
-                open_requirement.lane,
-            )
-    else:
-        for tool_call in prompt.pending:
-            carry(None, tool_call.tool_call_id, tool_call.tool_name, tool_call.lane)
-
-    if owned and subagent_suspension_available():
-        suspended: Dict[str, List[str]] = {lane: list(ids) for lane, ids in owned.items()}
-        for lane in owned:
-            for ancestor in state.ancestor_lanes(lane):
-                suspended.setdefault(ancestor, [])
-        state.suspended_lane_interrupts = suspended
-    return interrupts
-
-
-def _pause_nothing_can_answer(state: StreamState, prompt: _PausedPrompt) -> Optional[str]:
-    """Why this pause can never be continued, when it cannot be.
-
-    A resume has to answer every requirement the pause left open or the guard
-    stops it, so one requirement no answer resolves is a run that has ended for
-    good. Advertising the rest is what stranded it: the client answers everything
-    it was told about and the guard refuses the resume over a requirement it was
-    never told about, with nothing on the wire saying why.
-
-    Read only where the interrupt outcome is emitted. With it off this interface
-    advertises nothing and makes no claim about what a resume must carry, so its
-    stream stays exactly what it was.
-    """
-    if not state.emit_interrupt_outcome:
-        return None
-    return pause_not_continuable([open_requirement.needed for open_requirement in prompt.open_requirements])
-
-
 def on_run_completed(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
     prompt = _paused_tools_with_lanes(chunk, state)
-
-    # Read before anything is announced or emitted, because a pause nothing can
-    # answer ends the run as a failure here instead of prompting for it: the
-    # pending calls are rendered as an approval a client can act on, and this run
-    # cannot act on one. Reading the prompt above committed to nothing.
-    stranded = _pause_nothing_can_answer(state, prompt)
-    if stranded is not None:
-        log_warning(
-            f"AG-UI run {state.run_id} in session {state.thread_id} paused on something no client can "
-            f"answer, so the run is reported as failed rather than waiting: {stranded}"
-        )
-        return on_run_error(chunk, state, _normalized_event_of(chunk), pause_not_continuable_because=stranded)
-
     # Announced here, before the closing order is chosen, because it is only now
     # certain which lanes the prompt really carries, and because a lane
     # announced needs the run end to terminate it.
     announcements = _announce_paused_lanes(state, prompt.lanes)
-    try:
-        return _run_end_events(chunk, state, prompt, announcements)
-    except Exception:
-        # None of the terminal reached the wire, the announcements above with
-        # it, so the lanes they opened go back out of the record. Left in, the
-        # cleanup the caller runs next would terminate a member the client was
-        # never told started.
-        _forget_unsent_lanes(state, prompt.lanes)
-        raise
-
-
-def _forget_unsent_lanes(state: StreamState, lanes: Dict[str, _PausedMemberLane]) -> None:
-    """Unwind the lanes a pause opened, for a terminal that never reached the wire.
-
-    A pause has to open its lanes before the rest of its terminal is built,
-    because everything after reads them: which member an interrupt names, which
-    lanes the drain closes as suspended, and the order the spans close in. The
-    announcement that tells the client about them only leaves with the rest of
-    that terminal, so a terminal that raises sends none of it, and what this
-    interface holds has to go back to what the client was actually sent.
-
-    Every lane here is one this pause opened: a lane the stream had already
-    announced is not collected as pending, so none of these was known to the
-    client before the announcement that never went out.
-    """
-    for run_id in lanes:
-        state.open_subagents.pop(run_id, None)
-        state.announced_subagents.pop(run_id, None)
-        state.closed_subagents.discard(run_id)
-        state.suspended_lane_interrupts.pop(run_id, None)
-
-
-def _run_end_events(
-    chunk: BaseRunOutputEvent,
-    state: StreamState,
-    prompt: _PausedPrompt,
-    announcements: List[BaseEvent],
-) -> List[BaseEvent]:
-    """Everything a run's own end emits, from the closing sweep to the terminal.
-
-    Split from the caller so the lanes its pause announced are unwound as one
-    decision when any of this raises, rather than at each of the places it can.
-    """
-    # Built before the closing order runs, because the drain inside it reads
-    # which lanes this suspended, and the announcements the caller made have
-    # already settled which lanes the prompt names.
-    outcome = interrupt_outcome(_pause_interrupts(state, prompt)) if state.emit_interrupt_outcome else None
-
-    if (
-        isinstance(chunk, (AgentRunPausedEvent, TeamRunPausedEvent))
-        and prompt.dropped == prompt.carried
-        and outcome is None
-    ):
+    if isinstance(chunk, (AgentRunPausedEvent, TeamRunPausedEvent)) and prompt.dropped == prompt.carried:
         # The run is waiting on something nobody can resolve, and the two ways
         # that happens reach the client differently, so they are recorded
         # differently. A call left out because the client already has a start
         # for it is neither of them: that one is on the wire to be acted on.
-        # A terminal that carries the pause as an interrupt is neither: the
-        # client is told what the run waits on and can answer it by id.
         if prompt.carried:
             log_warning(
                 f"AG-UI run {state.run_id} in session {state.thread_id} paused on tool calls the client "
@@ -1676,51 +1243,9 @@ def _run_end_events(
     if state.run_state is not None:
         authoritative_state = getattr(chunk, "session_state", None)
         final_state = authoritative_state if authoritative_state is not None else state.run_state
-        # Copied so a write after the run cannot rewrite what the client was
-        # sent, and guarded because a session state holds whatever a tool put in
-        # it and a value with no copy of its own raises here. This is the last
-        # thing the terminal builds, after the closing sweep: a raise would
-        # discard every span end and the terminal with them, leaving the client
-        # a message nothing closes. A state that cannot be copied is one the
-        # protocol's encoder refuses too, and an event it refuses stops the
-        # response body short of the terminal, so the snapshot is dropped with a
-        # record rather than sent uncopied.
-        try:
-            copied_state = copy.deepcopy(final_state)
-        except Exception:
-            log_exception(
-                f"AG-UI run {state.run_id} in session {state.thread_id} could not copy the session state "
-                "it ends holding, so the run ends with no state snapshot"
-            )
-        else:
-            events.append(StateSnapshotEvent(type=EventType.STATE_SNAPSHOT, snapshot=copied_state))
+        events.append(StateSnapshotEvent(type=EventType.STATE_SNAPSHOT, snapshot=copy.deepcopy(final_state)))
 
-    if state.emit_interrupt_outcome and outcome is None and prompt.carried:
-        # The run is waiting, and the terminal cannot say so: the protocol
-        # rejects an interrupt outcome with nothing in it, so this reaches the
-        # client as the plain finished run it was before the outcome existed.
-        # Every pending call read here was one the client cannot be shown, which
-        # the sweep above has already recorded per call.
-        log_warning(
-            f"AG-UI run {state.run_id} in session {state.thread_id} paused with no interrupt the terminal "
-            "can carry, so the pause reaches the client as a plain finished run"
-        )
-
-    # The outcome is named only when there is one. An omitted outcome is the
-    # protocol's own back-compat shape, and naming the field to say there is none
-    # would put it on the wire as an explicit null on a release that does not
-    # declare it, which is not the same thing to a client.
-    if outcome is not None:
-        events.append(
-            RunFinishedEvent(
-                type=EventType.RUN_FINISHED,
-                thread_id=state.thread_id,
-                run_id=state.run_id,
-                outcome=outcome,
-            )
-        )
-    else:
-        events.append(RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id=state.thread_id, run_id=state.run_id))
+    events.append(RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id=state.thread_id, run_id=state.run_id))
     return events
 
 

--- a/libs/agno/tests/unit/os/interfaces/agui_baseline/input.py.snapshot
+++ b/libs/agno/tests/unit/os/interfaces/agui_baseline/input.py.snapshot
@@ -10,7 +10,6 @@ from ag_ui.core.types import ToolMessage as AGUIToolMessage
 from pydantic import BaseModel
 
 from agno.media import Audio, File, Image, Video
-from agno.os.interfaces.agui.interrupts import declares
 from agno.tools.function import Function
 from agno.utils.log import log_warning
 
@@ -166,40 +165,6 @@ def extract_tool_messages(messages: List[AGUIMessage]) -> List[AGUIToolMessage]:
         else:
             break
     return list(reversed(tool_msgs))
-
-
-# The request field a client's answers to a paused run's interrupts arrive in.
-RESUME_FIELD = "resume"
-
-
-def extract_resume_entries(run_input: Any) -> List[Any]:
-    """The answers the request carries for the interrupts of a paused run.
-
-    The field is an optional part of the protocol, and whether this release has
-    it is a question about the schema, so it is asked of the schema. Asking the
-    parsed request instead answers a different question: the protocol's models
-    keep a key they do not declare as untyped extra data, so a client's array
-    still arrives on a release that never declared the field, as raw dictionaries
-    an attribute lookup then hands on as entries. The first resolver reads a
-    field off one of them and the run fails, having passed over the tool-message
-    channel the same request carried its answers in.
-
-    A release without the field leaves this interface the tool-message channel,
-    which is what it had before the interrupt round trip existed. Answers that
-    arrived for a channel this release does not have are dropped, and dropping
-    them is said once, naming the field, because silence here is a client left
-    waiting on a run nothing will continue.
-    """
-    if not declares(type(run_input), RESUME_FIELD):
-        if getattr(run_input, RESUME_FIELD, None):
-            log_warning(
-                f"AG-UI request carries a {RESUME_FIELD} array, which the installed ag-ui-protocol does not "
-                "declare: the answers it holds are dropped. Please upgrade with `pip install -U ag-ui-protocol`."
-            )
-        return []
-
-    entries = getattr(run_input, RESUME_FIELD, None)
-    return list(entries) if entries else []
 
 
 def parse_client_tools(agui_tools: Optional[List[AGUITool]]) -> List[Function]:

--- a/libs/agno/tests/unit/os/interfaces/agui_baseline/resume.py.snapshot
+++ b/libs/agno/tests/unit/os/interfaces/agui_baseline/resume.py.snapshot
@@ -1,0 +1,190 @@
+from typing import Any, Dict, List, Optional, Union
+
+from ag_ui.core.types import ToolMessage as AGUIToolMessage
+
+from agno.agent import Agent
+from agno.run.base import RunContext, RunStatus
+from agno.run.requirement import RunRequirement
+from agno.run.team import TeamRunOutput
+from agno.session.agent import AgentSession
+from agno.session.team import TeamSession
+from agno.team.team import Team
+from agno.utils.string import parse_response_dict_str
+
+
+def _resolve_confirmation(requirement: RunRequirement, payload: Dict[str, Any], error: Optional[str]) -> None:
+    if error or payload.get("accepted") is not True:
+        requirement.reject(note=payload.get("note") or error)
+    else:
+        requirement.confirm()
+
+
+def _resolve_user_input(requirement: RunRequirement, payload: Dict[str, Any]) -> None:
+    values = payload.get("values")
+    if not isinstance(values, dict):
+        raise ValueError("user_input expects {'values': {...}}")
+    requirement.provide_user_input(values)
+
+
+def _resolve_user_feedback(requirement: RunRequirement, payload: Dict[str, Any]) -> None:
+    selections = payload.get("selections")
+    if not isinstance(selections, dict) or not all(isinstance(v, list) for v in selections.values()):
+        raise ValueError("user_feedback expects {'selections': {question: [labels]}}")
+    requirement.provide_user_feedback(selections)
+
+
+def _resolve_external_execution(requirement: RunRequirement, content: str, error: Optional[str]) -> None:
+    if error and requirement.tool_execution:
+        requirement.tool_execution.tool_call_error = True
+    requirement.set_external_execution_result(error or content)
+
+
+def resolve_requirements_from_tool_messages(
+    requirements: List[RunRequirement],
+    tool_messages: List[AGUIToolMessage],
+) -> List[RunRequirement]:
+    tool_message_by_call_id = {msg.tool_call_id: msg for msg in tool_messages}
+
+    for requirement in requirements:
+        if requirement.is_resolved():
+            continue
+
+        tool_exec = requirement.tool_execution
+        if not tool_exec or not tool_exec.tool_call_id:
+            continue
+
+        tool_message = tool_message_by_call_id.get(tool_exec.tool_call_id)
+        if tool_message is None:
+            continue
+
+        # External execution: raw content, no JSON parsing
+        if requirement.pause_type == "external_execution":
+            _resolve_external_execution(requirement, tool_message.content, tool_message.error)
+            continue
+
+        # Structured pause types: parse JSON payload
+        parsed = parse_response_dict_str(tool_message.content)
+        payload: Dict[str, Any] = parsed if isinstance(parsed, dict) else {}
+
+        if requirement.pause_type == "confirmation":
+            _resolve_confirmation(requirement, payload, tool_message.error)
+        elif requirement.pause_type == "user_input":
+            _resolve_user_input(requirement, payload)
+        elif requirement.pause_type == "user_feedback":
+            _resolve_user_feedback(requirement, payload)
+
+    return requirements
+
+
+def ensure_requirements_resolved(requirements: List[RunRequirement]) -> None:
+    """Guard: raise if any requirement is still unresolved after merging tool messages.
+
+    A partial resume (some tools answered, some not) must fail loud here rather than
+    reach dispatch where unanswered confirmation tools are silently rejected.
+    """
+    unresolved = [r for r in requirements if not r.is_resolved()]
+    if unresolved:
+        ids = [r.tool_execution.tool_call_id for r in unresolved if r.tool_execution]
+        raise ValueError(f"Partial resume: requirements {ids} still unresolved")
+
+
+def _find_paused_run(
+    session: Union[AgentSession, TeamSession],
+    tool_messages: List[AGUIToolMessage],
+    is_team: bool,
+):
+    incoming_call_ids = {msg.tool_call_id for msg in tool_messages}
+
+    for run in session.runs or []:
+        if is_team and not isinstance(run, TeamRunOutput):
+            continue
+        if run.status != RunStatus.paused:
+            continue
+        for req in run.requirements or []:
+            if req.tool_execution and req.tool_execution.tool_call_id in incoming_call_ids:
+                # The resume flow writes the user's answers into this run's
+                # requirements before continuing it. History run objects are
+                # shared between session reads, so the resume works on a copy
+                # of its own.
+                from copy import deepcopy
+
+                return deepcopy(run)
+
+    return None
+
+
+async def resume_paused_run(
+    entity: Union[Agent, Team],
+    session_id: str,
+    tool_messages: List[AGUIToolMessage],
+    run_context: RunContext,
+    run_kwargs: dict,
+):
+    if not isinstance(entity, (Agent, Team)):
+        raise ValueError("Frontend tool resume requires a local Agent or Team")
+    if not entity.db:
+        raise ValueError("Frontend tool resume requires a database")
+
+    session = await entity.aget_session(session_id=session_id)
+    if not session:
+        raise ValueError(f"Session {session_id} not found")
+    if not isinstance(session, (AgentSession, TeamSession)):
+        raise ValueError(f"Session {session_id} is not a valid session type")
+
+    paused_run = _find_paused_run(session, tool_messages, is_team=isinstance(entity, Team))
+    if not paused_run:
+        raise ValueError(f"No paused run matching the provided tool results found in session {session_id}")
+    if not paused_run.requirements:
+        raise ValueError(f"Run {paused_run.run_id} has no requirements to resume")
+
+    requirements = resolve_requirements_from_tool_messages(paused_run.requirements, tool_messages)
+
+    if paused_run.run_id:
+        run_context.run_id = paused_run.run_id
+
+    # Inline-door admission gate (see agno.os.job_queue): a durable ticket
+    # owns this run's continuation - AG-UI must not execute it inline while
+    # an HTTP durable continue CASes the ticket. 409/503 HTTPException raises
+    # into the AG-UI route.
+    from agno.os.job_queue import araise_if_ticket_owns_continue, get_active_queue_worker
+
+    await araise_if_ticket_owns_continue(
+        get_active_queue_worker(),
+        paused_run.run_id,
+        component_type="team" if isinstance(entity, Team) else "agent",
+        component_id=getattr(entity, "id", None),
+    )
+
+    inner = entity.acontinue_run(  # type: ignore
+        run_id=paused_run.run_id,
+        session_id=session_id,
+        requirements=requirements,
+        stream=True,
+        stream_events=True,
+        run_context=run_context,
+        **run_kwargs,
+    )
+
+    run_id = paused_run.run_id
+
+    async def _stream_then_sync():
+        # Status-only stream sync after the continue is consumed (parity with
+        # the REST continue doors): a formerly-queued/streamed run's stream
+        # view must stop saying PAUSED once the continue settles - otherwise
+        # every later /resume replays the stale paused snapshot, and on Redis
+        # the pausing replica's TTL refresher keeps those keys alive
+        # indefinitely. only_if_tracked leaves never-streamed runs alone; a
+        # re-paused continue re-parks the stream as PAUSED. Best-effort: a
+        # stream-backend failure must not fail the AG-UI response.
+        import contextlib
+
+        from agno.os.utils import acomplete_continue_stream
+
+        try:
+            async for chunk in inner:
+                yield chunk
+        finally:
+            with contextlib.suppress(Exception):
+                await acomplete_continue_stream(entity, run_id, session_id, only_if_tracked=True)
+
+    return _stream_then_sync()

--- a/libs/agno/tests/unit/os/interfaces/agui_baseline/router.py.snapshot
+++ b/libs/agno/tests/unit/os/interfaces/agui_baseline/router.py.snapshot
@@ -25,14 +25,12 @@ from agno.os.interfaces.agui.handlers import validate_subagent_visibility
 from agno.os.interfaces.agui.input import (
     extract_context,
     extract_media,
-    extract_resume_entries,
     extract_tool_messages,
     extract_user_input,
     parse_client_tools,
     validate_state,
 )
-from agno.os.interfaces.agui.interrupts import validate_interrupt_outcome
-from agno.os.interfaces.agui.resume import resume_paused_run, resume_paused_run_from_entries
+from agno.os.interfaces.agui.resume import resume_paused_run
 from agno.os.interfaces.agui.stream import async_stream_agno_response_as_agui_events
 from agno.os.middleware.user_scope import assert_session_writable, caller_is_admin, resolve_run_user_id
 from agno.run.base import RunContext
@@ -45,7 +43,6 @@ async def run_entity(
     run_input: RunAgentInput,
     user_id: Optional[str] = None,
     subagent_visibility: Optional[str] = None,
-    emit_interrupt_outcome: bool = False,
 ) -> AsyncIterator[BaseEvent]:
     """Shared handler for running an Agent or Team with AG-UI input/output mapping.
 
@@ -62,7 +59,6 @@ async def run_entity(
         user_input = extract_user_input(messages)
         images, audio, videos, files = extract_media(messages)
         tool_messages = extract_tool_messages(messages)
-        resume_entries = extract_resume_entries(run_input)
 
         # 2. Convert frontend tool definitions to Agno Functions
         client_tools = parse_client_tools(run_input.tools) or None
@@ -87,27 +83,11 @@ async def run_entity(
         )
 
         run_kwargs: dict = {}
+        if ui_deps:
+            run_kwargs["add_dependencies_to_context"] = True
 
-        # 4. Determine if this is a resume, on either channel, or a fresh run.
-        # A request carrying both is answered from both: the array names the
-        # interrupts the run reported, the tool messages beside it carry the
-        # results of tools the frontend ran, and one assistant turn can pause on
-        # both kinds at once. They are merged rather than one being dropped, the
-        # array winning where both answer one requirement. An array that answers
-        # no paused run answers nothing at all, and the protocol proceeds without
-        # entries it does not recognise, so the request falls through to the
-        # fresh run it otherwise describes.
-        response_stream = None
-        if resume_entries:
-            response_stream = await resume_paused_run_from_entries(
-                entity=entity,  # type: ignore[arg-type]
-                session_id=run_input.thread_id,
-                resume_entries=resume_entries,
-                tool_messages=tool_messages,
-                run_context=run_context,
-                run_kwargs=run_kwargs,
-            )
-        elif tool_messages:
+        # 4. Determine if this is a resume (trailing ToolMessages) or fresh run
+        if tool_messages:
             # Resume: frontend executed external tools and sent results back
             response_stream = await resume_paused_run(
                 entity=entity,  # type: ignore[arg-type]
@@ -116,15 +96,8 @@ async def run_entity(
                 run_context=run_context,
                 run_kwargs=run_kwargs,
             )
-
-        if response_stream is None:
+        else:
             # Fresh run: new user input
-            # The dependency option belongs to this branch alone: it is read
-            # while a user message is built, and a continue replays the paused
-            # run's stored messages instead of building one. A resumed run still
-            # receives the request's context through run_context.dependencies.
-            if ui_deps:
-                run_kwargs["add_dependencies_to_context"] = True
             if isinstance(entity, (RemoteAgent, RemoteTeam)):
                 # A RunContext is an in-process object: RemoteAgent/RemoteTeam forward every
                 # unknown kwarg as a form field, and the remote AgentOS would hand the
@@ -156,7 +129,6 @@ async def run_entity(
             run_id=run_id,
             run_state=session_state,
             subagent_visibility=subagent_visibility,
-            emit_interrupt_outcome=emit_interrupt_outcome,
         ):
             yield event
 
@@ -170,7 +142,6 @@ def attach_routes(
     agent: Optional[Union[Agent, RemoteAgent]] = None,
     team: Optional[Union[Team, RemoteTeam]] = None,
     subagent_visibility: Optional[str] = None,
-    emit_interrupt_outcome: bool = False,
 ) -> APIRouter:
     if agent is None and team is None:
         raise ValueError("Either agent or team must be provided.")
@@ -178,7 +149,6 @@ def attach_routes(
     # Validated at mount time, not per request: an unserveable setting is a
     # startup failure, never an in-band error after a run has already begun.
     subagent_visibility = validate_subagent_visibility(subagent_visibility)
-    emit_interrupt_outcome = validate_interrupt_outcome(emit_interrupt_outcome)
 
     # An agent takes precedence over a team, decided on presence, so the entity a
     # request runs is the one the interface's scope mapping named.
@@ -207,7 +177,6 @@ def attach_routes(
                 run_input,
                 user_id=user_id,
                 subagent_visibility=subagent_visibility,
-                emit_interrupt_outcome=emit_interrupt_outcome,
             ):
                 yield encoder.encode(event)
 

--- a/libs/agno/tests/unit/os/interfaces/agui_baseline/state.py.snapshot
+++ b/libs/agno/tests/unit/os/interfaces/agui_baseline/state.py.snapshot
@@ -141,15 +141,6 @@ class StreamState:
     run_id: str = ""
     run_state: Optional[Dict[str, Any]] = None
 
-    # Interrupts. ``emit_interrupt_outcome`` off is the pre-interrupt stream: a
-    # pause ends in the plain terminal it has always ended in.
-    # ``suspended_lane_interrupts`` is written by the pause terminal, once the
-    # lanes it prompts for are settled, and read by the drain that closes them:
-    # a lane in it closes as suspended, carrying the interrupts it owns, rather
-    # than as work that finished.
-    emit_interrupt_outcome: bool = False
-    suspended_lane_interrupts: Dict[str, List[str]] = field(default_factory=dict)
-
     # Lineage
     subagent_visibility: str = SUBAGENT_VISIBILITY_INLINE
     lanes: Dict[Optional[str], Lane] = field(default_factory=dict)

--- a/libs/agno/tests/unit/os/interfaces/agui_baseline/stream.py.snapshot
+++ b/libs/agno/tests/unit/os/interfaces/agui_baseline/stream.py.snapshot
@@ -1,11 +1,8 @@
 from collections.abc import Iterator
-from typing import Any, AsyncIterator, Dict, List, Optional, Tuple, Union
+from typing import Any, AsyncIterator, Dict, List, Optional, Union
 
 from ag_ui.core import BaseEvent
 
-from agno.os.interfaces.agui.handlers import (
-    _readable as readable_value,
-)
 from agno.os.interfaces.agui.handlers import (
     close_open_spans,
     is_completion_event,
@@ -14,7 +11,9 @@ from agno.os.interfaces.agui.handlers import (
     process_event,
     validate_subagent_visibility,
 )
-from agno.os.interfaces.agui.interrupts import validate_interrupt_outcome
+from agno.os.interfaces.agui.handlers import (
+    _readable as readable_value,
+)
 from agno.os.interfaces.agui.state import StreamState
 from agno.run.agent import RunCompletedEvent, RunOutputEvent
 from agno.run.base import BaseRunOutputEvent
@@ -85,50 +84,12 @@ def _cleanup_events(state: StreamState, run_id: str, error_message: str) -> List
         return []
 
 
-def _run_terminal_events(
-    state: StreamState,
-    run_id: str,
-    root_terminal: Optional[BaseRunOutputEvent],
-    subagent_terminal: Optional[BaseRunOutputEvent],
-) -> Tuple[List[BaseEvent], Optional[Exception]]:
-    """The run terminal, or the span closes a terminal that could not be built owes.
-
-    Building the terminal is failable work: it renders a paused run's own words,
-    serializes the arguments of every call the pause prompts for, and copies the
-    session state the run ends holding. Outside a guard, a raise from any of
-    that sent no span end and no terminal, leaving the client spinning on a
-    message and a tool call with the caller's own in-band error as the only
-    account of how the run stopped.
-
-    Guarded apart from the event loop rather than with it, because the two are
-    different faults and the record has to say which happened: a source stream
-    that died is the run's, a terminal that cannot be built is this interface's
-    own. One guard could name only one of them, and would report a bug here as a
-    dead source stream.
-
-    The failure is returned rather than raised so the caller can send the closes
-    before it propagates, and it does propagate: nothing may follow a run
-    terminal, so a terminal written from here would leave the caller writing a
-    second one, and a failure that is loud today must not go quiet because the
-    stream around it was tidied up.
-    """
-    try:
-        return process_completion(_run_terminal(root_terminal, subagent_terminal), state), None
-    except Exception as error:
-        log_exception(
-            f"AG-UI stream for run {run_id} could not build its run terminal, closing open spans: "
-            f"{_failure_detail(error)}"
-        )
-        return _cleanup_events(state, run_id, _failure_message(error)), error
-
-
 def stream_agno_response_as_agui_events(
     response_stream: Iterator[Union[RunOutputEvent, TeamRunOutputEvent]],
     thread_id: str,
     run_id: str,
     run_state: Optional[Dict[str, Any]] = None,
     subagent_visibility: Optional[str] = None,
-    emit_interrupt_outcome: bool = False,
 ) -> Iterator[BaseEvent]:
     """Map the Agno response stream to AG-UI format."""
     state = StreamState(
@@ -136,7 +97,6 @@ def stream_agno_response_as_agui_events(
         run_id=run_id,
         run_state=run_state,
         subagent_visibility=validate_subagent_visibility(subagent_visibility),
-        emit_interrupt_outcome=validate_interrupt_outcome(emit_interrupt_outcome),
     )
 
     if run_state is not None:
@@ -169,11 +129,8 @@ def stream_agno_response_as_agui_events(
             yield event
         raise
 
-    terminal, failure = _run_terminal_events(state, run_id, terminal_chunk, subagent_terminal_chunk)
-    for event in terminal:
+    for event in process_completion(_run_terminal(terminal_chunk, subagent_terminal_chunk), state):
         yield event
-    if failure is not None:
-        raise failure
 
 
 async def async_stream_agno_response_as_agui_events(
@@ -182,7 +139,6 @@ async def async_stream_agno_response_as_agui_events(
     run_id: str,
     run_state: Optional[Dict[str, Any]] = None,
     subagent_visibility: Optional[str] = None,
-    emit_interrupt_outcome: bool = False,
 ) -> AsyncIterator[BaseEvent]:
     """Map the Agno response stream to AG-UI format."""
     state = StreamState(
@@ -190,7 +146,6 @@ async def async_stream_agno_response_as_agui_events(
         run_id=run_id,
         run_state=run_state,
         subagent_visibility=validate_subagent_visibility(subagent_visibility),
-        emit_interrupt_outcome=validate_interrupt_outcome(emit_interrupt_outcome),
     )
 
     if run_state is not None:
@@ -223,8 +178,5 @@ async def async_stream_agno_response_as_agui_events(
             yield event
         raise
 
-    terminal, failure = _run_terminal_events(state, run_id, terminal_chunk, subagent_terminal_chunk)
-    for event in terminal:
+    for event in process_completion(_run_terminal(terminal_chunk, subagent_terminal_chunk), state):
         yield event
-    if failure is not None:
-        raise failure

--- a/libs/agno/tests/unit/os/interfaces/agui_baseline/utils.py.snapshot
+++ b/libs/agno/tests/unit/os/interfaces/agui_baseline/utils.py.snapshot
@@ -1,0 +1,29 @@
+import ast
+import json
+from typing import Optional
+
+
+def to_json_str(value: Optional[str]) -> str:
+    # Tool results arrive as strings but may be Python repr format ("{'key': 'value'}")
+    # because base.py uses str(dict). Frontend needs valid JSON for JSON.parse().
+
+    if value is None:
+        return "null"
+
+    # 1. Already valid JSON — pass through unchanged
+    try:
+        json.loads(value)
+        return value
+    except (json.JSONDecodeError, TypeError):
+        pass
+
+    # 2. Python repr — parse with ast.literal_eval (safe, literals only), then serialize as JSON
+    # Handles: "{'a': 1}" → {"a": 1}, "True" → true, "None" → null
+    try:
+        obj = ast.literal_eval(value)
+        return json.dumps(obj)
+    except (ValueError, SyntaxError):
+        pass
+
+    # 3. Plain string — wrap as JSON string literal
+    return json.dumps(value)

--- a/libs/agno/tests/unit/os/interfaces/agui_baseline_tree.py
+++ b/libs/agno/tests/unit/os/interfaces/agui_baseline_tree.py
@@ -1,0 +1,88 @@
+"""The AG-UI interface as it was before the interrupt round trip, importable beside it.
+
+The interrupt outcome is off by default, and the promise that makes it safe to
+ship to released clients is that with it off a client receives what it received
+before the feature existed. Nothing in the suite pinned that, so it held only for
+as long as somebody kept checking it by hand.
+
+Pinning it needs the old emission to run rather than to be described, so the
+package as it stood at the commit named in ``BASELINE_COMMIT`` is checked in
+here, one ``.py.snapshot`` per module. Verbatim, and under a suffix the tooling
+does not read: a checked-in ``.py`` would be reformatted by this repo's own
+formatter and linted against today's rules, and either one edits the baseline,
+which is the one thing it may never be. ``test_agui_emission_identity`` holds the
+snapshot against the commit whenever the checkout can still reach it, so what is
+checked in cannot drift from what was released.
+
+Importing it takes one rewrite: the package's own absolute imports of
+``agno.os.interfaces.agui.X`` have to reach these modules rather than today's.
+Nothing else is touched, so everything outside the package, ``agno.run``,
+``agno.models`` and the protocol itself, resolves to the installed one. That is
+what makes the comparison one of this interface rather than of its dependencies.
+"""
+
+import atexit
+import importlib
+import re
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+from types import ModuleType
+from typing import Dict
+
+# The last commit before the interrupt round trip reached this package.
+BASELINE_COMMIT = "1aa4b49a8"
+
+# Where the snapshot was taken from, so the provenance check reads the same
+# files back out of that commit.
+PACKAGE_PATH_IN_REPO = "libs/agno/agno/os/interfaces/agui"
+
+SNAPSHOT_DIR = Path(__file__).parent / "agui_baseline"
+SNAPSHOT_SUFFIX = ".py.snapshot"
+
+LIVE_PACKAGE = "agno.os.interfaces.agui"
+BASELINE_PACKAGE = "agui_before_the_interrupt_round_trip"
+
+
+def snapshot_sources() -> Dict[str, str]:
+    """Every module of the snapshot, by module name, exactly as it is checked in."""
+    return {
+        path.name[: -len(SNAPSHOT_SUFFIX)]: path.read_text()
+        for path in sorted(SNAPSHOT_DIR.glob("*" + SNAPSHOT_SUFFIX))
+    }
+
+
+def rewritten(source: str) -> str:
+    """One snapshot module with its own package's imports pointed at the snapshot.
+
+    Bounded to the package's own dotted name, so an import of anything else in
+    ``agno`` still resolves to the installed one. Word-bounded on the right too:
+    the live name is a prefix of nothing in the package today but would be of a
+    later sibling, and a rewrite that matched one would move a live module in
+    under the baseline.
+    """
+    return re.sub(rf"\b{re.escape(LIVE_PACKAGE)}\b", BASELINE_PACKAGE, source)
+
+
+def _materialize() -> ModuleType:
+    root = Path(tempfile.mkdtemp(prefix="agui-baseline-"))
+    atexit.register(shutil.rmtree, root, True)
+    package = root / BASELINE_PACKAGE
+    package.mkdir()
+    for name, source in snapshot_sources().items():
+        (package / f"{name}.py").write_text(rewritten(source))
+    sys.path.insert(0, str(root))
+    return importlib.import_module(BASELINE_PACKAGE)
+
+
+_package = _materialize()
+
+
+def module(name: str) -> ModuleType:
+    """One module of the baseline package, under the name it has in the live one."""
+    return importlib.import_module(f"{BASELINE_PACKAGE}.{name}")
+
+
+baseline_stream = module("stream")
+baseline_router = module("router")

--- a/libs/agno/tests/unit/os/interfaces/agui_stream_invariants.py
+++ b/libs/agno/tests/unit/os/interfaces/agui_stream_invariants.py
@@ -31,6 +31,17 @@ suites do the thing that kept going wrong:
     The single door to everything the subagent lineage protocol release added.
     Asking for the attributed setting, or for a ``SUBAGENT_*`` event type, on an
     install that has neither skips the test instead of failing it.
+``member_mentions``
+    Every way one stream names a member, for the assertions whose subject is a
+    visibility that must name none. Reading one member event class passes while
+    the privacy is broken, because a member announced and then closed as an
+    error is named twice and counted zero times.
+``assert_stream_is_malformed_as_recorded``
+    The stream this interface emits malformed today, pinned to the violation it
+    breaks. For a behaviour that is deferred rather than blessed: an exemption
+    would say the stream is well formed and stop an invariant being checked on
+    every later stream that names it, and these streams are not well formed at
+    all.
 ``HOSTILE_VALUES`` / ``encoding_failures``
     Values a run's content can hold that serialization handles badly or not at
     all, to drive through every boundary that builds an event out of run
@@ -45,6 +56,7 @@ suites do the thing that kept going wrong:
     can only widen what a test sees, never narrow it.
 """
 
+import json
 import logging
 from collections import Counter
 from collections.abc import Iterator
@@ -58,6 +70,8 @@ import pytest
 from ag_ui.core import BaseEvent, EventType
 from ag_ui.encoder import EventEncoder
 
+from agno.models.base import Model
+from agno.models.response import ModelResponse, ModelResponseEvent
 from agno.os.interfaces.agui.handlers import validate_subagent_visibility
 from agno.os.interfaces.agui.state import SUBAGENT_VISIBILITY_ATTRIBUTED
 from agno.os.interfaces.agui.stream import (
@@ -186,6 +200,14 @@ SUBAGENT_FINISHED = _event_type("SUBAGENT_FINISHED")
 SUBAGENT_ERROR = _event_type("SUBAGENT_ERROR")
 
 _MEMBER_TERMINAL_TYPES = tuple(t for t in (SUBAGENT_FINISHED, SUBAGENT_ERROR) if t is not None)
+# Every event kind that is about a member at all, read off the installed
+# EventType rather than listed beside the three the interface writes today, so a
+# release that adds a fourth is covered here without an edit.
+_MEMBER_EVENT_TYPES = tuple(
+    event_type
+    for event_type in (_event_type(name) for name in dir(EventType) if name.startswith("SUBAGENT_"))
+    if event_type is not None
+)
 _RUN_TERMINAL_TYPES = (EventType.RUN_FINISHED, EventType.RUN_ERROR)
 # The lifecycle of the run itself. Derived from the terminals rather than listed
 # beside them, so the two cannot come to disagree about what ends a run.
@@ -328,6 +350,25 @@ def short_type_name(event_type: "EventType") -> str:
     return str(event_type).removeprefix("EventType.")
 
 
+def member_mentions(events: Sequence[BaseEvent]) -> List[Tuple[str, Optional[str]]]:
+    """(event, member) for everything in this stream that names a member.
+
+    For an assertion whose subject is a visibility that must name none. A member
+    reaches a client two ways: an event of one of the member kinds, and a lane
+    stamped on any event at all. Reading one of those kinds is a check that
+    holds while the privacy it is about is broken, because a member announced
+    and then closed as an error is named twice over and counted zero times.
+
+    The lane is read for presence rather than truthiness, as the invariants read
+    it: an empty lane is still a lane on the wire.
+    """
+    return [
+        (short_type(event), lane_of(event))
+        for event in events
+        if event.type in _MEMBER_EVENT_TYPES or lane_of(event) is not None
+    ]
+
+
 # --- The named invariants ---------------------------------------------------
 
 # One name per structural promise, so an exemption can waive exactly the one it
@@ -424,6 +465,18 @@ _EXEMPTIONS: Dict[str, Tuple[str, str]] = {
 EXEMPTIONS = tuple(_EXEMPTIONS)
 
 
+class StreamInvariantCheckerFailure(Exception):
+    """The checker could not reach a verdict, which is never a fact about the stream.
+
+    An exemption nobody justified, an exemption the stream does not need, and
+    anything raised inside an invariant that is not that invariant failing, all
+    say the harness is wrong rather than the stream. Deliberately not an
+    ``AssertionError``: the reporter returns those as the stream's violation, so
+    a checker fault needs a channel of its own or it reaches the caller dressed
+    as the verdict it prevented.
+    """
+
+
 def exemption_waives(exemption: str) -> str:
     """The single invariant one exemption waives."""
     return _EXEMPTIONS[exemption][0]
@@ -431,13 +484,69 @@ def exemption_waives(exemption: str) -> str:
 
 def _assert_exemptions_are_justified(exempt: Sequence[str]) -> None:
     for granted in exempt:
-        assert granted in _EXEMPTIONS, f"{granted!r} is not a justified stream invariant exemption"
+        if granted not in _EXEMPTIONS:
+            raise StreamInvariantCheckerFailure(f"{granted!r} is not a justified stream invariant exemption")
 
 
 def _waived(exempt: Sequence[str], invariant: str) -> bool:
     """Whether one named invariant is waived, refusing an exemption nobody justified."""
     _assert_exemptions_are_justified(exempt)
     return any(_EXEMPTIONS[granted][0] == invariant for granted in exempt)
+
+
+# --- Streams this interface emits malformed today ---------------------------
+
+# A stream the interface really emits that the invariants above reject, whose
+# behaviour is deferred rather than agreed to be correct. Deliberately not an
+# exemption: an exemption says a stream is well formed for a stated reason and
+# stops one named invariant being checked on every later stream that claims it,
+# and these streams are not well formed at all. Naming one here pins the
+# violation instead. Nothing stops being checked, the caller states the
+# disagreement where a reader sees it, and the day the behaviour changes the pin
+# fails rather than going quiet.
+A_CALL_PROMPTED_ONCE_PER_PAUSE_KIND = "a_call_prompted_once_per_pause_kind"
+
+_DEFERRED_VIOLATIONS: Dict[str, Tuple[str, str]] = {
+    A_CALL_PROMPTED_ONCE_PER_PAUSE_KIND: (
+        "tool call ids opened more than once",
+        "the pause prompt shows every pending call the pause listed, so two of "
+        "them under one tool call id reach the client as one id opened, argued "
+        "and closed twice. Three promises break at once there, not the one an "
+        "exemption could waive: the span opens twice, it closes twice, and the "
+        "second batch of arguments arrives after the first end. The prompt is "
+        "what this interface has always emitted and no test here changes it. "
+        "Two shapes reach it. A pause reporting one call under two pause-kind "
+        "lists is the first, and asking for the interrupt outcome ends that run "
+        "instead of prompting it only where the two kinds are one requirement "
+        "nothing can answer. A run reports them as two entries under the call's "
+        "own id and raises one answerable requirement, and a model is free to "
+        "number two of its calls alike, so both reach the prompt under either "
+        "setting.",
+    ),
+}
+
+
+def deferred_violation(deferred: str) -> str:
+    """The violation one deliberately malformed stream is pinned to."""
+    assert deferred in _DEFERRED_VIOLATIONS, f"{deferred!r} is not a recorded deferred stream violation"
+    return _DEFERRED_VIOLATIONS[deferred][0]
+
+
+def assert_stream_is_malformed_as_recorded(events: Sequence[BaseEvent], deferred: str) -> None:
+    """Hold a deliberately malformed stream to the violation recorded for it.
+
+    A stream that is well formed now fails here, and so does one that breaks
+    something other than what is recorded, so pinning a violation waives
+    nothing: every invariant still runs, and what the run reports is compared
+    against the one thing this stream is allowed to break.
+    """
+    recorded = deferred_violation(deferred)
+    violation = stream_invariant_violation(events)
+    assert violation is not None, (
+        f"this stream is well formed now, so the {deferred} record is stale: "
+        "delete the record and the pin that names it"
+    )
+    assert recorded in violation, f"this stream breaks {violation!r}, and not the recorded {recorded!r}"
 
 
 # --- One executable definition of a well-formed stream ----------------------
@@ -485,7 +594,7 @@ def assert_well_formed_stream(events: Sequence[BaseEvent], exempt: Sequence[str]
             _assert_invariants(events, narrowed)
         except AssertionError:
             continue
-        raise AssertionError(
+        raise StreamInvariantCheckerFailure(
             f"this stream is well formed without the {granted} exemption, so granting it waives "
             f"{exemption_waives(granted)} on a stream that does not break it"
         )
@@ -496,11 +605,22 @@ def stream_invariant_violation(events: Sequence[BaseEvent], exempt: Sequence[str
 
     For the few callers that have to state, and pin, that a stream is NOT well
     formed today. Everything else asserts well-formedness directly.
+
+    Three outcomes, not two: the string, ``None``, or a raised
+    ``StreamInvariantCheckerFailure`` when the checker never reached a verdict.
+    Callers read the returned string as the thing this stream breaks, so a fault
+    in the checker has to arrive as a raise or it is filed against the stream.
     """
     try:
         assert_well_formed_stream(events, exempt)
     except AssertionError as violation:
         return str(violation)
+    except StreamInvariantCheckerFailure:
+        raise
+    except BaseException as raised:
+        raise StreamInvariantCheckerFailure(
+            f"an invariant raised {type(raised).__name__} instead of failing: {raised}"
+        ) from raised
     return None
 
 
@@ -1114,8 +1234,8 @@ def captured_agno_logs(caplog: Any, level: str) -> Iterator[None]:
 
 # --- The same chunks through both mappers -----------------------------------
 
-Collected = Tuple[List[BaseEvent], Optional[Exception]]
-MalformedCollected = Tuple[List[BaseEvent], Optional[Exception], Optional[str]]
+Collected = Tuple[List[BaseEvent], Optional[BaseException]]
+MalformedCollected = Tuple[List[BaseEvent], Optional[BaseException], Optional[str]]
 
 
 class SideEffect:
@@ -1128,6 +1248,67 @@ class SideEffect:
 
     def __init__(self, action: Callable[[], Any]) -> None:
         self.action = action
+
+
+def sse_events(body: str) -> List[Dict[str, Any]]:
+    """The events of an SSE response body, decoded in the order they arrived.
+
+    Shared, because a suite that drives the mounted route reads its result this
+    way and a second copy of the decoding is a second thing that can be wrong
+    about what the wire carried.
+    """
+    return [json.loads(line[len("data: ") :]) for line in body.splitlines() if line.startswith("data: ")]
+
+
+class ScriptedModel(Model):
+    """Emits scripted turns offline: ('tool', name, args, id) or ('content', text)."""
+
+    def __init__(self, model_id: str, script: List[tuple], fail_with: Optional[str] = None):
+        super().__init__(id=model_id, name=model_id, provider="test")
+        self._script = list(script)
+        self._i = 0
+        self._fail_with = fail_with
+
+    def _next(self) -> ModelResponse:
+        if self._fail_with:
+            raise RuntimeError(self._fail_with)
+        if not self._script:
+            raise AssertionError(f"{self.id} was asked for a turn but was given an empty script")
+        # Refused rather than clamped to the last turn: a test that asks for more
+        # turns than it scripted is asserting about a turn it never wrote.
+        assert self._i < len(self._script), (
+            f"{self.id} was asked for turn {self._i} of a {len(self._script)}-turn script"
+        )
+        turn = self._script[self._i]
+        self._i += 1
+        if turn[0] == "tool":
+            _, name, args, tcid = turn
+            response = ModelResponse(role="assistant")
+            response.tool_calls = [
+                {"id": tcid, "type": "function", "function": {"name": name, "arguments": json.dumps(args)}}
+            ]
+            return response
+        response = ModelResponse(content=turn[1], role="assistant")
+        response.event = ModelResponseEvent.assistant_response.value
+        return response
+
+    def invoke(self, *args, **kwargs):
+        return self._next()
+
+    async def ainvoke(self, *args, **kwargs):
+        return self._next()
+
+    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+        yield self._next()
+
+    async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+        yield self._next()
+
+    def _parse_provider_response(self, response: Any, **kwargs) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
 
 
 def sync_source(chunks: Iterable[Any]) -> Iterator[Any]:
@@ -1165,27 +1346,46 @@ def _servable(visibility: Optional[str]) -> Optional[str]:
     return visibility
 
 
+def _recorded(raised: BaseException, chunks: Sequence[Any]) -> BaseException:
+    """The failure a driver collects, re-raising an interruption no chunk placed.
+
+    The sources above raise whatever the chunk list holds, and a chunk list may
+    hold any ``BaseException``. Catching ``Exception`` alone let one of those
+    out of the driver, which returned nothing: no invariant ran on the events it
+    had already collected, and the test read a raise where it had asked for a
+    recorded failure. What still has to pass through is an interruption from
+    outside the run, which is why this is by identity against the list rather
+    than a wider except.
+    """
+    if isinstance(raised, Exception) or any(raised is chunk for chunk in chunks):
+        return raised
+    raise raised
+
+
 def _drive_sync(
     chunks: Iterable[Any],
     visibility: Optional[str],
     thread_id: str,
     run_id: str,
     run_state: Optional[Dict[str, Any]],
+    emit_interrupt_outcome: bool,
 ) -> Collected:
     resolved = _servable(visibility)
+    driving = list(chunks)
     events: List[BaseEvent] = []
-    error: Optional[Exception] = None
+    error: Optional[BaseException] = None
     try:
         for event in stream_agno_response_as_agui_events(
-            sync_source(chunks),
+            sync_source(driving),
             thread_id=thread_id,
             run_id=run_id,
             run_state=run_state,
             subagent_visibility=resolved,
+            emit_interrupt_outcome=emit_interrupt_outcome,
         ):
             events.append(event)
-    except Exception as raised:
-        error = raised
+    except BaseException as raised:
+        error = _recorded(raised, driving)
     return events, error
 
 
@@ -1195,21 +1395,24 @@ async def _drive_async(
     thread_id: str,
     run_id: str,
     run_state: Optional[Dict[str, Any]],
+    emit_interrupt_outcome: bool,
 ) -> Collected:
     resolved = _servable(visibility)
+    driving = list(chunks)
     events: List[BaseEvent] = []
-    error: Optional[Exception] = None
+    error: Optional[BaseException] = None
     try:
         async for event in async_stream_agno_response_as_agui_events(
-            async_source(chunks),
+            async_source(driving),
             thread_id=thread_id,
             run_id=run_id,
             run_state=run_state,
             subagent_visibility=resolved,
+            emit_interrupt_outcome=emit_interrupt_outcome,
         ):
             events.append(event)
-    except Exception as raised:
-        error = raised
+    except BaseException as raised:
+        error = _recorded(raised, driving)
     return events, error
 
 
@@ -1221,8 +1424,9 @@ async def collect_sync(
     run_id: str,
     run_state: Optional[Dict[str, Any]] = None,
     exempt: Sequence[str] = (),
+    emit_interrupt_outcome: bool = False,
 ) -> Collected:
-    events, error = _drive_sync(chunks, visibility, thread_id, run_id, run_state)
+    events, error = _drive_sync(chunks, visibility, thread_id, run_id, run_state, emit_interrupt_outcome)
     assert_well_formed_stream(events, exempt)
     return events, error
 
@@ -1235,8 +1439,9 @@ async def collect_async(
     run_id: str,
     run_state: Optional[Dict[str, Any]] = None,
     exempt: Sequence[str] = (),
+    emit_interrupt_outcome: bool = False,
 ) -> Collected:
-    events, error = await _drive_async(chunks, visibility, thread_id, run_id, run_state)
+    events, error = await _drive_async(chunks, visibility, thread_id, run_id, run_state, emit_interrupt_outcome)
     assert_well_formed_stream(events, exempt)
     return events, error
 
@@ -1249,6 +1454,7 @@ async def collect_sync_recording_violations(
     run_id: str,
     run_state: Optional[Dict[str, Any]] = None,
     exempt: Sequence[str] = (),
+    emit_interrupt_outcome: bool = False,
 ) -> MalformedCollected:
     """As ``collect_sync``, reporting the invariant a stream broke instead of failing.
 
@@ -1256,7 +1462,7 @@ async def collect_sync_recording_violations(
     invariants still run, on exactly the same definition, so a stream that stops
     being malformed is a diff rather than a silence.
     """
-    events, error = _drive_sync(chunks, visibility, thread_id, run_id, run_state)
+    events, error = _drive_sync(chunks, visibility, thread_id, run_id, run_state, emit_interrupt_outcome)
     return events, error, stream_invariant_violation(events, exempt)
 
 
@@ -1268,8 +1474,9 @@ async def collect_async_recording_violations(
     run_id: str,
     run_state: Optional[Dict[str, Any]] = None,
     exempt: Sequence[str] = (),
+    emit_interrupt_outcome: bool = False,
 ) -> MalformedCollected:
-    events, error = await _drive_async(chunks, visibility, thread_id, run_id, run_state)
+    events, error = await _drive_async(chunks, visibility, thread_id, run_id, run_state, emit_interrupt_outcome)
     return events, error, stream_invariant_violation(events, exempt)
 
 
@@ -1328,6 +1535,37 @@ class RaisesOnSerialization:
         raise RuntimeError("to_dict exploded")
 
 
+class UnrenderableError(Exception):
+    """A failure that raises while being described, as one carrying a value does.
+
+    An exception built out of the thing that failed holds that thing, so
+    rendering the exception runs the same code the read did. Every guard that
+    interpolates a caught exception into its own record is running this.
+    """
+
+    def __str__(self) -> str:
+        raise RuntimeError("the exception cannot render itself")
+
+
+class RaisesAnUnreadableError(RaisesOnSerialization):
+    """A value whose serialization raises a failure that cannot be rendered either.
+
+    One level past ``RaisesOnSerialization``, which raises a failure that does
+    render: a guard can catch that one and still write its record. This value is
+    the case where catching is not enough, so it drives what a recovery path
+    does with the exception it caught rather than what it does with the value.
+    """
+
+    def model_dump_json(self) -> str:
+        raise UnrenderableError("dump exploded")
+
+    def __repr__(self) -> str:
+        raise UnrenderableError("repr exploded")
+
+    def to_dict(self) -> Dict[str, Any]:
+        raise UnrenderableError("to_dict exploded")
+
+
 def circular() -> Dict[str, Any]:
     """A mapping that holds itself, which the JSON encoder refuses."""
     cycle: Dict[str, Any] = {}
@@ -1340,9 +1578,13 @@ def circular() -> Dict[str, Any]:
 # of them are unserializable: ``not_a_number`` and ``none`` are the two most
 # serializers do handle, and what they are here for is that the boundaries
 # disagree about them, which the hostile suite's own table records.
+# ``raises_an_unreadable_error`` is not about serialization at all: it is the
+# level past a value that raises, where the failure raised cannot be rendered
+# either, so it drives the recovery paths rather than the reads they guard.
 HOSTILE_VALUES: Tuple[Tuple[str, Callable[[], Any]], ...] = (
     ("circular", circular),
     ("raises_on_serialization", RaisesOnSerialization),
+    ("raises_an_unreadable_error", RaisesAnUnreadableError),
     ("set", lambda: {"a", "b"}),
     ("not_a_number", lambda: float("nan")),
     ("none", lambda: None),

--- a/libs/agno/tests/unit/os/interfaces/agui_stream_invariants.py
+++ b/libs/agno/tests/unit/os/interfaces/agui_stream_invariants.py
@@ -1,0 +1,1349 @@
+"""An executable definition of a well-formed AG-UI stream, shared by the suites.
+
+Three shapes of weak test kept reappearing in the AG-UI member attribution
+suites: an assertion that passed because it folded two emissions into one key, an
+assertion made against a fixture that emitted nothing of the kind it reasoned
+about, and a wire-level invariant that no test checked at all. A fourth kept
+reappearing too: a use of the subagent lineage protocol on an install that has
+none, which fails rather than skipping. Each helper here is the one way the
+suites do the thing that kept going wrong:
+
+``assert_well_formed_stream``
+    Every structural promise the protocol and this interface make, checked at
+    once. Every collector below runs it, and so does every collector in the
+    suites, so a new test inherits the whole set without opting in. Each of
+    those promises has a stream that breaks it in
+    ``test_agui_stream_invariants``, so one going quiet is a failure there
+    rather than a silence everywhere.
+``in_emitted_order``
+    Ordered tuples of what was emitted, in place of a mapping keyed by a wire id
+    or by content. A mapping silently folds a duplicate emission, and two
+    members that produced identical text, into one entry.
+``assert_stream_contains`` / ``assert_stream_carries_exactly``
+    A census, so an assertion about reasoning, pauses or state cannot be made
+    against a stream that carries none of it. A test that means "none of it"
+    says the count, which the first of the two refuses to be handed.
+``collect_sync`` / ``collect_async``
+    The same chunk list driven through the sync and the async mapper, so the two
+    bodies cannot drift. The ``*_recording_violations`` pair is for the one
+    suite whose subject is streams that are NOT well formed today.
+``attributed`` / ``event_type_named`` / ``needs_lineage_events``
+    The single door to everything the subagent lineage protocol release added.
+    Asking for the attributed setting, or for a ``SUBAGENT_*`` event type, on an
+    install that has neither skips the test instead of failing it.
+``HOSTILE_VALUES`` / ``encoding_failures``
+    Values a run's content can hold that serialization handles badly or not at
+    all, to drive through every boundary that builds an event out of run
+    content, and the protocol's own encoder to say whether what came out could
+    have reached a client at all.
+``LINEAGE_EVENTS_PROTOCOL_FLOOR`` / ``lineage_announcement_fields_missing``
+    The protocol release member attribution needs, beside the fields this
+    checker actually reads off an announcement, so the floor is recomputed
+    against those fields rather than left standing as a comment.
+``captured_agno_logs``
+    Log capture at every logger this codebase writes through, at a level that
+    can only widen what a test sees, never narrow it.
+"""
+
+import logging
+from collections import Counter
+from collections.abc import Iterator
+from contextlib import ExitStack, contextmanager
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as installed_version
+from typing import Any, AsyncIterator, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Union
+
+import ag_ui.core
+import pytest
+from ag_ui.core import BaseEvent, EventType
+from ag_ui.encoder import EventEncoder
+
+from agno.os.interfaces.agui.handlers import validate_subagent_visibility
+from agno.os.interfaces.agui.state import SUBAGENT_VISIBILITY_ATTRIBUTED
+from agno.os.interfaces.agui.stream import (
+    async_stream_agno_response_as_agui_events,
+    stream_agno_response_as_agui_events,
+)
+from agno.run.agent import RunContentEvent
+from agno.run.team import RunContentEvent as TeamRunContentEvent
+from agno.utils.log import LOGGER_NAME, TEAM_LOGGER_NAME, WORKFLOW_LOGGER_NAME
+
+# --- The one door to the lineage protocol -----------------------------------
+
+# The lineage events arrived in the ag-ui-protocol release named by
+# ``LINEAGE_EVENTS_PROTOCOL_FLOOR`` below, and this package's agui extra still
+# permits older ones, so everything that needs them skips instead of failing
+# while the settings that work on any release keep running.
+# Both halves of what ``attributed`` needs are feature-detected by the interface
+# itself, so this asks the interface rather than guessing.
+_NO_LINEAGE_REASON = "installed ag-ui-protocol cannot serve subagent_visibility='attributed'"
+
+
+def _attributed_is_servable() -> bool:
+    try:
+        validate_subagent_visibility(SUBAGENT_VISIBILITY_ATTRIBUTED)
+    except ValueError:
+        return False
+    return True
+
+
+ATTRIBUTED_IS_SERVABLE = _attributed_is_servable()
+
+needs_lineage_events = pytest.mark.skipif(not ATTRIBUTED_IS_SERVABLE, reason=_NO_LINEAGE_REASON)
+
+
+def require_lineage_events() -> None:
+    """Skip unless this install can serve member attribution."""
+    if not ATTRIBUTED_IS_SERVABLE:
+        pytest.skip(_NO_LINEAGE_REASON)
+
+
+def attributed() -> str:
+    """The attributed visibility, skipping when this install cannot serve it.
+
+    Every request for member attribution in the suites comes through here, so an
+    install without the lineage events cannot be asked for a setting the
+    interface refuses at startup.
+    """
+    require_lineage_events()
+    return SUBAGENT_VISIBILITY_ATTRIBUTED
+
+
+# The same value without the skip, for the tests whose subject IS the refusal:
+# on an install that lacks the lineage events those are the only tests that
+# still have something to assert, so they must not skip there.
+ATTRIBUTED_EVEN_WHEN_REFUSED = SUBAGENT_VISIBILITY_ATTRIBUTED
+
+
+def event_type_named(name: str) -> "EventType":
+    """One AG-UI event type by name, skipping when this install lacks it.
+
+    The ``SUBAGENT_*`` members arrived with the lineage release, so naming one
+    directly is what breaks a suite on an older install. Reaching an event type
+    through here means a test that needs one this install does not define skips.
+    """
+    event_type = _event_type(name)
+    if event_type is None:
+        require_lineage_events()
+        raise AssertionError(f"the installed ag_ui.core defines no {name} event type")
+    return event_type
+
+
+# --- Reading an event -------------------------------------------------------
+
+
+def lane_of(event: BaseEvent) -> Optional[str]:
+    """The member lane an event is stamped with, or None for the top-level entity."""
+    return getattr(event, "subagent_run_id", None)
+
+
+def of_type(events: Sequence[BaseEvent], event_type: "EventType") -> List[BaseEvent]:
+    return [event for event in events if event.type == event_type]
+
+
+def short_type(event: BaseEvent) -> str:
+    return str(event.type).removeprefix("EventType.")
+
+
+def declared_fields_of(event_class: Any) -> Optional[Iterable[str]]:
+    """The field names one event class declares, or None for a class with no model.
+
+    A protocol event's model accepts attributes it does not declare, so the
+    presence of an attribute on an instance says nothing about whether the wire
+    format carries it. A class with no model at all, which is what a stand-in
+    for a renamed event is, declares nothing to compare against.
+    """
+    return getattr(event_class, "model_fields", None)
+
+
+def field_of(event: BaseEvent, name: str) -> Any:
+    """One declared field of an event, refusing to read one its model does not declare.
+
+    Defaulting a missing attribute to None makes a renamed or removed field
+    compare equal to itself on both sides of an assertion, so the comparison
+    passes while nothing is being compared. Declared, not merely present: the
+    protocol models accept extra attributes, so a field the wire format no
+    longer carries can still be read back off an event something set it on, and
+    the comparison is then between a test's own writes.
+    """
+    declared = declared_fields_of(type(event))
+    carried = hasattr(event, name) if declared is None else name in declared
+    assert carried, f"{short_type(event)} declares no {name} field, so nothing here compares it"
+    return getattr(event, name)
+
+
+def _event_type(name: str) -> Optional["EventType"]:
+    """One protocol event type, or None on a release that does not define it.
+
+    The lineage event types arrived after this interface's minimum protocol
+    release, so this module has to import on an install that lacks them.
+    """
+    return getattr(EventType, name, None)
+
+
+SUBAGENT_STARTED = _event_type("SUBAGENT_STARTED")
+SUBAGENT_FINISHED = _event_type("SUBAGENT_FINISHED")
+SUBAGENT_ERROR = _event_type("SUBAGENT_ERROR")
+
+_MEMBER_TERMINAL_TYPES = tuple(t for t in (SUBAGENT_FINISHED, SUBAGENT_ERROR) if t is not None)
+_RUN_TERMINAL_TYPES = (EventType.RUN_FINISHED, EventType.RUN_ERROR)
+# The lifecycle of the run itself. Derived from the terminals rather than listed
+# beside them, so the two cannot come to disagree about what ends a run.
+_RUN_LEVEL_TYPES = (EventType.RUN_STARTED,) + _RUN_TERMINAL_TYPES
+_STATE_TYPES = (EventType.STATE_SNAPSHOT, EventType.STATE_DELTA)
+
+# Each link an announcement can carry beyond its parent member: the field, the
+# event that has to have put what it names on the wire, and that event's own id
+# field. The parent member link is not here; it resolves against the
+# announcements themselves, which is a different lookup and its own invariant.
+_ANNOUNCEMENT_PARENT_LINKS: Tuple[Tuple[str, "EventType", str], ...] = (
+    ("parent_tool_call_id", EventType.TOOL_CALL_START, "tool_call_id"),
+    ("parent_message_id", EventType.TEXT_MESSAGE_START, "message_id"),
+)
+
+# Each span family: a label, the event that opens a span, the one that closes
+# it, and the field both carry the span's id in.
+_SPAN_FAMILIES: Tuple[Tuple[str, "EventType", "EventType", str], ...] = (
+    ("text message", EventType.TEXT_MESSAGE_START, EventType.TEXT_MESSAGE_END, "message_id"),
+    ("tool call", EventType.TOOL_CALL_START, EventType.TOOL_CALL_END, "tool_call_id"),
+    ("reasoning", EventType.REASONING_START, EventType.REASONING_END, "message_id"),
+    (
+        "reasoning message",
+        EventType.REASONING_MESSAGE_START,
+        EventType.REASONING_MESSAGE_END,
+        "message_id",
+    ),
+)
+
+# Each content event, and the span it has to arrive inside. TOOL_CALL_RESULT is
+# absent on purpose: the interface emits a call's result after that call's end,
+# which is the shape the protocol asks for and which
+# ``_assert_every_tool_result_follows_its_calls_end`` holds it to.
+_CONTENT_IN_SPAN: Tuple[Tuple[str, "EventType", "EventType", "EventType", str], ...] = (
+    (
+        "text message content",
+        EventType.TEXT_MESSAGE_CONTENT,
+        EventType.TEXT_MESSAGE_START,
+        EventType.TEXT_MESSAGE_END,
+        "message_id",
+    ),
+    (
+        "tool call arguments",
+        EventType.TOOL_CALL_ARGS,
+        EventType.TOOL_CALL_START,
+        EventType.TOOL_CALL_END,
+        "tool_call_id",
+    ),
+    (
+        "reasoning content",
+        EventType.REASONING_MESSAGE_CONTENT,
+        EventType.REASONING_MESSAGE_START,
+        EventType.REASONING_MESSAGE_END,
+        "message_id",
+    ),
+)
+
+
+# --- Ordered comparison instead of id-keyed folding -------------------------
+
+Projection = Union[str, Callable[[BaseEvent], Any]]
+
+
+def in_emitted_order(
+    events: Sequence[BaseEvent],
+    event_type: "EventType",
+    *projections: Projection,
+) -> List[Tuple[Any, ...]]:
+    """Ordered tuples of the named fields, one entry per event of that type.
+
+    A mapping keyed by a wire id or by content is the wrong shape for comparing
+    what was emitted: a second emission of the same id overwrites the first, and
+    two members that produced identical text collapse into one key. The list
+    this returns keeps both, so a duplicate is a diff rather than a silence.
+
+    A projection is a field name, which the event has to declare, or a callable
+    given the event. A single projection still yields one-tuples, so every
+    comparison reads the same way.
+    """
+    assert projections, "in_emitted_order needs at least one projection to compare"
+    rows: List[Tuple[Any, ...]] = []
+    for event in of_type(events, event_type):
+        row = tuple(
+            projection(event) if callable(projection) else field_of(event, projection) for projection in projections
+        )
+        rows.append(row)
+    return rows
+
+
+def joined_text_in_emitted_order(events: Sequence[BaseEvent]) -> List[Tuple[Optional[str], str]]:
+    """(lane, joined text) per text message, in the order the messages opened.
+
+    Ordered rather than keyed by message id or by the text itself, so a message
+    emitted twice and two lanes saying the same thing both stay visible.
+    """
+    deltas: Dict[str, str] = {}
+    for event in of_type(events, EventType.TEXT_MESSAGE_CONTENT):
+        message_id = field_of(event, "message_id")
+        deltas[message_id] = deltas.get(message_id, "") + field_of(event, "delta")
+    return [
+        (lane_of(event), deltas.get(field_of(event, "message_id"), ""))
+        for event in of_type(events, EventType.TEXT_MESSAGE_START)
+    ]
+
+
+# --- The fixture census -----------------------------------------------------
+
+
+def assert_stream_contains(events: Sequence[BaseEvent], event_type: "EventType", at_least: int = 1) -> None:
+    """The stream really carries the kind of event the test is about to reason about.
+
+    An assertion about reasoning, or a pause, or a state change, run against a
+    stream that emitted none of it passes no matter what the implementation
+    does. Stating the subject up front is what makes deleting the code that
+    produces it fail a test.
+
+    A lower bound of zero is refused rather than allowed to read as a check: it
+    holds for every stream ever emitted. A test whose subject is an absence
+    states the count instead.
+    """
+    assert at_least >= 1, (
+        f"a lower bound of {at_least} {short_type_name(event_type)} events holds for any stream at all; "
+        "state the count with assert_stream_carries_exactly instead"
+    )
+    found = len(of_type(events, event_type))
+    assert found >= at_least, (
+        f"this stream carries {found} {short_type_name(event_type)} events, "
+        f"but the test reasons about at least {at_least}: the assertions below "
+        "cannot exercise what they claim to"
+    )
+
+
+def assert_stream_carries_exactly(events: Sequence[BaseEvent], event_type: "EventType", count: int) -> None:
+    """The stream carries exactly this many of an event, zero included."""
+    found = len(of_type(events, event_type))
+    assert found == count, f"this stream carries {found} {short_type_name(event_type)} events, not {count}"
+
+
+def short_type_name(event_type: "EventType") -> str:
+    return str(event_type).removeprefix("EventType.")
+
+
+# --- The named invariants ---------------------------------------------------
+
+# One name per structural promise, so an exemption can waive exactly the one it
+# was written for and nothing else.
+NO_SPAN_OPENS_TWICE = "no_span_opens_twice"
+NO_SPAN_CLOSES_TWICE = "no_span_closes_twice"
+NO_SPAN_CLOSES_UNOPENED = "no_span_closes_unopened"
+EVERY_SPAN_CLOSES = "every_span_closes"
+NO_SPAN_CLOSES_BEFORE_IT_OPENS = "no_span_closes_before_it_opens"
+CONTENT_LANDS_INSIDE_ITS_SPAN = "content_lands_inside_its_span"
+CONTENT_CARRIES_ITS_SPANS_MEMBER = "content_carries_its_spans_member"
+A_SPAN_CLOSES_IN_THE_MEMBER_IT_OPENED_IN = "a_span_closes_in_the_member_it_opened_in"
+EVERY_TOOL_CALL_PARENT_MESSAGE_WAS_OPENED = "every_tool_call_parent_message_was_opened"
+A_TOOL_CALL_SITS_IN_ITS_PARENT_MESSAGES_MEMBER = "a_tool_call_sits_in_its_parent_messages_member"
+EVERY_TOOL_RESULT_NAMES_A_STARTED_CALL = "every_tool_result_names_a_started_call"
+EVERY_TOOL_RESULT_FOLLOWS_ITS_CALLS_END = "every_tool_result_follows_its_calls_end"
+A_TOOL_RESULT_CARRIES_ITS_CALLS_MEMBER = "a_tool_result_carries_its_calls_member"
+ONE_RUN_TERMINAL_AND_NOTHING_AFTER_IT = "one_run_terminal_and_nothing_after_it"
+NO_MEMBER_IS_ANNOUNCED_TWICE = "no_member_is_announced_twice"
+EVERY_STAMP_NAMES_AN_ANNOUNCED_MEMBER = "every_stamp_names_an_announced_member"
+EVERY_ANNOUNCED_PARENT_IS_ANNOUNCED_TOO = "every_announced_parent_is_announced_too"
+AN_ANNOUNCED_PARENT_PRECEDES_ITS_CHILD = "an_announced_parent_precedes_its_child"
+EVERY_ANNOUNCED_PARENT_LINK_RESOLVES = "every_announced_parent_link_resolves"
+EVERY_ANNOUNCED_MEMBER_TERMINATES = "every_announced_member_terminates"
+NOTHING_CARRIES_A_MEMBER_AFTER_ITS_TERMINAL = "nothing_carries_a_member_after_its_terminal"
+A_CHILDS_TERMINAL_PRECEDES_ITS_PARENTS = "a_childs_terminal_precedes_its_parents"
+STATE_EVENTS_ARE_NEVER_STAMPED = "state_events_are_never_stamped"
+RUN_EVENTS_ARE_NEVER_STAMPED = "run_events_are_never_stamped"
+
+INVARIANTS = (
+    NO_SPAN_OPENS_TWICE,
+    NO_SPAN_CLOSES_TWICE,
+    NO_SPAN_CLOSES_UNOPENED,
+    EVERY_SPAN_CLOSES,
+    NO_SPAN_CLOSES_BEFORE_IT_OPENS,
+    CONTENT_LANDS_INSIDE_ITS_SPAN,
+    CONTENT_CARRIES_ITS_SPANS_MEMBER,
+    A_SPAN_CLOSES_IN_THE_MEMBER_IT_OPENED_IN,
+    EVERY_TOOL_CALL_PARENT_MESSAGE_WAS_OPENED,
+    A_TOOL_CALL_SITS_IN_ITS_PARENT_MESSAGES_MEMBER,
+    EVERY_TOOL_RESULT_NAMES_A_STARTED_CALL,
+    EVERY_TOOL_RESULT_FOLLOWS_ITS_CALLS_END,
+    A_TOOL_RESULT_CARRIES_ITS_CALLS_MEMBER,
+    ONE_RUN_TERMINAL_AND_NOTHING_AFTER_IT,
+    NO_MEMBER_IS_ANNOUNCED_TWICE,
+    EVERY_STAMP_NAMES_AN_ANNOUNCED_MEMBER,
+    EVERY_ANNOUNCED_PARENT_IS_ANNOUNCED_TOO,
+    AN_ANNOUNCED_PARENT_PRECEDES_ITS_CHILD,
+    EVERY_ANNOUNCED_PARENT_LINK_RESOLVES,
+    EVERY_ANNOUNCED_MEMBER_TERMINATES,
+    NOTHING_CARRIES_A_MEMBER_AFTER_ITS_TERMINAL,
+    A_CHILDS_TERMINAL_PRECEDES_ITS_PARENTS,
+    STATE_EVENTS_ARE_NEVER_STAMPED,
+    RUN_EVENTS_ARE_NEVER_STAMPED,
+)
+
+
+# --- Exemptions -------------------------------------------------------------
+
+# A stream that legitimately breaks one invariant names its exemption. Each
+# exemption waives exactly one named invariant and is justified here and nowhere
+# else, so an unexplained one cannot be introduced by passing a bare string and
+# a waiver cannot quietly widen to cover a second promise.
+TRAILING_OUTPUT_AFTER_A_MEMBER_TERMINAL = "trailing_output_after_a_member_terminal"
+ABANDONED_MID_STREAM = "abandoned_mid_stream"
+ABANDONED_WITH_A_MEMBER_STILL_OPEN = "abandoned_with_a_member_still_open"
+
+_EXEMPTIONS: Dict[str, Tuple[str, str]] = {
+    TRAILING_OUTPUT_AFTER_A_MEMBER_TERMINAL: (
+        NOTHING_CARRIES_A_MEMBER_AFTER_ITS_TERMINAL,
+        "something still carries the member after its terminal, from one of the "
+        "two places that can. The source stream emits a chunk from a member "
+        "whose own run already completed, and a terminal is final for the id it "
+        "names, so the interface keeps that output attributed to the member "
+        "rather than giving one invocation a second lifecycle. Or the run-end "
+        "sweep writes the end of a tool call that member left open, because a "
+        "member's terminal ends no tool call: only the call's own completion "
+        "knows what it produced. Either way the terminal is still unique.",
+    ),
+    ABANDONED_MID_STREAM: (
+        EVERY_SPAN_CLOSES,
+        "the consumer walked away mid-message, so the collected events are a "
+        "deliberate prefix of a stream: the spans open at that point are never "
+        "closed, because there is no client left to write them to.",
+    ),
+    ABANDONED_WITH_A_MEMBER_STILL_OPEN: (
+        EVERY_ANNOUNCED_MEMBER_TERMINATES,
+        "the consumer walked away while a member was streaming, so the member "
+        "announced in that prefix never reaches a terminal, for the same reason "
+        "its spans never close: nothing is written to a client that left.",
+    ),
+}
+
+EXEMPTIONS = tuple(_EXEMPTIONS)
+
+
+def exemption_waives(exemption: str) -> str:
+    """The single invariant one exemption waives."""
+    return _EXEMPTIONS[exemption][0]
+
+
+def _assert_exemptions_are_justified(exempt: Sequence[str]) -> None:
+    for granted in exempt:
+        assert granted in _EXEMPTIONS, f"{granted!r} is not a justified stream invariant exemption"
+
+
+def _waived(exempt: Sequence[str], invariant: str) -> bool:
+    """Whether one named invariant is waived, refusing an exemption nobody justified."""
+    _assert_exemptions_are_justified(exempt)
+    return any(_EXEMPTIONS[granted][0] == invariant for granted in exempt)
+
+
+# --- One executable definition of a well-formed stream ----------------------
+
+
+def _assert_invariants(events: Sequence[BaseEvent], exempt: Sequence[str]) -> None:
+    """The invariant set itself, run once per set of granted exemptions."""
+    _assert_spans_open_once_and_close(events, exempt)
+    _assert_content_lands_inside_its_span(events)
+    _assert_content_carries_its_spans_member(events)
+    _assert_a_span_closes_in_the_member_it_opened_in(events)
+    _assert_every_tool_call_parent_message_was_opened(events)
+    _assert_a_tool_call_sits_in_its_parent_messages_member(events)
+    _assert_every_tool_result_names_a_started_call(events)
+    _assert_every_tool_result_follows_its_calls_end(events)
+    _assert_a_tool_result_carries_its_calls_member(events)
+    _assert_nothing_follows_the_run_terminal(events)
+    _assert_no_member_is_announced_twice(events)
+    _assert_every_stamp_names_an_announced_member(events)
+    _assert_every_announced_parent_is_announced_too(events)
+    _assert_an_announced_parent_precedes_its_child(events)
+    _assert_every_announced_parent_link_resolves(events)
+    _assert_each_member_owns_exactly_one_terminal(events, exempt)
+    _assert_a_childs_terminal_precedes_its_parents(events)
+    _assert_state_events_are_never_stamped(events)
+    _assert_run_events_are_never_stamped(events)
+
+
+def assert_well_formed_stream(events: Sequence[BaseEvent], exempt: Sequence[str] = ()) -> None:
+    """Every structural invariant the protocol and member attribution promise.
+
+    Called by every collector in this module, and by every collector in the
+    suites, so each test gets the whole set whether or not it thought to ask. A
+    stream that breaks one of these for a correct reason names its exemption; a
+    bare string is refused, and so is an exemption this stream turns out not to
+    need: a waiver granted for a case that no longer arises silently stops the
+    invariant from being checked on every later run of that same stream.
+    """
+    _assert_exemptions_are_justified(exempt)
+    _assert_invariants(events, exempt)
+
+    for granted in exempt:
+        narrowed = [other for other in exempt if other != granted]
+        try:
+            _assert_invariants(events, narrowed)
+        except AssertionError:
+            continue
+        raise AssertionError(
+            f"this stream is well formed without the {granted} exemption, so granting it waives "
+            f"{exemption_waives(granted)} on a stream that does not break it"
+        )
+
+
+def stream_invariant_violation(events: Sequence[BaseEvent], exempt: Sequence[str] = ()) -> Optional[str]:
+    """The first invariant a stream breaks, or None when it is well formed.
+
+    For the few callers that have to state, and pin, that a stream is NOT well
+    formed today. Everything else asserts well-formedness directly.
+    """
+    try:
+        assert_well_formed_stream(events, exempt)
+    except AssertionError as violation:
+        return str(violation)
+    return None
+
+
+def _assert_spans_open_once_and_close(events: Sequence[BaseEvent], exempt: Sequence[str]) -> None:
+    allow_open = _waived(exempt, EVERY_SPAN_CLOSES)
+    for label, start_type, end_type, id_field in _SPAN_FAMILIES:
+        opened = [field_of(event, id_field) for event in of_type(events, start_type)]
+        closed = [field_of(event, id_field) for event in of_type(events, end_type)]
+
+        repeated = sorted(span_id for span_id, count in Counter(opened).items() if count > 1)
+        assert not repeated, f"{label} ids opened more than once: {repeated}"
+
+        # Counted before the two set comparisons below, which cannot see a
+        # duplicate at all: a span opened once and closed twice subtracts to a
+        # balance of zero, and reporting the leftover close as a span that never
+        # opened names the wrong fault on an id the stream did open.
+        closed_twice = sorted(span_id for span_id, count in Counter(closed).items() if count > 1)
+        assert not closed_twice, f"{label} ids closed more than once: {closed_twice}"
+
+        # Sets, now that neither side can hold a duplicate: a count difference
+        # here could only restate the two assertions above.
+        unopened = sorted(set(closed) - set(opened))
+        assert not unopened, f"{label} ids closed without ever being opened: {unopened}"
+
+        if not allow_open:
+            unclosed = sorted(set(opened) - set(closed))
+            assert not unclosed, f"{label} ids opened and never closed: {unclosed}"
+
+        # Ordering is checked whether or not a span is allowed to stay open: a
+        # close that precedes its own open is malformed in either stream.
+        first_close: Dict[Any, int] = {}
+        for index, event in enumerate(events):
+            if event.type == end_type:
+                first_close.setdefault(field_of(event, id_field), index)
+        for index, event in enumerate(events):
+            if event.type != start_type:
+                continue
+            span_id = field_of(event, id_field)
+            closed_at = first_close.get(span_id)
+            assert closed_at is None or closed_at > index, f"{label} {span_id} was closed before it opened"
+
+
+def _assert_content_lands_inside_its_span(events: Sequence[BaseEvent]) -> None:
+    """A delta belongs to a span the client has a start for and not yet an end.
+
+    Without this, a delta naming an id that was never opened, and one arriving
+    after that id's own end, are both accepted as well formed, and a client has
+    nowhere to put either.
+    """
+    for label, content_type, start_type, end_type, id_field in _CONTENT_IN_SPAN:
+        opened: Dict[Any, int] = {}
+        closed: Dict[Any, int] = {}
+        for index, event in enumerate(events):
+            if event.type == start_type:
+                opened.setdefault(field_of(event, id_field), index)
+            elif event.type == end_type:
+                closed.setdefault(field_of(event, id_field), index)
+            elif event.type == content_type:
+                span_id = field_of(event, id_field)
+                assert span_id in opened, (
+                    f"{label} at index {index} names {span_id}, which no earlier {short_type_name(start_type)} opened"
+                )
+                assert span_id not in closed, (
+                    f"{label} at index {index} names {span_id}, whose "
+                    f"{short_type_name(end_type)} already went out at index {closed[span_id]}"
+                )
+
+
+def _assert_content_carries_its_spans_member(events: Sequence[BaseEvent]) -> None:
+    """A delta is stamped with the member whose span it belongs to.
+
+    A client routes an event by the span it names and renders it in the member
+    it is stamped with. Those two disagreeing puts one member's words inside
+    another member's bubble, which no other check here would notice: the delta
+    names an open span, and its lane names an announced member.
+    """
+    for label, content_type, start_type, _end_type, id_field in _CONTENT_IN_SPAN:
+        lane_of_span: Dict[Any, Optional[str]] = {}
+        for event in events:
+            if event.type == start_type:
+                lane_of_span.setdefault(field_of(event, id_field), lane_of(event))
+            elif event.type == content_type:
+                span_id = field_of(event, id_field)
+                if span_id not in lane_of_span:
+                    # The span itself was never opened, which the check above reports.
+                    continue
+                assert lane_of(event) == lane_of_span[span_id], (
+                    f"{label} for {span_id} is stamped with member {lane_of(event)}, while the "
+                    f"{short_type_name(start_type)} that opened it named {lane_of_span[span_id]}"
+                )
+
+
+def _assert_a_span_closes_in_the_member_it_opened_in(events: Sequence[BaseEvent]) -> None:
+    """A span's end is stamped with the member its start named.
+
+    The end is what tells a client the bubble is finished, so an end stamped
+    with another member, or with none, closes a bubble in a lane that never
+    opened one and leaves the real one open forever. The delta check above
+    compares content against its start and would not notice either.
+    """
+    for label, start_type, end_type, id_field in _SPAN_FAMILIES:
+        lane_of_span: Dict[Any, Optional[str]] = {}
+        for event in events:
+            if event.type == start_type:
+                lane_of_span.setdefault(field_of(event, id_field), lane_of(event))
+            elif event.type == end_type:
+                span_id = field_of(event, id_field)
+                if span_id not in lane_of_span:
+                    # The span was closed without ever opening, which the span
+                    # check above reports.
+                    continue
+                assert lane_of(event) == lane_of_span[span_id], (
+                    f"the {short_type_name(end_type)} for {label} {span_id} is stamped with member "
+                    f"{lane_of(event)}, while the {short_type_name(start_type)} that opened it named "
+                    f"{lane_of_span[span_id]}"
+                )
+
+
+def _assert_every_tool_call_parent_message_was_opened(events: Sequence[BaseEvent]) -> None:
+    """A call's parent message is one this stream opened.
+
+    A conforming client attaches a call to the assistant message its
+    ``parent_message_id`` names, so a call naming a message the stream never
+    opened is one the client has nowhere to attach and no way to render in
+    place. The lane rule below compares the pair only where both halves are
+    present, which is exactly what an unresolvable parent is not.
+    """
+    opened = {field_of(event, "message_id") for event in of_type(events, EventType.TEXT_MESSAGE_START)}
+    for event in of_type(events, EventType.TOOL_CALL_START):
+        parent = field_of(event, "parent_message_id")
+        if parent is None:
+            # A call parented to nothing is rendered on its own, which is a
+            # shape the protocol allows and this rule has no subject in.
+            continue
+        assert parent in opened, (
+            f"tool call {field_of(event, 'tool_call_id')} names parent message {parent}, which no "
+            "TEXT_MESSAGE_START in this stream opened, so a client has nothing to attach it to"
+        )
+
+
+def _assert_a_tool_call_sits_in_its_parent_messages_member(events: Sequence[BaseEvent]) -> None:
+    """A tool call is stamped with the member of the message it names as its parent.
+
+    A conforming client attaches a call to the assistant message its
+    ``parent_message_id`` names and renders each of the two in the member it is
+    stamped with, so a call and its parent message disagreeing puts the call in
+    a lane where its own message was never drawn. Every other lane check
+    compares an event against its own span, and a call's parent message is
+    another span, so none of them looks at this pair.
+    """
+    lane_of_message: Dict[Any, Optional[str]] = {}
+    for event in events:
+        if event.type == EventType.TEXT_MESSAGE_START:
+            lane_of_message.setdefault(field_of(event, "message_id"), lane_of(event))
+
+    for event in of_type(events, EventType.TOOL_CALL_START):
+        parent = field_of(event, "parent_message_id")
+        if parent is None or parent not in lane_of_message:
+            # A call parented to no message has no pair here to disagree, and
+            # one parented to a message this stream never opened is refused by
+            # the check above rather than by comparing it against nothing.
+            continue
+        assert lane_of(event) == lane_of_message[parent], (
+            f"tool call {field_of(event, 'tool_call_id')} is stamped with member {lane_of(event)}, while the "
+            f"message {parent} it names as its parent was opened in member {lane_of_message[parent]}"
+        )
+
+
+def _assert_every_tool_result_names_a_started_call(events: Sequence[BaseEvent]) -> None:
+    """A result belongs to a call the client already has a start for.
+
+    The result arrives outside its call's span, so the in-span check deliberately
+    skips it, which left a result naming a call that was never started, and one
+    arriving ahead of its own start, as well-formed streams: in both the client
+    has no card to put the result in at the moment it arrives.
+    """
+    started_at: Dict[Any, int] = {}
+    for index, event in enumerate(events):
+        if event.type == EventType.TOOL_CALL_START:
+            started_at.setdefault(field_of(event, "tool_call_id"), index)
+
+    orphans = [
+        field_of(event, "tool_call_id")
+        for event in of_type(events, EventType.TOOL_CALL_RESULT)
+        if field_of(event, "tool_call_id") not in started_at
+    ]
+    assert not orphans, f"tool call results name calls no TOOL_CALL_START opened: {orphans}"
+
+    for index, event in enumerate(events):
+        if event.type != EventType.TOOL_CALL_RESULT:
+            continue
+        call_id = field_of(event, "tool_call_id")
+        assert started_at[call_id] < index, (
+            f"the result for tool call {call_id} went out at index {index}, ahead of the "
+            f"TOOL_CALL_START that opened it at index {started_at[call_id]}"
+        )
+
+
+def _assert_every_tool_result_follows_its_calls_end(events: Sequence[BaseEvent]) -> None:
+    """A result goes out after its own call's end, not inside the call's span.
+
+    The result is the reason TOOL_CALL_RESULT is left out of the in-span table:
+    it belongs after the end rather than between the start and the end. Holding
+    it only to the start is a weaker promise than that, and it accepts the shape
+    the table is written around, a result delivered while the client still has
+    the call open and its arguments still streaming.
+    """
+    started_at: Dict[Any, int] = {}
+    ended_at: Dict[Any, int] = {}
+    for index, event in enumerate(events):
+        if event.type == EventType.TOOL_CALL_START:
+            started_at.setdefault(field_of(event, "tool_call_id"), index)
+        elif event.type == EventType.TOOL_CALL_END:
+            ended_at.setdefault(field_of(event, "tool_call_id"), index)
+
+    for index, event in enumerate(events):
+        if event.type != EventType.TOOL_CALL_RESULT:
+            continue
+        call_id = field_of(event, "tool_call_id")
+        if call_id not in started_at or index < started_at[call_id]:
+            # No start, or a result ahead of it, which the check above reports.
+            continue
+        if call_id not in ended_at:
+            # The call never closed, which the span check reports, except on the
+            # abandoned prefix where it is waived and there is no end to follow.
+            continue
+        assert ended_at[call_id] < index, (
+            f"the result for tool call {call_id} went out at index {index}, inside the call's own span: "
+            f"the TOOL_CALL_END that closed it is at index {ended_at[call_id]}"
+        )
+
+
+def _assert_a_tool_result_carries_its_calls_member(events: Sequence[BaseEvent]) -> None:
+    """A result is stamped with the member whose call produced it.
+
+    A result stamped with another member puts one member's tool output in
+    another member's card. The result sits outside its call's span, so neither
+    the in-span check nor the span-lane check above looks at it.
+    """
+    lane_of_call: Dict[Any, Optional[str]] = {}
+    for event in events:
+        if event.type == EventType.TOOL_CALL_START:
+            lane_of_call.setdefault(field_of(event, "tool_call_id"), lane_of(event))
+            continue
+        if event.type != EventType.TOOL_CALL_RESULT:
+            continue
+        call_id = field_of(event, "tool_call_id")
+        if call_id not in lane_of_call:
+            # No start for this result, which the check above reports.
+            continue
+        assert lane_of(event) == lane_of_call[call_id], (
+            f"the result for tool call {call_id} is stamped with member {lane_of(event)}, while the "
+            f"TOOL_CALL_START that opened it named {lane_of_call[call_id]}"
+        )
+
+
+def _assert_nothing_follows_the_run_terminal(events: Sequence[BaseEvent]) -> None:
+    terminals = [index for index, event in enumerate(events) if event.type in _RUN_TERMINAL_TYPES]
+    assert len(terminals) <= 1, (
+        f"a run carries at most one terminal, got {[short_type(events[index]) for index in terminals]}"
+    )
+    if terminals:
+        following = [short_type(event) for event in events[terminals[0] + 1 :]]
+        assert not following, f"events followed the run terminal: {following}"
+        return
+
+    # A run the client was told began owes it an end. No terminal at all is
+    # nonetheless well formed for a list that is a fragment of a response body
+    # rather than a whole one: the router writes RUN_STARTED and owns the
+    # terminal when the source stream raises, and a source that never says the
+    # run completed gets no terminal written for it. What the fragment must not
+    # do is announce a start and stop, which leaves a client waiting forever.
+    started = of_type(events, EventType.RUN_STARTED)
+    assert not started, (
+        f"this stream carries {len(started)} RUN_STARTED and no terminal, so a client is left "
+        "waiting on a run it was told had begun"
+    )
+
+
+def announcements(events: Sequence[BaseEvent]) -> List[BaseEvent]:
+    """Every member announcement in order, of which an old install can carry none.
+
+    An install without the lineage events cannot put a SUBAGENT_STARTED on the
+    wire, so an empty list is the truth there rather than a waived check. A test
+    that needs the event type itself asks ``event_type_named`` and skips.
+    """
+    if SUBAGENT_STARTED is None:
+        return []
+    return of_type(events, SUBAGENT_STARTED)
+
+
+def announced_lane(announcement: BaseEvent) -> Any:
+    """The member one announcement names, read as a declared field.
+
+    Every check that resolves a stamp, a parent link or a terminal against the
+    announcements reads the announced id through here. The permissive lookup
+    would default a renamed field to None, which leaves every announcement
+    naming the top-level entity: stamps stop resolving to anything, parent links
+    and terminals resolve to each other, and the checks pass while nothing about
+    member attribution is being compared.
+    """
+    return field_of(announcement, "subagent_run_id")
+
+
+def _assert_no_member_is_announced_twice(events: Sequence[BaseEvent]) -> None:
+    """One announcement per member.
+
+    A member id is one invocation, and Agno mints a fresh one per delegation, so
+    a second announcement of the same id either restarts a lane the client has
+    already drawn or splits one invocation across two. Its own promise rather
+    than a line inside the stamp check: a stamp resolves against the announced
+    ids either way, so the stamp check cannot be what holds this.
+    """
+    seen: Dict[Any, int] = {}
+    for index, event in enumerate(announcements(events)):
+        lane = announced_lane(event)
+        assert lane not in seen, f"member {lane} was announced more than once"
+        seen[lane] = index
+
+
+def _assert_every_stamp_names_an_announced_member(events: Sequence[BaseEvent]) -> None:
+    announced: Dict[Optional[str], int] = {}
+    for index, event in enumerate(events):
+        lane = lane_of(event)
+        if SUBAGENT_STARTED is not None and event.type == SUBAGENT_STARTED:
+            announced.setdefault(announced_lane(event), index)
+            continue
+        if lane is None:
+            continue
+        assert lane in announced, (
+            f"{short_type(event)} at index {index} is stamped with member {lane}, "
+            "which no earlier announcement named, so a client cannot resolve it"
+        )
+
+
+def _assert_every_announced_parent_is_announced_too(events: Sequence[BaseEvent]) -> None:
+    """A member's parent link names a member this stream also announces.
+
+    Left unchecked, an announcement can hand the client a parent id that appears
+    nowhere on the wire, which is a lane the client can neither draw nor resolve.
+
+    Announced anywhere in the stream, which is the floor: it refuses the case no
+    ordering can rescue, a parent the stream never announces at all.
+    ``_assert_an_announced_parent_precedes_its_child`` holds the rest, that the
+    announcement comes first.
+    """
+    announced = {announced_lane(event) for event in announcements(events)}
+    for event in announcements(events):
+        # Read as a declared field: defaulting a renamed one to None would make
+        # every announcement look parentless and this check pass on anything.
+        parent = field_of(event, "parent_subagent_run_id")
+        if parent is None:
+            continue
+        assert parent in announced, (
+            f"member {announced_lane(event)} names parent {parent}, which this stream never "
+            "announces, so a client cannot place it under anything"
+        )
+
+
+def _assert_an_announced_parent_precedes_its_child(events: Sequence[BaseEvent]) -> None:
+    """A parent link names a member this stream has already announced.
+
+    A client reads the stream in order and resolves a parent link when it
+    arrives, so a link to a member announced further down is one it cannot place
+    at the moment it is handed it. The check above is the floor under this and
+    refuses only a parent the stream never announces at all; this one refuses
+    the forward reference the interface avoids by announcing a parent before any
+    child that names it.
+    """
+    announced_at: Dict[Any, int] = {}
+    in_order = [
+        (index, event)
+        for index, event in enumerate(events)
+        if SUBAGENT_STARTED is not None and event.type == SUBAGENT_STARTED
+    ]
+    for index, event in in_order:
+        announced_at.setdefault(announced_lane(event), index)
+
+    for index, event in in_order:
+        parent = field_of(event, "parent_subagent_run_id")
+        if parent is None or parent not in announced_at:
+            # A parent this stream never announces, which the check above reports.
+            continue
+        assert announced_at[parent] < index, (
+            f"member {announced_lane(event)} announced at index {index} names parent {parent}, which this "
+            f"stream does not announce until index {announced_at[parent]}, so a client reading in order "
+            "cannot place it when it arrives"
+        )
+
+
+def _assert_every_announced_parent_link_resolves(events: Sequence[BaseEvent]) -> None:
+    """The call and the message an announcement names are ones this stream carries.
+
+    An announcement places the member under a delegating tool call and under the
+    assistant message that call hangs off, which is what a client nests the
+    member's lane inside. Either of those naming something the stream never put
+    on the wire leaves the client a lane it cannot place, exactly as a parent
+    member it never announced does, and only the member link was resolved.
+    """
+    for field, start_type, id_field in _ANNOUNCEMENT_PARENT_LINKS:
+        carried = {field_of(event, id_field) for event in of_type(events, start_type)}
+        for event in announcements(events):
+            named = field_of(event, field)
+            if named is None:
+                # A member announced under no call or no message: a top-level
+                # delegation the interface reports without either, which is a
+                # lane the client draws at the top rather than nested.
+                continue
+            assert named in carried, (
+                f"member {announced_lane(event)} names {field} {named}, which no "
+                f"{short_type_name(start_type)} in this stream carries, so a client cannot place it"
+            )
+
+
+def _assert_each_member_owns_exactly_one_terminal(events: Sequence[BaseEvent], exempt: Sequence[str]) -> None:
+    announced = [announced_lane(event) for event in announcements(events)]
+    terminals: Dict[Optional[str], List[int]] = {}
+    for index, event in enumerate(events):
+        if event.type in _MEMBER_TERMINAL_TYPES:
+            terminals.setdefault(lane_of(event), []).append(index)
+
+    # A member may always own at most one terminal. Owning none is what the
+    # abandonment exemption waives, and nothing else.
+    at_most_one_only = _waived(exempt, EVERY_ANNOUNCED_MEMBER_TERMINATES)
+    for lane in announced:
+        count = len(terminals.get(lane, []))
+        if at_most_one_only:
+            assert count <= 1, f"member {lane} owns {count} terminals, expected at most one"
+        else:
+            assert count == 1, f"member {lane} owns {count} terminals, expected exactly one"
+
+    # A terminal naming a member nothing announced is not checked here. It
+    # carries that member's lane, so the stamp check above already refuses it,
+    # and a second assertion for it can never be reached to be trusted.
+
+    if _waived(exempt, NOTHING_CARRIES_A_MEMBER_AFTER_ITS_TERMINAL):
+        return
+    for lane in announced:
+        indexes = terminals.get(lane, [])
+        if not indexes:
+            continue
+        after = [
+            short_type(event) for index, event in enumerate(events) if index > indexes[0] and lane_of(event) == lane
+        ]
+        assert not after, f"events carrying member {lane} followed its terminal: {after}"
+
+
+def _assert_a_childs_terminal_precedes_its_parents(events: Sequence[BaseEvent]) -> None:
+    # The parent link is read as a declared field: defaulting a renamed one to
+    # None would leave every lane parentless and this check ordering nothing.
+    parent_of = {announced_lane(event): field_of(event, "parent_subagent_run_id") for event in announcements(events)}
+    # The first terminal a lane owns, as every other helper here keeps the first
+    # of anything: a member owning a second one is refused by the check above,
+    # and under the waiver that permits owning none this ordering would
+    # otherwise be read off whichever terminal happened to come last.
+    first_terminal_at: Dict[Optional[str], int] = {}
+    for index, event in enumerate(events):
+        if event.type in _MEMBER_TERMINAL_TYPES:
+            first_terminal_at.setdefault(lane_of(event), index)
+    for lane, parent in parent_of.items():
+        if parent is None or parent not in first_terminal_at or lane not in first_terminal_at:
+            continue
+        assert first_terminal_at[lane] < first_terminal_at[parent], (
+            f"member {lane} terminated after its parent {parent}, so a client would "
+            "see a child resolve inside a member it had already closed"
+        )
+
+
+def _assert_state_events_are_never_stamped(events: Sequence[BaseEvent]) -> None:
+    # Presence, not truthiness: an empty lane is still a lane on the wire, and a
+    # client filtering by member drops the document just as surely.
+    stamped = [
+        (short_type(event), lane_of(event))
+        for event in events
+        if event.type in _STATE_TYPES and lane_of(event) is not None
+    ]
+    assert not stamped, (
+        f"state events carry a member lane: {stamped}. A team's session state is one "
+        "shared document, so a client filtering by member must not lose it"
+    )
+
+
+def _assert_run_events_are_never_stamped(events: Sequence[BaseEvent]) -> None:
+    """The run's own lifecycle belongs to the run, not to a member.
+
+    A member lane on RUN_STARTED or on a run terminal tells a client the run
+    itself began or ended inside one member, which a client filtering by member
+    either misplaces or drops: the start it needs to open the run, or the
+    terminal it needs to stop waiting for one. Read for presence, as the state
+    rule is, because an empty lane is still a lane on the wire.
+    """
+    stamped = [
+        (short_type(event), lane_of(event))
+        for event in events
+        if event.type in _RUN_LEVEL_TYPES and lane_of(event) is not None
+    ]
+    assert not stamped, (
+        f"run lifecycle events carry a member lane: {stamped}. A run begins and ends once, "
+        "for the whole stream, so no member owns either end of it"
+    )
+
+
+# --- The protocol release member attribution needs --------------------------
+
+# The release the subagent lineage events arrived in. Nothing gates on it: what
+# ``attributed`` needs is feature-detected, above and in the interface itself.
+# It is here to be recomputed against those features by
+# ``test_agui_stream_invariants``, which is what keeps the number in the comment
+# at the head of this module, and in the interface's own documentation, from
+# drifting away from the release that actually carries them.
+LINEAGE_EVENTS_PROTOCOL_FLOOR = (0, 1, 21)
+
+# Every field this checker reads off an announcement. The parent links come from
+# the table the invariant reads, so a link added there is one the floor is
+# recomputed against too.
+LINEAGE_ANNOUNCEMENT_FIELDS_READ_HERE = ("subagent_run_id", "parent_subagent_run_id") + tuple(
+    field for field, _start_type, _id_field in _ANNOUNCEMENT_PARENT_LINKS
+)
+
+
+def installed_protocol_release() -> Tuple[int, ...]:
+    """The installed ag-ui-protocol release, as its leading numeric components.
+
+    Parsed rather than compared as a string, where 0.1.9 sorts above 0.1.21, and
+    truncated at the first component that is not a plain number, so a
+    pre-release or a local build compares as the release it is built from.
+    """
+    try:
+        raw = installed_version("ag-ui-protocol")
+    except PackageNotFoundError as missing:  # pragma: no cover - ag_ui imported from somewhere else
+        raise AssertionError(f"ag_ui is importable but its distribution metadata is not: {missing}")
+    components: List[int] = []
+    for piece in raw.split("."):
+        digits = ""
+        for character in piece:
+            if not character.isdigit():
+                break
+            digits += character
+        if not digits:
+            break
+        components.append(int(digits))
+    return tuple(components)
+
+
+def announcement_fields_missing_from(event_class: Any) -> List[str]:
+    """The fields this checker reads that one announcement class does not declare."""
+    declared = declared_fields_of(event_class) or ()
+    return sorted(field for field in LINEAGE_ANNOUNCEMENT_FIELDS_READ_HERE if field not in declared)
+
+
+def lineage_announcement_fields_missing() -> List[str]:
+    """Those fields the installed announcement omits, of which an old release omits all."""
+    announcement = getattr(ag_ui.core, "SubagentStartedEvent", None)
+    if announcement is None:
+        return sorted(LINEAGE_ANNOUNCEMENT_FIELDS_READ_HERE)
+    return announcement_fields_missing_from(announcement)
+
+
+# --- What the protocol's own encoder can put on a wire ----------------------
+
+
+def encoding_failures(events: Sequence[BaseEvent]) -> List[Tuple[str, str]]:
+    """(event type, failure) for every event the protocol's encoder refuses.
+
+    The interface hands its events to this same encoder, so an event it cannot
+    serialize reaches no client at all: the response body stops there, with
+    whatever was written before it and no run terminal.
+    """
+    encoder = EventEncoder()
+    refused: List[Tuple[str, str]] = []
+    for event in events:
+        try:
+            encoder.encode(event)
+        except Exception as error:
+            refused.append((short_type(event), type(error).__name__))
+    return refused
+
+
+# --- Log capture at the loggers this codebase writes through ----------------
+
+# ``log_error`` and ``log_warning`` write to whichever of these the last agent,
+# team or workflow run selected, and agno's level setters run on every one of
+# those runs, so any of the three can be sitting at a level that drops the
+# records a test is about to assert on.
+AGNO_LOGGER_NAMES = (LOGGER_NAME, TEAM_LOGGER_NAME, WORKFLOW_LOGGER_NAME)
+
+
+@contextmanager
+def captured_agno_logs(caplog: Any, level: str) -> Iterator[None]:
+    """Capture at every logger agno's log helpers can write through, never above it.
+
+    ``caplog.at_level`` sets the level it is given on the logger it names, so
+    asking for ERROR on a logger sitting at INFO RAISES that logger's threshold
+    and drops every warning underneath. The threshold entered here is therefore
+    the most permissive of the level asked for and the levels the three loggers
+    already have, which can only widen what a test sees.
+    """
+    # Looked up with a default so a name that is not a level is reported as one
+    # rather than raising AttributeError out of a context manager's entry. A
+    # bool is refused explicitly: it passes an int check, and the module holds
+    # bool settings, so a true one would enter capture at level 1 and quietly
+    # read as the widest capture there is.
+    wanted = getattr(logging, level, None)
+    assert isinstance(wanted, int) and not isinstance(wanted, bool), f"{level!r} is not a logging level name"
+    floor = min([wanted, *(logging.getLogger(name).getEffectiveLevel() for name in AGNO_LOGGER_NAMES)])
+    with ExitStack() as stack:
+        for name in AGNO_LOGGER_NAMES:
+            stack.enter_context(caplog.at_level(floor, logger=name))
+        yield
+
+
+# --- The same chunks through both mappers -----------------------------------
+
+Collected = Tuple[List[BaseEvent], Optional[Exception]]
+MalformedCollected = Tuple[List[BaseEvent], Optional[Exception], Optional[str]]
+
+
+class SideEffect:
+    """A chunk list entry the source runs for its effect, emitting nothing.
+
+    A fixture that changes the session state partway through a run only produces
+    the delta the client should see if the change happens while the stream is
+    being consumed, not while the chunk list is being built.
+    """
+
+    def __init__(self, action: Callable[[], Any]) -> None:
+        self.action = action
+
+
+def sync_source(chunks: Iterable[Any]) -> Iterator[Any]:
+    """A sync source stream that raises any exception placed in the chunk list."""
+    for chunk in chunks:
+        if isinstance(chunk, BaseException):
+            raise chunk
+        if isinstance(chunk, SideEffect):
+            chunk.action()
+            continue
+        yield chunk
+
+
+async def async_source(chunks: Iterable[Any]) -> AsyncIterator[Any]:
+    """An async source stream that raises any exception placed in the chunk list."""
+    for chunk in chunks:
+        if isinstance(chunk, BaseException):
+            raise chunk
+        if isinstance(chunk, SideEffect):
+            chunk.action()
+            continue
+        yield chunk
+
+
+def _servable(visibility: Optional[str]) -> Optional[str]:
+    """The visibility to drive with, keeping a configuration error out of the stream.
+
+    A setting this install cannot serve skips, and an invalid one is raised from
+    here rather than from inside the drivers below, where it would be collected
+    as though the source stream itself had failed.
+    """
+    if visibility == SUBAGENT_VISIBILITY_ATTRIBUTED:
+        require_lineage_events()
+    validate_subagent_visibility(visibility)
+    return visibility
+
+
+def _drive_sync(
+    chunks: Iterable[Any],
+    visibility: Optional[str],
+    thread_id: str,
+    run_id: str,
+    run_state: Optional[Dict[str, Any]],
+) -> Collected:
+    resolved = _servable(visibility)
+    events: List[BaseEvent] = []
+    error: Optional[Exception] = None
+    try:
+        for event in stream_agno_response_as_agui_events(
+            sync_source(chunks),
+            thread_id=thread_id,
+            run_id=run_id,
+            run_state=run_state,
+            subagent_visibility=resolved,
+        ):
+            events.append(event)
+    except Exception as raised:
+        error = raised
+    return events, error
+
+
+async def _drive_async(
+    chunks: Iterable[Any],
+    visibility: Optional[str],
+    thread_id: str,
+    run_id: str,
+    run_state: Optional[Dict[str, Any]],
+) -> Collected:
+    resolved = _servable(visibility)
+    events: List[BaseEvent] = []
+    error: Optional[Exception] = None
+    try:
+        async for event in async_stream_agno_response_as_agui_events(
+            async_source(chunks),
+            thread_id=thread_id,
+            run_id=run_id,
+            run_state=run_state,
+            subagent_visibility=resolved,
+        ):
+            events.append(event)
+    except Exception as raised:
+        error = raised
+    return events, error
+
+
+async def collect_sync(
+    chunks: Iterable[Any],
+    visibility: Optional[str] = None,
+    *,
+    thread_id: str,
+    run_id: str,
+    run_state: Optional[Dict[str, Any]] = None,
+    exempt: Sequence[str] = (),
+) -> Collected:
+    events, error = _drive_sync(chunks, visibility, thread_id, run_id, run_state)
+    assert_well_formed_stream(events, exempt)
+    return events, error
+
+
+async def collect_async(
+    chunks: Iterable[Any],
+    visibility: Optional[str] = None,
+    *,
+    thread_id: str,
+    run_id: str,
+    run_state: Optional[Dict[str, Any]] = None,
+    exempt: Sequence[str] = (),
+) -> Collected:
+    events, error = await _drive_async(chunks, visibility, thread_id, run_id, run_state)
+    assert_well_formed_stream(events, exempt)
+    return events, error
+
+
+async def collect_sync_recording_violations(
+    chunks: Iterable[Any],
+    visibility: Optional[str] = None,
+    *,
+    thread_id: str,
+    run_id: str,
+    run_state: Optional[Dict[str, Any]] = None,
+    exempt: Sequence[str] = (),
+) -> MalformedCollected:
+    """As ``collect_sync``, reporting the invariant a stream broke instead of failing.
+
+    For the callers whose subject is a stream that is not well formed today. The
+    invariants still run, on exactly the same definition, so a stream that stops
+    being malformed is a diff rather than a silence.
+    """
+    events, error = _drive_sync(chunks, visibility, thread_id, run_id, run_state)
+    return events, error, stream_invariant_violation(events, exempt)
+
+
+async def collect_async_recording_violations(
+    chunks: Iterable[Any],
+    visibility: Optional[str] = None,
+    *,
+    thread_id: str,
+    run_id: str,
+    run_state: Optional[Dict[str, Any]] = None,
+    exempt: Sequence[str] = (),
+) -> MalformedCollected:
+    events, error = await _drive_async(chunks, visibility, thread_id, run_id, run_state)
+    return events, error, stream_invariant_violation(events, exempt)
+
+
+# --- The lineage fields a source chunk carries ------------------------------
+
+# The id the suites give the top-level entity's own run. Shared, because a
+# member chunk's ``parent_run_id`` has to name it for the chunk to be a
+# member's at all.
+TOP_LEVEL_RUN = "top-level-run"
+
+
+def member_chunk_kwargs(member: str, run: str, parent: str = TOP_LEVEL_RUN) -> Dict[str, Any]:
+    """The lineage fields Agno stamps on one member Agent's chunks."""
+    return {"agent_id": member, "agent_name": member.capitalize(), "run_id": run, "parent_run_id": parent}
+
+
+def team_chunk_kwargs(team_id: str, name: str, run: str, parent: Optional[str] = None) -> Dict[str, Any]:
+    """The lineage fields Agno stamps on one Team's chunks, top-level or nested."""
+    kwargs: Dict[str, Any] = {"team_id": team_id, "team_name": name, "run_id": run}
+    if parent is not None:
+        kwargs["parent_run_id"] = parent
+    return kwargs
+
+
+def agent_said(content: Any, **kwargs: Any) -> RunContentEvent:
+    """One Agent content chunk carrying whatever a run's content can hold.
+
+    The content is assigned rather than passed to the constructor, so a value
+    the field's own type refuses still reaches the mapper.
+    """
+    chunk = RunContentEvent(**kwargs)
+    chunk.content = content
+    return chunk
+
+
+def team_said(content: Any, **kwargs: Any) -> TeamRunContentEvent:
+    """One Team content chunk carrying whatever a run's content can hold."""
+    chunk = TeamRunContentEvent(**kwargs)
+    chunk.content = content
+    return chunk
+
+
+# --- Hostile values ---------------------------------------------------------
+
+
+class RaisesOnSerialization:
+    """A value every serialization route refuses, as a partly-built object can be."""
+
+    def model_dump_json(self) -> str:
+        raise RuntimeError("dump exploded")
+
+    def __repr__(self) -> str:
+        raise RuntimeError("repr exploded")
+
+    def to_dict(self) -> Dict[str, Any]:
+        raise RuntimeError("to_dict exploded")
+
+
+def circular() -> Dict[str, Any]:
+    """A mapping that holds itself, which the JSON encoder refuses."""
+    cycle: Dict[str, Any] = {}
+    cycle["self"] = cycle
+    return cycle
+
+
+# The values a run's content can hold that serialization handles badly, driven
+# through every boundary that builds an AG-UI event out of run content. Not all
+# of them are unserializable: ``not_a_number`` and ``none`` are the two most
+# serializers do handle, and what they are here for is that the boundaries
+# disagree about them, which the hostile suite's own table records.
+HOSTILE_VALUES: Tuple[Tuple[str, Callable[[], Any]], ...] = (
+    ("circular", circular),
+    ("raises_on_serialization", RaisesOnSerialization),
+    ("set", lambda: {"a", "b"}),
+    ("not_a_number", lambda: float("nan")),
+    ("none", lambda: None),
+)

--- a/libs/agno/tests/unit/os/interfaces/conftest.py
+++ b/libs/agno/tests/unit/os/interfaces/conftest.py
@@ -1,0 +1,50 @@
+"""Assert rewriting for the shared stream-invariant helper.
+
+The helper is not a test module, so pytest rewrites its asserts only when it is
+registered, and it has to be registered before any suite here imports it, which
+is what a conftest guarantees. Unregistered, a broken invariant arrives as a
+bare AssertionError without the values that say what the stream actually did.
+
+Registration takes a dotted path and says nothing when it names no module, so a
+mistyped or stale path leaves every suite here running against an unrewritten
+helper and passing. Both ways that can happen are checked rather than trusted:
+the path has to resolve to the helper sitting beside this file, and the helper
+must not already be imported, since registering after the import is the other
+way this silently does nothing.
+
+The order of those two matters. Resolving the dotted path is what imports the
+packages along it, so the helper cannot yet be in ``sys.modules`` when the
+lookup has not run, and an import check placed first passes on a tree where one
+of those packages imports the helper. The lookup goes first, the import check
+second.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_HELPER = "tests.unit.os.interfaces.agui_stream_invariants"
+_HELPER_FILE = Path(__file__).with_name("agui_stream_invariants.py").resolve()
+
+assert _HELPER_FILE.exists(), f"the shared stream-invariant helper is gone from {_HELPER_FILE.parent}"
+
+try:
+    _spec = importlib.util.find_spec(_HELPER)
+except ModuleNotFoundError:  # a package along the dotted path does not exist
+    _spec = None
+# Both sides resolved: a checkout reached through a symlink gives the spec an
+# origin naming this very file by another path, which a string comparison reads
+# as some other module and refuses a registration that would have worked.
+_origin = Path(_spec.origin).resolve() if _spec is not None and _spec.origin is not None else None
+assert _origin == _HELPER_FILE, (
+    f"{_HELPER} resolves to {_origin or 'nothing'}, not {_HELPER_FILE}: "
+    "registering that path rewrites nothing, and every invariant here would then fail without its values"
+)
+
+assert _HELPER not in sys.modules, (
+    f"{_HELPER} was imported before this conftest ran, so registering its assert rewrite here does nothing"
+)
+
+pytest.register_assert_rewrite(_HELPER)

--- a/libs/agno/tests/unit/os/interfaces/test_agui_documented_contract.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_documented_contract.py
@@ -1,0 +1,850 @@
+"""The AG-UI cookbook's documented contract, read out of the document and checked.
+
+The 16_agui README and TEST_LOG restate facts that live in the interface: which
+events carry a member's ``subagentRunId``, which visibility values exist and
+which one is the default, what an announcement's parent links are called, which
+files the folder holds. A restatement that nothing recomputes drifts silently,
+so every enumerable claim is parsed out of the document here and compared with
+the implementation's own constants rather than with a second copy of them.
+Adding an event type to the interface, or a visibility value, or a field to an
+announcement, without saying so in the README fails one of these tests.
+
+Genuine prose is left alone. Only claims that enumerate something the code
+already enumerates are pinned.
+"""
+
+import ast
+import importlib
+import inspect
+import re
+from pathlib import Path
+from types import ModuleType
+from typing import Dict, List, Optional, Set, Tuple
+
+import pytest
+
+pytest.importorskip("ag_ui", reason="ag_ui not installed")
+
+from ag_ui.core import BaseEvent
+
+from agno.os.interfaces.agui import AGUI
+from agno.os.interfaces.agui import handlers as agui_handlers
+from agno.os.interfaces.agui import state as agui_state
+from agno.os.interfaces.agui.handlers import validate_subagent_visibility
+from agno.os.interfaces.agui.state import SUBAGENT_VISIBILITY_VALUES
+
+from .agui_stream_invariants import needs_lineage_events, require_lineage_events
+
+_REPO_ROOT = Path(__file__).resolve().parents[6]
+_COOKBOOK = _REPO_ROOT / "cookbook" / "05_agent_os" / "16_agui"
+_README = _COOKBOOK / "README.md"
+_TEST_LOG = _COOKBOOK / "TEST_LOG.md"
+_EXAMPLE = _COOKBOOK / "team_subagent_lineage.py"
+_PACKAGE_PYPROJECT = _REPO_ROOT / "libs" / "agno" / "pyproject.toml"
+
+# The root is identified by the package these tests are about, which sits at a
+# fixed place under it. Counted wrong, the walk above lands somewhere with no
+# cookbook under it, and every document read below then reads as a checkout
+# that ships none: moving this file one directory turned most of this module
+# into skips, the protocol-floor check among them.
+assert (_REPO_ROOT / "libs" / "agno" / "agno" / "os" / "interfaces" / "agui").is_dir(), (
+    f"{_REPO_ROOT} is not this repository's root, so every document this module reads would be "
+    "reported as absent from the checkout rather than checked"
+)
+
+# The sentence the machine-checkable event list hangs off. Kept as one string so
+# a README that drops the list fails here instead of passing vacuously.
+_ATTRIBUTED_LIST_MARKER = "These are the events that carry a `subagentRunId`:"
+_UNATTRIBUTED_MARKER = "kinds of event carry none."
+
+# The unattributed marker does carry a count, one word ahead of it, so that word
+# is recomputed from the same paragraph rather than left to be edited in
+# lockstep. Spelled numbers only, which is how the document writes it.
+_SPELLED_COUNTS = {"one": 1, "two": 2, "three": 3, "four": 4, "five": 5, "six": 6, "seven": 7}
+
+
+def _doc(path: Path) -> str:
+    """One document of the cookbook folder, skipped only when the folder itself is gone.
+
+    A checkout can ship without the cookbook, which is the one thing worth
+    skipping for. A file missing from a folder that is there is a document this
+    module was written against and no longer holds, so it fails.
+    """
+    if not _COOKBOOK.is_dir():
+        pytest.skip("cookbook not present in this checkout")
+    assert path.exists(), f"the cookbook folder no longer holds {path.name}, which this module reads"
+    return path.read_text(encoding="utf-8")
+
+
+def _section(text: str, heading: str) -> str:
+    """One `##` section of a markdown document, heading excluded.
+
+    Anchored at the start of a line, so a heading named in a sentence somewhere
+    above cannot be mistaken for the section itself, and reported rather than
+    raised bare, so a renamed heading says which one went missing.
+    """
+    found = re.search(rf"^{re.escape(heading)}$", text, re.MULTILINE)
+    assert found is not None, f"the document no longer has a {heading!r} section, so nothing here can read it"
+    rest = text[found.end() :]
+    end = rest.find("\n## ")
+    return rest if end == -1 else rest[:end]
+
+
+def _attribution_section() -> str:
+    return _section(_doc(_README), "## Team member attribution")
+
+
+_FIRST_CELL = re.compile(r"^\| `([^`]+)`([^|]*)\|")
+
+
+def _table_rows(section: str) -> List[Tuple[str, str]]:
+    """(backticked value, rest of that first cell) per table row, first cell only.
+
+    Read with one pattern rather than by splitting on backticks and pipes,
+    which raises an index error of its own on a row shaped differently, and cut
+    at the first cell so a word in the row's description cannot be read as a
+    mark on its value.
+    """
+    rows: List[Tuple[str, str]] = []
+    for line in section.splitlines():
+        if not line.startswith("| `"):
+            continue
+        found = _FIRST_CELL.match(line)
+        assert found is not None, f"this table row does not open with a backticked cell: {line}"
+        rows.append((found.group(1), found.group(2)))
+    return rows
+
+
+def _first_column_entries(section: str) -> List[str]:
+    """The backticked value opening every table row in a section."""
+    return [value for value, _ in _table_rows(section)]
+
+
+def _backticked(text: str) -> List[str]:
+    return re.findall(r"`([^`\n]+)`", text)
+
+
+def _expand_event_token(token: str) -> Set[str]:
+    """An event name, or the documented ``PREFIX_*`` family, within what is emitted.
+
+    Expanded over the events this interface emits rather than over the installed
+    protocol's whole enumeration. A family covers whatever the protocol adds to
+    it, and an addition this interface never emits is not something the README
+    can be expected to have accounted for.
+    """
+    emitted = _implementation_emitted_events()
+    if token.endswith("_*"):
+        prefix = token[:-1]
+        return {name for name in emitted if name.startswith(prefix)}
+    return {token} & emitted
+
+
+def _implementation_attributed_events() -> Set[str]:
+    return {event_type.value for event_type in agui_handlers._SUBAGENT_ATTRIBUTABLE_EVENT_TYPES}
+
+
+_AG_UI = "ag_ui"
+_AG_UI_CORE = "ag_ui.core"
+_CORE = "core"
+
+
+def _dotted(node: ast.expr) -> Optional[str]:
+    """A ``Name`` or dotted ``Attribute`` chain rendered back as source text."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        base = _dotted(node.value)
+        return f"{base}.{node.attr}" if base is not None else None
+    return None
+
+
+def _protocol_module(name: str) -> Optional[ModuleType]:
+    """One module of the installed protocol, or None on a release that has no such module."""
+    if name != _AG_UI_CORE and not name.startswith(_AG_UI_CORE + "."):
+        return None
+    try:
+        return importlib.import_module(name)
+    except ImportError:
+        return None
+
+
+def _names_the_protocol(module: Optional[str]) -> bool:
+    """Whether a from-import's module is ``ag_ui.core`` or a submodule of it.
+
+    The package re-exports its event classes and the interface imports them
+    from there, but importing the same class out of the submodule that defines
+    it is the same construction and this census has to see it.
+    """
+    return module == _AG_UI_CORE or (module or "").startswith(_AG_UI_CORE + ".")
+
+
+def _event_class_named(name: str, module: str = _AG_UI_CORE) -> Optional[type]:
+    """An AG-UI event class of the protocol, by the name the protocol gives it.
+
+    Looked for on the module the import named and then on the package that
+    re-exports it, so a class taken out of a submodule resolves whichever of the
+    two the installed release defines it on.
+    """
+    for where in (module, _AG_UI_CORE):
+        found = getattr(_protocol_module(where), name, None)
+        if isinstance(found, type) and issubclass(found, BaseEvent):
+            return found
+    return None
+
+
+def _event_classes_by_local_name(tree: ast.Module) -> Dict[str, type]:
+    """Every AG-UI event class one module imported, under the name it uses locally.
+
+    Aliased imports are what make a text search unreliable here: the interface
+    imports the protocol's run-error event under a name of its own.
+    """
+    classes: Dict[str, type] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom) or not _names_the_protocol(node.module):
+            continue
+        for alias in node.names:
+            imported = _event_class_named(alias.name, node.module or _AG_UI_CORE)
+            if imported is not None:
+                classes[alias.asname or alias.name] = imported
+    return classes
+
+
+def _core_module_aliases(tree: ast.Module) -> Dict[str, str]:
+    """Every local dotted prefix that reaches the protocol, against the module it names.
+
+    An event built through the module rather than through a from-imported class
+    is the same construction, and reading only ``Call`` nodes whose callee is a
+    bare name misses it. Reading any attribute call by its last segment instead
+    would credit ``anything.RawEvent(...)``, so the prefixes are resolved here
+    and nothing else is treated as the protocol.
+
+    ``import ag_ui`` binds the package alone, and the protocol is then reached
+    one attribute further along, which is why the prefix recorded for it carries
+    that attribute rather than the bound name.
+    """
+    aliases: Dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == _AG_UI:
+                    aliases[f"{alias.asname or _AG_UI}.{_CORE}"] = _AG_UI_CORE
+                elif alias.name == _AG_UI_CORE or alias.name.startswith(_AG_UI_CORE + "."):
+                    # Without an alias the whole dotted path is what the source
+                    # writes, since the name bound is the top package.
+                    aliases[alias.asname or alias.name] = alias.name
+        elif isinstance(node, ast.ImportFrom) and node.module == _AG_UI:
+            for alias in node.names:
+                if alias.name == _CORE:
+                    aliases[alias.asname or _CORE] = _AG_UI_CORE
+    return aliases
+
+
+def _constructed_event_class(func: ast.expr, classes: Dict[str, type], aliases: Dict[str, str]) -> Optional[type]:
+    """The AG-UI event class a call constructs, or None when it constructs none."""
+    if isinstance(func, ast.Name):
+        return classes.get(func.id)
+    if isinstance(func, ast.Attribute):
+        prefix = _dotted(func.value)
+        module = aliases.get(prefix) if prefix is not None else None
+        if module is not None:
+            return _event_class_named(func.attr, module)
+    return None
+
+
+def _event_type_default(event_class: type) -> str:
+    """The event type a protocol class declares, reported rather than raised for.
+
+    A class with no concrete default has nothing to name it by. Read straight
+    through, that arrives as an attribute error from inside the scan, which
+    takes down this module and the hostile-content suite whose census rests on
+    it instead of saying which class is unreadable.
+    """
+    declared = event_class.model_fields["type"].default  # type: ignore[attr-defined]
+    assert getattr(declared, "value", None) is not None, (
+        f"{event_class.__name__} declares {declared!r} as its event type, which names no event: "
+        "the census cannot say what a scope building one of these builds"
+    )
+    return str(declared.value)
+
+
+# Every node that starts a scope of its own. A construction inside one belongs
+# to that scope and not to the scope holding it, so a helper defined inside a
+# function cannot be covered by driving the function around it.
+def _scan_scope(
+    body: List[ast.stmt],
+    scope: str,
+    classes: Dict[str, type],
+    aliases: Dict[str, str],
+    built: Dict[str, Set[str]],
+) -> None:
+    for statement in body:
+        _scan_node(statement, scope, classes, aliases, built)
+
+
+def _scan_node(
+    node: ast.AST,
+    scope: str,
+    classes: Dict[str, type],
+    aliases: Dict[str, str],
+    built: Dict[str, Set[str]],
+) -> None:
+    """Record the event constructions in one scope, nested scopes named separately."""
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        # A decorator, a default and a base class are evaluated where the
+        # definition is written, so they stay in the enclosing scope.
+        for outer in [*node.decorator_list, *getattr(node, "bases", [])]:
+            _scan_node(outer, scope, classes, aliases, built)
+        if not isinstance(node, ast.ClassDef):
+            for outer in [*node.args.defaults, *(d for d in node.args.kw_defaults if d is not None)]:
+                _scan_node(outer, scope, classes, aliases, built)
+        _scan_scope(node.body, f"{scope}.{node.name}", classes, aliases, built)
+        return
+    if isinstance(node, ast.Lambda):
+        for outer in [*node.args.defaults, *(d for d in node.args.kw_defaults if d is not None)]:
+            _scan_node(outer, scope, classes, aliases, built)
+        _scan_node(node.body, f"{scope}.<lambda>", classes, aliases, built)
+        return
+    if isinstance(node, ast.Call):
+        event_class = _constructed_event_class(node.func, classes, aliases)
+        if event_class is not None:
+            built.setdefault(scope, set()).add(_event_type_default(event_class))
+    for child in ast.iter_child_nodes(node):
+        _scan_node(child, scope, classes, aliases, built)
+
+
+MODULE_SCOPE = "<module>"
+
+
+def event_constructions_in(module_name: str, source: str) -> Dict[str, Set[str]]:
+    """Every AG-UI event type one module's source builds, per scope that builds it.
+
+    Scopes are named ``module.function``, and a scope nested inside another is
+    named through it, so two modules holding a function of the same name are two
+    entries rather than one merged set. Code at a module's top level is named
+    ``module.<module>``: an event built there is built once at import and never
+    driven by any run, which is a fact about the package rather than something
+    to leave unreported.
+    """
+    tree = ast.parse(source)
+    built: Dict[str, Set[str]] = {}
+    _scan_scope(
+        tree.body,
+        module_name,
+        _event_classes_by_local_name(tree),
+        _core_module_aliases(tree),
+        built,
+    )
+    return {f"{scope}.{MODULE_SCOPE}" if scope == module_name else scope: events for scope, events in built.items()}
+
+
+def event_constructions_by_function() -> Dict[str, Set[str]]:
+    """Every AG-UI event type the interface builds, per source scope that builds it.
+
+    Read off the event classes the package constructs rather than off mentions
+    of ``EventType.X``, which count a comparison against a type this interface
+    never emits. It is a scan of source, so it says which scopes build which
+    events, not which of them any particular run reaches.
+
+    Shared with the hostile-content suite, which uses the same scan to check
+    that its table of event-building boundaries names every one of them.
+    """
+    package = Path(agui_handlers.__file__).parent
+    built: Dict[str, Set[str]] = {}
+    for module in sorted(package.glob("*.py")):
+        for scope, events in event_constructions_in(module.stem, module.read_text(encoding="utf-8")).items():
+            built.setdefault(scope, set()).update(events)
+    assert built, "found no AG-UI event constructions in the interface package"
+    return built
+
+
+# Sources that build one AG-UI event by a route the scan above has to see. Each
+# was a way a construction went unrecorded, so each is written out here rather
+# than described: a scan that stops seeing one of these stops being the census
+# the coverage test in the hostile-content suite rests on.
+_CONSTRUCTIONS_THE_SCAN_HAS_TO_SEE: Dict[str, Tuple[str, str]] = {
+    "through the module it was imported from": (
+        "import ag_ui.core\n\ndef builds():\n    ag_ui.core.RawEvent()\n",
+        "scanned.builds",
+    ),
+    "through an aliased module": (
+        "import ag_ui.core as protocol\n\ndef builds():\n    protocol.RawEvent()\n",
+        "scanned.builds",
+    ),
+    "through a module imported from its package": (
+        "from ag_ui import core\n\ndef builds():\n    core.RawEvent()\n",
+        "scanned.builds",
+    ),
+    "from the submodule that defines it": (
+        "from ag_ui.core.events import RawEvent\n\ndef builds():\n    RawEvent()\n",
+        "scanned.builds",
+    ),
+    "through the top package alone": (
+        "import ag_ui\n\ndef builds():\n    ag_ui.core.RawEvent()\n",
+        "scanned.builds",
+    ),
+    "through the top package under an alias": (
+        "import ag_ui as protocol\n\ndef builds():\n    protocol.core.RawEvent()\n",
+        "scanned.builds",
+    ),
+    "through an imported submodule": (
+        "import ag_ui.core.events\n\ndef builds():\n    ag_ui.core.events.RawEvent()\n",
+        "scanned.builds",
+    ),
+    "at a module's own top level": (
+        "from ag_ui.core import RawEvent\n\nPRELUDE = RawEvent()\n",
+        f"scanned.{MODULE_SCOPE}",
+    ),
+    "in a function nested inside another": (
+        "from ag_ui.core import RawEvent\n\ndef outer():\n    def inner():\n        RawEvent()\n\n    return inner\n",
+        "scanned.outer.inner",
+    ),
+    "in a method of a class": (
+        "from ag_ui.core import RawEvent\n\nclass Builder:\n    def build(self):\n        RawEvent()\n",
+        "scanned.Builder.build",
+    ),
+    "in a lambda": (
+        "from ag_ui.core import RawEvent\n\ndef outer():\n    return lambda: RawEvent()\n",
+        "scanned.outer.<lambda>",
+    ),
+}
+
+
+@pytest.mark.parametrize("route", sorted(_CONSTRUCTIONS_THE_SCAN_HAS_TO_SEE))
+def test_the_event_scan_records_a_construction_reached_by_each_route(route):
+    """One construction per route, credited to the scope that really writes it."""
+    source, scope = _CONSTRUCTIONS_THE_SCAN_HAS_TO_SEE[route]
+    assert event_constructions_in("scanned", source) == {scope: {"RAW"}}
+
+
+def test_the_event_scan_credits_no_scope_that_only_encloses_the_construction():
+    """A nested scope's construction is that scope's alone.
+
+    Credited to the function around it, a helper defined inside another is
+    covered by driving the outer one, which drives none of it.
+    """
+    source = (
+        "from ag_ui.core import RawEvent\n\ndef outer():\n    def inner():\n        RawEvent()\n\n    return inner\n"
+    )
+    assert "scanned.outer" not in event_constructions_in("scanned", source)
+
+
+def test_the_event_scan_reads_no_event_off_an_attribute_of_something_else():
+    """Only ``ag_ui.core`` itself is the protocol.
+
+    Reading any attribute call by its last segment would credit a scope with an
+    event it never built, which is the other way this census can go wrong.
+    """
+    source = "from ag_ui.core import RawEvent\n\ndef builds(registry):\n    registry.RawEvent()\n"
+    assert event_constructions_in("scanned", source) == {}
+
+
+def test_the_event_scan_keeps_two_modules_same_named_functions_apart():
+    """One name in two modules is two scopes.
+
+    Merged, a function that builds nothing is credited with what its namesake
+    elsewhere builds, and a row of the hostile-content table claiming either one
+    accounts for both.
+    """
+    source = "from ag_ui.core import RawEvent\n\ndef build():\n    RawEvent()\n"
+    first = event_constructions_in("one", source)
+    second = event_constructions_in("two", source)
+    assert set(first) == {"one.build"}
+    assert set(second) == {"two.build"}
+    assert not set(first) & set(second)
+
+
+def _implementation_emitted_events() -> Set[str]:
+    """Every AG-UI event type the interface's own source constructs an event of."""
+    return set().union(*event_constructions_by_function().values())
+
+
+def _documented_attributed_events() -> Set[str]:
+    """The event names listed in the README's fenced block, which must be exact."""
+    section = _attribution_section()
+    assert _ATTRIBUTED_LIST_MARKER in section, (
+        f"the attribution section no longer contains {_ATTRIBUTED_LIST_MARKER!r}, "
+        "so the documented event list cannot be checked against the code"
+    )
+    after = section[section.index(_ATTRIBUTED_LIST_MARKER) + len(_ATTRIBUTED_LIST_MARKER) :]
+    fence = re.search(r"```[a-z]*\n(.*?)```", after, re.DOTALL)
+    assert fence is not None, "the documented event list is no longer a fenced block"
+    return set(fence.group(1).split())
+
+
+def _unattributed_paragraph() -> str:
+    """The paragraph that accounts for the events carrying no ``subagentRunId``."""
+    section = _attribution_section()
+    assert _UNATTRIBUTED_MARKER in section, f"the attribution section no longer contains {_UNATTRIBUTED_MARKER!r}"
+    return section[section.index(_UNATTRIBUTED_MARKER) :].split("\n\n")[0]
+
+
+def _documented_unattributed_events() -> Set[str]:
+    """The event families the README says carry no ``subagentRunId``."""
+    paragraph = _unattributed_paragraph()
+    documented: Set[str] = set()
+    for token in _backticked(paragraph):
+        expanded = _expand_event_token(token)
+        assert expanded, f"the README names {token!r} as unattributed, and this interface emits no such event"
+        documented.update(expanded)
+    return documented
+
+
+def _subagent_event_classes() -> Dict[str, type]:
+    require_lineage_events()
+    from ag_ui.core import SubagentErrorEvent, SubagentFinishedEvent, SubagentStartedEvent
+
+    return {
+        "SUBAGENT_STARTED": SubagentStartedEvent,
+        "SUBAGENT_FINISHED": SubagentFinishedEvent,
+        "SUBAGENT_ERROR": SubagentErrorEvent,
+    }
+
+
+def _own_field_aliases(event_class: type) -> Set[str]:
+    """The event's own payload fields, named as the wire names them.
+
+    A field the protocol gave no alias is named as the model names it, so a
+    documented field name can carry underscores.
+    """
+    return {
+        field.alias or name
+        for name, field in event_class.model_fields.items()  # type: ignore[attr-defined]
+        if name not in BaseEvent.model_fields
+    }
+
+
+def test_the_documented_event_list_is_the_implementations_own_set():
+    assert _documented_attributed_events() == _implementation_attributed_events(), (
+        "the README's list of events carrying a subagentRunId no longer matches "
+        "_SUBAGENT_ATTRIBUTABLE_EVENT_TYPES in agno/os/interfaces/agui/handlers.py"
+    )
+
+
+@needs_lineage_events
+def test_every_event_the_interface_emits_unattributed_is_documented_as_such():
+    # The documented families include the lineage events, which an install
+    # without them cannot name at all.
+    unattributed = _implementation_emitted_events() - _implementation_attributed_events()
+    assert _documented_unattributed_events() == unattributed, (
+        "the README's account of which events carry no subagentRunId no longer "
+        "matches what the interface emits without one"
+    )
+
+
+def test_the_documented_count_of_unattributed_kinds_matches_the_kinds_it_then_names():
+    """The count one word ahead of the marker, against the families the paragraph names.
+
+    Recomputed from the same paragraph, so the sentence cannot keep saying
+    "three" while naming a fourth family underneath it. A family is an event
+    name prefix: the two state events are one kind, which is how the paragraph
+    itself accounts for them.
+    """
+    paragraph = _unattributed_paragraph()
+    section = _attribution_section()
+    counted = re.search(r"(\w+) " + re.escape(_UNATTRIBUTED_MARKER), section)
+    assert counted is not None, f"nothing in the attribution section counts the {_UNATTRIBUTED_MARKER!r}"
+    word = counted.group(1).lower()
+    assert word in _SPELLED_COUNTS, f"the unattributed kinds are counted as {word!r}, which is not a spelled number"
+
+    families = {token.split("_")[0] for token in _backticked(paragraph)}
+    assert families, "the paragraph counting the unattributed kinds then names none of them"
+    assert _SPELLED_COUNTS[word] == len(families), (
+        f"the README counts {word} kinds of unattributed event and then names {sorted(families)}"
+    )
+
+
+def test_the_documented_visibility_values_are_the_supported_ones():
+    # The visibility table is the one whose first cell is a quoted value; the
+    # field table in the same section is keyed by event field instead.
+    documented = {entry.strip('"') for entry in _first_column_entries(_attribution_section()) if entry.startswith('"')}
+    assert documented == set(SUBAGENT_VISIBILITY_VALUES)
+
+
+def test_the_value_documented_as_the_default_is_the_default():
+    """Both defaults, because a caller can reach either without passing through the other.
+
+    The interface resolves an unset keyword through the validator, and a
+    ``StreamState`` built by any other route falls back to the field's own
+    default. Pinning one leaves the document true of half the code.
+    """
+    marked = [value.strip('"') for value, rest in _table_rows(_attribution_section()) if "(default)" in rest]
+    assert marked == [validate_subagent_visibility(None)], (
+        "the README marks a default the validator does not resolve to"
+    )
+    assert marked == [agui_state.StreamState().subagent_visibility], (
+        "the README marks a default that is not the one a StreamState carries when nobody sets it"
+    )
+
+
+def _hidden_row() -> str:
+    """The visibility table's row for ``hidden``, whole.
+
+    Read as the entire line rather than through the first-cell reader above,
+    which deliberately stops before a row's description.
+    """
+    rows = [line for line in _attribution_section().splitlines() if line.startswith('| `"hidden"`')]
+    assert len(rows) == 1, f"the attribution section holds {len(rows)} rows describing the hidden visibility, not one"
+    return rows[0]
+
+
+# The two claims every account of ``hidden`` has to make, because the delegation
+# call it keeps carries the member id and the task text verbatim. Both, because
+# a description that keeps one and drops the other still promises a client that
+# half of what the member was given stays off the wire.
+_WHAT_THE_DELEGATION_STILL_CARRIES = ("name the member", "carry the task")
+
+
+def _hidden_visibility_comment() -> str:
+    """The state module's own account of ``hidden``, and only that account.
+
+    Matched against the whole module, the claim below is satisfied by the words
+    turning up anywhere in five hundred lines, the paragraph describing a
+    different visibility included, so the description of ``hidden`` could drift
+    off the constant while the check stayed green. The bullet is read from the
+    line naming the value to the line before the next bullet or the end of the
+    comment block.
+    """
+    lines = Path(agui_state.__file__).read_text(encoding="utf-8").splitlines()
+    opens = [index for index, line in enumerate(lines) if re.match(r'^#\s+"hidden"', line)]
+    assert len(opens) == 1, f"the state module opens {len(opens)} comment bullets for the hidden visibility, not one"
+    bullet = [lines[opens[0]]]
+    for line in lines[opens[0] + 1 :]:
+        if not line.startswith("#") or re.match(r'^#\s+"', line):
+            break
+        bullet.append(line)
+    return "\n".join(bullet)
+
+
+def _accounts_of_hidden() -> Dict[str, str]:
+    """Every place this repository describes the ``hidden`` visibility, as prose.
+
+    Read with the line breaks and comment markers taken out, so a sentence that
+    says something and happens to wrap in the middle of a phrase still counts as
+    saying it. Shared by the claim checks below, so a claim added to one of them
+    is checked against every account rather than against whichever was handy,
+    and an account added here is held to all of them.
+    """
+    constructor_doc = inspect.getdoc(AGUI.__init__)
+    assert constructor_doc, "the AGUI constructor carries no docstring, so nothing here can check what it claims"
+    return {
+        where: " ".join(text.replace("#", " ").split())
+        for where, text in (
+            ("the README's hidden row", _hidden_row()),
+            ("the AGUI constructor docstring", constructor_doc),
+            ("the hidden bullet in the state module", _hidden_visibility_comment()),
+        )
+    }
+
+
+def test_every_account_of_the_hidden_visibility_says_the_delegation_call_names_the_member():
+    """Hidden withholds the member surface, and what it keeps still names the member.
+
+    A description that says nothing reaching the client names a member is false
+    in the direction that matters: it reads as a promise to keep a member's
+    identity and its task off the wire, which this interface does not make.
+    """
+    for where, prose in _accounts_of_hidden().items():
+        missing = [claim for claim in _WHAT_THE_DELEGATION_STILL_CARRIES if claim not in prose]
+        assert not missing, (
+            f"{where} does not say that the delegation call hidden keeps carries arguments that {missing}"
+        )
+
+
+# What every account of ``hidden`` has to say about a member's failure. It
+# withholds the member's identity, and the interface goes on emitting a run
+# terminal whose message is that member's own failure text, so an account that
+# stops at "withheld" reads as a promise the operator's client will not see why
+# the run stopped.
+_WHAT_HIDDEN_STILL_LETS_THROUGH = (
+    "nothing on it names the",
+    "the reason the run stopped still reaches the client",
+)
+
+
+def test_every_account_of_the_hidden_visibility_says_the_reason_the_run_stopped_still_reaches_the_client():
+    """Hidden withholds a failing member's identity, not the reason the run ended.
+
+    A member's terminal can be the only account the stream carries of how the
+    run ended, and is then read as the run's own, so the failure text reaches
+    the client as the run's reason with nothing beside it naming the member.
+    Every description of the setting has to say both halves: one that says only
+    that the failure is withheld describes an interface that stops the operator
+    finding out why their run died, which this is not.
+    """
+    for where, prose in _accounts_of_hidden().items():
+        missing = [claim for claim in _WHAT_HIDDEN_STILL_LETS_THROUGH if claim not in prose]
+        assert not missing, f"{where} does not say, of a member's failure, that {missing}"
+
+
+# The single-Agent guarantee is that the setting changes nothing for a run with
+# no member on the wire, and a pause is where it is easiest to lose: a paused
+# run's terminal carries several lists of pending calls, one call can sit on
+# more than one of them, and it goes out once per listing. An account that
+# states the guarantee without that case reads as a promise that every setting
+# sends the well-formed stream, which none of them does.
+_WHAT_THE_SINGLE_AGENT_GUARANTEE_COVERS = ("once per listing", "duplicate tool call id and all")
+
+
+def test_every_account_of_the_single_agent_guarantee_covers_a_pending_call_listed_twice():
+    """The guarantee is stated with the case it is hardest to keep, in all three places."""
+    constructor_doc = inspect.getdoc(AGUI.__init__)
+    assert constructor_doc, "the AGUI constructor carries no docstring, so nothing here can check what it claims"
+    documented = {
+        "the AGUI constructor docstring": constructor_doc,
+        "the README's attribution section": _attribution_section(),
+        "the TEST_LOG's lineage entry": _doc(_TEST_LOG),
+    }
+
+    for where, text in documented.items():
+        prose = " ".join(text.split())
+        missing = [claim for claim in _WHAT_THE_SINGLE_AGENT_GUARANTEE_COVERS if claim not in prose]
+        assert not missing, f"{where} states the single-Agent guarantee without saying {missing}"
+
+
+def test_the_documented_keyword_is_the_one_the_interface_takes():
+    assert "subagent_visibility" in inspect.signature(AGUI.__init__).parameters
+    assert "subagent_visibility" in _doc(_README)
+    assert "subagent_visibility" in _doc(_EXAMPLE)
+
+
+@needs_lineage_events
+def test_every_field_of_an_announcement_is_documented():
+    # Matched against the section's backticked tokens rather than its raw text:
+    # a field named "name" or "description" occurs in ordinary prose, so a
+    # substring search finds those two whether or not anything documents them.
+    documented = set(_backticked(_attribution_section()))
+    started = _subagent_event_classes()["SUBAGENT_STARTED"]
+    missing = sorted(
+        alias
+        for alias in _own_field_aliases(started)
+        if alias not in documented and f"SUBAGENT_STARTED.{alias}" not in documented
+    )
+    assert not missing, f"the attribution section does not describe SUBAGENT_STARTED fields {missing}"
+
+
+@needs_lineage_events
+def test_every_documented_subagent_field_exists_on_its_event():
+    classes = _subagent_event_classes()
+    # The field name is read whole, underscores included. Stopping at the first
+    # non-letter let a documented field validate as its own prefix, so
+    # SUBAGENT_ERROR.message_id passed on the strength of the message field.
+    named = re.findall(r"(SUBAGENT_[A-Z]+)\.([A-Za-z_][A-Za-z0-9_]*)", _attribution_section())
+    assert named, "the attribution section names no subagent event fields at all"
+    for event_name, field in named:
+        assert event_name in classes, f"the README names an unknown event {event_name}"
+        assert field in _own_field_aliases(classes[event_name]), (
+            f"the README documents {event_name}.{field}, which the protocol event does not carry"
+        )
+
+
+def _root_examples() -> Set[str]:
+    """The standalone example files in the folder's own root.
+
+    The nested OpenUI server is a server too, and the log counts it, but it is
+    the backend half of one example rather than a standalone one, so it is not
+    in here.
+    """
+    return {path.name for path in _COOKBOOK.glob("*.py")}
+
+
+def test_the_files_table_lists_every_example_in_the_folder():
+    if not _COOKBOOK.exists():
+        pytest.skip("cookbook not present in this checkout")
+    listed = set(_first_column_entries(_section(_doc(_README), "## Files")))
+    present = _root_examples()
+    present |= {
+        f"{path.name}/"
+        for path in _COOKBOOK.iterdir()
+        if path.is_dir() and not path.name.startswith((".", "_")) and any(path.rglob("*.py"))
+    }
+    assert listed == present
+
+
+def test_the_protocol_floor_is_stated_the_same_way_everywhere():
+    pattern = r"ag-ui-protocol[`'\s>=]{1,4}(\d+\.\d+\.\d+)"
+    # Per document, because one set of versions gathered from all of them is
+    # satisfied by a single document stating the floor while the rest go silent.
+    stated = {
+        name: set(re.findall(pattern, text)) for name, text in (("README", _doc(_README)), ("example", _doc(_EXAMPLE)))
+    }
+    silent = sorted(name for name, versions in stated.items() if not versions)
+    assert not silent, f"these documents no longer state the lineage protocol floor: {silent}"
+    versions = set().union(*stated.values())
+    assert len(versions) == 1, f"the lineage protocol floor is documented as {sorted(versions)}"
+
+
+def test_the_packaged_extra_still_permits_a_release_below_the_documented_floor():
+    """The README tells the reader to upgrade by hand, which the extra must justify."""
+    # The packaged extra is read straight off the package, which the root check
+    # at the top of this module guarantees is there: it is not a cookbook file
+    # and a checkout without the cookbook still has it.
+    documented = re.search(r"ag-ui-protocol>=(\d+\.\d+\.\d+)", _doc(_README))
+    packaged = re.search(r"ag-ui-protocol>=(\d+\.\d+\.\d+)", _PACKAGE_PYPROJECT.read_text(encoding="utf-8"))
+    assert documented is not None and packaged is not None
+
+    def parts(match: re.Match) -> tuple:
+        return tuple(int(piece) for piece in match.group(1).split("."))
+
+    assert parts(packaged) < parts(documented), (
+        "the agui extra now requires the lineage events, so the README should stop "
+        "saying it allows older releases and stop teaching a manual upgrade"
+    )
+
+
+def _bullet_naming(log: str, phrase: str) -> str:
+    """The one list item that makes a claim, so names are read from that claim alone."""
+    assert phrase in log, f"the Validation section no longer says {phrase!r}"
+    return log[log.index(phrase) :].split("\n- ")[0]
+
+
+def test_the_validation_counts_match_the_folder():
+    log = _doc(_TEST_LOG)
+    if not _COOKBOOK.exists():
+        pytest.skip("cookbook not present in this checkout")
+    root = _root_examples()
+
+    # The document states its own breakdown, and the files beyond the root are
+    # read from that sentence rather than from a recursive walk: a walk counts
+    # anything a nested frontend's installed dependencies bring with them, and
+    # would disagree with the non-recursive count the files table is checked
+    # against.
+    breakdown = re.search(r"the (\d+) in its root plus ((?:`[^`]+\.py`(?:,| and)? ?)+)", " ".join(log.split()))
+    assert breakdown is not None, "the Validation section no longer states how its count is made up"
+    assert int(breakdown.group(1)) == len(root), (
+        f"the Validation section counts {breakdown.group(1)} files in the folder root, which holds {len(root)}"
+    )
+    nested = re.findall(r"`([^`]+\.py)`", breakdown.group(2))
+    assert nested, "the Validation section names no file beyond the root, so its total cannot be checked"
+    absent = sorted(name for name in nested if not (_COOKBOOK / name).exists())
+    assert not absent, f"the Validation section counts files that are gone: {absent}"
+    servers = len(root) + len(nested)
+
+    booted = re.search(r"All (\d+) server files", log)
+    assert booted is not None, "the Validation section no longer counts the server files it booted"
+    assert int(booted.group(1)) == servers
+
+    scanned = re.search(r"checked exactly (\d+) Python files", log)
+    assert scanned is not None, "the Validation section no longer counts the scanned Python files"
+    assert int(scanned.group(1)) == servers
+
+    posted = re.search(r"(\d+) of the (\d+) files completed", log)
+    assert posted is not None, "the Validation section no longer counts the completed POST flows"
+    assert int(posted.group(2)) == servers
+    # The shortfall is derived from the files the same claim names as covered
+    # elsewhere, rather than from a hard-coded allowance of one.
+    # The same pattern the nested files are read with: a name written with a
+    # directory in front of it is one of the files this claim can excuse, and a
+    # pattern that could not match one reported it as excusing something the
+    # folder does not hold.
+    uncovered = re.findall(r"`([^`]+\.py)`", _bullet_naming(log, "of the {} files completed".format(servers)))
+    assert uncovered, "the Validation section no longer names the files whose POST flow it did not run"
+    missing = sorted(name for name in uncovered if name not in root and name not in nested)
+    assert not missing, f"the Validation section excuses files the folder does not hold: {missing}"
+    assert int(posted.group(1)) == servers - len(set(uncovered))
+
+
+def test_the_test_log_cites_suites_that_exist():
+    cited = re.findall(r"`(libs/agno/tests/[^`\n]+\.py)`", _doc(_TEST_LOG))
+    assert cited, "the test log cites no unit suite for the payloads it does not run itself"
+    missing = sorted(path for path in cited if not (_REPO_ROOT / path).exists())
+    assert not missing, f"the test log cites suites that are gone: {missing}"

--- a/libs/agno/tests/unit/os/interfaces/test_agui_documented_contract.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_documented_contract.py
@@ -6,8 +6,8 @@ which one is the default, what an announcement's parent links are called, which
 files the folder holds. A restatement that nothing recomputes drifts silently,
 so every enumerable claim is parsed out of the document here and compared with
 the implementation's own constants rather than with a second copy of them.
-Adding an event type to the interface, or a visibility value, or a field to an
-announcement, without saying so in the README fails one of these tests.
+Adding an event type to the interface, or a visibility value, or a field to any
+of the lineage events, without saying so in the README fails one of these tests.
 
 Genuine prose is left alone. Only claims that enumerate something the code
 already enumerates are pinned.
@@ -16,31 +16,62 @@ already enumerates are pinned.
 import ast
 import importlib
 import inspect
+import json
 import re
 from pathlib import Path
 from types import ModuleType
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 import pytest
 
 pytest.importorskip("ag_ui", reason="ag_ui not installed")
 
-from ag_ui.core import BaseEvent
+from ag_ui.core import BaseEvent, RunAgentInput
 
+from agno.models.response import ToolExecution, UserInputField
 from agno.os.interfaces.agui import AGUI
 from agno.os.interfaces.agui import handlers as agui_handlers
+from agno.os.interfaces.agui import interrupts as agui_interrupts
 from agno.os.interfaces.agui import state as agui_state
-from agno.os.interfaces.agui.handlers import validate_subagent_visibility
-from agno.os.interfaces.agui.state import SUBAGENT_VISIBILITY_VALUES
+from agno.os.interfaces.agui.handlers import on_run_completed, validate_subagent_visibility
+from agno.os.interfaces.agui.resume import (
+    ADVERTISED_KEYWORDS_READ,
+    RESUME_RESOLVED,
+    SCHEMA_ANNOTATIONS,
+    SCHEMA_COMPLETENESS,
+)
+from agno.os.interfaces.agui.state import SUBAGENT_VISIBILITY_VALUES, StreamState
+from agno.run.agent import RunPausedEvent
+from agno.run.requirement import RunRequirement
+from agno.tools.function import UserFeedbackOption, UserFeedbackQuestion
 
-from .agui_stream_invariants import needs_lineage_events, require_lineage_events
+from .agui_stream_invariants import (
+    LINEAGE_EVENTS_PROTOCOL_FLOOR,
+    assert_well_formed_stream,
+    needs_lineage_events,
+    require_lineage_events,
+)
 
 _REPO_ROOT = Path(__file__).resolve().parents[6]
 _COOKBOOK = _REPO_ROOT / "cookbook" / "05_agent_os" / "16_agui"
 _README = _COOKBOOK / "README.md"
 _TEST_LOG = _COOKBOOK / "TEST_LOG.md"
 _EXAMPLE = _COOKBOOK / "team_subagent_lineage.py"
+_INTERRUPT_EXAMPLE = _COOKBOOK / "interrupt_round_trip.py"
+
+# The examples that ask for an optional part of the protocol, and so have to name
+# the release that first served it. Listed rather than discovered, because an
+# example that stops naming its floor is exactly what the check below is for and
+# a discovery rule keyed on the naming would then find nothing to check.
+_FLOOR_EXAMPLES = (_EXAMPLE, _INTERRUPT_EXAMPLE)
 _PACKAGE_PYPROJECT = _REPO_ROOT / "libs" / "agno" / "pyproject.toml"
+
+# A floor as any of the documents write it: the release named in prose after the
+# package, the constraint the reader is told to install, and the constraint the
+# package's own extra declares. One pattern for every check below, so two of
+# them cannot disagree about what counts as a stated floor and read different
+# sets out of the same document.
+_FLOOR = r"ag-ui-protocol[`'\s>=]{1,4}(\d+\.\d+\.\d+)"
 
 # The root is identified by the package these tests are about, which sits at a
 # fixed place under it. Counted wrong, the walk above lands somewhere with no
@@ -77,21 +108,56 @@ def _doc(path: Path) -> str:
 
 
 def _section(text: str, heading: str) -> str:
-    """One `##` section of a markdown document, heading excluded.
+    """One section of a markdown document, heading excluded.
 
     Anchored at the start of a line, so a heading named in a sentence somewhere
     above cannot be mistaken for the section itself, and reported rather than
     raised bare, so a renamed heading says which one went missing.
+
+    The section ends at the next heading of any depth, the document's own title
+    level included. Cut at a `##` heading alone, a `###` subsection was read as
+    part of the section holding it, so a claim checked against one section could
+    be satisfied by a sentence in a subsection about something else, and a
+    subsection could not be read on its own at all. Cut at `##` and deeper, a
+    section that a `#` heading ends ran on to the end of the document, which is
+    the same failure one level up.
     """
     found = re.search(rf"^{re.escape(heading)}$", text, re.MULTILINE)
     assert found is not None, f"the document no longer has a {heading!r} section, so nothing here can read it"
     rest = text[found.end() :]
-    end = rest.find("\n## ")
-    return rest if end == -1 else rest[:end]
+    end = re.search(r"^#{1,6} ", rest, re.MULTILINE)
+    return rest if end is None else rest[: end.start()]
 
 
 def _attribution_section() -> str:
     return _section(_doc(_README), "## Team member attribution")
+
+
+# Every place the README accounts for the member surface. The attribution
+# section describes the lanes themselves; the subsection on a member the run
+# paused inside describes what a member's terminal carries when the pause was
+# reported inside it, which is where one of that terminal's own fields is
+# documented. A census of those fields has to read both, or a field documented
+# in one reads as undocumented because the other was the section that was handy.
+_MEMBER_SURFACE_HEADINGS = ("## Team member attribution", "### A member the run paused inside")
+
+
+def _member_surface_documentation() -> str:
+    readme = _doc(_README)
+    return "\n\n".join(_section(readme, heading) for heading in _MEMBER_SURFACE_HEADINGS)
+
+
+def test_a_section_ends_at_the_next_heading_of_any_depth():
+    """A subsection is a section of its own, not the tail of the one holding it.
+
+    The last two hold the shallowest heading level: a section the document's own
+    title ends must not run on into whatever the next title introduces.
+    """
+    document = "## One\n\nfirst\n\n### Under one\n\nsecond\n\n## Two\n\nthird\n\n# Elsewhere\n\nfourth\n"
+    assert _section(document, "## One").split() == ["first"]
+    assert _section(document, "### Under one").split() == ["second"]
+    assert _section(document, "## Two").split() == ["third"]
+    assert _section(document, "# Elsewhere").split() == ["fourth"]
 
 
 _FIRST_CELL = re.compile(r"^\| `([^`]+)`([^|]*)\|")
@@ -122,6 +188,44 @@ def _first_column_entries(section: str) -> List[str]:
 
 def _backticked(text: str) -> List[str]:
     return re.findall(r"`([^`\n]+)`", text)
+
+
+def _unwrapped(text: str) -> str:
+    """One piece of prose with the document's own line wrapping taken out.
+
+    Every claim below is read off prose normalised here rather than off the raw
+    text, because a hard-wrapped document breaks a claim wherever the line
+    happens to end and a parse that reads the raw text then says the document
+    stopped making it. An inline-code span that wrapped desynchronised the
+    backtick reader onto the next span, and a phrase that wrapped between two of
+    its own words was not found at all. Normalised in one place, so no two
+    parses can disagree about what the document says.
+    """
+    return " ".join(text.split())
+
+
+def _paragraphs(text: str) -> List[str]:
+    """The paragraphs of one piece of prose, each with its wrapping taken out.
+
+    Paragraph by paragraph rather than whole, so a fenced block stays a block of
+    its own rather than being run into the prose around it and pairing every
+    backtick after it wrongly.
+    """
+    return [_unwrapped(paragraph) for paragraph in re.split(r"\n\s*\n", text)]
+
+
+def test_a_claim_reads_the_same_whether_it_wraps_or_sits_on_one_line():
+    """The document's line wrapping is the document's, not the claim's.
+
+    A claim dropped because it wrapped is a claim nothing checks, so the
+    document can then drift by being reflowed. Both halves are held here: the
+    wrapped form reads as the same claim as the unwrapped one, and a span whose
+    own content wraps stays one token instead of resynchronising the reader onto
+    the backtick after it.
+    """
+    wrapped = 'The `STATE_DELTA` and the `{"type": "suspended",\n"interruptIds": [...]}` it carries.'
+    assert _backticked(_unwrapped(wrapped)) == ["STATE_DELTA", '{"type": "suspended", "interruptIds": [...]}']
+    assert _backticked(_unwrapped(wrapped)) == _backticked(_unwrapped(wrapped.replace("\n", " ")))
 
 
 def _expand_event_token(token: str) -> Set[str]:
@@ -221,6 +325,11 @@ def _core_module_aliases(tree: ast.Module) -> Dict[str, str]:
     ``import ag_ui`` binds the package alone, and the protocol is then reached
     one attribute further along, which is why the prefix recorded for it carries
     that attribute rather than the bound name.
+
+    A submodule imported out of the protocol, ``from ag_ui.core import events``,
+    binds a name that reaches it too, so it is recorded here as well: a name
+    imported that way is a module only on the installed release, which is what
+    decides it rather than the shape of the import.
     """
     aliases: Dict[str, str] = {}
     for node in ast.walk(tree):
@@ -232,11 +341,46 @@ def _core_module_aliases(tree: ast.Module) -> Dict[str, str]:
                     # Without an alias the whole dotted path is what the source
                     # writes, since the name bound is the top package.
                     aliases[alias.asname or alias.name] = alias.name
+                    if alias.asname is None:
+                        # The statement binds the top package, so everything
+                        # under it is reachable, not only the submodule named:
+                        # ``import ag_ui.core.events`` and then
+                        # ``ag_ui.core.RawEvent()`` is the same construction as
+                        # the one written through the module it was imported
+                        # from, and was credited to no scope at all.
+                        aliases.setdefault(_AG_UI_CORE, _AG_UI_CORE)
         elif isinstance(node, ast.ImportFrom) and node.module == _AG_UI:
             for alias in node.names:
                 if alias.name == _CORE:
                     aliases[alias.asname or _CORE] = _AG_UI_CORE
+        elif isinstance(node, ast.ImportFrom) and _names_the_protocol(node.module):
+            for alias in node.names:
+                submodule = f"{node.module}.{alias.name}"
+                if _protocol_module(submodule) is not None:
+                    aliases[alias.asname or alias.name] = submodule
     return aliases
+
+
+def _protocol_module_reached_by(prefix: str, aliases: Dict[str, str]) -> Optional[str]:
+    """The protocol module a local dotted prefix reaches, submodules included.
+
+    A prefix can name a module the source never imported by name: ``import
+    ag_ui`` and then ``ag_ui.core.events.RawEvent()`` reaches the submodule
+    through the package alone. So the longest prefix that is a recorded alias is
+    resolved and whatever the source wrote after it is read as the path below
+    that module, and the result has to be a module of the protocol for the call
+    to count. Nothing else does: ``ag_ui.core.registry.RawEvent()`` resolves to
+    no module and is credited to no scope.
+    """
+    segments = prefix.split(".")
+    for cut in range(len(segments), 0, -1):
+        base = aliases.get(".".join(segments[:cut]))
+        if base is None:
+            continue
+        module = ".".join([base, *segments[cut:]])
+        if _protocol_module(module) is not None:
+            return module
+    return None
 
 
 def _constructed_event_class(func: ast.expr, classes: Dict[str, type], aliases: Dict[str, str]) -> Optional[type]:
@@ -245,7 +389,7 @@ def _constructed_event_class(func: ast.expr, classes: Dict[str, type], aliases: 
         return classes.get(func.id)
     if isinstance(func, ast.Attribute):
         prefix = _dotted(func.value)
-        module = aliases.get(prefix) if prefix is not None else None
+        module = _protocol_module_reached_by(prefix, aliases) if prefix is not None else None
         if module is not None:
             return _event_class_named(func.attr, module)
     return None
@@ -257,9 +401,13 @@ def _event_type_default(event_class: type) -> str:
     A class with no concrete default has nothing to name it by. Read straight
     through, that arrives as an attribute error from inside the scan, which
     takes down this module and the hostile-content suite whose census rests on
-    it instead of saying which class is unreadable.
+    it instead of saying which class is unreadable. A class declaring no ``type``
+    field at all has to arrive the same way, so the field is looked up rather
+    than indexed: indexed, that one case raises a bare key error and the message
+    below, which is the whole point of the guard, is never reached.
     """
-    declared = event_class.model_fields["type"].default  # type: ignore[attr-defined]
+    field = event_class.model_fields.get("type")  # type: ignore[attr-defined]
+    declared = getattr(field, "default", None)
     assert getattr(declared, "value", None) is not None, (
         f"{event_class.__name__} declares {declared!r} as its event type, which names no event: "
         "the census cannot say what a scope building one of these builds"
@@ -302,7 +450,12 @@ def _scan_node(
     if isinstance(node, ast.Lambda):
         for outer in [*node.args.defaults, *(d for d in node.args.kw_defaults if d is not None)]:
             _scan_node(outer, scope, classes, aliases, built)
-        _scan_node(node.body, f"{scope}.<lambda>", classes, aliases, built)
+        # Named by where it is written, because a lambda has no name of its own
+        # and two written side by side are two scopes: called ``<lambda>`` alike,
+        # they merged, and one of them was then credited with what the other
+        # builds, which is the same wrong two same-named functions in one module
+        # would be.
+        _scan_node(node.body, f"{scope}.<lambda:{node.lineno}:{node.col_offset}>", classes, aliases, built)
         return
     if isinstance(node, ast.Call):
         event_class = _constructed_event_class(node.func, classes, aliases)
@@ -390,6 +543,18 @@ _CONSTRUCTIONS_THE_SCAN_HAS_TO_SEE: Dict[str, Tuple[str, str]] = {
         "import ag_ui.core.events\n\ndef builds():\n    ag_ui.core.events.RawEvent()\n",
         "scanned.builds",
     ),
+    "through the package an imported submodule binds": (
+        "import ag_ui.core.events\n\ndef builds():\n    ag_ui.core.RawEvent()\n",
+        "scanned.builds",
+    ),
+    "through a submodule imported out of the protocol": (
+        "from ag_ui.core import events\n\ndef builds():\n    events.RawEvent()\n",
+        "scanned.builds",
+    ),
+    "through a submodule of the top package alone": (
+        "import ag_ui\n\ndef builds():\n    ag_ui.core.events.RawEvent()\n",
+        "scanned.builds",
+    ),
     "at a module's own top level": (
         "from ag_ui.core import RawEvent\n\nPRELUDE = RawEvent()\n",
         f"scanned.{MODULE_SCOPE}",
@@ -404,7 +569,7 @@ _CONSTRUCTIONS_THE_SCAN_HAS_TO_SEE: Dict[str, Tuple[str, str]] = {
     ),
     "in a lambda": (
         "from ag_ui.core import RawEvent\n\ndef outer():\n    return lambda: RawEvent()\n",
-        "scanned.outer.<lambda>",
+        "scanned.outer.<lambda:4:11>",
     ),
 }
 
@@ -429,13 +594,46 @@ def test_the_event_scan_credits_no_scope_that_only_encloses_the_construction():
 
 
 def test_the_event_scan_reads_no_event_off_an_attribute_of_something_else():
-    """Only ``ag_ui.core`` itself is the protocol.
+    """Only ``ag_ui.core`` itself, and the modules under it, are the protocol.
 
     Reading any attribute call by its last segment would credit a scope with an
-    event it never built, which is the other way this census can go wrong.
+    event it never built, which is the other way this census can go wrong. The
+    second source is the same mistake one attribute further along: resolving a
+    prefix through the protocol is what lets a submodule of it be reached
+    without being imported by name, and a name under it that is no module of the
+    protocol has to stay uncredited.
     """
     source = "from ag_ui.core import RawEvent\n\ndef builds(registry):\n    registry.RawEvent()\n"
     assert event_constructions_in("scanned", source) == {}
+    reached_through = "import ag_ui\n\ndef builds():\n    ag_ui.core.registry.RawEvent()\n"
+    assert event_constructions_in("scanned", reached_through) == {}
+
+
+def test_a_dotted_import_under_an_alias_binds_the_alias_and_nothing_else():
+    """Only the name the statement really binds reaches the protocol.
+
+    A dotted import binds the top package, and one written ``as`` binds the
+    alias instead, so the dotted path the source could otherwise have written
+    reaches nothing and a call through it is no construction of this package's.
+    """
+    source = "import ag_ui.core.events as protocol\n\ndef builds():\n    ag_ui.core.RawEvent()\n"
+    assert event_constructions_in("scanned", source) == {}
+
+
+def test_the_event_scan_keeps_two_lambdas_of_one_scope_apart():
+    """Two lambdas written side by side are two scopes, not one.
+
+    Merged under one ``<lambda>`` name, the one that builds nothing is credited
+    with what the one beside it builds, so a boundary the hostile-content table
+    claims is covered by driving its neighbour.
+    """
+    source = (
+        "from ag_ui.core import RawEvent, CustomEvent\n\n"
+        "def outer():\n    return (lambda: RawEvent(), lambda: CustomEvent())\n"
+    )
+    built = event_constructions_in("scanned", source)
+    assert sorted(built.values(), key=sorted) == [{"CUSTOM"}, {"RAW"}]
+    assert len(built) == 2, f"two lambdas were credited to {sorted(built)}"
 
 
 def test_the_event_scan_keeps_two_modules_same_named_functions_apart():
@@ -472,17 +670,36 @@ def _documented_attributed_events() -> Set[str]:
 
 
 def _unattributed_paragraph() -> str:
-    """The paragraph that accounts for the events carrying no ``subagentRunId``."""
+    """The whole paragraph that accounts for the events carrying no ``subagentRunId``.
+
+    Read from where the paragraph starts rather than from the marker inside it.
+    Started at the marker, the sentence carrying it began half way through, and
+    everything the paragraph said before it went unread: the count that has to
+    match what the paragraph then names sits in that half.
+    """
     section = _attribution_section()
     assert _UNATTRIBUTED_MARKER in section, f"the attribution section no longer contains {_UNATTRIBUTED_MARKER!r}"
-    return section[section.index(_UNATTRIBUTED_MARKER) :].split("\n\n")[0]
+    marker = section.index(_UNATTRIBUTED_MARKER)
+    opens = section.rfind("\n\n", 0, marker)
+    return section[0 if opens == -1 else opens + 2 :].split("\n\n")[0]
+
+
+def _sentences(paragraph: str) -> List[str]:
+    """The sentences of one paragraph, its line wrapping taken out."""
+    return [sentence for sentence in re.split(r"(?<=\.)\s+", _unwrapped(paragraph)) if sentence]
 
 
 def _documented_unattributed_events() -> Set[str]:
-    """The event families the README says carry no ``subagentRunId``."""
+    """The event families the README says carry no ``subagentRunId``.
+
+    Read off the unwrapped paragraph, like its two siblings: read off the raw
+    text, a span that wrapped left the backtick reader pairing the close of one
+    token with the open of the next, and the prose between them was then
+    reported as an event this interface does not emit.
+    """
     paragraph = _unattributed_paragraph()
     documented: Set[str] = set()
-    for token in _backticked(paragraph):
+    for token in _backticked(_unwrapped(paragraph)):
         expanded = _expand_event_token(token)
         assert expanded, f"the README names {token!r} as unattributed, and this interface emits no such event"
         documented.update(expanded)
@@ -532,24 +749,28 @@ def test_every_event_the_interface_emits_unattributed_is_documented_as_such():
 
 
 def test_the_documented_count_of_unattributed_kinds_matches_the_kinds_it_then_names():
-    """The count one word ahead of the marker, against the families the paragraph names.
+    """The count one word ahead of the marker, against the kinds the paragraph names.
 
     Recomputed from the same paragraph, so the sentence cannot keep saying
-    "three" while naming a fourth family underneath it. A family is an event
-    name prefix: the two state events are one kind, which is how the paragraph
-    itself accounts for them.
+    "three" while accounting for a fourth kind underneath it. A kind is one
+    sentence's account of one group of events, which is how the paragraph itself
+    is written: the two state events are named in one sentence and are one kind.
+    Grouping the names by the prefix they open with instead read two kinds that
+    share a prefix as one, so a paragraph that grew a separate account of
+    another ``RUN_`` event went on counting as three.
     """
     paragraph = _unattributed_paragraph()
-    section = _attribution_section()
-    counted = re.search(r"(\w+) " + re.escape(_UNATTRIBUTED_MARKER), section)
-    assert counted is not None, f"nothing in the attribution section counts the {_UNATTRIBUTED_MARKER!r}"
+    sentences = _sentences(paragraph)
+    counted = re.search(r"(\w+) " + re.escape(_UNATTRIBUTED_MARKER), _unwrapped(paragraph))
+    assert counted is not None, f"nothing in the paragraph counts the {_UNATTRIBUTED_MARKER!r}"
     word = counted.group(1).lower()
     assert word in _SPELLED_COUNTS, f"the unattributed kinds are counted as {word!r}, which is not a spelled number"
 
-    families = {token.split("_")[0] for token in _backticked(paragraph)}
-    assert families, "the paragraph counting the unattributed kinds then names none of them"
-    assert _SPELLED_COUNTS[word] == len(families), (
-        f"the README counts {word} kinds of unattributed event and then names {sorted(families)}"
+    kinds = [sentence for sentence in sentences if _backticked(sentence)]
+    assert kinds, "the paragraph counting the unattributed kinds then names none of them"
+    assert _SPELLED_COUNTS[word] == len(kinds), (
+        f"the README counts {word} kinds of unattributed event and then gives {len(kinds)} accounts of them, "
+        f"naming {[sorted(_backticked(kind)) for kind in kinds]}"
     )
 
 
@@ -627,7 +848,7 @@ def _accounts_of_hidden() -> Dict[str, str]:
     constructor_doc = inspect.getdoc(AGUI.__init__)
     assert constructor_doc, "the AGUI constructor carries no docstring, so nothing here can check what it claims"
     return {
-        where: " ".join(text.replace("#", " ").split())
+        where: _unwrapped(text.replace("#", " "))
         for where, text in (
             ("the README's hidden row", _hidden_row()),
             ("the AGUI constructor docstring", constructor_doc),
@@ -696,7 +917,7 @@ def test_every_account_of_the_single_agent_guarantee_covers_a_pending_call_liste
     }
 
     for where, text in documented.items():
-        prose = " ".join(text.split())
+        prose = _unwrapped(text)
         missing = [claim for claim in _WHAT_THE_SINGLE_AGENT_GUARANTEE_COVERS if claim not in prose]
         assert not missing, f"{where} states the single-Agent guarantee without saying {missing}"
 
@@ -707,29 +928,1123 @@ def test_the_documented_keyword_is_the_one_the_interface_takes():
     assert "subagent_visibility" in _doc(_EXAMPLE)
 
 
-@needs_lineage_events
-def test_every_field_of_an_announcement_is_documented():
-    # Matched against the section's backticked tokens rather than its raw text:
-    # a field named "name" or "description" occurs in ordinary prose, so a
-    # substring search finds those two whether or not anything documents them.
-    documented = set(_backticked(_attribution_section()))
-    started = _subagent_event_classes()["SUBAGENT_STARTED"]
-    missing = sorted(
-        alias
-        for alias in _own_field_aliases(started)
-        if alias not in documented and f"SUBAGENT_STARTED.{alias}" not in documented
+# --- The interrupt round trip ------------------------------------------------
+
+# Every place the README accounts for a paused run's terminal and the answers
+# that continue it. Three sections, because the claims are spread across them:
+# the option's own section describes the terminal, the subsection below it the
+# pause nothing can answer, and the resuming subsection the channel the answers
+# arrive in. A census that read one of them calls a claim documented elsewhere
+# undocumented, and a claim check that read one is satisfied by a sentence in
+# whichever section was handy.
+_INTERRUPT_HEADINGS = (
+    "## The interrupt round trip",
+    "### A pause no client could answer",
+    "### Resuming",
+)
+
+_INTERRUPT_OPTION = "emit_interrupt_outcome"
+
+needs_interrupt_outcome = pytest.mark.skipif(
+    not agui_interrupts.INTERRUPT_OUTCOME_AVAILABLE,
+    reason="the installed ag_ui.core has no interrupt-aware run lifecycle",
+)
+
+
+def _interrupt_documentation() -> str:
+    readme = _doc(_README)
+    return "\n\n".join(_section(readme, heading) for heading in _INTERRUPT_HEADINGS)
+
+
+def _interrupt_prose() -> str:
+    """The same account with its line wrapping taken out, for a claim to be read from."""
+    return _unwrapped(_interrupt_documentation())
+
+
+def _tables_in(section: str) -> List[str]:
+    """Each table of one section, as the block of data rows it is written as.
+
+    A section can hold more than one, and a claim about one must not be
+    satisfied by a row of another: the option's two values and Agno's four pause
+    kinds are both tables whose rows open with a backticked cell. They are told
+    apart by the prose between them, which no data row of either can look like.
+    """
+    tables: List[List[str]] = []
+    rows: List[str] = []
+    for line in section.splitlines():
+        if line.startswith("| `"):
+            rows.append(line)
+            continue
+        if rows:
+            tables.append(rows)
+            rows = []
+    if rows:
+        tables.append(rows)
+    return ["\n".join(table) for table in tables]
+
+
+def _interrupt_section_tables() -> List[str]:
+    tables = _tables_in(_section(_doc(_README), _INTERRUPT_HEADINGS[0]))
+    assert len(tables) >= 2, (
+        f"the interrupt section holds {len(tables)} tables, and this module reads two of them: "
+        "the option's values, and Agno's pause kinds against the reasons they carry"
     )
-    assert not missing, f"the attribution section does not describe SUBAGENT_STARTED fields {missing}"
+    return tables
+
+
+def _the_interrupt_option() -> inspect.Parameter:
+    parameters = inspect.signature(AGUI.__init__).parameters
+    assert _INTERRUPT_OPTION in parameters, (
+        f"the interface no longer takes {_INTERRUPT_OPTION!r}, which the README documents as one of its options"
+    )
+    return parameters[_INTERRUPT_OPTION]
+
+
+def test_the_documented_interrupt_option_is_the_one_the_interface_takes():
+    _the_interrupt_option()
+    assert _INTERRUPT_OPTION in _doc(_README)
+    assert _INTERRUPT_OPTION in _doc(_INTERRUPT_EXAMPLE)
+
+
+def test_the_documented_values_of_the_interrupt_option_are_the_ones_it_takes():
+    """The option is a boolean, so its table states those two values and no others.
+
+    Recomputed from the signature rather than left as prose: what a reader is
+    told to pass has to be what the constructor takes, and a table that grew a
+    third row, or wrote the setting as though it took a list of them, would
+    document an option this interface does not have. The default is read from
+    the same signature, so the row carrying the mark cannot drift off it either.
+    """
+    option = _the_interrupt_option()
+    assert option.annotation is bool, (
+        f"{_INTERRUPT_OPTION} is annotated {option.annotation!r}, and the README documents the two values of a boolean"
+    )
+    rows = _table_rows(_interrupt_section_tables()[0])
+    assert {value for value, _ in rows} == {str(True), str(False)}, (
+        f"the README states the values {sorted(value for value, _ in rows)} for {_INTERRUPT_OPTION}, "
+        f"which takes {str(False)} and {str(True)}"
+    )
+    marked = [value for value, rest in rows if "(default)" in rest]
+    assert marked == [str(option.default)], (
+        f"the README marks {marked} as the default of {_INTERRUPT_OPTION}, which defaults to {option.default}"
+    )
+
+
+def _documented_pause_kinds() -> Dict[str, str]:
+    """Per Agno pause kind, the ``reason`` the README says its interrupt carries.
+
+    The kind is matched as a whole token, so ``user_input`` is not found inside
+    ``requires_user_input`` and every row is credited to the kind it names
+    rather than to the one its decorator's keyword happens to spell.
+    """
+    documented: Dict[str, str] = {}
+    for row in _interrupt_section_tables()[1].splitlines():
+        cells = [cell.strip() for cell in row.strip().strip("|").split("|")]
+        assert len(cells) >= 2, f"this pause row states no reason: {row}"
+        named = [
+            pause_type
+            for pause_type in agui_interrupts._PAUSE_TYPE_REASONS
+            if re.search(rf"(?<![a-z_]){pause_type}(?![a-z_])", cells[0])
+        ]
+        assert len(named) == 1, f"this pause row names {named} of Agno's pause kinds, and has to name one: {row}"
+        reasons = _backticked(cells[1])
+        assert len(reasons) == 1, f"this pause row names {reasons} as its reason, and has to name one: {row}"
+        documented[named[0]] = reasons[0]
+    return documented
+
+
+def test_the_documented_pause_kinds_carry_the_reasons_the_interface_sends():
+    """All four kinds, each against the protocol reason the interface maps it to."""
+    assert _documented_pause_kinds() == dict(agui_interrupts._PAUSE_TYPE_REASONS), (
+        "the README's table of Agno's pause kinds no longer matches _PAUSE_TYPE_REASONS in "
+        "agno/os/interfaces/agui/interrupts.py"
+    )
+
+
+class _ATypeWithNoJsonEquivalent:
+    """A declared input field type this interface maps to no JSON type."""
+
+
+def _waiting_on(**flags: Any) -> RunRequirement:
+    return RunRequirement(
+        tool_execution=ToolExecution(tool_call_id="tc-advertised", tool_name="advertised", tool_args={}, **flags)
+    )
+
+
+def _a_requirement_per_pause_kind() -> Dict[str, RunRequirement]:
+    """One open requirement of each of Agno's pause kinds, shaped to say everything.
+
+    The structured kinds are built to reach every constraint their schema can
+    state: a field whose declared type this maps and one whose type it does not,
+    a field the model already filled, a single-select question and a multi-select
+    one. A schema gathered from anything less states fewer keywords than a client
+    is really sent, and the document would be checked against the smaller set.
+
+    Every kind the interface maps is here, checked against its own table, so a
+    kind added to the interface is one the checks below read rather than one they
+    quietly skip.
+    """
+    waiting = {
+        "external_execution": _waiting_on(external_execution_required=True),
+        "confirmation": _waiting_on(requires_confirmation=True),
+        "user_input": _waiting_on(
+            requires_user_input=True,
+            user_input_schema=[
+                UserInputField(name="topic", field_type=str, description="What to write about"),
+                UserInputField(name="unmapped", field_type=_ATypeWithNoJsonEquivalent),
+                UserInputField(name="filled", field_type=str, value="already there"),
+            ],
+        ),
+        "user_feedback": _waiting_on(
+            requires_user_input=True,
+            user_feedback_schema=[
+                UserFeedbackQuestion(
+                    question="Which budget?",
+                    header="Budget",
+                    options=[UserFeedbackOption(label="low"), UserFeedbackOption(label="high")],
+                    multi_select=False,
+                ),
+                UserFeedbackQuestion(
+                    question="Which regions?",
+                    options=[UserFeedbackOption(label="emea")],
+                    multi_select=True,
+                ),
+            ],
+        ),
+    }
+    assert set(waiting) == set(agui_interrupts._PAUSE_TYPE_REASONS), (
+        f"this builds requirements for {sorted(waiting)} and the interface maps "
+        f"{sorted(agui_interrupts._PAUSE_TYPE_REASONS)}"
+    )
+    misread = {kind: requirement.pause_type for kind, requirement in waiting.items() if requirement.pause_type != kind}
+    assert not misread, f"these requirements report a pause kind other than the one they were built for: {misread}"
+    return waiting
+
+
+def _schemas_the_interface_advertises() -> Dict[str, Dict[str, Any]]:
+    """The advertised answer schema of every pause kind that describes one.
+
+    The external execution describes none, because a client hands back whatever
+    its tool returned, so it is the one kind left out here rather than a kind
+    this fails over.
+    """
+    advertised = {
+        kind: requirement
+        for kind, requirement in _a_requirement_per_pause_kind().items()
+        if kind != "external_execution"
+    }
+    schemas = {kind: agui_interrupts.advertised_answer_schema(requirement) for kind, requirement in advertised.items()}
+    unadvertised = sorted(kind for kind, schema in schemas.items() if not schema)
+    assert not unadvertised, (
+        f"these pause kinds advertise no schema for the document to be checked against: {unadvertised}"
+    )
+    return schemas  # type: ignore[return-value]
+
+
+def _keywords_in(schema: Any) -> Set[str]:
+    """Every JSON Schema keyword one advertised schema states, at any depth.
+
+    A schema's ``properties`` are keyed by the field or question they describe,
+    which are names off the pause rather than keywords, so the walk goes through
+    them without counting them.
+    """
+    found: Set[str] = set()
+    if not isinstance(schema, dict):
+        return found
+    for keyword, constraint in schema.items():
+        found.add(keyword)
+        described = (
+            list(constraint.values()) if keyword == "properties" and isinstance(constraint, dict) else [constraint]
+        )
+        for value in described:
+            found |= _keywords_in(value)
+    return found
+
+
+def _keywords_the_schemas_state() -> Set[str]:
+    stated: Set[str] = set()
+    for schema in _schemas_the_interface_advertises().values():
+        stated |= _keywords_in(schema)
+    assert stated, "the advertised schemas state no constraint at all, so nothing here checks the document"
+    return stated
+
+
+def test_every_constraint_the_advertised_schemas_state_is_documented():
+    """A constraint a client is held to has to be one the document names.
+
+    The schemas grew constraints the document did not have: a client reading it
+    would send an answer the interface then refuses, and nothing said which
+    keyword refused it.
+    """
+    documented = _documented_field_names(_interrupt_documentation())
+    missing = sorted(keyword for keyword in _keywords_the_schemas_state() if keyword not in documented)
+    assert not missing, (
+        f"the advertised answer schemas state {missing}, which the README's account of the interrupt "
+        "round trip does not name"
+    )
+
+
+# The sentence that splits the advertised keywords into the ones this interface
+# holds an answer to and the ones it deliberately does not. Both halves are
+# recomputed, because either one going stale is the same wrong in a different
+# direction: a keyword claimed as checked and enforced nowhere, or one claimed
+# unenforced that a client is in fact refused over.
+_KEYWORDS_LEFT_UNENFORCED = "left to somebody else"
+
+
+def _left_to_somebody_else() -> Tuple[str, str, str]:
+    """The claim about the split, as the count and the two halves it separates."""
+    stated = [sentence for sentence in _sentences(_interrupt_prose()) if _KEYWORDS_LEFT_UNENFORCED in sentence]
+    assert len(stated) == 1, (
+        f"{len(stated)} sentences of the interrupt account say what is {_KEYWORDS_LEFT_UNENFORCED!r}, and this "
+        "check reads one"
+    )
+    counted = re.search(r"(\w+) are deliberately " + re.escape(_KEYWORDS_LEFT_UNENFORCED), stated[0])
+    assert counted is not None, f"nothing in that sentence counts what is {_KEYWORDS_LEFT_UNENFORCED!r}"
+    checked, unenforced = stated[0].split(_KEYWORDS_LEFT_UNENFORCED)
+    return counted.group(1).lower(), checked, unenforced
+
+
+def test_the_documented_split_of_schema_keywords_is_the_one_the_resume_side_reads():
+    """Which advertised keywords are enforced, and which are somebody else's.
+
+    Recomputed against the resume side's own tables and restricted to what the
+    schemas really state, so a keyword the builders stop stating does not have
+    to stay in the prose, and one they start stating cannot arrive unaccounted
+    for on either side of the split.
+    """
+    stated = _keywords_the_schemas_state()
+    somebody_elses = (set(SCHEMA_ANNOTATIONS) | set(SCHEMA_COMPLETENESS)) & stated
+    enforced = (set(ADVERTISED_KEYWORDS_READ) - somebody_elses) & stated
+
+    word, checked, unenforced = _left_to_somebody_else()
+    assert set(_backticked(checked)) == enforced, (
+        f"the README names {sorted(set(_backticked(checked)))} as the constraints an answer is checked against, "
+        f"and the resume side checks {sorted(enforced)}"
+    )
+    assert set(_backticked(unenforced)) == somebody_elses, (
+        f"the README leaves {sorted(set(_backticked(unenforced)))} to somebody else, and the resume side "
+        f"leaves {sorted(somebody_elses)}"
+    )
+    assert word in _SPELLED_COUNTS, f"what is left to somebody else is counted as {word!r}, not a spelled number"
+    assert _SPELLED_COUNTS[word] == len(somebody_elses), (
+        f"the README counts {word} keywords left to somebody else and the resume side leaves {sorted(somebody_elses)}"
+    )
+
+
+def _pause_reporting(*tools: ToolExecution, requirements: Optional[List[RunRequirement]] = None) -> RunPausedEvent:
+    """A pause the way a run reports one: pending calls, and a requirement per call.
+
+    ``requirements`` is passed only where the two lists are the subject, which is
+    what every check below is about: a pause whose prompt and whose open
+    requirements are the same list cannot tell which of the two the terminal is
+    built from.
+    """
+    return RunPausedEvent(
+        tools=list(tools),
+        requirements=[RunRequirement(tool_execution=tool) for tool in tools] if requirements is None else requirements,
+    )
+
+
+def _terminal_of(chunk: RunPausedEvent, **settings: Any) -> List[Any]:
+    """What this interface sends for one pause, held to the shared stream definition."""
+    events = on_run_completed(chunk, StreamState(**settings))
+    assert_well_formed_stream(events)
+    return events
+
+
+def _run_terminal(events: List[Any]) -> Any:
+    terminals = [event for event in events if type(event).__name__ in ("RunFinishedEvent", "RunErrorEvent")]
+    assert len(terminals) == 1, f"expected one run terminal, got {[type(event).__name__ for event in events]}"
+    return terminals[0]
+
+
+def _interrupts_carried(events: List[Any]) -> List[Any]:
+    outcome = getattr(_run_terminal(events), "outcome", None)
+    return list(getattr(outcome, "interrupts", None) or [])
+
+
+def _prompted_calls(events: List[Any]) -> List[str]:
+    return [event.tool_call_id for event in events if type(event).__name__ == "ToolCallStartEvent"]
+
+
+def _a_decision(tool_call_id: str = "tc-decide", tool_name: Optional[str] = "send_email") -> ToolExecution:
+    return ToolExecution(
+        tool_call_id=tool_call_id, tool_name=tool_name, tool_args={"to": "ops@example.com"}, requires_confirmation=True
+    )
+
+
+# What every account of the outcome has to say about what its entries are
+# counted by. The two lists the terminal could be built from differ, and a
+# reader told the wrong one writes a client that answers the prompt and leaves
+# the run unresumable, which is the failure this whole round trip is for.
+_WHAT_THE_OUTCOME_IS_COUNTED_BY = (
+    "one entry per requirement the pause left open",
+    "and not one per pending call",
+)
+
+
+def test_the_outcome_is_documented_as_counted_by_requirement():
+    prose = _interrupt_prose()
+    missing = [claim for claim in _WHAT_THE_OUTCOME_IS_COUNTED_BY if claim not in prose]
+    assert not missing, f"the README's account of the interrupt outcome does not say {missing}"
+
+
+@needs_interrupt_outcome
+def test_the_outcome_carries_one_entry_per_open_requirement_and_not_per_prompted_call():
+    """A pause whose prompt lists a call with nothing open behind it.
+
+    The prompt shows both calls, because its lists are the record of what the
+    client is shown, and only one of them is still waiting for an answer. Built
+    from the prompt, the terminal would hand a client an id the resume channel
+    refuses.
+    """
+    still_open = _a_decision("tc-open")
+    already_decided = _a_decision("tc-decided", "archive_email")
+    already_decided.confirmed = True
+    events = _terminal_of(_pause_reporting(still_open, already_decided), emit_interrupt_outcome=True)
+
+    assert _prompted_calls(events) == ["tc-open", "tc-decided"]
+    assert [interrupt.tool_call_id for interrupt in _interrupts_carried(events)] == ["tc-open"]
+
+
+@needs_interrupt_outcome
+def test_a_pending_call_the_client_cannot_be_shown_still_carries_its_entry():
+    """A call with no tool name is dropped from the prompt and still advertised.
+
+    Its requirement is open whether or not anything can be rendered for it, and
+    a resume has to answer every open requirement, so an outcome that left it
+    out would advertise a set no client could complete.
+    """
+    events = _terminal_of(_pause_reporting(_a_decision("tc-nameless", None)), emit_interrupt_outcome=True)
+
+    assert _prompted_calls(events) == []
+    assert [interrupt.tool_call_id for interrupt in _interrupts_carried(events)] == ["tc-nameless"]
+
+
+@needs_interrupt_outcome
+def test_a_pause_reported_only_through_requirements_is_carried_under_the_default_visibility():
+    """The pause the default prompts nothing for is still reported as an interrupt.
+
+    The prompt reads such a call on a Team's pause only, so under the default an
+    Agent's reaches the client with nothing to act on. The terminal is built
+    from the run's own open requirements under every visibility, so with the
+    outcome on the client is still told the run is waiting; with it off this is
+    the plain finished run the visibility table describes.
+    """
+    reported_by_an_inner_run = RunRequirement(tool_execution=_a_decision("tc-inner"))
+    reported_by_an_inner_run.member_agent_id = "inner"
+    reported_by_an_inner_run.member_agent_name = "Inner"
+    reported_by_an_inner_run.member_run_id = "inner-run"
+    chunk = _pause_reporting(requirements=[reported_by_an_inner_run])
+
+    carried = _terminal_of(chunk, emit_interrupt_outcome=True)
+    assert _prompted_calls(carried) == []
+    assert [interrupt.tool_call_id for interrupt in _interrupts_carried(carried)] == ["tc-inner"]
+
+    quiet = _terminal_of(chunk)
+    assert type(_run_terminal(quiet)).__name__ == "RunFinishedEvent"
+    assert _interrupts_carried(quiet) == []
+
+
+@needs_interrupt_outcome
+def test_a_pause_no_client_could_answer_ends_the_run_under_the_documented_code():
+    """The code the README names, recomputed from the constant and from a real pause.
+
+    A call flagged for two pause kinds at once is the pause nothing resolves:
+    whichever resolver its kind picks leaves the other kind open, and the guard
+    on the resume stops the run over it. The terminal says so instead of
+    advertising the rest, and it says it under a code of its own.
+    """
+    assert agui_interrupts.PAUSE_NOT_CONTINUABLE_CODE in _interrupt_documentation(), (
+        "the README no longer names PAUSE_NOT_CONTINUABLE_CODE, which is the code a client tells this case by"
+    )
+    two_kinds_at_once = ToolExecution(
+        tool_call_id="tc-both",
+        tool_name="send_email",
+        tool_args={},
+        requires_confirmation=True,
+        requires_user_input=True,
+        user_input_schema=[UserInputField(name="body", field_type=str)],
+    )
+    events = _terminal_of(_pause_reporting(two_kinds_at_once), emit_interrupt_outcome=True)
+
+    terminal = _run_terminal(events)
+    assert type(terminal).__name__ == "RunErrorEvent"
+    assert terminal.code == agui_interrupts.PAUSE_NOT_CONTINUABLE_CODE
+    assert _prompted_calls(events) == [], "the pause was prompted as something a client could act on"
+
+
+def _requests_the_readme_shows() -> List[Dict[str, Any]]:
+    """Every request body the README hands a reader to paste, as parsed JSON.
+
+    Read out of the shell blocks rather than described, because what a reader
+    pastes is exactly this text: a body that is not valid JSON, or that leaves
+    out a field the protocol requires, is a copy-paste the server refuses before
+    it reads anything the document was teaching.
+    """
+    shown: List[Dict[str, Any]] = []
+    for fence in re.findall(r"```bash\n(.*?)```", _doc(_README), re.DOTALL):
+        if "-d '" not in fence:
+            continue
+        body = fence[fence.index("-d '") + len("-d '") : fence.rindex("'")]
+        try:
+            shown.append(json.loads(body))
+        except json.JSONDecodeError as unreadable:
+            raise AssertionError(f"a request body the README shows is not valid JSON: {unreadable}") from None
+    assert shown, "the README shows no request body, so nothing here checks what a reader would paste"
+    return shown
+
+
+def test_every_request_the_readme_shows_is_one_the_protocol_accepts():
+    """Each pasted body against the protocol's own model, the resume one included.
+
+    A field left out of the resume example is the failure this guards: the
+    request is refused for the missing field, and a reader is left debugging the
+    part of it the document was not about.
+    """
+    for shown in _requests_the_readme_shows():
+        try:
+            RunAgentInput.model_validate(shown)
+        except Exception as refused:
+            raise AssertionError(
+                f"the README shows a request carrying {sorted(shown)}, which the protocol refuses: {refused}"
+            ) from None
+
+
+def test_the_readme_shows_a_request_that_carries_the_answers():
+    """One of those bodies is the resume, or the round trip is documented half way."""
+    resuming = [shown for shown in _requests_the_readme_shows() if shown.get("resume")]
+    assert len(resuming) == 1, (
+        f"{len(resuming)} of the requests the README shows carry a resume array, and the resuming section shows one"
+    )
+    answered = resuming[0]["resume"]
+    assert [entry.get("status") for entry in answered] == [RESUME_RESOLVED], (
+        f"the resume the README shows carries the statuses {[entry.get('status') for entry in answered]}, "
+        f"and an answered interrupt is {RESUME_RESOLVED!r}"
+    )
+
+
+def _reported_failure_path() -> List[str]:
+    """Where a client says its own tool failed, built from the constants both sides read."""
+    return ["metadata", agui_interrupts.RESUME_METADATA_NAMESPACE, agui_interrupts.RESUME_ERROR_KEY]
+
+
+@needs_interrupt_outcome
+def test_the_documented_failure_report_path_is_the_one_the_interrupt_advertises():
+    """The path is documented as the code writes it, and only for the kind that has one.
+
+    Nothing else on the wire says the convention exists, so a client-run tool
+    that raised has this path or has nowhere to say so, and the document is the
+    only other place it is written down.
+    """
+    documented = _interrupt_documentation()
+    path = _reported_failure_path()
+    namespace = agui_interrupts.RESUME_METADATA_NAMESPACE
+    advertised_under = ".".join([*path[:-1], agui_interrupts.ERROR_REPORT_PATH_KEY])
+    assert advertised_under in documented, (
+        f"the README does not say the interrupt for a client-run tool advertises {advertised_under}"
+    )
+    assert f'"{namespace}": {{"{agui_interrupts.RESUME_ERROR_KEY}"' in documented, (
+        f"the README does not show a resume entry reporting a failure under {'.'.join(path)}"
+    )
+
+    client_runs_it = ToolExecution(
+        tool_call_id="tc-external",
+        tool_name="change_background",
+        tool_args={},
+        external_execution_required=True,
+    )
+    ran_it_itself = _interrupts_carried(_terminal_of(_pause_reporting(_a_decision()), emit_interrupt_outcome=True))
+    advertised = _interrupts_carried(_terminal_of(_pause_reporting(client_runs_it), emit_interrupt_outcome=True))
+
+    assert advertised[0].metadata[namespace][agui_interrupts.ERROR_REPORT_PATH_KEY] == path
+    assert agui_interrupts.ERROR_REPORT_PATH_KEY not in ran_it_itself[0].metadata[namespace], (
+        "a pause the server runs the tool for advertises a path for a failure only the client could report"
+    )
+
+    # All four kinds, because the README names this as the one of them that
+    # advertises the path: read off two, a third kind growing one would go
+    # undocumented while the row still called the external execution the only one.
+    carrying_it = sorted(
+        kind
+        for kind, requirement in _a_requirement_per_pause_kind().items()
+        if agui_interrupts.ERROR_REPORT_PATH_KEY
+        in _interrupts_carried(
+            _terminal_of(
+                _pause_reporting(requirement.tool_execution, requirements=[requirement]), emit_interrupt_outcome=True
+            )
+        )[0].metadata[namespace]
+    )
+    assert carrying_it == ["external_execution"], (
+        f"the pause kinds advertising {agui_interrupts.ERROR_REPORT_PATH_KEY} are {carrying_it}, and the README "
+        "names the external execution as the one of the four that does"
+    )
+
+
+def _a_pause_whose_every_pending_call_was_dropped() -> RunPausedEvent:
+    """A pause whose one call has no tool name, so nothing of it can be rendered."""
+    return _pause_reporting(_a_decision("tc-nameless", None))
+
+
+def _a_pause_no_pending_call_is_read_from() -> RunPausedEvent:
+    """An Agent's pause whose one call arrives through the run's requirements.
+
+    The default reads that list on a Team's pause only, so under it nothing of
+    this pause reaches the prompt, the run's own words included.
+    """
+    through_an_inner_run = RunRequirement(tool_execution=_a_decision("tc-inner"))
+    through_an_inner_run.member_agent_id = "inner"
+    through_an_inner_run.member_agent_name = "Inner"
+    through_an_inner_run.member_run_id = "inner-run"
+    return _pause_reporting(requirements=[through_an_inner_run])
+
+
+def _a_pause_nothing_can_answer() -> RunPausedEvent:
+    """Two open requirements sharing one id, which one answer could only half resolve.
+
+    Two calls rather than one flagged for two kinds at once, so the pause the
+    outcome prompts nothing for is one an ordinary prompt sends two distinct
+    calls for: a call the pause lists twice is prompted once per listing, and the
+    duplicate would be the subject rather than the pause being.
+    """
+    both = [RunRequirement(tool_execution=_a_decision("tc-a")), RunRequirement(tool_execution=_a_decision("tc-b"))]
+    for requirement in both:
+        requirement.id = "the-same-id"
+    return _pause_reporting(*(requirement.tool_execution for requirement in both), requirements=both)
+
+
+# Every pause this interface sends with no pending call for a client to act on,
+# against the setting of the outcome that sends it that way. Two documents count
+# these and they counted different populations: the README counts all of them,
+# the constructor's docstring counts the ones the outcome-off stream has. Both
+# numbers are recomputed from this list rather than from each other, which is
+# how they came to disagree, and each entry is driven so a shape that stopped
+# happening fails here rather than staying documented.
+_NO_CALL_TO_ACT_ON = (
+    ("every pending call dropped", _a_pause_whose_every_pending_call_was_dropped, False),
+    ("no pending call read at all", _a_pause_no_pending_call_is_read_from, False),
+    ("nothing can answer it", _a_pause_nothing_can_answer, True),
+)
+
+_COUNTS_THE_NO_CALL_PAUSES = re.compile(r"(\w+) pauses reach (?:the client|it) with no call to act on")
+
+
+@needs_interrupt_outcome
+def test_each_pause_documented_as_reaching_a_client_with_nothing_to_act_on_reaches_it_that_way():
+    """Driven, so the enumeration is of shapes this interface still sends.
+
+    A prompted call is what a client acts on, so a shape that prompts one is not
+    one of these however it is described, and a shape that stopped being
+    reachable is an enumeration nobody can check against anything.
+    """
+    for name, build, needs_the_outcome in _NO_CALL_TO_ACT_ON:
+        events = _terminal_of(build(), emit_interrupt_outcome=needs_the_outcome)
+        assert _prompted_calls(events) == [], f"the pause {name!r} prompted a call for the client to act on"
+
+
+@needs_interrupt_outcome
+def test_every_account_of_a_pause_with_nothing_to_act_on_counts_the_ones_the_interface_sends():
+    """The README counts all of them; the constructor's docstring counts the quiet ones.
+
+    Counted off the same list the check above drives, so neither document can be
+    right only because the other says the same number.
+    """
+    quiet = sum(1 for _, _, needs_the_outcome in _NO_CALL_TO_ACT_ON if not needs_the_outcome)
+    counted = {
+        "the README": (_unwrapped(_interrupt_documentation()), len(_NO_CALL_TO_ACT_ON)),
+        f"the {AGUI.__name__} constructor": (_unwrapped(inspect.getdoc(AGUI.__init__) or ""), quiet),
+    }
+    for where, (prose, expected) in counted.items():
+        stated = _COUNTS_THE_NO_CALL_PAUSES.findall(prose)
+        assert len(stated) == 1, (
+            f"{where} counts the pauses with no call to act on {len(stated)} times, and this reads one count"
+        )
+        word = stated[0].lower()
+        assert word in _SPELLED_COUNTS, f"{where} counts those pauses as {word!r}, which is not a spelled number"
+        assert _SPELLED_COUNTS[word] == expected, (
+            f"{where} counts {word} pauses with no call to act on, and the interface sends {expected}"
+        )
+
+
+# The two headings the README describes the rest of the option under. The value
+# table says what the option does to a pause a client can answer, and these two
+# are the things it does that no row of that table mentions, so a document that
+# calls the rows the whole of it sends a reader looking for neither.
+_WHAT_THE_OPTION_ALSO_DECIDES = (
+    "### A pause no client could answer",
+    "### A member the run paused inside",
+)
+
+
+@needs_interrupt_outcome
+def test_the_option_decides_the_two_things_the_value_table_does_not_state():
+    """Both driven off the flag, and both pointed at from where the option is introduced.
+
+    Each is a run the client sees differently depending on this one boolean, and
+    neither is a row of the table beside it, so the table is not the whole of the
+    option and the section that introduces it has to say where the rest is.
+    """
+    stranded_on = _terminal_of(_a_pause_nothing_can_answer(), emit_interrupt_outcome=True)
+    stranded_off = _terminal_of(_a_pause_nothing_can_answer())
+    assert type(_run_terminal(stranded_on)).__name__ == "RunErrorEvent"
+    assert type(_run_terminal(stranded_off)).__name__ == "RunFinishedEvent", (
+        "the option no longer decides whether a pause nothing can answer ends the run"
+    )
+    assert _prompted_calls(stranded_off) == ["tc-a", "tc-b"], (
+        "with the outcome off that pause is prompted like any other"
+    )
+
+    paused_inside = RunRequirement(tool_execution=_a_decision("tc-member"))
+    paused_inside.member_agent_id = "member"
+    paused_inside.member_agent_name = "Member"
+    paused_inside.member_run_id = "member-run"
+    suspended = {}
+    for on in (True, False):
+        state = StreamState(subagent_visibility=agui_state.SUBAGENT_VISIBILITY_ATTRIBUTED, emit_interrupt_outcome=on)
+        assert_well_formed_stream(on_run_completed(_pause_reporting(requirements=[paused_inside]), state))
+        suspended[on] = dict(state.suspended_lane_interrupts)
+    if agui_interrupts.subagent_suspension_available():
+        assert suspended[True], "the outcome no longer closes the lane of a member the run paused inside"
+    assert not suspended[False], "a lane is closed as suspended with the outcome off"
+
+    introduces = _section(_doc(_README), _INTERRUPT_HEADINGS[0])
+    unmentioned = [
+        heading for heading in _WHAT_THE_OPTION_ALSO_DECIDES if heading.lstrip("# ").lower() not in introduces.lower()
+    ]
+    assert not unmentioned, (
+        f"the section introducing {_INTERRUPT_OPTION} points at neither of {unmentioned}, which it also decides"
+    )
+
+
+# What the README has to say about the entries of a pause that reports no
+# requirement to key them by. The kind is what a client switches on to tell
+# "approve this call" from "run it yourself", so a document that lets a reader
+# expect one on every entry sends a client to run a tool the server runs itself,
+# and one that leaves the absent report path unsaid leaves the row above it
+# reading as though some other entry carries one. Both halves are stated, and
+# then what such an entry does carry, so the account is what it advertises and
+# not only what it does not.
+_WHAT_THE_FALLBACK_ADVERTISES = (
+    "no `pause_type` is written and no `error_report_path` with it",
+    "the `tool_call` reason such a call is shown under",
+    "the tool's name as the whole of its `metadata.agno`",
+    "no `responseSchema`",
+)
+
+
+@needs_interrupt_outcome
+def test_the_kind_an_interrupt_advertises_is_the_one_its_own_requirement_declares():
+    """One call, keyed by its requirement and keyed by the fallback, side by side.
+
+    The entries of a pause reporting no requirement at all are keyed by the
+    pending calls instead, and a pending call declares no pause kind, so no kind
+    is advertised for them and no report path either, that being carried by one
+    kind alone. What such an entry carries is what the pause did report: a
+    proposed call, keyed and reasoned as one, with the tool's name and nothing
+    else beside it.
+    """
+    namespace = agui_interrupts.RESUME_METADATA_NAMESPACE
+    decision = _a_decision("call-1")
+    borne = _interrupts_carried(_terminal_of(_pause_reporting(decision), emit_interrupt_outcome=True))
+    fell_back = _interrupts_carried(
+        _terminal_of(_pause_reporting(decision, requirements=[]), emit_interrupt_outcome=True)
+    )
+
+    assert [interrupt.metadata[namespace]["pause_type"] for interrupt in borne] == ["confirmation"]
+    keyed_by_the_call = fell_back[0]
+    assert "pause_type" not in keyed_by_the_call.metadata[namespace], (
+        "an entry keyed by a pending call now reads a kind off something, so the README should say which kind "
+        "and where it is read from rather than that none is written"
+    )
+    assert agui_interrupts.ERROR_REPORT_PATH_KEY not in keyed_by_the_call.metadata[namespace], (
+        "an entry with no kind behind it now carries the path only the external execution carries, so the pause "
+        "table should stop saying no such entry does"
+    )
+    assert set(keyed_by_the_call.metadata[namespace]) == {"tool_name"}
+    assert keyed_by_the_call.reason == agui_interrupts.REASON_TOOL_CALL
+    assert keyed_by_the_call.id == decision.tool_call_id
+    assert keyed_by_the_call.tool_call_id == decision.tool_call_id
+    assert keyed_by_the_call.response_schema is None
+
+    prose = _interrupt_prose()
+    missing = [claim for claim in _WHAT_THE_FALLBACK_ADVERTISES if claim not in prose]
+    assert not missing, f"the README's account of the interrupt outcome does not say {missing}"
+
+
+def _a_feedback_pause(*questions: UserFeedbackQuestion) -> RunRequirement:
+    return _waiting_on(requires_user_input=True, user_feedback_schema=list(questions))
+
+
+def _what_a_question_advertises(schema: Optional[Dict[str, Any]], question: str) -> Dict[str, Any]:
+    """The array one question is described as, whose ``items`` carry the labels."""
+    assert schema, "a pause waiting on feedback advertised no schema at all"
+    return schema["properties"]["selections"]["properties"][question]
+
+
+def test_the_enum_a_feedback_question_advertises_is_documented_as_the_conditional_it_is():
+    """A question declaring no label is advertised without one.
+
+    The README stated the ``enum`` the way it states ``minItems``, which every
+    question carries, so a client holding itself to the document would refuse an
+    answer to a question that listed nothing to choose from.
+    """
+    labelled = agui_interrupts.advertised_answer_schema(
+        _a_feedback_pause(UserFeedbackQuestion(question="Pick", options=[UserFeedbackOption(label="a")]))
+    )
+    label_less = agui_interrupts.advertised_answer_schema(_a_feedback_pause(UserFeedbackQuestion(question="Pick")))
+
+    assert "enum" in _what_a_question_advertises(labelled, "Pick")["items"]
+    assert "enum" not in _what_a_question_advertises(label_less, "Pick")["items"], (
+        "a question declaring no label now advertises an enum, so the README can state it without a qualifier"
+    )
+    assert "minItems" in _what_a_question_advertises(label_less, "Pick"), (
+        "the README states minItems for every question, and this one carries none"
+    )
+
+    feedback_row = [row for row in _interrupt_section_tables()[1].splitlines() if "user_feedback" in row]
+    assert len(feedback_row) == 1, f"the pause table states {len(feedback_row)} rows for the feedback pause"
+    stated = _unwrapped(feedback_row[0])
+    assert "where it declares any" in stated, (
+        "the README's feedback row states the enum without saying a question declaring no label carries none"
+    )
+
+
+def _an_entry_from_before_the_envelope_was_declared(**carried: Any) -> Any:
+    """A resume entry shaped as the release below the one that declared ``metadata``.
+
+    The protocol's own model is the installed one, which declares the field, so
+    the older shape is built here: the same undeclared-key handling the released
+    model has, and no ``metadata`` among its fields.
+    """
+    from pydantic import BaseModel, ConfigDict
+
+    class _OlderResumeEntry(BaseModel):
+        model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+        interrupt_id: str
+        status: str
+        payload: Any = None
+
+    declared = set(_OlderResumeEntry.model_fields)
+    assert agui_interrupts.ERROR_REPORT_PATH[0] not in declared, (
+        "this stand-in declares the envelope, so it says nothing about a release that did not"
+    )
+    return _OlderResumeEntry.model_validate(carried)
+
+
+def test_a_failure_is_reported_through_an_entry_that_never_declared_the_envelope():
+    """The README says the envelope works below the release that declared it.
+
+    It works because a resume entry keeps a key it does not declare and this side
+    reads the report off the entry rather than off a declared field. Driven
+    against an entry with no such field, so the claim rests on the reading rather
+    than on the installed model happening to declare one.
+    """
+    from agno.os.interfaces.agui.resume import resolve_requirements_from_resume_entries
+
+    client_ran_it = ToolExecution(
+        tool_call_id="tc-extern", tool_name="change_background", tool_args={}, external_execution_required=True
+    )
+    waiting = RunRequirement(tool_execution=client_ran_it)
+    waiting.id = "the-interrupt"
+    envelope, namespace, key = agui_interrupts.ERROR_REPORT_PATH
+    reported = "the browser refused"
+
+    resolve_requirements_from_resume_entries(
+        [waiting],
+        [
+            _an_entry_from_before_the_envelope_was_declared(
+                interrupt_id=waiting.id, status=RESUME_RESOLVED, payload="", **{envelope: {namespace: {key: reported}}}
+            )
+        ],
+    )
+
+    assert waiting.is_resolved()
+    assert client_ran_it.result == reported
+    assert client_ran_it.tool_call_error is True, "the report resolved the call as a success rather than a failure"
+
+
+def _statuses_the_protocol_declares() -> Tuple[str, ...]:
+    """The two the resume entry's own field is typed as, read off that field."""
+    from ag_ui.core import ResumeEntry
+
+    declared = ResumeEntry.model_fields["status"].annotation
+    return tuple(getattr(declared, "__args__", ()))
+
+
+@needs_interrupt_outcome
+def test_a_resume_status_the_protocol_does_not_declare_is_refused_before_any_stream_opens():
+    """Refused by the route's own validation, so no run terminal reports it.
+
+    The README described this as a run that stops, which is what the in-band
+    guard would do. Over HTTP the body is validated against ``RunAgentInput``
+    first, so a client waiting to read the reason off the stream is waiting for a
+    stream that never opens.
+    """
+    from fastapi.testclient import TestClient
+
+    from agno.agent import Agent
+    from agno.db.in_memory import InMemoryDb
+    from agno.os import AgentOS
+
+    from .agui_stream_invariants import ScriptedModel
+
+    declared = _statuses_the_protocol_declares()
+    assert RESUME_RESOLVED in declared and len(declared) == 2, (
+        f"the protocol declares the resume statuses {declared}, and the README states two"
+    )
+    undeclared = "skipped"
+    assert undeclared not in declared
+
+    agent = Agent(id="a", name="A", db=InMemoryDb(), model=ScriptedModel("m", [("content", "never asked")]))
+    served = AgentOS(id="os", agents=[agent], interfaces=[AGUI(agent=agent)], telemetry=False)
+    refused = TestClient(served.get_app()).post(
+        "/agui",
+        json={
+            "threadId": "t",
+            "runId": "r",
+            "state": {},
+            "messages": [],
+            "tools": [],
+            "context": [],
+            "forwardedProps": {},
+            "resume": [{"interruptId": "whatever", "status": undeclared, "payload": {}}],
+        },
+    )
+
+    assert refused.status_code == 422, f"a third resume status was answered {refused.status_code}: {refused.text}"
+    assert "data:" not in refused.text, f"the refusal carried a stream after all: {refused.text}"
+    assert str(refused.status_code) in _interrupt_prose(), (
+        f"the README does not say an entry carrying a third status is refused as an HTTP {refused.status_code}"
+    )
+
+
+# How every account of the outcome qualifies the tool call id it names. An
+# interrupt is keyed by its requirement and carries the call only where the call
+# had an id of its own, so an account that promises one unconditionally has a
+# client indexing the outcome by a field that is sometimes absent.
+_THE_TOOL_CALL_ID_IS_CONDITIONAL = "where that call had an id of its own"
+
+
+def _accounts_of_what_an_interrupt_names() -> Dict[str, str]:
+    """Every document that says what one interrupt of the outcome names.
+
+    Three of them say it, and the one that promised the call unconditionally was
+    the example a reader runs, so this is pinned over all three rather than over
+    the README alone.
+    """
+    return {
+        "the README": _interrupt_prose(),
+        _INTERRUPT_EXAMPLE.name: _unwrapped(_doc(_INTERRUPT_EXAMPLE)),
+        f"the {AGUI.__name__} constructor": _unwrapped(inspect.getdoc(AGUI.__init__) or ""),
+    }
+
+
+@needs_interrupt_outcome
+def test_every_account_of_the_outcome_says_the_tool_call_id_is_the_conditional_it_is():
+    """Driven from a requirement whose pending call carries no id of its own."""
+    nameless = RunRequirement(
+        tool_execution=ToolExecution(
+            tool_call_id=None, tool_name="send_email", tool_args={}, requires_confirmation=True
+        )
+    )
+    carried = _interrupts_carried(_terminal_of(_pause_reporting(requirements=[nameless]), emit_interrupt_outcome=True))
+
+    assert len(carried) == 1, "a requirement whose call carries no id is still open and still advertised"
+    assert carried[0].tool_call_id is None, (
+        "an interrupt now carries a tool call id for a call that had none, so the documents can promise one"
+    )
+    silent = sorted(
+        where
+        for where, prose in _accounts_of_what_an_interrupt_names().items()
+        if _THE_TOOL_CALL_ID_IS_CONDITIONAL not in prose
+    )
+    assert not silent, f"these accounts promise the tool call id unconditionally: {silent}"
+
+
+# What the example's resume recipe has to say beyond which fields to send. One
+# array answers every interrupt the outcome carried, and a reader following a
+# recipe that answers the one id it happened to read is refused by the guard
+# below with the run still paused.
+_THE_RESUME_IS_ALL_OR_NOTHING = "answering one of them is refused as a partial resume"
+
+
+class _OneAnswer:
+    """A resume entry as the array carries them, for a pause that needs two."""
+
+    status = RESUME_RESOLVED
+    payload = {"accepted": True}
+
+    def __init__(self, interrupt_id: Optional[str]) -> None:
+        self.interrupt_id = interrupt_id
+
+
+def test_the_example_recipe_states_the_rule_the_resume_guard_holds_a_client_to():
+    """The refusal is driven, so the rule is one the interface really enforces."""
+    from agno.os.interfaces.agui.resume import resolve_requirements_from_resume_entries
+
+    answered = RunRequirement(tool_execution=_a_decision("tc-a"))
+    left_open = RunRequirement(tool_execution=_a_decision("tc-b", "archive_email"))
+    with pytest.raises(ValueError, match="Partial resume"):
+        resolve_requirements_from_resume_entries(
+            [answered, left_open], [_OneAnswer(agui_interrupts.interrupt_id_of(answered))]
+        )
+
+    assert _THE_RESUME_IS_ALL_OR_NOTHING in _unwrapped(_doc(_INTERRUPT_EXAMPLE)), (
+        f"{_INTERRUPT_EXAMPLE.name} hands a reader a resume recipe without saying {_THE_RESUME_IS_ALL_OR_NOTHING!r}"
+    )
+
+
+_FIELDS_A_RESUME_MUST_CARRY = re.compile(
+    r"Those are (.+?) on every release this file runs on, and (\w+) as well on the releases that still required it"
+)
+
+
+def _field_names_in(listed: str) -> Set[str]:
+    return {name.strip() for name in re.split(r",| and ", listed) if name.strip()}
+
+
+def test_the_fields_the_example_says_a_resume_must_carry_are_the_ones_the_protocol_requires():
+    """The list is stated over a range of releases, and the range is what it got wrong.
+
+    ``state`` is required at the floor the example names and optional from 0.1.21
+    on, so a list asserting all seven as required is false on the newer half,
+    which includes the release the README's own upgrade command installs. What is
+    checked holds on either half: every field the example calls always required
+    is required on the installed release, and every field the installed release
+    requires is one the example either calls always required or names as the one
+    that moved.
+    """
+    stated = _FIELDS_A_RESUME_MUST_CARRY.findall(_unwrapped(_doc(_INTERRUPT_EXAMPLE)))
+    assert len(stated) == 1, (
+        f"{_INTERRUPT_EXAMPLE.name} states the fields a resume must carry {len(stated)} times, and this reads one"
+    )
+    always, moved = _field_names_in(stated[0][0]), {stated[0][1]}
+
+    required = {field.alias or name for name, field in RunAgentInput.model_fields.items() if field.is_required()}
+    assert always <= required, (
+        f"{_INTERRUPT_EXAMPLE.name} calls {sorted(always - required)} required on every release, and the installed "
+        "protocol does not require them"
+    )
+    assert required <= always | moved, (
+        f"the installed protocol requires {sorted(required - always - moved)}, which {_INTERRUPT_EXAMPLE.name} "
+        "neither calls always required nor names as having become optional"
+    )
+
+
+def _documented_field_names(text: str) -> Set[str]:
+    """Every field name a piece of the README names, however it writes the field.
+
+    Backticked tokens are read paragraph by paragraph with the line wrapping
+    inside each one taken out, so a token that wraps mid-phrase is still one
+    token, while a fenced block stays a paragraph of its own rather than being
+    run into the prose around it and pairing every backtick after it wrongly. A
+    token written as a field and the shape it carries, ``outcome: {...}``,
+    counts under the field it opens with.
+    """
+    documented: Set[str] = set()
+    for paragraph in _paragraphs(text):
+        for token in _backticked(paragraph):
+            documented.add(token)
+            carries_a_shape = re.match(r"([A-Za-z_][A-Za-z0-9_]*):", token)
+            if carries_a_shape is not None:
+                documented.add(carries_a_shape.group(1))
+    return documented
+
+
+def _fields_every_subagent_event_carries() -> Set[str]:
+    """The own fields all three lineage events share.
+
+    One account documents such a field for all three, because it means the same
+    thing on each. A field only one of them carries does not: it has to be
+    documented under the name of the event that carries it.
+    """
+    carried = [_own_field_aliases(event_class) for event_class in _subagent_event_classes().values()]
+    return set.intersection(*carried) if carried else set()
+
+
+@needs_lineage_events
+def test_every_field_of_every_subagent_event_is_documented():
+    """Every field of all three lineage events, not the announcement's alone.
+
+    A field added to a terminal is as undocumented as one added to the
+    announcement, and read for ``SUBAGENT_STARTED`` by itself this census had
+    nothing to say about either terminal.
+
+    A field is documented by the qualified ``EVENT.field``, and by the bare name
+    only where every one of the three carries it. Any bare token counted before,
+    which let one event's field be documented by an account of another's:
+    ``outcome`` written for the terminal that has one also passed for the two
+    that do not, so a field added to either would have read as documented.
+    """
+    # Matched against the backticked tokens rather than the raw text: a field
+    # named "name" or "description" occurs in ordinary prose, so a substring
+    # search finds those two whether or not anything documents them.
+    documented = _documented_field_names(_member_surface_documentation())
+    shared = _fields_every_subagent_event_carries()
+    missing = {
+        event_name: sorted(
+            alias
+            for alias in _own_field_aliases(event_class)
+            if f"{event_name}.{alias}" not in documented and not (alias in shared and alias in documented)
+        )
+        for event_name, event_class in _subagent_event_classes().items()
+    }
+    undocumented = {event_name: fields for event_name, fields in missing.items() if fields}
+    assert not undocumented, (
+        "the README's account of the member surface does not describe "
+        f"{undocumented}, either under the event that carries it or, for a field all three carry, by name"
+    )
+
+
+# A field documented under the event that carries it. The field name is read
+# whole, underscores included: stopping at the first non-letter let a documented
+# field validate as its own prefix, so SUBAGENT_ERROR.message_id passed on the
+# strength of the message field.
+#
+# The single space is the one unwrapping a document leaves behind when the name
+# wrapped after the dot, and it is allowed only before a name written the way
+# the protocol writes its fields. Allowed before anything, the full stop ending
+# a sentence with an event name in it would read as a field whose name is the
+# next sentence's first word.
+_A_DOCUMENTED_FIELD = re.compile(r"(SUBAGENT_[A-Z]+)\.(?: (?=[a-z_]))?([A-Za-z_][A-Za-z0-9_]*)")
+
+
+def _documented_qualified_fields(text: str) -> List[Tuple[str, str]]:
+    """Every ``EVENT.field`` a piece of the README names, wrapped or not."""
+    return [named for paragraph in _paragraphs(text) for named in _A_DOCUMENTED_FIELD.findall(paragraph)]
+
+
+def test_a_documented_field_is_read_whether_it_wraps_after_the_dot_or_not():
+    """The same field, written both ways, is the same claim.
+
+    Dropped when it wraps, a field the event does not carry is documented by
+    reflowing the paragraph that names it.
+    """
+    assert _documented_qualified_fields("names SUBAGENT_STARTED.\nparentToolCallId here") == [
+        ("SUBAGENT_STARTED", "parentToolCallId")
+    ]
+    assert _documented_qualified_fields("names SUBAGENT_STARTED.parentToolCallId here") == [
+        ("SUBAGENT_STARTED", "parentToolCallId")
+    ]
+
+
+def test_a_sentence_that_ends_on_an_event_name_documents_no_field():
+    """The other direction: a read loose enough to never miss starts reading prose.
+
+    A sentence ending on an event name and the next one starting below it is the
+    shape a wrapped field has once the wrapping is out, so the two are told
+    apart by how the name that follows is written.
+    """
+    assert _documented_qualified_fields("carried on SUBAGENT_FINISHED.\nThe client reads it.") == []
 
 
 @needs_lineage_events
 def test_every_documented_subagent_field_exists_on_its_event():
     classes = _subagent_event_classes()
-    # The field name is read whole, underscores included. Stopping at the first
-    # non-letter let a documented field validate as its own prefix, so
-    # SUBAGENT_ERROR.message_id passed on the strength of the message field.
-    named = re.findall(r"(SUBAGENT_[A-Z]+)\.([A-Za-z_][A-Za-z0-9_]*)", _attribution_section())
-    assert named, "the attribution section names no subagent event fields at all"
+    named = _documented_qualified_fields(_member_surface_documentation())
+    assert named, "the README's account of the member surface names no subagent event fields at all"
     for event_name, field in named:
         assert event_name in classes, f"the README names an unknown event {event_name}"
         assert field in _own_field_aliases(classes[event_name]), (
@@ -760,87 +2075,310 @@ def test_the_files_table_lists_every_example_in_the_folder():
     assert listed == present
 
 
+def _floors_stated_in(text: str) -> Set[Tuple[int, ...]]:
+    """Every protocol floor one document states, as comparable version tuples."""
+    return {tuple(int(piece) for piece in version.split(".")) for version in re.findall(_FLOOR, text)}
+
+
+def _as_written(versions: Set[Tuple[int, ...]]) -> List[str]:
+    return [".".join(str(piece) for piece in version) for version in sorted(versions)]
+
+
+# The package's own ``agui`` extra, as the requirements it declares. Read off
+# the assignment rather than off the whole file: a floor gathered from the file
+# is stated by whichever extra happens to state one, so the check reported it as
+# the release installing this extra leaves a reader on while the extra itself
+# required no protocol release at all.
+_AGUI_EXTRA = re.compile(r"^agui\s*=\s*\[(.*?)\]", re.MULTILINE | re.DOTALL)
+
+
+def _agui_extra_in(pyproject: str) -> str:
+    declared = _AGUI_EXTRA.findall(pyproject)
+    assert len(declared) == 1, (
+        f"the package declares {len(declared)} agui extras, and this check reads the one a reader installs"
+    )
+    return declared[0]
+
+
+def _agui_extra_requirements() -> str:
+    return _agui_extra_in(_PACKAGE_PYPROJECT.read_text(encoding="utf-8"))
+
+
+def test_the_packaged_extra_is_read_off_the_extra_a_reader_installs():
+    """What one extra requires is not what the package requires.
+
+    Read off the whole file, the floor another extra states was reported as the
+    release installing this one leaves a reader on, so the extra could stop
+    requiring the protocol at all with nothing here saying so.
+    """
+    pyproject = '[project.optional-dependencies]\nagui = ["ag-ui-protocol>=0.1.15"]\na2a = ["ag-ui-protocol>=0.1.21"]\n'
+    assert _floors_stated_in(_agui_extra_in(pyproject)) == {(0, 1, 15)}
+    assert _floors_stated_in(_agui_extra_in('agui = ["jsonpatch>=1.33"]\na2a = ["ag-ui-protocol>=0.1.21"]\n')) == set()
+
+
 def test_the_protocol_floor_is_stated_the_same_way_everywhere():
-    pattern = r"ag-ui-protocol[`'\s>=]{1,4}(\d+\.\d+\.\d+)"
-    # Per document, because one set of versions gathered from all of them is
-    # satisfied by a single document stating the floor while the rest go silent.
-    stated = {
-        name: set(re.findall(pattern, text)) for name, text in (("README", _doc(_README)), ("example", _doc(_EXAMPLE)))
-    }
+    """Every optional part of the protocol names one floor, in both places it is named.
+
+    There is more than one such part, and they arrived in different releases, so
+    the floors are per example rather than one number for the folder. What has to
+    hold is that each example states exactly one, and that the README states the
+    same set the examples do: a reader who follows either document has to end up
+    on a release that serves what they are being shown, and a document going
+    silent is how that stops being true.
+    """
+    assert _FLOOR_EXAMPLES, "no example is read for a protocol floor, so this check compares two empty sets"
+    # Per example, because one set of versions gathered from all of them is
+    # satisfied by a single document stating a floor while the rest go silent.
+    stated = {path.name: _floors_stated_in(_doc(path)) for path in _FLOOR_EXAMPLES}
     silent = sorted(name for name, versions in stated.items() if not versions)
-    assert not silent, f"these documents no longer state the lineage protocol floor: {silent}"
-    versions = set().union(*stated.values())
-    assert len(versions) == 1, f"the lineage protocol floor is documented as {sorted(versions)}"
+    assert not silent, f"these examples no longer state the protocol floor they need: {silent}"
+    ambiguous = {name: _as_written(versions) for name, versions in stated.items() if len(versions) != 1}
+    assert not ambiguous, f"these examples state more than one protocol floor: {ambiguous}"
+
+    # The lineage floor is pinned to the release the invariants recompute
+    # against the announcement fields they read, so the documents cannot agree
+    # with each other on a release that serves none of what they show. The
+    # interrupt round trip has no such constant: what it needs is feature
+    # detected on the installed release and nothing recomputes the number, so
+    # its floor stays document to document until something does.
+    assert stated[_EXAMPLE.name] == {LINEAGE_EVENTS_PROTOCOL_FLOOR}, (
+        f"{_EXAMPLE.name} names the protocol floor {_as_written(stated[_EXAMPLE.name])} for the subagent events, "
+        f"which arrived in {_as_written({LINEAGE_EVENTS_PROTOCOL_FLOOR})[0]}"
+    )
+
+    documented = _floors_stated_in(_doc(_README))
+    needed = set().union(*stated.values())
+    assert documented == needed, (
+        f"the README documents the protocol floors {_as_written(documented)}, and the examples need "
+        f"{_as_written(needed)}: {_as_written(needed - documented)} is named by no README and "
+        f"{_as_written(documented - needed)} by no example"
+    )
 
 
 def test_the_packaged_extra_still_permits_a_release_below_the_documented_floor():
-    """The README tells the reader to upgrade by hand, which the extra must justify."""
+    """The README tells the reader to upgrade by hand, which the extra must justify.
+
+    Against the lowest floor the README documents, since that is the one the
+    extra has to sit below for the instruction to be worth giving: an extra
+    above it resolves a release that serves none of what the folder shows.
+    Compared with whichever floor the document happened to state first, the
+    check moved with the prose, and the README states several.
+    """
     # The packaged extra is read straight off the package, which the root check
     # at the top of this module guarantees is there: it is not a cookbook file
     # and a checkout without the cookbook still has it.
-    documented = re.search(r"ag-ui-protocol>=(\d+\.\d+\.\d+)", _doc(_README))
-    packaged = re.search(r"ag-ui-protocol>=(\d+\.\d+\.\d+)", _PACKAGE_PYPROJECT.read_text(encoding="utf-8"))
-    assert documented is not None and packaged is not None
+    documented = _floors_stated_in(_doc(_README))
+    assert documented, "the README states no protocol floor, so nothing here says what the extra sits below"
+    packaged = _floors_stated_in(_agui_extra_requirements())
+    assert packaged, (
+        "the agui extra requires no ag-ui-protocol release at all, so the README's instruction to upgrade it "
+        "by hand rests on nothing"
+    )
+    assert len(packaged) == 1, (
+        f"the agui extra requires the protocol floors {_as_written(packaged)}, and this check needs the one "
+        "release a reader who installs the extra ends up above"
+    )
 
-    def parts(match: re.Match) -> tuple:
-        return tuple(int(piece) for piece in match.group(1).split("."))
-
-    assert parts(packaged) < parts(documented), (
+    assert next(iter(packaged)) < min(documented), (
         "the agui extra now requires the lineage events, so the README should stop "
         "saying it allows older releases and stop teaching a manual upgrade"
     )
 
 
 def _bullet_naming(log: str, phrase: str) -> str:
-    """The one list item that makes a claim, so names are read from that claim alone."""
-    assert phrase in log, f"the Validation section no longer says {phrase!r}"
-    return log[log.index(phrase) :].split("\n- ")[0]
+    """The one list item that makes a claim, so names are read from that claim alone.
+
+    A bullet ends where its wrapped lines stop being indented, which is the next
+    bullet, a blank line, a heading or the end of the document. Cut at the next
+    bullet alone, the last bullet of a list swallowed the rest of the log, and
+    names from anywhere below it read as names this claim had made.
+
+    The claim is found across the document's own line wrapping, since the bullet
+    it opens is what has to be read line by line, not the phrase naming it: a
+    claim that wrapped between two of its words was reported as a claim the log
+    no longer makes.
+
+    The bullet is then read from its own first line, not from where the phrase
+    starts inside it. Read from the phrase, everything the claim wrote before it
+    went unread, so a name written ahead of the phrase was excused from both the
+    check that the folder holds it and the arithmetic that counts it.
+    """
+    opens = re.search(r"\s+".join(re.escape(word) for word in phrase.split()), log)
+    assert opens is not None, f"the Validation section no longer says {phrase!r}"
+    lines = log.splitlines()
+    # A wrapped line of a bullet is an indented one, so the bullet opens at the
+    # first line at or above the phrase that is not indented.
+    first = log.count("\n", 0, opens.start())
+    while first > 0 and lines[first].strip() and lines[first].startswith((" ", "\t")):
+        first -= 1
+    bullet = [lines[first]]
+    for line in lines[first + 1 :]:
+        if not line.strip() or not line.startswith((" ", "\t")):
+            break
+        bullet.append(line)
+    return "\n".join(bullet)
+
+
+def test_a_bullet_is_read_to_its_end_and_no_further():
+    """The last bullet of a list ends with the list, not with the document.
+
+    Read to the next bullet alone, the last one swallowed everything below it,
+    so a name from a later section counted as a name its own claim had made.
+    """
+    log = "- first, which\n  wraps\n- the claim names `kept.py`\n  and `also_kept.py`\n\n## Later\n\n`elsewhere.py`\n"
+    assert re.findall(r"`([^`]+\.py)`", _bullet_naming(log, "the claim names")) == ["kept.py", "also_kept.py"]
+
+
+def test_a_bullet_is_read_from_its_start_whatever_line_the_claim_opens_on():
+    """A name the claim writes before the phrase is a name the claim made.
+
+    Both places it can sit: ahead of the phrase on the bullet's own first line,
+    and on a wrapped line above the one the phrase starts on.
+    """
+    ahead = "- first\n- Except `excused.py`, the claim names `kept.py`\n- last\n"
+    assert re.findall(r"`([^`]+\.py)`", _bullet_naming(ahead, "the claim names")) == ["excused.py", "kept.py"]
+    above = "- first\n- Except `excused.py`,\n  the claim names `kept.py`\n- last\n"
+    assert re.findall(r"`([^`]+\.py)`", _bullet_naming(above, "the claim names")) == ["excused.py", "kept.py"]
+
+
+def _counted_once(text: str, pattern: str, what: str) -> Tuple[str, ...]:
+    """The one set of numbers a document states for something it counts.
+
+    Every statement is read rather than the first. The log restates its counts
+    in the entries that re-measured them, and a check reading whichever comes
+    first says nothing about the rest: a restatement that drifted from the one
+    at the top passed as long as the top one still held.
+    """
+    stated = set(re.findall(pattern, text))
+    assert stated, f"the Validation section no longer counts {what}"
+    assert len(stated) == 1, f"the Validation section states {sorted(stated)} for {what}, so it counts it two ways"
+    counted = stated.pop()
+    return counted if isinstance(counted, tuple) else (counted,)
+
+
+# Every count in the TEST_LOG that this module recomputes from the folder, as the
+# pattern each is read by. The log states how many of its counts are facts about
+# the folder rather than records of one run, and that number is read off this
+# list: written down twice, the statement outlived the checks it described, which
+# is what this whole folder's documented-claim drift keeps being.
+_COUNTS_RECOMPUTED_FROM_THE_FOLDER: Dict[str, str] = {
+    "how its count is made up": r"the (\d+) in its root plus ((?:`[^`]+\.py`(?:,| and)? ?)+)",
+    "the server files it booted": r"All (\d+) server files",
+    "the scanned Python files": r"checked exactly (\d+) Python files",
+    "the completed POST flows": r"(\d+) of the (\d+) files completed",
+    "the status routes it asserted": r"(\d+) status routes in all",
+}
+
+
+def _how_many_counts_the_log_says_are_recomputed() -> str:
+    stated = re.findall(r"(\w+) of the counts kept below are facts about this folder", _unwrapped(_doc(_TEST_LOG)))
+    assert len(stated) == 1, (
+        f"the TEST_LOG says how many of its counts are facts about this folder {len(stated)} times, "
+        "and this reads one statement"
+    )
+    return stated[0].lower()
+
+
+def _a_recomputed_count(what: str) -> Tuple[str, str]:
+    """One recomputed count's pattern and the name a refusal calls it by."""
+    return _COUNTS_RECOMPUTED_FROM_THE_FOLDER[what], what
+
+
+def test_the_log_counts_the_counts_this_suite_recomputes():
+    """The claim about the claims, which is the one nothing recomputed.
+
+    The log used to say the only counts it kept were the ones recomputed here,
+    while keeping a dozen it does not: the events one stream carried, the files
+    one sweep walked, the violations it found. What it may say is how many are
+    recomputed, and that number comes off the list the checks below run on.
+    """
+    word = _how_many_counts_the_log_says_are_recomputed()
+    assert word in _SPELLED_COUNTS, f"the TEST_LOG counts those as {word!r}, which is not a spelled number"
+    assert _SPELLED_COUNTS[word] == len(_COUNTS_RECOMPUTED_FROM_THE_FOLDER), (
+        f"the TEST_LOG says {word} of its counts are recomputed from the folder, and this suite recomputes "
+        f"{len(_COUNTS_RECOMPUTED_FROM_THE_FOLDER)}: {sorted(_COUNTS_RECOMPUTED_FROM_THE_FOLDER)}"
+    )
 
 
 def test_the_validation_counts_match_the_folder():
     log = _doc(_TEST_LOG)
-    if not _COOKBOOK.exists():
-        pytest.skip("cookbook not present in this checkout")
     root = _root_examples()
+    # Every count is read off the same normalised text. Read off the raw
+    # document instead, a claim that happens to wrap between two of its own
+    # words stops being found at all, so reflowing a correct paragraph failed
+    # the check that it counts something.
+    prose = _unwrapped(log)
 
     # The document states its own breakdown, and the files beyond the root are
     # read from that sentence rather than from a recursive walk: a walk counts
     # anything a nested frontend's installed dependencies bring with them, and
     # would disagree with the non-recursive count the files table is checked
     # against.
-    breakdown = re.search(r"the (\d+) in its root plus ((?:`[^`]+\.py`(?:,| and)? ?)+)", " ".join(log.split()))
-    assert breakdown is not None, "the Validation section no longer states how its count is made up"
-    assert int(breakdown.group(1)) == len(root), (
-        f"the Validation section counts {breakdown.group(1)} files in the folder root, which holds {len(root)}"
+    in_root, listing = _counted_once(prose, *_a_recomputed_count("how its count is made up"))
+    assert int(in_root) == len(root), (
+        f"the Validation section counts {in_root} files in the folder root, which holds {len(root)}"
     )
-    nested = re.findall(r"`([^`]+\.py)`", breakdown.group(2))
+    nested = set(re.findall(r"`([^`]+\.py)`", listing))
     assert nested, "the Validation section names no file beyond the root, so its total cannot be checked"
     absent = sorted(name for name in nested if not (_COOKBOOK / name).exists())
     assert not absent, f"the Validation section counts files that are gone: {absent}"
-    servers = len(root) + len(nested)
+    # De-duplicated on both sides of the arithmetic below, since the same file
+    # named twice is one file wherever it is named.
+    servers = len(root | nested)
 
-    booted = re.search(r"All (\d+) server files", log)
-    assert booted is not None, "the Validation section no longer counts the server files it booted"
-    assert int(booted.group(1)) == servers
+    booted = _counted_once(prose, *_a_recomputed_count("the server files it booted"))
+    assert int(booted[0]) == servers
 
-    scanned = re.search(r"checked exactly (\d+) Python files", log)
-    assert scanned is not None, "the Validation section no longer counts the scanned Python files"
-    assert int(scanned.group(1)) == servers
+    scanned = _counted_once(prose, *_a_recomputed_count("the scanned Python files"))
+    assert int(scanned[0]) == servers
 
-    posted = re.search(r"(\d+) of the (\d+) files completed", log)
-    assert posted is not None, "the Validation section no longer counts the completed POST flows"
-    assert int(posted.group(2)) == servers
+    completed, of_files = _counted_once(prose, *_a_recomputed_count("the completed POST flows"))
+    assert int(of_files) == servers
     # The shortfall is derived from the files the same claim names as covered
     # elsewhere, rather than from a hard-coded allowance of one.
     # The same pattern the nested files are read with: a name written with a
     # directory in front of it is one of the files this claim can excuse, and a
     # pattern that could not match one reported it as excusing something the
     # folder does not hold.
-    uncovered = re.findall(r"`([^`]+\.py)`", _bullet_naming(log, "of the {} files completed".format(servers)))
+    uncovered = set(re.findall(r"`([^`]+\.py)`", _bullet_naming(log, "of the {} files completed".format(servers))))
     assert uncovered, "the Validation section no longer names the files whose POST flow it did not run"
     missing = sorted(name for name in uncovered if name not in root and name not in nested)
     assert not missing, f"the Validation section excuses files the folder does not hold: {missing}"
-    assert int(posted.group(1)) == servers - len(set(uncovered))
+    assert int(completed) == servers - len(uncovered)
+
+
+def _interfaces_mounted_by(source: str) -> int:
+    """How many AG-UI interfaces one example mounts, read off its own source.
+
+    Counted by construction rather than from the prefixes the log lists, because
+    the routes an example exposes are one per interface it builds, and an
+    example that grows a second mount grows a second status route with it.
+    """
+    return sum(
+        1
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call) and (_dotted(node.func) or "").split(".")[-1] == AGUI.__name__
+    )
+
+
+def test_the_status_routes_the_log_counts_are_the_ones_the_examples_mount():
+    """The one measured count the log still writes down, recomputed from the folder.
+
+    The boot sweep asserts a status route per mounted interface, so the number
+    it reports is a fact about these files rather than about the run that day,
+    and an example that mounts one more moves it.
+
+    The log is read first, so a checkout shipping no cookbook skips here. Read
+    after the folder was walked, this failed for holding no example that mounts
+    an interface, which is a report that the folder is wrong rather than absent.
+    """
+    log = _unwrapped(_doc(_TEST_LOG))
+    mounted = sum(_interfaces_mounted_by((_COOKBOOK / name).read_text(encoding="utf-8")) for name in _root_examples())
+    assert mounted, "no example in the folder root mounts an AG-UI interface, so the log's count checks nothing"
+    counted = _counted_once(log, *_a_recomputed_count("the status routes it asserted"))
+    assert int(counted[0]) == mounted, (
+        f"the log counts {counted[0]} status routes and this folder's root examples mount {mounted} interfaces"
+    )
 
 
 def test_the_test_log_cites_suites_that_exist():

--- a/libs/agno/tests/unit/os/interfaces/test_agui_emission_identity.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_emission_identity.py
@@ -1,0 +1,930 @@
+"""What a client receives with the interrupt outcome off, against what it received before it existed.
+
+The whole feature rests on one promise: ``emit_interrupt_outcome`` is off by
+default, and with it off a released client sees the stream it has always seen.
+That promise is what makes the change safe to ship, and until this module nothing
+held it. It was checked by hand after each wave of work, which is exactly as good
+as the last time somebody remembered to check.
+
+So the interface as it stood before the round trip is checked in beside this one
+(see ``agui_baseline_tree``) and run. Every stream below is driven through both,
+encoded with the protocol's own encoder, and compared as JSON. Not the events in
+memory: what a client receives is the encoded body, and an event the models
+accept but the encoder writes differently is a difference to a client and no
+difference at all in memory.
+
+Three things keep the comparison from passing for the wrong reason.
+
+The streams are enumerated rather than listed. They come from the tables the
+other sweeps in this directory already keep: every place the interface builds an
+event out of run content, driven with benign content and with every hostile
+value, and every shape of pause. A stream added to either table is compared here
+with nothing to opt in, which is the property a hand-written list does not have.
+Three more are written here, and only because they are shared-path changes no
+stream in those tables reaches; each says so where it is defined.
+
+The normalisation is one rule. A minted identifier is aliased to the order it
+was first seen in, so an interface that mints one more, or reuses one where it
+used to mint, still fails. Nothing else is normalised, timestamps included: a
+timestamp on the wire is copied off the chunk it came from, and one chunk list is
+driven through both trees, so the two sides carry the same value rather than one
+that has to be normalised away.
+
+And the differences that are real are stated, not waived. The branch fixed
+defects on the path both settings share, so some streams legitimately differ. Each
+one is named in ``INTENDED_DIFFERENCES`` with the exact divergence it produces and
+the reason it is intended, and a stream that is not named there has to be
+identical. A stated difference that changes shape fails just as loudly as a new
+one, because what is stated is where the two streams part and what each does
+after.
+
+The line this draws is the emission. It is not drawn around the route, and the
+last class here says why: the route makes two decisions differently now, and both
+are about what it asks the entity to do rather than about what it writes, so they
+are driven and pinned as decisions.
+"""
+
+import copy
+import json
+import re
+from pathlib import Path
+from typing import Any, AsyncIterator, Callable, Dict, Iterator, List, NamedTuple, Optional, Sequence, Tuple
+
+import pytest
+
+pytest.importorskip("ag_ui", reason="ag_ui not installed")
+
+from ag_ui.core import RunAgentInput, ToolMessage, UserMessage
+from ag_ui.encoder import EventEncoder
+
+from agno.agent import Agent
+from agno.db.in_memory import InMemoryDb
+from agno.models.response import ToolExecution
+from agno.os.interfaces.agui import stream as live_stream_module
+from agno.os.interfaces.agui.router import run_entity as live_run_entity
+from agno.os.interfaces.agui.state import SUBAGENT_VISIBILITY_ATTRIBUTED, SUBAGENT_VISIBILITY_VALUES
+from agno.run.agent import RunCompletedEvent, RunOutput, RunStartedEvent
+from agno.run.base import RunStatus
+from agno.run.requirement import RunRequirement
+from agno.run.team import RunErrorEvent as TeamRunErrorEvent
+from agno.run.team import RunStartedEvent as TeamRunStartedEvent
+from agno.session.agent import AgentSession
+
+from . import agui_baseline_tree
+from .agui_stream_invariants import (
+    ATTRIBUTED_IS_SERVABLE,
+    TOP_LEVEL_RUN,
+    member_chunk_kwargs,
+    team_chunk_kwargs,
+)
+from .test_agui_hostile_run_content import _BOUNDARIES as CONTENT_BOUNDARIES
+from .test_agui_hostile_run_content import _HOSTILE as HOSTILE_VALUES
+from .test_agui_interrupts import _PAUSE_SHAPES, _PAUSES_NOTHING_CAN_ANSWER
+
+baseline_stream_module = agui_baseline_tree.module("stream")
+baseline_run_entity = agui_baseline_tree.module("router").run_entity
+
+THREAD_ID = "emission-identity"
+
+# The setting under test, spelled out so every drive below reads as the claim it
+# makes: this is the default, and the default is what has to be unchanged.
+THE_OUTCOME_IS_OFF = False
+
+
+# --- What a client receives --------------------------------------------------
+
+# A minted identifier, which is the one thing on the wire this interface makes up
+# rather than copies. Matched by shape and nothing else: a value that is not one
+# of these is compared as it is.
+_MINTED = re.compile(r"\A[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\Z")
+
+MINTED_ALIAS = "minted-{}"
+
+
+def aliased(value: Any, minted: Dict[str, str]) -> Any:
+    """One decoded event with its minted ids replaced by the order they appeared in.
+
+    Narrow on purpose. Only a value shaped like a minted id is touched, and each
+    distinct one gets its own alias, assigned when it is first seen, so the
+    result still carries how many ids the stream minted, which events shared one
+    and in what order they arrived. A stream that mints one id more than it used
+    to, or reuses one where it used to mint a fresh one, differs here even though
+    no literal value survives the rewrite.
+    """
+    if isinstance(value, str):
+        return minted.setdefault(value, MINTED_ALIAS.format(len(minted) + 1)) if _MINTED.match(value) else value
+    if isinstance(value, dict):
+        return {key: aliased(item, minted) for key, item in value.items()}
+    if isinstance(value, list):
+        return [aliased(item, minted) for item in value]
+    return value
+
+
+UNSENDABLE = "the encoder refused this event"
+
+
+def _failure(error: Optional[BaseException]) -> Optional[Tuple[str, str]]:
+    """A failure the mapper let out, as the two things about it a client can see.
+
+    The class, because the route reports a failure it catches by name in its own
+    log, and the text, because the same route puts ``str(error)`` on the wire as
+    the run's error message. So a failure that changed its wording changed what a
+    client is shown.
+
+    Read through a guard, since rendering a failure runs the value that failed:
+    the read this comparison is about is one of the reads that can raise.
+    """
+    if error is None:
+        return None
+    try:
+        return type(error).__name__, str(error)
+    except BaseException:
+        return type(error).__name__, UNSENDABLE
+
+
+class Received(NamedTuple):
+    """One whole stream as a client receives it: the encoded events, then the end.
+
+    ``failure`` is what the mapper raised out, which a client sees as a body that
+    stops without a run terminal.
+    """
+
+    events: List[Any]
+    failure: Optional[Tuple[str, str]]
+
+
+def received(events: Sequence[Any], error: Optional[BaseException]) -> Received:
+    """Encode a stream the way the route does, and normalise only its minted ids.
+
+    An event the encoder refuses is recorded as refused rather than dropped: on a
+    real wire the body stops there, so a stream that refuses one event where the
+    other refuses none is not the same stream at all.
+    """
+    encoder = EventEncoder()
+    minted: Dict[str, str] = {}
+    encoded: List[Any] = []
+    for event in events:
+        try:
+            body = encoder.encode(event)
+        except Exception as refusal:
+            encoded.append({UNSENDABLE: type(refusal).__name__})
+            continue
+        encoded.append(aliased(json.loads(body.removeprefix("data: ").strip()), minted))
+    return Received(encoded, _failure(error))
+
+
+# --- Driving one stream through both trees -----------------------------------
+
+
+def _sync_source(chunks: Sequence[Any]) -> Iterator[Any]:
+    for chunk in chunks:
+        yield chunk
+
+
+async def _async_source(chunks: Sequence[Any]) -> AsyncIterator[Any]:
+    for chunk in chunks:
+        yield chunk
+
+
+def _drive_sync(mapper: Callable[..., Iterator[Any]], chunks: Sequence[Any], **kwargs: Any) -> Received:
+    events: List[Any] = []
+    error: Optional[BaseException] = None
+    try:
+        for event in mapper(_sync_source(chunks), **kwargs):
+            events.append(event)
+    except BaseException as raised:
+        error = raised
+    return received(events, error)
+
+
+async def _drive_async(mapper: Callable[..., AsyncIterator[Any]], chunks: Sequence[Any], **kwargs: Any) -> Received:
+    events: List[Any] = []
+    error: Optional[BaseException] = None
+    try:
+        async for event in mapper(_async_source(chunks), **kwargs):
+            events.append(event)
+    except BaseException as raised:
+        error = raised
+    return received(events, error)
+
+
+SYNC = "sync"
+ASYNC = "async"
+MAPPERS = (SYNC, ASYNC)
+
+
+async def through_both_trees(
+    chunks: Sequence[Any],
+    run_state: Optional[Dict[str, Any]],
+    visibility: Optional[str],
+    mapper: str,
+) -> Tuple[Received, Received]:
+    """The same chunk list through the baseline and through this interface.
+
+    The same list, not two builds of one: a chunk carries the moment it was made,
+    and that value is copied onto the wire, so two builds would differ by when
+    they happened and the comparison would need a rule to forgive it. One list
+    removes the question instead of normalising an answer to it.
+    """
+    common = dict(thread_id=THREAD_ID, run_id=TOP_LEVEL_RUN, run_state=run_state, subagent_visibility=visibility)
+    if mapper == SYNC:
+        before = _drive_sync(baseline_stream_module.stream_agno_response_as_agui_events, chunks, **common)
+        after = _drive_sync(
+            live_stream_module.stream_agno_response_as_agui_events,
+            chunks,
+            emit_interrupt_outcome=THE_OUTCOME_IS_OFF,
+            **common,
+        )
+        return before, after
+    before = await _drive_async(baseline_stream_module.async_stream_agno_response_as_agui_events, chunks, **common)
+    after = await _drive_async(
+        live_stream_module.async_stream_agno_response_as_agui_events,
+        chunks,
+        emit_interrupt_outcome=THE_OUTCOME_IS_OFF,
+        **common,
+    )
+    return before, after
+
+
+# --- How two streams are said to differ --------------------------------------
+
+IDENTICAL = "identical"
+
+
+def _ending(stream: Received) -> str:
+    if stream.failure is None:
+        return f"sent {len(stream.events)} and reached its terminal"
+    return f"sent {len(stream.events)} and raised {stream.failure[0]}"
+
+
+def divergence(before: Received, after: Received) -> str:
+    """Where two streams part, and what each of them did from there.
+
+    Stated rather than counted, because the table below is read by whoever has to
+    decide whether a change was meant. The point they agree up to is what says a
+    difference is confined to the end of a stream rather than running through the
+    whole of it, and an entry whose agreement point moves is a different change
+    from the one that was blessed.
+    """
+    if before == after:
+        return IDENTICAL
+    common = min(len(before.events), len(after.events))
+    agreed = next(
+        (index for index in range(common) if before.events[index] != after.events[index]),
+        common,
+    )
+    return f"agree on {agreed}; baseline {_ending(before)}; now {_ending(after)}"
+
+
+def _at(stream: Received, index: int) -> str:
+    return json.dumps(stream.events[index]) if index < len(stream.events) else "nothing, the stream ended here"
+
+
+def where_they_part(before: Received, after: Received) -> str:
+    """The two events a comparison first disagreed on, for the failure to be read by.
+
+    The divergence above is the signature the table states, which is deliberately
+    coarse: whoever has to act on a failure needs the events themselves, and
+    printing two whole streams buries the one line that matters.
+    """
+    common = min(len(before.events), len(after.events))
+    index = next((position for position in range(common) if before.events[position] != after.events[position]), common)
+    return (
+        f"they first differ at event {index}\n  before: {_at(before, index)}\n  now:    {_at(after, index)}\n"
+        f"  baseline failure: {before.failure}\n  failure now:      {after.failure}"
+    )
+
+
+# --- The streams this compares -----------------------------------------------
+
+# Every visibility a caller can set, plus the absence of one, which is what a
+# caller who sets nothing gets and is therefore the setting most streams run
+# under.
+VISIBILITIES: Tuple[Optional[str], ...] = (None,) + tuple(SUBAGENT_VISIBILITY_VALUES)
+
+BENIGN = "benign"
+
+
+def _content_streams() -> List[Tuple[str, Callable[[], Any]]]:
+    """Every event-building boundary, with benign content and with each hostile value.
+
+    Read off the table the hostile-content suite keeps, so a boundary added there
+    is compared here without being mentioned here, and so is a value added to the
+    shared list of them. Both halves matter: the benign column is where the
+    promise is really made, and the hostile one is where every difference this
+    branch introduced turns out to live.
+    """
+    streams = []
+    for boundary in CONTENT_BOUNDARIES:
+        streams.append((f"{boundary.name}/{BENIGN}", lambda b=boundary: b.builder(b.benign())))
+        for value_name, value in HOSTILE_VALUES.items():
+            streams.append((f"{boundary.name}/{value_name}", lambda b=boundary, v=value: b.builder(v())))
+    return streams
+
+
+class Stream(NamedTuple):
+    chunks: List[Any]
+    run_state: Optional[Dict[str, Any]] = None
+
+
+def _pause_streams() -> List[Tuple[str, Callable[[], Any]]]:
+    """Every shape of pause the interrupt suite enumerates, continuable or not.
+
+    A pause is the only run whose terminal the setting changes, so these are the
+    streams the promise is most exposed on: with the outcome off, each of them has
+    to reach a client as the plain prompt and plain terminal it always did.
+    """
+    shapes = {**_PAUSE_SHAPES, **_PAUSES_NOTHING_CAN_ANSWER}
+    return [(f"pause/{name}", lambda s=shape: Stream([s()])) for name, shape in shapes.items()]
+
+
+class _NoCopy:
+    """A session state value with no copy of its own, as one holding a live handle is."""
+
+    def __deepcopy__(self, memo: Dict[int, Any]) -> Any:
+        raise RuntimeError("this state has no copy")
+
+
+def _a_failed_run_whose_chunk_names_a_member() -> Stream:
+    """A failed team run whose own chunk carries a member's identity inside it.
+
+    Written here because no boundary in the reused table reaches it. The terminal
+    of a failed run embeds the chunk verbatim, and this branch made that embed
+    conditional on whether the chunk names a member under a visibility that names
+    none. Every existing test of that condition drives it with the outcome on,
+    where a pause can reach the failed terminal; with the outcome off only a real
+    failure gets there, and the framework's failure chunks carry a member only in
+    the free-form field used here.
+    """
+    failed = TeamRunErrorEvent(
+        content="the run failed", **team_chunk_kwargs("research-team", "Research Team", TOP_LEVEL_RUN)
+    )
+    failed.additional_data = {"member_id": "scout"}
+    return Stream(
+        [
+            TeamRunStartedEvent(**team_chunk_kwargs("research-team", "Research Team", TOP_LEVEL_RUN)),
+            RunStartedEvent(**member_chunk_kwargs("scout", "run-scout")),
+            failed,
+        ]
+    )
+
+
+def _a_session_state_that_cannot_be_copied() -> Stream:
+    """A run ending on a session state with no copy of its own.
+
+    Written here for the reason above: the terminal's own state snapshot is
+    copied, and the copy is only reached when the request carried state, which is
+    a property of the request rather than of any chunk the content table builds.
+    The state the run ends holding is the chunk's, and the one it started with is
+    left copyable so the difference is about the terminal's copy and not the
+    stream's opening one.
+    """
+    done = RunCompletedEvent(content="done", run_id=TOP_LEVEL_RUN)
+    done.session_state = {"held": _NoCopy()}
+    return Stream([RunStartedEvent(run_id=TOP_LEVEL_RUN), done], run_state={})
+
+
+# Streams for changes on the shared path that none of the reused tables reach.
+# Each one's own docstring says why it cannot come from there.
+SHARED_PATH_STREAMS: Tuple[Tuple[str, Callable[[], Stream]], ...] = (
+    ("shared-path/a_failed_run_whose_chunk_names_a_member", _a_failed_run_whose_chunk_names_a_member),
+    ("shared-path/a_session_state_that_cannot_be_copied", _a_session_state_that_cannot_be_copied),
+)
+
+
+STREAMS: List[Tuple[str, Callable[[], Any]]] = (
+    _content_streams() + _pause_streams() + [(name, builder) for name, builder in SHARED_PATH_STREAMS]
+)
+
+
+# --- The differences that are intended ---------------------------------------
+
+A_VALUE_THAT_CANNOT_BE_READ_NO_LONGER_ENDS_THE_RUN = (
+    "A value the interface could not render or serialize used to raise out of the mapper, so the body "
+    "stopped where it raised and the client was left with no run terminal at all. It is now recorded and "
+    "dropped, and the run reaches its terminal. Every one of these is a stream that was broken before."
+)
+
+A_PENDING_CALL_WITH_AN_UNUSABLE_ID_FAILS_UNDER_A_DIFFERENT_NAME = (
+    "A pause listing a call whose id is not a string still ends the run, and the client still receives the "
+    "same events, but the failure reaching the route has a different class and text: the pause is now read "
+    "through a mapping keyed by that id before the protocol's own model is asked to refuse it. The route "
+    "puts the failure's text on the wire, so the wording a client is shown changes even though nothing "
+    "before it does."
+)
+
+THE_VERBATIM_CHUNK_IS_WITHHELD_WHERE_NO_MEMBER_MAY_BE_NAMED = (
+    "A failed run's terminal embeds the chunk it died on. Under the visibility that names no member, a "
+    "chunk naming one is now withheld and recorded for the operator instead. Passing it through published "
+    "the member identity the setting exists to withhold."
+)
+
+THE_TERMINAL_STATE_SNAPSHOT_IS_DROPPED_RATHER_THAN_ENDING_THE_RUN = (
+    "Copying the session state a run ends holding is the last thing the terminal builds. A state with no "
+    "copy of its own raised there, which discarded the closing sweep and the terminal with it. The snapshot "
+    "is now dropped with a record and the run reaches its terminal."
+)
+
+
+class Intended(NamedTuple):
+    """One stream that legitimately differs, and the account of why.
+
+    ``divergence`` is per visibility, because a change on the shared path can be
+    reachable under one setting and not another, and a table that stated one
+    verdict for all of them would pass on a stream that started differing
+    somewhere new.
+    """
+
+    reason: str
+    divergence: Dict[Optional[str], str]
+
+
+def _everywhere(divergence_text: str) -> Dict[Optional[str], str]:
+    return {visibility: divergence_text for visibility in VISIBILITIES}
+
+
+# Every stream that differs, with the exact divergence it produces. A stream not
+# named here has to be identical, and a stream named here has to differ in the
+# way it says, so a further change to one of these is as loud as a new one.
+INTENDED_DIFFERENCES: Dict[str, Intended] = {
+    "member_identity/raises_an_unreadable_error": Intended(
+        A_VALUE_THAT_CANNOT_BE_READ_NO_LONGER_ENDS_THE_RUN,
+        {
+            SUBAGENT_VISIBILITY_ATTRIBUTED: "agree on 1; baseline sent 1 and raised RuntimeError; now sent 8 and reached its terminal"
+        },
+    ),
+    "paused_member_name/raises_an_unreadable_error": Intended(
+        A_VALUE_THAT_CANNOT_BE_READ_NO_LONGER_ENDS_THE_RUN,
+        {
+            SUBAGENT_VISIBILITY_ATTRIBUTED: "agree on 1; baseline sent 1 and raised RuntimeError; now sent 9 and reached its terminal"
+        },
+    ),
+    "pause_prompt_args/circular": Intended(
+        A_VALUE_THAT_CANNOT_BE_READ_NO_LONGER_ENDS_THE_RUN,
+        _everywhere("agree on 1; baseline sent 1 and raised ValueError; now sent 7 and reached its terminal"),
+    ),
+    "pause_prompt_args/raises_on_serialization": Intended(
+        A_VALUE_THAT_CANNOT_BE_READ_NO_LONGER_ENDS_THE_RUN,
+        _everywhere("agree on 1; baseline sent 1 and raised TypeError; now sent 7 and reached its terminal"),
+    ),
+    "pause_prompt_args/raises_an_unreadable_error": Intended(
+        A_VALUE_THAT_CANNOT_BE_READ_NO_LONGER_ENDS_THE_RUN,
+        _everywhere("agree on 1; baseline sent 1 and raised TypeError; now sent 7 and reached its terminal"),
+    ),
+    "pause_prompt_args/set": Intended(
+        A_VALUE_THAT_CANNOT_BE_READ_NO_LONGER_ENDS_THE_RUN,
+        _everywhere("agree on 1; baseline sent 1 and raised TypeError; now sent 7 and reached its terminal"),
+    ),
+    "pause_prompt_content/raises_on_serialization": Intended(
+        A_VALUE_THAT_CANNOT_BE_READ_NO_LONGER_ENDS_THE_RUN,
+        _everywhere("agree on 1; baseline sent 1 and raised RuntimeError; now sent 7 and reached its terminal"),
+    ),
+    "pause_prompt_content/raises_an_unreadable_error": Intended(
+        A_VALUE_THAT_CANNOT_BE_READ_NO_LONGER_ENDS_THE_RUN,
+        _everywhere("agree on 1; baseline sent 1 and raised UnrenderableError; now sent 7 and reached its terminal"),
+    ),
+    "run_error_message/raises_on_serialization": Intended(
+        A_VALUE_THAT_CANNOT_BE_READ_NO_LONGER_ENDS_THE_RUN,
+        {
+            None: "agree on 4; baseline sent 4 and raised RuntimeError; now sent 6 and reached its terminal",
+            "inline": "agree on 4; baseline sent 4 and raised RuntimeError; now sent 6 and reached its terminal",
+            "attributed": "agree on 5; baseline sent 5 and raised RuntimeError; now sent 8 and reached its terminal",
+            "hidden": "agree on 1; baseline sent 1 and raised RuntimeError; now sent 2 and reached its terminal",
+        },
+    ),
+    "run_error_message/raises_an_unreadable_error": Intended(
+        A_VALUE_THAT_CANNOT_BE_READ_NO_LONGER_ENDS_THE_RUN,
+        {
+            None: "agree on 4; baseline sent 4 and raised UnrenderableError; now sent 6 and reached its terminal",
+            "inline": "agree on 4; baseline sent 4 and raised UnrenderableError; now sent 6 and reached its terminal",
+            "attributed": "agree on 5; baseline sent 5 and raised UnrenderableError; now sent 8 and reached its terminal",
+            "hidden": "agree on 1; baseline sent 1 and raised UnrenderableError; now sent 2 and reached its terminal",
+        },
+    ),
+    "run_error_lane_message/raises_on_serialization": Intended(
+        A_VALUE_THAT_CANNOT_BE_READ_NO_LONGER_ENDS_THE_RUN,
+        {
+            None: "agree on 4; baseline sent 4 and raised RuntimeError; now sent 6 and reached its terminal",
+            "inline": "agree on 4; baseline sent 4 and raised RuntimeError; now sent 6 and reached its terminal",
+            "attributed": "agree on 5; baseline sent 5 and raised RuntimeError; now sent 8 and reached its terminal",
+            "hidden": "agree on 1; baseline sent 1 and raised RuntimeError; now sent 2 and reached its terminal",
+        },
+    ),
+    "run_error_lane_message/raises_an_unreadable_error": Intended(
+        A_VALUE_THAT_CANNOT_BE_READ_NO_LONGER_ENDS_THE_RUN,
+        {
+            None: "agree on 4; baseline sent 4 and raised UnrenderableError; now sent 6 and reached its terminal",
+            "inline": "agree on 4; baseline sent 4 and raised UnrenderableError; now sent 6 and reached its terminal",
+            "attributed": "agree on 5; baseline sent 5 and raised UnrenderableError; now sent 8 and reached its terminal",
+            "hidden": "agree on 1; baseline sent 1 and raised UnrenderableError; now sent 2 and reached its terminal",
+        },
+    ),
+    "subagent_error_message/raises_an_unreadable_error": Intended(
+        A_VALUE_THAT_CANNOT_BE_READ_NO_LONGER_ENDS_THE_RUN,
+        {
+            "attributed": "agree on 3; baseline sent 4 and raised RuntimeError; now sent 5 and reached its terminal",
+            "hidden": "agree on 1; baseline sent 1 and raised RuntimeError; now sent 2 and reached its terminal",
+        },
+    ),
+    "subagent_error_correlation/raises_an_unreadable_error": Intended(
+        A_VALUE_THAT_CANNOT_BE_READ_NO_LONGER_ENDS_THE_RUN,
+        {
+            "attributed": "agree on 3; baseline sent 3 and raised RuntimeError; now sent 5 and reached its terminal",
+            "hidden": "agree on 1; baseline sent 1 and raised RuntimeError; now sent 2 and reached its terminal",
+        },
+    ),
+    "subagent_cancellation_reason/raises_an_unreadable_error": Intended(
+        A_VALUE_THAT_CANNOT_BE_READ_NO_LONGER_ENDS_THE_RUN,
+        {
+            "attributed": "agree on 3; baseline sent 4 and raised RuntimeError; now sent 5 and reached its terminal",
+            "hidden": "agree on 1; baseline sent 1 and raised RuntimeError; now sent 2 and reached its terminal",
+        },
+    ),
+    "pause_tool_id/circular": Intended(
+        A_PENDING_CALL_WITH_AN_UNUSABLE_ID_FAILS_UNDER_A_DIFFERENT_NAME,
+        _everywhere("agree on 1; baseline sent 1 and raised ValidationError; now sent 1 and raised TypeError"),
+    ),
+    "pause_tool_id/set": Intended(
+        A_PENDING_CALL_WITH_AN_UNUSABLE_ID_FAILS_UNDER_A_DIFFERENT_NAME,
+        _everywhere("agree on 1; baseline sent 1 and raised ValidationError; now sent 1 and raised TypeError"),
+    ),
+    "shared-path/a_failed_run_whose_chunk_names_a_member": Intended(
+        THE_VERBATIM_CHUNK_IS_WITHHELD_WHERE_NO_MEMBER_MAY_BE_NAMED,
+        {"hidden": "agree on 1; baseline sent 2 and reached its terminal; now sent 2 and reached its terminal"},
+    ),
+    "shared-path/a_session_state_that_cannot_be_copied": Intended(
+        THE_TERMINAL_STATE_SNAPSHOT_IS_DROPPED_RATHER_THAN_ENDING_THE_RUN,
+        _everywhere("agree on 1; baseline sent 1 and raised RuntimeError; now sent 2 and reached its terminal"),
+    ),
+}
+
+
+def _expected(name: str, visibility: Optional[str]) -> str:
+    intended = INTENDED_DIFFERENCES.get(name)
+    if intended is None:
+        return IDENTICAL
+    return intended.divergence.get(visibility, IDENTICAL)
+
+
+def _servable(visibility: Optional[str]) -> bool:
+    return visibility != SUBAGENT_VISIBILITY_ATTRIBUTED or ATTRIBUTED_IS_SERVABLE
+
+
+_CASES = [pytest.param(name, builder, id=name) for name, builder in STREAMS]
+
+
+# --- The sweep ---------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("name,builder", _CASES)
+async def test_the_client_receives_what_it_received_before_the_outcome_existed(name, builder):
+    """One stream, every visibility, both mappers, against the released interface.
+
+    The visibilities and the mappers are walked inside one test rather than
+    parametrized out, because what has to hold is that they all say the same
+    thing: the setting is about a run's terminal and never about which mapper
+    drove it, so the two mappers disagreeing is itself a defect and is reported
+    as one here rather than as two unrelated failures.
+    """
+    for visibility in VISIBILITIES:
+        if not _servable(visibility):
+            continue
+        stated = _expected(name, visibility)
+        for mapper in MAPPERS:
+            stream = builder()
+            before, after = await through_both_trees(stream.chunks, stream.run_state, visibility, mapper)
+
+            assert divergence(before, after) == stated, (
+                f"the {mapper} mapper now sends something else for {name} under subagent_visibility="
+                f"{visibility!r} with emit_interrupt_outcome off. With the outcome off a client has to "
+                "receive the stream it received before the outcome existed. If this difference is meant, "
+                f"state it in INTENDED_DIFFERENCES with the reason it is meant.\n"
+                f"{where_they_part(before, after)}"
+            )
+
+
+class TestTheSweepCannotGoQuiet:
+    """The sweep's own guards, since a comparison that stopped comparing looks green."""
+
+    def test_every_stated_difference_names_a_stream_the_sweep_drives(self):
+        """A stated difference for a stream nobody drives forgives nothing and hides that it does."""
+        driven = {name for name, _ in STREAMS}
+        assert sorted(set(INTENDED_DIFFERENCES) - driven) == []
+
+    def test_every_stated_difference_gives_a_reason(self):
+        for name, intended in INTENDED_DIFFERENCES.items():
+            assert intended.reason.strip(), f"{name} is exempted from the comparison with no reason given"
+            assert intended.divergence, f"{name} is listed as differing and names no visibility it differs under"
+
+    def test_no_stated_difference_says_two_streams_are_identical(self):
+        """``identical`` in the table is a difference blessed into invisibility."""
+        said_twice = sorted(
+            name for name, intended in INTENDED_DIFFERENCES.items() if IDENTICAL in intended.divergence.values()
+        )
+        assert said_twice == []
+
+    def test_every_stream_the_reused_tables_hold_is_swept(self):
+        """The enumerations are read, not listed, so an empty one would sweep nothing and pass.
+
+        Counted against the tables rather than against a floor: a floor passes
+        while a table is halved, and the whole reason these are read rather than
+        listed is that the set has to follow them.
+        """
+        from_content = len(CONTENT_BOUNDARIES) * (1 + len(HOSTILE_VALUES))
+        from_pauses = len(_PAUSE_SHAPES) + len(_PAUSES_NOTHING_CAN_ANSWER)
+        assert len(STREAMS) == from_content + from_pauses + len(SHARED_PATH_STREAMS)
+        assert len({name for name, _ in STREAMS}) == len(STREAMS), "two streams share a name, so one is unstated"
+
+    def test_the_two_trees_are_not_the_same_module(self):
+        """Every assertion above is vacuous if the baseline resolved to the live package."""
+        assert baseline_stream_module is not live_stream_module
+        assert baseline_run_entity is not live_run_entity
+        assert baseline_stream_module.stream_agno_response_as_agui_events.__module__.startswith(
+            agui_baseline_tree.BASELINE_PACKAGE
+        )
+
+
+class TestTheNormalisationIsNarrow:
+    """What the one rewrite does and does not equate.
+
+    A normalisation wide enough to hide a change is the way a comparison like this
+    stops meaning anything, so the rule is held to what it claims: shape, and
+    first-seen order.
+    """
+
+    def test_nothing_but_a_minted_id_is_rewritten(self):
+        original = {"tool": "send_email", "count": 3, "flag": True, "nothing": None, "list": ["tc-a", 1.5]}
+        assert aliased(copy.deepcopy(original), {}) == original
+
+    def test_one_id_keeps_one_alias_wherever_it_appears(self):
+        minted: Dict[str, str] = {}
+        identifier = "11111111-2222-3333-4444-555555555555"
+        assert aliased({"a": identifier, "b": [identifier]}, minted) == {"a": "minted-1", "b": ["minted-1"]}
+
+    def test_two_ids_never_collapse_into_one(self):
+        first = "11111111-2222-3333-4444-555555555555"
+        second = "66666666-7777-8888-9999-000000000000"
+        assert aliased([first, second, first], {}) == ["minted-1", "minted-2", "minted-1"]
+
+    def test_a_stream_that_minted_one_more_id_is_not_equal_to_one_that_reused_it(self):
+        """Which is what an interface minting an id where it used to reuse one looks like."""
+        first = "11111111-2222-3333-4444-555555555555"
+        second = "66666666-7777-8888-9999-000000000000"
+        assert aliased([first, first], {}) != aliased([first, second], {})
+
+
+class TestTheBaselineIsTheReleasedInterface:
+    """The snapshot held against the commit it was taken from.
+
+    Everything above compares this interface with a copy of the old one, which is
+    worth exactly what that copy is worth. So the copy is checked back against the
+    commit, whenever the checkout can still reach it. It will not always: this
+    branch's history is not guaranteed to survive the way it lands. That is why
+    the snapshot is checked in rather than read out of the commit at run time, and
+    why this check skips where it cannot run instead of taking the comparison down
+    with it.
+    """
+
+    def _at_the_baseline_commit(self, module: str) -> str:
+        import subprocess
+
+        path = f"{agui_baseline_tree.PACKAGE_PATH_IN_REPO}/{module}.py"
+        found = subprocess.run(
+            ["git", "show", f"{agui_baseline_tree.BASELINE_COMMIT}:{path}"],
+            capture_output=True,
+            text=True,
+            cwd=Path(__file__).resolve().parents[5],
+        )
+        if found.returncode != 0:
+            pytest.skip(f"this checkout cannot read {path} at {agui_baseline_tree.BASELINE_COMMIT}")
+        return found.stdout
+
+    def test_every_snapshot_module_is_the_file_that_was_released(self):
+        for module, source in agui_baseline_tree.snapshot_sources().items():
+            assert source == self._at_the_baseline_commit(module), (
+                f"the checked-in baseline of {module}.py is not what {agui_baseline_tree.BASELINE_COMMIT} "
+                "released, so the comparison above is against something nobody shipped"
+            )
+
+    def test_the_snapshot_covers_the_whole_package(self):
+        """A module left out would resolve to today's, and compare it with itself."""
+        live = {path.stem for path in Path(live_stream_module.__file__).parent.glob("*.py")}
+        snapshot = set(agui_baseline_tree.snapshot_sources())
+        assert sorted(live - snapshot) == ["interrupts"], (
+            "the package gained a module the baseline does not have a copy of, so the baseline imports today's"
+        )
+
+    def test_the_rewrite_touches_only_this_packages_own_imports(self):
+        """The one edit made on the way in, held to being the one it claims."""
+        for module, source in agui_baseline_tree.snapshot_sources().items():
+            rewritten = agui_baseline_tree.rewritten(source)
+            assert agui_baseline_tree.LIVE_PACKAGE not in rewritten, f"{module}.py still imports the live package"
+            assert rewritten == source.replace(agui_baseline_tree.LIVE_PACKAGE, agui_baseline_tree.BASELINE_PACKAGE), (
+                f"the rewrite of {module}.py changed something other than the package it names"
+            )
+
+
+# --- A terminal that cannot be built at all ----------------------------------
+
+
+class _TerminalBoom(Exception):
+    pass
+
+
+def _the_terminal_explodes(*_: Any, **__: Any) -> Any:
+    raise _TerminalBoom("terminal exploded")
+
+
+def _a_run_that_pauses_mid_message() -> List[Any]:
+    """A run holding an open message and an open tool call when its terminal is built."""
+    from .test_agui_interrupts import _mid_message_pause_chunks
+
+    return _mid_message_pause_chunks()
+
+
+class TestATerminalThatCannotBeBuilt:
+    """The one shared-path change that no stream reaches without a fault injected.
+
+    The terminal used to sit outside the guard that closes what the stream opened,
+    so a raise from it sent no span end and no terminal. Reaching that needs the
+    terminal to raise, which is a fault rather than a value, so it is driven by
+    the same injection in both trees rather than written into the table above.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("mapper", MAPPERS)
+    async def test_the_spans_the_run_left_open_are_now_closed_before_the_failure(self, mapper, monkeypatch, caplog):
+        monkeypatch.setattr(live_stream_module, "process_completion", _the_terminal_explodes)
+        monkeypatch.setattr(baseline_stream_module, "process_completion", _the_terminal_explodes)
+
+        before, after = await through_both_trees(_a_run_that_pauses_mid_message(), None, None, mapper)
+
+        assert before.failure == after.failure, "the failure a client is told about changed"
+        assert [event["type"] for event in after.events[len(before.events) :]] == [
+            "TOOL_CALL_END",
+            "TEXT_MESSAGE_END",
+        ], "the spans the baseline left open are not the ones this interface closes"
+        assert after.events[: len(before.events)] == before.events, (
+            "closing the open spans changed something the baseline had already sent"
+        )
+
+
+# --- Where the line falls: the route ------------------------------------------
+
+PAUSED_REQUIREMENT_ID = "11111111-2222-3333-4444-555555555555"
+PAUSED_CALL_ID = "tc-paused"
+
+
+class _RecordingEntity(Agent):
+    """An Agent that answers the route and records what it was asked to do.
+
+    The route's own decisions are what this class is here to read. Its run is a
+    fixed chunk list, so the body is the same on both trees by construction and
+    the only thing left to compare is the call the route made.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(name="Recorder", id="recorder", db=InMemoryDb())
+        self.asked: List[Tuple[str, Dict[str, Any]]] = []
+
+    def _one_run(self) -> Any:
+        async def source() -> AsyncIterator[Any]:
+            yield RunStartedEvent(run_id="paused-run")
+            yield RunCompletedEvent(content="done", run_id="paused-run")
+
+        return source()
+
+    def _record(self, call: str, kwargs: Dict[str, Any]) -> Any:
+        # Only what the route decided, not the objects it built: a RunContext and
+        # a requirement list are compared by identity and would report every call
+        # as different.
+        readable = {key: value for key, value in kwargs.items() if isinstance(value, (str, bool, int, type(None)))}
+        self.asked.append((call, readable))
+        return self._one_run()
+
+    def arun(self, **kwargs: Any) -> Any:
+        return self._record("arun", kwargs)
+
+    def acontinue_run(self, **kwargs: Any) -> Any:
+        return self._record("acontinue_run", kwargs)
+
+    async def aget_session(self, session_id: Optional[str] = None, **_: Any) -> Any:
+        requirement = RunRequirement(
+            tool_execution=ToolExecution(
+                tool_call_id=PAUSED_CALL_ID, tool_name="send_email", requires_confirmation=True
+            )
+        )
+        requirement.id = PAUSED_REQUIREMENT_ID
+        return AgentSession(
+            session_id=session_id,
+            runs=[RunOutput(run_id="paused-run", status=RunStatus.paused, requirements=[requirement])],
+        )
+
+
+def _request(**overrides: Any) -> RunAgentInput:
+    fields: Dict[str, Any] = dict(
+        thread_id=THREAD_ID,
+        run_id="request-1",
+        state={},
+        messages=[UserMessage(id="m1", role="user", content="go")],
+        tools=[],
+        context=[],
+        forwarded_props={},
+    )
+    fields.update(overrides)
+    return RunAgentInput(**fields)
+
+
+_CARRIES_CONTEXT = [{"description": "the caller's own context", "value": "kept"}]
+_ANSWERS_THE_CALL = ToolMessage(id="t1", role="tool", tool_call_id=PAUSED_CALL_ID, content='{"accepted": true}')
+
+
+async def _through_both_routes(request: RunAgentInput) -> Tuple[Tuple[Received, List[Any]], Tuple[Received, List[Any]]]:
+    """One request through both routes, each against its own recorder."""
+    results = []
+    for route in (baseline_run_entity, live_run_entity):
+        entity = _RecordingEntity()
+        kwargs: Dict[str, Any] = {}
+        if route is live_run_entity:
+            kwargs["emit_interrupt_outcome"] = THE_OUTCOME_IS_OFF
+        events = [event async for event in route(entity, request, **kwargs)]
+        results.append((received(events, None), entity.asked))
+    return results[0], results[1]
+
+
+class TestTheRouteChoosesWhatItChose:
+    """Where identity stops being about emission.
+
+    The two things the route now decides differently are decisions rather than
+    events: they change what the entity is asked to do, which a scripted entity's
+    stream cannot show and a real run would. So they are read off the call the
+    route made, and both are stated here rather than left to be noticed.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_fresh_run_is_asked_for_in_the_same_words(self):
+        (before_body, before_asked), (after_body, after_asked) = await _through_both_routes(_request())
+
+        assert after_asked == before_asked
+        assert after_body == before_body
+
+    @pytest.mark.asyncio
+    async def test_a_fresh_run_carrying_context_still_gets_the_dependency_option(self):
+        """The option belongs to the branch that builds a user message, which this is."""
+        (_, before_asked), (_, after_asked) = await _through_both_routes(_request(context=_CARRIES_CONTEXT))
+
+        assert before_asked[0][1]["add_dependencies_to_context"] is True
+        assert after_asked == before_asked
+
+    @pytest.mark.asyncio
+    async def test_a_resume_is_continued_in_the_same_words(self):
+        request = _request(messages=[UserMessage(id="m1", role="user", content="go"), _ANSWERS_THE_CALL])
+
+        (before_body, before_asked), (after_body, after_asked) = await _through_both_routes(request)
+
+        assert [call for call, _ in after_asked] == ["acontinue_run"]
+        assert after_asked == before_asked
+        assert after_body == before_body
+
+    @pytest.mark.asyncio
+    async def test_a_resume_carrying_context_no_longer_gets_the_fresh_run_option(self):
+        """The first of the two intended route differences.
+
+        A continue replays the paused run's stored messages instead of building a
+        user message, so the option that decides how one is built had nothing to
+        act on there. The request's context still reaches the resumed run through
+        the run context, which is why dropping the option takes nothing away.
+        """
+        request = _request(
+            messages=[UserMessage(id="m1", role="user", content="go"), _ANSWERS_THE_CALL],
+            context=_CARRIES_CONTEXT,
+        )
+
+        (_, before_asked), (_, after_asked) = await _through_both_routes(request)
+
+        assert before_asked[0][1]["add_dependencies_to_context"] is True
+        assert "add_dependencies_to_context" not in after_asked[0][1]
+        # Nothing else about the call moved with it.
+        assert [call for call, _ in after_asked] == [call for call, _ in before_asked]
+        assert {key: value for key, value in before_asked[0][1].items() if key != "add_dependencies_to_context"} == (
+            after_asked[0][1]
+        )
+
+    @pytest.mark.asyncio
+    async def test_an_answer_in_the_resume_array_now_continues_the_run(self):
+        """The second, and the one a released client cannot reach.
+
+        The array is how a client answers the interrupts a terminal advertised,
+        and with the outcome off this interface advertises none, so nothing it
+        sends can prompt one. A client that sends one anyway used to get a fresh
+        run, with its answers silently unread.
+        """
+        request = _request(
+            resume=[{"interrupt_id": PAUSED_REQUIREMENT_ID, "status": "resolved", "payload": {"accepted": True}}]
+        )
+
+        (_, before_asked), (_, after_asked) = await _through_both_routes(request)
+
+        assert [call for call, _ in before_asked] == ["arun"]
+        assert [call for call, _ in after_asked] == ["acontinue_run"]

--- a/libs/agno/tests/unit/os/interfaces/test_agui_hostile_run_content.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_hostile_run_content.py
@@ -1,0 +1,1436 @@
+"""Hostile run content driven through every AG-UI event-building boundary.
+
+A member result that could not be serialized once turned a successful run into a
+failed one, so that one boundary was hardened to fall back rather than raise.
+Nothing checked the others. This module drives one table of hostile values
+through every place the interface builds an AG-UI event out of run content, and
+pins, per cell, what actually happens today:
+
+``TERMINATES``
+    The run reaches its own terminal with the value rendered, dropped or
+    replaced, the stream is well formed, and every event it carries is one the
+    protocol's own encoder can put on a wire.
+``TERMINATES_UNSENDABLE``
+    The run reaches its terminal in memory, but the event THIS boundary built is
+    one that encoder refuses. On a real wire the response body stops at that
+    event: the client is left with a truncated stream and no terminal at all.
+    Worse than a failed run, and reported as a finding rather than fixed here.
+``dies_on(...)``
+    The run reaches its terminal, this boundary's own event is one the encoder
+    accepts, and the stream dies at some other event instead. The verdict names
+    that event, because the same value can be harmless where this boundary
+    reads it and fatal where another one does, and a cell that did not say
+    which credited the wrong boundary with the failure.
+``DROPPED_BEFORE_THE_BOUNDARY``
+    The run terminates, every event it carries is sendable, and the event this
+    boundary builds was never emitted: the value was discarded before the
+    boundary was reached. Such a cell pins the extractor that swallowed it
+    rather than the boundary, which is why it is named instead of counted as a
+    success.
+``dropped_and_dies_on(...)``
+    The value was discarded before the boundary AND the stream is one the
+    encoder refuses elsewhere, so the client never sees the run's terminal. Read
+    without consulting the encoder, such a cell reported a truncated stream as a
+    run that reached the client.
+``ENDS_THE_RUN``
+    Building the event raises, the mapper's own cleanup closes what it opened,
+    and the failure propagates instead of the run terminal. The client sees a
+    failed run rather than a rendered one, but nothing is left dangling.
+``ENDS_THE_RUN_MALFORMED``
+    Building the event raises AFTER the mapper recorded the span in its state,
+    so the wire is left with a span the client can never resolve: a tool call
+    with no end, a reasoning block ended without a start, or a text message left
+    open. This is worse than a failed run and is reported as a finding rather
+    than fixed here.
+
+Five things keep a cell from going green, or red, for the wrong reason. Every
+cell drives its boundary with content the boundary handles, so a verdict is
+attributable to the value the case injected rather than to a broken fixture or a
+misconfigured stream. Each fixture injects the value at one boundary only: a
+fixture that put it in two places reported whichever the interface read first
+under the name of the other. The verdict says whether the boundary's own event
+reached the wire before it attributes a refusal, and it consults the encoder
+either way, so a stream carrying some other unsendable event cannot stand in for
+this boundary building one and a boundary that built nothing cannot hide one.
+Every boundary is driven with every hostile value, checked against an
+independent list of those values, so a row cannot quietly stop being swept and a
+value added to the shared table cannot go undriven. And the set of boundaries
+itself is recomputed from the interface's own source, per function AND per event
+type: every event each scope of the package constructs is claimed by a row,
+covered by a named test here, or justified as built out of no run content, so a
+function that builds six events cannot be counted as driven because one row
+drives one of them.
+
+One row is not an event boundary at all: the identifiers a member's failure is
+recorded with never reach the wire, so that row drives its value through the log
+line the member's terminal is accompanied by, and pins the terminal it must not
+prevent. Everything else in that row reads exactly like the others.
+
+The table is the point. Hardening any boundary flips its cells, which fails this
+module and forces the table to be brought up to date rather than letting the new
+behavior go unrecorded. The same cells are asserted under the default
+visibility, which differs only by the member lifecycle, so a boundary that
+behaves differently there is a difference the default was not supposed to have.
+A boundary that builds nothing under the default is still held to what the rest
+of that stream did with the value, the encoder included, since the member's own
+chunks go out there as RAW.
+
+The whole module holds on a protocol release without the lineage events too. The
+interface builds those behind a guarded import, so on such a release its source
+constructs none of them; the coverage check leaves an event type the installed
+protocol does not define out of the comparison on both sides rather than
+reporting the rows naming it as claims about nothing.
+"""
+
+from types import MappingProxyType
+from typing import Any, Callable, Dict, List, Mapping, NamedTuple, Optional, Set, Tuple
+
+import pytest
+
+pytest.importorskip("ag_ui", reason="ag_ui not installed")
+
+from ag_ui.core import BaseEvent, EventType, RunAgentInput, UserMessage
+
+from agno.models.response import ToolExecution
+from agno.os.interfaces.agui.router import run_entity
+from agno.reasoning.step import ReasoningStep
+from agno.run.agent import (
+    CustomEvent,
+    ReasoningContentDeltaEvent,
+    ReasoningStepEvent,
+    RunCancelledEvent,
+    RunCompletedEvent,
+    RunErrorEvent,
+    RunStartedEvent,
+    ToolCallCompletedEvent,
+    ToolCallStartedEvent,
+)
+from agno.run.requirement import RunRequirement
+from agno.run.team import RunCompletedEvent as TeamRunCompletedEvent
+from agno.run.team import RunContentEvent as TeamRunContentEvent
+from agno.run.team import RunErrorEvent as TeamRunErrorEvent
+from agno.run.team import RunPausedEvent as TeamRunPausedEvent
+from agno.run.team import RunStartedEvent as TeamRunStartedEvent
+
+from .agui_stream_invariants import (
+    HOSTILE_VALUES,
+    TOP_LEVEL_RUN,
+    MalformedCollected,
+    SideEffect,
+    agent_said,
+    assert_stream_contains,
+    attributed,
+    collect_async_recording_violations,
+    collect_sync_recording_violations,
+    encoding_failures,
+    event_type_named,
+    lane_of,
+    member_chunk_kwargs,
+    of_type,
+    short_type_name,
+    team_chunk_kwargs,
+    team_said,
+)
+from .test_agui_documented_contract import event_constructions_by_function
+
+THREAD_ID = "hostile-session"
+# The same lineage fields the attribution suite builds its chunks from.
+_TOP_LEVEL = team_chunk_kwargs("research-team", "Research Team", TOP_LEVEL_RUN)
+_MEMBER = member_chunk_kwargs("scout", "run-scout")
+
+TERMINATES = "terminates"
+TERMINATES_UNSENDABLE = "terminates in memory and dies on the wire at this boundary's own event"
+DROPPED_BEFORE_THE_BOUNDARY = "terminates, with the value dropped before the boundary"
+ENDS_THE_RUN = "ends the run"
+ENDS_THE_RUN_MALFORMED = "ends the run and leaves the stream malformed"
+
+_DIES_ELSEWHERE = "terminates, with this boundary's own event sendable and the stream dying on "
+_DROPPED_AND_DIES_ELSEWHERE = "terminates, with the value dropped before the boundary and the stream dying on "
+
+
+def _naming(prefix: str, event_names: Tuple[str, ...]) -> str:
+    assert event_names, "a verdict about a refused event has to name the event"
+    return prefix + ", ".join(sorted(event_names))
+
+
+def dies_on(*event_names: str) -> str:
+    """The verdict for a stream the encoder refuses somewhere other than here.
+
+    The event is named, so a cell cannot report a stream-wide refusal as though
+    this boundary had built the event the encoder choked on.
+    """
+    return _naming(_DIES_ELSEWHERE, event_names)
+
+
+def dropped_and_dies_on(*event_names: str) -> str:
+    """The verdict for a value dropped before the boundary on a stream that still dies.
+
+    "Dropped" alone is a claim that the run reached the client, which is false
+    of a stream the encoder refuses partway through. The value never reached
+    this boundary AND the client is left with a truncated stream, so the cell
+    has to say both and name the event that truncated it.
+    """
+    return _naming(_DROPPED_AND_DIES_ELSEWHERE, event_names)
+
+
+# What every surviving verdict has in common, for the one claim that holds
+# across all of them.
+REACHES_ITS_TERMINAL = "reaches its terminal"
+_ENDED = (ENDS_THE_RUN, ENDS_THE_RUN_MALFORMED)
+
+
+def _survives(verdict: str) -> bool:
+    return verdict not in _ENDED
+
+
+def _is_a_verdict(outcome: str) -> bool:
+    """Whether an outcome is one this module can actually reach."""
+    return outcome in (TERMINATES, TERMINATES_UNSENDABLE, DROPPED_BEFORE_THE_BOUNDARY, *_ENDED) or outcome.startswith(
+        (_DIES_ELSEWHERE, _DROPPED_AND_DIES_ELSEWHERE)
+    )
+
+
+_HOSTILE = dict(HOSTILE_VALUES)
+_RUN_TERMINALS = (EventType.RUN_FINISHED, EventType.RUN_ERROR)
+
+
+class Fixture(NamedTuple):
+    """One boundary's chunk list, and the session state the run carries with it."""
+
+    chunks: List[Any]
+    run_state: Optional[Dict[str, Any]] = None
+
+
+# --- Chunk lists, one per event-building boundary ----------------------------
+
+
+def _member_run(*inner: Any) -> List[Any]:
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**_MEMBER),
+        *inner,
+        RunCompletedEvent(content="scout done", **_MEMBER),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+def _member_terminal_result(value: Any) -> Fixture:
+    """The member terminal's ``result``, built by the one hardened boundary."""
+    return Fixture(
+        [
+            TeamRunStartedEvent(**_TOP_LEVEL),
+            RunStartedEvent(**_MEMBER),
+            RunCompletedEvent(content=value, **_MEMBER),
+            TeamRunCompletedEvent(**_TOP_LEVEL),
+        ]
+    )
+
+
+def _agent_text_delta(value: Any) -> Fixture:
+    """TEXT_MESSAGE_CONTENT built from an Agent chunk's content."""
+    return Fixture(_member_run(agent_said(value, **_MEMBER)))
+
+
+def _team_text_delta(value: Any) -> Fixture:
+    """TEXT_MESSAGE_CONTENT built from a Team chunk's own content."""
+    leader = TeamRunContentEvent(**_TOP_LEVEL)
+    leader.content = value
+    return Fixture([TeamRunStartedEvent(**_TOP_LEVEL), leader, TeamRunCompletedEvent(**_TOP_LEVEL)])
+
+
+def _team_member_response_delta(value: Any) -> Fixture:
+    """TEXT_MESSAGE_CONTENT built by folding a Team chunk's nested member outputs.
+
+    The leader says nothing of its own here. Its own text would put a delta on
+    the wire whatever the fold did with the member's output, which is a green
+    cell for a boundary the case never exercised.
+    """
+    leader = TeamRunContentEvent(**_TOP_LEVEL)
+    leader.member_responses = [agent_said(value, **_MEMBER)]
+    return Fixture([TeamRunStartedEvent(**_TOP_LEVEL), leader, TeamRunCompletedEvent(**_TOP_LEVEL)])
+
+
+def _tool_call_args(value: Any) -> Fixture:
+    """TOOL_CALL_ARGS built from a tool call's arguments."""
+    tool = ToolExecution(tool_call_id="tc-hostile", tool_name="do_it", tool_args=value)
+    return Fixture(
+        _member_run(ToolCallStartedEvent(tool=tool, **_MEMBER), ToolCallCompletedEvent(tool=tool, **_MEMBER))
+    )
+
+
+def _tool_call_result(value: Any) -> Fixture:
+    """TOOL_CALL_RESULT built from a tool call's result."""
+    tool = ToolExecution(tool_call_id="tc-hostile", tool_name="do_it", tool_args={}, result=value)
+    return Fixture(
+        _member_run(ToolCallStartedEvent(tool=tool, **_MEMBER), ToolCallCompletedEvent(tool=tool, **_MEMBER))
+    )
+
+
+def _reasoning_content_delta(value: Any) -> Fixture:
+    """REASONING_MESSAGE_CONTENT built from a streamed reasoning delta."""
+    chunk = ReasoningContentDeltaEvent(**_MEMBER)
+    chunk.reasoning_content = value
+    return Fixture(_member_run(chunk))
+
+
+def _reasoning_step_payload(value: Any) -> Fixture:
+    """REASONING_MESSAGE_CONTENT built from a reasoning step that is not one."""
+    chunk = ReasoningStepEvent(**_MEMBER)
+    chunk.content = value
+    return Fixture(_member_run(chunk))
+
+
+def _reasoning_step_field(value: Any) -> Fixture:
+    """REASONING_MESSAGE_CONTENT built from a reasoning step holding hostile text."""
+    step = ReasoningStep(title="scout plan", reasoning="scout is thinking")
+    step.reasoning = value
+    chunk = ReasoningStepEvent(**_MEMBER)
+    chunk.content = step
+    return Fixture(_member_run(chunk))
+
+
+def _custom_event_payload(value: Any) -> Fixture:
+    """CUSTOM built from a custom chunk's own dump."""
+    chunk = CustomEvent(**_MEMBER)
+    chunk.to_dict = lambda: {"payload": value}  # type: ignore[method-assign]
+    return Fixture(_member_run(chunk))
+
+
+def _raw_event_payload(value: Any) -> Fixture:
+    """RAW built from an unmapped chunk's own dump.
+
+    The stream opens on the leader's own text rather than on a run-started
+    chunk, which this interface passes through as RAW itself. With one of those
+    ahead of it, a RAW is on the wire whatever this boundary does, so the
+    boundary's own event can never be reported missing and a dump discarded
+    before the boundary would read as one that reached it.
+    """
+    chunk = RunStartedEvent(**_MEMBER)
+    chunk.to_dict = lambda: {"event": "RunStarted", "payload": value}  # type: ignore[method-assign]
+    return Fixture(
+        [
+            team_said("leader speaking", **_TOP_LEVEL),
+            chunk,
+            RunCompletedEvent(content="scout done", **_MEMBER),
+            TeamRunCompletedEvent(**_TOP_LEVEL),
+        ]
+    )
+
+
+def _failing_run_with_a_member_mid_sentence(value: Any) -> Fixture:
+    """A run that fails on hostile content while a member is still streaming.
+
+    Two boundaries read that content: the run terminal the client is told about,
+    and the terminal every member lane still open is closed with.
+    """
+    return Fixture(
+        [
+            TeamRunStartedEvent(**_TOP_LEVEL),
+            RunStartedEvent(**_MEMBER),
+            agent_said("half a sen", **_MEMBER),
+            TeamRunErrorEvent(content=value, error_type="RuntimeError", **_TOP_LEVEL),
+        ]
+    )
+
+
+def _state_delta(value: Any) -> Fixture:
+    """STATE_DELTA built by diffing the session state a member's tool changed."""
+    session_state: Dict[str, Any] = {"approved": False}
+    tool = ToolExecution(tool_call_id="tc-approve", tool_name="approve", tool_args={}, result="ok")
+    return Fixture(
+        [
+            TeamRunStartedEvent(**_TOP_LEVEL),
+            RunStartedEvent(**_MEMBER),
+            ToolCallStartedEvent(tool=tool, **_MEMBER),
+            # Applied while the stream is being consumed, so the delta really is
+            # computed from a change the client had not seen yet.
+            SideEffect(lambda: session_state.__setitem__("value", value)),
+            ToolCallCompletedEvent(tool=tool, **_MEMBER),
+            RunCompletedEvent(content="scout done", **_MEMBER),
+            TeamRunCompletedEvent(**_TOP_LEVEL),
+        ],
+        run_state=session_state,
+    )
+
+
+# What a caller that says nothing about the paused run's words passes. A missing
+# argument cannot be spelled None here: None is one of the hostile values, and a
+# cell keyed on it would pin what an unset content does rather than what an
+# explicitly empty one does.
+_SAYS_NOTHING = object()
+
+
+def _paused_run(tool: ToolExecution, content: Any = _SAYS_NOTHING) -> Fixture:
+    """A run that pauses on one pending call, and says what it says while pausing.
+
+    One hostile value per fixture, never two. A pause reads its own words before
+    it builds any of the prompt, so a fixture injecting the value into both the
+    words and the call credited the call's boundary with whatever the words did
+    first: the value that cannot be rendered ends the run from inside
+    ``_pause_content``, several events before the arguments are serialized.
+    """
+    paused = TeamRunPausedEvent(tools=[tool], **_TOP_LEVEL)
+    if content is not _SAYS_NOTHING:
+        paused.content = content
+    return Fixture([TeamRunStartedEvent(**_TOP_LEVEL), paused])
+
+
+def _pause_prompt_args(value: Any) -> Fixture:
+    """TOOL_CALL_ARGS built from the arguments of a call a paused run waits on."""
+    return _paused_run(
+        ToolExecution(
+            tool_call_id="tc-hostile-confirm", tool_name="confirm", tool_args=value, requires_confirmation=True
+        )
+    )
+
+
+def _benign_pending_call() -> ToolExecution:
+    return ToolExecution(
+        tool_call_id="tc-hostile-confirm", tool_name="confirm", tool_args={"to": "ops"}, requires_confirmation=True
+    )
+
+
+def _pause_prompt_content(value: Any) -> Fixture:
+    """TEXT_MESSAGE_CONTENT built from what a paused run says while it waits."""
+    return _paused_run(_benign_pending_call(), content=value)
+
+
+def _pause_tool_name(value: Any) -> Fixture:
+    """TOOL_CALL_START built from the name of a call a paused run waits on."""
+    return _paused_run(
+        ToolExecution(
+            tool_call_id="tc-hostile-confirm", tool_name=value, tool_args={"to": "ops"}, requires_confirmation=True
+        )
+    )
+
+
+def _pause_tool_id(value: Any) -> Fixture:
+    """TOOL_CALL_START built from the id of a call a paused run waits on."""
+    return _paused_run(
+        ToolExecution(tool_call_id=value, tool_name="confirm", tool_args={"to": "ops"}, requires_confirmation=True)
+    )
+
+
+def _tool_call_name(value: Any) -> Fixture:
+    """TOOL_CALL_START built from the name the model gave the tool it called.
+
+    The call completes, as it does at the two boundaries above: a member's
+    terminal ends no tool call, so a call left dangling here would make the
+    benign row of this boundary a stream the run end closes after the member's
+    terminal, which is a shape of its own rather than anything this boundary is
+    about.
+    """
+    tool = ToolExecution(tool_call_id="tc-hostile", tool_name=value, tool_args={})
+    return Fixture(
+        _member_run(ToolCallStartedEvent(tool=tool, **_MEMBER), ToolCallCompletedEvent(tool=tool, **_MEMBER))
+    )
+
+
+def _tool_call_id(value: Any) -> Fixture:
+    """TOOL_CALL_START built from the id the model gave the call, which may be missing."""
+    tool = ToolExecution(tool_call_id=value, tool_name="do_it", tool_args={})
+    return Fixture(
+        _member_run(ToolCallStartedEvent(tool=tool, **_MEMBER), ToolCallCompletedEvent(tool=tool, **_MEMBER))
+    )
+
+
+def _subagent_error_message(value: Any) -> Fixture:
+    """SUBAGENT_ERROR's message, built from what a member's failing run reported.
+
+    The team finishes afterwards, so the member's failure is this boundary's
+    subject rather than the run terminal: read as the run's own terminal, which
+    is what the default does with it, the value would land at the RUN_ERROR
+    boundary above instead.
+    """
+    failure = RunErrorEvent(error_type="RuntimeError", **_MEMBER)
+    failure.content = value
+    return Fixture(
+        [
+            TeamRunStartedEvent(**_TOP_LEVEL),
+            RunStartedEvent(**_MEMBER),
+            failure,
+            TeamRunCompletedEvent(**_TOP_LEVEL),
+        ]
+    )
+
+
+def _subagent_error_correlation(value: Any) -> Fixture:
+    """The identifiers a member's failure is recorded with, alongside its SUBAGENT_ERROR."""
+    failure = RunErrorEvent(content="member exploded", error_type="RuntimeError", error_id="err-42", **_MEMBER)
+    failure.additional_data = {"attempt": value}
+    return Fixture(
+        [
+            TeamRunStartedEvent(**_TOP_LEVEL),
+            RunStartedEvent(**_MEMBER),
+            failure,
+            TeamRunCompletedEvent(**_TOP_LEVEL),
+        ]
+    )
+
+
+def _subagent_cancellation_reason(value: Any) -> Fixture:
+    """SUBAGENT_ERROR's message, built from the reason a member's run was cancelled."""
+    cancelled = RunCancelledEvent(**_MEMBER)
+    cancelled.reason = value
+    return Fixture(
+        [
+            TeamRunStartedEvent(**_TOP_LEVEL),
+            RunStartedEvent(**_MEMBER),
+            cancelled,
+            TeamRunCompletedEvent(**_TOP_LEVEL),
+        ]
+    )
+
+
+def _paused_member_name(value: Any) -> Fixture:
+    """SUBAGENT_STARTED's name, built from the identity a paused run names its member by.
+
+    The member id stays readable, so a name that cannot be read has somewhere to
+    fall back to and the announcement is still expected on the wire.
+    """
+    tool = ToolExecution(
+        tool_call_id="tc-member-confirm", tool_name="send_email", tool_args={"to": "ops"}, requires_confirmation=True
+    )
+    requirement = RunRequirement(tool)
+    requirement.member_agent_id = "scout"
+    requirement.member_run_id = "run-scout"
+    requirement.member_agent_name = value
+    return Fixture(
+        [
+            TeamRunStartedEvent(**_TOP_LEVEL),
+            TeamRunPausedEvent(tools=[], requirements=[requirement], **_TOP_LEVEL),
+        ]
+    )
+
+
+def _member_identity(value: Any) -> Fixture:
+    """SUBAGENT_STARTED built from the name and id a member's chunks carry."""
+    member = {"agent_id": value, "agent_name": value, "run_id": "run-anonymous", "parent_run_id": TOP_LEVEL_RUN}
+    return Fixture(
+        [
+            TeamRunStartedEvent(**_TOP_LEVEL),
+            RunStartedEvent(**member),
+            agent_said("member speaking", **member),
+            RunCompletedEvent(content="done", **member),
+            TeamRunCompletedEvent(**_TOP_LEVEL),
+        ]
+    )
+
+
+_ALL_VALUES = tuple(name for name, _ in HOSTILE_VALUES)
+
+# The values this table was written against, named rather than derived from the
+# shared list the sweep reads. Derived, the completeness check compares the
+# shared list with itself and holds however that list changes; named, a value
+# added to it lands here first and every row has to state an outcome for it.
+_HOSTILE_VALUE_NAMES = (
+    "circular",
+    "raises_on_serialization",
+    "set",
+    "not_a_number",
+    "none",
+)
+
+
+def _everywhere(outcome: str) -> Dict[str, str]:
+    return {name: outcome for name in _ALL_VALUES}
+
+
+def _terminates_except(**overrides: str) -> Dict[str, str]:
+    expected = _everywhere(TERMINATES)
+    expected.update(overrides)
+    return expected
+
+
+def _dropped_except(**overrides: str) -> Dict[str, str]:
+    expected = _everywhere(DROPPED_BEFORE_THE_BOUNDARY)
+    expected.update(overrides)
+    return expected
+
+
+_NO_DEFAULT_OVERRIDES: Mapping[str, str] = MappingProxyType({})
+
+
+class Boundary(NamedTuple):
+    """One place the interface builds an AG-UI event out of run content."""
+
+    name: str
+    builder: Callable[[Any], Fixture]
+    # The event this boundary builds, by name, so a cell that emitted none of it
+    # cannot pass as one that exercised the boundary.
+    event: str
+    # The interface function that constructs that event, named as the source
+    # scan names it: module, then the scope inside it. Checked against a scan of
+    # the package's own source, so a row cannot claim a function that builds
+    # something else, and a function-and-event pair nothing here claims fails
+    # the coverage check below.
+    builds: str
+    # A value the boundary handles, to prove the fixture reaches it at all.
+    # Built per case, so no two cases share one object.
+    benign: Callable[[], Any]
+    # What every hostile value does here. Every boundary is driven with every
+    # value, so this states one outcome per value and nothing narrows the sweep.
+    outcomes: Dict[str, str]
+    # Whether that event exists on the wire only under member attribution.
+    lineage_only: bool = False
+    # What the same fixture does under the default visibility, stated only where
+    # that differs from the run merely reaching its terminal. Only a
+    # lineage-only boundary can need one: it builds nothing there, so the cell
+    # is about what the rest of the stream did with the value instead, and the
+    # member's own unmapped chunks still carry it out as RAW.
+    #
+    # A NamedTuple default is one object shared by every row that leaves it
+    # unset, so this one is immutable: a row reaching for it and writing into it
+    # would otherwise state that cell for every other row too.
+    under_the_default: Mapping[str, str] = _NO_DEFAULT_OVERRIDES
+
+
+# Every boundary that builds an AG-UI event out of run content, the values it is
+# driven with, and what happens today under member attribution. ``not_a_number``
+# and ``none`` are the two values most serializers handle, which is why they are
+# the quiet column. Each row names the interface function that builds its event,
+# which the coverage test at the bottom of this module checks the whole table
+# against.
+_BOUNDARIES: Tuple[Boundary, ...] = (
+    # The one hardened boundary: every route falls back rather than raising.
+    Boundary(
+        "member_terminal_result",
+        _member_terminal_result,
+        "SUBAGENT_FINISHED",
+        "handlers._lane_finished",
+        lambda: "scout done",
+        _everywhere(TERMINATES),
+        lineage_only=True,
+    ),
+    # json.dumps of the content is unguarded, so a cycle ends the run. Every
+    # other value is swallowed by the text extractor before a delta is built,
+    # so those cells reach the extractor and stop there.
+    Boundary(
+        "agent_text_delta",
+        _agent_text_delta,
+        "TEXT_MESSAGE_CONTENT",
+        "handlers.on_run_content",
+        lambda: "hello",
+        _dropped_except(circular=ENDS_THE_RUN),
+    ),
+    Boundary(
+        "team_text_delta",
+        _team_text_delta,
+        "TEXT_MESSAGE_CONTENT",
+        "handlers.on_run_content",
+        lambda: "hello",
+        _dropped_except(circular=ENDS_THE_RUN),
+    ),
+    # The leader says nothing of its own here, so a nested member output that
+    # folds into nothing leaves no delta on the wire at all: the leader's text
+    # message opens and closes empty.
+    Boundary(
+        "team_member_response_delta",
+        _team_member_response_delta,
+        "TEXT_MESSAGE_CONTENT",
+        "handlers.on_run_content",
+        lambda: "hello",
+        _dropped_except(circular=ENDS_THE_RUN),
+    ),
+    # json.dumps of the arguments is unguarded, so anything it refuses ends the
+    # run. The tool call itself is never announced, so nothing dangles.
+    Boundary(
+        "tool_call_args",
+        _tool_call_args,
+        "TOOL_CALL_ARGS",
+        "handlers.on_tool_call_started",
+        lambda: {"query": "agno"},
+        _terminates_except(circular=ENDS_THE_RUN, raises_on_serialization=ENDS_THE_RUN, set=ENDS_THE_RUN),
+    ),
+    # The call is marked ended in the mapper's state before its result is
+    # serialized, so a result the serializer refuses discards the end event and
+    # leaves the tool call open on the wire for good.
+    Boundary(
+        "tool_call_result",
+        _tool_call_result,
+        "TOOL_CALL_RESULT",
+        "handlers.on_tool_call_completed",
+        lambda: "three sources",
+        _terminates_except(
+            circular=ENDS_THE_RUN_MALFORMED,
+            raises_on_serialization=ENDS_THE_RUN_MALFORMED,
+            set=ENDS_THE_RUN_MALFORMED,
+            none=DROPPED_BEFORE_THE_BOUNDARY,
+        ),
+    ),
+    # The reasoning span is opened in the mapper's state before the content
+    # event is built, so a delta the protocol model refuses discards the start
+    # while the state keeps the span, and the cleanup ends an id the client was
+    # never given a start for.
+    Boundary(
+        "reasoning_content_delta",
+        _reasoning_content_delta,
+        "REASONING_MESSAGE_CONTENT",
+        "handlers.on_reasoning_content_delta",
+        lambda: "first I ",
+        _terminates_except(
+            circular=ENDS_THE_RUN_MALFORMED,
+            raises_on_serialization=ENDS_THE_RUN_MALFORMED,
+            set=ENDS_THE_RUN_MALFORMED,
+            not_a_number=ENDS_THE_RUN_MALFORMED,
+            none=DROPPED_BEFORE_THE_BOUNDARY,
+        ),
+    ),
+    Boundary(
+        "reasoning_step_payload",
+        _reasoning_step_payload,
+        "REASONING_MESSAGE_CONTENT",
+        "handlers.on_reasoning_step",
+        lambda: ReasoningStep(title="scout plan", reasoning="scout is thinking"),
+        _terminates_except(
+            circular=ENDS_THE_RUN_MALFORMED,
+            raises_on_serialization=ENDS_THE_RUN_MALFORMED,
+            set=ENDS_THE_RUN_MALFORMED,
+            not_a_number=ENDS_THE_RUN_MALFORMED,
+            none=DROPPED_BEFORE_THE_BOUNDARY,
+        ),
+    ),
+    # The step's own title still renders, so a step whose reasoning text is
+    # missing leaves a delta on the wire rather than nothing.
+    Boundary(
+        "reasoning_step_field",
+        _reasoning_step_field,
+        "REASONING_MESSAGE_CONTENT",
+        "handlers.on_reasoning_step",
+        lambda: "scout is thinking",
+        _terminates_except(
+            circular=ENDS_THE_RUN_MALFORMED,
+            raises_on_serialization=ENDS_THE_RUN_MALFORMED,
+            set=ENDS_THE_RUN_MALFORMED,
+            not_a_number=ENDS_THE_RUN_MALFORMED,
+        ),
+    ),
+    # These two dump the chunk behind a guard, so a dump that RAISES is caught.
+    # A dump that succeeds is not filtered at all: both events declare their
+    # payload as an untyped field, so a value inside the dump rides out on the
+    # event and the protocol's encoder is where the stream then dies.
+    Boundary(
+        "custom_event_payload",
+        _custom_event_payload,
+        "CUSTOM",
+        "handlers.on_custom_event",
+        lambda: {"payload": "fine"},
+        _terminates_except(circular=TERMINATES_UNSENDABLE, raises_on_serialization=TERMINATES_UNSENDABLE),
+    ),
+    Boundary(
+        "raw_event_payload",
+        _raw_event_payload,
+        "RAW",
+        "handlers.on_unknown_event",
+        lambda: {"payload": "fine"},
+        _terminates_except(circular=TERMINATES_UNSENDABLE, raises_on_serialization=TERMINATES_UNSENDABLE),
+    ),
+    # The run terminal is built after the mapper's own cleanup has run, so a
+    # message that cannot be rendered leaves the open text message unclosed and
+    # writes no terminal at all.
+    Boundary(
+        "run_error_message",
+        _failing_run_with_a_member_mid_sentence,
+        "RUN_ERROR",
+        "handlers.on_run_error",
+        lambda: "the team blew up",
+        _terminates_except(raises_on_serialization=ENDS_THE_RUN_MALFORMED),
+    ),
+    # The same content, read at the other boundary it reaches: closing the run
+    # writes it as the terminal of every member lane still open. It is rendered
+    # with a bare stringification here, unlike a member's own failure message,
+    # so the value that cannot be rendered ends the run from inside the record
+    # of why it stopped, before either terminal is built.
+    Boundary(
+        "run_error_lane_message",
+        _failing_run_with_a_member_mid_sentence,
+        "SUBAGENT_ERROR",
+        "handlers._lane_errored",
+        lambda: "the team blew up",
+        _terminates_except(raises_on_serialization=ENDS_THE_RUN_MALFORMED),
+        lineage_only=True,
+    ),
+    # The delta is a diff of the session state, which holds anything, and the
+    # ops it carries are untyped, so the value reaches the encoder unfiltered.
+    Boundary(
+        "state_delta",
+        _state_delta,
+        "STATE_DELTA",
+        "handlers._emit_state_delta",
+        lambda: "approved",
+        _terminates_except(circular=TERMINATES_UNSENDABLE, raises_on_serialization=TERMINATES_UNSENDABLE),
+    ),
+    # The four things a paused run puts on the wire out of its own content, one
+    # row each rather than one fixture carrying the value into several of them:
+    # the prompt is built in this order, so a fixture that injected the value
+    # twice reported whichever boundary came first under the name of the later
+    # one.
+    Boundary(
+        "pause_prompt_content",
+        _pause_prompt_content,
+        "TEXT_MESSAGE_CONTENT",
+        "handlers._prompt_block",
+        lambda: "confirm this before I send it",
+        # Rendered with a bare stringification, which only the value that raises
+        # from its own repr refuses. A run that says nothing while pausing sends
+        # no delta, which is where the empty value stops.
+        _terminates_except(raises_on_serialization=ENDS_THE_RUN, none=DROPPED_BEFORE_THE_BOUNDARY),
+    ),
+    # The protocol model requires a string name and a string id here as much as
+    # it does on a streamed call, and nothing coerces either. The one difference
+    # from the streamed rows is the empty value: a pending call missing either
+    # is dropped, with a warning, before the prompt is built, so the client is
+    # told the run is waiting with nothing on the wire to act on.
+    Boundary(
+        "pause_tool_name",
+        _pause_tool_name,
+        "TOOL_CALL_START",
+        "handlers._prompt_block",
+        lambda: "confirm",
+        _everywhere(ENDS_THE_RUN) | {"none": DROPPED_BEFORE_THE_BOUNDARY},
+    ),
+    Boundary(
+        "pause_tool_id",
+        _pause_tool_id,
+        "TOOL_CALL_START",
+        "handlers._prompt_block",
+        lambda: "tc-benign",
+        _everywhere(ENDS_THE_RUN) | {"none": DROPPED_BEFORE_THE_BOUNDARY},
+    ),
+    Boundary(
+        "pause_prompt_args",
+        _pause_prompt_args,
+        "TOOL_CALL_ARGS",
+        "handlers._prompt_block",
+        lambda: {"to": "ops"},
+        _terminates_except(circular=ENDS_THE_RUN, raises_on_serialization=ENDS_THE_RUN, set=ENDS_THE_RUN),
+    ),
+    # The protocol model requires a string name, and nothing coerces the value
+    # or drops the call before the event is built.
+    Boundary(
+        "tool_call_name",
+        _tool_call_name,
+        "TOOL_CALL_START",
+        "handlers.on_tool_call_started",
+        lambda: "do_it",
+        _everywhere(ENDS_THE_RUN),
+    ),
+    # The id the model gave the call: the protocol model requires a string there
+    # too, and nothing coerces the value or drops the call before it is built.
+    Boundary(
+        "tool_call_id",
+        _tool_call_id,
+        "TOOL_CALL_START",
+        "handlers.on_tool_call_started",
+        lambda: "tc-benign",
+        _everywhere(ENDS_THE_RUN),
+    ),
+    # The member's own identity, which the announcement's name is read off.
+    # Every value is read through the same guarded stringification, so a name
+    # that cannot be rendered leaves the lane announced under its run id and the
+    # run finishes, announcement included. The one exception is nothing this
+    # boundary built: the member's unmapped chunks are passed through as RAW,
+    # whose payload is the chunk's own dump, so an identity object the encoder
+    # refuses rides out on that event and the stream dies there.
+    Boundary(
+        "member_identity",
+        _member_identity,
+        "SUBAGENT_STARTED",
+        "handlers._announce_subagent",
+        lambda: "Scout",
+        _terminates_except(raises_on_serialization=dies_on("RAW")),
+        lineage_only=True,
+        # The default announces no member, so nothing here builds an event at
+        # all; the member's unmapped chunks still go out as RAW, and the
+        # identity the encoder refuses rides out on one of those.
+        under_the_default={"raises_on_serialization": dies_on("RAW")},
+    ),
+    # The three ways a member's own terminal reports what happened to it, each
+    # read through the same guarded stringification the names are: a failure
+    # that cannot be described leaves the lane errored with the interface's own
+    # wording rather than ending a run that is still going.
+    Boundary(
+        "subagent_error_message",
+        _subagent_error_message,
+        "SUBAGENT_ERROR",
+        "handlers._lane_errored",
+        lambda: "member exploded",
+        _everywhere(TERMINATES),
+        lineage_only=True,
+    ),
+    Boundary(
+        "subagent_cancellation_reason",
+        _subagent_cancellation_reason,
+        "SUBAGENT_ERROR",
+        "handlers._lane_errored",
+        lambda: "user cancelled the run",
+        _everywhere(TERMINATES),
+        lineage_only=True,
+        # The default builds no lane terminal, and reads the member's
+        # cancellation as the run's own: the RUN_ERROR it writes embeds the
+        # cancelled chunk verbatim, reason included, so the reason the encoder
+        # refuses truncates the stream at the run's own terminal.
+        under_the_default={"raises_on_serialization": dies_on("RAW")},
+    ),
+    # The identifiers that failure is recorded with never reach the wire, so the
+    # value is driven through the log line the terminal is accompanied by: one
+    # that cannot be rendered used to end the run from inside the record of why
+    # a lane had already closed.
+    Boundary(
+        "subagent_error_correlation",
+        _subagent_error_correlation,
+        "SUBAGENT_ERROR",
+        "handlers._lane_errored",
+        lambda: "second try",
+        _everywhere(TERMINATES),
+        lineage_only=True,
+    ),
+    # The identity a paused run names its member by, which the announcement the
+    # pause prompt needs is built from.
+    Boundary(
+        "paused_member_name",
+        _paused_member_name,
+        "SUBAGENT_STARTED",
+        "handlers._announce_paused_lanes",
+        lambda: "Scout",
+        _everywhere(TERMINATES),
+        lineage_only=True,
+    ),
+)
+
+# Named rather than counted, so a boundary cannot be swapped for a different one
+# while the total stays the same.
+_BOUNDARY_NAMES = (
+    "member_terminal_result",
+    "agent_text_delta",
+    "team_text_delta",
+    "team_member_response_delta",
+    "tool_call_args",
+    "tool_call_result",
+    "reasoning_content_delta",
+    "reasoning_step_payload",
+    "reasoning_step_field",
+    "custom_event_payload",
+    "raw_event_payload",
+    "run_error_message",
+    "run_error_lane_message",
+    "state_delta",
+    "pause_prompt_content",
+    "pause_tool_name",
+    "pause_tool_id",
+    "pause_prompt_args",
+    "tool_call_name",
+    "tool_call_id",
+    "member_identity",
+    "subagent_error_message",
+    "subagent_cancellation_reason",
+    "subagent_error_correlation",
+    "paused_member_name",
+)
+
+
+# --- Collectors -------------------------------------------------------------
+
+# Both collectors are the shared ones, so this module's streams are checked
+# against exactly the same definition of a well-formed stream as every other
+# suite's. They report the invariant a stream broke rather than failing on it,
+# because a malformed stream is this module's subject.
+
+Collect = Callable[..., Any]
+
+mappers = pytest.mark.parametrize(
+    "collect",
+    [collect_sync_recording_violations, collect_async_recording_violations],
+    ids=["sync", "async"],
+)
+
+
+async def _collect(collect: Collect, fixture: Fixture, visibility: Optional[str]) -> MalformedCollected:
+    return await collect(
+        fixture.chunks,
+        visibility,
+        thread_id=THREAD_ID,
+        run_id=TOP_LEVEL_RUN,
+        run_state=fixture.run_state,
+    )
+
+
+# A cell the table does not state arrives as None and is reported by the test
+# body. Read at collection instead, a missing cell raises a bare KeyError from
+# import, which takes the whole module down and leaves the completeness check
+# below unable to say what is missing.
+_CASES = [
+    pytest.param(boundary, value, boundary.outcomes.get(value), id=f"{boundary.name}-{value}")
+    for boundary in _BOUNDARIES
+    for value in _ALL_VALUES
+]
+
+
+def _stated(boundary: Boundary, value: str, expected: Optional[str]) -> str:
+    assert expected is not None, (
+        f"the table states no outcome for a {value} value at the {boundary.name} boundary. "
+        "Drive it, and add the cell saying what it does."
+    )
+    return expected
+
+
+def _survival(events: List[BaseEvent], error: Optional[Exception], violation: Optional[str]) -> str:
+    """Whether the run reached a terminal at all, and what it left behind if not."""
+    if error is None:
+        assert violation is None, f"a run that terminated left the stream malformed: {violation}"
+        assert events, "a run that terminated emitted nothing at all"
+        assert events[-1].type in _RUN_TERMINALS, f"a run that terminated ended on {events[-1].type}"
+        return REACHES_ITS_TERMINAL
+    # Nothing may follow a run terminal, so a failure must not have written one.
+    assert not [event for event in events if event.type in _RUN_TERMINALS], (
+        "the failure path wrote a run terminal of its own"
+    )
+    return ENDS_THE_RUN if violation is None else ENDS_THE_RUN_MALFORMED
+
+
+def _verdict(
+    events: List[BaseEvent],
+    error: Optional[Exception],
+    violation: Optional[str],
+    boundary_event: "EventType",
+) -> str:
+    """What became of the value, including whether the boundary ran at all.
+
+    Whether the boundary's own event reached the wire is decided before a
+    refusal is attributed. Attributed the other way round, a stream carrying any
+    unsendable event at all reports as unsendable even where this boundary never
+    built anything, which is the one thing the verdict has to distinguish.
+
+    The encoder is consulted either way. A boundary whose event never appeared
+    says so, but the stream can still be one the client never sees the end of,
+    and a cell that stopped at "dropped" reported such a run as one that reached
+    the client. So a drop names the event the encoder refused too, when there
+    was one.
+
+    A refusal is attributed by event type: this boundary's own event if the
+    encoder refused one of those, and otherwise the event it did refuse, named.
+    A cell that says only "unsendable" credits this boundary with a failure some
+    unrelated event on the same stream caused.
+    """
+    survival = _survival(events, error, violation)
+    if survival != REACHES_ITS_TERMINAL:
+        return survival
+    refused = {refused_type for refused_type, _ in encoding_failures(events)}
+    if not of_type(events, boundary_event):
+        return dropped_and_dies_on(*refused) if refused else DROPPED_BEFORE_THE_BOUNDARY
+    if not refused:
+        return TERMINATES
+    if short_type_name(boundary_event) in refused:
+        return TERMINATES_UNSENDABLE
+    return dies_on(*refused)
+
+
+async def _assert_the_fixture_reaches_its_boundary(
+    collect: Collect, boundary: Boundary, visibility: Optional[str], boundary_event: Optional["EventType"]
+) -> None:
+    """The same boundary with content it handles, so a verdict above is the value's.
+
+    Without this the verdict cannot tell a failure the injected value caused
+    from any other failure the run happened to hit, and a cell whose event never
+    appears cannot be told from a fixture that never reached the boundary.
+    """
+    events, error, violation = await _collect(collect, boundary.builder(boundary.benign()), visibility)
+
+    assert error is None, f"the {boundary.name} fixture fails on content the boundary handles: {error!r}"
+    assert violation is None, f"the {boundary.name} fixture is malformed on benign content: {violation}"
+    refused = encoding_failures(events)
+    assert not refused, f"the {boundary.name} fixture writes an unsendable event on benign content: {refused}"
+    if boundary_event is not None:
+        assert_stream_contains(events, boundary_event)
+
+
+def _outcome_without_a_boundary(events: List[BaseEvent], error: Optional[Exception], violation: Optional[str]) -> str:
+    """What became of a run whose stream this boundary builds no event on.
+
+    The encoder is consulted here too. A lineage-only boundary builds nothing
+    under the default, but the member's own chunks still reach the wire, mapped
+    or passed through as RAW, so a value the encoder refuses can still truncate
+    the stream. Stopping at whether the run reached its terminal reported such a
+    stream as one the client saw the end of.
+    """
+    survival = _survival(events, error, violation)
+    if survival != REACHES_ITS_TERMINAL:
+        return survival
+    refused = {refused_type for refused_type, _ in encoding_failures(events)}
+    return dies_on(*refused) if refused else REACHES_ITS_TERMINAL
+
+
+def _default_outcome(boundary: Boundary, value: str, stated: str) -> str:
+    """What the table says the default does where this boundary builds nothing.
+
+    Derived from the attributed cell, since the two streams differ only by the
+    member lifecycle, unless the row states otherwise: the member's own chunks
+    are passed through as RAW here, which carries out a value that member
+    attribution kept off the wire.
+    """
+    return boundary.under_the_default.get(value, REACHES_ITS_TERMINAL if _survives(stated) else stated)
+
+
+def _boundary_event(boundary: Boundary, visibility: Optional[str]) -> Optional["EventType"]:
+    """The event type this boundary builds, or None when this stream cannot carry it."""
+    if boundary.lineage_only and visibility is None:
+        return None
+    return event_type_named(boundary.event)
+
+
+@pytest.mark.asyncio
+@mappers
+@pytest.mark.parametrize("boundary,value,expected", _CASES)
+async def test_hostile_run_content_through_an_event_boundary(collect, boundary, value, expected):
+    stated = _stated(boundary, value, expected)
+    visibility = attributed()
+    boundary_event = _boundary_event(boundary, visibility)
+
+    await _assert_the_fixture_reaches_its_boundary(collect, boundary, visibility, boundary_event)
+    events, error, violation = await _collect(collect, boundary.builder(_HOSTILE[value]()), visibility)
+
+    assert _verdict(events, error, violation, boundary_event) == stated, (
+        f"the {boundary.name} boundary now does something else with a {value} value. "
+        "Update the table in this module to say what, and say whether the change "
+        "was intended."
+    )
+
+
+@pytest.mark.asyncio
+@mappers
+@pytest.mark.parametrize("boundary,value,expected", _CASES)
+async def test_hostile_run_content_under_the_default_visibility(collect, boundary, value, expected):
+    """The default visibility reaches the same verdict, cell for cell.
+
+    The default stream differs from the attributed one only by the member
+    lifecycle, so every boundary whose event is not one of those has to do
+    exactly what it does above, verdict and all, rather than merely surviving
+    where it survived. A lineage-only boundary builds nothing here, which is
+    what the two assertions about member events below say.
+    """
+    stated = _stated(boundary, value, expected)
+    boundary_event = _boundary_event(boundary, None)
+
+    await _assert_the_fixture_reaches_its_boundary(collect, boundary, None, boundary_event)
+    events, error, violation = await _collect(collect, boundary.builder(_HOSTILE[value]()), None)
+
+    if boundary_event is None:
+        assert _outcome_without_a_boundary(events, error, violation) == _default_outcome(boundary, value, stated), (
+            f"the {boundary.name} fixture does something else with a {value} value under the default "
+            "visibility, where this boundary builds no event of its own"
+        )
+    else:
+        assert _verdict(events, error, violation, boundary_event) == stated, (
+            f"the {boundary.name} boundary does something else with a {value} value under the default "
+            "visibility than it does under member attribution"
+        )
+    assert not [event for event in events if "SUBAGENT" in str(event.type)]
+    assert not [event for event in events if lane_of(event) is not None]
+
+
+@pytest.mark.asyncio
+@mappers
+@pytest.mark.parametrize("value", list(_HOSTILE), ids=list(_HOSTILE))
+async def test_hostile_session_state_still_reaches_the_state_snapshot(collect, value):
+    """STATE_SNAPSHOT is built by deep-copying the run's state, which holds anything."""
+    injected = _HOSTILE[value]()
+    fixture = Fixture(
+        [
+            TeamRunStartedEvent(**_TOP_LEVEL),
+            RunStartedEvent(**_MEMBER),
+            RunCompletedEvent(content="scout done", **_MEMBER),
+            TeamRunCompletedEvent(**_TOP_LEVEL),
+        ],
+        run_state={"value": injected},
+    )
+    # Two of these snapshots are ones the protocol's encoder refuses, so the run
+    # terminates in memory while the client's stream stops at the snapshot.
+    unsendable = value in ("circular", "raises_on_serialization")
+
+    events, error, violation = await _collect(collect, fixture, attributed())
+
+    assert _verdict(events, error, violation, EventType.STATE_SNAPSHOT) == (
+        TERMINATES_UNSENDABLE if unsendable else TERMINATES
+    )
+    snapshots = of_type(events, EventType.STATE_SNAPSHOT)
+    assert len(snapshots) == 1
+    snapshot = snapshots[0].snapshot  # type: ignore[attr-defined]
+    # Compared by type, never by value: one of these values raises from its own
+    # repr, which an equality failure would try to render.
+    assert "value" in snapshot, "the hostile value never reached the snapshot"
+    assert type(snapshot["value"]) is type(injected), "the snapshot holds something other than the injected value"
+
+
+# --- The router's own terminal ----------------------------------------------
+
+
+class _StubEntity:
+    """An entity whose run is the chunk list, so the router's own mapping is driven.
+
+    The router hands whatever the entity's ``arun`` returns to the async mapper.
+    Nothing else about an Agent or a Team is read on this path, so a stub is what
+    keeps the test about the terminal the router writes.
+    """
+
+    def __init__(self, chunks: List[Any]) -> None:
+        self._chunks = chunks
+
+    def arun(self, **_: Any) -> Any:
+        chunks = self._chunks
+
+        async def source() -> Any:
+            for chunk in chunks:
+                yield chunk
+
+        return source()
+
+
+def _run_input() -> "RunAgentInput":
+    return RunAgentInput(
+        thread_id=THREAD_ID,
+        run_id=TOP_LEVEL_RUN,
+        state={},
+        messages=[UserMessage(id="message-1", role="user", content="go")],
+        tools=[],
+        context=[],
+        forwarded_props={},
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value", list(_HOSTILE), ids=list(_HOSTILE))
+async def test_the_router_terminal_reports_a_stream_the_hostile_value_ended(value):
+    """The RUN_ERROR the router writes when the mapper raises on run content.
+
+    This is the one event the interface builds that no boundary row can reach:
+    the mapper raising is what produces it, so the row for the boundary that
+    raised has already ended before the router writes anything. Driven with
+    every hostile value through the boundary that ends the run on one of them,
+    so the cells that do not end it pin that the router writes no terminal of
+    its own instead.
+    """
+    injected = _HOSTILE[value]()
+    chunks = [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**_MEMBER),
+        agent_said(injected, **_MEMBER),
+        RunCompletedEvent(content="scout done", **_MEMBER),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+    events: List[BaseEvent] = []
+    async for event in run_entity(_StubEntity(chunks), _run_input()):  # type: ignore[arg-type]
+        events.append(event)
+
+    assert not encoding_failures(events), "the router wrote an event the protocol's own encoder refuses"
+    errors = of_type(events, EventType.RUN_ERROR)
+    if value != "circular":
+        # Every other value is swallowed by the text extractor, so the mapper
+        # never raises and the router's terminal is the run's own completion.
+        assert not errors
+        assert events[-1].type == EventType.RUN_FINISHED
+        return
+    # The mapper raises on a cycle, so the router turns the propagated failure
+    # into the run's terminal. The message is the failure's own text, and the
+    # run terminal is the last thing on the wire.
+    assert [error.message for error in errors] == ["Circular reference detected"]  # type: ignore[attr-defined]
+    assert events[-1].type == EventType.RUN_ERROR
+    assert not of_type(events, EventType.RUN_FINISHED), "the router wrote two run terminals"
+
+
+# --- What the whole table is checked against --------------------------------
+
+
+def _because(reason: str, *pairs: Tuple[str, str]) -> Dict[Tuple[str, str], str]:
+    """One justification, against each function-and-event pair it accounts for."""
+    return {pair: reason for pair in pairs}
+
+
+def _one_justification_each(*groups: Dict[Tuple[str, str], str]) -> Dict[Tuple[str, str], str]:
+    """Merge the justifications, refusing to let one pair be justified twice.
+
+    A pair justified in two groups would have one of them silently discarded,
+    leaving a reason in this module that accounts for nothing.
+    """
+    merged: Dict[Tuple[str, str], str] = {}
+    for group in groups:
+        clashing = sorted(set(group) & set(merged))
+        assert not clashing, f"these pairs are justified more than once: {clashing}"
+        merged.update(group)
+    return merged
+
+
+# Every event the interface builds without reading anything a run produced,
+# named as a function-and-event pair rather than as a bare function: a function
+# that builds six events out of one of them is driven for that one and unchecked
+# for the other five, which is how two events of the pause path went undriven
+# while this module stayed green. Each pair is justified here and nowhere else.
+_BUILDS_NOTHING_OUT_OF_RUN_CONTENT: Dict[Tuple[str, str], str] = _one_justification_each(
+    _because(
+        "closes a span by an id this interface minted when it opened it",
+        ("handlers._end_lane_text_message", "TEXT_MESSAGE_END"),
+        ("handlers._end_lane_reasoning", "REASONING_MESSAGE_END"),
+        ("handlers._end_lane_reasoning", "REASONING_END"),
+        ("handlers.on_reasoning_completed", "REASONING_MESSAGE_END"),
+        ("handlers.on_reasoning_completed", "REASONING_END"),
+        ("handlers.on_reasoning_started", "TEXT_MESSAGE_END"),
+        ("handlers.on_reasoning_content_delta", "TEXT_MESSAGE_END"),
+        ("handlers.on_reasoning_step", "TEXT_MESSAGE_END"),
+        ("handlers.on_tool_call_started", "TEXT_MESSAGE_END"),
+        ("handlers._prompt_block", "TEXT_MESSAGE_END"),
+    ),
+    _because(
+        "opens a span, carrying an id this interface minted and a role, and none of what the run said",
+        ("handlers.on_run_content", "TEXT_MESSAGE_START"),
+        ("handlers.on_tool_call_started", "TEXT_MESSAGE_START"),
+        ("handlers.on_reasoning_started", "REASONING_START"),
+        ("handlers.on_reasoning_started", "REASONING_MESSAGE_START"),
+        ("handlers.on_reasoning_content_delta", "REASONING_START"),
+        ("handlers.on_reasoning_content_delta", "REASONING_MESSAGE_START"),
+        ("handlers.on_reasoning_step", "REASONING_START"),
+        ("handlers.on_reasoning_step", "REASONING_MESSAGE_START"),
+        ("handlers._prompt_block", "TEXT_MESSAGE_START"),
+    ),
+    _because(
+        "closes a tool call by an id the client already has a start for, which the tool_call_id and "
+        "pause_tool_id boundaries are where the run's own value first reaches the wire",
+        ("handlers._end_lane_tool_calls", "TOOL_CALL_END"),
+        ("handlers.on_tool_call_completed", "TOOL_CALL_END"),
+        ("handlers._prompt_block", "TOOL_CALL_END"),
+    ),
+    _because(
+        "writes the run's own terminal, carrying the thread and run ids the request named and nothing "
+        "the response stream produced",
+        ("handlers.on_run_completed", "RUN_FINISHED"),
+    ),
+    _because(
+        "writes the run's opening and the request's own state, neither of which comes out of the "
+        "response stream this module drives",
+        ("router.run_entity", "RUN_STARTED"),
+        ("router.run_entity", "STATE_SNAPSHOT"),
+    ),
+)
+
+# Pairs no row drives because a test of this module's own drives them instead,
+# each naming that test. A pair here is covered, not excused.
+_COVERED_BY_ANOTHER_TEST: Dict[Tuple[str, str], str] = {
+    # The snapshot is built out of the run's session state, which is content,
+    # but by a route no chunk of the stream carries.
+    ("handlers.on_run_completed", "STATE_SNAPSHOT"): "test_hostile_session_state_still_reaches_the_state_snapshot",
+    # The router's own terminal, built from the stringified failure the mapper
+    # raised rather than from a chunk, so it is reached by driving a run that
+    # ends the run rather than by a row of the table.
+    ("router.run_entity", "RUN_ERROR"): "test_the_router_terminal_reports_a_stream_the_hostile_value_ended",
+}
+
+
+def _the_protocol_defines(event_name: str) -> bool:
+    """Whether the installed ag_ui.core has an event type of this name.
+
+    The lineage events arrived after this package's minimum protocol release. On
+    a release without them the interface imports their constructions inside a
+    guarded import that fails, so the source scan finds none of them and every
+    pair naming one is a pair the scan cannot report. Read off the protocol
+    rather than off a skip marker, so any future event the interface builds
+    behind a version guard is accounted the same way, and so this module holds
+    on both releases instead of failing on one where its siblings skip.
+    """
+    return getattr(EventType, event_name, None) is not None
+
+
+def _servable(pairs: Dict[Tuple[str, str], Any]) -> Set[Tuple[str, str]]:
+    return {pair for pair in pairs if _the_protocol_defines(pair[1])}
+
+
+def _claimed_pairs() -> Set[Tuple[str, str]]:
+    """The (function, event) pair every row of the table claims, on this install."""
+    return _servable({(boundary.builds, boundary.event): None for boundary in _BOUNDARIES})
+
+
+def _built_pairs() -> Set[Tuple[str, str]]:
+    return {(function, event) for function, events in event_constructions_by_function().items() for event in events}
+
+
+def test_every_hostile_value_is_driven_through_every_boundary():
+    """The table is complete: every boundary, every value, one stated outcome.
+
+    Checked against the value names this module was written against, which are
+    independent of the shared list the sweep is built from: comparing that list
+    with itself holds whatever it says. So a value added to it fails here until
+    every row states an outcome for it, a row cannot quietly stop being driven
+    with one, and an outcome cannot be stated for a value that no longer exists.
+    """
+    assert _ALL_VALUES == _HOSTILE_VALUE_NAMES, (
+        f"the shared hostile values are now {list(_ALL_VALUES)}, and this table is written against "
+        f"{list(_HOSTILE_VALUE_NAMES)}: state an outcome per boundary for whatever changed"
+    )
+    for boundary in _BOUNDARIES:
+        assert set(boundary.outcomes) == set(_ALL_VALUES), (
+            f"the {boundary.name} boundary states outcomes for {sorted(boundary.outcomes)}, not {sorted(_ALL_VALUES)}"
+        )
+        undefined = sorted(outcome for outcome in boundary.outcomes.values() if not _is_a_verdict(outcome))
+        assert not undefined, f"the {boundary.name} boundary states an outcome this module does not define: {undefined}"
+        assert boundary.lineage_only or not boundary.under_the_default, (
+            f"the {boundary.name} boundary builds its own event under the default, so the cell above already "
+            "states what happens there and a second statement can disagree with it"
+        )
+        unknown = sorted(set(boundary.under_the_default) - set(_ALL_VALUES))
+        assert not unknown, f"the {boundary.name} boundary states a default outcome for {unknown}, which is no value"
+        undefined = sorted(
+            outcome
+            for outcome in boundary.under_the_default.values()
+            if outcome != REACHES_ITS_TERMINAL and not _is_a_verdict(outcome)
+        )
+        assert not undefined, (
+            f"the {boundary.name} boundary states a default outcome this module does not define: {undefined}"
+        )
+    assert tuple(boundary.name for boundary in _BOUNDARIES) == _BOUNDARY_NAMES, (
+        "the boundaries in the table are no longer the ones it is written against"
+    )
+    assert len(_CASES) == len(_BOUNDARY_NAMES) * len(_HOSTILE), (
+        "some boundary is no longer driven with every hostile value"
+    )
+
+
+def test_the_table_names_every_event_the_interface_builds_one_of():
+    """The boundary list, recomputed from the interface's own source.
+
+    The table's claim is that it covers every place an AG-UI event is built out
+    of run content. Nothing recomputed that, so a new event-building function
+    could ship uncovered while every cell here stayed green.
+
+    Accounted per function AND event, not per function: a function that builds
+    six event types is driven for the one a row names and unchecked for the
+    other five. So each event each scope of the package constructs has to be
+    claimed by a row, covered by a named test, or justified above as built out
+    of no run content.
+
+    An event type the installed protocol does not define is left out of the
+    comparison on both sides. The interface builds those behind a guarded
+    import, so on such a release the source scan reports none of them and the
+    rows naming them have nothing to be checked against, which used to fail this
+    one test where every sibling skipped.
+    """
+    built = _built_pairs()
+    claimed = _claimed_pairs()
+    excused = _servable(_BUILDS_NOTHING_OUT_OF_RUN_CONTENT)
+    covered = _servable(_COVERED_BY_ANOTHER_TEST)
+
+    overlapping = sorted(claimed & (excused | covered))
+    assert not overlapping, f"a boundary claims what this module also accounts for another way: {overlapping}"
+    doubly_accounted = sorted(excused & covered)
+    assert not doubly_accounted, f"these pairs are both excused and covered by a test: {doubly_accounted}"
+
+    unclaimed = sorted(built - (claimed | excused | covered))
+    assert not unclaimed, (
+        f"the interface builds these events and no row of this table drives them: {unclaimed}. "
+        "Drive each one with every hostile value and add its row, or justify it above."
+    )
+    imaginary = sorted((claimed | excused | covered) - built)
+    assert not imaginary, f"the interface builds none of these any more: {imaginary}"
+
+    # A pair is only covered if the test it names is really in this module: a
+    # renamed or deleted test would otherwise leave the pair accounted for by a
+    # string.
+    absent = sorted(name for name in _COVERED_BY_ANOTHER_TEST.values() if name not in globals())
+    assert not absent, f"these pairs name a test this module does not define: {absent}"

--- a/libs/agno/tests/unit/os/interfaces/test_agui_hostile_run_content.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_hostile_run_content.py
@@ -82,6 +82,7 @@ protocol does not define out of the comparison on both sides rather than
 reporting the rows naming it as claims about nothing.
 """
 
+import json
 from types import MappingProxyType
 from typing import Any, Callable, Dict, List, Mapping, NamedTuple, Optional, Set, Tuple
 
@@ -90,6 +91,7 @@ import pytest
 pytest.importorskip("ag_ui", reason="ag_ui not installed")
 
 from ag_ui.core import BaseEvent, EventType, RunAgentInput, UserMessage
+from ag_ui.encoder import EventEncoder
 
 from agno.models.response import ToolExecution
 from agno.os.interfaces.agui.router import run_entity
@@ -116,10 +118,12 @@ from .agui_stream_invariants import (
     HOSTILE_VALUES,
     TOP_LEVEL_RUN,
     MalformedCollected,
+    RaisesAnUnreadableError,
     SideEffect,
     agent_said,
     assert_stream_contains,
     attributed,
+    captured_agno_logs,
     collect_async_recording_violations,
     collect_sync_recording_violations,
     encoding_failures,
@@ -526,6 +530,7 @@ _ALL_VALUES = tuple(name for name, _ in HOSTILE_VALUES)
 _HOSTILE_VALUE_NAMES = (
     "circular",
     "raises_on_serialization",
+    "raises_an_unreadable_error",
     "set",
     "not_a_number",
     "none",
@@ -592,15 +597,22 @@ class Boundary(NamedTuple):
 # which the coverage test at the bottom of this module checks the whole table
 # against.
 _BOUNDARIES: Tuple[Boundary, ...] = (
-    # The one hardened boundary: every route falls back rather than raising.
+    # The boundary hardened against a value that cannot be serialized: every
+    # route falls back rather than raising. Each of those fallbacks records the
+    # failure by rendering it, though, so the value whose failure cannot be
+    # rendered either ends the run from inside the record of the first route
+    # that refused it, before any of the later routes is tried.
     Boundary(
         "member_terminal_result",
         _member_terminal_result,
         "SUBAGENT_FINISHED",
         "handlers._lane_finished",
         lambda: "scout done",
-        _everywhere(TERMINATES),
+        _terminates_except(raises_an_unreadable_error=ENDS_THE_RUN),
         lineage_only=True,
+        # The default opens no member lane, so the serialization this boundary
+        # is about is never run there at all and the value reaches nothing.
+        under_the_default={"raises_an_unreadable_error": REACHES_ITS_TERMINAL},
     ),
     # json.dumps of the content is unguarded, so a cycle ends the run. Every
     # other value is swallowed by the text extractor before a delta is built,
@@ -640,7 +652,12 @@ _BOUNDARIES: Tuple[Boundary, ...] = (
         "TOOL_CALL_ARGS",
         "handlers.on_tool_call_started",
         lambda: {"query": "agno"},
-        _terminates_except(circular=ENDS_THE_RUN, raises_on_serialization=ENDS_THE_RUN, set=ENDS_THE_RUN),
+        _terminates_except(
+            circular=ENDS_THE_RUN,
+            raises_on_serialization=ENDS_THE_RUN,
+            raises_an_unreadable_error=ENDS_THE_RUN,
+            set=ENDS_THE_RUN,
+        ),
     ),
     # The call is marked ended in the mapper's state before its result is
     # serialized, so a result the serializer refuses discards the end event and
@@ -654,6 +671,7 @@ _BOUNDARIES: Tuple[Boundary, ...] = (
         _terminates_except(
             circular=ENDS_THE_RUN_MALFORMED,
             raises_on_serialization=ENDS_THE_RUN_MALFORMED,
+            raises_an_unreadable_error=ENDS_THE_RUN_MALFORMED,
             set=ENDS_THE_RUN_MALFORMED,
             none=DROPPED_BEFORE_THE_BOUNDARY,
         ),
@@ -671,6 +689,7 @@ _BOUNDARIES: Tuple[Boundary, ...] = (
         _terminates_except(
             circular=ENDS_THE_RUN_MALFORMED,
             raises_on_serialization=ENDS_THE_RUN_MALFORMED,
+            raises_an_unreadable_error=ENDS_THE_RUN_MALFORMED,
             set=ENDS_THE_RUN_MALFORMED,
             not_a_number=ENDS_THE_RUN_MALFORMED,
             none=DROPPED_BEFORE_THE_BOUNDARY,
@@ -685,6 +704,7 @@ _BOUNDARIES: Tuple[Boundary, ...] = (
         _terminates_except(
             circular=ENDS_THE_RUN_MALFORMED,
             raises_on_serialization=ENDS_THE_RUN_MALFORMED,
+            raises_an_unreadable_error=ENDS_THE_RUN_MALFORMED,
             set=ENDS_THE_RUN_MALFORMED,
             not_a_number=ENDS_THE_RUN_MALFORMED,
             none=DROPPED_BEFORE_THE_BOUNDARY,
@@ -701,6 +721,7 @@ _BOUNDARIES: Tuple[Boundary, ...] = (
         _terminates_except(
             circular=ENDS_THE_RUN_MALFORMED,
             raises_on_serialization=ENDS_THE_RUN_MALFORMED,
+            raises_an_unreadable_error=ENDS_THE_RUN_MALFORMED,
             set=ENDS_THE_RUN_MALFORMED,
             not_a_number=ENDS_THE_RUN_MALFORMED,
         ),
@@ -715,7 +736,11 @@ _BOUNDARIES: Tuple[Boundary, ...] = (
         "CUSTOM",
         "handlers.on_custom_event",
         lambda: {"payload": "fine"},
-        _terminates_except(circular=TERMINATES_UNSENDABLE, raises_on_serialization=TERMINATES_UNSENDABLE),
+        _terminates_except(
+            circular=TERMINATES_UNSENDABLE,
+            raises_on_serialization=TERMINATES_UNSENDABLE,
+            raises_an_unreadable_error=TERMINATES_UNSENDABLE,
+        ),
     ),
     Boundary(
         "raw_event_payload",
@@ -723,32 +748,50 @@ _BOUNDARIES: Tuple[Boundary, ...] = (
         "RAW",
         "handlers.on_unknown_event",
         lambda: {"payload": "fine"},
-        _terminates_except(circular=TERMINATES_UNSENDABLE, raises_on_serialization=TERMINATES_UNSENDABLE),
+        _terminates_except(
+            circular=TERMINATES_UNSENDABLE,
+            raises_on_serialization=TERMINATES_UNSENDABLE,
+            raises_an_unreadable_error=TERMINATES_UNSENDABLE,
+        ),
     ),
-    # The run terminal is built after the mapper's own cleanup has run, so a
-    # message that cannot be rendered leaves the open text message unclosed and
-    # writes no terminal at all.
+    # The message is read through the interface's guarded reader, so one that
+    # cannot be rendered falls back to a fixed line and the terminal is still
+    # written, spans closed. The terminal embeds the failing chunk verbatim
+    # though, and the value rides out inside that dump, so the encoder refuses
+    # the very event this boundary builds.
     Boundary(
         "run_error_message",
         _failing_run_with_a_member_mid_sentence,
         "RUN_ERROR",
         "handlers.on_run_error",
         lambda: "the team blew up",
-        _terminates_except(raises_on_serialization=ENDS_THE_RUN_MALFORMED),
+        _terminates_except(
+            raises_on_serialization=TERMINATES_UNSENDABLE,
+            raises_an_unreadable_error=TERMINATES_UNSENDABLE,
+        ),
     ),
     # The same content, read at the other boundary it reaches: closing the run
-    # writes it as the terminal of every member lane still open. It is rendered
-    # with a bare stringification here, unlike a member's own failure message,
-    # so the value that cannot be rendered ends the run from inside the record
-    # of why it stopped, before either terminal is built.
+    # writes it as the terminal of every member lane still open. It is the same
+    # guarded reading as the run's own message, so the lane terminates under the
+    # fallback line and this event is sendable; the stream still dies at the run
+    # terminal, which embeds the failing chunk verbatim.
     Boundary(
         "run_error_lane_message",
         _failing_run_with_a_member_mid_sentence,
         "SUBAGENT_ERROR",
         "handlers._lane_errored",
         lambda: "the team blew up",
-        _terminates_except(raises_on_serialization=ENDS_THE_RUN_MALFORMED),
+        _terminates_except(
+            raises_on_serialization=dies_on("RUN_ERROR"),
+            raises_an_unreadable_error=dies_on("RUN_ERROR"),
+        ),
         lineage_only=True,
+        # The default builds no lane terminal, and the run's own terminal
+        # embeds the same dump there too, so the stream dies at the same event.
+        under_the_default={
+            "raises_on_serialization": dies_on("RUN_ERROR"),
+            "raises_an_unreadable_error": dies_on("RUN_ERROR"),
+        },
     ),
     # The delta is a diff of the session state, which holds anything, and the
     # ops it carries are untyped, so the value reaches the encoder unfiltered.
@@ -758,7 +801,11 @@ _BOUNDARIES: Tuple[Boundary, ...] = (
         "STATE_DELTA",
         "handlers._emit_state_delta",
         lambda: "approved",
-        _terminates_except(circular=TERMINATES_UNSENDABLE, raises_on_serialization=TERMINATES_UNSENDABLE),
+        _terminates_except(
+            circular=TERMINATES_UNSENDABLE,
+            raises_on_serialization=TERMINATES_UNSENDABLE,
+            raises_an_unreadable_error=TERMINATES_UNSENDABLE,
+        ),
     ),
     # The four things a paused run puts on the wire out of its own content, one
     # row each rather than one fixture carrying the value into several of them:
@@ -771,10 +818,18 @@ _BOUNDARIES: Tuple[Boundary, ...] = (
         "TEXT_MESSAGE_CONTENT",
         "handlers._prompt_block",
         lambda: "confirm this before I send it",
-        # Rendered with a bare stringification, which only the value that raises
-        # from its own repr refuses. A run that says nothing while pausing sends
-        # no delta, which is where the empty value stops.
-        _terminates_except(raises_on_serialization=ENDS_THE_RUN, none=DROPPED_BEFORE_THE_BOUNDARY),
+        # Read through the interface's guarded reader, so the value that raises
+        # from its own repr is dropped and the prompt sends no delta, which is
+        # where the empty value stops too. The reader's own record names the
+        # failure's type rather than rendering it, so the value whose failure
+        # cannot be rendered either is dropped here as well rather than ending
+        # the run from inside the recovery, several events before this terminal
+        # writes anything.
+        _terminates_except(
+            raises_on_serialization=DROPPED_BEFORE_THE_BOUNDARY,
+            raises_an_unreadable_error=DROPPED_BEFORE_THE_BOUNDARY,
+            none=DROPPED_BEFORE_THE_BOUNDARY,
+        ),
     ),
     # The protocol model requires a string name and a string id here as much as
     # it does on a streamed call, and nothing coerces either. The one difference
@@ -803,7 +858,11 @@ _BOUNDARIES: Tuple[Boundary, ...] = (
         "TOOL_CALL_ARGS",
         "handlers._prompt_block",
         lambda: {"to": "ops"},
-        _terminates_except(circular=ENDS_THE_RUN, raises_on_serialization=ENDS_THE_RUN, set=ENDS_THE_RUN),
+        # Serialized behind a guard, unlike the arguments of a streamed call:
+        # this is the run terminal, and a raise here would discard the closing
+        # sweep built before it. Arguments the encoder refuses are dropped, and
+        # the call is still prompted under the id a resume answers it by.
+        _everywhere(TERMINATES),
     ),
     # The protocol model requires a string name, and nothing coerces the value
     # or drops the call before the event is built.
@@ -838,12 +897,18 @@ _BOUNDARIES: Tuple[Boundary, ...] = (
         "SUBAGENT_STARTED",
         "handlers._announce_subagent",
         lambda: "Scout",
-        _terminates_except(raises_on_serialization=dies_on("RAW")),
+        _terminates_except(
+            raises_on_serialization=dies_on("RAW"),
+            raises_an_unreadable_error=dies_on("RAW"),
+        ),
         lineage_only=True,
         # The default announces no member, so nothing here builds an event at
         # all; the member's unmapped chunks still go out as RAW, and the
         # identity the encoder refuses rides out on one of those.
-        under_the_default={"raises_on_serialization": dies_on("RAW")},
+        under_the_default={
+            "raises_on_serialization": dies_on("RAW"),
+            "raises_an_unreadable_error": dies_on("RAW"),
+        },
     ),
     # The three ways a member's own terminal reports what happened to it, each
     # read through the same guarded stringification the names are: a failure
@@ -870,7 +935,10 @@ _BOUNDARIES: Tuple[Boundary, ...] = (
         # cancellation as the run's own: the RUN_ERROR it writes embeds the
         # cancelled chunk verbatim, reason included, so the reason the encoder
         # refuses truncates the stream at the run's own terminal.
-        under_the_default={"raises_on_serialization": dies_on("RAW")},
+        under_the_default={
+            "raises_on_serialization": dies_on("RAW"),
+            "raises_an_unreadable_error": dies_on("RAW"),
+        },
     ),
     # The identifiers that failure is recorded with never reach the wire, so the
     # value is driven through the log line the terminal is accompanied by: one
@@ -1143,9 +1211,9 @@ async def test_hostile_session_state_still_reaches_the_state_snapshot(collect, v
         ],
         run_state={"value": injected},
     )
-    # Two of these snapshots are ones the protocol's encoder refuses, so the run
-    # terminates in memory while the client's stream stops at the snapshot.
-    unsendable = value in ("circular", "raises_on_serialization")
+    # Three of these snapshots are ones the protocol's encoder refuses, so the
+    # run terminates in memory while the client's stream stops at the snapshot.
+    unsendable = value in ("circular", "raises_on_serialization", "raises_an_unreadable_error")
 
     events, error, violation = await _collect(collect, fixture, attributed())
 
@@ -1159,6 +1227,121 @@ async def test_hostile_session_state_still_reaches_the_state_snapshot(collect, v
     # repr, which an equality failure would try to render.
     assert "value" in snapshot, "the hostile value never reached the snapshot"
     assert type(snapshot["value"]) is type(injected), "the snapshot holds something other than the injected value"
+
+
+# --- The recovery path a run terminal is built inside ------------------------
+
+# The table above says what became of a value at each boundary. These two say
+# what a client is actually handed when the value is one the interface's guarded
+# reader cannot read, at the two run terminals that reader is called from: a
+# record written by rendering the failure runs the same value the read did, so
+# the guard raises out of its own recovery and takes the terminal being built
+# around it with it. A cell of the table would report that as "ends the run",
+# which is true of any raise; these name what a client loses instead.
+
+
+def _as_a_client_receives(events: List[BaseEvent]) -> List[Dict[str, Any]]:
+    """Every event read back off the bytes the protocol's encoder puts on a wire.
+
+    Read off the encoding rather than off the mapped objects. The events built
+    before a raise exist in memory whatever happens after it, so a list of
+    mapped objects cannot say where a client's stream stopped, and the symptom
+    here is a stream that stops before its terminal.
+    """
+    encoder = EventEncoder()
+    received: List[Dict[str, Any]] = []
+    for event in events:
+        encoded = encoder.encode(event)
+        prefix, _, payload = encoded.partition("data: ")
+        assert not prefix and payload, f"the encoder no longer writes one data frame per event: {encoded!r}"
+        received.append(json.loads(payload))
+    return received
+
+
+@pytest.mark.asyncio
+@mappers
+async def test_a_pause_whose_own_words_cannot_be_read_still_prompts_the_client(collect, caplog):
+    """A pause that says something unreadable still asks its question and terminates.
+
+    The words are read through the guarded reader, at the run terminal. A raise
+    out of the reader's recovery discards the prompt, the call the client is
+    meant to answer and the terminal itself, leaving a run that was merely
+    waiting for an answer to end as a failure over its prose.
+    """
+    with captured_agno_logs(caplog, "WARNING"):
+        events, error, violation = await _collect(
+            collect, _pause_prompt_content(RaisesAnUnreadableError()), attributed()
+        )
+
+    assert error is None, f"reading the paused run's own words ended the run: {error!r}"
+    assert violation is None, f"the pause left the stream malformed: {violation}"
+
+    received = _as_a_client_receives(events)
+    assert [event["type"] for event in received] == [
+        "RAW",
+        "TEXT_MESSAGE_START",
+        "TEXT_MESSAGE_END",
+        "TOOL_CALL_START",
+        "TOOL_CALL_ARGS",
+        "TOOL_CALL_END",
+        "RUN_FINISHED",
+    ], "the pause prompt a client receives is not the whole prompt"
+    # The words are the one thing dropped: the call is still advertised under
+    # the id a resume answers it by, which is what the pause is for.
+    assert [event["toolCallId"] for event in received if event["type"] == "TOOL_CALL_START"] == ["tc-hostile-confirm"]
+    assert "AG-UI could not read a paused run's own words: UnrenderableError" in [
+        record.getMessage() for record in caplog.records
+    ], "nothing records the words the client was not sent"
+
+
+@pytest.mark.asyncio
+@mappers
+async def test_a_failure_whose_own_message_cannot_be_read_still_terminates_the_run(collect, caplog):
+    """A run that fails unreadably still reports a failure and closes what it opened.
+
+    The message is read through the same reader, before the terminal's cleanup
+    runs, and is also what every member lane still open terminates under. A
+    raise out of the reader's recovery here closes no span, terminates no lane
+    and writes no terminal: the client is left mid-sentence, and the run's real
+    failure is replaced by the one raised while naming it.
+    """
+    failure = TeamRunErrorEvent(error_type="RuntimeError", **_TOP_LEVEL)
+    failure.content = RaisesAnUnreadableError()
+    # Dumped as a payload that holds none of the value, so the terminal carrying
+    # this dump is one the encoder accepts and the test is about the message
+    # rather than about the verbatim chunk beside it.
+    failure.to_dict = lambda: {"event": "TeamRunError"}  # type: ignore[method-assign]
+    fixture = Fixture(
+        [
+            TeamRunStartedEvent(**_TOP_LEVEL),
+            RunStartedEvent(**_MEMBER),
+            agent_said("half a sen", **_MEMBER),
+            failure,
+        ]
+    )
+
+    with captured_agno_logs(caplog, "WARNING"):
+        events, error, violation = await _collect(collect, fixture, attributed())
+
+    assert error is None, f"reading the failed run's own message ended the run: {error!r}"
+    assert violation is None, f"the failed terminal left the stream malformed: {violation}"
+
+    received = _as_a_client_receives(events)
+    assert [event["type"] for event in received] == [
+        "RAW",
+        "SUBAGENT_STARTED",
+        "RAW",
+        "TEXT_MESSAGE_START",
+        "TEXT_MESSAGE_CONTENT",
+        "TEXT_MESSAGE_END",
+        "SUBAGENT_ERROR",
+        "RUN_ERROR",
+    ], "the failed run a client receives is not the whole terminal"
+    assert received[-1]["message"] == "Run failed"
+    assert received[-1]["code"] == "RuntimeError"
+    assert "AG-UI could not read a failed run message: UnrenderableError" in [
+        record.getMessage() for record in caplog.records
+    ], "nothing records the failure text the client was not sent"
 
 
 # --- The router's own terminal ----------------------------------------------
@@ -1301,7 +1484,7 @@ _BUILDS_NOTHING_OUT_OF_RUN_CONTENT: Dict[Tuple[str, str], str] = _one_justificat
     _because(
         "writes the run's own terminal, carrying the thread and run ids the request named and nothing "
         "the response stream produced",
-        ("handlers.on_run_completed", "RUN_FINISHED"),
+        ("handlers._run_end_events", "RUN_FINISHED"),
     ),
     _because(
         "writes the run's opening and the request's own state, neither of which comes out of the "
@@ -1316,7 +1499,7 @@ _BUILDS_NOTHING_OUT_OF_RUN_CONTENT: Dict[Tuple[str, str], str] = _one_justificat
 _COVERED_BY_ANOTHER_TEST: Dict[Tuple[str, str], str] = {
     # The snapshot is built out of the run's session state, which is content,
     # but by a route no chunk of the stream carries.
-    ("handlers.on_run_completed", "STATE_SNAPSHOT"): "test_hostile_session_state_still_reaches_the_state_snapshot",
+    ("handlers._run_end_events", "STATE_SNAPSHOT"): "test_hostile_session_state_still_reaches_the_state_snapshot",
     # The router's own terminal, built from the stringified failure the mapper
     # raised rather than from a chunk, so it is reached by driving a run that
     # ends the run rather than by a row of the table.

--- a/libs/agno/tests/unit/os/interfaces/test_agui_interrupts.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_interrupts.py
@@ -1,0 +1,6744 @@
+"""The AG-UI interrupt round trip over the AGUI interface.
+
+The failure this covers is a pause that looks convincing and then continues
+nothing, so the suite is written in two halves that have to agree.
+
+Out: a paused run's terminal says the run is waiting, once per requirement it
+still needs answered, each naming the tool call it is bound to and the shape of
+the answer it wants. Off by default, where the stream stays exactly what it was.
+
+In: the answers come back in the request's resume array and the paused run
+continues from them. That half is driven over a real ``POST /agui`` against a
+real Agent and Team, because the only proof that a resume continued the run is
+the tool body running and its result reaching the wire under the id the pause
+reported.
+"""
+
+import ast
+import asyncio
+import importlib
+import inspect
+import json
+import logging
+from collections import Counter
+from copy import deepcopy
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, get_args, get_type_hints
+from uuid import uuid4
+
+import pytest
+
+pytest.importorskip("ag_ui", reason="ag_ui not installed")
+
+from ag_ui.core import BaseEvent, Event, EventType, RunAgentInput, RunFinishedEvent, UserMessage
+from pydantic import BaseModel, TypeAdapter, create_model
+
+from agno.agent.agent import Agent
+from agno.db.in_memory import InMemoryDb
+from agno.models.response import ToolExecution, UserInputField
+from agno.os.interfaces.agui import interrupts
+from agno.os.interfaces.agui import resume as resume_module
+from agno.os.interfaces.agui import stream as stream_module
+from agno.os.interfaces.agui.handlers import on_run_completed as _build_the_run_terminal
+from agno.os.interfaces.agui.resume import (
+    ADVERTISED_KEYWORDS_READ,
+    CANCELLED_NOTE,
+    SCHEMA_ADVERTISED_ONLY,
+    ensure_requirements_resolved,
+    resolve_requirements_from_resume_entries,
+    resolve_requirements_from_tool_messages,
+)
+
+# Every source of a stream is wrapped below, under the name this suite calls it
+# by, so the unwrapped one must not also be reachable under that name. Which
+# names those are is derived from these imports rather than listed, at the end
+# of this file.
+from agno.os.interfaces.agui.router import run_entity as _run_entity
+from agno.os.interfaces.agui.state import (
+    SUBAGENT_VISIBILITY_ATTRIBUTED,
+    SUBAGENT_VISIBILITY_VALUES,
+    StreamState,
+)
+from agno.run.agent import (
+    RunCompletedEvent,
+    RunContentEvent,
+    RunErrorEvent,
+    RunEvent,
+    RunPausedEvent,
+    RunStartedEvent,
+    ToolCallStartedEvent,
+)
+from agno.run.requirement import RunRequirement
+from agno.run.team import RunPausedEvent as TeamRunPausedEvent
+from agno.run.team import TeamRunEvent
+from agno.team import Team
+from agno.tools import tool
+from agno.tools.function import Function, UserFeedbackOption, UserFeedbackQuestion
+from agno.tools.user_feedback import UserFeedbackTools
+
+from .agui_stream_invariants import (
+    A_CALL_PROMPTED_ONCE_PER_PAUSE_KIND,
+    ABANDONED_MID_STREAM,
+    RaisesOnSerialization,
+    ScriptedModel,
+    assert_stream_contains,
+    assert_stream_is_malformed_as_recorded,
+    assert_well_formed_stream,
+    attributed,
+    captured_agno_logs,
+    circular,
+    in_emitted_order,
+    member_mentions,
+    of_type,
+    require_lineage_events,
+    short_type,
+    sse_events,
+)
+from .agui_stream_invariants import collect_async as _collect_async
+from .agui_stream_invariants import collect_sync as _collect_sync
+
+THREAD_ID = "interrupt-session"
+RUN_ID = "interrupt-run"
+
+
+def on_run_completed(
+    chunk: Any,
+    state: StreamState,
+    *,
+    malformed: Optional[str] = None,
+    encoder_refuses: Sequence[str] = (),
+) -> List[Any]:
+    """The interface's own run terminal, with the stream it built held to the invariants.
+
+    Named over the import so that every call in this suite, and every call a
+    later test adds, reaches the shared definition of a well-formed stream
+    without opting in. Which helper a test happened to reach for is what decided
+    that before: the route harness checked its bodies and this path checked
+    nothing, so one guard in this directory could bless a stream the other
+    rejects with nothing saying so.
+
+    ``malformed`` names the record for a stream this interface really does emit
+    malformed today, which pins the violation rather than waiving it.
+
+    A stream recorded as malformed is still held to what it encoded: the
+    violations recorded there are about the order and pairing of events, and a
+    key no model declares is a defect under any ordering.
+
+    ``encoder_refuses`` names the paths of the values the protocol's encoder
+    refuses in this stream, for a caller whose subject is a run holding one.
+    """
+    events = _build_the_run_terminal(chunk, state)
+    if malformed is None:
+        assert_well_formed_stream(events)
+    else:
+        assert_stream_is_malformed_as_recorded(events, malformed)
+    _assert_nothing_undeclared_reached_the_client(events, encoder_refuses)
+    return events
+
+
+async def collect_async(chunks: Any, *args: Any, encoder_refuses: Sequence[str] = (), **kwargs: Any) -> Any:
+    """The shared async driver, with the stream it produced held to what it encoded.
+
+    Named over the import for the reason the run terminal above is: a test
+    reaching the driver directly gets a stream nothing checks the encoded keys
+    of, and the whole point of that check is that no call site can skip it.
+    """
+    events, error = await _collect_async(chunks, *args, **kwargs)
+    _assert_nothing_undeclared_reached_the_client(events, encoder_refuses)
+    return events, error
+
+
+async def collect_sync(chunks: Any, *args: Any, encoder_refuses: Sequence[str] = (), **kwargs: Any) -> Any:
+    """The shared sync-mapper driver, wrapped for the same reason as the async one."""
+    events, error = await _collect_sync(chunks, *args, **kwargs)
+    _assert_nothing_undeclared_reached_the_client(events, encoder_refuses)
+    return events, error
+
+
+async def run_entity(*args: Any, encoder_refuses: Sequence[str] = (), **kwargs: Any) -> List[Any]:
+    """The route's own mapping of an entity's run, collected and held to both checks.
+
+    The fourth way this suite obtains a stream, and the one that reached only
+    half of them: it was driven under the interface's own name, so no wrapper
+    stood between it and a caller, and a body the route really sends went unheld
+    to the keys it encoded while every other stream here was held to them.
+
+    The whole body rather than each event as it arrives, because a stream is
+    well formed or not only once it has ended.
+    """
+    events = [event async for event in _run_entity(*args, **kwargs)]
+    assert_well_formed_stream(events)
+    _assert_nothing_undeclared_reached_the_client(events, encoder_refuses)
+    return events
+
+
+# The three pieces of the round trip reached the protocol in three separate
+# releases, and the package's own extra permits a release older than all of
+# them, so each is gated on its own. Every gate asks the probe the interface
+# decides that one piece by: the import flag for the lifecycle, which is what
+# the builders check, and the field tables for the two later pieces, because a
+# release can declare a type and still omit the field this module writes on it.
+needs_interrupt_outcome = pytest.mark.skipif(
+    not interrupts.INTERRUPT_OUTCOME_AVAILABLE,
+    reason="the installed ag_ui.core has no interrupt-aware run lifecycle",
+)
+needs_member_attribution = pytest.mark.skipif(
+    not interrupts.interrupt_attribution_available(),
+    reason="the installed ag_ui.core cannot name the member an interrupt was raised inside",
+)
+needs_suspended_outcome = pytest.mark.skipif(
+    not interrupts.subagent_suspension_available(),
+    reason="the installed ag_ui.core cannot serve the suspended subagent outcome",
+)
+
+
+def _resume_array_is_readable() -> bool:
+    """Whether a request can carry a client's answers at all.
+
+    The interface reads the array off the parsed request through an attribute
+    lookup, so on a release that does not declare the field the answers arrive
+    as an unknown key and are dropped. The field's presence is therefore the
+    probe, which is how the interrupt floor reads it too, and it is a piece of
+    its own: an install can declare it without the interrupt types, and that is
+    the install the tests below prove the array is read on.
+    """
+    from ag_ui.core import RunAgentInput
+
+    return "resume" in RunAgentInput.model_fields
+
+
+RESUME_ARRAY_IS_READABLE = _resume_array_is_readable()
+
+needs_resume_array = pytest.mark.skipif(
+    not RESUME_ARRAY_IS_READABLE,
+    reason="the installed ag_ui.core has no resume array for a client's answers to arrive in",
+)
+
+
+# --- Building a pause the way a real run reports one -------------------------
+
+
+def _confirmation(tool_call_id: str = "tc-confirm", tool_name: str = "send_email") -> ToolExecution:
+    return ToolExecution(
+        tool_call_id=tool_call_id,
+        tool_name=tool_name,
+        tool_args={"to": "ops@example.com"},
+        requires_confirmation=True,
+    )
+
+
+def _external(tool_call_id: str = "tc-external", tool_name: str = "change_background") -> ToolExecution:
+    return ToolExecution(
+        tool_call_id=tool_call_id,
+        tool_name=tool_name,
+        tool_args={"color": "blue"},
+        external_execution_required=True,
+    )
+
+
+def _user_input(fields: Optional[List[UserInputField]] = None) -> ToolExecution:
+    return ToolExecution(
+        tool_call_id="tc-input",
+        tool_name="write_post",
+        tool_args={},
+        requires_user_input=True,
+        user_input_schema=fields
+        if fields is not None
+        else [UserInputField(name="topic", field_type=str, description="What to write about")],
+    )
+
+
+def _user_feedback(multi_select: bool = False) -> ToolExecution:
+    return ToolExecution(
+        tool_call_id="tc-feedback",
+        tool_name="ask_user",
+        tool_args={},
+        requires_user_input=True,
+        user_feedback_schema=[
+            UserFeedbackQuestion(
+                question="What budget?",
+                header="Budget",
+                options=[UserFeedbackOption(label="low"), UserFeedbackOption(label="high")],
+                multi_select=multi_select,
+            )
+        ],
+    )
+
+
+def _two_pause_kinds() -> ToolExecution:
+    """One pending call flagged for two pause kinds, which the prompt lists twice.
+
+    The prompt has always shown it once per list it appears on. Nothing can
+    answer it: the resume channel runs one resolver per requirement, picked by
+    pause kind, and whichever it picks leaves the other kind open.
+    """
+    return ToolExecution(
+        tool_call_id="tc-both",
+        tool_name="send_email",
+        tool_args={"to": "ops@example.com"},
+        requires_confirmation=True,
+        requires_user_input=True,
+        user_input_schema=[UserInputField(name="body", field_type=str)],
+    )
+
+
+def _answered_its_questions_and_still_waits_on_a_decision() -> ToolExecution:
+    """A pause whose kind picks the one resolver that has nothing left to give it.
+
+    ``pause_type`` reads the feedback schema first and its questions are answered
+    already, so the resolver the resume channel runs is the one Agno refuses to
+    run at all, while the decision it is really waiting on stays open.
+    """
+    answered = UserFeedbackQuestion(question="What budget?", options=[UserFeedbackOption(label="low")])
+    answered.selected_options = ["low"]
+    return ToolExecution(
+        tool_call_id="tc-answered-feedback",
+        tool_name="send_email",
+        tool_args={},
+        requires_confirmation=True,
+        user_feedback_schema=[answered],
+    )
+
+
+def _asks_a_question_while_a_field_it_needs_stays_empty() -> ToolExecution:
+    """One call waiting on a selection and on a value, which one answer cannot give.
+
+    Agno marks a call answered once its questions are, and that one flag stands
+    for both structured kinds, so the feedback resolver clears the input the
+    tool is still missing without anything having filled it.
+    """
+    return ToolExecution(
+        tool_call_id="tc-feedback-and-input",
+        tool_name="book_trip",
+        tool_args={},
+        requires_user_input=True,
+        user_feedback_schema=[UserFeedbackQuestion(question="What budget?", options=[UserFeedbackOption(label="low")])],
+        user_input_schema=[UserInputField(name="city", field_type=str)],
+    )
+
+
+def _filled_a_field_no_answer_could_name() -> ToolExecution:
+    """A pause whose one field cannot be named and already carries a value.
+
+    Nothing of it is still empty, so a census of the empty fields finds nothing
+    to report, while the field itself is one no payload can be keyed to and the
+    schema built from it describes nothing at all.
+    """
+    unnameable = UserInputField(name="", field_type=str)
+    unnameable.value = "prefilled"
+    return _user_input([unnameable])
+
+
+def _waits_on_two_fields_no_answer_could_name() -> ToolExecution:
+    """A pause with one field a client can fill and two it cannot name."""
+    return _user_input(
+        [
+            UserInputField(name="topic", field_type=str),
+            UserInputField(name="", field_type=str),
+            UserInputField(name="", field_type=str),
+        ]
+    )
+
+
+def _user_feedback_offering(*options: UserFeedbackOption) -> ToolExecution:
+    """A feedback pause asking one question over exactly these options."""
+    return ToolExecution(
+        tool_call_id="tc-feedback",
+        tool_name="ask_user",
+        tool_args={},
+        requires_user_input=True,
+        user_feedback_schema=[UserFeedbackQuestion(question="What budget?", options=list(options))],
+    )
+
+
+def _paused(*tools: ToolExecution, content: Optional[str] = None) -> RunPausedEvent:
+    """An Agent pause reported the way a real run reports one.
+
+    A real pause carries the pending calls on the terminal's own lists AND a
+    requirement per call, which is what says the pause kind and the answer shape.
+    A pause built from the tool list alone is a different subject, and the tests
+    whose subject that is build it themselves.
+    """
+    return RunPausedEvent(
+        tools=list(tools),
+        requirements=[RunRequirement(tool_execution=tool) for tool in tools],
+        content=content,
+    )
+
+
+def _member_paused(*tools: ToolExecution, member_run_id: str, member_id: str = "mailer") -> TeamRunPausedEvent:
+    """A Team pause whose pending calls belong to a member, as a real one reports it."""
+    requirements = []
+    for pending in tools:
+        requirement = RunRequirement(tool_execution=pending)
+        requirement.member_agent_id = member_id
+        requirement.member_agent_name = "Mailer"
+        requirement.member_run_id = member_run_id
+        requirements.append(requirement)
+    return TeamRunPausedEvent(tools=[], requirements=requirements)
+
+
+def _member_paused_on_something_nothing_can_answer() -> TeamRunPausedEvent:
+    """A Team pause waiting on a member, on a call no client could ever answer.
+
+    One pending call flagged for two pause kinds, which is the shape that ends
+    the run instead of prompting for it. The terminal is then a failed run
+    reporting the chunk it ended on, and that chunk is the leader's own while
+    carrying the member's id, name and run id inside it.
+    """
+    return _member_paused(_two_pause_kinds(), member_run_id="member-run")
+
+
+def _how_a_pause_names_its_member(chunk: Any) -> List[str]:
+    """Every value the pause itself names its member by.
+
+    Read off the fixture rather than written out beside it, so an assertion that
+    none of them reached a client cannot pass by looking for a string this pause
+    never carried.
+    """
+    named = [
+        str(value)
+        for requirement in chunk.requirements or []
+        for value in (requirement.member_agent_id, requirement.member_agent_name, requirement.member_run_id)
+        if value
+    ]
+    assert named, "this pause names no member, so an assertion that nothing named one proves nothing"
+    return named
+
+
+def _paused_inside_an_inner_agent(member_run_id: str = "inner-run") -> RunPausedEvent:
+    """An Agent pause whose only pending call arrives on the requirement list.
+
+    An agent that ran an inner agent reports a pending call exactly as a team
+    reports a member's: the terminal's own tool lists carry nothing, and the
+    requirement names the run that is really waiting.
+    """
+    requirement = RunRequirement(tool_execution=_confirmation("tc-inner"))
+    requirement.member_agent_id = "inner"
+    requirement.member_agent_name = "Inner"
+    requirement.member_run_id = member_run_id
+    return RunPausedEvent(tools=[], requirements=[requirement])
+
+
+def _paused_where_two_requirements_share_one_id() -> RunPausedEvent:
+    """A pause whose two open requirements are keyed by the same interrupt id.
+
+    One correlation key for two answers: the resume channel looks an answer up
+    by id, so it would resolve whichever requirement the lookup found and leave
+    the other open. A release that stores no requirement id keys by the tool call
+    instead, which is where two requirements waiting on one call collide.
+    """
+    decide = _confirmation("tc-shared")
+    run_it = _external("tc-shared", "change_background")
+    requirements = [RunRequirement(tool_execution=decide), RunRequirement(tool_execution=run_it)]
+    for requirement in requirements:
+        requirement.id = None
+    return RunPausedEvent(tools=[decide, run_it], requirements=requirements)
+
+
+def _paused_listing_a_call_with_nothing_open_behind_it() -> RunPausedEvent:
+    """A pause listing a pending call whose answer the run already holds.
+
+    The terminal's own lists are the record of what the client is shown, and a
+    call on one of them can have no open requirement behind it. There is then
+    nothing for the resume channel to look an answer up by.
+    """
+    open_call = _confirmation("tc-open")
+    decided = _confirmation("tc-decided", "archive_email")
+    decided.confirmed = True
+    return RunPausedEvent(
+        tools=[open_call, decided],
+        requirements=[RunRequirement(tool_execution=open_call), RunRequirement(tool_execution=decided)],
+    )
+
+
+def _run_finished(events: List[Any]) -> Any:
+    finished = [event for event in events if type(event).__name__ == "RunFinishedEvent"]
+    assert len(finished) == 1, f"expected exactly one run terminal, got {[type(e).__name__ for e in events]}"
+    return finished[0]
+
+
+def _encoded(event: Any) -> Dict[str, Any]:
+    """One event as the bytes a client receives, read back as the keys they carry.
+
+    Through the protocol's own encoder, which is what the route hands the client:
+    a field the models do not declare still sets an attribute, so reading the
+    object cannot tell what reached the client from what did not.
+    """
+    from ag_ui.encoder import EventEncoder
+
+    return json.loads(EventEncoder().encode(event)[len("data: ") :])
+
+
+def _outcome_on_the_wire(event: Any) -> Any:
+    """The outcome as a client reads it, which is the encoded event and not the object."""
+    return _encoded(event).get("outcome", "absent")
+
+
+def _everything_the_client_received(events: List[Any]) -> str:
+    """A whole stream as the bytes a client receives, for an assertion about an absence.
+
+    Read off the encoded events and not the objects, and off all of them rather
+    than the fields a test thought to look at: a value nested anywhere inside an
+    event's payload is on the wire whether or not a field of that event names it.
+    """
+    return json.dumps([_encoded(event) for event in events])
+
+
+# --- The invariant over what the stream encoded ------------------------------
+
+# Eight times now this interface has written a protocol field the installed
+# models do not declare, three of them while fixing the last round of the same
+# thing. The models keep such a key as untyped extra data and serialize it, so
+# it leaves the server under a name the wire format has no place for and a
+# client reads a field that is not one. Per-field vigilance is what failed
+# eight times, so what follows is a property of the encoded output instead: it
+# holds over every stream this suite produces and cannot be forgotten at a call
+# site nobody thought to check.
+
+
+def _declared_wire_keys(model: Any) -> Dict[str, str]:
+    """Serialized key -> field name, for every field this model declares.
+
+    Both spellings, because a producer chooses between the field name and its
+    alias and a key under either is one the model declares.
+    """
+    keys: Dict[str, str] = {}
+    for name, field in type(model).model_fields.items():
+        keys[name] = name
+        for alias in (field.alias, field.serialization_alias):
+            if alias:
+                keys[alias] = name
+    return keys
+
+
+def _undeclared_keys_under(model: BaseModel, encoded: Dict[str, Any], path: str) -> List[str]:
+    declared = _declared_wire_keys(model)
+    found: List[str] = []
+    for key, value in encoded.items():
+        if key not in declared:
+            found.append(f"{path}.{key}")
+            continue
+        found += _undeclared_keys_in(getattr(model, declared[key], None), value, f"{path}.{key}")
+    return found
+
+
+def _undeclared_keys_in(written: Any, encoded: Any, path: str) -> List[str]:
+    """Every undeclared key under one written value, paired with what it encoded to.
+
+    The written object is what says which model a nested payload belongs to. A
+    value that is not a protocol model carries no declaration to be held to, so
+    it ends the descent: an open-by-key metadata object is data the client reads
+    whole, not a schema.
+    """
+    if isinstance(written, BaseModel) and isinstance(encoded, dict):
+        return _undeclared_keys_under(written, encoded, path)
+    if isinstance(written, (list, tuple)) and isinstance(encoded, list):
+        return [
+            entry
+            for index, (one, its) in enumerate(zip(written, encoded))
+            for entry in _undeclared_keys_in(one, its, f"{path}[{index}]")
+        ]
+    if isinstance(written, dict) and isinstance(encoded, dict):
+        return [
+            entry
+            for key, value in encoded.items()
+            if key in written
+            for entry in _undeclared_keys_in(written[key], value, f"{path}.{key}")
+        ]
+    return []
+
+
+# A value the protocol's encoder refuses never reaches a client: the response
+# body dies where that event should have been. The keys around such a value are
+# still this interface's to get right, and an event the check gives up on is a
+# check that stops reading exactly where a run's content turns hostile. So an
+# event the encoder refuses is encoded a second time with those values stood in
+# for. A stand-in sits at a leaf and can neither add nor remove a key, so the
+# walk still reads the key set the client would have seen, and the paths the
+# stand-ins sat at are reported so nothing is passed over in silence.
+
+
+def _paths_the_encoder_refused(encoded: Any, stood_in_for: str, path: str) -> List[str]:
+    if isinstance(encoded, str):
+        return [path] if encoded == stood_in_for else []
+    if isinstance(encoded, dict):
+        # A key can be stood in for as readily as a value, and a key the encoder
+        # refuses is the case that changes the key set the walk reads.
+        return [
+            found
+            for key, value in encoded.items()
+            for found in (
+                [f"{path}.<a key the encoder refused>"]
+                if key == stood_in_for
+                else _paths_the_encoder_refused(value, stood_in_for, f"{path}.{key}")
+            )
+        ]
+    if isinstance(encoded, list):
+        return [
+            found
+            for index, value in enumerate(encoded)
+            for found in _paths_the_encoder_refused(value, stood_in_for, f"{path}[{index}]")
+        ]
+    return []
+
+
+def _encoded_as_far_as_it_reads(event: Any) -> Tuple[Dict[str, Any], List[str]]:
+    """One event's encoded keys, and the path of every value the encoder refused.
+
+    The protocol's own encoder first, so a stream with nothing hostile in it is
+    read exactly as a client reads it. Only an event that encoder refuses is
+    re-encoded with stand-ins, and an event that cannot be read even that way is
+    named whole rather than counted clean.
+    """
+    try:
+        return _encoded(event), []
+    except Exception:
+        pass
+    stood_in_for = f"<a value the encoder refused {uuid4()}>"
+    try:
+        payload = json.loads(event.model_dump_json(by_alias=True, fallback=lambda _: stood_in_for))
+    except Exception as refused_outright:
+        # Named by type: rendering this exception reads the value that raised.
+        return {}, [f"{type(event).__name__}: no key of this event could be read ({type(refused_outright).__name__})"]
+    return payload, _paths_the_encoder_refused(payload, stood_in_for, type(event).__name__)
+
+
+def _what_the_stream_encoded(events: Sequence[Any]) -> Tuple[List[str], List[str]]:
+    """(keys no model declares, paths the encoder refused) over one stream."""
+    undeclared: List[str] = []
+    refused: List[str] = []
+    for event in events:
+        encoded, paths = _encoded_as_far_as_it_reads(event)
+        undeclared += _undeclared_keys_under(event, encoded, type(event).__name__)
+        refused += paths
+    return undeclared, refused
+
+
+def undeclared_keys_on_the_wire(events: Sequence[Any]) -> List[str]:
+    """Every key this stream encoded that the model it came from does not declare.
+
+    What it cannot see: a declared field carrying a wrong or null value, and
+    anything inside an open-by-key object such as an interrupt's metadata, whose
+    keys are this interface's own and are declared nowhere. It reads the models
+    the installed release presents, so it says what this install would send and
+    not what an older one would.
+
+    A value the encoder refuses is stood in for, so the keys around it are read.
+    Which keys went unread is the other half of the answer, and
+    ``values_the_encoder_refused`` is where a caller gets it.
+    """
+    return _what_the_stream_encoded(events)[0]
+
+
+def values_the_encoder_refused(events: Sequence[Any]) -> List[str]:
+    """Every path in this stream holding a value the protocol's encoder refuses."""
+    return _what_the_stream_encoded(events)[1]
+
+
+def _assert_nothing_undeclared_reached_the_client(events: Sequence[Any], encoder_refuses: Sequence[str] = ()) -> None:
+    """Held to the keys the stream encoded, and to the values it could not encode.
+
+    A refused value is not a clean bill of health: the keys around it were read,
+    the subtree under it was not, and the client is served no such event at all.
+    So it fails here unless the caller names the paths its stream means to
+    produce, which pins the refusal where a reader can see it. Named and refused
+    have to match both ways, so a pin that stops being true fails too.
+    """
+    undeclared, refused = _what_the_stream_encoded(events)
+    assert undeclared == [], f"the encoded stream carries keys no protocol model declares: {undeclared}"
+    assert sorted(refused) == sorted(encoder_refuses), (
+        "this stream holds values the protocol's encoder refuses, which are not the ones it says it holds: "
+        f"refused {sorted(refused)}, named {sorted(encoder_refuses)}"
+    )
+
+
+def _subagent_terminals(events: List[Any]) -> List[Any]:
+    """The member terminals that closed as finished, for a test that reads one.
+
+    Not what a privacy assertion asks: a stream that named a member some other
+    way carries none of these. That question is ``member_mentions``, which reads
+    every way one stream can name a member.
+    """
+    return [event for event in events if type(event).__name__ == "SubagentFinishedEvent"]
+
+
+# --- The default: a pause reaches the client as it always has ----------------
+
+
+class TestOutcomeIsOffByDefault:
+    def test_a_pause_carries_no_outcome(self):
+        events = on_run_completed(_paused(_confirmation()), StreamState())
+        assert _outcome_on_the_wire(_run_finished(events)) == "absent"
+
+    @pytest.mark.parametrize(
+        "pending",
+        [_confirmation(), _external(), _user_input(), _user_feedback()],
+        ids=["confirmation", "external_execution", "user_input", "user_feedback"],
+    )
+    def test_no_pause_kind_carries_an_outcome(self, pending):
+        events = on_run_completed(_paused(pending), StreamState())
+        assert _outcome_on_the_wire(_run_finished(events)) == "absent"
+
+    @pytest.mark.parametrize(
+        ("pending", "malformed"),
+        [
+            (_two_pause_kinds(), A_CALL_PROMPTED_ONCE_PER_PAUSE_KIND),
+            (_user_input([]), None),
+        ],
+        ids=["one_call_for_two_pause_kinds", "no_field_to_answer_in"],
+    )
+    def test_a_pause_nothing_can_answer_still_finishes(self, pending, malformed):
+        """A pause no client could answer reaches this default unchanged.
+
+        With the outcome on it ends the run, because nothing would continue it.
+        With it off this interface advertises nothing and makes no claim about
+        what a resume must carry, so the pause reaches the client as the finished
+        run it always did. Which for the call listed by two pause kinds is a
+        stream this directory's own invariants reject, pinned to the violation it
+        breaks rather than passing unseen.
+        """
+        events = on_run_completed(_paused(pending), StreamState(), malformed=malformed)
+
+        assert _outcome_on_the_wire(_run_finished(events)) == "absent"
+
+    def test_the_prompt_a_call_listed_twice_produces_is_unchanged(self):
+        """A call flagged for two pause kinds is listed by each, and prompted twice.
+
+        With the outcome off, which is the stream this interface has always sent,
+        that pause reaches the client exactly as it did: the terminal makes no
+        claim about what a resume must carry, so nothing about the pause is
+        refused. With the outcome on, no answer resolves such a call and the run
+        ends instead, which the section on a pause no answer could resolve
+        drives.
+
+        Which is a stream the directory's own definition of a well-formed one
+        rejects, and says so here rather than passing because this test builds
+        its events by a path that used to reach no checker.
+        """
+        events = on_run_completed(
+            _paused(_two_pause_kinds()),
+            StreamState(),
+            malformed=A_CALL_PROMPTED_ONCE_PER_PAUSE_KIND,
+        )
+
+        started = [event.tool_call_id for event in events if type(event).__name__ == "ToolCallStartEvent"]
+        assert started == ["tc-both", "tc-both"]
+        assert _outcome_on_the_wire(_run_finished(events)) == "absent"
+
+    def test_the_interface_defaults_to_off(self):
+        from agno.os.interfaces.agui import AGUI
+
+        assert AGUI(agent=Agent(name="A")).emit_interrupt_outcome is False
+
+    @pytest.mark.asyncio
+    async def test_a_suspended_member_still_finishes_plainly(self):
+        """With the outcome off, a member the run paused inside closes as it always did.
+
+        The two halves are one setting: a lane closed as suspended beside a run
+        terminal that reports a completion tells a client the member is waiting
+        on a run that says it finished.
+
+        Gated on the lineage events it needs a member terminal from, and on
+        nothing else: an install that cannot serve the suspended outcome is one
+        where this promise still holds and is still worth proving.
+        """
+        require_lineage_events()
+        events, error = await collect_async(
+            [_member_paused(_confirmation(), member_run_id="member-run")],
+            attributed(),
+            thread_id=THREAD_ID,
+            run_id=RUN_ID,
+        )
+        assert error is None
+        # Both halves, because the promise is about the pair: a member closing
+        # as waiting is only wrong beside a run terminal that says it finished.
+        assert [_outcome_on_the_wire(terminal) for terminal in _subagent_terminals(events)] == ["absent"]
+        assert _outcome_on_the_wire(_run_finished(events)) == "absent"
+
+
+# --- The outcome a pause carries when it is asked for ------------------------
+
+
+@needs_interrupt_outcome
+class TestInterruptOutcome:
+    def test_a_completed_run_still_carries_no_outcome(self):
+        """The setting speaks about pauses only, exactly as the reference bridges do."""
+        events = on_run_completed(RunCompletedEvent(), StreamState(emit_interrupt_outcome=True))
+        assert _outcome_on_the_wire(_run_finished(events)) == "absent"
+
+    def test_a_pause_says_the_run_is_waiting(self):
+        chunk = _paused(_confirmation())
+        events = on_run_completed(chunk, StreamState(emit_interrupt_outcome=True))
+
+        outcome = _outcome_on_the_wire(_run_finished(events))
+        assert outcome["type"] == "interrupt"
+        assert [interrupt["id"] for interrupt in outcome["interrupts"]] == _accepted_by_the_resume_side(chunk)
+
+    def test_the_paused_runs_own_words_are_the_message_the_pending_call_hangs_from(self):
+        """Which is why no interrupt carries a message of its own.
+
+        The words the run paused on are already an assistant message, and the
+        pending call is parented to it, so a client renders the prompt beside
+        the call it is about. A message on the interrupt as well would be the
+        same prompt a second time, in a place a renderer shows on its own.
+        """
+        said = "I need your approval before I send this."
+        chunk = _paused(_confirmation(), content=said)
+
+        events = on_run_completed(chunk, StreamState(emit_interrupt_outcome=True))
+
+        spoken = [event for event in events if type(event).__name__ == "TextMessageContentEvent"]
+        assert [event.delta for event in spoken] == [said]
+        prompted = [event for event in events if type(event).__name__ == "ToolCallStartEvent"]
+        assert [event.parent_message_id for event in prompted] == [spoken[0].message_id]
+        assert "message" not in _advertised_interrupts(events)[0]
+
+    @pytest.mark.parametrize(
+        ("pending", "reason"),
+        [
+            (_confirmation(), interrupts.REASON_TOOL_CALL),
+            (_external(), interrupts.REASON_TOOL_CALL),
+            (_user_input(), interrupts.REASON_INPUT_REQUIRED),
+            (_user_feedback(), interrupts.REASON_INPUT_REQUIRED),
+        ],
+        ids=["confirmation", "external_execution", "user_input", "user_feedback"],
+    )
+    def test_each_pause_kind_reports_its_reason_and_its_call(self, pending, reason):
+        """A decision about one proposed call, or a request for data the model needs.
+
+        Both are spec-defined reason values a client switches on, and both carry
+        the tool call the interrupt is bound to, because that call is what the
+        client was shown and what the resume is answered against.
+        """
+        events = on_run_completed(_paused(pending), StreamState(emit_interrupt_outcome=True))
+
+        interrupt = _outcome_on_the_wire(_run_finished(events))["interrupts"][0]
+        assert interrupt["reason"] == reason
+        assert interrupt["toolCallId"] == pending.tool_call_id
+
+    @pytest.mark.parametrize(
+        ("pending", "pause_type"),
+        [
+            (_confirmation(), "confirmation"),
+            (_external(), "external_execution"),
+            (_user_input(), "user_input"),
+            (_user_feedback(), "user_feedback"),
+        ],
+        ids=["confirmation", "external_execution", "user_input", "user_feedback"],
+    )
+    def test_the_exact_pause_kind_stays_readable(self, pending, pause_type):
+        """Two kinds share a reason and ask for opposite things: approve, or run it.
+
+        The reason is the routing hint the protocol defines, so what tells those
+        two apart travels beside it, with the name of the tool that is waiting.
+        """
+        events = on_run_completed(_paused(pending), StreamState(emit_interrupt_outcome=True))
+
+        described = dict(self._described_pause(events))
+        # Where a failure is reported is owned by the checks below. What every
+        # kind carries is the pause kind and the tool that is waiting.
+        described.pop(interrupts.ERROR_REPORT_PATH_KEY, None)
+        assert described == {"pause_type": pause_type, "tool_name": pending.tool_name}
+
+    def _described_pause(self, events: List[Any]) -> Dict[str, Any]:
+        """What the interrupt says about the pause, under this interface's own key.
+
+        Read through the namespace the resume channel reads its own metadata
+        under, because it is one key: an emit site spelling it out as a literal
+        is how the two sides come to disagree about where this interface's data
+        lives.
+        """
+        interrupt = _outcome_on_the_wire(_run_finished(events))["interrupts"][0]
+        return interrupt["metadata"][interrupts.RESUME_METADATA_NAMESPACE]
+
+    def test_a_pause_recording_no_tool_name_says_nothing_about_one(self):
+        """An absent name is left out, not published as an explicit null.
+
+        The key is this interface's own, so a client reading it reads what is
+        there: a null under it says the pause named its tool and the name is
+        nothing, which is a different claim from the pause not recording one.
+        """
+        nameless = ToolExecution(tool_call_id="tc-nameless", tool_name=None, requires_confirmation=True)
+
+        events = on_run_completed(_paused(nameless), StreamState(emit_interrupt_outcome=True))
+
+        described = self._described_pause(events)
+        assert "tool_name" not in described
+        assert described["pause_type"] == "confirmation"
+
+    def test_an_external_execution_asks_for_no_particular_answer(self):
+        """The client runs the tool and hands back whatever it returned.
+
+        There is no shape to describe, and describing one would tell a client to
+        validate a tool result against it.
+        """
+        events = on_run_completed(_paused(_external()), StreamState(emit_interrupt_outcome=True))
+
+        assert "responseSchema" not in _outcome_on_the_wire(_run_finished(events))["interrupts"][0]
+
+    def test_a_client_run_tool_is_told_where_to_report_that_it_failed(self):
+        """A client can only find the convention by reading Agno's source otherwise.
+
+        The answer to this pause is whatever the client's tool returned, so a
+        tool that raised has nowhere in the payload to say so without reaching
+        the model as output it never produced. Where it says so instead is
+        envelope data about the response, so the interrupt names the path rather
+        than describing an answer shape.
+        """
+        events = on_run_completed(_paused(_external()), StreamState(emit_interrupt_outcome=True))
+
+        interrupt = _outcome_on_the_wire(_run_finished(events))["interrupts"][0]
+        assert interrupt["metadata"]["agno"][interrupts.ERROR_REPORT_PATH_KEY] == [
+            "metadata",
+            interrupts.RESUME_METADATA_NAMESPACE,
+            interrupts.RESUME_ERROR_KEY,
+        ]
+
+    @pytest.mark.parametrize(
+        "pending",
+        [_confirmation(), _user_input(), _user_feedback()],
+        ids=["confirmation", "user_input", "user_feedback"],
+    )
+    def test_no_other_pause_kind_advertises_that_path(self, pending):
+        """Only an opaque tool result has no way of its own to say answering failed.
+
+        A decision says no through the schema it advertises, and a request for
+        input cannot be resumed from a failure at all, so naming the path on
+        either would advertise a report that is either redundant or refused.
+        """
+        events = on_run_completed(_paused(pending), StreamState(emit_interrupt_outcome=True))
+
+        described = _outcome_on_the_wire(_run_finished(events))["interrupts"][0]["metadata"]["agno"]
+        assert interrupts.ERROR_REPORT_PATH_KEY not in described
+
+    def test_every_pending_call_gets_its_own_interrupt(self):
+        """In the order the pause prompt shows them, which is the order of the
+        terminal's own pending-call lists rather than the order the tools were
+        given: a client renders the two side by side and the outcome has to name
+        the same two, in the same order, as the calls it was shown."""
+        chunk = _paused(_confirmation("tc-a", "send_email"), _external("tc-b", "change_background"))
+        events = on_run_completed(chunk, StreamState(emit_interrupt_outcome=True))
+
+        outcome = _outcome_on_the_wire(_run_finished(events))
+        prompted = [event.tool_call_id for event in events if type(event).__name__ == "ToolCallStartEvent"]
+        assert [interrupt["toolCallId"] for interrupt in outcome["interrupts"]] == prompted
+        # Which requirement each interrupt is keyed by, with both sides sorted
+        # because the terminal advertises in the order it prompts the calls and
+        # not in the order the requirements are listed. The order is the line
+        # above, against the order it really is in.
+        assert sorted(interrupt["id"] for interrupt in outcome["interrupts"]) == _accepted_by_the_resume_side(chunk)
+
+    def test_a_pause_the_client_cannot_be_shown_stays_a_plain_terminal(self, caplog):
+        """The protocol refuses an interrupt outcome with nothing in it.
+
+        A pending call with no id is one a client can neither render nor resolve,
+        so the run reaches it as the finished run it reached before the outcome
+        existed, and the interface says so rather than dropping it quietly.
+        """
+        unshowable = ToolExecution(tool_call_id=None, tool_name="send_email", requires_confirmation=True)
+        with captured_agno_logs(caplog, "WARNING"):
+            events = on_run_completed(RunPausedEvent(tools=[unshowable]), StreamState(emit_interrupt_outcome=True))
+
+        assert _outcome_on_the_wire(_run_finished(events)) == "absent"
+        assert "no interrupt the terminal can carry" in caplog.text
+
+    def test_a_pause_with_no_pending_call_at_all_stays_a_plain_terminal(self):
+        events = on_run_completed(RunPausedEvent(), StreamState(emit_interrupt_outcome=True))
+
+        assert _outcome_on_the_wire(_run_finished(events)) == "absent"
+
+    @pytest.mark.parametrize(
+        "pending",
+        [_confirmation(), _external(), _user_input(), _user_feedback()],
+        ids=["confirmation", "external_execution", "user_input", "user_feedback"],
+    )
+    def test_a_pause_reported_without_requirements_still_reports_its_call(self, pending):
+        """A pause carrying only the terminal's tool lists is keyed by the call.
+
+        Every kind of pending call reaches this, because the requirements are
+        what say which kind it is and this pause reports none. What is left is a
+        proposed call the client was shown, which is the reason it carries and
+        the id it is answered under.
+        """
+        events = on_run_completed(RunPausedEvent(tools=[pending]), StreamState(emit_interrupt_outcome=True))
+
+        interrupt = _outcome_on_the_wire(_run_finished(events))["interrupts"][0]
+        assert (interrupt["id"], interrupt["reason"], interrupt["toolCallId"]) == (
+            pending.tool_call_id,
+            interrupts.REASON_TOOL_CALL,
+            pending.tool_call_id,
+        )
+
+    @pytest.mark.parametrize(
+        "pending",
+        [_confirmation(), _external(), _user_input(), _user_feedback()],
+        ids=["confirmation", "external_execution", "user_input", "user_feedback"],
+    )
+    def test_a_pause_reported_without_requirements_claims_no_pause_kind(self, pending):
+        """Naming a kind here would be inventing one, and each invention is a lie
+        a client acts on: an approval published as external execution is a tool
+        the client runs itself, and the path for reporting that a client-run tool
+        raised is answerable on no other kind. The tool that is waiting is still
+        named, because the terminal really did report it.
+        """
+        events = on_run_completed(RunPausedEvent(tools=[pending]), StreamState(emit_interrupt_outcome=True))
+
+        described = self._described_pause(events)
+        assert "pause_type" not in described
+        assert interrupts.ERROR_REPORT_PATH_KEY not in described
+        assert described == {"tool_name": pending.tool_name}
+
+
+# --- The one property the two halves have to agree on ------------------------
+
+
+class _Entry:
+    """One resume entry, in the shape the protocol model presents."""
+
+    def __init__(
+        self,
+        interrupt_id: str,
+        status: str = "resolved",
+        payload: Any = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ):
+        self.interrupt_id = interrupt_id
+        self.status = status
+        self.payload = payload
+        self.metadata = metadata
+
+
+def _requirement(pending: ToolExecution) -> RunRequirement:
+    return RunRequirement(tool_execution=pending)
+
+
+def _needs_answering(requirement: RunRequirement) -> Any:
+    """The one entry the interface's own computation returns for this requirement.
+
+    Both halves of the round trip read that computation, so a test driving one
+    builder directly hands it what the interface would have handed it.
+    """
+    needed = interrupts.answers_a_pause_needs([requirement])
+    assert len(needed) == 1, f"one open requirement, {len(needed)} answers needed"
+    return needed[0]
+
+
+def _accepted_by_the_resume_side(chunk: Any) -> List[str]:
+    """The interrupt ids the resume side would take for this paused run.
+
+    Read off the run's own open requirements, keyed exactly as
+    ``resolve_requirements_from_resume_entries`` keys them, so the property
+    below compares the terminal against the channel that has to answer it and
+    not against a second opinion about what the pause meant.
+    """
+    return sorted(interrupts.interrupt_id_of(requirement) for requirement in chunk.active_requirements)
+
+
+def _failed_terminal(events: List[Any]) -> Any:
+    """The run's failed terminal, or None when the run finished.
+
+    A body carrying both is refused: which of the two a client acted on is not
+    something to guess at.
+    """
+    failed = [event for event in events if type(event).__name__ == "RunErrorEvent"]
+    finished = [event for event in events if type(event).__name__ == "RunFinishedEvent"]
+    assert len(failed) + len(finished) == 1, (
+        f"expected exactly one run terminal, got {[type(event).__name__ for event in events]}"
+    )
+    return failed[0] if failed else None
+
+
+# What a terminal that carries no outcome at all reads as. Its own value rather
+# than an empty list: a terminal with no outcome and a terminal carrying an
+# outcome with an empty interrupt list are different things on the wire, the
+# second is one the protocol refuses, and a helper that returns [] for both lets
+# a test that means the first pass on the second.
+NO_OUTCOME_AT_ALL = "the terminal carried no outcome"
+
+
+def _advertised_interrupts(events: List[Any]) -> Any:
+    """The interrupts the terminal advertised in order, or NO_OUTCOME_AT_ALL.
+
+    A run that failed carries no outcome to advertise one in, and neither does a
+    finished run with the emission off. Both read as no outcome at all, which is
+    not the same wire shape as an outcome whose interrupt list is empty.
+    """
+    if _failed_terminal(events) is not None:
+        return NO_OUTCOME_AT_ALL
+    outcome = _outcome_on_the_wire(_run_finished(events))
+    return NO_OUTCOME_AT_ALL if outcome == "absent" else list(outcome["interrupts"])
+
+
+def _advertised_interrupt_ids(events: List[Any]) -> Any:
+    """Every id the terminal advertised in the order it advertised them, or NO_OUTCOME_AT_ALL.
+
+    Emitted order, duplicates included, because that is what the terminal put on
+    the wire. Sorted here instead, it was compared against a list in emission
+    order: the terminal advertises in the order it prompts the calls, which is
+    not the order a pause lists its requirements in, so that comparison was
+    neither an order check nor a set one, and held by how two ids happened to
+    sort.
+    """
+    advertised = _advertised_interrupts(events)
+    if advertised == NO_OUTCOME_AT_ALL:
+        return NO_OUTCOME_AT_ALL
+    return [interrupt["id"] for interrupt in advertised]
+
+
+def _advertised_interrupt_ids_keyed_as_the_resume_side_keys_them(events: List[Any]) -> Any:
+    """The same ids in the order ``_accepted_by_the_resume_side`` returns them.
+
+    For the comparisons whose subject is which ids reached the terminal rather
+    than the order it advertised them in, which the emitted order above is what
+    says. Keyed here rather than sorted at the call site so that a terminal
+    carrying no outcome still reads as that and not as a sorted string.
+    """
+    advertised = _advertised_interrupt_ids(events)
+    return advertised if advertised == NO_OUTCOME_AT_ALL else sorted(advertised)
+
+
+def _an_answer_to(interrupt: Dict[str, Any]) -> Any:
+    """A payload that answers one advertised interrupt.
+
+    Built from what the interrupt itself advertised: the pause kind says which
+    envelope the answer travels in and the response schema says what goes in it.
+    So a client that read only the terminal could have sent this, which is what
+    makes answering it evidence about the terminal rather than about the test.
+    """
+    pause_type = interrupt["metadata"]["agno"]["pause_type"]
+    if pause_type == "confirmation":
+        return {interrupts.CONFIRMATION_ACCEPTED_KEY: True}
+    if pause_type == "external_execution":
+        return "the client ran it"
+    described = interrupt["responseSchema"]["properties"]
+    if pause_type == "user_input":
+        values = described[interrupts.USER_INPUT_VALUES_KEY]
+        return {interrupts.USER_INPUT_VALUES_KEY: {name: "answered" for name in values.get("required", [])}}
+    selections = described[interrupts.USER_FEEDBACK_SELECTIONS_KEY]
+    return {
+        interrupts.USER_FEEDBACK_SELECTIONS_KEY: {
+            question: [asked["items"]["enum"][0]] for question, asked in selections["properties"].items()
+        }
+    }
+
+
+def _answering_everything_advertised(chunk: Any, advertised: List[Dict[str, Any]]) -> None:
+    """Answer exactly what the terminal advertised, through the resume side itself.
+
+    On a copy of the paused run, because the answers are written onto the
+    requirements. Raises whatever the route would: the resume side, guard
+    included, is what decides whether the run continues, so it is driven rather
+    than second-guessed here.
+    """
+    requirements = deepcopy(list(chunk.requirements or []))
+    resolve_requirements_from_resume_entries(
+        requirements,
+        [_Entry(interrupt["id"], payload=_an_answer_to(interrupt)) for interrupt in advertised],
+    )
+
+
+# Every shape of pause that reports its requirements and can be continued. A
+# pause reporting none has no requirement id to be keyed by and keeps the tool
+# call as its key, which is pinned separately.
+_PAUSE_SHAPES = {
+    "one_call": lambda: _paused(_confirmation()),
+    "two_calls": lambda: _paused(_confirmation("tc-a"), _external("tc-b")),
+    "structured_input": lambda: _paused(_user_input()),
+    "structured_feedback": lambda: _paused(_user_feedback()),
+    "an_inner_agents_call": _paused_inside_an_inner_agent,
+    "a_members_call": lambda: _member_paused(_confirmation(), member_run_id="member-run"),
+    "a_call_with_nothing_open_behind_it": _paused_listing_a_call_with_nothing_open_behind_it,
+}
+
+# Every shape of pause that cannot be continued at all, because one of the
+# requirements it left open is one no answer resolves. The run ends on those, so
+# the same property reads the other way: nothing is advertised, and the terminal
+# says why.
+_PAUSES_NOTHING_CAN_ANSWER = {
+    "one_call_for_two_pause_kinds": lambda: _paused(_two_pause_kinds()),
+    "no_field_to_answer_in": lambda: _paused(_user_input([])),
+    "one_answerable_beside_one_that_is_not": lambda: _paused(_two_pause_kinds(), _confirmation("tc-answerable")),
+    "two_requirements_under_one_id": _paused_where_two_requirements_share_one_id,
+    "a_question_that_answers_for_an_empty_field": lambda: _paused(
+        _asks_a_question_while_a_field_it_needs_stays_empty()
+    ),
+    "no_field_an_answer_could_be_keyed_to": lambda: _paused(_filled_a_field_no_answer_could_name()),
+    "a_members_call_nothing_can_answer": _member_paused_on_something_nothing_can_answer,
+}
+
+_EVERY_PAUSE_SHAPE = [pytest.param(shape, True, id=name) for name, shape in _PAUSE_SHAPES.items()] + [
+    pytest.param(shape, False, id=name) for name, shape in _PAUSES_NOTHING_CAN_ANSWER.items()
+]
+
+
+@needs_interrupt_outcome
+class TestTheTerminalAdvertisesWhatTheResumeSideAccepts:
+    """The property the two halves of the round trip stand or fall on.
+
+    A pause's terminal advertises the ids a client answers under, and the resume
+    channel looks each answer up by the same id. Those two sets have to be the
+    same set, and answering the advertised set has to continue the run. An id the
+    resume side cannot place stops the entire resume array, stranding the run; an
+    open requirement the terminal never advertised is one nobody answers, which
+    the partial-resume guard then stops; and an id advertised twice is one
+    correlation key standing for two things.
+
+    A subset is not good enough, which is the hole this closes. A terminal that
+    advertised only the requirements it could describe left the resume side
+    demanding one it had not mentioned: the client answered everything it was
+    told about and the guard refused the resume, with nothing on the wire saying
+    what was missing. So a pause holding one requirement no answer resolves ends
+    the run here, saying so, and advertises nothing at all.
+    """
+
+    @pytest.mark.parametrize("visibility", SUBAGENT_VISIBILITY_VALUES)
+    @pytest.mark.parametrize(("shape", "continuable"), _EVERY_PAUSE_SHAPE)
+    def test_a_pause_is_continuable_exactly_when_its_terminal_advertised_it(self, shape, visibility, continuable):
+        """Across every visibility, because a setting decides what the client is
+        shown and never what the run is still waiting on."""
+        if visibility == SUBAGENT_VISIBILITY_ATTRIBUTED:
+            require_lineage_events()
+        chunk = shape()
+
+        events = on_run_completed(chunk, StreamState(emit_interrupt_outcome=True, subagent_visibility=visibility))
+
+        advertised = _advertised_interrupts(events)
+        if not continuable:
+            assert advertised == NO_OUTCOME_AT_ALL
+            assert "cannot be continued" in _failed_terminal(events).message
+            return
+        assert _failed_terminal(events) is None
+        assert sorted(interrupt["id"] for interrupt in advertised) == _accepted_by_the_resume_side(chunk)
+        # Which is the half a matching set of ids does not prove: the resume side
+        # has to take those answers and leave nothing open behind them.
+        _answering_everything_advertised(chunk, advertised)
+
+    def test_answering_all_but_one_of_them_is_refused(self):
+        """The advertised set is the whole demand, not a menu.
+
+        Every id on it is one the run cannot continue without, which is what
+        makes the set the terminal sends the thing a client has to answer in
+        full.
+        """
+        chunk = _paused(_confirmation("tc-a"), _external("tc-b"))
+        advertised = _advertised_interrupts(
+            on_run_completed(chunk, StreamState(emit_interrupt_outcome=True)),
+        )
+
+        with pytest.raises(ValueError, match="still unresolved"):
+            _answering_everything_advertised(chunk, advertised[:1])
+
+    def test_a_requirement_the_prompt_never_read_still_reaches_the_terminal(self):
+        """The default visibility reads no member lane, and the pause is still open.
+
+        A client answering only what it was shown fails the partial-resume guard
+        on the requirement nobody told it about.
+        """
+        chunk = _paused_inside_an_inner_agent()
+
+        events = on_run_completed(chunk, StreamState(emit_interrupt_outcome=True))
+
+        # Both sides keyed alike, because the two orders are not the same one:
+        # the terminal advertises in the order it prompts the calls, and a pause
+        # lists its requirements in its own.
+        assert _advertised_interrupt_ids_keyed_as_the_resume_side_keys_them(events) == _accepted_by_the_resume_side(
+            chunk
+        )
+        # Unattributed: the default visibility names no member, and the terminal
+        # carrying the requirement must not start naming one.
+        assert "subagentRunId" not in _outcome_on_the_wire(_run_finished(events))["interrupts"][0]
+
+    @pytest.mark.asyncio
+    async def test_an_unannounced_member_is_not_named_by_the_interrupt_it_owns(self):
+        """A member whose every pending call was dropped is never announced.
+
+        Its requirement is still open, so the terminal still has to carry it.
+        Naming the member there would leave the client an interrupt from a
+        subagent it never saw start.
+        """
+        require_lineage_events()
+        nameless = ToolExecution(tool_call_id="tc-ghost", tool_name=None, requires_confirmation=True)
+        chunk = _member_paused(nameless, member_run_id="ghost-run")
+
+        events, error = await collect_async(
+            [chunk],
+            attributed(),
+            thread_id=THREAD_ID,
+            run_id=RUN_ID,
+            emit_interrupt_outcome=True,
+        )
+
+        assert error is None
+        assert _advertised_interrupt_ids_keyed_as_the_resume_side_keys_them(events) == _accepted_by_the_resume_side(
+            chunk
+        )
+        interrupt = _outcome_on_the_wire(_run_finished(events))["interrupts"][0]
+        assert "subagentRunId" not in interrupt
+        # Every way this stream could name the member, not one terminal kind: a
+        # member announced and then closed as an error is named twice over.
+        assert member_mentions(events) == []
+
+    def test_a_listed_call_with_nothing_open_behind_it_is_not_advertised(self):
+        """Advertising it hands the client an id the resume side refuses.
+
+        One refused entry stops the whole array, so the run is stranded by an
+        interrupt it never needed answered.
+
+        Which call each advertised interrupt stands for, because every id on the
+        wire is a minted one: a tool call id can reach the id field only where
+        the run recorded no requirement id, so naming the settled call there
+        pins nothing this pause can produce.
+        """
+        chunk = _paused_listing_a_call_with_nothing_open_behind_it()
+
+        events = on_run_completed(chunk, StreamState(emit_interrupt_outcome=True))
+
+        assert _advertised_interrupt_ids_keyed_as_the_resume_side_keys_them(events) == _accepted_by_the_resume_side(
+            chunk
+        )
+        assert [interrupt["toolCallId"] for interrupt in _advertised_interrupts(events)] == ["tc-open"]
+
+
+# --- The answer shapes the outcome advertises --------------------------------
+
+
+class _UnmappedType:
+    """A declared field type that no JSON Schema type maps, as a real tool can carry."""
+
+
+# The values a client could put in one field: one per JSON type, and the
+# integral float that is how JSON spells a whole number. A field the advertised
+# schema leaves open permits nearly all of them, and every value it permits has
+# to resolve the pause.
+_EVERY_JSON_SHAPE: List[Any] = [None, "otters", 0, 1.5, 2.0, True, ["a"], {"a": 1}]
+
+
+def _is_of_json_type(value: Any, json_type: str) -> bool:
+    if json_type == "null":
+        return value is None
+    if json_type == "boolean":
+        return isinstance(value, bool)
+    if json_type == "integer":
+        # JSON has one number type, so a whole number can arrive as a float and
+        # is still the integer the schema named.
+        if isinstance(value, float):
+            return value.is_integer()
+        return isinstance(value, int) and not isinstance(value, bool)
+    if json_type == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if json_type == "string":
+        return isinstance(value, str)
+    if json_type == "array":
+        return isinstance(value, list)
+    if json_type == "object":
+        return isinstance(value, dict)
+    raise AssertionError(f"the advertised schema names the type {json_type!r}, which this check cannot read")
+
+
+def _permits(described: Dict[str, Any], value: Any) -> bool:
+    """Whether one advertised field schema accepts this value.
+
+    Only the keywords this interface emits are read, and any other one fails the
+    check loudly: a constraint silently skipped here would let a schema be
+    tested against a meaning it does not carry.
+    """
+    for keyword, constraint in described.items():
+        if keyword in ("description", "title"):
+            continue
+        if keyword == "type":
+            if not _is_of_json_type(value, constraint):
+                return False
+        elif keyword == "not":
+            if _permits(constraint, value):
+                return False
+        else:
+            raise AssertionError(f"the advertised schema uses {keyword!r}, which this check cannot read")
+    return True
+
+
+def _the_interrupt_advertised_for(pending: ToolExecution) -> Dict[str, Any]:
+    """The one interrupt a pause on this call reaches a client as."""
+    events = on_run_completed(_paused(pending), StreamState(emit_interrupt_outcome=True))
+    return _outcome_on_the_wire(_run_finished(events))["interrupts"][0]
+
+
+def _the_schema_advertised_for(pending: ToolExecution) -> Dict[str, Any]:
+    """The answer shape a client is told to send, read off the wire and not rebuilt.
+
+    One reader for both halves: the schemas are asserted through it, and the
+    payloads the resume side is held to are derived from what it returns, so a
+    test cannot hold the resume side to a shape the client was never shown.
+    """
+    return _the_interrupt_advertised_for(pending)["responseSchema"]
+
+
+def _keywords_in(described: Dict[str, Any]) -> Set[str]:
+    """Every JSON Schema keyword one advertised schema is built out of.
+
+    Schema-aware rather than a plain walk: the keys under ``properties`` are the
+    names of an answer's fields, and reading those as keywords would let any
+    field name pass for a constraint somebody checks.
+    """
+    found = set(described)
+    for keyword, constraint in described.items():
+        if keyword == "properties":
+            for child in constraint.values():
+                found |= _keywords_in(child)
+        elif keyword in ("items", "not"):
+            found |= _keywords_in(constraint)
+    return found
+
+
+@needs_interrupt_outcome
+class TestResponseSchemas:
+    def _schema_for(self, pending: ToolExecution) -> Dict[str, Any]:
+        return _the_schema_advertised_for(pending)
+
+    def _described_field(self, pending: ToolExecution, name: str) -> Dict[str, Any]:
+        return self._schema_for(pending)["properties"][interrupts.USER_INPUT_VALUES_KEY]["properties"][name]
+
+    def test_a_decision_asks_for_the_key_agno_reads(self):
+        """One payload shape has to work on both resume channels."""
+        schema = self._schema_for(_confirmation())
+
+        assert schema["required"] == [interrupts.CONFIRMATION_ACCEPTED_KEY]
+        assert schema["properties"][interrupts.CONFIRMATION_ACCEPTED_KEY]["type"] == "boolean"
+
+    def test_a_decision_offers_no_edited_arguments(self):
+        """Advertising the field is what tells a client it may offer edit UI."""
+        properties = self._schema_for(_confirmation())["properties"]
+
+        # Named beside the absence, so a schema that describes nothing at all
+        # cannot read as one that merely declines to offer the field.
+        assert interrupts.CONFIRMATION_ACCEPTED_KEY in properties
+        assert "editedArgs" not in properties
+
+    def test_user_input_describes_every_field_it_is_waiting_on(self):
+        schema = self._schema_for(_user_input())["properties"][interrupts.USER_INPUT_VALUES_KEY]
+
+        assert schema["properties"]["topic"] == {"type": "string", "description": "What to write about"}
+        assert schema["required"] == ["topic"]
+
+    def test_a_field_the_model_already_filled_is_not_required(self):
+        """The run continues once the fields still missing arrive."""
+        pre_filled = UserInputField(name="topic", field_type=str)
+        pre_filled.value = "otters"
+        fields = [pre_filled, UserInputField(name="tone", field_type=str)]
+
+        schema = self._schema_for(_user_input(fields))["properties"][interrupts.USER_INPUT_VALUES_KEY]
+
+        assert sorted(schema["properties"]) == ["tone", "topic"]
+        assert schema["required"] == ["tone"]
+
+    def test_user_input_maps_each_declared_type(self):
+        fields = [
+            UserInputField(name="count", field_type=int),
+            UserInputField(name="ratio", field_type=float),
+            UserInputField(name="agreed", field_type=bool),
+            UserInputField(name="tags", field_type=list),
+        ]
+
+        schema = self._schema_for(_user_input(fields))["properties"][interrupts.USER_INPUT_VALUES_KEY]
+
+        assert {name: described["type"] for name, described in schema["properties"].items()} == {
+            "count": "integer",
+            "ratio": "number",
+            "agreed": "boolean",
+            "tags": "array",
+        }
+
+    def test_a_type_nothing_recognises_is_left_unconstrained(self):
+        """A wrong type in the schema makes a client refuse an answer Agno accepts."""
+        described = self._described_field(
+            _user_input([UserInputField(name="thing", field_type=_UnmappedType)]), "thing"
+        )
+
+        assert "type" not in described
+
+    def test_a_field_left_unconstrained_still_cannot_be_null(self):
+        """Not naming the type is not the same as accepting anything at all.
+
+        A null leaves the field unfilled: the resume writes it on, the field
+        counts as unanswered, and the run the client was told to resume dies on
+        the partial-resume guard. So the one constraint that is known is stated
+        without the type that is not.
+        """
+        described = self._described_field(
+            _user_input([UserInputField(name="thing", field_type=_UnmappedType)]), "thing"
+        )
+
+        assert described == {"not": {"type": "null"}}
+        assert _permits(described, None) is False
+
+    def test_every_value_the_advertised_schema_permits_resolves_the_pause(self):
+        """The client did what it was told, so the run has to continue.
+
+        Read off the schema rather than written by hand: what a client may send
+        is exactly what is advertised, and the pause must be resolvable by any
+        of it.
+        """
+
+        def unmapped() -> ToolExecution:
+            return _user_input([UserInputField(name="thing", field_type=_UnmappedType)])
+
+        described = self._described_field(unmapped(), "thing")
+        permitted = [value for value in _EVERY_JSON_SHAPE if _permits(described, value)]
+
+        assert permitted, f"the advertised field schema {described} permits no answer at all"
+        for value in permitted:
+            requirement = _requirement(unmapped())
+
+            _answer_by_resume_entry(requirement, {interrupts.USER_INPUT_VALUES_KEY: {"thing": value}})
+
+            assert requirement.is_resolved() is True, value
+
+    def test_two_declarations_that_agree_on_nothing_still_cannot_be_null(self):
+        """The merge drops the type the two disagree on, which leaves the same hole."""
+        fields = [
+            UserInputField(name="topic", field_type=str),
+            UserInputField(name="topic", field_type=_UnmappedType),
+        ]
+
+        assert self._described_field(_user_input(fields), "topic") == {"not": {"type": "null"}}
+
+    def test_user_feedback_offers_only_the_labels_the_question_declared(self):
+        schema = self._schema_for(_user_feedback())["properties"][interrupts.USER_FEEDBACK_SELECTIONS_KEY]
+
+        answered = schema["properties"]["What budget?"]
+        assert answered["items"]["enum"] == ["low", "high"]
+        assert schema["required"] == ["What budget?"]
+
+    def _question_asked_by(self, pending: ToolExecution) -> Dict[str, Any]:
+        """What the one question of this feedback pause asks a client for."""
+        asked = self._schema_for(pending)["properties"][interrupts.USER_FEEDBACK_SELECTIONS_KEY]["properties"]
+        (text,) = asked
+        return asked[text]
+
+    def test_a_label_of_another_kind_is_offered_as_the_text_of_itself(self):
+        """A choice list holding a value the type beside it excludes satisfies nothing.
+
+        The label reaches the enum as its display text, which is the one form
+        the resume side accepts for it: the item type is enforced there, so the
+        label as the tool wrote it is refused and its text is taken. Offering
+        the text is therefore offering the only answer that choice has, and a
+        client that validates before it submits, which the protocol says it
+        should, can build one.
+        """
+        offered = self._question_asked_by(
+            _user_feedback_offering(UserFeedbackOption(label=3), UserFeedbackOption(label="high"))
+        )["items"]
+
+        assert [label for label in offered["enum"] if not _is_of_json_type(label, offered["type"])] == []
+        assert offered["enum"] == ["3", "high"]
+
+    def test_a_converted_label_is_one_the_resume_side_takes(self):
+        """The choice is advertised because answering with it continues the run.
+
+        Which is what makes converting the label better than leaving it out: the
+        label as the tool wrote it is refused for its type, so the text is the
+        only answer that choice ever had, and a pause that offers it is a pause
+        whose every advertised choice can be picked.
+        """
+        pending = _user_feedback_offering(UserFeedbackOption(label=3))
+
+        assert self._question_asked_by(pending)["items"]["enum"] == ["3"]
+
+        requirement = _requirement(pending)
+        _answer_by_resume_entry(requirement, {interrupts.USER_FEEDBACK_SELECTIONS_KEY: {"What budget?": ["3"]}})
+        assert requirement.is_resolved() is True
+
+    def test_a_label_that_cannot_be_offered_at_all_is_reported(self, caplog):
+        """A choice list short of what the tool offered is one nothing recorded.
+
+        An empty label is nothing to show and reaches no client, so the question
+        is advertised without it. Left unsaid, the pause reads as one the tool
+        declared fewer choices for than it did.
+        """
+        with captured_agno_logs(caplog, "WARNING"):
+            offered = self._question_asked_by(
+                _user_feedback_offering(UserFeedbackOption(label=""), UserFeedbackOption(label="high"))
+            )["items"]
+
+        assert offered["enum"] == ["high"]
+        assert "without 1 of its options" in caplog.text
+
+    def test_a_question_left_with_no_usable_label_still_asks_its_question(self):
+        """Leaving out every label gives the shape a question with no options has.
+
+        Which is one a client can answer and Agno resolves: a selection is
+        written onto the question as it arrives, matched against no label. So
+        the pause is advertised rather than refused, and answering it continues
+        the run.
+        """
+        pending = _user_feedback_offering(UserFeedbackOption(label=""))
+
+        assert "enum" not in self._question_asked_by(pending)["items"]
+
+        requirement = _requirement(pending)
+        _answer_by_resume_entry(requirement, {interrupts.USER_FEEDBACK_SELECTIONS_KEY: {"What budget?": ["low"]}})
+        assert requirement.is_resolved() is True
+
+    def test_a_single_select_question_caps_the_answer_at_one(self):
+        """Otherwise a client offers a choice Agno would then have to refuse."""
+        single = self._schema_for(_user_feedback(multi_select=False))
+        multi = self._schema_for(_user_feedback(multi_select=True))
+
+        key = interrupts.USER_FEEDBACK_SELECTIONS_KEY
+        assert single["properties"][key]["properties"]["What budget?"]["maxItems"] == 1
+        assert "maxItems" not in multi["properties"][key]["properties"]["What budget?"]
+
+    @pytest.mark.parametrize("multi_select", [False, True], ids=["single_select", "multi_select"])
+    def test_a_question_asks_for_at_least_one_selection(self, multi_select):
+        """An empty array is a payload that satisfies the schema and answers nothing."""
+        schema = self._schema_for(_user_feedback(multi_select=multi_select))
+
+        answered = schema["properties"][interrupts.USER_FEEDBACK_SELECTIONS_KEY]["properties"]["What budget?"]
+        assert answered["minItems"] == 1
+
+    def test_two_fields_sharing_a_name_are_advertised_once(self):
+        """Two keys of one name in the payload are one key, and Agno fills both.
+
+        Where the two declarations disagree the key is described by what they
+        agree on: a constraint one of them would fail is a client refusing an
+        answer Agno accepts.
+        """
+        fields = [
+            UserInputField(name="topic", field_type=str, description="What to write about"),
+            UserInputField(name="topic", field_type=str),
+        ]
+
+        schema = self._schema_for(_user_input(fields))["properties"][interrupts.USER_INPUT_VALUES_KEY]
+
+        assert list(schema["properties"]) == ["topic"]
+        assert schema["properties"]["topic"] == {"type": "string"}
+        assert schema["required"] == ["topic"]
+
+    def test_two_questions_sharing_their_text_are_advertised_once(self):
+        """One key per question text, because that is what Agno matches by."""
+        asked_twice = ToolExecution(
+            tool_call_id="tc-feedback",
+            tool_name="ask_user",
+            tool_args={},
+            requires_user_input=True,
+            user_feedback_schema=[
+                UserFeedbackQuestion(question="What budget?", options=[UserFeedbackOption(label="low")]),
+                UserFeedbackQuestion(question="What budget?", options=[UserFeedbackOption(label="high")]),
+            ],
+        )
+
+        schema = self._schema_for(asked_twice)["properties"][interrupts.USER_FEEDBACK_SELECTIONS_KEY]
+
+        assert list(schema["properties"]) == ["What budget?"]
+        assert schema["required"] == ["What budget?"]
+        # The two offer different labels, so no label list is advertised: one
+        # naming only what the other offers would refuse a valid answer.
+        assert "enum" not in schema["properties"]["What budget?"]["items"]
+
+
+class TestThePayloadsThoseSchemasAdvertise:
+    """The resume-side half of a claim the schemas above make.
+
+    It is the reason a schema is shaped the way it is, and it touches no
+    interrupt type: it answers a requirement through the resume channel, which
+    every install has. Kept out of the class above so a gate written for the
+    schemas does not skip it on an install where it still holds.
+    """
+
+    def test_one_value_answers_every_field_of_that_name(self):
+        """Why the collapsed key is a shape that can be satisfied and not a loss."""
+        fields = [UserInputField(name="topic", field_type=str), UserInputField(name="topic", field_type=str)]
+        requirement = _requirement(_user_input(fields))
+
+        _answer_by_resume_entry(requirement, {interrupts.USER_INPUT_VALUES_KEY: {"topic": "otters"}})
+
+        assert [input_field.value for input_field in requirement.user_input_schema] == ["otters", "otters"]
+        assert requirement.is_resolved() is True
+
+
+# --- The advertised shape is the shape that is accepted ----------------------
+
+
+# Every pause kind that tells a client the shape of the answer it wants. A
+# client-run tool is not one: it hands back whatever its tool returned, which
+# this interface never described.
+_PAUSES_THAT_ADVERTISE_A_SHAPE = {
+    "decision": _confirmation,
+    "input": _user_input,
+    "single_select": lambda: _user_feedback(multi_select=False),
+    "multi_select": lambda: _user_feedback(multi_select=True),
+}
+
+
+@needs_interrupt_outcome
+class TestOnlyTheAdvertisedShapeIsAccepted:
+    """A value under a described key has to be of the kind the key was described as.
+
+    Every payload here is derived from what the terminal advertised rather than
+    written out, so each test is evidence about the interface's own promise: the
+    constraint is read off the emitted schema, and the answer that violates it is
+    built from that constraint. A value of another kind under a described key
+    reaches the tool as an argument it never asked for, which is worse than the
+    refusal.
+
+    What is checked is narrower than what is advertised, deliberately, and the
+    class below pins what that gives up.
+    """
+
+    @pytest.mark.parametrize(
+        "pending", list(_PAUSES_THAT_ADVERTISE_A_SHAPE.values()), ids=list(_PAUSES_THAT_ADVERTISE_A_SHAPE)
+    )
+    def test_an_answer_the_advertised_schema_asked_for_resolves_the_pause(self, pending):
+        """The strictness has to keep taking what the client was told to send."""
+        requirement = _requirement(pending())
+
+        _answer_by_resume_entry(requirement, _an_answer_to(_the_interrupt_advertised_for(pending())))
+
+        assert requirement.is_resolved() is True
+
+    def test_every_constraint_it_advertises_is_one_this_side_accounts_for(self):
+        """Enforced, an annotation, or described for the client alone: nothing else.
+
+        A keyword outside those is one the interface publishes and no side of the
+        round trip decided anything about, which is how a constraint ends up
+        enforced nowhere and written down as enforced. The check itself also
+        passes over a keyword it cannot read rather than refusing an answer over
+        a constraint it does not understand, so this is what keeps that case
+        hypothetical.
+        """
+        advertised: Set[str] = set()
+        for build in (
+            _confirmation,
+            _user_input,
+            lambda: _user_input(
+                [
+                    UserInputField(name="count", field_type=int),
+                    UserInputField(name="thing", field_type=_UnmappedType),
+                ]
+            ),
+            lambda: _user_feedback(multi_select=False),
+            lambda: _user_feedback(multi_select=True),
+        ):
+            advertised |= _keywords_in(_the_schema_advertised_for(build()))
+
+        assert advertised, "no schema keyword was read at all, so this check proves nothing"
+        accounted_for = set(ADVERTISED_KEYWORDS_READ) | set(SCHEMA_ADVERTISED_ONLY)
+        assert advertised <= accounted_for, sorted(advertised - accounted_for)
+        # And the two halves are really two: a schema stating only what is
+        # enforced would pass the line above while describing nothing extra,
+        # which is the arrangement the class below exists to pin.
+        assert advertised & set(SCHEMA_ADVERTISED_ONLY)
+
+    def test_a_field_resolves_on_exactly_the_values_its_declared_type_permits(self):
+        """Both directions off one description, so neither strictness nor leniency drifts.
+
+        A field advertised as one type used to resolve with any other, which
+        reaches the tool as an argument of a type it never asked for.
+        """
+
+        def declared_as_a_number() -> ToolExecution:
+            return _user_input([UserInputField(name="count", field_type=int)])
+
+        described = _the_schema_advertised_for(declared_as_a_number())["properties"][interrupts.USER_INPUT_VALUES_KEY][
+            "properties"
+        ]["count"]
+        permitted = [value for value in _EVERY_JSON_SHAPE if _permits(described, value)]
+        assert permitted and len(permitted) < len(_EVERY_JSON_SHAPE), described
+
+        for value in _EVERY_JSON_SHAPE:
+            requirement = _requirement(declared_as_a_number())
+            answer = {interrupts.USER_INPUT_VALUES_KEY: {"count": value}}
+
+            if value in permitted:
+                _answer_by_resume_entry(requirement, answer)
+                assert requirement.is_resolved() is True, value
+            else:
+                with pytest.raises(ValueError, match="user_input expects"):
+                    _answer_by_resume_entry(requirement, answer)
+                assert requirement.is_resolved() is False, value
+
+    def test_a_note_of_a_shape_the_schema_never_offered_is_refused(self):
+        """The note is what the model reads as the reason a call was refused.
+
+        Taken untyped, a structured object lands where the run records a string,
+        so a client's own object reaches the model as that reason. The null is
+        left out of this: an optional key a client sent nothing under is the
+        subject of the test below.
+        """
+        described = _the_schema_advertised_for(_confirmation())["properties"][interrupts.CONFIRMATION_NOTE_KEY]
+        refused = [value for value in _EVERY_JSON_SHAPE if value is not None and not _permits(described, value)]
+        assert refused, described
+
+        for value in refused:
+            requirement = _requirement(_confirmation())
+            answer = {interrupts.CONFIRMATION_ACCEPTED_KEY: False, interrupts.CONFIRMATION_NOTE_KEY: value}
+
+            with pytest.raises(ValueError, match="confirmation expects"):
+                _answer_by_resume_entry(requirement, answer)
+
+            assert requirement.is_resolved() is False, value
+
+    def test_a_selection_of_a_kind_the_question_never_offered_is_refused(self):
+        """A label is the text of an option, and the run stores the list as text.
+
+        ``selected_options`` is typed as text and the run serialises it straight
+        back to the model as the selection somebody made, so a number arriving
+        where a label belongs is a value of another kind reaching a tool, which
+        is the one thing this side checks for. Which labels a question offers,
+        and how many it takes, are not checked and the class below pins that:
+        the entry's declared type is what separates the two.
+        """
+        pending = _user_feedback(multi_select=True)
+        asked = _the_schema_advertised_for(pending)["properties"][interrupts.USER_FEEDBACK_SELECTIONS_KEY]
+        (text,) = asked["properties"]
+        entry = asked["properties"][text]["items"]
+        refused = [value for value in _EVERY_JSON_SHAPE if not _permits({"type": entry["type"]}, value)]
+        assert refused, entry
+
+        for value in refused:
+            requirement = _requirement(_user_feedback(multi_select=True))
+            answer = {interrupts.USER_FEEDBACK_SELECTIONS_KEY: {text: [value]}}
+
+            with pytest.raises(ValueError, match="user_feedback expects"):
+                _answer_by_resume_entry(requirement, answer)
+
+            assert requirement.is_resolved() is False, value
+            assert requirement.user_feedback_schema[0].selected_options is None, value
+
+    def test_a_selection_the_question_offered_still_resolves_it(self):
+        """The strictness above has to keep taking the labels a client was shown."""
+        pending = _user_feedback(multi_select=True)
+        asked = _the_schema_advertised_for(pending)["properties"][interrupts.USER_FEEDBACK_SELECTIONS_KEY]
+        (text,) = asked["properties"]
+        offered = asked["properties"][text]["items"]["enum"]
+        requirement = _requirement(pending)
+
+        _answer_by_resume_entry(requirement, {interrupts.USER_FEEDBACK_SELECTIONS_KEY: {text: offered}})
+
+        assert requirement.is_resolved() is True
+        assert requirement.user_feedback_schema[0].selected_options == offered
+
+    def test_a_key_the_schema_leaves_out_of_required_may_arrive_empty(self):
+        """A client that had no value for an optional key sent no value, not a wrong one.
+
+        Which is the same reading that lets a decision written under the spec's
+        own field resolve past a null under Agno's. Refusing it instead would
+        turn away a resume that answered the question it was asked.
+        """
+        schema = _the_schema_advertised_for(_confirmation())
+        assert interrupts.CONFIRMATION_NOTE_KEY not in schema["required"]
+        requirement = _requirement(_confirmation())
+
+        _answer_by_resume_entry(
+            requirement,
+            {interrupts.CONFIRMATION_ACCEPTED_KEY: True, interrupts.CONFIRMATION_NOTE_KEY: None},
+        )
+
+        assert requirement.tool_execution.confirmed is True
+        assert requirement.confirmation_note is None
+
+
+@needs_interrupt_outcome
+class TestWhatTheSchemaDescribesAndThisSideDoesNotCheck:
+    """Known limitations: what a client is told and holds itself to, and nothing here enforces.
+
+    The round trip is written this way on purpose. The interrupt describes the
+    answer fully, so a client can validate before it submits, and this side
+    checks only that a value is of the kind its key was described as. These are
+    the payloads that arrangement lets through, each pinned so the giving-up is a
+    decision on the record rather than something to be discovered by a run that
+    acted on one.
+
+    Each reads the constraint off the emitted schema and then breaks it, so the
+    pair is the evidence: the interrupt still publishes the constraint, and the
+    answer that violates it still resolves the pause.
+    """
+
+    def _question(self, pending: ToolExecution) -> Tuple[str, Dict[str, Any]]:
+        """The one question a feedback pause advertised, and what it asks for."""
+        asked = _the_schema_advertised_for(pending)["properties"][interrupts.USER_FEEDBACK_SELECTIONS_KEY]
+        (text,) = asked["properties"]
+        return text, asked["properties"][text]
+
+    def test_an_empty_selection_resolves_the_question_that_asked_for_one(self):
+        """Agno counts a list it was handed as the answer, empty or not.
+
+        So the tool runs on no selection at all. Refusing it here is not the fix:
+        what counts as answered is Agno's own rule, across every question at
+        once, and reaching into that from this interface is a separate change.
+        """
+        pending = _user_feedback()
+        text, answered = self._question(pending)
+        assert answered["minItems"] == 1
+        requirement = _requirement(pending)
+
+        _answer_by_resume_entry(requirement, {interrupts.USER_FEEDBACK_SELECTIONS_KEY: {text: []}})
+
+        assert requirement.is_resolved() is True
+        assert requirement.user_feedback_schema[0].selected_options == []
+
+    def test_more_selections_than_a_single_select_question_offers_resolve_it(self):
+        pending = _user_feedback(multi_select=False)
+        text, answered = self._question(pending)
+        too_many = answered["items"]["enum"][: answered["maxItems"] + 1]
+        assert len(too_many) > answered["maxItems"], "the question offers too few labels to overrun its own cap"
+        requirement = _requirement(pending)
+
+        _answer_by_resume_entry(requirement, {interrupts.USER_FEEDBACK_SELECTIONS_KEY: {text: too_many}})
+
+        assert requirement.user_feedback_schema[0].selected_options == too_many
+
+    def test_a_label_the_question_never_offered_resolves_it(self):
+        pending = _user_feedback(multi_select=True)
+        text, answered = self._question(pending)
+        never_offered = "-".join(answered["items"]["enum"]) + "-none-of-these"
+        assert never_offered not in answered["items"]["enum"]
+        requirement = _requirement(pending)
+
+        _answer_by_resume_entry(requirement, {interrupts.USER_FEEDBACK_SELECTIONS_KEY: {text: [never_offered]}})
+
+        assert requirement.user_feedback_schema[0].selected_options == [never_offered]
+
+    def test_a_null_under_a_required_field_the_schema_left_untyped_reaches_the_guard(self):
+        """The one advertised-only constraint that still refuses the resume.
+
+        Nothing checks the null out of the payload, so it is written onto the
+        field, the field counts as unfilled, and the resolved-set guard is what
+        stops the run. A client is refused either way; which check refuses it
+        decides only what the refusal says.
+        """
+        pending = _user_input([UserInputField(name="thing", field_type=_UnmappedType)])
+        described = _the_schema_advertised_for(pending)["properties"][interrupts.USER_INPUT_VALUES_KEY]
+        assert described["properties"]["thing"] == {"not": {"type": "null"}}
+        assert described["required"] == ["thing"]
+        requirement = _requirement(pending)
+
+        with pytest.raises(ValueError, match="still unresolved"):
+            _answer_by_resume_entry(requirement, {interrupts.USER_INPUT_VALUES_KEY: {"thing": None}})
+
+        assert requirement.is_resolved() is False
+
+
+# --- A member the run paused inside -----------------------------------------
+
+
+@needs_interrupt_outcome
+class TestSuspendedMember:
+    @needs_member_attribution
+    @pytest.mark.asyncio
+    async def test_the_interrupt_names_the_member_that_asked(self):
+        require_lineage_events()
+        chunk = _member_paused(_confirmation(), member_run_id="member-run")
+        events, error = await collect_async(
+            [chunk],
+            attributed(),
+            thread_id=THREAD_ID,
+            run_id=RUN_ID,
+            emit_interrupt_outcome=True,
+        )
+
+        assert error is None
+        interrupt = _outcome_on_the_wire(_run_finished(events))["interrupts"][0]
+        assert interrupt["subagentRunId"] == "member-run"
+
+    @needs_suspended_outcome
+    @pytest.mark.asyncio
+    async def test_the_member_closes_as_waiting_not_as_finished(self):
+        require_lineage_events()
+        chunk = _member_paused(_confirmation(), member_run_id="member-run")
+        events, error = await collect_async(
+            [chunk],
+            attributed(),
+            thread_id=THREAD_ID,
+            run_id=RUN_ID,
+            emit_interrupt_outcome=True,
+        )
+
+        assert error is None
+        outcome = _outcome_on_the_wire(_subagent_terminals(events)[0])
+        assert outcome["type"] == "suspended"
+        assert sorted(outcome["interruptIds"]) == _accepted_by_the_resume_side(chunk)
+
+    @pytest.mark.asyncio
+    async def test_a_visibility_that_names_no_member_attributes_nothing(self):
+        """``hidden`` must not let a confirmation prompt reveal which member asked."""
+        events, error = await collect_async(
+            [_member_paused(_confirmation(), member_run_id="member-run")],
+            "hidden",
+            thread_id=THREAD_ID,
+            run_id=RUN_ID,
+            emit_interrupt_outcome=True,
+        )
+
+        assert error is None
+        interrupt = _outcome_on_the_wire(_run_finished(events))["interrupts"][0]
+        assert "subagentRunId" not in interrupt
+        # Every way this stream could name the member: an announcement, a
+        # terminal of any kind, or a lane stamped on anything at all.
+        assert member_mentions(events) == []
+
+    @pytest.mark.asyncio
+    async def test_the_default_visibility_attributes_nothing_either(self):
+        events, error = await collect_async(
+            [_member_paused(_confirmation(), member_run_id="member-run")],
+            None,
+            thread_id=THREAD_ID,
+            run_id=RUN_ID,
+            emit_interrupt_outcome=True,
+        )
+
+        assert error is None
+        interrupt = _outcome_on_the_wire(_run_finished(events))["interrupts"][0]
+        assert "subagentRunId" not in interrupt
+        assert member_mentions(events) == []
+
+
+# --- Resuming: the half that has to actually continue the run ----------------
+
+
+# What each tool's body actually did, which is the only record that says a
+# declined call did not run: nothing on the wire tells a call the run refused
+# from one it ran and whose result it withheld.
+EMAILS_SENT: List[str] = []
+POSTS_WRITTEN: List[str] = []
+
+
+@pytest.fixture(autouse=True)
+def _forget_what_the_tools_did():
+    """No earlier test's tool call can read as this one's evidence."""
+    EMAILS_SENT.clear()
+    POSTS_WRITTEN.clear()
+    yield
+
+
+@tool(requires_confirmation=True)
+def send_email(to: str) -> str:
+    """Send one email."""
+    EMAILS_SENT.append(to)
+    return f"EMAIL SENT to {to}"
+
+
+@tool(requires_user_input=True, user_input_fields=["topic"])
+def write_post(topic: str = "") -> str:
+    """Write a post."""
+    POSTS_WRITTEN.append(topic)
+    return f"POST ABOUT {topic}"
+
+
+@tool(requires_user_input=True)
+def ask_nothing() -> str:
+    """Ask for input, taking no argument an answer could be written into."""
+    raise AssertionError("a tool with nothing to answer must never run")
+
+
+@tool(external_execution=True)
+def change_background(color: str) -> str:
+    """Change the background. Never runs server side."""
+    raise AssertionError("an external execution must not run in the server")
+
+
+_WIRE_EVENT = TypeAdapter(Event)
+
+
+def _as_protocol_events(events: List[Dict[str, Any]]) -> List[Any]:
+    """The body's events read back through the protocol's own models.
+
+    The shared invariants are written against protocol events and what the route
+    hands a client is an encoded body, so the body is decoded back into the
+    events it carries rather than checked here in a second, weaker way.
+    """
+    return [_WIRE_EVENT.validate_python(event) for event in events]
+
+
+def _one_run_terminal(events: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """The single run terminal on the wire, refusing a body that carries two.
+
+    Taking the last of several hides a second terminal instead of failing on it,
+    and which of two a client would have acted on is not something to guess.
+    """
+    terminals = [event for event in events if event["type"] in ("RUN_FINISHED", "RUN_ERROR")]
+    assert len(terminals) == 1, f"expected exactly one run terminal, got {[event['type'] for event in events]}"
+    return terminals[0]
+
+
+def _finished_on_the_wire(events: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """The run's terminal, which has to be a finish rather than a failure."""
+    terminal = _one_run_terminal(events)
+    assert terminal["type"] == "RUN_FINISHED", f"the run did not finish: {terminal}"
+    return terminal
+
+
+class Wire:
+    """One AGUI interface over a real entity, driven by real requests.
+
+    Every resume assertion in this suite is about what the second request does to
+    the run the first one paused, so both go through the mounted route against one
+    live entity and one live session.
+
+    Every body this harness reads is held to the shared definition of a
+    well-formed stream, the same one every other suite in this directory uses, so
+    a resume that continues the run through a malformed stream fails here rather
+    than passing on the one payload a test happened to look at, and to what its
+    events encoded, so a key no model declares fails on the real route rather
+    than only where a builder is driven directly.
+    """
+
+    def __init__(self, entity, **agui_kwargs):
+        from fastapi.testclient import TestClient
+
+        from agno.os import AgentOS
+        from agno.os.interfaces.agui import AGUI
+
+        is_team = isinstance(entity, Team)
+        interface = AGUI(team=entity, **agui_kwargs) if is_team else AGUI(agent=entity, **agui_kwargs)
+        agent_os = AgentOS(
+            id="interrupt-os",
+            agents=None if is_team else [entity],
+            teams=[entity] if is_team else None,
+            interfaces=[interface],
+            telemetry=False,
+        )
+        self._entity = entity
+        self._client = TestClient(agent_os.get_app())
+        self._turn = 0
+
+    def post(self, prompt: str, *, malformed: Optional[str] = None, **extra: Any) -> List[Dict[str, Any]]:
+        """One request, with the body it answered with held to the shared definition.
+
+        ``malformed`` names the record for a body this interface really does
+        send malformed today, pinning the violation as the direct-driver
+        wrapper above does rather than waiving it.
+        """
+        self._turn += 1
+        response = self._client.post(
+            "/agui",
+            json={
+                "thread_id": THREAD_ID,
+                "run_id": f"request-{self._turn}",
+                "messages": [{"id": "m1", "role": "user", "content": prompt}],
+                "tools": [],
+                "context": [],
+                "forwarded_props": {},
+                **extra,
+            },
+        )
+        assert response.status_code == 200, response.text
+        events = sse_events(response.text)
+        as_protocol_events = _as_protocol_events(events)
+        if malformed is None:
+            assert_well_formed_stream(as_protocol_events)
+        else:
+            assert_stream_is_malformed_as_recorded(as_protocol_events, malformed)
+        _assert_nothing_undeclared_reached_the_client(as_protocol_events)
+        terminal = _one_run_terminal(events)
+        assert events[-1] is terminal, (
+            f"the response body does not end on its run terminal: {[event['type'] for event in events[-3:]]}"
+        )
+        return events
+
+    def recorded_tool_messages(self) -> List[Tuple[Optional[str], Any]]:
+        """(tool call id, content) per tool message the last run recorded, in order.
+
+        Where a client-run tool's result exists at all: nothing of it reaches the
+        wire, and this is the message the run went on to continue from.
+        """
+        return [
+            (message.tool_call_id, message.content)
+            for message in self._last_run().messages or []
+            if message.role == "tool"
+        ]
+
+    def open_interrupt_ids(self) -> List[Optional[str]]:
+        """The interrupt id of every requirement the last run left open.
+
+        Read off the stored run rather than off the wire, so a test can drive
+        the ids a client was never advertised: a resume for one of those is what
+        a client that guessed would send.
+        """
+        return [
+            interrupts.interrupt_id_of(requirement)
+            for requirement in self._last_run().requirements or []
+            if not requirement.is_resolved()
+        ]
+
+    def _last_run(self) -> Any:
+        session = self._entity.get_session(session_id=THREAD_ID)
+        assert session is not None, f"the entity recorded no session {THREAD_ID} to read"
+        assert session.runs, f"session {THREAD_ID} recorded no run to read"
+        return session.runs[-1]
+
+
+def _interrupts_of(events: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    outcome = _finished_on_the_wire(events).get("outcome")
+    assert outcome and outcome["type"] == "interrupt", f"the run did not report an interrupt: {outcome}"
+    return outcome["interrupts"]
+
+
+def _tool_results(events: List[Dict[str, Any]]) -> Dict[str, str]:
+    """The result each tool call reported, refusing to fold a call reported twice.
+
+    A mapping keyed by the call id lets a second result overwrite the first,
+    which is what a tool running twice looks like on the wire.
+    """
+    reported = [(event["toolCallId"], event["content"]) for event in events if event["type"] == "TOOL_CALL_RESULT"]
+    repeated = sorted(call for call, count in Counter(call for call, _ in reported).items() if count > 1)
+    assert not repeated, f"a tool call reported a result more than once: {repeated}"
+    return dict(reported)
+
+
+def _said(events: List[Dict[str, Any]]) -> str:
+    return "".join(event["delta"] for event in events if event["type"] == "TEXT_MESSAGE_CONTENT")
+
+
+def _errors(events: List[Dict[str, Any]]) -> List[str]:
+    return [event["message"] for event in events if event["type"] == "RUN_ERROR"]
+
+
+def _errors_naming(events: List[Dict[str, Any]], *fragments: str) -> List[str]:
+    """The run errors carrying every fragment, for a test whose subject is one refusal.
+
+    A test satisfied by any error at all is satisfied by a crash anywhere on the
+    path, which is the failure it was written to tell apart from the refusal it
+    asked for.
+    """
+    return [message for message in _errors(events) if all(fragment in message for fragment in fragments)]
+
+
+def _confirming_agent(tools=None, script=None) -> Agent:
+    return Agent(
+        id="interrupt-agent",
+        name="Interrupt Agent",
+        model=ScriptedModel(
+            "m",
+            script
+            or [
+                ("tool", "send_email", {"to": "ops@example.com"}, "tc-1"),
+                ("content", "Sent."),
+            ],
+        ),
+        db=InMemoryDb(),
+        tools=tools or [send_email],
+        telemetry=False,
+    )
+
+
+class _ProposingSeveralAtOnce(ScriptedModel):
+    """A model whose first turn proposes several tool calls, then talks.
+
+    One run pausing on two requirements at once needs one assistant turn
+    proposing two calls, and the shared scripted model states one call per turn.
+    """
+
+    def __init__(self, calls: List[Tuple[str, Dict[str, Any], str]], then: str):
+        super().__init__("m", [("content", then)])
+        self._proposed = list(calls)
+
+    def _next(self) -> Any:
+        if not self._proposed:
+            return super()._next()
+        from agno.models.response import ModelResponse
+
+        proposing, self._proposed = self._proposed, []
+        response = ModelResponse(role="assistant")
+        response.tool_calls = [
+            {"id": call_id, "type": "function", "function": {"name": name, "arguments": json.dumps(args)}}
+            for name, args, call_id in proposing
+        ]
+        return response
+
+
+def _agent_pausing_on_one_answerable_and_one_not() -> Agent:
+    """An Agent whose one turn proposes a decision and a tool nothing can answer.
+
+    ``ask_nothing`` asks for input and takes no argument, so the pause it
+    reports declares no field a value could be sent under: it is open, and no
+    payload resolves it. The decision beside it is answerable on its own.
+    """
+    return Agent(
+        id="interrupt-agent",
+        name="Interrupt Agent",
+        model=_ProposingSeveralAtOnce(
+            [("send_email", {"to": "ops@example.com"}, "tc-1"), ("ask_nothing", {}, "tc-2")],
+            "Done.",
+        ),
+        db=InMemoryDb(),
+        tools=[send_email, ask_nothing],
+        telemetry=False,
+    )
+
+
+# The question a feedback pause over the route asks, in the arguments the
+# ask_user call carries it in. Its labels are what the interrupt advertises as
+# the entries of the array an answer sends back.
+A_QUESTION_WITH_LABELS = [
+    {
+        "question": "What budget?",
+        "header": "Budget",
+        "options": [{"label": "low"}, {"label": "high"}],
+        "multi_select": False,
+    }
+]
+
+
+def _agent_asking_a_question() -> Agent:
+    """An Agent whose one turn asks the user to pick one of two labels.
+
+    ``ask_user`` is intercepted rather than run, so what a selection reaches is
+    the question it is written onto and the tool message the run continues from,
+    which is where the model reads the answer back.
+    """
+    return Agent(
+        id="interrupt-agent",
+        name="Interrupt Agent",
+        model=ScriptedModel(
+            "m",
+            [("tool", "ask_user", {"questions": A_QUESTION_WITH_LABELS}, "tc-ask"), ("content", "Noted.")],
+        ),
+        db=InMemoryDb(),
+        tools=[UserFeedbackTools(add_instructions=False)],
+        telemetry=False,
+    )
+
+
+A_MIXED_PAUSE_PROMPT = "email ops@example.com and ask me something"
+
+
+@needs_interrupt_outcome
+class TestAMixedPauseOverTheRoute:
+    """One answerable requirement beside one nothing can answer, end to end.
+
+    The strand this closes only exists in the round trip, so it is driven
+    through the mounted route against a real Agent: the terminal advertised the
+    answerable requirement, a client answered exactly that, and the resume was
+    refused over the requirement it had never been told about, with nothing on
+    the wire ever saying the run could not go on.
+    """
+
+    def test_the_run_fails_on_the_wire_and_says_why(self):
+        wire = Wire(_agent_pausing_on_one_answerable_and_one_not(), emit_interrupt_outcome=True)
+
+        events = wire.post(A_MIXED_PAUSE_PROMPT)
+
+        terminal = _one_run_terminal(events)
+        assert terminal["type"] == "RUN_ERROR"
+        assert terminal["code"] == interrupts.PAUSE_NOT_CONTINUABLE_CODE
+        assert "cannot be continued" in terminal["message"]
+        assert "declares no field" in terminal["message"]
+
+    def test_the_answerable_half_is_not_advertised_and_its_tool_never_runs(self):
+        """Answering it could not continue the run, so it is not offered.
+
+        The tool body is the only record that says the call did not run, and the
+        run has to reach its terminal without it: a pause the client cannot
+        resolve must not be resolved on the client's behalf either.
+        """
+        wire = Wire(_agent_pausing_on_one_answerable_and_one_not(), emit_interrupt_outcome=True)
+
+        events = wire.post(A_MIXED_PAUSE_PROMPT)
+
+        assert "outcome" not in _one_run_terminal(events)
+        assert EMAILS_SENT == []
+
+    @needs_resume_array
+    def test_a_client_that_resumes_it_anyway_is_told_the_same_thing(self):
+        """Nothing stops a client sending a resume array it was never offered.
+
+        It reaches the guard, which reads the same computation the terminal
+        read, so the answer it gets is the terminal's answer and not a bare
+        refusal.
+        """
+        wire = Wire(_agent_pausing_on_one_answerable_and_one_not(), emit_interrupt_outcome=True)
+        wire.post(A_MIXED_PAUSE_PROMPT)
+        guessed = wire.open_interrupt_ids()[0]
+
+        resumed = wire.post(
+            A_MIXED_PAUSE_PROMPT,
+            resume=[{"interrupt_id": guessed, "status": "resolved", "payload": {"accepted": True}}],
+        )
+
+        assert [message for message in _errors(resumed) if "cannot be continued" in message]
+        assert EMAILS_SENT == []
+
+
+class TestAMixedPauseWithTheOutcomeOff:
+    """The same run on an install that has no interrupt-aware lifecycle at all.
+
+    Which is the half of the setting's promise that holds everywhere, so it sits
+    outside the gate above: asking for the emission is what needs the release
+    piece, and this asks for nothing.
+    """
+
+    def test_the_same_pause_prompts_as_it_always_did(self):
+        """The setting decides what the terminal claims, and nothing else.
+
+        With it off this interface advertises no ids and holds a resume to
+        nothing, so the pause reaches the client as the finished run and the two
+        pending calls it always did.
+        """
+        wire = Wire(_agent_pausing_on_one_answerable_and_one_not())
+
+        events = wire.post(A_MIXED_PAUSE_PROMPT)
+
+        assert "outcome" not in _finished_on_the_wire(events)
+        started = [event["toolCallId"] for event in events if event["type"] == "TOOL_CALL_START"]
+        assert started == ["tc-1", "tc-2"]
+
+
+@needs_interrupt_outcome
+@needs_resume_array
+class TestResumeContinuesTheRun:
+    """Every test here reads a pause off an emitted outcome and answers it by id.
+
+    Both gates, because those are two release pieces: the outcome the pause is
+    advertised through, and the array the answer arrives in.
+    """
+
+    def test_a_feedback_pause_continues_from_the_selections_it_advertised(self):
+        """The fourth pause kind over the route the other three already run.
+
+        It was the one answered only by calling a resolver directly, so nothing
+        said a client could reach it over the wire at all. Answered from the
+        advertised schema alone, which is all such a client reads, and the proof
+        it arrived is the selection reaching the tool that asked for it.
+        """
+        asked = {
+            "question": "Which colour?",
+            "header": "Colour",
+            "options": [{"label": "blue"}, {"label": "red"}],
+        }
+        wire = Wire(
+            _confirming_agent(
+                tools=[UserFeedbackTools()],
+                script=[("tool", "ask_user", {"questions": [asked]}, "tc-ask"), ("content", "Blue it is.")],
+            ),
+            emit_interrupt_outcome=True,
+        )
+        interrupt = _interrupts_of(wire.post("pick a colour"))[0]
+
+        assert interrupt["metadata"]["agno"]["pause_type"] == "user_feedback"
+
+        resumed = wire.post(
+            "pick a colour",
+            resume=[{"interrupt_id": interrupt["id"], "status": "resolved", "payload": _an_answer_to(interrupt)}],
+        )
+
+        assert _errors(resumed) == []
+        assert _said(resumed) == "Blue it is."
+        assert wire.recorded_tool_messages() == [
+            ("tc-ask", 'User feedback received: [{"question": "Which colour?", "selected": ["blue"]}]')
+        ]
+
+    def test_a_decision_runs_the_tool_the_pause_proposed(self):
+        """The proof a pause was real: the tool body ran, against the original call.
+
+        A restarted run would propose the call again and report a result for a
+        new id; this asserts the id the pause reported.
+        """
+        wire = Wire(_confirming_agent(), emit_interrupt_outcome=True)
+        paused = wire.post("email ops@example.com")
+        interrupt = _interrupts_of(paused)[0]
+
+        resumed = wire.post(
+            "email ops@example.com",
+            resume=[{"interrupt_id": interrupt["id"], "status": "resolved", "payload": {"accepted": True}}],
+        )
+
+        assert _tool_results(resumed) == {"tc-1": json.dumps("EMAIL SENT to ops@example.com")}
+        assert _said(resumed) == "Sent."
+
+    def test_the_resumed_run_is_finished_not_waiting(self):
+        wire = Wire(_confirming_agent(), emit_interrupt_outcome=True)
+        interrupt = _interrupts_of(wire.post("email ops@example.com"))[0]
+
+        resumed = wire.post(
+            "email ops@example.com",
+            resume=[{"interrupt_id": interrupt["id"], "status": "resolved", "payload": {"accepted": True}}],
+        )
+
+        assert "outcome" not in _finished_on_the_wire(resumed)
+        # The pause it continued from is what makes a terminal with no outcome
+        # mean finished rather than a run that never got that far.
+        assert EMAILS_SENT == ["ops@example.com"]
+
+    def test_a_denied_decision_does_not_run_the_tool(self):
+        """A denial continues the run, and the call it declined never ran.
+
+        The absence of the tool's output from the stream is not the subject: a
+        resume that failed outright carries none of it either. What is asserted
+        is that the run went on past the pause, that the body never ran, and
+        that the reason the client gave is what the run continued from.
+        """
+        wire = Wire(_confirming_agent(), emit_interrupt_outcome=True)
+        interrupt = _interrupts_of(wire.post("email ops@example.com"))[0]
+
+        resumed = wire.post(
+            "email ops@example.com",
+            resume=[
+                {
+                    "interrupt_id": interrupt["id"],
+                    "status": "resolved",
+                    "payload": {"accepted": False, "note": "wrong recipient"},
+                }
+            ],
+        )
+
+        assert _errors(resumed) == []
+        assert _said(resumed) == "Sent."
+        assert EMAILS_SENT == []
+        assert wire.recorded_tool_messages() == [("tc-1", "wrong recipient")]
+
+    def test_a_decision_nobody_can_read_fails_the_run_instead_of_declining(self):
+        """A denial the client never gave reads exactly like one it did.
+
+        So the run fails where a client can see it, rather than the call being
+        declined and the refusal recorded against whoever asked.
+        """
+        wire = Wire(_confirming_agent(), emit_interrupt_outcome=True)
+        interrupt = _interrupts_of(wire.post("email ops@example.com"))[0]
+
+        resumed = wire.post(
+            "email ops@example.com",
+            resume=[{"interrupt_id": interrupt["id"], "status": "resolved", "payload": {"decision": "approve"}}],
+        )
+
+        assert _errors_naming(resumed, "confirmation expects"), (
+            f"an unreadable decision was taken for an answer: {_errors(resumed)}"
+        )
+        assert EMAILS_SENT == []
+
+    def test_the_interrupt_specs_own_approval_field_is_read_too(self):
+        """A payload written against the spec's example must resolve, not refuse."""
+        wire = Wire(_confirming_agent(), emit_interrupt_outcome=True)
+        interrupt = _interrupts_of(wire.post("email ops@example.com"))[0]
+
+        resumed = wire.post(
+            "email ops@example.com",
+            resume=[
+                {
+                    "interrupt_id": interrupt["id"],
+                    "status": "resolved",
+                    "payload": {interrupts.CONFIRMATION_ACCEPTED_ALIAS: True},
+                }
+            ],
+        )
+
+        assert _tool_results(resumed) == {"tc-1": json.dumps("EMAIL SENT to ops@example.com")}
+
+    def test_structured_input_reaches_the_tool_that_asked_for_it(self):
+        wire = Wire(
+            _confirming_agent(
+                tools=[write_post],
+                script=[("tool", "write_post", {}, "tc-post"), ("content", "Written.")],
+            ),
+            emit_interrupt_outcome=True,
+        )
+        interrupt = _interrupts_of(wire.post("write a post"))[0]
+
+        resumed = wire.post(
+            "write a post",
+            resume=[
+                {
+                    "interrupt_id": interrupt["id"],
+                    "status": "resolved",
+                    "payload": {interrupts.USER_INPUT_VALUES_KEY: {"topic": "otters"}},
+                }
+            ],
+        )
+
+        assert _tool_results(resumed) == {"tc-post": json.dumps("POST ABOUT otters")}
+
+    def test_a_client_run_tool_hands_its_result_back(self):
+        """Text the client returned is what the run continues from, unchanged.
+
+        A client-run tool's result reaches no client back, so the tool message
+        the run recorded under the call the pause reported is where it exists.
+        """
+        wire = Wire(
+            _confirming_agent(
+                tools=[change_background],
+                script=[("tool", "change_background", {"color": "blue"}, "tc-bg"), ("content", "Changed.")],
+            ),
+            emit_interrupt_outcome=True,
+        )
+        interrupt = _interrupts_of(wire.post("make it blue"))[0]
+
+        resumed = wire.post(
+            "make it blue",
+            resume=[{"interrupt_id": interrupt["id"], "status": "resolved", "payload": "the client changed it"}],
+        )
+
+        assert _errors(resumed) == []
+        assert _said(resumed) == "Changed."
+        assert wire.recorded_tool_messages() == [("tc-bg", "the client changed it")]
+
+    def test_a_structured_client_result_travels_as_json(self):
+        """A structured result is serialised, so a Python repr is not what it needs.
+
+        Nothing of this result reaches the wire, so the run continuing is not
+        what tells a repr from JSON: the tool message the run recorded is, and
+        it is what anything reading the thread back parses.
+        """
+        wire = Wire(
+            _confirming_agent(
+                tools=[change_background],
+                script=[("tool", "change_background", {"color": "blue"}, "tc-bg"), ("content", "Changed.")],
+            ),
+            emit_interrupt_outcome=True,
+        )
+        interrupt = _interrupts_of(wire.post("make it blue"))[0]
+
+        resumed = wire.post(
+            "make it blue",
+            resume=[
+                {
+                    "interrupt_id": interrupt["id"],
+                    "status": "resolved",
+                    "payload": {"ok": True, "changed": ["body"]},
+                }
+            ],
+        )
+
+        assert _errors(resumed) == []
+        assert _said(resumed) == "Changed."
+        assert wire.recorded_tool_messages() == [("tc-bg", json.dumps({"ok": True, "changed": ["body"]}))]
+
+    def test_the_resume_array_wins_over_trailing_tool_messages(self):
+        """Both channels can arrive at once, and only one of them names interrupts."""
+        wire = Wire(_confirming_agent(), emit_interrupt_outcome=True)
+        interrupt = _interrupts_of(wire.post("email ops@example.com"))[0]
+
+        resumed = wire.post(
+            "email ops@example.com",
+            resume=[{"interrupt_id": interrupt["id"], "status": "resolved", "payload": {"accepted": True}}],
+            messages=[
+                {"id": "m1", "role": "user", "content": "email ops@example.com"},
+                {
+                    "id": "t1",
+                    "role": "tool",
+                    "tool_call_id": "tc-1",
+                    "content": json.dumps({"accepted": False}),
+                },
+            ],
+        )
+
+        assert _tool_results(resumed) == {"tc-1": json.dumps("EMAIL SENT to ops@example.com")}
+
+    def test_a_cancelled_decision_declines_the_call(self):
+        """A decision the client withdrew is a refusal, and the run continues.
+
+        Nothing stands in for the answer, so what the run continues from says
+        the interrupt was cancelled rather than declined for a reason nobody
+        gave, and the tool the pause proposed never runs.
+        """
+        wire = Wire(_confirming_agent(), emit_interrupt_outcome=True)
+        interrupt = _interrupts_of(wire.post("email ops@example.com"))[0]
+
+        resumed = wire.post(
+            "email ops@example.com",
+            resume=[{"interrupt_id": interrupt["id"], "status": "cancelled"}],
+        )
+
+        assert _errors(resumed) == []
+        assert _said(resumed) == "Sent."
+        assert EMAILS_SENT == []
+        assert wire.recorded_tool_messages() == [("tc-1", CANCELLED_NOTE)]
+
+    def test_a_cancelled_request_for_input_stops_the_run(self):
+        """There is no value that stands in for data the tool needs to run at all."""
+        wire = Wire(
+            _confirming_agent(
+                tools=[write_post],
+                script=[("tool", "write_post", {}, "tc-post"), ("content", "Written.")],
+            ),
+            emit_interrupt_outcome=True,
+        )
+        interrupt = _interrupts_of(wire.post("write a post"))[0]
+
+        resumed = wire.post(
+            "write a post",
+            resume=[{"interrupt_id": interrupt["id"], "status": "cancelled"}],
+        )
+
+        assert _errors_naming(resumed, interrupt["id"], "cannot be resumed without the input"), (
+            f"a cancelled input request continued the run anyway: {_errors(resumed)}"
+        )
+        assert POSTS_WRITTEN == []
+
+
+@needs_interrupt_outcome
+@needs_resume_array
+class TestAnEntryThePausedRunDoesNotRecognise:
+    """An answer to a question this run never asked must not discard the real ones.
+
+    The protocol has a producer proceed without an entry it does not recognise
+    and warn, rather than fail a run over an answer it never asked for. Three
+    ways a client gets there: an id that never existed, an id the run already
+    resolved, and the same request body arriving twice.
+    """
+
+    def _paused_wire(self, script=None) -> Tuple[Wire, str]:
+        """Pauses on the first turn; a test that drives more runs than one states the turns they take."""
+        wire = Wire(_confirming_agent(script=script), emit_interrupt_outcome=True)
+        return wire, _interrupts_of(wire.post("email ops@example.com"))[0]["id"]
+
+    @pytest.mark.parametrize("stale_first", [False, True], ids=["stale_last", "stale_first"])
+    def test_the_valid_answer_beside_it_still_continues_the_run(self, stale_first):
+        """Order does not decide it: whichever entry is read first, the real answer applies."""
+        wire, interrupt_id = self._paused_wire()
+        answered = {"interrupt_id": interrupt_id, "status": "resolved", "payload": {"accepted": True}}
+        stale = {"interrupt_id": "int-from-an-older-run", "status": "resolved", "payload": {"accepted": True}}
+
+        resumed = wire.post(
+            "email ops@example.com",
+            resume=[stale, answered] if stale_first else [answered, stale],
+        )
+
+        assert _errors(resumed) == []
+        assert _tool_results(resumed) == {"tc-1": json.dumps("EMAIL SENT to ops@example.com")}
+        assert EMAILS_SENT == ["ops@example.com"]
+
+    def test_the_entry_it_skipped_is_warned_about(self, caplog):
+        """Skipping it quietly would leave a client's answer with nowhere it was reported.
+
+        The level is the subject: naming the id while failing the run is what
+        this already did, so the record has to be the warning a continued run
+        left behind.
+        """
+        wire, interrupt_id = self._paused_wire()
+
+        with captured_agno_logs(caplog, "WARNING"):
+            resumed = wire.post(
+                "email ops@example.com",
+                resume=[
+                    {"interrupt_id": interrupt_id, "status": "resolved", "payload": {"accepted": True}},
+                    {"interrupt_id": "int-from-an-older-run", "status": "resolved", "payload": {"accepted": True}},
+                ],
+            )
+
+        assert _errors(resumed) == []
+        named = [record.levelname for record in caplog.records if "int-from-an-older-run" in record.message]
+        assert named == ["WARNING"]
+
+    def test_a_wrong_answer_to_a_question_this_run_did_ask_still_fails_the_run(self):
+        """The skip is for an entry nobody asked for, not for an unreadable answer.
+
+        An answer to an interrupt this run is waiting on cannot be dropped: the
+        pause stays open and the client is owed the reason its payload was
+        refused. Nothing is spent by refusing it, which is what makes the refusal
+        the right answer rather than a lost turn: the same pause answers a second
+        request that sends a payload this side can read.
+        """
+        wire, interrupt_id = self._paused_wire()
+
+        refused = wire.post(
+            "email ops@example.com",
+            resume=[{"interrupt_id": interrupt_id, "status": "resolved", "payload": {"decision": "approve"}}],
+        )
+
+        assert _errors_naming(refused, "confirmation expects"), (
+            f"an unreadable answer to an open interrupt was skipped: {_errors(refused)}"
+        )
+        assert EMAILS_SENT == []
+
+        resumed = wire.post(
+            "email ops@example.com",
+            resume=[{"interrupt_id": interrupt_id, "status": "resolved", "payload": {"accepted": True}}],
+        )
+
+        assert _tool_results(resumed) == {"tc-1": json.dumps("EMAIL SENT to ops@example.com")}
+
+    def test_the_same_request_body_sent_twice_does_not_fail_the_second_time(self):
+        """A browser retry or a double submit replays one body; it must not error.
+
+        The run it answered is finished, so the entries answer nothing and the
+        request runs on without them. What must not happen either way is the
+        tool running a second time.
+
+        The third scripted turn is what the replay runs on its own: a replay
+        answered out of the resumed run's turn would be a repeat nobody asked
+        the model for.
+        """
+        wire, interrupt_id = self._paused_wire(
+            script=[
+                ("tool", "send_email", {"to": "ops@example.com"}, "tc-1"),
+                ("content", "Sent."),
+                ("content", "Nothing left to answer."),
+            ]
+        )
+        answering = [{"interrupt_id": interrupt_id, "status": "resolved", "payload": {"accepted": True}}]
+
+        resumed = wire.post("email ops@example.com", resume=answering)
+        replayed = wire.post("email ops@example.com", resume=answering)
+
+        assert _errors(resumed) == []
+        assert _said(resumed) == "Sent."
+        assert _errors(replayed) == []
+        assert _said(replayed) == "Nothing left to answer."
+        assert _tool_results(replayed) == {}
+        assert EMAILS_SENT == ["ops@example.com"]
+
+    def test_the_pause_it_could_not_place_is_still_answerable_afterwards(self):
+        """An array nothing in the run answers must not consume the pause either.
+
+        Proceeding without the entries leaves the interrupt exactly where it was,
+        so the client that sends the right id next gets its run continued rather
+        than a pause the earlier request spent.
+
+        Two runs follow the pause and the script states a turn for each: the
+        request whose entries placed nowhere runs fresh on its own turn, and the
+        continued run finishes on the turn after it.
+        """
+        wire, interrupt_id = self._paused_wire(
+            script=[
+                ("tool", "send_email", {"to": "ops@example.com"}, "tc-1"),
+                ("content", "Nothing to answer here."),
+                ("content", "Sent."),
+            ]
+        )
+        unplaceable = wire.post(
+            "email ops@example.com",
+            resume=[{"interrupt_id": "int-that-never-existed", "status": "resolved", "payload": {"accepted": True}}],
+        )
+
+        assert _errors(unplaceable) == []
+        assert _said(unplaceable) == "Nothing to answer here."
+        assert _tool_results(unplaceable) == {}
+
+        resumed = wire.post(
+            "email ops@example.com",
+            resume=[{"interrupt_id": interrupt_id, "status": "resolved", "payload": {"accepted": True}}],
+        )
+
+        assert _errors(resumed) == []
+        assert _tool_results(resumed) == {"tc-1": json.dumps("EMAIL SENT to ops@example.com")}
+        assert _said(resumed) == "Sent."
+        assert EMAILS_SENT == ["ops@example.com"]
+
+
+@needs_resume_array
+class TestTheResumeArrayIsInput:
+    def test_an_array_that_answers_no_paused_run_runs_fresh(self):
+        """A resume list on a run that continues no interrupted run answers nothing.
+
+        The protocol has those entries treated as unrecognised, and the request
+        carries a user message like any other, so what is left is the fresh run
+        it describes rather than a run error.
+        """
+        wire = Wire(_confirming_agent(script=[("content", "Nothing to resume.")]))
+
+        events = wire.post(
+            "hello",
+            resume=[{"interrupt_id": "int-that-never-existed", "status": "resolved", "payload": {"accepted": True}}],
+        )
+
+        assert _errors(events) == []
+        assert _said(events) == "Nothing to resume."
+
+    def test_the_resume_array_is_read_whether_or_not_the_outcome_is_emitted(self):
+        """The array is input, and the setting is about output.
+
+        A client that resumes this way is not the reason the emission is opt-in,
+        and ignoring its answers would strand a run over a setting that only
+        decides what the terminal says. With the emission off the pause reports
+        no id, so the answer is addressed to the one the run recorded: the proof
+        the array was read is the tool body running against the call the pause
+        held, which an ignored array leaves pending forever.
+
+        Gated on the array alone, which is the piece it reads. Sitting under the
+        gate for the emission is what made it skip on the one install it exists
+        to prove: a release that declares the array without the interrupt types.
+        """
+        wire = Wire(_confirming_agent())
+        paused = wire.post("email ops@example.com")
+        assert "outcome" not in _finished_on_the_wire(paused)
+        interrupt_id = wire.open_interrupt_ids()[0]
+
+        resumed = wire.post(
+            "email ops@example.com",
+            resume=[{"interrupt_id": interrupt_id, "status": "resolved", "payload": {"accepted": True}}],
+        )
+
+        assert _errors(resumed) == []
+        assert _tool_results(resumed) == {"tc-1": json.dumps("EMAIL SENT to ops@example.com")}
+
+
+def _run_input_type_without_the_resume_array() -> Any:
+    """``RunAgentInput`` as a release that never declared the resume array presents it.
+
+    A real model built from the installed one's remaining fields on the protocol's
+    own configured base, so it keeps the configuration that decides what happens
+    to a key it does not declare. That configuration is the whole subject: the
+    protocol's models keep such a key as untyped extra data, so a client's resume
+    array still arrives on this release, as raw dictionaries rather than entries.
+    """
+    return _type_without(RunAgentInput, "resume")
+
+
+@needs_resume_array
+class TestAReleaseWithoutTheResumeArray:
+    """The install this interface says it still serves: no array, tool messages only.
+
+    The route is mounted against the simulated release, so the request the client
+    sends is parsed by it, which is the one thing that decides whether the answers
+    arrive as entries or as extra data. Nothing about the detection is stood in
+    for: it reads the model the route actually parsed with.
+    """
+
+    def _wire_on_the_older_release(self, monkeypatch) -> Wire:
+        from agno.os.interfaces.agui import router as router_module
+
+        monkeypatch.setattr(router_module, "RunAgentInput", _run_input_type_without_the_resume_array())
+        return Wire(_confirming_agent())
+
+    def test_a_client_that_sends_both_is_continued_from_its_tool_message(self, monkeypatch):
+        """The shape a newer client sends an older server, which has to keep working.
+
+        The array cannot be read here, so the answer the request also carries in
+        the channel this release does have is what continues the run. Reading the
+        array off the parsed request instead finds raw dictionaries, and the run
+        fails on the first one without ever reaching the tool message.
+        """
+        wire = self._wire_on_the_older_release(monkeypatch)
+        wire.post("email ops@example.com")
+        guessed = wire.open_interrupt_ids()[0]
+
+        resumed = wire.post(
+            "email ops@example.com",
+            resume=[{"interrupt_id": guessed, "status": "resolved", "payload": {"accepted": True}}],
+            messages=[
+                {"id": "m1", "role": "user", "content": "email ops@example.com"},
+                {"id": "t1", "role": "tool", "tool_call_id": "tc-1", "content": json.dumps({"accepted": True})},
+            ],
+        )
+
+        assert _errors(resumed) == []
+        assert _tool_results(resumed) == {"tc-1": json.dumps("EMAIL SENT to ops@example.com")}
+        assert EMAILS_SENT == ["ops@example.com"]
+
+    def test_an_array_nothing_can_read_is_dropped_by_name(self, monkeypatch, caplog):
+        """Dropping answers silently is what leaves a client waiting on a run.
+
+        The release has no place for them, so the run goes on as it did before the
+        round trip existed, and what was dropped is said once, naming the field,
+        rather than reaching a resolver as dictionaries.
+        """
+        wire = self._wire_on_the_older_release(monkeypatch)
+        wire.post("email ops@example.com")
+        guessed = wire.open_interrupt_ids()[0]
+
+        with caplog.at_level(logging.WARNING, logger="agno"):
+            resumed = wire.post(
+                "email ops@example.com",
+                resume=[{"interrupt_id": guessed, "status": "resolved", "payload": {"accepted": True}}],
+            )
+
+        assert _errors(resumed) == [], "the unreadable array reached a resolver as dictionaries"
+        assert [record for record in caplog.records if "resume" in record.message], (
+            "a client's answers were dropped without saying so"
+        )
+
+
+@needs_interrupt_outcome
+@needs_resume_array
+class TestTeamResumeContinuesTheMember:
+    def _team(self) -> Team:
+        db = InMemoryDb()
+        member = Agent(
+            name="Mailer",
+            id="mailer",
+            model=ScriptedModel(
+                "m-mailer",
+                [("tool", "send_email", {"to": "ops@example.com"}, "tc-mem"), ("content", "Member done.")],
+            ),
+            db=db,
+            tools=[send_email],
+            telemetry=False,
+        )
+        return Team(
+            name="Team",
+            id="interrupt-team",
+            model=ScriptedModel(
+                "m-leader",
+                [
+                    ("tool", "delegate_task_to_member", {"member_id": "mailer", "task": "email ops"}, "tc-lead"),
+                    ("content", "Leader done."),
+                ],
+            ),
+            members=[member],
+            db=db,
+            telemetry=False,
+        )
+
+    @needs_member_attribution
+    @needs_suspended_outcome
+    def test_the_members_pause_is_attributed_and_then_continued(self):
+        require_lineage_events()
+        wire = Wire(self._team(), emit_interrupt_outcome=True, subagent_visibility=attributed())
+        paused = wire.post("email ops@example.com")
+
+        interrupt = _interrupts_of(paused)[0]
+        lane = interrupt["subagentRunId"]
+        assert lane, "the interrupt did not name the member that asked"
+
+        suspended = [
+            event
+            for event in paused
+            if event["type"] == "SUBAGENT_FINISHED" and event.get("outcome", {}).get("type") == "suspended"
+        ]
+        assert [event["subagentRunId"] for event in suspended] == [lane]
+        assert suspended[0]["outcome"]["interruptIds"] == [interrupt["id"]]
+
+        resumed = wire.post(
+            "email ops@example.com",
+            resume=[{"interrupt_id": interrupt["id"], "status": "resolved", "payload": {"accepted": True}}],
+        )
+
+        assert _tool_results(resumed)["tc-mem"] == json.dumps("EMAIL SENT to ops@example.com")
+        # The same member, continued rather than replaced by a fresh invocation.
+        assert {event["subagentRunId"] for event in resumed if event.get("subagentRunId")} == {lane}
+
+    def test_answering_exactly_what_the_pause_advertised_continues_the_run(self):
+        """The property end to end, on the shape a real team pause has.
+
+        A team leader's terminal lists its own delegation call and nothing else,
+        so the member's pending call reaches the client only through the
+        requirement list. Answering every advertised id has to continue the run:
+        an id the run cannot place stops the array, and an open requirement
+        nobody answered stops it at the partial-resume guard.
+        """
+        wire = Wire(self._team(), emit_interrupt_outcome=True)
+        advertised = _interrupts_of(wire.post("email ops@example.com"))
+
+        # Keyed by the requirement rather than by the call, which is the id the
+        # resume side looks an answer up by.
+        assert [interrupt["id"] for interrupt in advertised] != [interrupt["toolCallId"] for interrupt in advertised]
+
+        resumed = wire.post(
+            "email ops@example.com",
+            resume=[
+                {"interrupt_id": interrupt["id"], "status": "resolved", "payload": {"accepted": True}}
+                for interrupt in advertised
+            ],
+        )
+
+        assert _errors(resumed) == []
+        assert _tool_results(resumed)["tc-mem"] == json.dumps("EMAIL SENT to ops@example.com")
+
+    def test_a_team_resumes_without_member_attribution_too(self):
+        """The default visibility names no member, and the run still continues."""
+        wire = Wire(self._team(), emit_interrupt_outcome=True)
+        interrupt = _interrupts_of(wire.post("email ops@example.com"))[0]
+        assert "subagentRunId" not in interrupt
+
+        resumed = wire.post(
+            "email ops@example.com",
+            resume=[{"interrupt_id": interrupt["id"], "status": "resolved", "payload": {"accepted": True}}],
+        )
+
+        assert _tool_results(resumed)["tc-mem"] == json.dumps("EMAIL SENT to ops@example.com")
+
+
+# --- The channel that predates the resume array, at the wire -----------------
+
+
+# Every decision payload the trailing-tool-message channel already had a verdict
+# for, paired with whether that verdict ran the proposed tool, and with the note
+# the run went on to continue from where the payload named one. Each row was read
+# off the interface at the commit this work starts from and driven through it, so
+# the table is that channel's answers rather than a restatement of the reading
+# under test.
+#
+# This channel took answers before the interface advertised any answer shape, and
+# its callers were written against exactly these verdicts. The two channels share
+# one reading of a decision payload, so a widening meant for the protocol's own
+# array reaches this one for free: a payload that used to decline the call would
+# start running the tool, and nobody who wrote against the older channel asked for
+# that. The table is what a change to the shared reading has to survive.
+DECISIONS_THIS_CHANNEL_ALREADY_ANSWERED = pytest.mark.parametrize(
+    "payload,runs_the_tool,continued_from",
+    [
+        ({interrupts.CONFIRMATION_ACCEPTED_KEY: True}, True, None),
+        ({interrupts.CONFIRMATION_ACCEPTED_KEY: False}, False, None),
+        ({interrupts.CONFIRMATION_ACCEPTED_ALIAS: True}, False, None),
+        ({interrupts.CONFIRMATION_ACCEPTED_ALIAS: False}, False, None),
+        (
+            {interrupts.CONFIRMATION_ACCEPTED_KEY: None, interrupts.CONFIRMATION_ACCEPTED_ALIAS: True},
+            False,
+            None,
+        ),
+        (
+            {interrupts.CONFIRMATION_ACCEPTED_KEY: True, interrupts.CONFIRMATION_ACCEPTED_ALIAS: False},
+            True,
+            None,
+        ),
+        (
+            {interrupts.CONFIRMATION_ACCEPTED_KEY: False, interrupts.CONFIRMATION_ACCEPTED_ALIAS: True},
+            False,
+            None,
+        ),
+        (
+            {interrupts.CONFIRMATION_ACCEPTED_ALIAS: True, interrupts.CONFIRMATION_NOTE_KEY: "wrong recipient"},
+            False,
+            "wrong recipient",
+        ),
+        ({interrupts.CONFIRMATION_ACCEPTED_ALIAS: "yes"}, False, None),
+        ({interrupts.CONFIRMATION_ACCEPTED_ALIAS: None}, False, None),
+        ({interrupts.CONFIRMATION_ACCEPTED_KEY: "true"}, False, None),
+        ({interrupts.CONFIRMATION_NOTE_KEY: "no reason to"}, False, "no reason to"),
+        (
+            {interrupts.CONFIRMATION_ACCEPTED_KEY: False, interrupts.CONFIRMATION_NOTE_KEY: ["wrong recipient"]},
+            False,
+            ["wrong recipient"],
+        ),
+        ({}, False, None),
+        (True, False, None),
+        ("yes", False, None),
+    ],
+    ids=[
+        "agnos_own_field_accepting",
+        "agnos_own_field_denying",
+        "the_spec_field_accepting",
+        "the_spec_field_denying",
+        "the_spec_field_past_a_null",
+        "agnos_own_field_over_a_denying_alias",
+        "agnos_own_denial_over_an_accepting_alias",
+        "the_spec_field_beside_a_note",
+        "a_non_boolean_alias",
+        "a_null_alias",
+        "a_non_boolean_decision",
+        "a_note_and_nothing_else",
+        "a_denial_whose_note_is_not_text",
+        "no_fields_at_all",
+        "not_an_object",
+        "a_bare_string",
+    ],
+)
+
+
+class TestTheTrailingToolMessageChannelAnswersAtTheWire:
+    """What a client sending a trailing tool result gets back, decision by decision.
+
+    Driven through the mounted route so the subject is what the encoded stream
+    carries: a resumed run reports the proposed call's result only where the
+    answer confirmed it, so the presence of that ``TOOL_CALL_RESULT`` is the
+    client-visible difference between a tool that ran and one that did not.
+    """
+
+    def _resume_with(self, wire: Wire, payload: Any) -> List[Dict[str, Any]]:
+        return wire.post(
+            "email ops@example.com",
+            messages=[
+                {"id": "m1", "role": "user", "content": "email ops@example.com"},
+                {"id": "t1", "role": "tool", "tool_call_id": "tc-1", "content": json.dumps(payload)},
+            ],
+        )
+
+    @DECISIONS_THIS_CHANNEL_ALREADY_ANSWERED
+    def test_a_decision_gets_the_verdict_this_channel_always_gave_it(self, payload, runs_the_tool, continued_from):
+        wire = Wire(_confirming_agent())
+        wire.post("email ops@example.com")
+
+        resumed = self._resume_with(wire, payload)
+
+        assert _errors(resumed) == []
+        assert _tool_results(resumed) == (
+            {"tc-1": json.dumps("EMAIL SENT to ops@example.com")} if runs_the_tool else {}
+        )
+        assert EMAILS_SENT == (["ops@example.com"] if runs_the_tool else [])
+
+    @DECISIONS_THIS_CHANNEL_ALREADY_ANSWERED
+    def test_a_decision_leaves_the_run_continuing_from_what_it_carried(self, payload, runs_the_tool, continued_from):
+        """The reason a refusal names is what the model reads next, so it is pinned too.
+
+        Nothing of it reaches the wire: a declined call reports no result, and
+        the note is only visible in the message the run continued from. A row
+        naming no note leaves the refusal wording to Agno rather than restating
+        a string this interface does not own.
+        """
+        wire = Wire(_confirming_agent())
+        wire.post("email ops@example.com")
+
+        self._resume_with(wire, payload)
+
+        if runs_the_tool:
+            assert wire.recorded_tool_messages() == [("tc-1", "EMAIL SENT to ops@example.com")]
+        elif continued_from is not None:
+            assert wire.recorded_tool_messages() == [("tc-1", continued_from)]
+        else:
+            assert [call for call, _ in wire.recorded_tool_messages()] == ["tc-1"]
+
+
+A_QUESTION_PROMPT = "ask me about the budget"
+
+
+@needs_interrupt_outcome
+class TestAnswersToAQuestionOverTheRoute:
+    """A selection of another kind, on the channel that advertised a shape and on the one that did not.
+
+    Nothing of a feedback answer reaches the wire as a tool result, so the run
+    the second request produced is the subject: the message it continued from is
+    what the model read the selection back as, and that is where a label of
+    another kind lands.
+
+    The question text and its labels are read off the emitted interrupt rather
+    than restated, so neither half can be held to a shape no client was shown.
+    """
+
+    def _paused_on_the_question(self) -> Tuple[Wire, Dict[str, Any]]:
+        wire = Wire(_agent_asking_a_question(), emit_interrupt_outcome=True)
+        return wire, _interrupts_of(wire.post(A_QUESTION_PROMPT))[0]
+
+    def _asks_for(self, interrupt: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:
+        """The one question the interrupt advertised, and the array it wants back."""
+        asked = interrupt["responseSchema"]["properties"][interrupts.USER_FEEDBACK_SELECTIONS_KEY]
+        (text,) = asked["properties"]
+        return text, asked["properties"][text]
+
+    @needs_resume_array
+    def test_a_selection_the_question_offered_reaches_the_model(self):
+        wire, interrupt = self._paused_on_the_question()
+        text, answered = self._asks_for(interrupt)
+        picked = answered["items"]["enum"][:1]
+
+        resumed = wire.post(
+            A_QUESTION_PROMPT,
+            resume=[
+                {
+                    "interrupt_id": interrupt["id"],
+                    "status": "resolved",
+                    "payload": {interrupts.USER_FEEDBACK_SELECTIONS_KEY: {text: picked}},
+                }
+            ],
+        )
+
+        assert _errors(resumed) == []
+        assert _said(resumed) == "Noted."
+        assert wire.recorded_tool_messages() == [("tc-ask", _the_model_was_told(text, picked))]
+
+    @needs_resume_array
+    def test_a_selection_that_is_not_a_label_fails_the_run(self):
+        """The entry type is declared, so an entry of another kind is refused here.
+
+        A refusal a client can see, rather than the run continuing and the model
+        reading a number back as the option somebody chose.
+        """
+        wire, interrupt = self._paused_on_the_question()
+        text, answered = self._asks_for(interrupt)
+        assert answered["items"]["type"] == "string"
+
+        resumed = wire.post(
+            A_QUESTION_PROMPT,
+            resume=[
+                {
+                    "interrupt_id": interrupt["id"],
+                    "status": "resolved",
+                    "payload": {interrupts.USER_FEEDBACK_SELECTIONS_KEY: {text: [7]}},
+                }
+            ],
+        )
+
+        assert _errors(resumed), "a selection that is not a label was taken for an answer"
+        assert _said(resumed) == ""
+        assert wire.recorded_tool_messages() == []
+
+    def test_the_same_selection_in_a_tool_message_reaches_the_model_as_it_always_did(self):
+        """The older channel is not held to the shape the interrupt advertised.
+
+        Same payload, same pause, opposite verdict, because this channel took
+        answers before this interface described any answer shape and the callers
+        it already had were written against that. Restoring a check here would
+        refuse a resume Agno used to continue from.
+        """
+        wire, interrupt = self._paused_on_the_question()
+        text, _ = self._asks_for(interrupt)
+
+        resumed = wire.post(
+            A_QUESTION_PROMPT,
+            messages=[
+                {"id": "m1", "role": "user", "content": A_QUESTION_PROMPT},
+                {
+                    "id": "t1",
+                    "role": "tool",
+                    "tool_call_id": "tc-ask",
+                    "content": json.dumps({interrupts.USER_FEEDBACK_SELECTIONS_KEY: {text: [7]}}),
+                },
+            ],
+        )
+
+        assert _errors(resumed) == []
+        assert _said(resumed) == "Noted."
+        assert wire.recorded_tool_messages() == [("tc-ask", _the_model_was_told(text, [7]))]
+
+
+def _the_model_was_told(question: str, selected: List[Any]) -> str:
+    """The tool message a resumed feedback pause continues from, as Agno writes it."""
+    return f"User feedback received: {json.dumps([{'question': question, 'selected': selected}])}"
+
+
+# --- Answers arriving on both channels of one request ------------------------
+
+
+BOTH_CHANNELS_PROMPT = "email ops@example.com and change the background"
+
+
+def _agent_pausing_on_a_decision_and_a_client_run_tool() -> Agent:
+    """An Agent whose one turn proposes a call to decide on and one the client runs.
+
+    Two pause kinds in one turn is what a frontend that runs tools produces. The
+    decision comes back in the resume array under the interrupt id it was
+    advertised by, and the tool's result comes back as the trailing tool message
+    keyed by its tool call, which is how a client-run tool's result has entered
+    the conversation since before the array existed.
+    """
+    return Agent(
+        id="interrupt-agent",
+        name="Interrupt Agent",
+        model=_ProposingSeveralAtOnce(
+            [
+                ("send_email", {"to": "ops@example.com"}, "tc-confirm"),
+                ("change_background", {"color": "blue"}, "tc-extern"),
+            ],
+            "Both done.",
+        ),
+        db=InMemoryDb(),
+        tools=[send_email, change_background],
+        telemetry=False,
+    )
+
+
+def _a_trailing_tool_message(tool_call_id: str, content: str) -> Dict[str, Any]:
+    """One tool result in the shape a client puts it in the request body."""
+    return {"id": f"t-{tool_call_id}", "role": "tool", "tool_call_id": tool_call_id, "content": content}
+
+
+BACKGROUND_CHANGED = json.dumps({"ok": True})
+
+
+def _paused_on_both_kinds(**agui_kwargs: Any) -> Tuple[Wire, List[Dict[str, Any]]]:
+    """A wire whose one turn has paused on a decision and on a client-run tool."""
+    wire = Wire(_agent_pausing_on_a_decision_and_a_client_run_tool(), **agui_kwargs)
+    paused = wire.post(BOTH_CHANNELS_PROMPT)
+    assert len(wire.open_interrupt_ids()) == 2, f"the run did not pause on both: {wire.open_interrupt_ids()}"
+    return wire, paused
+
+
+class TestBothPausesAnsweredOnTheOlderChannelAlone:
+    """The control the mixed request below is measured against.
+
+    Both answers in trailing tool messages is what a client sent before the
+    resume array existed, and it resolves. A client that moves one of those two
+    answers onto the array must not be the one that gets refused.
+    """
+
+    def test_two_trailing_tool_messages_answer_both_pauses(self):
+        wire, _ = _paused_on_both_kinds()
+
+        resumed = wire.post(
+            BOTH_CHANNELS_PROMPT,
+            messages=[
+                {"id": "m1", "role": "user", "content": BOTH_CHANNELS_PROMPT},
+                _a_trailing_tool_message("tc-confirm", json.dumps({"accepted": True})),
+                _a_trailing_tool_message("tc-extern", BACKGROUND_CHANGED),
+            ],
+        )
+
+        assert _errors(resumed) == []
+        assert EMAILS_SENT == ["ops@example.com"]
+
+
+@needs_interrupt_outcome
+@needs_resume_array
+class TestARequestCarryingBothChannels:
+    """One pause answered on both channels at once, over the route.
+
+    The two channels are not two spellings of one answer: the array addresses
+    interrupts by id, and a trailing tool message is how a frontend-executed
+    tool's result enters the conversation, keyed by tool call. One turn can pause
+    on both kinds at once, so a client running frontend tools sends exactly this
+    mixture, and dropping either channel leaves the pause it answered open for
+    the completeness guard to fail the run over.
+    """
+
+    def _paused_on_both(self) -> Tuple[Wire, Dict[str, str]]:
+        """The wire and the interrupt id advertised for each pending call."""
+        wire, paused = _paused_on_both_kinds(emit_interrupt_outcome=True)
+        advertised = {interrupt["toolCallId"]: interrupt["id"] for interrupt in _interrupts_of(paused)}
+        assert sorted(advertised) == ["tc-confirm", "tc-extern"], f"the run did not advertise both: {advertised}"
+        return wire, advertised
+
+    def test_each_channel_answers_the_pause_it_was_sent_for(self):
+        """The decision and the client-run tool's result both land, and the run continues."""
+        wire, advertised = self._paused_on_both()
+
+        resumed = wire.post(
+            BOTH_CHANNELS_PROMPT,
+            resume=[{"interrupt_id": advertised["tc-confirm"], "status": "resolved", "payload": {"accepted": True}}],
+            messages=[
+                {"id": "m1", "role": "user", "content": BOTH_CHANNELS_PROMPT},
+                _a_trailing_tool_message("tc-extern", BACKGROUND_CHANGED),
+            ],
+        )
+
+        assert _errors(resumed) == []
+        assert _said(resumed) == "Both done."
+        assert EMAILS_SENT == ["ops@example.com"]
+        assert _tool_results(resumed) == {"tc-confirm": json.dumps("EMAIL SENT to ops@example.com")}
+        assert wire.recorded_tool_messages() == [
+            ("tc-confirm", "EMAIL SENT to ops@example.com"),
+            ("tc-extern", BACKGROUND_CHANGED),
+        ]
+
+    def test_a_pause_the_two_channels_together_leave_open_still_fails_the_run(self):
+        """Merging the channels is not a way around the completeness guard.
+
+        The array answers the decision and nothing answers the client-run tool,
+        so the merged result is still a partial resume, and a partial resume
+        reaches dispatch as an answer nobody gave.
+        """
+        wire, advertised = self._paused_on_both()
+
+        resumed = wire.post(
+            BOTH_CHANNELS_PROMPT,
+            resume=[{"interrupt_id": advertised["tc-confirm"], "status": "resolved", "payload": {"accepted": True}}],
+        )
+
+        assert [error for error in _errors(resumed) if "Partial resume" in error], _errors(resumed)
+        assert advertised["tc-extern"] in _errors(resumed)[0]
+        assert EMAILS_SENT == []
+
+
+# --- Writing the answers onto the requirements -------------------------------
+
+
+def _tool_message(tool_call_id: str, content: str, error: Optional[str] = None) -> Any:
+    """One trailing tool message, in the shape the protocol model presents."""
+    from ag_ui.core.types import ToolMessage
+
+    return ToolMessage(id=f"m-{tool_call_id}", role="tool", content=content, tool_call_id=tool_call_id, error=error)
+
+
+def _answer_by_resume_entry(requirement: RunRequirement, payload: Any) -> None:
+    resolve_requirements_from_resume_entries(
+        [requirement], [_Entry(interrupts.interrupt_id_of(requirement), payload=payload)]
+    )
+
+
+def _answer_by_tool_message(requirement: RunRequirement, payload: Any) -> None:
+    resolve_requirements_from_tool_messages(
+        [requirement], [_tool_message(requirement.tool_execution.tool_call_id, json.dumps(payload))]
+    )
+
+
+# The two ways an answer reaches a paused requirement, for the payloads both of
+# them read. Where they part is stated by the tests that name one channel: what
+# an unreadable answer means, and which spelling of a decision each one reads.
+both_channels = pytest.mark.parametrize(
+    "answer",
+    [_answer_by_resume_entry, _answer_by_tool_message],
+    ids=["resume_entry", "tool_message"],
+)
+
+
+def _a_pause_whose_answered_twin_shares_an_open_id() -> List[RunRequirement]:
+    """Two requirements under one id, the one already answered listed second.
+
+    The id is the pending tool call, which is what a requirement carrying none of
+    its own is keyed by, and the answered twin is what a lookup built over every
+    requirement rather than the open ones keeps.
+    """
+    still_open = _requirement(_confirmation("tc-shared"))
+    already_answered = _requirement(_confirmation("tc-shared"))
+    for requirement in (still_open, already_answered):
+        requirement.id = None
+    already_answered.confirm()
+    return [still_open, already_answered]
+
+
+class TestTheIdTheTerminalAdvertisedIsTheIdResumeAnswers:
+    """Both sides of the round trip key answers off the same population.
+
+    The terminal advertises what the run's open requirements need, so an id it
+    hands a client has to be one the resume side writes that client's answer
+    onto. Built over two different populations they disagree, and the client is
+    refused for answering exactly the id it was given.
+    """
+
+    def test_an_answered_twin_does_not_shadow_the_open_requirement_it_shares_an_id_with(self):
+        requirements = _a_pause_whose_answered_twin_shares_an_open_id()
+        advertised = [needed.interrupt_id for needed in interrupts.answers_a_pause_needs(requirements)]
+        assert advertised == ["tc-shared"], "the terminal did not advertise the open requirement's id"
+
+        resolve_requirements_from_resume_entries(requirements, [_Entry("tc-shared", payload={"accepted": True})])
+
+        assert requirements[0].tool_execution.confirmed is True
+
+    def test_an_answer_the_run_already_holds_is_still_passed_over_in_silence(self, caplog):
+        """A replay is not an entry naming an interrupt the run does not carry.
+
+        A client that re-sent a body the run has already been continued from
+        addresses an id this pause really does hold, so it is left alone rather
+        than warned about as an entry for some other run.
+        """
+        already_answered = _requirement(_confirmation("tc-answered"))
+        already_answered.confirm()
+        still_open = _requirement(_confirmation("tc-open"))
+
+        with captured_agno_logs(caplog, "WARNING"):
+            resolve_requirements_from_resume_entries(
+                [already_answered, still_open],
+                [
+                    _Entry(interrupts.interrupt_id_of(already_answered), payload={"accepted": False}),
+                    _Entry(interrupts.interrupt_id_of(still_open), payload={"accepted": True}),
+                ],
+            )
+
+        assert already_answered.tool_execution.confirmed is True, "a replay overwrote the answer the run holds"
+        assert still_open.tool_execution.confirmed is True
+        assert interrupts.interrupt_id_of(already_answered) not in caplog.text
+
+
+def _a_pause_whose_two_open_requirements_share_one_tool_call() -> List[RunRequirement]:
+    """Three open requirements of one pause, two of them waiting on one call.
+
+    Each carries an id of its own, so the terminal advertises three answers and
+    the guard holds a resume to all three. The two under one call are where the
+    round trip's two keys meet: an entry names the interrupt it answers, and a
+    trailing tool result names the call.
+    """
+    return [
+        _requirement(_confirmation("tc-one", "send_email")),
+        _requirement(_external("tc-same", "change_background")),
+        _requirement(_confirmation("tc-same", "wire_funds")),
+    ]
+
+
+class TestOneToolResultCannotAnswerTwoInterrupts:
+    """A request whose result would land on two open interrupts is refused.
+
+    The older channel matches a tool result to every open requirement waiting on
+    its call. It answered that way before this interface advertised an id to
+    answer by and its own callers were written against it, so that is not what
+    changes here, and neither is the terminal: a pause can hold two requirements
+    for one real call, where one result answers both, and a stored run read back
+    cannot be told from two calls a model numbered alike. What can tell them
+    apart is the request, which says which interrupts the client answered by id.
+
+    So a request that leaves two of them open under one call and reports a result
+    for it is refused: otherwise one answer a client sent once resolves two, and
+    the completeness guard sees a pause fully answered.
+    """
+
+    def test_a_result_two_open_interrupts_wait_on_is_refused_naming_both(self):
+        requirements = _a_pause_whose_two_open_requirements_share_one_tool_call()
+        answered_by_id, *under_one_call = [interrupts.interrupt_id_of(each) for each in requirements]
+
+        with pytest.raises(ValueError) as refused:
+            resolve_requirements_from_resume_entries(
+                requirements,
+                [_Entry(answered_by_id, payload={interrupts.CONFIRMATION_ACCEPTED_KEY: True})],
+                [_tool_message("tc-same", BACKGROUND_CHANGED)],
+            )
+
+        assert all(interrupt_id in str(refused.value) for interrupt_id in under_one_call), str(refused.value)
+        assert [each.is_resolved() for each in requirements] == [False, False, False], (
+            "an answer was written onto a requirement before the request was refused"
+        )
+
+    def test_the_result_lands_where_the_array_answered_the_other_interrupt(self):
+        """What is refused is the ambiguity, not the two channels meeting.
+
+        A client that answered one of the two by id left one open requirement on
+        that call, so the result it sent beside it has one place to go.
+        """
+        requirements = _a_pause_whose_two_open_requirements_share_one_tool_call()
+
+        resolve_requirements_from_resume_entries(
+            requirements,
+            [
+                _Entry(
+                    interrupts.interrupt_id_of(requirements[0]),
+                    payload={interrupts.CONFIRMATION_ACCEPTED_KEY: True},
+                ),
+                _Entry(
+                    interrupts.interrupt_id_of(requirements[2]),
+                    payload={interrupts.CONFIRMATION_ACCEPTED_KEY: False},
+                ),
+            ],
+            [_tool_message("tc-same", BACKGROUND_CHANGED)],
+        )
+
+        assert requirements[1].external_execution_result == BACKGROUND_CHANGED
+        assert requirements[2].tool_execution.confirmed is False
+
+    def test_a_request_carrying_no_result_for_that_call_is_not_refused(self):
+        """The array alone addresses each of them by its own id, so it is enough."""
+        requirements = _a_pause_whose_two_open_requirements_share_one_tool_call()
+
+        resolve_requirements_from_resume_entries(
+            requirements,
+            [
+                _Entry(
+                    interrupts.interrupt_id_of(requirements[0]),
+                    payload={interrupts.CONFIRMATION_ACCEPTED_KEY: True},
+                ),
+                _Entry(interrupts.interrupt_id_of(requirements[1]), payload="the client ran it"),
+                _Entry(
+                    interrupts.interrupt_id_of(requirements[2]),
+                    payload={interrupts.CONFIRMATION_ACCEPTED_KEY: True},
+                ),
+            ],
+        )
+
+        assert [each.is_resolved() for each in requirements] == [True, True, True]
+
+    def test_the_older_channel_alone_still_answers_every_requirement_on_the_call(self):
+        """Base behaviour, pinned: nothing above changes what that channel does.
+
+        A request carrying no resume array never reaches the guard, and one
+        result resolving every requirement waiting on its call is what Agno did
+        there before any of this, for every caller written against it.
+        """
+        requirements = _a_pause_whose_two_open_requirements_share_one_tool_call()
+
+        resolve_requirements_from_tool_messages(requirements, [_tool_message("tc-same", BACKGROUND_CHANGED)])
+
+        assert requirements[1].external_execution_result == BACKGROUND_CHANGED
+        assert requirements[2].tool_execution.confirmed is False
+
+    def test_two_requirements_recorded_for_one_real_call_are_answered_by_id_as_they_were(self):
+        """The shape the refusal must not reach: one call, recorded twice.
+
+        Both are advertised, because a client that was told about one of them
+        would be refused over the one nobody named, and answering each by its own
+        id resolves the pause. The refusal above is about a request that leaves
+        them to a result keyed by the call, not about the pause.
+        """
+        one_call = _confirmation("tc-twice")
+        requirements = [_requirement(one_call), _requirement(one_call)]
+        advertised = [needed.interrupt_id for needed in interrupts.answers_a_pause_needs(requirements)]
+        assert len(advertised) == 2, "the pause stopped advertising both answers it needs"
+
+        resolve_requirements_from_resume_entries(
+            requirements,
+            [_Entry(interrupt_id, payload={interrupts.CONFIRMATION_ACCEPTED_KEY: True}) for interrupt_id in advertised],
+        )
+
+        assert [each.is_resolved() for each in requirements] == [True, True]
+
+    @needs_interrupt_outcome
+    @needs_resume_array
+    def test_the_refusal_reaches_the_client_and_the_run_does_not_go_on(self):
+        """Over the route, on a stored pause holding two requirements for one call.
+
+        The pause is a real one; the second requirement on its client-run call is
+        written onto the stored run, because a model has to number two of its
+        calls alike for a run to record that and nothing else about the request
+        would differ. What the second request does to it is the subject, and that
+        is the route's own: one result for the call, one decision answered by id,
+        and the completeness guard would have read the pause as answered.
+        """
+        agent = _agent_pausing_on_a_decision_and_a_client_run_tool()
+        wire = Wire(agent, emit_interrupt_outcome=True)
+        paused = wire.post(BOTH_CHANNELS_PROMPT)
+        advertised = {interrupt["toolCallId"]: interrupt["id"] for interrupt in _interrupts_of(paused)}
+        recorded = agent.get_session(session_id=THREAD_ID).runs[-1]
+        recorded.requirements.append(_requirement(_confirmation("tc-extern", "wire_funds")))
+        also_waiting = interrupts.interrupt_id_of(recorded.requirements[-1])
+
+        resumed = wire.post(
+            BOTH_CHANNELS_PROMPT,
+            resume=[{"interrupt_id": advertised["tc-confirm"], "status": "resolved", "payload": {"accepted": True}}],
+            messages=[
+                {"id": "m1", "role": "user", "content": BOTH_CHANNELS_PROMPT},
+                _a_trailing_tool_message("tc-extern", BACKGROUND_CHANGED),
+            ],
+        )
+
+        assert _errors_naming(resumed, advertised["tc-extern"], also_waiting), _errors(resumed)
+        assert _said(resumed) == "", "the run went on from a pause one answer had resolved twice"
+        assert EMAILS_SENT == []
+
+
+class TestResolvingResumeEntries:
+    def test_every_open_requirement_has_to_be_answered(self):
+        """A partial resume is silently declined at dispatch, so it stops here.
+
+        The protocol says one resume array addresses every open interrupt of the
+        interrupted run, and an unanswered confirmation reaching dispatch is read
+        there as a refusal the client never gave.
+        """
+        answered = _requirement(_confirmation("tc-a"))
+        unanswered = _requirement(_confirmation("tc-b"))
+
+        with pytest.raises(ValueError, match="still unresolved"):
+            resolve_requirements_from_resume_entries(
+                [answered, unanswered],
+                [_Entry(interrupts.interrupt_id_of(answered), payload={"accepted": True})],
+            )
+
+    def test_the_refusal_names_the_ids_this_channel_is_addressed_by(self):
+        """A resume array answers interrupts, so a refusal naming tool calls
+        named something the client never sent."""
+        answered = _requirement(_confirmation("tc-a"))
+        unanswered = _requirement(_confirmation("tc-b"))
+
+        with pytest.raises(ValueError) as refused:
+            resolve_requirements_from_resume_entries(
+                [answered, unanswered],
+                [_Entry(interrupts.interrupt_id_of(answered), payload={"accepted": True})],
+            )
+
+        assert interrupts.interrupt_id_of(unanswered) in str(refused.value)
+        assert "tc-b" not in str(refused.value)
+
+    def test_a_requirement_with_no_id_at_all_is_still_named_by_something(self):
+        """The refusal could name an empty list or a null, which named nothing to answer."""
+        nameless = _requirement(_confirmation("tc-nameless"))
+        del nameless.id
+        nameless.tool_execution.tool_call_id = None
+
+        assert interrupts.interrupt_id_of(nameless) is None
+        with pytest.raises(ValueError, match="1 carrying no id to name them by"):
+            ensure_requirements_resolved([nameless])
+
+    def test_an_entry_naming_no_requirement_is_skipped_rather_than_matched(self, caplog):
+        """Skipped, and never answered off some other pause that happens to be open."""
+        requirement = _requirement(_confirmation())
+
+        with captured_agno_logs(caplog, "WARNING"):
+            resolve_requirements_from_resume_entries(
+                [requirement],
+                [
+                    _Entry("no-such-interrupt", payload={"accepted": False}),
+                    _Entry(interrupts.interrupt_id_of(requirement), payload={"accepted": True}),
+                ],
+            )
+
+        assert requirement.tool_execution.confirmed is True
+        assert "no-such-interrupt" in caplog.text
+
+    def test_a_cancelled_decision_is_declined_with_the_reason(self):
+        requirement = _requirement(_confirmation())
+
+        resolve_requirements_from_resume_entries(
+            [requirement], [_Entry(interrupts.interrupt_id_of(requirement), status="cancelled")]
+        )
+
+        assert requirement.tool_execution.confirmed is False
+        assert requirement.confirmation_note == CANCELLED_NOTE
+
+    def test_a_cancelled_client_run_tool_reports_back_as_a_failure(self):
+        """The model has to learn the tool did not run, not read the reason as output."""
+        requirement = _requirement(_external())
+
+        resolve_requirements_from_resume_entries(
+            [requirement], [_Entry(interrupts.interrupt_id_of(requirement), status="cancelled")]
+        )
+
+        assert requirement.tool_execution.tool_call_error is True
+        assert requirement.external_execution_result == CANCELLED_NOTE
+
+    @pytest.mark.parametrize("pending", [_user_input(), _user_feedback()], ids=["user_input", "user_feedback"])
+    def test_a_cancelled_request_for_input_cannot_be_resolved(self, pending):
+        requirement = _requirement(pending)
+
+        with pytest.raises(ValueError, match="cannot be resumed without"):
+            resolve_requirements_from_resume_entries(
+                [requirement], [_Entry(interrupts.interrupt_id_of(requirement), status="cancelled")]
+            )
+
+    @pytest.mark.parametrize("pending", [_user_input(), _user_feedback()], ids=["user_input", "user_feedback"])
+    def test_a_failed_request_for_input_cannot_be_resolved_either(self, pending):
+        """There is no failure to record on a pause that is waiting on data.
+
+        A declined tool call and a client-run tool both have somewhere to put
+        the reason. A request for input has none, so a client reporting that it
+        could not collect the data leaves the run as unresumable as a
+        cancellation does, and the reason it gave is what says so.
+        """
+        requirement = _requirement(pending)
+
+        with pytest.raises(ValueError, match="the form could not be shown"):
+            resolve_requirements_from_resume_entries(
+                [requirement],
+                [
+                    _Entry(
+                        interrupts.interrupt_id_of(requirement),
+                        metadata={
+                            interrupts.RESUME_METADATA_NAMESPACE: {
+                                interrupts.RESUME_ERROR_KEY: "the form could not be shown"
+                            }
+                        },
+                    )
+                ],
+            )
+
+        assert requirement.is_resolved() is False
+
+    def test_a_client_run_tools_structured_result_is_stored_as_json(self):
+        """A frontend parses the result back, so a Python repr is not what it needs."""
+        requirement = _requirement(_external())
+
+        resolve_requirements_from_resume_entries(
+            [requirement],
+            [_Entry(interrupts.interrupt_id_of(requirement), payload={"ok": True, "changed": ["body"]})],
+        )
+
+        assert json.loads(requirement.external_execution_result) == {"ok": True, "changed": ["body"]}
+
+    def test_a_client_run_tools_text_result_is_stored_as_it_arrived(self):
+        requirement = _requirement(_external())
+
+        resolve_requirements_from_resume_entries(
+            [requirement], [_Entry(interrupts.interrupt_id_of(requirement), payload="the client changed it")]
+        )
+
+        assert requirement.external_execution_result == "the client changed it"
+
+    def test_an_answer_already_written_is_left_alone(self):
+        """A replayed entry must not overwrite the answer the run already holds."""
+        requirement = _requirement(_confirmation())
+        entry = _Entry(interrupts.interrupt_id_of(requirement), payload={"accepted": True})
+
+        resolve_requirements_from_resume_entries([requirement], [entry])
+        resolve_requirements_from_resume_entries([requirement], [entry])
+
+        assert requirement.tool_execution.confirmed is True
+
+    def test_a_requirement_with_no_stored_id_is_keyed_by_its_tool_call(self):
+        """The id is what an answer comes back under, so there has to be one."""
+        requirement = _requirement(_confirmation("tc-keyed"))
+        del requirement.id
+
+        assert interrupts.interrupt_id_of(requirement) == "tc-keyed"
+
+        resolve_requirements_from_resume_entries([requirement], [_Entry("tc-keyed", payload={"accepted": True})])
+
+        assert requirement.tool_execution.confirmed is True
+
+    def test_a_failure_report_with_no_reason_stops_the_resume(self):
+        """Dropping it stores the payload as the result and says the tool ran."""
+        requirement = _requirement(_external())
+
+        with pytest.raises(ValueError, match="non-empty string"):
+            resolve_requirements_from_resume_entries(
+                [requirement],
+                [
+                    _Entry(
+                        interrupts.interrupt_id_of(requirement),
+                        payload={"ok": False},
+                        metadata={interrupts.RESUME_METADATA_NAMESPACE: {interrupts.RESUME_ERROR_KEY: True}},
+                    )
+                ],
+            )
+
+        assert requirement.is_resolved() is False
+
+    @pytest.mark.parametrize(
+        "envelope",
+        [
+            {interrupts.RESUME_ERROR_KEY: "TypeError: color is not a string"},
+            {interrupts.RESUME_METADATA_NAMESPACE: "TypeError: color is not a string"},
+        ],
+        ids=["outside_the_namespace", "as_the_namespace_itself"],
+    )
+    def test_a_failure_reported_in_another_shape_is_read_rather_than_dropped(self, envelope):
+        """A report only read inside the advertised namespace was dropped elsewhere.
+
+        Which stores the payload beside it as the tool's result and tells the
+        model the tool ran, the one thing the resolver must never do with an
+        entry that said it failed.
+        """
+        requirement = _requirement(_external())
+
+        resolve_requirements_from_resume_entries(
+            [requirement],
+            [_Entry(interrupts.interrupt_id_of(requirement), payload={"ok": False}, metadata=envelope)],
+        )
+
+        assert requirement.tool_execution.tool_call_error is True
+        assert requirement.external_execution_result == "TypeError: color is not a string"
+
+    def test_a_report_in_another_shape_naming_no_reason_is_refused_too(self):
+        """Present and unreadable is refused wherever it sits, for the same reason."""
+        requirement = _requirement(_external())
+
+        with pytest.raises(ValueError, match="non-empty string"):
+            resolve_requirements_from_resume_entries(
+                [requirement],
+                [
+                    _Entry(
+                        interrupts.interrupt_id_of(requirement),
+                        payload={"ok": False},
+                        metadata={interrupts.RESUME_METADATA_NAMESPACE: 500},
+                    )
+                ],
+            )
+
+        assert requirement.is_resolved() is False
+
+    def test_an_error_the_entry_leaves_empty_is_no_failure_report(self):
+        """The protocol allows a null under any metadata key, so it reports nothing."""
+        requirement = _requirement(_external())
+
+        resolve_requirements_from_resume_entries(
+            [requirement],
+            [
+                _Entry(
+                    interrupts.interrupt_id_of(requirement),
+                    payload="the client changed it",
+                    metadata={interrupts.RESUME_METADATA_NAMESPACE: {interrupts.RESUME_ERROR_KEY: None}},
+                )
+            ],
+        )
+
+        assert requirement.external_execution_result == "the client changed it"
+        assert requirement.tool_execution.tool_call_error is not True
+
+    def test_an_entry_carrying_no_metadata_at_all_still_resolves(self):
+        """The envelope is an optional part of the protocol, so it is read as one."""
+        requirement = _requirement(_external())
+        entry = _Entry(interrupts.interrupt_id_of(requirement), payload="the client changed it")
+        del entry.metadata
+
+        resolve_requirements_from_resume_entries([requirement], [entry])
+
+        assert requirement.external_execution_result == "the client changed it"
+
+    def test_a_cancelled_entry_stays_the_cancellation_it_declares(self):
+        """Cancelling is abandoning the question, whatever envelope rides along."""
+        requirement = _requirement(_external())
+
+        resolve_requirements_from_resume_entries(
+            [requirement],
+            [
+                _Entry(
+                    interrupts.interrupt_id_of(requirement),
+                    status="cancelled",
+                    metadata={
+                        interrupts.RESUME_METADATA_NAMESPACE: {interrupts.RESUME_ERROR_KEY: "the tool never ran"}
+                    },
+                )
+            ],
+        )
+
+        assert requirement.tool_execution.tool_call_error is True
+        assert requirement.external_execution_result.startswith(CANCELLED_NOTE)
+
+    @pytest.mark.parametrize(
+        "pending,payload",
+        [
+            (_confirmation, {interrupts.CONFIRMATION_ACCEPTED_KEY: True}),
+            (_user_input, {interrupts.USER_INPUT_VALUES_KEY: {"topic": "otters"}}),
+            (_user_feedback, {interrupts.USER_FEEDBACK_SELECTIONS_KEY: {"What budget?": ["low"]}}),
+        ],
+        ids=["decision", "input", "feedback"],
+    )
+    def test_an_answer_sent_as_a_string_is_read_as_the_answer_it_carries(self, pending, payload):
+        """The same payload the tool-message channel parses out of a string.
+
+        A client that put its JSON in a string answered on one channel and was
+        refused on the other, for a difference in how the two read one payload
+        rather than in what they mean. Both go through one parser now.
+        """
+        requirement = _requirement(pending())
+
+        _answer_by_resume_entry(requirement, json.dumps(payload))
+
+        assert requirement.is_resolved() is True
+
+    def test_a_resolved_entry_carrying_no_result_is_refused_like_a_decision_with_none(self):
+        """One entry shape, one verdict, whichever pause kind it addresses.
+
+        Resolving a client-run tool from nothing stored a result nobody returned
+        and told the model the tool ran, while the same entry against a decision
+        was already refused. A client that ran nothing cancels instead, and one
+        whose tool returned nothing sends an empty result rather than none.
+        """
+        ran_a_tool = _requirement(_external())
+        decided = _requirement(_confirmation())
+
+        with pytest.raises(ValueError, match="no result"):
+            resolve_requirements_from_resume_entries([ran_a_tool], [_Entry(interrupts.interrupt_id_of(ran_a_tool))])
+        with pytest.raises(ValueError, match="confirmation expects"):
+            resolve_requirements_from_resume_entries([decided], [_Entry(interrupts.interrupt_id_of(decided))])
+
+        assert (ran_a_tool.is_resolved(), decided.is_resolved()) == (False, False)
+
+    def test_a_tool_that_returned_nothing_still_resolves_with_an_empty_result(self):
+        """The refusal above is about an entry with no answer, not about an empty one."""
+        requirement = _requirement(_external())
+
+        _answer_by_resume_entry(requirement, "")
+
+        assert requirement.is_resolved() is True
+        assert requirement.external_execution_result == ""
+
+    def test_a_status_the_protocol_does_not_declare_is_refused(self):
+        """The protocol declares two statuses and validates the field as a literal of them.
+
+        So this is about an entry that did not come through that model: the
+        interface reads the array loosely typed, because the model is there only
+        on a release that declares it. A third value taking the resolved path
+        answers the interrupt from a payload that means something else, which for
+        a decision is a definite answer read off input nothing understood.
+        """
+        requirement = _requirement(_confirmation())
+
+        with pytest.raises(ValueError, match="status"):
+            resolve_requirements_from_resume_entries(
+                [requirement],
+                [_Entry(interrupts.interrupt_id_of(requirement), status="deferred", payload={"accepted": True})],
+            )
+
+        assert requirement.is_resolved() is False
+
+
+def _nested_deeper_than_python_walks() -> List[Any]:
+    """A value both serializers run out of stack walking, as a graph dump can be."""
+    outermost: List[Any] = []
+    innermost = outermost
+    for _ in range(2000):
+        deeper: List[Any] = []
+        innermost.append(deeper)
+        innermost = deeper
+    return outermost
+
+
+class TestAResultThisServerCannotSerialize:
+    """A client-run tool's result that JSON refuses, on the way to the model.
+
+    The result is whatever the client's own tool returned, so serializing it can
+    fail and rendering it can fail after that. Both are the tool's answer
+    arriving in a shape this interface did not choose, and neither is a reason
+    to replace the tool's result with a stringification error, or to hand the
+    model a Python rendering nothing recorded.
+    """
+
+    def test_a_result_json_refuses_is_recorded_and_handed_over_as_its_python_rendering(self, caplog):
+        """The fallback is the documented one; going unrecorded is what hid it.
+
+        A datetime is the ordinary way a client's tool returns something JSON
+        has no spelling for, and the model then reads a Python repr as the tool's
+        output. That is the best this interface can do with it, and an operator
+        reading the answer the model gave has nothing to trace it by unless the
+        fallback says it ran.
+        """
+        requirement = _requirement(_external())
+
+        with captured_agno_logs(caplog, "WARNING"):
+            _answer_by_resume_entry(requirement, {"at": datetime(2020, 1, 1)})
+
+        assert requirement.external_execution_result == "{'at': datetime.datetime(2020, 1, 1, 0, 0)}"
+        _record_naming(caplog, "could not serialize a client-run tool's result")
+
+    def test_a_result_that_cannot_be_rendered_at_all_does_not_raise_out_of_the_resume(self, caplog):
+        """The fallback ran the payload's own code outside any guard.
+
+        A result whose rendering raises then left the resume reporting a
+        stringification error in place of the tool-result problem it was
+        handling, which fails the whole resume over the one entry that did
+        report a result.
+        """
+        requirement = _requirement(_external())
+
+        with captured_agno_logs(caplog, "WARNING"):
+            _answer_by_resume_entry(requirement, RaisesOnSerialization())
+
+        assert requirement.is_resolved() is True
+        assert requirement.external_execution_result == interrupts.UNREADABLE_RESULT_NOTE
+        _record_naming(caplog, "could not read a client-run tool's result")
+
+    def test_a_result_nested_deeper_than_the_serializers_walk_is_handled_like_any_other(self, caplog):
+        """The depth limit is raised as neither of the two errors the fallback caught.
+
+        Both serializers walk the value recursively, so a deeply nested result
+        raises ``RecursionError`` out of each of them in turn. It derives from
+        neither ``TypeError`` nor ``ValueError``, so it went straight out of the
+        function and out of the resume with it.
+        """
+        requirement = _requirement(_external())
+
+        with captured_agno_logs(caplog, "WARNING"):
+            _answer_by_resume_entry(requirement, _nested_deeper_than_python_walks())
+
+        assert requirement.is_resolved() is True
+        assert requirement.external_execution_result == interrupts.UNREADABLE_RESULT_NOTE
+
+
+# --- A decision, on whichever channel it arrives by --------------------------
+
+
+# Every payload that says nothing about the proposed call that this interface
+# can read. One list, read by both channels below, because what the two differ on
+# is what they do with it and not which payloads they cannot read.
+decisions_nobody_can_read = pytest.mark.parametrize(
+    "payload",
+    [
+        True,
+        "yes",
+        {"decision": "approve"},
+        {interrupts.CONFIRMATION_ACCEPTED_KEY: "true"},
+        {},
+    ],
+    ids=["not_an_object", "a_bare_string", "an_unrelated_field", "a_non_boolean", "no_fields_at_all"],
+)
+
+
+class TestResolvingADecision:
+    """Both channels answer the same question, and read a decision the same way.
+
+    They part on two things, both of them the older channel keeping what it
+    already had. What an answer this interface cannot read means: on the
+    protocol's own channel it fails the run, because ``reject(note=None)`` is a
+    refusal nobody gave and nothing on the wire or in the run's record tells it
+    from a real denial, while a trailing tool message declines the call, which is
+    what Agno did there before any of this. And which spelling of a decision is
+    read: the spec's approval field is named by the interrupt the resume array
+    answers, and reading it on the older channel would run a proposed tool that
+    channel declined for every caller written against it.
+    """
+
+    @decisions_nobody_can_read
+    def test_a_decision_nobody_can_read_stops_a_resume_entry(self, payload):
+        requirement = _requirement(_confirmation())
+
+        with pytest.raises(ValueError, match="confirmation expects"):
+            _answer_by_resume_entry(requirement, payload)
+
+        assert requirement.tool_execution.confirmed is None
+        assert requirement.is_resolved() is False
+
+    @decisions_nobody_can_read
+    def test_the_same_payload_in_a_tool_message_declines_the_call_as_it_always_did(self, payload):
+        """The older channel's answer to it, which this round trip does not get to change.
+
+        Every one of these used to decline the proposed call there. Failing the
+        run instead refuses a resume Agno accepted, and the client cannot tell
+        the difference from the pause being broken.
+        """
+        requirement = _requirement(_confirmation())
+
+        _answer_by_tool_message(requirement, payload)
+
+        assert requirement.tool_execution.confirmed is False
+        assert requirement.confirmation_note is None
+        assert requirement.is_resolved() is True
+
+    def test_an_entry_carrying_no_payload_at_all_stops_the_resume(self):
+        requirement = _requirement(_confirmation())
+
+        with pytest.raises(ValueError, match="confirmation expects"):
+            resolve_requirements_from_resume_entries([requirement], [_Entry(interrupts.interrupt_id_of(requirement))])
+
+        assert requirement.tool_execution.confirmed is None
+
+    @both_channels
+    def test_a_decision_is_written_through_to_the_tool(self, answer):
+        """Dispatch reads the nested copy, so a decision that stops at the
+        requirement is audited as a refusal."""
+        requirement = _requirement(_confirmation())
+
+        answer(requirement, {interrupts.CONFIRMATION_ACCEPTED_KEY: True})
+
+        assert requirement.tool_execution.confirmed is True
+
+    @both_channels
+    def test_a_denial_declines_the_call(self, answer):
+        requirement = _requirement(_confirmation())
+
+        answer(requirement, {interrupts.CONFIRMATION_ACCEPTED_KEY: False})
+
+        assert requirement.tool_execution.confirmed is False
+        assert requirement.confirmation_note is None
+
+    @both_channels
+    def test_a_denial_carries_its_note(self, answer):
+        requirement = _requirement(_confirmation())
+
+        answer(
+            requirement,
+            {interrupts.CONFIRMATION_ACCEPTED_KEY: False, interrupts.CONFIRMATION_NOTE_KEY: "wrong recipient"},
+        )
+
+        assert (requirement.tool_execution.confirmed, requirement.confirmation_note) == (False, "wrong recipient")
+
+    @pytest.mark.parametrize("decision", [True, False], ids=["approved", "denied"])
+    def test_the_interrupt_specs_own_approval_field_is_read_on_the_array(self, decision):
+        """A payload written against the spec's own approval example resolves the call.
+
+        On the array only. The interrupt that names the field is what the array
+        answers, and the trailing-tool-message channel never advertised it: an
+        acceptance spelled that way declined the call there, and reading it would
+        run a tool that channel used to refuse, which the table at the wire pins.
+        """
+        requirement = _requirement(_confirmation())
+
+        _answer_by_resume_entry(requirement, {interrupts.CONFIRMATION_ACCEPTED_ALIAS: decision})
+
+        assert requirement.tool_execution.confirmed is decision
+
+    @pytest.mark.parametrize("decision", [True, False], ids=["approved", "denied"])
+    def test_the_spec_field_is_read_past_a_null_under_agnos_own(self, decision):
+        """Which key is read is decided by the value, not by the key being there.
+
+        A client that writes both keys and leaves the one it had no value for
+        null sent exactly one decision. Reading the empty key refused a resume
+        that could have been answered, and the run it was told to continue died.
+        """
+        requirement = _requirement(_confirmation())
+
+        _answer_by_resume_entry(
+            requirement,
+            {interrupts.CONFIRMATION_ACCEPTED_KEY: None, interrupts.CONFIRMATION_ACCEPTED_ALIAS: decision},
+        )
+
+        assert requirement.tool_execution.confirmed is decision
+
+    @both_channels
+    def test_agnos_own_field_stays_authoritative(self, answer):
+        requirement = _requirement(_confirmation())
+
+        answer(
+            requirement,
+            {
+                interrupts.CONFIRMATION_ACCEPTED_KEY: False,
+                interrupts.CONFIRMATION_ACCEPTED_ALIAS: True,
+            },
+        )
+
+        assert requirement.tool_execution.confirmed is False
+
+    def test_a_value_under_agnos_field_that_cannot_be_read_is_not_answered_off_the_alias(self):
+        """One payload, one verdict, whatever else it carries.
+
+        The same unreadable value was refused alone and, with an alias beside it,
+        recorded the alias as the decision: the client wrote a decision under the
+        key it meant to be read and it was answered off another. A null under
+        that key is different, and the test above is what says so.
+        """
+        alone = _requirement(_confirmation())
+        beside_an_alias = _requirement(_confirmation())
+        malformed = {interrupts.CONFIRMATION_ACCEPTED_KEY: "true"}
+
+        with pytest.raises(ValueError, match="confirmation expects"):
+            _answer_by_resume_entry(alone, malformed)
+        with pytest.raises(ValueError, match="confirmation expects"):
+            _answer_by_resume_entry(beside_an_alias, {**malformed, interrupts.CONFIRMATION_ACCEPTED_ALIAS: False})
+
+        assert (alone.is_resolved(), beside_an_alias.is_resolved()) == (False, False)
+
+
+class TestTheNoteBesideADecision:
+    """The note a decision carries, described as the decision that keeps one.
+
+    Agno records a note on a denial, where the model reads it as why the call
+    was refused. Its approval path takes none: ``confirm`` has nowhere to put
+    one, and a note written on the requirement beside an approval does not
+    survive the reload a stored run is read back through, which copies a note to
+    the tool only where the decision was a denial. The schema offered the field
+    to both decisions all the same, and the approve branch read it and dropped
+    it without a word, so a client was told to send something nothing here could
+    keep.
+    """
+
+    @needs_interrupt_outcome
+    def test_the_note_reaches_the_client_described_as_what_keeps_it(self):
+        """The advertisement says which decision keeps a note, because it cannot
+        do it anywhere else: one schema is advertised for both of them.
+        """
+        described = _the_schema_advertised_for(_confirmation())["properties"][interrupts.CONFIRMATION_NOTE_KEY]
+
+        assert described == {"type": "string", "description": interrupts.CONFIRMATION_NOTE_DESCRIPTION}
+
+    @both_channels
+    def test_a_denial_records_the_note_it_carried_and_says_nothing(self, answer, caplog):
+        requirement = _requirement(_confirmation())
+
+        with captured_agno_logs(caplog, "WARNING"):
+            answer(
+                requirement,
+                {
+                    interrupts.CONFIRMATION_ACCEPTED_KEY: False,
+                    interrupts.CONFIRMATION_NOTE_KEY: "wrong recipient",
+                },
+            )
+
+        assert requirement.tool_execution.confirmation_note == "wrong recipient"
+        assert "wrong recipient" not in caplog.text, "a note the run kept was reported as dropped"
+
+    @both_channels
+    def test_an_approval_says_out_loud_that_it_dropped_the_note(self, answer, caplog):
+        """The one thing left to do with it: nothing the run records afterwards
+        says the note was ever sent.
+        """
+        requirement = _requirement(_confirmation())
+
+        with captured_agno_logs(caplog, "WARNING"):
+            answer(
+                requirement,
+                {
+                    interrupts.CONFIRMATION_ACCEPTED_KEY: True,
+                    interrupts.CONFIRMATION_NOTE_KEY: "the vendor is verified",
+                },
+            )
+
+        assert requirement.tool_execution.confirmed is True
+        assert requirement.confirmation_note is None
+        assert "the vendor is verified" in caplog.text
+        assert requirement.tool_execution.tool_name in caplog.text
+
+    @both_channels
+    def test_an_approval_carrying_no_note_says_nothing(self, answer, caplog):
+        requirement = _requirement(_confirmation())
+
+        with captured_agno_logs(caplog, "WARNING"):
+            answer(requirement, {interrupts.CONFIRMATION_ACCEPTED_KEY: True})
+
+        assert requirement.tool_execution.confirmed is True
+        assert interrupts.CONFIRMATION_NOTE_KEY not in caplog.text
+
+
+class TestTheTrailingToolMessageChannelTakesWhatItAlwaysTook:
+    """The channel that predates the advertised schema is not held to it.
+
+    Agno took these answers before this interface described any answer shape,
+    and every caller of the tool-message resume was written against that. Holding
+    them to a schema the client was never shown refuses a resume the run used to
+    continue from: the pause is real, the client answered it, and the run dies on
+    a constraint invented afterwards.
+    """
+
+    def test_a_field_declared_as_an_integer_still_takes_the_string_it_arrives_as(self):
+        requirement = _requirement(_user_input([UserInputField(name="count", field_type=int)]))
+
+        _answer_by_tool_message(requirement, {interrupts.USER_INPUT_VALUES_KEY: {"count": "12"}})
+
+        assert [input_field.value for input_field in requirement.user_input_schema] == ["12"]
+        assert requirement.is_resolved() is True
+
+    def test_a_note_of_a_shape_no_schema_offered_still_reaches_the_run(self):
+        """Both copies, because a note of another kind is written on both.
+
+        This is what the channel did before any of this interface described an
+        answer shape, and the resume array is where a note of another kind is
+        refused instead. Dropping it here would be a change to the older channel
+        rather than a check restored to it, which is the one thing that channel
+        is not allowed: the client answered the question, and what it attached
+        to the answer is not this channel's to re-judge.
+        """
+        requirement = _requirement(_confirmation())
+
+        _answer_by_tool_message(
+            requirement,
+            {interrupts.CONFIRMATION_ACCEPTED_KEY: False, interrupts.CONFIRMATION_NOTE_KEY: {"why": "wrong"}},
+        )
+
+        assert requirement.tool_execution.confirmed is False
+        assert requirement.confirmation_note == {"why": "wrong"}
+        assert requirement.tool_execution.confirmation_note == {"why": "wrong"}
+
+    def test_a_selection_that_is_not_text_still_reaches_the_run(self):
+        """The counterpart of the entry-type check the resume array runs.
+
+        Which channel refuses a value of another kind is the whole of the split:
+        the array is this interface's own, so it holds an answer to the shape it
+        advertised, and this one predates the shape entirely.
+        """
+        requirement = _requirement(_user_feedback(multi_select=True))
+
+        _answer_by_tool_message(requirement, {interrupts.USER_FEEDBACK_SELECTIONS_KEY: {"What budget?": [7]}})
+
+        assert requirement.is_resolved() is True
+        assert requirement.user_feedback_schema[0].selected_options == [7]
+
+
+# --- Reporting that answering failed, on whichever channel -------------------
+
+
+def _report_failure_by_resume_entry(requirement: RunRequirement, reason: str, payload: Any = None) -> None:
+    resolve_requirements_from_resume_entries(
+        [requirement],
+        [
+            _Entry(
+                interrupts.interrupt_id_of(requirement),
+                payload=payload,
+                metadata={interrupts.RESUME_METADATA_NAMESPACE: {interrupts.RESUME_ERROR_KEY: reason}},
+            )
+        ],
+    )
+
+
+def _report_failure_by_tool_message(requirement: RunRequirement, reason: str, payload: Any = None) -> None:
+    resolve_requirements_from_tool_messages(
+        [requirement],
+        [
+            _tool_message(
+                requirement.tool_execution.tool_call_id,
+                json.dumps(payload) if payload is not None else "",
+                error=reason,
+            )
+        ],
+    )
+
+
+def _advertised_error_report_path(pending: ToolExecution) -> List[str]:
+    """Where the emitted interrupt tells a client to report that its tool failed."""
+    events = on_run_completed(_paused(pending), StreamState(emit_interrupt_outcome=True))
+    described = _outcome_on_the_wire(_run_finished(events))["interrupts"][0]["metadata"]["agno"]
+    return described[interrupts.ERROR_REPORT_PATH_KEY]
+
+
+def _nested(path: List[str], value: Any) -> Dict[str, Any]:
+    """One value at the end of a path, keyed by the entry field the path starts at."""
+    for key in reversed(path):
+        value = {key: value}
+    return value
+
+
+def _entry_carrying(interrupt_id: str, path: List[str], value: Any) -> "_Entry":
+    """One resume entry carrying ``value`` at the path an interrupt advertised.
+
+    The path starts at the entry field a client writes it on, so a path rooted
+    anywhere else is an interrupt naming a place the resume channel has none of.
+    Read against the fields an entry declares and said here: splatted straight
+    in, it arrives as a constructor's arity, which reports this helper rather
+    than the advertisement it is about.
+    """
+    carries = set(inspect.signature(_Entry.__init__).parameters) - {"self", "interrupt_id"}
+
+    assert path and path[0] in carries, (
+        f"the advertised report path {path} starts at a field no resume entry carries: {sorted(carries)}"
+    )
+
+    return _Entry(interrupt_id, **_nested(path, value))
+
+
+# The two ways a client says the tool raised. Both channels answer the same
+# interrupt, so a failure one of them can report the other has to report too.
+both_failure_channels = pytest.mark.parametrize(
+    "report_failure",
+    [_report_failure_by_resume_entry, _report_failure_by_tool_message],
+    ids=["resume_entry", "tool_message"],
+)
+
+
+class TestReportingAFailure:
+    """A client whose tool raised has to be able to say so on either channel.
+
+    A trailing tool message has always carried an error field. The resume array
+    only ever produced one for a cancelled entry, which left a client on the
+    protocol's own channel choosing between reporting the failure as a result,
+    which tells the model a tool ran that never did, and cancelling, which the
+    protocol reserves for abandoning the question rather than answering it.
+    """
+
+    @both_failure_channels
+    def test_a_client_run_tool_that_failed_reaches_the_model_as_a_failed_call(self, report_failure):
+        """The result the model reads is the reason, and the call is marked failed."""
+        requirement = _requirement(_external())
+
+        report_failure(requirement, "TypeError: color is not a string", payload={"ok": False})
+
+        assert requirement.tool_execution.tool_call_error is True
+        assert requirement.external_execution_result == "TypeError: color is not a string"
+
+    @both_failure_channels
+    def test_a_reported_failure_declines_a_proposed_call(self, report_failure):
+        """A client reporting a failure answered the question, so it is a refusal."""
+        requirement = _requirement(_confirmation())
+
+        report_failure(requirement, "the prompt was dismissed")
+
+        assert requirement.tool_execution.confirmed is False
+        assert requirement.confirmation_note == "the prompt was dismissed"
+
+    @both_failure_channels
+    def test_a_reported_failure_prefers_the_note_it_carries(self, report_failure):
+        requirement = _requirement(_confirmation())
+
+        report_failure(
+            requirement,
+            "the prompt was dismissed",
+            payload={interrupts.CONFIRMATION_NOTE_KEY: "wrong recipient"},
+        )
+
+        assert requirement.tool_execution.confirmed is False
+        assert requirement.confirmation_note == "wrong recipient"
+
+    @needs_interrupt_outcome
+    def test_a_client_that_followed_the_advertised_path_is_read(self):
+        """What is advertised has to be what the resolver reads.
+
+        The entry is built by walking the path off the wire, so an interrupt
+        that named a report the resume channel does not read would fail here
+        rather than reach a client as a convention that does nothing.
+        """
+        pending = _external()
+        path = _advertised_error_report_path(pending)
+        requirement = _requirement(pending)
+
+        resolve_requirements_from_resume_entries(
+            [requirement],
+            [_entry_carrying(interrupts.interrupt_id_of(requirement), path, "TypeError: color is not a string")],
+        )
+
+        assert requirement.tool_execution.tool_call_error is True
+        assert requirement.external_execution_result == "TypeError: color is not a string"
+
+    def test_a_client_run_tool_that_worked_is_not_read_as_a_failure(self):
+        requirement = _requirement(_external())
+
+        _answer_by_resume_entry(requirement, {"ok": True, "changed": ["body"]})
+
+        assert requirement.tool_execution.tool_call_error is not True
+        assert json.loads(requirement.external_execution_result) == {"ok": True, "changed": ["body"]}
+
+
+def _cancel_reporting(requirement: RunRequirement, reason: Any) -> None:
+    """Cancel one interrupt, in the envelope a client reports a failed answer in."""
+    resolve_requirements_from_resume_entries(
+        [requirement],
+        [
+            _Entry(
+                interrupts.interrupt_id_of(requirement),
+                status="cancelled",
+                metadata={interrupts.RESUME_METADATA_NAMESPACE: {interrupts.RESUME_ERROR_KEY: reason}},
+            )
+        ],
+    )
+
+
+class TestACancellationThatSaysWhy:
+    """A client that gave up can say why, and the entry carrying both is read as both.
+
+    The status says the question was abandoned and the envelope says what went
+    wrong, so the reason is recorded exactly where a resolved entry's is: in what
+    the run records about the call. Reading the envelope only on a resolved entry
+    lost both halves of that, the reason a run could have recorded and the
+    refusal of a report nothing could read.
+    """
+
+    def test_a_cancelled_client_run_tool_reports_back_with_the_reason(self):
+        requirement = _requirement(_external())
+
+        _cancel_reporting(requirement, "the tool never ran")
+
+        assert requirement.tool_execution.tool_call_error is True
+        assert requirement.external_execution_result == f"{CANCELLED_NOTE}: the tool never ran"
+
+    def test_a_cancelled_decision_is_declined_with_the_reason_the_client_gave(self):
+        requirement = _requirement(_confirmation())
+
+        _cancel_reporting(requirement, "the user closed the tab")
+
+        assert requirement.tool_execution.confirmed is False
+        assert requirement.confirmation_note == f"{CANCELLED_NOTE}: the user closed the tab"
+
+    @pytest.mark.parametrize("pending", [_user_input(), _user_feedback()], ids=["user_input", "user_feedback"])
+    def test_a_cancelled_request_for_input_stops_the_run_naming_the_reason(self, pending):
+        """Nowhere to record it, so the reason is what the refusal carries."""
+        requirement = _requirement(pending)
+
+        with pytest.raises(ValueError, match="the form could not be shown"):
+            _cancel_reporting(requirement, "the form could not be shown")
+
+    @pytest.mark.parametrize("status", ["resolved", "cancelled"], ids=["resolved", "cancelled"])
+    def test_a_report_naming_no_reason_is_refused_whatever_the_status(self, status):
+        """One envelope, one refusal: the status is not what makes a report readable."""
+        requirement = _requirement(_external())
+
+        with pytest.raises(ValueError, match="non-empty string"):
+            resolve_requirements_from_resume_entries(
+                [requirement],
+                [
+                    _Entry(
+                        interrupts.interrupt_id_of(requirement),
+                        status=status,
+                        metadata={interrupts.RESUME_METADATA_NAMESPACE: {interrupts.RESUME_ERROR_KEY: 500}},
+                    )
+                ],
+            )
+
+        assert requirement.is_resolved() is False
+
+
+# A failure report path with its nesting moved, for the checks whose subject is
+# that one path is advertised and read. Deeper and differently named, so a side
+# still reading the old structure finds nothing rather than finding it by luck.
+_A_MOVED_REPORT_PATH: Tuple[str, ...] = ("metadata", interrupts.RESUME_METADATA_NAMESPACE, "tool_failure", "reason")
+
+
+def _as_a_client_reads_it(path: List[str]) -> str:
+    """One advertised path as a refusal about it names the place it looked."""
+    return path[0] + "".join(f"[{key!r}]" for key in path[1:])
+
+
+class TestOnePathIsAdvertisedAndRead:
+    """Where a client says its own tool failed is one spelling, not two.
+
+    The interrupt advertises the path as a nesting and the resume side walked
+    that nesting out by hand. The two shared their last two segments and not
+    their structure, so moving the nesting on the advertising side left the
+    reader looking where no client was ever told to write, and a client that
+    followed the advertisement would have had its report read as a result the
+    tool returned.
+    """
+
+    @needs_interrupt_outcome
+    def test_a_report_is_read_wherever_the_advertised_path_moves_to(self, monkeypatch):
+        monkeypatch.setattr(interrupts, "ERROR_REPORT_PATH", _A_MOVED_REPORT_PATH)
+        pending = _external()
+        advertised = _advertised_error_report_path(pending)
+        assert advertised == list(_A_MOVED_REPORT_PATH), "the interrupt advertised something else"
+        requirement = _requirement(pending)
+
+        resolve_requirements_from_resume_entries(
+            [requirement],
+            [_entry_carrying(interrupts.interrupt_id_of(requirement), advertised, "TypeError: color is not a string")],
+        )
+
+        assert requirement.tool_execution.tool_call_error is True
+        assert requirement.external_execution_result == "TypeError: color is not a string"
+
+    @needs_interrupt_outcome
+    def test_a_report_nothing_can_read_is_refused_naming_where_it_was_looked_for(self, monkeypatch):
+        """The refusal names the path too, so it is a third place to drift from."""
+        monkeypatch.setattr(interrupts, "ERROR_REPORT_PATH", _A_MOVED_REPORT_PATH)
+        pending = _external()
+        advertised = _advertised_error_report_path(pending)
+        requirement = _requirement(pending)
+
+        with pytest.raises(ValueError) as refused:
+            resolve_requirements_from_resume_entries(
+                [requirement], [_entry_carrying(interrupts.interrupt_id_of(requirement), advertised, 500)]
+            )
+
+        assert _as_a_client_reads_it(advertised) in str(refused.value)
+        assert requirement.is_resolved() is False
+
+    def test_a_reason_written_straight_onto_the_envelope_is_still_read(self):
+        """The one reading that is not the advertised path, kept deliberately.
+
+        A client that wrote the reason on the envelope rather than inside the
+        namespace reported a failure all the same, and passing it over stores
+        the payload beside it as the tool's result and tells the model a tool
+        ran that raised.
+        """
+        requirement = _requirement(_external())
+
+        resolve_requirements_from_resume_entries(
+            [requirement],
+            [_Entry(interrupts.interrupt_id_of(requirement), metadata={interrupts.RESUME_ERROR_KEY: "it raised"})],
+        )
+
+        assert requirement.tool_execution.tool_call_error is True
+        assert requirement.external_execution_result == "it raised"
+
+
+# --- A pause no answer could resolve ----------------------------------------
+
+
+@needs_interrupt_outcome
+class TestAPauseNoAnswerCouldResolve:
+    """A pause holding one requirement nothing resolves ends the run, saying why.
+
+    One resolver runs per requirement, picked by pause kind, and it refuses to
+    run unless that kind is what the requirement is still waiting on. A
+    requirement with anything left open afterwards fails the partial-resume
+    guard, which stops the whole resume. So such a requirement is a dead end for
+    the run and not only for itself: a resume has to answer every open one, and
+    this is one no client can answer.
+
+    The run therefore ends here rather than waiting. Advertising the
+    requirements beside it would strand the run silently, which is the failure
+    this replaces: the client answers everything the terminal named, the guard
+    refuses the resume over the one it did not, and nothing on the wire ever
+    said the run could not go on.
+    """
+
+    def _terminal_for(self, pending: ToolExecution, caplog) -> Any:
+        with captured_agno_logs(caplog, "WARNING"):
+            events = on_run_completed(_paused(pending), StreamState(emit_interrupt_outcome=True))
+        assert _advertised_interrupts(events) == NO_OUTCOME_AT_ALL
+        return _failed_terminal(events)
+
+    def test_a_call_flagged_for_a_decision_and_for_input_ends_the_run(self, caplog):
+        failed = self._terminal_for(_two_pause_kinds(), caplog)
+
+        assert "leaves a decision unresolved" in failed.message
+        assert failed.code == interrupts.PAUSE_NOT_CONTINUABLE_CODE
+        assert "leaves a decision unresolved" in caplog.text
+
+    def test_a_tool_that_asks_for_input_and_declares_no_field_ends_the_run(self, caplog):
+        """There is no key to send a value under, so the schema had nothing in it.
+
+        The interrupt went out with no schema at all, which reads as a pause
+        that wants no particular answer, and every answer left it open.
+        """
+        failed = self._terminal_for(_user_input([]), caplog)
+
+        assert "declares no field" in failed.message
+        assert "declares no field" in caplog.text
+
+    def test_an_answerable_pause_beside_it_is_not_advertised_either(self, caplog):
+        """Answering it could not continue the run, so offering it would strand it.
+
+        The guard demands every open requirement, so a client answering the one
+        the terminal named would be refused over the one it could not name. The
+        run ends on the wire instead, and the reason names the requirement that
+        ended it.
+        """
+        chunk = _paused(_two_pause_kinds(), _confirmation("tc-answerable"))
+
+        with captured_agno_logs(caplog, "WARNING"):
+            events = on_run_completed(chunk, StreamState(emit_interrupt_outcome=True))
+
+        assert _advertised_interrupts(events) == NO_OUTCOME_AT_ALL
+        nothing_resolves_it, answerable = chunk.requirements
+        message = _failed_terminal(events).message
+        assert interrupts.interrupt_id_of(nothing_resolves_it) in message
+        assert interrupts.interrupt_id_of(answerable) not in message
+        # And a client left with no id to answer is refused with the reason the
+        # terminal gave, which is what that terminal is there to say before it
+        # tries.
+        with pytest.raises(ValueError, match="cannot be continued"):
+            _answering_everything_advertised(chunk, [])
+
+    def test_a_pause_whose_one_field_cannot_be_named_ends_the_run(self, caplog):
+        """The guard has to ask whether a shape was produced, not count empty fields.
+
+        This field can be keyed to by no payload and is filled already, so a
+        census of what is still empty finds nothing to report while the schema
+        built from it describes nothing at all. The interrupt went out saying
+        input was required and naming no shape for it, which is the one state
+        the guard exists to prevent.
+        """
+        with captured_agno_logs(caplog, "WARNING"):
+            events = on_run_completed(
+                _paused(_filled_a_field_no_answer_could_name()),
+                StreamState(emit_interrupt_outcome=True),
+            )
+
+        advertised = _advertised_interrupts(events)
+        assert advertised == NO_OUTCOME_AT_ALL, f"advertised with no shape to answer in: {advertised}"
+        terminal = _encoded(_failed_terminal(events))
+        assert terminal["code"] == interrupts.PAUSE_NOT_CONTINUABLE_CODE
+        assert "declares no field" in terminal["message"]
+
+    def test_a_pause_whose_question_answers_for_a_field_it_never_fills_ends_the_run(self, caplog):
+        """One flag stands for both structured kinds, and only one of them was given.
+
+        Answering the questions marks the whole call answered, so the run goes on
+        with the value the tool asked for still missing and the client never told
+        there was one.
+        """
+        chunk = _paused(_asks_a_question_while_a_field_it_needs_stays_empty())
+
+        with captured_agno_logs(caplog, "WARNING"):
+            events = on_run_completed(chunk, StreamState(emit_interrupt_outcome=True))
+
+        advertised = _advertised_interrupts(events)
+        assert advertised == NO_OUTCOME_AT_ALL, f"advertised an answer that leaves the field empty: {advertised}"
+        assert "input values still missing" in _encoded(_failed_terminal(events))["message"]
+        # And the resume side reads the same computation, so a client that sent
+        # an array anyway is told what the terminal said.
+        with pytest.raises(ValueError, match="cannot be continued"):
+            _answering_everything_advertised(chunk, [])
+
+    def test_the_count_of_unnamed_fields_reads_as_a_count(self, caplog):
+        """This sentence reaches the client inside the failed run's message.
+
+        Two of them reported as one unnamed field reads as a statement about a
+        pause that is not the one the run died on.
+        """
+        failed = self._terminal_for(_waits_on_two_fields_no_answer_could_name(), caplog)
+
+        assert "2 unnamed fields or questions" in _encoded(failed)["message"]
+
+    def test_two_requirements_under_one_id_end_the_run(self, caplog):
+        """One correlation key for two answers resolves one and strands the other.
+
+        Which the terminal used to hide: it advertised the first of the two and
+        dropped the second as a duplicate id, leaving a requirement no client was
+        told about.
+        """
+        chunk = _paused_where_two_requirements_share_one_id()
+
+        with captured_agno_logs(caplog, "WARNING"):
+            events = on_run_completed(chunk, StreamState(emit_interrupt_outcome=True))
+
+        assert _advertised_interrupts(events) == NO_OUTCOME_AT_ALL
+        assert "keyed by tc-shared too" in _failed_terminal(events).message
+
+    @pytest.mark.asyncio
+    async def test_the_terminal_names_no_member_under_a_visibility_that_names_none(self):
+        """The run ends here, and ending it must withhold what prompting withholds.
+
+        The terminal reports the chunk the run ended on, which is the leader's
+        own and carries a requirement per member the run was waiting on, each
+        naming the member, its id and its run. Whose lane the chunk came from
+        says nothing about that: this one is the leader's.
+        """
+        chunk = _member_paused_on_something_nothing_can_answer()
+
+        events, error = await collect_async(
+            [chunk],
+            "hidden",
+            thread_id=THREAD_ID,
+            run_id=RUN_ID,
+            emit_interrupt_outcome=True,
+        )
+
+        assert error is None
+        assert "cannot be continued" in _failed_terminal(events).message
+        received = _everything_the_client_received(events)
+        assert [named for named in _how_a_pause_names_its_member(chunk) if named in received] == []
+        # And the other way a stream names a member: an event of one of the
+        # member kinds, or a lane stamped on anything at all.
+        assert member_mentions(events) == []
+
+    @pytest.mark.asyncio
+    async def test_the_withheld_chunk_reaches_the_operator_instead(self, caplog):
+        """Nothing else holds it: the terminal says why the run stopped and no more.
+
+        A client is told nothing about the member, so this line is the only copy
+        of the chunk the run died on, and an operator diagnosing the failure has
+        it and nothing else.
+        """
+        chunk = _member_paused_on_something_nothing_can_answer()
+
+        with captured_agno_logs(caplog, "WARNING"):
+            events, error = await collect_async(
+                [chunk],
+                "hidden",
+                thread_id=THREAD_ID,
+                run_id=RUN_ID,
+                emit_interrupt_outcome=True,
+            )
+
+        assert error is None
+        recorded = [line for line in caplog.messages if "withheld the chunk" in line]
+        assert len(recorded) == 1
+        assert [named for named in _how_a_pause_names_its_member(chunk) if named not in recorded[0]] == []
+
+    @pytest.mark.asyncio
+    async def test_the_visibility_that_names_members_still_reports_the_chunk(self):
+        """Withholding it where a member is hidden must not withhold it everywhere.
+
+        Nothing is announced on this path, because the run ends before the pause
+        prompt's lanes are, so the chunk the terminal reports is the whole of
+        what this stream says about the member the run was waiting on.
+        """
+        chunk = _member_paused_on_something_nothing_can_answer()
+
+        events, error = await collect_async(
+            [chunk],
+            attributed(),
+            thread_id=THREAD_ID,
+            run_id=RUN_ID,
+            emit_interrupt_outcome=True,
+        )
+
+        assert error is None
+        reported = _encoded(_failed_terminal(events))["rawEvent"]
+        assert reported["event"] == TeamRunEvent.run_paused.value
+        received = json.dumps(reported)
+        assert [named for named in _how_a_pause_names_its_member(chunk) if named not in received] == []
+
+    @pytest.mark.asyncio
+    async def test_a_pause_with_no_member_in_it_still_reports_its_chunk(self):
+        """What is withheld is member identity, not every failed run's diagnostics.
+
+        A pause reports the member fields on every requirement it carries,
+        emptily when no member is involved, so a visibility that hid the chunk
+        on the sight of those fields would take the dump off every failed
+        terminal it has ever been on.
+        """
+        chunk = _paused(_two_pause_kinds())
+
+        events, error = await collect_async(
+            [chunk],
+            "hidden",
+            thread_id=THREAD_ID,
+            run_id=RUN_ID,
+            emit_interrupt_outcome=True,
+        )
+
+        assert error is None
+        assert _encoded(_failed_terminal(events))["rawEvent"]["event"] == RunEvent.run_paused.value
+
+
+def _two_pause_kinds_as_a_real_run_reports_it() -> Function:
+    """One tool carrying two pause flags, which a real run splits across two entries.
+
+    ``@tool`` refuses two of the flags at once, and a ``Function`` configured
+    directly does not, which is the only way to obtain the tool the two-kind
+    pause is reported for.
+    """
+
+    def send_two_ways(to: str, body: str = "") -> str:
+        """Send one email."""
+        raise AssertionError("a paused call must not run")
+
+    function = Function.from_callable(send_two_ways)
+    function.name = "send_email"
+    function.requires_confirmation = True
+    function.requires_user_input = True
+    function.user_input_fields = ["body"]
+    return function
+
+
+def _agent_whose_one_call_is_flagged_for_two_kinds() -> Agent:
+    return Agent(
+        id="interrupt-agent",
+        name="Interrupt Agent",
+        model=ScriptedModel("m", [("tool", "send_email", {"to": "ops@example.com"}, "tc-1"), ("content", "Sent.")]),
+        db=InMemoryDb(),
+        tools=[_two_pause_kinds_as_a_real_run_reports_it()],
+        telemetry=False,
+    )
+
+
+def _agent_whose_model_numbers_two_calls_alike() -> Agent:
+    return Agent(
+        id="interrupt-agent",
+        name="Interrupt Agent",
+        model=_ProposingSeveralAtOnce(
+            [
+                ("send_email", {"to": "ops@example.com"}, "tc-same"),
+                ("send_email", {"to": "sre@example.com"}, "tc-same"),
+            ],
+            "Done.",
+        ),
+        db=InMemoryDb(),
+        tools=[send_email],
+        telemetry=False,
+    )
+
+
+@needs_interrupt_outcome
+class TestTwoPendingCallsUnderOneIdOverTheRoute:
+    """A pause whose prompt carries one tool call id twice, driven end to end.
+
+    The refusal above reads one ``ToolExecution`` carrying two pause flags. A
+    real run does not report one: it records one entry per flag, both under the
+    call's own id, and raises a single requirement for whichever kind it paused
+    on. That requirement is answerable, so nothing refuses the pause, and the
+    prompt opens the shared id once per entry.
+
+    A model numbering two of its calls alike reaches the same stream by a route
+    that needs no flag at all.
+
+    Both are streams this directory's own definition rejects, and both are
+    pinned to the violation they break rather than passing unseen. Asking for
+    the interrupt outcome does not change either: it is the pause the prompt was
+    built from that carries the duplicate, and the outcome is written beside it.
+    """
+
+    def test_a_tool_flagged_for_two_kinds_opens_its_id_twice(self):
+        wire = Wire(_agent_whose_one_call_is_flagged_for_two_kinds(), emit_interrupt_outcome=True)
+
+        events = wire.post("email ops", malformed=A_CALL_PROMPTED_ONCE_PER_PAUSE_KIND)
+
+        assert [event["toolCallId"] for event in events if event["type"] == "TOOL_CALL_START"] == ["tc-1", "tc-1"]
+        assert [interrupt["toolCallId"] for interrupt in _interrupts_of(events)] == ["tc-1"]
+
+    def test_a_model_numbering_two_calls_alike_opens_that_id_twice(self):
+        wire = Wire(_agent_whose_model_numbers_two_calls_alike(), emit_interrupt_outcome=True)
+
+        events = wire.post("email ops and sre", malformed=A_CALL_PROMPTED_ONCE_PER_PAUSE_KIND)
+
+        assert [event["toolCallId"] for event in events if event["type"] == "TOOL_CALL_START"] == [
+            "tc-same",
+            "tc-same",
+        ]
+        assert [interrupt["toolCallId"] for interrupt in _interrupts_of(events)] == ["tc-same", "tc-same"]
+
+
+class TestNothingResumesAPauseNoAnswerCouldResolve:
+    """Why ending the run is a promise kept rather than a pause withheld.
+
+    Ending it above is only right because no answer would have continued the
+    run, and that half is the resume channel refusing the payload, on every
+    install: nothing here builds an interrupt or reads one off a terminal, so
+    the gate on the class above does not belong on these three.
+    """
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {interrupts.USER_INPUT_VALUES_KEY: {"body": "the copy"}},
+            {interrupts.CONFIRMATION_ACCEPTED_KEY: True},
+            {
+                interrupts.CONFIRMATION_ACCEPTED_KEY: True,
+                interrupts.USER_INPUT_VALUES_KEY: {"body": "the copy"},
+            },
+        ],
+        ids=["values", "decision", "both"],
+    )
+    def test_nothing_a_client_could_send_resumes_that_call(self, payload):
+        requirement = _requirement(_two_pause_kinds())
+
+        with pytest.raises(ValueError):
+            _answer_by_resume_entry(requirement, payload)
+
+        assert requirement.is_resolved() is False
+
+    def test_nothing_a_client_could_send_resumes_that_tool(self):
+        requirement = _requirement(_user_input([]))
+
+        with pytest.raises(ValueError):
+            _answer_by_resume_entry(requirement, {interrupts.USER_INPUT_VALUES_KEY: {"topic": "otters"}})
+
+        assert requirement.is_resolved() is False
+
+    def test_the_guard_reports_the_same_reason_to_a_client_that_resumed_anyway(self):
+        """Nothing stops a client sending a resume array for a pause it was not offered.
+
+        It reaches the guard, which reads the same computation the terminal did,
+        so it is told what the terminal said rather than only that something is
+        unresolved.
+        """
+        requirement = _requirement(_two_pause_kinds())
+
+        with pytest.raises(ValueError, match="cannot be continued"):
+            _answer_by_resume_entry(requirement, {interrupts.USER_INPUT_VALUES_KEY: {"body": "the copy"}})
+
+    def test_that_reason_is_read_before_an_answer_is_written_onto_anything(self):
+        """Otherwise the client is told what Agno's own resolver said instead.
+
+        The resolver this pause's kind picks is one Agno refuses to run, and it
+        raises from inside that refusal, which says nothing about why the pause
+        was a dead end. The computed reason is the thing the terminal promised,
+        so it is what the resume reports.
+        """
+        requirement = _requirement(_answered_its_questions_and_still_waits_on_a_decision())
+
+        with pytest.raises(ValueError, match="cannot be continued") as refused:
+            _answer_by_resume_entry(requirement, {interrupts.USER_FEEDBACK_SELECTIONS_KEY: {"What budget?": ["low"]}})
+
+        assert "is not waiting on" in str(refused.value)
+        assert requirement.is_resolved() is False
+
+    def test_a_pause_still_waiting_on_its_values_is_refused_by_agnos_own_reckoning(self):
+        """The case the narrowed check leaves to Agno, and it is still caught.
+
+        An answer that fills no field is not refused as a payload: nothing about
+        it is of the wrong kind. The field stays empty, Agno counts the
+        requirement as unanswered, and the resolved-set guard stops the resume.
+        """
+        requirement = _requirement(_user_input())
+
+        with pytest.raises(ValueError, match="still unresolved"):
+            _answer_by_resume_entry(requirement, {interrupts.USER_INPUT_VALUES_KEY: {}})
+
+        assert requirement.is_resolved() is False
+
+
+# --- The invariant that reads what the stream encoded ------------------------
+
+
+class TestUndeclaredKeysAreVisibleOnTheWire:
+    """The check every stream in this suite is held to, held to itself.
+
+    An invariant nothing has ever seen fail is one that may be reading nothing,
+    which is exactly what the per-field guard it replaces turned out to be
+    doing. So a key no model declares is constructed here and the check has to
+    name it, at the top level and nested inside the outcome a pause carries.
+    """
+
+    def _a_run_terminal_carrying(self, **written: Any) -> Any:
+        return RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id=THREAD_ID, run_id=RUN_ID, **written)
+
+    def test_an_undeclared_key_on_an_event_is_named(self):
+        carried = self._a_run_terminal_carrying(nothing_declares_this="x")
+
+        assert "nothing_declares_this" in _encoded(carried)
+        assert undeclared_keys_on_the_wire([carried]) == ["RunFinishedEvent.nothing_declares_this"]
+
+    def test_a_declared_event_is_reported_clean(self):
+        """Otherwise a check that names everything would pass the test above."""
+        assert undeclared_keys_on_the_wire([self._a_run_terminal_carrying()]) == []
+
+    @needs_interrupt_outcome
+    def test_an_undeclared_key_nested_in_the_outcome_is_named_too(self):
+        """Which is where every instance of this defect has actually been.
+
+        The interrupt an emit site builds is two models below the event, so a
+        check reading only the event's own keys would have seen none of them.
+        """
+        interrupt = interrupts.Interrupt(id="i-1", reason=interrupts.REASON_TOOL_CALL, nothing_declares_this="x")
+        carried = self._a_run_terminal_carrying(outcome=interrupts.interrupt_outcome([interrupt]))
+
+        assert undeclared_keys_on_the_wire([carried]) == [
+            "RunFinishedEvent.outcome.interrupts[0].nothing_declares_this"
+        ]
+
+    def test_a_key_inside_an_open_object_is_not_one_this_check_can_see(self):
+        """Stated rather than left to be discovered as a false clean bill.
+
+        An interrupt's metadata is open by key: what this interface writes there
+        is declared by no model, so nothing there can be held to a declaration,
+        and a null under one of those keys is a defect this check cannot report.
+        The test above it is where a missing tool name is caught instead.
+        """
+        carried = self._a_run_terminal_carrying(metadata={"anything": {"at_all": None}})
+
+        assert undeclared_keys_on_the_wire([carried]) == []
+
+
+class TestAValueTheEncoderRefuses:
+    """A stream holding what no encoder can render, and what this check makes of it.
+
+    A run's content is whatever a model or a tool put there, so an event can
+    carry a value the protocol's encoder refuses, and this interface really does
+    emit one: a failing chunk is embedded on the terminal verbatim. Giving up on
+    such an event would make the check stop reading at exactly the input a
+    hostile run produces, and reporting it clean would be worse than either. So
+    the value is stood in for, the keys around it are still read, and the path
+    it sat at comes back named. The two answers a reader needs are separate:
+    ``undeclared_keys_on_the_wire`` says what no model declares,
+    ``values_the_encoder_refused`` says what went unread.
+    """
+
+    def _a_run_terminal_carrying(self, **written: Any) -> Any:
+        return RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id=THREAD_ID, run_id=RUN_ID, **written)
+
+    def test_the_client_gets_no_such_event_at_all(self):
+        """The premise: what the encoder refuses is what a response body dies on."""
+        carried = self._a_run_terminal_carrying(raw_event={"content": RaisesOnSerialization()})
+
+        with pytest.raises(Exception):
+            _encoded(carried)
+
+    def test_the_path_it_sat_at_is_named(self):
+        carried = self._a_run_terminal_carrying(raw_event={"content": RaisesOnSerialization()})
+
+        assert values_the_encoder_refused([carried]) == ["RunFinishedEvent.rawEvent.content"]
+
+    def test_a_stream_the_encoder_takes_whole_names_none(self):
+        """Otherwise a reader could not tell a refusal from an ordinary stream."""
+        assert values_the_encoder_refused([self._a_run_terminal_carrying(raw_event={"content": "readable"})]) == []
+
+    def test_the_keys_around_it_are_still_read(self):
+        """The point of standing the value in rather than giving up on the event.
+
+        An undeclared key beside a value nobody can render is the defect this
+        whole check exists for, and it is the one a check that skipped the event
+        would miss.
+        """
+        carried = self._a_run_terminal_carrying(
+            raw_event={"content": RaisesOnSerialization()}, nothing_declares_this="x"
+        )
+
+        assert undeclared_keys_on_the_wire([carried]) == ["RunFinishedEvent.nothing_declares_this"]
+        assert values_the_encoder_refused([carried]) == ["RunFinishedEvent.rawEvent.content"]
+
+    def test_an_event_no_stand_in_can_rescue_is_named_whole(self):
+        """A structure the encoder refuses, not a leaf it cannot render.
+
+        A payload holding itself has no leaf to stand in for, so this event
+        yields no keys at all. Reporting it as an event with no undeclared key
+        is the silence this check is built to refuse, so it is named instead.
+        """
+        carried = self._a_run_terminal_carrying(raw_event=circular())
+
+        assert undeclared_keys_on_the_wire([carried]) == []
+        refused = values_the_encoder_refused([carried])
+        assert len(refused) == 1
+        assert refused[0].startswith("RunFinishedEvent: no key of this event could be read")
+
+    def test_a_stream_that_holds_one_is_refused_unless_it_says_so(self):
+        """What every driver in this suite does with the answer.
+
+        Naming the path is how a test whose subject is an unrenderable value
+        gets past the check; a stream that grows one nobody named fails, which
+        is what keeps the check from quietly reading less than it claims.
+        """
+        carried = self._a_run_terminal_carrying(raw_event={"content": RaisesOnSerialization()})
+
+        with pytest.raises(AssertionError, match="values the protocol's encoder refuses"):
+            _assert_nothing_undeclared_reached_the_client([carried])
+
+        _assert_nothing_undeclared_reached_the_client([carried], ["RunFinishedEvent.rawEvent.content"])
+
+    def test_a_path_named_that_the_encoder_takes_fails_too(self):
+        """So a pin that stops being true is a diff rather than a silence."""
+        with pytest.raises(AssertionError, match="values the protocol's encoder refuses"):
+            _assert_nothing_undeclared_reached_the_client(
+                [self._a_run_terminal_carrying(raw_event={"content": "readable"})],
+                ["RunFinishedEvent.rawEvent.content"],
+            )
+
+
+# --- A run terminal that cannot be built -------------------------------------
+
+
+class _TerminalBoom(RuntimeError):
+    """A failure raised while the run terminal is being built."""
+
+
+def _the_terminal_explodes(chunk: Any, state: StreamState) -> List[Any]:
+    """The interface's terminal builder, replaced by one that raises.
+
+    Everything the terminal reads comes out of the run: the paused run's own
+    words, the arguments of every call it prompts for, the session state it ends
+    holding. The reads below drive those one at a time; this one stands for the
+    rest of that code and for whatever it grows, which is what the guard around
+    the terminal is there for.
+    """
+    raise _TerminalBoom("terminal exploded")
+
+
+def _the_advertised_shape_explodes(*_: Any, **__: Any) -> Any:
+    """The builder the terminal describes an answer's shape with, replaced by a raiser."""
+    raise _TerminalBoom("terminal exploded")
+
+
+def _a_call_still_running() -> ToolExecution:
+    return ToolExecution(tool_call_id="tc-lookup", tool_name="look_up", tool_args={"query": "ops"})
+
+
+def _mid_message_pause_chunks() -> List[Any]:
+    """A run mid-sentence and mid-tool-call when it pauses.
+
+    Both spans are open when the terminal is built, which is exactly what a
+    client is left holding if the terminal raises and nothing closes them.
+    """
+    return [
+        RunStartedEvent(run_id=RUN_ID),
+        ToolCallStartedEvent(run_id=RUN_ID, tool=_a_call_still_running()),
+        RunContentEvent(run_id=RUN_ID, content="working on it"),
+        _paused(_confirmation()),
+    ]
+
+
+def _mid_message_member_pause_chunks() -> List[Any]:
+    """A run mid-sentence when it pauses inside a member nothing has announced.
+
+    The member's lane is first named by the pause itself, so when the terminal
+    starts building, nothing on the wire has mentioned that member at all and
+    the only thing that can is the terminal being built.
+    """
+    return [
+        RunStartedEvent(run_id=RUN_ID),
+        RunContentEvent(run_id=RUN_ID, content="working on it"),
+        _member_paused(_confirmation(), member_run_id="member-run"),
+    ]
+
+
+def _unreadable_failure_chunk() -> Any:
+    """A failed terminal whose own message cannot be rendered.
+
+    A run's content is whatever a model or a tool put there, and reading it runs
+    that value's own code. This is the failed half of the terminal path: the
+    message it renders is also what every span the run left open is closed
+    under.
+    """
+    chunk = RunErrorEvent(run_id=RUN_ID)
+    chunk.content = RaisesOnSerialization()
+    return chunk
+
+
+class _NameNobodyCanRender:
+    """An event name that reports itself and refuses to be rendered.
+
+    The interface normalizes an event through its ``value``, so a chunk carrying
+    this is routed like any other failed run while the fallback that stringifies
+    the name raises.
+    """
+
+    value = "RunError"
+
+    def __str__(self) -> str:
+        raise RuntimeError("event name exploded")
+
+
+class _NoCopy:
+    """A session state value with no copy of its own, as a live handle has none."""
+
+    def __deepcopy__(self, memo: Any) -> Any:
+        raise RuntimeError("copy exploded")
+
+
+def _the_dump_explodes(*_: Any, **__: Any) -> Any:
+    raise RuntimeError("dump exploded")
+
+
+class _ChunksAsAnEntity:
+    """An entity whose run is a chunk list, so the route's own mapping is driven.
+
+    The route hands whatever ``arun`` returns to the mapper and reads nothing
+    else off an Agent or a Team on this path, which is what keeps the test about
+    the body a client receives.
+    """
+
+    def __init__(self, chunks: List[Any]) -> None:
+        self._chunks = chunks
+
+    def arun(self, **_: Any) -> Any:
+        chunks = self._chunks
+
+        async def source() -> Any:
+            for chunk in chunks:
+                yield chunk
+
+        return source()
+
+
+def _one_request() -> Any:
+    """The request the route reads, carrying nothing but a prompt and a session."""
+    return RunAgentInput(
+        thread_id=THREAD_ID,
+        run_id=RUN_ID,
+        state={},
+        messages=[UserMessage(id="m1", role="user", content="go")],
+        tools=[],
+        context=[],
+        forwarded_props={},
+    )
+
+
+def _record_naming(caplog: Any, wanted: str) -> Any:
+    """The one log record that mentions ``wanted``, refusing several or none."""
+    recorded = [record for record in caplog.records if wanted in record.message]
+    assert len(recorded) == 1, f"{wanted} was recorded {len(recorded)} times: {[r.message for r in caplog.records]}"
+    return recorded[0]
+
+
+both_mappers = pytest.mark.parametrize("collect", [collect_sync, collect_async], ids=["sync", "async"])
+
+
+class TestATerminalThatCannotBeBuilt:
+    """A raise while the run terminal is built, driven through both mappers.
+
+    The terminal is where this interface does its last and most failable work,
+    and it used to sit outside the guard that closes what the stream opened. A
+    raise from it sent no span end and no terminal at all, so the client was
+    left holding a message and a tool call that never resolve, with the router's
+    own in-band error as the only account of how the run stopped.
+    """
+
+    @pytest.mark.asyncio
+    @both_mappers
+    async def test_every_span_the_mapper_opened_is_closed(self, collect, monkeypatch, caplog):
+        monkeypatch.setattr(stream_module, "process_completion", _the_terminal_explodes)
+
+        with captured_agno_logs(caplog, "ERROR"):
+            events, error = await collect(_mid_message_pause_chunks(), thread_id=THREAD_ID, run_id=RUN_ID)
+
+        assert type(error) is _TerminalBoom, f"the failure did not propagate: {error!r}"
+        # Every span closing is one of the invariants the collector runs, so
+        # what is left to state is that the two this run had open when the
+        # terminal was built are the ones closed, and that they close last.
+        assert [short_type(event) for event in events[-2:]] == ["TOOL_CALL_END", "TEXT_MESSAGE_END"]
+        assert in_emitted_order(events, EventType.TOOL_CALL_END, "tool_call_id") == [("tc-lookup",)]
+
+    @pytest.mark.asyncio
+    @both_mappers
+    async def test_the_mapper_writes_no_terminal_of_its_own(self, collect, monkeypatch, caplog):
+        """Nothing may follow a run terminal, so the caller writes the only one."""
+        monkeypatch.setattr(stream_module, "process_completion", _the_terminal_explodes)
+
+        with captured_agno_logs(caplog, "ERROR"):
+            events, _ = await collect(_mid_message_pause_chunks(), thread_id=THREAD_ID, run_id=RUN_ID)
+
+        assert [short_type(event) for event in events if "RUN_" in short_type(event)] == []
+
+    @pytest.mark.asyncio
+    @both_mappers
+    async def test_the_failure_is_recorded_as_the_terminals_and_carries_its_traceback(
+        self, collect, monkeypatch, caplog
+    ):
+        """A cleanup that leaves no trace is the other half of this defect.
+
+        The record has to say what raised and where: a source stream that died
+        is the run's own failure, and a terminal that cannot be built is this
+        interface's bug, so one record naming the other misdirects whoever reads
+        it.
+        """
+        monkeypatch.setattr(stream_module, "process_completion", _the_terminal_explodes)
+
+        with captured_agno_logs(caplog, "ERROR"):
+            await collect(_mid_message_pause_chunks(), thread_id=THREAD_ID, run_id=RUN_ID)
+
+        recorded = _record_naming(caplog, "terminal exploded")
+        assert "_TerminalBoom" in recorded.message, f"the record does not name what raised: {recorded.message}"
+        assert "run terminal" in recorded.message, f"the record does not say where it raised: {recorded.message}"
+        assert RUN_ID in recorded.message, f"the record names no run: {recorded.message}"
+        assert recorded.exc_info is not None, "the record carries no traceback, so the raise site is lost"
+
+    @pytest.mark.asyncio
+    async def test_the_client_is_told_the_run_failed(self, monkeypatch, caplog):
+        """What a client receives, read off the route that streams to it.
+
+        The response is committed and streaming by the time the terminal is
+        built, so the only thing that can still say the run failed is another
+        event on that same body. The whole body is held to the shared definition
+        of a well-formed stream: before the guard it carried an open message and
+        an open tool call, then the route's own in-band error, and nothing that
+        closed either of them.
+        """
+        monkeypatch.setattr(stream_module, "process_completion", _the_terminal_explodes)
+
+        with captured_agno_logs(caplog, "ERROR"):
+            events = await run_entity(_ChunksAsAnEntity(_mid_message_pause_chunks()), _one_request())
+
+        assert [short_type(event) for event in events[-3:]] == ["TOOL_CALL_END", "TEXT_MESSAGE_END", "RUN_ERROR"]
+        assert in_emitted_order(events, EventType.RUN_ERROR, "message") == [("terminal exploded",)]
+
+    @pytest.mark.asyncio
+    @needs_interrupt_outcome
+    @both_mappers
+    async def test_the_answer_shape_the_terminal_advertises_is_inside_the_guard_too(self, collect, monkeypatch, caplog):
+        """The terminal's most distant read, and the one only the option reaches.
+
+        Advertising a pause means describing the shape of the answer it wants,
+        which happens two modules away from where the terminal is built and is
+        the same description the resume side holds an incoming answer to. So it
+        is on the terminal path with the option on, and a raise from it has to
+        close the same spans and be recorded the same way as any other. Read
+        rather than assumed: nothing about it says which guard it sits under.
+        """
+        monkeypatch.setattr(interrupts, "advertised_answer_schema", _the_advertised_shape_explodes)
+
+        with captured_agno_logs(caplog, "ERROR"):
+            events, error = await collect(
+                _mid_message_pause_chunks(),
+                thread_id=THREAD_ID,
+                run_id=RUN_ID,
+                emit_interrupt_outcome=True,
+            )
+
+        assert type(error) is _TerminalBoom, f"the failure did not propagate: {error!r}"
+        assert [short_type(event) for event in events[-2:]] == ["TOOL_CALL_END", "TEXT_MESSAGE_END"]
+        assert [short_type(event) for event in events if "RUN_" in short_type(event)] == []
+        recorded = _record_naming(caplog, "terminal exploded")
+        assert "run terminal" in recorded.message, f"the record does not say where it raised: {recorded.message}"
+
+    @pytest.mark.asyncio
+    @needs_interrupt_outcome
+    @both_mappers
+    async def test_a_member_the_client_never_saw_start_owns_no_terminal(self, collect, monkeypatch, caplog):
+        """A lane the pause opened in this interface's own record, on a terminal that never went out.
+
+        The pause names its member's lane and opens it before the announcement
+        that tells the client about it is emitted, and that announcement only
+        leaves with the terminal. A raise in between left the record holding a
+        lane the client had never seen, and the cleanup that follows terminated
+        it: a member's terminal for a member nothing ever started.
+        """
+        require_lineage_events()
+        chunk = _member_paused(_confirmation(), member_run_id="member-run")
+        monkeypatch.setattr(interrupts, "advertised_answer_schema", _the_advertised_shape_explodes)
+
+        with captured_agno_logs(caplog, "ERROR"):
+            events, error = await collect(
+                _mid_message_member_pause_chunks(),
+                attributed(),
+                thread_id=THREAD_ID,
+                run_id=RUN_ID,
+                emit_interrupt_outcome=True,
+            )
+
+        assert type(error) is _TerminalBoom, f"the failure did not propagate: {error!r}"
+        # The spans the run did open still close, which is what the guard is for.
+        assert [short_type(event) for event in events[-1:]] == ["TEXT_MESSAGE_END"]
+        received = _everything_the_client_received(events)
+        assert [named for named in _how_a_pause_names_its_member(chunk) if named in received] == []
+        assert member_mentions(events) == []
+
+
+class _RefusesToBeRead:
+    """A schema value that raises the moment anything asks whether it is there.
+
+    The advertised shape reads a description, a header, a label and the flag
+    capping a question for their truth before anything else is done with them,
+    so this is what an in-process value can be: a lazily loaded label whose
+    source is gone, a proxy to a store that closed. A schema rebuilt from JSON
+    holds scalars and never raises, which is why the other half of this subject
+    is a value that reads fine and is not words.
+    """
+
+    def __bool__(self) -> bool:
+        raise RuntimeError("cannot be tested for truth")
+
+
+class _OptionsNobodyCanWalk(list):
+    """A question's choices that refuse to be walked, as a spent iterator does."""
+
+    def __iter__(self) -> Any:
+        raise RuntimeError("options exploded")
+
+
+def _paused_on_a_field_described_by(description: Any) -> RunPausedEvent:
+    described = UserInputField(name="topic", field_type=str)
+    described.description = description
+    return _paused(_user_input([described]))
+
+
+def _paused_asking(question: UserFeedbackQuestion) -> RunPausedEvent:
+    return _paused(
+        ToolExecution(
+            tool_call_id="tc-feedback",
+            tool_name="ask_user",
+            tool_args={},
+            requires_user_input=True,
+            user_feedback_schema=[question],
+        )
+    )
+
+
+def _a_question_headed_by(header: Any) -> UserFeedbackQuestion:
+    asked = UserFeedbackQuestion(question="What budget?", options=[UserFeedbackOption(label="low")])
+    asked.header = header
+    return asked
+
+
+def _a_question_offering(options: Any) -> UserFeedbackQuestion:
+    asked = UserFeedbackQuestion(question="What budget?", options=[UserFeedbackOption(label="low")])
+    asked.options = options
+    return asked
+
+
+def _a_question_taking_several(multi_select: Any) -> UserFeedbackQuestion:
+    asked = UserFeedbackQuestion(question="What budget?", options=[UserFeedbackOption(label="low")])
+    asked.multi_select = multi_select
+    return asked
+
+
+def _text_the_schema_states(described: Any) -> List[Any]:
+    """Every value an advertised schema offers a client as words to read.
+
+    Walked rather than read at the paths one test knows about, so a value a
+    later builder writes under one of these keywords is held to the same thing
+    without the walk having to be told it exists.
+    """
+    found: List[Any] = []
+    if isinstance(described, dict):
+        for keyword, value in described.items():
+            if keyword in ("description", "title"):
+                found.append(value)
+            elif keyword == "enum" and isinstance(value, list):
+                found += value
+            else:
+                found += _text_the_schema_states(value)
+    elif isinstance(described, list):
+        for entry in described:
+            found += _text_the_schema_states(entry)
+    return found
+
+
+class TestTheTerminalSurvivesWhatARunPutInIt:
+    """The reads the terminal really does, driven with values that refuse them.
+
+    Each of these raised from inside the terminal before, and the guard around
+    it cannot put back what a raise discards: the closing sweep is built before
+    the pause prompt and the state snapshot, so a raise there loses every span
+    end with it while the mapper's own record of those spans says they closed.
+    That is why these are guarded where they are read, and the guard around the
+    terminal is the backstop for the rest.
+    """
+
+    def test_a_pause_whose_arguments_cannot_be_serialized_still_prompts_the_call(self, caplog):
+        pending = _confirmation()
+        pending.tool_args = circular()
+
+        with captured_agno_logs(caplog, "WARNING"):
+            events = on_run_completed(_paused(pending), StreamState(thread_id=THREAD_ID, run_id=RUN_ID))
+
+        assert in_emitted_order(events, EventType.TOOL_CALL_START, "tool_call_id", "tool_call_name") == [
+            ("tc-confirm", "send_email")
+        ]
+        assert in_emitted_order(events, EventType.TOOL_CALL_ARGS, "delta") == [("{}",)]
+        _run_finished(events)
+        assert "tc-confirm" in _record_naming(caplog, "could not serialize the arguments").message
+
+    def test_a_pause_whose_words_cannot_be_rendered_still_prompts_the_call(self, caplog):
+        chunk = _paused(_confirmation())
+        chunk.content = RaisesOnSerialization()
+
+        with captured_agno_logs(caplog, "WARNING"):
+            events = on_run_completed(chunk, StreamState(thread_id=THREAD_ID, run_id=RUN_ID))
+
+        assert of_type(events, EventType.TEXT_MESSAGE_CONTENT) == [], "the words nobody can read reached the wire"
+        assert in_emitted_order(events, EventType.TOOL_CALL_START, "tool_call_id") == [("tc-confirm",)]
+        _run_finished(events)
+        _record_naming(caplog, "a paused run's own words")
+
+    @needs_interrupt_outcome
+    @pytest.mark.parametrize(
+        ("chunk", "advertises", "unreadable_reads"),
+        [
+            (_paused_on_a_field_described_by(_RefusesToBeRead()), "topic", 1),
+            (_paused_asking(_a_question_headed_by(_RefusesToBeRead())), "What budget?", 1),
+            (
+                _paused_asking(_a_question_offering(_OptionsNobodyCanWalk([UserFeedbackOption(label="low")]))),
+                "What budget?",
+                1,
+            ),
+            (_paused_asking(_a_question_taking_several(_RefusesToBeRead())), "What budget?", 1),
+            (_paused_on_a_field_described_by({"nested": "object"}), "topic", 0),
+        ],
+        ids=[
+            "field_description",
+            "question_header",
+            "question_options",
+            "question_multi_select",
+            "description_that_is_not_words",
+        ],
+    )
+    def test_a_pause_whose_schema_text_cannot_be_read_still_advertises_the_answer_shape(
+        self, chunk, advertises, unreadable_reads, caplog
+    ):
+        """The words the advertised shape is built out of come off the run.
+
+        A description, a question's header, an option's label and the flag that
+        says how many selections a question takes are all values a tool put
+        there, and each was read for its truth before anything else was done
+        with it. Read unguarded, one that raises took the whole terminal with
+        it: no interrupt, no terminal, nothing on the wire saying the run was
+        waiting. Written verbatim afterwards, one that is not words leaves a
+        schema whose own keywords contradict it, which a client that validates
+        before answering can construct no payload for.
+
+        Asserted off the encoded events, because the symptom is that a client
+        receives nothing: an assertion over the objects the builder returned
+        cannot tell a schema that reached the wire from one that did not.
+        """
+        with captured_agno_logs(caplog, "WARNING"):
+            events = on_run_completed(
+                chunk, StreamState(thread_id=THREAD_ID, run_id=RUN_ID, emit_interrupt_outcome=True)
+            )
+
+        schema = _outcome_on_the_wire(_run_finished(events))["interrupts"][0]["responseSchema"]
+        (answered,) = schema["properties"].values()
+        assert list(answered["properties"]) == [advertises], (
+            f"the pause is waiting on {advertises!r} and advertises {list(answered['properties'])}"
+        )
+        stated = _text_the_schema_states(schema)
+        assert all(isinstance(text, str) for text in stated), (
+            f"the advertised schema states {stated!r} where a client reads words"
+        )
+        unread = [record for record in caplog.records if "could not read" in record.message]
+        assert len(unread) == unreadable_reads, f"{len(unread)} unreadable values recorded: {unread}"
+
+    @pytest.mark.asyncio
+    @both_mappers
+    async def test_a_session_state_that_cannot_be_copied_still_ends_the_run(self, collect, caplog):
+        """The snapshot is the last thing the terminal builds, after the sweep.
+
+        The state it copies is the one the terminal chunk carries, which is not
+        the document the request opened with: a run whose tools put a value with
+        no copy of its own into the session state reaches this line with
+        everything before it already copied.
+
+        The snapshot is dropped rather than sent uncopied, since a state with no
+        copy of its own is one the protocol's encoder refuses too, and an event
+        it refuses stops the response body short of the terminal.
+        """
+        chunk = _paused(_confirmation())
+        chunk.session_state = {"handle": _NoCopy()}
+
+        with captured_agno_logs(caplog, "ERROR"):
+            events, error = await collect(
+                [RunContentEvent(run_id=RUN_ID, content="working on it"), chunk],
+                thread_id=THREAD_ID,
+                run_id=RUN_ID,
+                run_state={"draft": "hello"},
+            )
+
+        assert error is None, f"a state nothing could copy ended the stream: {error!r}"
+        assert of_type(events, EventType.STATE_SNAPSHOT) == [], "a state nothing could copy reached the wire"
+        assert_stream_contains(events, EventType.RUN_FINISHED)
+        recorded = _record_naming(caplog, "could not copy the session state")
+        assert recorded.exc_info is not None, "the record carries no traceback, so the raise site is lost"
+
+    @pytest.mark.asyncio
+    @both_mappers
+    async def test_a_failure_whose_message_cannot_be_read_still_reports_the_failure(self, collect, caplog):
+        """The terminal reports the failure, and embeds the chunk that caused it.
+
+        Embedding it verbatim carries the unreadable value onto the terminal's
+        own ``rawEvent``, where the protocol's encoder refuses it and a real
+        response body would die at this event. That is the standing report this
+        interface makes about a failing chunk it cannot read, so it is named
+        here rather than left for the encoded-keys check to discover: the keys
+        of this event are still read, the subtree under the named path is not.
+        """
+        chunks = [
+            RunStartedEvent(run_id=RUN_ID),
+            RunContentEvent(run_id=RUN_ID, content="halfway"),
+            _unreadable_failure_chunk(),
+        ]
+
+        with captured_agno_logs(caplog, "WARNING"):
+            events, error = await collect(
+                chunks,
+                thread_id=THREAD_ID,
+                run_id=RUN_ID,
+                encoder_refuses=["RunErrorEvent.rawEvent.content"],
+            )
+
+        assert error is None, f"a failure that cannot describe itself ended the stream: {error!r}"
+        assert in_emitted_order(events, EventType.RUN_ERROR, "message") == [("Run failed",)]
+        assert_stream_contains(events, EventType.TEXT_MESSAGE_END)
+        _record_naming(caplog, "a failed run message")
+
+    @pytest.mark.asyncio
+    @both_mappers
+    async def test_a_failing_chunk_that_cannot_be_dumped_is_recorded_and_reported_by_name(
+        self, collect, monkeypatch, caplog
+    ):
+        """The chunk the terminal embeds verbatim, and the fallback for it.
+
+        The dump ran behind a guard that logged nothing at all, and its fallback
+        stringified the event name unguarded, so a chunk that could neither be
+        dumped nor named took down the span closing and the terminal together
+        from inside the code reporting why the run stopped.
+        """
+        chunk = RunErrorEvent(run_id=RUN_ID, content="the model died")
+        monkeypatch.setattr(chunk, "to_dict", _the_dump_explodes)
+        monkeypatch.setattr(chunk, "event", _NameNobodyCanRender())
+        chunks = [RunStartedEvent(run_id=RUN_ID), RunContentEvent(run_id=RUN_ID, content="halfway"), chunk]
+
+        with captured_agno_logs(caplog, "WARNING"):
+            events, error = await collect(chunks, thread_id=THREAD_ID, run_id=RUN_ID)
+
+        assert error is None, f"the chunk nothing could read ended the stream: {error!r}"
+        assert in_emitted_order(events, EventType.RUN_ERROR, "message", "raw_event") == [
+            ("the model died", {"event": "RunError"})
+        ]
+        assert_stream_contains(events, EventType.TEXT_MESSAGE_END)
+        _record_naming(caplog, "could not dump the chunk")
+
+
+# --- A run that stopped before it could report anything ----------------------
+
+
+class TestWhatStoppedTheRunReachesTheAssertion:
+    """The collectors record what ended a run, whatever base it derives from.
+
+    Everything here that is not driven over the route is driven through those
+    collectors, and the events and the failure they return are the whole of what
+    an assertion reads. A failure they do not record leaves by raising instead:
+    the events collected before it are dropped, no invariant runs on any of them,
+    and a test asking what the client was left holding never gets to ask.
+
+    A chunk list holds whatever the source stream does, which includes the one
+    failure this interface really meets that is not an ``Exception``: the
+    cancellation a disconnected client's request is torn down with, mid-run and
+    mid-message.
+    """
+
+    @pytest.mark.asyncio
+    @both_mappers
+    async def test_a_cancelled_run_is_recorded_like_any_other_failure(self, collect):
+        events, error = await collect(
+            [RunContentEvent(run_id=RUN_ID, content="working on it"), asyncio.CancelledError()],
+            thread_id=THREAD_ID,
+            run_id=RUN_ID,
+            exempt=[ABANDONED_MID_STREAM],
+        )
+
+        assert type(error) is asyncio.CancelledError, f"the driver did not record what ended the run: {error!r}"
+        # And the prefix the client was left holding reached the invariants,
+        # which is the whole of what recording it rather than raising buys.
+        assert in_emitted_order(events, EventType.TEXT_MESSAGE_CONTENT, "delta") == [("working on it",)]
+
+
+# --- Refusing an install that cannot serve the outcome -----------------------
+
+
+def _the_protocols_own_base_model() -> Any:
+    """The base every protocol type is configured by, whatever it is called.
+
+    Its configuration is what decides how a release serializes: which keys it
+    keeps, which it omits, and what it does with one it never declared. A
+    simulated release built on anything else would answer a different question
+    than the installed one.
+    """
+    for ancestor in interrupts.Interrupt.__mro__:
+        if issubclass(ancestor, BaseModel) and not ancestor.model_fields:
+            return ancestor
+    raise AssertionError("the installed Interrupt declares no configured base model to simulate a release from")
+
+
+def _type_without(model: Any, field: str) -> Any:
+    """This protocol type as a release that does not declare ``field`` presents it.
+
+    A real model, built from the installed one's remaining fields on the same
+    configured base, rather than a stand-in carrying only a field table. What a
+    release omitting a field costs is what its encoder then writes, and only a
+    model can be built from and encoded, so a stand-in can prove that a check
+    read the table and nothing at all about what left the server.
+    """
+    assert field in model.model_fields, f"the installed {model.__name__} declares no {field} for a release to omit"
+    kept = {
+        name: (model_field.annotation, model_field) for name, model_field in model.model_fields.items() if name != field
+    }
+    return create_model(model.__name__, __base__=_the_protocols_own_base_model(), **kept)
+
+
+def _interrupt_type_without(field: str) -> Any:
+    return _type_without(interrupts.Interrupt, field)
+
+
+def _census() -> Dict[Any, Tuple[str, ...]]:
+    """Every protocol field this interface feature-detects, per class, all tables read.
+
+    The three tables are three separate releases' worth of pieces and are asked
+    of the interface rather than copied here, so a row moved between them is
+    still one row to everything below.
+    """
+    merged: Dict[Any, Tuple[str, ...]] = {}
+    for table in (
+        interrupts.interrupt_round_trip_fields(),
+        interrupts.interrupt_attribution_fields(),
+        interrupts.subagent_suspension_fields(),
+    ):
+        for model, fields in table.items():
+            merged[model] = tuple(sorted(set(merged.get(model, ())) | set(fields)))
+    return merged
+
+
+def _everything_a_pause_makes_this_interface_build() -> List[Any]:
+    """Every protocol object this interface builds for a pause, from its own builders.
+
+    Built rather than listed: what a builder writes is read back off the object
+    it returned, so a field added to one is seen here without any list of field
+    names being kept in step by hand.
+    """
+    requirements = [
+        _requirement(pending) for pending in (_confirmation(), _external(), _user_input(), _user_feedback())
+    ]
+    interrupt_list = [
+        interrupts.build_interrupt(
+            _needs_answering(requirement),
+            tool_call_id=requirement.tool_execution.tool_call_id,
+            tool_name=requirement.tool_execution.tool_name,
+            subagent_run_id=member,
+        )
+        for requirement in requirements
+        for member in (None, "member-run")
+    ]
+    built = [
+        *interrupt_list,
+        interrupts.interrupt_outcome([one for one in interrupt_list if one is not None]),
+        interrupts.suspended_outcome(["an-interrupt"]),
+        interrupts.suspended_outcome([]),
+    ]
+    return [one for one in built if one is not None]
+
+
+def _protocol_types_imported_under_a_guard() -> Set[str]:
+    """Every protocol type this interface imports behind an ImportError handler.
+
+    Such a type exists only from the release that introduced it onward, so every
+    field written on one or read off one is a field an older install has no
+    place for, and a table saying which is the whole of what stands between that
+    install and a run that fails halfway. Derived from the source, so a fourth
+    type added beside the three is held to the same thing on the day it lands.
+    """
+    source = ast.parse(Path(inspect.getfile(interrupts)).read_text(encoding="utf-8"))
+    guarded: Set[str] = set()
+    for node in ast.walk(source):
+        if not isinstance(node, ast.Try):
+            continue
+        caught = {
+            name.id
+            for handler in node.handlers
+            for name in ast.walk(handler.type)
+            if handler.type is not None and isinstance(name, ast.Name)
+        }
+        if "ImportError" not in caught:
+            continue
+        guarded |= {
+            alias.asname or alias.name
+            for inner in ast.walk(node)
+            if isinstance(inner, ast.ImportFrom)
+            for alias in inner.names
+        }
+    return guarded
+
+
+# The name the incoming half binds one answer to. Its fields are read straight
+# off it, and which fields those are is read from the source below rather than
+# written down, so the floor and the reads cannot come apart.
+_ONE_ANSWER = "entry"
+
+
+def _plain_attributes_read_on(source: str, name: str) -> Set[str]:
+    """Every attribute this source reads straight off ``name``.
+
+    A lookup carrying a default is not one of these and is not meant to be: it
+    answers a release that declares no such field instead of raising on it,
+    which is what makes that read safe on an install the floor let through.
+    """
+    return {
+        node.attr
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name) and node.value.id == name
+    }
+
+
+def _the_entry_model() -> Any:
+    """The model one answer arrives as, or None on a release that declares none.
+
+    Resolved off the module rather than imported, because a release without it
+    is one this suite still runs on.
+    """
+    import ag_ui.core
+
+    return getattr(ag_ui.core, "ResumeEntry", None)
+
+
+def _the_incoming_half_as_source() -> str:
+    """The module that applies a client's answers, read as text."""
+    return Path(inspect.getfile(resume_module)).read_text(encoding="utf-8")
+
+
+_READ_OFF_ONE_ANSWER = _plain_attributes_read_on(_the_incoming_half_as_source(), _ONE_ANSWER)
+
+
+class TestStartupCheck:
+    def test_the_types_the_emission_needs_are_feature_detected(self, monkeypatch):
+        """A field nothing detects rides out under a name the wire format omits."""
+        monkeypatch.setattr(interrupts, "INTERRUPT_OUTCOME_AVAILABLE", False)
+
+        with pytest.raises(ValueError, match="interrupt-aware run lifecycle"):
+            interrupts.validate_interrupt_outcome(True)
+
+    @needs_interrupt_outcome
+    def test_a_missing_field_names_itself(self, monkeypatch):
+        """The census this message is built from is only reached once the lifecycle is there."""
+        monkeypatch.setattr(interrupts, "_missing_interrupt_fields", lambda: ["Interrupt.toolCallId"])
+
+        with pytest.raises(ValueError, match="Interrupt.toolCallId"):
+            interrupts.validate_interrupt_outcome(True)
+
+    def test_the_check_is_silent_when_nothing_is_asked_for(self, monkeypatch):
+        monkeypatch.setattr(interrupts, "INTERRUPT_OUTCOME_AVAILABLE", False)
+
+        assert interrupts.validate_interrupt_outcome(False) is False
+
+    def test_the_routes_refuse_the_outcome_when_they_are_mounted(self, monkeypatch):
+        """An unserveable setting is a startup failure, not an in-band run error."""
+        from agno.os.interfaces.agui import AGUI
+
+        monkeypatch.setattr(interrupts, "INTERRUPT_OUTCOME_AVAILABLE", False)
+
+        with pytest.raises(ValueError, match="interrupt-aware run lifecycle"):
+            AGUI(agent=Agent(name="A"), emit_interrupt_outcome=True)
+
+    @needs_interrupt_outcome
+    def test_the_field_the_answers_arrive_in_is_part_of_the_floor(self, monkeypatch):
+        """A release that does not declare it drops a client's answers unread.
+
+        The outcome tells the client to answer by id, and the resume array is
+        where those answers arrive, so an install without it cannot continue the
+        run it advertised as waiting.
+        """
+        monkeypatch.setattr("ag_ui.core.RunAgentInput", type("RunAgentInput", (), {"model_fields": {}}))
+
+        with pytest.raises(ValueError, match="RunAgentInput.resume"):
+            interrupts.validate_interrupt_outcome(True)
+
+    @needs_interrupt_outcome
+    def test_naming_a_member_is_not_part_of_that_floor(self, monkeypatch):
+        """It reached the protocol a release later than the rest of the lifecycle.
+
+        A server exposing a single agent never writes it, so refusing the whole
+        round trip over it would demand an upgrade for a field the install would
+        never be asked for.
+        """
+        monkeypatch.setattr(interrupts, "Interrupt", _interrupt_type_without(interrupts.MEMBER_ATTRIBUTION_FIELD))
+
+        assert interrupts.validate_interrupt_outcome(True) is True
+        assert interrupts.interrupt_attribution_available() is False
+
+    @needs_interrupt_outcome
+    def test_an_install_that_cannot_name_a_member_says_so_and_answers_anyway(self, monkeypatch, caplog):
+        """The interrupt still goes out, under an id the resume channel accepts.
+
+        Writing the field a release does not declare would put the value on the
+        wire under a name the format does not define, so the attribution is
+        dropped instead and the pause stays answerable.
+
+        Read off what the interrupt serialized to, on a model that really omits
+        the field. The check this replaces patched the availability probe and
+        then read the attribute back, which is the one pair of choices that can
+        prove nothing: the models keep a key they never declared, so the
+        attribute is there whether the field was dropped or written out
+        undeclared, and patching the probe leaves the model still declaring it.
+        """
+        monkeypatch.setattr(interrupts, "Interrupt", _interrupt_type_without(interrupts.MEMBER_ATTRIBUTION_FIELD))
+        requirement = _requirement(_confirmation())
+
+        with captured_agno_logs(caplog, "WARNING"):
+            interrupt = interrupts.build_interrupt(
+                _needs_answering(requirement),
+                tool_call_id="tc-confirm",
+                tool_name="send_email",
+                subagent_run_id="member-run",
+            )
+
+        assert interrupt.id == interrupts.interrupt_id_of(requirement)
+        serialized = interrupt.model_dump(by_alias=True)
+        assert interrupts.MEMBER_ATTRIBUTION_FIELD not in serialized
+        assert _camel(interrupts.MEMBER_ATTRIBUTION_FIELD) not in serialized
+        assert "unattributed" in caplog.text
+
+    @needs_interrupt_outcome
+    def test_a_pause_with_no_member_to_name_writes_that_field_nowhere_either(self, monkeypatch):
+        """Which is the whole of what a single agent's install ever asks for.
+
+        Nothing is passed rather than a null: on a release declaring the field a
+        null is omitted anyway, and on one that does not it is an undeclared key
+        published to every client of every single-agent server.
+        """
+        monkeypatch.setattr(interrupts, "Interrupt", _interrupt_type_without(interrupts.MEMBER_ATTRIBUTION_FIELD))
+
+        interrupt = interrupts.build_interrupt(
+            _needs_answering(_requirement(_confirmation())),
+            tool_call_id="tc-confirm",
+            tool_name="send_email",
+        )
+
+        assert interrupts.MEMBER_ATTRIBUTION_FIELD not in interrupt.model_dump(by_alias=True)
+
+    @needs_interrupt_outcome
+    def test_the_tag_the_outcome_is_read_by_is_part_of_the_floor(self, monkeypatch):
+        """The outcome reaches a client as a tagged union, and this is the tag.
+
+        It is what tells a client this terminal carries interrupts rather than a
+        plain completion, and the builder writes it on every outcome it makes. A
+        release that renamed it takes the value as data it never declared, so the
+        terminal a paused run ends on is one nothing tells the client to answer.
+        """
+        monkeypatch.setattr(
+            interrupts,
+            "RunFinishedInterruptOutcome",
+            _type_without(interrupts.RunFinishedInterruptOutcome, "type"),
+        )
+
+        with pytest.raises(ValueError, match="RunFinishedInterruptOutcome.type"):
+            interrupts.validate_interrupt_outcome(True)
+
+    @needs_interrupt_outcome
+    @pytest.mark.parametrize("field", sorted(_READ_OFF_ONE_ANSWER))
+    def test_the_fields_one_answer_is_read_off_are_part_of_the_floor(self, monkeypatch, field):
+        """An install that shapes an answer otherwise has to be refused, not discovered.
+
+        Each of these is read as a plain attribute while the answer is applied,
+        so a release declaring one of them differently is not a client whose
+        answer is refused with a reason: it is an AttributeError partway through
+        the continue of a run this interface told that client to answer, after
+        the startup check reported nothing missing. The array they arrive in
+        being declared says nothing about them.
+        """
+        entry_model = _the_entry_model()
+        if entry_model is None:
+            pytest.skip("the installed ag_ui.core declares no model for one answer to arrive as")
+        monkeypatch.setattr("ag_ui.core.ResumeEntry", _type_without(entry_model, field))
+
+        with pytest.raises(ValueError, match=f"ResumeEntry.{field}"):
+            interrupts.validate_interrupt_outcome(True)
+
+    @needs_interrupt_outcome
+    def test_an_envelope_a_release_omits_is_not_part_of_that_floor(self, monkeypatch):
+        """The failure report is read with a default, so an entry without one answers.
+
+        A release declaring the entry without it is serviceable: every answer it
+        carries is read, and the one thing it cannot say is that the client's own
+        tool raised. Demanding it would refuse that install over a field most
+        answers never carry.
+        """
+        entry_model = _the_entry_model()
+        if entry_model is None or "metadata" not in entry_model.model_fields:
+            pytest.skip("the installed ag_ui.core declares no envelope on an answer to omit")
+        monkeypatch.setattr("ag_ui.core.ResumeEntry", _type_without(entry_model, "metadata"))
+
+        assert interrupts.validate_interrupt_outcome(True) is True
+
+    @needs_suspended_outcome
+    def test_a_release_missing_one_part_of_the_suspended_outcome_builds_none_of_it(self, monkeypatch):
+        """The type alone being importable is not the same as being serviceable.
+
+        A release carrying the outcome type without one of the fields it is built
+        from would otherwise be handed one whose content rides out undeclared,
+        and the member terminal would carry it as a lane that says nothing. Every
+        field of it, because each is written on every one of them.
+        """
+        for field in interrupts.subagent_suspension_fields()[interrupts.SubagentFinishedSuspendedOutcome]:
+            with monkeypatch.context() as without:
+                without.setattr(
+                    interrupts,
+                    "SubagentFinishedSuspendedOutcome",
+                    _type_without(interrupts.SubagentFinishedSuspendedOutcome, field),
+                )
+
+                assert interrupts.subagent_suspension_available() is False, f"{field} is detected by nothing"
+                assert interrupts.suspended_outcome(["an-interrupt"]) is None
+
+    @needs_interrupt_outcome
+    def test_an_install_without_the_suspended_outcome_says_so(self, monkeypatch, caplog):
+        """The member is still attributed; only its lane stops saying it is waiting."""
+        require_lineage_events()
+        from agno.os.interfaces.agui import AGUI, agui
+
+        monkeypatch.setattr(agui, "subagent_suspension_available", lambda: False)
+
+        with captured_agno_logs(caplog, "WARNING"):
+            AGUI(agent=Agent(name="A"), emit_interrupt_outcome=True, subagent_visibility=attributed())
+
+        assert "cannot close a subagent the run paused inside as suspended" in caplog.text
+
+
+class TestWhatIsWrittenIsWhatIsDetected:
+    """The two halves of the rule this interface is built on, held to each other.
+
+    A field is feature-detected so that an install which cannot carry it is
+    refused before a run starts. That only works while the census and the code
+    say the same thing, and twice now they have not: an outcome tag written by
+    both builders that no table listed, and the fields of an incoming answer
+    read as plain attributes while only the array around them was checked.
+    Neither was catchable by anything here, because both tables were lists kept
+    in step by care.
+
+    So each check below derives one side from the other. What the builders write
+    is read off the objects they return; what an answer is read off is read from
+    the source of the half that reads it; which types are new enough to need a
+    table at all is read from the imports that guard them. A field added to any
+    of the three without a row fails here rather than on the install that omits
+    it.
+    """
+
+    @needs_interrupt_outcome
+    @needs_suspended_outcome
+    def test_no_field_is_written_that_the_census_does_not_declare(self):
+        """Read off what the builders return, over every pause kind they build for."""
+        census = _census()
+        built = _everything_a_pause_makes_this_interface_build()
+
+        assert built, "no object was built at all, so this check holds nothing to anything"
+        undetected = {
+            type(one).__name__: sorted(set(one.model_fields_set) - set(census.get(type(one), ())))
+            for one in built
+            if set(one.model_fields_set) - set(census.get(type(one), ()))
+        }
+
+        assert undetected == {}, f"these are written where nothing detects them: {undetected}"
+
+    @needs_interrupt_outcome
+    def test_every_protocol_type_this_interface_guards_its_import_of_is_censused(self):
+        """A type new enough to import defensively is one every field of is new.
+
+        Resolved against the installed protocol first: a type this release does
+        not carry is one nothing detects because there is nothing to detect.
+        """
+        import ag_ui.core
+
+        censused = {model.__name__ for model in _census()}
+        guarded = {
+            name for name in _protocol_types_imported_under_a_guard() if getattr(ag_ui.core, name, None) is not None
+        }
+
+        assert guarded, "this scan found no guarded import at all, so it holds nothing to anything"
+        assert guarded <= censused, (
+            f"the installed release carries these, and no table says so: {sorted(guarded - censused)}"
+        )
+
+    @needs_interrupt_outcome
+    def test_the_census_names_every_field_one_answer_is_read_off_and_no_others(self):
+        """Both directions, because each is a way this interface has already failed.
+
+        A field read off an answer that no table names is the install that passes
+        the startup check and raises mid-continue. A field named that nothing
+        reads is a release refused over something this interface never touches.
+        """
+        entry_model = _the_entry_model()
+        if entry_model is None:
+            pytest.skip("the installed ag_ui.core declares no model for one answer to arrive as")
+        censused = {model.__name__: set(fields) for model, fields in _census().items()}
+
+        assert _READ_OFF_ONE_ANSWER, "this scan found nothing read off an answer, so it holds nothing to anything"
+        assert censused.get(entry_model.__name__) == _READ_OFF_ONE_ANSWER, (
+            f"read off an answer and detected by nothing: "
+            f"{sorted(_READ_OFF_ONE_ANSWER - censused.get(entry_model.__name__, set()))}; "
+            f"detected and read nowhere: {sorted(censused.get(entry_model.__name__, set()) - _READ_OFF_ONE_ANSWER)}"
+        )
+
+    def test_this_scan_reports_a_field_read_off_an_answer_that_nothing_detects(self):
+        """The check above is one whose whole job is to fire, so it is made to.
+
+        Its subject is what the scan reads, so the scan is handed a read of a
+        field no table names and has to report it. A scan that cannot report one
+        would pass the check above on any source at all.
+        """
+        read = _plain_attributes_read_on("if entry.expires_at:\n    pass\n", _ONE_ANSWER)
+
+        assert read == {"expires_at"}
+        assert _plain_attributes_read_on("value = getattr(entry, 'status', None)\n", _ONE_ANSWER) == set()
+
+
+# --- The gates, held to the piece each test's own body needs -----------------
+
+# Six times in this suite a gate has named a piece other than the one the test
+# under it depends on: the test failed where it should have skipped, skipped
+# where it had nothing to skip for, or skipped on the very install it exists to
+# prove. Each was found by reading a test and fixed on its own. What follows
+# reads the tests instead, off this file's own source, so the next one is a
+# failure here rather than the seventh instance of the same mistake.
+
+_OUTCOME = "the interrupt-aware run lifecycle"
+_ATTRIBUTION = "naming the member an interrupt was raised inside"
+_SUSPENSION = "the suspended subagent outcome"
+_RESUME = "the resume array a client's answers arrive in"
+
+# Every gate this suite has: the piece it stands for, and the probe the
+# interface itself decides that piece by. A gate written against something other
+# than that probe is the original mistake, so each marker's own source is held
+# to it below.
+_GATES: Dict[str, Tuple[str, str]] = {
+    "needs_interrupt_outcome": (_OUTCOME, "INTERRUPT_OUTCOME_AVAILABLE"),
+    "needs_member_attribution": (_ATTRIBUTION, "interrupt_attribution_available"),
+    "needs_suspended_outcome": (_SUSPENSION, "subagent_suspension_available"),
+    "needs_resume_array": (_RESUME, "RESUME_ARRAY_IS_READABLE"),
+}
+
+
+def _camel(field: str) -> str:
+    """One protocol field as the wire spells it, which is how a test reads it."""
+    head, *rest = field.split("_")
+    return head + "".join(piece.capitalize() for piece in rest)
+
+
+# The suspended outcome's own spellings, held to what the interface actually
+# builds by the first test below rather than trusted: a rename there would
+# otherwise leave this check quietly matching nothing.
+_SUSPENDED_TYPE = "suspended"
+_SUSPENDED_INTERRUPT_IDS = "interruptIds"
+
+# An argument that asks a piece for something. Counted only where it is passed
+# something other than a falsy literal, so reading the emission setting to
+# assert that it defaults to off asks for nothing.
+_ASKED_FOR_BY_ARGUMENT: Dict[str, Tuple[str, ...]] = {
+    _OUTCOME: ("emit_interrupt_outcome",),
+    _RESUME: ("resume",),
+}
+
+# A name or a wire key that means nothing on an install without the piece. The
+# attribution spellings are derived from the interface's own field name so the
+# two cannot drift apart.
+_WRITTEN_IN_THE_SOURCE: Dict[str, Tuple[str, ...]] = {
+    _OUTCOME: (
+        "INTERRUPT_OUTCOME_AVAILABLE",
+        "validate_interrupt_outcome",
+        "build_interrupt",
+        "interrupt_outcome",
+        "interrupt_round_trip_fields",
+    ),
+    _ATTRIBUTION: (
+        "interrupt_attribution_available",
+        "MEMBER_ATTRIBUTION_FIELD",
+        interrupts.MEMBER_ATTRIBUTION_FIELD,
+        _camel(interrupts.MEMBER_ATTRIBUTION_FIELD),
+    ),
+    _SUSPENSION: (
+        "subagent_suspension_available",
+        "suspended_outcome",
+        _SUSPENDED_TYPE,
+        _SUSPENDED_INTERRUPT_IDS,
+    ),
+}
+
+# The class whose subject is this file's own source. Every spelling above
+# appears in it, and it depends on no release piece at all, so the walk leaves
+# it out and the first test below refuses to run if it has been renamed away.
+_READS_THIS_FILE = "TestTheGatesNameThePieceTheBodyNeeds"
+
+
+def _suite_source() -> ast.Module:
+    return ast.parse(Path(__file__).read_text(encoding="utf-8"))
+
+
+def _is_a_gate(decorator: ast.AST) -> bool:
+    return any(isinstance(node, ast.Name) and node.id in _GATES for node in ast.walk(decorator))
+
+
+def _gates_on(node: ast.AST) -> Set[str]:
+    """The pieces one class or function is gated on, whichever gates are stacked."""
+    return {
+        _GATES[inner.id][0]
+        for decorator in getattr(node, "decorator_list", [])
+        for inner in ast.walk(decorator)
+        if isinstance(inner, ast.Name) and inner.id in _GATES
+    }
+
+
+def _named_by(nodes: Sequence[ast.AST]) -> Set[str]:
+    """Identifiers and string literals these nodes carry, absence claims aside.
+
+    A literal used to assert that the wire does not carry it is dropped where it
+    is written: a test checking that a field is absent is the opposite of one
+    that needs it. Dropped there and nowhere else, because these nodes are a
+    whole test together with every helper it reads, and subtracting the spelling
+    from the finished set erased it at every other site too: one negative
+    assertion then took a gate requirement off a sibling site that genuinely has
+    it.
+    """
+    found: Set[str] = set()
+    for node in nodes:
+        claimed_absent = {
+            inner.left
+            for inner in ast.walk(node)
+            if isinstance(inner, ast.Compare)
+            and isinstance(inner.left, ast.Constant)
+            and isinstance(inner.left.value, str)
+            and any(isinstance(op, ast.NotIn) for op in inner.ops)
+        }
+        for inner in ast.walk(node):
+            if isinstance(inner, ast.Name):
+                found.add(inner.id)
+            elif isinstance(inner, ast.Attribute):
+                found.add(inner.attr)
+            elif isinstance(inner, ast.Constant) and isinstance(inner.value, str):
+                if inner not in claimed_absent:
+                    found.add(inner.value)
+    return found
+
+
+def _asked_for_by(nodes: Sequence[ast.AST]) -> Set[str]:
+    """Keyword argument names these nodes pass something other than a falsy literal."""
+    found: Set[str] = set()
+    for node in nodes:
+        for inner in ast.walk(node):
+            if isinstance(inner, ast.keyword) and inner.arg:
+                if isinstance(inner.value, ast.Constant) and not inner.value.value:
+                    continue
+                found.add(inner.arg)
+    return found
+
+
+def _simulated_away_by(nodes: Sequence[ast.AST]) -> Set[str]:
+    """The pieces these nodes replace the detection of, which is not a dependency.
+
+    A test whose subject is the refusal patches the probe or the type a piece is
+    detected through, and it is the only kind of test with anything left to
+    assert on an install that really lacks that piece, so it has to run there.
+    """
+    away: Set[str] = set()
+    for node in nodes:
+        for inner in ast.walk(node):
+            if not isinstance(inner, ast.Call):
+                continue
+            called = inner.func.attr if isinstance(inner.func, ast.Attribute) else None
+            if called != "setattr":
+                continue
+            named = _named_by([inner])
+            away |= {piece for piece, spellings in _WRITTEN_IN_THE_SOURCE.items() if set(spellings) & named}
+    return away
+
+
+def _helpers_of_this_suite(tree: ast.Module) -> Dict[str, ast.AST]:
+    """Every module-level name of this suite a test body can carry a dependency in.
+
+    An annotated assignment as readily as a bare one: this file writes tables
+    both ways, and reading only the bare ones left a dependency carried in an
+    annotated table invisible for no reason a reader of either could see.
+    """
+    helpers: Dict[str, ast.AST] = {}
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            helpers[node.name] = node
+        elif isinstance(node, ast.AnnAssign):
+            if isinstance(node.target, ast.Name) and node.value is not None:
+                helpers[node.target.id] = node.value
+        elif isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    helpers[target.id] = node.value
+    return helpers
+
+
+def _methods_of(tree: ast.Module) -> Dict[str, Dict[str, ast.AST]]:
+    """Every class of this file and what it defines, wherever the class is written."""
+    return {
+        node.name: {
+            child.name: child for child in node.body if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+        }
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ClassDef)
+    }
+
+
+def _everything_read_by(node: ast.AST, owner: Optional[str], tree: ast.Module) -> List[ast.AST]:
+    """The test's own nodes and every helper of this suite it names, transitively.
+
+    Names rather than call sites: a helper handed to ``parametrize`` as a value
+    is read by the test just as surely as one it calls, and a call written as an
+    attribute is a call the plain-name scan this replaces used to skip.
+    """
+    helpers = _helpers_of_this_suite(tree)
+    methods = _methods_of(tree)
+    reading = [
+        *getattr(node, "body", []),
+        *(decorator for decorator in getattr(node, "decorator_list", []) if not _is_a_gate(decorator)),
+    ]
+    collected = list(reading)
+    seen: Set[str] = set()
+    frontier = [(reading, owner)]
+    while frontier:
+        nodes, in_class = frontier.pop()
+        siblings = methods.get(in_class or "", {})
+        for name in _named_by(nodes):
+            if name in seen:
+                continue
+            body = siblings.get(name) or helpers.get(name)
+            if body is None:
+                continue
+            seen.add(name)
+            collected.append(body)
+            frontier.append(([body], in_class if name in siblings else None))
+    return collected
+
+
+def _pieces_needed_by(node: ast.AST, owner: Optional[str], tree: ast.Module) -> Set[str]:
+    read = _everything_read_by(node, owner, tree)
+    named = _named_by(read)
+    asked = _asked_for_by(read)
+    needed = {piece for piece, spellings in _WRITTEN_IN_THE_SOURCE.items() if set(spellings) & named}
+    needed |= {piece for piece, arguments in _ASKED_FOR_BY_ARGUMENT.items() if set(arguments) & asked}
+    return needed - _simulated_away_by(read)
+
+
+def _every_test_in_this_suite() -> List[Tuple[str, Set[str], Set[str]]]:
+    """(name, the pieces its body needs, the pieces it is gated on) per test."""
+    tree = _suite_source()
+    rows: List[Tuple[str, Set[str], Set[str]]] = []
+
+    def walk(body: Sequence[ast.AST], owner: Optional[str], inherited: Set[str]) -> None:
+        for node in body:
+            if isinstance(node, ast.ClassDef):
+                if node.name != _READS_THIS_FILE:
+                    walk(node.body, node.name, inherited | _gates_on(node))
+            elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith("test"):
+                name = f"{owner}::{node.name}" if owner else node.name
+                rows.append((name, _pieces_needed_by(node, owner, tree), inherited | _gates_on(node)))
+
+    walk(tree.body, None, set())
+    return rows
+
+
+def _every_test_this_file_defines() -> Set[str]:
+    """Every test defined here, found without the walk's own recursion.
+
+    ``ast.walk`` descends everything, so this cannot miss a test for any of the
+    reasons the walk above can: a class it declines to enter, a nesting it does
+    not expect, a name it filters on. It is what the walk is compared against,
+    in place of a floor that held while most of the suite went unwalked.
+    """
+    return {
+        node.name
+        for node in ast.walk(_suite_source())
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith("test")
+    }
+
+
+def _tests_of_the_class_that_reads_this_file() -> Set[str]:
+    """The tests the walk leaves out, which are the ones in this file's own subject."""
+    return {
+        child.name
+        for node in _suite_source().body
+        if isinstance(node, ast.ClassDef) and node.name == _READS_THIS_FILE
+        for child in node.body
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)) and child.name.startswith("test")
+    }
+
+
+# --- Every source of a stream, derived rather than listed --------------------
+
+# A stream reaches this suite from a callable that builds protocol events, and
+# every one of those is imported under a private name and wrapped under the name
+# the suite calls it by, so that no call site can skip the shared checks. Which
+# callables those are used to be a list of three wrapper names, and a fourth
+# source was imported and driven under its own name with nothing able to report
+# it. So the set is derived from this file's imports and the signatures of what
+# they bind.
+#
+# What the derivation cannot see, stated because every scan in this directory
+# has a blind spot: a source whose signature does not say it builds events, one
+# this file writes itself rather than imports, one reached through a module
+# object instead of an imported name, and events a test constructs by hand. The
+# route harness is the first of those, and it calls both checks in its own body.
+
+
+def _builds_protocol_events(candidate: Any) -> bool:
+    """Whether calling this yields or returns AG-UI events, read off its signature.
+
+    A reader of a stream is not a source of one: it is handed the events it
+    filters, so a parameter of that type is what tells the two apart.
+    """
+    if not inspect.isfunction(candidate):
+        return False
+    try:
+        annotations = get_type_hints(candidate)
+    except Exception:
+        # A signature this check cannot resolve says nothing either way, and the
+        # completeness test below is what refuses to let that go unnoticed.
+        return False
+    if not _mentions_a_protocol_event(annotations.pop("return", None)):
+        return False
+    return not any(_mentions_a_protocol_event(annotation) for annotation in annotations.values())
+
+
+def _mentions_a_protocol_event(annotation: Any) -> bool:
+    if isinstance(annotation, type) and issubclass(annotation, BaseEvent):
+        return True
+    return any(_mentions_a_protocol_event(argument) for argument in get_args(annotation))
+
+
+def _imports_of(tree: ast.Module) -> List[Tuple[str, str]]:
+    """(the name imported, the name it is bound to here) for every from-import."""
+    return [
+        (alias.name, alias.asname or alias.name)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+        for alias in node.names
+    ]
+
+
+def _imported_stream_sources() -> Dict[str, Tuple[str, ...]]:
+    """{the name a source is wrapped under: the names this file binds it to}.
+
+    Resolved through the module each import names rather than through this
+    file's own globals, so a wrapper shadowing the name it wraps cannot hide the
+    import behind it.
+    """
+    found: Dict[str, List[str]] = {}
+    for node in ast.walk(_suite_source()):
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        try:
+            source_module = importlib.import_module("." * node.level + (node.module or ""), __package__)
+        except ImportError:  # pragma: no cover - every import here is one this file already ran
+            continue
+        for alias in node.names:
+            if _builds_protocol_events(getattr(source_module, alias.name, None)):
+                found.setdefault(alias.name, []).append(alias.asname or alias.name)
+    return {name: tuple(bound) for name, bound in found.items()}
+
+
+_STREAM_SOURCES = _imported_stream_sources()
+
+_THE_ENCODED_KEYS = ("_assert_nothing_undeclared_reached_the_client",)
+_A_WELL_FORMED_STREAM = ("assert_well_formed_stream", "assert_stream_is_malformed_as_recorded")
+
+# What each wrapper owes the stream it hands back, as groups of calls it must
+# name at least one of. Every wrapper owes the encoded keys, which is the check
+# no caller can run for itself: the paths its encoder is allowed to refuse
+# arrive as this wrapper's own argument. The two that hand back the stream alone
+# also owe well-formedness; the drivers hand back the error that ended the
+# stream beside it, so what a stream cut short should look like is the caller's
+# statement to make.
+_THE_CHECKS_EACH_WRAPPER_OWES: Dict[str, Tuple[Tuple[str, ...], ...]] = {
+    "on_run_completed": (_THE_ENCODED_KEYS, _A_WELL_FORMED_STREAM),
+    "run_entity": (_THE_ENCODED_KEYS, _A_WELL_FORMED_STREAM),
+    "collect_async": (_THE_ENCODED_KEYS,),
+    "collect_sync": (_THE_ENCODED_KEYS,),
+}
+
+
+def _calls_inside(tree: ast.Module, function: str) -> Set[str]:
+    """Every name this file's ``function`` calls, the callee's last name only."""
+    defined = [
+        node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == function
+    ]
+    assert len(defined) == 1, f"{function} is defined {len(defined)} times at this module's top level"
+    called: Set[str] = set()
+    for node in ast.walk(defined[0]):
+        if not isinstance(node, ast.Call):
+            continue
+        if isinstance(node.func, ast.Name):
+            called.add(node.func.id)
+        elif isinstance(node.func, ast.Attribute):
+            called.add(node.func.attr)
+    return called
+
+
+def _scopes_of_this_file_that_read(tree: ast.Module, name: str) -> Set[str]:
+    """Every scope of this file that names ``name``, module level included.
+
+    Scopes rather than function definitions: a module-level parametrize handing
+    a driver out as a value drives a stream exactly as a call does, and a scan
+    filtered to function definitions could not see one. A decorator counts as
+    part of the definition it is written on, which is where such a list is read.
+
+    A scope is named by its whole path, so a method of some class sharing a
+    wrapper's name is not mistaken for the wrapper and subtracted.
+    """
+    found: Set[str] = set()
+
+    def walk(node: ast.AST, owner: str) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                walk(child, child.name if owner == "<module>" else f"{owner}.{child.name}")
+                continue
+            if isinstance(child, ast.Name) and child.id == name:
+                found.add(owner)
+            elif isinstance(child, ast.Attribute) and child.attr == name:
+                found.add(owner)
+            walk(child, owner)
+
+    walk(tree, "<module>")
+    return found
+
+
+class TestTheGatesNameThePieceTheBodyNeeds:
+    """This suite's own gates, read off its source.
+
+    The three pieces of the round trip reached the protocol in three separate
+    releases, the array the answers arrive in is a fourth, and this suite runs
+    on installs that have any subset of them. Which piece a test needs is read
+    from what its body asks for and what it reads off the wire, not from a table
+    of test names, because such a table is the next thing to drift.
+    """
+
+    def test_this_walk_reads_the_suite_it_is_written_about(self):
+        """A walk that sees no tests would pass every check below in silence.
+
+        Every test this file defines and none it does not, rather than a floor:
+        the floor stood at eighty against a suite of over a hundred and fifty, so
+        the walk could have lost half of them and still cleared it.
+        """
+        walked = {name.rpartition("::")[2] for name, _needed, _gated in _every_test_in_this_suite()}
+        defined = _every_test_this_file_defines()
+        left_out = _tests_of_the_class_that_reads_this_file()
+
+        assert left_out, f"{_READS_THIS_FILE} defines no test, so the walk leaves nothing out"
+        assert walked == defined - left_out, (
+            f"this walk reads {len(walked)} of the {len(defined - left_out)} tests it is written about: "
+            f"missed {sorted(defined - left_out - walked)}, invented {sorted(walked - defined)}"
+        )
+        assert {name for name in _GATES} == {
+            target.id
+            for node in ast.walk(_suite_source())
+            if isinstance(node, ast.Assign)
+            for target in node.targets
+            if isinstance(target, ast.Name) and target.id.startswith("needs_")
+        }, "a gate this suite defines is not one this check knows the probe for"
+        assert any(node.name == _READS_THIS_FILE for node in _suite_source().body if isinstance(node, ast.ClassDef)), (
+            f"{_READS_THIS_FILE} is the class the walk leaves out, and it is no longer there"
+        )
+
+    def test_the_spellings_this_check_reads_are_the_ones_the_interface_writes(self):
+        """Derived where the interface exposes the name, and compared where it does not."""
+        assert _camel(interrupts.MEMBER_ATTRIBUTION_FIELD) == "subagentRunId"
+
+        suspended = interrupts.suspended_outcome(["an-interrupt"])
+        if suspended is None:
+            pytest.skip("the installed ag_ui.core builds no suspended subagent outcome to read")
+        assert suspended.type == _SUSPENDED_TYPE
+        fields = interrupts.subagent_suspension_fields()[type(suspended)]
+        assert _SUSPENDED_INTERRUPT_IDS in {_camel(field) for field in fields}
+
+    def test_every_gate_names_the_probe_the_interface_decides_that_piece_by(self):
+        """A gate reading anything else is how a test skips on the wrong install."""
+        tree = _suite_source()
+        written_as = {
+            target.id: ast.unparse(node.value)
+            for node in tree.body
+            if isinstance(node, ast.Assign)
+            for target in node.targets
+            if isinstance(target, ast.Name) and target.id in _GATES
+        }
+
+        assert sorted(written_as) == sorted(_GATES), f"a gate is not defined at this module's top level: {written_as}"
+        for gate, (_piece, probe) in _GATES.items():
+            source = written_as[gate]
+            assert "skipif" in source, f"{gate} is not a skip gate: {source}"
+            assert probe in source, f"{gate} decides by {source}, not by the interface's own {probe}"
+
+    def test_no_test_is_gated_on_a_piece_its_body_does_not_need(self):
+        """A gate for a piece a test never touches skips it where it still holds.
+
+        Which is how a class-level gate goes wrong: it is true of most of the
+        class and false of the test that only answers a requirement.
+        """
+        over_gated = {
+            name: sorted(gated - needed) for name, needed, gated in _every_test_in_this_suite() if gated - needed
+        }
+
+        assert over_gated == {}, f"these tests skip on installs where they would still hold: {over_gated}"
+
+    def test_no_test_that_needs_a_piece_runs_ungated(self):
+        """The other direction: a test that fails where it should have skipped."""
+        ungated = {
+            name: sorted(needed - gated) for name, needed, gated in _every_test_in_this_suite() if needed - gated
+        }
+
+        assert ungated == {}, f"these tests need a release piece nothing gates them on: {ungated}"
+
+    def test_every_source_of_a_stream_this_suite_imports_has_a_wrapper(self):
+        """The derivation and the wrappers say the same thing, both ways.
+
+        A source it found that nothing wraps is one a test can drive past every
+        check, which is how the fourth of them went unheld to the keys it
+        encoded. A wrapper for something it no longer finds is the other
+        failure, and the one a list of names cannot report at all: the
+        derivation has gone blind and every check below it is reading nothing.
+        """
+        tree = _suite_source()
+        defined_here = {node.name for node in tree.body if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))}
+        wrapped_here = {name for name, bound in _imports_of(tree) if bound.startswith("_") and name in defined_here}
+
+        assert _STREAM_SOURCES, "this check found no source of a stream at all, so it holds nothing to anything"
+        assert set(_STREAM_SOURCES) == wrapped_here, (
+            f"sources with no wrapper: {sorted(set(_STREAM_SOURCES) - wrapped_here)}; "
+            f"wrappers for something this check no longer reads as a source: "
+            f"{sorted(wrapped_here - set(_STREAM_SOURCES))}"
+        )
+
+    @pytest.mark.parametrize("wrapped", sorted(_STREAM_SOURCES))
+    def test_every_stream_this_suite_drives_reaches_the_shared_checker(self, wrapped):
+        """Each wrapper is the only place in this file that reads what it wraps.
+
+        A test reaching past a wrapper gets a stream nothing holds to the shared
+        definition of a well-formed one, nor to the keys it encoded, which is
+        what let this suite assert a stream was correct while the checker next
+        door rejected it. Read over every scope of the file, module level
+        included: a parametrize list built there hands the unwrapped one out to
+        every test under it, and the scan this replaces looked at function
+        definitions only.
+        """
+        bound = _STREAM_SOURCES[wrapped]
+        assert len(bound) == 1 and bound[0].startswith("_"), (
+            f"{wrapped} is not imported under exactly one private name for its wrapper to read: {list(bound)}"
+        )
+
+        reached_past_it = sorted(_scopes_of_this_file_that_read(_suite_source(), bound[0]) - {wrapped})
+
+        assert reached_past_it == [], f"these drive a stream the checks never see: {reached_past_it}"
+
+    @pytest.mark.parametrize("wrapped", sorted(_STREAM_SOURCES))
+    def test_every_wrapper_still_runs_the_checks_it_stands_there_to_run(self, wrapped):
+        """Funnelling every stream through a wrapper proves nothing if the wrapper checks nothing.
+
+        The test above holds every caller to the wrapper; this one holds the
+        wrapper to its body. Gut all of them and the suite above still passes:
+        the sole place each check is made would be gone with no test left
+        reading a stream it used to reject.
+        """
+        owed = _THE_CHECKS_EACH_WRAPPER_OWES.get(wrapped)
+
+        assert owed is not None, f"{wrapped} wraps a stream this file drives and states no check it owes it"
+
+        called = _calls_inside(_suite_source(), wrapped)
+        unmade = [sorted(group) for group in owed if not set(group) & called]
+
+        assert unmade == [], f"{wrapped} hands back a stream without making these checks: {unmade}"

--- a/libs/agno/tests/unit/os/interfaces/test_agui_router.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_router.py
@@ -1,16 +1,28 @@
+import json
 import logging
+from types import SimpleNamespace
 from unittest.mock import MagicMock
+from uuid import uuid4
 
 import pytest
 
 pytest.importorskip("ag_ui", reason="ag_ui not installed")
 
-from ag_ui.core import EventType
+from ag_ui.core import EventType, RunAgentInput
+from ag_ui.core.types import Context, UserMessage
 from ag_ui.core.types import Tool as AGUITool
+from ag_ui.core.types import ToolMessage as AGUIToolMessage
 
+from agno.agent.agent import Agent
 from agno.agent.remote import RemoteAgent
+from agno.db.in_memory import InMemoryDb
+from agno.os.interfaces.agui import router
 from agno.os.interfaces.agui.router import run_entity
+from agno.run.base import RunContext
 from agno.team.remote import RemoteTeam
+from agno.tools import tool
+
+from .agui_stream_invariants import ScriptedModel
 
 
 class FakeRunInput:
@@ -112,9 +124,9 @@ async def test_run_entity_passes_client_tools_in_run_context():
     assert "change_background" in tool_names
     assert "show_modal" in tool_names
 
-    for tool in run_context.client_tools:
-        assert tool.external_execution is True
-        assert tool.external_execution_silent is True
+    for client_tool in run_context.client_tools:
+        assert client_tool.external_execution is True
+        assert client_tool.external_execution_silent is True
 
 
 @pytest.mark.asyncio
@@ -218,3 +230,117 @@ async def test_run_entity_remote_agent_warns_and_drops_client_tools(caplog):
     assert "run_context" not in captured
     assert any("client tools are not forwarded" in record.message for record in caplog.records)
     assert events[-1].type == EventType.RUN_FINISHED
+
+
+# --- Options a resumed run must not be handed ---------------------------------
+
+
+DEPENDENCIES_THE_TOOL_SAW: list = []
+
+
+@tool(requires_confirmation=True)
+def send_email(to: str, run_context: RunContext) -> str:
+    DEPENDENCIES_THE_TOOL_SAW.append(dict(run_context.dependencies or {}))
+    return f"Email sent to {to}"
+
+
+def _request(*, context=None, trailing=None):
+    """The request the route reads, carrying a prompt and optionally an answer."""
+    messages = [UserMessage(id="m1", role="user", content="email ops@example.com")]
+    messages.extend(trailing or [])
+    return RunAgentInput(
+        thread_id="deps-session",
+        run_id=str(uuid4()),
+        state={},
+        messages=messages,
+        tools=[],
+        context=context or [],
+        forwarded_props={},
+    )
+
+
+def _confirmation(tool_call_id: str):
+    return AGUIToolMessage(
+        id="answer-1",
+        role="tool",
+        content=json.dumps({"accepted": True}),
+        tool_call_id=tool_call_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_resumed_run_is_not_handed_the_fresh_run_dependency_option():
+    """``add_dependencies_to_context`` is a fresh-run option, and a resume must not carry it.
+
+    The continue entry point does not declare it, so it lands in that call's
+    catch-all keywords and is splatted into the run's post-hook arguments, where
+    a hook taking ``**kwargs`` is handed an option on turn two that turn one
+    never handed it. Nothing on the continue path reads it as an option: it is
+    read while a user message is built, and a continue replays the paused run's
+    stored messages rather than building one. The request's context still
+    reaches the resumed run, through the run context, which is the other half
+    pinned here.
+    """
+    DEPENDENCIES_THE_TOOL_SAW.clear()
+    hook_arguments: list = []
+
+    def record_hook_arguments(**kwargs):
+        hook_arguments.append(dict(kwargs))
+
+    agent = Agent(
+        id="dependency-agent",
+        model=ScriptedModel(
+            "m",
+            [("tool", "send_email", {"to": "ops@example.com"}, "tc-1"), ("content", "Sent.")],
+        ),
+        db=InMemoryDb(),
+        tools=[send_email],
+        post_hooks=[record_hook_arguments],
+        telemetry=False,
+    )
+    context = [Context(description="user_name", value="Alice")]
+
+    async for _ in run_entity(agent, _request(context=context)):
+        pass
+
+    request = _request(context=context, trailing=[_confirmation("tc-1")])
+    resumed = [event async for event in run_entity(agent, request)]
+
+    assert [event.message for event in resumed if event.type == EventType.RUN_ERROR] == []
+    assert hook_arguments, "the resumed run ran no post hook, so it pins nothing"
+    handed = [sorted(args) for args in hook_arguments if "add_dependencies_to_context" in args]
+    assert handed == [], f"a resumed run's post hook was handed a fresh-run option: {handed}"
+    assert DEPENDENCIES_THE_TOOL_SAW == [{"user_name": "Alice"}]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "channel, extra_input",
+    [
+        ("resume_paused_run_from_entries", {"resume": [SimpleNamespace(interrupt_id="i-1")]}),
+        ("resume_paused_run", {"messages": [MagicMock(role="user", content="go"), MagicMock(role="tool")]}),
+    ],
+    ids=["resume-array", "tool-messages"],
+)
+async def test_neither_resume_channel_is_handed_the_fresh_run_dependency_option(channel, extra_input, monkeypatch):
+    """Both channels resume through the same continue entry point, which takes no such option."""
+    captured: dict = {}
+
+    async def capture(**kwargs):
+        captured.update(kwargs["run_kwargs"])
+
+        async def nothing():
+            return
+            yield
+
+        return nothing()
+
+    monkeypatch.setattr(router, channel, capture)
+    run_input = FakeRunInput(context=[MagicMock(description="user_name", value="Alice")])
+    for name, value in extra_input.items():
+        setattr(run_input, name, value)
+
+    async for _ in run_entity(MagicMock(), run_input):
+        pass
+
+    assert "add_dependencies_to_context" not in captured

--- a/libs/agno/tests/unit/os/interfaces/test_agui_stream_failure.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_stream_failure.py
@@ -1,0 +1,916 @@
+"""AG-UI mapping of an Agno stream that ends badly, or ends somewhere unexpected.
+
+A run's event stream can raise mid-flight: a model call dies, a tool raises, the
+connection to a remote entity drops. Both mappers open spans as events flow, so
+a failure that escapes without closing them leaves the client holding a text
+bubble and tool cards that spin forever and, under ``attributed`` visibility,
+member lanes that never resolve.
+
+A stream can also stop on a subagent's own terminal, with the top-level entity
+reporting none of its own. That chunk is then the only account of how the run
+ended, so which chunk the run terminal is built from is pinned here too, under
+every visibility: a run that died inside a member must not reach the client as a
+success.
+
+Every test here runs against the sync mapper and the async mapper, so the two
+cannot drift apart.
+"""
+
+import inspect
+import json
+from typing import Any, AsyncGenerator, Iterable, List, Optional
+
+import pytest
+
+pytest.importorskip("ag_ui", reason="ag_ui not installed")
+
+from ag_ui.core import BaseEvent, EventType
+
+from agno.models.response import ToolExecution
+from agno.os.interfaces.agui import handlers
+from agno.os.interfaces.agui import stream as stream_module
+from agno.os.interfaces.agui.state import SUBAGENT_VISIBILITY_HIDDEN, SUBAGENT_VISIBILITY_INLINE, StreamState
+from agno.os.interfaces.agui.stream import (
+    async_stream_agno_response_as_agui_events,
+    stream_agno_response_as_agui_events,
+)
+from agno.run.agent import (
+    RunCancelledEvent,
+    RunCompletedEvent,
+    RunErrorEvent,
+    RunEvent,
+    RunStartedEvent,
+    ToolCallStartedEvent,
+)
+from agno.run.agent import RunPausedEvent as AgentRunPausedEvent
+from agno.run.team import RunCompletedEvent as TeamRunCompletedEvent
+from agno.run.team import RunErrorEvent as TeamRunErrorEvent
+from agno.run.team import RunStartedEvent as TeamRunStartedEvent
+from agno.run.team import ToolCallStartedEvent as TeamToolCallStartedEvent
+
+from .agui_stream_invariants import (
+    ABANDONED_MID_STREAM,
+    ABANDONED_WITH_A_MEMBER_STILL_OPEN,
+    TOP_LEVEL_RUN,
+    Collected,
+    agent_said,
+    assert_stream_contains,
+    assert_well_formed_stream,
+    async_source,
+    attributed,
+    captured_agno_logs,
+    collect_async,
+    collect_sync,
+    event_type_named,
+    field_of,
+    in_emitted_order,
+    lane_of,
+    member_chunk_kwargs,
+    of_type,
+    short_type,
+    sync_source,
+)
+
+THREAD_ID = "failure-session"
+
+
+# --- Streams ----------------------------------------------------------------
+
+
+class _Boom(RuntimeError):
+    """The failure a source stream raises. Distinct so a test can match it exactly."""
+
+
+# The member's lineage fields and the content chunk come from the shared module,
+# which the attribution suite builds the same chunks from.
+_member_kwargs = member_chunk_kwargs
+_content = agent_said
+
+
+def _open_text_message_chunks(message: str) -> List[Any]:
+    """A run that opened a text message and then died."""
+    return [
+        RunStartedEvent(run_id=TOP_LEVEL_RUN),
+        _content("half a sen", run_id=TOP_LEVEL_RUN),
+        _Boom(message),
+    ]
+
+
+def _open_tool_call_chunks(message: str) -> List[Any]:
+    """A run that started a tool call and then died before its result."""
+    return [
+        RunStartedEvent(run_id=TOP_LEVEL_RUN),
+        ToolCallStartedEvent(
+            run_id=TOP_LEVEL_RUN,
+            tool=ToolExecution(tool_call_id="tc-search", tool_name="search_docs", tool_args={"query": "agno"}),
+        ),
+        _Boom(message),
+    ]
+
+
+def _delegation() -> ToolExecution:
+    return ToolExecution(
+        tool_call_id="tc-delegate-scout",
+        tool_name="delegate_task_to_member",
+        tool_args={"member_id": "scout", "task": "scout the topic"},
+    )
+
+
+def _open_member_lane_chunks(message: str) -> List[Any]:
+    """A team whose member was mid-sentence inside a delegation when the stream died."""
+    member = _member_kwargs("scout", "run-scout")
+    return [
+        TeamRunStartedEvent(team_id="research-team", team_name="Research Team", run_id=TOP_LEVEL_RUN),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=_delegation()),
+        RunStartedEvent(**member),
+        _content("scouting so", **member),
+        _Boom(message),
+    ]
+
+
+_MEMBER = _member_kwargs("scout", "run-scout")
+
+
+def _ends_on_the_members_terminal_chunks(*terminals: Any) -> List[Any]:
+    """A team that reported no terminal of its own, so a member's is the last thing on it.
+
+    The delegation the member ran inside is left open, so the run terminal is
+    also what has to close the leader's own call.
+    """
+    return [
+        TeamRunStartedEvent(team_id="research-team", team_name="Research Team", run_id=TOP_LEVEL_RUN),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=_delegation()),
+        RunStartedEvent(**_MEMBER),
+        _content("half a sen", **_MEMBER),
+        *terminals,
+    ]
+
+
+def _member_failed() -> Any:
+    return RunErrorEvent(content="member exploded", error_type="RuntimeError", **_MEMBER)
+
+
+def _member_finished() -> Any:
+    return RunCompletedEvent(content="scout done", **_MEMBER)
+
+
+def _member_cancelled() -> Any:
+    return RunCancelledEvent(reason="the operator stopped it", **_MEMBER)
+
+
+def _pending_member_tool() -> ToolExecution:
+    return ToolExecution(
+        tool_call_id="tc-member-confirm",
+        tool_name="send_email",
+        tool_args={"to": "ops"},
+        requires_confirmation=True,
+    )
+
+
+def _member_paused() -> Any:
+    return AgentRunPausedEvent(tools=[_pending_member_tool()], **_MEMBER)
+
+
+def _member_paused_saying_something() -> Any:
+    """The same pause, with words of the member's own on it."""
+    return AgentRunPausedEvent(tools=[_pending_member_tool()], content="I need approval to email ops.", **_MEMBER)
+
+
+def _team_finished() -> Any:
+    return TeamRunCompletedEvent(team_id="research-team", team_name="Research Team", run_id=TOP_LEVEL_RUN)
+
+
+def _team_failed() -> Any:
+    return TeamRunErrorEvent(
+        content="the team blew up", error_type="RuntimeError", team_id="research-team", run_id=TOP_LEVEL_RUN
+    )
+
+
+def _visibilities() -> List[Any]:
+    """The settings a stream is driven under, the attributed one resolved lazily.
+
+    Named through the shared door, so an install that cannot serve member
+    attribution skips those cases instead of failing them, and resolved inside
+    the test rather than at collection time.
+    """
+    return [
+        pytest.param(lambda: None, id="default"),
+        pytest.param(lambda: SUBAGENT_VISIBILITY_INLINE, id="inline"),
+        pytest.param(attributed, id="attributed"),
+        pytest.param(lambda: SUBAGENT_VISIBILITY_HIDDEN, id="hidden"),
+    ]
+
+
+visibilities = pytest.mark.parametrize("visibility", _visibilities())
+
+
+# --- Collectors -------------------------------------------------------------
+
+# Both collectors run the shared stream-invariant helper before handing the
+# events back, so every test in this module inherits the whole invariant set.
+
+
+async def _collect_sync(chunks: Iterable[Any], visibility: Optional[str] = None) -> Collected:
+    return await collect_sync(chunks, visibility, thread_id=THREAD_ID, run_id=TOP_LEVEL_RUN)
+
+
+async def _collect_async(chunks: Iterable[Any], visibility: Optional[str] = None) -> Collected:
+    return await collect_async(chunks, visibility, thread_id=THREAD_ID, run_id=TOP_LEVEL_RUN)
+
+
+mappers = pytest.mark.parametrize("collect", [_collect_sync, _collect_async], ids=["sync", "async"])
+
+
+# --- Assertions helpers -----------------------------------------------------
+
+_lane = lane_of
+_of_type = of_type
+
+
+def _only(events: List[BaseEvent], described: str = "event") -> BaseEvent:
+    assert len(events) == 1, f"expected exactly one {described}, got {len(events)}"
+    return events[0]
+
+
+def _one(events: List[BaseEvent], event_type: EventType) -> BaseEvent:
+    return _only(_of_type(events, event_type), str(event_type))
+
+
+def _terminals(events: List[BaseEvent]) -> List[str]:
+    return [str(e.type) for e in events if e.type in (EventType.RUN_FINISHED, EventType.RUN_ERROR)]
+
+
+# The field each closing event names its span by. Read through this rather than
+# through the first of two attributes that happens to be set: that reads a
+# renamed message_id as an absent one and falls through to the tool call id,
+# which is the comparison passing while nothing is compared.
+_SPAN_ID_FIELD = {
+    EventType.TEXT_MESSAGE_END: "message_id",
+    EventType.TOOL_CALL_END: "tool_call_id",
+}
+
+
+def _span_id(event: BaseEvent) -> Optional[str]:
+    """The id of the span an event closes, or None for an event that closes none."""
+    field = _SPAN_ID_FIELD.get(event.type)
+    return None if field is None else field_of(event, field)
+
+
+def _terminals_with_reason(events: List[BaseEvent]) -> List[tuple]:
+    """(terminal, message, code) per run terminal, in order.
+
+    One list for both terminals, so a run reported as finished where the client
+    had to be told it failed is a diff here rather than an absence somewhere
+    else. RUN_FINISHED declares neither field, so only the error terminal's are
+    read, and those are read as declared fields.
+    """
+    rows: List[tuple] = []
+    for event in events:
+        if event.type == EventType.RUN_ERROR:
+            rows.append((short_type(event), field_of(event, "message"), field_of(event, "code")))
+        elif event.type == EventType.RUN_FINISHED:
+            rows.append((short_type(event), None, None))
+    return rows
+
+
+# --- The failure path -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@mappers
+async def test_an_open_text_message_is_ended_when_the_source_stream_fails(collect):
+    events, error = await collect(_open_text_message_chunks("model connection dropped"))
+
+    assert_stream_contains(events, EventType.TEXT_MESSAGE_END)
+    started = _one(events, EventType.TEXT_MESSAGE_START)
+    ended = _one(events, EventType.TEXT_MESSAGE_END)
+    assert ended.message_id == started.message_id
+    # The close is the last thing on the wire, after the partial content.
+    assert [str(e.type) for e in events[-2:]] == [
+        str(EventType.TEXT_MESSAGE_CONTENT),
+        str(EventType.TEXT_MESSAGE_END),
+    ]
+    assert isinstance(error, _Boom) and str(error) == "model connection dropped"
+
+
+@pytest.mark.asyncio
+@mappers
+async def test_an_open_tool_call_is_ended_when_the_source_stream_fails(collect):
+    events, error = await collect(_open_tool_call_chunks("tool executor died"))
+
+    assert_stream_contains(events, EventType.TOOL_CALL_END)
+    # Ordered, so a call started or ended twice is a diff rather than a silence.
+    assert in_emitted_order(events, EventType.TOOL_CALL_START, "tool_call_id") == [("tc-search",)]
+    assert in_emitted_order(events, EventType.TOOL_CALL_END, "tool_call_id") == [("tc-search",)]
+    assert str(events[-1].type) == str(EventType.TOOL_CALL_END)
+    assert isinstance(error, _Boom) and str(error) == "tool executor died"
+
+
+# What a lane still open is told the run failed of. A failure carrying no text
+# of its own is described by the type that raised, which is the only thing left
+# to name it by: an empty message would leave the client a lane that errored for
+# no stated reason.
+_FAILURE_DESCRIPTIONS = [
+    pytest.param("member exploded mid-stream", "member exploded mid-stream", id="with_a_message"),
+    pytest.param("", "_Boom", id="with_no_message"),
+]
+
+
+@pytest.mark.asyncio
+@mappers
+@pytest.mark.parametrize("raised,described", _FAILURE_DESCRIPTIONS)
+async def test_a_member_lane_still_open_is_errored_when_the_source_stream_fails(collect, raised, described):
+    subagent_error = event_type_named("SUBAGENT_ERROR")
+    events, error = await collect(_open_member_lane_chunks(raised), attributed())
+
+    assert_stream_contains(events, subagent_error)
+    # The other open message is the leader's empty parent for the delegation call.
+    member_message = _only([e for e in _of_type(events, EventType.TEXT_MESSAGE_START) if _lane(e) == "run-scout"])
+
+    # The member's span closes, then the leader's delegation call, and the
+    # member's lane errors last: a terminal lands outside every span the stream
+    # had open, never inside the delegation call that spawned it.
+    assert [(str(e.type), _lane(e), _span_id(e)) for e in events[-3:]] == [
+        (str(EventType.TEXT_MESSAGE_END), "run-scout", member_message.message_id),
+        (str(EventType.TOOL_CALL_END), None, "tc-delegate-scout"),
+        (str(subagent_error), "run-scout", None),
+    ]
+
+    assert in_emitted_order(events, subagent_error, "subagent_run_id", "message", "code") == [
+        ("run-scout", described, None)
+    ]
+    # A lane that errored is not also reported as finished.
+    assert not _of_type(events, event_type_named("SUBAGENT_FINISHED"))
+    assert isinstance(error, _Boom) and str(error) == raised
+
+
+# Each stream with the visibility its own shape needs. Driving the two that
+# carry no member under ``attributed`` skipped them wholesale on a protocol
+# release without the lineage events, which the packaged extra still permits,
+# and neither has anything to do with member lanes.
+_DEAD_STREAMS = [
+    pytest.param(_open_text_message_chunks, lambda: None, id="text"),
+    pytest.param(_open_tool_call_chunks, lambda: SUBAGENT_VISIBILITY_INLINE, id="tool_call"),
+    pytest.param(_open_member_lane_chunks, attributed, id="member_lane"),
+]
+
+
+@pytest.mark.asyncio
+@mappers
+@pytest.mark.parametrize("chunk_factory,visibility", _DEAD_STREAMS)
+async def test_the_failure_path_emits_no_terminal_of_its_own(collect, chunk_factory, visibility):
+    # Built per case: a chunk list assembled at collection time would share one
+    # exception instance, and its traceback, across every case that uses it.
+    events, error = await collect(chunk_factory("boom"), visibility())
+
+    # The caller writes the run terminal, and nothing may follow one on the wire.
+    assert _terminals(events) == []
+    assert isinstance(error, _Boom)
+
+
+@pytest.mark.asyncio
+@mappers
+async def test_the_failure_propagates_unchanged(collect):
+    boom = _Boom("keep me")
+    events, error = await collect([RunStartedEvent(run_id=TOP_LEVEL_RUN), boom])
+
+    assert error is boom
+    assert _terminals(events) == []
+
+
+@pytest.mark.asyncio
+@mappers
+async def test_a_stream_that_does_not_fail_still_gets_exactly_one_terminal(collect):
+    events, error = await collect(
+        [RunStartedEvent(run_id=TOP_LEVEL_RUN), _content("all done", run_id=TOP_LEVEL_RUN)],
+        SUBAGENT_VISIBILITY_INLINE,
+    )
+
+    assert error is None
+    assert_stream_contains(events, EventType.RUN_FINISHED)
+    assert _terminals(events) == [str(EventType.RUN_FINISHED)]
+    assert str(events[-1].type) == str(EventType.RUN_FINISHED)
+    # The synthesized completion closes the open message, exactly as before.
+    assert _one(events, EventType.TEXT_MESSAGE_END).message_id == _one(events, EventType.TEXT_MESSAGE_START).message_id
+
+
+# --- A stream that stops on a member's own terminal -------------------------
+
+# A source stream can end on a subagent's terminal without the top-level entity
+# reporting one of its own. That terminal is then the only account of how the run
+# ended, and every visibility has to read it the same way: the default already
+# does, because it knows no member lanes.
+
+_TERMINAL_CASES = [
+    pytest.param(_member_failed, [("RUN_ERROR", "member exploded", "RuntimeError")], id="error"),
+    pytest.param(_member_finished, [("RUN_FINISHED", None, None)], id="completed"),
+]
+
+_MEMBER_TERMINALS = [pytest.param(_member_failed, id="error"), pytest.param(_member_finished, id="completed")]
+
+
+@pytest.mark.asyncio
+@mappers
+@visibilities
+@pytest.mark.parametrize("terminal,expected", _TERMINAL_CASES)
+async def test_a_stream_that_ends_on_a_members_terminal_reports_what_that_terminal_said(
+    collect, visibility, terminal, expected
+):
+    events, error = await collect(_ends_on_the_members_terminal_chunks(terminal()), visibility())
+
+    assert error is None, f"the source stream raised {error!r}"
+    assert _terminals_with_reason(events) == expected
+    # The terminal is the last thing on the wire, as it is on any other stream.
+    assert short_type(events[-1]) == expected[0][0]
+
+
+@pytest.mark.asyncio
+@mappers
+@visibilities
+@pytest.mark.parametrize("terminal", _MEMBER_TERMINALS)
+async def test_the_top_level_entitys_own_terminal_supersedes_a_members(collect, visibility, terminal):
+    """The member ended, the run went on and finished, so the run finished."""
+    events, error = await collect(_ends_on_the_members_terminal_chunks(terminal(), _team_finished()), visibility())
+
+    assert error is None, f"the source stream raised {error!r}"
+    assert _terminals_with_reason(events) == [("RUN_FINISHED", None, None)]
+
+
+@pytest.mark.asyncio
+@mappers
+@pytest.mark.parametrize(
+    "visibility",
+    [pytest.param(attributed, id="attributed"), pytest.param(lambda: SUBAGENT_VISIBILITY_HIDDEN, id="hidden")],
+)
+async def test_a_member_terminal_after_the_top_level_entitys_own_does_not_replace_it(collect, visibility):
+    """The run's own failure is what the client is told, whatever a member reports afterwards.
+
+    The default is not driven here: it reads every terminal as the run's, so the
+    last one on the stream wins there, which is the stream it has always emitted.
+    """
+    events, error = await collect(
+        _ends_on_the_members_terminal_chunks(_team_failed(), _member_finished()), visibility()
+    )
+
+    assert error is None, f"the source stream raised {error!r}"
+    assert _terminals_with_reason(events) == [("RUN_ERROR", "the team blew up", "RuntimeError")]
+
+
+@pytest.mark.asyncio
+@mappers
+@visibilities
+async def test_a_stream_that_ends_on_a_members_pause_still_prompts_the_client(collect, visibility):
+    """A pause is a terminal too, and no resume can get past a call nobody was shown."""
+    events, error = await collect(_ends_on_the_members_terminal_chunks(_member_paused()), visibility())
+
+    assert error is None, f"the source stream raised {error!r}"
+    assert _terminals_with_reason(events) == [("RUN_FINISHED", None, None)]
+    assert in_emitted_order(events, EventType.TOOL_CALL_START, "tool_call_id") == [
+        ("tc-delegate-scout",),
+        ("tc-member-confirm",),
+    ]
+    assert in_emitted_order(events, EventType.TOOL_CALL_ARGS, "tool_call_id", lambda e: json.loads(e.delta)) == [
+        ("tc-delegate-scout", {"member_id": "scout", "task": "scout the topic"}),
+        ("tc-member-confirm", {"to": "ops"}),
+    ]
+
+
+@pytest.mark.asyncio
+@mappers
+async def test_the_member_whose_failure_ended_the_run_still_owns_its_own_terminal(collect):
+    subagent_error = event_type_named("SUBAGENT_ERROR")
+    events, error = await collect(_ends_on_the_members_terminal_chunks(_member_failed()), attributed())
+
+    assert error is None, f"the source stream raised {error!r}"
+    assert_stream_contains(events, subagent_error)
+    assert in_emitted_order(events, subagent_error, "subagent_run_id", "message", "code") == [
+        ("run-scout", "member exploded", "RuntimeError")
+    ]
+    # The member's lane resolves first, then the run reports the same failure.
+    assert _terminals_with_reason(events) == [("RUN_ERROR", "member exploded", "RuntimeError")]
+
+
+@pytest.mark.asyncio
+@mappers
+async def test_hidden_still_reports_a_run_that_ended_on_a_member_failure(collect):
+    """Hidden withholds which member failed, never that the run failed."""
+    events, error = await collect(_ends_on_the_members_terminal_chunks(_member_failed()), SUBAGENT_VISIBILITY_HIDDEN)
+
+    assert error is None, f"the source stream raised {error!r}"
+    assert _terminals_with_reason(events) == [("RUN_ERROR", "member exploded", "RuntimeError")]
+    assert not [event for event in events if "SUBAGENT" in str(event.type)]
+    assert not [event for event in events if _lane(event) is not None]
+
+
+# --- Every terminal a member can end a stream on ----------------------------
+
+# The chunk types that stop a member, each with the chunk that reports it and
+# what the run terminal has to say when the stream ends there. The interface
+# splits them in two: a terminal ends the member's lane, and a withheld chunk
+# stops the member without ending it. Both halves are driven, one table each, so
+# a type added to either is a stream ending on it rather than a set that grew.
+
+_LINEAGE_RUN_TERMINAL = {
+    RunEvent.run_completed.value: (_member_finished, ("RUN_FINISHED", None, None)),
+    RunEvent.run_error.value: (_member_failed, ("RUN_ERROR", "member exploded", "RuntimeError")),
+    RunEvent.run_cancelled.value: (_member_cancelled, ("RUN_ERROR", "the operator stopped it", "cancelled")),
+}
+
+_LINEAGE_WITHHELD = {
+    RunEvent.run_paused.value: (_member_paused, ("RUN_FINISHED", None, None)),
+}
+
+_STOPS_A_SUBAGENT = {**_LINEAGE_RUN_TERMINAL, **_LINEAGE_WITHHELD}
+
+
+def test_every_chunk_that_stops_a_subagent_is_driven_here():
+    """Both halves of the set the stream reads, each against the table that drives it.
+
+    Which chunks stop a member decides how a stream ending on one is read: the
+    run terminal is built from that chunk rather than reported as a plain
+    completion. The interface unions its terminal table with its withheld set to
+    get there, so comparing the union against either half holds however the
+    other grows, and adding a withheld type would end a lane with nothing here
+    to say so. Each half is compared against the table this module drives, and
+    the union against the two together.
+    """
+    handled = set(handlers._SUBAGENT_TERMINAL_HANDLERS)
+    assert handled == set(_LINEAGE_RUN_TERMINAL), (
+        "the subagent terminals the mapper handles and the ones driven here have diverged: "
+        f"handled={sorted(handled)}, driven={sorted(_LINEAGE_RUN_TERMINAL)}"
+    )
+    withheld = set(handlers._SUBAGENT_WITHHELD_EVENTS)
+    assert withheld == set(_LINEAGE_WITHHELD), (
+        "the chunks the mapper withholds from a member's lane and the ones driven here have diverged: "
+        f"withheld={sorted(withheld)}, driven={sorted(_LINEAGE_WITHHELD)}"
+    )
+    assert not handled & withheld, (
+        f"these chunks both end a member's lane and are withheld from it: {sorted(handled & withheld)}"
+    )
+    assert set(handlers._SUBAGENT_RUN_ENDING_EVENTS) == set(_STOPS_A_SUBAGENT), (
+        "the chunks the stream reads as stopping a subagent are no longer the terminals plus the "
+        f"withheld ones: {sorted(handlers._SUBAGENT_RUN_ENDING_EVENTS)} against {sorted(_STOPS_A_SUBAGENT)}. "
+        "A stream ending on one it no longer reads reports the run finished after saying the subagent did not."
+    )
+
+
+@pytest.mark.asyncio
+@mappers
+@pytest.mark.parametrize(
+    "visibility",
+    [pytest.param(attributed, id="attributed"), pytest.param(lambda: SUBAGENT_VISIBILITY_HIDDEN, id="hidden")],
+)
+@pytest.mark.parametrize("normalized", sorted(_STOPS_A_SUBAGENT))
+async def test_a_lineage_stream_ending_on_a_member_terminal_reports_what_that_terminal_said(
+    collect, visibility, normalized
+):
+    """A chunk that stopped a member is the run's only account of how it ended.
+
+    Cancellation included, and a pause included: the run terminal is built from
+    whichever of them the stream ended on, and is the last thing on the wire.
+    """
+    terminal, expected = _STOPS_A_SUBAGENT[normalized]
+    events, error = await collect(_ends_on_the_members_terminal_chunks(terminal()), visibility())
+
+    assert error is None, f"the source stream raised {error!r}"
+    assert _terminals_with_reason(events) == [expected]
+    assert short_type(events[-1]) == expected[0]
+
+
+@pytest.mark.asyncio
+@mappers
+@visibilities
+async def test_a_run_terminal_promoted_from_a_member_carries_no_chunk_of_that_members_own(collect, visibility):
+    """The chunk names the member, its run and the run above it, so only the default embeds it.
+
+    Hidden spends the whole stream keeping that identity off the wire and then
+    logs that it withheld the failure, so shipping the member's own chunk in the
+    very next event undoes both. Attributed has the member on the wire already,
+    but the terminal is the run's and carries nothing of the member's. The
+    default is the stream from before member attribution existed, raw event and
+    all.
+    """
+    resolved = visibility()
+    events, error = await collect(_ends_on_the_members_terminal_chunks(_member_failed()), resolved)
+
+    assert error is None, f"the source stream raised {error!r}"
+    raw_event = field_of(_one(events, EventType.RUN_ERROR), "raw_event")
+    if resolved in (None, SUBAGENT_VISIBILITY_INLINE):
+        assert raw_event is not None, "the default stream no longer embeds the chunk it always did"
+        assert (raw_event.get("run_id"), raw_event.get("agent_id"), raw_event.get("parent_run_id")) == (
+            "run-scout",
+            "scout",
+            TOP_LEVEL_RUN,
+        )
+    else:
+        assert raw_event is None, f"a lineage terminal shipped the member's own chunk: {raw_event}"
+    # Either way the run says why it stopped.
+    assert _terminals_with_reason(events) == [("RUN_ERROR", "member exploded", "RuntimeError")]
+
+
+@pytest.mark.asyncio
+@mappers
+async def test_a_members_pause_that_becomes_the_run_terminal_stays_that_members(collect):
+    """The words and the pending call are the member's, so both go out on its lane."""
+    subagent_finished = event_type_named("SUBAGENT_FINISHED")
+    events, error = await collect(_ends_on_the_members_terminal_chunks(_member_paused_saying_something()), attributed())
+
+    assert error is None, f"the source stream raised {error!r}"
+    assert_stream_contains(events, subagent_finished)
+    assert in_emitted_order(events, EventType.TEXT_MESSAGE_CONTENT, "delta", _lane) == [
+        ("half a sen", "run-scout"),
+        ("I need approval to email ops.", "run-scout"),
+    ]
+    assert in_emitted_order(events, EventType.TOOL_CALL_START, "tool_call_id", _lane) == [
+        ("tc-delegate-scout", None),
+        ("tc-member-confirm", "run-scout"),
+    ]
+    # The call and the message carrying it name the same member.
+    lane_of_message = {
+        event.message_id: _lane(event)  # type: ignore[attr-defined]
+        for event in _of_type(events, EventType.TEXT_MESSAGE_START)
+    }
+    prompted = [e for e in _of_type(events, EventType.TOOL_CALL_START) if e.tool_call_id == "tc-member-confirm"]  # type: ignore[attr-defined]
+    assert [lane_of_message[e.parent_message_id] for e in prompted] == ["run-scout"]  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+@mappers
+async def test_hidden_does_not_stream_a_paused_members_words_as_the_runs_own_reply(collect):
+    """The pending call still reaches the client, because no resume gets past it.
+
+    Its words do not: nothing a member produced is sent as the run's own work,
+    and a prompt is not a licence to relabel the member's prose as the leader's.
+    """
+    events, error = await collect(
+        _ends_on_the_members_terminal_chunks(_member_paused_saying_something()), SUBAGENT_VISIBILITY_HIDDEN
+    )
+
+    assert error is None, f"the source stream raised {error!r}"
+    assert in_emitted_order(events, EventType.TOOL_CALL_START, "tool_call_id", _lane) == [
+        ("tc-delegate-scout", None),
+        ("tc-member-confirm", None),
+    ]
+    assert in_emitted_order(events, EventType.TEXT_MESSAGE_CONTENT, "delta") == []
+    assert not [event for event in events if _lane(event) is not None]
+
+
+# --- Abandonment ------------------------------------------------------------
+
+
+_UP_TO_OPEN_MESSAGE = [
+    str(EventType.RAW),
+    str(EventType.TEXT_MESSAGE_START),
+    str(EventType.TEXT_MESSAGE_CONTENT),
+]
+
+_AGEN_CLOSED = "closed"
+
+
+def _async_generator_state(generator: AsyncGenerator[Any, None]) -> str:
+    """Whether an async generator is closed, running, or still holding its frame.
+
+    ``inspect.getasyncgenstate`` and its ``AGEN_CLOSED`` constant are Python
+    3.12, and this package supports 3.9, so the state is read the way that
+    helper reads it: a closed async generator has dropped its frame. The sync
+    twin below keeps ``inspect.getgeneratorstate``, which has been there since
+    3.2.
+    """
+    if generator.ag_running:
+        return "running"
+    return _AGEN_CLOSED if generator.ag_frame is None else "still holding its frame"
+
+
+def _recorded_cleanups(monkeypatch) -> List[str]:
+    """A spy on the mapper's own cleanup, so its absence can be observed rather than assumed.
+
+    Collecting events up to the abandonment and inspecting the list afterwards
+    cannot see a cleanup: whatever the closed generator does next is not written
+    into any list the test still holds.
+    """
+    called: List[str] = []
+
+    def spy(state: StreamState, error_message: str) -> List[BaseEvent]:
+        called.append(error_message)
+        return []
+
+    monkeypatch.setattr(stream_module, "close_open_spans", spy)
+    return called
+
+
+def test_abandoning_the_sync_mapper_mid_message_emits_no_cleanup(monkeypatch):
+    """A consumer that walks away is not a failure: the client is gone, so nothing is written to it."""
+    cleanups = _recorded_cleanups(monkeypatch)
+    generator = stream_agno_response_as_agui_events(
+        sync_source(_open_text_message_chunks("never raised")), thread_id=THREAD_ID, run_id=TOP_LEVEL_RUN
+    )
+    seen = [next(generator) for _ in _UP_TO_OPEN_MESSAGE]
+
+    generator.close()
+    # A closed generator yields nothing ever, so draining it here would observe
+    # nothing an abandonment wrote. The spy is what observes the cleanup's
+    # absence; this pins that the close really left the generator closed rather
+    # than resuming it into one.
+    assert inspect.getgeneratorstate(generator) == inspect.GEN_CLOSED
+
+    assert cleanups == []
+    assert [str(e.type) for e in seen] == _UP_TO_OPEN_MESSAGE
+    assert_well_formed_stream(seen, exempt=[ABANDONED_MID_STREAM])
+
+
+@pytest.mark.asyncio
+async def test_abandoning_the_async_mapper_mid_message_emits_no_cleanup(monkeypatch):
+    cleanups = _recorded_cleanups(monkeypatch)
+    generator = async_stream_agno_response_as_agui_events(
+        async_source(_open_text_message_chunks("never raised")), thread_id=THREAD_ID, run_id=TOP_LEVEL_RUN
+    )
+    seen = [await generator.__anext__() for _ in _UP_TO_OPEN_MESSAGE]
+
+    await generator.aclose()
+    assert _async_generator_state(generator) == _AGEN_CLOSED
+
+    assert cleanups == []
+    assert [str(e.type) for e in seen] == _UP_TO_OPEN_MESSAGE
+    assert_well_formed_stream(seen, exempt=[ABANDONED_MID_STREAM])
+
+
+def _assert_the_abandoned_member_never_resolved(seen: List[BaseEvent], cleanups: List[str]) -> None:
+    assert cleanups == []
+    assert_stream_contains(seen, event_type_named("SUBAGENT_STARTED"))
+    assert not _of_type(seen, event_type_named("SUBAGENT_ERROR"))
+    assert not _of_type(seen, event_type_named("SUBAGENT_FINISHED"))
+    assert_well_formed_stream(seen, exempt=[ABANDONED_MID_STREAM, ABANDONED_WITH_A_MEMBER_STILL_OPEN])
+
+
+def test_abandoning_the_sync_mapper_inside_a_member_leaves_that_member_unterminated(monkeypatch):
+    """The member is announced and then abandoned, so its lane never resolves either."""
+    cleanups = _recorded_cleanups(monkeypatch)
+    generator = stream_agno_response_as_agui_events(
+        sync_source(_open_member_lane_chunks("never raised")),
+        thread_id=THREAD_ID,
+        run_id=TOP_LEVEL_RUN,
+        subagent_visibility=attributed(),
+    )
+    seen: List[BaseEvent] = []
+    for event in generator:
+        seen.append(event)
+        if event.type == EventType.TEXT_MESSAGE_CONTENT and _lane(event) == "run-scout":
+            break
+
+    generator.close()
+    assert inspect.getgeneratorstate(generator) == inspect.GEN_CLOSED
+
+    _assert_the_abandoned_member_never_resolved(seen, cleanups)
+
+
+@pytest.mark.asyncio
+async def test_abandoning_the_async_mapper_inside_a_member_leaves_that_member_unterminated(monkeypatch):
+    cleanups = _recorded_cleanups(monkeypatch)
+    generator = async_stream_agno_response_as_agui_events(
+        async_source(_open_member_lane_chunks("never raised")),
+        thread_id=THREAD_ID,
+        run_id=TOP_LEVEL_RUN,
+        subagent_visibility=attributed(),
+    )
+    seen: List[BaseEvent] = []
+    async for event in generator:
+        seen.append(event)
+        if event.type == EventType.TEXT_MESSAGE_CONTENT and _lane(event) == "run-scout":
+            break
+
+    await generator.aclose()
+    assert _async_generator_state(generator) == _AGEN_CLOSED
+
+    _assert_the_abandoned_member_never_resolved(seen, cleanups)
+
+
+# --- A cleanup that fails itself --------------------------------------------
+
+
+def _explodes(state, error_message: str) -> List[BaseEvent]:
+    raise RuntimeError("cleanup exploded")
+
+
+def test_a_failed_cleanup_does_not_replace_the_sync_failure_it_followed(monkeypatch, caplog):
+    """The failure the caller turns into the run terminal is the run's own, never the cleanup's."""
+    visibility = attributed()
+    monkeypatch.setattr(stream_module, "close_open_spans", _explodes)
+    events: List[BaseEvent] = []
+
+    with captured_agno_logs(caplog, "ERROR"):
+        with pytest.raises(_Boom, match="keep me"):
+            for event in stream_agno_response_as_agui_events(
+                sync_source(_open_member_lane_chunks("keep me")),
+                thread_id=THREAD_ID,
+                run_id=TOP_LEVEL_RUN,
+                subagent_visibility=visibility,
+            ):
+                events.append(event)
+
+    assert _terminals(events) == []
+    logged = "\n".join(r.message for r in caplog.records)
+    assert "keep me" in logged
+    assert "cleanup exploded" in logged
+
+
+@pytest.mark.asyncio
+async def test_a_failed_cleanup_does_not_replace_the_async_failure_it_followed(monkeypatch, caplog):
+    visibility = attributed()
+    monkeypatch.setattr(stream_module, "close_open_spans", _explodes)
+    events: List[BaseEvent] = []
+
+    with captured_agno_logs(caplog, "ERROR"):
+        with pytest.raises(_Boom, match="keep me"):
+            async for event in async_stream_agno_response_as_agui_events(
+                async_source(_open_member_lane_chunks("keep me")),
+                thread_id=THREAD_ID,
+                run_id=TOP_LEVEL_RUN,
+                subagent_visibility=visibility,
+            ):
+                events.append(event)
+
+    assert _terminals(events) == []
+    logged = "\n".join(r.message for r in caplog.records)
+    assert "keep me" in logged
+    assert "cleanup exploded" in logged
+
+
+@pytest.mark.asyncio
+@mappers
+async def test_the_cleanup_after_a_failed_stream_is_recorded(collect, caplog):
+    """The cleanup is invisible to the operator unless the failure it followed is logged."""
+    subagent_error = event_type_named("SUBAGENT_ERROR")
+    with captured_agno_logs(caplog, "ERROR"):
+        events, error = await collect(_open_member_lane_chunks("member exploded mid-stream"), attributed())
+
+    assert isinstance(error, _Boom)
+    assert_stream_contains(events, subagent_error)
+    logged = "\n".join(r.message for r in caplog.records)
+    assert "member exploded mid-stream" in logged
+
+
+@pytest.mark.asyncio
+@mappers
+async def test_the_recorded_mid_run_failure_names_its_type_and_carries_its_traceback(collect, caplog):
+    """The message alone says where a failure surfaced, never what raised or from where.
+
+    This package logs tracebacks only when they are switched on, so the one
+    record an operator gets for a dead stream has to carry both by itself.
+    """
+    with captured_agno_logs(caplog, "ERROR"):
+        events, error = await collect(_open_text_message_chunks("model connection dropped"))
+
+    assert isinstance(error, _Boom)
+    assert_stream_contains(events, EventType.TEXT_MESSAGE_END)
+    recorded = [record for record in caplog.records if "model connection dropped" in record.message]
+    assert len(recorded) == 1, f"the mid-run failure was recorded {len(recorded)} times"
+    assert "_Boom" in recorded[0].message, f"the record does not name what raised: {recorded[0].message}"
+    assert recorded[0].exc_info is not None, "the record carries no traceback, so the raise site is lost"
+
+
+# --- A failure that cannot describe itself ----------------------------------
+
+
+class _Unspeakable(RuntimeError):
+    """A failure whose own text cannot be rendered, as a proxy object's cannot."""
+
+    def __str__(self) -> str:
+        raise RuntimeError("str exploded")
+
+
+def _member_lane_open_when_an_unspeakable_failure_arrives() -> List[Any]:
+    member = _member_kwargs("scout", "run-scout")
+    return [
+        TeamRunStartedEvent(team_id="research-team", team_name="Research Team", run_id=TOP_LEVEL_RUN),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=_delegation()),
+        RunStartedEvent(**member),
+        _content("scouting so", **member),
+        _Unspeakable(),
+    ]
+
+
+@pytest.mark.asyncio
+@mappers
+async def test_a_failure_whose_text_cannot_be_read_still_closes_every_span_it_left_open(collect, caplog):
+    """Naming a failure must never become the failure.
+
+    The message and the record are both built from the exception before any
+    cleanup runs, so rendering one unguarded ends the stream with no record, no
+    closed span, no terminated member lane, and the run's real failure replaced
+    by whatever the attempt to describe it raised.
+    """
+    subagent_error = event_type_named("SUBAGENT_ERROR")
+    with captured_agno_logs(caplog, "WARNING"):
+        events, error = await collect(_member_lane_open_when_an_unspeakable_failure_arrives(), attributed())
+
+    assert type(error) is _Unspeakable, f"the run's own failure was replaced by {type(error).__name__}"
+    # The lane still resolves, under the name of what raised, since it has no
+    # text of its own to report.
+    assert_stream_contains(events, subagent_error)
+    assert in_emitted_order(events, subagent_error, "subagent_run_id", "message", "code") == [
+        ("run-scout", "_Unspeakable", None)
+    ]
+    assert_stream_contains(events, EventType.TEXT_MESSAGE_END)
+    assert in_emitted_order(events, EventType.TOOL_CALL_END, "tool_call_id") == [("tc-delegate-scout",)]
+    logged = "\n".join(record.message for record in caplog.records)
+    assert "_Unspeakable" in logged, f"the failure was not recorded at all: {logged}"

--- a/libs/agno/tests/unit/os/interfaces/test_agui_stream_invariants.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_stream_invariants.py
@@ -50,6 +50,7 @@ from ag_ui.core import (
     ToolCallStartEvent,
 )
 
+from . import agui_stream_invariants
 from .agui_stream_invariants import (
     A_CHILDS_TERMINAL_PRECEDES_ITS_PARENTS,
     A_SPAN_CLOSES_IN_THE_MEMBER_IT_OPENED_IN,
@@ -84,6 +85,8 @@ from .agui_stream_invariants import (
     RUN_EVENTS_ARE_NEVER_STAMPED,
     STATE_EVENTS_ARE_NEVER_STAMPED,
     TRAILING_OUTPUT_AFTER_A_MEMBER_TERMINAL,
+    ScriptedModel,
+    StreamInvariantCheckerFailure,
     announced_lane,
     announcement_fields_missing_from,
     assert_stream_carries_exactly,
@@ -845,7 +848,7 @@ def test_the_run_lifecycle_rule_refuses_a_stamped_terminal_as_well_as_a_stamped_
 
 
 def test_an_exemption_nobody_justified_is_refused():
-    with pytest.raises(AssertionError, match="not a justified stream invariant exemption"):
+    with pytest.raises(StreamInvariantCheckerFailure, match="not a justified stream invariant exemption"):
         assert_well_formed_stream([_run_finished()], exempt=["whatever_i_felt_like"])
 
 
@@ -854,8 +857,54 @@ def test_an_exemption_the_stream_does_not_need_is_refused():
     well_formed = [_text_start("m-1"), _text_content("m-1"), _text_end("m-1"), _run_finished()]
 
     assert_well_formed_stream(well_formed)
-    with pytest.raises(AssertionError, match="well formed without the abandoned_mid_stream exemption"):
+    with pytest.raises(StreamInvariantCheckerFailure, match="well formed without the abandoned_mid_stream exemption"):
         assert_well_formed_stream(well_formed, exempt=[ABANDONED_MID_STREAM])
+
+
+# --- A checker fault is not a verdict about the stream ------------------------
+
+# The reporter returns the violation a stream breaks, and callers read the
+# returned string as a fact about that stream. Anything the checker itself got
+# wrong therefore has to leave by a different door, or a bug in the harness is
+# filed against the subject it was checking.
+
+
+def test_a_stream_that_is_well_formed_is_reported_as_breaking_nothing():
+    well_formed = [_text_start("m-1"), _text_content("m-1"), _text_end("m-1"), _run_finished()]
+
+    assert stream_invariant_violation(well_formed) is None
+
+
+def test_an_exemption_nobody_justified_reaches_the_caller_as_a_checker_failure():
+    """Not a string: a harness typo returned as prose reads as the stream's violation."""
+    well_formed = [_text_start("m-1"), _text_content("m-1"), _text_end("m-1"), _run_finished()]
+
+    with pytest.raises(StreamInvariantCheckerFailure, match="not a justified stream invariant exemption"):
+        stream_invariant_violation(well_formed, exempt=["abandoned_mid_strem"])
+
+
+def test_an_exemption_the_stream_does_not_need_reaches_the_caller_as_a_checker_failure():
+    well_formed = [_text_start("m-1"), _text_content("m-1"), _text_end("m-1"), _run_finished()]
+
+    with pytest.raises(StreamInvariantCheckerFailure, match="well formed without the abandoned_mid_stream exemption"):
+        stream_invariant_violation(well_formed, exempt=[ABANDONED_MID_STREAM])
+
+
+def test_an_invariant_that_raises_rather_than_fails_is_reported_as_a_checker_failure(monkeypatch):
+    """A ``TypeError`` inside an invariant says the checker is broken, not the stream."""
+    well_formed = [_text_start("m-1"), _text_content("m-1"), _text_end("m-1"), _run_finished()]
+
+    def _raises_rather_than_asserting(events, *args, **kwargs):
+        raise TypeError("the invariant itself is broken")
+
+    monkeypatch.setattr(
+        agui_stream_invariants,
+        "_assert_nothing_follows_the_run_terminal",
+        _raises_rather_than_asserting,
+    )
+
+    with pytest.raises(StreamInvariantCheckerFailure, match="an invariant raised TypeError"):
+        stream_invariant_violation(well_formed)
 
 
 @pytest.mark.parametrize("exemption", list(EXEMPTIONS))
@@ -1128,3 +1177,22 @@ def test_the_encoder_check_reports_the_event_a_wire_would_die_on():
     assert [name for name, _ in encoding_failures([StateDeltaEvent(type=EventType.STATE_DELTA, delta=[refused])])] == [
         "STATE_DELTA"
     ]
+
+
+# --- The scripted model answers only what a test scripted ---------------------
+
+
+def test_the_scripted_model_serves_each_turn_it_was_given_in_order():
+    model = ScriptedModel("scripted", [("content", "first"), ("content", "second")])
+
+    assert [model.invoke().content, model.invoke().content] == ["first", "second"]
+
+
+def test_the_scripted_model_refuses_a_turn_it_was_never_given():
+    """Clamping to the last turn would answer, so the over-asking test would pass."""
+    model = ScriptedModel("scripted", [("content", "first"), ("content", "second")])
+    model.invoke()
+    model.invoke()
+
+    with pytest.raises(AssertionError, match="was asked for turn 2 of a 2-turn script"):
+        model.invoke()

--- a/libs/agno/tests/unit/os/interfaces/test_agui_stream_invariants.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_stream_invariants.py
@@ -1,0 +1,1130 @@
+"""Negative controls for the shared definition of a well-formed AG-UI stream.
+
+``agui_stream_invariants`` is what every AG-UI suite's collectors assert their
+streams against, so an invariant that has stopped biting takes the whole set
+down with it silently: every suite keeps passing, and nothing says the promise
+went unchecked. A reviewer demonstrated exactly that by deleting six of the
+individual checks with the suites still green.
+
+Each invariant therefore gets a stream here that breaks it and nothing else,
+built as a plain list of protocol events rather than by driving the interface,
+so a control cannot drift into agreeing with whatever the interface does today.
+The table below is keyed by the invariant each case is for, and one test asserts
+that every invariant the checker names is in it.
+
+An invariant reads its event types out of a table, so a case per invariant is
+not enough on its own: a row deleted from ``_SPAN_FAMILIES``, ``_CONTENT_IN_SPAN``,
+``_ANNOUNCEMENT_PARENT_LINKS``, the run terminal types, the run-level types, the
+member terminal types or the state types leaves the invariant biting on every
+other row and silently blind to that one. Every row therefore has a case whose
+reported violation can only come from that row.
+"""
+
+import logging
+from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple, cast
+
+import pytest
+
+pytest.importorskip("ag_ui", reason="ag_ui not installed")
+
+import ag_ui.core
+from ag_ui.core import (
+    BaseEvent,
+    EventType,
+    ReasoningEndEvent,
+    ReasoningMessageContentEvent,
+    ReasoningMessageEndEvent,
+    ReasoningMessageStartEvent,
+    ReasoningStartEvent,
+    RunErrorEvent,
+    RunFinishedEvent,
+    RunStartedEvent,
+    StateDeltaEvent,
+    StateSnapshotEvent,
+    TextMessageContentEvent,
+    TextMessageEndEvent,
+    TextMessageStartEvent,
+    ToolCallArgsEvent,
+    ToolCallEndEvent,
+    ToolCallResultEvent,
+    ToolCallStartEvent,
+)
+
+from .agui_stream_invariants import (
+    A_CHILDS_TERMINAL_PRECEDES_ITS_PARENTS,
+    A_SPAN_CLOSES_IN_THE_MEMBER_IT_OPENED_IN,
+    A_TOOL_CALL_SITS_IN_ITS_PARENT_MESSAGES_MEMBER,
+    A_TOOL_RESULT_CARRIES_ITS_CALLS_MEMBER,
+    ABANDONED_MID_STREAM,
+    ABANDONED_WITH_A_MEMBER_STILL_OPEN,
+    AGNO_LOGGER_NAMES,
+    AN_ANNOUNCED_PARENT_PRECEDES_ITS_CHILD,
+    ATTRIBUTED_IS_SERVABLE,
+    CONTENT_CARRIES_ITS_SPANS_MEMBER,
+    CONTENT_LANDS_INSIDE_ITS_SPAN,
+    EVERY_ANNOUNCED_MEMBER_TERMINATES,
+    EVERY_ANNOUNCED_PARENT_IS_ANNOUNCED_TOO,
+    EVERY_ANNOUNCED_PARENT_LINK_RESOLVES,
+    EVERY_SPAN_CLOSES,
+    EVERY_STAMP_NAMES_AN_ANNOUNCED_MEMBER,
+    EVERY_TOOL_CALL_PARENT_MESSAGE_WAS_OPENED,
+    EVERY_TOOL_RESULT_FOLLOWS_ITS_CALLS_END,
+    EVERY_TOOL_RESULT_NAMES_A_STARTED_CALL,
+    EXEMPTIONS,
+    INVARIANTS,
+    LINEAGE_ANNOUNCEMENT_FIELDS_READ_HERE,
+    LINEAGE_EVENTS_PROTOCOL_FLOOR,
+    NO_MEMBER_IS_ANNOUNCED_TWICE,
+    NO_SPAN_CLOSES_BEFORE_IT_OPENS,
+    NO_SPAN_CLOSES_TWICE,
+    NO_SPAN_CLOSES_UNOPENED,
+    NO_SPAN_OPENS_TWICE,
+    NOTHING_CARRIES_A_MEMBER_AFTER_ITS_TERMINAL,
+    ONE_RUN_TERMINAL_AND_NOTHING_AFTER_IT,
+    RUN_EVENTS_ARE_NEVER_STAMPED,
+    STATE_EVENTS_ARE_NEVER_STAMPED,
+    TRAILING_OUTPUT_AFTER_A_MEMBER_TERMINAL,
+    announced_lane,
+    announcement_fields_missing_from,
+    assert_stream_carries_exactly,
+    assert_stream_contains,
+    assert_well_formed_stream,
+    captured_agno_logs,
+    circular,
+    encoding_failures,
+    event_type_named,
+    exemption_waives,
+    field_of,
+    in_emitted_order,
+    installed_protocol_release,
+    lineage_announcement_fields_missing,
+    require_lineage_events,
+    stream_invariant_violation,
+)
+
+THREAD_ID = "invariant-session"
+RUN_ID = "invariant-run"
+
+
+# --- Building one event at a time -------------------------------------------
+
+
+def _stamped(event: BaseEvent, lane: Optional[str]) -> BaseEvent:
+    """One event carrying a member lane, set directly rather than by the interface.
+
+    The protocol models accept extra attributes, so this reaches even an event
+    type the interface refuses to attribute, which is what the state-event
+    control needs.
+    """
+    if lane is not None:
+        setattr(event, "subagent_run_id", lane)
+    return event
+
+
+def _text_start(message_id: str, lane: Optional[str] = None) -> BaseEvent:
+    return _stamped(
+        TextMessageStartEvent(type=EventType.TEXT_MESSAGE_START, message_id=message_id, role="assistant"), lane
+    )
+
+
+def _text_content(message_id: str, delta: str = "hello", lane: Optional[str] = None) -> BaseEvent:
+    return _stamped(
+        TextMessageContentEvent(type=EventType.TEXT_MESSAGE_CONTENT, message_id=message_id, delta=delta), lane
+    )
+
+
+def _text_end(message_id: str, lane: Optional[str] = None) -> BaseEvent:
+    return _stamped(TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=message_id), lane)
+
+
+def _tool_start(tool_call_id: str, lane: Optional[str] = None, parent_message_id: Optional[str] = None) -> BaseEvent:
+    return _stamped(
+        ToolCallStartEvent(
+            type=EventType.TOOL_CALL_START,
+            tool_call_id=tool_call_id,
+            tool_call_name="do_it",
+            parent_message_id=parent_message_id,
+        ),
+        lane,
+    )
+
+
+def _tool_args(tool_call_id: str, delta: str = "{}", lane: Optional[str] = None) -> BaseEvent:
+    return _stamped(ToolCallArgsEvent(type=EventType.TOOL_CALL_ARGS, tool_call_id=tool_call_id, delta=delta), lane)
+
+
+def _tool_end(tool_call_id: str, lane: Optional[str] = None) -> BaseEvent:
+    return _stamped(ToolCallEndEvent(type=EventType.TOOL_CALL_END, tool_call_id=tool_call_id), lane)
+
+
+def _tool_result(tool_call_id: str, lane: Optional[str] = None) -> BaseEvent:
+    return _stamped(
+        ToolCallResultEvent(
+            type=EventType.TOOL_CALL_RESULT,
+            tool_call_id=tool_call_id,
+            message_id=tool_call_id,
+            content="done",
+            role="tool",
+        ),
+        lane,
+    )
+
+
+def _reasoning_start(message_id: str, lane: Optional[str] = None) -> BaseEvent:
+    return _stamped(ReasoningStartEvent(type=EventType.REASONING_START, message_id=message_id), lane)
+
+
+def _reasoning_end(message_id: str, lane: Optional[str] = None) -> BaseEvent:
+    return _stamped(ReasoningEndEvent(type=EventType.REASONING_END, message_id=message_id), lane)
+
+
+def _reasoning_message_start(message_id: str, lane: Optional[str] = None) -> BaseEvent:
+    return _stamped(
+        ReasoningMessageStartEvent(type=EventType.REASONING_MESSAGE_START, message_id=message_id, role="reasoning"),
+        lane,
+    )
+
+
+def _reasoning_message_content(message_id: str, delta: str = "thinking", lane: Optional[str] = None) -> BaseEvent:
+    return _stamped(
+        ReasoningMessageContentEvent(type=EventType.REASONING_MESSAGE_CONTENT, message_id=message_id, delta=delta),
+        lane,
+    )
+
+
+def _reasoning_message_end(message_id: str, lane: Optional[str] = None) -> BaseEvent:
+    return _stamped(ReasoningMessageEndEvent(type=EventType.REASONING_MESSAGE_END, message_id=message_id), lane)
+
+
+def _state_delta(lane: Optional[str] = None) -> BaseEvent:
+    return _stamped(
+        StateDeltaEvent(type=EventType.STATE_DELTA, delta=[{"op": "replace", "path": "/approved", "value": True}]),
+        lane,
+    )
+
+
+def _state_snapshot(lane: Optional[str] = None) -> BaseEvent:
+    return _stamped(StateSnapshotEvent(type=EventType.STATE_SNAPSHOT, snapshot={"approved": True}), lane)
+
+
+def _run_started(lane: Optional[str] = None) -> BaseEvent:
+    return _stamped(RunStartedEvent(type=EventType.RUN_STARTED, thread_id=THREAD_ID, run_id=RUN_ID), lane)
+
+
+def _run_finished(lane: Optional[str] = None) -> BaseEvent:
+    return _stamped(RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id=THREAD_ID, run_id=RUN_ID), lane)
+
+
+def _run_error(lane: Optional[str] = None) -> BaseEvent:
+    return _stamped(RunErrorEvent(type=EventType.RUN_ERROR, message="the run failed"), lane)
+
+
+def _lineage_event(class_name: str, **fields: Any) -> BaseEvent:
+    """One SUBAGENT_* event, skipping on a release that defines none.
+
+    The class is reached by name off the installed module and its event type
+    off the class itself. Naming ``EventType.SUBAGENT_*`` in a caller would not
+    do: the argument is evaluated before this function is entered, so the skip
+    below never runs and the case fails instead on a release the packaged extra
+    still permits.
+    """
+    require_lineage_events()
+    event_class = getattr(ag_ui.core, class_name)
+    return event_class(**fields)
+
+
+def _announced(
+    lane: str,
+    parent: Optional[str] = None,
+    parent_tool_call_id: Optional[str] = None,
+    parent_message_id: Optional[str] = None,
+) -> BaseEvent:
+    return _lineage_event(
+        "SubagentStartedEvent",
+        subagent_run_id=lane,
+        name=lane.capitalize(),
+        parent_subagent_run_id=parent,
+        parent_tool_call_id=parent_tool_call_id,
+        parent_message_id=parent_message_id,
+    )
+
+
+def _member_finished(lane: str) -> BaseEvent:
+    return _lineage_event("SubagentFinishedEvent", subagent_run_id=lane)
+
+
+def _member_errored(lane: str) -> BaseEvent:
+    return _lineage_event("SubagentErrorEvent", subagent_run_id=lane, message="the member failed")
+
+
+# --- One stream per invariant ------------------------------------------------
+
+
+class Control(NamedTuple):
+    """One stream that breaks exactly one invariant, and how it is reported."""
+
+    invariant: str
+    case: str
+    # Built when the case runs, so a member case skips rather than failing on a
+    # protocol release without the lineage events.
+    build: Callable[[], List[BaseEvent]]
+    # Part of what the checker says. Enough to tell this violation from every
+    # other one the same stream could plausibly break.
+    reported: str
+
+
+_CONTROLS: Tuple[Control, ...] = (
+    # Each of these opens twice and closes once, so the second open is the only
+    # thing wrong with the stream: opening and closing twice would break the
+    # duplicate-close promise below as well.
+    Control(
+        NO_SPAN_OPENS_TWICE,
+        "one message id opened twice",
+        lambda: [_text_start("m-1"), _text_start("m-1"), _text_end("m-1"), _run_finished()],
+        "text message ids opened more than once: ['m-1']",
+    ),
+    Control(
+        NO_SPAN_OPENS_TWICE,
+        "one tool call id opened twice",
+        lambda: [_tool_start("tc-1"), _tool_start("tc-1"), _tool_end("tc-1"), _run_finished()],
+        "tool call ids opened more than once: ['tc-1']",
+    ),
+    Control(
+        NO_SPAN_OPENS_TWICE,
+        "one reasoning span opened twice",
+        lambda: [
+            _reasoning_start("r-1"),
+            _reasoning_start("r-1"),
+            _reasoning_end("r-1"),
+            _run_finished(),
+        ],
+        "reasoning ids opened more than once: ['r-1']",
+    ),
+    Control(
+        NO_SPAN_CLOSES_TWICE,
+        "one message closed twice",
+        # A second end for an id the stream did open. Counting the closes
+        # against the opens nets this to zero and reports nothing, and reporting
+        # the leftover close as a span that never opened names the wrong fault.
+        lambda: [_text_start("m-1"), _text_end("m-1"), _text_end("m-1"), _run_finished()],
+        "text message ids closed more than once: ['m-1']",
+    ),
+    Control(
+        NO_SPAN_CLOSES_UNOPENED,
+        "a message closed that never opened",
+        lambda: [_text_end("m-ghost"), _run_finished()],
+        "text message ids closed without ever being opened: ['m-ghost']",
+    ),
+    Control(
+        EVERY_SPAN_CLOSES,
+        "a tool call left open at the run terminal",
+        lambda: [_text_start("m-1"), _text_content("m-1"), _text_end("m-1"), _tool_start("tc-1"), _run_finished()],
+        "tool call ids opened and never closed: ['tc-1']",
+    ),
+    Control(
+        NO_SPAN_CLOSES_BEFORE_IT_OPENS,
+        "a reasoning message closed before it opened",
+        lambda: [
+            _reasoning_message_end("r-1"),
+            _reasoning_message_start("r-1"),
+            _run_finished(),
+        ],
+        "reasoning message r-1 was closed before it opened",
+    ),
+    Control(
+        CONTENT_LANDS_INSIDE_ITS_SPAN,
+        "a delta after its message ended",
+        lambda: [_text_start("m-1"), _text_end("m-1"), _text_content("m-1"), _run_finished()],
+        "text message content at index 2 names m-1, whose TEXT_MESSAGE_END already went out",
+    ),
+    Control(
+        CONTENT_LANDS_INSIDE_ITS_SPAN,
+        "tool arguments for a call that never started",
+        lambda: [_tool_args("tc-ghost"), _run_finished()],
+        "tool call arguments at index 0 names tc-ghost, which no earlier TOOL_CALL_START opened",
+    ),
+    Control(
+        CONTENT_LANDS_INSIDE_ITS_SPAN,
+        "a reasoning delta after its reasoning message ended",
+        lambda: [
+            _reasoning_message_start("r-1"),
+            _reasoning_message_end("r-1"),
+            _reasoning_message_content("r-1"),
+            _run_finished(),
+        ],
+        "reasoning content at index 2 names r-1, whose REASONING_MESSAGE_END already went out",
+    ),
+    Control(
+        CONTENT_CARRIES_ITS_SPANS_MEMBER,
+        "one member's delta inside another member's message",
+        lambda: [
+            _announced("run-alpha"),
+            _announced("run-beta"),
+            _text_start("m-1", lane="run-alpha"),
+            _text_content("m-1", lane="run-beta"),
+            _text_end("m-1", lane="run-alpha"),
+            _member_finished("run-alpha"),
+            _member_finished("run-beta"),
+            _run_finished(),
+        ],
+        "text message content for m-1 is stamped with member run-beta, while the "
+        "TEXT_MESSAGE_START that opened it named run-alpha",
+    ),
+    Control(
+        A_SPAN_CLOSES_IN_THE_MEMBER_IT_OPENED_IN,
+        "one member's message closed in another member",
+        lambda: [
+            _announced("run-alpha"),
+            _announced("run-beta"),
+            _text_start("m-1", lane="run-alpha"),
+            _text_end("m-1", lane="run-beta"),
+            _member_finished("run-alpha"),
+            _member_finished("run-beta"),
+            _run_finished(),
+        ],
+        "the TEXT_MESSAGE_END for text message m-1 is stamped with member run-beta, while the "
+        "TEXT_MESSAGE_START that opened it named run-alpha",
+    ),
+    Control(
+        A_SPAN_CLOSES_IN_THE_MEMBER_IT_OPENED_IN,
+        "a member's tool call closed with no member at all",
+        lambda: [
+            _announced("run-alpha"),
+            _tool_start("tc-1", lane="run-alpha"),
+            _tool_end("tc-1"),
+            _member_finished("run-alpha"),
+            _run_finished(),
+        ],
+        "the TOOL_CALL_END for tool call tc-1 is stamped with member None, while the "
+        "TOOL_CALL_START that opened it named run-alpha",
+    ),
+    Control(
+        EVERY_TOOL_CALL_PARENT_MESSAGE_WAS_OPENED,
+        "a tool call hung off a message this stream never opened",
+        lambda: [_tool_start("tc-1", parent_message_id="m-ghost"), _tool_end("tc-1"), _run_finished()],
+        "tool call tc-1 names parent message m-ghost, which no TEXT_MESSAGE_START in this stream opened",
+    ),
+    Control(
+        A_TOOL_CALL_SITS_IN_ITS_PARENT_MESSAGES_MEMBER,
+        "a member's tool call hung off a message attributed to nobody",
+        lambda: [
+            _announced("run-alpha"),
+            _text_start("m-1"),
+            _text_end("m-1"),
+            _tool_start("tc-1", lane="run-alpha", parent_message_id="m-1"),
+            _tool_end("tc-1", lane="run-alpha"),
+            _member_finished("run-alpha"),
+            _run_finished(),
+        ],
+        "tool call tc-1 is stamped with member run-alpha, while the message m-1 it names as its "
+        "parent was opened in member None",
+    ),
+    Control(
+        A_TOOL_CALL_SITS_IN_ITS_PARENT_MESSAGES_MEMBER,
+        "an unattributed tool call hung off a member's message",
+        lambda: [
+            _announced("run-alpha"),
+            _text_start("m-1", lane="run-alpha"),
+            _text_end("m-1", lane="run-alpha"),
+            _tool_start("tc-1", parent_message_id="m-1"),
+            _tool_end("tc-1"),
+            _member_finished("run-alpha"),
+            _run_finished(),
+        ],
+        "tool call tc-1 is stamped with member None, while the message m-1 it names as its "
+        "parent was opened in member run-alpha",
+    ),
+    Control(
+        A_TOOL_CALL_SITS_IN_ITS_PARENT_MESSAGES_MEMBER,
+        "one member's tool call hung off another member's message",
+        lambda: [
+            _announced("run-alpha"),
+            _announced("run-beta"),
+            _text_start("m-1", lane="run-alpha"),
+            _text_end("m-1", lane="run-alpha"),
+            _tool_start("tc-1", lane="run-beta", parent_message_id="m-1"),
+            _tool_end("tc-1", lane="run-beta"),
+            _member_finished("run-alpha"),
+            _member_finished("run-beta"),
+            _run_finished(),
+        ],
+        "tool call tc-1 is stamped with member run-beta, while the message m-1 it names as its "
+        "parent was opened in member run-alpha",
+    ),
+    Control(
+        EVERY_TOOL_RESULT_NAMES_A_STARTED_CALL,
+        "a result for a call the client never saw start",
+        lambda: [_tool_result("tc-ghost"), _run_finished()],
+        "tool call results name calls no TOOL_CALL_START opened: ['tc-ghost']",
+    ),
+    Control(
+        EVERY_TOOL_RESULT_NAMES_A_STARTED_CALL,
+        "a result ahead of its own call's start",
+        lambda: [_tool_result("tc-1"), _tool_start("tc-1"), _tool_end("tc-1"), _run_finished()],
+        "the result for tool call tc-1 went out at index 0, ahead of the TOOL_CALL_START that opened it at index 1",
+    ),
+    Control(
+        EVERY_TOOL_RESULT_FOLLOWS_ITS_CALLS_END,
+        "a result delivered while its own call was still open",
+        lambda: [
+            _tool_start("tc-1"),
+            _tool_args("tc-1"),
+            _tool_result("tc-1"),
+            _tool_end("tc-1"),
+            _run_finished(),
+        ],
+        "the result for tool call tc-1 went out at index 2, inside the call's own span: "
+        "the TOOL_CALL_END that closed it is at index 3",
+    ),
+    Control(
+        A_TOOL_RESULT_CARRIES_ITS_CALLS_MEMBER,
+        "one member's tool result against another member's call",
+        lambda: [
+            _announced("run-alpha"),
+            _announced("run-beta"),
+            _tool_start("tc-1", lane="run-alpha"),
+            _tool_end("tc-1", lane="run-alpha"),
+            _tool_result("tc-1", lane="run-beta"),
+            _member_finished("run-alpha"),
+            _member_finished("run-beta"),
+            _run_finished(),
+        ],
+        "the result for tool call tc-1 is stamped with member run-beta, while the "
+        "TOOL_CALL_START that opened it named run-alpha",
+    ),
+    Control(
+        ONE_RUN_TERMINAL_AND_NOTHING_AFTER_IT,
+        "two run terminals",
+        lambda: [_run_finished(), _run_finished()],
+        "a run carries at most one terminal",
+    ),
+    Control(
+        ONE_RUN_TERMINAL_AND_NOTHING_AFTER_IT,
+        "an event after the run terminal",
+        lambda: [_run_finished(), _text_start("m-1"), _text_end("m-1")],
+        "events followed the run terminal:",
+    ),
+    Control(
+        ONE_RUN_TERMINAL_AND_NOTHING_AFTER_IT,
+        "an event after the run error",
+        lambda: [_run_error(), _text_start("m-1"), _text_end("m-1")],
+        "events followed the run terminal:",
+    ),
+    Control(
+        ONE_RUN_TERMINAL_AND_NOTHING_AFTER_IT,
+        "a run announced as started and never ended",
+        lambda: [_run_started(), _text_start("m-1"), _text_end("m-1")],
+        "this stream carries 1 RUN_STARTED and no terminal",
+    ),
+    Control(
+        EVERY_STAMP_NAMES_AN_ANNOUNCED_MEMBER,
+        "a stamp naming a member nothing announced",
+        lambda: [
+            _text_start("m-1", lane="run-ghost"),
+            _text_end("m-1", lane="run-ghost"),
+            _run_finished(),
+        ],
+        "is stamped with member run-ghost, which no earlier announcement named",
+    ),
+    Control(
+        NO_MEMBER_IS_ANNOUNCED_TWICE,
+        "one member announced twice",
+        lambda: [
+            _announced("run-alpha"),
+            _announced("run-alpha"),
+            _member_finished("run-alpha"),
+            _run_finished(),
+        ],
+        "member run-alpha was announced more than once",
+    ),
+    Control(
+        EVERY_ANNOUNCED_PARENT_IS_ANNOUNCED_TOO,
+        "a parent link naming a member nothing announces",
+        lambda: [
+            _announced("run-child", parent="run-ghost"),
+            _member_finished("run-child"),
+            _run_finished(),
+        ],
+        "member run-child names parent run-ghost, which this stream never announces",
+    ),
+    Control(
+        AN_ANNOUNCED_PARENT_PRECEDES_ITS_CHILD,
+        "a parent link naming a member announced further down the stream",
+        lambda: [
+            _announced("run-child", parent="run-parent"),
+            _announced("run-parent"),
+            _member_finished("run-child"),
+            _member_finished("run-parent"),
+            _run_finished(),
+        ],
+        "member run-child announced at index 0 names parent run-parent, which this stream does not "
+        "announce until index 1",
+    ),
+    Control(
+        EVERY_ANNOUNCED_PARENT_LINK_RESOLVES,
+        "a member announced under a delegating call this stream never carried",
+        lambda: [
+            _announced("run-alpha", parent_tool_call_id="tc-ghost"),
+            _member_finished("run-alpha"),
+            _run_finished(),
+        ],
+        "member run-alpha names parent_tool_call_id tc-ghost, which no TOOL_CALL_START in this stream carries",
+    ),
+    Control(
+        EVERY_ANNOUNCED_PARENT_LINK_RESOLVES,
+        "a member announced under a message this stream never opened",
+        lambda: [
+            _announced("run-alpha", parent_message_id="m-ghost"),
+            _member_finished("run-alpha"),
+            _run_finished(),
+        ],
+        "member run-alpha names parent_message_id m-ghost, which no TEXT_MESSAGE_START in this stream carries",
+    ),
+    Control(
+        EVERY_ANNOUNCED_MEMBER_TERMINATES,
+        "a member announced and never terminated",
+        lambda: [_announced("run-alpha"), _run_finished()],
+        "member run-alpha owns 0 terminals, expected exactly one",
+    ),
+    # A member owning two terminals is not in this table: a second terminal is
+    # itself an event carrying that member after the first, so the stream breaks
+    # what-follows-a-terminal as well and cannot be narrowed to one promise. It
+    # is held to the count by the two exemption tests below, under each of the
+    # waivers that could otherwise let a second terminal through.
+    Control(
+        NOTHING_CARRIES_A_MEMBER_AFTER_ITS_TERMINAL,
+        "output stamped with a member the stream already closed",
+        lambda: [
+            _announced("run-alpha"),
+            _member_finished("run-alpha"),
+            _text_start("m-1", lane="run-alpha"),
+            _text_end("m-1", lane="run-alpha"),
+            _run_finished(),
+        ],
+        "events carrying member run-alpha followed its terminal",
+    ),
+    Control(
+        NOTHING_CARRIES_A_MEMBER_AFTER_ITS_TERMINAL,
+        "output stamped with a member the stream already errored",
+        lambda: [
+            _announced("run-alpha"),
+            _member_errored("run-alpha"),
+            _text_start("m-1", lane="run-alpha"),
+            _text_end("m-1", lane="run-alpha"),
+            _run_finished(),
+        ],
+        "events carrying member run-alpha followed its terminal",
+    ),
+    Control(
+        A_CHILDS_TERMINAL_PRECEDES_ITS_PARENTS,
+        "a parent terminating before its child",
+        lambda: [
+            _announced("run-parent"),
+            _announced("run-child", parent="run-parent"),
+            _member_finished("run-parent"),
+            _member_finished("run-child"),
+            _run_finished(),
+        ],
+        "member run-child terminated after its parent run-parent",
+    ),
+    Control(
+        RUN_EVENTS_ARE_NEVER_STAMPED,
+        "a run start stamped with the member the run happened to begin in",
+        lambda: [
+            _announced("run-alpha"),
+            _run_started(lane="run-alpha"),
+            _member_finished("run-alpha"),
+            _run_finished(),
+        ],
+        "run lifecycle events carry a member lane: [('RUN_STARTED', 'run-alpha')]",
+    ),
+    Control(
+        RUN_EVENTS_ARE_NEVER_STAMPED,
+        "a run start stamped with an empty lane",
+        # An empty lane is a stamp a client filters on like any other, so this
+        # check reads presence rather than truth, as the state one does.
+        lambda: [
+            _announced(""),
+            _run_started(lane=""),
+            _member_finished(""),
+            _run_finished(),
+        ],
+        "run lifecycle events carry a member lane: [('RUN_STARTED', '')]",
+    ),
+    Control(
+        STATE_EVENTS_ARE_NEVER_STAMPED,
+        "a state delta stamped with the member that caused it",
+        lambda: [
+            _announced("run-alpha"),
+            _state_delta(lane="run-alpha"),
+            _member_finished("run-alpha"),
+            _run_finished(),
+        ],
+        "state events carry a member lane: [('STATE_DELTA', 'run-alpha')]",
+    ),
+    Control(
+        STATE_EVENTS_ARE_NEVER_STAMPED,
+        "a state snapshot stamped with the member that caused it",
+        lambda: [
+            _announced("run-alpha"),
+            _state_snapshot(lane="run-alpha"),
+            _member_finished("run-alpha"),
+            _run_finished(),
+        ],
+        "state events carry a member lane: [('STATE_SNAPSHOT', 'run-alpha')]",
+    ),
+    Control(
+        STATE_EVENTS_ARE_NEVER_STAMPED,
+        "a state delta stamped with an empty lane",
+        # An empty lane is a stamp a client filters on like any other, so the
+        # check has to read presence rather than truth.
+        lambda: [
+            _announced(""),
+            _state_delta(lane=""),
+            _member_finished(""),
+            _run_finished(),
+        ],
+        "state events carry a member lane: [('STATE_DELTA', '')]",
+    ),
+)
+
+_CASES = [pytest.param(control, id=f"{control.invariant}-{control.case}") for control in _CONTROLS]
+
+
+@pytest.mark.parametrize("control", _CASES)
+def test_a_stream_breaking_one_invariant_is_reported_as_breaking_it(control):
+    events = control.build()
+
+    violation = stream_invariant_violation(events)
+
+    assert violation is not None, (
+        f"a stream that breaks {control.invariant} passed as well formed, so nothing checks that promise"
+    )
+    assert control.reported in violation, (
+        f"a stream that breaks {control.invariant} was reported as something else: {violation}"
+    )
+
+
+def test_every_invariant_the_checker_names_has_a_stream_that_breaks_it():
+    """An invariant with no control is one whose deletion nothing would notice."""
+    covered = {control.invariant for control in _CONTROLS}
+    assert covered == set(INVARIANTS), (
+        f"invariants with no negative control: {sorted(set(INVARIANTS) - covered)}; "
+        f"controls for invariants the checker does not name: {sorted(covered - set(INVARIANTS))}"
+    )
+
+
+# --- What the two pair rules have to let through ------------------------------
+
+# The controls above are each rule's rejecting half. A rule that rejected every
+# pair would satisfy them and fail every real stream, so the agreeing shapes are
+# stated here as well.
+
+
+def test_a_tool_call_and_its_parent_message_agreeing_on_a_member_is_well_formed():
+    """One agreeing shape: a single member owning both the call and its parent message."""
+    in_one_member = [
+        _announced("run-alpha"),
+        _text_start("m-1", lane="run-alpha"),
+        _text_end("m-1", lane="run-alpha"),
+        _tool_start("tc-1", lane="run-alpha", parent_message_id="m-1"),
+        _tool_end("tc-1", lane="run-alpha"),
+        _member_finished("run-alpha"),
+        _run_finished(),
+    ]
+
+    assert_well_formed_stream(in_one_member)
+
+
+def test_a_tool_call_and_its_parent_message_both_unattributed_is_well_formed():
+    """The other agreeing shape: neither the call nor the message it hangs off attributed.
+
+    Its own test rather than a second stream inside the member one above, which
+    cannot be built at all on a protocol release without the lineage events: this
+    shape would skip along with it while needing none of them.
+    """
+    at_the_top_level = [
+        _text_start("m-1"),
+        _text_end("m-1"),
+        _tool_start("tc-1", parent_message_id="m-1"),
+        _tool_end("tc-1"),
+        _run_finished(),
+    ]
+
+    assert_well_formed_stream(at_the_top_level)
+
+
+def test_an_announced_parent_ahead_of_its_child_is_well_formed():
+    """The agreeing half of the parent-ordering rule: the parent announced first."""
+    ordered = [
+        _announced("run-parent"),
+        _announced("run-child", parent="run-parent"),
+        _member_finished("run-child"),
+        _member_finished("run-parent"),
+        _run_finished(),
+    ]
+
+    assert_well_formed_stream(ordered)
+
+
+def test_a_tool_call_parented_to_a_message_the_stream_opened_is_well_formed():
+    """The agreeing half of the parent-message rule, and the shape it must not refuse.
+
+    A call parented to nothing is rendered on its own, which is the protocol's
+    own shape and not a dangling reference, so the rule has to let it through.
+    """
+    attached = [
+        _text_start("m-1"),
+        _text_end("m-1"),
+        _tool_start("tc-1", parent_message_id="m-1"),
+        _tool_end("tc-1"),
+        _run_finished(),
+    ]
+    parented_to_nothing = [_tool_start("tc-1"), _tool_end("tc-1"), _run_finished()]
+
+    assert_well_formed_stream(attached)
+    assert_well_formed_stream(parented_to_nothing)
+
+
+def test_an_announcement_whose_links_the_stream_carries_is_well_formed():
+    """The agreeing half of the parent-link rule, in the shape the interface emits.
+
+    The member is announced inside the still open delegation call, which is what
+    ``parent_tool_call_id`` names, and under the assistant message that call
+    hangs off. A member announced under neither is well formed too: that is a
+    lane a client draws at the top rather than nested.
+    """
+    nested = [
+        _text_start("m-1"),
+        _text_end("m-1"),
+        _tool_start("tc-1", parent_message_id="m-1"),
+        _announced("run-alpha", parent_tool_call_id="tc-1", parent_message_id="m-1"),
+        _member_finished("run-alpha"),
+        _tool_end("tc-1"),
+        _run_finished(),
+    ]
+    linked_to_nothing = [_announced("run-alpha"), _member_finished("run-alpha"), _run_finished()]
+
+    assert_well_formed_stream(nested)
+    assert_well_formed_stream(linked_to_nothing)
+
+
+def test_an_unstamped_run_lifecycle_is_well_formed():
+    """The agreeing half of the run-lifecycle rule: a run that begins and ends unattributed."""
+    around_a_member = [
+        _run_started(),
+        _announced("run-alpha"),
+        _text_start("m-1", lane="run-alpha"),
+        _text_end("m-1", lane="run-alpha"),
+        _member_finished("run-alpha"),
+        _run_finished(),
+    ]
+
+    assert_well_formed_stream(around_a_member)
+
+
+def test_the_run_lifecycle_rule_refuses_a_stamped_terminal_as_well_as_a_stamped_start():
+    """The terminals, which no control can isolate, held under the waiver that isolates them.
+
+    A run terminal is the last event in the stream and a member's own terminal
+    comes before it, so a stamped run terminal always carries a member after
+    that member's terminal too. Granting the waiver for that second promise
+    leaves the run-lifecycle stamp as the only thing left wrong.
+    """
+    for terminal, reported in ((_run_finished, "RUN_FINISHED"), (_run_error, "RUN_ERROR")):
+        stamped = [_announced("run-alpha"), _member_finished("run-alpha"), terminal(lane="run-alpha")]
+
+        violation = stream_invariant_violation(stamped, exempt=[TRAILING_OUTPUT_AFTER_A_MEMBER_TERMINAL])
+
+        assert violation is not None and f"run lifecycle events carry a member lane: [('{reported}', 'run-alpha')]" in (
+            violation
+        ), f"a stamped {reported} passed as well formed: {violation}"
+
+
+# --- The exemptions ---------------------------------------------------------
+
+
+def test_an_exemption_nobody_justified_is_refused():
+    with pytest.raises(AssertionError, match="not a justified stream invariant exemption"):
+        assert_well_formed_stream([_run_finished()], exempt=["whatever_i_felt_like"])
+
+
+def test_an_exemption_the_stream_does_not_need_is_refused():
+    """A waiver granted where nothing breaks stops the invariant being checked at all."""
+    well_formed = [_text_start("m-1"), _text_content("m-1"), _text_end("m-1"), _run_finished()]
+
+    assert_well_formed_stream(well_formed)
+    with pytest.raises(AssertionError, match="well formed without the abandoned_mid_stream exemption"):
+        assert_well_formed_stream(well_formed, exempt=[ABANDONED_MID_STREAM])
+
+
+@pytest.mark.parametrize("exemption", list(EXEMPTIONS))
+def test_every_exemption_waives_an_invariant_the_checker_runs(exemption):
+    waived = exemption_waives(exemption)
+    assert waived in INVARIANTS, f"{exemption} waives {waived!r}, which is not an invariant this checker runs"
+
+
+# A case per exemption and control rather than one case per exemption looping
+# over the controls: a control that needs the lineage events cannot be built on
+# a protocol release without them, and inside a loop that skip takes every
+# remaining control with it. Built from the invariant names alone, so assembling
+# the list needs no lineage event either.
+_EXEMPTION_CASES = [
+    pytest.param(exemption, control, id=f"{exemption}-{control.invariant}-{control.case}")
+    for exemption in EXEMPTIONS
+    for control in _CONTROLS
+    if control.invariant != exemption_waives(exemption)
+]
+
+
+@pytest.mark.parametrize(("exemption", "control"), _EXEMPTION_CASES)
+def test_each_exemption_waives_its_invariant_and_only_that_one(exemption, control):
+    """The stream an exemption is for still gets every other invariant checked."""
+    violation = stream_invariant_violation(control.build(), exempt=[exemption])
+
+    assert violation is not None and control.reported in violation, (
+        f"granting {exemption} stopped {control.invariant} being reported on a stream that breaks it, "
+        f"so it waives more than {exemption_waives(exemption)}: {violation}"
+    )
+
+
+def test_the_abandonment_exemptions_permit_the_stream_they_were_written_for():
+    """A prefix of a stream: spans left open and a member left unterminated."""
+    prefix = [_announced("run-alpha"), _text_start("m-1", lane="run-alpha"), _text_content("m-1", lane="run-alpha")]
+
+    assert_well_formed_stream(prefix, exempt=[ABANDONED_MID_STREAM, ABANDONED_WITH_A_MEMBER_STILL_OPEN])
+    assert stream_invariant_violation(prefix) is not None
+
+
+def test_the_trailing_output_exemption_permits_the_stream_it_was_written_for():
+    """A member's own run emitted after its terminal, still attributed to it."""
+    trailing = [
+        _announced("run-alpha"),
+        _member_finished("run-alpha"),
+        _text_start("m-1", lane="run-alpha"),
+        _text_end("m-1", lane="run-alpha"),
+        _run_finished(),
+    ]
+
+    assert_well_formed_stream(trailing, exempt=[TRAILING_OUTPUT_AFTER_A_MEMBER_TERMINAL])
+    assert stream_invariant_violation(trailing) is not None
+
+
+def test_the_trailing_output_exemption_still_holds_a_member_to_one_terminal():
+    """The exemption's own promise: whatever follows a terminal, the terminal is unique."""
+    twice = [
+        _announced("run-alpha"),
+        _member_finished("run-alpha"),
+        _member_finished("run-alpha"),
+        _run_finished(),
+    ]
+
+    violation = stream_invariant_violation(twice, exempt=[TRAILING_OUTPUT_AFTER_A_MEMBER_TERMINAL])
+    assert violation is not None and "member run-alpha owns 2 terminals" in violation, (
+        f"a member owning two terminals passed under {TRAILING_OUTPUT_AFTER_A_MEMBER_TERMINAL}: {violation}"
+    )
+
+
+def test_the_abandonment_waiver_still_holds_a_member_to_one_terminal():
+    """Owning none is what the waiver permits; owning two is malformed either way."""
+    twice = [
+        _announced("run-alpha"),
+        _member_finished("run-alpha"),
+        _member_finished("run-alpha"),
+        _run_finished(),
+    ]
+
+    violation = stream_invariant_violation(twice, exempt=[ABANDONED_WITH_A_MEMBER_STILL_OPEN])
+    assert violation is not None and "member run-alpha owns 2 terminals, expected at most one" in violation, (
+        f"a member owning two terminals passed under {ABANDONED_WITH_A_MEMBER_STILL_OPEN}: {violation}"
+    )
+
+
+# --- The census -------------------------------------------------------------
+
+
+def test_the_census_refuses_a_bound_that_holds_for_any_stream():
+    events = [_text_start("m-1"), _text_end("m-1"), _run_finished()]
+
+    assert_stream_contains(events, EventType.TEXT_MESSAGE_START)
+    with pytest.raises(AssertionError, match="holds for any stream at all"):
+        assert_stream_contains(events, EventType.REASONING_START, 0)
+    assert_stream_carries_exactly(events, EventType.REASONING_START, 0)
+    with pytest.raises(AssertionError, match="carries 1 TEXT_MESSAGE_START events, not 2"):
+        assert_stream_carries_exactly(events, EventType.TEXT_MESSAGE_START, 2)
+
+
+def test_the_census_refuses_a_stream_that_carries_less_than_the_test_reasons_about():
+    """The anti-vacuity guard itself: a fixture short of its subject is not a pass."""
+    events = [_text_start("m-1"), _text_end("m-1"), _run_finished()]
+
+    with pytest.raises(AssertionError, match="carries 0 REASONING_START events, but the test reasons about at least 1"):
+        assert_stream_contains(events, EventType.REASONING_START)
+    with pytest.raises(AssertionError, match="cannot exercise what they claim to"):
+        assert_stream_contains(events, EventType.TEXT_MESSAGE_START, 2)
+
+
+def test_reading_a_field_an_event_does_not_carry_is_refused():
+    """A renamed field read with a default compares equal to itself on both sides."""
+    assert field_of(_text_start("m-1"), "message_id") == "m-1"
+    with pytest.raises(AssertionError, match="declares no invented_field"):
+        field_of(_text_start("m-1"), "invented_field")
+
+
+def test_reading_a_field_the_event_carries_only_as_an_extra_is_refused():
+    """Declared, not merely present: the models accept attributes they never declare.
+
+    A run terminal cannot carry a member on the wire, and setting one on the
+    object anyway is what a test comparing its own writes looks like. Reading it
+    back through a permissive attribute lookup is what makes that comparison
+    pass.
+    """
+    stamped_where_the_wire_carries_nothing = _stamped(_run_started(), "run-alpha")
+
+    assert getattr(stamped_where_the_wire_carries_nothing, "subagent_run_id") == "run-alpha"
+    with pytest.raises(AssertionError, match="declares no subagent_run_id"):
+        field_of(stamped_where_the_wire_carries_nothing, "subagent_run_id")
+
+
+class _AnnouncementWithoutItsLane:
+    """An announcement with the lane field gone, as a protocol rename would leave it.
+
+    Built by hand because the installed models all declare the field: a rename
+    is the case the strict read exists for, and no real event can stand in for
+    it.
+    """
+
+    def __init__(self, event_type: EventType) -> None:
+        self.type = event_type
+
+
+def test_reading_an_announcement_that_names_no_member_is_refused():
+    """The announced id is what every stamp, parent link and terminal resolves against.
+
+    Read with a default, a renamed field would leave every announcement naming
+    the top-level entity, and those three checks would resolve to each other and
+    pass without comparing any member attribution at all.
+    """
+    require_lineage_events()
+    renamed = cast(BaseEvent, _AnnouncementWithoutItsLane(event_type_named("SUBAGENT_STARTED")))
+
+    assert announced_lane(_announced("run-alpha")) == "run-alpha"
+    with pytest.raises(AssertionError, match="declares no subagent_run_id"):
+        announced_lane(renamed)
+
+
+def test_the_projection_helper_refuses_a_comparison_of_nothing():
+    with pytest.raises(AssertionError, match="at least one projection"):
+        in_emitted_order([_text_start("m-1")], EventType.TEXT_MESSAGE_START)
+
+
+# --- Log capture at the agno loggers -----------------------------------------
+
+
+def test_capturing_agno_logs_refuses_a_name_that_is_not_a_level(caplog):
+    with pytest.raises(AssertionError, match="not a logging level name"):
+        with captured_agno_logs(caplog, "SHOUTING"):
+            pass
+
+    with pytest.raises(AssertionError, match="not a logging level name"):
+        with captured_agno_logs(caplog, "getLogger"):
+            pass
+
+    # A bool passes an int check and reads as level 1, the widest capture there
+    # is, so a test asking for a name that happens to be a bool setting would
+    # capture everything and never say it had asked for nothing.
+    assert logging.raiseExceptions is True
+    with pytest.raises(AssertionError, match="not a logging level name"):
+        with captured_agno_logs(caplog, "raiseExceptions"):
+            pass
+
+
+def test_capturing_agno_logs_widens_a_narrow_logger_rather_than_narrowing_a_wide_one(caplog):
+    """The level entered is the most permissive of the one asked for and the ones in place.
+
+    Asking for ERROR on a logger already sitting lower has to keep the lower
+    one: raising it instead drops the warnings the test is about to assert on,
+    and a test that then finds nothing reads as the code not having warned.
+    """
+    logger = logging.getLogger(AGNO_LOGGER_NAMES[0])
+    previous = logger.level
+    logger.setLevel(logging.DEBUG)
+    try:
+        with captured_agno_logs(caplog, "ERROR"):
+            logger.warning("a warning below the level that was asked for")
+    finally:
+        logger.setLevel(previous)
+
+    assert "a warning below the level that was asked for" in caplog.text, (
+        "asking for ERROR raised a logger that was sitting at DEBUG, so records under ERROR were dropped"
+    )
+
+
+# --- The protocol release member attribution needs ----------------------------
+
+
+class _AnnouncementDeclaringNoLineage:
+    """An announcement class from before the lineage fields, declaring none of them.
+
+    Built by hand: the installed class declares every one, so the release this
+    checker's floor is about cannot be stood in for by a real event.
+    """
+
+    model_fields = {"type": object()}
+
+
+def test_every_lineage_field_this_checker_reads_is_reported_when_it_is_missing():
+    """The floor recomputed against the fields, rather than asserted as a number.
+
+    Each of these is read off an announcement by an invariant, so a release that
+    declares none of them cannot serve member attribution, whatever the version
+    string says. Listed here rather than derived from the checker's own tuple,
+    which would agree with itself however that tuple shrank.
+    """
+    assert announcement_fields_missing_from(_AnnouncementDeclaringNoLineage) == [
+        "parent_message_id",
+        "parent_subagent_run_id",
+        "parent_tool_call_id",
+        "subagent_run_id",
+    ]
+    assert sorted(LINEAGE_ANNOUNCEMENT_FIELDS_READ_HERE) == [
+        "parent_message_id",
+        "parent_subagent_run_id",
+        "parent_tool_call_id",
+        "subagent_run_id",
+    ]
+
+
+def test_the_lineage_protocol_floor_agrees_with_what_this_install_can_serve():
+    """The version claim and the feature detection have to say the same thing.
+
+    Everything member attribution needs is feature-detected, so the floor is a
+    claim about which release carries those features and nothing enforces it.
+    An install at or above it whose announcement omits a field this checker
+    reads, or one below it that serves attribution anyway, means the floor names
+    the wrong release.
+    """
+    installed = installed_protocol_release()
+    assert installed, "the installed ag-ui-protocol version parsed to no numeric components"
+    at_or_above_the_floor = installed >= LINEAGE_EVENTS_PROTOCOL_FLOOR
+
+    assert at_or_above_the_floor == ATTRIBUTED_IS_SERVABLE, (
+        f"ag-ui-protocol {installed} sits {'at or above' if at_or_above_the_floor else 'below'} the "
+        f"{LINEAGE_EVENTS_PROTOCOL_FLOOR} floor this module names, while member attribution is "
+        f"{'servable' if ATTRIBUTED_IS_SERVABLE else 'not servable'} on it"
+    )
+    assert (lineage_announcement_fields_missing() == []) == at_or_above_the_floor, (
+        f"ag-ui-protocol {installed} against the {LINEAGE_EVENTS_PROTOCOL_FLOOR} floor, with these "
+        f"announcement fields missing: {lineage_announcement_fields_missing()}"
+    )
+
+
+# --- What the encoder can put on a wire --------------------------------------
+
+
+def test_the_encoder_check_reports_the_event_a_wire_would_die_on():
+    assert encoding_failures([_text_start("m-1"), _run_finished()]) == []
+    refused: Dict[str, Any] = {"op": "replace", "path": "/value", "value": circular()}
+    assert [name for name, _ in encoding_failures([StateDeltaEvent(type=EventType.STATE_DELTA, delta=[refused])])] == [
+        "STATE_DELTA"
+    ]

--- a/libs/agno/tests/unit/os/interfaces/test_agui_subagent_lineage.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_subagent_lineage.py
@@ -34,20 +34,20 @@ from dataclasses import fields
 from functools import partial
 from itertools import combinations
 from pathlib import Path
-from typing import Any, AsyncIterator, Callable, Dict, Iterable, Iterator, List, Optional, Sequence, Set, Tuple
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple
 
 import pytest
 
 pytest.importorskip("ag_ui", reason="ag_ui not installed")
 
 from ag_ui.core import BaseEvent, EventType
+from ag_ui.encoder import EventEncoder
 from pydantic import BaseModel
 
 from agno.agent import Agent
 from agno.db.in_memory import InMemoryDb
-from agno.models.base import Model
-from agno.models.response import ModelResponse, ModelResponseEvent, ToolExecution
-from agno.os.interfaces.agui import handlers
+from agno.models.response import ToolExecution
+from agno.os.interfaces.agui import handlers, interrupts
 from agno.os.interfaces.agui.handlers import validate_subagent_visibility
 from agno.os.interfaces.agui.state import (
     ROOT_LANE,
@@ -90,6 +90,7 @@ from .agui_stream_invariants import (
     ATTRIBUTED_EVEN_WHEN_REFUSED,
     TOP_LEVEL_RUN,
     TRAILING_OUTPUT_AFTER_A_MEMBER_TERMINAL,
+    ScriptedModel,
     SideEffect,
     agent_said,
     announcements,
@@ -111,6 +112,7 @@ from .agui_stream_invariants import (
     needs_lineage_events,
     of_type,
     require_lineage_events,
+    sse_events,
     stream_invariant_violation,
     team_chunk_kwargs,
     team_said,
@@ -118,51 +120,11 @@ from .agui_stream_invariants import (
 
 THREAD_ID = "lineage-session"
 
-
-class ScriptedModel(Model):
-    """Emits scripted turns offline: ('tool', name, args, id) or ('content', text)."""
-
-    def __init__(self, model_id: str, script: List[tuple], fail_with: Optional[str] = None):
-        super().__init__(id=model_id, name=model_id, provider="test")
-        self._script = list(script)
-        self._i = 0
-        self._fail_with = fail_with
-
-    def _next(self) -> ModelResponse:
-        if self._fail_with:
-            raise RuntimeError(self._fail_with)
-        if not self._script:
-            raise AssertionError(f"{self.id} was asked for a turn but was given an empty script")
-        turn = self._script[min(self._i, len(self._script) - 1)]
-        self._i += 1
-        if turn[0] == "tool":
-            _, name, args, tcid = turn
-            response = ModelResponse(role="assistant")
-            response.tool_calls = [
-                {"id": tcid, "type": "function", "function": {"name": name, "arguments": json.dumps(args)}}
-            ]
-            return response
-        response = ModelResponse(content=turn[1], role="assistant")
-        response.event = ModelResponseEvent.assistant_response.value
-        return response
-
-    def invoke(self, *args, **kwargs):
-        return self._next()
-
-    async def ainvoke(self, *args, **kwargs):
-        return self._next()
-
-    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
-        yield self._next()
-
-    async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
-        yield self._next()
-
-    def _parse_provider_response(self, response: Any, **kwargs) -> ModelResponse:
-        return response if isinstance(response, ModelResponse) else ModelResponse()
-
-    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
-        return response if isinstance(response, ModelResponse) else ModelResponse()
+# The suspended subagent outcome arrived after the lineage events themselves, so
+# a release can serve member attribution and still declare no ``outcome`` on a
+# member's terminal. Anything here that reads or expects that field asks this
+# rather than taking the lineage gate to cover it.
+_SUSPENDED_OUTCOME_IS_SERVABLE = interrupts.subagent_suspension_available()
 
 
 @tool
@@ -309,10 +271,17 @@ async def _collect_chunks_sync(
     run_id: str = TOP_LEVEL_RUN,
     run_state: Optional[Dict[str, Any]] = None,
     exempt: Sequence[str] = (),
+    emit_interrupt_outcome: bool = False,
 ) -> List[BaseEvent]:
     """One hand-built chunk list, mapped by the sync mapper."""
     events, error = await collect_sync(
-        chunks, visibility, thread_id=THREAD_ID, run_id=run_id, run_state=run_state, exempt=exempt
+        chunks,
+        visibility,
+        thread_id=THREAD_ID,
+        run_id=run_id,
+        run_state=run_state,
+        exempt=exempt,
+        emit_interrupt_outcome=emit_interrupt_outcome,
     )
     assert error is None, f"the source stream raised {error!r}"
     return events
@@ -325,10 +294,17 @@ async def _collect_chunks_async(
     run_id: str = TOP_LEVEL_RUN,
     run_state: Optional[Dict[str, Any]] = None,
     exempt: Sequence[str] = (),
+    emit_interrupt_outcome: bool = False,
 ) -> List[BaseEvent]:
     """One hand-built chunk list, mapped by the async mapper."""
     events, error = await collect_async(
-        chunks, visibility, thread_id=THREAD_ID, run_id=run_id, run_state=run_state, exempt=exempt
+        chunks,
+        visibility,
+        thread_id=THREAD_ID,
+        run_id=run_id,
+        run_state=run_state,
+        exempt=exempt,
+        emit_interrupt_outcome=emit_interrupt_outcome,
     )
     assert error is None, f"the source stream raised {error!r}"
     return events
@@ -371,6 +347,20 @@ def _is_terminal(event: BaseEvent) -> bool:
     """
     require_lineage_events()
     return event.type in (EventType.SUBAGENT_FINISHED, EventType.SUBAGENT_ERROR)
+
+
+def _suspended_outcomes(terminals: Sequence[BaseEvent]) -> List[Any]:
+    """What each member terminal says about being suspended, in the order given.
+
+    A release that declares the field is read straight, so one that later drops
+    it fails here rather than quietly reading as carrying nothing. A release
+    that never had it can carry no outcome, and an outcome written on it anyway
+    would ride out as an undeclared attribute, so it is read through ``getattr``
+    and a terminal that carries nothing reads as ``None``.
+    """
+    if _SUSPENDED_OUTCOME_IS_SERVABLE:
+        return [event.outcome for event in terminals]  # type: ignore[attr-defined]
+    return [getattr(event, "outcome", None) for event in terminals]
 
 
 def _lane_names(events: List[BaseEvent]) -> Dict[str, str]:
@@ -1912,10 +1902,6 @@ async def test_a_real_member_that_pauses_is_prompted_on_its_own_lane(collect_ent
 # --- Over the wire ----------------------------------------------------------
 
 
-def _sse_events(body: str) -> List[Dict[str, Any]]:
-    return [json.loads(line[len("data: ") :]) for line in body.splitlines() if line.startswith("data: ")]
-
-
 @needs_lineage_events
 def test_lineage_reaches_the_wire_through_the_agui_interface():
     """The AGUI constructor option must survive all the way to the SSE stream."""
@@ -1947,7 +1933,7 @@ def test_lineage_reaches_the_wire_through_the_agui_interface():
     )
     assert response.status_code == 200
 
-    events = _sse_events(response.text)
+    events = sse_events(response.text)
     # The body is the whole deliverable here, so it has to end the way every
     # other stream in this module ends. Without this the run terminal could go
     # missing from the response and every payload assertion below would still
@@ -2132,9 +2118,11 @@ async def test_a_paused_member_gets_one_plain_terminal_after_all_of_its_events(c
     finished = _of_type(events, EventType.SUBAGENT_FINISHED)
 
     # Pausing is not finishing, so the lane stays open until the run-end drain
-    # closes it. No suspended outcome: this interface emits no run-level
-    # interrupt outcome to pair one with.
-    assert [(e.subagent_run_id, e.result, e.outcome) for e in finished] == [("run-scout", None, None)]  # type: ignore[attr-defined]
+    # closes it. No suspended outcome either: the run-level interrupt outcome is
+    # opt-in and this stream did not ask for one, and a suspended lane only ever
+    # travels with it.
+    assert [(e.subagent_run_id, e.result) for e in finished] == [("run-scout", None)]  # type: ignore[attr-defined]
+    assert _suspended_outcomes(finished) == [None]
     terminal_at = events.index(finished[0])
     assert [str(e.type) for i, e in enumerate(events) if _lane(e) == "run-scout" and i > terminal_at] == []
     assert str(events[-1].type) == str(EventType.RUN_FINISHED)
@@ -3060,6 +3048,127 @@ async def test_hidden_prompts_a_paused_tool_listed_twice_once_and_names_no_membe
     assert in_emitted_order(events, EventType.TOOL_CALL_END, "tool_call_id", _lane) == [("tc-shared-confirm", None)]
     assert not [e for e in events if "SUBAGENT" in str(e.type)]
     assert not [e for e in events if _lane(e) is not None]
+
+
+# --- The terminal's interrupts against the calls the prompt showed ----------
+
+# The interrupt-aware lifecycle arrived after the lineage events, so an install
+# that serves member attribution can still have no terminal to advertise an
+# interrupt on.
+needs_interrupt_outcome = pytest.mark.skipif(
+    not interrupts.INTERRUPT_OUTCOME_AVAILABLE,
+    reason="the installed ag_ui.core has no interrupt-aware run lifecycle",
+)
+
+
+def _encoded(event: BaseEvent) -> Dict[str, Any]:
+    """One event as the bytes a client receives, through the protocol's own encoder.
+
+    A field the installed models do not declare still sets an attribute, so
+    reading the object says nothing about what reached the client.
+    """
+    return json.loads(EventEncoder().encode(event)[len("data: ") :])
+
+
+def _prompted_call_ids(events: List[BaseEvent]) -> List[str]:
+    """Every pending call the prompt sent, in the order a client reads them."""
+    return [_encoded(event)["toolCallId"] for event in _of_type(events, EventType.TOOL_CALL_START)]
+
+
+def _advertised_interrupts(events: List[BaseEvent]) -> List[Dict[str, Any]]:
+    """The interrupts the run terminal carried, in the order it advertised them."""
+    finished = _of_type(events, EventType.RUN_FINISHED)
+    assert len(finished) == 1, f"expected one run terminal, got {[str(event.type) for event in events]}"
+    outcome = _encoded(finished[0]).get("outcome")
+    assert outcome is not None, "the run terminal carried no interrupt outcome"
+    return list(outcome["interrupts"])
+
+
+def _confirmable(tool_call_id: str, tool_name: str) -> ToolExecution:
+    """A pending call waiting on a confirmation a client can answer."""
+    return ToolExecution(
+        tool_call_id=tool_call_id, tool_name=tool_name, tool_args={"to": "ops"}, requires_confirmation=True
+    )
+
+
+def _two_requirements_on_one_call_chunks() -> Tuple[List[Any], List[str]]:
+    """A pause whose requirements wait on one call, with the ids it needs answered.
+
+    The ids come back alongside because they are minted per requirement: they
+    are what tells the two apart once they are on the wire, the call they share
+    cannot.
+    """
+    shared = _confirmable("tc-shared", "send_email")
+    other = _confirmable("tc-other", "publish")
+    reported = [RunRequirement(shared), RunRequirement(shared), RunRequirement(other)]
+    solo = {"agent_id": "solo", "agent_name": "Solo", "run_id": TOP_LEVEL_RUN}
+
+    return (
+        [RunStartedEvent(**solo), AgentRunPausedEvent(tools=[shared, other], requirements=reported, **solo)],
+        [requirement.id for requirement in reported],
+    )
+
+
+@needs_interrupt_outcome
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_two_requirements_waiting_on_one_call_are_both_advertised(collect):
+    """Neither answer the run needs is displaced by the other naming the same call.
+
+    The terminal advertises what the run cannot continue without, and both of
+    these are that, so a client told about one of them answers what it was told
+    and the resume refuses it over the requirement nobody named. They go out in
+    the order the pause reported them, at the place the prompt showed the call
+    they share.
+
+    Driven on the default visibility: no member is involved, so this is a run
+    any supported protocol release serves.
+    """
+    chunks, needed = _two_requirements_on_one_call_chunks()
+
+    events = await collect(chunks, emit_interrupt_outcome=True)
+
+    advertised = _advertised_interrupts(events)
+    assert _prompted_call_ids(events) == ["tc-shared", "tc-other"]
+    assert [interrupt["id"] for interrupt in advertised] == needed
+    assert [interrupt["toolCallId"] for interrupt in advertised] == ["tc-shared", "tc-shared", "tc-other"]
+
+
+def _pause_interleaving_two_members_chunks() -> Tuple[List[Any], List[str]]:
+    """Two members' pending calls, reported in an order that returns to the first."""
+    reported = [
+        _requirement(_confirmable("tc-1", "send_email"), "scout", "run-scout", "Scout"),
+        _requirement(_confirmable("tc-2", "publish"), "writer", "run-writer", "Writer"),
+        _requirement(_confirmable("tc-3", "archive"), "scout", "run-scout", "Scout"),
+    ]
+
+    return (
+        [TeamRunStartedEvent(**_TOP_LEVEL), TeamRunPausedEvent(tools=[], requirements=reported, **_TOP_LEVEL)],
+        [requirement.id for requirement in reported],
+    )
+
+
+@needs_lineage_events
+@needs_interrupt_outcome
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_the_terminal_advertises_in_the_order_the_prompt_sent_the_calls(collect):
+    """The prompt sends one message per member, so a member's calls arrive together.
+
+    A client renders the pending calls in the order they arrived and reads the
+    terminal's interrupts beside them, so the terminal follows what the wire
+    showed rather than the order the pause happened to list its requirements in.
+    """
+    chunks, reported = _pause_interleaving_two_members_chunks()
+
+    events = await collect(chunks, attributed(), emit_interrupt_outcome=True)
+
+    advertised = _advertised_interrupts(events)
+    assert _prompted_call_ids(events) == ["tc-1", "tc-3", "tc-2"]
+    assert [interrupt["toolCallId"] for interrupt in advertised] == ["tc-1", "tc-3", "tc-2"]
+    # Named by id too, which is what a client answers under, and in an order the
+    # pause did not report: the middle requirement is advertised last.
+    assert [interrupt["id"] for interrupt in advertised] == [reported[0], reported[2], reported[1]]
 
 
 def _pause_while_a_member_tool_is_still_running_chunks() -> List[Any]:
@@ -4137,6 +4246,19 @@ class _AnnouncementWithoutADescription(BaseModel):
     parent_message_id: Optional[str] = None
 
 
+def _one_of_the_protocols_events(name: str) -> bool:
+    """Whether this class is one of the protocol's events rather than an outcome.
+
+    Resolved against the installed release, because what separates the two is
+    where the discriminator comes from: an event inherits it from the base every
+    release declares, and an outcome brought its own with it.
+    """
+    import ag_ui.core
+
+    candidate = getattr(ag_ui.core, name, None)
+    return isinstance(candidate, type) and issubclass(candidate, BaseEvent)
+
+
 def _lineage_fields_the_interface_writes(event_class_names: Set[str]) -> Dict[str, Set[str]]:
     """The arguments the interface really passes to each lineage event class.
 
@@ -4165,12 +4287,31 @@ def _lineage_fields_the_interface_writes(event_class_names: Set[str]) -> Dict[st
             assert all(keyword.arg is not None for keyword in node.keywords), (
                 f"{path.name} builds a {node.func.id} from a starred mapping, which this scan cannot read"
             )
-            # ``type`` is the protocol's own discriminator, which every event
-            # declares by definition, so it is not one of the fields at issue.
+            # ``type`` on an event is the protocol's own discriminator, declared
+            # by the base every release carries, so it is not one of the fields
+            # at issue. On an outcome it is the tag the union is read by, and it
+            # arrived with the outcome itself, so it is one of them: excluding it
+            # everywhere is how a tag written by two builders stayed invisible to
+            # both this scan and the check it feeds.
             written.setdefault(node.func.id, set()).update(
-                keyword.arg for keyword in node.keywords if keyword.arg is not None and keyword.arg != "type"
+                keyword.arg
+                for keyword in node.keywords
+                if keyword.arg is not None
+                and not (keyword.arg == "type" and _one_of_the_protocols_events(node.func.id))
             )
     return written
+
+
+# The suspended outcome's own contribution to what the interface writes. The
+# interrupt round trip builds both of these behind its suspension probe, so a
+# release without that outcome detects neither while the source still reads as
+# writing them and nothing can reach the wire under either name. Named here so
+# the comparison below holds on such a release, and checked against the probe's
+# own table wherever it is served, so the two cannot drift.
+_SUSPENDED_OUTCOME_WRITES: Dict[str, Set[str]] = {
+    "SubagentFinishedEvent": {"outcome"},
+    "SubagentFinishedSuspendedOutcome": {"type", "interrupt_ids"},
+}
 
 
 @needs_lineage_events
@@ -4182,17 +4323,31 @@ def test_the_startup_check_feature_detects_every_lineage_field_the_interface_wri
     here instead of the one the wire format defines, and the client reads a lane
     with no description, no parent or no result.
     """
-    detected = {event_class.__name__: set(fields) for event_class, fields in handlers._lineage_event_fields().items()}
+    lineage: Dict[str, Set[str]] = {
+        event_class.__name__: set(field_names) for event_class, field_names in handlers._lineage_event_fields().items()
+    }
     # The scan below is handed the very names this table is keyed by, so an
     # empty table leaves it scanning for nothing and the comparison is between
     # two empty mappings. The three classes the interface builds are the floor.
     scanned_for = _enumerated_by_the_interface(
-        detected,
+        lineage,
         "SubagentStartedEvent",
         "SubagentFinishedEvent",
         "SubagentErrorEvent",
         described="the lineage classes the startup check feature-detects fields on",
-    )
+    ) | set(_SUSPENDED_OUTCOME_WRITES)
+    # The interrupt round trip's own check, kept separate because the protocol
+    # added the suspended outcome after the lineage events: a release carrying
+    # that outcome has to detect exactly the fields written for it, and a
+    # release without it has no class to key them by and detects none.
+    suspension = {
+        event_class.__name__: set(field_names)
+        for event_class, field_names in interrupts.subagent_suspension_fields().items()
+    }
+    assert suspension == (_SUSPENDED_OUTCOME_WRITES if interrupts.SUBAGENT_SUSPENDED_OUTCOME_AVAILABLE else {})
+    detected = {name: set(field_names) for name, field_names in lineage.items()}
+    for name, field_names in _SUSPENDED_OUTCOME_WRITES.items():
+        detected.setdefault(name, set()).update(field_names)
 
     assert _lineage_fields_the_interface_writes(scanned_for) == detected
 
@@ -4717,10 +4872,12 @@ async def test_a_member_name_the_interface_cannot_read_does_not_end_the_run(coll
     assert [(e.subagent_run_id, e.name) for e in _announcements(events)] == [("run-scout", "run-scout")]  # type: ignore[attr-defined]
     assert str(events[-1].type) == str(EventType.RUN_FINISHED)
     # The client is shown a run id where a name belongs, so the raise that cost
-    # it the name has to reach the operator.
-    assert [record.message for record in caplog.records if "name exploded" in record.message], (
-        "the member name the interface could not read left no trace at all"
-    )
+    # it the name has to reach the operator. Recorded by type rather than by the
+    # failure's own text: rendering that text runs the same name the read did,
+    # which is the read raising a second time from inside its own record.
+    assert "AG-UI could not read a subagent name from agent_name: RuntimeError" in [
+        record.getMessage() for record in caplog.records
+    ], "the member name the interface could not read left no trace at all"
 
 
 @pytest.mark.parametrize(

--- a/libs/agno/tests/unit/os/interfaces/test_agui_subagent_lineage.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_subagent_lineage.py
@@ -1,0 +1,5197 @@
+"""AG-UI subagent lineage for Team runs.
+
+Agno stamps every streamed chunk with the run it came from and, for a member,
+the run that delegated to it. These tests assert, from the emitted payloads,
+that each message, tool call and reasoning block is attributed to the member
+that produced it.
+
+Wherever a scripted (no-network) model can drive the behavior, the stream is a
+real entity run: one test drives the whole interface over SSE, and the state,
+stamp and startup checks call the interface directly. A member that pauses is
+one of those: a member whose tool needs a confirmation pauses for real under a
+scripted model, and the announcement and the prompt on its lane are asserted
+against that run. Reasoning inside a member, output that trails a member's own
+terminal, a lane whose parent lane terminated before it and a run that fails
+with member lanes still open are not reachable from a scripted model, and
+neither are the pause shapes one run cannot produce: a leader and a member
+paused at once, a pause naming a member whose lane already terminated, a paused
+grandchild, and a pause reported only through requirements. Those tests
+hand-build the chunk sequence. A hand-built chunk carries the lineage fields the framework
+really stamps on a member's chunks: ``run_id`` for the run the chunk came from,
+``parent_run_id`` for the run that delegated to it, and
+``agent_id``/``agent_name`` or ``team_id``/``team_name`` for the member's
+identity, which the real-stream tests in this module pin independently.
+
+The default ``inline`` visibility is asserted to emit the same stream as before
+lineage existed, and a single Agent is asserted to be unaffected by the setting.
+"""
+
+import ast
+import inspect
+import json
+import threading
+from dataclasses import fields
+from functools import partial
+from itertools import combinations
+from pathlib import Path
+from typing import Any, AsyncIterator, Callable, Dict, Iterable, Iterator, List, Optional, Sequence, Set, Tuple
+
+import pytest
+
+pytest.importorskip("ag_ui", reason="ag_ui not installed")
+
+from ag_ui.core import BaseEvent, EventType
+from pydantic import BaseModel
+
+from agno.agent import Agent
+from agno.db.in_memory import InMemoryDb
+from agno.models.base import Model
+from agno.models.response import ModelResponse, ModelResponseEvent, ToolExecution
+from agno.os.interfaces.agui import handlers
+from agno.os.interfaces.agui.handlers import validate_subagent_visibility
+from agno.os.interfaces.agui.state import (
+    ROOT_LANE,
+    SUBAGENT_VISIBILITY_HIDDEN,
+    SUBAGENT_VISIBILITY_INLINE,
+    StreamState,
+)
+from agno.os.interfaces.agui.stream import (
+    async_stream_agno_response_as_agui_events,
+    stream_agno_response_as_agui_events,
+)
+from agno.reasoning.step import ReasoningStep
+from agno.run.agent import (
+    CustomEvent,
+    ReasoningCompletedEvent,
+    ReasoningContentDeltaEvent,
+    ReasoningStartedEvent,
+    ReasoningStepEvent,
+    RunCancelledEvent,
+    RunCompletedEvent,
+    RunErrorEvent,
+    RunEvent,
+    RunStartedEvent,
+    ToolCallCompletedEvent,
+    ToolCallErrorEvent,
+    ToolCallStartedEvent,
+)
+from agno.run.agent import RunPausedEvent as AgentRunPausedEvent
+from agno.run.requirement import RunRequirement
+from agno.run.team import RunCompletedEvent as TeamRunCompletedEvent
+from agno.run.team import RunErrorEvent as TeamRunErrorEvent
+from agno.run.team import RunPausedEvent as TeamRunPausedEvent
+from agno.run.team import RunStartedEvent as TeamRunStartedEvent
+from agno.run.team import ToolCallCompletedEvent as TeamToolCallCompletedEvent
+from agno.run.team import ToolCallStartedEvent as TeamToolCallStartedEvent
+from agno.team import Team
+from agno.tools import tool
+
+from .agui_stream_invariants import (
+    ATTRIBUTED_EVEN_WHEN_REFUSED,
+    TOP_LEVEL_RUN,
+    TRAILING_OUTPUT_AFTER_A_MEMBER_TERMINAL,
+    SideEffect,
+    agent_said,
+    announcements,
+    assert_stream_carries_exactly,
+    assert_stream_contains,
+    assert_well_formed_stream,
+    attributed,
+    captured_agno_logs,
+    circular,
+    collect_async,
+    collect_async_recording_violations,
+    collect_sync,
+    collect_sync_recording_violations,
+    event_type_named,
+    in_emitted_order,
+    joined_text_in_emitted_order,
+    lane_of,
+    member_chunk_kwargs,
+    needs_lineage_events,
+    of_type,
+    require_lineage_events,
+    stream_invariant_violation,
+    team_chunk_kwargs,
+    team_said,
+)
+
+THREAD_ID = "lineage-session"
+
+
+class ScriptedModel(Model):
+    """Emits scripted turns offline: ('tool', name, args, id) or ('content', text)."""
+
+    def __init__(self, model_id: str, script: List[tuple], fail_with: Optional[str] = None):
+        super().__init__(id=model_id, name=model_id, provider="test")
+        self._script = list(script)
+        self._i = 0
+        self._fail_with = fail_with
+
+    def _next(self) -> ModelResponse:
+        if self._fail_with:
+            raise RuntimeError(self._fail_with)
+        if not self._script:
+            raise AssertionError(f"{self.id} was asked for a turn but was given an empty script")
+        turn = self._script[min(self._i, len(self._script) - 1)]
+        self._i += 1
+        if turn[0] == "tool":
+            _, name, args, tcid = turn
+            response = ModelResponse(role="assistant")
+            response.tool_calls = [
+                {"id": tcid, "type": "function", "function": {"name": name, "arguments": json.dumps(args)}}
+            ]
+            return response
+        response = ModelResponse(content=turn[1], role="assistant")
+        response.event = ModelResponseEvent.assistant_response.value
+        return response
+
+    def invoke(self, *args, **kwargs):
+        return self._next()
+
+    async def ainvoke(self, *args, **kwargs):
+        return self._next()
+
+    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+        yield self._next()
+
+    async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+        yield self._next()
+
+    def _parse_provider_response(self, response: Any, **kwargs) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+
+@tool
+def search_docs(query: str) -> str:
+    return f"docs about {query}"
+
+
+@tool
+def spell_check(text: str) -> str:
+    return f"checked: {text}"
+
+
+def _researcher(db: InMemoryDb) -> Agent:
+    return Agent(
+        name="Researcher",
+        id="researcher",
+        model=ScriptedModel(
+            "m-researcher",
+            [
+                ("tool", "search_docs", {"query": "agno"}, "tc-search"),
+                ("content", "Found three sources."),
+            ],
+        ),
+        tools=[search_docs],
+        db=db,
+        telemetry=False,
+    )
+
+
+def _writer(db: InMemoryDb) -> Agent:
+    return Agent(
+        name="Writer",
+        id="writer",
+        model=ScriptedModel(
+            "m-writer",
+            [
+                ("tool", "spell_check", {"text": "draft"}, "tc-spell"),
+                ("content", "Here is the brief."),
+            ],
+        ),
+        tools=[spell_check],
+        db=db,
+        telemetry=False,
+    )
+
+
+def _team(db: InMemoryDb, members: List[Agent], calls: List[tuple]) -> Team:
+    script: List[tuple] = [("tool", "delegate_task_to_member", args, tcid) for args, tcid in calls]
+    script.append(("content", "Final synthesis."))
+    return Team(
+        name="Research Team",
+        id="research-team",
+        model=ScriptedModel("m-leader", script),
+        members=members,
+        db=db,
+        telemetry=False,
+    )
+
+
+def _two_member_team(db: InMemoryDb) -> Team:
+    return _team(
+        db,
+        [_researcher(db), _writer(db)],
+        [
+            ({"member_id": "researcher", "task": "research the topic"}, "tc-delegate-researcher"),
+            ({"member_id": "writer", "task": "write the brief"}, "tc-delegate-writer"),
+        ],
+    )
+
+
+def _twin(db: InMemoryDb, member_id: str, name: str) -> Agent:
+    """One member whose run reports the same words as its twin's."""
+    return Agent(
+        name=name,
+        id=member_id,
+        model=ScriptedModel(f"m-{member_id}", [("content", "identical wording")]),
+        db=db,
+        telemetry=False,
+    )
+
+
+def _twins_team(db: InMemoryDb) -> Team:
+    """A leader that delegates to two members which report identical content."""
+    return _team(
+        db,
+        [_twin(db, "alpha", "Alpha"), _twin(db, "beta", "Beta")],
+        [
+            ({"member_id": "alpha", "task": "say it"}, "tc-delegate-alpha"),
+            ({"member_id": "beta", "task": "say it too"}, "tc-delegate-beta"),
+        ],
+    )
+
+
+# Every collector below runs the shared stream-invariant helper before handing
+# the events back, so each test in this module inherits the whole invariant set
+# whether or not it thought to ask for it.
+
+
+async def _collect_entity_sync(
+    entity: Any, visibility: Optional[str] = None, prompt: str = "Write a brief"
+) -> List[BaseEvent]:
+    """One real entity run, mapped by the sync mapper."""
+    events = list(
+        stream_agno_response_as_agui_events(
+            entity.run(prompt, session_id=THREAD_ID, stream=True, stream_events=True, run_id=TOP_LEVEL_RUN),
+            thread_id=THREAD_ID,
+            run_id=TOP_LEVEL_RUN,
+            subagent_visibility=visibility,
+        )
+    )
+    assert_well_formed_stream(events)
+    return events
+
+
+async def _collect_entity_async(
+    entity: Any, visibility: Optional[str] = None, prompt: str = "Write a brief"
+) -> List[BaseEvent]:
+    """One real entity run, mapped by the async mapper."""
+    stream = entity.arun(prompt, session_id=THREAD_ID, stream=True, stream_events=True, run_id=TOP_LEVEL_RUN)
+    events = [
+        event
+        async for event in async_stream_agno_response_as_agui_events(
+            stream, thread_id=THREAD_ID, run_id=TOP_LEVEL_RUN, subagent_visibility=visibility
+        )
+    ]
+    assert_well_formed_stream(events)
+    return events
+
+
+# The two mappers duplicate the same body, so the attribution cases run through
+# both rather than trusting the async one to stand for the pair.
+entity_mappers = pytest.mark.parametrize(
+    "collect_entity", [_collect_entity_sync, _collect_entity_async], ids=["sync", "async"]
+)
+
+_lane = lane_of
+_of_type = of_type
+
+
+async def _collect_chunks_sync(
+    chunks: Iterable[Any],
+    visibility: Optional[str] = None,
+    *,
+    run_id: str = TOP_LEVEL_RUN,
+    run_state: Optional[Dict[str, Any]] = None,
+    exempt: Sequence[str] = (),
+) -> List[BaseEvent]:
+    """One hand-built chunk list, mapped by the sync mapper."""
+    events, error = await collect_sync(
+        chunks, visibility, thread_id=THREAD_ID, run_id=run_id, run_state=run_state, exempt=exempt
+    )
+    assert error is None, f"the source stream raised {error!r}"
+    return events
+
+
+async def _collect_chunks_async(
+    chunks: Iterable[Any],
+    visibility: Optional[str] = None,
+    *,
+    run_id: str = TOP_LEVEL_RUN,
+    run_state: Optional[Dict[str, Any]] = None,
+    exempt: Sequence[str] = (),
+) -> List[BaseEvent]:
+    """One hand-built chunk list, mapped by the async mapper."""
+    events, error = await collect_async(
+        chunks, visibility, thread_id=THREAD_ID, run_id=run_id, run_state=run_state, exempt=exempt
+    )
+    assert error is None, f"the source stream raised {error!r}"
+    return events
+
+
+chunk_mappers = pytest.mark.parametrize("collect", [_collect_chunks_sync, _collect_chunks_async], ids=["sync", "async"])
+
+# For the few streams whose subject is a shape the shared checker calls
+# malformed. The invariants still run, on the same definition, so a stream that
+# stops breaking one is a diff rather than a silence.
+malformed_mappers = pytest.mark.parametrize(
+    "collect_malformed",
+    [collect_sync_recording_violations, collect_async_recording_violations],
+    ids=["sync", "async"],
+)
+
+
+def _announcements(events: List[BaseEvent]) -> List[BaseEvent]:
+    """Every SUBAGENT_STARTED in order.
+
+    A list rather than a mapping, so a second announcement, or two lanes sharing
+    a name, stays visible in whatever the caller compares. A lane announced twice
+    is refused by the shared checker every collector here runs, so this does not
+    assert it a second time.
+
+    Built on the shared announcement reader, which names no event type an older
+    protocol release lacks, so the visibility settings that work on such a
+    release keep running here.
+    """
+    return announcements(events)
+
+
+def _is_terminal(event: BaseEvent) -> bool:
+    """Whether an event is a member's terminal, refusing to read the announcement as one.
+
+    Matched on the two terminal types rather than on ``SUBAGENT`` appearing in
+    the type name, which also matches ``SUBAGENT_STARTED``: the announcement
+    precedes everything its lane carries, so an ordering claim made against it
+    holds no matter what the stream does afterwards.
+    """
+    require_lineage_events()
+    return event.type in (EventType.SUBAGENT_FINISHED, EventType.SUBAGENT_ERROR)
+
+
+def _lane_names(events: List[BaseEvent]) -> Dict[str, str]:
+    """subagent run id -> the name it was announced under."""
+    return {e.subagent_run_id: e.name for e in _announcements(events)}  # type: ignore[attr-defined]
+
+
+def _messages_in_order(events: List[BaseEvent]) -> List[Tuple[Optional[str], str]]:
+    """(name of the member that owns it, joined text) per message, in the order they opened.
+
+    Ordered, never keyed by the text: two members that happen to say the same
+    thing have to stay two entries.
+    """
+    names = _lane_names(events)
+    return [(names[lane] if lane is not None else None, text) for lane, text in joined_text_in_emitted_order(events)]
+
+
+def _tool_calls_in_order(events: List[BaseEvent]) -> List[Tuple[str, Optional[str]]]:
+    """(tool call id, name of the member that owns it) per TOOL_CALL_START, in order."""
+    names = _lane_names(events)
+    return [
+        (tool_call_id, names[lane] if lane is not None else None)
+        for tool_call_id, lane in in_emitted_order(events, EventType.TOOL_CALL_START, "tool_call_id", _lane)
+    ]
+
+
+def _tool_call_lanes_in_order(events: List[BaseEvent]) -> List[Tuple[str, Optional[str]]]:
+    """(tool call id, raw member lane) per TOOL_CALL_START, in order."""
+    return [
+        (tool_call_id, lane)
+        for tool_call_id, lane in in_emitted_order(events, EventType.TOOL_CALL_START, "tool_call_id", _lane)
+    ]
+
+
+def _reasoning_blocks_in_order(events: List[BaseEvent]) -> List[Tuple[Optional[str], str]]:
+    """(member lane, joined reasoning text) per reasoning message, in the order they opened."""
+    deltas: Dict[str, str] = {}
+    for event in _of_type(events, EventType.REASONING_MESSAGE_CONTENT):
+        message_id = event.message_id  # type: ignore[attr-defined]
+        deltas[message_id] = deltas.get(message_id, "") + event.delta  # type: ignore[attr-defined]
+    return [
+        (_lane(event), deltas.get(event.message_id, ""))  # type: ignore[attr-defined]
+        for event in _of_type(events, EventType.REASONING_MESSAGE_START)
+    ]
+
+
+def _lane_of_message_id(events: List[BaseEvent]) -> Dict[str, Optional[str]]:
+    """message id -> the member lane that opened it.
+
+    A mapping is the right shape here: this is looked up by id to answer "who
+    owns this message", never compared against an expected mapping. The stream
+    invariant helper is what refuses a message id opened twice.
+    """
+    return {e.message_id: _lane(e) for e in _of_type(events, EventType.TEXT_MESSAGE_START)}  # type: ignore[attr-defined]
+
+
+def _type_sequence(events: List[BaseEvent]) -> List[str]:
+    return [str(e.type) for e in events]
+
+
+def _lane_sequence(events: List[BaseEvent], lane: Optional[str]) -> List[str]:
+    return [str(e.type).removeprefix("EventType.") for e in events if _lane(e) == lane]
+
+
+def _span_pairs(events: List[BaseEvent], start: EventType, end: EventType) -> Tuple[List[str], List[str]]:
+    """The message ids a span type opened and the ones it closed, in order."""
+    return (
+        [e.message_id for e in _of_type(events, start)],  # type: ignore[attr-defined]
+        [e.message_id for e in _of_type(events, end)],  # type: ignore[attr-defined]
+    )
+
+
+def _normalized_payloads(events: List[BaseEvent]) -> List[Tuple[str, Dict[str, Any]]]:
+    """Event payloads with generated ids replaced by first-seen ordinals, so two runs compare."""
+    aliases: Dict[str, str] = {}
+
+    def alias(value: Any) -> Any:
+        if not isinstance(value, str) or len(value) != 36 or value.count("-") != 4:
+            return value
+        return aliases.setdefault(value, f"id-{len(aliases)}")
+
+    normalized = []
+    for event in events:
+        payload = event.model_dump(exclude_none=True, by_alias=True)
+        payload.pop("type", None)
+        payload.pop("timestamp", None)
+        if event.type == EventType.RAW:
+            # RAW carries the whole Agno chunk, including timings and token
+            # counts that differ between runs; its identity is the event name.
+            payload = {"event": payload.get("event", {}).get("event")}
+        normalized.append((str(event.type), {k: alias(v) for k, v in payload.items()}))
+    return normalized
+
+
+# The lineage fields a member's or a team's chunks carry, and the two content
+# chunks, come from the shared module: the failure and hostile suites build the
+# same chunks, and a member chunk only reads as one while its parent names the
+# same top-level run these do.
+_member_kwargs = member_chunk_kwargs
+_team_kwargs = team_chunk_kwargs
+_agent_said = agent_said
+_team_said = team_said
+
+_TOP_LEVEL = _team_kwargs("research-team", "Research Team", TOP_LEVEL_RUN)
+
+
+def _reasoning_step(title: str, reasoning: str, **kwargs: Any) -> ReasoningStepEvent:
+    chunk = ReasoningStepEvent(**kwargs)
+    chunk.content = ReasoningStep(title=title, reasoning=reasoning)
+    return chunk
+
+
+def _delegation(tool_call_id: str, member_id: str, task: str, result: Optional[str] = None) -> ToolExecution:
+    """The call a leader delegates to one member with, as the framework records it.
+
+    The name and the two arguments are what the interface reads to tie a member
+    to the call that spawned it, so they are written once here rather than at
+    every site that needs one.
+    """
+    return ToolExecution(
+        tool_call_id=tool_call_id,
+        tool_name="delegate_task_to_member",
+        tool_args={"member_id": member_id, "task": task},
+        result=result,
+    )
+
+
+def _requirement(
+    tool: ToolExecution,
+    member_id: Optional[str] = None,
+    run_id: Optional[str] = None,
+    name: Optional[str] = None,
+) -> RunRequirement:
+    """A pending call a paused run names the member waiting on it by.
+
+    The three member fields travel together, so they are written together: a
+    case that means to leave one out passes None and says so, rather than
+    omitting a line among three that reads as an oversight.
+    """
+    requirement = RunRequirement(tool)
+    requirement.member_agent_id = member_id
+    requirement.member_agent_name = name
+    requirement.member_run_id = run_id
+    return requirement
+
+
+def _nameless_tool() -> ToolExecution:
+    """A pending call with no tool name, which the client cannot be shown."""
+    return ToolExecution(tool_call_id="tc-nameless", tool_args={"to": "ops"}, requires_confirmation=True)
+
+
+def _idless_tool() -> ToolExecution:
+    """A pending call with no id, which a resume has nothing to resolve against."""
+    return ToolExecution(tool_name="send_invoice", tool_args={"to": "ops"}, requires_confirmation=True)
+
+
+def _enumerated_by_the_interface(table: Iterable[Any], *floor: Any, described: str) -> Set[Any]:
+    """One of the interface's own enumerations, refused when it has lost a member it must hold.
+
+    Several checks in this module scan the interface for what one of its
+    enumerations names and are handed that same enumeration to scan for. An
+    empty one folds such a check to nothing found against nothing expected, and
+    it then holds whatever the interface does. Naming a member that has to be
+    there is what keeps the comparison from being between two absences, so every
+    check of that shape states its floor through here.
+    """
+    names = set(table)
+    missing = sorted(str(entry) for entry in floor if entry not in names)
+    assert not missing, (
+        f"{described} no longer names {missing}, so what is keyed by it compares nothing: "
+        f"it holds {sorted(str(name) for name in names)}"
+    )
+    return names
+
+
+# --- Attribution ------------------------------------------------------------
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@entity_mappers
+async def test_team_attributes_each_message_to_its_member(collect_entity):
+    events = await collect_entity(_two_member_team(InMemoryDb()), attributed())
+
+    assert_stream_contains(events, EventType.TEXT_MESSAGE_CONTENT, 3)
+    # In order, so two lanes are never folded together by what they said. The
+    # empty entries are the assistant messages a tool call has to be parented to.
+    assert _messages_in_order(events) == [
+        (None, ""),
+        ("Researcher", ""),
+        ("Researcher", "Found three sources."),
+        ("Writer", ""),
+        ("Writer", "Here is the brief."),
+        # The team leader's own reply belongs to no subagent.
+        (None, "Final synthesis."),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@entity_mappers
+async def test_two_members_that_say_the_same_thing_stay_two_messages(collect_entity):
+    events = await collect_entity(_twins_team(InMemoryDb()), attributed())
+    names = _lane_names(events)
+
+    assert_stream_contains(events, EventType.TEXT_MESSAGE_CONTENT, 3)
+    assert_stream_contains(events, EventType.SUBAGENT_FINISHED, 2)
+    # In order, so the two identical messages stay two entries. The empty entry
+    # is the assistant message the delegation calls are parented to.
+    assert _messages_in_order(events) == [
+        (None, ""),
+        ("Alpha", "identical wording"),
+        ("Beta", "identical wording"),
+        (None, "Final synthesis."),
+    ]
+    terminals = in_emitted_order(events, EventType.SUBAGENT_FINISHED, "subagent_run_id", "result")
+    assert [(names[lane], result) for lane, result in terminals] == [
+        ("Alpha", "identical wording"),
+        ("Beta", "identical wording"),
+    ]
+    # The framework gives each delegation its own run id, which is what keeps
+    # two members saying one thing from sharing a lane.
+    first, second = [lane for lane, _ in terminals]
+    assert first != second, "both members were reported under one run id"
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@entity_mappers
+async def test_team_attributes_each_tool_call_to_its_member(collect_entity):
+    events = await collect_entity(_two_member_team(InMemoryDb()), attributed())
+
+    assert_stream_contains(events, EventType.TOOL_CALL_START, 4)
+    # In order, so a call emitted twice cannot hide behind its own id, and the
+    # delegations themselves stay the leader's own tool calls.
+    assert _tool_calls_in_order(events) == [
+        ("tc-delegate-researcher", None),
+        ("tc-search", "Researcher"),
+        ("tc-delegate-writer", None),
+        ("tc-spell", "Writer"),
+    ]
+
+
+def _reasoning_team_chunks() -> List[Any]:
+    """Two members reasoning at the same time, which a scripted model cannot drive.
+
+    Both spans open before any step arrives and the four steps then alternate
+    between the lanes, which is what tells per-lane step numbering apart from one
+    counter for the whole stream: reset at each reasoning span or never reset,
+    one counter numbers the alternating steps 1, 2, 3, 4, so the two blocks read
+    "Step 1" then "Step 3" and "Step 2" then "Step 4". Only a counter kept per
+    lane numbers both members 1 then 2.
+    """
+
+    def delegation(member_id: str, tool_call_id: str) -> ToolExecution:
+        return _delegation(tool_call_id, member_id, f"work for {member_id}", result=f"{member_id} finished")
+
+    researcher = _member_kwargs("researcher", "run-1")
+    writer = _member_kwargs("writer", "run-2")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=delegation("researcher", "tc-d1")),
+        RunStartedEvent(**researcher),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=delegation("writer", "tc-d2")),
+        RunStartedEvent(**writer),
+        ReasoningStartedEvent(**researcher),
+        ReasoningStartedEvent(**writer),
+        _reasoning_step("researcher plan", "researcher is thinking", **researcher),
+        _reasoning_step("writer plan", "writer is thinking", **writer),
+        _reasoning_step("researcher check", "researcher is checking", **researcher),
+        _reasoning_step("writer check", "writer is checking", **writer),
+        ReasoningCompletedEvent(**researcher),
+        ReasoningCompletedEvent(**writer),
+        _agent_said("researcher says hello", **researcher),
+        RunCompletedEvent(content="researcher says hello", **researcher),
+        TeamToolCallCompletedEvent(run_id=TOP_LEVEL_RUN, tool=delegation("researcher", "tc-d1")),
+        _agent_said("writer says hello", **writer),
+        RunCompletedEvent(content="writer says hello", **writer),
+        TeamToolCallCompletedEvent(run_id=TOP_LEVEL_RUN, tool=delegation("writer", "tc-d2")),
+        _team_said("Final synthesis.", **_TOP_LEVEL),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_team_attributes_each_reasoning_block_to_its_member(collect):
+    events = await collect(_reasoning_team_chunks(), attributed())
+    names = _lane_names(events)
+
+    assert_stream_contains(events, EventType.REASONING_MESSAGE_CONTENT, 4)
+    # Ordered, and the whole block text rather than a phrase inside it: a member's
+    # reasoning landing in another member's block stays visible, and so does the
+    # step numbering, which the two lanes count separately even while the steps
+    # they contribute alternate on the wire.
+    blocks = [(names[lane] if lane is not None else None, text) for lane, text in _reasoning_blocks_in_order(events)]
+    assert blocks == [
+        (
+            "Researcher",
+            "## Step 1: researcher plan\nresearcher is thinking\n\n"
+            "## Step 2: researcher check\nresearcher is checking\n\n",
+        ),
+        (
+            "Writer",
+            "## Step 1: writer plan\nwriter is thinking\n\n## Step 2: writer check\nwriter is checking\n\n",
+        ),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_two_members_reasoning_at_once_keep_a_reasoning_span_each(collect):
+    """Neither lane's reasoning span is closed by the other lane's steps arriving.
+
+    The two spans are open together and their steps alternate on the wire, so a
+    lane switch that ended whichever span was current would split each member's
+    reasoning into two blocks and interleave the pieces. The shared checker
+    holds every delta to the span it names, which such a stream still satisfies.
+    """
+    events = await collect(_reasoning_team_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.REASONING_MESSAGE_CONTENT, 4)
+    # One reasoning span per lane, holding both of that lane's steps, and the
+    # same shape on both lanes so neither is the other's leftovers.
+    for lane in ("run-1", "run-2"):
+        assert _lane_sequence(events, lane) == [
+            "SUBAGENT_STARTED",
+            "RAW",
+            "REASONING_START",
+            "REASONING_MESSAGE_START",
+            "REASONING_MESSAGE_CONTENT",
+            "REASONING_MESSAGE_CONTENT",
+            "REASONING_MESSAGE_END",
+            "REASONING_END",
+            "TEXT_MESSAGE_START",
+            "TEXT_MESSAGE_CONTENT",
+            "TEXT_MESSAGE_END",
+            "SUBAGENT_FINISHED",
+        ], lane
+
+
+def _streamed_reasoning_chunks() -> List[Any]:
+    """A member whose reasoning arrives as deltas rather than as whole steps.
+
+    A model that streams its reasoning takes this path instead of the step path,
+    and it opens the reasoning span itself rather than being told to.
+    """
+    member = _member_kwargs("scout", "run-scout")
+
+    def delta(text: str) -> ReasoningContentDeltaEvent:
+        chunk = ReasoningContentDeltaEvent(**member)
+        chunk.reasoning_content = text
+        return chunk
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**member),
+        delta("first I "),
+        delta("then I"),
+        RunCompletedEvent(content="scout done", **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_streamed_reasoning_deltas_are_attributed_to_the_member_that_streamed_them(collect):
+    events = await collect(_streamed_reasoning_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.REASONING_MESSAGE_CONTENT, 2)
+    # One span opened by the first delta, both deltas inside it, all on the
+    # member's lane, and ordered so a delta emitted twice stays visible.
+    assert in_emitted_order(events, EventType.REASONING_MESSAGE_CONTENT, "delta", _lane) == [
+        ("first I ", "run-scout"),
+        ("then I", "run-scout"),
+    ]
+    assert in_emitted_order(events, EventType.REASONING_START, _lane) == [("run-scout",)]
+    assert _lane_sequence(events, "run-scout") == [
+        "SUBAGENT_STARTED",
+        "RAW",
+        "REASONING_START",
+        "REASONING_MESSAGE_START",
+        "REASONING_MESSAGE_CONTENT",
+        "REASONING_MESSAGE_CONTENT",
+        "REASONING_MESSAGE_END",
+        "REASONING_END",
+        "SUBAGENT_FINISHED",
+    ]
+
+
+def _text_then_reasoning_and_tool_chunks() -> List[Any]:
+    """A member that is mid-sentence when it starts reasoning, and again when it calls a tool."""
+    member = _member_kwargs("scout", "run-scout")
+    scout_tool = ToolExecution(tool_call_id="tc-scout-lookup", tool_name="lookup", tool_args={"q": "x"}, result="found")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**member),
+        _agent_said("Let me think.", **member),
+        ReasoningStartedEvent(**member),
+        _reasoning_step("scout plan", "scout is thinking", **member),
+        ReasoningCompletedEvent(**member),
+        _agent_said("Now I will look it up.", **member),
+        ToolCallStartedEvent(tool=scout_tool, **member),
+        ToolCallCompletedEvent(tool=scout_tool, **member),
+        RunCompletedEvent(content="scout done", **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_lanes_open_text_message_is_closed_before_its_reasoning_or_tool_calls(collect):
+    events = await collect(_text_then_reasoning_and_tool_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.REASONING_MESSAGE_CONTENT)
+    assert_stream_contains(events, EventType.TOOL_CALL_START)
+    # The member lane in full: each open text message is ended by the reasoning
+    # or tool call that follows it, rather than staying open around it.
+    assert _lane_sequence(events, "run-scout") == [
+        "SUBAGENT_STARTED",
+        "RAW",
+        "TEXT_MESSAGE_START",
+        "TEXT_MESSAGE_CONTENT",
+        "TEXT_MESSAGE_END",
+        "REASONING_START",
+        "REASONING_MESSAGE_START",
+        "REASONING_MESSAGE_CONTENT",
+        "REASONING_MESSAGE_END",
+        "REASONING_END",
+        "TEXT_MESSAGE_START",
+        "TEXT_MESSAGE_CONTENT",
+        "TEXT_MESSAGE_END",
+        "TOOL_CALL_START",
+        "TOOL_CALL_ARGS",
+        "TOOL_CALL_END",
+        "TOOL_CALL_RESULT",
+        "SUBAGENT_FINISHED",
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "chunk_factory",
+    [_reasoning_team_chunks, _text_then_reasoning_and_tool_chunks],
+    ids=["two_members_reasoning", "one_member_interleaving"],
+)
+@chunk_mappers
+async def test_no_lane_ever_holds_a_reasoning_or_tool_event_inside_an_open_text_message(collect, chunk_factory):
+    events = await collect(chunk_factory(), attributed())
+
+    assert_stream_contains(events, EventType.REASONING_MESSAGE_START)
+    assert_stream_contains(events, EventType.TOOL_CALL_START)
+    open_in_lane: Dict[Optional[str], bool] = {}
+    for event in events:
+        lane = _lane(event)
+        if event.type == EventType.TEXT_MESSAGE_START:
+            open_in_lane[lane] = True
+        elif event.type == EventType.TEXT_MESSAGE_END:
+            open_in_lane[lane] = False
+        elif str(event.type).rsplit(".", 1)[-1].startswith(("REASONING_", "TOOL_CALL_")):
+            assert not open_in_lane.get(lane), f"{event.type} arrived inside an open text message in lane {lane}"
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@entity_mappers
+async def test_member_and_leader_text_never_share_a_message(collect_entity):
+    """Inline joins the leader's reply to the message the last member left open; attributed does not.
+
+    The shared checker holds every delta to the member its own span was opened
+    in, so the leader's words written into a member's message and stamped with
+    that member would satisfy it. What refuses that shape is the pair of
+    streams read together: inline really does put the two in one bubble, which
+    is what makes the split under attributed a change rather than a restatement.
+    """
+    inline = await collect_entity(_two_member_team(InMemoryDb()), SUBAGENT_VISIBILITY_INLINE)
+    events = await collect_entity(_two_member_team(InMemoryDb()), attributed())
+
+    assert_stream_contains(events, EventType.TEXT_MESSAGE_CONTENT, 3)
+    assert joined_text_in_emitted_order(inline)[-1] == (None, "Here is the brief.Final synthesis.")
+    assert _messages_in_order(events)[-2:] == [("Writer", "Here is the brief."), (None, "Final synthesis.")]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@entity_mappers
+async def test_subagent_started_links_back_to_its_delegation(collect_entity):
+    events = await collect_entity(_two_member_team(InMemoryDb()), attributed())
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED, 2)
+    started = _announcements(events)
+    parent_of_tool_call = {
+        e.tool_call_id: e.parent_message_id  # type: ignore[attr-defined]
+        for e in _of_type(events, EventType.TOOL_CALL_START)
+    }
+
+    # One announcement per delegation, in the order the leader delegated, and
+    # neither has a parent subagent because the top-level team delegated to both.
+    assert [
+        (e.name, e.description, e.parent_tool_call_id, e.parent_subagent_run_id)  # type: ignore[attr-defined]
+        for e in started
+    ] == [
+        ("Researcher", "research the topic", "tc-delegate-researcher", None),
+        ("Writer", "write the brief", "tc-delegate-writer", None),
+    ]
+    # The delegation's own parent message, which has to be a message this stream
+    # really opened: read back as None on both sides, this compares nothing.
+    parents = [parent_of_tool_call["tc-delegate-researcher"], parent_of_tool_call["tc-delegate-writer"]]
+    lane_of_message = _lane_of_message_id(events)
+    assert all(parent in lane_of_message for parent in parents), (parents, sorted(lane_of_message))
+    assert in_emitted_order(events, EventType.SUBAGENT_STARTED, "parent_message_id") == [
+        (parent,) for parent in parents
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@entity_mappers
+async def test_each_subagent_gets_exactly_one_terminal_carrying_its_result(collect_entity):
+    events = await collect_entity(_two_member_team(InMemoryDb()), attributed())
+    names = _lane_names(events)
+    assert_stream_contains(events, EventType.SUBAGENT_FINISHED, 2)
+    finished = _of_type(events, EventType.SUBAGENT_FINISHED)
+
+    assert [(names[e.subagent_run_id], e.result) for e in finished] == [  # type: ignore[attr-defined]
+        ("Researcher", "Found three sources."),
+        ("Writer", "Here is the brief."),
+    ]
+    assert not _of_type(events, EventType.SUBAGENT_ERROR)
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@entity_mappers
+async def test_a_members_terminal_goes_out_before_its_delegation_reports_a_result(collect_entity):
+    """The member's card resolves before the leader's delegation renders what it returned.
+
+    The shared checker orders a member's own events against its own terminal,
+    and a child's terminal against its parent's. Neither says where that
+    terminal sits relative to the leader's own tool call, which is what decides
+    whether a client sees the member close before the result reporting it
+    arrives, and before the next member is announced under the same leader.
+    """
+    events = await collect_entity(_two_member_team(InMemoryDb()), attributed())
+    assert_stream_contains(events, EventType.SUBAGENT_FINISHED, 2)
+    names = _lane_names(events)
+
+    def described(event: BaseEvent) -> Optional[str]:
+        lane = _lane(event)
+        return names[lane] if lane is not None else getattr(event, "tool_call_id", None)
+
+    lifecycle = [
+        (str(event.type).removeprefix("EventType."), described(event))
+        for event in events
+        if event.type == EventType.SUBAGENT_STARTED
+        or _is_terminal(event)
+        or (_lane(event) is None and event.type in (EventType.TOOL_CALL_END, EventType.TOOL_CALL_RESULT))
+    ]
+    assert lifecycle == [
+        ("SUBAGENT_STARTED", "Researcher"),
+        ("SUBAGENT_FINISHED", "Researcher"),
+        ("TOOL_CALL_END", "tc-delegate-researcher"),
+        ("TOOL_CALL_RESULT", "tc-delegate-researcher"),
+        ("SUBAGENT_STARTED", "Writer"),
+        ("SUBAGENT_FINISHED", "Writer"),
+        ("TOOL_CALL_END", "tc-delegate-writer"),
+        ("TOOL_CALL_RESULT", "tc-delegate-writer"),
+    ]
+
+
+# --- Nesting ----------------------------------------------------------------
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@entity_mappers
+async def test_nested_team_reports_the_full_parent_chain(collect_entity):
+    db = InMemoryDb()
+    scout = Agent(
+        name="Scout",
+        id="scout",
+        model=ScriptedModel(
+            "m-scout",
+            [("tool", "search_docs", {"query": "x"}, "tc-scout"), ("content", "Scout done.")],
+        ),
+        tools=[search_docs],
+        db=db,
+        telemetry=False,
+    )
+    inner = Team(
+        name="Inner Team",
+        id="inner-team",
+        model=ScriptedModel(
+            "m-inner",
+            [
+                ("tool", "delegate_task_to_member", {"member_id": "scout", "task": "scout it"}, "tc-inner"),
+                ("content", "Inner done."),
+            ],
+        ),
+        members=[scout],
+        db=db,
+        telemetry=False,
+    )
+    outer = _team(db, [inner], [({"member_id": "inner-team", "task": "run inner"}, "tc-outer")])
+
+    events = await collect_entity(outer, attributed())
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED, 2)
+    started = _announcements(events)
+    # A mapping is the right shape here: it resolves a member name to the run id
+    # the expected values below are written against, and the ordered assertions
+    # that follow are what would catch two members sharing a name.
+    lane_named = {e.name: e.subagent_run_id for e in started}  # type: ignore[attr-defined]
+
+    assert [
+        (e.name, e.parent_subagent_run_id, e.parent_tool_call_id, e.description)  # type: ignore[attr-defined]
+        for e in started
+    ] == [
+        ("Inner Team", None, "tc-outer", "run inner"),
+        ("Scout", lane_named["Inner Team"], "tc-inner", "scout it"),
+    ]
+
+    finished = [e.subagent_run_id for e in _of_type(events, EventType.SUBAGENT_FINISHED)]  # type: ignore[attr-defined]
+    assert finished == [lane_named["Scout"], lane_named["Inner Team"]]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@entity_mappers
+async def test_parallel_delegation_keeps_each_member_in_its_own_lane(collect_entity):
+    db = InMemoryDb()
+    team = Team(
+        name="Research Team",
+        id="research-team",
+        model=ScriptedModel(
+            "m-leader",
+            [
+                ("tool", "delegate_task_to_members", {"task": "both of you work"}, "tc-broadcast"),
+                ("content", "Final synthesis."),
+            ],
+        ),
+        members=[_researcher(db), _writer(db)],
+        delegate_to_all_members=True,
+        db=db,
+        telemetry=False,
+    )
+
+    events = await collect_entity(team, attributed())
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED, 2)
+    said = [entry for entry in _messages_in_order(events) if entry[1]]
+
+    # This path runs the members as concurrent tasks merged through one queue, so
+    # which of the two lanes reaches the wire first is the scheduler's and not a
+    # promise. What is promised holds per lane: each member's own words arrive
+    # whole in its own lane, and the leader's reply is the run's last word.
+    assert sorted(entry for entry in said if entry[0] is not None) == [
+        ("Researcher", "Found three sources."),
+        ("Writer", "Here is the brief."),
+    ]
+    assert [entry for entry in said if entry[0] is None] == [(None, "Final synthesis.")]
+    assert said[-1] == (None, "Final synthesis."), "the leader replied before both members had spoken"
+    # Each member gets its own announcement rather than one shared between them.
+    # The broadcast call names no member, so neither is linked to it: the link
+    # is only reported off a delegation that says which member it spawned.
+    assert sorted(
+        in_emitted_order(events, EventType.SUBAGENT_STARTED, "name", "parent_tool_call_id", "description")
+    ) == [
+        ("Researcher", None, None),
+        ("Writer", None, None),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@entity_mappers
+async def test_the_same_member_delegated_twice_occupies_two_lanes(collect_entity):
+    db = InMemoryDb()
+    scout = Agent(
+        name="Scout",
+        id="scout",
+        model=ScriptedModel("m-scout", [("content", "done: scout the north"), ("content", "done: scout the south")]),
+        db=db,
+        telemetry=False,
+    )
+    team = _team(
+        db,
+        [scout],
+        [
+            ({"member_id": "scout", "task": "scout the north"}, "tc-first"),
+            ({"member_id": "scout", "task": "scout the south"}, "tc-second"),
+        ],
+    )
+
+    events = await collect_entity(team, attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED, 2)
+    assert_stream_contains(events, EventType.SUBAGENT_FINISHED, 2)
+    # One invocation is one lane, and the framework mints a run id per
+    # delegation: keyed by name or by member id these would be one entry.
+    announced = in_emitted_order(
+        events, EventType.SUBAGENT_STARTED, "subagent_run_id", "name", "description", "parent_tool_call_id"
+    )
+    assert [row[1:] for row in announced] == [
+        ("Scout", "scout the north", "tc-first"),
+        ("Scout", "scout the south", "tc-second"),
+    ]
+    first, second = [row[0] for row in announced]
+    assert first != second, "both delegations to one member were reported under a single run id"
+    assert in_emitted_order(events, EventType.SUBAGENT_FINISHED, "subagent_run_id", "result") == [
+        (first, "done: scout the north"),
+        (second, "done: scout the south"),
+    ]
+
+
+# --- Failure paths ----------------------------------------------------------
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@entity_mappers
+async def test_a_failing_member_is_errored_and_the_team_run_still_finishes(collect_entity):
+    db = InMemoryDb()
+    broken = Agent(
+        name="Broken",
+        id="broken",
+        model=ScriptedModel("m-broken", [], fail_with="member exploded"),
+        db=db,
+        telemetry=False,
+    )
+    team = _team(db, [broken], [({"member_id": "broken", "task": "break"}, "tc-delegate-broken")])
+
+    events = await collect_entity(team, attributed())
+    names = _lane_names(events)
+    assert_stream_contains(events, EventType.SUBAGENT_ERROR)
+    errors = _of_type(events, EventType.SUBAGENT_ERROR)
+
+    assert [names[e.subagent_run_id] for e in errors] == ["Broken"]  # type: ignore[attr-defined]
+    assert "member exploded" in errors[0].message  # type: ignore[attr-defined]
+    # A lane that errored is not also reported as finished.
+    assert not _of_type(events, EventType.SUBAGENT_FINISHED)
+    # The leader recovered from its member's failure, so the run itself finished.
+    assert str(events[-1].type) == str(EventType.RUN_FINISHED)
+    assert (None, "Final synthesis.") in _messages_in_order(events)
+
+
+def _run_error_with_open_lanes_chunks(message: str) -> List[Any]:
+    """A nested team and its member are both mid-run when the top-level run fails."""
+    inner = _team_kwargs("inner-team", "Inner Team", "run-inner", parent=TOP_LEVEL_RUN)
+    member = _member_kwargs("scout", "run-scout", parent="run-inner")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamRunStartedEvent(**inner),
+        RunStartedEvent(**member),
+        _agent_said("half a sen", **member),
+        TeamRunErrorEvent(content=message, error_type="RuntimeError", **_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_run_that_errors_closes_every_open_member_lane_deepest_first(collect):
+    events = await collect(_run_error_with_open_lanes_chunks("team blew up"), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_ERROR, 2)
+    assert_stream_contains(events, EventType.RUN_ERROR)
+    # The member's own span closes, then the lanes error child before parent, and
+    # the run terminal is last with nothing after it.
+    assert [(str(e.type).removeprefix("EventType."), _lane(e), getattr(e, "message", None)) for e in events[-4:]] == [
+        ("TEXT_MESSAGE_END", "run-scout", None),
+        ("SUBAGENT_ERROR", "run-scout", "team blew up"),
+        ("SUBAGENT_ERROR", "run-inner", "team blew up"),
+        ("RUN_ERROR", None, "team blew up"),
+    ]
+    assert [e.code for e in _of_type(events, EventType.RUN_ERROR)] == ["RuntimeError"]  # type: ignore[attr-defined]
+    # Errored lanes are never also reported as finished.
+    assert not _of_type(events, EventType.SUBAGENT_FINISHED)
+
+
+_A_CHILD_RESOLVED_AFTER_ITS_PARENT = "terminated after its parent"
+
+
+def _assert_the_child_resolved_after_its_parent(violation: Optional[str]) -> None:
+    """The one thing a member's own terminal cannot put in order, stated once.
+
+    A member's terminal terminates that member and nothing else, so a run whose
+    source says a parent finished while its child was still streaming puts the
+    child's terminal after its parent's. The alternatives were both worse and
+    both reproduced defects: terminating the child from the parent's terminal
+    sent a terminal for a member that was still working, with no result, after
+    which the child's own completion was read as a repeat and dropped; holding
+    the parent's terminal back would report the parent as running after its own
+    run said otherwise.
+
+    Pinned as a violation rather than exempted: the shared checker still calls
+    such a stream malformed, which is the honest verdict on a source that
+    reported those two things in that order.
+    """
+    assert violation is not None, "a child resolving after its parent passed as a well-formed stream"
+    assert _A_CHILD_RESOLVED_AFTER_ITS_PARENT in violation, violation
+
+
+def _parent_lane_terminates_first_chunks(fail: bool) -> List[Any]:
+    """A sub-team reaches its own terminal with two generations still open below it.
+
+    Two, at different depths, because with a single open descendant the order
+    the run-end drain puts them in is whatever order one element comes in:
+    reversing it would still pass.
+    """
+    inner = _team_kwargs("inner-team", "Inner Team", "run-inner", parent=TOP_LEVEL_RUN)
+    middle = _team_kwargs("middle-team", "Middle Team", "run-middle", parent="run-inner")
+    member = _member_kwargs("scout", "run-scout", parent="run-middle")
+    parent_terminal = (
+        TeamRunErrorEvent(content="inner exploded", error_type="RuntimeError", **inner)
+        if fail
+        else TeamRunCompletedEvent(content="inner done", **inner)
+    )
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamRunStartedEvent(**inner),
+        TeamRunStartedEvent(**middle),
+        RunStartedEvent(**member),
+        _agent_said("scouting", **member),
+        parent_terminal,
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "fail,terminal",
+    [(False, "SUBAGENT_FINISHED"), (True, "SUBAGENT_ERROR")],
+    ids=["finished", "errored"],
+)
+@malformed_mappers
+async def test_a_members_own_terminal_terminates_only_that_member(collect_malformed, fail, terminal):
+    """The generations below it are still running, so the run end is what terminates them.
+
+    Neither of them is finished or errored here, which is what keeps a member
+    that never failed from carrying the failure above it and keeps a member that
+    is still working from being reported as done with nothing to show.
+    """
+    events, error, violation = await collect_malformed(
+        _parent_lane_terminates_first_chunks(fail),
+        attributed(),
+        thread_id=THREAD_ID,
+        run_id=TOP_LEVEL_RUN,
+    )
+
+    assert error is None, f"the source stream raised {error!r}"
+    terminals = [
+        (str(e.type).removeprefix("EventType."), e.subagent_run_id)  # type: ignore[attr-defined]
+        for e in events
+        if str(e.type).removeprefix("EventType.") in {"SUBAGENT_FINISHED", "SUBAGENT_ERROR"}
+    ]
+    # Only the lane whose run reported the terminal takes it. The two below it
+    # are drained by the run end, deepest first, as plain completions.
+    assert terminals == [
+        (terminal, "run-inner"),
+        ("SUBAGENT_FINISHED", "run-scout"),
+        ("SUBAGENT_FINISHED", "run-middle"),
+    ]
+    _assert_the_child_resolved_after_its_parent(violation)
+
+
+def _open_lanes_at_run_end_chunks() -> List[Any]:
+    """A nested team and its member never reach their own terminals."""
+    inner = _team_kwargs("inner-team", "Inner Team", "run-inner", parent=TOP_LEVEL_RUN)
+    member = _member_kwargs("scout", "run-scout", parent="run-inner")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamRunStartedEvent(**inner),
+        RunStartedEvent(**member),
+        _agent_said("scouting", **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_the_run_end_drain_terminates_open_member_lanes_deepest_first(collect):
+    events = await collect(_open_lanes_at_run_end_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_FINISHED, 2)
+    # The drain closes the child before its parent and the run terminal is last,
+    # with nothing after it.
+    assert [(str(e.type).removeprefix("EventType."), _lane(e)) for e in events[-3:]] == [
+        ("SUBAGENT_FINISHED", "run-scout"),
+        ("SUBAGENT_FINISHED", "run-inner"),
+        ("RUN_FINISHED", None),
+    ]
+    # A lane the run terminated carries no result: the member never reported one.
+    # Read as a declared field, so a renamed or removed result field is a failure
+    # here rather than two Nones comparing equal.
+    assert in_emitted_order(events, EventType.SUBAGENT_FINISHED, "subagent_run_id", "result") == [
+        ("run-scout", None),
+        ("run-inner", None),
+    ]
+    assert not _of_type(events, EventType.SUBAGENT_ERROR)
+
+
+def _two_lanes_holding_a_message_and_a_tool_call_chunks() -> List[Any]:
+    """A sub-team and its member each reach the run end mid-sentence with a call still open.
+
+    The tool call goes out before the words in each lane, and the lane has no
+    message open when it does: the call opens an empty parent message of its own
+    and closes it in the same breath, and the words that follow open a second
+    one. Given the other way round the call would close the message the words
+    opened, and only the call would still be open when the run ends, which is
+    not the two-spans-per-lane shape this run end is about.
+    """
+    inner = _team_kwargs("inner-team", "Inner Team", "run-inner", parent=TOP_LEVEL_RUN)
+    member = _member_kwargs("scout", "run-scout", parent="run-inner")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamRunStartedEvent(**inner),
+        RunStartedEvent(**member),
+        TeamToolCallStartedEvent(tool=ToolExecution(tool_call_id="tc-inner-plan", tool_name="plan"), **inner),
+        _team_said("inner speaking", **inner),
+        ToolCallStartedEvent(tool=ToolExecution(tool_call_id="tc-scout-look", tool_name="look"), **member),
+        _agent_said("scout speaking", **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_the_run_end_closes_every_lanes_messages_then_its_tool_calls_then_terminates_it(collect):
+    """One sweep per kind across all lanes, rather than one lane emptied at a time.
+
+    Emptying a lane at a time would put the deeper lane's terminal ahead of the
+    shallower lane's message end, which lands a terminal inside another lane's
+    open span, and would put a member's terminal ahead of the tool call end it
+    is still holding. Both orders are ones the shared checker accepts.
+    """
+    events = await collect(_two_lanes_holding_a_message_and_a_tool_call_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.TOOL_CALL_END, 2)
+    assert [(str(e.type).removeprefix("EventType."), _lane(e)) for e in events[-7:]] == [
+        ("TEXT_MESSAGE_END", "run-scout"),
+        ("TEXT_MESSAGE_END", "run-inner"),
+        ("TOOL_CALL_END", "run-scout"),
+        ("TOOL_CALL_END", "run-inner"),
+        ("SUBAGENT_FINISHED", "run-scout"),
+        ("SUBAGENT_FINISHED", "run-inner"),
+        ("RUN_FINISHED", None),
+    ]
+    # The ends name the calls each lane really opened, so the pairing above is
+    # not two ends of one lane's making.
+    assert in_emitted_order(events, EventType.TOOL_CALL_END, "tool_call_id", _lane) == [
+        ("tc-scout-look", "run-scout"),
+        ("tc-inner-plan", "run-inner"),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_tool_call_opened_after_its_members_terminal_is_still_closed(collect):
+    member = _member_kwargs("scout", "run-scout")
+    late = ToolExecution(tool_call_id="tc-late", tool_name="cleanup", tool_args={})
+
+    chunks = [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**member),
+        RunCompletedEvent(content="scout done", **member),
+        # Output trailing the member's own terminal: the lane is closed but the
+        # tool call it opens still has to be ended before the run terminal.
+        ToolCallStartedEvent(tool=late, **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+    events = await collect(chunks, attributed(), exempt=[TRAILING_OUTPUT_AFTER_A_MEMBER_TERMINAL])
+
+    assert_stream_contains(events, EventType.TOOL_CALL_END)
+    assert _tool_call_lanes_in_order(events) == [("tc-late", "run-scout")]
+    assert in_emitted_order(events, EventType.TOOL_CALL_END, "tool_call_id", _lane) == [("tc-late", "run-scout")]
+    # A terminal is final for the lane it names, so the trailing output does not
+    # earn the member a second one.
+    assert [e.subagent_run_id for e in _of_type(events, EventType.SUBAGENT_FINISHED)] == ["run-scout"]  # type: ignore[attr-defined]
+    assert str(events[-1].type) == str(EventType.RUN_FINISHED)
+
+
+def _member_content_after_its_terminal_chunks() -> List[Any]:
+    """A member says one more thing after its own terminal, while its delegation is still open."""
+    delegation = _delegation("tc-delegate-scout", "scout", "scout the topic", result="scout done")
+    member = _member_kwargs("scout", "run-scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=delegation),
+        RunStartedEvent(**member),
+        RunCompletedEvent(content="scout done", **member),
+        _agent_said("one more thing", **member),
+        TeamToolCallCompletedEvent(run_id=TOP_LEVEL_RUN, tool=delegation),
+        _team_said("Final synthesis.", **_TOP_LEVEL),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_content_trailing_a_members_terminal_stays_attributed_without_holding_a_span_open(collect):
+    events = await collect(
+        _member_content_after_its_terminal_chunks(),
+        attributed(),
+        exempt=[TRAILING_OUTPUT_AFTER_A_MEMBER_TERMINAL],
+    )
+
+    assert_stream_contains(events, EventType.TOOL_CALL_RESULT)
+    # The attribution is kept: the trailing text is still the member's.
+    assert _messages_in_order(events) == [(None, ""), ("Scout", "one more thing"), (None, "Final synthesis.")]
+    trailing = [e for e in _of_type(events, EventType.TEXT_MESSAGE_START) if _lane(e) == "run-scout"]
+    assert len(trailing) == 1
+    closed_at = [
+        index
+        for index, event in enumerate(events)
+        if event.type == EventType.TEXT_MESSAGE_END and event.message_id == trailing[0].message_id  # type: ignore[attr-defined]
+    ]
+    result_at = [index for index, event in enumerate(events) if event.type == EventType.TOOL_CALL_RESULT]
+    assert closed_at and result_at
+    assert closed_at[0] < result_at[0], (
+        "the member's trailing message was still open when the leader's tool result arrived, "
+        "so a client renders that result inside the member's bubble"
+    )
+
+
+def _closed_lane_trailing_spans_chunks() -> List[Any]:
+    """A member and its sub-team both emit new spans after their own run completed."""
+    inner = _team_kwargs("inner-team", "Inner Team", "run-inner", parent=TOP_LEVEL_RUN)
+    member = _member_kwargs("scout", "run-scout", parent="run-inner")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamRunStartedEvent(**inner),
+        RunStartedEvent(**member),
+        RunCompletedEvent(content="scout done", **member),
+        TeamRunCompletedEvent(content="inner done", **inner),
+        # Trailing output from lanes whose own terminal has already been emitted.
+        ReasoningStartedEvent(**member),
+        _agent_said("scout afterword", **member),
+        _team_said("inner afterword", **inner),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@entity_mappers
+async def test_no_lane_is_left_with_an_open_span_at_the_end_of_the_run(collect_entity):
+    events = await collect_entity(_two_member_team(InMemoryDb()), attributed())
+    assert_stream_contains(events, EventType.TEXT_MESSAGE_START, 3)
+    assert_stream_contains(events, EventType.TOOL_CALL_START, 4)
+    _assert_every_span_closed(events)
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "chunk_factory,reasoning_spans,exempt",
+    [
+        (_reasoning_team_chunks, 2, ()),
+        (_text_then_reasoning_and_tool_chunks, 1, ()),
+        (_open_lanes_at_run_end_chunks, 0, ()),
+        # This one streams chunks from members whose own runs already completed,
+        # so its stamped events deliberately outlive their member terminals.
+        (_closed_lane_trailing_spans_chunks, 1, (TRAILING_OUTPUT_AFTER_A_MEMBER_TERMINAL,)),
+    ],
+    ids=["two_members_reasoning", "one_member_interleaving", "open_lanes_at_run_end", "trailing_spans"],
+)
+@chunk_mappers
+async def test_every_reasoning_and_message_span_is_closed_before_the_run_ends(
+    collect, chunk_factory, reasoning_spans, exempt
+):
+    events = await collect(chunk_factory(), attributed(), exempt=exempt)
+    # How much reasoning this particular stream carries is stated per case, as a
+    # count, so the case that carries none says so rather than stating a bound
+    # that holds for every stream there is.
+    assert_stream_contains(events, EventType.TEXT_MESSAGE_START)
+    assert_stream_carries_exactly(events, EventType.REASONING_START, reasoning_spans)
+    _assert_every_span_closed(events)
+
+
+def _assert_every_span_closed(events: List[BaseEvent]) -> None:
+    """Every span the stream opened was closed, by id, before the run terminal."""
+    for start, end in (
+        (EventType.TEXT_MESSAGE_START, EventType.TEXT_MESSAGE_END),
+        (EventType.REASONING_START, EventType.REASONING_END),
+        (EventType.REASONING_MESSAGE_START, EventType.REASONING_MESSAGE_END),
+    ):
+        opened, closed = _span_pairs(events, start, end)
+        assert sorted(opened) == sorted(closed), f"{start} ids {opened} do not match {end} ids {closed}"
+
+    open_tool_calls = [e.tool_call_id for e in _of_type(events, EventType.TOOL_CALL_START)]  # type: ignore[attr-defined]
+    ended_tool_calls = [e.tool_call_id for e in _of_type(events, EventType.TOOL_CALL_END)]  # type: ignore[attr-defined]
+    assert sorted(open_tool_calls) == sorted(ended_tool_calls)
+
+    # A conforming client rejects a run that ends inside a span, so the terminal
+    # really is the last thing on the wire.
+    assert str(events[-1].type) in {str(EventType.RUN_FINISHED), str(EventType.RUN_ERROR)}
+
+
+# --- Visibility -------------------------------------------------------------
+
+# The stream a two-member Team produced before lineage existed. Under the default
+# inline visibility it must still be exactly this.
+_INLINE_TEAM_SEQUENCE = [
+    "EventType.RAW",  # TeamRunStarted
+    "EventType.RAW",  # TeamModelRequestStarted
+    "EventType.RAW",  # TeamModelRequestCompleted
+    "EventType.TEXT_MESSAGE_START",  # empty parent for the first delegation
+    "EventType.TEXT_MESSAGE_END",
+    "EventType.TOOL_CALL_START",  # delegate to Researcher
+    "EventType.TOOL_CALL_ARGS",
+    "EventType.RAW",  # Researcher RunStarted
+    "EventType.RAW",  # Researcher ModelRequestStarted
+    "EventType.RAW",  # Researcher ModelRequestCompleted
+    "EventType.TOOL_CALL_START",  # search_docs
+    "EventType.TOOL_CALL_ARGS",
+    "EventType.TOOL_CALL_END",
+    "EventType.TOOL_CALL_RESULT",
+    "EventType.RAW",  # Researcher ModelRequestStarted
+    "EventType.TEXT_MESSAGE_START",
+    "EventType.TEXT_MESSAGE_CONTENT",  # "Found three sources."
+    "EventType.RAW",  # Researcher ModelRequestCompleted
+    "EventType.RAW",  # Researcher RunContentCompleted
+    "EventType.TOOL_CALL_END",  # delegation to Researcher returns
+    "EventType.TOOL_CALL_RESULT",
+    "EventType.RAW",  # TeamModelRequestStarted
+    "EventType.RAW",  # TeamModelRequestCompleted
+    "EventType.TEXT_MESSAGE_END",
+    "EventType.TOOL_CALL_START",  # delegate to Writer
+    "EventType.TOOL_CALL_ARGS",
+    "EventType.RAW",  # Writer RunStarted
+    "EventType.RAW",  # Writer ModelRequestStarted
+    "EventType.RAW",  # Writer ModelRequestCompleted
+    "EventType.TOOL_CALL_START",  # spell_check
+    "EventType.TOOL_CALL_ARGS",
+    "EventType.TOOL_CALL_END",
+    "EventType.TOOL_CALL_RESULT",
+    "EventType.RAW",  # Writer ModelRequestStarted
+    "EventType.TEXT_MESSAGE_START",
+    "EventType.TEXT_MESSAGE_CONTENT",  # "Here is the brief."
+    "EventType.RAW",  # Writer ModelRequestCompleted
+    "EventType.RAW",  # Writer RunContentCompleted
+    "EventType.TOOL_CALL_END",  # delegation to Writer returns
+    "EventType.TOOL_CALL_RESULT",
+    "EventType.RAW",  # TeamModelRequestStarted
+    "EventType.TEXT_MESSAGE_CONTENT",  # the leader's reply joins the Writer's message
+    "EventType.RAW",  # TeamModelRequestCompleted
+    "EventType.RAW",  # TeamRunContentCompleted
+    "EventType.TEXT_MESSAGE_END",
+    "EventType.RUN_FINISHED",
+]
+
+
+@pytest.mark.asyncio
+@entity_mappers
+async def test_inline_is_the_default_and_leaves_the_team_stream_unchanged(collect_entity):
+    default_events = await collect_entity(_two_member_team(InMemoryDb()))
+    inline_events = await collect_entity(_two_member_team(InMemoryDb()), SUBAGENT_VISIBILITY_INLINE)
+
+    assert _type_sequence(default_events) == _INLINE_TEAM_SEQUENCE
+    assert _normalized_payloads(default_events) == _normalized_payloads(inline_events)
+    assert all(_lane(e) is None for e in default_events)
+    assert not [e for e in default_events if "SUBAGENT" in str(e.type)]
+
+
+@pytest.mark.asyncio
+@malformed_mappers
+async def test_the_default_keeps_the_duplicate_prompt_a_paused_tool_listed_twice_produced(collect_malformed):
+    """Part of the same claim: the default stream is what it was, defect and all.
+
+    The fixture has to carry a tool listed twice or the claim is vacuous: before
+    member attribution existed a paused tool was prompted once per listing,
+    duplicate tool call id and all. That duplicate is a defect the default keeps
+    rather than a stream the default is allowed to change, which is why it is
+    pinned here as the invariant violation it is.
+    """
+
+    async def paused(visibility):
+        return await collect_malformed(
+            _paused_tool_listed_in_both_places_chunks(),
+            visibility,
+            thread_id=THREAD_ID,
+            run_id=TOP_LEVEL_RUN,
+        )
+
+    default_paused, default_error, violation = await paused(None)
+    inline_paused, inline_error, inline_violation = await paused(SUBAGENT_VISIBILITY_INLINE)
+
+    assert default_error is None and inline_error is None
+    assert _normalized_payloads(default_paused) == _normalized_payloads(inline_paused)
+    assert in_emitted_order(default_paused, EventType.TOOL_CALL_START, "tool_call_id", _lane) == [
+        ("tc-shared-confirm", None),
+        ("tc-shared-confirm", None),
+    ]
+    # The duplicate itself is pinned above, in order. This states that the
+    # shared checker still calls such a stream malformed, without pinning the
+    # sentence it says so in.
+    assert violation is not None and "tc-shared-confirm" in violation
+    assert inline_violation == violation
+
+
+@pytest.mark.asyncio
+@entity_mappers
+async def test_hidden_withholds_member_internals_but_keeps_the_delegation(collect_entity):
+    events = await collect_entity(_two_member_team(InMemoryDb()), SUBAGENT_VISIBILITY_HIDDEN)
+
+    # Only the leader's own delegations, only the leader's own reply, and nothing
+    # a member produced: no member tool call, no member text, no lineage at all.
+    assert_stream_contains(events, EventType.TOOL_CALL_RESULT, 2)
+    assert _tool_call_lanes_in_order(events) == [("tc-delegate-researcher", None), ("tc-delegate-writer", None)]
+    # The empty entry is the assistant message the delegation calls are parented
+    # to; ordered, so it stays visible rather than being folded away by content.
+    assert _messages_in_order(events) == [(None, ""), (None, "Final synthesis.")]
+    assert in_emitted_order(events, EventType.TOOL_CALL_RESULT, "tool_call_id", lambda e: json.loads(e.content)) == [
+        ("tc-delegate-researcher", "Found three sources."),
+        ("tc-delegate-writer", "Here is the brief."),
+    ]
+    assert not [e for e in events if "SUBAGENT" in str(e.type)]
+    assert not [e for e in events if _lane(e) is not None]
+
+
+@pytest.mark.asyncio
+@entity_mappers
+async def test_hidden_keeps_the_delegation_calls_own_arguments_which_name_the_member(collect_entity):
+    """What hidden withholds is the member surface, not the team's own delegation call.
+
+    Those arguments are the team's own work, and the default puts exactly the
+    same ones on the wire, so no account of hidden may say nothing reaching the
+    client names a member.
+    """
+    events = await collect_entity(_two_member_team(InMemoryDb()), SUBAGENT_VISIBILITY_HIDDEN)
+
+    assert_stream_contains(events, EventType.TOOL_CALL_ARGS, 2)
+    assert in_emitted_order(events, EventType.TOOL_CALL_ARGS, "tool_call_id", lambda e: json.loads(e.delta)) == [
+        ("tc-delegate-researcher", {"member_id": "researcher", "task": "research the topic"}),
+        ("tc-delegate-writer", {"member_id": "writer", "task": "write the brief"}),
+    ]
+    # Withheld all the same: nothing tells the client which member produced what.
+    assert not [e for e in events if "SUBAGENT" in str(e.type)]
+    assert not [e for e in events if _lane(e) is not None]
+
+
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_hidden_withholds_a_nested_teams_members_too(collect):
+    inner = _team_kwargs("inner-team", "Inner Team", "run-inner", parent=TOP_LEVEL_RUN)
+    member = _member_kwargs("scout", "run-scout", parent="run-inner")
+    delegation = _delegation("tc-delegate-inner", "inner-team", "run inner", result="inner finished")
+    scout_tool = ToolExecution(tool_call_id="tc-scout-search", tool_name="search_docs", tool_args={"query": "x"})
+
+    chunks = [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=delegation),
+        TeamRunStartedEvent(**inner),
+        RunStartedEvent(**member),
+        ToolCallStartedEvent(tool=scout_tool, **member),
+        _agent_said("Scout says hello.", **member),
+        _team_said("Inner says hello.", **inner),
+        TeamToolCallCompletedEvent(run_id=TOP_LEVEL_RUN, tool=delegation),
+        _team_said("Final synthesis.", **_TOP_LEVEL),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+    events = await collect(chunks, SUBAGENT_VISIBILITY_HIDDEN)
+
+    # Nesting does not earn a grandchild any exposure the direct member lacks.
+    assert _tool_call_lanes_in_order(events) == [("tc-delegate-inner", None)]
+    # The empty entry is the assistant message the delegation calls are parented
+    # to; ordered, so it stays visible rather than being folded away by content.
+    assert _messages_in_order(events) == [(None, ""), (None, "Final synthesis.")]
+    assert not [e for e in events if _lane(e) is not None]
+    assert not [e for e in events if "SUBAGENT" in str(e.type)]
+    assert str(events[-1].type) == str(EventType.RUN_FINISHED)
+
+
+@pytest.mark.asyncio
+@entity_mappers
+@pytest.mark.parametrize(
+    # Resolved inside the test rather than at collection: naming the attributed
+    # setting is what skips on a release that cannot serve it.
+    "setting",
+    [
+        lambda: None,
+        lambda: SUBAGENT_VISIBILITY_INLINE,
+        attributed,
+        lambda: SUBAGENT_VISIBILITY_HIDDEN,
+    ],
+    ids=["default", "inline", "attributed", "hidden"],
+)
+async def test_a_single_agent_is_unaffected_by_the_visibility_setting(collect_entity, setting):
+    """Each setting against the unset default, which is the stream a released client reads.
+
+    The baseline is the setting left unset rather than any named one, so the
+    default arm compares that stream with a second run of itself. That arm is
+    the run-to-run determinism control the other three rest on rather than a
+    claim about the setting: without it a difference between two runs of the
+    same code would read as a difference the setting made.
+    """
+    visibility = setting()
+    baseline = await collect_entity(_researcher(InMemoryDb()), prompt="Research agno")
+    events = await collect_entity(_researcher(InMemoryDb()), visibility, prompt="Research agno")
+
+    assert _normalized_payloads(events) == _normalized_payloads(baseline)
+    assert all(_lane(e) is None for e in events)
+    assert not [e for e in events if "SUBAGENT" in str(e.type)]
+
+
+_SINGLE_AGENT: Dict[str, Any] = {"agent_id": "assistant", "agent_name": "Assistant", "run_id": TOP_LEVEL_RUN}
+
+
+def _pending(tool_call_id: str, **flags: Any) -> ToolExecution:
+    return ToolExecution(tool_call_id=tool_call_id, tool_name="send_email", tool_args={"to": "ops"}, **flags)
+
+
+def _paused_single_agent_chunks() -> List[Any]:
+    """One Agent, no inner agent, pausing on a tool call it already streamed a start for."""
+    return [
+        RunStartedEvent(**_SINGLE_AGENT),
+        ToolCallStartedEvent(tool=_pending("tc-confirm"), **_SINGLE_AGENT),
+        AgentRunPausedEvent(
+            tools=[_pending("tc-confirm", requires_confirmation=True)], content="Send it?", **_SINGLE_AGENT
+        ),
+    ]
+
+
+def _flags_that_list_a_pending_call() -> List[str]:
+    """Every ToolExecution flag that puts a pending call on a list the pause prompt reads.
+
+    Asked of the paused event itself, one candidate flag at a time, rather than
+    written out here. A flag added to the framework, or a list added to the ones
+    the prompt reads, is a new way for one pending call to be reported twice,
+    and the cases below are generated from whatever this finds so that such an
+    addition arrives already covered instead of quietly widening the gap this
+    test exists to close.
+    """
+    found: List[str] = []
+    for candidate in fields(ToolExecution):
+        probe = ToolExecution(tool_call_id="probe", tool_name="probe")
+        setattr(probe, candidate.name, True)
+        paused = AgentRunPausedEvent(tools=[probe])
+        if any(getattr(paused, list_name, None) for list_name in handlers._PAUSE_TOOL_LISTS):
+            found.append(candidate.name)
+    return found
+
+
+def _ways_one_pending_call_is_reported_twice() -> Dict[str, Callable[[], List[Any]]]:
+    """The shapes in which one paused Agent reports the same pending call more than once.
+
+    Two of them are hand-written: a call the run already streamed a start for,
+    and two separate pending records sharing one id. The rest are generated,
+    one per combination of the flags discovered above, because a call flagged
+    for several lists is listed by each of them. Generating that part is what
+    makes a flag added to the framework arrive covered; the two hand-written
+    shapes are the ones that were reported, and nothing here proves they are
+    the only two.
+    """
+    flags = _flags_that_list_a_pending_call()
+    ways: Dict[str, Callable[[], List[Any]]] = {
+        "already-streamed": _paused_single_agent_chunks,
+        "two-records-one-id": lambda: [
+            RunStartedEvent(**_SINGLE_AGENT),
+            AgentRunPausedEvent(
+                tools=[
+                    _pending("tc-twice", requires_confirmation=True),
+                    _pending("tc-twice", requires_confirmation=True),
+                ],
+                **_SINGLE_AGENT,
+            ),
+        ],
+    }
+    for size in range(2, len(flags) + 1):
+        for combination in combinations(flags, size):
+            ways["+".join(combination)] = partial(_paused_on_every_flag, combination)
+    return ways
+
+
+def _paused_on_every_flag(flags: Tuple[str, ...]) -> List[Any]:
+    """One Agent pausing on a single pending call carrying several pause flags at once."""
+    return [
+        RunStartedEvent(**_SINGLE_AGENT),
+        AgentRunPausedEvent(
+            tools=[_pending("tc-many-flags", **{flag: True for flag in flags})], content="Send it?", **_SINGLE_AGENT
+        ),
+    ]
+
+
+_WAYS_REPORTED_TWICE = _ways_one_pending_call_is_reported_twice()
+
+
+def test_the_pause_prompt_reads_more_than_one_list_of_pending_calls():
+    """Otherwise the generated cases below collapse to the two hand-written ones."""
+    assert len(_flags_that_list_a_pending_call()) >= 2, (
+        "the pause prompt reads one list of pending calls at most, so no generated case reports one twice"
+    )
+
+
+@pytest.mark.parametrize("paused", [AgentRunPausedEvent, TeamRunPausedEvent], ids=["agent", "team"])
+def test_every_list_the_pause_prompt_reads_is_one_the_paused_event_carries(paused):
+    """A name the event does not carry is read as an empty list, so it has to be checked here.
+
+    The prompt reaches these by name and treats a missing one as no pending
+    calls, because a paused run may not be told what the client cannot render
+    by raising at it. That tolerance is what makes a misnamed entry silently
+    drop everything on that list, which is what this refuses.
+    """
+    missing = [name for name in handlers._PAUSE_TOOL_LISTS if not hasattr(paused(tools=[]), name)]
+    assert not missing, f"{paused.__name__} carries no such list of pending calls: {missing}"
+
+
+@pytest.mark.asyncio
+@malformed_mappers
+@pytest.mark.parametrize(
+    "setting",
+    [lambda: None, attributed, lambda: SUBAGENT_VISIBILITY_HIDDEN],
+    ids=["default", "attributed", "hidden"],
+)
+@pytest.mark.parametrize("way", sorted(_WAYS_REPORTED_TWICE), ids=sorted(_WAYS_REPORTED_TWICE))
+async def test_a_paused_single_agent_is_unaffected_by_the_visibility_setting(collect_malformed, setting, way):
+    """A run with no member on the wire streams the same events whatever the setting.
+
+    A pause is where that is easiest to lose, and every way one pending call can
+    be reported twice is a way to lose it: the prompt de-duplicates by tool call
+    id, and a de-duplication the default does not do makes an Agent alone stream
+    one thing under the default and another under either lineage setting. So the
+    cases are the whole class rather than the one shape that was reported.
+
+    The default's stream here is the duplicate prompt it has always emitted, so
+    the shared checker calls it malformed. That is what these settings have to
+    match, defect and all, which is why it is driven through the collector that
+    records the violation instead of failing on it. The duplicate is asserted on
+    the baseline first, so a case that stopped producing one fails here rather
+    than passing on three identical well-formed streams.
+    """
+
+    async def paused(visibility):
+        return await collect_malformed(
+            _WAYS_REPORTED_TWICE[way](), visibility, thread_id=THREAD_ID, run_id=TOP_LEVEL_RUN
+        )
+
+    baseline, baseline_error, baseline_violation = await paused(SUBAGENT_VISIBILITY_INLINE)
+    events, error, violation = await paused(setting())
+
+    assert baseline_error is None and error is None
+    prompted = in_emitted_order(baseline, EventType.TOOL_CALL_START, "tool_call_id", _lane)
+    assert len(prompted) > len(set(prompted)), f"the {way} case prompts no call twice, so it tests nothing"
+    assert _normalized_payloads(events) == _normalized_payloads(baseline)
+    assert violation == baseline_violation
+    assert not [e for e in events if "SUBAGENT" in str(e.type)]
+
+
+def test_visibility_is_validated():
+    assert validate_subagent_visibility(None) == SUBAGENT_VISIBILITY_INLINE
+    assert validate_subagent_visibility(SUBAGENT_VISIBILITY_HIDDEN) == SUBAGENT_VISIBILITY_HIDDEN
+    with pytest.raises(ValueError, match="subagent_visibility must be one of"):
+        validate_subagent_visibility("loud")
+
+
+def test_attributed_is_refused_when_the_protocol_lacks_the_lineage_events(monkeypatch):
+    """Named without the usual skip: on such a release this is the behavior under test."""
+    monkeypatch.setattr(handlers, "SUBAGENT_EVENTS_AVAILABLE", False)
+    with pytest.raises(ValueError, match="ag-ui-protocol"):
+        validate_subagent_visibility(ATTRIBUTED_EVEN_WHEN_REFUSED)
+    # Every other setting keeps working on an older protocol.
+    assert validate_subagent_visibility(SUBAGENT_VISIBILITY_HIDDEN) == SUBAGENT_VISIBILITY_HIDDEN
+
+
+# --- A real member that pauses ----------------------------------------------
+
+
+@tool(requires_confirmation=True)
+def send_email(to: str) -> str:
+    return f"emailed {to}"
+
+
+def _emailer(db: InMemoryDb) -> Agent:
+    """A member whose only tool needs a confirmation, so its run really pauses."""
+    return Agent(
+        name="Emailer",
+        id="emailer",
+        model=ScriptedModel(
+            "m-emailer",
+            [("tool", "send_email", {"to": "ops"}, "tc-send"), ("content", "Email sent.")],
+        ),
+        tools=[send_email],
+        db=db,
+        telemetry=False,
+    )
+
+
+def _team_whose_member_pauses(db: InMemoryDb) -> Team:
+    return _team(db, [_emailer(db)], [({"member_id": "emailer", "task": "email ops"}, "tc-delegate-emailer")])
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@entity_mappers
+async def test_a_real_member_that_pauses_is_prompted_on_its_own_lane(collect_entity):
+    """A genuine member pause, from a real team run rather than a hand-built chunk list.
+
+    The framework decides the member's run id here, so the lane is read off the
+    announcement rather than written down. What the hand-built pauses still
+    cover is the shapes one scripted run cannot produce: a leader and a member
+    paused at once, a pause naming a member whose lane already terminated, a
+    paused grandchild, and a pause reported only through requirements.
+    """
+    events = await collect_entity(_team_whose_member_pauses(InMemoryDb()), attributed(), prompt="Email ops")
+
+    announced = _announcements(events)
+    assert [(e.name, e.parent_tool_call_id) for e in announced] == [("Emailer", "tc-delegate-emailer")]  # type: ignore[attr-defined]
+    lane = announced[0].subagent_run_id  # type: ignore[attr-defined]
+
+    assert_stream_contains(events, EventType.TOOL_CALL_ARGS, 2)
+    assert in_emitted_order(events, EventType.TOOL_CALL_ARGS, "tool_call_id", "delta", _lane) == [
+        ("tc-delegate-emailer", '{"member_id": "emailer", "task": "email ops"}', None),
+        ("tc-send", '{"to": "ops"}', lane),
+    ]
+    # The pending call is prompted before the lane's own terminal, and pausing
+    # is not finishing, so the terminal carries no result.
+    assert [(e.subagent_run_id, e.result) for e in _of_type(events, EventType.SUBAGENT_FINISHED)] == [(lane, None)]  # type: ignore[attr-defined]
+    assert str(events[-1].type) == str(EventType.RUN_FINISHED)
+
+
+# --- Over the wire ----------------------------------------------------------
+
+
+def _sse_events(body: str) -> List[Dict[str, Any]]:
+    return [json.loads(line[len("data: ") :]) for line in body.splitlines() if line.startswith("data: ")]
+
+
+@needs_lineage_events
+def test_lineage_reaches_the_wire_through_the_agui_interface():
+    """The AGUI constructor option must survive all the way to the SSE stream."""
+    from fastapi.testclient import TestClient
+
+    from agno.os import AgentOS
+    from agno.os.interfaces.agui import AGUI
+
+    team = _two_member_team(InMemoryDb())
+    agent_os = AgentOS(
+        id="lineage-os",
+        teams=[team],
+        interfaces=[AGUI(team=team, subagent_visibility=attributed())],
+        telemetry=False,
+    )
+    client = TestClient(agent_os.get_app())
+
+    response = client.post(
+        "/agui",
+        json={
+            "thread_id": "wire-thread",
+            "run_id": "wire-run",
+            "state": {"approved": False},
+            "messages": [{"id": "m1", "role": "user", "content": "Write a brief"}],
+            "tools": [],
+            "context": [],
+            "forwarded_props": {},
+        },
+    )
+    assert response.status_code == 200
+
+    events = _sse_events(response.text)
+    # The body is the whole deliverable here, so it has to end the way every
+    # other stream in this module ends. Without this the run terminal could go
+    # missing from the response and every payload assertion below would still
+    # hold on the truncated body.
+    types = [event["type"] for event in events]
+    assert types[-1] == "RUN_FINISHED", f"the response body does not end on the run terminal: {types[-3:]}"
+    assert "RUN_ERROR" not in types, (
+        f"the run reached the wire as a failure: {[e for e in events if e['type'] == 'RUN_ERROR']}"
+    )
+
+    started = [e for e in events if e["type"] == "SUBAGENT_STARTED"]
+    assert [(e["name"], e["parentToolCallId"]) for e in started] == [
+        ("Researcher", "tc-delegate-researcher"),
+        ("Writer", "tc-delegate-writer"),
+    ]
+
+    # A set is the right shape for this one claim: every lane that appears on
+    # the wire was announced. Which events carry it is asserted in order below.
+    lanes = {e["subagentRunId"] for e in events if e.get("subagentRunId")}
+    assert lanes == {e["subagentRunId"] for e in started}
+
+    name_of_lane = {e["subagentRunId"]: e["name"] for e in started}
+    deltas: Dict[str, str] = {}
+    for event in events:
+        if event["type"] == "TEXT_MESSAGE_CONTENT":
+            deltas[event["messageId"]] = deltas.get(event["messageId"], "") + event["delta"]
+    # Ordered over the message starts, so a member's message never disappears
+    # into another's key and an empty parent message stays visible.
+    said = [
+        (name_of_lane.get(event.get("subagentRunId")), deltas.get(event["messageId"], ""))
+        for event in events
+        if event["type"] == "TEXT_MESSAGE_START"
+    ]
+    assert said == [
+        (None, ""),
+        ("Researcher", ""),
+        ("Researcher", "Found three sources."),
+        ("Writer", ""),
+        ("Writer", "Here is the brief."),
+        (None, "Final synthesis."),
+    ]
+
+    # A team's session state is one shared document, so state events are left
+    # unattributed on purpose: a client filtering by member must not lose state
+    # written during a delegation.
+    state_events = [e for e in events if e["type"].startswith("STATE_")]
+    assert {e["type"] for e in state_events} == {"STATE_SNAPSHOT", "STATE_DELTA"}
+    assert [e.get("subagentRunId") for e in state_events] == [None] * len(state_events)
+    assert [e["snapshot"]["approved"] for e in state_events if e["type"] == "STATE_SNAPSHOT"] == [False, False]
+
+
+def test_the_agui_interface_defaults_to_inline():
+    from agno.os.interfaces.agui import AGUI
+
+    team = _two_member_team(InMemoryDb())
+    assert AGUI(team=team).subagent_visibility == SUBAGENT_VISIBILITY_INLINE
+    with pytest.raises(ValueError, match="subagent_visibility must be one of"):
+        AGUI(team=team, subagent_visibility="loud")
+
+
+# --- Lane lifecycle ---------------------------------------------------------
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_spans_opened_after_a_lane_terminated_are_still_closed_before_the_run_ends(collect):
+    events = await collect(
+        _closed_lane_trailing_spans_chunks(),
+        attributed(),
+        exempt=[TRAILING_OUTPUT_AFTER_A_MEMBER_TERMINAL],
+    )
+
+    assert_stream_contains(events, EventType.REASONING_END)
+    # Ordered on both sides, so a span opened or closed twice cannot hide behind
+    # a shared message id.
+    assert in_emitted_order(events, EventType.TEXT_MESSAGE_START, "message_id", _lane) == in_emitted_order(
+        events, EventType.TEXT_MESSAGE_END, "message_id", _lane
+    )
+    assert in_emitted_order(events, EventType.TEXT_MESSAGE_START, _lane) == [("run-scout",), ("run-inner",)]
+
+    assert in_emitted_order(events, EventType.REASONING_START, "message_id", _lane) == in_emitted_order(
+        events, EventType.REASONING_END, "message_id", _lane
+    )
+    assert in_emitted_order(events, EventType.REASONING_START, _lane) == [("run-scout",)]
+
+    # A child lane's spans close before its parent's.
+    ends = [_lane(e) for e in _of_type(events, EventType.TEXT_MESSAGE_END)]
+    assert ends.index("run-scout") < ends.index("run-inner")
+    assert str(events[-1].type) == str(EventType.RUN_FINISHED)
+
+
+def test_closing_the_root_lane_ignores_whichever_lane_is_current():
+    state = StreamState(subagent_visibility=attributed(), root_run_id=TOP_LEVEL_RUN)
+    state.current_lane = ROOT_LANE
+    root_message_id = state.open_text_message()
+    state.current_lane = "run-scout"
+    state.open_text_message()
+
+    closed = handlers._close_lane_spans(state, ROOT_LANE)
+
+    assert [(str(e.type), e.message_id, _lane(e)) for e in closed] == [  # type: ignore[attr-defined]
+        (str(EventType.TEXT_MESSAGE_END), root_message_id, None)
+    ]
+    # The subagent lane is untouched by a root-lane close.
+    assert state.lane("run-scout").text_message_open is True
+
+
+@needs_lineage_events
+def test_open_tool_calls_close_in_the_order_the_run_opened_them():
+    """The close order is part of the wire, so it may not be left to set iteration.
+
+    The 24 ids go out interleaved from both ends, lowest then highest then next
+    lowest, an order that is neither ascending nor descending and so is not the
+    output of sorting them either way. The three orders that would pass without
+    the run's own order being kept are refused below before the ids are opened.
+    """
+    state = StreamState(subagent_visibility=attributed(), root_run_id=TOP_LEVEL_RUN)
+    state.current_lane = ROOT_LANE
+    ends = [f"tc-{index:02d}" for index in range(24)]
+    opened = [ends[index // 2] if index % 2 == 0 else ends[-1 - index // 2] for index in range(24)]
+    assert sorted(opened) == ends, "the interleave dropped or repeated an id"
+    assert opened != ends, "an ascending sort reproduces this order"
+    assert opened != ends[::-1], "a descending sort reproduces this order"
+    for tool_call_id in opened:
+        state.start_tool_call(tool_call_id)
+    assert list(state.active_tool_call_ids) != opened, "this interpreter's set iteration reproduces this order"
+
+    closed = [e.tool_call_id for e in handlers._close_all_lane_spans(state)]  # type: ignore[attr-defined]
+
+    assert closed == opened
+
+
+@needs_lineage_events
+def test_an_open_tool_call_is_closed_even_when_its_lane_holds_no_other_span():
+    """The run-end close reaches a lane through the tool call it owns, not only through its spans."""
+    state = StreamState(subagent_visibility=attributed(), root_run_id=TOP_LEVEL_RUN)
+    state.current_lane = "run-scout"
+    state.start_tool_call("tc-only")
+    assert state.lanes == {}, "the lane must hold nothing else for this to test what it claims"
+
+    closed = handlers._close_all_lane_spans(state)
+
+    assert [(str(e.type), e.tool_call_id, _lane(e)) for e in closed] == [  # type: ignore[attr-defined]
+        (str(EventType.TOOL_CALL_END), "tc-only", "run-scout")
+    ]
+    assert "tc-only" not in state.active_tool_call_ids
+
+
+def _paused_member_chunks() -> List[Any]:
+    """A member pauses for a confirmation while the leader also has one of its own."""
+    member_tool = ToolExecution(
+        tool_call_id="tc-member-confirm",
+        tool_name="send_email",
+        tool_args={"to": "ops"},
+        requires_confirmation=True,
+    )
+    requirement = _requirement(member_tool, "scout", "run-scout")
+    leader_tool = ToolExecution(
+        tool_call_id="tc-leader-confirm",
+        tool_name="publish",
+        tool_args={"channel": "blog"},
+        requires_confirmation=True,
+    )
+    member = _member_kwargs("scout", "run-scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**member),
+        _agent_said("I need approval.", **member),
+        AgentRunPausedEvent(tools=[member_tool], **member),
+        TeamRunPausedEvent(tools=[leader_tool], requirements=[requirement], **_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_paused_member_gets_one_plain_terminal_after_all_of_its_events(collect):
+    events = await collect(_paused_member_chunks(), attributed())
+    assert_stream_contains(events, EventType.SUBAGENT_FINISHED)
+    finished = _of_type(events, EventType.SUBAGENT_FINISHED)
+
+    # Pausing is not finishing, so the lane stays open until the run-end drain
+    # closes it. No suspended outcome: this interface emits no run-level
+    # interrupt outcome to pair one with.
+    assert [(e.subagent_run_id, e.result, e.outcome) for e in finished] == [("run-scout", None, None)]  # type: ignore[attr-defined]
+    terminal_at = events.index(finished[0])
+    assert [str(e.type) for i, e in enumerate(events) if _lane(e) == "run-scout" and i > terminal_at] == []
+    assert str(events[-1].type) == str(EventType.RUN_FINISHED)
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_paused_tool_is_attributed_to_the_member_that_owns_it(collect):
+    events = await collect(_paused_member_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.TOOL_CALL_START, 2)
+    assert_stream_contains(events, EventType.TOOL_CALL_ARGS, 2)
+    assert _tool_call_lanes_in_order(events) == [("tc-leader-confirm", None), ("tc-member-confirm", "run-scout")]
+    assert in_emitted_order(events, EventType.TOOL_CALL_ARGS, "tool_call_id", lambda e: json.loads(e.delta)) == [
+        ("tc-leader-confirm", {"channel": "blog"}),
+        ("tc-member-confirm", {"to": "ops"}),
+    ]
+
+    # The confirmation prompt the client must render arrives inside the lane, so
+    # it precedes that member's terminal, and it opens a message of the member's
+    # own rather than borrowing the leader's.
+    lane_events = _lane_sequence(events, "run-scout")
+    assert lane_events[-6:] == [
+        "TEXT_MESSAGE_START",
+        "TEXT_MESSAGE_END",
+        "TOOL_CALL_START",
+        "TOOL_CALL_ARGS",
+        "TOOL_CALL_END",
+        "SUBAGENT_FINISHED",
+    ]
+
+    # A tool call and the message carrying it name the same member. One message
+    # cannot name two, so each lane's pending calls get a message of their own.
+    parent_of = {e.tool_call_id: e.parent_message_id for e in _of_type(events, EventType.TOOL_CALL_START)}  # type: ignore[attr-defined]
+    lane_of_message = _lane_of_message_id(events)
+    assert lane_of_message[parent_of["tc-member-confirm"]] == "run-scout"
+    assert lane_of_message[parent_of["tc-leader-confirm"]] is None
+    assert parent_of["tc-member-confirm"] != parent_of["tc-leader-confirm"]
+
+
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_hidden_does_not_attribute_a_paused_member_tool(collect):
+    events = await collect(_paused_member_chunks(), SUBAGENT_VISIBILITY_HIDDEN)
+
+    assert _tool_call_lanes_in_order(events) == [("tc-leader-confirm", None), ("tc-member-confirm", None)]
+    assert not [e for e in events if _lane(e) is not None]
+
+
+def _grandchild_announced_first_chunks() -> List[Any]:
+    """A grandchild whose first chunk precedes its parent sub-team's first chunk."""
+    inner = _team_kwargs("inner-team", "Inner Team", "run-inner", parent=TOP_LEVEL_RUN)
+    member = _member_kwargs("scout", "run-scout", parent="run-inner")
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        _agent_said("Scout first.", **member),
+        _team_said("Inner second.", **inner),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+def _grandchild_under_an_announced_parent_chunks() -> List[Any]:
+    """The same nesting, with the parent sub-team streaming before its member."""
+    inner = _team_kwargs("inner-team", "Inner Team", "run-inner", parent=TOP_LEVEL_RUN)
+    member = _member_kwargs("scout", "run-scout", parent="run-inner")
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        _team_said("Inner first.", **inner),
+        _agent_said("Scout second.", **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_grandchild_is_placed_under_a_parent_the_client_already_has(collect):
+    """A parent link resolves against an announcement the client has already read."""
+    events = await collect(_grandchild_under_an_announced_parent_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED, 2)
+    assert [(e.subagent_run_id, e.parent_subagent_run_id) for e in _announcements(events)] == [  # type: ignore[attr-defined]
+        ("run-inner", None),
+        ("run-scout", "run-inner"),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_grandchild_whose_parent_is_not_announced_yet_names_no_parent(collect):
+    """A forward reference is refused: no announcement names a lane the client lacks.
+
+    A grandchild's first event can outrun its parent's. Naming the parent anyway
+    hands the client a link it cannot resolve at the moment it reads it, which a
+    client validating the protocol rejects outright, so the lane is announced
+    with no parent and drawn directly under the run instead.
+    """
+    events = await collect(_grandchild_announced_first_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED, 2)
+    assert [(e.subagent_run_id, e.parent_subagent_run_id) for e in _announcements(events)] == [  # type: ignore[attr-defined]
+        ("run-scout", None),
+        ("run-inner", None),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_parent_this_stream_never_announces_is_not_well_formed(collect):
+    """A parent named but never announced is malformed, and the checker says so.
+
+    Driven by deleting one lane from a stream the interface really produced,
+    which is what a client would be left with if an announcement went missing:
+    the surviving child still names a parent, and nothing on the wire says what
+    that parent is.
+    """
+    events = await collect(_grandchild_under_an_announced_parent_chunks(), attributed())
+    without_the_parent = [event for event in events if _lane(event) != "run-inner"]
+
+    assert [e.subagent_run_id for e in _announcements(without_the_parent)] == ["run-scout"]  # type: ignore[attr-defined]
+    violation = stream_invariant_violation(without_the_parent)
+    assert violation is not None, "a parent no announcement names passed as a well-formed stream"
+    assert "names parent run-inner" in violation, violation
+    assert "never announces" in violation, violation
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_no_parent_is_reported_while_the_top_level_run_is_still_unknown(collect):
+    member = _member_kwargs("scout", "run-scout", parent="run-inner")
+
+    chunks = [
+        # No chunk reporting no parent has arrived yet, so the top-level run id
+        # is unknown and naming a parent would be a guess.
+        _agent_said("Scout first.", **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+    events = await collect(chunks, attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED)
+    assert [(e.subagent_run_id, e.parent_subagent_run_id) for e in _announcements(events)] == [("run-scout", None)]  # type: ignore[attr-defined]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_resumed_runs_member_is_not_mistaken_for_a_grandchild(collect):
+    """On resume the entity runs under the stored paused run's id, not the request's."""
+    stored = _team_kwargs("research-team", "Research Team", "stored-paused-run")
+    member = _member_kwargs("scout", "run-scout", parent="stored-paused-run")
+
+    chunks = [
+        TeamRunStartedEvent(**stored),
+        _agent_said("Scout resumed.", **member),
+        _team_said("Leader resumed.", **stored),
+        TeamRunCompletedEvent(**stored),
+    ]
+
+    # The request's run id differs from the stored paused run's on purpose.
+    events = await collect(chunks, attributed(), run_id="wire-run")
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED)
+    assert [(e.subagent_run_id, e.parent_subagent_run_id) for e in _announcements(events)] == [("run-scout", None)]  # type: ignore[attr-defined]
+    assert _messages_in_order(events) == [("Scout", "Scout resumed."), (None, "Leader resumed.")]
+
+
+def _grandchild_of_a_lane_announced_first_chunks() -> List[Any]:
+    """A sub-team's chunk opens the stream, and a member of that sub-team follows it.
+
+    No chunk reporting no parent has arrived, so the top-level run id is still
+    unknown when both lanes are announced.
+    """
+    inner = _team_kwargs("inner-team", "Inner Team", "run-inner", parent=TOP_LEVEL_RUN)
+    member = _member_kwargs("scout", "run-scout", parent="run-inner")
+
+    return [
+        TeamRunStartedEvent(**inner),
+        _agent_said("Scout first.", **member),
+        _team_said("Inner second.", **inner),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_lane_announced_before_the_top_level_run_is_known_still_parents_its_own_children(collect):
+    """An announced lane is one the top-level run cannot be confused with, known or not.
+
+    Reporting no parent for a member of it would flatten a grandchild into a
+    direct child of the top-level entity, which is a delegation tree the run
+    never had.
+    """
+    events = await collect(_grandchild_of_a_lane_announced_first_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED, 2)
+    assert [(e.subagent_run_id, e.parent_subagent_run_id) for e in _announcements(events)] == [  # type: ignore[attr-defined]
+        ("run-inner", None),
+        ("run-scout", "run-inner"),
+    ]
+    assert _messages_in_order(events) == [("Scout", "Scout first."), ("Inner Team", "Inner second.")]
+
+
+def _leader_tool_open_when_a_member_starts_chunks(tool: ToolExecution) -> List[Any]:
+    member = _member_kwargs("scout", "run-scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=tool),
+        RunStartedEvent(**member),
+        RunCompletedEvent(content="scout done", **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_leader_tool_that_is_not_a_delegation_is_never_reported_as_one(collect):
+    tool = ToolExecution(tool_call_id="tc-leader-search", tool_name="search_docs", tool_args={"query": "x"})
+
+    events = await collect(_leader_tool_open_when_a_member_starts_chunks(tool), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED)
+    assert [
+        (e.subagent_run_id, e.parent_tool_call_id, e.description, e.parent_message_id)  # type: ignore[attr-defined]
+        for e in _announcements(events)
+    ] == [("run-scout", None, None, None)]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_non_mapping_tool_arguments_do_not_break_the_announce_path(collect):
+    tool = ToolExecution(
+        tool_call_id="tc-weird",
+        tool_name="delegate_task_to_member",
+        tool_args="not a mapping",  # type: ignore[arg-type]
+    )
+
+    events = await collect(_leader_tool_open_when_a_member_starts_chunks(tool), attributed())
+
+    # Arguments that are not a mapping name no member, so the link is left out
+    # rather than guessed, and the run finishes either way.
+    assert [
+        (e.subagent_run_id, e.parent_tool_call_id, e.description)  # type: ignore[attr-defined]
+        for e in _announcements(events)
+    ] == [("run-scout", None, None)]
+    assert str(events[-1].type) == str(EventType.RUN_FINISHED)
+
+
+def _two_open_delegations_chunks(member_id: str, member_run: str) -> List[Any]:
+    """Two delegation calls open at once, then one member's first event arrives."""
+
+    def delegation(tool_call_id: str, target: str) -> ToolExecution:
+        return _delegation(tool_call_id, target, f"work for {target}")
+
+    member = _member_kwargs(member_id, member_run)
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=delegation("tc-alpha", "alpha")),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=delegation("tc-beta", "beta")),
+        RunStartedEvent(**member),
+        RunCompletedEvent(content=f"{member_id} done", **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_the_delegation_that_names_the_member_wins_when_several_are_open(collect):
+    events = await collect(_two_open_delegations_chunks("beta", "run-beta"), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED)
+    assert [
+        (e.subagent_run_id, e.parent_tool_call_id, e.description)  # type: ignore[attr-defined]
+        for e in _announcements(events)
+    ] == [("run-beta", "tc-beta", "work for beta")]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_the_delegation_link_is_omitted_rather_than_guessed_when_no_open_call_names_the_member(collect):
+    events = await collect(_two_open_delegations_chunks("gamma", "run-gamma"), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED)
+    # Two candidates, neither naming this member: the link is left out, not
+    # picked at random, and the description that would come with it goes too.
+    assert [
+        (e.subagent_run_id, e.parent_tool_call_id, e.description, e.parent_message_id)  # type: ignore[attr-defined]
+        for e in _announcements(events)
+    ] == [("run-gamma", None, None, None)]
+
+
+def _member_tool_changes_state_chunks(session_state: Dict[str, Any], member: Dict[str, Any]) -> List[Any]:
+    """A member runs two tools, each writing the team's shared session state.
+
+    The writes are side effects driven by iteration: the mapper snapshots the
+    state when the stream opens, so a write that happened while the chunk list
+    was being built would produce no delta at all. Two writes rather than one,
+    because one delta is the same whether or not the mapper banked the state it
+    just reported: only the second says the baseline moved with it.
+    """
+    approve = ToolExecution(tool_call_id="tc-member-approve", tool_name="approve", tool_args={}, result="ok")
+    notify = ToolExecution(tool_call_id="tc-member-notify", tool_name="notify", tool_args={}, result="sent")
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**member),
+        ToolCallStartedEvent(tool=approve, **member),
+        SideEffect(lambda: session_state.__setitem__("approved", True)),
+        ToolCallCompletedEvent(tool=approve, **member),
+        ToolCallStartedEvent(tool=notify, **member),
+        SideEffect(lambda: session_state.__setitem__("notified", True)),
+        ToolCallCompletedEvent(tool=notify, **member),
+        RunCompletedEvent(content="scout done", **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+# The two deltas that fixture produces, in order. The second is what shows the
+# mapper reports a change against the state it last sent rather than against the
+# state the stream opened on, which would repeat the first change inside it.
+_STATE_DELTAS_IN_ORDER = [
+    ([{"op": "replace", "path": "/approved", "value": True}],),
+    ([{"op": "add", "path": "/notified", "value": True}],),
+]
+
+
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_hidden_still_delivers_a_state_change_a_member_tool_made(collect):
+    session_state: Dict[str, Any] = {"approved": False}
+    member = _member_kwargs("scout", "run-scout")
+
+    events = await collect(
+        _member_tool_changes_state_chunks(session_state, member),
+        SUBAGENT_VISIBILITY_HIDDEN,
+        run_state=session_state,
+    )
+
+    assert_stream_contains(events, EventType.STATE_DELTA, 2)
+    assert in_emitted_order(events, EventType.STATE_DELTA, "delta") == _STATE_DELTAS_IN_ORDER
+    # The member's own tool call is withheld: this fixture holds no delegation
+    # call of the leader's, so nothing at all here is attributed or attributable.
+    assert not [e for e in events if "TOOL_CALL" in str(e.type)]
+    assert not [e for e in events if _lane(e) is not None]
+    assert not _messages_in_order(events)
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_state_events_are_never_attributed_to_the_member_that_changed_them(collect):
+    session_state: Dict[str, Any] = {"approved": False}
+    member = _member_kwargs("scout", "run-scout")
+
+    events = await collect(
+        _member_tool_changes_state_chunks(session_state, member),
+        attributed(),
+        run_state=session_state,
+    )
+
+    assert_stream_contains(events, EventType.STATE_DELTA, 2)
+    assert_stream_contains(events, EventType.STATE_SNAPSHOT)
+    # The changes were made inside a member lane, yet the state events carry no
+    # member: a team's session state is one shared document.
+    state_events = [e for e in events if str(e.type).removeprefix("EventType.").startswith("STATE_")]
+    assert [(str(e.type).removeprefix("EventType."), _lane(e)) for e in state_events] == [
+        ("STATE_DELTA", None),
+        ("STATE_DELTA", None),
+        ("STATE_SNAPSHOT", None),
+    ]
+    assert in_emitted_order(events, EventType.STATE_DELTA, "delta") == _STATE_DELTAS_IN_ORDER
+
+
+def _member_result_chunks(content: Any) -> List[Any]:
+    """One member whose run reports ``content`` as its result."""
+    member = _member_kwargs("scout", "run-scout")
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**member),
+        RunCompletedEvent(content=content, **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    # Built per case rather than at collection time, so the two mappers cannot
+    # hand each other a result one of them has already been through.
+    "content_factory,expected",
+    [
+        (lambda: {"headline": "found it", "sources": 3}, {"headline": "found it", "sources": 3}),
+        (lambda: ["a", "b"], ["a", "b"]),
+    ],
+    ids=["mapping", "sequence"],
+)
+@chunk_mappers
+async def test_a_non_text_member_result_is_serialized_rather_than_dropped(collect, content_factory, expected):
+    events = await collect(_member_result_chunks(content_factory()), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_FINISHED)
+    finished = _of_type(events, EventType.SUBAGENT_FINISHED)
+    assert [e.subagent_run_id for e in finished] == ["run-scout"]  # type: ignore[attr-defined]
+    assert json.loads(finished[0].result) == expected  # type: ignore[attr-defined]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_structured_member_result_is_serialized_rather_than_dropped(collect):
+    class Brief(BaseModel):
+        headline: str
+        sources: int
+
+    events = await collect(_member_result_chunks(Brief(headline="found it", sources=3)), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_FINISHED)
+    finished = _of_type(events, EventType.SUBAGENT_FINISHED)
+    assert json.loads(finished[0].result) == {"headline": "found it", "sources": 3}  # type: ignore[attr-defined]
+
+
+# --- Optional dependency diagnostics ----------------------------------------
+
+
+def _probe(script: str) -> str:
+    """Run a snippet in a fresh interpreter that can see this checkout."""
+    import os
+    import subprocess
+    import sys
+
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(path for path in sys.path if path)
+    result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True, env=env)
+    assert result.returncode == 0, result.stderr
+    return result.stdout
+
+
+def test_the_handlers_module_names_the_missing_optional_dependency():
+    output = _probe(
+        "import sys\n"
+        "sys.modules['ag_ui'] = None\n"
+        "sys.modules['ag_ui.core'] = None\n"
+        "try:\n"
+        "    import agno.os.interfaces.agui.handlers\n"
+        "except ImportError as error:\n"
+        "    print(error)\n"
+    )
+    assert "ag-ui-protocol" in output
+
+
+def test_missing_subagent_lineage_events_are_reported_at_debug_level():
+    output = _probe(
+        "import logging, sys\n"
+        "import agno.utils.log as agno_log\n"
+        "probe = logging.getLogger('probe')\n"
+        "probe.setLevel(logging.DEBUG)\n"
+        "handler = logging.StreamHandler(sys.stdout)\n"
+        # The level is written into the line, so the level itself is read back
+        # below rather than only the text, which any log helper would produce.
+        "handler.setFormatter(logging.Formatter('%(levelname)s %(message)s'))\n"
+        "probe.addHandler(handler)\n"
+        "agno_log.logger = probe\n"
+        "agno_log.debug_on = True\n"
+        "agno_log.debug_level = 1\n"
+        "import ag_ui.core as core\n"
+        "for name in ('SubagentStartedEvent', 'SubagentFinishedEvent', 'SubagentErrorEvent'):\n"
+        # Conditional, because the install this probe describes is exactly the
+        # one where these are already absent.
+        "    if hasattr(core, name):\n"
+        "        delattr(core, name)\n"
+        "import agno.os.interfaces.agui.handlers as probed\n"
+        "print('AVAILABLE', probed.SUBAGENT_EVENTS_AVAILABLE)\n"
+    )
+    assert "AVAILABLE False" in output
+    reported = [line for line in output.splitlines() if "ag-ui-protocol" in line]
+    assert reported, f"the missing lineage events were reported nowhere: {output}"
+    assert all(line.startswith("DEBUG ") for line in reported), reported
+
+
+# --- Which tool call is the delegation --------------------------------------
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_leader_tool_that_merely_takes_a_task_is_not_read_as_the_delegation(collect):
+    """Agno's own ``update_user_memory`` takes a ``task``, and is not a delegation."""
+    tool = ToolExecution(
+        tool_call_id="tc-memory",
+        tool_name="update_user_memory",
+        tool_args={"task": "the user likes brevity"},
+    )
+
+    events = await collect(_leader_tool_open_when_a_member_starts_chunks(tool), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED)
+    assert [
+        (e.subagent_run_id, e.parent_tool_call_id, e.description, e.parent_message_id)  # type: ignore[attr-defined]
+        for e in _announcements(events)
+    ] == [("run-scout", None, None, None)]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    # The two tasks-mode delegation tools differ in what they name: one takes
+    # the member it hands the task to, the other takes only task ids, so only
+    # the first can be shown to have spawned this member.
+    "tool_name,tool_args,links",
+    [
+        ("execute_task", {"task_id": "t-1", "member_id": "scout"}, True),
+        ("execute_tasks_parallel", {"task_ids": ["t-1"]}, False),
+    ],
+    ids=["execute_task", "execute_tasks_parallel"],
+)
+@chunk_mappers
+async def test_a_tasks_mode_delegation_links_the_member_it_names(collect, tool_name, tool_args, links):
+    tool = ToolExecution(tool_call_id="tc-task", tool_name=tool_name, tool_args=tool_args)
+
+    events = await collect(_leader_tool_open_when_a_member_starts_chunks(tool), attributed())
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED)
+    parent_of_tool_call = {
+        e.tool_call_id: e.parent_message_id  # type: ignore[attr-defined]
+        for e in _of_type(events, EventType.TOOL_CALL_START)
+    }
+
+    # A tasks-mode delegation carries no task text, so a link it does report
+    # comes without a description rather than with an invented one. The parent
+    # message it names has to be one this stream really opened: read back as
+    # None on both sides, that field compares nothing.
+    parent_message = parent_of_tool_call["tc-task"]
+    if links:
+        assert parent_message in _lane_of_message_id(events), parent_message
+    expected = ("tc-task", None, parent_message) if links else (None, None, None)
+    assert [
+        (e.subagent_run_id, e.parent_tool_call_id, e.description, e.parent_message_id)  # type: ignore[attr-defined]
+        for e in _announcements(events)
+    ] == [("run-scout", *expected)]
+
+
+def test_an_open_tool_call_is_recorded_under_its_tool_name():
+    """The name is a required part of the record, so a reader cannot fall back to argument shape."""
+    delegating = StreamState(subagent_visibility=attributed())
+    delegating.record_open_tool_call("tc-1", "delegate_task_to_member", {"member_id": "scout", "task": "go"}, "m-1")
+    assert delegating.find_delegation_call(ROOT_LANE, "scout") == "tc-1"
+    assert delegating.delegation_task(ROOT_LANE, "tc-1") == "go"
+
+    # The unrelated call names a member, so the lookup is asked for that member
+    # rather than for nothing: given a falsy member id it answers None without
+    # ever reading the record, which is true of any tool at all.
+    unrelated = StreamState(subagent_visibility=attributed())
+    unrelated.record_open_tool_call("tc-2", "update_user_memory", {"member_id": "scout", "task": "remember"}, "m-1")
+    assert unrelated.find_delegation_call(ROOT_LANE, "scout") is None
+    assert unrelated.delegation_task(ROOT_LANE, "tc-2") is None
+
+
+def _delegation_args(member: str) -> Dict[str, Any]:
+    return {"member_id": member, "task": f"{member}, do the leader's task"}
+
+
+def _state_with_a_delegation_in_every_kind_of_lane() -> StreamState:
+    """A state where the root lane and two member lanes each hold a delegation to ``scout``.
+
+    Three lanes, so a lookup that reaches past the lane it was asked about lands
+    on somebody else's call rather than on nothing.
+    """
+    state = StreamState(subagent_visibility=attributed())
+    state.resolve_lane(TOP_LEVEL_RUN, None)
+    state.record_open_tool_call("tc-root", "delegate_task_to_member", _delegation_args("scout"), "m-root")
+
+    for run_id, tool_call_id in (("run-open", "tc-open"), ("run-closed", "tc-closed")):
+        state.open_subagent(run_id, name=run_id, parent_lane=ROOT_LANE)
+        state.current_lane = run_id
+        state.record_open_tool_call(tool_call_id, "delegate_task_to_member", _delegation_args("scout"), f"m-{run_id}")
+    state.close_subagent("run-closed")
+    state.current_lane = ROOT_LANE
+    return state
+
+
+# "No lane can be named" is spelled with a marker of its own rather than with
+# None, which is what the root lane is spelled with: written as None the two
+# expectations would be one, and a case expecting no lane would pass on an
+# answer of the root lane's own delegation call.
+_UNNAMEABLE = "<no lane can be named>"
+
+# The parent kinds this module drives, one per state a named run can be in as
+# far as the lane table is concerned, and the lane each resolves to. Written out
+# rather than derived from anything, so it is what is covered rather than a
+# proof that nothing else exists: the property below is stated over all of them
+# so that a new reason a lane cannot be named inherits the check, but a kind
+# nobody adds here still goes undriven.
+_PARENTS_A_CHUNK_CAN_NAME: Dict[str, Tuple[Optional[str], Optional[str]]] = {
+    "no parent at all": (None, ROOT_LANE),
+    "the top-level run": (TOP_LEVEL_RUN, ROOT_LANE),
+    "an announced lane still open": ("run-open", "run-open"),
+    "an announced lane already terminated": ("run-closed", _UNNAMEABLE),
+    "a lane this stream has never announced": ("run-unheard-of", _UNNAMEABLE),
+}
+
+
+@needs_lineage_events
+@pytest.mark.parametrize("parent", sorted(_PARENTS_A_CHUNK_CAN_NAME), ids=sorted(_PARENTS_A_CHUNK_CAN_NAME))
+def test_a_delegation_link_is_only_ever_read_from_the_parents_own_lane(parent):
+    """Whatever lane comes back, the call beside it belongs to that lane and to that parent.
+
+    Stated over each of the parent kinds above rather than over the one that was
+    reported, and as a property rather than as an expected pair, so a new reason
+    a lane cannot be named inherits the check instead of needing a case of its
+    own. What it forbids is the reach: answering with the top-level
+    entity's own open call for a parent that is not the top-level entity, which
+    hands a grandchild the leader's call, the leader's parent message and the
+    leader's task text as its own description.
+    """
+    parent_run_id, resolves_to = _PARENTS_A_CHUNK_CAN_NAME[parent]
+    state = _state_with_a_delegation_in_every_kind_of_lane()
+
+    lane, delegation_call_id = state.delegating_lane_for(parent_run_id, "scout")
+
+    if resolves_to == _UNNAMEABLE:
+        assert (lane, delegation_call_id) == (None, None)
+        assert state.delegation_task(lane, delegation_call_id) is None
+        assert state.delegation_parent_message_id(lane, delegation_call_id) is None
+        return
+    assert lane == resolves_to
+    assert delegation_call_id in (state.open_tool_calls.get(lane) or {}), (
+        f"the call reported for {parent} belongs to some other lane"
+    )
+
+
+def _grandchild_whose_parent_was_never_announced_chunks() -> List[Any]:
+    """A member appears under an inner team's run that this stream never saw start.
+
+    The leader's own delegation names the same member id, which is what makes
+    the reach visible: reaching past for it hands this member the leader's call.
+    """
+    delegation = _delegation("tc-delegate-scout", **_delegation_args("scout"))
+    grandchild = _member_kwargs("scout", "run-grandchild", parent="run-inner-team")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamToolCallStartedEvent(tool=delegation, **_TOP_LEVEL),
+        _agent_said("Reporting in.", **grandchild),
+        RunCompletedEvent(content="done", **grandchild),
+        _team_said("Final synthesis.", **_TOP_LEVEL),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_member_under_an_unannounced_parent_carries_no_part_of_the_leaders_delegation(collect):
+    """No parent means no parent call, no parent message and no description either.
+
+    All three are read off the delegating lane's own open calls, so a lane that
+    cannot be named leaves the announcement with none of them. Asserted on the
+    payload, because the reported symptom was an announcement reporting no
+    parent lane while carrying the leader's call id, the leader's parent message
+    and the leader's task text.
+    """
+    events = await collect(_grandchild_whose_parent_was_never_announced_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED)
+    assert [
+        (
+            e.subagent_run_id,  # type: ignore[attr-defined]
+            e.parent_subagent_run_id,  # type: ignore[attr-defined]
+            e.parent_tool_call_id,  # type: ignore[attr-defined]
+            e.parent_message_id,  # type: ignore[attr-defined]
+            e.description,  # type: ignore[attr-defined]
+        )
+        for e in _announcements(events)
+    ] == [("run-grandchild", None, None, None, None)]
+    # The leader's own delegation call is still on the wire as the leader's.
+    assert _tool_call_lanes_in_order(events) == [("tc-delegate-scout", None)]
+
+
+# --- Paused members ---------------------------------------------------------
+
+
+def _paused_on_two_members_chunks() -> List[Any]:
+    """One pause waiting on a pending call from each of two different members."""
+
+    def requirement(member: str, run: str, tool_call_id: str, tool_name: str) -> RunRequirement:
+        return _requirement(
+            ToolExecution(
+                tool_call_id=tool_call_id,
+                tool_name=tool_name,
+                tool_args={"for": member},
+                requires_confirmation=True,
+            ),
+            member,
+            run,
+            member.capitalize(),
+        )
+
+    def delegation(member: str) -> ToolExecution:
+        return _delegation(f"tc-delegate-{member}", member, f"{member} it")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamToolCallStartedEvent(tool=delegation("scout"), **_TOP_LEVEL),
+        TeamToolCallStartedEvent(tool=delegation("writer"), **_TOP_LEVEL),
+        TeamRunPausedEvent(
+            tools=[],
+            requirements=[
+                requirement("scout", "run-scout", "tc-scout-confirm", "send_email"),
+                requirement("writer", "run-writer", "tc-writer-confirm", "publish"),
+            ],
+            **_TOP_LEVEL,
+        ),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_pause_waiting_on_two_members_gives_each_a_message_of_its_own(collect):
+    """One message cannot name two members, so the prompt is split per member.
+
+    A tool call belongs to the message that carries it, so the two have to agree
+    about whose call it is. With pending calls from two members under one
+    message they cannot, whichever member that message were stamped with.
+    """
+    events = await collect(_paused_on_two_members_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.TEXT_MESSAGE_START, 2)
+    assert _tool_call_lanes_in_order(events) == [
+        ("tc-delegate-scout", None),
+        ("tc-delegate-writer", None),
+        ("tc-scout-confirm", "run-scout"),
+        ("tc-writer-confirm", "run-writer"),
+    ]
+
+    lane_of_message = _lane_of_message_id(events)
+    assert [
+        (e.tool_call_id, _lane(e), lane_of_message[e.parent_message_id])  # type: ignore[attr-defined]
+        for e in _of_type(events, EventType.TOOL_CALL_START)
+        if _lane(e) is not None
+    ] == [
+        ("tc-scout-confirm", "run-scout", "run-scout"),
+        ("tc-writer-confirm", "run-writer", "run-writer"),
+    ]
+
+
+# The events that open or close a message or a tool call. One of these landing
+# inside somebody else's open span is a nesting a validating client rejects.
+#
+# Nothing else is read. RAW and CUSTOM are opaque passthroughs the source stream
+# interleaves wherever it likes, and a delegation stays open for as long as the
+# member it spawned is producing them. A member's announcement belongs inside
+# that delegation too: the call it names in ``parentToolCallId`` is exactly the
+# one still open around it.
+_SPAN_LIFECYCLE_EVENTS = frozenset({"TEXT_MESSAGE_START", "TEXT_MESSAGE_END", "TOOL_CALL_START", "TOOL_CALL_END"})
+
+
+def _spans_a_prompt_opens_inside(events: List[BaseEvent]) -> List[Tuple[str, str]]:
+    """(what was emitted, what it landed inside) for every span event nested in another."""
+    nested: List[Tuple[str, str]] = []
+    open_messages: Set[str] = set()
+    open_tool_calls: Set[str] = set()
+    for event in events:
+        kind = str(event.type).removeprefix("EventType.")
+        own_message = getattr(event, "message_id", None)
+        own_call = getattr(event, "tool_call_id", None)
+        if kind in _SPAN_LIFECYCLE_EVENTS:
+            nested.extend(
+                (kind, f"TOOL_CALL {tool_call_id}") for tool_call_id in open_tool_calls if tool_call_id != own_call
+            )
+            nested.extend(
+                (kind, f"TEXT_MESSAGE {message_id}") for message_id in open_messages if message_id != own_message
+            )
+        if kind == "TEXT_MESSAGE_START":
+            open_messages.add(event.message_id)  # type: ignore[attr-defined]
+        elif kind == "TEXT_MESSAGE_END":
+            open_messages.discard(event.message_id)  # type: ignore[attr-defined]
+        elif kind == "TOOL_CALL_START":
+            open_tool_calls.add(event.tool_call_id)  # type: ignore[attr-defined]
+        elif kind == "TOOL_CALL_END":
+            open_tool_calls.discard(event.tool_call_id)  # type: ignore[attr-defined]
+    return nested
+
+
+def _paused_inside_one_open_delegation_chunks() -> List[Any]:
+    """The run pauses on a member's call with the delegation that spawned it still open."""
+    delegation = _delegation("tc-delegate-scout", "scout", "scout it")
+    requirement = _requirement(
+        ToolExecution(
+            tool_call_id="tc-scout-confirm",
+            tool_name="send_email",
+            tool_args={"to": "ops"},
+            requires_confirmation=True,
+        ),
+        "scout",
+        "run-scout",
+        "Scout",
+    )
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamToolCallStartedEvent(tool=delegation, **_TOP_LEVEL),
+        RunStartedEvent(**_member_kwargs("scout", "run-scout")),
+        TeamRunPausedEvent(tools=[], requirements=[requirement], **_TOP_LEVEL),
+    ]
+
+
+@pytest.mark.asyncio
+@chunk_mappers
+@pytest.mark.parametrize(
+    "setting",
+    [lambda: SUBAGENT_VISIBILITY_INLINE, attributed, lambda: SUBAGENT_VISIBILITY_HIDDEN],
+    ids=["inline", "attributed", "hidden"],
+)
+async def test_a_pause_prompt_never_lands_inside_a_span_whichever_setting_is_set(collect, setting):
+    """The three settings agree about nesting: the prompt goes out with nothing open.
+
+    The leader's delegation call is open when the run pauses, and the prompt
+    opens a message and a tool call of its own. A tool call carries only its own
+    arguments and its end between start and end, so those have to follow the
+    delegation's close, and they have to follow it under every setting: a client
+    reading one stream correctly and another not is the same defect twice.
+    """
+    events = await collect(_paused_inside_one_open_delegation_chunks(), setting())
+
+    assert_stream_contains(events, EventType.TOOL_CALL_START, 2)
+    assert _spans_a_prompt_opens_inside(events) == []
+
+
+def _paused_member_that_never_streamed_chunks() -> List[Any]:
+    """A member pauses without ever having emitted an event of its own."""
+    member_tool = ToolExecution(
+        tool_call_id="tc-ghost-confirm",
+        tool_name="send_email",
+        tool_args={"to": "ops"},
+        requires_confirmation=True,
+    )
+    requirement = _requirement(member_tool, "ghost", "run-ghost", "Ghost")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamRunPausedEvent(tools=[], requirements=[requirement], **_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_paused_members_lane_is_announced_before_anything_carries_it(collect):
+    events = await collect(_paused_member_that_never_streamed_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.TOOL_CALL_START)
+    assert _tool_call_lanes_in_order(events) == [("tc-ghost-confirm", "run-ghost")]
+    assert [(e.subagent_run_id, e.name) for e in _announcements(events)] == [("run-ghost", "Ghost")]  # type: ignore[attr-defined]
+    # A start and a terminal around the message and the tool call the client has
+    # to render, both on the member's own lane so the two agree about whose call
+    # it is.
+    assert _lane_sequence(events, "run-ghost") == [
+        "SUBAGENT_STARTED",
+        "TEXT_MESSAGE_START",
+        "TEXT_MESSAGE_END",
+        "TOOL_CALL_START",
+        "TOOL_CALL_ARGS",
+        "TOOL_CALL_END",
+        "SUBAGENT_FINISHED",
+    ]
+    carrying = [e.parent_message_id for e in _of_type(events, EventType.TOOL_CALL_START)]  # type: ignore[attr-defined]
+    assert [_lane_of_message_id(events)[message_id] for message_id in carrying] == ["run-ghost"]
+
+
+def _paused_tool_listed_in_both_places_chunks() -> List[Any]:
+    """One paused tool call reported both on the terminal event and in a member's requirement."""
+    shared = ToolExecution(
+        tool_call_id="tc-shared-confirm",
+        tool_name="send_email",
+        tool_args={"to": "ops"},
+        requires_confirmation=True,
+    )
+    requirement = _requirement(shared, "scout", "run-scout", "Scout")
+    member = _member_kwargs("scout", "run-scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**member),
+        TeamRunPausedEvent(tools=[shared], requirements=[requirement], **_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_paused_tool_listed_twice_is_prompted_once_on_its_members_lane(collect):
+    events = await collect(_paused_tool_listed_in_both_places_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.TOOL_CALL_START)
+    assert _tool_call_lanes_in_order(events) == [("tc-shared-confirm", "run-scout")]
+    assert in_emitted_order(events, EventType.TOOL_CALL_END, "tool_call_id", _lane) == [
+        ("tc-shared-confirm", "run-scout")
+    ]
+
+
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_hidden_prompts_a_paused_tool_listed_twice_once_and_names_no_member(collect):
+    """Hidden de-duplicates the prompt as attributed does, without attributing it.
+
+    Only the default keeps the duplicate, because only the default's stream has
+    to be what it was before member attribution existed.
+    """
+    events = await collect(_paused_tool_listed_in_both_places_chunks(), SUBAGENT_VISIBILITY_HIDDEN)
+
+    assert_stream_contains(events, EventType.TOOL_CALL_START)
+    assert _tool_call_lanes_in_order(events) == [("tc-shared-confirm", None)]
+    assert in_emitted_order(events, EventType.TOOL_CALL_END, "tool_call_id", _lane) == [("tc-shared-confirm", None)]
+    assert not [e for e in events if "SUBAGENT" in str(e.type)]
+    assert not [e for e in events if _lane(e) is not None]
+
+
+def _pause_while_a_member_tool_is_still_running_chunks() -> List[Any]:
+    """A member's own tool call is open, and the run pauses on the leader's instead."""
+    member = _member_kwargs("scout", "run-scout")
+    working = ToolExecution(tool_call_id="tc-scout-work", tool_name="search_docs", tool_args={"query": "agno"})
+    leader_tool = ToolExecution(
+        tool_call_id="tc-leader-confirm", tool_name="publish", tool_args={"channel": "blog"}, requires_confirmation=True
+    )
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**member),
+        ToolCallStartedEvent(tool=working, **member),
+        TeamRunPausedEvent(tools=[leader_tool], **_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_pause_still_closes_a_member_tool_call_left_running(collect):
+    """A pause ends the run's stream, so a member call nobody is waiting on still needs an end.
+
+    A member's terminal ends no tool call, so the end is written by the run's
+    final sweep. The sweep runs before that member's terminal, so the call is
+    put away while its lane is still open, and it is still the member's call,
+    which is what the client needs to put it away.
+    """
+    events = await collect(_pause_while_a_member_tool_is_still_running_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_FINISHED)
+    assert _tool_call_lanes_in_order(events) == [("tc-scout-work", "run-scout"), ("tc-leader-confirm", None)]
+    assert in_emitted_order(events, EventType.TOOL_CALL_END, "tool_call_id", _lane) == [
+        ("tc-scout-work", "run-scout"),
+        ("tc-leader-confirm", None),
+    ]
+    # The member's own call carries no result: it never reported one.
+    assert not _of_type(events, EventType.TOOL_CALL_RESULT)
+    assert str(events[-1].type) == str(EventType.RUN_FINISHED)
+
+
+def _pause_naming_a_member_that_already_terminated_chunks() -> List[Any]:
+    """The paused requirement names a member whose own terminal has already gone out."""
+    member = _member_kwargs("scout", "run-scout")
+    late = ToolExecution(
+        tool_call_id="tc-late-confirm", tool_name="send_email", tool_args={"to": "ops"}, requires_confirmation=True
+    )
+    requirement = _requirement(late, "scout", "run-scout", "Scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**member),
+        RunCompletedEvent(content="scout done", **member),
+        TeamRunPausedEvent(tools=[], requirements=[requirement], **_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_pause_naming_a_closed_member_prompts_on_the_root_lane(collect):
+    """A terminal is final for the id it names, so the prompt cannot be put in that lane.
+
+    Stamping it there would hand the client a tool call inside a member it has
+    already closed, and announcing the lane again would give one invocation two
+    lifecycles. The prompt goes out unattributed instead, which is a call the
+    client can still render and answer.
+    """
+    events = await collect(_pause_naming_a_member_that_already_terminated_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.TOOL_CALL_START)
+    assert _tool_call_lanes_in_order(events) == [("tc-late-confirm", None)]
+    assert [e.subagent_run_id for e in _announcements(events)] == ["run-scout"]  # type: ignore[attr-defined]
+    assert in_emitted_order(events, EventType.SUBAGENT_FINISHED, "subagent_run_id") == [("run-scout",)]
+    assert str(events[-1].type) == str(EventType.RUN_FINISHED)
+
+
+def _paused_member_with_nothing_to_show_chunks() -> List[Any]:
+    """A member pauses on a tool the client cannot be shown: it carries no name.
+
+    The pause carries the run's own words, as a real one does, so what the client
+    is left with when the call is dropped is a message that says why the run
+    stopped rather than an empty bubble.
+    """
+    nameless = _nameless_tool()
+    requirement = _requirement(nameless, "ghost", "run-ghost", "Ghost")
+    paused = TeamRunPausedEvent(tools=[], requirements=[requirement], **_TOP_LEVEL)
+    paused.content = "Waiting on an approval."
+
+    return [TeamRunStartedEvent(**_TOP_LEVEL), paused]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_lane_is_not_announced_when_the_prompt_it_was_for_is_dropped(collect):
+    """A dropped prompt must not leave the client a terminal for a member it never saw start."""
+    events = await collect(_paused_member_with_nothing_to_show_chunks(), attributed())
+
+    assert not [e for e in events if "SUBAGENT" in str(e.type)]
+    assert not [e for e in events if _lane(e) is not None]
+    assert not _of_type(events, EventType.TOOL_CALL_START)
+    assert str(events[-1].type) == str(EventType.RUN_FINISHED)
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_pause_the_client_cannot_act_on_is_recorded(collect, caplog):
+    """A pause prompting nothing has to be logged, and as the kind of pause it is.
+
+    Here the terminal listed a pending call and the client cannot be shown it,
+    so the client is told the run is waiting and given nothing to answer with.
+    That is not the same as a terminal that listed nothing, which is the case
+    below, so the two do not share a line.
+    """
+    with captured_agno_logs(caplog, "WARNING"):
+        events = await collect(_paused_member_with_nothing_to_show_chunks(), attributed())
+
+    assert not _of_type(events, EventType.TOOL_CALL_START)
+    assert_stream_contains(events, EventType.TEXT_MESSAGE_CONTENT)
+    # The joined text, not merely that a message opened: an empty bubble tells
+    # the client nothing about why the run stopped. Unattributed, because the
+    # lane the prompt was for is not announced when its call is dropped.
+    assert joined_text_in_emitted_order(events) == [(None, "Waiting on an approval.")]
+    # Matched on a phrase the line about the dropped call itself does not carry,
+    # so this cannot pass on that one instead.
+    assert [r.message for r in caplog.records if "the run is waiting" in r.message], (
+        "a pause the client was told about but cannot answer left no trace at all"
+    )
+
+
+def _paused_listing_no_pending_call_chunks() -> List[Any]:
+    """A run pauses without listing a pending tool call at all."""
+    paused = AgentRunPausedEvent(agent_id="solo", agent_name="Solo", run_id=TOP_LEVEL_RUN, tools=[])
+    paused.content = "Confirm before I send this."
+
+    return [RunStartedEvent(agent_id="solo", agent_name="Solo", run_id=TOP_LEVEL_RUN), paused]
+
+
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_pause_that_lists_nothing_reaches_the_client_as_a_finished_run_and_says_so(collect, caplog):
+    """Nothing announces this pause, so the log is the only place it exists.
+
+    The prompt turns on the terminal having listed a pending call at all, which
+    this one did not, so the pause's own content goes out nowhere either. A
+    terminal that listed a call the client cannot be shown still carries the
+    content, which is the pre-change stream and is pinned separately.
+
+    Driven on the default visibility: no member is involved, so this is a run
+    any supported protocol release serves.
+    """
+    chunks = _paused_listing_no_pending_call_chunks()
+    # The pause does carry content, so the silence below is that content being
+    # dropped rather than a fixture with nothing to say.
+    assert any(getattr(chunk, "content", None) for chunk in chunks)
+    with captured_agno_logs(caplog, "WARNING"):
+        events = await collect(chunks)
+
+    assert_stream_carries_exactly(events, EventType.TEXT_MESSAGE_START, 0)
+    assert not _of_type(events, EventType.TOOL_CALL_START)
+    assert str(events[-1].type) == str(EventType.RUN_FINISHED)
+    assert [r.message for r in caplog.records if "plain finished run" in r.message], (
+        "a pause the client cannot tell from a completion left no trace at all"
+    )
+
+
+def _paused_member_carrying_one_unusable_tool_chunks(unusable: ToolExecution) -> List[Any]:
+    """Two members pause, and one of them waits on a tool the client cannot be shown."""
+    ghost = _requirement(unusable, "ghost", "run-ghost", "Ghost")
+
+    usable = ToolExecution(
+        tool_call_id="tc-scout-confirm", tool_name="send_email", tool_args={"to": "ops"}, requires_confirmation=True
+    )
+    scout = _requirement(usable, "scout", "run-scout", "Scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamRunPausedEvent(tools=[], requirements=[ghost, scout], **_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_only_the_members_the_prompt_names_are_announced(collect):
+    """A lane the prompt carries nothing for tells the client about a member it never hears from."""
+    events = await collect(_paused_member_carrying_one_unusable_tool_chunks(_nameless_tool()), attributed())
+
+    assert_stream_contains(events, EventType.TOOL_CALL_START)
+    assert [(e.subagent_run_id, e.name) for e in _announcements(events)] == [("run-scout", "Scout")]  # type: ignore[attr-defined]
+    assert _tool_call_lanes_in_order(events) == [("tc-scout-confirm", "run-scout")]
+
+
+def _paused_tool_that_already_completed_chunks() -> List[Any]:
+    """The paused requirement repeats a member tool call that already streamed to its end."""
+    member = _member_kwargs("scout", "run-scout")
+    streamed = ToolExecution(tool_call_id="tc-member-search", tool_name="search_docs", tool_args={"query": "agno"})
+    completed = ToolExecution(
+        tool_call_id="tc-member-search", tool_name="search_docs", tool_args={"query": "agno"}, result="three sources"
+    )
+    repeated = ToolExecution(
+        tool_call_id="tc-member-search",
+        tool_name="search_docs",
+        tool_args={"query": "agno"},
+        requires_confirmation=True,
+    )
+    requirement = _requirement(repeated, "scout", "run-scout", "Scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**member),
+        ToolCallStartedEvent(tool=streamed, **member),
+        ToolCallCompletedEvent(tool=completed, **member),
+        TeamRunPausedEvent(tools=[], requirements=[requirement], **_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_paused_tool_that_already_ended_is_not_given_a_second_lifecycle(collect):
+    events = await collect(_paused_tool_that_already_completed_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.TOOL_CALL_RESULT)
+    assert in_emitted_order(events, EventType.TOOL_CALL_START, "tool_call_id", _lane) == [
+        ("tc-member-search", "run-scout")
+    ]
+    assert in_emitted_order(events, EventType.TOOL_CALL_END, "tool_call_id", _lane) == [
+        ("tc-member-search", "run-scout")
+    ]
+
+
+def _paused_grandchild_chunks() -> List[Any]:
+    """A sub-team's member pauses, and the requirement reaches the top-level terminal."""
+    inner = _team_kwargs("inner-team", "Inner Team", "run-inner", parent=TOP_LEVEL_RUN)
+    outer_delegation = _delegation("tc-delegate-inner", "inner-team", "run the inner team")
+    inner_delegation = _delegation("tc-delegate-scout", "scout", "scout the topic")
+    member_tool = ToolExecution(
+        tool_call_id="tc-scout-confirm",
+        tool_name="send_email",
+        tool_args={"to": "ops"},
+        requires_confirmation=True,
+    )
+    requirement = _requirement(member_tool, "scout", "run-scout", "Scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=outer_delegation),
+        TeamRunStartedEvent(**inner),
+        TeamToolCallStartedEvent(tool=inner_delegation, **inner),
+        TeamRunPausedEvent(tools=[], requirements=[requirement], **_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_paused_grandchild_is_announced_under_the_member_that_delegated_to_it(collect):
+    events = await collect(_paused_grandchild_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED, 2)
+    assert [
+        (e.subagent_run_id, e.parent_subagent_run_id, e.parent_tool_call_id, e.description)  # type: ignore[attr-defined]
+        for e in _announcements(events)
+    ] == [
+        ("run-inner", None, "tc-delegate-inner", "run the inner team"),
+        ("run-scout", "run-inner", "tc-delegate-scout", "scout the topic"),
+    ]
+    # The grandchild resolves inside its real parent, so its terminal comes first.
+    assert in_emitted_order(events, EventType.SUBAGENT_FINISHED, "subagent_run_id") == [("run-scout",), ("run-inner",)]
+
+
+def _paused_inner_agent_chunks() -> List[Any]:
+    """A single Agent pauses on a tool call its own inner agent is waiting on.
+
+    An agent that runs an inner agent reports what that run is waiting on the
+    way a team reports a member's: on the paused event's requirements, which
+    name the run waiting and carry the pending call itself.
+    """
+    outer = {"agent_id": "assistant", "agent_name": "Assistant", "run_id": TOP_LEVEL_RUN}
+    inner_tool = ToolExecution(
+        tool_call_id="tc-inner-confirm",
+        tool_name="send_email",
+        tool_args={"to": "ops"},
+        requires_confirmation=True,
+    )
+    requirement = _requirement(inner_tool, "memory-agent", "run-inner-agent", "Memory")
+
+    return [
+        RunStartedEvent(**outer),
+        AgentRunPausedEvent(tools=[], requirements=[requirement], **outer),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_paused_inner_agents_pending_tool_call_is_prompted_on_its_own_lane(collect):
+    """The run cannot be resumed past a call the client was never shown."""
+    events = await collect(_paused_inner_agent_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED)
+    assert [(e.subagent_run_id, e.name) for e in _announcements(events)] == [("run-inner-agent", "Memory")]  # type: ignore[attr-defined]
+    assert _tool_call_lanes_in_order(events) == [("tc-inner-confirm", "run-inner-agent")]
+    assert in_emitted_order(events, EventType.TOOL_CALL_ARGS, "tool_call_id", lambda e: json.loads(e.delta)) == [
+        ("tc-inner-confirm", {"to": "ops"})
+    ]
+    assert str(events[-1].type) == str(EventType.RUN_FINISHED)
+
+
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_paused_inner_agents_pending_tool_call_reaches_the_client_unattributed_too(collect):
+    """Hidden does not name the inner run and still has to render the call it is waiting on."""
+    events = await collect(_paused_inner_agent_chunks(), SUBAGENT_VISIBILITY_HIDDEN)
+
+    assert_stream_contains(events, EventType.TOOL_CALL_START)
+    assert _tool_call_lanes_in_order(events) == [("tc-inner-confirm", None)]
+    assert in_emitted_order(events, EventType.TOOL_CALL_ARGS, "tool_call_id", lambda e: json.loads(e.delta)) == [
+        ("tc-inner-confirm", {"to": "ops"})
+    ]
+    assert not [e for e in events if "SUBAGENT" in str(e.type)]
+
+
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_the_default_prompts_nothing_for_an_agent_pause_reported_only_through_requirements(collect):
+    """The default stream is the pre-change one, which read requirements on a team's pause only.
+
+    Losing the call is a real defect, and it is the pre-change default's, not
+    this one's: the default is defined as that stream, so the pending call
+    reaching the wire here would be a tool call a released client never
+    received, and one it may auto-execute.
+    """
+    expected = [
+        (str(EventType.RAW), {"event": "RunStarted"}),
+        (str(EventType.RUN_FINISHED), {"threadId": THREAD_ID, "runId": TOP_LEVEL_RUN}),
+    ]
+
+    assert _normalized_payloads(await collect(_paused_inner_agent_chunks())) == expected
+    assert _normalized_payloads(await collect(_paused_inner_agent_chunks(), SUBAGENT_VISIBILITY_INLINE)) == expected
+
+
+# --- A lane whose terminal has already gone out -----------------------------
+
+_INNER_TEAM = _team_kwargs("inner-team", "Inner Team", "run-inner", parent=TOP_LEVEL_RUN)
+
+
+def _sub_team_that_finished_holding_its_delegation_chunks(*tail: Any) -> List[Any]:
+    """A sub-team reaches its own terminal with the delegation it made still open.
+
+    A lane's terminal ends none of its tool calls, so that delegation outlives
+    the lane, and it is the only open call naming the member below it.
+    """
+    delegation = _delegation("tc-delegate-scout", "scout", "scout the topic")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamRunStartedEvent(**_INNER_TEAM),
+        TeamToolCallStartedEvent(tool=delegation, **_INNER_TEAM),
+        TeamRunCompletedEvent(content="inner done", **_INNER_TEAM),
+        *tail,
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_member_that_starts_after_its_parent_lane_terminated_is_not_announced_under_it(collect):
+    """A lane the client has already closed can neither gain a child nor resolve after one."""
+    member = _member_kwargs("scout", "run-scout", parent="run-inner")
+    chunks = _sub_team_that_finished_holding_its_delegation_chunks(
+        _agent_said("Scout speaking.", **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    )
+
+    # The delegation the sub-team left open is ended by the run-end sweep, which
+    # is after that lane's own terminal: a lane's terminal ends no tool call.
+    events = await collect(chunks, attributed(), exempt=[TRAILING_OUTPUT_AFTER_A_MEMBER_TERMINAL])
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED, 2)
+    assert [
+        (e.subagent_run_id, e.parent_subagent_run_id, e.parent_tool_call_id, e.description)  # type: ignore[attr-defined]
+        for e in _announcements(events)
+    ] == [("run-inner", None, None, None), ("run-scout", None, None, None)]
+    # The empty entry is the sub-team's own parent message for its delegation.
+    assert _messages_in_order(events) == [("Inner Team", ""), ("Scout", "Scout speaking.")]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_paused_member_is_not_announced_under_a_parent_lane_that_terminated(collect):
+    """The delegation that named the member outlives the lane that made it, and cannot speak for it."""
+    tool = ToolExecution(
+        tool_call_id="tc-scout-confirm",
+        tool_name="send_email",
+        tool_args={"to": "ops"},
+        requires_confirmation=True,
+    )
+    requirement = _requirement(tool, "scout", "run-scout", "Scout")
+    chunks = _sub_team_that_finished_holding_its_delegation_chunks(
+        TeamRunPausedEvent(tools=[], requirements=[requirement], **_TOP_LEVEL),
+    )
+
+    events = await collect(chunks, attributed(), exempt=[TRAILING_OUTPUT_AFTER_A_MEMBER_TERMINAL])
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED, 2)
+    assert [
+        (e.subagent_run_id, e.parent_subagent_run_id, e.parent_tool_call_id, e.description)  # type: ignore[attr-defined]
+        for e in _announcements(events)
+    ] == [("run-inner", None, None, None), ("run-scout", None, None, None)]
+    # The prompt itself is still the member's, on the member's own lane.
+    assert _tool_call_lanes_in_order(events) == [
+        ("tc-delegate-scout", "run-inner"),
+        ("tc-scout-confirm", "run-scout"),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_paused_member_is_still_linked_to_a_delegation_its_parent_lane_is_still_running(collect):
+    """The other half of that rule: a live lane's open delegation is the link it always was."""
+    tool = ToolExecution(
+        tool_call_id="tc-scout-confirm",
+        tool_name="send_email",
+        tool_args={"to": "ops"},
+        requires_confirmation=True,
+    )
+    requirement = _requirement(tool, "scout", "run-scout", "Scout")
+    delegation = _delegation("tc-delegate-scout", "scout", "scout the topic")
+
+    chunks = [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamRunStartedEvent(**_INNER_TEAM),
+        TeamToolCallStartedEvent(tool=delegation, **_INNER_TEAM),
+        TeamRunPausedEvent(tools=[], requirements=[requirement], **_TOP_LEVEL),
+    ]
+
+    events = await collect(chunks, attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED, 2)
+    assert [
+        (e.subagent_run_id, e.parent_subagent_run_id, e.parent_tool_call_id, e.description)  # type: ignore[attr-defined]
+        for e in _announcements(events)
+    ] == [("run-inner", None, None, None), ("run-scout", "run-inner", "tc-delegate-scout", "scout the topic")]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_members_own_pause_is_not_dumped_to_the_wire(collect):
+    events = await collect(_paused_member_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.RAW)
+    assert_stream_contains(events, EventType.TOOL_CALL_START, 2)
+    # The member's other chunks do reach the wire as RAW, on its own lane, so
+    # the absence below is this one event being withheld rather than the whole
+    # lane going unmapped. The name is the framework's own rather than a literal.
+    raw = in_emitted_order(events, EventType.RAW, lambda e: e.event.get("event"), _lane)  # type: ignore[attr-defined]
+    assert (RunEvent.run_started.value, "run-scout") in raw, raw
+    assert RunEvent.run_paused.value not in [name for name, _ in raw]
+    # The pending call still reaches the client once, from the team's requirement.
+    assert [e.tool_call_id for e in _of_type(events, EventType.TOOL_CALL_START)] == [  # type: ignore[attr-defined]
+        "tc-leader-confirm",
+        "tc-member-confirm",
+    ]
+
+
+def _pause_reported_by_a_member_whose_lane_closed_chunks() -> List[Any]:
+    """A member finishes, and then its own pause is the last thing the stream carries.
+
+    The pause is reported from the member's run, so the run terminal is built
+    out of a chunk whose lane the wire has already terminated.
+    """
+    member = _member_kwargs("scout", "run-scout")
+    pending = ToolExecution(
+        tool_call_id="tc-member-confirm", tool_name="send_email", tool_args={"to": "ops"}, requires_confirmation=True
+    )
+    paused = AgentRunPausedEvent(tools=[pending], **member)
+    paused.content = "I need approval to email ops."
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=_delegation("tc-delegate-scout", "scout", "scout it")),
+        RunStartedEvent(**member),
+        _agent_said("half a sen", **member),
+        RunCompletedEvent(content="scout done", **member),
+        paused,
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_pause_a_member_reports_after_its_own_terminal_is_prompted_on_the_root_lane(collect):
+    """A terminal is final for the lane it names, and this prompt is what would break that.
+
+    The pause is the run terminal here, so the prompt is built out of a chunk of
+    the member's. Named after it, every event of the prompt would carry that
+    member: the message, the words on it, and the three the pending call takes,
+    all of them after the lane's own terminal.
+    """
+    events = await collect(_pause_reported_by_a_member_whose_lane_closed_chunks(), attributed())
+
+    finished = _of_type(events, EventType.SUBAGENT_FINISHED)
+    assert [event.subagent_run_id for event in finished] == ["run-scout"]  # type: ignore[attr-defined]
+    after = events[events.index(finished[0]) + 1 :]
+    assert [(str(event.type), _lane(event)) for event in after if _lane(event) is not None] == []
+    # The pending call still reaches the client, unattributed, because no resume
+    # gets past a call nobody was shown.
+    assert _tool_call_lanes_in_order(events) == [("tc-delegate-scout", None), ("tc-member-confirm", None)]
+    # The member's own words are not relabeled as the leader's on the way out.
+    assert "I need approval to email ops." not in [
+        event.delta  # type: ignore[attr-defined]
+        for event in _of_type(events, EventType.TEXT_MESSAGE_CONTENT)
+    ]
+
+
+def _paused_member_the_run_names_by_id_alone_chunks() -> List[Any]:
+    """A pause whose requirement carries the member's id and no name of its own."""
+    pending = ToolExecution(
+        tool_call_id="tc-scout-confirm", tool_name="send_email", tool_args={"to": "ops"}, requires_confirmation=True
+    )
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamRunPausedEvent(tools=[], requirements=[_requirement(pending, "scout", "run-scout")], **_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_paused_member_with_no_name_is_announced_under_its_id(collect):
+    """The id is what the framework always has, and a lane announced under nothing is unreadable.
+
+    The streamed announcement falls back the same way and is pinned elsewhere.
+    This is the pause path's own copy of that fallback, which nothing reached.
+    """
+    events = await collect(_paused_member_the_run_names_by_id_alone_chunks(), attributed())
+
+    assert [(e.subagent_run_id, e.name) for e in _announcements(events)] == [("run-scout", "scout")]  # type: ignore[attr-defined]
+    assert _tool_call_lanes_in_order(events) == [("tc-scout-confirm", "run-scout")]
+
+
+# --- Run-end ordering -------------------------------------------------------
+
+
+def _member_open_inside_a_delegation_chunks(fail: bool) -> List[Any]:
+    """The leader is mid-sentence with a delegation open and its member still running."""
+    delegation = _delegation("tc-delegate-scout", "scout", "scout it")
+    member = _member_kwargs("scout", "run-scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=delegation),
+        _team_said("Delegating now.", **_TOP_LEVEL),
+        RunStartedEvent(**member),
+        _agent_said("scouting", **member),
+        TeamRunErrorEvent(content="team blew up", error_type="RuntimeError", **_TOP_LEVEL)
+        if fail
+        else TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+def _member_terminal_index(events: List[BaseEvent]) -> int:
+    terminals = [index for index, event in enumerate(events) if _is_terminal(event)]
+    assert len(terminals) == 1, f"expected one member terminal, got {len(terminals)}"
+    return terminals[0]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fail", [False, True], ids=["run_completed", "run_errored"])
+@chunk_mappers
+async def test_a_member_terminal_lands_outside_every_span_the_stream_had_open(collect, fail):
+    """The run end closes what is open first, so no terminal is nested in anything.
+
+    A tool call admits only its own arguments and its end between the two, and a
+    message admits only its own content, so a member terminal landing inside
+    either is a stream a validating client rejects. That covers the delegation
+    call the member was running inside, which closes before the terminal rather
+    than after it.
+    """
+    events = await collect(_member_open_inside_a_delegation_chunks(fail), attributed())
+    terminal_at = _member_terminal_index(events)
+
+    delegation_close_at = [
+        index
+        for index, event in enumerate(events)
+        if event.type == EventType.TOOL_CALL_END and getattr(event, "tool_call_id", None) == "tc-delegate-scout"  # type: ignore[attr-defined]
+    ]
+    assert delegation_close_at, "the delegation tool call was never closed"
+    assert delegation_close_at[0] < terminal_at
+
+    open_messages: Set[str] = set()
+    open_tool_calls: Set[str] = set()
+    for index, event in enumerate(events):
+        if index == terminal_at:
+            assert not open_messages, f"a member terminal landed inside open messages {sorted(open_messages)}"
+            assert not open_tool_calls, f"a member terminal landed inside open tool calls {sorted(open_tool_calls)}"
+        if event.type == EventType.TEXT_MESSAGE_START:
+            open_messages.add(event.message_id)  # type: ignore[attr-defined]
+        elif event.type == EventType.TEXT_MESSAGE_END:
+            open_messages.discard(event.message_id)  # type: ignore[attr-defined]
+        elif event.type == EventType.TOOL_CALL_START:
+            open_tool_calls.add(event.tool_call_id)  # type: ignore[attr-defined]
+        elif event.type == EventType.TOOL_CALL_END:
+            open_tool_calls.discard(event.tool_call_id)  # type: ignore[attr-defined]
+
+
+# --- Cancellation -----------------------------------------------------------
+
+
+def _cancelled_member_chunks() -> List[Any]:
+    member = _member_kwargs("scout", "run-scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**member),
+        RunCancelledEvent(reason="user cancelled the run", **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_cancelled_member_is_not_reported_as_a_success(collect):
+    events = await collect(_cancelled_member_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_ERROR)
+    assert not _of_type(events, EventType.SUBAGENT_FINISHED)
+    assert [(e.subagent_run_id, e.message, e.code) for e in _of_type(events, EventType.SUBAGENT_ERROR)] == [  # type: ignore[attr-defined]
+        ("run-scout", "user cancelled the run", "cancelled")
+    ]
+    # The member's other chunks do reach the wire as RAW, on its own lane, so
+    # the absence below is this one event being withheld rather than the whole
+    # lane going unmapped. The name is the framework's own rather than a literal.
+    assert_stream_contains(events, EventType.RAW)
+    raw = in_emitted_order(events, EventType.RAW, lambda e: e.event.get("event"), _lane)  # type: ignore[attr-defined]
+    assert (RunEvent.run_started.value, "run-scout") in raw, raw
+    assert RunEvent.run_cancelled.value not in [name for name, _ in raw]
+
+
+# --- Withheld failures are still recorded -----------------------------------
+
+
+def _failing_member_chunks() -> List[Any]:
+    member = _member_kwargs("scout", "run-scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**member),
+        RunErrorEvent(
+            content="member exploded",
+            error_type="RuntimeError",
+            error_id="err-42",
+            additional_data={"attempt": 2},
+            **member,
+        ),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "chunk_factory,expected",
+    [
+        (_failing_member_chunks, "member exploded"),
+        (_cancelled_member_chunks, "user cancelled the run"),
+    ],
+    ids=["error", "cancellation"],
+)
+@chunk_mappers
+async def test_hidden_records_a_member_failure_it_withholds(collect, caplog, chunk_factory, expected):
+    with captured_agno_logs(caplog, "WARNING"):
+        events = await collect(chunk_factory(), SUBAGENT_VISIBILITY_HIDDEN)
+
+    # Hidden withholds what identifies the member, not the fact that it failed.
+    assert not [e for e in events if "SUBAGENT" in str(e.type)]
+    assert not [e for e in events if _lane(e) is not None]
+    assert [r.message for r in caplog.records if expected in r.message]
+
+
+_SCOUT = _member_kwargs("scout", "run-scout")
+_WRITER = _member_kwargs("writer", "run-writer")
+
+# One chunk per way a member's run stops, with the text that member carried.
+# Keyed by the normalized event name so the coverage check below can compare
+# them with the events the interface itself treats as ending a member: a
+# terminal kind added there without a case here fails that check rather than
+# going unexamined by everything generated from this table.
+_MEMBER_RUN_TERMINALS: Dict[str, Tuple[Callable[[], Any], str]] = {
+    RunEvent.run_completed.value: (lambda: RunCompletedEvent(content="scout finished", **_SCOUT), "scout finished"),
+    RunEvent.run_error.value: (lambda: RunErrorEvent(content="scout exploded", **_SCOUT), "scout exploded"),
+    RunEvent.run_cancelled.value: (
+        lambda: RunCancelledEvent(reason="operator stopped scout", **_SCOUT),
+        "operator stopped scout",
+    ),
+    RunEvent.run_paused.value: (
+        lambda: AgentRunPausedEvent(
+            tools=[_pending("tc-scout-confirm", requires_confirmation=True)], content="scout is waiting", **_SCOUT
+        ),
+        "scout is waiting",
+    ),
+}
+
+
+def test_every_way_a_member_run_stops_has_a_case():
+    """The cases generated from the table are the class, checked against the interface's list."""
+    missing = sorted(handlers._SUBAGENT_RUN_ENDING_EVENTS.difference(_MEMBER_RUN_TERMINALS))
+    assert not missing, f"these member terminals have no case: {missing}"
+
+
+def _member_run_ending_chunks(terminal: Any) -> List[Any]:
+    """A run whose last chunk is one member terminal, so that terminal is the run's."""
+    return [TeamRunStartedEvent(**_TOP_LEVEL), RunStartedEvent(**_SCOUT), terminal]
+
+
+_WAYS_A_MEMBER_STOPS_UNDER_HIDDEN: Dict[str, Tuple[Callable[[], List[Any]], str]] = {
+    name: (lambda build=build: _member_run_ending_chunks(build()), text)  # type: ignore[misc]
+    for name, (build, text) in _MEMBER_RUN_TERMINALS.items()
+}
+# Not a way a member's run stops, and here for the contrast: a tool call
+# failure ends no run, so nothing of it can reach the client and its record
+# must not say otherwise.
+_WAYS_A_MEMBER_STOPS_UNDER_HIDDEN[RunEvent.tool_call_error.value] = (
+    lambda: _member_run_ending_chunks(
+        ToolCallErrorEvent(
+            tool=ToolExecution(tool_call_id="tc-boom", tool_name="search_docs"),
+            error="scout's tool exploded",
+            **_SCOUT,
+        )
+    ),
+    "scout's tool exploded",
+)
+
+
+@pytest.mark.asyncio
+@chunk_mappers
+@pytest.mark.parametrize(
+    "way", sorted(_WAYS_A_MEMBER_STOPS_UNDER_HIDDEN), ids=sorted(_WAYS_A_MEMBER_STOPS_UNDER_HIDDEN)
+)
+async def test_a_hidden_record_claims_the_reason_reached_the_client_exactly_when_it_did(collect, caplog, way):
+    """``hidden`` withholds the member's identity, and its record may not overstate that.
+
+    A member's terminal can be the only account the stream carries of how the
+    run ended, and is then read as the run's, so the text that member carried
+    reaches the client as the reason the run stopped even though nothing on the
+    wire names the member. Whether the record says so is checked against
+    whether the terminal really carries that text, over every way a member's
+    run can stop rather than over the one that was reported, so a terminal kind
+    added later cannot arrive with a record that claims the client was told
+    nothing while the client is reading the member's own words.
+    """
+    build, text = _WAYS_A_MEMBER_STOPS_UNDER_HIDDEN[way]
+    with captured_agno_logs(caplog, "WARNING"):
+        events = await collect(build(), SUBAGENT_VISIBILITY_HIDDEN)
+
+    assert not [e for e in events if "SUBAGENT" in str(e.type)]
+    assert not [e for e in events if _lane(e) is not None]
+    reason_on_the_wire = getattr(events[-1], "message", None)
+    claims = [r.message for r in caplog.records if handlers._REASON_STILL_REACHES_THE_CLIENT in r.message]
+
+    if reason_on_the_wire == text:
+        assert claims, f"the {way} record does not say the client is reading this member's own words"
+        assert all(text in claim for claim in claims)
+    else:
+        assert not claims, f"the {way} record claims a reason reached the client, and {reason_on_the_wire!r} did"
+
+
+@pytest.mark.asyncio
+@malformed_mappers
+@pytest.mark.parametrize(
+    "setting",
+    [lambda: None, lambda: SUBAGENT_VISIBILITY_INLINE, attributed, lambda: SUBAGENT_VISIBILITY_HIDDEN],
+    ids=["default", "inline", "attributed", "hidden"],
+)
+@pytest.mark.parametrize("stopped", sorted(_MEMBER_RUN_TERMINALS), ids=sorted(_MEMBER_RUN_TERMINALS))
+async def test_the_last_member_terminal_is_the_one_the_run_terminal_is_built_from(collect_malformed, setting, stopped):
+    """No member terminal outranks a later one, whichever way the earlier member stopped.
+
+    A run that reported no terminal of its own is described by the last member
+    terminal the stream carried and by nothing else. So a member that fails, and
+    then another member that completes, ends the run as a completion, and a
+    member that pauses followed by another member completing loses the pending
+    call the pause was waiting on: a completion carries none to prompt with.
+    Both hold under every setting, the default included, which is why the whole
+    class runs against all four rather than being described as a lineage
+    difference.
+
+    Driven through the collector that records violations, because the paused
+    arm leaves the member's own pending call opened by the stream and never
+    prompted, which the shared checker has an opinion about.
+    """
+    build, _ = _MEMBER_RUN_TERMINALS[stopped]
+    chunks = [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**_SCOUT),
+        build(),
+        RunStartedEvent(**_WRITER),
+        RunCompletedEvent(content="writer finished", **_WRITER),
+    ]
+
+    events, error, _ = await collect_malformed(chunks, setting(), thread_id=THREAD_ID, run_id=TOP_LEVEL_RUN)
+
+    assert error is None
+    assert str(events[-1].type) == str(EventType.RUN_FINISHED)
+    assert getattr(events[-1], "message", None) is None
+    # Nothing the run stopped for is prompted: the completion the terminal is
+    # built from asks the client to resolve nothing.
+    assert not _of_type(events, EventType.TOOL_CALL_START)
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_member_failure_is_logged_once_and_that_line_carries_the_ids(collect, caplog):
+    """One line, carrying everything an operator needs to find the failure again.
+
+    Read off the single record rather than off every record joined together: an
+    operator reads one line at a time, so identifiers scattered across separate
+    lines are identifiers that line does not have.
+    """
+    with captured_agno_logs(caplog, "ERROR"):
+        events = await collect(_failing_member_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_ERROR)
+    assert [(e.subagent_run_id, e.message, e.code) for e in _of_type(events, EventType.SUBAGENT_ERROR)] == [  # type: ignore[attr-defined]
+        ("run-scout", "member exploded", "RuntimeError")
+    ]
+    failures = [r.message for r in caplog.records if "member exploded" in r.message]
+    assert len(failures) == 1, f"one failure was recorded {len(failures)} times: {failures}"
+    assert "err-42" in failures[0], failures[0]
+    assert "attempt" in failures[0], failures[0]
+
+
+def _member_error_after_its_terminal_chunks() -> List[Any]:
+    """A member reports a failure after its own terminal has already gone out."""
+    member = _member_kwargs("scout", "run-scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**member),
+        RunCompletedEvent(content="scout done", **member),
+        RunErrorEvent(content="too late", error_type="RuntimeError", error_id="err-99", **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_failure_arriving_after_its_members_terminal_is_recorded_and_sends_no_second_terminal(collect, caplog):
+    """A terminal is final for the lane it names, so the late failure is recorded instead.
+
+    A second terminal for the same id would be a protocol violation, so the log
+    line is the only account of this failure and has to carry what an operator
+    needs from it: which lane failed, that the lane had already terminated so
+    the client was told nothing, and the identifiers the failure was reported
+    with.
+    """
+    with captured_agno_logs(caplog, "ERROR"):
+        events = await collect(_member_error_after_its_terminal_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_FINISHED)
+    # The one terminal the lane owns is its own, carrying what its run reported
+    # before the failure, and no error terminal joins it.
+    assert in_emitted_order(events, EventType.SUBAGENT_FINISHED, "subagent_run_id", "result") == [
+        ("run-scout", "scout done")
+    ]
+    assert in_emitted_order(events, EventType.SUBAGENT_ERROR, "subagent_run_id", "message") == []
+
+    recorded = [r.message for r in caplog.records if "too late" in r.message]
+    assert len(recorded) == 1, f"the late failure was recorded {len(recorded)} times: {recorded}"
+    assert "run-scout" in recorded[0], recorded[0]
+    assert "already terminated" in recorded[0], recorded[0]
+    assert "RuntimeError" in recorded[0], recorded[0]
+    assert "err-99" in recorded[0], recorded[0]
+
+
+# --- Serializing a member's result ------------------------------------------
+
+
+class _ExplodingDump:
+    """A result whose model dump raises, as a partly-built pydantic object can."""
+
+    def model_dump_json(self) -> str:
+        raise RuntimeError("dump exploded")
+
+    def __str__(self) -> str:
+        return "exploding result"
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    # Built per case rather than at collection time, so the two mappers cannot
+    # hand each other a result one of them has already mutated. What each falls
+    # back to is stated: an expectation of "some string" holds for every result
+    # the interface could possibly report. Every route that gave way on the way
+    # there is stated too, because a fallback nobody is told about is a member
+    # result quietly replaced by something else.
+    "content_factory,expected,recorded",
+    [
+        (
+            _ExplodingDump,
+            "exploding result",
+            ("could not dump a subagent result", "could not serialize a subagent result"),
+        ),
+        (circular, "{'self': {...}}", ("could not serialize a subagent result",)),
+    ],
+    ids=["model_dump_raises", "cyclic_content"],
+)
+@chunk_mappers
+async def test_an_unserializable_member_result_never_fails_the_run(
+    collect, caplog, content_factory, expected, recorded
+):
+    with captured_agno_logs(caplog, "WARNING"):
+        events = await collect(_member_result_chunks(content_factory()), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_FINISHED)
+    finished = _of_type(events, EventType.SUBAGENT_FINISHED)
+
+    assert [e.subagent_run_id for e in finished] == ["run-scout"]  # type: ignore[attr-defined]
+    assert finished[0].result == expected  # type: ignore[attr-defined]
+    assert str(events[-1].type) == str(EventType.RUN_FINISHED)
+    assert not _of_type(events, EventType.RUN_ERROR)
+    logged = [record.message for record in caplog.records]
+    for fragment in recorded:
+        assert [message for message in logged if fragment in message], (
+            f"the result the interface could not serialize left no trace of {fragment!r}: {logged}"
+        )
+
+
+# --- The lane stamp ---------------------------------------------------------
+
+_SCOUT_LANE = "run-scout"
+
+
+def _member_alone_chunks(*inner: Any) -> List[Any]:
+    """A team whose only speaker is one member, with no delegation call of the leader's.
+
+    The leader stays silent so that every event of a given type on the stream is
+    the member's, which is what lets the lanes below be stated as an exact list
+    rather than as a set with the leader's copies filtered out.
+    """
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**_SCOUT),
+        *inner,
+        RunCompletedEvent(content="scout done", **_SCOUT),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+def _a_member_spoke() -> List[Any]:
+    return _member_alone_chunks(_agent_said("scouting", **_SCOUT))
+
+
+def _a_member_called_a_tool() -> List[Any]:
+    tool = ToolExecution(tool_call_id="tc-scout", tool_name="search_docs", tool_args={"query": "agno"}, result="three")
+    return _member_alone_chunks(ToolCallStartedEvent(tool=tool, **_SCOUT), ToolCallCompletedEvent(tool=tool, **_SCOUT))
+
+
+def _a_member_reasoned() -> List[Any]:
+    delta = ReasoningContentDeltaEvent(**_SCOUT)
+    delta.reasoning_content = "first I "
+    return _member_alone_chunks(ReasoningStartedEvent(**_SCOUT), delta, ReasoningCompletedEvent(**_SCOUT))
+
+
+def _a_member_emitted_a_custom_event() -> List[Any]:
+    chunk = CustomEvent(**_SCOUT)
+    chunk.to_dict = lambda: {"event": "Custom", "payload": {"progress": 1}}  # type: ignore[method-assign]
+    return _member_alone_chunks(chunk)
+
+
+# One stream per attributable event type, with the lanes that type's events
+# carry on it, in order. Keyed by event name and checked against the stamp's own
+# set below, so an event type added to that set is driven here or named.
+_ATTRIBUTED_ON_A_MEMBER_LANE: Dict[str, Tuple[Callable[[], List[Any]], Tuple[Optional[str], ...]]] = {
+    # The team's own run-started chunk is unmapped too, and it is the leading
+    # unstamped RAW here; the member's is the stamped one.
+    "RAW": (_member_alone_chunks, (None, _SCOUT_LANE)),
+    "TEXT_MESSAGE_START": (_a_member_spoke, (_SCOUT_LANE,)),
+    "TEXT_MESSAGE_CONTENT": (_a_member_spoke, (_SCOUT_LANE,)),
+    "TEXT_MESSAGE_END": (_a_member_spoke, (_SCOUT_LANE,)),
+    # A tool call opens a message of the member's own to hang itself off, which
+    # is why this stream carries a text span with no content in it.
+    "TOOL_CALL_START": (_a_member_called_a_tool, (_SCOUT_LANE,)),
+    "TOOL_CALL_ARGS": (_a_member_called_a_tool, (_SCOUT_LANE,)),
+    "TOOL_CALL_END": (_a_member_called_a_tool, (_SCOUT_LANE,)),
+    "TOOL_CALL_RESULT": (_a_member_called_a_tool, (_SCOUT_LANE,)),
+    "REASONING_START": (_a_member_reasoned, (_SCOUT_LANE,)),
+    "REASONING_MESSAGE_START": (_a_member_reasoned, (_SCOUT_LANE,)),
+    "REASONING_MESSAGE_CONTENT": (_a_member_reasoned, (_SCOUT_LANE,)),
+    "REASONING_MESSAGE_END": (_a_member_reasoned, (_SCOUT_LANE,)),
+    "REASONING_END": (_a_member_reasoned, (_SCOUT_LANE,)),
+    "CUSTOM": (_a_member_emitted_a_custom_event, (_SCOUT_LANE,)),
+}
+
+
+def test_every_event_type_the_stamp_attributes_is_driven_onto_a_member_lane():
+    """The coverage is derived from the stamp's own set, so a type added to it lands here.
+
+    Named per event type rather than counted: a type nothing here puts on a
+    member's lane is one the stamp could skip with every test in this folder
+    still green, which is exactly what CUSTOM was.
+    """
+    attributable = _enumerated_by_the_interface(
+        {event_type.value for event_type in handlers._SUBAGENT_ATTRIBUTABLE_EVENT_TYPES},
+        EventType.CUSTOM.value,
+        described="the event types the lane stamp attributes",
+    )
+    assert set(_ATTRIBUTED_ON_A_MEMBER_LANE) == attributable, (
+        "these event types are attributable and no stream here puts one on a member's lane: "
+        f"{sorted(attributable - set(_ATTRIBUTED_ON_A_MEMBER_LANE))}; and these are driven here and no "
+        f"longer attributable: {sorted(set(_ATTRIBUTED_ON_A_MEMBER_LANE) - attributable)}"
+    )
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+@pytest.mark.parametrize("event_name", sorted(_ATTRIBUTED_ON_A_MEMBER_LANE))
+async def test_an_attributable_event_a_member_produced_carries_that_member(collect, event_name):
+    """Every attributable type, on the member that produced it, by payload and in order."""
+    chunks, expected = _ATTRIBUTED_ON_A_MEMBER_LANE[event_name]
+    event_type = event_type_named(event_name)
+    events = await collect(chunks(), attributed())
+
+    assert_stream_contains(events, event_type)
+    assert [lane for (lane,) in in_emitted_order(events, event_type, _lane)] == list(expected)
+
+
+class _EventWithoutLineage(BaseModel):
+    """An attributable event from a protocol release that cannot express a lane."""
+
+    model_config = {"extra": "allow"}
+
+    type: EventType = EventType.TEXT_MESSAGE_START
+
+
+@needs_lineage_events
+def test_a_protocol_that_cannot_carry_a_lane_is_refused_before_the_run_starts(monkeypatch):
+    """The refusal belongs at startup: mid-stream it would abort a run a client is already reading.
+
+    Gated, because this is the refusal for a release that HAS the lineage events
+    and not the field. A release with neither is refused for the missing events,
+    which is the test above.
+    """
+    visibility = attributed()
+    monkeypatch.setitem(handlers._ATTRIBUTABLE_EVENT_CLASSES, EventType.TEXT_MESSAGE_START, _EventWithoutLineage)
+
+    with pytest.raises(ValueError, match="subagent_run_id"):
+        validate_subagent_visibility(visibility)
+    # The settings that never stamp an event keep working on such a release.
+    assert validate_subagent_visibility(SUBAGENT_VISIBILITY_INLINE) == SUBAGENT_VISIBILITY_INLINE
+    assert validate_subagent_visibility(SUBAGENT_VISIBILITY_HIDDEN) == SUBAGENT_VISIBILITY_HIDDEN
+
+
+class _AnnouncementWithoutADescription(BaseModel):
+    """An announcement from a protocol release that declares no description field."""
+
+    model_config = {"extra": "allow"}
+
+    subagent_run_id: str = ""
+    name: str = ""
+    parent_subagent_run_id: Optional[str] = None
+    parent_tool_call_id: Optional[str] = None
+    parent_message_id: Optional[str] = None
+
+
+def _lineage_fields_the_interface_writes(event_class_names: Set[str]) -> Dict[str, Set[str]]:
+    """The arguments the interface really passes to each lineage event class.
+
+    Every module of the interface package is read, not just the one that happens
+    to construct these today, and the call sites are matched against the exact
+    class names the startup check enumerates rather than against a name prefix:
+    the state module declares its own ``Subagent`` record, which a prefix match
+    would count as a protocol event and compare its fields against the wire's.
+
+    Positional and starred arguments are refused rather than skipped. This scan
+    can put no name to either, so a field written that way would be missing from
+    what it returns and read as a field the interface does not write at all.
+    """
+    package = Path(handlers.__file__).parent
+    written: Dict[str, Set[str]] = {}
+    for path in sorted(package.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
+                continue
+            if node.func.id not in event_class_names:
+                continue
+            assert not node.args, (
+                f"{path.name} builds a {node.func.id} with positional arguments, which this scan cannot name"
+            )
+            assert all(keyword.arg is not None for keyword in node.keywords), (
+                f"{path.name} builds a {node.func.id} from a starred mapping, which this scan cannot read"
+            )
+            # ``type`` is the protocol's own discriminator, which every event
+            # declares by definition, so it is not one of the fields at issue.
+            written.setdefault(node.func.id, set()).update(
+                keyword.arg for keyword in node.keywords if keyword.arg is not None and keyword.arg != "type"
+            )
+    return written
+
+
+@needs_lineage_events
+def test_the_startup_check_feature_detects_every_lineage_field_the_interface_writes():
+    """A field nothing detects is one an older protocol takes as an undeclared attribute.
+
+    The protocol models accept what they do not declare, so a release missing
+    one of these does not raise: the value rides out under the name written
+    here instead of the one the wire format defines, and the client reads a lane
+    with no description, no parent or no result.
+    """
+    detected = {event_class.__name__: set(fields) for event_class, fields in handlers._lineage_event_fields().items()}
+    # The scan below is handed the very names this table is keyed by, so an
+    # empty table leaves it scanning for nothing and the comparison is between
+    # two empty mappings. The three classes the interface builds are the floor.
+    scanned_for = _enumerated_by_the_interface(
+        detected,
+        "SubagentStartedEvent",
+        "SubagentFinishedEvent",
+        "SubagentErrorEvent",
+        described="the lineage classes the startup check feature-detects fields on",
+    )
+
+    assert _lineage_fields_the_interface_writes(scanned_for) == detected
+
+
+@needs_lineage_events
+def test_a_protocol_missing_a_field_an_announcement_carries_is_refused_before_the_run_starts(monkeypatch):
+    visibility = attributed()
+    # The release accepts the write and keeps it as an undeclared attribute,
+    # which is why the field has to be detected rather than trusted.
+    silently_accepted = _AnnouncementWithoutADescription(description="scout the topic")
+    assert silently_accepted.description == "scout the topic"  # type: ignore[attr-defined]
+
+    monkeypatch.setattr(handlers, "SubagentStartedEvent", _AnnouncementWithoutADescription)
+
+    # The refusal names the class this install really carries, not the one the
+    # protocol would have provided.
+    with pytest.raises(ValueError, match=rf"{_AnnouncementWithoutADescription.__name__}\.description"):
+        validate_subagent_visibility(visibility)
+    # The settings that emit no lineage event keep working on such a release.
+    assert validate_subagent_visibility(SUBAGENT_VISIBILITY_INLINE) == SUBAGENT_VISIBILITY_INLINE
+    assert validate_subagent_visibility(SUBAGENT_VISIBILITY_HIDDEN) == SUBAGENT_VISIBILITY_HIDDEN
+
+
+def test_the_lane_stamp_cannot_fail_a_run_that_has_already_started():
+    stamped = handlers._stamp_lane([_EventWithoutLineage()], "run-scout")  # type: ignore[list-item]
+
+    assert [_lane(e) for e in stamped] == [None]
+
+
+def test_the_startup_check_covers_every_event_type_the_stamp_attributes():
+    """Feature-detecting a class the stamp never writes to would leave the mid-stream path exposed.
+
+    The set the stamp tests against is derived from the classes the startup
+    check reads, so the two cannot disagree and nothing here compares them.
+    What can drift is a class registered under an event type it does not carry:
+    the stamp would then skip an event the startup check cleared.
+    """
+    attributable = handlers._ATTRIBUTABLE_EVENT_CLASSES
+    # A registry that lost its entries stamps nothing and leaves the startup
+    # check nothing to feature-detect, and the assertion below holds for it, so
+    # the floor is stated first.
+    _enumerated_by_the_interface(
+        attributable, EventType.TEXT_MESSAGE_START, described="the event classes the lane stamp attributes"
+    )
+    mismatched = {
+        event_type: event_class.__name__
+        for event_type, event_class in attributable.items()
+        if event_class.model_fields["type"].default is not event_type
+    }
+    assert not mismatched, f"these classes do not carry the event type they are registered under: {mismatched}"
+
+
+@needs_lineage_events
+def test_the_lane_stamp_writes_the_declared_field_and_keeps_an_explicit_one():
+    from ag_ui.core import TextMessageStartEvent
+
+    plain = TextMessageStartEvent(type=EventType.TEXT_MESSAGE_START, message_id="m-1", role="assistant")
+    (stamped,) = handlers._stamp_lane([plain], "run-scout")
+    assert stamped.subagent_run_id == "run-scout"  # type: ignore[attr-defined]
+
+    explicit = TextMessageStartEvent(
+        type=EventType.TEXT_MESSAGE_START, message_id="m-2", role="assistant", subagent_run_id="run-other"
+    )
+    (kept,) = handlers._stamp_lane([explicit], "run-scout")
+    assert kept.subagent_run_id == "run-other"  # type: ignore[attr-defined]
+
+
+# --- Where the setting is validated -----------------------------------------
+
+
+def test_the_routes_refuse_an_invalid_visibility_when_they_are_mounted():
+    from fastapi import APIRouter
+
+    from agno.os.interfaces.agui.router import attach_routes
+
+    with pytest.raises(ValueError, match="subagent_visibility must be one of"):
+        attach_routes(APIRouter(), team=_two_member_team(InMemoryDb()), subagent_visibility="loud")
+
+
+def test_the_stream_state_refuses_an_invalid_visibility():
+    with pytest.raises(ValueError, match="subagent_visibility must be one of"):
+        StreamState(subagent_visibility="loud")
+
+
+def test_a_missing_agent_or_team_is_reported_before_the_visibility():
+    from agno.os.interfaces.agui import AGUI
+
+    with pytest.raises(ValueError, match="requires an agent or a team"):
+        AGUI(subagent_visibility="loud")
+
+
+# --- What the docs claim ----------------------------------------------------
+
+
+def _inner_agent_of_a_single_agent_chunks() -> List[Any]:
+    """A context provider runs an agent inside the outer run and stamps the outer run as its parent."""
+    outer = {"agent_id": "assistant", "agent_name": "Assistant", "run_id": TOP_LEVEL_RUN}
+    inner = {
+        "agent_id": "memory-agent",
+        "agent_name": "Memory",
+        "run_id": "run-inner-agent",
+        "parent_run_id": TOP_LEVEL_RUN,
+    }
+
+    return [
+        RunStartedEvent(**outer),
+        _agent_said("inner agent speaking", **inner),
+        _agent_said("outer agent speaking", **outer),
+        RunCompletedEvent(**outer),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_single_agents_inner_agent_becomes_a_lane_under_attributed(collect):
+    events = await collect(_inner_agent_of_a_single_agent_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED)
+    assert [(e.subagent_run_id, e.name) for e in _announcements(events)] == [("run-inner-agent", "Memory")]  # type: ignore[attr-defined]
+    assert _messages_in_order(events) == [("Memory", "inner agent speaking"), (None, "outer agent speaking")]
+
+
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_single_agents_inner_agent_is_withheld_under_hidden(collect):
+    events = await collect(_inner_agent_of_a_single_agent_chunks(), SUBAGENT_VISIBILITY_HIDDEN)
+
+    assert _messages_in_order(events) == [(None, "outer agent speaking")]
+
+
+def test_a_direct_child_lane_reports_the_same_depth_as_the_root():
+    state = StreamState(subagent_visibility=attributed(), root_run_id=TOP_LEVEL_RUN)
+    state.open_subagent("run-child", name="Child", parent_lane=None)
+    state.open_subagent("run-grandchild", name="Grandchild", parent_lane="run-child")
+
+    assert (state.lane_depth(ROOT_LANE), state.lane_depth("run-child"), state.lane_depth("run-grandchild")) == (0, 0, 1)
+
+
+def _within(seconds: float, described: str, call: Callable[[], Any]) -> Any:
+    """The call's result, failing rather than hanging when it does not return.
+
+    A parent chain that closes on itself is walked by the ordering helpers
+    below, and a walk that looped would wedge a run with no output and no
+    failure anywhere. The wait is therefore bounded, and the thread is a
+    daemon so a wedged walk cannot hold the suite open either.
+
+    Whatever the call raised is re-raised here rather than left in the worker:
+    reading the result by index instead would turn every exception inside the
+    walk into a bare IndexError on an empty list, which names neither the walk
+    nor what went wrong in it.
+    """
+    outcome: Dict[str, Any] = {}
+
+    def run() -> None:
+        try:
+            outcome["returned"] = call()
+        except BaseException as raised:  # noqa: BLE001 - re-raised below, in the calling thread
+            outcome["raised"] = raised
+
+    worker = threading.Thread(target=run, daemon=True)
+    worker.start()
+    worker.join(seconds)
+    assert not worker.is_alive(), (
+        f"{described} did not return within {seconds}s, so a parent chain that closes on itself is walked forever"
+    )
+    if "raised" in outcome:
+        raise AssertionError(f"{described} raised {outcome['raised']!r}") from outcome["raised"]
+    return outcome["returned"]
+
+
+def test_a_parent_chain_that_closes_on_itself_is_walked_once_and_stops():
+    """No run produces this, and every ordering helper has to survive one that did.
+
+    Each of these walks the parent chain, so a guard that stops guarding turns a
+    run into a hang, which is a failure no assertion about its output can catch.
+    """
+    state = StreamState(subagent_visibility=attributed(), root_run_id=TOP_LEVEL_RUN)
+    state.open_subagent("run-a", name="A", parent_lane="run-c")
+    state.open_subagent("run-b", name="B", parent_lane="run-a")
+    state.open_subagent("run-c", name="C", parent_lane="run-b")
+    state.open_subagent("run-self", name="Self", parent_lane="run-self")
+    for lane in ("run-a", "run-b", "run-c", "run-self"):
+        state.lane(lane)
+
+    # The walk stops on the first lane it has already passed, so each chain
+    # reports the lanes above it once and the lane itself never again.
+    assert _within(5, "the ancestor walk", lambda: state.ancestor_lanes("run-a")) == ["run-c", "run-b"]
+    assert _within(5, "the ancestor walk", lambda: state.ancestor_lanes("run-self")) == []
+    assert _within(5, "the lane depth", lambda: (state.lane_depth("run-a"), state.lane_depth("run-self"))) == (2, 0)
+    assert _within(5, "the member terminal order", lambda: state.subagents_deepest_first()) == [
+        "run-a",
+        "run-b",
+        "run-c",
+        "run-self",
+    ]
+    assert _within(5, "the lane sweep", lambda: state.lanes_deepest_first()) == [
+        "run-a",
+        "run-b",
+        "run-c",
+        "run-self",
+        ROOT_LANE,
+    ]
+
+
+def _docstring(owner: Any, described: str) -> str:
+    """The docstring, refusing an absent one.
+
+    Falling back to an empty string makes every claim below trivially absent the
+    moment a docstring is deleted, which leaves these assertions pinning the
+    absence of prose in a docstring that no longer exists.
+    """
+    text = owner.__doc__
+    assert text, f"{described} carries no docstring, so nothing here can check what it claims"
+    return text
+
+
+# --- What a lane terminal must not take with it -----------------------------
+
+
+def _live_descendant_tool_when_its_parent_terminates_chunks(session_state: Dict[str, Any]) -> List[Any]:
+    """A sub-team reaches its own terminal while its member's tool call is still running."""
+    inner = _team_kwargs("inner-team", "Inner Team", "run-inner", parent=TOP_LEVEL_RUN)
+    member = _member_kwargs("scout", "run-scout", parent="run-inner")
+    tool = ToolExecution(tool_call_id="tc-scout-approve", tool_name="approve", tool_args={}, result="approved")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamRunStartedEvent(**inner),
+        RunStartedEvent(**member),
+        ToolCallStartedEvent(tool=tool, **member),
+        TeamRunCompletedEvent(content="inner done", **inner),
+        SideEffect(lambda: session_state.__setitem__("approved", True)),
+        ToolCallCompletedEvent(tool=tool, **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@malformed_mappers
+async def test_a_lane_terminal_leaves_a_live_descendants_tool_call_to_its_own_completion(collect_malformed):
+    """The tool goes on running, so its call keeps its own end, result and state change.
+
+    Closing that call from the ancestor's terminal would mark it ended, which
+    makes the completion that follows read as a repeat and be dropped whole,
+    taking the result and the session state the tool wrote with it.
+    """
+    session_state: Dict[str, Any] = {"approved": False}
+
+    events, error, violation = await collect_malformed(
+        _live_descendant_tool_when_its_parent_terminates_chunks(session_state),
+        attributed(),
+        thread_id=THREAD_ID,
+        run_id=TOP_LEVEL_RUN,
+        run_state=session_state,
+    )
+
+    assert error is None, f"the source stream raised {error!r}"
+    assert_stream_contains(events, EventType.TOOL_CALL_RESULT)
+    assert in_emitted_order(events, EventType.TOOL_CALL_RESULT, "tool_call_id", "content") == [
+        ("tc-scout-approve", '"approved"')
+    ]
+    # Closed once, by the completion, and still attributed to the member.
+    assert in_emitted_order(events, EventType.TOOL_CALL_END, "tool_call_id", _lane) == [
+        ("tc-scout-approve", "run-scout")
+    ]
+    assert_stream_contains(events, EventType.STATE_DELTA)
+    assert in_emitted_order(events, EventType.STATE_DELTA, "delta") == [
+        ([{"op": "replace", "path": "/approved", "value": True}],)
+    ]
+    _assert_the_child_resolved_after_its_parent(violation)
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@malformed_mappers
+async def test_a_live_descendants_tool_call_that_never_completes_is_still_closed(collect_malformed):
+    """Left open for its own completion, and closed by the run end if that never comes.
+
+    The run end closes every open tool call before it terminates the members
+    that still hold one, so the end goes out while the lane is still open and the
+    member's terminal is the last thing that lane carries.
+    """
+    session_state: Dict[str, Any] = {"approved": False}
+    chunks = [
+        chunk
+        for chunk in _live_descendant_tool_when_its_parent_terminates_chunks(session_state)
+        if not isinstance(chunk, (ToolCallCompletedEvent, SideEffect))
+    ]
+
+    events, error, violation = await collect_malformed(
+        chunks,
+        attributed(),
+        thread_id=THREAD_ID,
+        run_id=TOP_LEVEL_RUN,
+        run_state=session_state,
+    )
+
+    assert error is None, f"the source stream raised {error!r}"
+    assert_stream_contains(events, EventType.TOOL_CALL_END)
+    assert in_emitted_order(events, EventType.TOOL_CALL_END, "tool_call_id", _lane) == [
+        ("tc-scout-approve", "run-scout")
+    ]
+    assert not _of_type(events, EventType.TOOL_CALL_RESULT)
+    # The member's terminal, read off the two terminal types: a substring match
+    # on SUBAGENT takes the announcement instead, which precedes everything the
+    # lane carries, and the ordering below then holds whatever the sweep does.
+    terminal_at = [index for index, event in enumerate(events) if _lane(event) == "run-scout" and _is_terminal(event)]
+    closed_at = [index for index, event in enumerate(events) if event.type == EventType.TOOL_CALL_END]
+    assert terminal_at and closed_at and closed_at[0] < terminal_at[0], (closed_at, terminal_at)
+    _assert_the_child_resolved_after_its_parent(violation)
+
+
+def _member_tool_completes_after_its_own_terminal_chunks(session_state: Dict[str, Any]) -> List[Any]:
+    """A member's own tool call completes after that member's run already ended."""
+    member = _member_kwargs("scout", "run-scout")
+    tool = ToolExecution(tool_call_id="tc-scout-approve", tool_name="approve", tool_args={}, result="approved")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**member),
+        ToolCallStartedEvent(tool=tool, **member),
+        RunCompletedEvent(content="scout done", **member),
+        SideEffect(lambda: session_state.__setitem__("approved", True)),
+        ToolCallCompletedEvent(tool=tool, **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_tool_result_arriving_after_its_members_terminal_still_reaches_the_client(collect):
+    """A member's terminal ends no tool call, so the one it left open keeps its own lifecycle.
+
+    Ending that call with the terminal would mark it ended, which makes the
+    completion that follows read as a repeat and be dropped whole, taking the
+    result and the session state the tool wrote with it.
+    """
+    session_state: Dict[str, Any] = {"approved": False}
+
+    events = await collect(
+        _member_tool_completes_after_its_own_terminal_chunks(session_state),
+        attributed(),
+        run_state=session_state,
+        exempt=[TRAILING_OUTPUT_AFTER_A_MEMBER_TERMINAL],
+    )
+
+    assert_stream_contains(events, EventType.TOOL_CALL_RESULT)
+    assert in_emitted_order(events, EventType.TOOL_CALL_RESULT, "tool_call_id", "content", _lane) == [
+        ("tc-scout-approve", '"approved"', "run-scout")
+    ]
+    # Closed once, by the completion, and still the member's.
+    assert in_emitted_order(events, EventType.TOOL_CALL_END, "tool_call_id", _lane) == [
+        ("tc-scout-approve", "run-scout")
+    ]
+    assert_stream_contains(events, EventType.STATE_DELTA)
+    assert in_emitted_order(events, EventType.STATE_DELTA, "delta") == [
+        ([{"op": "replace", "path": "/approved", "value": True}],)
+    ]
+    # The member's own terminal still carries what its run reported.
+    assert in_emitted_order(events, EventType.SUBAGENT_FINISHED, "subagent_run_id", "result") == [
+        ("run-scout", "scout done")
+    ]
+
+
+def _descendant_still_open_when_its_parent_terminates_chunks(fail: bool) -> List[Any]:
+    """A sub-team reaches its own terminal with its member still running."""
+    inner = _team_kwargs("inner-team", "Inner Team", "run-inner", parent=TOP_LEVEL_RUN)
+    member = _member_kwargs("scout", "run-scout", parent="run-inner")
+    parent_terminal = (
+        TeamRunErrorEvent(content="inner exploded", error_type="RuntimeError", **inner)
+        if fail
+        else TeamRunCompletedEvent(content="inner done", **inner)
+    )
+
+    chunks: List[Any] = [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamRunStartedEvent(**inner),
+        RunStartedEvent(**member),
+        _agent_said("scouting", **member),
+        parent_terminal,
+    ]
+    if not fail:
+        # The member goes on working and reports its own result afterwards.
+        chunks.append(RunCompletedEvent(content="scout done", **member))
+    chunks.append(TeamRunCompletedEvent(**_TOP_LEVEL))
+    return chunks
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@malformed_mappers
+async def test_a_member_still_running_reports_its_own_result_when_the_member_above_it_finishes(collect_malformed):
+    """A parent's terminal terminates the parent, so the child still delivers what it produced.
+
+    Terminating the child here instead would send a terminal with no result,
+    after which the child's own completion is read as a second terminal and
+    dropped, so the member's real content reaches nobody.
+    """
+    events, error, violation = await collect_malformed(
+        _descendant_still_open_when_its_parent_terminates_chunks(fail=False),
+        attributed(),
+        thread_id=THREAD_ID,
+        run_id=TOP_LEVEL_RUN,
+        exempt=[TRAILING_OUTPUT_AFTER_A_MEMBER_TERMINAL],
+    )
+
+    assert error is None, f"the source stream raised {error!r}"
+    assert_stream_contains(events, EventType.SUBAGENT_FINISHED, 2)
+    assert in_emitted_order(events, EventType.SUBAGENT_FINISHED, "subagent_run_id", "result") == [
+        ("run-inner", "inner done"),
+        ("run-scout", "scout done"),
+    ]
+    # The member's own words still reached the client, in its own lane.
+    assert joined_text_in_emitted_order(events) == [("run-scout", "scouting")]
+    _assert_the_child_resolved_after_its_parent(violation)
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@malformed_mappers
+async def test_a_member_that_never_failed_carries_no_error_from_the_member_above_it(collect_malformed, caplog):
+    """The failure belongs to the run that reported it, and to no lane below it."""
+    with captured_agno_logs(caplog, "ERROR"):
+        events, error, violation = await collect_malformed(
+            _descendant_still_open_when_its_parent_terminates_chunks(fail=True),
+            attributed(),
+            thread_id=THREAD_ID,
+            run_id=TOP_LEVEL_RUN,
+            exempt=[TRAILING_OUTPUT_AFTER_A_MEMBER_TERMINAL],
+        )
+
+    assert error is None, f"the source stream raised {error!r}"
+    assert_stream_contains(events, EventType.SUBAGENT_ERROR)
+    assert in_emitted_order(events, EventType.SUBAGENT_ERROR, "subagent_run_id", "message", "code") == [
+        ("run-inner", "inner exploded", "RuntimeError")
+    ]
+    # The member never failed, so the run end finishes it, without a code and
+    # without the message of the failure above it.
+    assert in_emitted_order(events, EventType.SUBAGENT_FINISHED, "subagent_run_id", "result") == [("run-scout", None)]
+    assert [record.message for record in caplog.records if "run-scout" in record.message] == []
+    _assert_the_child_resolved_after_its_parent(violation)
+
+
+def _pause_repeating_a_members_open_tool_call_chunks() -> List[Any]:
+    """The paused requirement repeats a member tool call that is still open."""
+    member = _member_kwargs("scout", "run-scout")
+    streaming = ToolExecution(tool_call_id="tc-member-confirm", tool_name="send_email", tool_args={"to": "ops"})
+    repeated = ToolExecution(
+        tool_call_id="tc-member-confirm",
+        tool_name="send_email",
+        tool_args={"to": "ops"},
+        requires_confirmation=True,
+    )
+    requirement = _requirement(repeated, "scout", "run-scout", "Scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**member),
+        ToolCallStartedEvent(tool=streaming, **member),
+        TeamRunPausedEvent(tools=[], requirements=[requirement], **_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_pause_does_not_open_a_second_start_for_a_call_the_client_already_has(collect):
+    """A call still open has had its start: prompting it again opens one span twice."""
+    events = await collect(_pause_repeating_a_members_open_tool_call_chunks(), attributed())
+
+    assert in_emitted_order(events, EventType.TOOL_CALL_START, "tool_call_id", _lane) == [
+        ("tc-member-confirm", "run-scout")
+    ]
+    assert in_emitted_order(events, EventType.TOOL_CALL_END, "tool_call_id", _lane) == [
+        ("tc-member-confirm", "run-scout")
+    ]
+
+    # Nothing survived the prompt, and every call it would have carried is
+    # already on the wire, so the prompt says nothing rather than adding an
+    # assistant message with neither words nor a call under it. Every message
+    # here is one a tool call is parented to.
+    carrying = {e.parent_message_id for e in _of_type(events, EventType.TOOL_CALL_START)}  # type: ignore[attr-defined]
+    assert [
+        (_lane(e), e.message_id in carrying)  # type: ignore[attr-defined]
+        for e in _of_type(events, EventType.TEXT_MESSAGE_START)
+    ] == [("run-scout", True)]
+    assert not _of_type(events, EventType.TEXT_MESSAGE_CONTENT)
+
+
+# --- A member name the interface cannot read --------------------------------
+
+
+class _UnreadableName:
+    """A name whose stringification raises, as a proxy object's can."""
+
+    def __str__(self) -> str:
+        raise RuntimeError("name exploded")
+
+
+def _member_with_an_unreadable_name_chunks() -> List[Any]:
+    member = {"agent_name": _UnreadableName(), "run_id": "run-scout", "parent_run_id": TOP_LEVEL_RUN}
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        _agent_said("scouting", **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_member_name_the_interface_cannot_read_does_not_end_the_run(collect, caplog):
+    with captured_agno_logs(caplog, "WARNING"):
+        events = await collect(_member_with_an_unreadable_name_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED)
+    # Nameable or not, the lane is announced, under the only name left: its run id.
+    assert [(e.subagent_run_id, e.name) for e in _announcements(events)] == [("run-scout", "run-scout")]  # type: ignore[attr-defined]
+    assert str(events[-1].type) == str(EventType.RUN_FINISHED)
+    # The client is shown a run id where a name belongs, so the raise that cost
+    # it the name has to reach the operator.
+    assert [record.message for record in caplog.records if "name exploded" in record.message], (
+        "the member name the interface could not read left no trace at all"
+    )
+
+
+@pytest.mark.parametrize(
+    "value",
+    [None, "", 0, 0.0, False, [], {}, ()],
+    ids=["none", "empty_text", "zero", "zero_float", "false", "empty_list", "empty_mapping", "empty_tuple"],
+)
+def test_a_falsy_label_is_read_as_no_label_at_all(value):
+    """Every falsy value is absent, not a label, which is what each caller falls back on.
+
+    Stated over the falsy values a chunk can carry rather than over None alone,
+    because the guard tests truthiness: a caller reading ``""`` or ``"0"`` off
+    this would put it on the wire as a member's name or its id, and the next
+    fallback would never be tried.
+    """
+    assert handlers._readable(value, "a label under test") is None
+
+
+def test_a_label_that_is_present_is_read_as_its_text():
+    """Otherwise the case above passes on a guard that discards everything."""
+    assert handlers._readable("Scout", "a label under test") == "Scout"
+    assert handlers._readable(7, "a label under test") == "7"
+
+
+# --- The member id the framework delegates by -------------------------------
+
+
+def _parallel_delegations_to_named_members_chunks() -> List[Any]:
+    """Two delegations open at once, to members named but never given ids."""
+    scout = {"agent_name": "Scout", "run_id": "run-scout", "parent_run_id": TOP_LEVEL_RUN}
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=_delegation("tc-scout", "scout", "scout the north")),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=_delegation("tc-ranger", "ranger", "range the south")),
+        _agent_said("scouting", **scout),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_named_member_without_an_id_is_still_linked_to_its_delegation(collect):
+    """The delegation argument carries the framework's derived member id, not the run's.
+
+    A member given no id of its own is delegated to by the url-safe form of its
+    name. Initializing a Team then assigns that same derived id to the member,
+    so a locally built Team's chunks carry it and this branch never runs for
+    one. It is there for the chunks that assignment does not stand behind, a
+    remote entity's among them, which are rebuilt from what its stream sent:
+    reading the run's own agent id alone would leave a member arriving with a
+    name and no id unmatched, and a parallel delegation then has no single
+    candidate to fall back on.
+    """
+    from agno.utils.team import get_member_id
+
+    named = Agent(name="Scout", telemetry=False)
+    assert named.id is None, "this fixture is about a member given no id of its own"
+    assert get_member_id(named) == "scout", "the framework no longer derives a member id from the name"
+    Team(name="Owner", members=[named], telemetry=False)._initialize_member(named)
+    assert named.id == "scout", "a Team no longer assigns its members the id it delegates to them by"
+
+    events = await collect(_parallel_delegations_to_named_members_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED)
+    announcement = _announcements(events)[0]
+    assert (
+        announcement.subagent_run_id,  # type: ignore[attr-defined]
+        announcement.name,  # type: ignore[attr-defined]
+        announcement.description,  # type: ignore[attr-defined]
+        announcement.parent_tool_call_id,  # type: ignore[attr-defined]
+    ) == ("run-scout", "Scout", "scout the north", "tc-scout")
+    # The delegation's own parent message, resolved against the messages this
+    # stream really opened: read back as None on both sides, that field compares
+    # nothing, and an id no start ever carried is one a client cannot place.
+    assert announcement.parent_message_id in _lane_of_message_id(events), (  # type: ignore[attr-defined]
+        "the delegation's own parent message names no message this stream opened"
+    )
+
+
+def _two_delegations_naming_one_member_chunks() -> List[Any]:
+    """Two open delegations name the same member, so neither can be shown to have spawned it."""
+    member = _member_kwargs("scout", "run-scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=_delegation("tc-first", "scout", "scout the north")),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=_delegation("tc-second", "scout", "scout the south")),
+        _agent_said("scouting", **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_two_open_delegations_naming_one_member_report_no_link_rather_than_a_guess(collect):
+    events = await collect(_two_delegations_naming_one_member_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED)
+    assert [
+        (e.subagent_run_id, e.description, e.parent_tool_call_id, e.parent_message_id)  # type: ignore[attr-defined]
+        for e in _announcements(events)
+    ] == [("run-scout", None, None, None)]
+
+
+def _broadcast_delegation(tool_call_id: str, task: str) -> ToolExecution:
+    """One of the delegation tools that names no member, because it targets them all."""
+    return ToolExecution(
+        tool_call_id=tool_call_id,
+        tool_name="delegate_task_to_members",
+        tool_args={"task": task},
+    )
+
+
+def _member_spawned_by_a_broadcast_chunks() -> List[Any]:
+    """The only open delegation is a broadcast, so nothing on it names the member."""
+    member = _member_kwargs("scout", "run-scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=_broadcast_delegation("tc-broadcast", "everyone work")),
+        RunStartedEvent(**member),
+        RunCompletedEvent(content="scout done", **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_broadcast_delegation_names_no_member_so_no_link_is_reported(collect):
+    """A lone open delegation is not evidence that it spawned this member.
+
+    Returning it because it is the only candidate hands an unrelated lane, such
+    as the inner run of a context provider, another member's parent call, task
+    text and parent message.
+    """
+    events = await collect(_member_spawned_by_a_broadcast_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED)
+    assert [
+        (e.subagent_run_id, e.parent_tool_call_id, e.description, e.parent_message_id)  # type: ignore[attr-defined]
+        for e in _announcements(events)
+    ] == [("run-scout", None, None, None)]
+
+
+def _paused_member_spawned_by_a_broadcast_chunks() -> List[Any]:
+    """A member pauses, and the only open delegation is a broadcast that names nobody."""
+    tool = ToolExecution(
+        tool_call_id="tc-scout-confirm", tool_name="send_email", tool_args={"to": "ops"}, requires_confirmation=True
+    )
+    requirement = _requirement(tool, "scout", "run-scout", "Scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=_broadcast_delegation("tc-broadcast", "everyone work")),
+        TeamRunPausedEvent(tools=[], requirements=[requirement], **_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_paused_member_a_broadcast_spawned_reports_no_link(collect):
+    """The paused path resolves the parent the same way, so it borrows nothing either."""
+    events = await collect(_paused_member_spawned_by_a_broadcast_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.TOOL_CALL_START, 2)
+    assert [
+        (e.subagent_run_id, e.parent_subagent_run_id, e.parent_tool_call_id, e.description, e.parent_message_id)  # type: ignore[attr-defined]
+        for e in _announcements(events)
+    ] == [("run-scout", None, None, None, None)]
+
+
+def _paused_grandchild_a_broadcast_delegated_chunks() -> List[Any]:
+    """A sub-team broadcasts to its members, and one of them pauses."""
+    inner = _team_kwargs("inner-team", "Inner Team", "run-inner", parent=TOP_LEVEL_RUN)
+    outer_delegation = _delegation("tc-delegate-inner", "inner-team", "run the inner team")
+    member_tool = ToolExecution(
+        tool_call_id="tc-scout-confirm", tool_name="send_email", tool_args={"to": "ops"}, requires_confirmation=True
+    )
+    requirement = _requirement(member_tool, "scout", "run-scout", "Scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=outer_delegation),
+        TeamRunStartedEvent(**inner),
+        TeamToolCallStartedEvent(tool=_broadcast_delegation("tc-inner-broadcast", "everyone scout"), **inner),
+        TeamRunPausedEvent(tools=[], requirements=[requirement], **_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_paused_grandchild_whose_parent_cannot_be_identified_reports_no_parent(collect):
+    """No parent beats the leader: the sub-team's task and the leader's message are not this member's.
+
+    Reaching past the sub-team for the leader's own open delegation also flattens
+    the tree, which puts the grandchild at the same depth as the member that
+    really delegated to it and reverses the order their terminals go out in.
+    """
+    events = await collect(_paused_grandchild_a_broadcast_delegated_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED, 2)
+    parent_of_tool_call = {
+        e.tool_call_id: e.parent_message_id  # type: ignore[attr-defined]
+        for e in _of_type(events, EventType.TOOL_CALL_START)
+    }
+    # The sub-team's own link names a message this stream really opened: read
+    # back as None on both sides, that field compares nothing.
+    assert parent_of_tool_call["tc-delegate-inner"] in _lane_of_message_id(events), parent_of_tool_call
+    assert [
+        (e.subagent_run_id, e.parent_subagent_run_id, e.parent_tool_call_id, e.description, e.parent_message_id)  # type: ignore[attr-defined]
+        for e in _announcements(events)
+    ] == [
+        ("run-inner", None, "tc-delegate-inner", "run the inner team", parent_of_tool_call["tc-delegate-inner"]),
+        ("run-scout", None, None, None, None),
+    ]
+
+
+def _paused_member_named_by_two_delegations_chunks() -> List[Any]:
+    """One lane holds two open delegations naming the member that then pauses."""
+    tool = ToolExecution(
+        tool_call_id="tc-scout-confirm", tool_name="send_email", tool_args={"to": "ops"}, requires_confirmation=True
+    )
+    requirement = _requirement(tool, "scout", "run-scout", "Scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=_delegation("tc-first", "scout", "scout the north")),
+        TeamToolCallStartedEvent(run_id=TOP_LEVEL_RUN, tool=_delegation("tc-second", "scout", "scout the south")),
+        TeamRunPausedEvent(tools=[], requirements=[requirement], **_TOP_LEVEL),
+    ]
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_paused_member_named_by_two_delegations_reports_no_link(collect):
+    """The paused path resolves the parent the same way, so it omits the same links."""
+    events = await collect(_paused_member_named_by_two_delegations_chunks(), attributed())
+
+    assert_stream_contains(events, EventType.SUBAGENT_STARTED)
+    assert [
+        (e.subagent_run_id, e.description, e.parent_subagent_run_id, e.parent_tool_call_id)  # type: ignore[attr-defined]
+        for e in _announcements(events)
+    ] == [("run-scout", None, None, None)]
+
+
+# --- Failures that have to reach somebody -----------------------------------
+
+
+def _member_tool_call_fails_chunks() -> List[Any]:
+    member = _member_kwargs("scout", "run-scout")
+    tool = ToolExecution(tool_call_id="tc-member-search", tool_name="search_docs", tool_args={"query": "agno"})
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**member),
+        ToolCallStartedEvent(tool=tool, **member),
+        ToolCallErrorEvent(tool=tool, error="tool exploded", **member),
+        RunCompletedEvent(content="scout done", **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_hidden_records_a_member_tool_call_failure_it_withholds(collect, caplog):
+    """Hidden withholds what identifies a member, never the fact that something failed."""
+    with captured_agno_logs(caplog, "WARNING"):
+        events = await collect(_member_tool_call_fails_chunks(), SUBAGENT_VISIBILITY_HIDDEN)
+
+    assert not [e for e in events if _lane(e) is not None]
+    assert not [e for e in events if "TOOL_CALL" in str(e.type)]
+    assert [r.message for r in caplog.records if "tool exploded" in r.message], (
+        "a member's tool call failed and neither the client nor the log was told"
+    )
+
+
+def _plain_member_failure_chunks() -> List[Any]:
+    """A member failure carrying nothing beyond its message and type."""
+    member = _member_kwargs("scout", "run-scout")
+
+    return [
+        TeamRunStartedEvent(**_TOP_LEVEL),
+        RunStartedEvent(**member),
+        RunErrorEvent(content="member exploded", error_type="RuntimeError", **member),
+        TeamRunCompletedEvent(**_TOP_LEVEL),
+    ]
+
+
+async def _assert_the_failure_line_names_only_what_it_has(collect, caplog, visibility: Optional[str]) -> None:
+    with captured_agno_logs(caplog, "ERROR"):
+        await collect(_plain_member_failure_chunks(), visibility)
+
+    failures = [r.message for r in caplog.records if "member exploded" in r.message]
+    assert len(failures) == 1, f"one failure was recorded {len(failures)} times: {failures}"
+    assert "None" not in failures[0], f"the failure line reports fields it does not have: {failures[0]}"
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_plain_member_failure_on_the_wire_is_recorded_without_empty_detail_fields(collect, caplog):
+    await _assert_the_failure_line_names_only_what_it_has(collect, caplog, attributed())
+
+
+@pytest.mark.asyncio
+@chunk_mappers
+async def test_a_plain_member_failure_hidden_from_the_wire_is_recorded_without_empty_detail_fields(collect, caplog):
+    await _assert_the_failure_line_names_only_what_it_has(collect, caplog, SUBAGENT_VISIBILITY_HIDDEN)
+
+
+@needs_lineage_events
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    # Built per case rather than at collection time, so the two mappers cannot
+    # hand each other a pending call one of them has already been through.
+    "unusable_factory,named",
+    [(_nameless_tool, "tc-nameless"), (_idless_tool, "send_invoice")],
+    ids=["no_name", "no_id"],
+)
+@chunk_mappers
+async def test_a_paused_tool_the_client_cannot_be_shown_is_recorded_even_when_another_survives(
+    collect, caplog, unusable_factory, named
+):
+    """A dropped pending call hangs the resume, so a partial drop cannot be silent."""
+    with captured_agno_logs(caplog, "WARNING"):
+        events = await collect(_paused_member_carrying_one_unusable_tool_chunks(unusable_factory()), attributed())
+
+    assert_stream_contains(events, EventType.TOOL_CALL_START)
+    assert [r.message for r in caplog.records if named in r.message], (
+        f"the dropped pending call {named} left no trace in the log"
+    )
+
+
+# --- The default pause prompt -----------------------------------------------
+
+
+def _paused_on_nothing_renderable_chunks() -> List[Any]:
+    """A run pauses on a single tool the client cannot be shown: it carries no name."""
+    nameless = _nameless_tool()
+    paused = AgentRunPausedEvent(agent_id="solo", agent_name="Solo", run_id=TOP_LEVEL_RUN, tools=[nameless])
+    paused.content = "Confirm before I send this."
+
+    return [RunStartedEvent(agent_id="solo", agent_name="Solo", run_id=TOP_LEVEL_RUN), paused]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    # Resolved inside the test rather than at collection: naming the attributed
+    # setting is what skips on a release that cannot serve it. It belongs here
+    # because it is the setting this behavior was reworked for, and because the
+    # prompt is now split one message per subagent, so a run with no subagent on
+    # it has to come out as the single unattributed message the others produce.
+    "setting",
+    [lambda: None, lambda: SUBAGENT_VISIBILITY_INLINE, attributed, lambda: SUBAGENT_VISIBILITY_HIDDEN],
+    ids=["default", "inline", "attributed", "hidden"],
+)
+@chunk_mappers
+async def test_a_pause_carrying_only_unrenderable_tools_still_says_so(collect, setting):
+    """The prompt message goes out whenever the terminal carries paused tools at all.
+
+    Before member attribution existed the renderability of a pending call
+    decided only whether that call was prompted, never whether the pause was
+    announced, so a run that paused on nothing renderable still told the client
+    why it stopped. It is the listing that decides: a terminal that listed no
+    pending call at all carries no prompt and no content with it, which is that
+    same stream and is pinned separately.
+    """
+    events = await collect(_paused_on_nothing_renderable_chunks(), setting())
+
+    assert_stream_contains(events, EventType.TEXT_MESSAGE_CONTENT)
+    # One message, unattributed, under every setting: no subagent is involved,
+    # so the per-subagent split has nothing to split and nothing to announce.
+    assert joined_text_in_emitted_order(events) == [(None, "Confirm before I send this.")]
+    assert not [e for e in events if "SUBAGENT" in str(e.type)]
+    assert not _of_type(events, EventType.TOOL_CALL_START)
+    assert str(events[-1].type) == str(EventType.RUN_FINISHED)
+
+
+# --- The interface's own shape ----------------------------------------------
+
+
+def _stream_state_attributes_read_outside(module_name: str) -> Set[str]:
+    """Every attribute the rest of the interface reads off a ``StreamState``.
+
+    Read off the syntax rather than by searching the source text for a bare
+    ``.name``: the per-lane ``Lane`` object declares fields under the same names
+    as the properties that front them, so a text search counts
+    ``lane.text_message_id`` as a read of the property and goes on reporting one
+    after every ``state.text_message_id`` is gone.
+    """
+    package = Path(handlers.__file__).parent
+    read: Set[str] = set()
+    for path in sorted(package.glob("*.py")):
+        if path.name == module_name:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        holders = {
+            argument.arg
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            for argument in node.args.args
+            if isinstance(argument.annotation, ast.Name) and argument.annotation.id == StreamState.__name__
+        }
+        holders.update(
+            target.id
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Assign)
+            and isinstance(node.value, ast.Call)
+            and isinstance(node.value.func, ast.Name)
+            and node.value.func.id == StreamState.__name__
+            for target in node.targets
+            if isinstance(target, ast.Name)
+        )
+        read.update(
+            node.attr
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Attribute)
+            and isinstance(node.ctx, ast.Load)
+            and isinstance(node.value, ast.Name)
+            and node.value.id in holders
+        )
+    return read
+
+
+def test_every_stream_state_property_is_read_somewhere_in_the_interface():
+    """A property nothing reads is a second home for state with one truth.
+
+    Each of these reads whichever lane is current, so one left unread outlives
+    the reader that justified it and answers for the wrong lane if anything
+    picks it up again.
+    """
+    # A walk that found no StreamState at all would report every property as
+    # unread rather than pass, so what it did find is stated first.
+    read = _enumerated_by_the_interface(
+        _stream_state_attributes_read_outside("state.py"),
+        "lane",
+        described="the StreamState attributes the rest of the interface reads",
+    )
+    unread = sorted(
+        name for name, member in vars(StreamState).items() if isinstance(member, property) if name not in read
+    )
+    assert not unread, f"nothing outside the state module reads these StreamState properties: {unread}"
+
+
+def test_the_terminal_check_requires_the_state_it_classifies_against():
+    """Its default is unreachable, and would read a member's terminal as the run's."""
+    state_parameter = inspect.signature(handlers.is_completion_event).parameters["state"]
+    assert state_parameter.default is inspect.Parameter.empty
+
+
+def test_the_hidden_visibility_says_what_still_reaches_the_client():
+    """Two things do, so neither the option nor the branch may claim it withholds all."""
+    from agno.os.interfaces.agui import AGUI
+
+    constructor_doc = _docstring(AGUI.__init__, "the AGUI constructor")
+    for claim in ("session state", "pending tool call"):
+        assert claim in constructor_doc, f"the documented hidden option does not mention the {claim} it delivers"
+        assert claim in inspect.getsource(handlers.process_event), (
+            f"the hidden branch does not mention the {claim} it delivers"
+        )
+
+
+def test_the_announcement_says_it_never_names_a_parent_the_stream_has_not_reached():
+    """A refusal a reader has to be told about: the parent link is dropped, not deferred."""
+    said = _docstring(handlers._announce_subagent, "the member announcement")
+    assert "already announced" in said
+    assert "forward reference" in said


### PR DESCRIPTION
## Summary

Adopts the AG-UI protocol's interrupt round trip in the AGUI interface, so a paused Agno run is something an AG-UI client can see and answer over the wire rather than something it has to infer.

A paused run already reached the client as a pending tool call. What it could not reach the client as was a run that is *waiting*: the run terminal said the same thing for a pause as for a completion, and there was no protocol-level way for a client to send an answer back keyed to the thing it was answering.

This change adds, behind a flag that is off by default:

- **`RunFinishedEvent.outcome`** carries `{"type": "interrupt", "interrupts": [...]}`, one entry per requirement the pause left open, each naming the call it is bound to and, where the pause has an answer shape, the JSON Schema of the answer it wants.
- **The request's `resume` array** is read back, keyed by interrupt id, and continues the paused run rather than starting a new one. It is read whether or not the outcome is emitted, so a client that already knows the ids can use it either way.
- **A Team member the run paused inside** closes its own lane as suspended, naming the interrupts it is waiting on.

Agents and Teams both. Everything is feature detected against the installed `ag-ui-protocol`: the interface refuses to start with the outcome enabled on a release that cannot express it, and degrades rather than failing where a field is merely absent.

### Default off, and identical when off

`emit_interrupt_outcome` defaults to `False`, because a released client that does not expect an outcome on the run terminal should see exactly what it saw before.

That is not asserted, it is measured. `test_agui_emission_identity.py` drives 189 streams through both this interface and a verbatim copy of the pre-change interface, under every subagent visibility and both the sync and async mappers, and compares the encoded events a client receives. On ordinary content the two streams are identical everywhere. The 19 places they differ are each a case where the old code raised out of the mapper and the client got no terminal at all; every one is stated in the test with its reason, and a difference that is not on that list fails the build.

## Type of change

- [x] New feature
- [x] Improvement

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated

## Additional Notes

**This branch is stacked.** It is based on the subagent attribution branch, not on `main`, because the interrupt round trip has to name the Team member a pause was raised inside and that lineage work is where members become nameable. It should land after that one, or be rebased if that one changes.
