### PR TITLE
[fix] Preserve all Gemini system and developer instructions

### DIFF
--- a/libs/agno/agno/models/google/gemini.py
+++ b/libs/agno/agno/models/google/gemini.py
@@ -797,7 +797,13 @@ class Gemini(Model):
             )
             role = message.role
             if role in ["system", "developer"]:
-                system_message = message.content
+                if message.content is not None:
+                    if system_message is None:
+                        system_message = message.content
+                    else:
+                        previous = system_message if isinstance(system_message, list) else [system_message]
+                        current = message.content if isinstance(message.content, list) else [message.content]
+                        system_message = previous + current
                 continue
 
             # Set the role for the message according to Gemini's requirements

--- a/libs/agno/tests/unit/models/google/test_gemini_system_instructions.py
+++ b/libs/agno/tests/unit/models/google/test_gemini_system_instructions.py
@@ -1,0 +1,39 @@
+import pytest
+
+pytest.importorskip("google.genai")
+
+from agno.models.google.gemini import Gemini
+from agno.models.message import Message
+
+
+@pytest.mark.parametrize("roles", [("system", "system"), ("system", "developer"), ("developer", "system")])
+def test_all_system_instructions_are_preserved(roles):
+    model = Gemini()
+    messages = [
+        Message(role=roles[0], content="Use only the supplied evidence."),
+        Message(role=roles[1], content="Respond in French."),
+        Message(role="user", content="Summarize the document."),
+    ]
+
+    contents, instruction = model._format_messages(messages)
+
+    assert instruction == ["Use only the supplied evidence.", "Respond in French."]
+    assert len(contents) == 1
+    assert contents[0].role == "user"
+    assert messages[0].content == "Use only the supplied evidence."
+
+
+def test_empty_system_message_does_not_erase_instructions():
+    _, instruction = Gemini()._format_messages(
+        [Message(role="system", content="Keep the policy."), Message(role="developer", content=None)]
+    )
+    assert instruction == "Keep the policy."
+
+
+def test_list_instructions_are_flattened_without_mutating_messages():
+    instructions = ["First constraint.", "Second constraint."]
+    _, instruction = Gemini()._format_messages(
+        [Message(role="system", content=instructions), Message(role="developer", content="Third constraint.")]
+    )
+    assert instruction == ["First constraint.", "Second constraint.", "Third constraint."]
+    assert instructions == ["First constraint.", "Second constraint."]


### PR DESCRIPTION
## Summary

With multiple system/developer messages, the formatter keeps only the last message and silently removes earlier constraints. Preserve all instruction parts in order using the SDK's supported list form. Keep the existing single-message representation and do not let a message with no content erase prior instructions.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed — human review pending; automated diff review completed
- [x] Documentation updated (comments/docstrings where applicable)
- [ ] Examples and guides: not applicable to this correction
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] Searched existing open pull requests; no PR found addressing this defect
- [ ] If a similar PR exists, explained why this approach is better
- [x] This PR was entirely AI-generated

## Additional Notes

All 5 new tests fail on main and pass with this patch. Covers repeated system messages, mixed system/developer order, empty messages, and list inputs without caller mutation.

`pytest libs/agno/tests/unit/models/google/test_gemini_system_instructions.py -q`

Tests use local SDK objects and mocked clients, with no live model requests. The broader related suite has 308 passes, 20 skips, and 3 existing Windows-specific file/MIME failures; the same 3 failures were reproduced on unmodified main. Format and validation pass in the repository's development dependency environment. Installing the optional Google SDK also exposes pre-existing typing errors, so SDK-backed tests use a separate environment.

Prepared and tested by Codex at the account owner's request. Kept as a draft for their human review; no claim of human review is made.
