### PR TITLE
feat: Add API Route model provider

### DIFF
--- a/cookbook/90_models/apiroute/README.md
+++ b/cookbook/90_models/apiroute/README.md
@@ -1,0 +1,39 @@
+# API Route Cookbook
+
+This cookbook demonstrates how to use [API Route](https://www.api-route.com) with the Agno framework. API Route is a unified AI model router and gateway providing access to Claude, GPT, Gemini, DeepSeek, Llama, and more through an OpenAI-compatible endpoint.
+
+## Quick Start
+
+### 1. Export your `APIROUTE_API_KEY`
+
+Get your API key from [API Route](https://www.api-route.com).
+
+```shell
+export APIROUTE_API_KEY=sk-***
+```
+
+### 2. Run basic Agent
+
+```shell
+python cookbook/90_models/apiroute/basic.py
+```
+
+### 3. Run Agent with Tools
+
+```shell
+python cookbook/90_models/apiroute/tool_use.py
+```
+
+### 4. Run Agent with Structured Output
+
+```shell
+python cookbook/90_models/apiroute/structured_output.py
+```
+
+## Configuration
+
+| Parameter | Environment Variable | Default | Description |
+|-----------|---------------------|---------|-------------|
+| `api_key` | `APIROUTE_API_KEY` | None | Your API Route API key |
+| `id` | - | `claude-3-7-sonnet-20250219` | Model ID to use |
+| `base_url` | - | `https://global.api-route.com/v1` | Base URL for API Route |

--- a/cookbook/90_models/apiroute/basic.py
+++ b/cookbook/90_models/apiroute/basic.py
@@ -1,0 +1,25 @@
+"""
+API Route Basic
+===============
+
+Cookbook example for `apiroute/basic.py`.
+"""
+
+from agno.agent import Agent
+from agno.models.apiroute import ApiRoute
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+agent = Agent(model=ApiRoute(id="claude-3-7-sonnet-20250219"), markdown=True)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    # --- Sync ---
+    agent.print_response("Share a 2 sentence horror story.")
+
+    # --- Sync + Streaming ---
+    agent.print_response("Share a 2 sentence horror story.", stream=True)

--- a/cookbook/90_models/apiroute/structured_output.py
+++ b/cookbook/90_models/apiroute/structured_output.py
@@ -1,0 +1,43 @@
+"""
+API Route Structured Output
+===========================
+
+Cookbook example for `apiroute/structured_output.py`.
+"""
+
+from typing import List
+
+from agno.agent import Agent
+from agno.models.apiroute import ApiRoute
+from pydantic import BaseModel, Field
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+
+class MovieScript(BaseModel):
+    setting: str = Field(..., description="The setting of the movie")
+    protagonist: str = Field(..., description="Name of the protagonist")
+    antagonist: str = Field(..., description="Name of the antagonist")
+    plot: str = Field(..., description="The plot of the movie")
+    genre: str = Field(..., description="The genre of the movie")
+    scenes: List[str] = Field(..., description="List of scenes in the movie")
+
+
+agent = Agent(
+    model=ApiRoute(id="claude-3-7-sonnet-20250219"),
+    description="You help people write movie scripts.",
+    output_schema=MovieScript,
+    use_json_mode=True,
+    markdown=True,
+)
+
+agent.print_response("Generate a movie script about a space exploration crew")
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    pass

--- a/cookbook/90_models/apiroute/tool_use.py
+++ b/cookbook/90_models/apiroute/tool_use.py
@@ -1,0 +1,29 @@
+"""
+API Route Tool Use
+==================
+
+Cookbook example for `apiroute/tool_use.py`.
+"""
+
+from agno.agent import Agent
+from agno.models.apiroute import ApiRoute
+from agno.tools.websearch import WebSearchTools
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+agent = Agent(
+    model=ApiRoute(id="claude-3-7-sonnet-20250219"),
+    markdown=True,
+    tools=[WebSearchTools()],
+)
+
+agent.print_response("What is the latest news about generative AI?", stream=True)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    pass

--- a/libs/agno/agno/models/apiroute/__init__.py
+++ b/libs/agno/agno/models/apiroute/__init__.py
@@ -1,0 +1,5 @@
+from agno.models.apiroute.apiroute import ApiRoute
+
+__all__ = [
+    "ApiRoute",
+]

--- a/libs/agno/agno/models/apiroute/apiroute.py
+++ b/libs/agno/agno/models/apiroute/apiroute.py
@@ -1,0 +1,97 @@
+from dataclasses import dataclass, field
+from os import getenv
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from agno.exceptions import ModelAuthenticationError
+from agno.models.openai.like import OpenAILike
+from agno.utils.log import log_debug
+
+
+@dataclass
+class ApiRoute(OpenAILike):
+    """
+    A class for interacting with API Route models.
+
+    API Route is a unified AI router and gateway connecting to hundreds of top models
+    (Claude, GPT, Gemini, DeepSeek, Llama, and more) with high availability and OpenAI compatibility.
+
+    Attributes:
+        id (str): The model ID to use. Defaults to "claude-3-7-sonnet-20250219".
+        name (str): The model name. Defaults to "ApiRoute".
+        provider (str): The provider name. Defaults to "ApiRoute".
+        api_key (Optional[str]): The API Route API key. Defaults to APIROUTE_API_KEY environment variable.
+        base_url (str): The base URL for API Route. Defaults to "https://global.api-route.com/v1".
+    """
+
+    id: str = "claude-3-7-sonnet-20250219"
+    name: str = "ApiRoute"
+    provider: str = "ApiRoute"
+
+    api_key: Optional[str] = field(default_factory=lambda: getenv("APIROUTE_API_KEY"))
+    base_url: str = "https://global.api-route.com/v1"
+
+    def _get_client_params(self) -> Dict[str, Any]:
+        """
+        Returns client parameters for API requests, checking for APIROUTE_API_KEY.
+
+        Returns:
+            Dict[str, Any]: A dictionary of client parameters for API requests.
+        """
+        if not self.api_key:
+            self.api_key = getenv("APIROUTE_API_KEY")
+            if not self.api_key:
+                raise ModelAuthenticationError(
+                    message="APIROUTE_API_KEY not set. Please set the APIROUTE_API_KEY environment variable.",
+                    model_name=self.name,
+                )
+
+        base_params = {
+            "api_key": self.api_key,
+            "organization": self.organization,
+            "base_url": self.base_url,
+            "timeout": self.timeout,
+            "max_retries": self.max_retries,
+            "default_headers": self.default_headers,
+            "default_query": self.default_query,
+        }
+
+        client_params = {k: v for k, v in base_params.items() if v is not None}
+
+        if self.client_params:
+            client_params.update(self.client_params)
+        return client_params
+
+    def get_available_models(self) -> List[str]:
+        """
+        Fetch available models from API Route.
+
+        Returns:
+            List[str]: List of available model IDs.
+        """
+        if not self.api_key:
+            self.api_key = getenv("APIROUTE_API_KEY")
+            if not self.api_key:
+                log_debug("No API key provided, returning empty model list")
+                return []
+
+        try:
+            with httpx.Client() as client:
+                response = client.get(
+                    f"{self.base_url}/models",
+                    headers={"Authorization": f"Bearer {self.api_key}", "Accept": "application/json"},
+                    timeout=30.0,
+                )
+                response.raise_for_status()
+
+                data = response.json()
+                raw_models = data.get("data", [])
+                model_ids = [m.get("id") if isinstance(m, dict) else str(m) for m in raw_models]
+
+                log_debug(f"Found {len(model_ids)} total models")
+                return sorted(model_ids)
+
+        except Exception as e:
+            log_debug(f"Error fetching models from API Route: {e}")
+            return []

--- a/libs/agno/agno/models/utils.py
+++ b/libs/agno/agno/models/utils.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 _PROVIDERS: Dict[str, Tuple[str, str, str, str]] = {
     "aimlapi": ("agno.models.aimlapi", "AIMLAPI", "AIMLAPI", "aimlapi"),
     "anthropic": ("agno.models.anthropic", "Claude", "Claude", "anthropic"),
+    "apiroute": ("agno.models.apiroute", "ApiRoute", "ApiRoute", "apiroute"),
     "aws-bedrock": ("agno.models.aws", "AwsBedrock", "AwsBedrock", "awsbedrock"),
     "aws-claude": ("agno.models.aws", "Claude", "AwsBedrockAnthropicClaude", "awsbedrock"),
     "azure-ai-foundry": ("agno.models.azure", "AzureAIFoundry", "AzureAIFoundry", "azure"),

--- a/libs/agno/tests/unit/models/test_apiroute.py
+++ b/libs/agno/tests/unit/models/test_apiroute.py
@@ -1,0 +1,63 @@
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agno.exceptions import ModelAuthenticationError
+from agno.models.apiroute import ApiRoute
+
+
+def test_apiroute_initialization_with_api_key():
+    model = ApiRoute(id="claude-3-7-sonnet-20250219", api_key="test-api-key")
+    assert model.id == "claude-3-7-sonnet-20250219"
+    assert model.name == "ApiRoute"
+    assert model.provider == "ApiRoute"
+    assert model.api_key == "test-api-key"
+    assert model.base_url == "https://global.api-route.com/v1"
+
+
+def test_apiroute_initialization_without_api_key():
+    with patch.dict(os.environ, {}, clear=True):
+        model = ApiRoute(id="claude-3-7-sonnet-20250219")
+        client_params = None
+        with pytest.raises(ModelAuthenticationError):
+            client_params = model._get_client_params()
+        assert client_params is None
+
+
+def test_apiroute_initialization_with_env_api_key():
+    with patch.dict(os.environ, {"APIROUTE_API_KEY": "env-api-key"}):
+        model = ApiRoute(id="claude-3-7-sonnet-20250219")
+        assert model.api_key == "env-api-key"
+
+
+def test_apiroute_client_params():
+    model = ApiRoute(id="claude-3-7-sonnet-20250219", api_key="test-api-key")
+    client_params = model._get_client_params()
+    assert client_params["api_key"] == "test-api-key"
+    assert client_params["base_url"] == "https://global.api-route.com/v1"
+
+
+def test_apiroute_get_available_models_without_key():
+    with patch.dict(os.environ, {}, clear=True):
+        model = ApiRoute(id="claude-3-7-sonnet-20250219")
+        assert model.get_available_models() == []
+
+
+def test_apiroute_get_available_models_mocked():
+    model = ApiRoute(id="claude-3-7-sonnet-20250219", api_key="test-api-key")
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "data": [
+            {"id": "claude-3-7-sonnet-20250219"},
+            {"id": "gpt-4o"},
+            {"id": "deepseek-chat"},
+        ]
+    }
+    mock_response.raise_for_status = MagicMock()
+
+    with patch("httpx.Client.get", return_value=mock_response):
+        models = model.get_available_models()
+        assert "claude-3-7-sonnet-20250219" in models
+        assert "gpt-4o" in models
+        assert "deepseek-chat" in models

--- a/libs/agno/tests/unit/models/test_provider_resolution.py
+++ b/libs/agno/tests/unit/models/test_provider_resolution.py
@@ -111,6 +111,7 @@ def test_resolve_sdk_gated_providers(provider, name, expected_key):
         # Plain providers whose display string already equals the key.
         ("openai", None, "openai"),
         ("anthropic", None, "anthropic"),
+        ("apiroute", None, "apiroute"),
     ],
 )
 def test_resolve_provider_aliases(provider, name, expected_key):


### PR DESCRIPTION
## Summary

Add [API Route](https://www.api-route.com) as a model provider for Agno. API Route is a high-availability AI model routing service and gateway that provides access to Claude, OpenAI, Gemini, DeepSeek, Llama, and more through an OpenAI-compatible API interface.

Key changes:
- Created `ApiRoute` model provider inheriting from `OpenAILike` (`agno.models.apiroute`)
- Registered `apiroute` in model provider registry (`agno.models.utils`)
- Added unit tests covering initialization, client parameter building, environment authentication, and model catalog listing (`test_apiroute.py`)
- Added provider resolution alias test in `test_provider_resolution.py`
- Added cookbook examples under `cookbook/90_models/apiroute/` (`basic.py`, `tool_use.py`, `structured_output.py`, `README.md`)

## Type of change

- [x] New feature
- [x] Model update

---

## Checklist

- [x] Code complies with style guidelines
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
