### PR TITLE
[fix] Accumulate Gemini audio parts within a response

### DIFF
--- a/libs/agno/agno/models/google/gemini.py
+++ b/libs/agno/agno/models/google/gemini.py
@@ -1300,11 +1300,14 @@ class Gemini(Model):
                     # Handle audio responses (for TTS models)
                     if part.inline_data.mime_type and part.inline_data.mime_type.startswith("audio/"):
                         # Store raw bytes data
-                        model_response.audio = Audio(
-                            id=str(uuid4()),
-                            content=part.inline_data.data,
-                            mime_type=part.inline_data.mime_type,
-                        )
+                        if model_response.audio is not None and model_response.audio.content is not None:
+                            model_response.audio.content += part.inline_data.data or b""
+                        else:
+                            model_response.audio = Audio(
+                                id=str(uuid4()),
+                                content=part.inline_data.data,
+                                mime_type=part.inline_data.mime_type,
+                            )
                     # Image responses
                     else:
                         if model_response.images is None:
@@ -1449,11 +1452,14 @@ class Gemini(Model):
                         # Audio responses
                         if part.inline_data.mime_type and part.inline_data.mime_type.startswith("audio/"):
                             # Store raw bytes audio data
-                            model_response.audio = Audio(
-                                id=str(uuid4()),
-                                content=part.inline_data.data,
-                                mime_type=part.inline_data.mime_type,
-                            )
+                            if model_response.audio is not None and model_response.audio.content is not None:
+                                model_response.audio.content += part.inline_data.data or b""
+                            else:
+                                model_response.audio = Audio(
+                                    id=str(uuid4()),
+                                    content=part.inline_data.data,
+                                    mime_type=part.inline_data.mime_type,
+                                )
                         # Image responses
                         else:
                             if model_response.images is None:

--- a/libs/agno/tests/unit/models/google/test_gemini_audio_parts.py
+++ b/libs/agno/tests/unit/models/google/test_gemini_audio_parts.py
@@ -1,0 +1,37 @@
+import pytest
+
+pytest.importorskip("google.genai")
+
+from google.genai.types import Blob, Candidate, Content, GenerateContentResponse, Part
+
+from agno.models.base import MessageData
+from agno.models.google.gemini import Gemini
+
+
+@pytest.mark.parametrize("stream", [False, True])
+def test_multiple_pcm_parts_are_not_discarded(stream):
+    model = Gemini()
+    response = GenerateContentResponse(
+        candidates=[
+            Candidate(
+                content=Content(
+                    role="model",
+                    parts=[
+                        Part(inline_data=Blob(data=b"\x00\x01", mime_type="audio/pcm;rate=24000")),
+                        Part(text="Transcript"),
+                        Part(inline_data=Blob(data=b"\x02\x03", mime_type="audio/pcm;rate=24000")),
+                    ],
+                )
+            )
+        ]
+    )
+
+    parsed = model._parse_provider_response_delta(response) if stream else model._parse_provider_response(response)
+
+    assert parsed.audio.content == b"\x00\x01\x02\x03"
+    assert parsed.audio.mime_type == "audio/pcm;rate=24000"
+    assert parsed.content == "Transcript"
+    if stream:
+        data = MessageData()
+        list(model._populate_stream_data(data, parsed))
+        assert data.response_audio.content == b"\x00\x01\x02\x03"


### PR DESCRIPTION
## Summary

When a Gemini candidate contains several audio parts, each part replaces the preceding audio and only the last segment reaches the caller. Accumulate the audio bytes in both response parsers so multipart PCM output retains its complete content, including in the streaming accumulator.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed — human review pending; automated diff review completed
- [x] Documentation updated (comments/docstrings where applicable)
- [ ] Examples and guides: not applicable to this correction
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] Searched existing open pull requests; no PR found addressing this defect
- [ ] If a similar PR exists, explained why this approach is better
- [x] This PR was entirely AI-generated

## Additional Notes

Both new tests fail on main and pass with this patch, covering non-streaming and streaming responses containing two PCM segments separated by text.

`pytest libs/agno/tests/unit/models/google/test_gemini_audio_parts.py -q`

Tests use local SDK objects and mocked clients, with no live model requests. The broader related suite has 308 passes, 20 skips, and 3 existing Windows-specific file/MIME failures; the same 3 failures were reproduced on unmodified main. Format and validation pass in the repository's development dependency environment. Installing the optional Google SDK also exposes pre-existing typing errors, so SDK-backed tests use a separate environment.

Prepared and tested by Codex at the account owner's request. Kept as a draft for their human review; no claim of human review is made.
