### PR TITLE
[fix] Match OpenAI batch embeddings to their input indices

### DIFF
--- a/libs/agno/agno/knowledge/embedder/azure_openai.py
+++ b/libs/agno/agno/knowledge/embedder/azure_openai.py
@@ -206,7 +206,10 @@ class AzureOpenAIEmbedder(Embedder):
             try:
                 response: CreateEmbeddingResponse = await self.aclient.embeddings.create(**req)
                 batch_embeddings = pad_batch_embeddings(
-                    [data.embedding for data in response.data], batch_texts, "AzureOpenAI"
+                    [data.embedding for data in response.data],
+                    batch_texts,
+                    "AzureOpenAI",
+                    indices=[data.index for data in response.data],
                 )
                 all_embeddings.extend(batch_embeddings)
 

--- a/libs/agno/agno/knowledge/embedder/base.py
+++ b/libs/agno/agno/knowledge/embedder/base.py
@@ -45,13 +45,30 @@ def pad_batch_embeddings(
     embeddings: List[List[float]],
     batch_texts: List[str],
     provider: Optional[str] = None,
+    *,
+    indices: Optional[List[int]] = None,
 ) -> List[List[float]]:
     """Pad a short batch response so every text keeps its own slot.
 
     Callers pair embeddings with documents by position, so a response carrying fewer
     embeddings than texts would shift every later text onto the wrong vector. Missing
     entries become empty vectors, which ingestion counts and reports as a shortfall.
+    When the provider supplies indices, use those positions rather than response order.
     """
+    if indices is not None:
+        aligned: List[List[float]] = [[] for _ in batch_texts]
+        seen = set()
+        for index, embedding in zip(indices, embeddings):
+            if not isinstance(index, int) or not 0 <= index < len(batch_texts) or index in seen:
+                raise ValueError(f"{provider or 'Embedder'} returned an invalid embedding index: {index}")
+            seen.add(index)
+            aligned[index] = embedding
+        if len(embeddings) < len(batch_texts):
+            log_warning(
+                f"{provider or 'Embedder'} batch response returned {len(embeddings)} of "
+                f"{len(batch_texts)} embeddings; missing indices are recorded as unembedded"
+            )
+        return aligned
     if len(embeddings) >= len(batch_texts):
         return embeddings
     log_warning(

--- a/libs/agno/agno/knowledge/embedder/openai.py
+++ b/libs/agno/agno/knowledge/embedder/openai.py
@@ -184,7 +184,10 @@ class OpenAIEmbedder(Embedder):
             try:
                 response: CreateEmbeddingResponse = await self.aclient.embeddings.create(**req)
                 batch_embeddings = pad_batch_embeddings(
-                    [data.embedding for data in response.data], batch_texts, "OpenAI"
+                    [data.embedding for data in response.data],
+                    batch_texts,
+                    "OpenAI",
+                    indices=[data.index for data in response.data],
                 )
                 all_embeddings.extend(batch_embeddings)
 

--- a/libs/agno/tests/unit/knowledge/test_indexed_embedding_batches.py
+++ b/libs/agno/tests/unit/knowledge/test_indexed_embedding_batches.py
@@ -1,0 +1,50 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from openai.types.create_embedding_response import CreateEmbeddingResponse
+
+from agno.knowledge.embedder.azure_openai import AzureOpenAIEmbedder
+from agno.knowledge.embedder.openai import OpenAIEmbedder
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("embedder_cls", [OpenAIEmbedder, AzureOpenAIEmbedder])
+@pytest.mark.parametrize("indices", [[2, 0, 1], [0, 2], [2], []])
+async def test_batch_preserves_input_positions(embedder_cls, indices):
+    response = CreateEmbeddingResponse(
+        data=[{"object": "embedding", "index": index, "embedding": [float(index)]} for index in indices],
+        model="test-embedding",
+        object="list",
+        usage={"prompt_tokens": 3, "total_tokens": 3},
+    )
+    client = MagicMock()
+    client.embeddings.create = AsyncMock(return_value=response)
+    embedder = embedder_cls(async_client=client)
+
+    embeddings, usage = await embedder.async_get_embeddings_batch_and_usage(["first", "second", "third"])
+
+    assert embeddings == [[float(index)] if index in indices else [] for index in range(3)]
+    assert len(usage) == 3
+    client.embeddings.create.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("embedder_cls", [OpenAIEmbedder, AzureOpenAIEmbedder])
+async def test_response_indices_restart_for_each_batch(embedder_cls):
+    def response(indices):
+        return CreateEmbeddingResponse(
+            data=[{"object": "embedding", "index": index, "embedding": [value]} for index, value in indices],
+            model="test-embedding",
+            object="list",
+            usage={"prompt_tokens": 2, "total_tokens": 2},
+        )
+
+    client = MagicMock()
+    client.embeddings.create = AsyncMock(side_effect=[response([(1, 2.0), (0, 1.0)]), response([(0, 3.0)])])
+    embedder = embedder_cls(async_client=client, batch_size=2)
+
+    embeddings, usage = await embedder.async_get_embeddings_batch_and_usage(["first", "second", "third"])
+
+    assert embeddings == [[1.0], [2.0], [3.0]]
+    assert len(usage) == 3
+    assert client.embeddings.create.await_count == 2


### PR DESCRIPTION
## Summary

A reordered embedding response currently assigns vectors to the wrong documents. A short response also shifts later vectors when the missing item is in the middle. Use each response entry's `index` in the OpenAI and Azure batch paths, retaining empty slots for missing results and the existing per-item fallback for invalid indices.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed — human review pending; automated diff review completed
- [x] Documentation updated (comments/docstrings where applicable)
- [ ] Examples and guides: not applicable to this correction
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] Searched existing open pull requests; no PR found addressing this defect
- [ ] If a similar PR exists, explained why this approach is better
- [x] This PR was entirely AI-generated

## Additional Notes

8 failures and 2 passes on main; all 10 cases pass with this patch. Covers reordered responses, missing middle/leading entries, empty responses, and batch-local indices across multiple requests.

`pytest libs/agno/tests/unit/knowledge/test_indexed_embedding_batches.py -q`

Tests use local SDK objects and mocked clients, with no live model requests. The broader related suite has 308 passes, 20 skips, and 3 existing Windows-specific file/MIME failures; the same 3 failures were reproduced on unmodified main. Format and validation pass in the repository's development dependency environment. Installing the optional Google SDK also exposes pre-existing typing errors, so SDK-backed tests use a separate environment.

Prepared and tested by Codex at the account owner's request. Kept as a draft for their human review; no claim of human review is made.
