### PR TITLE
[fix] Preserve nullable Gemini schemas without mutating tool definitions

### DIFF
--- a/libs/agno/agno/utils/gemini.py
+++ b/libs/agno/agno/utils/gemini.py
@@ -267,6 +267,17 @@ def convert_schema(
         return None
 
     schema_type = schema_dict.get("type", "")
+    if isinstance(schema_type, list) and "null" in schema_type:
+        if not any(value != "null" for value in schema_type):
+            return None
+        return convert_schema(
+            {
+                **{key: value for key, value in schema_dict.items() if key != "type"},
+                "anyOf": [{**schema_dict, "type": value} for value in schema_type],
+            },
+            root_schema,
+            visited_refs,
+        )
     if schema_type is None or schema_type == "null":
         return None
     description = schema_dict.get("description", None)
@@ -283,18 +294,9 @@ def convert_schema(
         if "properties" in schema_dict:
             properties = {}
             for key, prop_def in schema_dict["properties"].items():
-                # Process nullable types
-                prop_type = prop_def.get("type", "")
-                is_nullable = False
-                if isinstance(prop_type, list) and "null" in prop_type:
-                    prop_def["type"] = prop_type[0]
-                    is_nullable = True
-
                 # Process property schema (pass root_schema and visited_refs for $ref resolution)
                 converted_schema = convert_schema(prop_def, root_schema, visited_refs)
                 if converted_schema is not None:
-                    if is_nullable:
-                        converted_schema.nullable = True
                     properties[key] = converted_schema
                 else:
                     properties[key] = Schema(
@@ -425,6 +427,7 @@ def convert_schema(
         else:
             return Schema(
                 any_of=any_of,
+                nullable=is_nullable,
                 description=description,
                 default=default,
                 title=title,

--- a/libs/agno/tests/unit/utils/test_gemini_nullable_schema.py
+++ b/libs/agno/tests/unit/utils/test_gemini_nullable_schema.py
@@ -1,0 +1,41 @@
+from copy import deepcopy
+
+import pytest
+
+pytest.importorskip("google.genai")
+
+from agno.utils.gemini import convert_schema
+
+
+@pytest.mark.parametrize("types", [["string", "null"], ["null", "string"]])
+def test_nullable_property_conversion_preserves_source(types):
+    schema = {"type": "object", "properties": {"value": {"type": types, "format": "date"}}}
+    original = deepcopy(schema)
+
+    first = convert_schema(schema)
+    second = convert_schema(schema)
+
+    assert schema == original
+    assert first == second
+    assert first.properties["value"].type == "STRING"
+    assert first.properties["value"].nullable is True
+    assert first.properties["value"].format == "date"
+
+
+def test_nullable_array_retains_item_constraints():
+    schema = {"type": ["null", "array"], "items": {"type": "integer", "minimum": 0}, "minItems": 1}
+
+    converted = convert_schema(schema)
+
+    assert converted.type == "ARRAY"
+    assert converted.nullable is True
+    assert converted.items.type == "INTEGER"
+    assert converted.items.minimum == 0
+    assert converted.min_items == 1
+
+
+def test_nullable_union_keeps_null_alongside_multiple_types():
+    converted = convert_schema({"anyOf": [{"type": "string"}, {"type": "integer"}, {"type": "null"}]})
+
+    assert converted.nullable is True
+    assert [item.type for item in converted.any_of] == ["STRING", "INTEGER"]


### PR DESCRIPTION
## Summary

Converting a nullable property mutates the input schema, so a repeated conversion loses nullability; putting `null` first also loses the concrete type. Normalize nullable type lists through the existing union conversion, preserve nested constraints, and retain nullability when `anyOf` has multiple non-null alternatives.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed — human review pending; automated diff review completed
- [x] Documentation updated (comments/docstrings where applicable)
- [ ] Examples and guides: not applicable to this correction
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] Searched existing open pull requests; no PR found addressing this defect
- [ ] If a similar PR exists, explained why this approach is better
- [x] This PR was entirely AI-generated

## Additional Notes

All 4 new tests fail on main and pass with this patch. They cover repeated conversion, both type orders, nullable arrays with item constraints, and nullable multi-type unions.

`pytest libs/agno/tests/unit/utils/test_gemini_nullable_schema.py -q`

Tests use local SDK objects and mocked clients, with no live model requests. The broader related suite has 308 passes, 20 skips, and 3 existing Windows-specific file/MIME failures; the same 3 failures were reproduced on unmodified main. Format and validation pass in the repository's development dependency environment. Installing the optional Google SDK also exposes pre-existing typing errors, so SDK-backed tests use a separate environment.

Prepared and tested by Codex at the account owner's request. Kept as a draft for their human review; no claim of human review is made.
