### PR TITLE
[cookbook] Add read-only ParlayAPI MCP discovery example

### DIFF
--- a/cookbook/91_tools/mcp/README.md
+++ b/cookbook/91_tools/mcp/README.md
@@ -57,6 +57,52 @@ This example shows how to choose which MCP protocol era `MCPTools` negotiates. T
 
 This example connects to Magic Hour's hosted MCP server to create images and videos. It shows bearer authentication, long-running render handling, reuse of project IDs after timeouts, and exact output URL retrieval.
 
+14. ParlayAPI Read-Only Discovery (`parlayapi.py`)
+
+This example launches the published ParlayAPI MCP server with an explicit tool
+allowlist. The default only discovers four public metadata tools locally. It
+does not call an API endpoint or model, and ignores both ParlayAPI key environment
+variables. Account creation, login email, checkout, preference changes and betting
+verdict tools are excluded.
+
+```bash
+uv pip install "agno[mcp]==3.0.9" "parlayapi-mcp==0.3.7"
+python cookbook/91_tools/mcp/parlayapi.py
+```
+
+To ask a model about public metadata, install `openai`, supply your own
+`OPENAI_API_KEY` through your runtime's secret manager, and explicitly run:
+
+```bash
+python cookbook/91_tools/mcp/parlayapi.py --question "Which sports currently have live event counts? Summarize counts only."
+```
+
+For private data research, additionally supply your own `PARLAYAPI_KEY` (or
+`PARLAY_API_KEY`) and add `--private`. This adds only sport catalog, odds and
+props tools. `--private` alone still performs discovery without data or model
+calls. Keys remain in the server environment, not tool arguments or prompts.
+The fixed server origin is `https://parlay-api.com`; origin overrides are ignored.
+
+An explicit `--question` run may call up to two tools and incurs your model's
+charges; private data calls also consume the API account's applicable allowance.
+Raw tool results can go to the configured OpenAI model. Use only a private
+runtime and account permitted for that processing. No database or telemetry is
+configured, but this does not disable your model provider's own retention.
+Keep terminal output and research private. API access grants no public data
+redisplay or redistribution rights. This example does not place bets.
+
+This is a transport example, not a complete-data validator. Missing outcomes,
+unknown source ages and scoped results must not be read as complete coverage.
+The allowlist narrows tools exposed to this agent; it is not server-side access
+control against a program that bypasses the toolkit. Review the allowlist when
+upgrading the pinned server package.
+
+References: [MCP server](https://pypi.org/project/parlayapi-mcp/),
+[API documentation](https://parlay-api.com/docs),
+[account signup](https://parlay-api.com/signup),
+[current pricing](https://parlay-api.com/pricing),
+[data-use terms](https://parlay-api.com/terms).
+
 ## Getting Started
 
 ### Prerequisites

--- a/cookbook/91_tools/mcp/TEST_LOG.md
+++ b/cookbook/91_tools/mcp/TEST_LOG.md
@@ -1,5 +1,34 @@
 # Test Log
 
+### parlayapi.py
+
+**Status:** PASS (offline discovery and configuration)
+
+**Description:** Agno 3.0.9 connects over stdio to the published parlayapi-mcp
+0.3.7 package. The default discovers four read-only metadata tools without calling
+ParlayAPI or a model. Private discovery exposes seven allowlisted tools with a
+test-only key. Tests block TCP connections in the actual server subprocess and
+verify credential isolation, server-version pinning, excluded mutation tools,
+and agent configuration with model execution replaced by an inspection function.
+
+**Result:** Six focused tests pass on Python 3.12 with MCP 2.2.0 and FastMCP
+4.0.3. The default command and full repository `scripts/format.sh` and
+`scripts/validate.sh` pass. Validation used mypy 2.1.0 and required the repository's
+`types-regex` development dependency. Checks ran in a full verification worktree;
+formatting changed no contribution files and one unrelated existing test's layout.
+No live data request, model inference or unrelated runtime test suite was run.
+
+```bash
+python -m pytest -q --noconftest cookbook/91_tools/mcp/test_parlayapi.py
+python cookbook/91_tools/mcp/parlayapi.py
+ruff format --check cookbook/91_tools/mcp/parlayapi.py cookbook/91_tools/mcp/test_parlayapi.py
+ruff check cookbook/91_tools/mcp/parlayapi.py cookbook/91_tools/mcp/test_parlayapi.py
+bash scripts/format.sh
+bash scripts/validate.sh
+```
+
+---
+
 ### magic_hour.py
 
 **Status:** PASS

--- a/cookbook/91_tools/mcp/parlayapi.py
+++ b/cookbook/91_tools/mcp/parlayapi.py
@@ -1,0 +1,96 @@
+"""Inspect ParlayAPI's read-only MCP tools before an optional private agent run.
+
+Install: uv pip install "agno[mcp]==3.0.9" "parlayapi-mcp==0.3.7"
+Default: python cookbook/91_tools/mcp/parlayapi.py
+The default performs local MCP discovery only, with no API or model calls.
+"""
+
+import argparse
+import asyncio
+import os
+import sys
+from importlib.metadata import version
+
+from agno.tools.mcp import MCPTools
+from mcp import StdioServerParameters
+
+DISCOVERY_TOOLS = [
+    "parlayapi_get_pricing",
+    "parlayapi_live_sports",
+    "parlayapi_source_quality",
+    "parlayapi_book_coverage",
+]
+PRIVATE_TOOLS = ["parlayapi_list_sports", "parlayapi_get_odds", "parlayapi_get_props"]
+
+
+def make_tools(private: bool = False) -> MCPTools:
+    if version("parlayapi-mcp") != "0.3.7":
+        raise ValueError(
+            "Install parlayapi-mcp==0.3.7 for this reviewed tool allowlist."
+        )
+    key = ""
+    if private:
+        key = (os.getenv("PARLAYAPI_KEY") or os.getenv("PARLAY_API_KEY") or "").strip()
+        if not key or "\r" in key or "\n" in key:
+            raise ValueError(
+                "Private mode requires your own valid ParlayAPI key in the environment."
+            )
+    return MCPTools(
+        server_params=StdioServerParameters(
+            command=sys.executable,
+            args=["-m", "parlayapi_mcp"],
+            env={
+                "PARLAYAPI_BASE_URL": "https://parlay-api.com",
+                "PARLAYAPI_KEY": key,
+                "PARLAY_API_KEY": "",
+            },
+        ),
+        include_tools=DISCOVERY_TOOLS + (PRIVATE_TOOLS if private else []),
+        timeout_seconds=30,
+    )
+
+
+async def run_example(question: str | None = None, private: bool = False) -> None:
+    async with make_tools(private) as tools:
+        expected = set(DISCOVERY_TOOLS + (PRIVATE_TOOLS if private else []))
+        if set(tools.functions) != expected:
+            raise RuntimeError(
+                "MCP discovery did not match the reviewed tool allowlist."
+            )
+        if question is None:
+            print("Read-only MCP tools: " + ", ".join(sorted(tools.functions)))
+            print("Discovery only. No ParlayAPI endpoint or model was called.")
+            return
+
+        from agno.agent import Agent
+        from agno.models.openai import OpenAIResponses
+
+        agent = Agent(
+            name="Private Sports Data Research",
+            model=OpenAIResponses(id="gpt-5.6-luna", max_retries=0),
+            tools=[tools],
+            tool_call_limit=2,
+            telemetry=False,
+            instructions=[
+                "Use at most two read-only calls. Do not retry failed requests.",
+                "Return coverage counts and limitations, not raw odds or participant lists.",
+                "Keep missing outcomes and unknown source ages explicit. Never infer complete coverage.",
+                "Do not recommend or place bets, create accounts, send emails, or change billing.",
+            ],
+            markdown=True,
+        )
+        await agent.aprint_response(question)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--question", help="Explicitly call a model and the permitted discovery tools."
+    )
+    parser.add_argument(
+        "--private",
+        action="store_true",
+        help="Also permit own-key data tools; usage may be charged.",
+    )
+    args = parser.parse_args()
+    asyncio.run(run_example(args.question, args.private))

--- a/cookbook/91_tools/mcp/test_parlayapi.py
+++ b/cookbook/91_tools/mcp/test_parlayapi.py
@@ -1,0 +1,100 @@
+"""Offline checks for the cookbook's actual MCP connection and tool boundary."""
+
+import asyncio
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+spec = importlib.util.spec_from_file_location(
+    "parlayapi_example", Path(__file__).with_name("parlayapi.py")
+)
+assert spec and spec.loader
+example = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(example)
+
+
+def test_default_ignores_keys_and_origin(monkeypatch):
+    monkeypatch.setenv("PARLAYAPI_KEY", "private-sentinel")
+    monkeypatch.setenv("PARLAY_API_KEY", "alias-sentinel")
+    monkeypatch.setenv("PARLAYAPI_BASE_URL", "https://example.invalid")
+    tools = example.make_tools()
+    assert tools.server_params.env == {
+        "PARLAYAPI_BASE_URL": "https://parlay-api.com",
+        "PARLAYAPI_KEY": "",
+        "PARLAY_API_KEY": "",
+    }
+    assert tools.include_tools == example.DISCOVERY_TOOLS
+
+
+def test_private_requires_explicit_key(monkeypatch):
+    monkeypatch.delenv("PARLAYAPI_KEY", raising=False)
+    monkeypatch.delenv("PARLAY_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="requires your own"):
+        example.make_tools(private=True)
+    monkeypatch.setenv("PARLAY_API_KEY", "test-only-sentinel")
+    tools = example.make_tools(private=True)
+    assert tools.server_params.env["PARLAYAPI_KEY"] == "test-only-sentinel"
+    assert set(tools.include_tools) == set(
+        example.DISCOVERY_TOOLS + example.PRIVATE_TOOLS
+    )
+
+
+def test_server_version_change_requires_review(monkeypatch):
+    monkeypatch.setattr(example, "version", lambda name: "999.0.0")
+    with pytest.raises(ValueError, match="reviewed tool allowlist"):
+        example.make_tools()
+
+
+@pytest.mark.parametrize("private", [False, True])
+def test_actual_stdio_discovery_without_network_or_model(
+    tmp_path, monkeypatch, private
+):
+    # The actual published server runs in a child with TCP connection attempts blocked.
+    (tmp_path / "sitecustomize.py").write_text(
+        "import socket\n"
+        "def blocked(*args, **kwargs):\n"
+        "    raise RuntimeError('Network forbidden in MCP discovery test')\n"
+        "socket.socket.connect = blocked\n"
+        "socket.socket.connect_ex = blocked\n"
+    )
+    monkeypatch.setenv("PARLAYAPI_KEY", "test-only-sentinel")
+    tools = example.make_tools(private=private)
+    tools.server_params.env["PYTHONPATH"] = str(tmp_path)
+
+    async def check():
+        async with tools:
+            names = set(tools.functions)
+            assert names == set(
+                example.DISCOVERY_TOOLS + (example.PRIVATE_TOOLS if private else [])
+            )
+            assert not names.intersection(
+                {
+                    "parlayapi_signup",
+                    "parlayapi_magic_link",
+                    "parlayapi_checkout_link",
+                    "parlayapi_set_bettable_books",
+                }
+            )
+            for function in tools.functions.values():
+                assert "test-only-sentinel" not in str(function.to_dict())
+
+    asyncio.run(check())
+
+
+def test_optional_agent_configuration_without_model_call(monkeypatch):
+    from agno.agent import Agent
+
+    captured = []
+
+    async def inspect_only(agent, message):
+        captured.append(message)
+        assert agent.model.id == "gpt-5.6-luna"
+        assert agent.model.max_retries == 0
+        assert agent.tool_call_limit == 2
+        assert agent.telemetry is False
+        assert set(agent.tools[0].functions) == set(example.DISCOVERY_TOOLS)
+
+    monkeypatch.setattr(Agent, "aprint_response", inspect_only)
+    asyncio.run(example.run_example("Describe public metadata only."))
+    assert captured == ["Describe public metadata only."]


### PR DESCRIPTION
## Summary

Closes #10143

Add a ParlayAPI MCP cookbook that first inspects a narrow read-only tool allowlist without calling any API endpoint or model. Readers can explicitly enable a model question and optionally add their own account data tools. Signup, login email, checkout, preference changes and betting verdict tools remain excluded. The example reuses the published MCP server and existing MCPTools transport.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [x] Other: Cookbook example

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Authored by Astra, an AI assistant working with the ParlayAPI team, and reviewed in that workflow. Six focused tests pass using the actual Agno 3.0.9 runtime and published parlayapi-mcp 0.3.7 package. Actual stdio discovery was exercised with TCP connections blocked in the server process. The default CLI, focused Ruff format/check, and git diff checks pass. Optional agent configuration was inspected with model execution replaced; no live data request, paid service call or model inference is claimed.

The unchanged full repository scripts/format.sh and scripts/validate.sh passed in a complete verification worktree. Mypy checked 1,053 Agno source files and 21 agnoctl files; cookbook pattern checks reported zero violations. The first validation run identified missing types-regex stubs; installing that declared development dependency resolved the failure. Full formatting changed no contribution files and only one unrelated upstream test layout, which is excluded from this PR. The example disables Agno telemetry, stores no database, and documents that explicit private model runs send raw tool results to the configured provider. API licensing does not grant public data redistribution.
