### PR TITLE
[fix] Reject unfinished OpenAI Responses streams

### DIFF
--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -998,6 +998,7 @@ class OpenAIResponses(Model):
         """
         Send a streaming request to the OpenAI Responses API.
         """
+        completed = False
         try:
             request_params = self.get_request_params(
                 messages=messages,
@@ -1019,6 +1020,8 @@ class OpenAIResponses(Model):
                 stream=True,
                 **request_params,
             ):
+                if chunk.type == "response.completed":  # type: ignore[union-attr]
+                    completed = True
                 model_response, tool_use = self._parse_provider_response_delta(
                     stream_event=chunk,  # type: ignore
                     assistant_message=assistant_message,
@@ -1078,6 +1081,13 @@ class OpenAIResponses(Model):
             log_error(f"Error from OpenAI API: {exc}")
             raise ModelProviderError(message=str(exc), model_name=self.name, model_id=self.id) from exc
 
+        if not completed:
+            raise ModelProviderError(
+                message="OpenAI Responses stream ended without response.completed",
+                model_name=self.name,
+                model_id=self.id,
+            )
+
     async def ainvoke_stream(
         self,
         messages: List[Message],
@@ -1091,6 +1101,7 @@ class OpenAIResponses(Model):
         """
         Sends an asynchronous streaming request to the OpenAI Responses API.
         """
+        completed = False
         try:
             request_params = self.get_request_params(
                 messages=messages,
@@ -1113,6 +1124,8 @@ class OpenAIResponses(Model):
                 **request_params,
             )
             async for chunk in async_stream:  # type: ignore
+                if chunk.type == "response.completed":
+                    completed = True
                 model_response, tool_use = self._parse_provider_response_delta(chunk, assistant_message, tool_use)  # type: ignore
                 yield model_response
 
@@ -1167,6 +1180,13 @@ class OpenAIResponses(Model):
         except Exception as exc:
             log_error(f"Error from OpenAI API: {exc}")
             raise ModelProviderError(message=str(exc), model_name=self.name, model_id=self.id) from exc
+
+        if not completed:
+            raise ModelProviderError(
+                message="OpenAI Responses stream ended without response.completed",
+                model_name=self.name,
+                model_id=self.id,
+            )
 
     def format_function_call_results(
         self,
@@ -1295,12 +1315,8 @@ class OpenAIResponses(Model):
         """
         model_response = ModelResponse()
 
-        # 1. Add response ID
+        # 1. Record time to first token
         if stream_event.type == "response.created":
-            if stream_event.response.id:
-                if model_response.provider_data is None:
-                    model_response.provider_data = {}
-                model_response.provider_data["response_id"] = stream_event.response.id
             if assistant_message.metrics is not None and not assistant_message.metrics.time_to_first_token:
                 assistant_message.metrics.set_time_to_first_token()
 
@@ -1369,9 +1385,13 @@ class OpenAIResponses(Model):
             model_response.extra.setdefault("tool_call_ids", []).append(tool_use["call_id"])
             tool_use = {}
 
-        # 5. Add metrics
+        # 5. Add completed response metadata and metrics
         elif stream_event.type == "response.completed":
             model_response = ModelResponse()
+
+            # Only completed responses can safely anchor subsequent requests.
+            if stream_event.response.id:
+                model_response.provider_data = {"response_id": stream_event.response.id}
 
             # Handle reasoning output items for ZDR mode (store=False)
             if self.store is False:

--- a/libs/agno/tests/unit/models/openai/test_openai_responses_background.py
+++ b/libs/agno/tests/unit/models/openai/test_openai_responses_background.py
@@ -4,6 +4,7 @@ from typing import Any, List, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from openai.types.responses import Response, ResponseCompletedEvent
 
 from agno.exceptions import ModelProviderError
 from agno.models.message import Message
@@ -302,7 +303,15 @@ def test_invoke_stream_strips_background_flag():
     model = OpenAIResponses(id="gpt-4.1-mini", background=True)
 
     fake_client = _make_fake_client()
-    fake_client.responses.create.return_value = iter([])
+    fake_client.responses.create.return_value = iter(
+        [
+            ResponseCompletedEvent(
+                type="response.completed",
+                sequence_number=0,
+                response=Response.model_construct(id="resp_test", status="completed", output=[], usage=None),
+            )
+        ]
+    )
     model.client = fake_client
 
     assistant = _make_assistant_message()

--- a/libs/agno/tests/unit/models/openai/test_responses_stream_completion.py
+++ b/libs/agno/tests/unit/models/openai/test_responses_stream_completion.py
@@ -1,0 +1,230 @@
+"""Exercise Responses stream completion through the real SDK and agent runtime."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+from openai import AsyncOpenAI, OpenAI
+
+from agno.agent import Agent
+from agno.db.base import SessionType
+from agno.db.sqlite import SqliteDb
+from agno.exceptions import ModelProviderError
+from agno.models.message import Message
+from agno.models.openai import OpenAIResponses
+from agno.run.agent import RunCompletedEvent, RunErrorEvent
+from agno.run.base import RunStatus
+from agno.session.agent import AgentSession
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+    from agno.models.response import ModelResponse
+
+
+pytestmark = pytest.mark.asyncio
+
+
+def _event(kind: str, **fields: object) -> str:
+    return f"event: {kind}\ndata: {json.dumps({'type': kind, 'sequence_number': 0, **fields})}\n\n"
+
+
+def _response(response_id: str, status: str, output: list[dict[str, object]] | None = None) -> dict[str, object]:
+    return {
+        "id": response_id,
+        "object": "response",
+        "created_at": 1,
+        "model": "gpt-5.6",
+        "status": status,
+        "output": output or [],
+        "parallel_tool_calls": True,
+        "tool_choice": "auto",
+        "tools": [],
+        "temperature": 1,
+        "top_p": 1,
+        "usage": None,
+        "error": None,
+        "incomplete_details": None,
+    }
+
+
+def _created(response_id: str = "resp_unfinished") -> str:
+    return _event("response.created", response=_response(response_id, "in_progress"))
+
+
+def _text() -> str:
+    return _event("response.output_text.delta", item_id="msg_answer", output_index=0, content_index=0, delta="Ready")
+
+
+def _tool_stream() -> str:
+    call = {
+        "type": "function_call",
+        "id": "fc_status",
+        "call_id": "call_status",
+        "name": "get_status",
+        "arguments": "{}",
+        "status": "completed",
+    }
+    return (
+        _created("resp_tools")
+        + _event("response.output_item.added", output_index=0, item={**call, "arguments": "", "status": "in_progress"})
+        + _event("response.function_call_arguments.delta", output_index=0, item_id="fc_status", delta="{}")
+        + _event("response.output_item.done", output_index=0, item=call)
+        + _event("response.completed", response=_response("resp_tools", "completed", [call]))
+    )
+
+
+@asynccontextmanager
+async def _model(*streams: str, store: bool = True) -> AsyncIterator[OpenAIResponses]:
+    remaining = iter(streams)
+
+    def respond(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, headers={"content-type": "text/event-stream"}, content=next(remaining))
+
+    transport = httpx.MockTransport(respond)
+    with OpenAI(api_key="test-key", http_client=httpx.Client(transport=transport)) as client:
+        async with AsyncOpenAI(api_key="test-key", http_client=httpx.AsyncClient(transport=transport)) as async_client:
+            yield OpenAIResponses(id="gpt-5.6", client=client, async_client=async_client, store=store)
+
+
+async def _invoke(model: OpenAIResponses, *, sync: bool) -> AsyncIterator[ModelResponse]:
+    messages = [Message(role="user", content="Check status")]
+    assistant = Message(role="assistant")
+    if sync:
+        for chunk in model.invoke_stream(messages, assistant):
+            yield chunk
+    else:
+        async for chunk in model.ainvoke_stream(messages, assistant):
+            yield chunk
+
+
+@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
+@pytest.mark.parametrize(
+    "stream",
+    [
+        "",
+        _created(),
+        _created() + _text(),
+        _created()
+        + _event(
+            "response.failed",
+            response={
+                **_response("resp_unfinished", "failed"),
+                "error": {"code": "server_error", "message": "Generation failed"},
+            },
+        ),
+        _created()
+        + _event(
+            "response.incomplete",
+            response={
+                **_response("resp_unfinished", "incomplete"),
+                "incomplete_details": {"reason": "max_output_tokens"},
+            },
+        ),
+    ],
+    ids=["empty", "created-only", "partial-text", "failed", "incomplete"],
+)
+async def test_unsuccessful_stream_raises_without_publishing_response_id(stream: str, *, sync: bool) -> None:
+    """EOF, failed, and incomplete responses must not become replay anchors."""
+    async with _model(stream) as model:
+        with pytest.raises(ModelProviderError):  # noqa: PT012 - inspect each chunk before failure
+            async for chunk in _invoke(model, sync=sync):
+                assert not chunk.provider_data or "response_id" not in chunk.provider_data
+
+
+@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
+@pytest.mark.parametrize("store", [True, False], ids=["stored", "stateless"])
+async def test_completed_text_publishes_response_id_only_at_completion(*, sync: bool, store: bool) -> None:
+    """Successful completion is independent of usage metrics and storage mode."""
+    stream = (
+        _created("resp_answer") + _text() + _event("response.completed", response=_response("resp_answer", "completed"))
+    )
+    async with _model(stream, store=store) as model:
+        chunks = [chunk async for chunk in _invoke(model, sync=sync)]
+
+    assert "".join(chunk.content or "" for chunk in chunks) == "Ready"
+    assert all(not chunk.provider_data or "response_id" not in chunk.provider_data for chunk in chunks[:-1])
+    assert chunks[-1].provider_data == {"response_id": "resp_answer"}
+
+
+@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
+async def test_completed_tool_stream_does_not_complete_the_next_invocation(*, sync: bool) -> None:
+    """A valid tools-only response cannot hide a later truncated response."""
+    async with _model(_tool_stream(), _created()) as model:
+        chunks = [chunk async for chunk in _invoke(model, sync=sync)]
+        assert [call["function"]["name"] for chunk in chunks for call in chunk.tool_calls] == ["get_status"]
+        assert chunks[-1].provider_data == {"response_id": "resp_tools"}
+
+        with pytest.raises(ModelProviderError, match=r"response\.completed"):
+            _ = [chunk async for chunk in _invoke(model, sync=sync)]
+
+
+async def test_concurrent_invocations_do_not_share_completion_state() -> None:
+    """Completion of one request cannot validate another active request on the same model."""
+    completed = _created("resp_answer") + _event("response.completed", response=_response("resp_answer", "completed"))
+    async with _model(completed, _created()) as model:
+        first = model.ainvoke_stream([Message(role="user", content="First")], Message(role="assistant"))
+        second = model.ainvoke_stream([Message(role="user", content="Second")], Message(role="assistant"))
+        await first.__anext__()
+        await second.__anext__()
+        _ = [chunk async for chunk in first]
+        with pytest.raises(ModelProviderError, match=r"response\.completed"):
+            _ = [chunk async for chunk in second]
+
+
+async def test_cancelled_request_remains_cancelled() -> None:
+    """Cancellation while waiting for the provider must not become a completion error."""
+    entered = asyncio.Event()
+
+    async def respond(_request: httpx.Request) -> httpx.Response:
+        entered.set()
+        await asyncio.Future()
+        raise AssertionError
+
+    async with AsyncOpenAI(
+        api_key="test-key",
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(respond)),
+    ) as client:
+        model = OpenAIResponses(id="gpt-5.6", async_client=client)
+        task = asyncio.create_task(
+            model.ainvoke_stream([Message(role="user", content="Check")], Message(role="assistant")).__anext__(),
+        )
+        await entered.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+async def test_agent_records_truncated_followup_as_error_after_completed_tool(tmp_path: Path) -> None:
+    """An earlier successful tool must not allow a truncated final response into history."""
+
+    def get_status() -> str:
+        """Return the local status."""
+        return "ready"
+
+    db = SqliteDb(db_file=str(tmp_path / "sessions.db"))
+    async with _model(_tool_stream(), _created()) as model:
+        agent = Agent(
+            id="status_agent", model=model, db=db, tools=[get_status], add_history_to_context=True, telemetry=False
+        )
+        events = [
+            event
+            async for event in agent.arun("Check status", session_id="status_session", stream=True, stream_events=True)
+        ]
+        assert not any(isinstance(event, RunCompletedEvent) for event in events)
+        assert any(isinstance(event, RunErrorEvent) for event in events)
+
+        session = db.get_session("status_session", SessionType.AGENT)
+        assert isinstance(session, AgentSession)
+        run = session.runs[-1]
+        assert RunStatus(run.status) is RunStatus.error
+        assert run.tools is not None
+        assert [(tool.tool_name, tool.result) for tool in run.tools] == [("get_status", "ready")]
+        history = [*session.get_messages(agent_id="status_agent"), Message(role="user", content="Follow up")]
+        assert "previous_response_id" not in model.get_request_params(messages=history)


### PR DESCRIPTION
## Summary

`OpenAIResponses.invoke_stream` and `ainvoke_stream` treat normal iterator exhaustion as success, even if the stream never emits `response.completed`.
Meanwhile, `response.created` already publishes the response ID.
An unfinished response can therefore be saved as a completed run and reused as `previous_response_id`, leaving later requests dependent on tool calls the client never received.

Both stream loops now require `response.completed` before returning successfully, and the parser only publishes the response ID on that event.
The check is local to each invocation, including each model call after tool execution.
Successful text, tools-only responses, stateless reasoning metadata, and cancellation retain their existing behavior.

## Where this appeared

We hit this in production with Agno 3.0.9 while running MindRoom.
We are 100% certain this failure happened: an empty assistant response was persisted in a completed run with a response ID, and subsequent requests failed with missing-tool-output errors.
The provider's stored response contained a function call that was absent from the saved client history.

We still do not understand why the original stream ended this way.
We did not retain the full raw SSE trace, so we cannot attribute the interruption to the provider, SDK, transport, or application.
The regression simulates early EOF and reproduces the incorrect success/history handling using stock Agno and the real OpenAI SDK; it does not establish what caused the original interruption.

[mindroom-ai/mindroom#2025](https://github.com/mindroom-ai/mindroom/pull/2025) is our consumer-side workaround.
This PR fixes the behavior in Agno itself so that workaround can be removed once the fix is released.
It prevents newly unfinished responses from becoming continuation anchors; it does not repair already-persisted histories.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Related: #6911 checks reported truncation and empty outputs.
Its streaming check runs inside `response.completed` parsing, so it does not catch EOF when that event never arrives.
This PR covers that missing-terminal-event case and defers response-ID publication; it does not change Chat Completions or non-streaming Responses.

Added 19 regression cases in `libs/agno/tests/unit/models/openai/test_responses_stream_completion.py`, including a real Agent/SQLite run that completes a tool and then receives a truncated follow-up response.
On unmodified Agno, 18 fail and one cancellation test passes.
With the fix, all 19 pass.

Local validation on Python 3.12 with OpenAI SDK 3.13.0:

- OpenAI unit suite: 105 passed.
- Agent, session, Responses-provider, generator-error, retry, and Responses-formatting tests: 1,109 passed, one skipped.
- Repository format and validation scripts pass in the standard clean development environment.

The broader test selection additionally used the optional Anthropic and Google SDKs.
No live provider requests were needed.

Drafted, tested, and self-reviewed with Codex, then independently reviewed by a separate coding agent.
The independent review found no issues and checked stateless reasoning metadata and transport-error preservation in both stream paths.
