### PR TITLE
[fix] Make Curator maintain the user memory store

### DIFF
--- a/libs/agno/agno/learn/curate.py
+++ b/libs/agno/agno/learn/curate.py
@@ -8,7 +8,7 @@ Keeps memories tidy through:
 - Deduplication: Remove exact/near-exact duplicates
 
 Usage:
-    >>> learning = LearningMachine(db=db, model=model, user_profile=True)
+    >>> learning = LearningMachine(db=db, model=model, user_memory=True)
     >>>
     >>> # Remove memories older than 90 days, keep max 100
     >>> removed = learning.curator.prune(user_id="alice", max_age_days=90, max_count=100)
@@ -28,7 +28,7 @@ from agno.utils.log import log_debug
 class Curator:
     """Memory maintenance. Keeps things tidy.
 
-    Currently supports user_profile store only.
+    Maintains the user_memory store. Structured user_profile fields are not memories.
     """
 
     machine: Any  # LearningMachine
@@ -39,7 +39,7 @@ class Curator:
         max_age_days: int = 0,
         max_count: int = 0,
     ) -> int:
-        """Remove old memories from user profile.
+        """Remove old memories from the user_memory store.
 
         Args:
             user_id: User to prune memories for.
@@ -49,15 +49,15 @@ class Curator:
         Returns:
             Number of memories removed.
         """
-        store = self.machine.stores.get("user_profile")
+        store = self.machine.stores.get("user_memory")
         if not store:
             return 0
 
-        profile = store.get(user_id=user_id)
-        if not profile or not hasattr(profile, "memories"):
+        record = store.get(user_id=user_id)
+        if not record or not hasattr(record, "memories"):
             return 0
 
-        memories = profile.memories
+        memories = record.memories
         if not memories:
             return 0
 
@@ -75,8 +75,8 @@ class Curator:
         removed = original_count - len(memories)
 
         if removed > 0:
-            profile.memories = memories
-            store.save(user_id=user_id, profile=profile)
+            record.memories = memories
+            store.save(user_id=user_id, memories=record)
             log_debug(f"Curator.prune: removed {removed} memories for user_id={user_id}")
 
         return removed
@@ -85,7 +85,7 @@ class Curator:
         self,
         user_id: str,
     ) -> int:
-        """Remove duplicate memories from user profile.
+        """Remove duplicate memories from the user_memory store.
 
         Uses exact and near-exact string matching.
 
@@ -95,15 +95,15 @@ class Curator:
         Returns:
             Number of duplicate memories removed.
         """
-        store = self.machine.stores.get("user_profile")
+        store = self.machine.stores.get("user_memory")
         if not store:
             return 0
 
-        profile = store.get(user_id=user_id)
-        if not profile or not hasattr(profile, "memories"):
+        record = store.get(user_id=user_id)
+        if not record or not hasattr(record, "memories"):
             return 0
 
-        memories = profile.memories
+        memories = record.memories
         if len(memories) < 2:
             return 0
 
@@ -112,8 +112,8 @@ class Curator:
         removed = original_count - len(unique_memories)
 
         if removed > 0:
-            profile.memories = unique_memories
-            store.save(user_id=user_id, profile=profile)
+            record.memories = unique_memories
+            store.save(user_id=user_id, memories=record)
             log_debug(f"Curator.deduplicate: removed {removed} duplicates for user_id={user_id}")
 
         return removed

--- a/libs/agno/tests/unit/learn/test_curator.py
+++ b/libs/agno/tests/unit/learn/test_curator.py
@@ -1,0 +1,109 @@
+"""Curator must maintain persisted user memories, not structured profile fields."""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+
+from agno.db.sqlite import SqliteDb
+from agno.learn import LearningMachine
+from agno.learn.schemas import Memories, UserProfile
+
+
+@pytest.fixture
+def learning(tmp_path):
+    machine = LearningMachine(
+        db=SqliteDb(db_file=str(tmp_path / "learning.db")),
+        user_profile=True,
+        user_memory=True,
+    )
+    yield machine
+    machine.db.db_engine.dispose()
+
+
+def seed(machine, user_id="alice"):
+    now = datetime.now(timezone.utc)
+    entries = [
+        {"id": "old", "content": "Likes Python", "created_at": (now - timedelta(days=100)).isoformat()},
+        {"id": "new", "content": "likes python!", "created_at": (now - timedelta(days=1)).isoformat()},
+        {"id": "other", "content": "Uses Linux", "created_at": now.isoformat()},
+    ]
+    machine.stores["user_memory"].save(user_id=user_id, memories=Memories(user_id=user_id, memories=entries))
+    machine.stores["user_profile"].save(user_id=user_id, profile=UserProfile(user_id=user_id, name=user_id))
+    return entries
+
+
+@pytest.mark.parametrize(
+    "options,expected_ids",
+    [
+        ({"max_age_days": 90}, ["new", "other"]),
+        ({"max_count": 1}, ["other"]),
+        ({"max_age_days": 90, "max_count": 1}, ["other"]),
+    ],
+)
+def test_prune_persists_filtered_memories_and_preserves_other_user(learning, options, expected_ids):
+    seed(learning)
+    bob_entries = seed(learning, "bob")
+
+    assert learning.curator.prune("alice", **options) == 3 - len(expected_ids)
+    saved = learning.stores["user_memory"].get("alice")
+    assert [entry["id"] for entry in saved.memories] == expected_ids
+    assert learning.stores["user_memory"].get("bob").memories == bob_entries
+    assert learning.stores["user_profile"].get("alice").name == "alice"
+    assert learning.curator.prune("alice", **options) == 0
+
+
+def test_deduplicate_persists_first_entry_and_its_metadata(learning):
+    entries = seed(learning)
+    bob_entries = seed(learning, "bob")
+
+    assert learning.curator.deduplicate("alice") == 1
+    assert learning.stores["user_memory"].get("alice").memories == [entries[0], entries[2]]
+    assert learning.stores["user_memory"].get("bob").memories == bob_entries
+    assert learning.stores["user_profile"].get("alice").name == "alice"
+    assert learning.curator.deduplicate("alice") == 0
+
+
+def test_prune_can_persist_an_empty_memory_list(learning):
+    old = {"id": "old", "content": "Old fact", "created_at": "2000-01-01T00:00:00Z"}
+    learning.stores["user_memory"].save("alice", Memories(user_id="alice", memories=[old]))
+    assert learning.curator.prune("alice", max_age_days=1) == 1
+    assert learning.stores["user_memory"].get("alice").memories == []
+
+
+@pytest.mark.parametrize("method", ["prune", "deduplicate"])
+def test_missing_and_empty_memory_do_not_save(learning, method):
+    store = learning.stores["user_memory"]
+    with patch.object(store, "save", wraps=store.save) as save:
+        assert getattr(learning.curator, method)("missing") == 0
+        save.assert_not_called()
+    store.save("alice", Memories(user_id="alice"))
+    with patch.object(store, "save", wraps=store.save) as save:
+        assert getattr(learning.curator, method)("alice") == 0
+        save.assert_not_called()
+
+
+def test_disabled_memory_leaves_profile_alone(learning):
+    seed(learning)
+    del learning.stores["user_memory"]
+    assert learning.curator.prune("alice", max_count=1) == 0
+    assert learning.curator.deduplicate("alice") == 0
+    assert learning.stores["user_profile"].get("alice").name == "alice"
+
+
+def test_prune_without_limits_does_not_write(learning):
+    entries = seed(learning)
+    store = learning.stores["user_memory"]
+    with patch.object(store, "save", wraps=store.save) as save:
+        assert learning.curator.prune("alice") == 0
+        save.assert_not_called()
+    assert store.get("alice").memories == entries
+
+
+def test_memory_maintenance_does_not_require_a_profile_store(learning):
+    seed(learning)
+    memory_only = LearningMachine(db=learning.db, user_memory=True)
+    assert "user_profile" not in memory_only.stores
+    assert memory_only.curator.deduplicate("alice") == 1
+    assert memory_only.curator.prune("alice", max_count=1) == 1
+    assert [entry["id"] for entry in memory_only.stores["user_memory"].get("alice").memories] == ["other"]


### PR DESCRIPTION
## Summary

Fixes #10139.

`Curator.prune()` and `deduplicate()` read `user_profile`, whose standard schema has no `memories` field. Both operations therefore return zero without touching the user's actual memories.

Route both operations to `user_memory` and save through its `memories=` parameter. Update the usage example and docstrings to describe the store being maintained. The filtering and duplicate-selection algorithms are unchanged.

This fix targets the standard user-memory store rather than adding a general store selector. Structured profile fields remain untouched. No public method or async API is added in this patch; the two existing synchronous maintenance methods retain their signatures.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated

## Additional Notes

Validation used a fresh Python 3.12 environment with the workspace packages and dev dependencies. The learning unit suite passes: **443 tests**, including 10 new Curator cases. The regressions use `LearningMachine`, real `UserMemoryStore`/`UserProfileStore`, and a temporary SQLite database; assertions reload saved records rather than only inspecting a mock save call.

Coverage includes age/count pruning, deduplication metadata, user isolation, profile preservation, idempotence, an empty result, missing/empty/disabled memory, no-op writes, and a memory-only machine. Before the fix, the original five removal cases failed. Restoring the wrong store lookup in an isolated Python process made those five fail again; the unchanged source passes.

The repository format script completed successfully. The validate script passed Ruff, mypy (1,053 Agno and 21 agnoctl source files), and the cookbook pattern check. On Windows Git Bash, `python3` was mapped to the active virtual environment's `python` to run the last script step. One unrelated formatting-only change produced by the format script was excluded.

The full unit suite was also attempted. An import-time PostgreSQL probe initially waited indefinitely; with `PGCONNECT_TIMEOUT=2`, collection finished with 125 errors (including unavailable optional provider/tool dependencies such as `googleapiclient`) and 30 existing skips. This is not a full-suite pass. No tests were skipped or assertions weakened in the separate 443-test learning run. No live LLM service is needed for this fix.

The existing Curator docstring example is updated; no new cookbook or generic custom-store API is introduced.
