### PR TITLE
feat: serve Agno Workflows over the AG-UI interface

### DIFF
--- a/cookbook/05_agent_os/16_agui/README.md
+++ b/cookbook/05_agent_os/16_agui/README.md
@@ -1,9 +1,9 @@
 # AG-UI
 
 AG-UI is an event-stream protocol between an agent backend and an interactive
-frontend. AgentOS translates Agent and Team run events into AG-UI text, tool,
-reasoning, state, and lifecycle events, while keeping the model, tools,
-sessions, and approval state on the server.
+frontend. AgentOS translates Agent, Team, and Workflow run events into AG-UI
+text, tool, reasoning, step, state, and lifecycle events, while keeping the
+model, tools, sessions, and approval state on the server.
 
 Every example in this folder is a standalone server. A client sends a
 `RunAgentInput` to `POST {prefix}/agui` and receives
@@ -22,6 +22,7 @@ default empty prefix those routes are `POST /agui` and `GET /status`.
 | `shared_state.py` | Send state snapshots and JSON Patch deltas as session state changes. |
 | `human_in_the_loop.py` | Pause and resume a real backend tool that uses `requires_confirmation`. |
 | `research_team.py` | Stream a coordinated Team and its member activity over AG-UI. |
+| `workflow.py` | Stream a multi-step Workflow, including a step that runs no model. |
 | `multiple_instances.py` | Mount two independent AG-UI interfaces on one AgentOS. |
 | `openui/` | Render an Agent as streaming charts, follow-ups, and validated forms with OpenUI. |
 
@@ -50,6 +51,7 @@ Start one example at a time; every standalone server uses port 7777:
 .venvs/demo/bin/python cookbook/05_agent_os/16_agui/shared_state.py
 .venvs/demo/bin/python cookbook/05_agent_os/16_agui/human_in_the_loop.py
 .venvs/demo/bin/python cookbook/05_agent_os/16_agui/research_team.py
+.venvs/demo/bin/python cookbook/05_agent_os/16_agui/workflow.py
 .venvs/demo/bin/python cookbook/05_agent_os/16_agui/multiple_instances.py
 ```
 
@@ -70,6 +72,7 @@ endpoint:
 | `shared_state.py` | `http://localhost:7777/shared-state/agui` | `http://localhost:7777/shared-state/status` |
 | `human_in_the_loop.py` | `http://localhost:7777/human-in-the-loop/agui` | `http://localhost:7777/human-in-the-loop/status` |
 | `research_team.py` | `http://localhost:7777/research-team/agui` | `http://localhost:7777/research-team/status` |
+| `workflow.py` | `http://localhost:7777/workflow/agui` | `http://localhost:7777/workflow/status` |
 | `multiple_instances.py` | `http://localhost:7777/chat/agui` and `http://localhost:7777/analyst/agui` | `/chat/status` and `/analyst/status` |
 | `openui/server.py` | `http://localhost:7777/agui` | `http://localhost:7777/status` |
 
@@ -97,11 +100,85 @@ curl -N http://localhost:7777/agui \
   }'
 ```
 
-The stream begins with `RUN_STARTED`, emits message or capability-specific
-events, and ends with `RUN_FINISHED`. Tool calls use `TOOL_CALL_*`; reasoning
-uses `REASONING_*`; shared state uses `STATE_SNAPSHOT` and `STATE_DELTA`.
-`threadId` becomes the Agno session ID, so later requests can continue the same
-conversation.
+The stream begins with `RUN_STARTED` and then emits message or
+capability-specific events. A run that succeeds ends with `RUN_FINISHED`. A run
+that fails ends with `RUN_ERROR` instead, and so does a workflow run that was
+cancelled or that paused. Nothing follows the error.
+
+`RUN_ERROR` always carries a `message`. A `code` and a `rawEvent` are present on
+some endings and absent on others: a cancellation carries the code
+`WorkflowCancelled` and a pause one of the codes listed in
+[Workflows](#workflows) below, while a run ended by a failed last step carries
+neither. So read the value where there is one; the presence of a `code` on its
+own tells a client nothing.
+
+Tool calls use `TOOL_CALL_*`; reasoning uses `REASONING_*`; shared state uses
+`STATE_SNAPSHOT` and `STATE_DELTA`; workflow steps use `STEP_STARTED` and
+`STEP_FINISHED`. `threadId` becomes the Agno session ID, so later requests can
+continue the same conversation.
+
+## Workflows
+
+`AGUI(workflow=...)` serves a Workflow the same way `agent=` and `team=` serve
+their entities. Each step opens a `STEP_STARTED` span and closes it with
+`STEP_FINISHED`. A step whose executor is an Agent or Team streams its own text,
+tool, and reasoning events inside that span; a step that runs plain Python has
+its output emitted as one assistant message, since it streams nothing itself.
+
+A workflow run does not always end with `RUN_FINISHED`. A run cancelled while it
+is in flight ends with `RUN_ERROR` carrying the cancellation reason and the code
+`WorkflowCancelled`.
+
+When a run reaches its completion event, only the last step result decides. If
+that result reports a failure, the run ends with `RUN_ERROR` carrying the reason
+that result names. If it reports success, the run ends with `RUN_FINISHED` even
+though an earlier step failed and its result says so. A failure inside a
+`Parallel`, `Steps`, or `Router` container reaches that same ending from the
+other direction: the container catches its child's failure and the run carries on
+past it, so a later succeeding step is what the rule reads.
+
+`workflow.py` is easy to catch this on: run it with an invalid `OPENAI_API_KEY`
+and both agent steps fail against the provider, yet the stream still ends with
+`RUN_FINISHED`, because the last step is the plain Python summary and it
+succeeds. A failed step is not silent on the stream. Its span carries a pair of
+`RAW` passthrough events for every attempt the step made, each naming the step
+and its agent, and the summary step names the failed steps in its own output.
+
+A pause ends the run the same way, and this is the part most likely to surprise
+a frontend. No AG-UI pause can be resumed against a workflow, so calling a pause
+a finish would tell the client the run is complete when the gated work never
+happened. Every kind of workflow pause therefore ends the stream with
+`RUN_ERROR`, the message `Workflow paused at step '<name>'`, and a `code` naming
+the Agno pause event that ended it: one of `StepPaused`, `StepExecutorPaused`,
+`RouterPaused`, or `StepOutputReview`. That terminal error also carries the whole
+pause event on its `rawEvent`, so a client that needs the pause's own fields, such
+as the tool call awaiting confirmation or a router's available choices, can read
+them there.
+
+Sending a resume message anyway is worse than a no-op. The route drops the tool
+results and re-runs the whole workflow from the start against the original user
+message, logging `AG-UI cannot resume a paused workflow`. What the client gets
+back is a second full run, not a continuation of the first.
+
+The pauses a workflow can produce reach that ending by different routes.
+`Workflow.arun` takes no run context, so frontend-defined tools cannot be
+executed by a workflow and are dropped with a warning, which leaves no
+external-execution pause in the first place.
+
+A backend tool marked `requires_confirmation`, held by an Agent inside a step,
+opens that step's `STEP_STARTED` span but emits no `TOOL_CALL_*` event of any
+kind, so no confirmation card can render. The run ends with `RUN_ERROR` and the
+code `StepExecutorPaused`, and the Python behind the tool never executes.
+
+A step-level gate, `Step(human_review=HumanReview(requires_confirmation=True))`,
+holds the run before the gated step opens at all: no `STEP_STARTED`, no
+`TOOL_CALL_*` event, and the stream ends with `RUN_ERROR` and the code
+`StepPaused`. A `Condition` carrying the same `human_review` gate ends the run
+the same way and under the same code. A `Router` asking the user to choose a
+route ends it the same way under `RouterPaused`, and a step asking for its output
+to be reviewed ends it under `StepOutputReview` after that step has run.
+
+Use an Agent or Team for any of these patterns.
 
 ## Frontend tools and backend HITL are different
 
@@ -111,6 +188,11 @@ These two pause patterns look similar in a UI but have different ownership:
 |---|---|---|---|
 | Frontend-defined tool | The client sends its schema in `RunAgentInput.tools`; there is no Python implementation on the backend. | The browser executes it and sends a trailing AG-UI tool message with the result. | `agent_with_tools.py` |
 | Backend confirmation | Python registers a real `@tool(requires_confirmation=True)` implementation. | AgentOS persists the paused run; the frontend sends `{"accepted": true}` or a rejection, then AgentOS resumes and conditionally executes Python. | `human_in_the_loop.py` |
+
+Both rows assume an Agent or Team. Neither pattern can be resumed when the
+served entity is a Workflow. A workflow pause renders no card at all, since it
+surfaces no tool call, and it ends the run with `RUN_ERROR` rather than a
+success; see [Workflows](#workflows) above.
 
 The backend pause/resume mechanics themselves (`requires_confirmation`,
 `continue_run`, `@approval` records) are taught in

--- a/cookbook/05_agent_os/16_agui/TEST_LOG.md
+++ b/cookbook/05_agent_os/16_agui/TEST_LOG.md
@@ -6,11 +6,22 @@ Tested on 2026-07-24 against Agno source commit
 The OpenUI addition was tested on 2026-08-18 against Agno source commit
 `32e5fb9c2203fa98de19ca72750133a57a075899`.
 
-Each checked-in server was first booted on its default port 7777. The sweep
-asserted `GET /health`, `GET /config`, every mounted AG-UI status route, and a
-clean shutdown. Capability-specific POST tests then used
-`AGENT_OS_PORT=8877` so they could run independently of concurrent phase work;
-the checked-in examples retain the required default port.
+The Workflow addition was tested on 2026-09-11 against the tree that adds
+`workflow.py` and the AG-UI event-mapping changes it needs. No commit is named
+here because that work lands as a single squashed commit whose hash does not
+exist while this file is being written.
+
+The 2026-07-24 sweep booted each of the 9 servers the folder held on that date
+on its default port 7777, asserting `GET /health`, `GET /config`, every mounted
+AG-UI status route, and a clean shutdown. Capability-specific POST tests then
+used `AGENT_OS_PORT=8877` so they could run independently of concurrent phase
+work; the checked-in examples retain the required default port. `workflow.py`
+arrived after that sweep and after the OpenUI boot recorded below, and has never
+been booted on a port; its entry below says what was run instead.
+
+Changing an example's shape, step order, or output means updating this file and
+`README.md` in the same commit, and no entry here may describe a run that was
+not performed.
 
 ### basic.py
 
@@ -188,13 +199,84 @@ TypeScript compilation, and the Vite production build passed.
 
 ---
 
+### workflow.py
+
+**Status:** PASS
+
+**Test mode:** LIVE
+
+**Description:** Ran on 2026-09-11 against the file as it ships after this pass,
+which rewrites the `summarize_run` docstring and makes that step report the
+failed step names alongside the completed ones. Loaded the example module,
+wrapped its `app` in `fastapi.testclient.TestClient` so no port was bound, and
+sent a real `RunAgentInput` asking for a small internal status page to `POST
+/workflow/agui`. The first two steps run `gpt-5.5` agents; the third runs the
+plain Python function `summarize_run`.
+
+**Result:** `/workflow/status` returned `available`, and the POST returned 200
+with `text/event-stream`. The stream started with `RUN_STARTED` and ended with
+`RUN_FINISHED`. `STEP_STARTED` and `STEP_FINISHED` were balanced across `Plan`,
+`Review`, and `Summary`, in that order, matching the step order the file ships.
+Each step produced its own assistant message, and the function step's output
+arrived as one message reading `Run summary. Steps completed before this one:
+Plan, Review.` with no failed-step sentence, since none failed. A
+`STATE_SNAPSHOT` bracketed the run at each end. Event and delta totals are model
+output and vary between runs, so none is recorded here: two runs of this same
+request on the same day totalled 162 and 220 events. The structure above held on
+both.
+
+The same run also probed `GET /workflow/agui`, which returned 405 `Method Not
+Allowed`, which is why the file's `Try:` line names a POST. Calling
+`summarize_run` directly with no `previous_step_outputs` returned `Run summary.
+Steps completed before this one: none.`
+
+---
+
+### workflow.py with a failing model credential
+
+**Status:** PASS
+
+**Test mode:** LIVE
+
+**Description:** Ran on 2026-09-11. Same file, same `TestClient` harness, same
+request, with `OPENAI_API_KEY` set to an invalid value so both agent steps fail
+for real against the provider. This is the case the README's terminal-event rule
+has to survive, and the earlier probes of that rule never reached it.
+
+**Result:** Each agent step logged `Step <name> failed (attempt 1)` through
+`(attempt 4)` and then failed, which is the default `Step.max_retries` of 3 plus
+the initial call. The stream still ended with `RUN_FINISHED`, not `RUN_ERROR`,
+because the last step result belongs to the plain Python summary and it
+succeeded. `STEP_STARTED` and `STEP_FINISHED` were still balanced across `Plan`,
+`Review`, and `Summary`, and the two failed spans carried no `TEXT_MESSAGE_*`
+events, so the run's only assistant message was the summary's.
+
+Those spans are not empty. Each failed span carried exactly 8 `RAW` passthrough
+events, a `RunStarted` and a `ModelRequestStarted` pair for each of the 4
+attempts, every one of them naming its step on `step_name` and its agent on
+`agent_name`. An earlier entry here said the two failed spans held nothing and
+that the empty pair was the only sign those steps ran; both halves were wrong and
+were removed rather than annotated. The README carried the same claim and has
+been corrected to match.
+
+Before this pass `summarize_run` reported only the names that succeeded, so this
+run made it read `Run summary. Steps completed before this one: none.`, which is
+byte-for-byte what a run with no earlier steps produces. It now also names the
+failures, and on this run reported `Run summary. Steps completed before this one:
+none. Steps that failed: Plan, Review.` The passing run above still reports
+`Plan, Review.` as completed and adds no failed-step sentence.
+
+---
+
 ## Validation
 
-- All 9 standalone files booted, exposed their expected `/status` route, and
-  shut down cleanly.
-- All 9 files completed a real capability-specific AG-UI POST flow.
-- Recursive pattern validation checked exactly 9 Python files with 0
-  violations.
+- The 2026-07-24 sweep covered the 9 standalone files the folder held on that
+  date. Each booted, exposed its expected `/status` route, and shut down
+  cleanly.
+- Each of those 9 files completed a real capability-specific AG-UI POST flow.
+- Recursive pattern validation over that 9-file folder checked exactly 9 Python
+  files with 0 violations. `openui/server.py` and `workflow.py` arrived after
+  the sweep and were verified on their own; see their entries above.
 - Targeted Ruff format and check passed.
 - Python compilation, banned-model, stale-route, scope, Unicode/emoji,
   non-PASS status, and `git diff --check` gates passed.
@@ -203,6 +285,146 @@ TypeScript compilation, and the Vite production build passed.
 - The OpenUI server passed Python compilation, import, Ruff format, and Ruff
   check. Its frontend passed five tests, TypeScript compilation, and a
   production build.
-- Repository-wide Ruff, agnoctl mypy, and cookbook pattern checks passed. The
-  core Agno mypy step reported 27 existing errors in six files outside this
-  integration's diff.
+- `./scripts/format.sh` and `./scripts/validate.sh` were run again on 2026-09-11
+  during this pass, after the `summarize_run` change, and both passed. Validation reported Ruff clean across agno, agnoctl, and
+  cookbook, mypy clean over 1033 agno source files and 21 agnoctl source files,
+  and the cookbook pattern check clean. An earlier entry here recorded 27
+  standing mypy errors in six files; the current tree has none, so that count
+  was replaced rather than carried forward. The formatter also rewrote 13 files
+  under `libs/` unrelated to this folder; those were restored, leaving only
+  this folder's files changed.
+- `workflow.py` arrived after the sweep and is verified on its own. Three
+  earlier verifications of it were discarded rather than carried forward: one
+  described a `Plan`, `Handoff`, `Review` ordering the file no longer has, one
+  predated source changes to how a workflow run's ending is judged, and one
+  recorded the failed-step rule from probes that never reached the case the rule
+  turns on. The two entries above record fresh live runs on 2026-09-11 against
+  the file as it ships after this pass.
+- On 2026-09-11 the folder holds 10 standalone example servers plus
+  `openui/server.py`. Running
+  `check_cookbook_pattern.py --base-dir cookbook/05_agent_os/16_agui` on that
+  date reported `Checked 10 file(s) in <folder>. Violations: 0`, and the same
+  command with `--recursive` reported `Checked 11 file(s) in <folder>.
+  Violations: 0`. No new boot or POST sweep was run across all 10 servers on
+  that date; the per-file entries above remain the record of what each one
+  exercised, and only `workflow.py` was re-run live.
+- Unit tests, re-run on 2026-09-11 during this pass.
+  `libs/agno/tests/unit/os/interfaces/test_agui_workflow.py` reported 266
+  passed, with no xfailed and no skipped. The eight `test_agui_*.py` files under
+  `libs/agno/tests/unit/os/interfaces/` were then run together and reported 383
+  passed. An earlier entry here recorded 251 and 368 from an earlier state of the
+  branch; those were replaced rather than carried forward.
+- Integration tests, re-run on 2026-09-11 during this pass with `OPENAI_API_KEY`
+  set, since the AG-UI integration modules skip themselves without it. The three
+  `test_agui_*.py` modules under `libs/agno/tests/integration/os/interfaces/`, a
+  directory that holds five test modules in all, reported 50 passed together, and
+  individually: `test_agui_workflow.py` 5 passed, `test_agui_sse.py` 38 passed,
+  `test_agui_state_events.py` 7 passed. `test_agui_workflow.py` and
+  `test_agui_sse.py` are added by this change.
+  `libs/agno/tests/integration/os/test_agui_authorization.py` reported 9 passed.
+  An earlier entry here recorded 46 together and 34 for `test_agui_sse.py`; those
+  were replaced rather than carried forward.
+- The workflow terminal-event behaviour the README describes was checked on
+  2026-09-11 through `POST /workflow/agui` with `TestClient`, on throwaway
+  workflows built for the check. Which step result decides the run's ending was
+  probed both ways. A three-step workflow whose middle step returned
+  `StepOutput(success=False, error="disk quota exceeded")` and whose last step
+  succeeded opened and closed all three spans and ended with `RUN_FINISHED`.
+  Moving that same failing step to the end ended the run with `RUN_ERROR`
+  carrying `disk quota exceeded`, no `code`, and no `RUN_FINISHED`. A step whose
+  executor raised was invoked 4 times, which is the default `Step.max_retries`
+  of 3 plus the initial call, and ended the stream with `RUN_ERROR` carrying
+  `the exporter is offline` and no `code`. A run cancelled mid-step through
+  `Workflow.cancel_run` closed its open `STEP_STARTED` span and ended with
+  `RUN_ERROR`, message `Run cancel-thread-run was cancelled` and code
+  `WorkflowCancelled`. The first three of those were re-run during this pass and
+  reproduced: a failing middle step still ended with `RUN_FINISHED`, and a failing
+  last step still ended with `RUN_ERROR` carrying `disk quota exceeded` and a
+  `code` of `None`. That absent `code` is what the README's terminal-event
+  paragraph now states; it previously said `RUN_ERROR` carries a `code`.
+- LIVE, this pass. A failure inside a container does not end the run. On throwaway
+  workflows over `POST /workflow/agui` with `TestClient`, a `Parallel` whose child
+  raised, a `Steps` whose child raised, and a `Router` whose chosen step raised
+  each ended with `RUN_FINISHED` and balanced step spans, because the container
+  caught the child's failure and a later succeeding step became the last result
+  the rule reads. The README's rule previously covered only the plain-step case.
+- LIVE, this pass. Two endings leave the route's own bare error on the stream
+  instead of one the event mapper built. A `Loop` whose child raised, and a
+  `Step` carrying `HumanReview(on_error=OnError.fail)` whose executor raised, each
+  ended with `RUN_ERROR` carrying the message `the exporter is offline`, a `code`
+  of `None`, and no `rawEvent`, with `STEP_STARTED` at 1 and `STEP_FINISHED` at 0,
+  so the open span was never closed. This is `run_entity`'s `except Exception`
+  handler in `libs/agno/agno/os/interfaces/agui/router.py`, which is pre-existing
+  code this change does not touch. The README previously said open spans are
+  closed before the terminal error; that sentence was removed rather than
+  qualified.
+- LIVE, this pass. The scope of the failed-step rule. A plain `Step` and a
+  `Condition` default to `HumanReview.on_error` of `OnError.skip`, so a failure
+  leaves a failed result and the run carries on, which is the case `workflow.py`
+  demonstrates. Read from the source rather than run: in every
+  `_aexecute_stream` branch of `libs/agno/agno/workflow/workflow.py` the policy is
+  `_step_on_error(step) if isinstance(step, (Step, Condition)) else "fail"`, so
+  `Loop`, `Parallel`, `Steps`, and `Router` never consult a policy at all. The
+  README previously stated as a general rule that a step exhausting its retries
+  does not abort the run. It is true only for a plain step or a condition on the
+  default policy, so the rule was cut rather than given its three qualifications.
+- LIVE, this pass. Sending a resume message to a workflow re-runs it. Posting a
+  trailing AG-UI tool message to `workflow.py` logged `AG-UI cannot resume a
+  paused workflow: the tool results were dropped and the workflow is being re-run
+  from the start against the last user message`, then opened and closed all three
+  spans of `Plan`, `Review`, and `Summary` again and ended with `RUN_FINISHED`.
+  The README's pause section previously said only that a workflow pause cannot be
+  resumed, and now says what sending one actually does.
+- A failure's own `code` was checked on 2026-09-11 by serving a plain Agent over
+  AG-UI with an invalid `OPENAI_API_KEY`. The stream ended with `RUN_ERROR`
+  carrying the provider's message and the code `model_provider_error`, read from
+  the error event's `error_type`. So a `code` is present on a real failure too,
+  and only its value separates a failure from a pause or a cancellation. An
+  earlier entry here said the presence of a `code` was the discriminator; it was
+  removed rather than annotated.
+- The workflow pause behaviour documented in the README was checked on
+  2026-09-11 over `POST /workflow/agui` with `TestClient`, again on throwaway
+  workflows. On a workflow whose single step is a `gpt-5.5` agent holding a
+  `requires_confirmation` tool, the stream opened `STEP_STARTED` for the step,
+  emitted no `TOOL_CALL_*` event of any kind, left the Python unexecuted, and
+  ended with `RUN_ERROR`, message `Workflow paused at step 'Email'` and code
+  `StepExecutorPaused`. No `RUN_FINISHED` appeared, so no resume request was
+  sent: there was no tool call id to send a decision against. On a workflow
+  whose single step carries
+  `human_review=HumanReview(requires_confirmation=True)`, the four-event stream
+  emitted no `STEP_STARTED` and no `TOOL_CALL_*` event and ended with
+  `RUN_ERROR`, message `Workflow paused at step 'Gated'` and code `StepPaused`.
+  A `Condition` carrying the same `human_review` gate ended identically under
+  `StepPaused`. A `Router` carrying
+  `human_review=HumanReview(requires_user_input=True)` ended under
+  `RouterPaused`, and a `Step` carrying `requires_output_review=True` ran, closed
+  its span, and then ended the run under `StepOutputReview`. Those are the four
+  reachable members of the interface's pause-event set, and each was observed
+  here; see the source-read entry below for the two that are not reachable.
+- Each of those terminal errors carried the whole pause event on its `rawEvent`,
+  not just the code: the `StepExecutorPaused` payload included
+  `executor_requirements` naming the `send_email` tool call awaiting
+  confirmation, and the `RouterPaused` payload included
+  `available_choices: ["Left", "Right"]`. An earlier entry here said the code was
+  the whole of what a client receives; it was removed rather than annotated.
+- Two further earlier entries recorded the opposite of the pause results above,
+  describing the step-level gate as reaching the client as a `RAW` `StepPaused`
+  event on a stream that still ended with `RUN_FINISHED`, and the agent
+  confirmation tool as streaming `TOOL_CALL_START`, `TOOL_CALL_ARGS`, and
+  `TOOL_CALL_END`. Neither describes the current tree. They were removed rather
+  than annotated, since no entry here may describe a run that was not performed.
+- Read from the source rather than run: `WorkflowPaused` and `ConditionPaused`
+  cannot reach an AG-UI stream at all, which is why the README no longer names
+  them. `ConditionPaused` exists only as a `WorkflowRunEvent` value in
+  `libs/agno/agno/run/workflow.py`; it has no event class, is absent from
+  `WORKFLOW_RUN_EVENT_TYPE_REGISTRY`, and is constructed nowhere. The run above
+  agrees: a `Condition` gate paused under `StepPaused`. `WorkflowPausedEvent` is
+  never yielded by `Workflow.arun`; every construction site synthesizes it after
+  that generator is drained, on the workflows router's own streamers and on the
+  background and continue paths. The AG-UI route consumes
+  `entity.arun(stream=True)` directly, so none of those sites is on its stream.
+- That a frontend-defined tool is dropped for a workflow was confirmed on
+  2026-09-11 by posting a `change_background` schema in `RunAgentInput.tools` to
+  `workflow.py`. The server logged `AG-UI client tools are not forwarded to
+  workflows`, the stream carried no `TOOL_CALL_*` event, and the run ended with
+  `RUN_FINISHED`.

--- a/cookbook/05_agent_os/16_agui/workflow.py
+++ b/cookbook/05_agent_os/16_agui/workflow.py
@@ -1,0 +1,90 @@
+"""
+Serve a Workflow over AG-UI
+===========================
+
+Mount an AgentOS Workflow on AG-UI. Each step becomes an AG-UI step span, an
+agent step streams its own text, and a plain Python step streams nothing so the
+interface emits that step's output as its own assistant message.
+
+Prerequisites: OPENAI_API_KEY
+Run: .venvs/demo/bin/python cookbook/05_agent_os/16_agui/workflow.py
+Try: POST "Plan a small internal status page" to http://localhost:7777/workflow/agui
+"""
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIResponses
+from agno.os import AgentOS
+from agno.os.interfaces.agui import AGUI
+from agno.workflow.step import Step
+from agno.workflow.types import StepInput, StepOutput
+from agno.workflow.workflow import Workflow
+
+# ---------------------------------------------------------------------------
+# Create Workflow
+# ---------------------------------------------------------------------------
+
+db = SqliteDb(
+    id="agui-workflow-db",
+    db_file="tmp/agui_workflow.db",
+)
+
+planner = Agent(
+    id="agui-workflow-planner",
+    name="Planner",
+    model=OpenAIResponses(id="gpt-5.5"),
+    db=db,
+    instructions="Break the request into three concrete milestones. One short line each.",
+)
+
+reviewer = Agent(
+    id="agui-workflow-reviewer",
+    name="Reviewer",
+    model=OpenAIResponses(id="gpt-5.5"),
+    db=db,
+    instructions="Name the biggest risk in the supplied plan and how to reduce it.",
+)
+
+
+def summarize_run(step_input: StepInput) -> StepOutput:
+    """A step with no model. It runs last because it reports on the steps before it.
+
+    A failed step still leaves an output behind, so the names are split on success
+    and both lists are reported. Naming only the completed steps would make a run
+    whose earlier steps all failed read exactly like a run with no earlier steps.
+    """
+    previous_outputs = step_input.previous_step_outputs or {}
+    succeeded = [name for name, output in previous_outputs.items() if output.success]
+    failed = [name for name, output in previous_outputs.items() if not output.success]
+    completed = ", ".join(succeeded) if succeeded else "none"
+    summary = f"Run summary. Steps completed before this one: {completed}."
+    if failed:
+        summary += f" Steps that failed: {', '.join(failed)}."
+    return StepOutput(content=summary)
+
+
+launch_workflow = Workflow(
+    id="agui-launch-workflow",
+    name="AG-UI Launch Workflow",
+    db=db,
+    steps=[
+        Step(name="Plan", agent=planner),
+        Step(name="Review", agent=reviewer),
+        Step(name="Summary", executor=summarize_run),
+    ],
+)
+
+agent_os = AgentOS(
+    id="agui-workflow-os",
+    description="A multi-step Workflow served through AG-UI.",
+    workflows=[launch_workflow],
+    interfaces=[AGUI(workflow=launch_workflow, prefix="/workflow")],
+)
+app = agent_os.get_app()
+
+# ---------------------------------------------------------------------------
+# Run Workflow Server
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    agent_os.serve(app=app)

--- a/libs/agno/agno/os/interfaces/agui/agui.py
+++ b/libs/agno/agno/os/interfaces/agui/agui.py
@@ -1,4 +1,4 @@
-"""Main class for the AG-UI app, used to expose an Agno Agent or Team in an AG-UI compatible format."""
+"""Main class for the AG-UI app, used to expose an Agno Agent, Team or Workflow in an AG-UI compatible format."""
 
 from typing import List, Optional, Union
 
@@ -10,6 +10,8 @@ from agno.os.interfaces.agui.router import attach_routes
 from agno.os.interfaces.base import BaseInterface
 from agno.team import Team
 from agno.team.remote import RemoteTeam
+from agno.workflow.remote import RemoteWorkflow
+from agno.workflow.workflow import Workflow
 
 
 class AGUI(BaseInterface):
@@ -21,6 +23,7 @@ class AGUI(BaseInterface):
         self,
         agent: Optional[Union[Agent, RemoteAgent]] = None,
         team: Optional[Union[Team, RemoteTeam]] = None,
+        workflow: Optional[Union[Workflow, RemoteWorkflow]] = None,
         prefix: str = "",
         tags: Optional[List[str]] = None,
     ):
@@ -30,25 +33,32 @@ class AGUI(BaseInterface):
         Args:
             agent: The agent to expose via AG-UI
             team: The team to expose via AG-UI
+            workflow: The workflow to expose via AG-UI
             prefix: Custom prefix for the router (e.g., "/agui/v1", "/chat/public")
             tags: Custom tags for the router (e.g., ["AGUI", "Chat"], defaults to ["AGUI"])
         """
         self.agent = agent
         self.team = team
+        self.workflow = workflow
         self.prefix = prefix
         self.tags = tags or ["AGUI"]
 
-        if not (self.agent or self.team):
-            raise ValueError("AGUI requires an agent or a team")
+        if not (self.agent or self.team or self.workflow):
+            raise ValueError("AGUI requires an agent, team, or workflow")
 
     def get_router(self) -> APIRouter:
         self.router = APIRouter(prefix=self.prefix, tags=self.tags)  # type: ignore
 
-        self.router = attach_routes(router=self.router, agent=self.agent, team=self.team)
+        self.router = attach_routes(router=self.router, agent=self.agent, team=self.team, workflow=self.workflow)
 
         return self.router
 
     def get_scope_mappings(self) -> dict:
-        # Agent-wins precedence must match router dispatch (entity = agent or team)
-        family = "agents" if self.agent is not None else "teams"
+        # Precedence must match router dispatch (entity = agent or team or workflow)
+        if self.agent is not None:
+            family = "agents"
+        elif self.team is not None:
+            family = "teams"
+        else:
+            family = "workflows"
         return {f"POST {self.prefix}/agui": [f"{family}:run"]}

--- a/libs/agno/agno/os/interfaces/agui/handlers.py
+++ b/libs/agno/agno/os/interfaces/agui/handlers.py
@@ -1,7 +1,8 @@
 import copy
 import json
 import uuid
-from typing import Any, Callable, Dict, List, Optional
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterator, List, Optional
 
 from ag_ui.core import (
     BaseEvent,
@@ -13,10 +14,11 @@ from ag_ui.core import (
     ReasoningMessageEndEvent,
     ReasoningMessageStartEvent,
     ReasoningStartEvent,
-    RunErrorEvent as AGUIRunErrorEvent,
     RunFinishedEvent,
     StateDeltaEvent,
     StateSnapshotEvent,
+    StepFinishedEvent,
+    StepStartedEvent,
     TextMessageContentEvent,
     TextMessageEndEvent,
     TextMessageStartEvent,
@@ -25,20 +27,46 @@ from ag_ui.core import (
     ToolCallResultEvent,
     ToolCallStartEvent,
 )
+from ag_ui.core import (
+    RunErrorEvent as AGUIRunErrorEvent,
+)
+from pydantic import BaseModel
 
+from agno.models.message import Message
 from agno.models.response import ToolExecution
-from agno.os.interfaces.agui.state import StreamState
+from agno.os.interfaces.agui.state import SpanTransition, StreamState
 from agno.os.interfaces.agui.utils import to_json_str
 from agno.reasoning.step import ReasoningStep
-from agno.run.agent import RunContentEvent, RunEvent
+from agno.run.agent import RunCompletedEvent, RunContentEvent, RunEvent
 from agno.run.agent import RunPausedEvent as AgentRunPausedEvent
 from agno.run.base import BaseRunOutputEvent
 from agno.run.team import RunContentEvent as TeamRunContentEvent
 from agno.run.team import RunPausedEvent as TeamRunPausedEvent
 from agno.run.team import TeamRunEvent
+from agno.run.workflow import WorkflowRunEvent
+from agno.utils.log import log_warning
 from agno.utils.message import get_text_from_message
 
 EventHandler = Callable[[BaseRunOutputEvent, StreamState], List[BaseEvent]]
+
+
+def _message_text(content: Any) -> str:
+    """Read message shaped content as text, and nothing at all out of a shape it cannot read.
+
+    ``get_text_from_message`` is written for message content and probes a list's first
+    element for keys, which raises on a list of scalars. Content reaching the mapper is
+    typed as anything, so a shape the reading cannot take is not a failure here. Reading
+    one delta must never cost the client the rest of the run: an exception leaving the
+    mapper is caught by the route, which ends the run with an error in place of
+    everything it had left to send, and closes none of the spans the client holds open.
+    What was dropped is logged, because content vanishing without a trace is the fault
+    this guard was written to remove.
+    """
+    try:
+        return get_text_from_message(content)
+    except (TypeError, ValueError, AttributeError) as e:
+        log_warning(f"AG-UI could not read content of type {type(content).__name__} as text: {e}")
+        return ""
 
 
 def _extract_response_chunk_content(response: RunContentEvent) -> str:
@@ -47,8 +75,8 @@ def _extract_response_chunk_content(response: RunContentEvent) -> str:
     if hasattr(response, "messages") and response.messages:  # type: ignore
         for msg in reversed(response.messages):  # type: ignore
             if hasattr(msg, "role") and msg.role == "assistant" and hasattr(msg, "content") and msg.content:
-                return get_text_from_message(msg.content)
-    return get_text_from_message(response.content) if response.content is not None else ""
+                return _message_text(msg.content)
+    return _message_text(response.content) if response.content is not None else ""
 
 
 def _extract_team_response_chunk_content(response: TeamRunContentEvent) -> str:
@@ -65,8 +93,137 @@ def _extract_team_response_chunk_content(response: TeamRunContentEvent) -> str:
                 if member_content:
                     members_content.append(f"Team member: {member_content}")
     members_response = "\n".join(members_content) if members_content else ""
-    main_content = get_text_from_message(response.content) if response.content is not None else ""
+    main_content = _message_text(response.content) if response.content is not None else ""
     return main_content + members_response
+
+
+def _json_text(value: Any) -> str:
+    """Render a value as the readable JSON a reader sees in the transcript, and never raise.
+
+    A step returns whatever its executor returned, so a record it returns holds values the
+    standard serializer has no reading for: a datetime, a set, a model. Each of those is
+    rendered as its own text, which keeps the rest of the record readable and keeps the
+    run alive: an exception here is caught by the route and turned into the run's error,
+    so one unreadable value would abort a run that was otherwise fine.
+    """
+    try:
+        return json.dumps(value, indent=2, ensure_ascii=False, default=str)
+    except (TypeError, ValueError):
+        return str(value)
+
+
+# Roles whose turns in a transcript are not the step's own answer: what was written to
+# the step, and what its tools wrote back into it. A tool payload read as the step's
+# answer is wrong text on the wire, not missing text.
+_NON_ANSWER_ROLES = frozenset({"user", "system", "developer", "tool"})
+
+
+def _message_role(item: Any) -> Optional[str]:
+    """The role an element of a message list declares, or None when it declares none."""
+    if isinstance(item, Message):
+        return item.role
+    if isinstance(item, dict) and isinstance(item.get("role"), str):
+        return item["role"]
+    return None
+
+
+def _message_body(item: Any) -> Any:
+    """The content an element of a message list carries."""
+    if isinstance(item, Message):
+        return item.content
+    if isinstance(item, dict):
+        return item.get("content")
+    return item
+
+
+def _step_content_to_text(content: Any) -> str:
+    """Render a completed step's own output as the text a reader sees in the transcript.
+
+    A step returns whatever its executor returned, so its content is message shaped only
+    some of the time. Message shaped content keeps the reading the rest of the interface
+    gives it, and every other shape is rendered as something readable rather than dropped
+    or raised on. Content that carries nothing to read renders as the empty string, which
+    opens no message at all.
+    """
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        roles = [_message_role(item) for item in content]
+        if any(role is not None for role in roles):
+            # A list of messages is a transcript, not message content. Read as message
+            # content it yields the user turns, which would send the caller's own prompt
+            # back as the step's answer and drop the answer, so the turns that are not
+            # the step's answer are dropped here instead and what it replied is kept.
+            return "\n".join(
+                text
+                for text in (
+                    _step_content_to_text(_message_body(item))
+                    for item, role in zip(content, roles)
+                    if role not in _NON_ANSWER_ROLES
+                )
+                if text
+            )
+        # A list of records may be message content, which has an established text
+        # reading. Anything else is a plain sequence, rendered one element per line.
+        if content and all(isinstance(item, dict) for item in content):
+            from_message_shape = _message_text(content)
+            if from_message_shape:
+                return from_message_shape
+        return "\n".join(text for text in (_step_content_to_text(item) for item in content) if text)
+    if isinstance(content, dict):
+        if not content:
+            return ""
+        # A record whose only key is named for content is that content and nothing else.
+        # Every other record is rendered whole, because a key named content earns no
+        # right to speak for the keys beside it.
+        if set(content) == {"content"}:
+            return _step_content_to_text(content["content"])
+        return _json_text(content)
+    if isinstance(content, Message):
+        return _step_content_to_text(content.content)
+    if isinstance(content, BaseModel):
+        # A model holding a value pydantic has no serializer for raises here, and the
+        # model's own text still says what the step produced.
+        try:
+            return content.model_dump_json(indent=2, exclude_none=True)
+        except (TypeError, ValueError):
+            return str(content)
+    return str(content)
+
+
+def _tool_args_json(tool_args: Optional[Dict[str, Any]]) -> str:
+    """Serialize a tool call's arguments for whatever renders it, and never raise.
+
+    The render reads the arguments as an object, so every reading here is one: a call
+    made without arguments is an empty object rather than a null, and an argument the
+    standard serializer has no reading for is rendered as its text under its own name
+    rather than the whole record being replaced by a string of itself. A record that
+    defeats even that, because a key or a value cannot be rendered at all, comes back as
+    the empty object, which the render can read and finds nothing in.
+
+    A call announced as it starts and one held for approval are the same thing to the
+    client, which is why both are written this way. Raising instead costs the client the
+    run: an exception here is caught by the route, which ends the run with an error in
+    place of everything it still had to send, and a paused run's cards are built in the
+    same batch as its terminal event, so none of them would go out at all. No model
+    writes a record the first reading below cannot take, so the rest is there to keep
+    that promise rather than to serve a call anyone has made.
+    """
+    if not tool_args:
+        return "{}"
+    try:
+        return json.dumps(tool_args, default=str)
+    except (TypeError, ValueError):
+        pass
+    # Reached by a key the standard serializer refuses and by a record that refers to
+    # itself. Rendering each argument on its own settles both, since a key is named and
+    # a value's repr closes a cycle the serializer would walk forever.
+    try:
+        return json.dumps({str(key): repr(value) for key, value in tool_args.items()})
+    except Exception:
+        return "{}"
 
 
 def _format_reasoning_step(step: Optional[ReasoningStep], step_number: int = 0) -> str:
@@ -90,6 +247,17 @@ def _format_reasoning_step(step: Optional[ReasoningStep], step_number: int = 0) 
     return "\n".join(parts) + "\n\n" if parts else ""
 
 
+def _span_events(transitions: List[SpanTransition]) -> List[BaseEvent]:
+    """Render the span transitions a state change produced as AG-UI events."""
+    events: List[BaseEvent] = []
+    for transition in transitions:
+        if transition.started:
+            events.append(StepStartedEvent(type=EventType.STEP_STARTED, step_name=transition.step_name))
+        else:
+            events.append(StepFinishedEvent(type=EventType.STEP_FINISHED, step_name=transition.step_name))
+    return events
+
+
 def _emit_state_delta(state: StreamState) -> List[BaseEvent]:
     if state.run_state is None:
         return []
@@ -100,8 +268,26 @@ def _emit_state_delta(state: StreamState) -> List[BaseEvent]:
     return [StateDeltaEvent(type=EventType.STATE_DELTA, delta=ops)]
 
 
-def _close_open_spans(state: StreamState) -> List[BaseEvent]:
-    """End any reasoning, tool call, or text message still open, so a terminal event never leaves a dangling span."""
+def close_open_spans(state: StreamState) -> List[BaseEvent]:
+    """End any reasoning, tool call, text message or step still open, so a terminal event never leaves a dangling span.
+
+    The batch a caller assembles around these closings can be lost whole: a terminal
+    handler puts the closings and the run's ending in one list, and anything that raises
+    while the rest of that list is built discards the closings with it. So the closings
+    are remembered on the state, and a second call hands back the same ones rather than
+    the nothing a drained state would yield. The caller that ends the run after such a
+    failure therefore still closes what the client is holding open.
+
+    Remembering them makes this a once-per-stream closing, which is sound only because
+    the terminal call is the last thing a stream builds, so no two callers can both send
+    what it returns. A caller added mid-stream would replay a stale list instead.
+
+    Callers get their own list, because a terminal handler appends its ending to what it
+    is given and that must not become part of what a later call replays.
+    """
+    if state.built_closings is not None:
+        return list(state.built_closings)
+
     events: List[BaseEvent] = []
 
     # Close orphaned reasoning session
@@ -123,7 +309,11 @@ def _close_open_spans(state: StreamState) -> List[BaseEvent]:
         events.append(TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=state.text_message_id))
         state.close_text_message()
 
-    return events
+    # Close workflow steps still open, innermost first
+    events.extend(_span_events(state.close_all_spans()))
+
+    state.built_closings = events
+    return list(events)
 
 
 def on_run_content(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
@@ -149,6 +339,8 @@ def on_run_content(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEv
         )
 
     if content:
+        # A workflow step stamps its id onto the events its executor produces
+        state.record_text_delta(step_id=getattr(chunk, "step_id", None))
         events.append(
             TextMessageContentEvent(
                 type=EventType.TEXT_MESSAGE_CONTENT,
@@ -166,6 +358,10 @@ def on_tool_call_started(chunk: BaseRunOutputEvent, state: StreamState) -> List[
     if tool is None:
         return events
 
+    if tool.tool_call_id is None or tool.tool_name is None:
+        log_warning(f"AG-UI dropped a tool call with no id or name: {tool.tool_name!r} {tool.tool_call_id!r}")
+        return events
+
     # Close open text message before tool call
     if state.text_message_open:
         events.append(TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=state.text_message_id))
@@ -174,7 +370,9 @@ def on_tool_call_started(chunk: BaseRunOutputEvent, state: StreamState) -> List[
 
     parent_message_id = state.get_parent_message_id_for_tool_call()
 
-    # Create empty parent message if none exists (AG-UI protocol requirement)
+    # Clients that render a tool call nested under an assistant turn need one to nest it
+    # under. AG-UI itself allows parent_message_id to be absent, so this is what those
+    # clients need rather than what the protocol demands.
     if not parent_message_id:
         parent_message_id = str(uuid.uuid4())
         events.append(
@@ -200,7 +398,7 @@ def on_tool_call_started(chunk: BaseRunOutputEvent, state: StreamState) -> List[
         ToolCallArgsEvent(
             type=EventType.TOOL_CALL_ARGS,
             tool_call_id=tool.tool_call_id,
-            delta=json.dumps(tool.tool_args),
+            delta=_tool_args_json(tool.tool_args),
         )
     )
 
@@ -214,8 +412,14 @@ def on_tool_call_completed(chunk: BaseRunOutputEvent, state: StreamState) -> Lis
     if tool is None:
         return events
 
-    if tool.tool_call_id in state.ended_tool_call_ids:
+    if tool.tool_call_id is None:
+        log_warning(f"AG-UI dropped the completion of tool {tool.tool_name!r}, which carries no tool call id")
         return events
+
+    if tool.tool_call_id in state.ended_tool_call_ids:
+        # The client was told once that this call ended, and the state the event carries
+        # is owed all the same: the run moved on between the two reports of the call.
+        return _emit_state_delta(state)
 
     events.append(ToolCallEndEvent(type=EventType.TOOL_CALL_END, tool_call_id=tool.tool_call_id))
     state.end_tool_call(tool.tool_call_id)
@@ -319,6 +523,67 @@ def on_reasoning_completed(chunk: BaseRunOutputEvent, state: StreamState) -> Lis
     return events
 
 
+def on_workflow_step_started(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
+    return _span_events(
+        state.open_step(
+            step_name=getattr(chunk, "step_name", None),
+            step_id=getattr(chunk, "step_id", None),
+            parent_step_id=getattr(chunk, "parent_step_id", None),
+            step_index=getattr(chunk, "step_index", None),
+        )
+    )
+
+
+def on_workflow_step_completed(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
+    step_name = getattr(chunk, "step_name", None)
+    step_id = getattr(chunk, "step_id", None)
+    step = state.close_step(
+        step_name=step_name,
+        step_id=step_id,
+        step_index=getattr(chunk, "step_index", None),
+    )
+
+    events: List[BaseEvent] = []
+
+    # Each step gets its own assistant message rather than one message spanning the run
+    if state.text_message_open:
+        events.append(TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=state.text_message_id))
+        state.close_text_message()
+
+    if step is None:
+        log_warning(f"AG-UI matched the completion of workflow step '{step_name}' to no step it had started")
+
+    # A step run by a plain function streams nothing, so its output exists only here, and
+    # a step whose output the client already has must not send it a second time. The text
+    # is read before the claim because a completion carrying nothing has no output to
+    # claim: claiming it would tell every step containing this one that its own output had
+    # already been sent, and their output would never be emitted.
+    text = _step_content_to_text(getattr(chunk, "content", None))
+    if text and state.claim_step_output(step, step_id):
+        message_id = state.open_text_message()
+        state.clear_pending_tool_calls_parent_id()
+        events.append(
+            TextMessageStartEvent(
+                type=EventType.TEXT_MESSAGE_START,
+                message_id=message_id,
+                role="assistant",
+            )
+        )
+        events.append(
+            TextMessageContentEvent(
+                type=EventType.TEXT_MESSAGE_CONTENT,
+                message_id=message_id,
+                delta=text,
+            )
+        )
+        events.append(TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=message_id))
+        state.close_text_message()
+
+    # Finish this step, and every step it contained, innermost first
+    events.extend(_span_events(state.flush_spans()))
+    return events
+
+
 def on_custom_event(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
     try:
         custom_event_name = chunk.__class__.__name__
@@ -341,22 +606,113 @@ def on_unknown_event(chunk: BaseRunOutputEvent, state: StreamState) -> List[Base
     return [RawEvent(type=EventType.RAW, event=raw_dict, source="agno")]
 
 
-def on_run_error(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
+def _iter_step_results(results: Optional[List[Any]]) -> Iterator[Any]:
+    """Walk workflow step results depth first, innermost first.
+
+    An element is either a step result or a list of them, because a container step groups
+    the results of its children. A step result can also report children of its own under
+    ``StepOutput.steps``. Only the innermost result carries the real error, so both forms
+    have to be descended into.
+    """
+    for result in results or []:
+        if result is None:
+            continue
+        if isinstance(result, list):
+            yield from _iter_step_results(result)
+            continue
+        yield from _iter_step_results(getattr(result, "steps", None))
+        yield result
+
+
+def _last_step_result(results: Optional[List[Any]]) -> Optional[Any]:
+    """Return the step result the run ended on, or None when it produced none.
+
+    The run's own steps are sequential, so the last of them is where the run stopped. A
+    grouped element stands in for one of those steps and is not itself a result, so a
+    trailing group is descended into for its own last result. A grouped step that reports
+    its children under ``StepOutput.steps`` is not descended into: the children of a
+    parallel step are ordered by declaration rather than by when they ran, so the last of
+    them is not the last thing that happened. The step's own result speaks for them.
+    """
+    for result in reversed(results or []):
+        if result is None:
+            continue
+        if isinstance(result, list):
+            last = _last_step_result(result)
+            if last is None:
+                continue
+            return last
+        return result
+    return None
+
+
+def _reports_failure(result: Any) -> bool:
+    """Whether a step result, or anything it groups, failed.
+
+    Every container step in the engine folds its children's failures into its own success
+    flag, so a container reporting success over a failed child is a summary that lost the
+    failure rather than one that tolerated it.
+    """
+    if not getattr(result, "success", True):
+        return True
+    return any(_reports_failure(child) for child in _iter_step_results(getattr(result, "steps", None)))
+
+
+def _failed_step_error(chunk: BaseRunOutputEvent) -> Optional[str]:
+    """Return the failure that ended the run, if this completion event reports one.
+
+    A failed step result is fatal only when the run stopped there. The engine aborts a
+    fatal step failure by raising, so nothing can follow it. A step that opts out of
+    aborting, through skip_on_failure or an on_error policy of skip, leaves a failed
+    result behind and the engine carries on, so further results follow it and the run
+    really did complete. The last result the run produced therefore decides, and the
+    reason it reports is read from that result rather than from a failure the run
+    survived earlier.
+
+    The known limit of that rule: a step that opted out of aborting and happened to run
+    last leaves nothing behind it, so it is read as the run's ending. The engine records
+    the tolerance only in the result's prose content, and each policy words it
+    differently, so there is nothing here to read it from.
+    """
+    deciding = _last_step_result(getattr(chunk, "step_results", None))
+    if deciding is None or not _reports_failure(deciding):
+        return None
+
+    failed = [result for result in _iter_step_results([deciding]) if not getattr(result, "success", True)]
+    for result in failed:
+        error = getattr(result, "error", None)
+        if error:
+            return str(error)
+
+    # A container step can be marked failed while only its children name the reason
+    step_name = getattr(failed[0], "step_name", None)
+    return f"Workflow step '{step_name}' failed" if step_name else "Workflow step failed"
+
+
+def on_run_error(
+    chunk: BaseRunOutputEvent,
+    state: StreamState,
+    message: Optional[str] = None,
+    code: Optional[str] = None,
+) -> List[BaseEvent]:
     """Close open spans, then emit the terminal AG-UI error event. Nothing may follow RUN_ERROR."""
     try:
         raw_event: Any = chunk.to_dict()
     except Exception:
         raw_event = {"event": str(getattr(chunk, "event", "RunError"))}
 
-    message = getattr(chunk, "content", None) or "Run failed"
-    error_type = getattr(chunk, "error_type", None)
+    # Workflow error events carry the reason on `error`, agent and team ones on `content`
+    if message is None:
+        message = getattr(chunk, "content", None) or getattr(chunk, "error", None) or "Run failed"
+    if code is None:
+        code = getattr(chunk, "error_type", None)
 
-    events = _close_open_spans(state)
+    events = close_open_spans(state)
     events.append(
         AGUIRunErrorEvent(
             type=EventType.RUN_ERROR,
             message=str(message),
-            code=error_type,
+            code=code,
             rawEvent=raw_event,
         )
     )
@@ -364,7 +720,7 @@ def on_run_error(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEven
 
 
 def on_run_completed(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
-    events = _close_open_spans(state)
+    events = close_open_spans(state)
 
     # 1. Collect paused tools for frontend rendering
     paused_tools: List[ToolExecution] = []
@@ -424,7 +780,7 @@ def on_run_completed(chunk: BaseRunOutputEvent, state: StreamState) -> List[Base
                 ToolCallArgsEvent(
                     type=EventType.TOOL_CALL_ARGS,
                     tool_call_id=tool.tool_call_id,
-                    delta=json.dumps(tool.tool_args),
+                    delta=_tool_args_json(tool.tool_args),
                 )
             )
 
@@ -455,37 +811,179 @@ HANDLERS: Dict[str, EventHandler] = {
     RunEvent.reasoning_step.value: on_reasoning_step,
     RunEvent.reasoning_completed.value: on_reasoning_completed,
     RunEvent.custom_event.value: on_custom_event,
+    WorkflowRunEvent.step_started.value: on_workflow_step_started,
+    WorkflowRunEvent.step_completed.value: on_workflow_step_completed,
 }
 
-# Terminal events that trigger terminal handling
-_COMPLETION_EVENTS = frozenset(
+# Terminal engine events, normalized so a team event reuses its agent name. A run's
+# stream ends on one of these, and membership decides the run's disposition except for a
+# completion event, whose step results are read by `_failed_step_error`. A run whose
+# stream never reaches the mapper ends in the route's own error event instead.
+
+# Ends the run as a success
+_FINISHED_EVENTS = frozenset(
     {
         RunEvent.run_completed.value,
-        RunEvent.run_error.value,
         RunEvent.run_paused.value,
-        TeamRunEvent.run_completed.value,
-        TeamRunEvent.run_error.value,
-        TeamRunEvent.run_paused.value,
+        WorkflowRunEvent.workflow_completed.value,
     }
 )
 
+# A paused workflow surfaces no tool calls and offers the client no way to resume, so
+# reporting it as a finish would be a false success. It terminates like a cancellation.
+_PAUSE_EVENTS = frozenset(
+    {
+        WorkflowRunEvent.workflow_paused.value,
+        WorkflowRunEvent.step_paused.value,
+        WorkflowRunEvent.step_executor_paused.value,
+        WorkflowRunEvent.condition_paused.value,
+        WorkflowRunEvent.router_paused.value,
+        # An output review and a loop iteration review both pause under this name, and
+        # the engine returns straight after it, so nothing else reports that ending.
+        WorkflowRunEvent.step_output_review.value,
+    }
+)
 
-def is_completion_event(chunk: BaseRunOutputEvent) -> bool:
-    """Check if this event is terminal for the stream (completed, paused, or error)."""
+# The workflow's own report that it did not finish. The engine repeats itself here: a
+# cancellation is followed by a completion event carrying the cancellation text, and a
+# pause arrives once as a step event and again as a workflow event. So once one of these
+# has been seen, no later success can overrule it.
+_WORKFLOW_UNFINISHED_EVENTS = (
+    frozenset(
+        {
+            WorkflowRunEvent.workflow_error.value,
+            WorkflowRunEvent.workflow_cancelled.value,
+            WorkflowRunEvent.step_error.value,
+        }
+    )
+    | _PAUSE_EVENTS
+)
+
+# Ends the run without a success. An agent or team error is included but never latches:
+# inside a workflow it belongs to a step's executor, and a step is free to carry on past it.
+_UNFINISHED_EVENTS = _WORKFLOW_UNFINISHED_EVENTS | frozenset({RunEvent.run_error.value})
+
+
+@dataclass
+class _RunOutcome:
+    """How one terminal engine event says the run ended."""
+
+    chunk: BaseRunOutputEvent
+    finished: bool
+    message: Optional[str] = None
+    code: Optional[str] = None
+    final: bool = False
+
+
+def _event_value(chunk: BaseRunOutputEvent) -> Optional[str]:
     event = getattr(chunk, "event", None)
     if event is None:
-        return False
-    event_value = event.value if hasattr(event, "value") else str(event)
-    return event_value in _COMPLETION_EVENTS
+        return None
+    return event.value if hasattr(event, "value") else str(event)
+
+
+def _ended_an_inner_run(chunk: BaseRunOutputEvent) -> bool:
+    """Whether a terminal event ended a run other than the one the client is watching.
+
+    A nested workflow reports its ending on its parent's stream under a nesting depth
+    above zero. A team member and a sub-agent report theirs with the run that started
+    them on ``parent_run_id`` and the depth left at zero, so depth alone lets a member's
+    ending decide the run the client asked for.
+
+    Those two markers are not every inner run. A workflow step's own agent or team
+    executor reports its ending with neither, and is deliberately let through: the
+    workflow's own terminal event arrives afterwards and overrules it, and
+    ``_UNFINISHED_EVENTS`` is written so an executor's error never latches.
+    """
+    return bool(getattr(chunk, "nested_depth", 0)) or getattr(chunk, "parent_run_id", None) is not None
+
+
+def _pause_message(chunk: BaseRunOutputEvent) -> str:
+    step_name = getattr(chunk, "paused_step_name", None) or getattr(chunk, "step_name", None)
+    return f"Workflow paused at step '{step_name}'" if step_name else "Workflow paused"
+
+
+def _classify_terminal(chunk: BaseRunOutputEvent, normalized: str) -> _RunOutcome:
+    final = normalized in _WORKFLOW_UNFINISHED_EVENTS
+
+    if normalized in _PAUSE_EVENTS:
+        return _RunOutcome(chunk, finished=False, message=_pause_message(chunk), code=normalized, final=final)
+
+    if normalized == WorkflowRunEvent.workflow_cancelled.value:
+        # A cancelled run is not a failure, but it is not a success either. It carries its
+        # reason on `reason`, and gets a code clients can tell apart from a real failure.
+        reason = getattr(chunk, "reason", None) or getattr(chunk, "content", None) or "Run cancelled"
+        return _RunOutcome(chunk, finished=False, message=str(reason), code=normalized, final=final)
+
+    if normalized in _UNFINISHED_EVENTS:
+        return _RunOutcome(chunk, finished=False, final=final)
+
+    # A step that failed without aborting the run rides along on a completion event, so
+    # the payload decides whether this completion is really a success.
+    step_error = _failed_step_error(chunk)
+    if step_error is not None:
+        return _RunOutcome(chunk, finished=False, message=step_error)
+
+    return _RunOutcome(chunk, finished=True)
+
+
+class RunTerminalTracker:
+    """Decides the single terminal AG-UI event a run's stream ends on.
+
+    The engine reports a run's ending more than once and from more than one level: a
+    cancelled run is followed by a completion event repeating the cancellation text, a
+    pause arrives as a step event and again as a workflow event, and a nested workflow
+    reports its own ending onto the same stream. Every one of those is read here, so a
+    new engine outcome is handled by naming it in the sets above rather than by adding
+    another rule somewhere along the stream.
+    """
+
+    def __init__(self) -> None:
+        self._outcome: Optional[_RunOutcome] = None
+        self._reported_unfinished = False
+
+    def observe(self, chunk: BaseRunOutputEvent) -> bool:
+        """Take a chunk that reports how a run ended. Returns True when it was taken."""
+        event_value = _event_value(chunk)
+        if event_value is None:
+            return False
+
+        normalized = _normalize_event(event_value)
+        if normalized not in _FINISHED_EVENTS and normalized not in _UNFINISHED_EVENTS:
+            return False
+
+        # An ending belonging to a run the client never asked for is taken off the stream
+        # without being allowed to decide the run the client is watching.
+        if _ended_an_inner_run(chunk):
+            return True
+
+        candidate = _classify_terminal(chunk, normalized)
+
+        # Once the workflow has reported that the run did not finish, that report stands
+        # for the rest of the stream. Only another report from the workflow itself may
+        # replace it: a later success is the engine repeating the ending it already gave,
+        # and an agent or team error belongs to a step's executor rather than to the run.
+        if self._reported_unfinished and not candidate.final:
+            return True
+
+        self._reported_unfinished = self._reported_unfinished or candidate.final
+        self._outcome = candidate
+        return True
+
+    def emit(self, state: StreamState) -> List[BaseEvent]:
+        """Emit the terminal events, synthesizing a success if the stream just ran out."""
+        outcome = self._outcome or _RunOutcome(RunCompletedEvent(), finished=True)
+        if outcome.finished:
+            return on_run_completed(outcome.chunk, state)
+        return on_run_error(outcome.chunk, state, message=outcome.message, code=outcome.code)
 
 
 def process_event(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
     """Process a single Agno event and return AG-UI events to emit."""
-    event = getattr(chunk, "event", None)
-    if event is None:
+    event_value = _event_value(chunk)
+    if event_value is None:
         return on_unknown_event(chunk, state)
 
-    event_value = event.value if hasattr(event, "value") else str(event)
     normalized = _normalize_event(event_value)
 
     handler = HANDLERS.get(normalized)
@@ -493,12 +991,3 @@ def process_event(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEve
         return handler(chunk, state)
 
     return on_unknown_event(chunk, state)
-
-
-def process_completion(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
-    """Process a terminal event and return the corresponding AG-UI events."""
-    event = getattr(chunk, "event", None)
-    event_value = event.value if event is not None and hasattr(event, "value") else str(event)
-    if _normalize_event(event_value) == RunEvent.run_error.value:
-        return on_run_error(chunk, state)
-    return on_run_completed(chunk, state)

--- a/libs/agno/agno/os/interfaces/agui/router.py
+++ b/libs/agno/agno/os/interfaces/agui/router.py
@@ -35,14 +35,16 @@ from agno.os.middleware.user_scope import assert_session_writable, caller_is_adm
 from agno.run.base import RunContext
 from agno.team.remote import RemoteTeam
 from agno.team.team import Team
+from agno.workflow.remote import RemoteWorkflow
+from agno.workflow.workflow import Workflow
 
 
 async def run_entity(
-    entity: Union[Agent, RemoteAgent, Team, RemoteTeam],
+    entity: Union[Agent, RemoteAgent, Team, RemoteTeam, Workflow, RemoteWorkflow],
     run_input: RunAgentInput,
     user_id: Optional[str] = None,
 ) -> AsyncIterator[BaseEvent]:
-    """Shared handler for running an Agent or Team with AG-UI input/output mapping.
+    """Shared handler for running an Agent, Team or Workflow with AG-UI input/output mapping.
 
     ``user_id`` is the server-resolved identity (see the route handler). It is
     deliberately NOT read from ``run_input.forwarded_props`` here: an authenticated
@@ -80,12 +82,14 @@ async def run_entity(
             session_state=session_state,
         )
 
+        is_workflow = isinstance(entity, (Workflow, RemoteWorkflow))
+
         run_kwargs: dict = {}
-        if ui_deps:
+        if ui_deps and not isinstance(entity, RemoteWorkflow):
             run_kwargs["add_dependencies_to_context"] = True
 
         # 4. Determine if this is a resume (trailing ToolMessages) or fresh run
-        if tool_messages:
+        if tool_messages and not is_workflow:
             # Resume: frontend executed external tools and sent results back
             response_stream = await resume_paused_run(
                 entity=entity,  # type: ignore[arg-type]
@@ -96,7 +100,27 @@ async def run_entity(
             )
         else:
             # Fresh run: new user input
-            if isinstance(entity, (RemoteAgent, RemoteTeam)):
+            if is_workflow:
+                if tool_messages:
+                    # Dropped: this interface has no workflow resume, so the answers the
+                    # client sent back go nowhere and the run below starts over.
+                    log_warning(
+                        "AG-UI cannot resume a paused workflow: the tool results were dropped and the "
+                        "workflow is being re-run from the start against the last user message"
+                    )
+                # Workflow.arun takes no RunContext, so it cannot carry client tools.
+                # Send the wire fields the RunContext would have carried instead.
+                run_kwargs["session_state"] = session_state
+                if not isinstance(entity, RemoteWorkflow):
+                    run_kwargs["dependencies"] = ui_deps
+                elif ui_deps:
+                    # Dropped: RemoteWorkflow.arun sends every unknown kwarg to the remote
+                    # server as a form field, and dependencies are not one it declares.
+                    log_warning("AG-UI context is not forwarded to remote workflows")
+                if client_tools:
+                    # Dropped: a workflow has no way to execute a frontend tool.
+                    log_warning("AG-UI client tools are not forwarded to workflows")
+            elif isinstance(entity, (RemoteAgent, RemoteTeam)):
                 # A RunContext is an in-process object: RemoteAgent/RemoteTeam forward every
                 # unknown kwarg as a form field, and the remote AgentOS would hand the
                 # stringified object to Agent.arun. Send the wire fields it carries instead.
@@ -135,12 +159,15 @@ async def run_entity(
 
 
 def attach_routes(
-    router: APIRouter, agent: Optional[Union[Agent, RemoteAgent]] = None, team: Optional[Union[Team, RemoteTeam]] = None
+    router: APIRouter,
+    agent: Optional[Union[Agent, RemoteAgent]] = None,
+    team: Optional[Union[Team, RemoteTeam]] = None,
+    workflow: Optional[Union[Workflow, RemoteWorkflow]] = None,
 ) -> APIRouter:
-    if agent is None and team is None:
-        raise ValueError("Either agent or team must be provided.")
+    if agent is None and team is None and workflow is None:
+        raise ValueError("Either agent, team or workflow must be provided.")
 
-    entity = agent or team
+    entity = agent or team or workflow
     encoder = EventEncoder()
 
     @router.post("/agui", name="run_agent")

--- a/libs/agno/agno/os/interfaces/agui/state.py
+++ b/libs/agno/agno/os/interfaces/agui/state.py
@@ -6,6 +6,54 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 from agno.utils.log import log_warning
 
 
+def _sequence_position(step_index: Any) -> Optional[int]:
+    """Where in a sequence a step index says its step ran, if it says that at all.
+
+    The engine numbers a sequence's steps with plain integers and gives a container's
+    children a tuple instead, which every container kind does: Parallel, Loop, Steps and
+    Condition all build one. So an integer index is the only thing on an event that says
+    two steps ran one after the other rather than side by side.
+    """
+    if isinstance(step_index, bool) or not isinstance(step_index, int):
+        return None
+    return step_index
+
+
+@dataclass
+class StepSpan:
+    """One workflow step, from the engine's start event until its span has been emitted.
+
+    A step's identity and the name the client sees it under are separate things. Identity
+    is the step id, position and name together, and decides which step an event belongs
+    to. The display name is all AG-UI carries, and the client rejects a second
+    STEP_STARTED for a name it already holds open, so a step whose name is already held
+    is announced under a distinguished one instead of waiting for the name to come free.
+    """
+
+    step_name: Optional[str] = None
+    step_id: Optional[str] = None
+    parent_step_id: Optional[str] = None
+    step_index: Optional[Any] = None
+
+    # The name AG-UI pairs this step's STEP_STARTED and STEP_FINISHED on. Assigned when
+    # the step is announced and never changed, so the pair always agrees.
+    display_name: str = ""
+
+    # Whether the client has already been sent this step's own output, either because
+    # something inside the step streamed it or because closing the step emitted it.
+    produced_text: bool = False
+
+    closed: bool = False
+
+
+@dataclass(frozen=True)
+class SpanTransition:
+    """One STEP_STARTED or STEP_FINISHED the client is owed, named as the client sees it."""
+
+    step_name: str
+    started: bool
+
+
 @dataclass
 class StreamState:
     """Per-stream state for AG-UI event translation.
@@ -34,8 +82,22 @@ class StreamState:
     reasoning_message_id: Optional[str] = None
     reasoning_step_count: int = 0
 
+    # Workflow steps, in the order they opened, each announced to the client and holding
+    # its display name until its span has been emitted.
+    spans: List[StepSpan] = field(default_factory=list)
+
+    # Ids of steps whose output the client has already been sent. A span is dropped once
+    # its transitions are emitted, so a record kept only on the span cannot answer for a
+    # step whose completion arrives after that.
+    produced_step_ids: Set[str] = field(default_factory=set)
+
     # State delta tracking
     _last_snapshot: Optional[Dict[str, Any]] = field(default=None, repr=False)
+
+    # The events that closed everything still open, kept after the closing drained this
+    # state. A terminal batch is assembled around them and can still be lost whole, so
+    # the closings have to outlive the batch for the caller that ends the run instead.
+    built_closings: Optional[List[Any]] = field(default=None, repr=False)
 
     # Run context
     thread_id: str = ""
@@ -70,6 +132,210 @@ class StreamState:
 
     def clear_pending_tool_calls_parent_id(self) -> None:
         self.pending_tool_calls_parent_id = ""
+
+    def record_text_delta(self, step_id: Optional[str] = None) -> None:
+        """Credit an emitted text delta to the workflow step that produced it.
+
+        The engine stamps a step's id onto the events its executor produces, so an event
+        carrying one credits that step and everything containing it. Anything else names
+        no step and is credited to none: a guessed owner suppresses the output of the
+        step guessed wrong.
+        """
+        if step_id is None:
+            return
+        self.produced_step_ids.add(step_id)
+        owner = self._find_span_by_id(step_id)
+        if owner is not None:
+            self._mark_produced(owner)
+
+    def claim_step_output(self, span: Optional[StepSpan], step_id: Optional[str] = None) -> bool:
+        """Whether a closing step's output still has to be sent, claiming it if so.
+
+        A span answers for itself, and the steps containing it then own its output too,
+        so they must not send it again when they close. A completion matching no span
+        has only its step id to answer with: an id credited with text earlier in the run
+        names output the client already holds, and anything else is the only copy there
+        is of what that step produced.
+        """
+        if span is None:
+            owed = step_id is None or step_id not in self.produced_step_ids
+            if step_id is not None:
+                self.produced_step_ids.add(step_id)
+            return owed
+        owed = not span.produced_text
+        self._mark_produced(span)
+        return owed
+
+    def open_step(
+        self,
+        step_name: Optional[str] = None,
+        step_id: Optional[str] = None,
+        parent_step_id: Optional[str] = None,
+        step_index: Optional[Any] = None,
+    ) -> List[SpanTransition]:
+        """Open a workflow step and return the span transitions that follow from it.
+
+        A start for a step already open announces nothing, because the client holds that
+        name already. It still says where the run is, so it closes and drains either way.
+        """
+        already_open = any(
+            span.step_name == step_name and span.step_id == step_id and span.step_index == step_index
+            for span in self.spans
+            if not span.closed
+        )
+        self._close_steps_the_run_moved_past(parent_step_id, step_index)
+        transitions = self._drain_spans()
+        if already_open:
+            return transitions
+        span = StepSpan(
+            step_name=step_name,
+            step_id=step_id,
+            parent_step_id=parent_step_id,
+            step_index=step_index,
+            display_name=self._free_display_name(step_name or step_id or "Step"),
+        )
+        self.spans.append(span)
+        transitions.append(SpanTransition(step_name=span.display_name, started=True))
+        return transitions
+
+    def _free_display_name(self, wanted: str) -> str:
+        """A name no announced step still holds, so the client never sees one name twice.
+
+        Sequential steps reusing a name get that name back, because the earlier one has
+        finished by then. Concurrent ones are numbered from two, and a number already
+        taken by a step genuinely called that is skipped over.
+        """
+        taken = {span.display_name for span in self.spans}
+        if wanted not in taken:
+            return wanted
+        counter = 2
+        while f"{wanted} {counter}" in taken:
+            counter += 1
+        return f"{wanted} {counter}"
+
+    def close_step(
+        self,
+        step_name: Optional[str] = None,
+        step_id: Optional[str] = None,
+        step_index: Optional[Any] = None,
+    ) -> Optional[StepSpan]:
+        """Mark a workflow step closed and return it, or None when it was never open.
+
+        The span itself is emitted by ``flush_spans``, once the step's own output has
+        been sent.
+        """
+        span = self._find_open_span(step_name, step_id, step_index)
+        if span is None:
+            return None
+        self._close_span(span)
+        return span
+
+    def close_all_spans(self) -> List[SpanTransition]:
+        """Close every step still open and return every span transition still owed."""
+        for span in self.spans:
+            span.closed = True
+        return self._drain_spans()
+
+    def flush_spans(self) -> List[SpanTransition]:
+        """Return the span transitions the closings so far have made emittable."""
+        return self._drain_spans()
+
+    def _drain_spans(self) -> List[SpanTransition]:
+        """Finish every closed step, innermost first so a container outlives what it holds.
+
+        Spans go by identity, because removing by value drops whichever span happens to
+        compare equal rather than the one that closed.
+        """
+        transitions: List[SpanTransition] = []
+        still_open: List[StepSpan] = []
+        for span in reversed(self.spans):
+            if span.closed:
+                transitions.append(SpanTransition(step_name=span.display_name, started=False))
+            else:
+                still_open.append(span)
+        still_open.reverse()
+        self.spans = still_open
+        return transitions
+
+    def _close_steps_the_run_moved_past(self, parent_step_id: Optional[str], step_index: Optional[Any]) -> None:
+        """Close steps a newly started step proves are over.
+
+        A step that failed under a policy of carrying on never gets a completion event,
+        so nothing else would ever close it. Its sequence starting a later step is proof
+        it is over: steps sharing a parent and numbered by position run one at a time.
+        """
+        position = _sequence_position(step_index)
+        if position is None:
+            return
+        for span in list(self.spans):
+            if span.closed or span.parent_step_id != parent_step_id:
+                continue
+            span_position = _sequence_position(span.step_index)
+            if span_position is not None and span_position < position:
+                self._close_span(span)
+
+    def _close_span(self, span: StepSpan) -> None:
+        # A step ending ends everything it contains, whether or not the engine says so
+        span.closed = True
+        for other in self.spans:
+            if not other.closed and self._contains(span, other):
+                other.closed = True
+
+    def _contains(self, span: StepSpan, candidate: StepSpan) -> bool:
+        parent_id = candidate.parent_step_id
+        for _ in range(len(self.spans)):
+            if parent_id is None:
+                return False
+            if parent_id == span.step_id:
+                return True
+            parent = self._find_span_by_id(parent_id)
+            if parent is None:
+                return False
+            parent_id = parent.parent_step_id
+        return False
+
+    def _find_span_by_id(self, step_id: Optional[str]) -> Optional[StepSpan]:
+        if step_id is None:
+            return None
+        for span in self.spans:
+            if span.step_id == step_id:
+                return span
+        return None
+
+    def _find_open_span(
+        self, step_name: Optional[str], step_id: Optional[str], step_index: Optional[Any]
+    ) -> Optional[StepSpan]:
+        open_spans = [span for span in self.spans if not span.closed]
+        if step_id is not None:
+            for span in open_spans:
+                if span.step_id == step_id:
+                    return span
+            # An event that names a step id names one step, so it can only be about a
+            # step that never told us its own id. Matching anything else closes a step
+            # the engine did not say was over, and everything inside it with it.
+            open_spans = [span for span in open_spans if span.step_id is None]
+        # Not every completion event carries a step id, so fall back to the position in
+        # the run and then to the innermost open step of that name.
+        if step_index is not None:
+            for span in open_spans:
+                if span.step_name == step_name and span.step_index == step_index:
+                    return span
+        for span in reversed(open_spans):
+            if span.step_name == step_name:
+                return span
+        return None
+
+    def _mark_produced(self, span: StepSpan) -> None:
+        # Text produced inside a step is also output of the steps enclosing it, which
+        # must not emit it a second time when they close.
+        seen: Set[int] = set()
+        current: Optional[StepSpan] = span
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+            current.produced_text = True
+            if current.step_id is not None:
+                self.produced_step_ids.add(current.step_id)
+            current = self._find_span_by_id(current.parent_step_id)
 
     def start_reasoning(self) -> str:
         self.reasoning_message_id = str(uuid.uuid4())

--- a/libs/agno/agno/os/interfaces/agui/stream.py
+++ b/libs/agno/agno/os/interfaces/agui/stream.py
@@ -3,14 +3,15 @@ from typing import Any, AsyncIterator, Dict, Optional, Union
 
 from ag_ui.core import BaseEvent
 
-from agno.os.interfaces.agui.handlers import is_completion_event, process_completion, process_event
+from agno.os.interfaces.agui.handlers import RunTerminalTracker, close_open_spans, process_event
 from agno.os.interfaces.agui.state import StreamState
-from agno.run.agent import RunCompletedEvent, RunOutputEvent
+from agno.run.agent import RunOutputEvent
 from agno.run.team import TeamRunOutputEvent
+from agno.run.workflow import WorkflowRunOutputEvent
 
 
 def stream_agno_response_as_agui_events(
-    response_stream: Iterator[Union[RunOutputEvent, TeamRunOutputEvent]],
+    response_stream: Iterator[Union[RunOutputEvent, TeamRunOutputEvent, WorkflowRunOutputEvent]],
     thread_id: str,
     run_id: str,
     run_state: Optional[Dict[str, Any]] = None,
@@ -21,23 +22,31 @@ def stream_agno_response_as_agui_events(
     if run_state is not None:
         state.set_state_snapshot(run_state)
 
-    terminal_chunk = None
+    terminal = RunTerminalTracker()
 
-    for chunk in response_stream:
-        if is_completion_event(chunk):
-            terminal_chunk = chunk
-        else:
+    try:
+        for chunk in response_stream:
+            if terminal.observe(chunk):
+                continue
             for event in process_event(chunk, state):
                 yield event
 
-    # Process completion (or synthesize one if stream ended naturally)
-    final_chunk = terminal_chunk or RunCompletedEvent()
-    for event in process_completion(final_chunk, state):
+        terminal_events = terminal.emit(state)
+    except Exception:
+        # The route ends a failed run with RUN_ERROR, and it cannot close what this
+        # stream left open because the state lives here. Close it on the way out, so
+        # the client is not holding a step, a message or a tool call at the terminal
+        # event, and let the exception carry on to the route that reports it.
+        for event in close_open_spans(state):
+            yield event
+        raise
+
+    for event in terminal_events:
         yield event
 
 
 async def async_stream_agno_response_as_agui_events(
-    response_stream: AsyncIterator[Union[RunOutputEvent, TeamRunOutputEvent]],
+    response_stream: AsyncIterator[Union[RunOutputEvent, TeamRunOutputEvent, WorkflowRunOutputEvent]],
     thread_id: str,
     run_id: str,
     run_state: Optional[Dict[str, Any]] = None,
@@ -48,16 +57,22 @@ async def async_stream_agno_response_as_agui_events(
     if run_state is not None:
         state.set_state_snapshot(run_state)
 
-    terminal_chunk = None
+    terminal = RunTerminalTracker()
 
-    async for chunk in response_stream:
-        if is_completion_event(chunk):
-            terminal_chunk = chunk
-        else:
+    try:
+        async for chunk in response_stream:
+            if terminal.observe(chunk):
+                continue
             for event in process_event(chunk, state):
                 yield event
 
-    # Process completion (or synthesize one if stream ended naturally)
-    final_chunk = terminal_chunk or RunCompletedEvent()
-    for event in process_completion(final_chunk, state):
+        terminal_events = terminal.emit(state)
+    except Exception:
+        # As in the sync mapper above: the route reports the failure, this stream is the
+        # only thing that knows what the client still has open.
+        for event in close_open_spans(state):
+            yield event
+        raise
+
+    for event in terminal_events:
         yield event

--- a/libs/agno/tests/integration/os/interfaces/_agui_sse.py
+++ b/libs/agno/tests/integration/os/interfaces/_agui_sse.py
@@ -1,0 +1,163 @@
+"""SSE helpers shared by the AG-UI interface integration tests.
+
+Every AG-UI suite reads the same event stream off the same endpoint and then asserts
+that some event is absent. That assertion is only sound if the parser refuses to skip
+a payload it cannot read, so the strictness below has to hold for all of them at once.
+One copy is what keeps it that way.
+"""
+
+import json
+from typing import Any, Dict, Iterator, List
+
+DATA_PREFIX = "data:"
+
+
+def _iter_frame_payloads(content: str) -> Iterator[str]:
+    """Yield one payload per SSE frame.
+
+    A frame ends at an empty line and may carry several ``data:`` lines, which SSE
+    joins with a newline into a single payload. Reading each line as its own event
+    turns a legal reframing of the same stream into a parse failure.
+
+    Only a genuinely empty line ends a frame, and only a line whose first characters
+    are the field name counts as data. A line of spaces and a line that indents the
+    prefix are both something other than what they look like, and reading them as a
+    frame boundary or as data would let a body the browser reads one way be read
+    another way here. A ``data`` line with no colon is the one shape read differently:
+    SSE would take it as the field with an empty value, and it is dropped here as an
+    unknown field, which the AG-UI encoder never emits.
+
+    A frame whose payload comes out empty is not dispatched, which is how a keep-alive
+    carrying no payload stays a keep-alive. Nor is a trailing block that never met an
+    empty line: the browser discards an unterminated block, and dispatching it here
+    would let a body cut off mid-stream hand its last complete line to an assertion
+    that only means something on a run which reached the end.
+    """
+    normalized = content.replace("\r\n", "\n").replace("\r", "\n")
+    data_lines: List[str] = []
+    for line in normalized.split("\n"):
+        if not line:
+            payload = "\n".join(data_lines)
+            data_lines = []
+            if payload:
+                yield payload
+            continue
+        if line.startswith(DATA_PREFIX):
+            value = line[len(DATA_PREFIX) :]
+            # SSE strips one leading space from a field value, not every one.
+            data_lines.append(value[1:] if value.startswith(" ") else value)
+
+
+def parse_sse_events(content: str) -> List[Dict[str, Any]]:
+    """Parse an SSE body into events, refusing to return nothing.
+
+    Returning an empty list for a body that carries no frame is what makes an
+    absence assertion vacuous: an empty body, an error page and a stream that was
+    never read all come back looking like a run that simply emitted no such event.
+    An AG-UI run that reached the route's generator at all emits at least one event,
+    so a body with no frame in it is reported here, with the body quoted, rather
+    than handed on as a result.
+
+    A payload that parses as valid JSON but is not an object is reported the same
+    way. The return type says these are events, and every caller reads them as
+    mappings; handing one on would surface as an attribute error several frames
+    later, naming nothing about the body that caused it.
+    """
+    events: List[Dict[str, Any]] = []
+    for payload in _iter_frame_payloads(content):
+        try:
+            event = json.loads(payload)
+        except json.JSONDecodeError as error:
+            raise AssertionError(f"SSE data frame is not valid JSON: {payload!r}") from error
+        if not isinstance(event, dict):
+            raise AssertionError(f"SSE data frame is not a JSON object, so it is not an event: {payload!r}")
+        events.append(event)
+    if not events:
+        raise AssertionError(f"SSE body carried no data frames, so nothing about the stream was observed: {content!r}")
+    return events
+
+
+def get_event_types(events: List[Dict[str, Any]]) -> List[str]:
+    """Read the type off every event, refusing a frame that has none.
+
+    A frame with no type cannot be matched by any assertion written against these
+    names, so returning a None in its place quietly shortens the stream that the
+    presence and absence assertions are reading.
+    """
+    types: List[str] = []
+    for event in events:
+        event_type = event.get("type")
+        if not isinstance(event_type, str):
+            raise AssertionError(f"SSE event carries no type, so nothing can be asserted about it: {event!r}")
+        types.append(event_type)
+    return types
+
+
+def assert_event_absent(types: List[str], event_type: str) -> None:
+    """Assert an event is missing from a stream that ran to completion.
+
+    ``event_type not in types`` on its own passes for the wrong reason whenever the
+    stream never got going. A streaming response commits its 200 and its headers
+    before the generator runs, so a body carrying nothing but a failure still arrives
+    as a success, and a run that failed on its first event carries no more than the
+    error. RUN_STARTED alone does not rule that out either: the route can fail before
+    it is yielded, leaving RUN_ERROR alone, or after it, leaving RUN_STARTED then
+    RUN_ERROR. The bar is therefore the run reaching RUN_FINISHED: absence means
+    something only once the run that would have emitted the event got to the end.
+    """
+    assert types, f"the stream carried no events, so the absence of {event_type} proves nothing"
+    assert "RUN_STARTED" in types, f"the stream never started, so the absence of {event_type} proves nothing: {types}"
+    assert "RUN_FINISHED" in types, (
+        f"the run never finished, so the absence of {event_type} proves nothing about a run that did: {types}"
+    )
+    assert event_type not in types, f"expected no {event_type} in the stream: {types}"
+
+
+def assert_valid_wire_stream(events: List[Dict[str, Any]]) -> None:
+    """Check a served stream against the same framing rules the mapper suites use.
+
+    A run driven by the real engine over HTTP is the stream most worth checking and the
+    one no hand-built chunk list can stand in for. The rules themselves live with the
+    mapper suites that already apply them; importing them keeps one statement of what
+    the client will accept rather than a second copy that drifts.
+
+    Field spelling is checked here rather than left to the parse. The protocol models
+    allow extra fields and accept the snake_case spelling of every one of them, so a
+    payload that misspells a name or sends it unconverted validates cleanly and the
+    parse says nothing at all about what went over the wire. What the browser reads is
+    the camelCase key, so every key on the wire has to be one the model declares under
+    that name.
+    """
+    # Imported here, not at module scope: the parser above is what the SSE tests import,
+    # and they must keep collecting on an install without ag_ui.
+    from ag_ui.core import Event
+    from pydantic import TypeAdapter
+
+    from tests.unit.os.interfaces._agui_stream_rules import assert_valid_agui_stream
+
+    adapter = TypeAdapter(Event)
+    parsed = []
+    for event in events:
+        model = adapter.validate_python(event)
+        declared = {field.alias or name for name, field in type(model).model_fields.items()}
+        unknown = sorted(set(event) - declared)
+        assert not unknown, (
+            f"{event.get('type')} carries {unknown} on the wire, which {type(model).__name__} does not declare "
+            f"under those names: {event!r}"
+        )
+        parsed.append(model)
+    assert_valid_agui_stream(parsed)
+
+
+def make_request_body(
+    message: str, state: Any = None, thread_id: str = "test-thread", run_id: str = "test-run"
+) -> Dict[str, Any]:
+    return {
+        "threadId": thread_id,
+        "runId": run_id,
+        "state": state,
+        "messages": [{"id": "msg-1", "role": "user", "content": message}],
+        "tools": [],
+        "context": [],
+        "forwardedProps": {},
+    }

--- a/libs/agno/tests/integration/os/interfaces/conftest.py
+++ b/libs/agno/tests/integration/os/interfaces/conftest.py
@@ -1,0 +1,67 @@
+import pytest
+
+from agno.api.api import api as agno_api
+
+TELEMETRY_ENTRY_POINTS = ("post_in_background", "apost_in_background")
+
+
+def refuse_telemetry_post(route: str, payload: dict) -> None:
+    """Stand in for every telemetry entry point and fail the test that reached one.
+
+    A plain function, not a closure, so the guard's own tests can recognise it by
+    identity rather than by the message it happens to raise.
+    """
+    pytest.fail(f"an integration test posted telemetry to {route}; build the entity with telemetry=False")
+
+
+def install_telemetry_guard(target=agno_api):
+    """Put the guard on every telemetry entry point and return the undo.
+
+    The undo removes the attributes this added rather than writing back what
+    ``getattr`` returned, which would be a bound method and would stay on this
+    process-wide instance for good, shadowing the class attribute for every later
+    test in the run.
+    """
+    previous = {name: vars(target).get(name, ...) for name in TELEMETRY_ENTRY_POINTS}
+    for name in TELEMETRY_ENTRY_POINTS:
+        setattr(target, name, refuse_telemetry_post)
+
+    def undo() -> None:
+        for name, value in previous.items():
+            if value is ...:
+                delattr(target, name)
+            else:
+                setattr(target, name, value)
+
+    return undo
+
+
+@pytest.fixture(autouse=True, scope="package")
+def no_outbound_telemetry():
+    """Fail any test in this directory that reaches the telemetry endpoint.
+
+    These suites call a real model, so the network is already in play and a stray
+    telemetry post is easy to miss. Setting telemetry=False on one builder only fixes
+    the builder someone noticed; this catches every entity built here, including the
+    ones written later, and the AgentOS launch post the app lifespan makes.
+
+    Package scope, not function scope, because a module-scoped fixture that performs the
+    run is set up before any function-scoped guard exists, and that is exactly where the
+    expensive run lives. Not session scope either: the patch would then outlive this
+    directory and, since pytest collects it before its siblings, break every later suite
+    that posts telemetry on purpose.
+
+    Both entry points are covered. The async one currently delegates to the sync one, so
+    guarding it changes nothing today, and that is the point: nothing about the delegation
+    is promised, and a guard that depends on it would be disarmed by an ordinary edit.
+
+    Every telemetry path funnels through these two on the calling thread, and each call
+    site wraps it in `except Exception` so telemetry can never change a run's outcome.
+    pytest.fail raises outside that hierarchy, so the failure reaches the test instead of
+    being logged and dropped.
+    """
+    undo = install_telemetry_guard()
+    try:
+        yield
+    finally:
+        undo()

--- a/libs/agno/tests/integration/os/interfaces/test_agui_failed_run.py
+++ b/libs/agno/tests/integration/os/interfaces/test_agui_failed_run.py
@@ -1,0 +1,127 @@
+"""What the AG-UI route serves when a run fails part way through.
+
+A run that fails is the one case where the terminal event is written by the route rather
+than by the mapper, and the route sees only the exception: the spans the client is
+holding open are known to the mapper alone. So this is checked on the served body rather
+than on a mapper's return value, because it is the seam between the two that decides
+whether the stream the browser gets is one it will accept.
+
+The engine turns a failing workflow step into a completed run, so the failure here is
+raised by the entity's own stream, which is what an entity that dies mid-run does.
+"""
+
+import threading
+
+import pytest
+from fastapi import APIRouter
+from fastapi.testclient import TestClient
+
+from agno.run.agent import RunCompletedEvent, RunContentEvent
+from agno.run.workflow import StepStartedEvent
+
+from ._agui_sse import assert_valid_wire_stream, get_event_types, make_request_body, parse_sse_events
+
+pytest.importorskip("ag_ui", reason="ag_ui not installed")
+
+from agno.os.interfaces.agui.router import attach_routes  # noqa: E402
+
+pytestmark = pytest.mark.integration
+
+
+class FailsPartWayThroughEntity:
+    """An entity whose run opens a step, streams into it, and then dies."""
+
+    db = None
+
+    async def arun(self, **kwargs):
+        yield StepStartedEvent(step_name="Gather", step_id="gather")
+        yield RunContentEvent(content="half an answer", step_id="gather")
+        raise RuntimeError("the executor blew up")
+
+
+@pytest.fixture(scope="module")
+def response():
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    app.include_router(attach_routes(APIRouter(), agent=FailsPartWayThroughEntity()))  # type: ignore[arg-type]
+    with TestClient(app) as client:
+        return client.post("/agui", json=make_request_body("Say hello"))
+
+
+@pytest.fixture(scope="module")
+def events(response):
+    return parse_sse_events(response.text)
+
+
+def test_a_failed_run_is_served_as_an_error_the_client_can_reach(response, events):
+    # A streaming response commits its 200 before the generator runs, so the status says
+    # nothing about the run; the terminal event is what the client reads the failure off.
+    assert response.status_code == 200
+
+    types = get_event_types(events)
+
+    assert types[0] == "RUN_STARTED"
+    assert types[-1] == "RUN_ERROR"
+    assert events[-1]["message"] == "the executor blew up"
+
+
+def test_the_served_stream_of_a_failed_run_obeys_the_protocol_framing_rules(events):
+    """Without this, a mid-run failure serves a stream the client aborts on."""
+    assert_valid_wire_stream(events)
+
+
+def test_the_step_the_run_died_inside_is_finished_before_the_error(events):
+    types = get_event_types(events)
+
+    assert types.index("STEP_FINISHED") < types.index("RUN_ERROR")
+    assert types.index("TEXT_MESSAGE_END") < types.index("RUN_ERROR")
+
+
+class CompletesWithAnUncopyableStateEntity:
+    """An entity that opens a step and then completes carrying a state nothing can copy.
+
+    The completion is built as one batch: the open spans are closed at the top of it and
+    the final state is serialized at the bottom. A state the copy cannot walk therefore
+    fails the whole batch after the closings were already drained out of the mapper's
+    state, which is the seam this scenario exists to hold.
+    """
+
+    db = None
+
+    async def arun(self, **kwargs):
+        yield StepStartedEvent(step_name="Gather", step_id="gather")
+        yield RunContentEvent(content="half an answer", step_id="gather")
+        yield RunCompletedEvent(content="done", session_state={"seen": 2, "guard": threading.Lock()})
+
+
+@pytest.fixture(scope="module")
+def uncopyable_state_events():
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    app.include_router(
+        attach_routes(APIRouter(), agent=CompletesWithAnUncopyableStateEntity())  # type: ignore[arg-type]
+    )
+    with TestClient(app) as client:
+        response = client.post("/agui", json=make_request_body("Say hello", state={"seen": 1}))
+    return parse_sse_events(response.text)
+
+
+def test_a_run_whose_state_cannot_be_copied_serves_a_stream_the_client_accepts(uncopyable_state_events):
+    """Without this, the step opened mid-run is never finished and the client aborts."""
+    assert_valid_wire_stream(uncopyable_state_events)
+
+
+def test_a_run_whose_state_cannot_be_copied_closes_its_step_and_reports_the_failure(uncopyable_state_events):
+    """The state the client never received is the reason the run is reported as failed.
+
+    Ending on a success instead would hand the reader a finished turn whose state quietly
+    stayed behind, which is worse than an error they can see.
+    """
+    types = get_event_types(uncopyable_state_events)
+
+    assert types[-1] == "RUN_ERROR"
+    assert "RUN_FINISHED" not in types
+    assert types.index("STEP_FINISHED") < types.index("RUN_ERROR")
+    assert types.index("TEXT_MESSAGE_END") < types.index("RUN_ERROR")

--- a/libs/agno/tests/integration/os/interfaces/test_agui_sse.py
+++ b/libs/agno/tests/integration/os/interfaces/test_agui_sse.py
@@ -1,0 +1,208 @@
+"""The shared SSE parser is what makes every absence assertion in this directory sound.
+
+If it can return an empty list, a body that was never a stream reads the same as a run
+that emitted no such event, and the suites above pass without having seen anything. The
+same goes for a frame it hands on in a shape no assertion can read. These tests pin
+those properties down; they need no model and no network.
+
+The protocol and spelling checks the served-run suite applies are covered here too,
+since a check that passes everything would leave that suite asserting nothing.
+"""
+
+import importlib.util
+
+import pytest
+
+from ._agui_sse import assert_event_absent, assert_valid_wire_stream, get_event_types, parse_sse_events
+
+requires_ag_ui = pytest.mark.skipif(importlib.util.find_spec("ag_ui") is None, reason="ag_ui not installed")
+
+DEAD_BODIES = [
+    pytest.param("", id="empty body"),
+    pytest.param("   \n\n  \n", id="whitespace only"),
+    pytest.param("<html><body>500 Internal Server Error</body></html>", id="error page"),
+    pytest.param("upstream connect error or disconnect/reset before headers", id="proxy error"),
+    pytest.param(": keep-alive\n\n", id="comment frames only"),
+    pytest.param("data:\n\n", id="keep-alive frames only"),
+    pytest.param('data: {"type": "RUN_STARTED"}', id="a single frame that was never terminated"),
+]
+
+
+@pytest.mark.parametrize("body", DEAD_BODIES)
+def test_a_body_that_carries_no_frame_is_refused(body):
+    with pytest.raises(AssertionError, match="no data frames"):
+        parse_sse_events(body)
+
+
+@pytest.mark.parametrize("body", DEAD_BODIES)
+def test_an_absence_assertion_on_a_dead_body_cannot_pass(body):
+    # The vacuous pass this guards: `event_type not in types` is true of a stream that
+    # never ran. The parser has to be the thing that stops it, because an absence check
+    # can be written inline without going through assert_event_absent.
+    with pytest.raises(AssertionError):
+        assert "RUN_ERROR" not in get_event_types(parse_sse_events(body))
+
+
+def test_a_frame_split_across_several_data_lines_parses():
+    body = 'data: {"type":\ndata: "RUN_STARTED",\ndata: "threadId": "t"}\n\n'
+
+    assert parse_sse_events(body) == [{"type": "RUN_STARTED", "threadId": "t"}]
+
+
+def test_frames_are_kept_separate_and_crlf_framing_reads_the_same():
+    body = 'data: {"type": "RUN_STARTED"}\r\n\r\ndata: {"type": "RUN_FINISHED"}\r\n\r\n'
+
+    assert get_event_types(parse_sse_events(body)) == ["RUN_STARTED", "RUN_FINISHED"]
+
+
+def test_a_line_of_spaces_does_not_end_a_frame():
+    """SSE ends a frame at an empty line. A line of spaces is a field name with no
+    colon, which is ignored, so treating it as a boundary splits one payload in two."""
+    body = 'data: {"type":\n   \ndata: "RUN_STARTED"}\n\n'
+
+    assert parse_sse_events(body) == [{"type": "RUN_STARTED"}]
+
+
+def test_an_indented_data_prefix_is_not_a_data_line():
+    """``   data: ...`` names the field ``   data``, which SSE ignores. Reading it as
+    data accepts a body the browser would take as carrying no event at all."""
+    body = '   data: {"type": "RUN_STARTED"}\n\n'
+
+    with pytest.raises(AssertionError, match="no data frames"):
+        parse_sse_events(body)
+
+
+@pytest.mark.parametrize("keep_alive", ["data:\n\n", "data: \n\n", ": ping\n\n"], ids=["bare", "padded", "comment"])
+def test_a_keep_alive_between_frames_is_not_a_malformed_stream(keep_alive):
+    """A frame whose data buffer is empty is never dispatched, so it is not an event
+    and not a parse failure either."""
+    body = f'data: {{"type": "RUN_STARTED"}}\n\n{keep_alive}data: {{"type": "RUN_FINISHED"}}\n\n'
+
+    assert get_event_types(parse_sse_events(body)) == ["RUN_STARTED", "RUN_FINISHED"]
+
+
+def test_a_stream_cut_after_its_terminal_line_cannot_satisfy_the_absence_gate():
+    """A cut connection leaves the last block with no empty line to end it.
+
+    The browser discards an unterminated block, and reading one here would hand a
+    truncated run the RUN_FINISHED that assert_event_absent treats as proof the run
+    reached its end, which is the vacuous pass this file exists to rule out.
+    """
+    body = 'data: {"type": "RUN_STARTED"}\n\ndata: {"type": "RUN_FINISHED"}'
+
+    types = get_event_types(parse_sse_events(body))
+
+    assert types == ["RUN_STARTED"]
+    with pytest.raises(AssertionError, match="never finished"):
+        assert_event_absent(types, "STATE_DELTA")
+
+
+def test_a_stream_cut_inside_its_last_payload_is_not_read_as_an_event():
+    """The same cut a line earlier: the fragment must not be parsed or reported as JSON."""
+    body = 'data: {"type": "RUN_STARTED"}\n\ndata: {"type": "RUN_FINIS'
+
+    assert get_event_types(parse_sse_events(body)) == ["RUN_STARTED"]
+
+
+def test_a_payload_that_is_not_json_is_refused():
+    body = 'data: {"type": "RUN_STARTED"}\n\ndata: not-json\n\n'
+
+    with pytest.raises(AssertionError, match="not valid JSON"):
+        parse_sse_events(body)
+
+
+@pytest.mark.parametrize(
+    "payload", ['"a string"', "42", "null", "true", "[1, 2]"], ids=["string", "number", "null", "bool", "array"]
+)
+def test_a_payload_that_is_valid_json_but_not_an_object_is_refused(payload):
+    """Handing one on surfaces as an attribute error several frames later, naming
+    nothing about the body that caused it."""
+    with pytest.raises(AssertionError, match="not a JSON object"):
+        parse_sse_events(f"data: {payload}\n\n")
+
+
+def test_a_frame_without_a_type_is_refused():
+    """No assertion in these suites can match a typeless frame, so letting one through
+    quietly shortens the stream that the presence and absence checks read."""
+    with pytest.raises(AssertionError, match="carries no type"):
+        get_event_types(parse_sse_events('data: {"threadId": "t"}\n\n'))
+
+
+def test_absence_needs_a_stream_that_started():
+    with pytest.raises(AssertionError, match="never started"):
+        assert_event_absent(["RUN_FINISHED"], "STATE_DELTA")
+
+
+def test_absence_needs_a_run_that_finished():
+    """The route can fail before RUN_STARTED is yielded or after it, so a start is not
+    evidence the run got far enough for the absence to mean anything."""
+    with pytest.raises(AssertionError, match="never finished"):
+        assert_event_absent(["RUN_STARTED", "RUN_ERROR"], "STATE_DELTA")
+
+    assert_event_absent(["RUN_STARTED", "RUN_FINISHED"], "STATE_DELTA")
+
+
+def wire_run(*body):
+    return [
+        {"type": "RUN_STARTED", "threadId": "t", "runId": "r"},
+        *body,
+        {"type": "RUN_FINISHED", "threadId": "t", "runId": "r"},
+    ]
+
+
+@requires_ag_ui
+def test_a_well_formed_wire_stream_passes_the_protocol_check():
+    assert_valid_wire_stream(
+        wire_run(
+            {"type": "STEP_STARTED", "stepName": "Greet"},
+            {"type": "TEXT_MESSAGE_START", "messageId": "m1", "role": "assistant"},
+            {"type": "TEXT_MESSAGE_CONTENT", "messageId": "m1", "delta": "hi"},
+            {"type": "TEXT_MESSAGE_END", "messageId": "m1"},
+            {"type": "STEP_FINISHED", "stepName": "Greet"},
+        )
+    )
+
+
+@requires_ag_ui
+def test_a_wire_stream_leaving_a_step_open_is_refused():
+    with pytest.raises(AssertionError, match="still open at the terminal event"):
+        assert_valid_wire_stream(wire_run({"type": "STEP_STARTED", "stepName": "Greet"}))
+
+
+@requires_ag_ui
+def test_a_wire_stream_leaving_a_tool_call_open_is_refused():
+    with pytest.raises(AssertionError, match="still open at the terminal event"):
+        assert_valid_wire_stream(wire_run({"type": "TOOL_CALL_START", "toolCallId": "c1", "toolCallName": "lookup"}))
+
+
+@requires_ag_ui
+def test_a_misspelled_field_name_on_the_wire_is_refused():
+    """The protocol models allow extra fields, so this validates cleanly on its own."""
+    with pytest.raises(AssertionError, match=r"\['mesageId'\]"):
+        assert_valid_wire_stream(
+            wire_run(
+                {"type": "TEXT_MESSAGE_START", "mesageId": "m1", "messageId": "m1", "role": "assistant"},
+                {"type": "TEXT_MESSAGE_CONTENT", "messageId": "m1", "delta": "hi"},
+                {"type": "TEXT_MESSAGE_END", "messageId": "m1"},
+            )
+        )
+
+
+@requires_ag_ui
+def test_a_field_left_in_snake_case_on_the_wire_is_refused():
+    """The models accept the snake_case spelling of every field, so this validates
+    cleanly too, while the browser reads the camelCase key and finds nothing."""
+    with pytest.raises(AssertionError, match=r"\['message_id'\]"):
+        assert_valid_wire_stream(
+            wire_run(
+                {"type": "TEXT_MESSAGE_START", "message_id": "m1", "role": "assistant"},
+                {"type": "TEXT_MESSAGE_CONTENT", "messageId": "m1", "delta": "hi"},
+                {"type": "TEXT_MESSAGE_END", "messageId": "m1"},
+            )
+        )
+
+
+@requires_ag_ui
+def test_an_undeclared_key_on_the_wire_is_refused():
+    with pytest.raises(AssertionError, match=r"\['totallyMadeUp'\]"):
+        assert_valid_wire_stream(wire_run({"type": "STEP_STARTED", "stepName": "Greet", "totallyMadeUp": 1}))

--- a/libs/agno/tests/integration/os/interfaces/test_agui_state_events.py
+++ b/libs/agno/tests/integration/os/interfaces/test_agui_state_events.py
@@ -1,5 +1,4 @@
-import json
-from typing import Any, Dict, List
+import os
 
 import pytest
 from fastapi.testclient import TestClient
@@ -10,40 +9,16 @@ from agno.os.app import AgentOS
 from agno.run import RunContext
 from agno.team import Team
 
+from ._agui_sse import assert_event_absent, get_event_types, make_request_body, parse_sse_events
+
 pytest.importorskip("ag_ui", reason="ag_ui not installed")
 
-from agno.os.interfaces.agui import AGUI
+from agno.os.interfaces.agui import AGUI  # noqa: E402
 
-
-def parse_sse_events(content: str) -> List[Dict[str, Any]]:
-    events = []
-    for line in content.split("\n"):
-        line = line.strip()
-        if not line or not line.startswith("data:"):
-            continue
-        data_str = line[5:].strip()
-        try:
-            events.append(json.loads(data_str))
-        except json.JSONDecodeError:
-            continue
-    return events
-
-
-def get_event_types(events: List[Dict[str, Any]]) -> List[str]:
-    return [e.get("type") for e in events]
-
-
-def make_request_body(message: str, state: Any = None, thread_id: str = "test-thread") -> Dict[str, Any]:
-    return {
-        "threadId": thread_id,
-        "runId": "test-run",
-        "state": state,
-        "messages": [{"id": "msg-1", "role": "user", "content": message}],
-        "tools": [],
-        "context": [],
-        "forwardedProps": {},
-    }
-
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"),
+]
 
 # =============================================================================
 # Tools that mutate session state
@@ -87,20 +62,21 @@ class TestAgentStateEventsIntegration:
 When asked to add items, use the add_item_to_list tool.
 When asked to increment, use the increment_counter tool.
 Be brief in your responses.""",
+            telemetry=False,
         )
 
     @pytest.fixture
     def client(self, state_agent: Agent):
-        agent_os = AgentOS(agents=[state_agent], interfaces=[AGUI(agent=state_agent)])
-        app = agent_os.get_app()
-        return TestClient(app)
+        agent_os = AgentOS(agents=[state_agent], interfaces=[AGUI(agent=state_agent)], telemetry=False)
+        # As a context manager so the app lifespan runs, which is what a served AgentOS does.
+        with TestClient(agent_os.get_app()) as client:
+            yield client
 
     def test_initial_and_final_snapshot_with_real_agent(self, client):
         """Real agent emits initial and final STATE_SNAPSHOT when state is provided."""
         response = client.post(
             "/agui",
             json=make_request_body("Say hello briefly", state={"counter": 0}),
-            timeout=60.0,
         )
 
         assert response.status_code == 200
@@ -127,15 +103,14 @@ Be brief in your responses.""",
         response = client.post(
             "/agui",
             json=make_request_body("Say hello briefly", state=None),
-            timeout=60.0,
         )
 
         assert response.status_code == 200
         events = parse_sse_events(response.text)
         types = get_event_types(events)
 
-        assert "STATE_SNAPSHOT" not in types
-        assert "STATE_DELTA" not in types
+        assert_event_absent(types, "STATE_SNAPSHOT")
+        assert_event_absent(types, "STATE_DELTA")
         assert "RUN_FINISHED" in types
 
     def test_state_delta_emitted_when_tool_mutates_state(self, client):
@@ -146,7 +121,6 @@ Be brief in your responses.""",
                 "Add 'milk' to my list using the tool",
                 state={"items": []},
             ),
-            timeout=60.0,
         )
 
         assert response.status_code == 200
@@ -182,7 +156,6 @@ Be brief in your responses.""",
                 "Increment the counter by 5 using the tool",
                 state={"counter": 0},
             ),
-            timeout=60.0,
         )
 
         assert response.status_code == 200
@@ -208,7 +181,6 @@ Be brief in your responses.""",
                 "Add 'eggs' to my list",
                 state={"metadata": {"created": "today"}, "items": []},
             ),
-            timeout=60.0,
         )
 
         assert response.status_code == 200
@@ -235,25 +207,27 @@ class TestTeamStateEventsIntegration:
             model=OpenAIChat(id="gpt-4o-mini"),
             tools=[add_item_to_list],
             instructions="You manage a shopping list. Use add_item_to_list when asked to add items.",
+            telemetry=False,
         )
         return Team(
             name="state-test-team",
             members=[member],
             instructions="Delegate list management to the list-manager agent.",
+            telemetry=False,
         )
 
     @pytest.fixture
     def team_client(self, state_team: Team):
-        agent_os = AgentOS(teams=[state_team], interfaces=[AGUI(team=state_team)])
-        app = agent_os.get_app()
-        return TestClient(app)
+        agent_os = AgentOS(teams=[state_team], interfaces=[AGUI(team=state_team)], telemetry=False)
+        # As a context manager so the app lifespan runs, which is what a served AgentOS does.
+        with TestClient(agent_os.get_app()) as client:
+            yield client
 
     def test_team_emits_state_snapshots(self, team_client):
         """Team emits initial and final STATE_SNAPSHOT."""
         response = team_client.post(
             "/agui",
             json=make_request_body("Say hello", state={"task": "pending"}),
-            timeout=60.0,
         )
 
         assert response.status_code == 200
@@ -269,12 +243,11 @@ class TestTeamStateEventsIntegration:
         response = team_client.post(
             "/agui",
             json=make_request_body("Say hello", state=None),
-            timeout=60.0,
         )
 
         assert response.status_code == 200
         events = parse_sse_events(response.text)
         types = get_event_types(events)
 
-        assert "STATE_SNAPSHOT" not in types
-        assert "STATE_DELTA" not in types
+        assert_event_absent(types, "STATE_SNAPSHOT")
+        assert_event_absent(types, "STATE_DELTA")

--- a/libs/agno/tests/integration/os/interfaces/test_agui_workflow.py
+++ b/libs/agno/tests/integration/os/interfaces/test_agui_workflow.py
@@ -1,0 +1,122 @@
+import os
+from typing import Dict
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+from agno.os.app import AgentOS
+from agno.workflow.step import Step
+from agno.workflow.types import StepInput, StepOutput
+from agno.workflow.workflow import Workflow
+
+from ._agui_sse import (
+    assert_event_absent,
+    assert_valid_wire_stream,
+    get_event_types,
+    make_request_body,
+    parse_sse_events,
+)
+
+pytest.importorskip("ag_ui", reason="ag_ui not installed")
+
+from agno.os.interfaces.agui import AGUI  # noqa: E402
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"),
+]
+
+THREAD_ID = "workflow-thread"
+RUN_ID = "workflow-run"
+CLIENT_STATE = {"seen": 0}
+
+
+def summarize_length(step_input: StepInput) -> StepOutput:
+    """A step with no model, so the interface has to surface its output itself."""
+    previous = str(step_input.previous_step_content or "")
+    return StepOutput(content=f"The greeting was {len(previous.split())} words long.")
+
+
+# Every test below reads the same run, so it is paid for once per module.
+@pytest.fixture(scope="module")
+def response():
+    greeter = Agent(
+        name="workflow-greeter",
+        model=OpenAIChat(id="gpt-4o-mini"),
+        instructions="Greet the user in one short sentence.",
+        telemetry=False,
+    )
+    workflow = Workflow(
+        id="agui-integration-workflow",
+        name="Greeting Workflow",
+        steps=[
+            Step(name="Greet", agent=greeter),
+            Step(name="Measure", executor=summarize_length),
+        ],
+        telemetry=False,
+    )
+    agent_os = AgentOS(workflows=[workflow], interfaces=[AGUI(workflow=workflow)], telemetry=False)
+    # As a context manager so the app lifespan runs, which is what a served AgentOS does.
+    with TestClient(agent_os.get_app()) as client:
+        return client.post(
+            "/agui",
+            json=make_request_body("Say hello", state=CLIENT_STATE, thread_id=THREAD_ID, run_id=RUN_ID),
+        )
+
+
+@pytest.fixture(scope="module")
+def events(response):
+    return parse_sse_events(response.text)
+
+
+class TestWorkflowOverAGUI:
+    """A Workflow served over AG-UI, run end to end against a real model."""
+
+    def test_workflow_run_completes_end_to_end(self, response, events):
+        assert response.status_code == 200
+
+        types = get_event_types(events)
+        assert_event_absent(types, "RUN_ERROR")
+
+        assert types[0] == "RUN_STARTED"
+        assert types[-1] == "RUN_FINISHED"
+
+    def test_the_served_stream_obeys_the_protocol_framing_rules(self, events):
+        """The hand-built chunk lists in the mapper suites cannot stand in for this one."""
+        assert_valid_wire_stream(events)
+
+    def test_every_step_span_is_balanced(self, events):
+        started = [e.get("stepName") for e in events if e.get("type") == "STEP_STARTED"]
+        finished = [e.get("stepName") for e in events if e.get("type") == "STEP_FINISHED"]
+
+        assert started == ["Greet", "Measure"]
+        assert finished == ["Greet", "Measure"]
+
+    def test_both_the_agent_step_and_the_plain_step_produce_text(self, events):
+        by_message: Dict[str, str] = {}
+        for event in events:
+            if event.get("type") == "TEXT_MESSAGE_CONTENT":
+                by_message.setdefault(event["messageId"], "")
+                by_message[event["messageId"]] += event["delta"]
+
+        messages = list(by_message.values())
+        assert len(messages) >= 2
+        assert any("words long" in message for message in messages)
+
+    def test_state_snapshots_bracket_the_run_and_carry_the_state(self, events):
+        types = get_event_types(events)
+        snapshots = [e["snapshot"] for e in events if e.get("type") == "STATE_SNAPSHOT"]
+
+        assert types[1] == "STATE_SNAPSHOT"
+        assert types[-2] == "STATE_SNAPSHOT"
+        assert types[-1] == "RUN_FINISHED"
+
+        assert snapshots[0] == CLIENT_STATE
+
+        # Nothing here writes session state of its own: the terminal WorkflowCompletedEvent
+        # carries none, and a plain function step gets no handle on it. So the closing
+        # snapshot is the client's own state plus the run identity the interface handed
+        # down. Asserting it exactly is what keeps other internals out of the browser.
+        assert snapshots[-1] == {**CLIENT_STATE, "current_session_id": THREAD_ID, "current_run_id": RUN_ID}

--- a/libs/agno/tests/integration/os/interfaces/test_telemetry_guard.py
+++ b/libs/agno/tests/integration/os/interfaces/test_telemetry_guard.py
@@ -1,0 +1,77 @@
+"""The conftest telemetry guard, checked from inside the directory it covers.
+
+Every other suite here passes whether or not the guard is installed, because none of
+them posts telemetry on purpose. So the guard's own properties, that it stands on every
+telemetry entry point and that it is armed early enough for the module-scoped fixture
+that performs the expensive run, need saying out loud. None of them needs a model or the
+network.
+
+Each entry point is recognised by identity, and before anything is called. Calling one
+to find out whether it is guarded is the regression itself: on the run where the guard
+is missing or installed too late, that call is a telemetry post to the live endpoint.
+"""
+
+import pytest
+
+from agno.api.api import Api
+from agno.api.api import api as agno_api
+
+from .conftest import TELEMETRY_ENTRY_POINTS, install_telemetry_guard, refuse_telemetry_post
+
+
+@pytest.fixture(scope="module")
+def hook_seen_by_a_module_fixture(request):
+    """Record the telemetry hook as a module-scoped fixture finds it.
+
+    The runs in this directory are performed by fixtures at this scope, which are set up
+    before any function-scoped fixture exists. A guard installed later than this would
+    miss exactly the calls worth catching, so the scope is what gives this fixture its
+    point and is asserted rather than assumed.
+    """
+    assert request.scope == "module"
+    return agno_api.post_in_background
+
+
+@pytest.mark.parametrize("entry_point", TELEMETRY_ENTRY_POINTS)
+def test_the_guard_stands_on_every_telemetry_entry_point(entry_point):
+    assert getattr(agno_api, entry_point) is refuse_telemetry_post
+
+
+def test_the_guard_refuses_a_telemetry_post():
+    assert agno_api.post_in_background is refuse_telemetry_post
+
+    with pytest.raises(pytest.fail.Exception, match="posted telemetry"):
+        agno_api.post_in_background("os-launch", {})
+
+
+async def test_the_guard_refuses_an_async_telemetry_post():
+    """The async entry point is public and awaited from event-loop code. It delegates to
+    the sync one today, so nothing here depends on it continuing to."""
+    assert agno_api.apost_in_background is refuse_telemetry_post
+
+    with pytest.raises(pytest.fail.Exception, match="posted telemetry"):
+        await agno_api.apost_in_background("os-launch", {})
+
+
+def test_the_guard_is_armed_before_a_module_scoped_fixture_is_set_up(hook_seen_by_a_module_fixture):
+    assert hook_seen_by_a_module_fixture is refuse_telemetry_post
+
+
+def test_the_undo_leaves_the_instance_reading_its_class_again():
+    """Writing back what ``getattr`` returned pins a bound method on the instance, which
+    then answers every later call however the class changes. The telemetry client is a
+    module-level singleton, so a pin put there outlives this directory."""
+
+    class ApiUnderTest(Api):
+        pass
+
+    target = ApiUnderTest()
+    undo = install_telemetry_guard(target)
+    assert target.post_in_background is refuse_telemetry_post
+    undo()
+
+    for name in TELEMETRY_ENTRY_POINTS:
+        assert name not in vars(target)
+
+    ApiUnderTest.post_in_background = lambda self, route, payload: "from the class"
+    assert target.post_in_background("agent-run", {}) == "from the class"

--- a/libs/agno/tests/integration/os/test_telemetry_guard_scope.py
+++ b/libs/agno/tests/integration/os/test_telemetry_guard_scope.py
@@ -1,0 +1,16 @@
+"""The interfaces telemetry guard must not outlive the directory that installs it.
+
+pytest collects the interfaces package before the modules beside it, so a guard held for
+the whole session is still patched in here. It refuses with pytest.fail, which raises
+outside the `except Exception` every telemetry call site uses, and so takes down the
+AgentOS lifespan of suites that post telemetry on purpose. This module has no AG-UI
+content of its own; it exists to catch that regression.
+"""
+
+from agno.api.api import api as agno_api
+
+
+def test_telemetry_is_not_patched_outside_the_interfaces_directory():
+    assert agno_api.post_in_background.__module__.startswith("agno."), (
+        "the interfaces telemetry guard is still installed here; scope it to its own directory"
+    )

--- a/libs/agno/tests/unit/os/interfaces/_agui_mappers.py
+++ b/libs/agno/tests/unit/os/interfaces/_agui_mappers.py
@@ -1,0 +1,58 @@
+"""Drive a chunk sequence through the AG-UI mappers.
+
+stream.py keeps the sync and async mappers as near-duplicate implementations and the
+served HTTP route uses the async one, so a mapping test is worth running against both.
+Every stream driven through `validated` is also checked against the framing rules in
+`_agui_stream_rules`, so no test can assert its own two or three events while emitting a
+sequence that breaks the run, the step spans, a message or a tool call around it.
+"""
+
+import asyncio
+
+from agno.os.interfaces.agui.stream import (
+    async_stream_agno_response_as_agui_events,
+    stream_agno_response_as_agui_events,
+)
+
+from ._agui_stream_rules import assert_valid_agui_stream
+
+
+def drive_sync_mapper(chunks):
+    return list(stream_agno_response_as_agui_events(iter(chunks), thread_id="thread-1", run_id="run-1"))
+
+
+async def as_async_iterator(chunks):
+    if hasattr(chunks, "__aiter__"):
+        async for chunk in chunks:
+            yield chunk
+        return
+    for chunk in chunks:
+        yield chunk
+
+
+async def drain_async_mapper(chunks):
+    return [
+        event
+        async for event in async_stream_agno_response_as_agui_events(
+            as_async_iterator(chunks), thread_id="thread-1", run_id="run-1"
+        )
+    ]
+
+
+def drive_async_mapper(chunks):
+    return asyncio.run(drain_async_mapper(chunks))
+
+
+MAPPER_DRIVERS = [drive_sync_mapper, drive_async_mapper]
+MAPPER_IDS = ["sync_mapper", "async_mapper"]
+
+
+def validated(driver):
+    """Wrap a driver so the stream it produces is checked against the protocol rules."""
+
+    def run(chunks):
+        events = driver(chunks)
+        assert_valid_agui_stream(events)
+        return events
+
+    return run

--- a/libs/agno/tests/unit/os/interfaces/_agui_stream_rules.py
+++ b/libs/agno/tests/unit/os/interfaces/_agui_stream_rules.py
@@ -1,0 +1,183 @@
+"""Framing rules the AG-UI reference client enforces on an event stream.
+
+The TypeScript client verifies every stream it receives and aborts the run on the first
+violation, so a sequence this suite accepts but the client rejects is a defect the
+browser sees and the tests do not. Per-scenario assertions cannot catch that: they check
+the two deltas or the three span names the author had in mind, never the properties that
+hold over the whole stream.
+
+Five families of the client's rules are checked here, and nothing else: run framing,
+step spans, text-message framing, tool-call framing, and the shape a tool call's
+arguments arrive in. That is a subset, not a port. The client also rejects a text
+message opened while a tool call is in flight and the reverse, and it type-checks the
+rest of each payload; neither is checked here, so a stream this helper accepts is not
+certified against the client, only shown to be free of the faults below.
+
+One rule here is a house rule rather than the client's: an empty text message. The
+client accepts a message that carries no content, and the shipped mapper emits one
+deliberately, both as the parent message a tool call needs and as the assistant turn a
+pause with no text still has to open. What that leaves worth catching is the accidental
+shape, a message opened and then closed only after other events have gone out with no
+content ever arriving, so that is what the rule says.
+
+The mappers emit the body of a stream; the HTTP route prepends RUN_STARTED and the
+initial state snapshot. The RUN_STARTED rule therefore applies only when the event is
+present, which keeps the checker honest for a served stream without weakening it here.
+"""
+
+import json
+from typing import Any, Dict, List, Optional
+
+from ag_ui.core import EventType
+
+TERMINAL_TYPES = (EventType.RUN_FINISHED, EventType.RUN_ERROR)
+
+
+def _fail(rule: str, events: List[Any]) -> None:
+    raise AssertionError(f"AG-UI protocol violation: {rule}\nstream was: {[event.type for event in events]}")
+
+
+def _check_run_framing(events: List[Any]) -> None:
+    types = [event.type for event in events]
+
+    if not events:
+        _fail("the stream carried no events at all", events)
+
+    started = types.count(EventType.RUN_STARTED)
+    if started > 1:
+        _fail("RUN_STARTED appears more than once", events)
+    if started == 1 and types[0] != EventType.RUN_STARTED:
+        _fail("RUN_STARTED is not the first event", events)
+
+    terminals = [index for index, event_type in enumerate(types) if event_type in TERMINAL_TYPES]
+    if not terminals:
+        _fail("the stream never reached RUN_FINISHED or RUN_ERROR", events)
+    if len(terminals) > 1:
+        _fail("the stream carries more than one terminal event", events)
+    if terminals[0] != len(types) - 1:
+        _fail(f"{types[terminals[0]]} is not the last event", events)
+
+
+def _check_step_spans(events: List[Any]) -> None:
+    active: List[str] = []
+    for event in events:
+        if event.type == EventType.STEP_STARTED:
+            if event.step_name in active:
+                _fail(f'step "{event.step_name}" is started while already active', events)
+            active.append(event.step_name)
+        elif event.type == EventType.STEP_FINISHED:
+            if event.step_name not in active:
+                _fail(f'step "{event.step_name}" is finished while not active', events)
+            active.remove(event.step_name)
+        elif event.type in TERMINAL_TYPES and active:
+            _fail(f"steps {active} are still open at the terminal event", events)
+
+
+def _check_text_messages(events: List[Any]) -> None:
+    open_id: Optional[str] = None
+    opened_at = -1
+    content_seen = False
+    for index, event in enumerate(events):
+        if event.type == EventType.TEXT_MESSAGE_START:
+            if open_id is not None:
+                _fail(f"message {event.message_id} starts while message {open_id} is still open", events)
+            open_id = event.message_id
+            opened_at = index
+            content_seen = False
+        elif event.type == EventType.TEXT_MESSAGE_CONTENT:
+            if open_id is None:
+                _fail(f"content for message {event.message_id} arrives outside a message", events)
+            if event.message_id != open_id:
+                _fail(f"content for message {event.message_id} arrives inside message {open_id}", events)
+            content_seen = True
+        elif event.type == EventType.TEXT_MESSAGE_END:
+            if open_id is None:
+                _fail(f"message {event.message_id} ends without having started", events)
+            if event.message_id != open_id:
+                _fail(f"message {event.message_id} ends while message {open_id} is open", events)
+            if not content_seen and index != opened_at + 1:
+                _fail(
+                    f"message {open_id} carries no content and is closed only after other events went out",
+                    events,
+                )
+            open_id = None
+        elif event.type in TERMINAL_TYPES and open_id is not None:
+            _fail(f"message {open_id} is still open at the terminal event", events)
+
+
+def _check_tool_calls(events: List[Any]) -> None:
+    open_id: Optional[str] = None
+    closed: List[str] = []
+    resulted: List[str] = []
+    seen: List[str] = []
+    for event in events:
+        if event.type == EventType.TOOL_CALL_START:
+            if open_id is not None:
+                _fail(f"tool call {event.tool_call_id} starts while tool call {open_id} is still open", events)
+            if event.tool_call_id in seen:
+                _fail(f"tool call id {event.tool_call_id} is started twice in one stream", events)
+            open_id = event.tool_call_id
+            seen.append(event.tool_call_id)
+        elif event.type == EventType.TOOL_CALL_ARGS:
+            if open_id is None:
+                _fail(f"arguments for tool call {event.tool_call_id} arrive outside a tool call", events)
+            if event.tool_call_id != open_id:
+                _fail(f"arguments for tool call {event.tool_call_id} arrive inside tool call {open_id}", events)
+        elif event.type == EventType.TOOL_CALL_END:
+            if open_id is None:
+                _fail(f"tool call {event.tool_call_id} ends without having started", events)
+            if event.tool_call_id != open_id:
+                _fail(f"tool call {event.tool_call_id} ends while tool call {open_id} is open", events)
+            closed.append(open_id)
+            open_id = None
+        elif event.type == EventType.TOOL_CALL_RESULT:
+            if event.tool_call_id in resulted:
+                _fail(f"a second result arrives for tool call {event.tool_call_id}", events)
+            if event.tool_call_id not in closed:
+                _fail(f"a result arrives for tool call {event.tool_call_id}, which never ended", events)
+            resulted.append(event.tool_call_id)
+        elif event.type in TERMINAL_TYPES and open_id is not None:
+            _fail(f"tool call {open_id} is still open at the terminal event", events)
+
+
+def _check_tool_call_arguments(events: List[Any]) -> None:
+    """A tool call's arguments have to arrive as the object that renders it.
+
+    The client reads the deltas of one call as a single JSON document and hands it to
+    whatever renders the call, which reads an argument list as an object. A call made
+    without any arguments is therefore an empty object; a null is the absence of a
+    document rather than a document saying nothing, and the render has no keys to read
+    off it. The deltas are concatenated before being read, because a call whose
+    arguments arrive in pieces is only a document once all of them have.
+    """
+    deltas: Dict[str, str] = {}
+    order: List[str] = []
+    for event in events:
+        if event.type != EventType.TOOL_CALL_ARGS:
+            continue
+        if event.tool_call_id not in deltas:
+            deltas[event.tool_call_id] = ""
+            order.append(event.tool_call_id)
+        deltas[event.tool_call_id] += event.delta
+
+    for tool_call_id in order:
+        raw = deltas[tool_call_id]
+        try:
+            arguments = json.loads(raw)
+        except json.JSONDecodeError:
+            _fail(f"the arguments of tool call {tool_call_id} are not valid JSON: {raw!r}", events)
+            continue
+        if not isinstance(arguments, dict):
+            _fail(
+                f"the arguments of tool call {tool_call_id} arrive as {raw!r}, which is not the object a render reads",
+                events,
+            )
+
+
+def assert_valid_agui_stream(events: List[Any]) -> None:
+    """Assert an emitted event list is free of the framing faults documented above."""
+    _check_run_framing(events)
+    _check_step_spans(events)
+    _check_text_messages(events)
+    _check_tool_calls(events)
+    _check_tool_call_arguments(events)

--- a/libs/agno/tests/unit/os/interfaces/conftest.py
+++ b/libs/agno/tests/unit/os/interfaces/conftest.py
@@ -1,0 +1,61 @@
+import pytest
+
+from agno.api.api import api as agno_api
+
+TELEMETRY_ENTRY_POINTS = ("post_in_background", "apost_in_background")
+
+
+def refuse_telemetry_post(route: str, payload: dict) -> None:
+    """Stand in for every telemetry entry point and fail the test that reached one.
+
+    A plain function, not a closure, so the guard's own tests can recognise it by
+    identity rather than by the message it happens to raise.
+    """
+    pytest.fail(f"a unit test posted telemetry to {route}; build the entity with telemetry=False")
+
+
+def install_telemetry_guard(target=agno_api):
+    """Put the guard on every telemetry entry point and return the undo.
+
+    The undo removes the attributes this added rather than writing back what
+    ``getattr`` returned, which would be a bound method and would stay on this
+    process-wide instance for good, shadowing the class attribute for every later
+    test in the run.
+    """
+    previous = {name: vars(target).get(name, ...) for name in TELEMETRY_ENTRY_POINTS}
+    for name in TELEMETRY_ENTRY_POINTS:
+        setattr(target, name, refuse_telemetry_post)
+
+    def undo() -> None:
+        for name, value in previous.items():
+            if value is ...:
+                delattr(target, name)
+            else:
+                setattr(target, name, value)
+
+    return undo
+
+
+@pytest.fixture(autouse=True)
+def no_outbound_telemetry():
+    """Fail any test in this directory that reaches the telemetry endpoint.
+
+    A unit test must not touch the network. Adding telemetry=False to one builder only
+    fixes the builder someone noticed; this catches every entity built here, including
+    the ones written later, and it has to sit in the conftest rather than in one module
+    or the sibling interface suites are left unguarded.
+
+    Both entry points are covered. The async one currently delegates to the sync one, so
+    guarding it changes nothing today, and that is the point: nothing about the delegation
+    is promised, and a guard that depends on it would be disarmed by an ordinary edit.
+
+    Every telemetry path funnels through these two on the calling thread, and each call
+    site wraps it in `except Exception` so telemetry can never change a run's outcome.
+    pytest.fail raises outside that hierarchy, so the failure reaches the test instead of
+    being logged and dropped.
+    """
+    undo = install_telemetry_guard()
+    try:
+        yield
+    finally:
+        undo()

--- a/libs/agno/tests/unit/os/interfaces/test_agui_hitl.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_hitl.py
@@ -9,6 +9,7 @@ Covers the gap #8565 leaves open:
 """
 
 import json
+from datetime import datetime
 from unittest.mock import MagicMock
 
 import pytest
@@ -39,9 +40,30 @@ from agno.run.team import RunPausedEvent as TeamRunPausedEvent
 from agno.tools import tool
 from agno.tools.function import UserFeedbackOption, UserFeedbackQuestion
 
+from ._agui_stream_rules import assert_valid_agui_stream
+
+
+def _emitted(chunk) -> list:
+    """Drive a pause through the handler, checking the framing of everything it emits.
+
+    A pause emits the approval cards and the run's terminal event in one batch, so the
+    batch is a whole stream and the same rules apply to it as to a mapper's output. The
+    per-test assertions below each name one tool_call_id; none of them would notice the
+    batch opening a message it never closes or ending a tool call it never started.
+    """
+    events = on_run_completed(chunk, StreamState())
+    assert_valid_agui_stream(events)
+    return events
+
 
 def _tool_call_start_ids(events) -> list:
     return [e.tool_call_id for e in events if type(e).__name__ == "ToolCallStartEvent"]
+
+
+def _tool_args_delta(events, tool_call_id: str) -> str:
+    deltas = [e.delta for e in events if type(e).__name__ == "ToolCallArgsEvent" and e.tool_call_id == tool_call_id]
+    assert len(deltas) == 1
+    return deltas[0]
 
 
 def _paused(tool: ToolExecution) -> RunPausedEvent:
@@ -70,7 +92,7 @@ class TestPauseEmission:
             tool_args={"steps": []},
             requires_confirmation=True,
         )
-        assert "tc-confirm" in _tool_call_start_ids(on_run_completed(_paused(tool), StreamState()))
+        assert "tc-confirm" in _tool_call_start_ids(_emitted(_paused(tool)))
 
     def test_requires_user_input_emits_tool_call(self):
         tool = ToolExecution(
@@ -79,7 +101,7 @@ class TestPauseEmission:
             tool_args={},
             requires_user_input=True,
         )
-        assert "tc-input" in _tool_call_start_ids(on_run_completed(_paused(tool), StreamState()))
+        assert "tc-input" in _tool_call_start_ids(_emitted(_paused(tool)))
 
     def test_external_execution_still_emits_tool_call(self):
         tool = ToolExecution(
@@ -88,7 +110,7 @@ class TestPauseEmission:
             tool_args={},
             external_execution_required=True,
         )
-        assert "tc-external" in _tool_call_start_ids(on_run_completed(_paused(tool), StreamState()))
+        assert "tc-external" in _tool_call_start_ids(_emitted(_paused(tool)))
 
     def test_user_feedback_emits_exactly_one_tool_call(self):
         """A user_feedback (ask_user) tool already surfaces via the user_input partition
@@ -107,8 +129,48 @@ class TestPauseEmission:
                 )
             ],
         )
-        ids = _tool_call_start_ids(on_run_completed(_paused(tool), StreamState()))
+        ids = _tool_call_start_ids(_emitted(_paused(tool)))
         assert ids.count("tc-feedback") == 1
+
+
+class TestPauseArguments:
+    """A pause emits its cards and the run's terminal event in one batch.
+
+    Serializing an argument is the one step in that batch that reads a value the tool
+    author chose, so it is the one step that can raise. The batch is built before any of
+    it is yielded, so raising sends none of it: the route catches the exception and the
+    client gets the run's error in place of the cards it would have answered with.
+    """
+
+    def test_an_argument_json_cannot_serialize_keeps_the_card_and_the_terminal_event(self):
+        tool = ToolExecution(
+            tool_call_id="tc-datetime",
+            tool_name="schedule_meeting",
+            tool_args={"starts_at": datetime(2026, 1, 2, 3, 4, 5), "title": "review"},
+            requires_confirmation=True,
+        )
+
+        events = _emitted(_paused(tool))
+
+        assert "tc-datetime" in _tool_call_start_ids(events)
+        assert type(events[-1]).__name__ == "RunFinishedEvent"
+        assert json.loads(_tool_args_delta(events, "tc-datetime")) == {
+            "starts_at": "2026-01-02 03:04:05",
+            "title": "review",
+        }
+
+    def test_absent_arguments_are_an_empty_object_not_a_null(self):
+        """A tool call's arguments are an object, and a card cannot read a null as one."""
+        tool = ToolExecution(
+            tool_call_id="tc-noargs",
+            tool_name="approve",
+            tool_args=None,
+            requires_confirmation=True,
+        )
+
+        events = _emitted(_paused(tool))
+
+        assert json.loads(_tool_args_delta(events, "tc-noargs")) == {}
 
 
 class TestPauseResolution:
@@ -257,8 +319,8 @@ class TestDedupe:
 
 class TestStreamWrappers:
     """The pause emission must surface through BOTH AG-UI stream wrappers (sync + async),
-    not only the path-agnostic on_run_completed. Both delegate to process_completion ->
-    on_run_completed; these drive a requires_confirmation pause through each wrapper.
+    not only the path-agnostic on_run_completed. Both delegate to the shared terminal
+    tracker -> on_run_completed; these drive a requires_confirmation pause through each wrapper.
     (The resume path is async-only - acontinue_run - so it has no sync twin to cover.)"""
 
     def test_sync_wrapper_emits_tool_call_on_confirmation_pause(self):
@@ -266,6 +328,7 @@ class TestStreamWrappers:
         events = list(
             stream_agno_response_as_agui_events(iter([RunPausedEvent(tools=[tool])]), thread_id="t", run_id="r")
         )
+        assert_valid_agui_stream(events)
         assert "tc-sync" in _tool_call_start_ids(events)
 
     async def test_async_wrapper_emits_tool_call_on_confirmation_pause(self):
@@ -281,6 +344,7 @@ class TestStreamWrappers:
                 _aiter([RunPausedEvent(tools=[tool])]), thread_id="t", run_id="r"
             )
         ]
+        assert_valid_agui_stream(events)
         assert "tc-async" in _tool_call_start_ids(events)
 
 
@@ -313,12 +377,12 @@ class TestUnresolvedGuard:
 
 class TestTeamPauseEmission:
     """A Team paused run carries member pauses (all types) in active_requirements with member_agent_id,
-    and the team leader's external tools in .tools. on_run_completed must surface both as TOOL_CALL_*
-    (deduped by tool_call_id), not just external_execution."""
+    and the team leader's external tools in .tools. on_run_completed must surface both as TOOL_CALL_*,
+    not just external_execution. Nothing dedupes the two channels; see the last test here."""
 
     def test_team_member_confirmation_emits_tool_call(self):
         req = _member_req(ToolExecution(tool_call_id="m-confirm", tool_name="send_email", requires_confirmation=True))
-        assert "m-confirm" in _tool_call_start_ids(on_run_completed(_team_paused(requirements=[req]), StreamState()))
+        assert "m-confirm" in _tool_call_start_ids(_emitted(_team_paused(requirements=[req])))
 
     def test_team_member_user_input_emits_tool_call(self):
         req = _member_req(
@@ -329,7 +393,7 @@ class TestTeamPauseEmission:
                 user_input_schema=[UserInputField(name="city", field_type=str)],
             )
         )
-        assert "m-input" in _tool_call_start_ids(on_run_completed(_team_paused(requirements=[req]), StreamState()))
+        assert "m-input" in _tool_call_start_ids(_emitted(_team_paused(requirements=[req])))
 
     def test_team_member_user_feedback_emits_tool_call(self):
         req = _member_req(
@@ -340,20 +404,32 @@ class TestTeamPauseEmission:
                 user_feedback_schema=[UserFeedbackQuestion(question="Pick", options=[UserFeedbackOption(label="a")])],
             )
         )
-        assert "m-feedback" in _tool_call_start_ids(on_run_completed(_team_paused(requirements=[req]), StreamState()))
+        assert "m-feedback" in _tool_call_start_ids(_emitted(_team_paused(requirements=[req])))
 
     def test_team_leader_external_still_emits(self):
         """Regression guard: leader external tools live in .tools; the seam switch must not drop them."""
         tool = ToolExecution(tool_call_id="leader-ext", tool_name="run_browser_tool", external_execution_required=True)
-        assert "leader-ext" in _tool_call_start_ids(on_run_completed(_team_paused(tools=[tool]), StreamState()))
+        assert "leader-ext" in _tool_call_start_ids(_emitted(_team_paused(tools=[tool])))
 
-    def test_team_pause_dedups_by_tool_call_id(self):
-        """A leader external tool sits in BOTH .tools and active_requirements; it must emit exactly once."""
+    def test_a_tool_reported_through_both_channels_is_announced_twice(self):
+        """A leader external tool sits in BOTH .tools and active_requirements.
+
+        The handler folds a requirement in when it names a member agent, and nothing
+        compares tool_call_ids across the two channels, so the same call is announced
+        twice and the reference client aborts the run on the second TOOL_CALL_START.
+        This pins what ships: the dedupe is a known gap held out of this change, and
+        both assertions below fail the moment it is closed.
+
+        Built with the file's own member-requirement helper on purpose. A bare
+        RunRequirement carries no member_agent_id, the handler skips it, and the count
+        then comes from .tools alone and holds whether a dedupe exists or not.
+        """
         tool = ToolExecution(tool_call_id="dup-ext", tool_name="run_browser_tool", external_execution_required=True)
-        ids = _tool_call_start_ids(
-            on_run_completed(_team_paused(requirements=[RunRequirement(tool)], tools=[tool]), StreamState())
-        )
-        assert ids.count("dup-ext") == 1
+        events = on_run_completed(_team_paused(requirements=[_member_req(tool)], tools=[tool]), StreamState())
+
+        assert _tool_call_start_ids(events).count("dup-ext") == 2
+        with pytest.raises(AssertionError, match="tool call id dup-ext is started twice in one stream"):
+            assert_valid_agui_stream(events)
 
     def test_team_member_requirement_resolves_via_existing_merge(self):
         """A member (member_agent_id) confirmation resolves through the EXISTING

--- a/libs/agno/tests/unit/os/interfaces/test_agui_router.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_router.py
@@ -10,7 +10,11 @@ from ag_ui.core.types import Tool as AGUITool
 
 from agno.agent.remote import RemoteAgent
 from agno.os.interfaces.agui.router import run_entity
+from agno.run.agent import RunContentEvent
+from agno.run.workflow import StepStartedEvent
 from agno.team.remote import RemoteTeam
+
+from ._agui_stream_rules import assert_valid_agui_stream
 
 
 class FakeRunInput:
@@ -218,3 +222,30 @@ async def test_run_entity_remote_agent_warns_and_drops_client_tools(caplog):
     assert "run_context" not in captured
     assert any("client tools are not forwarded" in record.message for record in caplog.records)
     assert events[-1].type == EventType.RUN_FINISHED
+
+
+class FailsPartWayThroughEntity:
+    """An entity whose run opens a workflow step and then raises out of the stream."""
+
+    async def arun(self, **kwargs):
+        yield StepStartedEvent(step_name="One", step_id="one")
+        yield RunContentEvent(content="half an answer", step_id="one")
+        raise RuntimeError("the executor blew up")
+
+
+@pytest.mark.asyncio
+async def test_a_run_that_fails_part_way_through_still_serves_a_valid_stream():
+    """The route ends a failed run with RUN_ERROR, and nothing may still be open at it.
+
+    The route catches the exception below the mapper, so the spans the client is holding
+    open are the mapper's to close: without them the served stream is one the client
+    rejects, which costs the user the error the run failed with.
+    """
+    events = [event async for event in run_entity(FailsPartWayThroughEntity(), FakeRunInput())]
+
+    assert_valid_agui_stream(events)
+
+    types = [event.type for event in events]
+    assert types[-1] == EventType.RUN_ERROR
+    assert types.index(EventType.STEP_FINISHED) < types.index(EventType.RUN_ERROR)
+    assert events[-1].message == "the executor blew up"

--- a/libs/agno/tests/unit/os/interfaces/test_agui_run_content.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_run_content.py
@@ -1,0 +1,114 @@
+"""What an agent or team run puts on the stream as content.
+
+RunContentEvent.content is typed Any and the mapper reads it with a helper written for
+message content, so the mapper meets shapes that helper cannot read. Failing to read one
+may cost the client that content. It must never cost the client the rest of the run: the
+mapper raising takes the stream down with it, and no terminal event ever arrives.
+"""
+
+import logging
+
+import pytest
+
+pytest.importorskip("ag_ui", reason="ag_ui not installed")
+
+from ag_ui.core import EventType
+
+from agno.models.message import Message
+from agno.run.agent import RunContentEvent
+from agno.run.team import RunContentEvent as TeamRunContentEvent
+
+from ._agui_mappers import MAPPER_DRIVERS, MAPPER_IDS, validated
+
+
+@pytest.fixture(params=MAPPER_DRIVERS, ids=MAPPER_IDS)
+def run_stream(request):
+    """Drive one chunk sequence through a mapper, once per mapper."""
+    return validated(request.param)
+
+
+def deltas_of(events):
+    return [event.delta for event in events if event.type == EventType.TEXT_MESSAGE_CONTENT]
+
+
+UNREADABLE_CONTENTS = [
+    pytest.param([1, 2, 3], id="list_of_ints"),
+    pytest.param([1.5], id="list_of_floats"),
+    pytest.param([None], id="list_of_nones"),
+    pytest.param([True], id="list_of_bools"),
+]
+
+
+@pytest.mark.parametrize("content", UNREADABLE_CONTENTS)
+def test_content_the_message_helper_cannot_read_costs_only_that_delta(run_stream, content):
+    """The helper probes a list's first element for keys, which a scalar has none of.
+
+    The run keeps streaming and still reaches its terminal event, and the deltas around
+    the one it could not read arrive as they were sent.
+    """
+    events = run_stream([RunContentEvent(content=content), RunContentEvent(content="the rest of the answer")])
+
+    assert events[-1].type == EventType.RUN_FINISHED
+    assert deltas_of(events) == ["the rest of the answer"]
+
+
+def test_content_the_message_helper_cannot_read_is_reported(caplog):
+    """Content the mapper drops has to leave a trace, or it cannot be diagnosed at all.
+
+    Swallowing the read and returning empty text is what keeps the run alive, and a
+    crash guard that reports nothing is the fault it was written to remove.
+    """
+    with caplog.at_level(logging.WARNING):
+        validated(MAPPER_DRIVERS[0])([RunContentEvent(content=[1, 2, 3]), RunContentEvent(content="the rest")])
+
+    assert "could not read content" in caplog.text
+
+
+@pytest.mark.parametrize("content", UNREADABLE_CONTENTS)
+def test_team_content_the_message_helper_cannot_read_costs_only_that_delta(run_stream, content):
+    """A team folds member output into the same reading, from the same helper."""
+    events = run_stream([TeamRunContentEvent(content=content), TeamRunContentEvent(content="the rest of the answer")])
+
+    assert events[-1].type == EventType.RUN_FINISHED
+    assert deltas_of(events) == ["the rest of the answer"]
+
+
+READABLE_CONTENTS = [
+    pytest.param("plain text", "plain text", id="str"),
+    pytest.param(
+        [{"type": "text", "text": "first"}, {"type": "text", "text": "second"}],
+        "first\nsecond",
+        id="list_of_typed_dicts",
+    ),
+    pytest.param([Message(role="user", content="from a message")], "from a message", id="list_of_messages"),
+    pytest.param({"summary": "a record"}, '"summary": "a record"', id="dict"),
+]
+
+
+@pytest.mark.parametrize("content, expected_delta", READABLE_CONTENTS)
+def test_content_the_message_helper_reads_is_sent_as_it_was_before(run_stream, content, expected_delta):
+    """Guarding the read must not change the text a shape that already worked produces."""
+    events = run_stream([RunContentEvent(content=content)])
+
+    deltas = deltas_of(events)
+    assert len(deltas) == 1
+    assert expected_delta in deltas[0]
+
+
+def test_a_team_content_event_carrying_member_responses_still_sends_the_leader_text(run_stream):
+    """`member_responses` is not a field of the team content event, and the one path that
+    can put it there rebuilds the event from a dict, where each member is a finished
+    RunOutput. The mapper's fold reads members that are themselves content events, so it
+    contributes nothing here and the leader's own text is the whole delta."""
+    rebuilt = TeamRunContentEvent.from_dict(
+        {
+            "event": "TeamRunContent",
+            "content": "leader text",
+            "member_responses": [{"agent_id": "a1", "run_id": "r1", "content": "member text"}],
+        }
+    )
+
+    events = run_stream([rebuilt])
+
+    assert events[-1].type == EventType.RUN_FINISHED
+    assert deltas_of(events) == ["leader text"]

--- a/libs/agno/tests/unit/os/interfaces/test_agui_stream_rules.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_stream_rules.py
@@ -1,0 +1,295 @@
+"""The protocol checker's own coverage.
+
+Every AG-UI suite that drives a mapper leans on this checker, so a rule it silently
+fails to enforce is a rule none of those suites enforces either. Each rule the checker
+states gets a stream that breaks it, and each family gets a stream that satisfies it.
+
+Three families word their terminal-event rule alike, so each of those refusals matches
+the whole sentence its own family emits. A bare "still open at the terminal event" would
+pass on any of the three, and a stream that broke the wrong rule would look checked.
+"""
+
+import pytest
+
+pytest.importorskip("ag_ui", reason="ag_ui not installed")
+
+from ag_ui.core import (  # noqa: E402
+    RunErrorEvent,
+    RunFinishedEvent,
+    RunStartedEvent,
+    StepFinishedEvent,
+    StepStartedEvent,
+    TextMessageContentEvent,
+    TextMessageEndEvent,
+    TextMessageStartEvent,
+    ToolCallArgsEvent,
+    ToolCallEndEvent,
+    ToolCallResultEvent,
+    ToolCallStartEvent,
+)
+
+from ._agui_stream_rules import assert_valid_agui_stream  # noqa: E402
+
+THREAD = {"thread_id": "thread-1", "run_id": "run-1"}
+
+
+def started():
+    return RunStartedEvent(**THREAD)
+
+
+def finished():
+    return RunFinishedEvent(**THREAD)
+
+
+def message(message_id="msg-1", text="hi"):
+    return [
+        TextMessageStartEvent(message_id=message_id),
+        TextMessageContentEvent(message_id=message_id, delta=text),
+        TextMessageEndEvent(message_id=message_id),
+    ]
+
+
+def tool_call(call_id="call-1", name="lookup"):
+    return [
+        ToolCallStartEvent(tool_call_id=call_id, tool_call_name=name),
+        ToolCallArgsEvent(tool_call_id=call_id, delta="{}"),
+        ToolCallEndEvent(tool_call_id=call_id),
+    ]
+
+
+def refuses(match, *events):
+    with pytest.raises(AssertionError, match=match):
+        assert_valid_agui_stream(list(events))
+
+
+class TestRunFraming:
+    def test_a_well_framed_run_passes(self):
+        assert_valid_agui_stream([started(), *message(), finished()])
+
+    def test_a_run_that_ends_in_an_error_passes(self):
+        assert_valid_agui_stream([started(), *message(), RunErrorEvent(message="stopped")])
+
+    def test_a_body_without_run_started_passes_because_the_route_prepends_it(self):
+        assert_valid_agui_stream([*message(), finished()])
+
+    def test_an_empty_stream_is_refused(self):
+        refuses("carried no events at all")
+
+    def test_run_started_twice_is_refused(self):
+        refuses("appears more than once", started(), started(), finished())
+
+    def test_run_started_after_another_event_is_refused(self):
+        refuses("is not the first event", StepStartedEvent(step_name="Plan"), started(), finished())
+
+    def test_a_stream_that_never_terminates_is_refused(self):
+        refuses("never reached RUN_FINISHED or RUN_ERROR", started())
+
+    def test_two_terminal_events_are_refused(self):
+        refuses("more than one terminal event", started(), finished(), RunErrorEvent(message="stopped"))
+
+    def test_a_terminal_event_that_is_not_last_is_refused(self):
+        refuses("is not the last event", started(), finished(), StepStartedEvent(step_name="Plan"))
+
+
+class TestStepSpans:
+    def test_nested_spans_pass(self):
+        assert_valid_agui_stream(
+            [
+                started(),
+                StepStartedEvent(step_name="Outer"),
+                StepStartedEvent(step_name="Inner"),
+                StepFinishedEvent(step_name="Inner"),
+                StepFinishedEvent(step_name="Outer"),
+                finished(),
+            ]
+        )
+
+    def test_a_step_started_while_already_active_is_refused(self):
+        refuses(
+            "is started while already active",
+            started(),
+            StepStartedEvent(step_name="Plan"),
+            StepStartedEvent(step_name="Plan"),
+            StepFinishedEvent(step_name="Plan"),
+            StepFinishedEvent(step_name="Plan"),
+            finished(),
+        )
+
+    def test_a_step_finished_while_not_active_is_refused(self):
+        refuses("is finished while not active", started(), StepFinishedEvent(step_name="Plan"), finished())
+
+    def test_a_step_left_open_at_the_terminal_event_is_refused(self):
+        refuses(
+            r"steps \['Plan'\] are still open at the terminal event",
+            started(),
+            StepStartedEvent(step_name="Plan"),
+            finished(),
+        )
+
+
+class TestTextMessages:
+    def test_a_well_framed_message_passes(self):
+        assert_valid_agui_stream([started(), *message(), finished()])
+
+    def test_an_empty_message_closed_immediately_passes(self):
+        """The mapper opens and closes one on purpose, as a tool call's parent message
+        and as the assistant turn a pause with no text still has to open."""
+        assert_valid_agui_stream(
+            [
+                started(),
+                TextMessageStartEvent(message_id="msg-1"),
+                TextMessageEndEvent(message_id="msg-1"),
+                *tool_call(),
+                finished(),
+            ]
+        )
+
+    def test_an_empty_message_closed_after_other_events_is_refused(self):
+        refuses(
+            "carries no content and is closed only after other events went out",
+            started(),
+            TextMessageStartEvent(message_id="msg-1"),
+            StepStartedEvent(step_name="Plan"),
+            StepFinishedEvent(step_name="Plan"),
+            TextMessageEndEvent(message_id="msg-1"),
+            finished(),
+        )
+
+    def test_a_message_started_inside_another_is_refused(self):
+        refuses(
+            "starts while message msg-1 is still open",
+            started(),
+            TextMessageStartEvent(message_id="msg-1"),
+            TextMessageStartEvent(message_id="msg-2"),
+            TextMessageEndEvent(message_id="msg-2"),
+            TextMessageEndEvent(message_id="msg-1"),
+            finished(),
+        )
+
+    def test_content_outside_a_message_is_refused(self):
+        refuses(
+            "arrives outside a message",
+            started(),
+            TextMessageContentEvent(message_id="msg-1", delta="hi"),
+            finished(),
+        )
+
+    def test_content_naming_another_message_is_refused(self):
+        refuses(
+            "content for message msg-2 arrives inside message msg-1",
+            started(),
+            TextMessageStartEvent(message_id="msg-1"),
+            TextMessageContentEvent(message_id="msg-2", delta="hi"),
+            TextMessageEndEvent(message_id="msg-1"),
+            finished(),
+        )
+
+    def test_an_end_without_a_start_is_refused(self):
+        refuses(
+            "ends without having started",
+            started(),
+            TextMessageEndEvent(message_id="msg-1"),
+            finished(),
+        )
+
+    def test_an_end_naming_another_message_is_refused(self):
+        refuses(
+            "message msg-2 ends while message msg-1 is open",
+            started(),
+            TextMessageStartEvent(message_id="msg-1"),
+            TextMessageContentEvent(message_id="msg-1", delta="hi"),
+            TextMessageEndEvent(message_id="msg-2"),
+            finished(),
+        )
+
+    def test_a_message_left_open_at_the_terminal_event_is_refused(self):
+        refuses(
+            "message msg-1 is still open at the terminal event",
+            started(),
+            TextMessageStartEvent(message_id="msg-1"),
+            TextMessageContentEvent(message_id="msg-1", delta="hi"),
+            finished(),
+        )
+
+
+class TestToolCalls:
+    def test_a_well_formed_tool_call_passes(self):
+        assert_valid_agui_stream(
+            [
+                started(),
+                *tool_call(),
+                ToolCallResultEvent(message_id="msg-1", tool_call_id="call-1", content="done"),
+                finished(),
+            ]
+        )
+
+    def test_a_tool_call_left_open_is_refused(self):
+        refuses(
+            "tool call call-1 is still open at the terminal event",
+            started(),
+            ToolCallStartEvent(tool_call_id="call-1", tool_call_name="lookup"),
+            ToolCallArgsEvent(tool_call_id="call-1", delta="{}"),
+            finished(),
+        )
+
+    def test_a_tool_call_id_started_twice_is_refused(self):
+        refuses("started twice", started(), *tool_call(), *tool_call(), finished())
+
+    def test_a_second_tool_call_opened_inside_the_first_is_refused(self):
+        refuses(
+            "starts while tool call call-1 is still open",
+            started(),
+            ToolCallStartEvent(tool_call_id="call-1", tool_call_name="lookup"),
+            ToolCallStartEvent(tool_call_id="call-2", tool_call_name="lookup"),
+            ToolCallEndEvent(tool_call_id="call-2"),
+            ToolCallEndEvent(tool_call_id="call-1"),
+            finished(),
+        )
+
+    def test_arguments_outside_a_tool_call_are_refused(self):
+        refuses(
+            "arrive outside a tool call",
+            started(),
+            ToolCallArgsEvent(tool_call_id="call-1", delta="{}"),
+            finished(),
+        )
+
+    def test_arguments_naming_another_tool_call_are_refused(self):
+        refuses(
+            "arguments for tool call call-2 arrive inside tool call call-1",
+            started(),
+            ToolCallStartEvent(tool_call_id="call-1", tool_call_name="lookup"),
+            ToolCallArgsEvent(tool_call_id="call-2", delta="{}"),
+            ToolCallEndEvent(tool_call_id="call-1"),
+            finished(),
+        )
+
+    def test_an_end_without_a_start_is_refused(self):
+        refuses("ends without having started", started(), ToolCallEndEvent(tool_call_id="call-1"), finished())
+
+    def test_an_end_naming_another_tool_call_is_refused(self):
+        refuses(
+            "call-2 ends while tool call call-1 is open",
+            started(),
+            ToolCallStartEvent(tool_call_id="call-1", tool_call_name="lookup"),
+            ToolCallEndEvent(tool_call_id="call-2"),
+            finished(),
+        )
+
+    def test_a_result_for_a_tool_call_that_never_ended_is_refused(self):
+        refuses(
+            "never ended",
+            started(),
+            ToolCallResultEvent(message_id="msg-1", tool_call_id="call-1", content="done"),
+            finished(),
+        )
+
+    def test_a_second_result_for_the_same_tool_call_is_refused(self):
+        refuses(
+            "a second result arrives for tool call call-1",
+            started(),
+            *tool_call(),
+            ToolCallResultEvent(message_id="msg-1", tool_call_id="call-1", content="done"),
+            ToolCallResultEvent(message_id="msg-2", tool_call_id="call-1", content="done again"),
+            finished(),
+        )

--- a/libs/agno/tests/unit/os/interfaces/test_agui_tool_calls.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_tool_calls.py
@@ -1,0 +1,201 @@
+"""How the AG-UI mapper frames tool calls.
+
+A tool call reaches the client as three events that have to agree with each other and
+with the message they hang under. The engine offers no guarantee that a tool execution
+carries an id, and it repeats a completed call whenever a run is replayed from history,
+so both of those have to leave the stream valid and still reach its terminal event.
+"""
+
+import json
+import logging
+from datetime import datetime
+
+import pytest
+
+pytest.importorskip("ag_ui", reason="ag_ui not installed")
+
+from ag_ui.core import EventType
+
+from agno.models.response import ToolExecution
+from agno.os.interfaces.agui.handlers import _tool_args_json, on_tool_call_completed
+from agno.os.interfaces.agui.state import StreamState
+from agno.run.agent import RunContentEvent, ToolCallCompletedEvent, ToolCallStartedEvent
+from agno.run.workflow import StepCompletedEvent, StepStartedEvent, WorkflowCompletedEvent
+
+from ._agui_mappers import MAPPER_DRIVERS, MAPPER_IDS, validated
+
+
+@pytest.fixture(params=MAPPER_DRIVERS, ids=MAPPER_IDS)
+def run_stream(request):
+    """Drive one chunk sequence through a mapper, once per mapper."""
+    return validated(request.param)
+
+
+def event_types(events):
+    return [event.type for event in events]
+
+
+def tool_calls_of(events, event_type):
+    return [event for event in events if event.type == event_type]
+
+
+def test_a_completed_tool_call_with_no_id_does_not_take_the_stream_down(run_stream):
+    """The paused path already refuses a tool with no id; this path let it raise instead.
+
+    An exception here is caught by the route, which ends the run with an error in place
+    of everything it had still to send rather than the one thing it could not render.
+    """
+    events = run_stream(
+        [
+            ToolCallCompletedEvent(tool=ToolExecution(tool_name="search", result="ok")),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    assert events[-1].type == EventType.RUN_FINISHED
+    assert EventType.TOOL_CALL_END not in event_types(events)
+
+
+def test_a_started_tool_call_with_no_id_does_not_take_the_stream_down(run_stream):
+    """The same guard on the other half of the pair, which the client renders together."""
+    events = run_stream(
+        [
+            ToolCallStartedEvent(tool=ToolExecution(tool_name="search")),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    assert events[-1].type == EventType.RUN_FINISHED
+    assert EventType.TOOL_CALL_START not in event_types(events)
+
+
+def test_a_started_tool_call_with_no_arguments_announces_an_empty_object(run_stream):
+    """The paused path already renders an absent argument list as one; this path sent a null.
+
+    What a client renders a call with reads its arguments as an object, and a null has
+    no keys to read off it, so a tool taking no arguments rendered nothing at all.
+    """
+    events = run_stream(
+        [
+            ToolCallStartedEvent(tool=ToolExecution(tool_call_id="call-1", tool_name="now")),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    args = next(event for event in events if event.type == EventType.TOOL_CALL_ARGS)
+
+    assert json.loads(args.delta) == {}
+
+
+def test_a_started_tool_call_keeps_arguments_the_standard_serializer_cannot_read(run_stream):
+    """A datetime argument raised, which the route turned into the run's error."""
+    events = run_stream(
+        [
+            ToolCallStartedEvent(
+                tool=ToolExecution(
+                    tool_call_id="call-1",
+                    tool_name="schedule",
+                    tool_args={"starts_at": datetime(2026, 1, 2, 3, 4, 5), "title": "review"},
+                )
+            ),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    args = next(event for event in events if event.type == EventType.TOOL_CALL_ARGS)
+
+    assert json.loads(args.delta) == {"starts_at": "2026-01-02 03:04:05", "title": "review"}
+
+
+def _self_referring_args():
+    args = {"title": "review"}
+    args["itself"] = args
+    return args
+
+
+@pytest.mark.parametrize(
+    "tool_args",
+    [
+        pytest.param({("starts", "at"): "noon", "title": "review"}, id="a key the serializer refuses"),
+        pytest.param(_self_referring_args(), id="a record that refers to itself"),
+    ],
+)
+def test_arguments_no_serializer_can_walk_still_reach_the_client_as_an_object(tool_args):
+    """No model writes either record, so this holds the promise rather than a live case.
+
+    The promise is worth holding because the cost of breaking it is the whole run: the
+    route turns anything raised here into the run's error, in place of everything it
+    still had to send.
+    """
+    delta = _tool_args_json(tool_args)
+
+    arguments = json.loads(delta)
+    assert isinstance(arguments, dict)
+    assert arguments["title"] == "'review'"
+
+
+def test_a_tool_call_with_no_id_is_logged(caplog):
+    with caplog.at_level(logging.WARNING):
+        validated(MAPPER_DRIVERS[0])(
+            [
+                ToolCallCompletedEvent(tool=ToolExecution(tool_name="search", result="ok")),
+                WorkflowCompletedEvent(),
+            ]
+        )
+
+    assert "search" in caplog.text
+
+
+def test_a_repeated_tool_completion_still_sends_the_state_it_carries():
+    """The run's state moves on between two reports of one tool call, and the client is owed it.
+
+    The second report ends no tool call, because the client was already told this one
+    ended, but the state delta rides on the same event and is not a duplicate.
+    """
+    state = StreamState(run_state={"count": 0})
+    state.set_state_snapshot({"count": 0})
+    tool = ToolExecution(tool_call_id="call-1", tool_name="increment", result="ok")
+    state.start_tool_call("call-1")
+
+    first = on_tool_call_completed(ToolCallCompletedEvent(tool=tool), state)
+    assert [event.type for event in first] == [EventType.TOOL_CALL_END, EventType.TOOL_CALL_RESULT]
+
+    state.run_state["count"] = 1
+    second = on_tool_call_completed(ToolCallCompletedEvent(tool=tool), state)
+
+    assert [event.type for event in second] == [EventType.STATE_DELTA]
+
+
+def test_a_tool_call_after_a_step_output_hangs_under_the_message_the_client_holds(run_stream):
+    """A step's own output opens a message of its own, and the one before it is gone.
+
+    Parenting a later tool call to the message that was current before the step output
+    points the client at a message it has already finished reading.
+    """
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="One", step_id="one"),
+            RunContentEvent(content="thinking", step_id="one"),
+            ToolCallStartedEvent(tool=ToolExecution(tool_call_id="call-1", tool_name="search")),
+            ToolCallCompletedEvent(tool=ToolExecution(tool_call_id="call-1", tool_name="search", result="ok")),
+            StepCompletedEvent(step_name="One", step_id="one", content="thinking"),
+            StepStartedEvent(step_name="Two", step_id="two"),
+            StepCompletedEvent(step_name="Two", step_id="two", content="what the function returned"),
+            StepStartedEvent(step_name="Three", step_id="three"),
+            ToolCallStartedEvent(tool=ToolExecution(tool_call_id="call-2", tool_name="fetch")),
+            ToolCallCompletedEvent(tool=ToolExecution(tool_call_id="call-2", tool_name="fetch", result="ok")),
+            StepCompletedEvent(step_name="Three", step_id="three", content="done"),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    step_output_message = next(
+        event.message_id
+        for event in events
+        if event.type == EventType.TEXT_MESSAGE_CONTENT and event.delta == "what the function returned"
+    )
+    second_call = next(
+        event for event in tool_calls_of(events, EventType.TOOL_CALL_START) if event.tool_call_id == "call-2"
+    )
+
+    assert second_call.parent_message_id == step_output_message

--- a/libs/agno/tests/unit/os/interfaces/test_agui_workflow.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_workflow.py
@@ -1,0 +1,2201 @@
+import inspect
+import logging
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("ag_ui", reason="ag_ui not installed")
+
+from ag_ui.core import EventType
+from ag_ui.core.types import Tool as AGUITool
+from pydantic import BaseModel
+
+from agno.agent import Agent
+from agno.db.in_memory import InMemoryDb
+from agno.models.message import Message
+from agno.models.response import ToolExecution
+from agno.os.interfaces.agui import router as agui_router
+from agno.os.interfaces.agui.agui import AGUI
+from agno.os.interfaces.agui.handlers import _iter_step_results, on_run_content
+from agno.os.interfaces.agui.router import attach_routes, run_entity
+from agno.os.interfaces.agui.state import SpanTransition, StepSpan, StreamState
+from agno.os.interfaces.agui.stream import stream_agno_response_as_agui_events
+from agno.run.agent import RunCancelledEvent as AgentRunCancelledEvent
+from agno.run.agent import RunContentEvent
+from agno.run.agent import RunErrorEvent as AgentRunErrorEvent
+from agno.run.agent import RunPausedEvent as AgentRunPausedEvent
+from agno.run.base import RunStatus
+from agno.run.team import RunContentEvent as TeamRunContentEvent
+from agno.run.team import RunErrorEvent as TeamRunErrorEvent
+from agno.run.workflow import (
+    RouterPausedEvent,
+    StepCompletedEvent,
+    StepErrorEvent,
+    StepExecutorPausedEvent,
+    StepOutputReviewEvent,
+    StepPausedEvent,
+    StepStartedEvent,
+    WorkflowCancelledEvent,
+    WorkflowCompletedEvent,
+    WorkflowErrorEvent,
+    WorkflowPausedEvent,
+    WorkflowRunEvent,
+    WorkflowStartedEvent,
+)
+from agno.workflow.remote import RemoteWorkflow
+from agno.workflow.step import Step
+from agno.workflow.types import HumanReview, OnReject, StepInput, StepOutput
+from agno.workflow.workflow import Workflow
+
+from ._agui_mappers import (
+    MAPPER_DRIVERS,
+    MAPPER_IDS,
+    drain_async_mapper,
+    drive_sync_mapper,
+    validated,
+)
+from ._agui_stream_rules import assert_valid_agui_stream
+
+
+def echo_step(step_input: StepInput) -> StepOutput:
+    return StepOutput(content=str(step_input.input or ""))
+
+
+def exploding_step(step_input: StepInput) -> StepOutput:
+    raise ValueError("step exploded")
+
+
+def build_workflow() -> Workflow:
+    return Workflow(id="test-workflow", name="Test Workflow", steps=[Step(name="Echo", executor=echo_step)])
+
+
+def build_cancel_on_reject_workflow() -> Workflow:
+    """A workflow the engine cancels for real once its review gate is rejected."""
+    return Workflow(
+        id="cancel-workflow",
+        name="Cancel Workflow",
+        db=InMemoryDb(),
+        telemetry=False,
+        steps=[
+            Step(
+                name="Gate",
+                executor=echo_step,
+                human_review=HumanReview(requires_confirmation=True, on_reject=OnReject.cancel),
+            )
+        ],
+    )
+
+
+class FakeRunInput:
+    def __init__(self, *, context=None, state=None, tools=None, messages=None):
+        self.messages = messages if messages is not None else [MagicMock(role="user", content="test")]
+        self.thread_id = "test-thread"
+        self.run_id = "test-run"
+        self.forwarded_props = None
+        self.state = state
+        self.context = context
+        self.tools = tools
+
+
+def build_remote_workflow() -> RemoteWorkflow:
+    return RemoteWorkflow(base_url="http://localhost:9999", workflow_id="remote-workflow")
+
+
+def capture_arun(entity) -> dict:
+    """Replace an entity's arun with a no-op that records the kwargs it was called with."""
+    captured: dict = {}
+
+    async def arun(**kwargs):
+        captured.update(kwargs)
+        return
+        yield
+
+    entity.arun = arun  # type: ignore[method-assign]
+    return captured
+
+
+async def collect_events(entity, run_input) -> list:
+    """Drain a run, failing if it ended in RUN_ERROR.
+
+    run_entity turns any exception into a RUN_ERROR event rather than raising, so a
+    routing test that discards its events stays green even when the run never happened.
+    """
+    events = [event async for event in run_entity(entity, run_input)]
+    errors = [event.message for event in events if event.type == EventType.RUN_ERROR]
+    assert not errors, f"run ended in RUN_ERROR: {errors}"
+    assert_valid_agui_stream(events)
+    return events
+
+
+@pytest.fixture(params=MAPPER_DRIVERS, ids=MAPPER_IDS)
+def run_stream(request):
+    """Drive one chunk sequence through a mapper, once per mapper.
+
+    A failure is reported under the sync_mapper or async_mapper id of the mapper that
+    produced it.
+    """
+    return validated(request.param)
+
+
+def event_types(events):
+    return [event.type for event in events]
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def test_agui_accepts_a_workflow():
+    workflow = build_workflow()
+    interface = AGUI(workflow=workflow)
+
+    assert interface.workflow is workflow
+    assert interface.get_router() is not None
+
+
+def test_agui_without_any_entity_is_rejected():
+    with pytest.raises(ValueError, match="requires an agent, team, or workflow"):
+        AGUI()
+
+
+def test_agui_scope_mapping_for_a_workflow():
+    interface = AGUI(workflow=build_workflow(), prefix="/flow")
+
+    assert interface.get_scope_mappings() == {"POST /flow/agui": ["workflows:run"]}
+
+
+def test_agui_scope_mapping_prefers_agent_over_workflow():
+    interface = AGUI(agent=MagicMock(), workflow=build_workflow())
+
+    assert interface.get_scope_mappings() == {"POST /agui": ["agents:run"]}
+
+
+def test_attach_routes_accepts_a_workflow():
+    from fastapi.routing import APIRouter
+
+    router = attach_routes(router=APIRouter(), workflow=build_workflow())
+
+    assert {route.path for route in router.routes} == {"/agui", "/status"}
+
+
+def test_attach_routes_without_any_entity_is_rejected():
+    from fastapi.routing import APIRouter
+
+    with pytest.raises(ValueError, match="Either agent, team or workflow must be provided."):
+        attach_routes(router=APIRouter())
+
+
+# ---------------------------------------------------------------------------
+# Routing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_workflow_run_receives_session_state_and_not_a_run_context():
+    workflow = build_workflow()
+    captured = capture_arun(workflow)
+
+    await collect_events(workflow, FakeRunInput(state={"count": 1}))
+
+    assert captured["input"] == "test"
+    assert captured["session_state"] == {"count": 1}
+    assert captured["stream"] is True
+    assert captured["stream_events"] is True
+    assert "run_context" not in captured
+
+
+@pytest.mark.asyncio
+async def test_workflow_run_receives_agui_context_as_dependencies():
+    workflow = build_workflow()
+    captured = capture_arun(workflow)
+    context = [MagicMock(description="user_name", value="Alice")]
+
+    await collect_events(workflow, FakeRunInput(context=context))
+
+    assert captured["dependencies"] == {"user_name": "Alice"}
+    assert captured["add_dependencies_to_context"] is True
+
+
+@pytest.mark.asyncio
+async def test_client_tools_are_dropped_for_a_workflow(caplog):
+    """An agent receives this definition as a client tool; a workflow must get it under no kwarg."""
+    tool = AGUITool(name="change_background", description="Change it", parameters={"type": "object"})
+
+    agent = Agent(id="control-agent", name="Control")
+    agent_captured = capture_arun(agent)
+    await collect_events(agent, FakeRunInput(tools=[tool]))
+    assert [fn.name for fn in agent_captured["run_context"].client_tools] == ["change_background"]
+
+    workflow = build_workflow()
+    captured = capture_arun(workflow)
+    with caplog.at_level(logging.WARNING):
+        await collect_events(workflow, FakeRunInput(tools=[tool]))
+
+    assert "client_tools" not in captured
+    assert not any("change_background" in repr(value) for value in captured.values())
+    assert "not forwarded to workflows" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_trailing_tool_messages_do_not_resume_a_workflow(monkeypatch):
+    """A workflow has no external-execution pause, so a tool message must start a fresh run."""
+    workflow = build_workflow()
+    captured = capture_arun(workflow)
+
+    async def refuse_resume(**kwargs):
+        raise AssertionError("the workflow was routed to the resume path")
+
+    monkeypatch.setattr(agui_router, "resume_paused_run", refuse_resume)
+
+    messages = [
+        MagicMock(role="user", content="run it"),
+        MagicMock(role="tool", tool_call_id="call-1", content="done", error=None),
+    ]
+
+    await collect_events(workflow, FakeRunInput(messages=messages))
+
+    assert captured["input"] == "run it"
+    assert captured["stream"] is True
+
+
+@pytest.mark.asyncio
+async def test_a_discarded_workflow_resume_says_the_run_starts_over(monkeypatch, caplog):
+    """Trailing tool messages are a client answering a pause, and a workflow cannot take one.
+
+    The request is dropped and the workflow runs again from its first step against the
+    same user message, repeating every side effect the earlier run had. Saying so is the
+    part a reader needs: the client is told nothing, and sees an ordinary run it never
+    asked for.
+    """
+    workflow = build_workflow()
+    capture_arun(workflow)
+
+    async def refuse_resume(**kwargs):
+        raise AssertionError("the workflow was routed to the resume path")
+
+    monkeypatch.setattr(agui_router, "resume_paused_run", refuse_resume)
+
+    messages = [
+        MagicMock(role="user", content="run it"),
+        MagicMock(role="tool", tool_call_id="call-1", content="done", error=None),
+    ]
+
+    with caplog.at_level(logging.WARNING):
+        await collect_events(workflow, FakeRunInput(messages=messages))
+
+    assert "re-run from the start" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_a_remote_workflow_reports_the_context_it_cannot_forward(caplog):
+    """The client's context has nowhere to go on a remote workflow, so it is dropped.
+
+    Every other kwarg dropped on this path says so; this one left the client's own
+    per-run context to vanish without a line to find it by.
+    """
+    remote = build_remote_workflow()
+    captured = capture_arun(remote)
+    context = [MagicMock(description="user_name", value="Alice")]
+
+    with caplog.at_level(logging.WARNING):
+        await collect_events(remote, FakeRunInput(context=context))
+
+    assert "dependencies" not in captured
+    assert "not forwarded to remote workflows" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_a_remote_workflow_without_context_reports_nothing(caplog):
+    """The line names a drop, so a run with nothing to drop must not emit it."""
+    remote = build_remote_workflow()
+    capture_arun(remote)
+
+    with caplog.at_level(logging.WARNING):
+        await collect_events(remote, FakeRunInput(state={"count": 1}))
+
+    assert "not forwarded to remote workflows" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_a_remote_workflow_receives_only_wire_fields_its_arun_declares():
+    """RemoteWorkflow.arun forwards unrecognised kwargs to the remote server as form
+    fields, so dependency kwargs meant for an in-process workflow must not be sent."""
+    remote = build_remote_workflow()
+    captured = capture_arun(remote)
+    context = [MagicMock(description="user_name", value="Alice")]
+
+    await collect_events(remote, FakeRunInput(context=context, state={"count": 1}))
+
+    assert captured["session_state"] == {"count": 1}
+    assert "dependencies" not in captured
+    assert "add_dependencies_to_context" not in captured
+    assert "run_context" not in captured
+    declared = set(inspect.signature(RemoteWorkflow.arun).parameters)
+    assert set(captured) <= declared
+
+
+# ---------------------------------------------------------------------------
+# Event mapping
+# ---------------------------------------------------------------------------
+
+
+def test_step_spans_are_opened_and_closed(run_stream):
+    events = run_stream(
+        [
+            WorkflowStartedEvent(),
+            StepStartedEvent(step_name="Plan"),
+            StepCompletedEvent(step_name="Plan", content="a plan"),
+            WorkflowCompletedEvent(content="done"),
+        ]
+    )
+
+    types = event_types(events)
+    assert types.index(EventType.STEP_STARTED) < types.index(EventType.STEP_FINISHED)
+    assert types[-1] == EventType.RUN_FINISHED
+
+    started = [event for event in events if event.type == EventType.STEP_STARTED]
+    finished = [event for event in events if event.type == EventType.STEP_FINISHED]
+    assert [event.step_name for event in started] == ["Plan"]
+    assert [event.step_name for event in finished] == ["Plan"]
+
+
+def test_step_without_streamed_text_emits_its_output_as_a_message(run_stream):
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Handoff"),
+            StepCompletedEvent(step_name="Handoff", content="handed off"),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    deltas = [event.delta for event in events if event.type == EventType.TEXT_MESSAGE_CONTENT]
+    assert deltas == ["handed off"]
+
+
+def test_step_that_streamed_text_does_not_repeat_it(run_stream):
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Plan", step_id="plan"),
+            RunContentEvent(content="streamed ", step_id="plan", step_name="Plan"),
+            RunContentEvent(content="answer", step_id="plan", step_name="Plan"),
+            StepCompletedEvent(step_name="Plan", step_id="plan", content="streamed answer"),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    deltas = [event.delta for event in events if event.type == EventType.TEXT_MESSAGE_CONTENT]
+    assert deltas == ["streamed ", "answer"]
+
+
+def test_each_step_gets_its_own_message(run_stream):
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="One", step_id="one"),
+            RunContentEvent(content="first", step_id="one", step_name="One"),
+            StepCompletedEvent(step_name="One", step_id="one", content="first"),
+            StepStartedEvent(step_name="Two", step_id="two"),
+            RunContentEvent(content="second", step_id="two", step_name="Two"),
+            StepCompletedEvent(step_name="Two", step_id="two", content="second"),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    message_ids = {event.message_id for event in events if event.type == EventType.TEXT_MESSAGE_CONTENT}
+    assert len(message_ids) == 2
+
+
+def test_a_step_name_is_never_opened_twice(run_stream):
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Loop"),
+            StepStartedEvent(step_name="Loop"),
+            StepCompletedEvent(step_name="Loop", content="once"),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    assert event_types(events).count(EventType.STEP_STARTED) == 1
+    assert event_types(events).count(EventType.STEP_FINISHED) == 1
+
+
+def test_a_step_left_open_is_closed_before_the_run_ends(run_stream):
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Never finished"),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    types = event_types(events)
+    assert types.count(EventType.STEP_FINISHED) == 1
+    assert types.index(EventType.STEP_FINISHED) < types.index(EventType.RUN_FINISHED)
+
+
+def test_workflow_error_becomes_a_run_error_carrying_the_reason(run_stream):
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Plan"),
+            WorkflowErrorEvent(error="the step blew up", error_type="ValueError"),
+        ]
+    )
+
+    assert events[-1].type == EventType.RUN_ERROR
+    assert events[-1].message == "the step blew up"
+    assert events[-1].code == "ValueError"
+    assert EventType.RUN_FINISHED not in event_types(events)
+
+
+def test_a_failed_step_result_ends_the_run_with_an_error(run_stream):
+    """A workflow that gives up on a step still reports completion, so the failure lives on the payload."""
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Boom"),
+            WorkflowCompletedEvent(
+                content="Step skipped due to error: step exploded",
+                step_results=[
+                    StepOutput(
+                        step_name="Boom",
+                        content="Step skipped due to error: step exploded",
+                        success=False,
+                        error="step exploded",
+                    )
+                ],
+            ),
+        ]
+    )
+
+    assert events[-1].type == EventType.RUN_ERROR
+    assert events[-1].message == "step exploded"
+    assert EventType.RUN_FINISHED not in event_types(events)
+
+
+def test_a_failed_step_result_closes_open_spans_before_the_error(run_stream):
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Boom"),
+            WorkflowCompletedEvent(
+                step_results=[StepOutput(step_name="Boom", success=False, error="step exploded")],
+            ),
+        ]
+    )
+
+    types = event_types(events)
+    assert types.index(EventType.STEP_FINISHED) < types.index(EventType.RUN_ERROR)
+
+
+def test_a_nested_failed_step_result_ends_the_run_with_an_error(run_stream):
+    """Parallel, loop and condition steps report their children under StepOutput.steps."""
+    events = run_stream(
+        [
+            WorkflowCompletedEvent(
+                step_results=[
+                    StepOutput(
+                        step_name="Par",
+                        success=False,
+                        steps=[
+                            StepOutput(step_name="Ok", content="fine", success=True),
+                            StepOutput(step_name="Boom", success=False, error="nested exploded"),
+                        ],
+                    )
+                ],
+            ),
+        ]
+    )
+
+    assert events[-1].type == EventType.RUN_ERROR
+    assert events[-1].message == "nested exploded"
+
+
+def test_a_failed_step_result_without_an_error_message_still_ends_the_run_with_an_error(run_stream):
+    events = run_stream([WorkflowCompletedEvent(step_results=[StepOutput(step_name="Boom", success=False)])])
+
+    assert events[-1].type == EventType.RUN_ERROR
+    assert "Boom" in events[-1].message
+
+
+def test_successful_step_results_still_finish_the_run(run_stream):
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Plan"),
+            StepCompletedEvent(step_name="Plan", content="a plan"),
+            WorkflowCompletedEvent(
+                content="a plan",
+                step_results=[
+                    StepOutput(
+                        step_name="Plan",
+                        content="a plan",
+                        steps=[StepOutput(step_name="Inner", content="inner", success=True)],
+                    )
+                ],
+            ),
+        ]
+    )
+
+    assert events[-1].type == EventType.RUN_FINISHED
+    assert EventType.RUN_ERROR not in event_types(events)
+
+
+@pytest.mark.asyncio
+async def test_a_workflow_whose_step_raises_streams_a_run_error():
+    workflow = Workflow(
+        id="boom-workflow", name="Boom", telemetry=False, steps=[Step(name="Boom", executor=exploding_step)]
+    )
+
+    events = [event async for event in run_entity(workflow, FakeRunInput())]
+    assert_valid_agui_stream(events)
+
+    assert events[-1].type == EventType.RUN_ERROR
+    assert "step exploded" in events[-1].message
+    assert EventType.RUN_FINISHED not in event_types(events)
+
+
+# ---------------------------------------------------------------------------
+# Cancellation
+# ---------------------------------------------------------------------------
+
+
+def test_a_cancelled_workflow_does_not_finish_the_run(run_stream):
+    events = run_stream([WorkflowCancelledEvent(reason="user pressed stop")])
+
+    assert events[-1].type == EventType.RUN_ERROR
+    assert events[-1].message == "user pressed stop"
+    assert EventType.RUN_FINISHED not in event_types(events)
+
+
+def test_a_cancelled_workflow_reports_a_cancellation_code(run_stream):
+    events = run_stream([WorkflowCancelledEvent(reason="user pressed stop")])
+
+    assert events[-1].code == WorkflowRunEvent.workflow_cancelled.value
+
+
+def test_a_cancelled_workflow_without_a_reason_still_ends_the_run_with_an_error(run_stream):
+    events = run_stream([WorkflowCancelledEvent()])
+
+    assert events[-1].type == EventType.RUN_ERROR
+    assert events[-1].message
+    assert EventType.RUN_FINISHED not in event_types(events)
+
+
+def test_a_cancelled_workflow_closes_open_spans_before_the_error(run_stream):
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Plan"),
+            WorkflowCancelledEvent(reason="cancelled mid step"),
+        ]
+    )
+
+    types = event_types(events)
+    assert types.index(EventType.STEP_FINISHED) < types.index(EventType.RUN_ERROR)
+    assert events[-1].type == EventType.RUN_ERROR
+    assert events[-1].message == "cancelled mid step"
+
+
+def test_a_completion_following_a_cancellation_does_not_report_success(run_stream):
+    """cancel_run() makes the engine emit WorkflowCancelled and then WorkflowCompleted."""
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Plan"),
+            WorkflowCancelledEvent(reason="run was cancelled"),
+            WorkflowCompletedEvent(content="run was cancelled"),
+        ]
+    )
+
+    types = event_types(events)
+    assert types.index(EventType.STEP_FINISHED) < types.index(EventType.RUN_ERROR)
+    assert events[-1].type == EventType.RUN_ERROR
+    assert events[-1].message == "run was cancelled"
+    assert EventType.RUN_FINISHED not in types
+
+
+def test_an_agent_cancellation_is_left_untouched(run_stream):
+    """Agent and team cancellation keep their existing raw-event behaviour."""
+    events = run_stream([AgentRunCancelledEvent(reason="stopped")])
+
+    assert event_types(events) == [EventType.RAW, EventType.RUN_FINISHED]
+
+
+def test_a_real_workflow_cancelled_by_a_rejected_step_does_not_finish_the_run():
+    workflow = build_cancel_on_reject_workflow()
+    paused = workflow.run("go", session_id="cancel-session")
+    assert paused.status == RunStatus.paused
+    paused.step_requirements[0].reject()
+
+    events = validated(drive_sync_mapper)(workflow.continue_run(paused, stream=True, stream_events=True))
+
+    assert events[-1].type == EventType.RUN_ERROR
+    assert "rejected" in events[-1].message
+    assert EventType.RUN_FINISHED not in event_types(events)
+
+
+@pytest.mark.asyncio
+async def test_a_real_async_workflow_cancelled_by_a_rejected_step_does_not_finish_the_run():
+    workflow = build_cancel_on_reject_workflow()
+    paused = await workflow.arun("go", session_id="cancel-session")
+    assert paused.status == RunStatus.paused
+    paused.step_requirements[0].reject()
+
+    events = await drain_async_mapper(await workflow.acontinue_run(paused, stream=True, stream_events=True))
+    assert_valid_agui_stream(events)
+
+    assert events[-1].type == EventType.RUN_ERROR
+    assert "rejected" in events[-1].message
+    assert EventType.RUN_FINISHED not in event_types(events)
+
+
+# ---------------------------------------------------------------------------
+# Concurrent and repeated steps
+# ---------------------------------------------------------------------------
+#
+# AG-UI names a step and refuses a name it already holds open, so two steps a Parallel
+# runs at once cannot both be announced under one name. The second is announced under
+# that name plus a counter instead, which is why "Work" and "Work 2" appear below where
+# the workflow declares one step called Work. Sequential steps reusing a name are
+# untouched: the first has finished before the second starts.
+
+
+def deltas_of(events):
+    return [event.delta for event in events if event.type == EventType.TEXT_MESSAGE_CONTENT]
+
+
+def assert_spans_balanced(events, expected_names):
+    started = [event.step_name for event in events if event.type == EventType.STEP_STARTED]
+    finished = [event.step_name for event in events if event.type == EventType.STEP_FINISHED]
+    assert started == expected_names
+    assert sorted(finished) == sorted(expected_names)
+
+
+def test_concurrent_steps_do_not_share_one_text_attribution(run_stream):
+    """A step that streamed nothing must still emit its output while a sibling step is open."""
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="A", step_id="a", step_index=(0, 0)),
+            StepStartedEvent(step_name="B", step_id="b", step_index=(0, 1)),
+            RunContentEvent(content="A streams this", step_id="a", step_name="A"),
+            StepCompletedEvent(step_name="A", step_id="a", step_index=(0, 0), content="A streams this"),
+            StepCompletedEvent(step_name="B", step_id="b", step_index=(0, 1), content="B computed this"),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    assert deltas_of(events) == ["A streams this", "B computed this"]
+    assert_spans_balanced(events, ["A", "B"])
+
+
+def test_text_naming_no_step_suppresses_no_step_s_output(run_stream):
+    """Text that names no step is credited to none, so no step loses its own output.
+
+    Crediting it to a step picked by the stream, whichever that is, silently suppresses
+    the output of the step picked wrong. The cost of crediting it to nobody is that the
+    step that really produced it repeats it at its completion, which is text the client
+    has already seen rather than text it never gets.
+    """
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="A", step_id="a", step_index=(0, 0)),
+            StepStartedEvent(step_name="B", step_id="b", step_index=(0, 1)),
+            RunContentEvent(content="A streams this"),
+            StepCompletedEvent(step_name="A", step_id="a", step_index=(0, 0), content="A streams this"),
+            StepCompletedEvent(step_name="B", step_id="b", step_index=(0, 1), content="B computed this"),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    assert deltas_of(events) == ["A streams this", "A streams this", "B computed this"]
+    assert_spans_balanced(events, ["A", "B"])
+
+
+def test_text_naming_no_step_does_not_suppress_a_later_step_s_output(run_stream):
+    """Unattributed text belongs to the moment it arrived in, not to the rest of the run.
+
+    A step that closes without text of its own answers for nothing, and remembering the
+    text past that point hands it to a step that started after it was sent.
+    """
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="A", step_id="a", step_index=0),
+            RunContentEvent(content="A streams this"),
+            StepCompletedEvent(step_name="A", step_id="a", step_index=0),
+            StepStartedEvent(step_name="B", step_id="b", step_index=1),
+            StepCompletedEvent(step_name="B", step_id="b", step_index=1, content="B computed this"),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    assert deltas_of(events) == ["A streams this", "B computed this"]
+
+
+def test_unattributed_text_does_not_suppress_the_output_of_a_step_that_closes_first(run_stream):
+    """Under a parallel the first step to close is not the step that produced the text.
+
+    Both steps here are open when text arrives naming neither of them. Handing it to
+    whichever closes first costs that step its own output and says nothing true about
+    the step that actually streamed.
+    """
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="A", step_id="a", step_index=(0, 0)),
+            StepStartedEvent(step_name="B", step_id="b", step_index=(0, 1)),
+            RunContentEvent(content="B streams this"),
+            StepCompletedEvent(step_name="A", step_id="a", step_index=(0, 0), content="A computed this"),
+            StepCompletedEvent(step_name="B", step_id="b", step_index=(0, 1), content="B streams this"),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    assert "A computed this" in deltas_of(events)
+
+
+def test_text_stamped_with_a_step_id_no_span_answers_to_credits_no_step(run_stream):
+    """An id matching no open span names no step here, so it may not stand in for one.
+
+    Treating it as unattributed and handing it to the next step to close is the same
+    mistake as the one above, made without even the excuse of a missing id.
+    """
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="A", step_id="a", step_index=(0, 0)),
+            StepStartedEvent(step_name="B", step_id="b", step_index=(0, 1)),
+            RunContentEvent(content="from a step nobody started", step_id="ghost"),
+            StepCompletedEvent(step_name="A", step_id="a", step_index=(0, 0), content="A computed this"),
+            StepCompletedEvent(step_name="B", step_id="b", step_index=(0, 1), content="B computed this"),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    assert deltas_of(events) == ["from a step nobody started", "A computed this", "B computed this"]
+    assert_spans_balanced(events, ["A", "B"])
+
+
+def test_two_concurrent_steps_sharing_a_name_are_tracked_separately(run_stream):
+    """The second of two steps open at once under one name is announced under a counted name."""
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Work", step_id="w1", step_index=(0, 0)),
+            StepStartedEvent(step_name="Work", step_id="w2", step_index=(0, 1)),
+            RunContentEvent(content="first streamed", step_id="w1", step_name="Work"),
+            StepCompletedEvent(step_name="Work", step_id="w1", step_index=(0, 0), content="first streamed"),
+            StepCompletedEvent(step_name="Work", step_id="w2", step_index=(0, 1), content="second computed"),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    assert deltas_of(events) == ["first streamed", "second computed"]
+    assert_spans_balanced(events, ["Work", "Work 2"])
+
+
+def test_a_repeated_name_is_still_disambiguated_without_a_step_id_on_completion(run_stream):
+    """The sync engine path omits step_id from its completion events, leaving only step_index."""
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Work", step_id="w1", step_index=(0, 0)),
+            StepStartedEvent(step_name="Work", step_id="w2", step_index=(0, 1)),
+            RunContentEvent(content="first streamed", step_id="w1", step_name="Work"),
+            StepCompletedEvent(step_name="Work", step_index=(0, 0), content="first streamed"),
+            StepCompletedEvent(step_name="Work", step_index=(0, 1), content="second computed"),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    assert deltas_of(events) == ["first streamed", "second computed"]
+    assert_spans_balanced(events, ["Work", "Work 2"])
+
+
+def test_two_concurrent_steps_sharing_a_name_both_stream_their_own_text(run_stream):
+    """Both siblings stream, so neither of them may be treated as the other's output."""
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Work", step_id="w1", step_index=(0, 0)),
+            StepStartedEvent(step_name="Work", step_id="w2", step_index=(0, 1)),
+            RunContentEvent(content="from one", step_id="w1", step_name="Work"),
+            RunContentEvent(content="from two", step_id="w2", step_name="Work"),
+            StepCompletedEvent(step_name="Work", step_id="w1", step_index=(0, 0), content="from one"),
+            StepCompletedEvent(step_name="Work", step_id="w2", step_index=(0, 1), content="from two"),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    assert deltas_of(events) == ["from one", "from two"]
+    assert_spans_balanced(events, ["Work", "Work 2"])
+
+
+def test_concurrent_steps_sharing_a_name_may_complete_out_of_order(run_stream):
+    """A Parallel's children finish in whatever order they finish in, not the order they started."""
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Work", step_id="w1", step_index=(0, 0)),
+            StepStartedEvent(step_name="Work", step_id="w2", step_index=(0, 1)),
+            StepCompletedEvent(step_name="Work", step_id="w2", step_index=(0, 1), content="second finished first"),
+            StepCompletedEvent(step_name="Work", step_id="w1", step_index=(0, 0), content="first finished second"),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    assert deltas_of(events) == ["second finished first", "first finished second"]
+    assert_spans_balanced(events, ["Work", "Work 2"])
+    assert span_events(events) == [
+        (EventType.STEP_STARTED, "Work"),
+        (EventType.STEP_STARTED, "Work 2"),
+        (EventType.STEP_FINISHED, "Work 2"),
+        (EventType.STEP_FINISHED, "Work"),
+    ]
+
+
+def test_concurrent_steps_close_in_the_order_they_completed(run_stream):
+    """Differently named siblings have no reason to wait for each other."""
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Slow", step_id="slow", step_index=(0, 0)),
+            StepStartedEvent(step_name="Fast", step_id="fast", step_index=(0, 1)),
+            StepCompletedEvent(step_name="Fast", step_id="fast", step_index=(0, 1), content="fast done"),
+            StepCompletedEvent(step_name="Slow", step_id="slow", step_index=(0, 0), content="slow done"),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    assert deltas_of(events) == ["fast done", "slow done"]
+    assert span_events(events) == [
+        (EventType.STEP_STARTED, "Slow"),
+        (EventType.STEP_STARTED, "Fast"),
+        (EventType.STEP_FINISHED, "Fast"),
+        (EventType.STEP_FINISHED, "Slow"),
+    ]
+
+
+def test_two_unnamed_concurrent_steps_do_not_share_one_placeholder_span(run_stream):
+    """An unnamed step is announced under a placeholder name, which is counted like any other."""
+    events = run_stream(
+        [
+            StepStartedEvent(step_index=(0, 0)),
+            StepStartedEvent(step_index=(0, 1)),
+            StepCompletedEvent(step_index=(0, 0), content="first"),
+            StepCompletedEvent(step_index=(0, 1), content="second"),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    assert deltas_of(events) == ["first", "second"]
+    assert_spans_balanced(events, ["Step", "Step 2"])
+
+
+def test_a_nested_workflow_inside_a_parallel_keeps_each_branch_to_itself(run_stream):
+    """Each branch runs its own sequence of steps, under its own branch step.
+
+    A branch advancing to its next step says nothing about the other branch, whose steps
+    are numbered from zero as well and are still running.
+    """
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Left", step_id="left", parent_step_id="par", step_index=(0, 0)),
+            StepStartedEvent(step_name="Right", step_id="right", parent_step_id="par", step_index=(0, 1)),
+            StepStartedEvent(step_name="Fetch", step_id="l1", parent_step_id="left", step_index=0),
+            StepStartedEvent(step_name="Fetch", step_id="r1", parent_step_id="right", step_index=0),
+            RunContentEvent(content="left fetched", step_id="l1", step_name="Fetch"),
+            StepCompletedEvent(step_name="Fetch", step_id="l1", step_index=0, content="left fetched"),
+            StepStartedEvent(step_name="Report", step_id="l2", parent_step_id="left", step_index=1),
+            RunContentEvent(content="left reported", step_id="l2", step_name="Report"),
+            StepCompletedEvent(step_name="Report", step_id="l2", step_index=1, content="left reported"),
+            StepCompletedEvent(step_name="Left", step_id="left", step_index=(0, 0), content="left reported"),
+            StepCompletedEvent(step_name="Fetch", step_id="r1", step_index=0, content="right fetched"),
+            StepCompletedEvent(step_name="Right", step_id="right", step_index=(0, 1), content="right fetched"),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    assert deltas_of(events) == ["left fetched", "left reported", "right fetched"]
+    assert_spans_balanced(events, ["Left", "Right", "Fetch", "Fetch 2", "Report"])
+
+
+def test_text_from_a_nested_step_also_counts_for_the_step_containing_it(run_stream):
+    """An executor event names only its innermost step, so containment comes from the started events."""
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Outer", step_id="outer"),
+            StepStartedEvent(step_name="Inner", step_id="inner", parent_step_id="outer"),
+            RunContentEvent(content="nested output", step_id="inner", step_name="Inner"),
+            StepCompletedEvent(step_name="Inner", step_id="inner", content="nested output"),
+            StepCompletedEvent(step_name="Outer", step_id="outer", content="nested output"),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    assert deltas_of(events) == ["nested output"]
+    assert_spans_balanced(events, ["Outer", "Inner"])
+
+
+def test_concurrent_steps_left_open_are_all_closed_before_the_run_ends(run_stream):
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Work", step_id="w1", step_index=(0, 0)),
+            StepStartedEvent(step_name="Work", step_id="w2", step_index=(0, 1)),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    types = event_types(events)
+    assert types.count(EventType.STEP_STARTED) == 2
+    assert types.count(EventType.STEP_FINISHED) == 2
+    assert types.index(EventType.STEP_FINISHED) < types.index(EventType.RUN_FINISHED)
+
+
+def test_an_unknown_step_completion_does_not_emit_a_dangling_finish(run_stream):
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="A", step_id="a"),
+            StepCompletedEvent(step_name="Ghost", step_id="ghost", content="never started"),
+            StepCompletedEvent(step_name="A", step_id="a", content="a done"),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    assert deltas_of(events) == ["never started", "a done"]
+    assert_spans_balanced(events, ["A"])
+
+
+def test_an_unknown_step_completion_is_logged_and_keeps_its_output(caplog):
+    """Nothing else carries a step's output, so a span the mapper missed cannot cost it.
+
+    It is reported too: a completion for a step the mapper never saw start is a gap in
+    the mapping, and swallowing it leaves the gap with nothing to find it by.
+    """
+    with caplog.at_level(logging.WARNING):
+        events = validated(drive_sync_mapper)(
+            [
+                StepStartedEvent(step_name="A", step_id="a"),
+                StepCompletedEvent(step_name="Ghost", step_id="ghost", content="never started"),
+                StepCompletedEvent(step_name="A", step_id="a", content="a done"),
+                WorkflowCompletedEvent(),
+            ]
+        )
+
+    assert "never started" in deltas_of(events)
+    assert "Ghost" in caplog.text
+
+
+def test_an_unnamed_step_finishes_under_the_name_it_started_with(run_stream):
+    """A step with no name falls back to its id, which its completion event may not carry."""
+    events = run_stream(
+        [
+            StepStartedEvent(step_id="s1", step_index=0),
+            StepCompletedEvent(step_index=0, content="out"),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    assert deltas_of(events) == ["out"]
+    assert_spans_balanced(events, ["s1"])
+
+
+def spans_open_at(events, delta):
+    """The step names the client had open when a given text delta reached it."""
+    active = []
+    for event in events:
+        if event.type == EventType.STEP_STARTED:
+            active.append(event.step_name)
+        elif event.type == EventType.STEP_FINISHED:
+            active.remove(event.step_name)
+        elif event.type == EventType.TEXT_MESSAGE_CONTENT and event.delta == delta:
+            return list(active)
+    raise AssertionError(f"no delta {delta!r} in {[event.type for event in events]}")
+
+
+def test_a_sequential_step_reusing_a_name_keeps_that_name(run_stream):
+    """Nothing is contended when the first step of a name finished before the second began."""
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Work", step_id="w1", step_index=0),
+            StepCompletedEvent(step_name="Work", step_id="w1", step_index=0, content="first"),
+            StepStartedEvent(step_name="Work", step_id="w2", step_index=1),
+            StepCompletedEvent(step_name="Work", step_id="w2", step_index=1, content="second"),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    assert_spans_balanced(events, ["Work", "Work"])
+
+
+def test_a_counted_name_skips_one_a_step_is_genuinely_called(run_stream):
+    """A workflow may well declare a step called "Work 2", so the counter must step over it."""
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Work", step_id="w1", step_index=(0, 0)),
+            StepStartedEvent(step_name="Work 2", step_id="real", step_index=(0, 1)),
+            StepStartedEvent(step_name="Work", step_id="w2", step_index=(0, 2)),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    assert_spans_balanced(events, ["Work", "Work 2", "Work 3"])
+
+
+def test_a_short_output_survives_appearing_inside_a_siblings_text(run_stream):
+    """A step's own output is its own, however much of it another step happened to say.
+
+    Short outputs are the common case, and asking whether the client has already seen a
+    step's text by looking for that text in another step's makes "OK" indistinguishable
+    from part of "LOOKING".
+    """
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Look", step_id="look", step_index=(0, 0)),
+            StepStartedEvent(step_name="Check", step_id="check", step_index=(0, 1)),
+            RunContentEvent(content="LOOKING", step_id="look", step_name="Look"),
+            StepCompletedEvent(step_name="Look", step_id="look", step_index=(0, 0), content="LOOKING"),
+            StepCompletedEvent(step_name="Check", step_id="check", step_index=(0, 1), content="OK"),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    assert deltas_of(events) == ["LOOKING", "OK"]
+
+
+def test_a_same_named_sibling_emits_its_output_inside_its_own_span(run_stream):
+    """Every step's output reaches the client between that step's own start and finish."""
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Work", step_id="w1", step_index=(0, 0)),
+            StepStartedEvent(step_name="Work", step_id="w2", step_index=(0, 1)),
+            StepCompletedEvent(step_name="Work", step_id="w2", step_index=(0, 1), content="second finished first"),
+            StepCompletedEvent(step_name="Work", step_id="w1", step_index=(0, 0), content="first finished second"),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    assert "Work 2" in spans_open_at(events, "second finished first")
+    assert "Work" in spans_open_at(events, "first finished second")
+
+
+def test_a_long_run_does_not_park_its_transcript_on_every_open_span():
+    """A container step stays open for the whole run, so anything kept per span grows with it.
+
+    Text the run never attributed to a step says only that some step produced it, which
+    is one bit, and keeping the text itself instead makes a step's own output depend on
+    what unrelated steps happened to say.
+    """
+    state = StreamState()
+    state.open_step(step_name="Pipeline", step_id="pipe")
+    payload = "an unattributed sentence the mapper has no business remembering. "
+    for _ in range(50):
+        on_run_content(RunContentEvent(content=payload), state)
+
+    retained = "".join(value for span in state.spans for value in vars(span).values() if isinstance(value, str))
+    assert payload not in retained
+
+
+def test_the_span_a_drain_finishes_is_the_span_it_removes():
+    """A drain finishes the step that closed, not whichever step compares equal to it.
+
+    Two live spans cannot compare equal today, because the display name a step is
+    announced under is unique among the spans still held. This pins the drain to
+    identity so that stays an accident of naming rather than the thing holding the
+    lifecycle together.
+    """
+    state = StreamState()
+    still_running = StepSpan(step_name="Work", step_id="w", display_name="Work")
+    finished = StepSpan(step_name="Work", step_id="w", display_name="Work", closed=True)
+    state.spans = [still_running, finished]
+
+    assert state.flush_spans() == [SpanTransition(step_name="Work", started=False)]
+    assert [id(span) for span in state.spans] == [id(still_running)]
+
+
+def test_a_repeated_start_still_reports_the_steps_the_run_moved_past():
+    """A start the client already holds announces nothing, and still says where the run is.
+
+    The step it supersedes has no completion event of its own, so a start that returns
+    early leaves that step open until the run's terminal event closes it.
+    """
+    state = StreamState()
+    state.open_step(step_name="Second", step_id="s", step_index=1)
+    state.open_step(step_name="First", step_id="f", step_index=0)
+
+    assert state.open_step(step_name="Second", step_id="s", step_index=1) == [
+        SpanTransition(step_name="First", started=False)
+    ]
+
+
+def test_an_aborted_run_finishes_a_container_after_the_step_inside_it(run_stream):
+    """A cancellation ends steps the engine never reported on, and nesting still holds.
+
+    Both steps here are called Work, so the inner one is the contended case, and its span
+    must still open before the span containing it closes.
+    """
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Work", step_id="outer"),
+            StepStartedEvent(step_name="Work", step_id="inner", parent_step_id="outer"),
+            WorkflowCancelledEvent(reason="user pressed stop"),
+        ]
+    )
+
+    assert span_events(events) == [
+        (EventType.STEP_STARTED, "Work"),
+        (EventType.STEP_STARTED, "Work 2"),
+        (EventType.STEP_FINISHED, "Work 2"),
+        (EventType.STEP_FINISHED, "Work"),
+    ]
+
+
+def test_a_completion_naming_an_unknown_step_id_closes_nothing(run_stream):
+    """A completion names one step by id, so an id nothing matches names no open step."""
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Work", step_id="w1", step_index=0),
+            StepCompletedEvent(step_name="Work", step_id="ghost", step_index=0, content="from nowhere"),
+            StepCompletedEvent(step_name="Work", step_id="w1", step_index=0, content="w1 done"),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    assert deltas_of(events) == ["from nowhere", "w1 done"]
+    assert_spans_balanced(events, ["Work"])
+
+
+def test_a_completion_naming_an_unknown_step_id_leaves_a_running_subtree_alone(run_stream):
+    """Closing the wrong step closes everything inside it too, so the mistake cascades."""
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Outer", step_id="outer", step_index=0),
+            StepStartedEvent(step_name="Inner", step_id="inner", parent_step_id="outer"),
+            StepCompletedEvent(step_name="Outer", step_id="ghost", step_index=0, content="from nowhere"),
+            RunContentEvent(content="inner still running", step_id="inner", step_name="Inner"),
+            StepCompletedEvent(step_name="Inner", step_id="inner", content="inner still running"),
+            StepCompletedEvent(step_name="Outer", step_id="outer", step_index=0, content="inner still running"),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    assert deltas_of(events) == ["from nowhere", "inner still running"]
+    assert spans_open_at(events, "inner still running") == ["Outer", "Inner"]
+    assert span_events(events) == [
+        (EventType.STEP_STARTED, "Outer"),
+        (EventType.STEP_STARTED, "Inner"),
+        (EventType.STEP_FINISHED, "Inner"),
+        (EventType.STEP_FINISHED, "Outer"),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Terminal outcome matrix
+# ---------------------------------------------------------------------------
+#
+# One row per outcome the workflow engine can reach, each declaring the terminal AG-UI
+# event the client is owed. RunTerminalTracker decides that terminal event from three
+# predicates: the terminal event sets, the latch that keeps a run the workflow reported
+# unfinished from being reopened, and the step_results scan a completion event goes
+# through. Nothing else enumerates the outcome space, so a change to one predicate has
+# regressed its neighbours without failing a test. This table is the artefact any future
+# terminal-mapping change has to keep green.
+#
+# Every event shape below was taken from a real engine run, not invented.
+
+
+def outcome_clean_completion():
+    return [
+        StepStartedEvent(step_name="Plan"),
+        StepCompletedEvent(step_name="Plan", content="a plan"),
+        WorkflowCompletedEvent(
+            content="a plan",
+            step_results=[StepOutput(step_name="Plan", content="a plan", success=True)],
+        ),
+    ]
+
+
+def outcome_skip_on_failure():
+    """Step(skip_on_failure=True): the failed step is skipped and the run keeps going.
+
+    The engine names neither the skipped step nor its id on the result it leaves behind,
+    and never sends its StepCompletedEvent.
+    """
+    return [
+        StepStartedEvent(step_name="Boom", step_index=0),
+        StepStartedEvent(step_name="After", step_index=1),
+        StepCompletedEvent(step_name="After", step_index=1, content="ran anyway"),
+        WorkflowCompletedEvent(
+            content="ran anyway",
+            step_results=[
+                StepOutput(content="Step Boom failed but skipped", success=False, error="step exploded"),
+                StepOutput(step_name="After", content="ran anyway", success=True),
+            ],
+        ),
+    ]
+
+
+def outcome_on_error_skip():
+    """HumanReview(on_error="skip"), the default error policy: the run completes."""
+    return [
+        StepStartedEvent(step_name="Boom", step_index=0),
+        StepStartedEvent(step_name="After", step_index=1),
+        StepCompletedEvent(step_name="After", step_index=1, content="ran anyway"),
+        WorkflowCompletedEvent(
+            content="ran anyway",
+            step_results=[
+                StepOutput(step_name="Boom", success=False, error="step exploded"),
+                StepOutput(step_name="After", content="ran anyway", success=True),
+            ],
+        ),
+    ]
+
+
+def outcome_genuine_failure():
+    return [
+        StepStartedEvent(step_name="Boom"),
+        WorkflowCompletedEvent(
+            content="Step skipped due to error: step exploded",
+            step_results=[
+                StepOutput(
+                    step_name="Boom",
+                    content="Step skipped due to error: step exploded",
+                    success=False,
+                    error="step exploded",
+                )
+            ],
+        ),
+    ]
+
+
+def outcome_failure_in_a_nested_result_list():
+    """step_results is a recursive union: an element may itself be a list of results."""
+    return [
+        WorkflowCompletedEvent(
+            step_results=[
+                [
+                    StepOutput(step_name="Ok", content="fine", success=True),
+                    StepOutput(step_name="Boom", success=False, error="nested exploded"),
+                ]
+            ],
+        ),
+    ]
+
+
+def outcome_workflow_error():
+    return [
+        StepStartedEvent(step_name="Plan"),
+        WorkflowErrorEvent(error="the step blew up", error_type="ValueError"),
+    ]
+
+
+def outcome_top_level_cancellation():
+    return [WorkflowCancelledEvent(run_id="outer-run", reason="user pressed stop")]
+
+
+def outcome_nested_cancellation_then_outer_success():
+    """A nested workflow shares its parent's stream, tagged by run_id and nested_depth.
+
+    Verified against the engine: a workflow run as a step emits its own terminal event
+    onto the same stream, at nested_depth 1 and under its own run id. A cancellation
+    down there does not cancel the run the client asked for.
+    """
+    return [
+        WorkflowCancelledEvent(run_id="inner-run", nested_depth=1, reason="inner cancelled"),
+        WorkflowCompletedEvent(run_id="outer-run", nested_depth=0, content="outer finished anyway"),
+    ]
+
+
+def outcome_workflow_paused():
+    return [WorkflowPausedEvent(paused_step_name="Gate", status="paused")]
+
+
+def outcome_step_paused_for_confirmation():
+    """The whole stream a run parked on a confirmation gate produces."""
+    return [
+        StepPausedEvent(step_name="Gate", step_index=0, requires_confirmation=True),
+    ]
+
+
+def outcome_step_error_under_on_error_pause():
+    """HumanReview(on_error="pause"): the stream stops on StepError with no terminal event."""
+    return [
+        StepStartedEvent(step_name="Boom", step_index=0),
+        StepErrorEvent(step_name="Boom", step_index=0, error="step exploded"),
+    ]
+
+
+def outcome_agent_cancellation():
+    return [AgentRunCancelledEvent(reason="stopped")]
+
+
+TERMINAL_OUTCOMES = [
+    pytest.param(outcome_clean_completion, EventType.RUN_FINISHED, id="clean_completion"),
+    pytest.param(
+        outcome_skip_on_failure,
+        EventType.RUN_FINISHED,
+        id="completion_with_a_skip_on_failure_step",
+    ),
+    pytest.param(
+        outcome_on_error_skip,
+        EventType.RUN_FINISHED,
+        id="completion_with_on_error_skip",
+    ),
+    pytest.param(outcome_genuine_failure, EventType.RUN_ERROR, id="completion_whose_failed_step_is_last"),
+    pytest.param(
+        outcome_failure_in_a_nested_result_list,
+        EventType.RUN_ERROR,
+        id="completion_whose_failure_sits_in_a_nested_result_list",
+    ),
+    pytest.param(outcome_workflow_error, EventType.RUN_ERROR, id="workflow_error"),
+    pytest.param(outcome_top_level_cancellation, EventType.RUN_ERROR, id="top_level_cancellation"),
+    pytest.param(
+        outcome_nested_cancellation_then_outer_success,
+        EventType.RUN_FINISHED,
+        id="nested_cancellation_then_outer_success",
+    ),
+    pytest.param(
+        outcome_workflow_paused,
+        EventType.RUN_ERROR,
+        id="workflow_paused",
+    ),
+    pytest.param(
+        outcome_step_paused_for_confirmation,
+        EventType.RUN_ERROR,
+        id="step_paused_for_confirmation",
+    ),
+    pytest.param(
+        outcome_step_error_under_on_error_pause,
+        EventType.RUN_ERROR,
+        id="step_error_under_on_error_pause",
+    ),
+    pytest.param(outcome_agent_cancellation, EventType.RUN_FINISHED, id="agent_cancellation_is_unchanged"),
+]
+
+
+@pytest.mark.parametrize("build_chunks, expected_terminal", TERMINAL_OUTCOMES)
+def test_terminal_outcome_matrix(run_stream, build_chunks, expected_terminal):
+    """Every engine outcome maps to exactly one terminal AG-UI event, and it is the last one.
+
+    The agent cancellation row is a guard: it pins today's agent behaviour so a workflow
+    fix cannot change the agent path as a side effect.
+    """
+    events = run_stream(build_chunks())
+
+    assert events[-1].type == expected_terminal
+    opposite = EventType.RUN_FINISHED if expected_terminal is EventType.RUN_ERROR else EventType.RUN_ERROR
+    assert opposite not in event_types(events)
+
+
+def test_a_workflow_error_terminal_carries_its_reason_and_code(run_stream):
+    events = run_stream(outcome_workflow_error())
+
+    assert events[-1].message == "the step blew up"
+    assert events[-1].code == "ValueError"
+
+
+def test_a_cancellation_terminal_carries_its_reason_and_code(run_stream):
+    events = run_stream(outcome_top_level_cancellation())
+
+    assert events[-1].message == "user pressed stop"
+    assert events[-1].code == WorkflowRunEvent.workflow_cancelled.value
+
+
+# ---------------------------------------------------------------------------
+# Pause shapes
+# ---------------------------------------------------------------------------
+#
+# A pause reaches the stream as several events at different levels, and the engine
+# declares one pause value it does not yet emit an event class for. All of them park the
+# run, and the AG-UI interface offers a workflow no way to resume, so none of them may
+# be reported to the client as a finish.
+
+
+PAUSE_SHAPES = [
+    pytest.param(
+        lambda: WorkflowPausedEvent(paused_step_name="Gate", status="paused"),
+        WorkflowRunEvent.workflow_paused,
+        id="workflow_paused",
+    ),
+    pytest.param(
+        lambda: StepPausedEvent(step_name="Gate", step_index=0, requires_confirmation=True),
+        WorkflowRunEvent.step_paused,
+        id="step_paused",
+    ),
+    pytest.param(
+        lambda: StepExecutorPausedEvent(step_name="Gate", step_index=0, executor_type="agent"),
+        WorkflowRunEvent.step_executor_paused,
+        id="step_executor_paused",
+    ),
+    pytest.param(
+        lambda: RouterPausedEvent(step_name="Gate", step_index=0, available_choices=["left", "right"]),
+        WorkflowRunEvent.router_paused,
+        id="router_paused",
+    ),
+    pytest.param(
+        # The engine declares this outcome without a dedicated event class so far
+        lambda: StepPausedEvent(event=WorkflowRunEvent.condition_paused.value, step_name="Gate"),
+        WorkflowRunEvent.condition_paused,
+        id="condition_paused",
+    ),
+    pytest.param(
+        # An output review and a loop iteration review both park the run under this
+        # event, and the engine returns straight after it, so it is the last one sent.
+        lambda: StepOutputReviewEvent(step_name="Gate", step_index=0, output_review_message="approve?"),
+        WorkflowRunEvent.step_output_review,
+        id="step_output_review",
+    ),
+]
+
+
+@pytest.mark.parametrize("build_chunk, expected_code", PAUSE_SHAPES)
+def test_every_pause_shape_ends_the_run_naming_the_pause(run_stream, build_chunk, expected_code):
+    events = run_stream([StepStartedEvent(step_name="Gate"), build_chunk()])
+
+    assert events[-1].type == EventType.RUN_ERROR
+    assert events[-1].code == expected_code.value
+    assert "Gate" in events[-1].message
+    assert EventType.RUN_FINISHED not in event_types(events)
+
+
+def test_a_pause_without_a_step_name_still_ends_the_run(run_stream):
+    events = run_stream([WorkflowPausedEvent(status="paused")])
+
+    assert events[-1].type == EventType.RUN_ERROR
+    assert events[-1].message
+
+
+def test_the_step_pause_and_the_workflow_pause_end_the_run_once(run_stream):
+    """A pause is announced by the inner step event and again by the workflow event."""
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Gate"),
+            StepPausedEvent(step_name="Gate", step_index=0, requires_confirmation=True),
+            WorkflowPausedEvent(paused_step_name="Gate", status="paused"),
+        ]
+    )
+
+    assert event_types(events).count(EventType.RUN_ERROR) == 1
+    assert events[-1].code == WorkflowRunEvent.workflow_paused.value
+
+
+def test_a_completion_following_a_pause_does_not_report_success(run_stream):
+    events = run_stream(
+        [
+            WorkflowPausedEvent(paused_step_name="Gate", status="paused"),
+            WorkflowCompletedEvent(content="done"),
+        ]
+    )
+
+    assert events[-1].type == EventType.RUN_ERROR
+    assert EventType.RUN_FINISHED not in event_types(events)
+
+
+def test_an_executor_pause_does_not_offer_tool_calls_the_client_cannot_answer(run_stream):
+    """Executor HITL inside a workflow: the agent's own pause is followed by the workflow's.
+
+    The AG-UI route resumes agents and teams from trailing tool messages but never a
+    workflow, so tool calls raised here would ask the client for an answer it has
+    nowhere to send.
+
+    The tool carries a pause flag, which is what puts it in one of the three partitions
+    ``on_run_completed`` builds its cards from. A flagless tool raises no card on any
+    path, so the absence below would hold whatever the workflow pause did.
+    """
+    tool = ToolExecution(tool_call_id="tc-1", tool_name="approve", tool_args={}, requires_confirmation=True)
+    events = run_stream(
+        [
+            AgentRunPausedEvent(tools=[tool], content="waiting"),
+            StepExecutorPausedEvent(step_name="Gate", step_index=0, executor_type="agent"),
+            WorkflowPausedEvent(paused_step_name="Gate", status="paused"),
+        ]
+    )
+
+    assert events[-1].type == EventType.RUN_ERROR
+    assert EventType.TOOL_CALL_START not in event_types(events)
+
+
+# ---------------------------------------------------------------------------
+# Runs the client did not ask for
+# ---------------------------------------------------------------------------
+#
+# A nested workflow and a step's own agent or team both report their endings onto the
+# stream the client is watching. Neither of them ended that stream's run.
+
+
+def test_a_nested_workflow_error_does_not_bury_the_outer_run(run_stream):
+    events = run_stream(
+        [
+            WorkflowErrorEvent(run_id="inner-run", nested_depth=1, error="inner blew up"),
+            WorkflowCompletedEvent(run_id="outer-run", nested_depth=0, content="outer finished anyway"),
+        ]
+    )
+
+    assert events[-1].type == EventType.RUN_FINISHED
+    assert EventType.RUN_ERROR not in event_types(events)
+
+
+def test_a_nested_workflow_pause_does_not_bury_the_outer_run(run_stream):
+    events = run_stream(
+        [
+            WorkflowPausedEvent(run_id="inner-run", nested_depth=1, paused_step_name="Gate"),
+            WorkflowCompletedEvent(run_id="outer-run", nested_depth=0, content="outer finished anyway"),
+        ]
+    )
+
+    assert events[-1].type == EventType.RUN_FINISHED
+    assert EventType.RUN_ERROR not in event_types(events)
+
+
+def test_a_nested_completion_does_not_overrule_the_outer_cancellation(run_stream):
+    """The nested run reports its ending after the run the client asked for ended."""
+    events = run_stream(
+        [
+            WorkflowCancelledEvent(run_id="outer-run", reason="user pressed stop"),
+            WorkflowCompletedEvent(run_id="inner-run", nested_depth=1, content="inner finished"),
+        ]
+    )
+
+    assert events[-1].type == EventType.RUN_ERROR
+    assert events[-1].message == "user pressed stop"
+
+
+def test_a_team_member_failure_is_not_the_team_run_s_own_ending(run_stream):
+    """A member run carries the run that started it, and leaves the nesting depth at zero.
+
+    The team went on to answer, so the run the client is watching did not fail, and a
+    depth of zero must not be read as the member speaking for the team.
+    """
+    events = run_stream(
+        [
+            AgentRunErrorEvent(run_id="member-run", parent_run_id="run-1", content="the member failed"),
+            TeamRunContentEvent(run_id="run-1", content="answered without it"),
+        ]
+    )
+
+    assert events[-1].type == EventType.RUN_FINISHED
+    assert EventType.RUN_ERROR not in event_types(events)
+    assert deltas_of(events) == ["answered without it"]
+
+
+def test_a_team_s_own_failure_still_ends_the_run(run_stream):
+    """The control for the case above: the team's own error carries no parent run."""
+    events = run_stream([TeamRunErrorEvent(run_id="run-1", content="the team failed")])
+
+    assert events[-1].type == EventType.RUN_ERROR
+    assert events[-1].message == "the team failed"
+
+
+def test_an_executor_error_a_step_carried_on_past_does_not_fail_the_run(run_stream):
+    """A step's agent errors, the step tolerates it, and the workflow completes."""
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Ask", step_id="ask"),
+            AgentRunErrorEvent(content="model refused", step_id="ask"),
+            StepCompletedEvent(step_name="Ask", step_id="ask", content="fell back"),
+            WorkflowCompletedEvent(content="fell back"),
+        ]
+    )
+
+    assert events[-1].type == EventType.RUN_FINISHED
+    assert EventType.RUN_ERROR not in event_types(events)
+
+
+# ---------------------------------------------------------------------------
+# An ended run stays ended
+# ---------------------------------------------------------------------------
+#
+# The workflow reports that a run did not finish once, and the stream carries on: the
+# engine repeats the ending as a completion event, and a step's own agent or team can
+# report an error of its own after it. Neither may talk the mapper back into a success.
+
+
+UNFINISHED_THEN_AGENT_ERROR = [
+    pytest.param(
+        lambda: StepErrorEvent(step_name="Boom", step_index=0, error="step exploded"),
+        None,
+        id="step_error",
+    ),
+    pytest.param(
+        lambda: WorkflowPausedEvent(paused_step_name="Gate", status="paused"),
+        WorkflowRunEvent.workflow_paused.value,
+        id="workflow_paused",
+    ),
+    pytest.param(
+        lambda: WorkflowCancelledEvent(reason="user pressed stop"),
+        WorkflowRunEvent.workflow_cancelled.value,
+        id="workflow_cancelled",
+    ),
+]
+
+
+@pytest.mark.parametrize("build_unfinished, expected_code", UNFINISHED_THEN_AGENT_ERROR)
+def test_an_agent_error_does_not_reopen_a_run_the_workflow_already_ended(run_stream, build_unfinished, expected_code):
+    """An agent error belongs to a step's executor, so it cannot clear the workflow's report."""
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Boom", step_index=0),
+            build_unfinished(),
+            AgentRunErrorEvent(content="model refused"),
+            WorkflowCompletedEvent(content="done"),
+        ]
+    )
+
+    assert events[-1].type == EventType.RUN_ERROR
+    assert EventType.RUN_FINISHED not in event_types(events)
+    if expected_code is not None:
+        assert events[-1].code == expected_code
+
+
+# ---------------------------------------------------------------------------
+# Tolerated step failures
+# ---------------------------------------------------------------------------
+
+
+def test_a_failure_inside_the_last_grouped_step_is_not_masked_by_its_container(run_stream):
+    """A container reporting success over a failed child leaves the failure unreported.
+
+    Every container step in the engine folds its children into its own success flag, so a
+    container that reports success while a child failed is not a summary of a tolerance
+    its policy allowed. Nothing followed the container either, so the run stopped there.
+    """
+    events = run_stream(
+        [
+            WorkflowCompletedEvent(
+                content="done",
+                step_results=[
+                    StepOutput(
+                        step_name="Par",
+                        content="done",
+                        success=True,
+                        steps=[StepOutput(step_name="Boom", success=False, error="child exploded")],
+                    )
+                ],
+            )
+        ]
+    )
+
+    assert events[-1].type == EventType.RUN_ERROR
+    assert events[-1].message == "child exploded"
+
+
+def test_a_container_failure_the_run_continued_past_still_finishes(run_stream):
+    """The engine's own shape for a parallel child failure a later step ran on past."""
+    events = run_stream(
+        [
+            WorkflowCompletedEvent(
+                content="ran anyway",
+                step_results=[
+                    StepOutput(
+                        step_name="Par",
+                        success=False,
+                        steps=[
+                            StepOutput(step_name="Boom", success=False, error="child exploded"),
+                            StepOutput(step_name="Fine", content="fine", success=True),
+                        ],
+                    ),
+                    StepOutput(step_name="After", content="ran anyway", success=True),
+                ],
+            )
+        ]
+    )
+
+    assert events[-1].type == EventType.RUN_FINISHED
+    assert EventType.RUN_ERROR not in event_types(events)
+
+
+def test_the_failure_that_ended_the_run_is_the_one_reported(run_stream):
+    """A failure the run carried on past is not the failure the client is owed."""
+    events = run_stream(
+        [
+            WorkflowCompletedEvent(
+                step_results=[
+                    StepOutput(step_name="Skipped", success=False, error="a failure the run survived"),
+                    StepOutput(step_name="After", content="ran anyway", success=True),
+                    StepOutput(step_name="Boom", success=False, error="the failure that ended the run"),
+                ],
+            )
+        ]
+    )
+
+    assert events[-1].type == EventType.RUN_ERROR
+    assert events[-1].message == "the failure that ended the run"
+
+
+def test_a_run_that_continued_past_a_skipped_step_keeps_its_final_state_snapshot():
+    """Reporting a completed run as failed also costs the client the state it ended with."""
+    events = list(
+        stream_agno_response_as_agui_events(
+            iter(outcome_skip_on_failure()),
+            thread_id="thread-1",
+            run_id="run-1",
+            run_state={"count": 1},
+        )
+    )
+    assert_valid_agui_stream(events)
+
+    assert events[-1].type == EventType.RUN_FINISHED
+    assert EventType.STATE_SNAPSHOT in event_types(events)
+
+
+def test_a_failure_in_a_nested_result_list_names_the_inner_error(run_stream):
+    events = run_stream(outcome_failure_in_a_nested_result_list())
+
+    assert events[-1].message == "nested exploded"
+
+
+def test_a_run_that_continued_past_a_grouped_failure_still_finishes(run_stream):
+    """Descending into a grouped element must not turn a survived failure into a fatal one.
+
+    A step that opts out of aborting leaves a failed result behind and the run carries on,
+    so a result following the failure means the run really did complete.
+    """
+    events = run_stream(
+        [
+            WorkflowCompletedEvent(
+                step_results=[
+                    [
+                        StepOutput(step_name="Ok", content="fine", success=True),
+                        StepOutput(step_name="Boom", success=False, error="nested exploded"),
+                    ],
+                    StepOutput(step_name="After", content="ran anyway", success=True),
+                ],
+            ),
+        ]
+    )
+
+    assert events[-1].type == EventType.RUN_FINISHED
+    assert EventType.RUN_ERROR not in event_types(events)
+
+
+# ---------------------------------------------------------------------------
+# Engine payload shape corpus
+# ---------------------------------------------------------------------------
+#
+# The mapper consumes engine payloads whose declared types are Any or recursive unions,
+# and each consumption site re-derives its own traversal with getattr defaults and
+# isinstance chains. A shape the site did not anticipate does not raise there: it
+# returns the default and the run continues with the wrong answer. These rows feed both
+# traversal points every shape the engine declares, and assert that each one has a
+# defined outcome and that none of them escapes the mapper as an exception.
+
+
+class StructuredStepOutput(BaseModel):
+    title: str
+
+
+def yielded_step_names(results):
+    return [getattr(result, "step_name", None) for result in _iter_step_results(results)]
+
+
+STEP_RESULT_SHAPES = [
+    pytest.param(None, [], id="none_instead_of_a_list"),
+    pytest.param([], [], id="empty_list"),
+    pytest.param(
+        [StepOutput(step_name="A"), StepOutput(step_name="B")],
+        ["A", "B"],
+        id="flat_list",
+    ),
+    pytest.param(
+        [StepOutput(step_name="A"), None, StepOutput(step_name="B")],
+        ["A", "B"],
+        id="list_with_a_none_entry",
+    ),
+    pytest.param(
+        [StepOutput(step_name="Par", steps=[StepOutput(step_name="Ok"), StepOutput(step_name="Boom")])],
+        ["Ok", "Boom", "Par"],
+        id="result_carrying_children_under_steps",
+    ),
+    pytest.param(
+        [[StepOutput(step_name="Ok"), StepOutput(step_name="Boom")]],
+        ["Ok", "Boom"],
+        id="bare_nested_list_element",
+    ),
+    pytest.param(
+        [StepOutput(step_name="A"), [StepOutput(step_name="Ok"), StepOutput(step_name="Boom")]],
+        ["A", "Ok", "Boom"],
+        id="mixed_list_of_results_and_lists",
+    ),
+    pytest.param(
+        [[StepOutput(step_name="Par", steps=[StepOutput(step_name="Ok")])]],
+        ["Ok", "Par"],
+        id="bare_list_element_whose_result_carries_children",
+    ),
+    pytest.param(
+        [[None, StepOutput(step_name="Ok")]],
+        ["Ok"],
+        id="bare_list_element_with_a_none_entry",
+    ),
+    pytest.param([[]], [], id="empty_bare_list_element"),
+]
+
+
+@pytest.mark.parametrize("results, expected_names", STEP_RESULT_SHAPES)
+def test_every_declared_step_result_shape_is_walked(results, expected_names):
+    """step_results is declared List[Union[StepOutput, List[StepOutput]]] and the run
+    output flattens both forms, so the walker has to reach a result under either one."""
+    assert yielded_step_names(results) == expected_names
+
+
+STEP_CONTENT_SHAPES = [
+    pytest.param("plain text", "plain text", id="str"),
+    pytest.param({"role": "user", "content": "from a dict"}, "from a dict", id="dict_carrying_content"),
+    pytest.param({"summary": "no content key"}, "no content key", id="dict_without_a_content_key"),
+    pytest.param(StructuredStepOutput(title="structured"), "structured", id="basemodel"),
+    pytest.param(Message(role="user", content="from a message"), "from a message", id="message"),
+    pytest.param(
+        [{"type": "text", "text": "first"}, {"type": "text", "text": "second"}],
+        "first\nsecond",
+        id="list_of_typed_dicts",
+    ),
+    pytest.param(
+        [{"summary": "first"}, {"summary": "second"}],
+        "first",
+        id="list_of_plain_dicts",
+    ),
+    pytest.param(
+        ["first", "second"],
+        "first",
+        id="list_of_strings",
+    ),
+    pytest.param(
+        [1, 2, 3],
+        "1",
+        id="list_of_scalars",
+    ),
+    pytest.param(42, "42", id="scalar"),
+]
+
+
+@pytest.mark.parametrize("content, expected_text", STEP_CONTENT_SHAPES)
+def test_every_step_content_shape_reaches_the_client(run_stream, content, expected_text):
+    """StepCompletedEvent.content is Optional[Any] and a step may return any of these."""
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Step", step_id="s1"),
+            StepCompletedEvent(step_name="Step", step_id="s1", content=content),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    deltas = deltas_of(events)
+    assert len(deltas) == 1
+    assert expected_text in deltas[0]
+
+
+TRANSCRIPT_CONTENTS = [
+    pytest.param(
+        [Message(role="user", content="what is the capital?"), Message(role="assistant", content="Paris")],
+        id="messages",
+    ),
+    pytest.param(
+        [{"role": "user", "content": "what is the capital?"}, {"role": "assistant", "content": "Paris"}],
+        id="message_records",
+    ),
+    pytest.param(
+        [
+            Message(role="user", content="what is the capital?"),
+            Message(role="tool", content='{"capital": "Paris", "population": 2102650}'),
+            Message(role="assistant", content="Paris"),
+        ],
+        id="messages_including_a_tool_result",
+    ),
+    pytest.param(
+        [
+            {"role": "user", "content": "what is the capital?"},
+            {"role": "tool", "content": '{"capital": "Paris", "population": 2102650}'},
+            {"role": "assistant", "content": "Paris"},
+        ],
+        id="message_records_including_a_tool_result",
+    ),
+]
+
+
+@pytest.mark.parametrize("content", TRANSCRIPT_CONTENTS)
+def test_a_step_returning_a_transcript_sends_what_it_answered(run_stream, content):
+    """A step whose output is a conversation owes the client its reply, not the prompt.
+
+    The interface's reading of message content returns the user turns out of a list of
+    messages, so reusing it here sends the caller's own question back as the step's
+    answer and drops the answer. A tool turn is the same fault from the other side: the
+    raw payload a tool handed the step is not the step's answer either, and sending it
+    puts a JSON blob in the assistant text. Both are wrong text on the wire, not missing
+    text.
+    """
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Ask", step_id="ask"),
+            StepCompletedEvent(step_name="Ask", step_id="ask", content=content),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    assert deltas_of(events) == ["Paris"]
+
+
+PLAIN_LIST_CONTENTS = [
+    pytest.param(["first", "second"], ["first", "second"], id="strings"),
+    pytest.param([1, 2, 3], ["1", "2", "3"], id="scalars"),
+    pytest.param([{"summary": "first"}, {"summary": "second"}], ["first", "second"], id="dicts"),
+]
+
+
+@pytest.mark.parametrize("content, expected_parts", PLAIN_LIST_CONTENTS)
+def test_a_plain_list_sends_every_element_not_only_the_first(run_stream, content, expected_parts):
+    """Dropping the tail of a list would lose output as silently as dropping all of it."""
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Step", step_id="s1"),
+            StepCompletedEvent(step_name="Step", step_id="s1", content=content),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    deltas = deltas_of(events)
+    assert len(deltas) == 1
+    for part in expected_parts:
+        assert part in deltas[0]
+
+
+RECORDS_THE_JSON_SERIALIZER_REFUSES = [
+    pytest.param({"kept": "the readable part", "at": datetime(2026, 1, 2, 3, 4, 5)}, id="datetime_value"),
+    pytest.param({"kept": "the readable part", "tags": {"a", "b"}}, id="set_value"),
+    pytest.param({"kept": "the readable part", "inner": StructuredStepOutput(title="nested")}, id="model_value"),
+    pytest.param({"kept": "the readable part", "seen": [datetime(2026, 1, 2)]}, id="value_nested_in_a_list"),
+]
+
+
+@pytest.mark.parametrize("content", RECORDS_THE_JSON_SERIALIZER_REFUSES)
+def test_a_record_the_json_serializer_refuses_does_not_end_the_run(run_stream, content):
+    """A step returns whatever its executor returned, and json.dumps reads few of those.
+
+    The record still has to reach the reader, and the run still has to reach its end.
+    """
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Step", step_id="s1"),
+            StepCompletedEvent(step_name="Step", step_id="s1", content=content),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    assert events[-1].type == EventType.RUN_FINISHED
+    deltas = deltas_of(events)
+    assert len(deltas) == 1
+    assert "the readable part" in deltas[0]
+
+
+class Opaque:
+    """A value pydantic has no serializer for, whose own text still says what it holds."""
+
+    def __repr__(self) -> str:
+        return "the readable part"
+
+
+class ModelPydanticCannotSerialize(BaseModel):
+    model_config = {"arbitrary_types_allowed": True}
+
+    title: str
+    payload: Opaque
+
+
+def test_a_model_pydantic_cannot_serialize_does_not_end_the_run(run_stream):
+    """A step may return a model holding a value pydantic has no serializer for.
+
+    ``model_dump_json`` raises on it, and an exception leaving the mapper is caught by
+    the route, which ends the run with an error in place of the step's output and closes
+    none of the spans the client is holding open. The model still has to reach the
+    reader, and the run still has to reach its end.
+    """
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Step", step_id="s1"),
+            StepCompletedEvent(
+                step_name="Step",
+                step_id="s1",
+                content=ModelPydanticCannotSerialize(title="kept", payload=Opaque()),
+            ),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    assert events[-1].type == EventType.RUN_FINISHED
+    deltas = deltas_of(events)
+    assert len(deltas) == 1
+    assert "kept" in deltas[0]
+    assert "the readable part" in deltas[0]
+
+
+RECORDS_CARRYING_A_CONTENT_KEY = [
+    pytest.param(
+        {"content": "the summary", "detail": "the sibling the reader also needs"},
+        ["the summary", "the sibling the reader also needs"],
+        id="content_beside_a_sibling",
+    ),
+    pytest.param(
+        {"content": "", "result": "everything the step produced"},
+        ["everything the step produced"],
+        id="empty_content_beside_a_sibling",
+    ),
+    pytest.param(
+        {"content": None, "error": "the step said why it failed"},
+        ["the step said why it failed"],
+        id="null_content_beside_a_sibling",
+    ),
+]
+
+
+@pytest.mark.parametrize("content, expected_parts", RECORDS_CARRYING_A_CONTENT_KEY)
+def test_a_record_is_not_reduced_to_its_content_key(run_stream, content, expected_parts):
+    """A key named content is one key of a record, not a licence to drop the others."""
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Step", step_id="s1"),
+            StepCompletedEvent(step_name="Step", step_id="s1", content=content),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    deltas = deltas_of(events)
+    assert len(deltas) == 1
+    for part in expected_parts:
+        assert part in deltas[0]
+
+
+EMPTY_STEP_CONTENT_SHAPES = [
+    pytest.param(None, id="none"),
+    pytest.param("", id="empty_str"),
+    pytest.param([], id="empty_list"),
+    pytest.param(
+        {},
+        id="empty_dict",
+    ),
+    pytest.param({"content": {}}, id="dict_whose_content_is_empty"),
+    pytest.param({"content": []}, id="dict_whose_content_is_an_empty_list"),
+    pytest.param([None, "", {}], id="list_of_empty_entries"),
+    pytest.param(Message(role="user"), id="message_with_no_content"),
+]
+
+
+@pytest.mark.parametrize("content", EMPTY_STEP_CONTENT_SHAPES)
+def test_a_step_with_no_content_opens_no_message(run_stream, content):
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Step", step_id="s1"),
+            StepCompletedEvent(step_name="Step", step_id="s1", content=content),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    assert deltas_of(events) == []
+    assert EventType.TEXT_MESSAGE_START not in event_types(events)
+
+
+# ---------------------------------------------------------------------------
+# Span lifecycle and text framing
+# ---------------------------------------------------------------------------
+#
+# The stream-wide rules live in _agui_stream_rules and run on every test above through
+# the run_stream fixture. The cases below are lifecycle defects the client's own
+# verifier does not reject but a reader of the transcript would: identical text sent
+# twice, output that never arrives at all, and a span that outlives the step it
+# belongs to.
+
+
+def span_events(events):
+    return [(event.type, event.step_name) for event in events if event.type in _SPAN_TYPES]
+
+
+_SPAN_TYPES = (EventType.STEP_STARTED, EventType.STEP_FINISHED)
+
+
+def test_a_function_step_output_is_not_re_emitted_by_the_step_containing_it(run_stream):
+    """A function step streams nothing, so its output leaves through the completion path.
+
+    That path emits the text without crediting the step, and the enclosing step then
+    believes it still owes the client its own output.
+    """
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Outer", step_id="outer"),
+            StepStartedEvent(step_name="Inner", step_id="inner", parent_step_id="outer"),
+            StepCompletedEvent(step_name="Inner", step_id="inner", content="function output"),
+            StepCompletedEvent(step_name="Outer", step_id="outer", content="function output"),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    assert deltas_of(events) == ["function output"]
+
+
+def test_a_step_that_produced_nothing_does_not_claim_the_output_of_the_step_around_it(run_stream):
+    """A nested workflow's steps are children of the outer step, so what they claim it loses.
+
+    An inner step whose completion carries no content has no output to claim, and
+    claiming one anyway tells the outer step its own output has already been sent. The
+    outer step then emits nothing and the whole nested workflow's answer is dropped.
+    """
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Outer", step_id="outer"),
+            StepStartedEvent(step_name="Inner", step_id="inner", parent_step_id="outer"),
+            StepCompletedEvent(step_name="Inner", step_id="inner", content=None),
+            StepCompletedEvent(step_name="Outer", step_id="outer", content="what the nested workflow answered"),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    assert deltas_of(events) == ["what the nested workflow answered"]
+
+
+def test_a_completion_matching_no_span_does_not_repeat_text_its_step_already_streamed(run_stream):
+    """A span is dropped once its transitions are emitted, and the text it sent is not.
+
+    Here the sequence moves on to a later step, which closes and drains the span of the
+    step before it. That step's completion then matches nothing, and treating an
+    unmatched completion as unsent output sends the client its own step's text twice.
+    """
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="One", step_id="one", step_index=0),
+            RunContentEvent(content="what One streamed", step_id="one"),
+            StepStartedEvent(step_name="Two", step_id="two", step_index=1),
+            StepCompletedEvent(step_name="One", step_id="one", step_index=0, content="what One streamed"),
+            StepCompletedEvent(step_name="Two", step_id="two", step_index=1, content="what Two computed"),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    assert deltas_of(events) == ["what One streamed", "what Two computed"]
+
+
+def test_a_step_that_ends_first_takes_the_step_still_open_inside_it_with_it(run_stream):
+    """A step ending ends everything it contains, whether or not the engine says so.
+
+    Without that, the inner step's STEP_FINISHED waits for the run's terminal event and
+    arrives after its own container's and after every step that ran later, which tells
+    the client the inner step outlived the step it was running inside.
+    """
+    events = run_stream(
+        [
+            StepStartedEvent(step_name="Outer", step_id="outer"),
+            StepStartedEvent(step_name="Inner", step_id="inner", parent_step_id="outer"),
+            StepCompletedEvent(step_name="Outer", step_id="outer", content="outer done"),
+            StepStartedEvent(step_name="Next", step_id="next"),
+            StepCompletedEvent(step_name="Next", step_id="next", content="next done"),
+            WorkflowCompletedEvent(),
+        ]
+    )
+
+    assert span_events(events) == [
+        (EventType.STEP_STARTED, "Outer"),
+        (EventType.STEP_STARTED, "Inner"),
+        (EventType.STEP_FINISHED, "Inner"),
+        (EventType.STEP_FINISHED, "Outer"),
+        (EventType.STEP_STARTED, "Next"),
+        (EventType.STEP_FINISHED, "Next"),
+    ]
+
+
+def test_a_skipped_step_closes_its_span_before_the_next_step_finishes(run_stream):
+    """Step(skip_on_failure=True) sends no StepCompletedEvent for the step it skipped.
+
+    The terminal event closes the span instead, which puts the skipped step's
+    STEP_FINISHED after the STEP_FINISHED of every step that ran after it. The existing
+    balance helper sorts the finished names, so nesting order is asserted here directly.
+    """
+    events = run_stream(outcome_skip_on_failure())
+
+    assert span_events(events) == [
+        (EventType.STEP_STARTED, "Boom"),
+        (EventType.STEP_FINISHED, "Boom"),
+        (EventType.STEP_STARTED, "After"),
+        (EventType.STEP_FINISHED, "After"),
+    ]

--- a/libs/agno/tests/unit/os/interfaces/test_telemetry_guard.py
+++ b/libs/agno/tests/unit/os/interfaces/test_telemetry_guard.py
@@ -1,0 +1,58 @@
+"""The conftest telemetry guard, checked from inside the directory it covers.
+
+The guard used to sit in one interface module, which left every sibling suite here free
+to post telemetry from a unit test. Nothing in those suites posts on purpose, so they
+pass either way and cannot say whether the guard is armed. This says it.
+
+Each entry point is recognised by identity before it is called. Calling one to find out
+whether it is guarded is the regression itself: on the run where the guard is missing,
+that call is a telemetry post from a unit test.
+"""
+
+import pytest
+
+from agno.api.api import Api
+from agno.api.api import api as agno_api
+
+from .conftest import TELEMETRY_ENTRY_POINTS, install_telemetry_guard, refuse_telemetry_post
+
+
+@pytest.mark.parametrize("entry_point", TELEMETRY_ENTRY_POINTS)
+def test_the_guard_stands_on_every_telemetry_entry_point(entry_point):
+    assert getattr(agno_api, entry_point) is refuse_telemetry_post
+
+
+def test_the_guard_refuses_a_telemetry_post():
+    assert agno_api.post_in_background is refuse_telemetry_post
+
+    with pytest.raises(pytest.fail.Exception, match="posted telemetry"):
+        agno_api.post_in_background("agent-run", {})
+
+
+async def test_the_guard_refuses_an_async_telemetry_post():
+    """The async entry point is public and awaited from event-loop code. It delegates to
+    the sync one today, so nothing here depends on it continuing to."""
+    assert agno_api.apost_in_background is refuse_telemetry_post
+
+    with pytest.raises(pytest.fail.Exception, match="posted telemetry"):
+        await agno_api.apost_in_background("agent-run", {})
+
+
+def test_the_undo_leaves_the_instance_reading_its_class_again():
+    """Writing back what ``getattr`` returned pins a bound method on the instance, which
+    then answers every later call however the class changes. The telemetry client is a
+    module-level singleton, so a pin put there outlives this directory."""
+
+    class ApiUnderTest(Api):
+        pass
+
+    target = ApiUnderTest()
+    undo = install_telemetry_guard(target)
+    assert target.post_in_background is refuse_telemetry_post
+    undo()
+
+    for name in TELEMETRY_ENTRY_POINTS:
+        assert name not in vars(target)
+
+    ApiUnderTest.post_in_background = lambda self, route, payload: "from the class"
+    assert target.post_in_background("agent-run", {}) == "from the class"


### PR DESCRIPTION
## Summary

`AGUI` accepted an `Agent` or a `Team` but not a `Workflow`. This adds Workflow
as a third entity, matching what `Slack`, `Telegram` and `WhatsApp` already
accept. Closes #5220.

Registration, routing and the `workflows:run` scope. Step boundaries become
`STEP_STARTED` / `STEP_FINISHED`. Agent and Team behaviour is unchanged.

## Type of change

- [x] New feature

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**On #8900.** It also adds Workflow support, bundled with an unrelated feature
that turns tool return values into state events. This does only the entity, so
theirs can land on top. Happy to close this in favour of it if you prefer.