### PR TITLE
fix(learn): support user_memory store and store_key parameter in Curator (#10139)

### DIFF
--- a/libs/agno/agno/learn/curate.py
+++ b/libs/agno/agno/learn/curate.py
@@ -28,7 +28,7 @@ from agno.utils.log import log_debug
 class Curator:
     """Memory maintenance. Keeps things tidy.
 
-    Currently supports user_profile store only.
+    Supports user_memory and user_profile stores.
     """
 
     machine: Any  # LearningMachine
@@ -38,26 +38,28 @@ class Curator:
         user_id: str,
         max_age_days: int = 0,
         max_count: int = 0,
+        store_key: str = "user_memory",
     ) -> int:
-        """Remove old memories from user profile.
+        """Remove old memories from the specified memory store.
 
         Args:
             user_id: User to prune memories for.
             max_age_days: Remove memories older than this (0 = disabled).
             max_count: Keep at most this many memories (0 = disabled).
+            store_key: Key of store to prune (default "user_memory").
 
         Returns:
             Number of memories removed.
         """
-        store = self.machine.stores.get("user_profile")
+        store = self.machine.stores.get(store_key)
         if not store:
             return 0
 
-        profile = store.get(user_id=user_id)
-        if not profile or not hasattr(profile, "memories"):
+        entity = store.get(user_id=user_id)
+        if not entity or not hasattr(entity, "memories"):
             return 0
 
-        memories = profile.memories
+        memories = entity.memories
         if not memories:
             return 0
 
@@ -75,35 +77,37 @@ class Curator:
         removed = original_count - len(memories)
 
         if removed > 0:
-            profile.memories = memories
-            store.save(user_id=user_id, profile=profile)
-            log_debug(f"Curator.prune: removed {removed} memories for user_id={user_id}")
+            entity.memories = memories
+            store.save(user_id, entity)
+            log_debug(f"Curator.prune: removed {removed} memories for user_id={user_id} in {store_key}")
 
         return removed
 
     def deduplicate(
         self,
         user_id: str,
+        store_key: str = "user_memory",
     ) -> int:
-        """Remove duplicate memories from user profile.
+        """Remove duplicate memories from the specified memory store.
 
         Uses exact and near-exact string matching.
 
         Args:
             user_id: User to deduplicate memories for.
+            store_key: Key of store to deduplicate (default "user_memory").
 
         Returns:
             Number of duplicate memories removed.
         """
-        store = self.machine.stores.get("user_profile")
+        store = self.machine.stores.get(store_key)
         if not store:
             return 0
 
-        profile = store.get(user_id=user_id)
-        if not profile or not hasattr(profile, "memories"):
+        entity = store.get(user_id=user_id)
+        if not entity or not hasattr(entity, "memories"):
             return 0
 
-        memories = profile.memories
+        memories = entity.memories
         if len(memories) < 2:
             return 0
 
@@ -112,9 +116,9 @@ class Curator:
         removed = original_count - len(unique_memories)
 
         if removed > 0:
-            profile.memories = unique_memories
-            store.save(user_id=user_id, profile=profile)
-            log_debug(f"Curator.deduplicate: removed {removed} duplicates for user_id={user_id}")
+            entity.memories = unique_memories
+            store.save(user_id, entity)
+            log_debug(f"Curator.deduplicate: removed {removed} duplicates for user_id={user_id} in {store_key}")
 
         return removed
 

--- a/libs/agno/tests/unit/learn/test_curator.py
+++ b/libs/agno/tests/unit/learn/test_curator.py
@@ -1,0 +1,35 @@
+from types import SimpleNamespace
+from agno.learn.curate import Curator
+from agno.learn.schemas import Memories
+
+
+def test_curator_prune_and_deduplicate_user_memory():
+    dupes = Memories(
+        user_id="alice",
+        memories=[
+            {"content": "Prefers concise answers", "created_at": "2024-01-01T00:00:00Z"},
+            {"content": "prefers concise answers!", "created_at": "2024-01-02T00:00:00Z"},
+        ],
+    )
+    saved_calls = []
+
+    def mock_save(user_id, entity):
+        saved_calls.append((user_id, entity))
+
+    mem_store = SimpleNamespace(get=lambda user_id: dupes, save=mock_save)
+    curator = Curator(machine=SimpleNamespace(stores={"user_memory": mem_store}))
+
+    removed_dedup = curator.deduplicate(user_id="alice", store_key="user_memory")
+    assert removed_dedup == 1
+    assert len(dupes.memories) == 1
+    assert len(saved_calls) == 1
+
+    removed_prune = curator.prune(user_id="alice", max_count=0, max_age_days=1, store_key="user_memory")
+    assert removed_prune == 1
+    assert len(dupes.memories) == 0
+
+
+def test_curator_nonexistent_store_returns_zero():
+    curator = Curator(machine=SimpleNamespace(stores={}))
+    assert curator.deduplicate(user_id="bob", store_key="unknown") == 0
+    assert curator.prune(user_id="bob", store_key="unknown") == 0


### PR DESCRIPTION
### Summary
Fixes #10139. Curator's prune() and deduplicate() methods hardcoded user_profile store lookup and checked hasattr(profile, 'memories'). Since UserProfile schema does not contain a .memories field, both methods were silent no-ops returning 0. Furthermore, unstructured memories stored in UserMemoryStore (user_memory) could not be pruned or deduplicated.

### Fix
- Add store_key: str = 'user_memory' parameter to Curator.prune() and Curator.deduplicate().
- Pass entity schema positionally into store.save(user_id, entity) so it works cleanly with both UserMemoryStore (save(user_id, memories)) and UserProfileStore (save(user_id, profile)).
- Add unit tests under libs/agno/tests/unit/learn/test_curator.py.