### PR TITLE
[fix] Preserve Gemini function call IDs when replaying tool messages

### DIFF
--- a/libs/agno/agno/models/google/gemini.py
+++ b/libs/agno/agno/models/google/gemini.py
@@ -830,6 +830,8 @@ class Gemini(Model):
                         name=tool_call["function"]["name"],
                         args=args,
                     )
+                    if part.function_call is not None:
+                        part.function_call.id = tool_call.get("id")
                     if "thought_signature" in tool_call:
                         part.thought_signature = base64.b64decode(tool_call["thought_signature"])
                     message_parts.append(part)
@@ -837,13 +839,14 @@ class Gemini(Model):
             elif message.role == "tool" and message.tool_call_id is not None and message.tool_name is not None:
                 tc_content = message.get_content(use_compressed_content=compress_tool_results)
                 media_parts, fallback_media_parts = self._format_tool_result_media(message)
-                message_parts.append(
-                    Part.from_function_response(
-                        name=message.tool_name,
-                        response={"result": tc_content},
-                        parts=media_parts or None,
-                    )
+                part = Part.from_function_response(
+                    name=message.tool_name,
+                    response={"result": tc_content},
+                    parts=media_parts or None,
                 )
+                if part.function_response is not None:
+                    part.function_response.id = message.tool_call_id
+                message_parts.append(part)
                 message_parts.extend(fallback_media_parts)
             # Regular text content
             else:

--- a/libs/agno/tests/unit/models/google/test_gemini_tool_call_ids.py
+++ b/libs/agno/tests/unit/models/google/test_gemini_tool_call_ids.py
@@ -1,0 +1,39 @@
+import pytest
+
+pytest.importorskip("google.genai")
+
+from google.genai.types import Candidate, Content, FunctionCall, GenerateContentResponse, Part
+
+from agno.models.google.gemini import Gemini
+from agno.models.message import Message
+
+
+@pytest.mark.parametrize("stream", [False, True])
+def test_parallel_tool_call_ids_survive_round_trip(stream):
+    model = Gemini()
+    response = GenerateContentResponse(
+        candidates=[
+            Candidate(
+                content=Content(
+                    role="model",
+                    parts=[
+                        Part(function_call=FunctionCall(id="call-a", name="lookup", args={"city": "Paris"})),
+                        Part(function_call=FunctionCall(id="call-b", name="lookup", args={"city": "Tokyo"})),
+                    ],
+                )
+            )
+        ]
+    )
+    parsed = model._parse_provider_response_delta(response) if stream else model._parse_provider_response(response)
+    messages = [
+        Message(role="assistant", tool_calls=parsed.tool_calls),
+        Message(role="tool", tool_call_id="call-b", tool_name="lookup", content="Tokyo result"),
+        Message(role="tool", tool_call_id="call-a", tool_name="lookup", content="Paris result"),
+    ]
+
+    formatted, _ = model._format_messages(messages)
+
+    calls = [part.function_call for message in formatted for part in message.parts if part.function_call]
+    results = [part.function_response for message in formatted for part in message.parts if part.function_response]
+    assert [call.id for call in calls] == ["call-a", "call-b"]
+    assert [result.id for result in results] == ["call-b", "call-a"]


### PR DESCRIPTION
## Summary

Gemini response parsing retains function call IDs, but request formatting drops them from both the call and its result. Carry the IDs through both Parts so parallel calls to the same function retain their result association, including when results arrive in a different order.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed — human review pending; automated diff review completed
- [x] Documentation updated (comments/docstrings where applicable)
- [ ] Examples and guides: not applicable to this correction
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] Searched existing open pull requests; no PR found addressing this defect
- [ ] If a similar PR exists, explained why this approach is better
- [x] This PR was entirely AI-generated

## Additional Notes

Both new round-trip tests fail on main and pass with this patch, covering normal and streaming response parsing with two same-name calls and reversed results.

`pytest libs/agno/tests/unit/models/google/test_gemini_tool_call_ids.py -q`

Tests use local SDK objects and mocked clients, with no live model requests. The broader related suite has 308 passes, 20 skips, and 3 existing Windows-specific file/MIME failures; the same 3 failures were reproduced on unmodified main. Format and validation pass in the repository's development dependency environment. Installing the optional Google SDK also exposes pre-existing typing errors, so SDK-backed tests use a separate environment.

Prepared and tested by Codex at the account owner's request. Kept as a draft for their human review; no claim of human review is made.
