### PR TITLE
[fix] Await async chunking in WebsiteReader

### DIFF
--- a/libs/agno/agno/knowledge/reader/website_reader.py
+++ b/libs/agno/agno/knowledge/reader/website_reader.py
@@ -467,7 +467,7 @@ class WebsiteReader(Reader):
                         meta_data={"url": str(crawled_url)},
                         content=crawled_content,
                     )
-                    chunks = self.chunk_document(doc)
+                    chunks = await self.achunk_document(doc)
                     return chunks
                 else:
                     return [

--- a/libs/agno/tests/unit/reader/test_website_reader.py
+++ b/libs/agno/tests/unit/reader/test_website_reader.py
@@ -1,9 +1,11 @@
+import asyncio
 from unittest.mock import patch
 
 import httpx
 import pytest
 
 from agno.knowledge.chunking.fixed import FixedSizeChunking
+from agno.knowledge.chunking.strategy import ChunkingStrategy
 from agno.knowledge.document.base import Document
 from agno.knowledge.reader.utils.url_validation import is_host_allowed
 from agno.knowledge.reader.website_reader import WebsiteReader
@@ -217,32 +219,51 @@ async def test_async_read_basic(mock_html_content):
 
 
 @pytest.mark.asyncio
-async def test_async_read_with_chunking(mock_html_content):
-    reader = WebsiteReader(max_depth=1, max_links=1)
-    reader.chunk = True
+async def test_async_read_with_chunking():
+    reader = WebsiteReader(chunking_strategy=FixedSizeChunking(chunk_size=4, overlap=0))
+    crawler_result = {"https://example.com": "abcdefgh"}
 
-    # Create a simple crawler result to return
-    crawler_result = {"https://example.com": "This is the main content"}
-
-    # Create real Document objects instead of Mock
-    def mock_chunk_document(doc):
-        return [
-            doc,  # Original document
-            Document(
-                name=f"{doc.name}_chunk", id=f"{doc.id}_chunk", content="Chunked content", meta_data=doc.meta_data
-            ),
-        ]
-
-    # Mock the chunk_document method with our implementation
-    reader.chunk_document = mock_chunk_document
-
-    # Mock async_crawl to return a controlled result
     with patch.object(reader, "async_crawl", return_value=crawler_result):
         documents = await reader.async_read("https://example.com")
 
-        assert len(documents) == 2
-        assert documents[0].name == "https://example.com"
-        assert documents[1].name == "https://example.com_chunk"
+    assert [doc.content for doc in documents] == ["abcd", "efgh"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("chunk", [True, False])
+@pytest.mark.parametrize("name", [None, "Website"])
+async def test_async_read_respects_async_chunking(chunk, name):
+    class AsyncOnlyChunker(ChunkingStrategy):
+        def chunk(self, document):
+            raise AssertionError("The synchronous chunking method must not be used")
+
+        async def achunk(self, document):
+            await asyncio.sleep(0)
+            return [
+                Document(name=document.name, id=document.id, content=part, meta_data=document.meta_data)
+                for part in document.content.split("|")
+            ]
+
+    reader = WebsiteReader(chunking_strategy=AsyncOnlyChunker(), chunk=chunk)
+    crawler_result = {
+        "https://example.com": "first|second",
+        "https://example.com/page2": "third|fourth",
+    }
+
+    with patch.object(reader, "async_crawl", return_value=crawler_result):
+        documents = await reader.async_read("https://example.com", name=name)
+
+    assert [doc.content for doc in documents] == (
+        ["first", "second", "third", "fourth"] if chunk else ["first|second", "third|fourth"]
+    )
+    expected_urls = (
+        ["https://example.com", "https://example.com", "https://example.com/page2", "https://example.com/page2"]
+        if chunk
+        else ["https://example.com", "https://example.com/page2"]
+    )
+    assert [doc.id for doc in documents] == expected_urls
+    assert [doc.meta_data for doc in documents] == [{"url": url} for url in expected_urls]
+    assert [doc.name for doc in documents] == [name or "https://example.com"] * len(expected_urls)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`WebsiteReader.async_read()` calls synchronous chunking, so a custom strategy that requires `achunk()` fails instead of returning documents. Await the existing `Reader.achunk_document()` hook so async strategies work during website ingestion.

Regression tests cover async-only strategies, `chunk=False`, ordered results from multiple pages, document IDs and URL metadata, and default/custom names. The existing async chunking test now uses real `FixedSizeChunking`, verifying the fallback for strategies that only implement synchronous `chunk()`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation reviewed; no public API or documentation changes are needed
- [x] Examples and guides reviewed; this corrects existing reader behavior and is covered by offline regression tests
- [x] Tested in a local development environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I searched existing open pull requests and found no PR covering async chunking in WebsiteReader
- [x] Related PR #9976 was checked: it covers TextReader and MarkdownReader; this PR covers the separate WebsiteReader path
- [x] This PR was generated with AI assistance (OpenAI Codex); the diff received an independent agent review and the checks below were run locally

---

## Additional Notes

Validation on macOS with Python 3.13.13:

- Before the fix: the two new async-strategy cases failed at the synchronous `chunk()` call; the three focused control cases passed.
- After the fix: **44 tests passed** with:

```sh
.venv/bin/python -m pytest \
  libs/agno/tests/unit/reader/test_website_reader.py \
  libs/agno/tests/unit/knowledge/chunking/test_fixed_size_chunking.py \
  libs/agno/tests/unit/knowledge/test_reader_embedder_state.py -q
```

- `./scripts/format.sh` passed. An unrelated pre-existing formatting change in the Elasticsearch tests was excluded from this PR.
- `./scripts/validate.sh` passed, including Ruff, mypy for Agno and agnoctl, and the cookbook pattern check.

The new tests use controlled crawl results and local chunking strategies; no model API or external service is required.
