### PR TITLE
fix: repair cookbook import, dead links and typo

### DIFF
--- a/cookbook/07_knowledge/01_getting_started/README.md
+++ b/cookbook/07_knowledge/01_getting_started/README.md
@@ -14,7 +14,6 @@ Start here to learn the basics of RAG (Retrieval-Augmented Generation) with Agno
 | [01_basic_rag.py](./01_basic_rag.py) | Traditional RAG with automatic context injection |
 | [02_agentic_rag.py](./02_agentic_rag.py) | Agentic RAG where the agent decides when to search |
 | [03_loading_content.py](./03_loading_content.py) | Loading from files, URLs, text, topics, and batches |
-| [04_choosing_components.md](./04_choosing_components.md) | Decision guide for vector DBs, embedders, and chunking |
 | [05_website_per_page.py](./05_website_per_page.py) | Loading a website page by page from its sitemap, with per-page citations |
 
 ## Start Here

--- a/cookbook/07_knowledge/README.md
+++ b/cookbook/07_knowledge/README.md
@@ -52,7 +52,6 @@ cookbook/07_knowledge/
 |   |-- 01_basic_rag.py            Traditional RAG with context injection
 |   |-- 02_agentic_rag.py          Agent-driven search decisions
 |   |-- 03_loading_content.py      All source types: file, URL, text, topics
-|   +-- 04_choosing_components.md  Decision guide
 |
 |-- 02_building_blocks/        Core components
 |   |-- 01_chunking_strategies.py  Side-by-side comparison

--- a/cookbook/10_reasoning/README.md
+++ b/cookbook/10_reasoning/README.md
@@ -18,7 +18,7 @@ See the [examples](./models/).
 
 A powerful feature of Agno is the ability to use a separate reasoning model from the main model. This is useful when you want to use a more powerful reasoning model than the main model.
 
-See the [examples](./models/openai/reasoning_gpt_4_1.py).
+See the [examples](./models/openai/reasoning_model_gpt_4_1.py).
 
 ## Reasoning Tools
 

--- a/cookbook/90_models/cohere/retry.py
+++ b/cookbook/90_models/cohere/retry.py
@@ -1,7 +1,7 @@
 """Example demonstrating how to set up retries with Cohere."""
 
 from agno.agent import Agent
-from agno.models.cohere import CohereChat
+from agno.models.cohere import Cohere
 
 # ---------------------------------------------------------------------------
 # Create Agent
@@ -11,7 +11,7 @@ from agno.models.cohere import CohereChat
 wrong_model_id = "cohere-wrong-id"
 
 agent = Agent(
-    model=CohereChat(
+    model=Cohere(
         id=wrong_model_id,
         retries=3,  # Number of times to retry the request.
         delay_between_retries=1,  # Delay between retries in seconds.

--- a/cookbook/91_tools/mcp/README.md
+++ b/cookbook/91_tools/mcp/README.md
@@ -111,4 +111,4 @@ You can modify these examples to:
 ## More Information
 
 - Read more about [MCP](https://modelcontextprotocol.io/introduction)
-- Read about [Agno's MCP integration](https://docs.agno.com/tools/mcp)
+- Read about [Agno's MCP integration](https://docs.agno.com/mcp)

--- a/cookbook/91_tools/mcp/mcp_toolbox_demo/README.md
+++ b/cookbook/91_tools/mcp/mcp_toolbox_demo/README.md
@@ -8,7 +8,7 @@ In this demo, we have a collection of tools (defined in `config/tools.yaml`) tha
 - `hotel-management`: For searching and retrieving hotel information
 - `booking-system`: For handling reservations and cancellations
 
-Read more about the MCP Toolbox confiuration here: [MCP Toolbox Configuration](https://mcp-toolbox.dev/documentation/configuration).
+Read more about the MCP Toolbox configuration here: [MCP Toolbox Configuration](https://mcp-toolbox.dev/documentation/configuration).
 
 ## Prerequisites
 


### PR DESCRIPTION
Closes #10133

## Summary

Fix 5 small verified issues in the cookbook:

- `cookbook/90_models/cohere/retry.py`: import `CohereChat` → `Cohere`. The class was renamed and the old name raises ImportError; the retry params used (`retries`, `delay_between_retries`, `exponential_backoff`) are all base-`Model` fields, so the rename is the whole fix.
- `cookbook/91_tools/mcp/README.md`: dead link `docs.agno.com/tools/mcp` (404) → `docs.agno.com/mcp` (200).
- `cookbook/91_tools/mcp/mcp_toolbox_demo/README.md`: typo "confiuration" → "configuration".
- `cookbook/10_reasoning/README.md`: link to non-existent `reasoning_gpt_4_1.py` → actual file `reasoning_model_gpt_4_1.py`.
- `cookbook/07_knowledge/01_getting_started/README.md` + `cookbook/07_knowledge/README.md`: remove references to `04_choosing_components.md`, which no longer exists in the repo.

Verification: each dead URL checked (404) and each replacement fetched (200); `Cohere` and its params verified against `libs/agno` source; no references to the removed file remain.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

Prepared with AI coding assistance; each item was individually verified and the change reviewed by me.